### PR TITLE
`System.Windows.Forms.Design` - Refactor `!= null` to `is not null`

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Drawing/BitmapSelector.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/BitmapSelector.cs
@@ -30,10 +30,10 @@ namespace System.Drawing
                 {
                     _suffix = string.Empty;
                     var section = ConfigurationManager.GetSection("system.drawing") as SystemDrawingSection;
-                    if (section != null)
+                    if (section is not null)
                     {
                         var value = section.BitmapSuffix;
-                        if (value != null && value is string)
+                        if (value is not null && value is string)
                         {
                             _suffix = value;
                         }
@@ -105,7 +105,7 @@ namespace System.Drawing
 
         private static bool DoesAssemblyHaveCustomAttribute(Assembly assembly, Type attrType)
         {
-            if (attrType != null)
+            if (attrType is not null)
             {
                 var attr = assembly.GetCustomAttributes(attrType, false);
                 if (attr.Length > 0)
@@ -165,7 +165,7 @@ namespace System.Drawing
                     {
                         string newName = AppendSuffix(originalName);
                         Stream stream = GetResourceStreamHelper(assembly, type, newName);
-                        if (stream != null)
+                        if (stream is not null)
                         {
                             return stream;
                         }
@@ -187,10 +187,10 @@ namespace System.Drawing
                         assemblyName.ProcessorArchitecture = ProcessorArchitecture.None;
 #pragma warning restore SYSLIB0037 // Type or member is obsolete
                         Assembly satellite = Assembly.Load(assemblyName);
-                        if (satellite != null)
+                        if (satellite is not null)
                         {
                             Stream stream = GetResourceStreamHelper(satellite, type, originalName);
-                            if (stream != null)
+                            if (stream is not null)
                             {
                                 return stream;
                             }

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/ColorEditor.ColorUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/ColorEditor.ColorUI.cs
@@ -139,7 +139,7 @@ namespace System.Drawing.Design
                     if (prop.PropertyType == typeof(Color))
                     {
                         MethodInfo method = prop.GetGetMethod();
-                        if (method != null && (method.Attributes & attrs) == attrs)
+                        if (method is not null && (method.Attributes & attrs) == attrs)
                         {
                             object[] tempIndex = null;
                             colorList.Add(prop.GetValue(null, tempIndex));
@@ -232,7 +232,7 @@ namespace System.Drawing.Design
             private void OnListClick(object sender, EventArgs e)
             {
                 ListBox lb = (ListBox)sender;
-                if (lb.SelectedItem != null)
+                if (lb.SelectedItem is not null)
                 {
                     value = (Color)lb.SelectedItem;
                 }
@@ -307,7 +307,7 @@ namespace System.Drawing.Design
             {
                 TabPage selectedPage = tabControl.SelectedTab;
 
-                if (selectedPage != null && selectedPage.Controls.Count > 0)
+                if (selectedPage is not null && selectedPage.Controls.Count > 0)
                 {
                     selectedPage.Controls[0].Focus();
                 }
@@ -355,7 +355,7 @@ namespace System.Drawing.Design
 
                 // Now look for the current color so we can select the proper tab.
                 //
-                if (value != null)
+                if (value is not null)
                 {
                     object[] values = ColorValues;
                     TabPage selectedTab = paletteTabPage;
@@ -411,7 +411,7 @@ namespace System.Drawing.Design
                 protected override void OnGotFocus(EventArgs e)
                 {
                     TabPage selectedTab = SelectedTab;
-                    if (selectedTab != null && selectedTab.Controls.Count > 0)
+                    if (selectedTab is not null && selectedTab.Controls.Count > 0)
                     {
                         selectedTab.Controls[0].Focus();
                     }

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/CursorEditor.CursorUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/CursorEditor.CursorUI.cs
@@ -94,7 +94,7 @@ namespace System.Drawing.Design
                 _value = value;
 
                 // Select the current cursor
-                if (value != null)
+                if (value is not null)
                 {
                     for (int i = 0; i < Items.Count; i++)
                     {

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/ImageEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/ImageEditor.cs
@@ -89,7 +89,7 @@ namespace System.Drawing.Design
                         null);
 
                     Type myClass = GetType();
-                    if (!myClass.Equals(e.GetType()) && e != null && myClass.IsInstanceOfType(e))
+                    if (!myClass.Equals(e.GetType()) && e is not null && myClass.IsInstanceOfType(e))
                     {
                         filter += $"|{CreateFilterEntry(e)}";
                     }

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/ToolboxItem.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/ToolboxItem.cs
@@ -80,7 +80,7 @@ namespace System.Drawing.Design
             get
             {
                 AssemblyName[] names = (AssemblyName[])Properties["DependentAssemblies"];
-                if (names != null)
+                if (names is not null)
                 {
                     return (AssemblyName[])names.Clone();
                 }
@@ -317,7 +317,7 @@ namespace System.Drawing.Design
         {
             OnComponentsCreating(new ToolboxComponentsCreatingEventArgs(host));
             IComponent[] comps = CreateComponentsCore(host, new Hashtable());
-            if (comps != null && comps.Length > 0)
+            if (comps is not null && comps.Length > 0)
             {
                 OnComponentsCreated(new ToolboxComponentsCreatedEventArgs(comps));
             }
@@ -334,7 +334,7 @@ namespace System.Drawing.Design
         {
             OnComponentsCreating(new ToolboxComponentsCreatingEventArgs(host));
             IComponent[] comps = CreateComponentsCore(host, defaultValues);
-            if (comps != null && comps.Length > 0)
+            if (comps is not null && comps.Length > 0)
             {
                 OnComponentsCreated(new ToolboxComponentsCreatedEventArgs(comps));
             }
@@ -351,9 +351,9 @@ namespace System.Drawing.Design
             ArrayList comps = new ArrayList();
 
             Type createType = GetType(host, AssemblyName, TypeName, true);
-            if (createType != null)
+            if (createType is not null)
             {
-                if (host != null)
+                if (host is not null)
                 {
                     comps.Add(host.CreateComponent(createType));
                 }
@@ -376,7 +376,7 @@ namespace System.Drawing.Design
         {
             IComponent[] components = CreateComponentsCore(host);
 
-            if (host != null && components != null)
+            if (host is not null && components is not null)
             {
                 for (int i = 0; i < components.Length; i++)
                 {
@@ -485,7 +485,7 @@ namespace System.Drawing.Design
         private static bool AreAssemblyNamesEqual(AssemblyName name1, AssemblyName name2)
         {
             return name1 == name2 ||
-                   (name1 != null && name2 != null && name1.FullName == name2.FullName);
+                   (name1 is not null && name2 is not null && name1.FullName == name2.FullName);
         }
 
         public override int GetHashCode() => HashCode.Combine(TypeName, DisplayName);
@@ -550,16 +550,16 @@ namespace System.Drawing.Design
 
             ArgumentNullException.ThrowIfNull(typeName);
 
-            if (host != null)
+            if (host is not null)
             {
                 ts = host.GetService(typeof(ITypeResolutionService)) as ITypeResolutionService;
             }
 
-            if (ts != null)
+            if (ts is not null)
             {
                 if (reference)
                 {
-                    if (assemblyName != null)
+                    if (assemblyName is not null)
                     {
                         ts.ReferenceAssembly(assemblyName);
                         type = ts.GetType(typeName);
@@ -571,7 +571,7 @@ namespace System.Drawing.Design
                         type = ts.GetType(typeName);
                         type ??= Type.GetType(typeName);
 
-                        if (type != null)
+                        if (type is not null)
                         {
                             ts.ReferenceAssembly(type.Assembly.GetName());
                         }
@@ -579,10 +579,10 @@ namespace System.Drawing.Design
                 }
                 else
                 {
-                    if (assemblyName != null)
+                    if (assemblyName is not null)
                     {
                         Assembly a = ts.GetAssembly(assemblyName);
-                        if (a != null)
+                        if (a is not null)
                         {
                             type = a.GetType(typeName);
                         }
@@ -595,7 +595,7 @@ namespace System.Drawing.Design
             {
                 if (!string.IsNullOrEmpty(typeName))
                 {
-                    if (assemblyName != null)
+                    if (assemblyName is not null)
                     {
                         Assembly a = null;
                         try
@@ -631,7 +631,7 @@ namespace System.Drawing.Design
                         }
 #pragma warning restore SYSLIB0044 // Type or member is obsolete
 
-                        if (a != null)
+                        if (a is not null)
                         {
                             type = a.GetType(typeName);
                         }
@@ -651,20 +651,20 @@ namespace System.Drawing.Design
         {
             CheckUnlocked();
 
-            if (type != null)
+            if (type is not null)
             {
                 TypeName = type.FullName;
                 AssemblyName assemblyName = type.Assembly.GetName(true);
 
                 Dictionary<string, AssemblyName> parents = new Dictionary<string, AssemblyName>();
                 Type parentType = type;
-                while (parentType != null)
+                while (parentType is not null)
                 {
                     AssemblyName policiedName = parentType.Assembly.GetName(true);
 
                     AssemblyName aname = GetNonRetargetedAssemblyName(type, policiedName);
 
-                    if (aname != null && !parents.ContainsKey(aname.FullName))
+                    if (aname is not null && !parents.ContainsKey(aname.FullName))
                     {
                         parents[aname.FullName] = aname;
                     }
@@ -689,9 +689,9 @@ namespace System.Drawing.Design
                 if (!type.Assembly.ReflectionOnly)
                 {
                     object[] companyattrs = type.Assembly.GetCustomAttributes(typeof(AssemblyCompanyAttribute), true);
-                    if (companyattrs != null && companyattrs.Length > 0)
+                    if (companyattrs is not null && companyattrs.Length > 0)
                     {
-                        if (companyattrs[0] is AssemblyCompanyAttribute company && company.Company != null)
+                        if (companyattrs[0] is AssemblyCompanyAttribute company && company.Company is not null)
                         {
                             Company = company.Company;
                         }
@@ -699,16 +699,16 @@ namespace System.Drawing.Design
 
                     //set the description based off the description attribute of the given type.
                     DescriptionAttribute descattr = (DescriptionAttribute)TypeDescriptor.GetAttributes(type)[typeof(DescriptionAttribute)];
-                    if (descattr != null)
+                    if (descattr is not null)
                     {
                         Description = descattr.Description;
                     }
 
                     ToolboxBitmapAttribute attr = (ToolboxBitmapAttribute)TypeDescriptor.GetAttributes(type)[typeof(ToolboxBitmapAttribute)];
-                    if (attr != null)
+                    if (attr is not null)
                     {
                         Bitmap itemBitmap = attr.GetImage(type, false) as Bitmap;
-                        if (itemBitmap != null)
+                        if (itemBitmap is not null)
                         {
                             // Original bitmap is used when adding the item to the Visual Studio toolbox
                             // if running on a machine with HDPI scaling enabled.
@@ -749,7 +749,7 @@ namespace System.Drawing.Design
 
         private static AssemblyName GetNonRetargetedAssemblyName(Type type, AssemblyName policiedAssemblyName)
         {
-            Debug.Assert(type != null);
+            Debug.Assert(type is not null);
             if (policiedAssemblyName is null)
             {
                 return null;
@@ -906,7 +906,7 @@ namespace System.Drawing.Design
                     int filterCount = 0;
                     ICollection col = (ICollection)value;
 
-                    if (col != null)
+                    if (col is not null)
                     {
                         foreach (object f in col)
                         {
@@ -919,7 +919,7 @@ namespace System.Drawing.Design
 
                     ToolboxItemFilterAttribute[] filter = new ToolboxItemFilterAttribute[filterCount];
 
-                    if (col != null)
+                    if (col is not null)
                     {
                         filterCount = 0;
                         foreach (object f in col)

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/BaseContextMenuStrip.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/BaseContextMenuStrip.cs
@@ -71,7 +71,7 @@ namespace System.Windows.Forms.Design
         private void RefreshSelectionMenuItem()
         {
             int index = -1;
-            if (selectionMenuItem != null)
+            if (selectionMenuItem is not null)
             {
                 index = Items.IndexOf(selectionMenuItem);
                 Groups[StandardGroups.Selection].Items.Remove(selectionMenuItem);
@@ -85,13 +85,13 @@ namespace System.Windows.Forms.Design
             if (serviceProvider.GetService(typeof(ISelectionService)) is ISelectionService selectionService && serviceProvider.GetService(typeof(IDesignerHost)) is IDesignerHost host)
             {
                 IComponent root = host.RootComponent;
-                Debug.Assert(root != null, "Null root component. Will be unable to build selection menu");
-                if (selectionService.PrimarySelection is Control selectedControl && root != null && selectedControl != root)
+                Debug.Assert(root is not null, "Null root component. Will be unable to build selection menu");
+                if (selectionService.PrimarySelection is Control selectedControl && root is not null && selectedControl != root)
                 {
                     Control parentControl = selectedControl.Parent;
-                    while (parentControl != null)
+                    while (parentControl is not null)
                     {
-                        if (parentControl.Site != null)
+                        if (parentControl.Site is not null)
                         {
                             parentControls.Add(parentControl);
                             nParentControls++;
@@ -154,7 +154,7 @@ namespace System.Windows.Forms.Design
         {
             //Add Designer Verbs..
             IMenuCommandService menuCommandService = (IMenuCommandService)serviceProvider.GetService(typeof(IMenuCommandService));
-            if (menuCommandService != null)
+            if (menuCommandService is not null)
             {
                 DesignerVerbCollection verbCollection = menuCommandService.Verbs;
                 foreach (DesignerVerb verb in verbCollection)
@@ -258,10 +258,10 @@ namespace System.Windows.Forms.Design
                 _serviceProvider = provider;
                 // Get NestedSiteName...
                 string compName = null;
-                if (_comp != null)
+                if (_comp is not null)
                 {
                     ISite site = _comp.Site;
-                    if (site != null)
+                    if (site is not null)
                     {
                         if (site is INestedSite nestedSite && !string.IsNullOrEmpty(nestedSite.FullName))
                         {

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/Behavior.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/Behavior.cs
@@ -53,7 +53,7 @@ namespace System.Windows.Forms.Design.Behavior
         {
             get
             {
-                if (_callParentBehavior && GetNextBehavior != null)
+                if (_callParentBehavior && GetNextBehavior is not null)
                 {
                     return GetNextBehavior.DisableAllCommands;
                 }
@@ -72,7 +72,7 @@ namespace System.Windows.Forms.Design.Behavior
         {
             try
             {
-                if (_callParentBehavior && GetNextBehavior != null)
+                if (_callParentBehavior && GetNextBehavior is not null)
                 {
                     return GetNextBehavior.FindCommand(commandId);
                 }
@@ -94,7 +94,7 @@ namespace System.Windows.Forms.Design.Behavior
         /// </summary>
         private Behavior? GetGlyphBehavior(Glyph? g)
         {
-            return g?.Behavior != null && g.Behavior != this ? g.Behavior : null;
+            return g?.Behavior is not null && g.Behavior != this ? g.Behavior : null;
         }
 
         /// <summary>
@@ -110,7 +110,7 @@ namespace System.Windows.Forms.Design.Behavior
         /// </summary>
         public virtual void OnLoseCapture(Glyph? g, EventArgs e)
         {
-            if (_callParentBehavior && GetNextBehavior != null)
+            if (_callParentBehavior && GetNextBehavior is not null)
             {
                 GetNextBehavior.OnLoseCapture(g, e);
             }
@@ -128,7 +128,7 @@ namespace System.Windows.Forms.Design.Behavior
         /// </summary>
         public virtual bool OnMouseDoubleClick(Glyph? g, MouseButtons button, Point mouseLoc)
         {
-            if (_callParentBehavior && GetNextBehavior != null)
+            if (_callParentBehavior && GetNextBehavior is not null)
             {
                 return GetNextBehavior.OnMouseDoubleClick(g, button, mouseLoc);
             }
@@ -150,7 +150,7 @@ namespace System.Windows.Forms.Design.Behavior
         /// </summary>
         public virtual bool OnMouseDown(Glyph? g, MouseButtons button, Point mouseLoc)
         {
-            if (_callParentBehavior && GetNextBehavior != null)
+            if (_callParentBehavior && GetNextBehavior is not null)
             {
                 return GetNextBehavior.OnMouseDown(g, button, mouseLoc);
             }
@@ -170,7 +170,7 @@ namespace System.Windows.Forms.Design.Behavior
         /// </summary>
         public virtual bool OnMouseEnter(Glyph? g)
         {
-            if (_callParentBehavior && GetNextBehavior != null)
+            if (_callParentBehavior && GetNextBehavior is not null)
             {
                 return GetNextBehavior.OnMouseEnter(g);
             }
@@ -191,7 +191,7 @@ namespace System.Windows.Forms.Design.Behavior
         /// </summary>
         public virtual bool OnMouseHover(Glyph? g, Point mouseLoc)
         {
-            if (_callParentBehavior && GetNextBehavior != null)
+            if (_callParentBehavior && GetNextBehavior is not null)
             {
                 return GetNextBehavior.OnMouseHover(g, mouseLoc);
             }
@@ -210,7 +210,7 @@ namespace System.Windows.Forms.Design.Behavior
         /// </summary>
         public virtual bool OnMouseLeave(Glyph? g)
         {
-            if (_callParentBehavior && GetNextBehavior != null)
+            if (_callParentBehavior && GetNextBehavior is not null)
             {
                 return GetNextBehavior.OnMouseLeave(g);
             }
@@ -231,7 +231,7 @@ namespace System.Windows.Forms.Design.Behavior
         /// </summary>
         public virtual bool OnMouseMove(Glyph? g, MouseButtons button, Point mouseLoc)
         {
-            if (_callParentBehavior && GetNextBehavior != null)
+            if (_callParentBehavior && GetNextBehavior is not null)
             {
                 return GetNextBehavior.OnMouseMove(g, button, mouseLoc);
             }
@@ -254,7 +254,7 @@ namespace System.Windows.Forms.Design.Behavior
         /// </summary>
         public virtual bool OnMouseUp(Glyph? g, MouseButtons button)
         {
-            if (_callParentBehavior && GetNextBehavior != null)
+            if (_callParentBehavior && GetNextBehavior is not null)
             {
                 return GetNextBehavior.OnMouseUp(g, button);
             }
@@ -275,7 +275,7 @@ namespace System.Windows.Forms.Design.Behavior
         /// </summary>
         public virtual void OnDragDrop(Glyph? g, DragEventArgs e)
         {
-            if (_callParentBehavior && GetNextBehavior != null)
+            if (_callParentBehavior && GetNextBehavior is not null)
             {
                 GetNextBehavior.OnDragDrop(g, e);
             }
@@ -290,7 +290,7 @@ namespace System.Windows.Forms.Design.Behavior
         /// </summary>
         public virtual void OnDragEnter(Glyph? g, DragEventArgs e)
         {
-            if (_callParentBehavior && GetNextBehavior != null)
+            if (_callParentBehavior && GetNextBehavior is not null)
             {
                 GetNextBehavior.OnDragEnter(g, e);
             }
@@ -305,7 +305,7 @@ namespace System.Windows.Forms.Design.Behavior
         /// </summary>
         public virtual void OnDragLeave(Glyph? g, EventArgs e)
         {
-            if (_callParentBehavior && GetNextBehavior != null)
+            if (_callParentBehavior && GetNextBehavior is not null)
             {
                 GetNextBehavior.OnDragLeave(g, e);
             }
@@ -320,7 +320,7 @@ namespace System.Windows.Forms.Design.Behavior
         /// </summary>
         public virtual void OnDragOver(Glyph? g, DragEventArgs e)
         {
-            if (_callParentBehavior && GetNextBehavior != null)
+            if (_callParentBehavior && GetNextBehavior is not null)
             {
                 GetNextBehavior.OnDragOver(g, e);
             }
@@ -339,7 +339,7 @@ namespace System.Windows.Forms.Design.Behavior
         /// </summary>
         public virtual void OnGiveFeedback(Glyph? g, GiveFeedbackEventArgs e)
         {
-            if (_callParentBehavior && GetNextBehavior != null)
+            if (_callParentBehavior && GetNextBehavior is not null)
             {
                 GetNextBehavior.OnGiveFeedback(g, e);
             }
@@ -354,7 +354,7 @@ namespace System.Windows.Forms.Design.Behavior
         /// </summary>
         public virtual void OnQueryContinueDrag(Glyph? g, QueryContinueDragEventArgs e)
         {
-            if (_callParentBehavior && GetNextBehavior != null)
+            if (_callParentBehavior && GetNextBehavior is not null)
             {
                 GetNextBehavior.OnQueryContinueDrag(g, e);
             }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.AdornerWindow.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.AdornerWindow.cs
@@ -67,7 +67,7 @@ namespace System.Windows.Forms.Design.Behavior
                 s_adornerWindowList.Remove(this);
 
                 // Unregister the mouse hook once all adorner windows have been disposed.
-                if (s_adornerWindowList.Count == 0 && s_mouseHook != null)
+                if (s_adornerWindowList.Count == 0 && s_mouseHook is not null)
                 {
                     s_mouseHook.Dispose();
                     s_mouseHook = null;
@@ -81,7 +81,7 @@ namespace System.Windows.Forms.Design.Behavior
             /// </summary>
             protected override void Dispose(bool disposing)
             {
-                if (disposing && DesignerFrame != null)
+                if (disposing && DesignerFrame is not null)
                 {
                     DesignerFrame = null;
                 }
@@ -101,7 +101,7 @@ namespace System.Windows.Forms.Design.Behavior
             ///  Returns true if the DesignerFrame is created and not being disposed.
             /// </summary>
             internal bool DesignerFrameValid
-                => DesignerFrame != null && !DesignerFrame.IsDisposed && DesignerFrame.IsHandleCreated;
+                => DesignerFrame is not null && !DesignerFrame.IsDisposed && DesignerFrame.IsHandleCreated;
 
             public IEnumerable<Adorner> Adorners { get; private set; }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.cs
@@ -63,7 +63,7 @@ namespace System.Windows.Forms.Design.Behavior
 
             // Use the adornerWindow as an overlay
             IOverlayService os = (IOverlayService)serviceProvider.GetService(typeof(IOverlayService));
-            if (os != null)
+            if (os is not null)
             {
                 AdornerWindowIndex = os.PushOverlay(_adornerWindow);
             }
@@ -113,7 +113,7 @@ namespace System.Windows.Forms.Design.Behavior
 
         internal int AdornerWindowIndex { get; } = -1;
 
-        internal bool HasCapture => _captureBehavior != null;
+        internal bool HasCapture => _captureBehavior is not null;
 
         /// <summary>
         ///  Returns the LayoutMode setting of the current designer session.  Either SnapLines or SnapToGrid.
@@ -185,7 +185,7 @@ namespace System.Windows.Forms.Design.Behavior
                 menuCommandHandler = menuCommandService as MenuCommandHandler;
             }
 
-            if (menuCommandHandler != null && _serviceProvider.GetService(typeof(IDesignerHost)) is IDesignerHost host)
+            if (menuCommandHandler is not null && _serviceProvider.GetService(typeof(IDesignerHost)) is IDesignerHost host)
             {
                 IMenuCommandService oldMenuCommandService = menuCommandHandler.MenuService;
                 host.RemoveService(typeof(IMenuCommandService));
@@ -352,7 +352,7 @@ namespace System.Windows.Forms.Design.Behavior
         /// </summary>
         public Behavior GetNextBehavior(Behavior behavior)
         {
-            if (_behaviorStack != null && _behaviorStack.Count > 0)
+            if (_behaviorStack is not null && _behaviorStack.Count > 0)
             {
                 int index = _behaviorStack.IndexOf(behavior);
                 if ((index != -1) && (index < _behaviorStack.Count - 1))
@@ -420,7 +420,7 @@ namespace System.Windows.Forms.Design.Behavior
                 _adornerWindow.Capture = false;
 
                 // Defensive:  adornerWindow should get a WM_CAPTURECHANGED, but do this by hand if it didn't.
-                if (_captureBehavior != null)
+                if (_captureBehavior is not null)
                 {
                     OnLoseCapture();
                     Debug.Assert(_captureBehavior is null, "OnLostCapture should have cleared captureBehavior");
@@ -448,7 +448,7 @@ namespace System.Windows.Forms.Design.Behavior
             _behaviorStack.Insert(0, behavior);
 
             // If there is a capture behavior, and it isn't this behavior, notify it that it no longer has capture.
-            if (_captureBehavior != null && _captureBehavior != behavior)
+            if (_captureBehavior is not null && _captureBehavior != behavior)
             {
                 OnLoseCapture();
             }
@@ -486,7 +486,7 @@ namespace System.Windows.Forms.Design.Behavior
 
         internal void OnLoseCapture()
         {
-            if (_captureBehavior != null)
+            if (_captureBehavior is not null)
             {
                 Behavior b = _captureBehavior;
                 _captureBehavior = null;
@@ -512,7 +512,7 @@ namespace System.Windows.Forms.Design.Behavior
                 for (int j = 0; j < Adorners[i].Glyphs.Count; j++)
                 {
                     Cursor hitTestCursor = Adorners[i].Glyphs[j].GetHitTest(pt);
-                    if (hitTestCursor != null)
+                    if (hitTestCursor is not null)
                     {
                         // InvokeMouseEnterGlyph will cause the selection to change, which might change the number of glyphs, so we need to remember the new glyph before calling InvokeMouseEnterLeave. VSWhidbey #396611
                         Glyph newGlyph = Adorners[i].Glyphs[j];
@@ -536,7 +536,7 @@ namespace System.Windows.Forms.Design.Behavior
             if (_validDragArgs is null)
             {
                 Cursor cursor = Cursors.Default;
-                if ((_behaviorStack != null) && (_behaviorStack.Count > 0))
+                if ((_behaviorStack is not null) && (_behaviorStack.Count > 0))
                 {
                     if (_behaviorStack[0] is Behavior behavior)
                     {
@@ -560,13 +560,13 @@ namespace System.Windows.Forms.Design.Behavior
         {
             Behavior behavior = GetAppropriateBehavior(_hitTestedGlyph);
 
-            if (behavior != null)
+            if (behavior is not null)
             {
                 if (behavior.DisableAllCommands)
                 {
                     MenuCommand menuCommand = menuService.FindCommand(commandID);
 
-                    if (menuCommand != null)
+                    if (menuCommand is not null)
                     {
                         menuCommand.Enabled = false;
                     }
@@ -577,7 +577,7 @@ namespace System.Windows.Forms.Design.Behavior
                 {
                     // Check to see if the behavior wants to interrupt this command
                     MenuCommand menuCommand = behavior.FindCommand(commandID);
-                    if (menuCommand != null)
+                    if (menuCommand is not null)
                     {
                         // The behavior chose to interrupt - so return the new command
                         return menuCommand;
@@ -619,15 +619,15 @@ namespace System.Windows.Forms.Design.Behavior
 
         private void InvokeMouseEnterLeave(Glyph leaveGlyph, Glyph enterGlyph)
         {
-            if (leaveGlyph != null)
+            if (leaveGlyph is not null)
             {
-                if (enterGlyph != null && leaveGlyph.Equals(enterGlyph))
+                if (enterGlyph is not null && leaveGlyph.Equals(enterGlyph))
                 {
                     // Same glyph - no change
                     return;
                 }
 
-                if (_validDragArgs != null)
+                if (_validDragArgs is not null)
                 {
                     OnDragLeave(leaveGlyph, EventArgs.Empty);
                 }
@@ -637,9 +637,9 @@ namespace System.Windows.Forms.Design.Behavior
                 }
             }
 
-            if (enterGlyph != null)
+            if (enterGlyph is not null)
             {
-                if (_validDragArgs != null)
+                if (_validDragArgs is not null)
                 {
                     OnDragEnter(enterGlyph, _validDragArgs);
                 }
@@ -668,7 +668,7 @@ namespace System.Windows.Forms.Design.Behavior
             Debug.WriteLineIf(s_dragDropSwitch.TraceVerbose, "\tForwarding to behavior");
             behavior.OnDragEnter(g, e);
 
-            if (g != null && g is ControlBodyGlyph && e.Effect == DragDropEffects.None)
+            if (g is not null && g is ControlBodyGlyph && e.Effect == DragDropEffects.None)
             {
                 _dragEnterReplies[g] = this; // dummy value, we just need to set something.
                 Debug.WriteLineIf(s_dragDropSwitch.TraceVerbose, "\tCalled DragEnter on this glyph. Caching");
@@ -787,7 +787,7 @@ namespace System.Windows.Forms.Design.Behavior
         private void TestHook_GetRecentSnapLines(ref Message m)
         {
             string snapLineInfo = string.Empty;
-            if (_testHook_RecentSnapLines != null)
+            if (_testHook_RecentSnapLines is not null)
             {
                 foreach (string line in _testHook_RecentSnapLines)
                 {
@@ -867,7 +867,7 @@ namespace System.Windows.Forms.Design.Behavior
             }
 
             if (_hitTestedGlyph is null ||
-               (_hitTestedGlyph != null && !_dragEnterReplies.ContainsKey(_hitTestedGlyph)))
+               (_hitTestedGlyph is not null && !_dragEnterReplies.ContainsKey(_hitTestedGlyph)))
             {
                 Debug.WriteLineIf(s_dragDropSwitch.TraceVerbose, "\tFound glyph, forwarding to behavior");
                 behavior.OnDragOver(_hitTestedGlyph, e);

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/ContainerSelectorBehavior.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/ContainerSelectorBehavior.cs
@@ -86,7 +86,7 @@ namespace System.Windows.Forms.Design.Behavior
             {
                 //select our component
                 ISelectionService selSvc = (ISelectionService)_serviceProvider.GetService(typeof(ISelectionService));
-                if (selSvc != null && !_containerControl.Equals(selSvc.PrimarySelection as Control))
+                if (selSvc is not null && !_containerControl.Equals(selSvc.PrimarySelection as Control))
                 {
                     selSvc.SetSelectedComponents(new object[] { _containerControl }, SelectionTypes.Primary | SelectionTypes.Toggle);
                     // Setting the selected component will create a new glyph, so this instance of the glyph won't receive any more mouse messages. So we need to tell the new glyph what the initialDragPoint and okToMove are.
@@ -210,7 +210,7 @@ namespace System.Windows.Forms.Design.Behavior
             //create our list of controls-to-drag
             foreach (IComponent comp in selComps)
             {
-                if ((comp is Control ctrl) && (ctrl.Parent != null))
+                if ((comp is Control ctrl) && (ctrl.Parent is not null))
                 {
                     if (!ctrl.Parent.Equals(requiredParent))
                     {

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DesignerActionBehavior.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DesignerActionBehavior.cs
@@ -125,10 +125,10 @@ namespace System.Windows.Forms.Design.Behavior
             }
             else if (!_ignoreNextMouseUp)
             {
-                if (_serviceProvider != null)
+                if (_serviceProvider is not null)
                 {
                     ISelectionService selectionService = (ISelectionService)_serviceProvider.GetService(typeof(ISelectionService));
-                    if (selectionService != null)
+                    if (selectionService is not null)
                     {
                         if (selectionService.PrimarySelection != RelatedComponent)
                         {

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DesignerActionGlyph.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DesignerActionGlyph.cs
@@ -139,7 +139,7 @@ namespace System.Windows.Forms.Design.Behavior
 
         internal void InvalidateOwnerLocation()
         {
-            if (_alternativeParent != null)
+            if (_alternativeParent is not null)
             {
                 // alternative parent and adorner are exclusive...
                 _alternativeParent.Invalidate(_bounds);
@@ -162,7 +162,7 @@ namespace System.Windows.Forms.Design.Behavior
             IComponent relatedComponent = ((DesignerActionBehavior)Behavior).RelatedComponent;
             Point topRight = Point.Empty;
             //handle the case that our comp is a control
-            if (relatedComponent is Control relatedControl && !(relatedComponent is ToolStripDropDown) && _adorner != null)
+            if (relatedComponent is Control relatedControl && !(relatedComponent is ToolStripDropDown) && _adorner is not null)
             {
                 topRight = _adorner.BehaviorService.ControlToAdornerWindow(relatedControl);
                 topRight.X += relatedControl.Width;
@@ -176,7 +176,7 @@ namespace System.Windows.Forms.Design.Behavior
                 if (_alternativeParent is ComponentTray compTray)
                 {
                     ComponentTray.TrayControl trayControl = ComponentTray.GetTrayControlFromComponent(relatedComponent);
-                    if (trayControl != null)
+                    if (trayControl is not null)
                     {
                         _alternativeBounds = trayControl.Bounds;
                     }
@@ -226,7 +226,7 @@ namespace System.Windows.Forms.Design.Behavior
 
                 IComponent panelComponent = behavior.ParentUI.LastPanelComponent;
                 IComponent relatedComponent = behavior.RelatedComponent;
-                if (panelComponent != null && panelComponent == relatedComponent)
+                if (panelComponent is not null && panelComponent == relatedComponent)
                 {
                     image = GlyphImageOpened;
                 }
@@ -239,7 +239,7 @@ namespace System.Windows.Forms.Design.Behavior
                 {
                     _insidePaint = true;
                     pe.Graphics.DrawImage(image, _bounds.Left, _bounds.Top);
-                    if (MouseOver || (panelComponent != null && panelComponent == relatedComponent))
+                    if (MouseOver || (panelComponent is not null && panelComponent == relatedComponent))
                     {
                         pe.Graphics.FillRectangle(DesignerUtils.HoverBrush, Rectangle.Inflate(_bounds, -1, -1));
                     }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DesignerActionKeyboardBehavior.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DesignerActionKeyboardBehavior.cs
@@ -17,10 +17,10 @@ namespace System.Windows.Forms.Design.Behavior
         public DesignerActionKeyboardBehavior(DesignerActionPanel panel, IServiceProvider serviceProvider, BehaviorService behaviorService) : base(true, behaviorService)
         {
             _panel = panel;
-            if (serviceProvider != null)
+            if (serviceProvider is not null)
             {
                 _menuService = serviceProvider.GetService(typeof(IMenuCommandService)) as IMenuCommandService;
-                Debug.Assert(_menuService != null, "we should have found a menu service here...");
+                Debug.Assert(_menuService is not null, "we should have found a menu service here...");
                 _daUISvc = serviceProvider.GetService(typeof(DesignerActionUIService)) as DesignerActionUIService;
             }
         }
@@ -28,7 +28,7 @@ namespace System.Windows.Forms.Design.Behavior
         // THIS should not stay here, creation of a custom command or of the real thing should be handled in the designeractionpanel itself
         public override MenuCommand FindCommand(CommandID commandId)
         {
-            if (_panel != null && _menuService != null)
+            if (_panel is not null && _menuService is not null)
             {
                 // if the command we're looking for is handled by the panel, just tell VS that this command is disabled. otherwise let it through as usual...
                 foreach (CommandID candidateCommandId in _panel.FilteredCommandIDs)
@@ -46,7 +46,7 @@ namespace System.Windows.Forms.Design.Behavior
                 }
 
                 // in case of a ctrl-tab we need to close the DAP
-                if (_daUISvc != null && commandId.Guid == s_vSStandardCommandSet97 && commandId.ID == 1124)
+                if (_daUISvc is not null && commandId.Guid == s_vSStandardCommandSet97 && commandId.ID == 1124)
                 {
                     _daUISvc.HideUI(null);
                 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DragAssistanceManager.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DragAssistanceManager.cs
@@ -153,7 +153,7 @@ namespace System.Windows.Forms.Design.Behavior
                 if (isTarget)
                 {
                     //we will remove padding snaplines from targets - it doesn't make sense to snap to the target's padding lines
-                    if (snapLine.Filter != null && snapLine.Filter.StartsWith(SnapLine.Padding))
+                    if (snapLine.Filter is not null && snapLine.Filter.StartsWith(SnapLine.Padding))
                     {
                         continue;
                     }
@@ -171,7 +171,7 @@ namespace System.Windows.Forms.Design.Behavior
                     }
 
                     // store off the bounds in our dictionary, so if we draw snaplines we know the length of the line we need to remember different bounds based on what type of snapline this is.
-                    if ((snapLine.Filter != null) && snapLine.Filter.StartsWith(SnapLine.Padding))
+                    if ((snapLine.Filter is not null) && snapLine.Filter.StartsWith(SnapLine.Padding))
                     {
                         _snapLineToBounds.Add(snapLine, controlRect);
                     }
@@ -252,14 +252,14 @@ namespace System.Windows.Forms.Design.Behavior
         /// </summary>
         private Line[] EraseOldSnapLines(Line[] lines, List<Line> tempLines)
         {
-            if (lines != null)
+            if (lines is not null)
             {
                 for (int i = 0; i < lines.Length; i++)
                 {
                     bool foundMatch = false;
                     Line line = lines[i];
                     Rectangle invalidRect;
-                    if (tempLines != null)
+                    if (tempLines is not null)
                     {
                         for (int j = 0; j < tempLines.Count; j++)
                         {
@@ -270,14 +270,14 @@ namespace System.Windows.Forms.Design.Behavior
                             }
 
                             Line[] diffs = Line.GetDiffs(line, tempLines[j]);
-                            if (diffs != null)
+                            if (diffs is not null)
                             {
                                 for (int k = 0; k < diffs.Length; k++)
                                 {
                                     invalidRect = new Rectangle(diffs[k].x1, diffs[k].y1, diffs[k].x2 - diffs[k].x1, diffs[k].y2 - diffs[k].y1);
 
                                     invalidRect.Inflate(1, 1);
-                                    if (_backgroundImage != null)
+                                    if (_backgroundImage is not null)
                                     {
                                         _graphics.DrawImage(_backgroundImage, invalidRect, invalidRect, GraphicsUnit.Pixel);
                                     }
@@ -297,7 +297,7 @@ namespace System.Windows.Forms.Design.Behavior
                     {
                         invalidRect = new Rectangle(line.x1, line.y1, line.x2 - line.x1, line.y2 - line.y1);
                         invalidRect.Inflate(1, 1);
-                        if (_backgroundImage != null)
+                        if (_backgroundImage is not null)
                         {
                             _graphics.DrawImage(_backgroundImage, invalidRect, invalidRect, GraphicsUnit.Pixel);
                         }
@@ -309,7 +309,7 @@ namespace System.Windows.Forms.Design.Behavior
                 }
             }
 
-            if (tempLines != null)
+            if (tempLines is not null)
             {
                 // Now, store off all the new lines (from the temp structures), so next time around (next mousemove message) we know which lines to erase and which ones to keep
                 lines = new Line[tempLines.Count];
@@ -334,7 +334,7 @@ namespace System.Windows.Forms.Design.Behavior
         /// </summary>
         internal Line[] GetRecentLines()
         {
-            if (_recentLines != null)
+            if (_recentLines is not null)
             {
                 return _recentLines;
             }
@@ -374,7 +374,7 @@ namespace System.Windows.Forms.Design.Behavior
         private bool AddChildCompSnaplines(IComponent comp, List<IComponent> dragComponents, Rectangle clipBounds, Control targetControl)
         {
             if (!(comp is Control control) || //has to be a control to get snaplines
-               (dragComponents != null && dragComponents.Contains(comp) && !_ctrlDrag) || //cannot be something that we are dragging, unless we are in a ctrlDrag
+               (dragComponents is not null && dragComponents.Contains(comp) && !_ctrlDrag) || //cannot be something that we are dragging, unless we are in a ctrlDrag
                IsChildOfParent(control, targetControl) || //cannot be a child of the control we will drag
                !clipBounds.IntersectsWith(control.Bounds) || //has to be partially visible on the rootcomp's surface
                control.Parent is null || // control must have a parent.
@@ -405,8 +405,8 @@ namespace System.Windows.Forms.Design.Behavior
             if (_resizing &&
                 (designer is ParentControlDesigner) &&
                 (control.AutoSize) &&
-                (targetControl != null) &&
-                (targetControl.Parent != null) &&
+                (targetControl is not null) &&
+                (targetControl.Parent is not null) &&
                 (targetControl.Parent.Equals(control)))
             {
                 return false;
@@ -422,7 +422,7 @@ namespace System.Windows.Forms.Design.Behavior
         {
             // our targetControl will always be the 0th component in our dragComponents array list (a.k.a. the primary selected component).
             Control targetControl = null;
-            if (dragComponents != null && dragComponents.Count > 0)
+            if (dragComponents is not null && dragComponents.Count > 0)
             {
                 targetControl = dragComponents[0] as Control;
             }
@@ -432,27 +432,27 @@ namespace System.Windows.Forms.Design.Behavior
             Rectangle clipBounds = new Rectangle(0, 0, rootControl.ClientRectangle.Width, rootControl.ClientRectangle.Height);
             clipBounds.Inflate(-1, -1);
             //determine the screen offset from our rootComponent to the AdornerWindow (since all drag notification coords will be in adorner window coords)
-            if (targetControl != null)
+            if (targetControl is not null)
             {
                 _dragOffset = _behaviorService.ControlToAdornerWindow(targetControl);
             }
             else
             {
                 _dragOffset = _behaviorService.MapAdornerWindowPoint(rootControl.Handle, Point.Empty);
-                if (rootControl.Parent != null && rootControl.Parent.IsMirrored)
+                if (rootControl.Parent is not null && rootControl.Parent.IsMirrored)
                 {
                     _dragOffset.Offset(-rootControl.Width, 0);
                 }
             }
 
-            if (targetControl != null)
+            if (targetControl is not null)
             {
                 bool disposeDesigner = false;
                 //get all the target snapline information we need to create one then
                 if (!(host.GetDesigner(targetControl) is ControlDesigner designer))
                 {
                     designer = TypeDescriptor.CreateDesigner(targetControl, typeof(IDesigner)) as ControlDesigner;
-                    if (designer != null)
+                    if (designer is not null)
                     {
                         //Make sure the control is not forced visible
                         designer.ForceVisible = false;
@@ -461,7 +461,7 @@ namespace System.Windows.Forms.Design.Behavior
                     }
                 }
 
-                AddSnapLines(designer, _targetHorizontalSnapLines, _targetVerticalSnapLines, true, targetControl != null);
+                AddSnapLines(designer, _targetHorizontalSnapLines, _targetVerticalSnapLines, true, targetControl is not null);
                 if (disposeDesigner)
                 {
                     designer.Dispose();
@@ -480,7 +480,7 @@ namespace System.Windows.Forms.Design.Behavior
                 {
                     if (AddControlSnaplinesWhenResizing(designer, comp as Control, targetControl))
                     {
-                        AddSnapLines(designer, _horizontalSnapLines, _verticalSnapLines, false, targetControl != null);
+                        AddSnapLines(designer, _horizontalSnapLines, _verticalSnapLines, false, targetControl is not null);
                     }
 
                     // Does the designer have internal control designers for which we need to add snaplines (like SplitPanelContainer, ToolStripContainer)
@@ -488,11 +488,11 @@ namespace System.Windows.Forms.Design.Behavior
                     for (int i = 0; i < numInternalDesigners; i++)
                     {
                         ControlDesigner internalDesigner = designer.InternalControlDesigner(i);
-                        if (internalDesigner != null &&
+                        if (internalDesigner is not null &&
                             AddChildCompSnaplines(internalDesigner.Component, dragComponents, clipBounds, targetControl) &&
                             AddControlSnaplinesWhenResizing(internalDesigner, internalDesigner.Component as Control, targetControl))
                         {
-                            AddSnapLines(internalDesigner, _horizontalSnapLines, _verticalSnapLines, false, targetControl != null);
+                            AddSnapLines(internalDesigner, _horizontalSnapLines, _verticalSnapLines, false, targetControl is not null);
                         }
                     }
                 }
@@ -514,7 +514,7 @@ namespace System.Windows.Forms.Design.Behavior
             }
 
             Control currentParent = child.Parent;
-            while (currentParent != null)
+            while (currentParent is not null)
             {
                 if (currentParent.Equals(parent))
                 {
@@ -532,7 +532,7 @@ namespace System.Windows.Forms.Design.Behavior
         /// </summary>
         private static bool IsMarginOrPaddingSnapLine(SnapLine snapLine)
         {
-            return snapLine.Filter != null && (snapLine.Filter.StartsWith(SnapLine.Margin) || snapLine.Filter.StartsWith(SnapLine.Padding));
+            return snapLine.Filter is not null && (snapLine.Filter.StartsWith(SnapLine.Margin) || snapLine.Filter.StartsWith(SnapLine.Padding));
         }
 
         /// <summary>
@@ -782,7 +782,7 @@ namespace System.Windows.Forms.Design.Behavior
             {
                 Line curLine = currentLines[i];
                 Line mergedLine = Line.Overlap(snapLine, curLine);
-                if (mergedLine != null)
+                if (mergedLine is not null)
                 {
                     currentLines[i] = mergedLine;
                     merged = true;
@@ -1046,7 +1046,7 @@ namespace System.Windows.Forms.Design.Behavior
         internal void OnMouseUp()
         {
             // Here, we store off our recent snapline info to the behavior service - this is used for testing purposes
-            if (_behaviorService != null)
+            if (_behaviorService is not null)
             {
                 Line[] recent = GetRecentLines();
                 string[] lines = new string[recent.Length];
@@ -1060,7 +1060,7 @@ namespace System.Windows.Forms.Design.Behavior
 
             EraseSnapLines();
             _graphics.Dispose();
-            if (_disposeEdgePen && _edgePen != null)
+            if (_disposeEdgePen && _edgePen is not null)
             {
                 _edgePen.Dispose();
             }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DropSourceBehavior.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DropSourceBehavior.cs
@@ -165,7 +165,7 @@ namespace System.Windows.Forms.Design.Behavior
 
         private Point MapPointFromSourceToTarget(Point pt)
         {
-            if (srcHost != destHost && destHost != null)
+            if (srcHost != destHost && destHost is not null)
             {
                 pt = behaviorServiceSource.AdornerWindowPointToScreen(pt);
                 return behaviorServiceTarget.MapAdornerWindowPoint(IntPtr.Zero, pt);
@@ -178,7 +178,7 @@ namespace System.Windows.Forms.Design.Behavior
 
         private Point MapPointFromTargetToSource(Point pt)
         {
-            if (srcHost != destHost && destHost != null)
+            if (srcHost != destHost && destHost is not null)
             {
                 pt = behaviorServiceTarget.AdornerWindowPointToScreen(pt);
                 return behaviorServiceSource.MapAdornerWindowPoint(IntPtr.Zero, pt);
@@ -216,7 +216,7 @@ namespace System.Windows.Forms.Design.Behavior
                 SetDesignerHost(control);
             }
 
-            if (c.Site != null && !(c.Site is INestedSite) && destHost != null)
+            if (c.Site is not null && !(c.Site is INestedSite) && destHost is not null)
             {
                 destHost.Container.Add(c);
             }
@@ -225,13 +225,13 @@ namespace System.Windows.Forms.Design.Behavior
         private void DropControl(int dragComponentIndex, Control dragTarget, Control dragSource, bool localDrag)
         {
             Control currentControl = dragComponents[dragComponentIndex].dragComponent as Control;
-            if (lastEffect == DragDropEffects.Copy || (srcHost != destHost && destHost != null))
+            if (lastEffect == DragDropEffects.Copy || (srcHost != destHost && destHost is not null))
             {
                 //between forms or copy
                 currentControl.Visible = true;
                 bool visibleState = true;
                 PropertyDescriptor propLoc = TypeDescriptor.GetProperties(currentControl)["Visible"];
-                if (propLoc != null)
+                if (propLoc is not null)
                 {
                     // store off the visible state. When adding the control to the new designer host, a new control designer will be created for the control. Since currentControl.Visible is currently FALSE (See InitiateDrag), the shadowed Visible property will be FALSE as well. This is not what we want.
                     visibleState = (bool)propLoc.GetValue(currentControl);
@@ -255,7 +255,7 @@ namespace System.Windows.Forms.Design.Behavior
         private void SetLocationPropertyAndChildIndex(int dragComponentIndex, Control dragTarget, Point dropPoint, int newIndex, bool allowSetChildIndexOnDrop)
         {
             PropertyDescriptor propLoc = TypeDescriptor.GetProperties(dragComponents[dragComponentIndex].dragComponent)["Location"];
-            if ((propLoc != null) && (dragComponents[dragComponentIndex].dragComponent is Control currentControl))
+            if ((propLoc is not null) && (dragComponents[dragComponentIndex].dragComponent is Control currentControl))
             {
                 // ControlDesigner shadows the Location property. If the control is parented and the parent is a scrollable control, then it expects the Location to be in displayrectangle coordinates. At this point bounds are in clientrectangle coordinates, so we need to check if we need to adjust the coordinates.
                 Point pt = new Point(dropPoint.X, dropPoint.Y);
@@ -333,14 +333,14 @@ namespace System.Windows.Forms.Design.Behavior
 
             // If we are dropping between hosts, we want to set the selection in the new host to be the components that we are dropping. ... or if we are copying
             ISelectionService selSvc = null;
-            if (performCopy || (srcHost != destHost && destHost != null))
+            if (performCopy || (srcHost != destHost && destHost is not null))
             {
                 selSvc = (ISelectionService)serviceProviderTarget.GetService(typeof(ISelectionService));
             }
 
             try
             {
-                if (dragComponents != null && dragComponents.Length > 0)
+                if (dragComponents is not null && dragComponents.Length > 0)
                 {
                     DesignerTransaction transSource = null;
                     DesignerTransaction transTarget = null;
@@ -361,12 +361,12 @@ namespace System.Windows.Forms.Design.Behavior
                     }
 
                     // We don't want to create a transaction in the source, if we are doing a cross-form copy
-                    if (srcHost != null && !(srcHost != destHost && destHost != null && performCopy))
+                    if (srcHost is not null && !(srcHost != destHost && destHost is not null && performCopy))
                     {
                         transSource = srcHost.CreateTransaction(transDesc);
                     }
 
-                    if (srcHost != destHost && destHost != null)
+                    if (srcHost != destHost && destHost is not null)
                     {
                         transTarget = destHost.CreateTransaction(transDesc);
                     }
@@ -380,7 +380,7 @@ namespace System.Windows.Forms.Design.Behavior
                         {
                             // As part of a Ctrl-Drag, components might have been added to the component tray, make sure that their location gets updated as well (think ToolStrips). Get the current number of controls in the Component Tray in the target
                             tray = serviceProviderTarget.GetService(typeof(ComponentTray)) as ComponentTray;
-                            numberOfOriginalTrayControls = tray != null ? tray.Controls.Count : 0;
+                            numberOfOriginalTrayControls = tray is not null ? tray.Controls.Count : 0;
 
                             // Get the objects to copy
                             ArrayList temp = new ArrayList();
@@ -407,7 +407,7 @@ namespace System.Windows.Forms.Design.Behavior
                             }
                         }
 
-                        if ((!localDrag || performCopy) && componentChangeSvcSource != null && componentChangeSvcTarget != null)
+                        if ((!localDrag || performCopy) && componentChangeSvcSource is not null && componentChangeSvcTarget is not null)
                         {
                             componentChangeSvcTarget.OnComponentChanging(dragTarget, targetProp);
                             // If we are performing a copy, then the dragSource will not change
@@ -433,7 +433,7 @@ namespace System.Windows.Forms.Design.Behavior
                         // check permission to do that
                         Control primaryComponent = dragComponents[primaryComponentIndex].dragComponent as Control;
                         PropertyDescriptor propLoc = TypeDescriptor.GetProperties(primaryComponent)["Location"];
-                        if (primaryComponent != null && propLoc != null)
+                        if (primaryComponent is not null && propLoc is not null)
                         {
                             try
                             {
@@ -472,7 +472,7 @@ namespace System.Windows.Forms.Design.Behavior
                             selSvc?.SetSelectedComponents(new object[] { dragComponents[i].dragComponent }, SelectionTypes.Add);
                         }
 
-                        if ((!localDrag || performCopy) && componentChangeSvcSource != null && componentChangeSvcTarget != null)
+                        if ((!localDrag || performCopy) && componentChangeSvcSource is not null && componentChangeSvcTarget is not null)
                         {
                             componentChangeSvcTarget.OnComponentChanged(dragTarget, targetProp, dragTarget.Controls, dragTarget.Controls);
                             if (!performCopy)
@@ -482,7 +482,7 @@ namespace System.Windows.Forms.Design.Behavior
                         }
 
                         // If we did a Copy, then restore the old controls to make sure we set state correctly
-                        if (originalControls != null)
+                        if (originalControls is not null)
                         {
                             for (int i = 0; i < originalControls.Count; i++)
                             {
@@ -498,7 +498,7 @@ namespace System.Windows.Forms.Design.Behavior
                             // the target did not have a tray already, so let's go get it - if there is one
                             tray ??= serviceProviderTarget.GetService(typeof(ComponentTray)) as ComponentTray;
 
-                            if (tray != null)
+                            if (tray is not null)
                             {
                                 int numberOfTrayControlsAdded = tray.Controls.Count - numberOfOriginalTrayControls;
 
@@ -517,13 +517,13 @@ namespace System.Windows.Forms.Design.Behavior
 
                         // We need to CleanupDrag BEFORE we commit the transaction.  The reason is that cleaning up can potentially cause a layout, and then any changes that happen due to the layout would be in a separate UndoUnit. We want the D&D to be undoable in one step.
                         CleanupDrag(false);
-                        if (transSource != null)
+                        if (transSource is not null)
                         {
                             transSource.Commit();
                             transSource = null;
                         }
 
-                        if (transTarget != null)
+                        if (transTarget is not null)
                         {
                             transTarget.Commit();
                             transTarget = null;
@@ -541,7 +541,7 @@ namespace System.Windows.Forms.Design.Behavior
             finally
             {
                 // If we did a Copy, then restore the old controls to make sure we set state correctly
-                if (originalControls != null)
+                if (originalControls is not null)
                 {
                     for (int i = 0; i < originalControls.Count; i++)
                     {
@@ -585,7 +585,7 @@ namespace System.Windows.Forms.Design.Behavior
             bool createNewDragAssistance = false;
             Point mouseLoc = Control.MousePosition;
             bool altKeyPressed = Control.ModifierKeys == Keys.Alt;
-            if (altKeyPressed && dragAssistanceManager != null)
+            if (altKeyPressed && dragAssistanceManager is not null)
             {
                 //erase any snaplines (if we had any)
                 dragAssistanceManager.EraseSnapLines();
@@ -604,7 +604,7 @@ namespace System.Windows.Forms.Design.Behavior
 
             // only do this drawing when the mouse pointer has actually moved so we don't continuously redraw and flicker like mad.
             Control target = data.Target as Control;
-            if ((mouseLoc != lastFeedbackLocation) || (altKeyPressed && dragAssistanceManager != null))
+            if ((mouseLoc != lastFeedbackLocation) || (altKeyPressed && dragAssistanceManager is not null))
             {
                 if (!data.Target.Equals(lastDropTarget))
                 {
@@ -631,7 +631,7 @@ namespace System.Windows.Forms.Design.Behavior
                     // Spin up new stuff if the host changes, or if this is the first time through (lastDropTarget will be null in this case)
                     if ((lastDropTarget is null) || (newDestHost != destHost))
                     {
-                        if (destHost != null && destHost != srcHost)
+                        if (destHost is not null && destHost != srcHost)
                         {
                             // re-enable all glyphs in the old host... need to do this before we get the new behaviorservice
                             behaviorServiceTarget.EnableAllAdorners(true);
@@ -655,7 +655,7 @@ namespace System.Windows.Forms.Design.Behavior
                         ClearAllDragImages();
 
                         // Build a new dragImageRegion -- but only if we are changing hosts
-                        if (lastDropTarget != null)
+                        if (lastDropTarget is not null)
                         {
                             for (int i = 0; i < dragObjects.Count; i++)
                             {
@@ -713,7 +713,7 @@ namespace System.Windows.Forms.Design.Behavior
                                                     dragComponents[primaryComponentIndex].dragImage.Width,
                                                     dragComponents[primaryComponentIndex].dragImage.Height);
                 //if we have a valid snapline engine - ask it to offset our drag
-                if (dragAssistanceManager != null)
+                if (dragAssistanceManager is not null)
                 {
                     if (targetAllowsSnapLines && !altKeyPressed)
                     {
@@ -769,7 +769,7 @@ namespace System.Windows.Forms.Design.Behavior
                 }
 
                 invalidRegion.Dispose();
-                if (graphicsTarget != null)
+                if (graphicsTarget is not null)
                 {
                     graphicsTarget.SetClip(newImageRect);
                     graphicsTarget.DrawImage(dragImage, newImageRect.X, newImageRect.Y);
@@ -791,7 +791,7 @@ namespace System.Windows.Forms.Design.Behavior
                 }
 
                 // allow any snaplines to be drawn above our drag images as long as the alt key is not pressed and the mouse is over the root comp
-                if (dragAssistanceManager != null && !altKeyPressed && targetAllowsSnapLines)
+                if (dragAssistanceManager is not null && !altKeyPressed && targetAllowsSnapLines)
                 {
                     dragAssistanceManager.RenderSnapLinesInternal();
                 }
@@ -828,20 +828,20 @@ namespace System.Windows.Forms.Design.Behavior
         {
             // Clear out whatever value we might have had stored off
             parentGridSize = Size.Empty;
-            if (bhvSvc != null && !bhvSvc.UseSnapLines)
+            if (bhvSvc is not null && !bhvSvc.UseSnapLines)
             {
                 PropertyDescriptor snapProp = TypeDescriptor.GetProperties(parentControl)["SnapToGrid"];
-                if (snapProp != null && (bool)snapProp.GetValue(parentControl))
+                if (snapProp is not null && (bool)snapProp.GetValue(parentControl))
                 {
                     PropertyDescriptor gridProp = TypeDescriptor.GetProperties(parentControl)["GridSize"];
-                    if (gridProp != null)
+                    if (gridProp is not null)
                     {
                         //cache of the gridsize and the location of the parent on the adornerwindow
                         if (dragComponents[primaryComponentIndex].dragComponent is Control)
                         {
                             parentGridSize = (Size)gridProp.GetValue(parentControl);
                             parentLocation = bhvSvc.MapAdornerWindowPoint(parentControl.Handle, Point.Empty);
-                            if (parentControl.Parent != null && parentControl.Parent.IsMirrored)
+                            if (parentControl.Parent is not null && parentControl.Parent.IsMirrored)
                             {
                                 parentLocation.Offset(-parentControl.Width, 0);
                             }
@@ -856,7 +856,7 @@ namespace System.Windows.Forms.Design.Behavior
             // find our body glyph adorner offered by the behavior service we don't want to disable the transparent body glyphs
             Adorner bodyGlyphAdorner = null;
             SelectionManager selMgr = (SelectionManager)serviceProvider.GetService(typeof(SelectionManager));
-            if (selMgr != null)
+            if (selMgr is not null)
             {
                 bodyGlyphAdorner = selMgr.BodyGlyphAdorner;
             }
@@ -864,7 +864,7 @@ namespace System.Windows.Forms.Design.Behavior
             //disable all adorners except for body glyph adorner
             foreach (Adorner a in behaviorService.Adorners)
             {
-                if (bodyGlyphAdorner != null && a.Equals(bodyGlyphAdorner))
+                if (bodyGlyphAdorner is not null && a.Equals(bodyGlyphAdorner))
                 {
                     continue;
                 }
@@ -889,7 +889,7 @@ namespace System.Windows.Forms.Design.Behavior
             DisableAdorners(serviceProviderSource, behaviorServiceSource, false);
             Control primaryControl = dragObjects[0] as Control;
             Control primaryParent = primaryControl?.Parent;
-            Color backColor = primaryParent != null ? primaryParent.BackColor : Color.Empty;
+            Color backColor = primaryParent is not null ? primaryParent.BackColor : Color.Empty;
             dragImageRect = Rectangle.Empty;
             clearDragImageRect = Rectangle.Empty;
             initialMouseLoc = initialMouseLocation;
@@ -921,7 +921,7 @@ namespace System.Windows.Forms.Design.Behavior
                 DesignerUtils.GenerateSnapShot(dragControl, ref dragComponents[i].dragImage, i == 0 ? 2 : 1, 1, backColor);
 
                 // The dragged components are not in any specific order. If they all share the same parent, we will sort them by their index in that parent's control's collection to preserve correct Z-order
-                if (primaryParent != null && shareParent)
+                if (primaryParent is not null && shareParent)
                 {
                     dragComponents[i].zorderIndex = primaryParent.Controls.GetChildIndex(dragControl, false /*throwException*/);
                     if (dragComponents[i].zorderIndex == -1)
@@ -948,7 +948,7 @@ namespace System.Windows.Forms.Design.Behavior
 
             Debug.Assert(primaryComponentIndex != -1, "primaryComponentIndex was not set!");
             //suspend layout of the parent
-            if (primaryParent != null)
+            if (primaryParent is not null)
             {
                 suspendedParent = primaryParent;
                 suspendedParent.SuspendLayout();
@@ -1008,7 +1008,7 @@ namespace System.Windows.Forms.Design.Behavior
             //create our list of controls-to-drag
             ArrayList dragControls = new ArrayList();
             primaryControlIndex = -1;
-            if ((dragComponents != null) && (dragComponents.Length > 0))
+            if ((dragComponents is not null) && (dragComponents.Length > 0))
             {
                 primaryControlIndex = primaryComponentIndex;
                 for (int i = 0; i < dragComponents.Length; i++)
@@ -1026,7 +1026,7 @@ namespace System.Windows.Forms.Design.Behavior
         internal void QueryContinueDrag(object sender, QueryContinueDragEventArgs e)
         {
             //Clean up if the action was cancelled, or we had no effect when dropped. Otherwise EndDragDrop() will do this after the locations have been properly changed.
-            if (behaviorServiceSource != null && behaviorServiceSource.CancelDrag)
+            if (behaviorServiceSource is not null && behaviorServiceSource.CancelDrag)
             {
                 e.Action = DragAction.Cancel;
                 CleanupDrag(true);
@@ -1058,7 +1058,7 @@ namespace System.Windows.Forms.Design.Behavior
             }
 
             currentShowState = show;
-            if (dragComponents != null)
+            if (dragComponents is not null)
             {
                 for (int i = 0; i < dragComponents.Length; i++)
                 {
@@ -1097,7 +1097,7 @@ namespace System.Windows.Forms.Design.Behavior
                     suspendedParent = null;
                     //re-enable all glyphs in all adorners
                     behaviorServiceSource.EnableAllAdorners(true);
-                    if (destHost != srcHost && destHost != null)
+                    if (destHost != srcHost && destHost is not null)
                     {
                         behaviorServiceTarget.EnableAllAdorners(true);
                         behaviorServiceTarget.SyncSelection();
@@ -1106,23 +1106,23 @@ namespace System.Windows.Forms.Design.Behavior
                     // Layout may have caused controls to resize, which would mean their BodyGlyphs are wrong.  We need to sync these.
                     behaviorServiceSource?.SyncSelection();
 
-                    if (dragImageRegion != null)
+                    if (dragImageRegion is not null)
                     {
                         dragImageRegion.Dispose();
                         dragImageRegion = null;
                     }
 
-                    if (dragImage != null)
+                    if (dragImage is not null)
                     {
                         dragImage.Dispose();
                         dragImage = null;
                     }
 
-                    if (dragComponents != null)
+                    if (dragComponents is not null)
                     {
                         for (int i = 0; i < dragComponents.Length; i++)
                         {
-                            if (dragComponents[i].dragImage != null)
+                            if (dragComponents[i].dragImage is not null)
                             {
                                 dragComponents[i].dragImage.Dispose();
                                 dragComponents[i].dragImage = null;
@@ -1130,7 +1130,7 @@ namespace System.Windows.Forms.Design.Behavior
                         }
                     }
 
-                    if (graphicsTarget != null)
+                    if (graphicsTarget is not null)
                     {
                         graphicsTarget.Dispose();
                         graphicsTarget = null;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/ResizeBehavior.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/ResizeBehavior.cs
@@ -161,7 +161,7 @@ namespace System.Windows.Forms.Design.Behavior
             if ((rules & SelectionRules.BottomSizeable) != 0)
             {
                 lines.Add(new SnapLine(SnapLineType.Bottom, loc.Y - 1));
-                if (_primaryControl != null)
+                if (_primaryControl is not null)
                 {
                     lines.Add(new SnapLine(SnapLineType.Horizontal, loc.Y + _primaryControl.Margin.Bottom, SnapLine.MarginBottom, SnapLinePriority.Always));
                 }
@@ -169,7 +169,7 @@ namespace System.Windows.Forms.Design.Behavior
             else if ((rules & SelectionRules.TopSizeable) != 0)
             {
                 lines.Add(new SnapLine(SnapLineType.Top, loc.Y));
-                if (_primaryControl != null)
+                if (_primaryControl is not null)
                 {
                     lines.Add(new SnapLine(SnapLineType.Horizontal, loc.Y - _primaryControl.Margin.Top, SnapLine.MarginTop, SnapLinePriority.Always));
                 }
@@ -178,7 +178,7 @@ namespace System.Windows.Forms.Design.Behavior
             if ((rules & SelectionRules.RightSizeable) != 0)
             {
                 lines.Add(new SnapLine(SnapLineType.Right, loc.X - 1));
-                if (_primaryControl != null)
+                if (_primaryControl is not null)
                 {
                     lines.Add(new SnapLine(SnapLineType.Vertical, loc.X + _primaryControl.Margin.Right, SnapLine.MarginRight, SnapLinePriority.Always));
                 }
@@ -186,7 +186,7 @@ namespace System.Windows.Forms.Design.Behavior
             else if ((rules & SelectionRules.LeftSizeable) != 0)
             {
                 lines.Add(new SnapLine(SnapLineType.Left, loc.X));
-                if (_primaryControl != null)
+                if (_primaryControl is not null)
                 {
                     lines.Add(new SnapLine(SnapLineType.Vertical, loc.X - _primaryControl.Margin.Left, SnapLine.MarginLeft, SnapLinePriority.Always));
                 }
@@ -229,7 +229,7 @@ namespace System.Windows.Forms.Design.Behavior
             BehaviorService.EnableAllAdorners(false);
             //build up our resize transaction
             IDesignerHost host = (IDesignerHost)_serviceProvider.GetService(typeof(IDesignerHost));
-            if (host != null)
+            if (host is not null)
             {
                 string locString;
                 if (_resizeComponents.Length == 1)
@@ -259,13 +259,13 @@ namespace System.Windows.Forms.Design.Behavior
             else if (_resizeComponents.Length > 0)
             {
                 //try to get the parents grid and snap settings
-                if (_resizeComponents[0].resizeControl is Control control && control.Parent != null)
+                if (_resizeComponents[0].resizeControl is Control control && control.Parent is not null)
                 {
                     PropertyDescriptor snapProp = TypeDescriptor.GetProperties(control.Parent)["SnapToGrid"];
-                    if (snapProp != null && (bool)snapProp.GetValue(control.Parent))
+                    if (snapProp is not null && (bool)snapProp.GetValue(control.Parent))
                     {
                         PropertyDescriptor gridProp = TypeDescriptor.GetProperties(control.Parent)["GridSize"];
-                        if (gridProp != null)
+                        if (gridProp is not null)
                         {
                             //cache of the gridsize and the location of the parent on the adornerwindow
                             _parentGridSize = (Size)gridProp.GetValue(control.Parent);
@@ -324,7 +324,7 @@ namespace System.Windows.Forms.Design.Behavior
                 {
                     //don't drag locked controls
                     PropertyDescriptor prop = TypeDescriptor.GetProperties(o)["Locked"];
-                    if (prop != null)
+                    if (prop is not null)
                     {
                         if ((bool)prop.GetValue(o))
                         {
@@ -362,8 +362,8 @@ namespace System.Windows.Forms.Design.Behavior
             if (_pushedBehavior)
             {
                 _pushedBehavior = false;
-                Debug.Assert(BehaviorService != null, "We should have a behavior service.");
-                if (BehaviorService != null)
+                Debug.Assert(BehaviorService is not null, "We should have a behavior service.");
+                if (BehaviorService is not null)
                 {
                     if (_dragging)
                     {
@@ -395,7 +395,7 @@ namespace System.Windows.Forms.Design.Behavior
 
                     BehaviorService.PopBehavior(this);
 
-                    if (_lastResizeRegion != null)
+                    if (_lastResizeRegion is not null)
                     {
                         BehaviorService.Invalidate(_lastResizeRegion); //might be the same, might not.
                         _lastResizeRegion.Dispose();
@@ -406,7 +406,7 @@ namespace System.Windows.Forms.Design.Behavior
 
             Debug.Assert(!_dragging, "How can we be dragging without pushing a behavior?");
             // If we still have a transaction, roll it back.
-            if (_resizeTransaction != null)
+            if (_resizeTransaction is not null)
             {
                 DesignerTransaction t = _resizeTransaction;
                 _resizeTransaction = null;
@@ -420,13 +420,13 @@ namespace System.Windows.Forms.Design.Behavior
         internal static int AdjustPixelsForIntegralHeight(Control control, int pixelsMoved)
         {
             PropertyDescriptor propIntegralHeight = TypeDescriptor.GetProperties(control)["IntegralHeight"];
-            if (propIntegralHeight != null)
+            if (propIntegralHeight is not null)
             {
                 object value = propIntegralHeight.GetValue(control);
                 if (value is bool && (bool)value)
                 {
                     PropertyDescriptor propItemHeight = TypeDescriptor.GetProperties(control)["ItemHeight"];
-                    if (propItemHeight != null)
+                    if (propItemHeight is not null)
                     {
                         if (pixelsMoved >= 0)
                         {
@@ -456,7 +456,7 @@ namespace System.Windows.Forms.Design.Behavior
             }
 
             bool altKeyPressed = Control.ModifierKeys == Keys.Alt;
-            if (altKeyPressed && _dragManager != null)
+            if (altKeyPressed && _dragManager is not null)
             {
                 //erase any snaplines (if we had any)
                 _dragManager.EraseSnapLines();
@@ -511,22 +511,22 @@ namespace System.Windows.Forms.Design.Behavior
                 propLeft = TypeDescriptor.GetProperties(_resizeComponents[0].resizeControl)["Left"];
 
                 // validate each of the property descriptors.
-                if (propWidth != null && !typeof(int).IsAssignableFrom(propWidth.PropertyType))
+                if (propWidth is not null && !typeof(int).IsAssignableFrom(propWidth.PropertyType))
                 {
                     propWidth = null;
                 }
 
-                if (propHeight != null && !typeof(int).IsAssignableFrom(propHeight.PropertyType))
+                if (propHeight is not null && !typeof(int).IsAssignableFrom(propHeight.PropertyType))
                 {
                     propHeight = null;
                 }
 
-                if (propTop != null && !typeof(int).IsAssignableFrom(propTop.PropertyType))
+                if (propTop is not null && !typeof(int).IsAssignableFrom(propTop.PropertyType))
                 {
                     propTop = null;
                 }
 
-                if (propLeft != null && !typeof(int).IsAssignableFrom(propLeft.PropertyType))
+                if (propLeft is not null && !typeof(int).IsAssignableFrom(propLeft.PropertyType))
                 {
                     propLeft = null;
                 }
@@ -538,7 +538,7 @@ namespace System.Windows.Forms.Design.Behavior
             PInvoke.ClientToScreen(_behaviorService.AdornerWindowControl, ref _lastMouseAbs);
             int minHeight = Math.Max(targetControl.MinimumSize.Height, MINSIZE);
             int minWidth = Math.Max(targetControl.MinimumSize.Width, MINSIZE);
-            if (_dragManager != null)
+            if (_dragManager is not null)
             {
                 bool shouldSnap = true;
                 bool shouldSnapHorizontally = true;
@@ -556,7 +556,7 @@ namespace System.Windows.Forms.Design.Behavior
 
                 //if the targetControl has IntegralHeight turned on, then don't snap if the control can be resized vertically
                 PropertyDescriptor propIntegralHeight = TypeDescriptor.GetProperties(targetControl)["IntegralHeight"];
-                if (propIntegralHeight != null)
+                if (propIntegralHeight is not null)
                 {
                     object value = propIntegralHeight.GetValue(targetControl);
                     if (value is bool && (bool)value)
@@ -588,7 +588,7 @@ namespace System.Windows.Forms.Design.Behavior
             // IF WE ARE SNAPPING TO A CONTROL, then we also need to adjust for the offset between the initialPoint (where the MouseDown happened) and the edge of the control otherwise we would be those pixels off when resizing the control. Remember that snaplines are based on the targetControl, so we need to use the targetControl to figure out the offset.
             Rectangle controlBounds = new Rectangle(_resizeComponents[0].resizeBounds.X, _resizeComponents[0].resizeBounds.Y,
                                                       _resizeComponents[0].resizeBounds.Width, _resizeComponents[0].resizeBounds.Height);
-            if ((_didSnap) && (targetControl.Parent != null))
+            if ((_didSnap) && (targetControl.Parent is not null))
             {
                 controlBounds.Location = _behaviorService.MapAdornerWindowPoint(targetControl.Parent.Handle, controlBounds.Location);
                 if (targetControl.Parent.IsMirrored)
@@ -600,7 +600,7 @@ namespace System.Windows.Forms.Design.Behavior
             Rectangle newBorderRect = Rectangle.Empty;
             Rectangle targetBorderRect = Rectangle.Empty;
             bool drawSnapline = true;
-            Color backColor = targetControl.Parent != null ? targetControl.Parent.BackColor : Color.Empty;
+            Color backColor = targetControl.Parent is not null ? targetControl.Parent.BackColor : Color.Empty;
             for (int i = 0; i < _resizeComponents.Length; i++)
             {
                 Control control = _resizeComponents[i].resizeControl as Control;
@@ -616,7 +616,7 @@ namespace System.Windows.Forms.Design.Behavior
                 {
                     bool fRTL = false;
                     // If the container is mirrored the control origin is in upper-right, so we need to adjust our math for that. Remember that mouse coords have origin in upper left.
-                    if (control.Parent != null && control.Parent.IsMirrored)
+                    if (control.Parent is not null && control.Parent.IsMirrored)
                     {
                         fRTL = true;
                     }
@@ -709,25 +709,25 @@ namespace System.Windows.Forms.Design.Behavior
                     // 1. Create a form and add 2 buttons. Make sure that they are snapped to the left edge. Now grab the left edge of button 1, and start resizing to the left, past the snapline you will initially get, and then back to the right. What you would expect is to get the left edge snapline again. But without the specified check you wouldn't. This is because the bounds.<foo> != resizeBounds[i].<foo> checks would fail, since the new size would now be the original size. We could probably live with that, except that we draw the snapline below, since we correctly identified one. We could hack it so that we didn't draw the snapline, but that would confuse the user even more.
                     // 2. Create a form and add a single button. Place it at 100,100. Now start resizing it to the left and then back to the right. Note that with the original check (see diff), you would never be able to resize it back to position 100,100. You would get to 99,100 and then to 101,100.
                     if (((specified & BoundsSpecified.Width) == BoundsSpecified.Width) &&
-                        _dragging && _initialResize && propWidth != null)
+                        _dragging && _initialResize && propWidth is not null)
                     {
                         propWidth.SetValue(_resizeComponents[i].resizeControl, bounds.Width);
                     }
 
                     if (((specified & BoundsSpecified.Height) == BoundsSpecified.Height) &&
-                        _dragging && _initialResize && propHeight != null)
+                        _dragging && _initialResize && propHeight is not null)
                     {
                         propHeight.SetValue(_resizeComponents[i].resizeControl, bounds.Height);
                     }
 
                     if (((specified & BoundsSpecified.X) == BoundsSpecified.X) &&
-                        _dragging && _initialResize && propLeft != null)
+                        _dragging && _initialResize && propLeft is not null)
                     {
                         propLeft.SetValue(_resizeComponents[i].resizeControl, bounds.X);
                     }
 
                     if (((specified & BoundsSpecified.Y) == BoundsSpecified.Y) &&
-                        _dragging && _initialResize && propTop != null)
+                        _dragging && _initialResize && propTop is not null)
                     {
                         propTop.SetValue(_resizeComponents[i].resizeControl, bounds.Y);
                     }
@@ -757,7 +757,7 @@ namespace System.Windows.Forms.Design.Behavior
                         }
                     }
 
-                    if (control == _primaryControl && _statusCommandUI != null)
+                    if (control == _primaryControl && _statusCommandUI is not null)
                     {
                         _statusCommandUI.SetStatusInformation(control);
                     }
@@ -770,7 +770,7 @@ namespace System.Windows.Forms.Design.Behavior
                     if (needToUpdate)
                     {
                         Control parent = control.Parent;
-                        if (parent != null)
+                        if (parent is not null)
                         {
                             control.Invalidate(/* invalidateChildren = */ true);
                             parent.Invalidate(oldBounds, /* invalidateChildren = */ true);
@@ -803,7 +803,7 @@ namespace System.Windows.Forms.Design.Behavior
                             {
                                 using (Graphics graphics = BehaviorService.AdornerWindowGraphics)
                                 {
-                                    if (_lastResizeRegion != null)
+                                    if (_lastResizeRegion is not null)
                                     {
                                         if (!_lastResizeRegion.Equals(newRegion, graphics))
                                         {
@@ -824,7 +824,7 @@ namespace System.Windows.Forms.Design.Behavior
                 }
             }
 
-            if ((drawSnapline) && (!altKeyPressed) && (_dragManager != null))
+            if ((drawSnapline) && (!altKeyPressed) && (_dragManager is not null))
             {
                 _dragManager.RenderSnapLinesInternal(targetBorderRect);
             }
@@ -842,7 +842,7 @@ namespace System.Windows.Forms.Design.Behavior
             {
                 if (_dragging)
                 {
-                    if (_dragManager != null)
+                    if (_dragManager is not null)
                     {
                         _dragManager.OnMouseUp();
                         _dragManager = null;
@@ -850,7 +850,7 @@ namespace System.Windows.Forms.Design.Behavior
                         _didSnap = false;
                     }
 
-                    if (_resizeComponents != null && _resizeComponents.Length > 0)
+                    if (_resizeComponents is not null && _resizeComponents.Length > 0)
                     {
                         // we do these separately so as not to disturb the cached sizes for values we're not actually changing.  For example, if a control is docked top and we modify the height, the width shouldn't be modified.
                         PropertyDescriptor propWidth = TypeDescriptor.GetProperties(_resizeComponents[0].resizeControl)["Width"];
@@ -859,27 +859,27 @@ namespace System.Windows.Forms.Design.Behavior
                         PropertyDescriptor propLeft = TypeDescriptor.GetProperties(_resizeComponents[0].resizeControl)["Left"];
                         for (int i = 0; i < _resizeComponents.Length; i++)
                         {
-                            if (propWidth != null && ((Control)_resizeComponents[i].resizeControl).Width != _resizeComponents[i].resizeBounds.Width)
+                            if (propWidth is not null && ((Control)_resizeComponents[i].resizeControl).Width != _resizeComponents[i].resizeBounds.Width)
                             {
                                 propWidth.SetValue(_resizeComponents[i].resizeControl, ((Control)_resizeComponents[i].resizeControl).Width);
                             }
 
-                            if (propHeight != null && ((Control)_resizeComponents[i].resizeControl).Height != _resizeComponents[i].resizeBounds.Height)
+                            if (propHeight is not null && ((Control)_resizeComponents[i].resizeControl).Height != _resizeComponents[i].resizeBounds.Height)
                             {
                                 propHeight.SetValue(_resizeComponents[i].resizeControl, ((Control)_resizeComponents[i].resizeControl).Height);
                             }
 
-                            if (propTop != null && ((Control)_resizeComponents[i].resizeControl).Top != _resizeComponents[i].resizeBounds.Y)
+                            if (propTop is not null && ((Control)_resizeComponents[i].resizeControl).Top != _resizeComponents[i].resizeBounds.Y)
                             {
                                 propTop.SetValue(_resizeComponents[i].resizeControl, ((Control)_resizeComponents[i].resizeControl).Top);
                             }
 
-                            if (propLeft != null && ((Control)_resizeComponents[i].resizeControl).Left != _resizeComponents[i].resizeBounds.X)
+                            if (propLeft is not null && ((Control)_resizeComponents[i].resizeControl).Left != _resizeComponents[i].resizeBounds.X)
                             {
                                 propLeft.SetValue(_resizeComponents[i].resizeControl, ((Control)_resizeComponents[i].resizeControl).Left);
                             }
 
-                            if (_resizeComponents[i].resizeControl == _primaryControl && _statusCommandUI != null)
+                            if (_resizeComponents[i].resizeControl == _primaryControl && _statusCommandUI is not null)
                             {
                                 _statusCommandUI.SetStatusInformation(_primaryControl);
                             }
@@ -887,7 +887,7 @@ namespace System.Windows.Forms.Design.Behavior
                     }
                 }
 
-                if (_resizeTransaction != null)
+                if (_resizeTransaction is not null)
                 {
                     DesignerTransaction t = _resizeTransaction;
                     _resizeTransaction = null;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/SelectionManager.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/SelectionManager.cs
@@ -69,7 +69,7 @@ namespace System.Windows.Forms.Design.Behavior
             _componentToDesigner = new Hashtable();
 
             IComponentChangeService cs = (IComponentChangeService)serviceProvider.GetService(typeof(IComponentChangeService));
-            if (cs != null)
+            if (cs is not null)
             {
                 cs.ComponentAdded += new ComponentEventHandler(OnComponentAdded);
                 cs.ComponentRemoved += new ComponentEventHandler(OnComponentRemoved);
@@ -82,7 +82,7 @@ namespace System.Windows.Forms.Design.Behavior
             if (_designerHost.GetService(typeof(DesignerOptionService)) is DesignerOptionService options)
             {
                 PropertyDescriptor p = options.Options.Properties["UseSmartTags"];
-                if (p != null && p.PropertyType == typeof(bool) && (bool)p.GetValue(null))
+                if (p is not null && p.PropertyType == typeof(bool) && (bool)p.GetValue(null))
                 {
                     _designerActionUI = new DesignerActionUI(serviceProvider, _selectionAdorner);
                     behaviorService.DesignerActionUI = _designerActionUI;
@@ -153,10 +153,10 @@ namespace System.Windows.Forms.Design.Behavior
         private void AddControlGlyphs(Control c, GlyphSelectionType selType)
         {
             ControlDesigner cd = (ControlDesigner)_componentToDesigner[c];
-            if (cd != null)
+            if (cd is not null)
             {
                 ControlBodyGlyph bodyGlyph = cd.GetControlGlyphInternal(selType);
-                if (bodyGlyph != null)
+                if (bodyGlyph is not null)
                 {
                     _bodyAdorner.Glyphs.Add(bodyGlyph);
                     if (selType == GlyphSelectionType.SelectedPrimary ||
@@ -174,7 +174,7 @@ namespace System.Windows.Forms.Design.Behavior
                 }
 
                 GlyphCollection glyphs = cd.GetGlyphs(selType);
-                if (glyphs != null)
+                if (glyphs is not null)
                 {
                     _selectionAdorner.Glyphs.AddRange(glyphs);
                     if (selType == GlyphSelectionType.SelectedPrimary ||
@@ -200,23 +200,23 @@ namespace System.Windows.Forms.Design.Behavior
         // We don't need to Dispose rootComponent.
         public void Dispose()
         {
-            if (_designerHost != null)
+            if (_designerHost is not null)
             {
                 _designerHost.TransactionClosed -= new DesignerTransactionCloseEventHandler(OnTransactionClosed);
                 _designerHost = null;
             }
 
-            if (_serviceProvider != null)
+            if (_serviceProvider is not null)
             {
                 IComponentChangeService cs = (IComponentChangeService)_serviceProvider.GetService(typeof(IComponentChangeService));
-                if (cs != null)
+                if (cs is not null)
                 {
                     cs.ComponentAdded -= new ComponentEventHandler(OnComponentAdded);
                     cs.ComponentChanged -= new ComponentChangedEventHandler(OnComponentChanged);
                     cs.ComponentRemoved -= new ComponentEventHandler(OnComponentRemoved);
                 }
 
-                if (_selSvc != null)
+                if (_selSvc is not null)
                 {
                     _selSvc.SelectionChanged -= new EventHandler(OnSelectionChanged);
                     _selSvc = null;
@@ -225,7 +225,7 @@ namespace System.Windows.Forms.Design.Behavior
                 _serviceProvider = null;
             }
 
-            if (_behaviorService != null)
+            if (_behaviorService is not null)
             {
                 _behaviorService.Adorners.Remove(_bodyAdorner);
                 _behaviorService.Adorners.Remove(_selectionAdorner);
@@ -234,19 +234,19 @@ namespace System.Windows.Forms.Design.Behavior
                 _behaviorService = null;
             }
 
-            if (_selectionAdorner != null)
+            if (_selectionAdorner is not null)
             {
                 _selectionAdorner.Glyphs.Clear();
                 _selectionAdorner = null;
             }
 
-            if (_bodyAdorner != null)
+            if (_bodyAdorner is not null)
             {
                 _bodyAdorner.Glyphs.Clear();
                 _bodyAdorner = null;
             }
 
-            if (_designerActionUI != null)
+            if (_designerActionUI is not null)
             {
                 _designerActionUI.Dispose();
                 _designerActionUI = null;
@@ -408,7 +408,7 @@ namespace System.Windows.Forms.Design.Behavior
             using (Graphics g = _behaviorService.AdornerWindowGraphics)
             {
                 // If all that changed was the primary selection, then the refresh region was empty, but we do need to update the 2 controls.
-                if (toRefresh.IsEmpty(g) && primarySelection != null && !primarySelection.Equals(_prevPrimarySelection))
+                if (toRefresh.IsEmpty(g) && primarySelection is not null && !primarySelection.Equals(_prevPrimarySelection))
                 {
                     for (int i = 0; i < _curSelectionBounds.Length; i++)
                     {
@@ -450,7 +450,7 @@ namespace System.Windows.Forms.Design.Behavior
                 _curSelectionBounds = new Rectangle[selComps.Count];
                 AddAllControlGlyphs(_rootComponent, selComps, primarySelection);
 
-                if (_prevSelectionBounds != null)
+                if (_prevSelectionBounds is not null)
                 {
                     Region toUpdate = DetermineRegionToRefresh(primarySelection);
                     using (Graphics g = _behaviorService.AdornerWindowGraphics)

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/ToolboxItemSnapLineBehavior.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/ToolboxItemSnapLineBehavior.cs
@@ -49,7 +49,7 @@ namespace System.Windows.Forms.Design.Behavior
         {
             designer = controlDesigner;
             //check to see if the current designer participate with SnapLines
-            if (controlDesigner != null && !controlDesigner.ParticipatesWithSnapLines)
+            if (controlDesigner is not null && !controlDesigner.ParticipatesWithSnapLines)
             {
                 targetAllowsSnapLines = false;
             }
@@ -93,7 +93,7 @@ namespace System.Windows.Forms.Design.Behavior
                     lastRectangle = Rectangle.Empty;
 
                     //destroy the snapline engine (if we used it)
-                    if (dragManager != null)
+                    if (dragManager is not null)
                     {
                         dragManager.OnMouseUp();
                         dragManager = null;
@@ -118,7 +118,7 @@ namespace System.Windows.Forms.Design.Behavior
             bool horizontalComponentIdentified = false;
             bool verticalComponentIdentified = false;
 
-            if (dragManager != null)
+            if (dragManager is not null)
             {
                 DragAssistanceManager.Line[] lines = dragManager.GetRecentLines();
 
@@ -280,7 +280,7 @@ namespace System.Windows.Forms.Design.Behavior
         {
             Adorner bodyAdorner = null;
             SelectionManager selMgr = (SelectionManager)serviceProvider.GetService(typeof(SelectionManager));
-            if (selMgr != null)
+            if (selMgr is not null)
             {
                 bodyAdorner = selMgr.BodyGlyphAdorner;
             }
@@ -289,7 +289,7 @@ namespace System.Windows.Forms.Design.Behavior
             foreach (ControlBodyGlyph body in bodyAdorner.Glyphs)
             {
                 Control ctl = body.RelatedComponent as Control;
-                if (ctl != null)
+                if (ctl is not null)
                 {
                     if (!ctl.AllowDrop)
                     {
@@ -308,7 +308,7 @@ namespace System.Windows.Forms.Design.Behavior
         {
             bool altKeyPressed = Control.ModifierKeys == Keys.Alt;
 
-            if (altKeyPressed && dragManager != null)
+            if (altKeyPressed && dragManager is not null)
             {
                 //erase any snaplines (if we had any)
                 dragManager.EraseSnapLines();
@@ -324,7 +324,7 @@ namespace System.Windows.Forms.Design.Behavior
             //don't do anything if the loc is the same
             if (newRectangle != lastRectangle)
             {
-                if (dragManager != null && targetAllowsSnapLines && !altKeyPressed)
+                if (dragManager is not null && targetAllowsSnapLines && !altKeyPressed)
                 {
                     lastOffset = dragManager.OnMouseMove(newRectangle, GenerateNewToolSnapLines(newRectangle));
                     newRectangle.Offset(lastOffset.X, lastOffset.Y);
@@ -351,10 +351,10 @@ namespace System.Windows.Forms.Design.Behavior
 
                 //offset the mouse loc to screen coords for calculations on drops
                 IDesignerHost host = (IDesignerHost)serviceProvider.GetService(typeof(IDesignerHost));
-                if (host != null)
+                if (host is not null)
                 {
                     Control baseControl = host.RootComponent as Control;
-                    if (baseControl != null)
+                    if (baseControl is not null)
                     {
                         Point adornerServiceOrigin = behaviorService.MapAdornerWindowPoint(baseControl.Handle, new Point(0, 0));
                         Rectangle statusRect = new Rectangle(newRectangle.X - adornerServiceOrigin.X, newRectangle.Y - adornerServiceOrigin.Y, 0, 0);
@@ -362,7 +362,7 @@ namespace System.Windows.Forms.Design.Behavior
                     }
                 }
 
-                if (dragManager != null && targetAllowsSnapLines && !altKeyPressed)
+                if (dragManager is not null && targetAllowsSnapLines && !altKeyPressed)
                 {
                     dragManager.RenderSnapLinesInternal();
                 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/BorderSidesEditor.BorderSidesEditorUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/BorderSidesEditor.BorderSidesEditorUI.cs
@@ -365,7 +365,7 @@ namespace System.Windows.Forms.Design
             /// </summary>
             public void Start(IWindowsFormsEditorService edSvc, object value)
             {
-                Debug.Assert(edSvc != null);
+                Debug.Assert(edSvc is not null);
 
                 EditorService = edSvc;
                 originalValue = Value = value;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ButtonBaseDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ButtonBaseDesigner.cs
@@ -29,7 +29,7 @@ namespace System.Windows.Forms.Design
             base.InitializeNewComponent(defaultValues);
 
             PropertyDescriptor prop = TypeDescriptor.GetProperties(Component)["UseVisualStyleBackColor"];
-            if (prop != null && prop.PropertyType == typeof(bool) && !prop.IsReadOnly && prop.IsBrowsable)
+            if (prop is not null && prop.PropertyType == typeof(bool) && !prop.IsReadOnly && prop.IsBrowsable)
             {
                 // Dev10 Bug 685319: We should set the UseVisualStyleBackColor to trun only
                 // when this property has not been set/changed by user
@@ -56,12 +56,12 @@ namespace System.Windows.Forms.Design
                 PropertyDescriptor prop;
                 PropertyDescriptorCollection props = TypeDescriptor.GetProperties(Component);
 
-                if ((prop = props["TextAlign"]) != null)
+                if ((prop = props["TextAlign"]) is not null)
                 {
                     alignment = (ContentAlignment)prop.GetValue(Component);
                 }
 
-                if ((prop = props["FlatStyle"]) != null)
+                if ((prop = props["FlatStyle"]) is not null)
                 {
                     flatStyle = (FlatStyle)prop.GetValue(Component);
                 }
@@ -75,7 +75,7 @@ namespace System.Windows.Forms.Design
                 if ((Control is CheckBox) || (Control is RadioButton))
                 {
                     Appearance appearance = Appearance.Normal;
-                    if ((prop = props["Appearance"]) != null)
+                    if ((prop = props["Appearance"]) is not null)
                     {
                         appearance = (Appearance)prop.GetValue(Component);
                     }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ChangeToolStripParentVerb.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ChangeToolStripParentVerb.cs
@@ -24,7 +24,7 @@ namespace System.Windows.Forms.Design
         /// </summary>
         internal ChangeToolStripParentVerb(string text, ToolStripDesigner designer)
         {
-            Debug.Assert(designer != null, "Can't have a StandardMenuStripVerb without an associated designer");
+            Debug.Assert(designer is not null, "Can't have a StandardMenuStripVerb without an associated designer");
             _designer = designer;
             _provider = designer.Component.Site;
             _host = (IDesignerHost)_provider.GetService(typeof(IDesignerHost));
@@ -50,7 +50,7 @@ namespace System.Windows.Forms.Design
                     // close the DAP first - this is so that the autoshown panel on drag drop here is not conflicting with the currently opened panel
                     // if the verb was called from the panel
                     ToolStrip toolStrip = _designer.Component as ToolStrip;
-                    if (toolStrip != null && _designer != null && _designer.Component != null && _provider != null)
+                    if (toolStrip is not null && _designer is not null && _designer.Component is not null && _provider is not null)
                     {
                         DesignerActionUIService dapuisvc = _provider.GetService(typeof(DesignerActionUIService)) as DesignerActionUIService;
                         dapuisvc.HideUI(toolStrip);
@@ -59,25 +59,25 @@ namespace System.Windows.Forms.Design
                     // Get OleDragHandler ...
                     ToolboxItem tbi = new ToolboxItem(typeof(ToolStripContainer));
                     OleDragDropHandler ddh = rootDesigner.GetOleDragHandler();
-                    if (ddh != null)
+                    if (ddh is not null)
                     {
                         IComponent[] newComp = ddh.CreateTool(tbi, root, 0, 0, 0, 0, false, false);
                         if (newComp[0] is ToolStripContainer tsc)
                         {
-                            if (toolStrip != null)
+                            if (toolStrip is not null)
                             {
                                 var changeService = _provider.GetService<IComponentChangeService>();
                                 Control newParent = GetParent(tsc, toolStrip);
                                 PropertyDescriptor controlsProp = TypeDescriptor.GetProperties(newParent)["Controls"];
                                 Control oldParent = toolStrip.Parent;
-                                if (oldParent != null)
+                                if (oldParent is not null)
                                 {
                                     changeService.OnComponentChanging(oldParent, controlsProp);
                                     //remove control from the old parent
                                     oldParent.Controls.Remove(toolStrip);
                                 }
 
-                                if (newParent != null)
+                                if (newParent is not null)
                                 {
                                     changeService.OnComponentChanging(newParent, controlsProp);
                                     //finally add & relocate the control with the new parent
@@ -85,7 +85,7 @@ namespace System.Windows.Forms.Design
                                 }
 
                                 //fire our comp changed events
-                                if (changeService != null && oldParent != null && newParent != null)
+                                if (changeService is not null && oldParent is not null && newParent is not null)
                                 {
                                     changeService.OnComponentChanged(oldParent, controlsProp);
                                     changeService.OnComponentChanged(newParent, controlsProp);
@@ -109,7 +109,7 @@ namespace System.Windows.Forms.Design
                     uiService.ShowError(e.Message);
                 }
 
-                if (changeParent != null)
+                if (changeParent is not null)
                 {
                     changeParent.Cancel();
                     changeParent = null;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/CollectionEditVerbManager.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/CollectionEditVerbManager.cs
@@ -25,19 +25,19 @@ namespace System.Windows.Forms.Design
         /// </summary>
         internal CollectionEditVerbManager(string text, ComponentDesigner designer, PropertyDescriptor prop, bool addToDesignerVerbs)
         {
-            Debug.Assert(designer != null, "Can't have a CollectionEditVerbManager without an associated designer");
+            Debug.Assert(designer is not null, "Can't have a CollectionEditVerbManager without an associated designer");
             _designer = designer;
             _targetProperty = prop;
             if (prop is null)
             {
                 prop = TypeDescriptor.GetDefaultProperty(designer.Component);
-                if (prop != null && typeof(ICollection).IsAssignableFrom(prop.PropertyType))
+                if (prop is not null && typeof(ICollection).IsAssignableFrom(prop.PropertyType))
                 {
                     _targetProperty = prop;
                 }
             }
 
-            Debug.Assert(_targetProperty != null, "Need PropertyDescriptor for ICollection property to associate collection editor with.");
+            Debug.Assert(_targetProperty is not null, "Need PropertyDescriptor for ICollection property to associate collection editor with.");
             text ??= SR.ToolStripItemCollectionEditorVerb;
 
             _editItemsVerb = new DesignerVerb(text, new EventHandler(OnEditItems));
@@ -68,7 +68,7 @@ namespace System.Windows.Forms.Design
         {
             get
             {
-                if (_designer.Component.Site != null)
+                if (_designer.Component.Site is not null)
                 {
                     return _designer.Component.Site.Container;
                 }
@@ -135,7 +135,7 @@ namespace System.Windows.Forms.Design
                 return this;
             }
 
-            if (_designer.Component.Site != null)
+            if (_designer.Component.Site is not null)
             {
                 return _designer.Component.Site.GetService(serviceType);
             }
@@ -168,7 +168,7 @@ namespace System.Windows.Forms.Design
         DialogResult IWindowsFormsEditorService.ShowDialog(Form dialog)
         {
             IUIService uiSvc = (IUIService)((IServiceProvider)this).GetService(typeof(IUIService));
-            if (uiSvc != null)
+            if (uiSvc is not null)
             {
                 return uiSvc.ShowDialog(dialog);
             }
@@ -193,7 +193,7 @@ namespace System.Windows.Forms.Design
             }
 
             CollectionEditor itemsEditor = TypeDescriptor.GetEditor(propertyValue, typeof(UITypeEditor)) as CollectionEditor;
-            Debug.Assert(itemsEditor != null, "Didn't get a collection editor for type '" + _targetProperty.PropertyType.FullName + "'");
+            Debug.Assert(itemsEditor is not null, "Didn't get a collection editor for type '" + _targetProperty.PropertyType.FullName + "'");
             itemsEditor?.EditValue(this, this, propertyValue);
         }
     }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ComboBoxDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ComboBoxDesigner.cs
@@ -45,7 +45,7 @@ namespace System.Windows.Forms.Design
             if (disposing)
             {
                 // Hook up the property change notification so that we can dirty the SelectionUIItem when needed.
-                if (propChanged != null)
+                if (propChanged is not null)
                 {
                     ((ComboBox)Control).StyleChanged -= propChanged;
                 }
@@ -79,7 +79,7 @@ namespace System.Windows.Forms.Design
             ((ComboBox)Component).FormattingEnabled = true;
 
             PropertyDescriptor textProp = TypeDescriptor.GetProperties(Component)["Text"];
-            if (textProp != null && textProp.PropertyType == typeof(string) && !textProp.IsReadOnly && textProp.IsBrowsable)
+            if (textProp is not null && textProp.PropertyType == typeof(string) && !textProp.IsReadOnly && textProp.IsBrowsable)
             {
                 textProp.SetValue(Component, "");
             }
@@ -106,7 +106,7 @@ namespace System.Windows.Forms.Design
                 object component = Component;
 
                 PropertyDescriptor propStyle = TypeDescriptor.GetProperties(component)["DropDownStyle"];
-                if (propStyle != null)
+                if (propStyle is not null)
                 {
                     ComboBoxStyle style = (ComboBoxStyle)propStyle.GetValue(component);
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/CommandSet.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/CommandSet.cs
@@ -66,14 +66,14 @@ namespace System.Windows.Forms.Design
             this.site = site;
 
             eventService = (IEventHandlerService)site.GetService(typeof(IEventHandlerService));
-            Debug.Assert(eventService != null, "Command set must have the event service.  Is command set being initialized too early?");
+            Debug.Assert(eventService is not null, "Command set must have the event service.  Is command set being initialized too early?");
 
             eventService.EventHandlerChanged += new EventHandler(OnEventHandlerChanged);
 
             IDesignerHost host = (IDesignerHost)site.GetService(typeof(IDesignerHost));
-            Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || host != null, "IDesignerHost not found");
+            Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || host is not null, "IDesignerHost not found");
 
-            if (host != null)
+            if (host is not null)
             {
                 host.Activated += new EventHandler(UpdateClipboardItems);
             }
@@ -210,14 +210,14 @@ namespace System.Windows.Forms.Design
             };
 
             selectionService = (ISelectionService)site.GetService(typeof(ISelectionService));
-            Debug.Assert(selectionService != null, "CommandSet relies on the selection service, which is unavailable.");
-            if (selectionService != null)
+            Debug.Assert(selectionService is not null, "CommandSet relies on the selection service, which is unavailable.");
+            if (selectionService is not null)
             {
                 selectionService.SelectionChanged += new EventHandler(OnSelectionChanged);
             }
 
             menuService = (IMenuCommandService)site.GetService(typeof(IMenuCommandService));
-            if (menuService != null)
+            if (menuService is not null)
             {
                 for (int i = 0; i < commandSet.Length; i++)
                 {
@@ -230,7 +230,7 @@ namespace System.Windows.Forms.Design
             // dictionary of the root component.  Our host may pull this GUID out and use it.
             //
             IDictionaryService ds = site.GetService(typeof(IDictionaryService)) as IDictionaryService;
-            Debug.Assert(ds != null, "No dictionary service");
+            Debug.Assert(ds is not null, "No dictionary service");
             ds?.SetValue(typeof(CommandID), new CommandID(new Guid("BA09E2AF-9DF2-4068-B2F0-4C7E5CC19E2F"), 0));
         }
 
@@ -328,7 +328,7 @@ namespace System.Windows.Forms.Design
                     bool success = false;
                     IComponentChangeService changeService = (IComponentChangeService)GetService(typeof(IComponentChangeService));
 
-                    if (changeService != null)
+                    if (changeService is not null)
                     {
                         try
                         {
@@ -393,7 +393,7 @@ namespace System.Windows.Forms.Design
         // We don't need to Dispose snapLineTimer
         public virtual void Dispose()
         {
-            if (menuService != null)
+            if (menuService is not null)
             {
                 for (int i = 0; i < commandSet.Length; i++)
                 {
@@ -404,26 +404,26 @@ namespace System.Windows.Forms.Design
                 menuService = null;
             }
 
-            if (selectionService != null)
+            if (selectionService is not null)
             {
                 selectionService.SelectionChanged -= new EventHandler(OnSelectionChanged);
                 selectionService = null;
             }
 
-            if (eventService != null)
+            if (eventService is not null)
             {
                 eventService.EventHandlerChanged -= new EventHandler(OnEventHandlerChanged);
                 eventService = null;
             }
 
             IDesignerHost host = (IDesignerHost)site.GetService(typeof(IDesignerHost));
-            Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || host != null, "IDesignerHost not found");
-            if (host != null)
+            Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || host is not null, "IDesignerHost not found");
+            if (host is not null)
             {
                 host.Activated -= new EventHandler(UpdateClipboardItems);
             }
 
-            if (snapLineTimer != null)
+            if (snapLineTimer is not null)
             {
                 snapLineTimer.Stop();
                 snapLineTimer.Tick -= new EventHandler(OnSnapLineTimerExpire);
@@ -440,7 +440,7 @@ namespace System.Windows.Forms.Design
         /// </summary>
         protected void EndDragManager()
         {
-            if (dragManager != null)
+            if (dragManager is not null)
             {
                 snapLineTimer?.Stop();
 
@@ -453,7 +453,7 @@ namespace System.Windows.Forms.Design
         // Returns true if the action is successful, false otherwise
         internal static bool ExecuteSafely(Action action, bool throwOnException)
         {
-            if (action != null)
+            if (action is not null)
             {
                 try
                 {
@@ -478,7 +478,7 @@ namespace System.Windows.Forms.Design
         // Output of call to func is available in result out parameter
         private static bool ExecuteSafely<T>(Func<T> func, bool throwOnException, out T result)
         {
-            if (func != null)
+            if (func is not null)
             {
                 try
                 {
@@ -517,7 +517,7 @@ namespace System.Windows.Forms.Design
             if (selectionRules != SelectionRules.None)
             {
                 IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
-                if (host != null)
+                if (host is not null)
                 {
                     List<IComponent> list = new();
                     foreach (IComponent comp in components)
@@ -562,7 +562,7 @@ namespace System.Windows.Forms.Design
 
             selectedComponents = comps;
             IDesignerHost host = (IDesignerHost)site.GetService(typeof(IDesignerHost));
-            if (host != null)
+            if (host is not null)
             {
                 List<IComponent> copySelection = new();
                 foreach (IComponent comp in selectedComponents)
@@ -586,7 +586,7 @@ namespace System.Windows.Forms.Design
 
             foreach (IComponent childComp in designer.AssociatedComponents)
             {
-                if (childComp.Site != null)
+                if (childComp.Site is not null)
                 {
                     list.Add(childComp);
                     GetAssociatedComponents(childComp, host, list);
@@ -601,7 +601,7 @@ namespace System.Windows.Forms.Design
         {
             PropertyDescriptor prop = GetProperty(comp, "Location");
 
-            if (prop != null)
+            if (prop is not null)
             {
                 try
                 {
@@ -642,7 +642,7 @@ namespace System.Windows.Forms.Design
         private static Size GetSize(IComponent comp)
         {
             PropertyDescriptor prop = GetProperty(comp, "Size");
-            return prop != null ? (Size)prop.GetValue(comp) : Size.Empty;
+            return prop is not null ? (Size)prop.GetValue(comp) : Size.Empty;
         }
 
         /// <summary>
@@ -658,13 +658,13 @@ namespace System.Windows.Forms.Design
             props = TypeDescriptor.GetProperties(currentSnapComponent);
 
             PropertyDescriptor currentSnapProp = props["SnapToGrid"];
-            if (currentSnapProp != null && currentSnapProp.PropertyType != typeof(bool))
+            if (currentSnapProp is not null && currentSnapProp.PropertyType != typeof(bool))
             {
                 currentSnapProp = null;
             }
 
             PropertyDescriptor gridSizeProp = props["GridSize"];
-            if (gridSizeProp != null && gridSizeProp.PropertyType != typeof(Size))
+            if (gridSizeProp is not null && gridSizeProp.PropertyType != typeof(Size))
             {
                 gridSizeProp = null;
             }
@@ -674,7 +674,7 @@ namespace System.Windows.Forms.Design
             //
             snapComponent = currentSnapComponent;
             snapProperty = currentSnapProp;
-            snapSize = gridSizeProp != null ? (Size)gridSizeProp.GetValue(snapComponent) : Size.Empty;
+            snapSize = gridSizeProp is not null ? (Size)gridSizeProp.GetValue(snapComponent) : Size.Empty;
         }
 
         /// <summary>
@@ -687,7 +687,7 @@ namespace System.Windows.Forms.Design
             // look if it's ok to change
             IComponentChangeService changeSvc = (IComponentChangeService)GetService(typeof(IComponentChangeService));
             // is it ok to change?
-            if (changeSvc != null)
+            if (changeSvc is not null)
             {
                 try
                 {
@@ -773,12 +773,12 @@ namespace System.Windows.Forms.Design
             //
             ISelectionService selSvc = SelectionService;
 
-            if (selSvc != null)
+            if (selSvc is not null)
             {
                 if (selSvc.PrimarySelection is IComponent pri)
                 {
                     IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
-                    if (host != null)
+                    if (host is not null)
                     {
                         IDesigner designer = host.GetDesigner(pri);
 
@@ -797,12 +797,12 @@ namespace System.Windows.Forms.Design
             //
             ISelectionService selSvc = SelectionService;
 
-            if (selSvc != null)
+            if (selSvc is not null)
             {
                 if (selSvc.PrimarySelection is IComponent comp)
                 {
                     IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
-                    if (host != null)
+                    if (host is not null)
                     {
                         PropertyDescriptor lockedProp = TypeDescriptor.GetProperties(comp)["Locked"];
                         if (lockedProp is null || (lockedProp.PropertyType == typeof(bool) && ((bool)lockedProp.GetValue(comp))) == false)
@@ -861,21 +861,21 @@ namespace System.Windows.Forms.Design
                             {
                                 //if we can find the behaviorservice, then we can use it and the SnapLineEngine to help us
                                 //move these controls...
-                                if (BehaviorService != null)
+                                if (BehaviorService is not null)
                                 {
                                     Control primaryControl = comp as Control; //this can be null (when we are moving a component in the ComponentTray)
 
                                     bool useSnapLines = BehaviorService.UseSnapLines;
 
                                     // If we have previous snaplines, we always want to erase them, no matter what. VS Whidbey #397709
-                                    if (dragManager != null)
+                                    if (dragManager is not null)
                                     {
                                         EndDragManager();
                                     }
 
                                     //If we CTRL+Arrow and we're using SnapLines - snap to the next location
                                     //Don't snap if we are moving a component in the ComponentTray
-                                    if (invertSnap && useSnapLines && primaryControl != null)
+                                    if (invertSnap && useSnapLines && primaryControl is not null)
                                     {
                                         List<IComponent> selComps = (List<IComponent>)selSvc.GetSelectedComponents();
 
@@ -918,7 +918,7 @@ namespace System.Windows.Forms.Design
                                         Size snapSize = Size.Empty;
                                         GetSnapInformation(host, comp, out snapSize, out IComponent snapComponent, out PropertyDescriptor snapProperty);
 
-                                        if (snapProperty != null)
+                                        if (snapProperty is not null)
                                         {
                                             snapOn = (bool)snapProperty.GetValue(snapComponent);
                                         }
@@ -928,7 +928,7 @@ namespace System.Windows.Forms.Design
                                             moveOffsetX *= snapSize.Width;
                                             moveOffsetY *= snapSize.Height;
 
-                                            if (primaryControl != null)
+                                            if (primaryControl is not null)
                                             {
                                                 //ask the parent to adjust our wanna-be snapped position
                                                 if (host.GetDesigner(primaryControl.Parent) is ParentControlDesigner parentDesigner)
@@ -971,7 +971,7 @@ namespace System.Windows.Forms.Design
                                         else
                                         {
                                             // In this case we are just going to move 1 pixel, so let's adjust for Mirroring
-                                            if (primaryControl != null && primaryControl.Parent.IsMirrored)
+                                            if (primaryControl is not null && primaryControl.Parent.IsMirrored)
                                             {
                                                 moveOffsetX *= -1;
                                             }
@@ -979,7 +979,7 @@ namespace System.Windows.Forms.Design
                                     }
                                     else
                                     {
-                                        if (primaryControl != null && primaryControl.Parent.IsMirrored)
+                                        if (primaryControl is not null && primaryControl.Parent.IsMirrored)
                                         {
                                             moveOffsetX *= -1;
                                         }
@@ -997,7 +997,7 @@ namespace System.Windows.Forms.Design
                                         // Components are always moveable and visible
 
                                         PropertyDescriptor propLoc = TypeDescriptor.GetProperties(component)["Location"];
-                                        if (propLoc != null)
+                                        if (propLoc is not null)
                                         {
                                             Point loc = (Point)propLoc.GetValue(component);
                                             loc.Offset(moveOffsetX, moveOffsetY);
@@ -1005,7 +1005,7 @@ namespace System.Windows.Forms.Design
                                         }
 
                                         //change the Status information ....
-                                        if (component == selSvc.PrimarySelection && statusCommandUI != null)
+                                        if (component == selSvc.PrimarySelection && statusCommandUI is not null)
                                         {
                                             statusCommandUI.SetStatusInformation(component as Component);
                                         }
@@ -1016,7 +1016,7 @@ namespace System.Windows.Forms.Design
                             {
                                 trans?.Commit();
 
-                                if (dragManager != null)
+                                if (dragManager is not null)
                                 {
                                     //start our timer for the snaplines
                                     SnapLineTimer.Start();
@@ -1064,11 +1064,11 @@ namespace System.Windows.Forms.Design
                 // of properties.
                 //
                 IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
-                Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || host != null, "IDesignerHost not found");
+                Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || host is not null, "IDesignerHost not found");
                 DesignerTransaction trans = null;
                 try
                 {
-                    if (host != null)
+                    if (host is not null)
                     {
                         trans = host.CreateTransaction(string.Format(SR.CommandSetAlignByPrimary, comps.Count));
                     }
@@ -1084,7 +1084,7 @@ namespace System.Windows.Forms.Design
 
                         IComponent comp = obj as IComponent;
 
-                        if (comp != null && host != null)
+                        if (comp is not null && host is not null)
                         {
                             if (host.GetDesigner(comp) is not ControlDesigner des)
                             {
@@ -1100,7 +1100,7 @@ namespace System.Windows.Forms.Design
 
                         // Skip all components that are locked
                         //
-                        if (lockProp != null)
+                        if (lockProp is not null)
                         {
                             if ((bool)lockProp.GetValue(comp))
                                 continue;
@@ -1224,19 +1224,19 @@ namespace System.Windows.Forms.Design
 
                 ICollection selectedComponents = SelectionService.GetSelectedComponents();
                 IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
-                Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || host != null, "IDesignerHost not found");
+                Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || host is not null, "IDesignerHost not found");
                 DesignerTransaction trans = null;
 
                 try
                 {
-                    if (host != null)
+                    if (host is not null)
                     {
                         trans = host.CreateTransaction(string.Format(SR.CommandSetAlignToGrid, selectedComponents.Count));
 
                         if (host.RootComponent is Control baseComponent)
                         {
                             PropertyDescriptor prop = GetProperty(baseComponent, "GridSize");
-                            if (prop != null)
+                            if (prop is not null)
                             {
                                 gridSize = (Size)prop.GetValue(baseComponent);
                             }
@@ -1255,7 +1255,7 @@ namespace System.Windows.Forms.Design
                     {
                         // first check to see if the component is locked, if so - don't move it...
                         PropertyDescriptor lockedProp = GetProperty(comp, "Locked");
-                        if (lockedProp != null && ((bool)lockedProp.GetValue(comp)))
+                        if (lockedProp is not null && ((bool)lockedProp.GetValue(comp)))
                         {
                             continue;
                         }
@@ -1264,7 +1264,7 @@ namespace System.Windows.Forms.Design
                         // it's something in the component tray) then don't try to align it to grid.
                         //
                         IComponent component = comp as IComponent;
-                        if (component != null && host != null)
+                        if (component is not null && host is not null)
                         {
                             if (host.GetDesigner(component) is not ControlDesigner des)
                             {
@@ -1353,12 +1353,12 @@ namespace System.Windows.Forms.Design
                 Point loc = Point.Empty;
 
                 IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
-                Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || host != null, "IDesignerHost not found");
+                Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || host is not null, "IDesignerHost not found");
                 DesignerTransaction trans = null;
 
                 try
                 {
-                    if (host != null)
+                    if (host is not null)
                     {
                         string batchString = cmdID == StandardCommands.CenterHorizontally
                             ? string.Format(SR.WindowsFormsCommandCenterX, selectedComponents.Count)
@@ -1394,7 +1394,7 @@ namespace System.Windows.Forms.Design
                             // Also, skip all locked components...
                             //
                             PropertyDescriptor lockProp = props["Locked"];
-                            if (lockProp != null && (bool)lockProp.GetValue(comp))
+                            if (lockProp is not null && (bool)lockProp.GetValue(comp))
                             {
                                 continue;
                             }
@@ -1526,8 +1526,8 @@ namespace System.Windows.Forms.Design
                 selectedComponents = PrependComponentNames(selectedComponents);
 
                 IDesignerSerializationService ds = (IDesignerSerializationService)GetService(typeof(IDesignerSerializationService));
-                Debug.Assert(ds != null, "No designer serialization service -- we cannot copy to clipboard");
-                if (ds != null)
+                Debug.Assert(ds is not null, "No designer serialization service -- we cannot copy to clipboard");
+                if (ds is not null)
                 {
                     object serializationData = ds.Serialize(selectedComponents);
                     MemoryStream stream = new MemoryStream();
@@ -1572,8 +1572,8 @@ namespace System.Windows.Forms.Design
 
                 selectedComponents = PrependComponentNames(selectedComponents);
                 IDesignerSerializationService ds = (IDesignerSerializationService)GetService(typeof(IDesignerSerializationService));
-                Debug.Assert(ds != null, "No designer serialization service -- we cannot copy to clipboard");
-                if (ds != null)
+                Debug.Assert(ds is not null, "No designer serialization service -- we cannot copy to clipboard");
+                if (ds is not null)
                 {
                     object serializationData = ds.Serialize(selectedComponents);
                     MemoryStream stream = new MemoryStream();
@@ -1590,7 +1590,7 @@ namespace System.Windows.Forms.Design
                         IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
                         Control commonParent = null;
 
-                        if (host != null)
+                        if (host is not null)
                         {
                             IComponentChangeService changeService = (IComponentChangeService)GetService(typeof(IComponentChangeService));
                             DesignerTransaction trans = null;
@@ -1622,7 +1622,7 @@ namespace System.Windows.Forms.Design
                                     if (obj is Control c)
                                     {
                                         Control parent = c.Parent;
-                                        if (parent != null)
+                                        if (parent is not null)
                                         {
                                             if (host.GetDesigner(parent) is ParentControlDesigner designer
                                                 && !designerList.Contains(designer))
@@ -1652,11 +1652,11 @@ namespace System.Windows.Forms.Design
                                     //Cannot use idx = 1 to check (see diff) due to the call to PrependComponentNames, which
                                     //adds non IComponent objects to the beginning of selectedComponents. Thus when we finally get
                                     //here idx would be > 1.
-                                    if (commonParent is null && c != null)
+                                    if (commonParent is null && c is not null)
                                     {
                                         commonParent = c.Parent;
                                     }
-                                    else if (commonParent != null && c != null)
+                                    else if (commonParent is not null && c is not null)
                                     {
                                         Control selectedControl = c;
 
@@ -1667,7 +1667,7 @@ namespace System.Windows.Forms.Design
                                         }
                                     }
 
-                                    if (component != null)
+                                    if (component is not null)
                                     {
                                         List<IComponent> al = new();
                                         GetAssociatedComponents(component, host, al);
@@ -1689,7 +1689,7 @@ namespace System.Windows.Forms.Design
                                 }
                             }
 
-                            if (commonParent != null)
+                            if (commonParent is not null)
                             {
                                 SelectionService.SetSelectedComponents(new object[] { commonParent }, SelectionTypes.Replace);
                             }
@@ -1720,17 +1720,17 @@ namespace System.Windows.Forms.Design
             try
             {
                 Cursor.Current = Cursors.WaitCursor;
-                if (site != null)
+                if (site is not null)
                 {
                     IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
-                    Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || host != null, "IDesignerHost not found");
+                    Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || host is not null, "IDesignerHost not found");
 
                     if (SelectionService is null)
                     {
                         return;
                     }
 
-                    if (host != null)
+                    if (host is not null)
                     {
                         IComponentChangeService changeService = (IComponentChangeService)GetService(typeof(IComponentChangeService));
 
@@ -1757,7 +1757,7 @@ namespace System.Windows.Forms.Design
                                 if (obj is Control c)
                                 {
                                     Control parent = c.Parent;
-                                    if (parent != null)
+                                    if (parent is not null)
                                     {
                                         if (host.GetDesigner(parent) is ParentControlDesigner designer
                                             && !designerList.Contains(designer))
@@ -1790,7 +1790,7 @@ namespace System.Windows.Forms.Design
                                 Control control = obj as Control;
                                 if (!commonParentSet)
                                 {
-                                    if (control != null)
+                                    if (control is not null)
                                     {
                                         commonParent = control.Parent;
                                     }
@@ -1802,18 +1802,18 @@ namespace System.Windows.Forms.Design
                                         if (host.GetDesigner((IComponent)obj) is ITreeDesigner designer)
                                         {
                                             IDesigner parentDesigner = designer.Parent;
-                                            if (parentDesigner != null)
+                                            if (parentDesigner is not null)
                                             {
                                                 commonParent = parentDesigner.Component;
                                             }
                                         }
                                     }
 
-                                    commonParentSet = (commonParent != null);
+                                    commonParentSet = (commonParent is not null);
                                 }
-                                else if (commonParent != null)
+                                else if (commonParent is not null)
                                 {
-                                    if (control != null && commonParent is Control)
+                                    if (control is not null && commonParent is Control)
                                     {
                                         Control selectedControl = control;
                                         Control controlCommonParent = (Control)commonParent;
@@ -1828,7 +1828,7 @@ namespace System.Windows.Forms.Design
                                             else
                                             {
                                                 // start walking up until we find a common parent
-                                                while (controlCommonParent != null && !controlCommonParent.Contains(selectedControl))
+                                                while (controlCommonParent is not null && !controlCommonParent.Contains(selectedControl))
                                                 {
                                                     controlCommonParent = controlCommonParent.Parent;
                                                 }
@@ -1851,14 +1851,14 @@ namespace System.Windows.Forms.Design
                                             // up to the root component, and for the current component designer.
                                             //
                                             for (designer = designer.Parent as ITreeDesigner;
-                                                 designer != null;
+                                                 designer is not null;
                                                  designer = designer.Parent as ITreeDesigner)
                                             {
                                                 designerChain.Add(designer);
                                             }
 
                                             for (commonParentDesigner = commonParentDesigner.Parent as ITreeDesigner;
-                                                 commonParentDesigner != null;
+                                                 commonParentDesigner is not null;
                                                  commonParentDesigner = commonParentDesigner.Parent as ITreeDesigner)
                                             {
                                                 parentDesignerChain.Add(commonParentDesigner);
@@ -1914,16 +1914,16 @@ namespace System.Windows.Forms.Design
                             }
                         }
 
-                        if (commonParent != null && SelectionService.PrimarySelection is null)
+                        if (commonParent is not null && SelectionService.PrimarySelection is null)
                         {
-                            if (host.GetDesigner(commonParent) is ITreeDesigner commonParentDesigner && commonParentDesigner.Children != null)
+                            if (host.GetDesigner(commonParent) is ITreeDesigner commonParentDesigner && commonParentDesigner.Children is not null)
                             {
                                 // choose the first child of the common parent if it has any.
                                 //
                                 foreach (IDesigner designer in commonParentDesigner.Children)
                                 {
                                     IComponent component = designer.Component;
-                                    if (component.Site != null)
+                                    if (component.Site is not null)
                                     {
                                         commonParent = component;
                                         break;
@@ -1940,7 +1940,7 @@ namespace System.Windows.Forms.Design
 
                                     // 126240 -- make sure we've got a sited thing.
                                     //
-                                    while (controlCommonParent != null && controlCommonParent.Site is null)
+                                    while (controlCommonParent is not null && controlCommonParent.Site is null)
                                     {
                                         controlCommonParent = controlCommonParent.Parent;
                                     }
@@ -1949,7 +1949,7 @@ namespace System.Windows.Forms.Design
                                 }
                             }
 
-                            if (commonParent != null)
+                            if (commonParent is not null)
                             {
                                 SelectionService.SetSelectedComponents(new object[] { commonParent }, SelectionTypes.Replace);
                             }
@@ -1992,7 +1992,7 @@ namespace System.Windows.Forms.Design
                 ICollection associatedCompsOfFailedControl = null;
 
                 IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
-                Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || host != null, "IDesignerHost not found");
+                Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || host is not null, "IDesignerHost not found");
                 if (host is null)
                     return;   // nothing we can do here!
 
@@ -2007,7 +2007,7 @@ namespace System.Windows.Forms.Design
                     int numberOfOriginalTrayControls = 0;
                     // Get the current number of controls in the Component Tray in the target
                     tray = GetService(typeof(ComponentTray)) as ComponentTray;
-                    numberOfOriginalTrayControls = tray != null ? tray.Controls.Count : 0;
+                    numberOfOriginalTrayControls = tray is not null ? tray.Controls.Count : 0;
 
                     // We understand two things:  CF_DESIGNER, and toolbox items.
                     //
@@ -2018,13 +2018,13 @@ namespace System.Windows.Forms.Design
                         if (data is byte[] bytes)
                         {
                             MemoryStream s = new MemoryStream(bytes);
-                            if (s != null)
+                            if (s is not null)
                             {
                                 // CF_DESIGNER was put on the clipboard by us using the designer
                                 // serialization service.
                                 //
                                 IDesignerSerializationService ds = (IDesignerSerializationService)GetService(typeof(IDesignerSerializationService));
-                                if (ds != null)
+                                if (ds is not null)
                                 {
                                     BinaryFormatter formatter = new BinaryFormatter();
                                     s.Seek(0, SeekOrigin.Begin);
@@ -2044,10 +2044,10 @@ namespace System.Windows.Forms.Design
                             //
                             IToolboxService ts = (IToolboxService)GetService(typeof(IToolboxService));
 
-                            if (ts != null && ts.IsSupported(dataObj, host))
+                            if (ts is not null && ts.IsSupported(dataObj, host))
                             {
                                 ToolboxItem ti = ts.DeserializeToolboxItem(dataObj, host);
-                                if (ti != null)
+                                if (ti is not null)
                                 {
                                     using (DpiHelper.EnterDpiAwarenessScope(DPI_AWARENESS_CONTEXT.DPI_AWARENESS_CONTEXT_SYSTEM_AWARE))
                                     {
@@ -2061,7 +2061,7 @@ namespace System.Windows.Forms.Design
 
                         // Now, if we got some components, hook 'em up!
                         //
-                        if (components != null && components.Count > 0)
+                        if (components is not null && components.Count > 0)
                         {
                             IComponent curComp;
                             string name;
@@ -2089,7 +2089,7 @@ namespace System.Windows.Forms.Design
                             dragClient = false;
                             ITreeDesigner tree = host.GetDesigner(selectedComponent) as ITreeDesigner;
 
-                            while (!dragClient && tree != null)
+                            while (!dragClient && tree is not null)
                             {
                                 if (tree is IOleDragClient)
                                 {
@@ -2115,7 +2115,7 @@ namespace System.Windows.Forms.Design
                                 // that were created.
                                 if (obj is IComponent)
                                 {
-                                    if (componentNames != null && idx < componentNames.Length)
+                                    if (componentNames is not null && idx < componentNames.Length)
                                     {
                                         name = componentNames[idx++];
                                     }
@@ -2154,7 +2154,7 @@ namespace System.Windows.Forms.Design
                                 {
                                     bool foundAssociatedControl = false;
                                     // If we have failed to add a control in this Paste operation ...
-                                    if (associatedCompsOfFailedControl != null)
+                                    if (associatedCompsOfFailedControl is not null)
                                     {
                                         // then don't add its children controls.
                                         foreach (Component comp in associatedCompsOfFailedControl)
@@ -2186,16 +2186,16 @@ namespace System.Windows.Forms.Design
 
                                     ComponentDesigner parentCompDesigner = ((ITreeDesigner)cDesigner).Parent as ComponentDesigner;
                                     Component parentComp = null;
-                                    if (parentCompDesigner != null)
+                                    if (parentCompDesigner is not null)
                                     {
                                         parentComp = parentCompDesigner.Component as Component;
                                     }
 
                                     List<IComponent> associatedComps = new();
 
-                                    if (parentComp != null)
+                                    if (parentComp is not null)
                                     {
-                                        if (parentCompDesigner != null)
+                                        if (parentCompDesigner is not null)
                                         {
                                             foreach (IComponent childComp in parentCompDesigner.AssociatedComponents)
                                             {
@@ -2206,7 +2206,7 @@ namespace System.Windows.Forms.Design
 
                                     if (parentComp is null || !(associatedComps.Contains(curComp)))
                                     {
-                                        if (parentComp != null)
+                                        if (parentComp is not null)
                                         {
                                             if (host.GetDesigner(parentComp) is ParentControlDesigner parentDesigner && !designerList.Contains(parentDesigner))
                                             {
@@ -2228,7 +2228,7 @@ namespace System.Windows.Forms.Design
                                         }
 
                                         Control designerControl = ((IOleDragClient)designer).GetControlForComponent(curComp);
-                                        if (designerControl != null)
+                                        if (designerControl is not null)
                                         {
                                             controls.Add(designerControl);
                                         }
@@ -2254,7 +2254,7 @@ namespace System.Windows.Forms.Design
                                         // After we add the control, we'll update the text with
                                         // the new name.
                                         //
-                                        if (name != null && name.Equals(c.Text))
+                                        if (name is not null && name.Equals(c.Text))
                                         {
                                             changeName = true;
                                         }
@@ -2264,13 +2264,13 @@ namespace System.Windows.Forms.Design
                                     {
                                         PropertyDescriptorCollection props = TypeDescriptor.GetProperties(curComp);
                                         PropertyDescriptor nameProp = props["Name"];
-                                        if (nameProp != null && nameProp.PropertyType == typeof(string))
+                                        if (nameProp is not null && nameProp.PropertyType == typeof(string))
                                         {
                                             string newName = (string)nameProp.GetValue(curComp);
                                             if (!newName.Equals(name))
                                             {
                                                 PropertyDescriptor textProp = props["Text"];
-                                                if (textProp != null && textProp.PropertyType == nameProp.PropertyType)
+                                                if (textProp is not null && textProp.PropertyType == nameProp.PropertyType)
                                                 {
                                                     textProp.SetValue(curComp, nameProp.GetValue(curComp));
                                                 }
@@ -2311,7 +2311,7 @@ namespace System.Windows.Forms.Design
                             // the paste target did not have a tray already, so let's go get it - if there is one
                             tray ??= GetService(typeof(ComponentTray)) as ComponentTray;
 
-                            if (tray != null)
+                            if (tray is not null)
                             {
                                 int numberOfTrayControlsAdded = tray.Controls.Count - numberOfOriginalTrayControls;
 
@@ -2376,18 +2376,18 @@ namespace System.Windows.Forms.Design
             try
             {
                 Cursor.Current = Cursors.WaitCursor;
-                if (site != null)
+                if (site is not null)
                 {
-                    Debug.Assert(SelectionService != null, "We need the SelectionService, but we can't find it!");
+                    Debug.Assert(SelectionService is not null, "We need the SelectionService, but we can't find it!");
                     if (SelectionService is null)
                     {
                         return;
                     }
 
                     IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
-                    Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || host != null, "IDesignerHost not found");
+                    Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || host is not null, "IDesignerHost not found");
 
-                    if (host != null)
+                    if (host is not null)
                     {
                         ComponentCollection components = host.Container.Components;
                         object[] selComps;
@@ -2424,12 +2424,12 @@ namespace System.Windows.Forms.Design
         /// </summary>
         protected void OnMenuShowGrid(object sender, EventArgs e)
         {
-            if (site != null)
+            if (site is not null)
             {
                 IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
-                Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || host != null, "IDesignerHost not found");
+                Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || host is not null, "IDesignerHost not found");
 
-                if (host != null)
+                if (host is not null)
                 {
                     DesignerTransaction trans = null;
 
@@ -2441,7 +2441,7 @@ namespace System.Windows.Forms.Design
                         if (baseComponent is not null and Control)
                         {
                             PropertyDescriptor prop = GetProperty(baseComponent, "DrawGrid");
-                            if (prop != null)
+                            if (prop is not null)
                             {
                                 bool drawGrid = (bool)prop.GetValue(baseComponent);
                                 prop.SetValue(baseComponent, !drawGrid);
@@ -2503,15 +2503,15 @@ namespace System.Windows.Forms.Design
                     return;
                 }
 
-                Debug.Assert(null != selectedObjects, "queryStatus should have disabled this");
+                Debug.Assert(selectedObjects is not null, "queryStatus should have disabled this");
 
                 IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
-                Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || host != null, "IDesignerHost not found");
+                Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || host is not null, "IDesignerHost not found");
                 DesignerTransaction trans = null;
 
                 try
                 {
-                    if (host != null)
+                    if (host is not null)
                     {
                         trans = host.CreateTransaction(string.Format(SR.CommandSetSize, selectedObjects.Length));
                     }
@@ -2528,7 +2528,7 @@ namespace System.Windows.Forms.Design
 
                         //if the component is locked, no sizing is allowed...
                         PropertyDescriptor lockedDesc = GetProperty(obj, "Locked");
-                        if (lockedDesc != null && (bool)lockedDesc.GetValue(obj))
+                        if (lockedDesc is not null && (bool)lockedDesc.GetValue(obj))
                         {
                             continue;
                         }
@@ -2582,7 +2582,7 @@ namespace System.Windows.Forms.Design
 
             Cursor oldCursor = Cursor.Current;
             IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
-            Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || host != null, "IDesignerHost not found");
+            Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || host is not null, "IDesignerHost not found");
             DesignerTransaction trans = null;
 
             try
@@ -2597,12 +2597,12 @@ namespace System.Windows.Forms.Design
                 Size size = Size.Empty;
                 Point loc = Point.Empty;
 
-                Debug.Assert(null != selectedObjects, "queryStatus should have disabled this");
+                Debug.Assert(selectedObjects is not null, "queryStatus should have disabled this");
                 Size grid = Size.Empty;
                 PropertyDescriptor sizeProp = null;
                 PropertyDescriptor locProp = null;
 
-                if (host != null)
+                if (host is not null)
                 {
                     trans = host.CreateTransaction(string.Format(SR.CommandSetSizeToGrid, selectedObjects.Length));
 
@@ -2610,7 +2610,7 @@ namespace System.Windows.Forms.Design
                     if (baseComponent is not null and Control)
                     {
                         PropertyDescriptor prop = GetProperty(baseComponent, "CurrentGridSize");
-                        if (prop != null)
+                        if (prop is not null)
                         {
                             grid = (Size)prop.GetValue(baseComponent);
                         }
@@ -2631,8 +2631,8 @@ namespace System.Windows.Forms.Design
                         sizeProp = GetProperty(comp, "Size");
                         locProp = GetProperty(comp, "Location");
 
-                        Debug.Assert(sizeProp != null, "No size property on component");
-                        Debug.Assert(locProp != null, "No location property on component");
+                        Debug.Assert(sizeProp is not null, "No size property on component");
+                        Debug.Assert(locProp is not null, "No location property on component");
 
                         if (sizeProp is null || locProp is null || sizeProp.IsReadOnly || locProp.IsReadOnly)
                         {
@@ -2674,7 +2674,7 @@ namespace System.Windows.Forms.Design
             }
 
             IMenuCommandService menuSvc = (IMenuCommandService)GetService(typeof(IMenuCommandService));
-            if (menuSvc != null)
+            if (menuSvc is not null)
             {
                 if (menuSvc.GlobalInvoke(StandardCommands.PropertiesWindow))
                 {
@@ -2690,11 +2690,11 @@ namespace System.Windows.Forms.Design
         /// </summary>
         protected void OnMenuSnapToGrid(object sender, EventArgs e)
         {
-            if (site != null)
+            if (site is not null)
             {
                 IDesignerHost host = (IDesignerHost)site.GetService(typeof(IDesignerHost));
 
-                if (host != null)
+                if (host is not null)
                 {
                     DesignerTransaction trans = null;
 
@@ -2706,7 +2706,7 @@ namespace System.Windows.Forms.Design
                         if (baseComponent is not null and Control)
                         {
                             PropertyDescriptor prop = GetProperty(baseComponent, "SnapToGrid");
-                            if (prop != null)
+                            if (prop is not null)
                             {
                                 bool snapToGrid = (bool)prop.GetValue(baseComponent);
                                 prop.SetValue(baseComponent, !snapToGrid);
@@ -2739,7 +2739,7 @@ namespace System.Windows.Forms.Design
 
             Cursor oldCursor = Cursor.Current;
             IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
-            Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || host != null, "IDesignerHost not found");
+            Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || host is not null, "IDesignerHost not found");
 
             try
             {
@@ -2753,7 +2753,7 @@ namespace System.Windows.Forms.Design
                 IComponent[] selectedObjects = new IComponent[sel.Count];
                 sel.CopyTo(selectedObjects, 0);
 
-                if (host != null)
+                if (host is not null)
                 {
                     trans = host.CreateTransaction(string.Format(SR.CommandSetFormatSpacing, selectedObjects.Length));
 
@@ -2761,7 +2761,7 @@ namespace System.Windows.Forms.Design
                     if (baseComponent is not null and Control)
                     {
                         PropertyDescriptor prop = GetProperty(baseComponent, "CurrentGridSize");
-                        if (prop != null)
+                        if (prop is not null)
                         {
                             grid = (Size)prop.GetValue(baseComponent);
                         }
@@ -2772,7 +2772,7 @@ namespace System.Windows.Forms.Design
 
                 int nEqualDelta = 0;
 
-                Debug.Assert(null != selectedObjects, "queryStatus should have disabled this");
+                Debug.Assert(selectedObjects is not null, "queryStatus should have disabled this");
 
                 PropertyDescriptor curSizeDesc = null, lastSizeDesc = null;
                 PropertyDescriptor curLocDesc = null, lastLocDesc = null;
@@ -2807,7 +2807,7 @@ namespace System.Windows.Forms.Design
                 //
                 object primary = SelectionService.PrimarySelection;
                 int primaryIndex = 0;
-                if (primary != null)
+                if (primary is not null)
                     primaryIndex = Array.IndexOf(selectedObjects, primary);
 
                 // And compute delta values for Make Equal
@@ -2823,12 +2823,12 @@ namespace System.Windows.Forms.Design
 
                         IComponent component = selectedObjects[n];
 
-                        if (component != null)
+                        if (component is not null)
                         {
                             curComp = component;
 
                             curSizeDesc = GetProperty(curComp, "Size");
-                            if (curSizeDesc != null)
+                            if (curSizeDesc is not null)
                             {
                                 curSize = (Size)curSizeDesc.GetValue(curComp);
                             }
@@ -2851,7 +2851,7 @@ namespace System.Windows.Forms.Design
                     for (n = 0; n < selectedObjects.Length; n++)
                     {
                         curComp = selectedObjects[n];
-                        if (curComp != null)
+                        if (curComp is not null)
                         {
                             // only get the descriptors if we've changed component types
                             if (lastComp is null || curComp.GetType() != lastComp.GetType())
@@ -2862,7 +2862,7 @@ namespace System.Windows.Forms.Design
 
                             lastComp = curComp;
 
-                            if (curLocDesc != null)
+                            if (curLocDesc is not null)
                             {
                                 curLoc = (Point)curLocDesc.GetValue(curComp);
                             }
@@ -2871,7 +2871,7 @@ namespace System.Windows.Forms.Design
                                 continue;
                             }
 
-                            if (curSizeDesc != null)
+                            if (curSizeDesc is not null)
                             {
                                 curSize = (Size)curSizeDesc.GetValue(curComp);
                             }
@@ -2890,7 +2890,7 @@ namespace System.Windows.Forms.Design
                     for (n = selectedObjects.Length - 1; n >= 0; n--)
                     {
                         curComp = selectedObjects[n];
-                        if (curComp != null)
+                        if (curComp is not null)
                         {
                             // only get the descriptors if we've changed component types
                             if (lastComp is null || curComp.GetType() != lastComp.GetType())
@@ -2901,7 +2901,7 @@ namespace System.Windows.Forms.Design
 
                             lastComp = curComp;
 
-                            if (curLocDesc != null)
+                            if (curLocDesc is not null)
                             {
                                 lastLoc = (Point)curLocDesc.GetValue(curComp);
                             }
@@ -2910,7 +2910,7 @@ namespace System.Windows.Forms.Design
                                 continue;
                             }
 
-                            if (curSizeDesc != null)
+                            if (curSizeDesc is not null)
                             {
                                 lastSize = (Size)curSizeDesc.GetValue(curComp);
                             }
@@ -2919,14 +2919,14 @@ namespace System.Windows.Forms.Design
                                 continue;
                             }
 
-                            if (curSizeDesc != null && curLocDesc != null)
+                            if (curSizeDesc is not null && curLocDesc is not null)
                             {
                                 break;
                             }
                         }
                     }
 
-                    if (curSizeDesc != null && curLocDesc != null)
+                    if (curSizeDesc is not null && curLocDesc is not null)
                     {
                         nEqualDelta = sort == SORT_HORIZONTAL
                             ? (lastSize.Width + lastLoc.X - curLoc.X - total) / (selectedObjects.Length - 1)
@@ -2939,10 +2939,10 @@ namespace System.Windows.Forms.Design
 
                 curComp = lastComp = null;
 
-                if (primary != null)
+                if (primary is not null)
                 {
                     PropertyDescriptor primaryLocDesc = GetProperty(primary, "Location");
-                    if (primaryLocDesc != null)
+                    if (primaryLocDesc is not null)
                     {
                         primaryLoc = (Point)primaryLocDesc.GetValue(primary);
                     }
@@ -2959,7 +2959,7 @@ namespace System.Windows.Forms.Design
                     //Check to see if the component we are about to move is locked...
                     //
                     PropertyDescriptor lockedDesc = props["Locked"];
-                    if (lockedDesc != null && (bool)lockedDesc.GetValue(curComp))
+                    if (lockedDesc is not null && (bool)lockedDesc.GetValue(curComp))
                     {
                         continue; // locked property of our component is true, so don't move it
                     }
@@ -2975,7 +2975,7 @@ namespace System.Windows.Forms.Design
                         curLocDesc = lastLocDesc;
                     }
 
-                    if (curLocDesc != null)
+                    if (curLocDesc is not null)
                     {
                         curLoc = (Point)curLocDesc.GetValue(curComp);
                     }
@@ -2984,7 +2984,7 @@ namespace System.Windows.Forms.Design
                         continue;
                     }
 
-                    if (curSizeDesc != null)
+                    if (curSizeDesc is not null)
                     {
                         curSize = (Size)curSizeDesc.GetValue(curComp);
                     }
@@ -3006,7 +3006,7 @@ namespace System.Windows.Forms.Design
                         lastLocDesc = curLocDesc;
                     }
 
-                    if (lastLocDesc != null)
+                    if (lastLocDesc is not null)
                     {
                         lastLoc = (Point)lastLocDesc.GetValue(lastComp);
                     }
@@ -3015,7 +3015,7 @@ namespace System.Windows.Forms.Design
                         continue;
                     }
 
-                    if (lastSizeDesc != null)
+                    if (lastSizeDesc is not null)
                     {
                         lastSize = (Size)lastSizeDesc.GetValue(lastComp);
                     }
@@ -3127,14 +3127,14 @@ namespace System.Windows.Forms.Design
             selCount = SelectionService.SelectionCount;
 
             IDesignerHost designerHost = (IDesignerHost)GetService(typeof(IDesignerHost));
-            Debug.Assert(designerHost != null, "Failed to get designer host");
+            Debug.Assert(designerHost is not null, "Failed to get designer host");
 
             // if the base component is selected, we'll say that nothing's selected
             // so we don't get wierd behavior
-            if (selCount > 0 && designerHost != null)
+            if (selCount > 0 && designerHost is not null)
             {
                 object baseComponent = designerHost.RootComponent;
-                if (baseComponent != null && SelectionService.GetComponentSelected(baseComponent))
+                if (baseComponent is not null && SelectionService.GetComponentSelected(baseComponent))
                 {
                     selCount = 0;
                 }
@@ -3174,7 +3174,7 @@ namespace System.Windows.Forms.Design
         {
             Control marshalControl = BehaviorService.AdornerWindowControl;
 
-            if (marshalControl != null && marshalControl.IsHandleCreated)
+            if (marshalControl is not null && marshalControl.IsHandleCreated)
             {
                 marshalControl.BeginInvoke(new EventHandler(OnSnapLineTimerExpireMarshalled), new object[] { sender, e });
             }
@@ -3220,12 +3220,12 @@ namespace System.Windows.Forms.Design
             bool enable = false;
 
             IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
-            if (!selectionInherited && host != null && !host.Loading)
+            if (!selectionInherited && host is not null && !host.Loading)
             {
                 ISelectionService selSvc = (ISelectionService)GetService(typeof(ISelectionService));
-                Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || selSvc != null, "ISelectionService not found");
+                Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || selSvc is not null, "ISelectionService not found");
 
-                if (selSvc != null)
+                if (selSvc is not null)
                 {
                     // There must also be a component in the mix, and not the base component
                     //
@@ -3238,7 +3238,7 @@ namespace System.Windows.Forms.Design
                         {
                             // if the object is not sited to the same thing as the host container
                             // then don't allow copy. VSWhidbey# 275790
-                            if (obj is IComponent comp && comp.Site != null && comp.Site.Container == host.Container)
+                            if (obj is IComponent comp && comp.Site is not null && comp.Site.Container == host.Container)
                             {
                                 enable = true;
                                 break;
@@ -3280,17 +3280,17 @@ namespace System.Windows.Forms.Design
             else
             {
                 IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
-                if (host != null)
+                if (host is not null)
                 {
                     ISelectionService selSvc = (ISelectionService)GetService(typeof(ISelectionService));
-                    if (selSvc != null)
+                    if (selSvc is not null)
                     {
                         ICollection selectedComponents = selSvc.GetSelectedComponents();
                         foreach (object obj in selectedComponents)
                         {
                             // if the object is not sited to the same thing as the host container
                             // then don't allow delete. VSWhidbey# 275790
-                            if (obj is IComponent comp && (comp.Site is null || (comp.Site != null && comp.Site.Container != host.Container)))
+                            if (obj is IComponent comp && (comp.Site is null || (comp.Site is not null && comp.Site.Container != host.Container)))
                             {
                                 cmd.Enabled = false;
                                 return;
@@ -3329,17 +3329,17 @@ namespace System.Windows.Forms.Design
             // Before we even look at the data format, check to see if the thing we're going to paste
             // into is privately inherited.  If it is, then we definitely cannot paste.
             //
-            if (primarySelection != null)
+            if (primarySelection is not null)
             {
-                Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || host != null, "IDesignerHost not found");
+                Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || host is not null, "IDesignerHost not found");
 
-                if (host != null && host.GetDesigner(primarySelection) is ParentControlDesigner)
+                if (host is not null && host.GetDesigner(primarySelection) is ParentControlDesigner)
                 {
                     // This component is a target for our paste operation.  We must ensure
                     // that it is not privately inherited.
                     //
                     InheritanceAttribute attr = (InheritanceAttribute)TypeDescriptor.GetAttributes(primarySelection)[typeof(InheritanceAttribute)];
-                    Debug.Assert(attr != null, "Type descriptor gave us a null attribute -- problem in type descriptor");
+                    Debug.Assert(attr is not null, "Type descriptor gave us a null attribute -- problem in type descriptor");
                     if (attr.InheritanceLevel == InheritanceLevel.InheritedReadOnly)
                     {
                         cmd.Enabled = false;
@@ -3354,7 +3354,7 @@ namespace System.Windows.Forms.Design
 
             bool enable = false;
 
-            if (clipboardOperationSuccessful && dataObj != null)
+            if (clipboardOperationSuccessful && dataObj is not null)
             {
                 if (dataObj.GetDataPresent(CF_DESIGNER))
                 {
@@ -3365,9 +3365,9 @@ namespace System.Windows.Forms.Design
                     // Not ours, check to see if the toolbox service understands this
                     //
                     IToolboxService ts = (IToolboxService)GetService(typeof(IToolboxService));
-                    if (ts != null)
+                    if (ts is not null)
                     {
-                        enable = (host != null ? ts.IsSupported(dataObj, host) : ts.IsToolboxItem(dataObj));
+                        enable = (host is not null ? ts.IsSupported(dataObj, host) : ts.IsToolboxItem(dataObj));
                     }
                 }
             }
@@ -3378,7 +3378,7 @@ namespace System.Windows.Forms.Design
         private void OnStatusPrimarySelection(object sender, EventArgs e)
         {
             MenuCommand cmd = (MenuCommand)sender;
-            cmd.Enabled = primarySelection != null;
+            cmd.Enabled = primarySelection is not null;
         }
 
         protected virtual void OnStatusSelectAll(object sender, EventArgs e)
@@ -3548,7 +3548,7 @@ namespace System.Windows.Forms.Design
             // control because preserving the relationship between controls
             // is more important than obscuring a control.
             //
-            if (parentControl != null)
+            if (parentControl is not null)
             {
                 bool bumpIt;
                 bool wrapped = false;
@@ -3610,7 +3610,7 @@ namespace System.Windows.Forms.Design
                                 if (baseComponent is not null and Control)
                                 {
                                     PropertyDescriptor gs = GetProperty(baseComponent, "GridSize");
-                                    if (gs != null)
+                                    if (gs is not null)
                                     {
                                         gridSize = (Size)gs.GetValue(baseComponent);
                                     }
@@ -3772,7 +3772,7 @@ namespace System.Windows.Forms.Design
                 // and then filling in the results we get, so we can easily retrieve them when
                 // the selection hasn't changed.
                 //
-                if (optimizeStatus && statusHandler != null)
+                if (optimizeStatus && statusHandler is not null)
                 {
                     // we use this as our sentinel of when we're doing this.
                     //
@@ -3817,9 +3817,9 @@ namespace System.Windows.Forms.Design
                     // check to see if this is a command we have hashed up and if it's version stamp
                     // is the same as our current selection version.
                     //
-                    if (commandSet != null && commandStatusHash.TryGetValue(statusHandler, out StatusState state))
+                    if (commandSet is not null && commandStatusHash.TryGetValue(statusHandler, out StatusState state))
                     {
-                        if (state != null && state.SelectionVersion == commandSet.SelectionVersion)
+                        if (state is not null && state.SelectionVersion == commandSet.SelectionVersion)
                         {
                             return true;
                         }
@@ -3834,7 +3834,7 @@ namespace System.Windows.Forms.Design
             /// </summary>
             private void ApplyCachedStatus()
             {
-                if (commandSet != null && commandStatusHash.TryGetValue(statusHandler, out StatusState state))
+                if (commandSet is not null && commandStatusHash.TryGetValue(statusHandler, out StatusState state))
                 {
                     try
                     {
@@ -3862,10 +3862,10 @@ namespace System.Windows.Forms.Design
                 //
                 try
                 {
-                    if (eventService != null)
+                    if (eventService is not null)
                     {
                         IMenuStatusHandler msh = (IMenuStatusHandler)eventService.GetHandler(typeof(IMenuStatusHandler));
-                        if (msh != null && msh.OverrideInvoke(this))
+                        if (msh is not null && msh.OverrideInvoke(this))
                         {
                             return;
                         }
@@ -3923,16 +3923,16 @@ namespace System.Windows.Forms.Design
             {
                 // We allow outside parties to override the availability of particular menu commands.
                 //
-                if (eventService != null)
+                if (eventService is not null)
                 {
                     IMenuStatusHandler msh = (IMenuStatusHandler)eventService.GetHandler(typeof(IMenuStatusHandler));
-                    if (msh != null && msh.OverrideStatus(this))
+                    if (msh is not null && msh.OverrideStatus(this))
                     {
                         return;
                     }
                 }
 
-                if (statusHandler != null)
+                if (statusHandler is not null)
                 {
                     // if we need to update our status,
                     // call the status handler.  otherwise,
@@ -4135,7 +4135,7 @@ namespace System.Windows.Forms.Design
                     return 1;
                 }
 
-                return c1.Parent == c2.Parent && c1.Parent != null ? c1.Parent.Controls.GetChildIndex(c1) - c1.Parent.Controls.GetChildIndex(c2) : 1;
+                return c1.Parent == c2.Parent && c1.Parent is not null ? c1.Parent.Controls.GetChildIndex(c1) - c1.Parent.Controls.GetChildIndex(c2) : 1;
             }
         }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ComponentTray.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ComponentTray.cs
@@ -86,12 +86,12 @@ namespace System.Windows.Forms.Design
             controls = new();
             IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
             IExtenderProviderService es = (IExtenderProviderService)GetService(typeof(IExtenderProviderService));
-            Debug.Assert(es != null, "Component tray wants an extender provider service, but there isn't one.");
+            Debug.Assert(es is not null, "Component tray wants an extender provider service, but there isn't one.");
             es?.AddExtenderProvider(this);
 
             if (GetService(typeof(IEventHandlerService)) is null)
             {
-                if (host != null)
+                if (host is not null)
                 {
                     eventHandlerService = new EventHandlerService(this);
                     host.AddService(typeof(IEventHandlerService), eventHandlerService);
@@ -99,7 +99,7 @@ namespace System.Windows.Forms.Design
             }
 
             IMenuCommandService mcs = MenuService;
-            if (mcs != null)
+            if (mcs is not null)
             {
                 Debug.Assert(menucmdArrangeIcons is null, "Non-Null Menu Command for ArrangeIcons");
                 Debug.Assert(menucmdLineupIcons is null, "Non-Null Menu Command for LineupIcons");
@@ -115,7 +115,7 @@ namespace System.Windows.Forms.Design
             }
 
             IComponentChangeService componentChangeService = (IComponentChangeService)GetService(typeof(IComponentChangeService));
-            if (componentChangeService != null)
+            if (componentChangeService is not null)
             {
                 componentChangeService.ComponentRemoved += new ComponentEventHandler(OnComponentRemoved);
             }
@@ -158,7 +158,7 @@ namespace System.Windows.Forms.Design
             }
 
             ISelectionService selSvc = (ISelectionService)GetService(typeof(ISelectionService));
-            if (selSvc != null)
+            if (selSvc is not null)
             {
                 selSvc.SelectionChanged += new EventHandler(OnSelectionChanged);
             }
@@ -190,7 +190,7 @@ namespace System.Windows.Forms.Design
             if (e.ComponentChanged is IComponent component)
             {
                 TrayControl control = TrayControl.FromComponent(component);
-                if (control != null)
+                if (control is not null)
                 {
                     bool shouldDisplay = CanDisplayComponent(component);
                     if (shouldDisplay != control.Visible || !shouldDisplay)
@@ -247,7 +247,7 @@ namespace System.Windows.Forms.Design
                 if (selObj is IComponent component)
                 {
                     Control c = TrayControl.FromComponent(component);
-                    if (c != null)
+                    if (c is not null)
                     {
                         Debug.WriteLineIf(CompModSwitches.MSAA.TraceInfo, "MSAA: SelectionAdd, traycontrol = " + c.ToString());
                         User32.NotifyWinEvent((uint)AccessibleEvents.SelectionAdd, new HandleRef(c, c.Handle), User32.OBJID.CLIENT, 0);
@@ -258,13 +258,13 @@ namespace System.Windows.Forms.Design
             if (primary is IComponent comp)
             {
                 Control c = TrayControl.FromComponent(comp);
-                if (c != null && IsHandleCreated)
+                if (c is not null && IsHandleCreated)
                 {
                     ScrollControlIntoView(c);
                     User32.NotifyWinEvent((uint)AccessibleEvents.Focus, new HandleRef(c, c.Handle), User32.OBJID.CLIENT, 0);
                 }
 
-                if (glyphManager != null)
+                if (glyphManager is not null)
                 {
                     glyphManager.SelectionGlyphs.Clear();
                     IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
@@ -273,7 +273,7 @@ namespace System.Windows.Forms.Design
                         if (selObj is IComponent selectedComponent && !(host.GetDesigner(selectedComponent) is ControlDesigner))
                         { // don't want to do it for controls that are also in the tray
                             GlyphCollection glyphs = glyphManager.GetGlyphsForComponent(selectedComponent);
-                            if (glyphs != null && glyphs.Count > 0)
+                            if (glyphs is not null && glyphs.Count > 0)
                             {
                                 SelectionGlyphs.AddRange(glyphs);
                             }
@@ -437,7 +437,7 @@ namespace System.Windows.Forms.Design
         {
             get
             {
-                if (glyphManager != null)
+                if (glyphManager is not null)
                 {
                     return glyphManager.SelectionGlyphs;
                 }
@@ -469,7 +469,7 @@ namespace System.Windows.Forms.Design
 
         bool IExtenderProvider.CanExtend(object extendee)
         {
-            return (extendee is IComponent comp) && (TrayControl.FromComponent(comp) != null);
+            return (extendee is IComponent comp) && (TrayControl.FromComponent(comp) is not null);
         }
 
         IComponent IOleDragClient.Component
@@ -504,9 +504,9 @@ namespace System.Windows.Forms.Design
                 IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
                 try
                 {
-                    if (host != null && host.Container != null)
+                    if (host is not null && host.Container is not null)
                     {
-                        if (host.Container.Components[name] != null)
+                        if (host.Container.Components[name] is not null)
                         {
                             name = null;
                         }
@@ -587,7 +587,7 @@ namespace System.Windows.Forms.Design
                 foreach (IComponent comp in components)
                 {
                     TrayControl tc = TrayControl.FromComponent(comp);
-                    if (tc != null)
+                    if (tc is not null)
                     {
                         SetTrayLocation(comp, new Point(tc.Location.X - autoScrollPosBeforeDragging.X, tc.Location.Y - autoScrollPosBeforeDragging.Y));
                     }
@@ -706,7 +706,7 @@ namespace System.Windows.Forms.Design
                 // 6. This causes all sorts of badness
                 // Fix is to refresh.
                 TypeDescriptor.Refresh(component);
-                if (host != null && !host.Loading)
+                if (host is not null && !host.Loading)
                 {
                     PositionControl(trayctl);
                 }
@@ -725,7 +725,7 @@ namespace System.Windows.Forms.Design
                 ResumeLayout();
             }
 
-            if (host != null && !host.Loading)
+            if (host is not null && !host.Loading)
             {
                 ScrollControlIntoView(trayctl);
             }
@@ -735,7 +735,7 @@ namespace System.Windows.Forms.Design
         protected virtual bool CanCreateComponentFromTool(ToolboxItem tool)
         {
             IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
-            Debug.Assert(host != null, "Service object could not provide us with a designer host.");
+            Debug.Assert(host is not null, "Service object could not provide us with a designer host.");
             // Disallow controls to be added to the component tray.
             Type compType = host.GetType(tool.TypeName);
             if (compType is null)
@@ -762,11 +762,11 @@ namespace System.Windows.Forms.Design
                 if (attributes[i] is DesignerAttribute da)
                 {
                     Type attributeBaseType = Type.GetType(da.DesignerBaseTypeName);
-                    if (attributeBaseType != null && attributeBaseType == designerBaseType)
+                    if (attributeBaseType is not null && attributeBaseType == designerBaseType)
                     {
                         bool foundService = false;
                         ITypeResolutionService tr = (ITypeResolutionService)GetService(typeof(ITypeResolutionService));
-                        if (tr != null)
+                        if (tr is not null)
                         {
                             foundService = true;
                             designerType = tr.GetType(da.DesignerTypeName);
@@ -777,7 +777,7 @@ namespace System.Windows.Forms.Design
                             designerType = Type.GetType(da.DesignerTypeName);
                         }
 
-                        if (designerType != null)
+                        if (designerType is not null)
                         {
                             break;
                         }
@@ -817,7 +817,7 @@ namespace System.Windows.Forms.Design
         protected void DisplayError(Exception e)
         {
             IUIService uis = (IUIService)GetService(typeof(IUIService));
-            if (uis != null)
+            if (uis is not null)
             {
                 uis.ShowError(e);
             }
@@ -838,16 +838,16 @@ namespace System.Windows.Forms.Design
         /// </summary>
         protected override void Dispose(bool disposing)
         {
-            if (disposing && controls != null)
+            if (disposing && controls is not null)
             {
                 IExtenderProviderService es = (IExtenderProviderService)GetService(typeof(IExtenderProviderService));
-                Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || (es != null), "IExtenderProviderService not found");
+                Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || (es is not null), "IExtenderProviderService not found");
                 es?.RemoveExtenderProvider(this);
 
                 IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
-                if (eventHandlerService != null)
+                if (eventHandlerService is not null)
                 {
-                    if (host != null)
+                    if (host is not null)
                     {
                         host.RemoveService(typeof(IEventHandlerService));
                         eventHandlerService = null;
@@ -855,7 +855,7 @@ namespace System.Windows.Forms.Design
                 }
 
                 IComponentChangeService componentChangeService = (IComponentChangeService)GetService(typeof(IComponentChangeService));
-                if (componentChangeService != null)
+                if (componentChangeService is not null)
                 {
                     componentChangeService.ComponentRemoved -= new ComponentEventHandler(OnComponentRemoved);
                 }
@@ -864,11 +864,11 @@ namespace System.Windows.Forms.Design
                 SystemEvents.InstalledFontsChanged -= new EventHandler(OnSystemSettingChanged);
                 SystemEvents.UserPreferenceChanged -= new UserPreferenceChangedEventHandler(OnUserPreferenceChanged);
                 IMenuCommandService mcs = MenuService;
-                if (mcs != null)
+                if (mcs is not null)
                 {
-                    Debug.Assert(menucmdArrangeIcons != null, "Null Menu Command for ArrangeIcons");
-                    Debug.Assert(menucmdLineupIcons != null, "Null Menu Command for LineupIcons");
-                    Debug.Assert(menucmdLargeIcons != null, "Null Menu Command for LargeIcons");
+                    Debug.Assert(menucmdArrangeIcons is not null, "Null Menu Command for ArrangeIcons");
+                    Debug.Assert(menucmdLineupIcons is not null, "Null Menu Command for LineupIcons");
+                    Debug.Assert(menucmdLargeIcons is not null, "Null Menu Command for LargeIcons");
                     mcs.RemoveCommand(menucmdArrangeIcons);
                     mcs.RemoveCommand(menucmdLineupIcons);
                     mcs.RemoveCommand(menucmdLargeIcons);
@@ -876,7 +876,7 @@ namespace System.Windows.Forms.Design
 
                 selectionUISvc = null;
 
-                if (inheritanceUI != null)
+                if (inheritanceUI is not null)
                 {
                     inheritanceUI.Dispose();
                     inheritanceUI = null;
@@ -886,7 +886,7 @@ namespace System.Windows.Forms.Design
                 controls.Clear();
                 controls = null;
 
-                if (glyphManager != null)
+                if (glyphManager is not null)
                 {
                     glyphManager.Dispose();
                     glyphManager = null;
@@ -943,7 +943,7 @@ namespace System.Windows.Forms.Design
         public Point GetLocation(IComponent receiver)
         {
             PropertyDescriptor loc = TypeDescriptor.GetProperties(receiver.GetType())["Location"];
-            if (loc != null)
+            if (loc is not null)
             {
                 // In this case the component already had a Location property, and what the caller wants is the underlying components Location, not the tray location. Why? Because we now use TrayLocation.
                 return (Point)(loc.GetValue(receiver));
@@ -984,8 +984,8 @@ namespace System.Windows.Forms.Design
         protected override object GetService(Type serviceType)
         {
             object service = null;
-            Debug.Assert(serviceProvider != null, "Trying to access services too late or too early.");
-            if (serviceProvider != null)
+            Debug.Assert(serviceProvider is not null, "Trying to access services too late or too early.");
+            if (serviceProvider is not null)
             {
                 service = serviceProvider.GetService(serviceType);
             }
@@ -1017,7 +1017,7 @@ namespace System.Windows.Forms.Design
         protected override void OnMouseDoubleClick(MouseEventArgs e)
         {
             //give our glyphs first chance at this
-            if (glyphManager != null && glyphManager.OnMouseDoubleClick(e))
+            if (glyphManager is not null && glyphManager.OnMouseDoubleClick(e))
             {
                 //handled by a glyph - so don't send to the comp tray
                 return;
@@ -1028,7 +1028,7 @@ namespace System.Windows.Forms.Design
             {
                 OnLostCapture();
                 IEventBindingService eps = (IEventBindingService)GetService(typeof(IEventBindingService));
-                Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || (eps != null), "IEventBindingService not found");
+                Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || (eps is not null), "IEventBindingService not found");
                 eps?.ShowCode();
             }
         }
@@ -1052,11 +1052,11 @@ namespace System.Windows.Forms.Design
             // This will be used once during PositionComponent to place the component at the drop point. It is automatically set to null afterwards, so further components appear after the first one dropped.
             mouseDropLocation = PointToClient(new Point(de.X, de.Y));
             autoScrollPosBeforeDragging = AutoScrollPosition; // save the scroll position
-            if (mouseDragTool != null)
+            if (mouseDragTool is not null)
             {
                 ToolboxItem tool = mouseDragTool;
                 mouseDragTool = null;
-                Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || (GetService(typeof(IDesignerHost)) != null), "IDesignerHost not found");
+                Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || (GetService(typeof(IDesignerHost)) is not null), "IDesignerHost not found");
                 try
                 {
                     IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
@@ -1103,12 +1103,12 @@ namespace System.Windows.Forms.Design
                 OleDragDropHandler dragDropHandler = GetOleDragHandler();
                 object[] dragComps = OleDragDropHandler.GetDraggingObjects(de);
                 // Only assume the items came from the ToolBox if dragComps is null
-                if (toolboxService != null && dragComps is null)
+                if (toolboxService is not null && dragComps is null)
                 {
                     mouseDragTool = toolboxService.DeserializeToolboxItem(de.Data, (IDesignerHost)GetService(typeof(IDesignerHost)));
                 }
 
-                if (mouseDragTool != null)
+                if (mouseDragTool is not null)
                 {
                     Debug.Assert(0 != (de.AllowedEffect & (DragDropEffects.Move | DragDropEffects.Copy)), "DragDropEffect.Move | .Copy isn't allowed?");
                     if ((de.AllowedEffect & DragDropEffects.Move) != 0)
@@ -1142,7 +1142,7 @@ namespace System.Windows.Forms.Design
         /// </summary>
         protected override void OnDragOver(DragEventArgs de)
         {
-            if (mouseDragTool != null)
+            if (mouseDragTool is not null)
             {
                 Debug.Assert(0 != (de.AllowedEffect & DragDropEffects.Copy), "DragDropEffect.Move isn't allowed?");
                 de.Effect = DragDropEffects.Copy;
@@ -1201,7 +1201,7 @@ namespace System.Windows.Forms.Design
         protected override void OnMouseDown(MouseEventArgs e)
         {
             //give our glyphs first chance at this
-            if (glyphManager != null && glyphManager.OnMouseDown(e))
+            if (glyphManager is not null && glyphManager.OnMouseDown(e))
             {
                 //handled by a glyph - so don't send to the comp tray
                 return;
@@ -1213,10 +1213,10 @@ namespace System.Windows.Forms.Design
                 toolboxService ??= (IToolboxService)GetService(typeof(IToolboxService));
 
                 FocusDesigner();
-                if (e.Button == MouseButtons.Left && toolboxService != null)
+                if (e.Button == MouseButtons.Left && toolboxService is not null)
                 {
                     ToolboxItem tool = toolboxService.GetSelectedToolboxItem((IDesignerHost)GetService(typeof(IDesignerHost)));
-                    if (tool != null)
+                    if (tool is not null)
                     {
                         // mouseDropLocation is checked in PositionControl, which should get called as a result of adding a new component.  This allows us to set the position without flickering, while still providing support for auto layout if the control was double clicked or added through extensibility.
                         mouseDropLocation = new Point(e.X, e.Y);
@@ -1251,7 +1251,7 @@ namespace System.Windows.Forms.Design
                     try
                     {
                         ISelectionService ss = (ISelectionService)GetService(typeof(ISelectionService));
-                        Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || (ss != null), "ISelectionService not found");
+                        Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || (ss is not null), "ISelectionService not found");
                         ss?.SetSelectedComponents(new object[] { mainDesigner.Component });
                     }
                     catch (Exception ex)
@@ -1273,7 +1273,7 @@ namespace System.Windows.Forms.Design
         protected override void OnMouseMove(MouseEventArgs e)
         {
             //give our glyphs first chance at this
-            if (glyphManager != null && glyphManager.OnMouseMove(e))
+            if (glyphManager is not null && glyphManager.OnMouseMove(e))
             {
                 //handled by a glyph - so don't send to the comp tray
                 return;
@@ -1306,7 +1306,7 @@ namespace System.Windows.Forms.Design
         protected override void OnMouseUp(MouseEventArgs e)
         {
             //give our glyphs first chance at this
-            if (glyphManager != null && glyphManager.OnMouseUp(e))
+            if (glyphManager is not null && glyphManager.OnMouseUp(e))
             {
                 //handled by a glyph - so don't send to the comp tray
                 return;
@@ -1343,7 +1343,7 @@ namespace System.Windows.Forms.Design
                 try
                 {
                     ISelectionService ss = (ISelectionService)GetService(typeof(ISelectionService));
-                    Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || (ss != null), "ISelectionService not found");
+                    Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || (ss is not null), "ISelectionService not found");
                     ss?.SetSelectedComponents(comps);
                 }
                 catch (Exception ex)
@@ -1385,7 +1385,7 @@ namespace System.Windows.Forms.Design
                 fResetAmbient = false;
                 fSelectionChanged = false;
                 IUIService uiService = (IUIService)GetService(typeof(IUIService));
-                if (uiService != null)
+                if (uiService is not null)
                 {
                     Color styleColor;
                     if (uiService.Styles["ArtboardBackground"] is Color)
@@ -1422,7 +1422,7 @@ namespace System.Windows.Forms.Design
             base.OnPaint(pe);
             Graphics gr = pe.Graphics;
             // Now, if we have a selection, paint it
-            if (selectedObjects != null)
+            if (selectedObjects is not null)
             {
                 bool first = true; //indicates the first iteration of our foreach loop
                 HatchBrush selectionBorderBrush;
@@ -1440,7 +1440,7 @@ namespace System.Windows.Forms.Design
                     foreach (object o in selectedObjects)
                     {
                         Control c = ((IOleDragClient)this).GetControlForComponent(o);
-                        if (c != null && c.Visible)
+                        if (c is not null && c.Visible)
                         {
                             Rectangle innerRect = c.Bounds;
                             if (SystemInformation.HighContrast)
@@ -1491,12 +1491,12 @@ namespace System.Windows.Forms.Design
         public virtual void RemoveComponent(IComponent component)
         {
             TrayControl c = TrayControl.FromComponent(component);
-            if (c != null)
+            if (c is not null)
             {
                 try
                 {
                     InheritanceAttribute attr = c.InheritanceAttribute;
-                    if (attr.InheritanceLevel != InheritanceLevel.NotInherited && inheritanceUI != null)
+                    if (attr.InheritanceLevel != InheritanceLevel.NotInherited && inheritanceUI is not null)
                     {
                         inheritanceUI.RemoveInheritedControl(c);
                     }
@@ -1518,7 +1518,7 @@ namespace System.Windows.Forms.Design
         {
             // This really should only be called when we are loading.
             IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
-            if (host != null && host.Loading)
+            if (host is not null && host.Loading)
             {
                 // If we are loading, and we get called here, that's because we have provided the extended Location property. In this case we are loading an old project, and what we are really setting is the tray location.
                 SetTrayLocation(receiver, location);
@@ -1527,7 +1527,7 @@ namespace System.Windows.Forms.Design
             {
                 // we are not loading
                 PropertyDescriptor loc = TypeDescriptor.GetProperties(receiver.GetType())["Location"];
-                if (loc != null)
+                if (loc is not null)
                 {
                     // so if the component already had the Location property, what the caller wants is really the underlying component's Location property.
                     loc.SetValue(receiver, location);
@@ -1644,13 +1644,13 @@ namespace System.Windows.Forms.Design
                 {
                     queriedTabOrder = true;
                     IMenuCommandService mcs = MenuService;
-                    if (mcs != null)
+                    if (mcs is not null)
                     {
                         tabOrderCommand = mcs.FindCommand(StandardCommands.TabOrder);
                     }
                 }
 
-                if (tabOrderCommand != null)
+                if (tabOrderCommand is not null)
                 {
                     return tabOrderCommand.Checked;
                 }
@@ -1682,7 +1682,7 @@ namespace System.Windows.Forms.Design
         internal void FocusDesigner()
         {
             IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
-            if (host != null && host.RootComponent != null)
+            if (host is not null && host.RootComponent is not null)
             {
                 if (host.GetDesigner(host.RootComponent) is IRootDesigner rd)
                 {
@@ -1807,7 +1807,7 @@ namespace System.Windows.Forms.Design
             Debug.Assert(c.Visible, "TrayControl for " + c.Component + " should not be positioned");
             if (whiteSpace.IsEmpty)
             {
-                Debug.Assert(selectionUISvc != null, "No SelectionUIService available for tray.");
+                Debug.Assert(selectionUISvc is not null, "No SelectionUIService available for tray.");
                 whiteSpace = new Point(selectionUISvc.GetAdornmentDimensions(AdornmentType.GrabHandle));
                 whiteSpace.X = whiteSpace.X * 2 + 3;
                 whiteSpace.Y = whiteSpace.Y * 2 + 3;
@@ -1823,9 +1823,9 @@ namespace System.Windows.Forms.Design
                     if (dirtyDesigner)
                     {
                         IComponent comp = c.Component;
-                        Debug.Assert(comp != null, "Component for the TrayControl is null");
+                        Debug.Assert(comp is not null, "Component for the TrayControl is null");
                         PropertyDescriptor ctlLocation = TypeDescriptor.GetProperties(comp)["TrayLocation"];
-                        if (ctlLocation != null)
+                        if (ctlLocation is not null)
                         {
                             Point autoScrollLoc = AutoScrollPosition;
                             newLoc = new Point(newLoc.X - autoScrollLoc.X, newLoc.Y - autoScrollLoc.Y);
@@ -1858,9 +1858,9 @@ namespace System.Windows.Forms.Design
                     if (dirtyDesigner)
                     {
                         IComponent comp = c.Component;
-                        Debug.Assert(comp != null, "Component for the TrayControl is null");
+                        Debug.Assert(comp is not null, "Component for the TrayControl is null");
                         PropertyDescriptor ctlLocation = TypeDescriptor.GetProperties(comp)["TrayLocation"];
-                        if (ctlLocation != null)
+                        if (ctlLocation is not null)
                         {
                             Point autoScrollLoc = AutoScrollPosition;
                             newLoc = new Point(newLoc.X - autoScrollLoc.X, newLoc.Y - autoScrollLoc.Y);
@@ -1912,8 +1912,8 @@ namespace System.Windows.Forms.Design
                 UpdateIconInfo();
 
                 IComponentChangeService cs = (IComponentChangeService)tray.GetService(typeof(IComponentChangeService));
-                Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || (cs != null), "IComponentChangeService not found");
-                if (cs != null)
+                Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || (cs is not null), "IComponentChangeService not found");
+                if (cs is not null)
                 {
                     cs.ComponentRename += new ComponentRenameEventHandler(OnComponentRename);
                 }
@@ -1921,11 +1921,11 @@ namespace System.Windows.Forms.Design
                 ISite site = component.Site;
                 string name = null;
 
-                if (site != null)
+                if (site is not null)
                 {
                     name = site.Name;
                     IDictionaryService ds = (IDictionaryService)site.GetService(typeof(IDictionaryService));
-                    Debug.Assert(ds != null, "ComponentTray relies on IDictionaryService, which is not available.");
+                    Debug.Assert(ds is not null, "ComponentTray relies on IDictionaryService, which is not available.");
                     ds?.SetValue(GetType(), this);
                 }
 
@@ -2008,17 +2008,17 @@ namespace System.Windows.Forms.Design
                 if (disposing)
                 {
                     ISite site = _component.Site;
-                    if (site != null)
+                    if (site is not null)
                     {
                         IComponentChangeService cs = (IComponentChangeService)site.GetService(typeof(IComponentChangeService));
-                        Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || (cs != null), "IComponentChangeService not found");
-                        if (cs != null)
+                        Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || (cs is not null), "IComponentChangeService not found");
+                        if (cs is not null)
                         {
                             cs.ComponentRename -= new ComponentRenameEventHandler(OnComponentRename);
                         }
 
                         IDictionaryService ds = (IDictionaryService)site.GetService(typeof(IDictionaryService));
-                        Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || (ds != null), "IDictionaryService not found");
+                        Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || (ds is not null), "IDictionaryService not found");
                         ds?.SetValue(typeof(TrayControl), null);
                     }
                 }
@@ -2038,11 +2038,11 @@ namespace System.Windows.Forms.Design
                 }
 
                 ISite site = component.Site;
-                if (site != null)
+                if (site is not null)
                 {
                     IDictionaryService ds = (IDictionaryService)site.GetService(typeof(IDictionaryService));
-                    Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || (ds != null), "IDictionaryService not found");
-                    if (ds != null)
+                    Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || (ds is not null), "IDictionaryService not found");
+                    if (ds is not null)
                     {
                         c = (TrayControl)ds.GetValue(typeof(TrayControl));
                     }
@@ -2081,8 +2081,8 @@ namespace System.Windows.Forms.Design
                 if (!_tray.TabOrderActive)
                 {
                     IDesignerHost host = (IDesignerHost)_tray.GetService(typeof(IDesignerHost));
-                    Debug.Assert(host != null, "Component tray does not have access to designer host.");
-                    if (host != null)
+                    Debug.Assert(host is not null, "Component tray does not have access to designer host.");
+                    if (host is not null)
                     {
                         _mouseDragLast = InvalidPoint;
                         Capture = false;
@@ -2125,8 +2125,8 @@ namespace System.Windows.Forms.Design
                 OnSetCursor();
 
                 // And now finish the drag.
-                Debug.Assert(_tray.selectionUISvc != null, "We shouldn't be able to begin a drag without this");
-                if (_tray.selectionUISvc != null && _tray.selectionUISvc.Dragging)
+                Debug.Assert(_tray.selectionUISvc is not null, "We shouldn't be able to begin a drag without this");
+                if (_tray.selectionUISvc is not null && _tray.selectionUISvc.Dragging)
                 {
                     _tray.selectionUISvc.EndDrag(cancel);
                 }
@@ -2152,7 +2152,7 @@ namespace System.Windows.Forms.Design
                         {
                             ISelectionService sel = (ISelectionService)_tray.GetService(typeof(ISelectionService));
                             // Make sure the component is selected
-                            Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || (sel != null), "ISelectionService not found");
+                            Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || (sel is not null), "ISelectionService not found");
                             sel?.SetSelectedComponents(new object[] { Component }, SelectionTypes.Primary);
                         }
                     }
@@ -2199,7 +2199,7 @@ namespace System.Windows.Forms.Design
                     sel?.SetSelectedComponents(new object[] { Component }, SelectionTypes.Primary);
 
                     // Notify the selection service that all the components are in the "mouse down" mode.
-                    if (_tray.selectionUISvc != null && _tray.selectionUISvc.BeginDrag(SelectionRules.Visible | SelectionRules.Moveable, _mouseDragLast.X, _mouseDragLast.Y))
+                    if (_tray.selectionUISvc is not null && _tray.selectionUISvc.BeginDrag(SelectionRules.Visible | SelectionRules.Moveable, _mouseDragLast.X, _mouseDragLast.Y))
                     {
                         OnSetCursor();
                     }
@@ -2230,13 +2230,13 @@ namespace System.Windows.Forms.Design
                     Capture = false;
                     // Ensure that this component is selected.
                     ISelectionService s = (ISelectionService)_tray.GetService(typeof(ISelectionService));
-                    if (s != null && !s.GetComponentSelected(_component))
+                    if (s is not null && !s.GetComponentSelected(_component))
                     {
                         s.SetSelectedComponents(new object[] { _component }, SelectionTypes.Replace);
                     }
 
                     IMenuCommandService mcs = _tray.MenuService;
-                    if (mcs != null)
+                    if (mcs is not null)
                     {
                         Capture = false;
                         Cursor.Clip = Rectangle.Empty;
@@ -2269,7 +2269,7 @@ namespace System.Windows.Forms.Design
                     format.Alignment = StringAlignment.Center;
                     if (_tray.ShowLargeIcons)
                     {
-                        if (null != _toolboxBitmap)
+                        if (_toolboxBitmap is not null)
                         {
                             int x = rc.X + (rc.Width - _cxIcon) / 2;
                             int y = rc.Y + WhiteSpace;
@@ -2282,7 +2282,7 @@ namespace System.Windows.Forms.Design
                     }
                     else
                     {
-                        if (null != _toolboxBitmap)
+                        if (_toolboxBitmap is not null)
                         {
                             int y = rc.Y + (rc.Height - _cyIcon) / 2;
                             e.Graphics.DrawImage(_toolboxBitmap, new Rectangle(rc.X, y, _cxIcon, _cyIcon));
@@ -2306,7 +2306,7 @@ namespace System.Windows.Forms.Design
                 if (!InheritanceAttribute.NotInherited.Equals(_inheritanceAttribute))
                 {
                     InheritanceUI iui = _tray.InheritanceUI;
-                    if (iui != null)
+                    if (iui is not null)
                     {
                         e.Graphics.DrawImage(InheritanceUI.InheritanceGlyph, 0, 0);
                     }
@@ -2361,7 +2361,7 @@ namespace System.Windows.Forms.Design
                     return;
                 }
 
-                if (prop != null && ((bool)prop.GetValue(_component)))
+                if (prop is not null && ((bool)prop.GetValue(_component)))
                 {
                     Cursor.Current = Cursors.Default;
                     return;
@@ -2420,7 +2420,7 @@ namespace System.Windows.Forms.Design
             internal void UpdateIconInfo()
             {
                 ToolboxBitmapAttribute attr = (ToolboxBitmapAttribute)TypeDescriptor.GetAttributes(_component)[typeof(ToolboxBitmapAttribute)];
-                if (attr != null)
+                if (attr is not null)
                 {
                     _toolboxBitmap = attr.GetImage(_component, _tray.ShowLargeIcons);
                 }
@@ -2450,8 +2450,8 @@ namespace System.Windows.Forms.Design
                 PropertyDescriptor defaultPropEvent = null;
                 bool eventChanged = false;
                 IEventBindingService eps = (IEventBindingService)GetService(typeof(IEventBindingService));
-                Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || (eps != null), "IEventBindingService not found");
-                if (eps != null)
+                Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || (eps is not null), "IEventBindingService not found");
+                if (eps is not null)
                 {
                     defaultPropEvent = eps.GetEventProperty(defaultEvent);
                 }
@@ -2478,13 +2478,13 @@ namespace System.Windows.Forms.Design
 
                 try
                 {
-                    if (host != null)
+                    if (host is not null)
                     {
                         trans = host.CreateTransaction(string.Format(SR.WindowsFormsAddEvent, defaultEvent.Name));
                     }
 
                     // Save the new value... BEFORE navigating to it!
-                    if (eventChanged && defaultPropEvent != null)
+                    if (eventChanged && defaultPropEvent is not null)
                     {
                         defaultPropEvent.SetValue(component, handler);
                     }
@@ -2525,7 +2525,7 @@ namespace System.Windows.Forms.Design
                         OnContextMenu(location);
                         break;
                     case User32.WM.NCHITTEST:
-                        if (_tray.glyphManager != null)
+                        if (_tray.glyphManager is not null)
                         {
                             // Make sure tha we send our glyphs hit test messages over the TrayControls too
                             Point pt = PARAM.ToPoint(m.LParamInternal);
@@ -2563,7 +2563,7 @@ namespace System.Windows.Forms.Design
                     {
                         AccessibleStates state = base.State;
                         ISelectionService s = (ISelectionService)_tray.GetService(typeof(ISelectionService));
-                        if (s != null)
+                        if (s is not null)
                         {
                             if (s.GetComponentSelected(Component))
                             {
@@ -2612,7 +2612,7 @@ namespace System.Windows.Forms.Design
             /// </summary>
             public void Dispose()
             {
-                if (_traySelectionAdorner != null)
+                if (_traySelectionAdorner is not null)
                 {
                     _traySelectionAdorner.Glyphs.Clear();
                     _traySelectionAdorner = null;
@@ -2625,12 +2625,12 @@ namespace System.Windows.Forms.Design
             public GlyphCollection GetGlyphsForComponent(IComponent comp)
             {
                 GlyphCollection glyphs = new GlyphCollection();
-                if (_behaviorSvc != null && comp != null)
+                if (_behaviorSvc is not null && comp is not null)
                 {
-                    if (_behaviorSvc.DesignerActionUI != null)
+                    if (_behaviorSvc.DesignerActionUI is not null)
                     {
                         Glyph g = _behaviorSvc.DesignerActionUI.GetDesignerActionGlyph(comp);
-                        if (g != null)
+                        if (g is not null)
                         {
                             glyphs.Add(g);
                         }
@@ -2648,7 +2648,7 @@ namespace System.Windows.Forms.Design
                 for (int i = 0; i < _traySelectionAdorner.Glyphs.Count; i++)
                 {
                     Cursor hitTestCursor = _traySelectionAdorner.Glyphs[i].GetHitTest(p);
-                    if (hitTestCursor != null)
+                    if (hitTestCursor is not null)
                     {
                         _hitTestedGlyph = _traySelectionAdorner.Glyphs[i];
                         return hitTestCursor;
@@ -2664,7 +2664,7 @@ namespace System.Windows.Forms.Design
             /// </summary>
             public bool OnMouseDoubleClick(MouseEventArgs e)
             {
-                if (_hitTestedGlyph != null && _hitTestedGlyph.Behavior != null)
+                if (_hitTestedGlyph is not null && _hitTestedGlyph.Behavior is not null)
                 {
                     return _hitTestedGlyph.Behavior.OnMouseDoubleClick(_hitTestedGlyph, e.Button, new Point(e.X, e.Y));
                 }
@@ -2677,7 +2677,7 @@ namespace System.Windows.Forms.Design
             /// </summary>
             public bool OnMouseDown(MouseEventArgs e)
             {
-                if (_hitTestedGlyph != null && _hitTestedGlyph.Behavior != null)
+                if (_hitTestedGlyph is not null && _hitTestedGlyph.Behavior is not null)
                 {
                     return _hitTestedGlyph.Behavior.OnMouseDown(_hitTestedGlyph, e.Button, new Point(e.X, e.Y));
                 }
@@ -2690,7 +2690,7 @@ namespace System.Windows.Forms.Design
             /// </summary>
             public bool OnMouseMove(MouseEventArgs e)
             {
-                if (_hitTestedGlyph != null && _hitTestedGlyph.Behavior != null)
+                if (_hitTestedGlyph is not null && _hitTestedGlyph.Behavior is not null)
                 {
                     return _hitTestedGlyph.Behavior.OnMouseMove(_hitTestedGlyph, e.Button, new Point(e.X, e.Y));
                 }
@@ -2703,7 +2703,7 @@ namespace System.Windows.Forms.Design
             /// </summary>
             public bool OnMouseUp(MouseEventArgs e)
             {
-                if (_hitTestedGlyph != null && _hitTestedGlyph.Behavior != null)
+                if (_hitTestedGlyph is not null && _hitTestedGlyph.Behavior is not null)
                 {
                     return _hitTestedGlyph.Behavior.OnMouseUp(_hitTestedGlyph, e.Button);
                 }
@@ -2743,7 +2743,7 @@ namespace System.Windows.Forms.Design
         {
             int IComparer<Control>.Compare(Control o1, Control o2)
             {
-                Debug.Assert(o1 != null && o2 != null, "Null objects sent for comparison!!!");
+                Debug.Assert(o1 is not null && o2 is not null, "Null objects sent for comparison!!!");
                 Point tcLoc1 = o1.Location;
                 Point tcLoc2 = o2.Location;
                 int height = o1.Height / 2;
@@ -2877,7 +2877,7 @@ namespace System.Windows.Forms.Design
             protected override bool CanDropDataObject(IDataObject dataObj)
             {
                 ICollection comps = null;
-                if (dataObj != null)
+                if (dataObj is not null)
                 {
                     if (dataObj is ComponentDataObjectWrapper cdow)
                     {
@@ -2914,7 +2914,7 @@ namespace System.Windows.Forms.Design
                     }
                 }
 
-                if (comps != null && comps.Count > 0)
+                if (comps is not null && comps.Count > 0)
                 {
                     foreach (object comp in comps)
                     {

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ContextMenuStripActionList.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ContextMenuStripActionList.cs
@@ -22,8 +22,8 @@ namespace System.Windows.Forms.Design
         private object GetProperty(string propertyName)
         {
             PropertyDescriptor getProperty = TypeDescriptor.GetProperties(_toolStripDropDown)[propertyName];
-            Debug.Assert(getProperty != null, "Could not find given property in control.");
-            if (getProperty != null)
+            Debug.Assert(getProperty is not null, "Could not find given property in control.");
+            if (getProperty is not null)
             {
                 return getProperty.GetValue(_toolStripDropDown);
             }
@@ -35,7 +35,7 @@ namespace System.Windows.Forms.Design
         private void ChangeProperty(string propertyName, object value)
         {
             PropertyDescriptor changingProperty = TypeDescriptor.GetProperties(_toolStripDropDown)[propertyName];
-            Debug.Assert(changingProperty != null, "Could not find given property in control.");
+            Debug.Assert(changingProperty is not null, "Could not find given property in control.");
             changingProperty?.SetValue(_toolStripDropDown, value);
         }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlCodeDomSerializer.cs
@@ -33,7 +33,7 @@ namespace System.Windows.Forms.Design
             IContainer container = (IContainer)manager.GetService(typeof(IContainer));
             ArrayList suspendedComponents = null;
 
-            if (container != null)
+            if (container is not null)
             {
                 suspendedComponents = new ArrayList(container.Components.Count);
 
@@ -41,7 +41,7 @@ namespace System.Windows.Forms.Design
                 {
                     Control control = comp as Control;
 
-                    if (control != null)
+                    if (control is not null)
                     {
                         control.SuspendLayout();
 
@@ -70,7 +70,7 @@ namespace System.Windows.Forms.Design
             finally
             {
                 //resume all suspended comps we found earlier
-                if (suspendedComponents != null)
+                if (suspendedComponents is not null)
                 {
                     foreach (Control c in suspendedComponents)
                     {
@@ -108,7 +108,7 @@ namespace System.Windows.Forms.Design
             {
                 InheritanceAttribute ia = (InheritanceAttribute)TypeDescriptor.GetAttributes(c)[typeof(InheritanceAttribute)];
 
-                if (ia != null && ia.InheritanceLevel != InheritanceLevel.NotInherited)
+                if (ia is not null && ia.InheritanceLevel != InheritanceLevel.NotInherited)
                 {
                     inheritedChildren = true;
                 }
@@ -135,12 +135,12 @@ namespace System.Windows.Forms.Design
 
             foreach (Control c in parent.Controls)
             {
-                if (c.Site != null && c.Site.DesignMode)
+                if (c.Site is not null && c.Site.DesignMode)
                 {
                     // We only emit Size/Location information for controls that are sited and not inherited readonly.
                     InheritanceAttribute ia = (InheritanceAttribute)TypeDescriptor.GetAttributes(c)[typeof(InheritanceAttribute)];
 
-                    if (ia != null && ia.InheritanceLevel != InheritanceLevel.InheritedReadOnly)
+                    if (ia is not null && ia.InheritanceLevel != InheritanceLevel.InheritedReadOnly)
                     {
                         return true;
                     }
@@ -173,7 +173,7 @@ namespace System.Windows.Forms.Design
             InheritanceAttribute inheritanceAttribute = (InheritanceAttribute)TypeDescriptor.GetAttributes(value)[typeof(InheritanceAttribute)];
             InheritanceLevel inheritanceLevel = InheritanceLevel.NotInherited;
 
-            if (inheritanceAttribute != null)
+            if (inheritanceAttribute is not null)
             {
                 inheritanceLevel = inheritanceAttribute.InheritanceLevel;
             }
@@ -189,11 +189,11 @@ namespace System.Windows.Forms.Design
                 // control.
                 IDesignerHost host = (IDesignerHost)manager.GetService(typeof(IDesignerHost));
 
-                if (host != null)
+                if (host is not null)
                 {
                     PropertyDescriptor prop = TypeDescriptor.GetProperties(host.RootComponent)["Localizable"];
 
-                    if (prop != null && prop.PropertyType == typeof(bool) && ((bool)prop.GetValue(host.RootComponent)))
+                    if (prop is not null && prop.PropertyType == typeof(bool) && ((bool)prop.GetValue(host.RootComponent)))
                     {
                         SerializeControlHierarchy(manager, host, value);
                     }
@@ -201,19 +201,19 @@ namespace System.Windows.Forms.Design
 
                 CodeStatementCollection csCollection = retVal as CodeStatementCollection;
 
-                if (csCollection != null)
+                if (csCollection is not null)
                 {
                     Control control = (Control)value;
 
                     // Serialize a suspend / resume pair.  We always serialize this
                     // for the root component
-                    if ((host != null && control == host.RootComponent) || HasSitedNonReadonlyChildren(control))
+                    if ((host is not null && control == host.RootComponent) || HasSitedNonReadonlyChildren(control))
                     {
                         SerializeSuspendLayout(manager, csCollection, value);
                         SerializeResumeLayout(manager, csCollection, value);
                         ControlDesigner controlDesigner = host.GetDesigner(control) as ControlDesigner;
 
-                        if (HasAutoSizedChildren(control) || (controlDesigner != null && controlDesigner.SerializePerformLayout))
+                        if (HasAutoSizedChildren(control) || (controlDesigner is not null && controlDesigner.SerializePerformLayout))
                         {
                             SerializePerformLayout(manager, csCollection, value);
                         }
@@ -238,7 +238,7 @@ namespace System.Windows.Forms.Design
         {
             Control control = value as Control;
 
-            if (control != null)
+            if (control is not null)
             {
                 // Object name
                 string name;
@@ -268,7 +268,7 @@ namespace System.Windows.Forms.Design
                         string componentName = manager.GetName(component);
                         string componentTypeName = mthelperSvc is null ? component.GetType().AssemblyQualifiedName : mthelperSvc.GetAssemblyQualifiedName(component.GetType());
 
-                        if (componentName != null)
+                        if (componentName is not null)
                         {
                             SerializeResourceInvariant(manager, ">>" + componentName + ".Name", componentName);
                             SerializeResourceInvariant(manager, ">>" + componentName + ".Type", componentTypeName);
@@ -295,7 +295,7 @@ namespace System.Windows.Forms.Design
                 // Parent
                 Control parent = control.Parent;
 
-                if (parent != null && parent.Site != null)
+                if (parent is not null && parent.Site is not null)
                 {
                     string parentName;
 
@@ -308,7 +308,7 @@ namespace System.Windows.Forms.Design
                         parentName = manager.GetName(parent);
                     }
 
-                    if (parentName != null)
+                    if (parentName is not null)
                     {
                         SerializeResourceInvariant(manager, ">>" + name + ".Parent", parentName);
                     }
@@ -363,14 +363,14 @@ namespace System.Windows.Forms.Design
                 paramTypes = ToTargetTypes(control, paramTypes);
                 MethodInfo mi = TypeDescriptor.GetReflectionType(control).GetMethod(methodName, BindingFlags.Public | BindingFlags.Instance, null, paramTypes, null);
 
-                if (mi != null)
+                if (mi is not null)
                 {
                     CodeExpression field = SerializeToExpression(manager, control);
                     CodeMethodReferenceExpression method = new CodeMethodReferenceExpression(field, methodName);
                     CodeMethodInvokeExpression methodInvoke = new CodeMethodInvokeExpression();
                     methodInvoke.Method = method;
 
-                    if (parameters != null)
+                    if (parameters is not null)
                     {
                         methodInvoke.Parameters.AddRange(parameters);
                     }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlCommandSet.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlCommandSet.cs
@@ -267,7 +267,7 @@ namespace System.Windows.Forms.Design
                                   MenuCommands.KeySelectPrevious),
             };
 
-            if (MenuService != null)
+            if (MenuService is not null)
             {
                 for (int i = 0; i < commandSet.Length; i++)
                 {
@@ -278,10 +278,10 @@ namespace System.Windows.Forms.Design
             // Get the base control object.
             //
             IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
-            if (host != null)
+            if (host is not null)
             {
                 Control comp = host.RootComponent as Control;
-                if (comp != null)
+                if (comp is not null)
                 {
                     baseControl = comp;
                 }
@@ -326,7 +326,7 @@ namespace System.Windows.Forms.Design
                 // walk up the parent chain, checking each component to see if it's
                 // in the selection list.  If it is, we've got a bad selection.
                 //
-                for (Control parent = c.Parent; parent != null; parent = parent.Parent)
+                for (Control parent = c.Parent; parent is not null; parent = parent.Parent)
                 {
                     // if this parent has already been okayed, skip it.
                     //
@@ -336,7 +336,7 @@ namespace System.Windows.Forms.Design
                     }
 
                     object hashItem = itemHash[parent];
-                    if (hashItem != null && hashItem != component)
+                    if (hashItem is not null && hashItem != component)
                     {
                         return false;
                     }
@@ -358,7 +358,7 @@ namespace System.Windows.Forms.Design
         // We don't need to Dispose baseControl
         public override void Dispose()
         {
-            if (MenuService != null)
+            if (MenuService is not null)
             {
                 for (int i = 0; i < commandSet.Length; i++)
                 {
@@ -367,7 +367,7 @@ namespace System.Windows.Forms.Design
                 }
             }
 
-            if (tabOrder != null)
+            if (tabOrder is not null)
             {
                 tabOrder.Dispose();
                 tabOrder = null;
@@ -392,16 +392,16 @@ namespace System.Windows.Forms.Design
             // snap property.  If it fails to find one, it just gets the base component.
             //
             Control ctrl = component as Control;
-            if (ctrl != null)
+            if (ctrl is not null)
             {
                 Control c = ctrl.Parent;
-                while (c != null && currentSnapComponent is null)
+                while (c is not null && currentSnapComponent is null)
                 {
                     props = TypeDescriptor.GetProperties(c);
                     currentSnapProp = props["SnapToGrid"];
-                    if (currentSnapProp != null)
+                    if (currentSnapProp is not null)
                     {
-                        if (currentSnapProp.PropertyType == typeof(bool) && c.Site != null && c.Site.Container == container)
+                        if (currentSnapProp.PropertyType == typeof(bool) && c.Site is not null && c.Site.Container == container)
                         {
                             currentSnapComponent = c;
                         }
@@ -422,7 +422,7 @@ namespace System.Windows.Forms.Design
             if (currentSnapProp is null)
             {
                 currentSnapProp = props["SnapToGrid"];
-                if (currentSnapProp != null && currentSnapProp.PropertyType != typeof(bool))
+                if (currentSnapProp is not null && currentSnapProp.PropertyType != typeof(bool))
                 {
                     currentSnapProp = null;
                 }
@@ -431,7 +431,7 @@ namespace System.Windows.Forms.Design
             if (gridSizeProp is null)
             {
                 gridSizeProp = props["GridSize"];
-                if (gridSizeProp != null && gridSizeProp.PropertyType != typeof(Size))
+                if (gridSizeProp is not null && gridSizeProp.PropertyType != typeof(Size))
                 {
                     gridSizeProp = null;
                 }
@@ -442,7 +442,7 @@ namespace System.Windows.Forms.Design
             //
             snapComponent = currentSnapComponent;
             snapProperty = currentSnapProp;
-            if (gridSizeProp != null)
+            if (gridSizeProp is not null)
             {
                 snapSize = (Size)gridSizeProp.GetValue(snapComponent);
             }
@@ -480,7 +480,7 @@ namespace System.Windows.Forms.Design
             ArrayList lines = new ArrayList(2);
 
             Point pt = BehaviorService.ControlToAdornerWindow(primaryControl);
-            bool fRTL = (primaryControl.Parent != null && primaryControl.Parent.IsMirrored);
+            bool fRTL = (primaryControl.Parent is not null && primaryControl.Parent.IsMirrored);
 
             //remember that snaplines must be in adornerwindow coordinates
 
@@ -530,24 +530,24 @@ namespace System.Windows.Forms.Design
             // Arrow keys.  Begin a drag if the selection isn't locked.
             //
             ISelectionService selSvc = SelectionService;
-            if (selSvc != null)
+            if (selSvc is not null)
             {
                 IComponent comp = selSvc.PrimarySelection as IComponent;
-                if (comp != null)
+                if (comp is not null)
                 {
                     IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
-                    if (host != null)
+                    if (host is not null)
                     {
                         //This will excluded components in the ComponentTray, but that's okay, they are not resizable to begin with.
                         ControlDesigner des = host.GetDesigner(comp) as ControlDesigner;
-                        if (des != null && ((des.SelectionRules & SelectionRules.Locked) == 0))
+                        if (des is not null && ((des.SelectionRules & SelectionRules.Locked) == 0))
                         {
                             //Possibly flip our size adjustments depending on the dock prop of the control.
                             //EX: If the control is docked right, then shift+left arrow will cause
                             //the control's width to decrease when it should increase
                             bool flipOffset = false;
                             PropertyDescriptor dockProp = TypeDescriptor.GetProperties(comp)["Dock"];
-                            if (dockProp != null)
+                            if (dockProp is not null)
                             {
                                 DockStyle docked = (DockStyle)dockProp.GetValue(comp);
                                 flipOffset = (docked == DockStyle.Bottom) || (docked == DockStyle.Right);
@@ -624,14 +624,14 @@ namespace System.Windows.Forms.Design
                             {
                                 //if we can find the behaviorservice, then we can use it and the SnapLineEngine to help us
                                 //move these controls...
-                                if (BehaviorService != null)
+                                if (BehaviorService is not null)
                                 {
                                     Control primaryControl = comp as Control;
 
                                     bool useSnapLines = BehaviorService.UseSnapLines;
 
                                     // If we have previous snaplines, we always want to erase them, no matter what. VS Whidbey #397709
-                                    if (dragManager != null)
+                                    if (dragManager is not null)
                                     {
                                         EndDragManager();
                                     }
@@ -700,7 +700,7 @@ namespace System.Windows.Forms.Design
 
                                         GetSnapInformation(host, comp, out snapSize, out snapComponent, out snapProperty);
 
-                                        if (snapProperty != null)
+                                        if (snapProperty is not null)
                                         {
                                             snapOn = (bool)snapProperty.GetValue(snapComponent);
                                         }
@@ -708,7 +708,7 @@ namespace System.Windows.Forms.Design
                                         if (snapOn && !snapSize.IsEmpty)
                                         {
                                             ParentControlDesigner parentDesigner = host.GetDesigner(primaryControl.Parent) as ParentControlDesigner;
-                                            if (parentDesigner != null)
+                                            if (parentDesigner is not null)
                                             {
                                                 //ask the parent to adjust our wanna-be snapped position
                                                 moveOffsetX *= snapSize.Width;
@@ -769,7 +769,7 @@ namespace System.Windows.Forms.Design
                                     foreach (IComponent component in selSvc.GetSelectedComponents())
                                     {
                                         des = host.GetDesigner(component) as ControlDesigner;
-                                        if (des != null && ((des.SelectionRules & rules) != rules))
+                                        if (des is not null && ((des.SelectionRules & rules) != rules))
                                         {
                                             //the control must match the rules, if not, then we don't resize it
                                             continue;
@@ -777,20 +777,20 @@ namespace System.Windows.Forms.Design
 
                                         Control control = component as Control;
 
-                                        if (control != null)
+                                        if (control is not null)
                                         {
                                             int offsetY = moveOffsetY; //we don't want to change moveOFfsetY for all subsequent controls, so cache it off
 
                                             if (checkForIntegralHeight)
                                             {
                                                 PropertyDescriptor propIntegralHeight = TypeDescriptor.GetProperties(component)["IntegralHeight"];
-                                                if (propIntegralHeight != null)
+                                                if (propIntegralHeight is not null)
                                                 {
                                                     object value = propIntegralHeight.GetValue(component);
                                                     if (value is bool && (bool)value)
                                                     {
                                                         PropertyDescriptor propItemHeight = TypeDescriptor.GetProperties(component)["ItemHeight"];
-                                                        if (propItemHeight != null)
+                                                        if (propItemHeight is not null)
                                                         {
                                                             offsetY *= (int)propItemHeight.GetValue(component); //adjust for integralheight
                                                         }
@@ -799,7 +799,7 @@ namespace System.Windows.Forms.Design
                                             }
 
                                             PropertyDescriptor propSize = TypeDescriptor.GetProperties(component)["Size"];
-                                            if (propSize != null)
+                                            if (propSize is not null)
                                             {
                                                 Size size = (Size)propSize.GetValue(component);
                                                 size += new Size(moveOffsetX, offsetY);
@@ -808,7 +808,7 @@ namespace System.Windows.Forms.Design
                                         }
 
                                         //change the Status information ....
-                                        if (control == selSvc.PrimarySelection && statusCommandUI != null)
+                                        if (control == selSvc.PrimarySelection && statusCommandUI is not null)
                                         {
                                             statusCommandUI.SetStatusInformation(control);
                                         }
@@ -820,7 +820,7 @@ namespace System.Windows.Forms.Design
                             {
                                 trans?.Commit();
 
-                                if (dragManager != null)
+                                if (dragManager is not null)
                                 {
                                     //start our timer for the snaplines
                                     SnapLineTimer.Start();
@@ -865,11 +865,11 @@ namespace System.Windows.Forms.Design
 
                 IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
 
-                if (host != null)
+                if (host is not null)
                 {
                     ComponentCollection components = host.Container.Components;
 
-                    if (components != null && components.Count > 0)
+                    if (components is not null && components.Count > 0)
                     {
                         DesignerTransaction trans = null;
 
@@ -940,8 +940,8 @@ namespace System.Windows.Forms.Design
             MenuCommand cmd = (MenuCommand)sender;
             if (cmd.Checked)
             {
-                Debug.Assert(tabOrder != null, "Tab order and menu enabling are out of sync");
-                if (tabOrder != null)
+                Debug.Assert(tabOrder is not null, "Tab order and menu enabling are out of sync");
+                if (tabOrder is not null)
                 {
                     tabOrder.Dispose();
                     tabOrder = null;
@@ -956,10 +956,10 @@ namespace System.Windows.Forms.Design
                 //
                 ISelectionService selSvc = SelectionService;
                 IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
-                if (host != null && selSvc != null)
+                if (host is not null && selSvc is not null)
                 {
                     object baseComp = host.RootComponent;
-                    if (baseComp != null)
+                    if (baseComp is not null)
                     {
                         selSvc.SetSelectedComponents(new object[] { baseComp }, SelectionTypes.Replace);
                     }
@@ -982,7 +982,7 @@ namespace System.Windows.Forms.Design
             MenuCommand cmd = (MenuCommand)sender;
             CommandID cmdID = cmd.CommandID;
 
-            Debug.Assert(SelectionService != null, "Need SelectionService for sizing command");
+            Debug.Assert(SelectionService is not null, "Need SelectionService for sizing command");
 
             if (SelectionService is null)
             {
@@ -1033,13 +1033,13 @@ namespace System.Windows.Forms.Design
                             // If SplitterPanel is selected and you choose the SendToBack (or BringToFront) option then it should
                             // perform the operation on the Owner (namely SplitContainer)
                             IComponent selComp = selectedComponents[i] as IComponent;
-                            if (selComp != null)
+                            if (selComp is not null)
                             {
                                 INestedSite nestedSite = selComp.Site as INestedSite;
-                                if (nestedSite != null)
+                                if (nestedSite is not null)
                                 {
                                     INestedContainer nestedContainer = nestedSite.Container as INestedContainer;
-                                    if (nestedContainer != null)
+                                    if (nestedContainer is not null)
                                     {
                                         control = nestedContainer.Owner as Control;
                                         selectedComponents[i] = control; // set this so that we don't have to re-do this logic in the BringToFront case down.
@@ -1047,20 +1047,20 @@ namespace System.Windows.Forms.Design
                                 }
                             }
 
-                            if (control != null)
+                            if (control is not null)
                             {
                                 Control parent = control.Parent;
                                 PropertyDescriptor controlsProp = null;
-                                if (parent != null)
+                                if (parent is not null)
                                 {
-                                    if (ccs != null)
+                                    if (ccs is not null)
                                     {
                                         try
                                         {
                                             if (!parentList.Contains(parent))
                                             {
                                                 controlsProp = TypeDescriptor.GetProperties(parent)["Controls"];
-                                                if (controlsProp != null)
+                                                if (controlsProp is not null)
                                                 {
                                                     // For a perf improvement, we will
                                                     // call OnComponentChanging only once per parent to make sure we do not do unnecessary serialization for Undo
@@ -1118,13 +1118,13 @@ namespace System.Windows.Forms.Design
                 finally
                 {
                     // Do not fire changed events if the transaction was canceled
-                    if ((null != trans) && !trans.Canceled)
+                    if ((trans is not null) && !trans.Canceled)
                     {
                         foreach (Control parent in parentList)
                         {
                             PropertyDescriptor controlsProp = TypeDescriptor.GetProperties(parent)["Controls"];
-                            Debug.Assert(ccs != null && controlsProp != null, "Wrong parent in parent list");
-                            if (ccs != null && controlsProp != null)
+                            Debug.Assert(ccs is not null && controlsProp is not null, "Wrong parent in parent list");
+                            if (ccs is not null && controlsProp is not null)
                             {
                                 ccs.OnComponentChanged(parent, controlsProp);
                             }
@@ -1155,7 +1155,7 @@ namespace System.Windows.Forms.Design
         {
             MenuCommand cmd = (MenuCommand)sender;
             bool enabled = false;
-            if (baseControl != null && baseControl.Controls.Count > 0)
+            if (baseControl is not null && baseControl.Controls.Count > 0)
             {
                 enabled = true;
             }
@@ -1201,7 +1201,7 @@ namespace System.Windows.Forms.Design
             //Get the locked property of the base control first...
             //
             PropertyDescriptor lockedProp = TypeDescriptor.GetProperties(baseControl)["Locked"];
-            if (lockedProp != null && ((bool)lockedProp.GetValue(baseControl)))
+            if (lockedProp is not null && ((bool)lockedProp.GetValue(baseControl)))
             {
                 cmd.Checked = true;
                 return;
@@ -1219,7 +1219,7 @@ namespace System.Windows.Forms.Design
             foreach (object component in baseDesigner.AssociatedComponents)
             {
                 lockedProp = TypeDescriptor.GetProperties(component)["Locked"];
-                if (lockedProp != null && ((bool)lockedProp.GetValue(component)))
+                if (lockedProp is not null && ((bool)lockedProp.GetValue(component)))
                 {
                     cmd.Checked = true;
                     return;
@@ -1245,7 +1245,7 @@ namespace System.Windows.Forms.Design
         protected void OnStatusMultiSelectPrimary(object sender, EventArgs e)
         {
             MenuCommand cmd = (MenuCommand)sender;
-            cmd.Enabled = controlsOnlySelection && selCount > 1 && primarySelection != null;
+            cmd.Enabled = controlsOnlySelection && selCount > 1 && primarySelection is not null;
         }
 
         /// <summary>
@@ -1267,18 +1267,18 @@ namespace System.Windows.Forms.Design
         /// </summary>
         protected void OnStatusShowGrid(object sender, EventArgs e)
         {
-            if (site != null)
+            if (site is not null)
             {
                 IDesignerHost host = (IDesignerHost)site.GetService(typeof(IDesignerHost));
-                Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || host != null, "IDesignerHost not found");
+                Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || host is not null, "IDesignerHost not found");
 
-                if (host != null)
+                if (host is not null)
                 {
                     IComponent baseComponent = host.RootComponent;
-                    if (baseComponent != null && baseComponent is Control)
+                    if (baseComponent is not null && baseComponent is Control)
                     {
                         PropertyDescriptor prop = GetProperty(baseComponent, "DrawGrid");
-                        if (prop != null)
+                        if (prop is not null)
                         {
                             bool drawGrid = (bool)prop.GetValue(baseComponent);
                             MenuCommand cmd = (MenuCommand)sender;
@@ -1296,18 +1296,18 @@ namespace System.Windows.Forms.Design
         /// </summary>
         protected void OnStatusSnapToGrid(object sender, EventArgs e)
         {
-            if (site != null)
+            if (site is not null)
             {
                 IDesignerHost host = (IDesignerHost)site.GetService(typeof(IDesignerHost));
-                Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || host != null, "IDesignerHost not found");
+                Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || host is not null, "IDesignerHost not found");
 
-                if (host != null)
+                if (host is not null)
                 {
                     IComponent baseComponent = host.RootComponent;
-                    if (baseComponent != null && baseComponent is Control)
+                    if (baseComponent is not null && baseComponent is Control)
                     {
                         PropertyDescriptor prop = GetProperty(baseComponent, "SnapToGrid");
-                        if (prop != null)
+                        if (prop is not null)
                         {
                             bool snapToGrid = (bool)prop.GetValue(baseComponent);
                             MenuCommand cmd = (MenuCommand)sender;
@@ -1331,18 +1331,18 @@ namespace System.Windows.Forms.Design
         {
             MenuCommand cmd = (MenuCommand)sender;
             IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
-            if (host != null)
+            if (host is not null)
             {
                 ComponentCollection comps = host.Container.Components;
                 object baseComp = host.RootComponent;
 
                 // The form by itself is one component, so this means
                 // we need more than two.
-                bool enable = (comps != null && comps.Count > 2 && controlsOnlySelection);
+                bool enable = (comps is not null && comps.Count > 2 && controlsOnlySelection);
 
                 if (enable)
                 {
-                    Debug.Assert(SelectionService != null, "Need SelectionService for sizing command");
+                    Debug.Assert(SelectionService is not null, "Need SelectionService for sizing command");
 
                     if (SelectionService is null)
                     {
@@ -1417,7 +1417,7 @@ namespace System.Windows.Forms.Design
 
             Control component = selSvc.PrimarySelection as Control;
             Control current;
-            if (component != null)
+            if (component is not null)
             {
                 current = component;
             }
@@ -1428,7 +1428,7 @@ namespace System.Windows.Forms.Design
 
             if (backwards)
             {
-                if (current != null)
+                if (current is not null)
                 {
                     if (current.Controls.Count > 0)
                     {
@@ -1442,12 +1442,12 @@ namespace System.Windows.Forms.Design
             }
             else
             {
-                if (current != null)
+                if (current is not null)
                 {
                     next = current.Parent;
                     Control nextControl = next as Control;
                     IContainer controlSiteContainer = null;
-                    if (nextControl != null && nextControl.Site != null)
+                    if (nextControl is not null && nextControl.Site is not null)
                     {
                         controlSiteContainer = DesignerUtils.CheckForNestedContainer(nextControl.Site.Container); // ...necessary to support SplitterPanel components
                     }
@@ -1492,14 +1492,14 @@ namespace System.Windows.Forms.Design
             currentSelection = selSvc.PrimarySelection;
             ctl = currentSelection as Control;
 
-            if (targetSelection is null && ctl != null && (baseCtl.Contains(ctl) || baseCtl == currentSelection))
+            if (targetSelection is null && ctl is not null && (baseCtl.Contains(ctl) || baseCtl == currentSelection))
             {
                 // Our current selection is a control.  Select the next control in
                 // the z-order.
                 //
-                while (null != (ctl = GetNextControlInTab(baseCtl, ctl, !backwards)))
+                while ((ctl = GetNextControlInTab(baseCtl, ctl, !backwards)) is not null)
                 {
-                    if (ctl.Site != null && ctl.Site.Container == ctl.Container)
+                    if (ctl.Site is not null && ctl.Site.Container == ctl.Container)
                     {
                         break;
                     }
@@ -1511,21 +1511,21 @@ namespace System.Windows.Forms.Design
             if (targetSelection is null)
             {
                 ComponentTray tray = (ComponentTray)GetService(typeof(ComponentTray));
-                if (tray != null)
+                if (tray is not null)
                 {
                     targetSelection = tray.GetNextComponent((IComponent)currentSelection, !backwards);
-                    if (targetSelection != null)
+                    if (targetSelection is not null)
                     {
                         IComponent selection = targetSelection as IComponent;
                         ControlDesigner controlDesigner = host.GetDesigner(selection) as ControlDesigner;
                         // In Whidbey controls like ToolStrips have componentTray presence, So don't select them again
                         // through component tray since here we select only Components. Hence only
                         // components that have ComponentDesigners should be selected via the ComponentTray.
-                        while (controlDesigner != null)
+                        while (controlDesigner is not null)
                         {
                             // if the targetSelection from the Tray is a control .. try the next one.
                             selection = tray.GetNextComponent(selection, !backwards);
-                            if (selection != null)
+                            if (selection is not null)
                             {
                                 controlDesigner = host.GetDesigner(selection) as ControlDesigner;
                             }
@@ -1549,7 +1549,7 @@ namespace System.Windows.Forms.Design
             {
                 Control.ControlCollection ctlControls = ctl.Controls;
 
-                if (ctlControls != null && ctlControls.Count > 0)
+                if (ctlControls is not null && ctlControls.Count > 0)
                 {
                     Control found = null;
 
@@ -1581,7 +1581,7 @@ namespace System.Windows.Forms.Design
 
                     Control.ControlCollection parentControls = p.Controls;
 
-                    if (parentControls != null)
+                    if (parentControls is not null)
                     {
                         parentControlCount = parentControls.Count;
                     }
@@ -1625,7 +1625,7 @@ namespace System.Windows.Forms.Design
                         }
                     }
 
-                    if (found != null)
+                    if (found is not null)
                     {
                         return found;
                     }
@@ -1649,7 +1649,7 @@ namespace System.Windows.Forms.Design
 
                     Control.ControlCollection parentControls = p.Controls;
 
-                    if (parentControls != null)
+                    if (parentControls is not null)
                     {
                         parentControlCount = parentControls.Count;
                     }
@@ -1696,7 +1696,7 @@ namespace System.Windows.Forms.Design
                     // If we were unable to find a control we should return the control's parent.  However, if that parent is us, return
                     // NULL.
                     //
-                    if (found != null)
+                    if (found is not null)
                     {
                         ctl = found;
                     }
@@ -1717,7 +1717,7 @@ namespace System.Windows.Forms.Design
                 //
                 Control.ControlCollection ctlControls = ctl.Controls;
 
-                while (ctlControls != null && ctlControls.Count > 0)
+                while (ctlControls is not null && ctlControls.Count > 0)
                 {
                     Control found = null;
 
@@ -1768,7 +1768,7 @@ namespace System.Windows.Forms.Design
 
                 Control cX = x as Control;
                 Control cY = y as Control;
-                if (cX != null && cY != null)
+                if (cX is not null && cY is not null)
                 {
                     if (cX.Parent == cY.Parent)
                     {
@@ -1800,11 +1800,11 @@ namespace System.Windows.Forms.Design
                         return PARAM.ToInt(cX.Parent.Handle) - PARAM.ToInt(cY.Parent.Handle);
                     }
                 }
-                else if (cY != null)
+                else if (cY is not null)
                 {
                     return -1;
                 }
-                else if (cX != null)
+                else if (cX is not null)
                 {
                     return 1;
                 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.ChildSubClass.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.ChildSubClass.cs
@@ -17,7 +17,7 @@ namespace System.Windows.Forms.Design
             public ChildSubClass(ControlDesigner designer, IntPtr hwnd)
             {
                 _designer = designer;
-                if (designer != null)
+                if (designer is not null)
                 {
                     designer.DisposingHandler += new EventHandler(OnDesignerDisposing);
                 }
@@ -67,7 +67,7 @@ namespace System.Windows.Forms.Design
                 finally
                 {
                     // make sure the designer wasn't destroyed
-                    if (_designer != null && _designer.Component != null)
+                    if (_designer is not null && _designer.Component is not null)
                     {
                         _designer.DesignerTarget = designerTarget;
                     }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.ControlDesignerAccessibleObject.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.ControlDesignerAccessibleObject.cs
@@ -48,7 +48,7 @@ namespace System.Windows.Forms.Design
                 {
                     AccessibleStates state = _control.AccessibilityObject.State;
                     ISelectionService s = SelectionService;
-                    if (s != null)
+                    if (s is not null)
                     {
                         if (s.GetComponentSelected(_control))
                         {
@@ -76,7 +76,7 @@ namespace System.Windows.Forms.Design
                 if (_control.AccessibilityObject.GetChild(index) is Control.ControlAccessibleObject childAccObj)
                 {
                     AccessibleObject cao = GetDesignerAccessibleObject(childAccObj);
-                    if (cao != null)
+                    if (cao is not null)
                     {
                         return cao;
                     }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.DesignerControlCollection.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.DesignerControlCollection.cs
@@ -68,8 +68,8 @@ namespace System.Windows.Forms.Design
             {
                 for (int i = _realCollection.Count - 1; i >= 0; i--)
                 {
-                    if (_realCollection[i] != null &&
-                        _realCollection[i].Site != null &&
+                    if (_realCollection[i] is not null &&
+                        _realCollection[i].Site is not null &&
                         TypeDescriptor.GetAttributes(_realCollection[i]).Contains(InheritanceAttribute.NotInherited))
                     {
                         _realCollection.RemoveAt(i);

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.DesignerControlCollectionCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.DesignerControlCollectionCodeDomSerializer.cs
@@ -23,11 +23,11 @@ namespace System.Windows.Forms.Design
                 ICollection valuesToSerialize)
             {
                 ArrayList subset = new ArrayList();
-                if (valuesToSerialize != null && valuesToSerialize.Count > 0)
+                if (valuesToSerialize is not null && valuesToSerialize.Count > 0)
                 {
                     foreach (object val in valuesToSerialize)
                     {
-                        if (val is IComponent comp && comp.Site != null && !(comp.Site is INestedSite))
+                        if (val is IComponent comp && comp.Site is not null && !(comp.Site is INestedSite))
                         {
                             subset.Add(comp);
                         }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.DesignerWindowTarget.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.DesignerWindowTarget.cs
@@ -26,7 +26,7 @@ namespace System.Windows.Forms.Design
 
             public void Dispose()
             {
-                if (_designer != null)
+                if (_designer is not null)
                 {
                     _designer.Control.WindowTarget = _oldTarget;
                     _designer = null;
@@ -48,7 +48,7 @@ namespace System.Windows.Forms.Design
                 // to do default processing with the designer's DefWndProc.  So, we stuff ourselves into the designers
                 // window target and call their WndProc.
                 ControlDesigner currentDesigner = _designer;
-                if (currentDesigner != null)
+                if (currentDesigner is not null)
                 {
                     IDesignerTarget designerTarget = currentDesigner.DesignerTarget;
                     currentDesigner.DesignerTarget = this;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.DockingActionList.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.DockingActionList.cs
@@ -23,7 +23,7 @@ namespace System.Windows.Forms.Design
             private string GetActionName()
             {
                 PropertyDescriptor dockProp = TypeDescriptor.GetProperties(Component)["Dock"];
-                if (dockProp != null)
+                if (dockProp is not null)
                 {
                     DockStyle dockStyle = (DockStyle)dockProp.GetValue(Component);
                     if (dockStyle == DockStyle.Fill)
@@ -43,7 +43,7 @@ namespace System.Windows.Forms.Design
             {
                 DesignerActionItemCollection items = new DesignerActionItemCollection();
                 string actionName = GetActionName();
-                if (actionName != null)
+                if (actionName is not null)
                 {
                     items.Add(new DesignerActionVerbItem(new DesignerVerb(GetActionName(), OnDockActionClick)));
                 }
@@ -53,7 +53,7 @@ namespace System.Windows.Forms.Design
 
             private void OnDockActionClick(object sender, EventArgs e)
             {
-                if (sender is DesignerVerb designerVerb && _host != null)
+                if (sender is DesignerVerb designerVerb && _host is not null)
                 {
                     using DesignerTransaction t = _host.CreateTransaction(designerVerb.Text);
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.TransparentBehavior.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.TransparentBehavior.cs
@@ -44,7 +44,7 @@ namespace System.Windows.Forms.Design
             /// </summary>
             public override void OnDragEnter(Glyph g, DragEventArgs e)
             {
-                if (_designer != null && _designer.Control != null)
+                if (_designer is not null && _designer.Control is not null)
                 {
                     _controlRect = _designer.Control.RectangleToScreen(_designer.Control.ClientRectangle);
                 }
@@ -69,7 +69,7 @@ namespace System.Windows.Forms.Design
                 // If we are not over a valid drop area, then do not allow the drag/drop. Now that all
                 // dragging/dropping is done via the behavior service and adorner window, we have to do our own
                 // validation, and cannot rely on the OS to do it for us.
-                if (e != null && _controlRect != Rectangle.Empty && !_controlRect.Contains(new Point(e.X, e.Y)))
+                if (e is not null && _controlRect != Rectangle.Empty && !_controlRect.Contains(new Point(e.X, e.Y)))
                 {
                     e.Effect = DragDropEffects.None;
                     return;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
@@ -91,7 +91,7 @@ namespace System.Windows.Forms.Design
                 Point loc = Control.Location;
 
                 ScrollableControl p = Control.Parent as ScrollableControl;
-                if (p != null)
+                if (p is not null)
                 {
                     Point pt = p.AutoScrollPosition;
                     loc.Offset(-pt.X, -pt.Y);
@@ -102,7 +102,7 @@ namespace System.Windows.Forms.Design
             set
             {
                 ScrollableControl p = Control.Parent as ScrollableControl;
-                if (p != null)
+                if (p is not null)
                 {
                     Point pt = p.AutoScrollPosition;
                     value.Offset(pt.X, pt.Y);
@@ -123,7 +123,7 @@ namespace System.Windows.Forms.Design
                 ArrayList sitedChildren = null;
                 foreach (Control c in Control.Controls)
                 {
-                    if (c.Site != null)
+                    if (c.Site is not null)
                     {
                         sitedChildren ??= new ArrayList();
 
@@ -131,7 +131,7 @@ namespace System.Windows.Forms.Design
                     }
                 }
 
-                if (sitedChildren != null)
+                if (sitedChildren is not null)
                 {
                     return sitedChildren;
                 }
@@ -180,7 +180,7 @@ namespace System.Windows.Forms.Design
             {
                 // don't do anything here during loading, if a refactor changed it we don't want to do anything
                 IDesignerHost host = GetService(typeof(IDesignerHost)) as IDesignerHost;
-                if (host is null || (host != null && !host.Loading))
+                if (host is null || (host is not null && !host.Loading))
                 {
                     Component.Site.Name = value;
                 }
@@ -196,7 +196,7 @@ namespace System.Windows.Forms.Design
         {
             get
             {
-                if (Component is Control c && c.Parent != null)
+                if (Component is Control c && c.Parent is not null)
                 {
                     return c.Parent;
                 }
@@ -235,12 +235,12 @@ namespace System.Windows.Forms.Design
                 PropertyDescriptor autoSizeProp = props["AutoSize"];
                 PropertyDescriptor autoSizeModeProp = props["AutoSizeMode"];
 
-                if ((prop = props["Location"]) != null && !prop.IsReadOnly)
+                if ((prop = props["Location"]) is not null && !prop.IsReadOnly)
                 {
                     rules |= SelectionRules.Moveable;
                 }
 
-                if ((prop = props["Size"]) != null && !prop.IsReadOnly)
+                if ((prop = props["Size"]) is not null && !prop.IsReadOnly)
                 {
                     if (AutoResizeHandles && Component != _host.RootComponent)
                     {
@@ -255,14 +255,14 @@ namespace System.Windows.Forms.Design
                 }
 
                 PropertyDescriptor propDock = props["Dock"];
-                if (propDock != null)
+                if (propDock is not null)
                 {
                     DockStyle dock = (DockStyle)(int)propDock.GetValue(component);
 
                     // gotta adjust if the control's parent is mirrored... this is just such that we add the right
                     // resize handles. We need to do it this way, since resize glyphs are added in  AdornerWindow
                     // coords, and the AdornerWindow is never mirrored.
-                    if (Control.Parent != null && Control.Parent.IsMirrored)
+                    if (Control.Parent is not null && Control.Parent.IsMirrored)
                     {
                         if (dock == DockStyle.Left)
                         {
@@ -295,7 +295,7 @@ namespace System.Windows.Forms.Design
                 }
 
                 PropertyDescriptor pd = props["Locked"];
-                if (pd != null)
+                if (pd is not null)
                 {
                     object value = pd.GetValue(component);
 
@@ -338,14 +338,13 @@ namespace System.Windows.Forms.Design
             bool growOnly = false;
 
             AttributeCollection attributes = autoSizeProp?.Attributes;
-            if (attributes != null
-                && !(attributes.Contains(DesignerSerializationVisibilityAttribute.Hidden)
+            if (attributes is not null && !(attributes.Contains(DesignerSerializationVisibilityAttribute.Hidden)
                     || attributes.Contains(BrowsableAttribute.No)))
             {
                 autoSize = (bool)autoSizeProp.GetValue(component);
             }
 
-            if (autoSizeModeProp != null)
+            if (autoSizeModeProp is not null)
             {
                 AutoSizeMode mode = (AutoSizeMode)autoSizeModeProp.GetValue(component);
                 growOnly = mode == AutoSizeMode.GrowOnly;
@@ -396,7 +395,7 @@ namespace System.Windows.Forms.Design
         {
             get
             {
-                Debug.Assert(Component != null, "this.component needs to be set before this method is valid.");
+                Debug.Assert(Component is not null, "this.component needs to be set before this method is valid.");
                 return TryGetService(out IDesignerHost host) && Component == host.RootComponent;
             }
         }
@@ -471,14 +470,14 @@ namespace System.Windows.Forms.Design
         {
             if (disposing)
             {
-                if (Control != null)
+                if (Control is not null)
                 {
-                    if (_dataBindingsCollectionChanged != null)
+                    if (_dataBindingsCollectionChanged is not null)
                     {
                         Control.DataBindings.CollectionChanged -= _dataBindingsCollectionChanged;
                     }
 
-                    if (Inherited && _inheritanceUI != null)
+                    if (Inherited && _inheritanceUI is not null)
                     {
                         _inheritanceUI.RemoveInheritedControl(Control);
                     }
@@ -501,7 +500,7 @@ namespace System.Windows.Forms.Design
 
                 _downPos = Point.Empty;
 
-                if (Control != null)
+                if (Control is not null)
                 {
                     Control.ControlAdded -= new ControlEventHandler(OnControlAdded);
                     Control.ControlRemoved -= new ControlEventHandler(OnControlRemoved);
@@ -710,7 +709,7 @@ namespace System.Windows.Forms.Design
             ControlBodyGlyph g = null;
             Control parent = Control.Parent;
 
-            if (parent != null && _host != null && _host.RootComponent != Component)
+            if (parent is not null && _host is not null && _host.RootComponent != Component)
             {
                 Rectangle parentRect = parent.RectangleToScreen(parent.ClientRectangle);
                 Rectangle controlRect = Control.RectangleToScreen(Control.ClientRectangle);
@@ -786,10 +785,10 @@ namespace System.Windows.Forms.Design
 
                 // enable the designeractionpanel for this control if it needs one
                 if (TypeDescriptor.GetAttributes(Component).Contains(DesignTimeVisibleAttribute.Yes)
-                    && _behaviorService.DesignerActionUI != null)
+                    && _behaviorService.DesignerActionUI is not null)
                 {
                     Glyph dapGlyph = _behaviorService.DesignerActionUI.GetDesignerActionGlyph(Component);
-                    if (dapGlyph != null)
+                    if (dapGlyph is not null)
                     {
                         glyphs.Insert(0, dapGlyph); // we WANT to be in front of the other UI
                     }
@@ -844,10 +843,10 @@ namespace System.Windows.Forms.Design
 
                 // enable the designeractionpanel for this control if it needs one
                 if (TypeDescriptor.GetAttributes(Component).Contains(DesignTimeVisibleAttribute.Yes)
-                    && _behaviorService.DesignerActionUI != null)
+                    && _behaviorService.DesignerActionUI is not null)
                 {
                     Glyph dapGlyph = _behaviorService.DesignerActionUI.GetDesignerActionGlyph(Component);
-                    if (dapGlyph != null)
+                    if (dapGlyph is not null)
                     {
                         glyphs.Insert(0, dapGlyph); // we WANT to be in front of the other UI
                     }
@@ -953,7 +952,7 @@ namespace System.Windows.Forms.Design
             // This is to create the action in the DAP for this component if it requires docking/undocking logic
             AttributeCollection attributes = TypeDescriptor.GetAttributes(Component);
             DockingAttribute dockingAttribute = (DockingAttribute)attributes[typeof(DockingAttribute)];
-            if (dockingAttribute != null && dockingAttribute.DockingBehavior != DockingBehavior.Never)
+            if (dockingAttribute is not null && dockingAttribute.DockingBehavior != DockingBehavior.Never)
             {
                 // Create the action for this control
                 _dockingAction = new DockingActionList(this);
@@ -988,7 +987,7 @@ namespace System.Windows.Forms.Design
             }
 
             // If we are an inherited control, notify our inheritance UI
-            if (Inherited && _host != null && _host.RootComponent != component)
+            if (Inherited && _host is not null && _host.RootComponent != component)
             {
                 _inheritanceUI = GetService<InheritanceUI>();
                 _inheritanceUI?.AddInheritedControl(Control, InheritanceAttribute.InheritanceLevel);
@@ -1020,7 +1019,7 @@ namespace System.Windows.Forms.Design
         private void OnSizeChanged(object sender, EventArgs e)
         {
             object component = Component;
-            if (TryGetService(out ComponentCache cache) && component != null)
+            if (TryGetService(out ComponentCache cache) && component is not null)
             {
                 cache.RemoveEntry(component);
             }
@@ -1029,7 +1028,7 @@ namespace System.Windows.Forms.Design
         private void OnLocationChanged(object sender, EventArgs e)
         {
             object component = Component;
-            if (TryGetService(out ComponentCache cache) && component != null)
+            if (TryGetService(out ComponentCache cache) && component is not null)
             {
                 cache.RemoveEntry(component);
             }
@@ -1045,7 +1044,7 @@ namespace System.Windows.Forms.Design
 
         private void OnControlRemoved(object sender, ControlEventArgs e)
         {
-            if (e.Control != null)
+            if (e.Control is not null)
             {
                 // No designer means we must replace the window target in this control.
                 if (e.Control.WindowTarget is ChildWindowTarget oldTarget)
@@ -1136,10 +1135,10 @@ namespace System.Windows.Forms.Design
             // unhook any sited children that got ChildWindowTargets
             foreach (Control c in Control.Controls)
             {
-                if (c != null)
+                if (c is not null)
                 {
                     ISite site = c.Site;
-                    if (site != null && c.WindowTarget is ChildWindowTarget target)
+                    if (site is not null && c.WindowTarget is ChildWindowTarget target)
                     {
                         c.WindowTarget = target.OldWindowTarget;
                     }
@@ -1157,17 +1156,16 @@ namespace System.Windows.Forms.Design
         public override void InitializeNewComponent(IDictionary defaultValues)
         {
             ISite site = Component.Site;
-            if (site != null)
+            if (site is not null)
             {
                 PropertyDescriptor textProp = TypeDescriptor.GetProperties(Component)["Text"];
-                if (textProp != null && textProp.PropertyType == typeof(string) && !textProp.IsReadOnly && textProp.IsBrowsable)
+                if (textProp is not null && textProp.PropertyType == typeof(string) && !textProp.IsReadOnly && textProp.IsBrowsable)
                 {
                     textProp.SetValue(Component, site.Name);
                 }
             }
 
-            if (defaultValues != null
-                && defaultValues["Parent"] is IComponent parent
+            if (defaultValues is not null && defaultValues["Parent"] is IComponent parent
                 && TryGetService(out IDesignerHost host))
             {
                 if (host.GetDesigner(parent) is ParentControlDesigner parentDesigner)
@@ -1181,8 +1179,7 @@ namespace System.Windows.Forms.Design
                     AttributeCollection attributes = TypeDescriptor.GetAttributes(Component);
                     DockingAttribute dockingAttribute = (DockingAttribute)attributes[typeof(DockingAttribute)];
 
-                    if (dockingAttribute != null
-                        && dockingAttribute.DockingBehavior != DockingBehavior.Never
+                    if (dockingAttribute is not null && dockingAttribute.DockingBehavior != DockingBehavior.Never
                         && dockingAttribute.DockingBehavior == DockingBehavior.AutoDock)
                     {
                         bool onlyNonDockedChild = true;
@@ -1198,7 +1195,7 @@ namespace System.Windows.Forms.Design
                         if (onlyNonDockedChild)
                         {
                             PropertyDescriptor dockProp = TypeDescriptor.GetProperties(Component)["Dock"];
-                            if (dockProp != null && dockProp.IsBrowsable)
+                            if (dockProp is not null && dockProp.IsBrowsable)
                             {
                                 dockProp.SetValue(Component, DockStyle.Fill);
                             }
@@ -1219,10 +1216,10 @@ namespace System.Windows.Forms.Design
         public override void OnSetComponentDefaults()
         {
             ISite site = Component.Site;
-            if (site != null)
+            if (site is not null)
             {
                 PropertyDescriptor textProp = TypeDescriptor.GetProperties(Component)["Text"];
-                if (textProp != null && textProp.IsBrowsable)
+                if (textProp is not null && textProp.IsBrowsable)
                 {
                     textProp.SetValue(Component, site.Name);
                 }
@@ -1331,7 +1328,7 @@ namespace System.Windows.Forms.Design
             ISelectionService selectionService = GetService<ISelectionService>();
 
             // If the CTRL key isn't down, select this component, otherwise, we wait until the mouse up. Make sure the component is selected
-            if (!_ctrlSelect && selectionService != null)
+            if (!_ctrlSelect && selectionService is not null)
             {
                 selectionService.SetSelectedComponents(new object[] { Component }, SelectionTypes.Primary);
             }
@@ -1356,7 +1353,7 @@ namespace System.Windows.Forms.Design
                     bool shiftSelect = (Control.ModifierKeys & Keys.Shift) != 0;
                     if (!shiftSelect &&
                         (_ctrlSelect
-                            || (selectionService != null && !selectionService.GetComponentSelected(Component))))
+                            || (selectionService is not null && !selectionService.GetComponentSelected(Component))))
                     {
                         selectionService?.SetSelectedComponents(new object[] { Component }, SelectionTypes.Primary);
                         _ctrlSelect = false;
@@ -1370,7 +1367,7 @@ namespace System.Windows.Forms.Design
             _ctrlSelect = false;
 
             // And now finish the drag.
-            if (BehaviorService != null && BehaviorService.Dragging && cancel)
+            if (BehaviorService is not null && BehaviorService.Dragging && cancel)
             {
                 BehaviorService.CancelDrag = true;
             }
@@ -1423,12 +1420,12 @@ namespace System.Windows.Forms.Design
             // Make sure the component is selected
             // But only select it if it is not already the primary selection, and we want to toggle the current primary selection.
             ISelectionService selectionService = GetService<ISelectionService>();
-            if (selectionService != null && !Component.Equals(selectionService.PrimarySelection))
+            if (selectionService is not null && !Component.Equals(selectionService.PrimarySelection))
             {
                 selectionService.SetSelectedComponents(new object[] { Component }, SelectionTypes.Primary | SelectionTypes.Toggle);
             }
 
-            if (BehaviorService != null && selectionService != null)
+            if (BehaviorService is not null && selectionService is not null)
             {
                 // create our list of controls-to-drag
                 ArrayList dragControls = new ArrayList();
@@ -1479,10 +1476,10 @@ namespace System.Windows.Forms.Design
             Control parent = ctl;
             object parentDesigner = null;
 
-            while (parentDesigner is null && parent != null)
+            while (parentDesigner is null && parent is not null)
             {
                 parent = parent.Parent;
-                if (parent != null)
+                if (parent is not null)
                 {
                     object d = _host.GetDesigner(parent);
                     if (d != this)
@@ -1508,10 +1505,10 @@ namespace System.Windows.Forms.Design
             Control parent = ctl;
             object parentDesigner = null;
 
-            while (parentDesigner is null && parent != null)
+            while (parentDesigner is null && parent is not null)
             {
                 parent = parent.Parent;
-                if (parent != null)
+                if (parent is not null)
                 {
                     object d = _host.GetDesigner(parent);
                     if (d != this)
@@ -1537,10 +1534,10 @@ namespace System.Windows.Forms.Design
             Control parent = ctl;
             object parentDesigner = null;
 
-            while (parentDesigner is null && parent != null)
+            while (parentDesigner is null && parent is not null)
             {
                 parent = parent.Parent;
-                if (parent != null)
+                if (parent is not null)
                 {
                     object d = _host.GetDesigner(parent);
                     if (d != this)
@@ -1563,7 +1560,7 @@ namespace System.Windows.Forms.Design
         protected virtual void OnPaintAdornments(PaintEventArgs pe)
         {
             // If this control is being inherited, paint it
-            if (_inheritanceUI != null && pe.ClipRectangle.IntersectsWith(InheritanceUI.InheritanceGlyphRectangle))
+            if (_inheritanceUI is not null && pe.ClipRectangle.IntersectsWith(InheritanceUI.InheritanceGlyphRectangle))
             {
                 pe.Graphics.DrawImage(InheritanceUI.InheritanceGlyph, 0, 0);
             }
@@ -1592,7 +1589,7 @@ namespace System.Windows.Forms.Design
 
             _toolboxService ??= GetService<IToolboxService>();
 
-            if (_toolboxService != null && _toolboxService.SetCursor())
+            if (_toolboxService is not null && _toolboxService.SetCursor())
             {
                 return;
             }
@@ -1602,7 +1599,7 @@ namespace System.Windows.Forms.Design
                 _locationChecked = true;
                 try
                 {
-                    _hasLocation = TypeDescriptor.GetProperties(Component)["Location"] != null;
+                    _hasLocation = TypeDescriptor.GetProperties(Component)["Location"] is not null;
                 }
                 catch
                 {
@@ -1641,7 +1638,7 @@ namespace System.Windows.Forms.Design
             for (int i = 0; i < shadowProps.Length; i++)
             {
                 prop = (PropertyDescriptor)properties[shadowProps[i]];
-                if (prop != null)
+                if (prop is not null)
                 {
                     properties[shadowProps[i]] = TypeDescriptor.CreateProperty(typeof(ControlDesigner), prop, empty);
                 }
@@ -1651,7 +1648,7 @@ namespace System.Windows.Forms.Design
             // original property (ControlCollection)
             PropertyDescriptor controlsProp = (PropertyDescriptor)properties["Controls"];
 
-            if (controlsProp != null)
+            if (controlsProp is not null)
             {
                 Attribute[] attrs = new Attribute[controlsProp.Attributes.Count];
                 controlsProp.Attributes.CopyTo(attrs, 0);
@@ -1663,7 +1660,7 @@ namespace System.Windows.Forms.Design
             }
 
             PropertyDescriptor sizeProp = (PropertyDescriptor)properties["Size"];
-            if (sizeProp != null)
+            if (sizeProp is not null)
             {
                 properties["Size"] = new CanResetSizePropertyDescriptor(sizeProp);
             }
@@ -1691,7 +1688,7 @@ namespace System.Windows.Forms.Design
             foreach (Control child in firstChild.Controls)
             {
                 IWindowTarget oldTarget = null;
-                if (child != null)
+                if (child is not null)
                 {
                     // No, no designer means we must replace the window target in this control.
                     oldTarget = child.WindowTarget;
@@ -1785,7 +1782,7 @@ namespace System.Windows.Forms.Design
             {
                 _eventService ??= GetService<IEventHandlerService>();
 
-                if (_eventService != null)
+                if (_eventService is not null)
                 {
                     mouseHandler = (IMouseHandler)_eventService.GetHandler(typeof(IMouseHandler));
                 }
@@ -1921,7 +1918,7 @@ namespace System.Windows.Forms.Design
                         {
                             _toolboxService ??= GetService<IToolboxService>();
 
-                            if (_toolboxService?.GetSelectedToolboxItem(GetService<IDesignerHost>()) != null)
+                            if (_toolboxService?.GetSelectedToolboxItem(GetService<IDesignerHost>()) is not null)
                             {
                                 // There is a tool to be dragged, so set passthrough and pass to the parent.
                                 _toolPassThrough = true;
@@ -1942,7 +1939,7 @@ namespace System.Windows.Forms.Design
                             return;
                         }
 
-                        if (mouseHandler != null)
+                        if (mouseHandler is not null)
                         {
                             mouseHandler.OnMouseDown(Component, button, location.X, location.Y);
                         }
@@ -2138,9 +2135,9 @@ namespace System.Windows.Forms.Design
                     // themes on.... this can happen when someone calls RedrawWindow without the flags to send an
                     // NCPAINT.  So that we don't double process this event, our calls to redraw window should not have
                     // RDW_ERASENOW | RDW_UPDATENOW.
-                    if (OverlayService != null)
+                    if (OverlayService is not null)
                     {
-                        if (Control != null && Control.Size != Control.ClientSize && Control.Parent != null)
+                        if (Control is not null && Control.Size != Control.ClientSize && Control.Parent is not null)
                         {
                             // we have a non-client region to invalidate
                             Rectangle controlScreenBounds = new Rectangle(Control.Parent.PointToScreen(Control.Location), Control.Size);
@@ -2163,7 +2160,7 @@ namespace System.Windows.Forms.Design
                         break;
                     }
 
-                    if (mouseHandler != null)
+                    if (mouseHandler is not null)
                     {
                         mouseHandler.OnSetCursor(Component);
                     }
@@ -2174,7 +2171,7 @@ namespace System.Windows.Forms.Design
 
                     break;
                 case User32.WM.SIZE:
-                    if (_thrownException != null)
+                    if (_thrownException is not null)
                     {
                         Control.Invalidate();
                     }
@@ -2197,8 +2194,7 @@ namespace System.Windows.Forms.Design
                     //    DefWndProc(ref m);
                     //}
                     //else
-                    if (_host != null && _host.RootComponent != null
-                        && _host.GetDesigner(_host.RootComponent) is IRootDesigner rd)
+                    if (_host is not null && _host.RootComponent is not null && _host.GetDesigner(_host.RootComponent) is IRootDesigner rd)
                     {
                         ViewTechnology[] techs = rd.SupportedTechnologies;
                         if (techs.Length > 0)
@@ -2502,7 +2498,7 @@ namespace System.Windows.Forms.Design
 
         internal void SetUnhandledException(Control owner, Exception exception)
         {
-            if (_thrownException != null)
+            if (_thrownException is not null)
             {
                 return;
             }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewCellStyleBuilder.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewCellStyleBuilder.cs
@@ -45,7 +45,7 @@ namespace System.Windows.Forms.Design
             _serviceProvider = serviceProvider;
             _comp = comp;
 
-            if (_serviceProvider != null)
+            if (_serviceProvider is not null)
             {
                 _helpService = (IHelpService)serviceProvider.GetService(typeof(IHelpService));
             }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataMemberFieldConverter.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataMemberFieldConverter.cs
@@ -16,7 +16,7 @@ namespace System.Windows.Forms.Design
 
         public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
         {
-            return value != null && value.Equals(SR.None) ? string.Empty : value;
+            return value is not null && value.Equals(SR.None) ? string.Empty : value;
         }
 
         public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignBindingValueUIHandler.LocalUIItem.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignBindingValueUIHandler.LocalUIItem.cs
@@ -31,7 +31,7 @@ namespace System.Windows.Forms.Design
                 string name = "";
                 if (binding.DataSource is IComponent comp)
                 {
-                    if (comp.Site != null)
+                    if (comp.Site is not null)
                     {
                         name = comp.Site.Name;
                     }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerActionVerbItem.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerActionVerbItem.cs
@@ -12,7 +12,7 @@ namespace System.ComponentModel.Design
 
         public DesignerActionVerbItem(DesignerVerb verb) : base(null, null, null)
         {
-            Debug.Assert(verb != null, "All callers check whether the verb is null.");
+            Debug.Assert(verb is not null, "All callers check whether the verb is null.");
             _targetVerb = verb;
         }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerExtenders.NameExtenderProvider.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerExtenders.NameExtenderProvider.cs
@@ -30,10 +30,10 @@ namespace System.Windows.Forms.Design
                 if (baseComponent is null)
                 {
                     ISite site = ((IComponent)o).Site;
-                    if (site != null)
+                    if (site is not null)
                     {
                         IDesignerHost host = (IDesignerHost)site.GetService(typeof(IDesignerHost));
-                        if (host != null)
+                        if (host is not null)
                         {
                             baseComponent = host.RootComponent;
                         }
@@ -80,7 +80,7 @@ namespace System.Windows.Forms.Design
             public virtual string GetName(IComponent comp)
             {
                 ISite site = comp.Site;
-                if (site != null)
+                if (site is not null)
                 {
                     return site.Name;
                 }
@@ -95,7 +95,7 @@ namespace System.Windows.Forms.Design
             public static void SetName(IComponent comp, string newName)
             {
                 ISite site = comp.Site;
-                if (site != null)
+                if (site is not null)
                 {
                     site.Name = newName;
                 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerExtenders.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerExtenders.cs
@@ -40,7 +40,7 @@ namespace System.Windows.Forms.Design
         /// </summary>
         public void Dispose()
         {
-            if (extenderService != null && providers != null)
+            if (extenderService is not null && providers is not null)
             {
                 for (int i = 0; i < providers.Length; i++)
                 {

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerFrame.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerFrame.cs
@@ -45,7 +45,7 @@ namespace System.Windows.Forms.Design
             _designerSite = site;
             _designerRegion = new OverlayControl(site);
             _uiService = _designerSite.GetService(typeof(IUIService)) as IUIService;
-            if (_uiService != null)
+            if (_uiService is not null)
             {
                 if (_uiService.Styles["ArtboardBackground"] is Color)
                 {
@@ -85,7 +85,7 @@ namespace System.Windows.Forms.Design
         {
             if (disposing)
             {
-                if (_designer != null)
+                if (_designer is not null)
                 {
                     Control designerHolder = _designer;
                     _designer = null;
@@ -93,7 +93,7 @@ namespace System.Windows.Forms.Design
                     designerHolder.Parent = null;
                 }
 
-                if (_splitter != null)
+                if (_splitter is not null)
                 {
                     _splitter.SplitterMoved -= new SplitterEventHandler(OnSplitterMoved);
                 }
@@ -135,7 +135,7 @@ namespace System.Windows.Forms.Design
         {
             ForceDesignerRedraw(true);
             ISelectionService selSvc = (ISelectionService)_designerSite.GetService(typeof(ISelectionService));
-            if (selSvc != null)
+            if (selSvc is not null)
             {
                 if (selSvc.PrimarySelection is Control ctrl && !ctrl.IsDisposed)
                 {
@@ -170,7 +170,7 @@ namespace System.Windows.Forms.Design
 
         void OnUserPreferenceChanged(object sender, UserPreferenceChangedEventArgs e)
         {
-            if (e.Category == UserPreferenceCategory.Window && _designer != null)
+            if (e.Category == UserPreferenceCategory.Window && _designer is not null)
             {
                 SyncDesignerUI();
             }
@@ -315,7 +315,7 @@ namespace System.Windows.Forms.Design
             if (_splitter is null)
             {
                 _splitter = new Splitter();
-                if (_uiService != null && _uiService.Styles["HorizontalResizeGrip"] is Color)
+                if (_uiService is not null && _uiService.Styles["HorizontalResizeGrip"] is Color)
                 {
                     _splitter.BackColor = (Color)_uiService.Styles["HorizontalResizeGrip"];
                 }
@@ -429,7 +429,7 @@ namespace System.Windows.Forms.Design
             {
                 base.OnCreateControl();
                 // Loop through all of the overlays, create them, and hook them up
-                if (_overlayList != null)
+                if (_overlayList is not null)
                 {
                     foreach (Control c in _overlayList)
                     {
@@ -451,7 +451,7 @@ namespace System.Windows.Forms.Design
 
                 // Loop through all of the overlays and size them.  Also make sure that they are still on top of the
                 // zorder, because a handle recreate could have changed this.
-                if (_overlayList != null)
+                if (_overlayList is not null)
                 {
                     foreach (Control c in _overlayList)
                     {
@@ -568,7 +568,7 @@ namespace System.Windows.Forms.Design
                 base.WndProc(ref m);
                 if (m.MsgInternal == User32.WM.PARENTNOTIFY && (User32.WM)m.WParamInternal.LOWORD == User32.WM.CREATE)
                 {
-                    if (_overlayList != null)
+                    if (_overlayList is not null)
                     {
                         bool ourWindow = false;
                         foreach (Control c in _overlayList)
@@ -593,7 +593,7 @@ namespace System.Windows.Forms.Design
                         }
                     }
                 }
-                else if ((m.Msg == (int)User32.WM.VSCROLL || m.Msg == (int)User32.WM.HSCROLL) && BehaviorService != null)
+                else if ((m.Msg == (int)User32.WM.VSCROLL || m.Msg == (int)User32.WM.HSCROLL) && BehaviorService is not null)
                 {
                     BehaviorService.SyncSelection();
                 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerUtils.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerUtils.cs
@@ -373,13 +373,13 @@ namespace System.Windows.Forms.Design
             if (provider.GetService(typeof(DesignerOptionService)) is DesignerOptionService options)
             {
                 PropertyDescriptor snaplinesProp = options.Options.Properties["UseSnapLines"];
-                if (snaplinesProp != null)
+                if (snaplinesProp is not null)
                 {
                     optionValue = snaplinesProp.GetValue(null);
                 }
             }
 
-            if (optionValue != null && optionValue is bool)
+            if (optionValue is not null && optionValue is bool)
             {
                 useSnapLines = (bool)optionValue;
             }
@@ -390,12 +390,12 @@ namespace System.Windows.Forms.Design
         public static object GetOptionValue(IServiceProvider provider, string name)
         {
             object optionValue = null;
-            if (provider != null)
+            if (provider is not null)
             {
                 if (provider.GetService(typeof(DesignerOptionService)) is DesignerOptionService desOpts)
                 {
                     PropertyDescriptor prop = desOpts.Options.Properties[name];
-                    if (prop != null)
+                    if (prop is not null)
                     {
                         optionValue = prop.GetValue(null);
                     }
@@ -798,9 +798,9 @@ namespace System.Windows.Forms.Design
                 Cursor.Current = Cursors.WaitCursor;
                 ComponentSerializationService css = svcProvider.GetService(typeof(ComponentSerializationService)) as ComponentSerializationService;
                 IDesignerHost host = svcProvider.GetService(typeof(IDesignerHost)) as IDesignerHost;
-                Debug.Assert(css != null, "No component serialization service -- we cannot copy the objects");
-                Debug.Assert(host != null, "No host -- we cannot copy the objects");
-                if (css != null && host != null)
+                Debug.Assert(css is not null, "No component serialization service -- we cannot copy the objects");
+                Debug.Assert(host is not null, "No host -- we cannot copy the objects");
+                if (css is not null && host is not null)
                 {
                     SerializationStore store = css.CreateStore();
                     // Get all the objects, meaning we want the children too
@@ -822,7 +822,7 @@ namespace System.Windows.Forms.Design
                     foreach (IComponent comp in copyObjects)
                     {
                         Control c = comp as Control;
-                        if (c != null && c.Parent is null)
+                        if (c is not null && c.Parent is null)
                         {
                             newObjects.Add(comp);
                         }
@@ -878,7 +878,7 @@ namespace System.Windows.Forms.Design
 
             foreach (IComponent childComp in designer.AssociatedComponents)
             {
-                if (childComp.Site != null)
+                if (childComp.Site is not null)
                 {
                     list.Add(childComp);
                     GetAssociatedComponents(childComp, host, list);

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerVerbToolStripMenuItem.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerVerbToolStripMenuItem.cs
@@ -22,7 +22,7 @@ namespace System.Windows.Forms.Design
 
         public void RefreshItem()
         {
-            if (_verb != null)
+            if (_verb is not null)
             {
                 Visible = _verb.Visible;
                 Enabled = _verb.Enabled;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DocumentDesigner.AxToolboxItem.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DocumentDesigner.AxToolboxItem.cs
@@ -63,10 +63,10 @@ namespace System.Windows.Forms.Design
                 RegistryKey key = Registry.ClassesRoot.OpenSubKey(controlKey);
 
                 //fail later -- not for tooltip info...
-                if (key != null)
+                if (key is not null)
                 {
                     RegistryKey verKey = key.OpenSubKey("Version");
-                    if (verKey != null)
+                    if (verKey is not null)
                     {
                         version = (string)verKey.GetValue("");
                         verKey.Close();
@@ -82,12 +82,12 @@ namespace System.Windows.Forms.Design
             /// </summary>
             protected override IComponent[] CreateComponentsCore(IDesignerHost host)
             {
-                Debug.Assert(host != null, "Designer host is null!!!");
+                Debug.Assert(host is not null, "Designer host is null!!!");
 
                 // Get the DTE References object
                 //
                 object references = GetReferences(host);
-                if (references != null)
+                if (references is not null)
                 {
                     try
                     {
@@ -101,11 +101,11 @@ namespace System.Windows.Forms.Design
 
                         args[4] = "";
                         object tlbRef = references.GetType().InvokeMember("AddActiveX", BindingFlags.InvokeMethod | BindingFlags.Public | BindingFlags.Instance, null, references, args, CultureInfo.InvariantCulture);
-                        Debug.Assert(tlbRef != null, "Null reference returned by AddActiveX (tlbimp) by the project system for: " + clsid);
+                        Debug.Assert(tlbRef is not null, "Null reference returned by AddActiveX (tlbimp) by the project system for: " + clsid);
 
                         args[4] = "aximp";
                         object axRef = references.GetType().InvokeMember("AddActiveX", BindingFlags.InvokeMethod | BindingFlags.Public | BindingFlags.Instance, null, references, args, CultureInfo.InvariantCulture);
-                        Debug.Assert(axRef != null, "Null reference returned by AddActiveX (aximp) by the project system for: " + clsid);
+                        Debug.Assert(axRef is not null, "Null reference returned by AddActiveX (aximp) by the project system for: " + clsid);
 
                         axctlType = GetAxTypeFromReference(axRef, host);
                     }
@@ -148,7 +148,7 @@ namespace System.Windows.Forms.Design
                     throw;
                 }
 
-                Debug.Assert(comps[0] != null, "Could not create instance of ActiveX control wrappers!!!");
+                Debug.Assert(comps[0] is not null, "Could not create instance of ActiveX control wrappers!!!");
                 return comps;
             }
 
@@ -183,10 +183,10 @@ namespace System.Windows.Forms.Design
                 Debug.WriteLineIf(AxToolSwitch.TraceVerbose, "Checking: " + fullPath);
 
                 ITypeResolutionService trs = (ITypeResolutionService)host.GetService(typeof(ITypeResolutionService));
-                Debug.Assert(trs != null, "No type resolution service found.");
+                Debug.Assert(trs is not null, "No type resolution service found.");
 
                 Assembly a = trs.GetAssembly(AssemblyName.GetAssemblyName(fullPath));
-                Debug.Assert(a != null, "No assembly found at " + fullPath);
+                Debug.Assert(a is not null, "No assembly found at " + fullPath);
 
                 return GetAxTypeFromAssembly(a);
             }
@@ -208,7 +208,7 @@ namespace System.Windows.Forms.Design
                     }
 
                     object[] attrs = t.GetCustomAttributes(typeof(AxHost.ClsidAttribute), false);
-                    Debug.Assert(attrs != null && attrs.Length == 1, "Invalid number of GuidAttributes found on: " + t.FullName);
+                    Debug.Assert(attrs is not null && attrs.Length == 1, "Invalid number of GuidAttributes found on: " + t.FullName);
 
                     AxHost.ClsidAttribute guid = (AxHost.ClsidAttribute)attrs[0];
                     if (string.Equals(guid.Value, clsid, StringComparison.OrdinalIgnoreCase))
@@ -229,7 +229,7 @@ namespace System.Windows.Forms.Design
             /// </summary>
             private static object GetReferences(IDesignerHost host)
             {
-                Debug.Assert(host != null, "Null Designer Host");
+                Debug.Assert(host is not null, "Null Designer Host");
 
                 Type type;
                 type = Type.GetType("EnvDTE.ProjectItem, " + AssemblyRef.EnvDTE);
@@ -246,13 +246,13 @@ namespace System.Windows.Forms.Design
                 string name = ext.GetType().InvokeMember("Name", BindingFlags.GetProperty | BindingFlags.Public | BindingFlags.Instance, null, ext, null, CultureInfo.InvariantCulture).ToString();
 
                 object project = ext.GetType().InvokeMember("ContainingProject", BindingFlags.GetProperty | BindingFlags.Public | BindingFlags.Instance, null, ext, null, CultureInfo.InvariantCulture);
-                Debug.Assert(project != null, "No DTE Project for the current project item: " + name);
+                Debug.Assert(project is not null, "No DTE Project for the current project item: " + name);
 
                 object vsproject = project.GetType().InvokeMember("Object", BindingFlags.GetProperty | BindingFlags.Public | BindingFlags.Instance, null, project, null, CultureInfo.InvariantCulture);
-                Debug.Assert(vsproject != null, "No VS Project for the current project item: " + name);
+                Debug.Assert(vsproject is not null, "No VS Project for the current project item: " + name);
 
                 object references = vsproject.GetType().InvokeMember("References", BindingFlags.GetProperty | BindingFlags.Public | BindingFlags.Instance, null, vsproject, null, CultureInfo.InvariantCulture);
-                Debug.Assert(references != null, "No References for the current project item: " + name);
+                Debug.Assert(references is not null, "No References for the current project item: " + name);
 
                 return references;
             }
@@ -279,12 +279,12 @@ namespace System.Windows.Forms.Design
                 //
                 RegistryKey tlbKey = key.OpenSubKey("TypeLib");
 
-                if (tlbKey != null)
+                if (tlbKey is not null)
                 {
                     // Get the major and minor version numbers.
                     //
                     RegistryKey verKey = key.OpenSubKey("Version");
-                    Debug.Assert(verKey != null, "No version registry key found for: " + controlKey);
+                    Debug.Assert(verKey is not null, "No version registry key found for: " + controlKey);
 
                     string ver = (string)verKey.GetValue("");
                     int dot = ver.IndexOf('.');
@@ -334,10 +334,10 @@ namespace System.Windows.Forms.Design
                 if (pTLB is null)
                 {
                     RegistryKey inprocServerKey = key.OpenSubKey("InprocServer32");
-                    if (inprocServerKey != null)
+                    if (inprocServerKey is not null)
                     {
                         string inprocServer = (string)inprocServerKey.GetValue("");
-                        Debug.Assert(inprocServer != null, "No valid InprocServer32 found for: " + controlKey);
+                        Debug.Assert(inprocServer is not null, "No valid InprocServer32 found for: " + controlKey);
                         inprocServerKey.Close();
 
                         pTLB = Oleaut32.LoadTypeLib(inprocServer);
@@ -346,7 +346,7 @@ namespace System.Windows.Forms.Design
 
                 key.Close();
 
-                if (pTLB != null)
+                if (pTLB is not null)
                 {
                     try
                     {

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DocumentDesigner.DocumentInheritanceService.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DocumentDesigner.DocumentInheritanceService.cs
@@ -40,12 +40,12 @@ namespace System.Windows.Forms.Design
                 //
                 bool privateMember;
                 Type memberType;
-                if (field != null)
+                if (field is not null)
                 {
                     privateMember = field.IsPrivate || field.IsAssembly;
                     memberType = field.FieldType;
                 }
-                else if (method != null)
+                else if (method is not null)
                 {
                     privateMember = method.IsPrivate || method.IsAssembly;
                     memberType = method.ReturnType;
@@ -63,25 +63,25 @@ namespace System.Windows.Forms.Design
                         // See if this member is a child of our document...
                         //
                         Control child = null;
-                        if (field != null)
+                        if (field is not null)
                         {
                             child = (Control)field.GetValue(component);
                         }
-                        else if (method != null)
+                        else if (method is not null)
                         {
                             child = (Control)method.Invoke(component, null);
                         }
 
                         Control parent = designer.Control;
 
-                        while (child != null && child != parent)
+                        while (child is not null && child != parent)
                         {
                             child = child.Parent;
                         }
 
                         // If it is a child of our designer, we don't want to ignore this member.
                         //
-                        if (child != null)
+                        if (child is not null)
                         {
                             return false;
                         }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DocumentDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DocumentDesigner.cs
@@ -72,7 +72,7 @@ namespace System.Windows.Forms.Design
             get
             {
                 ContainerControl c = Control as ContainerControl;
-                if (c != null)
+                if (c is not null)
                 {
                     return c.CurrentAutoScaleDimensions;
                 }
@@ -83,7 +83,7 @@ namespace System.Windows.Forms.Design
             set
             {
                 ContainerControl c = Control as ContainerControl;
-                if (c != null)
+                if (c is not null)
                 {
                     c.AutoScaleDimensions = value;
                 }
@@ -100,7 +100,7 @@ namespace System.Windows.Forms.Design
             get
             {
                 ContainerControl c = Control as ContainerControl;
-                if (c != null)
+                if (c is not null)
                 {
                     return c.AutoScaleMode;
                 }
@@ -112,14 +112,14 @@ namespace System.Windows.Forms.Design
             {
                 ShadowProperties[nameof(AutoScaleMode)] = value;
                 ContainerControl c = Control as ContainerControl;
-                if (c != null && c.AutoScaleMode != value)
+                if (c is not null && c.AutoScaleMode != value)
                 {
                     c.AutoScaleMode = value;
 
                     // If we're not loading and this changes update
                     // the current auto scale dimensions.
                     IDesignerHost host = GetService(typeof(IDesignerHost)) as IDesignerHost;
-                    if (host != null && !host.Loading)
+                    if (host is not null && !host.Loading)
                     {
                         c.AutoScaleDimensions = c.CurrentAutoScaleDimensions;
                     }
@@ -190,11 +190,11 @@ namespace System.Windows.Forms.Design
                 {
                     queriedTabOrder = true;
                     IMenuCommandService menuCommandService = (IMenuCommandService)GetService(typeof(IMenuCommandService));
-                    if (menuCommandService != null)
+                    if (menuCommandService is not null)
                         tabOrderCommand = menuCommandService.FindCommand(StandardCommands.TabOrder);
                 }
 
-                if (tabOrderCommand != null)
+                if (tabOrderCommand is not null)
                 {
                     return tabOrderCommand.Checked;
                 }
@@ -216,7 +216,7 @@ namespace System.Windows.Forms.Design
             set
             {
                 trayAutoArrange = value;
-                if (componentTray != null)
+                if (componentTray is not null)
                 {
                     componentTray.AutoArrange = trayAutoArrange;
                 }
@@ -236,7 +236,7 @@ namespace System.Windows.Forms.Design
             set
             {
                 trayLargeIcon = value;
-                if (componentTray != null)
+                if (componentTray is not null)
                 {
                     componentTray.ShowLargeIcons = trayLargeIcon;
                 }
@@ -250,7 +250,7 @@ namespace System.Windows.Forms.Design
         {
             get
             {
-                if (componentTray != null)
+                if (componentTray is not null)
                 {
                     return componentTray.Height;
                 }
@@ -263,7 +263,7 @@ namespace System.Windows.Forms.Design
             set
             {
                 trayHeight = value;
-                if (componentTray != null)
+                if (componentTray is not null)
                 {
                     componentTray.Height = trayHeight;
                 }
@@ -278,10 +278,10 @@ namespace System.Windows.Forms.Design
         Control IOleDragClient.GetControlForComponent(object component)
         {
             Control c = GetControl(component);
-            if (c != null)
+            if (c is not null)
                 return c;
 
-            if (componentTray != null)
+            if (componentTray is not null)
             {
                 return ((IOleDragClient)componentTray).GetControlForComponent(component);
             }
@@ -301,7 +301,7 @@ namespace System.Windows.Forms.Design
             OleDragDropHandler ddh = GetOleDragHandler();
             object[] dragComps = OleDragDropHandler.GetDraggingObjects(de);
 
-            if (dragComps != null)
+            if (dragComps is not null)
             {
                 IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
                 for (int i = 0; i < dragComps.Length; i++)
@@ -350,10 +350,10 @@ namespace System.Windows.Forms.Design
                 AxToolboxItem tool;
                 // Look to see if we have already cached the ToolboxItem.
                 //
-                if (axTools != null)
+                if (axTools is not null)
                 {
                     tool = (AxToolboxItem)axTools[clsid];
-                    if (tool != null)
+                    if (tool is not null)
                     {
                         if (AxToolSwitch.TraceVerbose)
                             Debug.WriteLine("Found AxToolboxItem in tool cache");
@@ -377,13 +377,13 @@ namespace System.Windows.Forms.Design
         private static ToolboxItem CreateCfCodeToolboxItem(IDataObject dataObject)
         {
             object serializationData = dataObject.GetData(OleDragDropHandler.NestedToolboxItemFormat, false);
-            if (serializationData != null)
+            if (serializationData is not null)
             {
                 return (ToolboxItem)serializationData;
             }
 
             serializationData = dataObject.GetData(OleDragDropHandler.DataFormat, false);
-            if (serializationData != null)
+            if (serializationData is not null)
             {    //backcompat
                 return new OleDragDropHandler.CfCodeToolboxItem(serializationData);
                 ;
@@ -400,13 +400,13 @@ namespace System.Windows.Forms.Design
             if (disposing)
             {
                 IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
-                Debug.Assert(host != null, "Must have a designer host on dispose");
+                Debug.Assert(host is not null, "Must have a designer host on dispose");
 
-                if (host != null)
+                if (host is not null)
                 {
                     //Remove Adorner Window which hosts DropDowns.
                     ToolStripAdornerWindowService toolWindow = (ToolStripAdornerWindowService)GetService(typeof(ToolStripAdornerWindowService));
-                    if (toolWindow != null)
+                    if (toolWindow is not null)
                     {
                         toolWindow.Dispose();
                         host.RemoveService(typeof(ToolStripAdornerWindowService));
@@ -418,10 +418,10 @@ namespace System.Windows.Forms.Design
                     // If the tray wasn't destroyed, then we got some sort of imbalance
                     // in our add/remove calls.  Don't sweat it, but do remove the tray.
                     //
-                    if (componentTray != null)
+                    if (componentTray is not null)
                     {
                         ISplitWindowService sws = (ISplitWindowService)GetService(typeof(ISplitWindowService));
-                        if (sws != null)
+                        if (sws is not null)
                         {
                             sws.RemoveSplitWindow(componentTray);
                             componentTray.Dispose();
@@ -432,24 +432,24 @@ namespace System.Windows.Forms.Design
                     }
 
                     IComponentChangeService cs = (IComponentChangeService)GetService(typeof(IComponentChangeService));
-                    if (cs != null)
+                    if (cs is not null)
                     {
                         cs.ComponentAdded -= new ComponentEventHandler(OnComponentAdded);
                         cs.ComponentChanged -= new ComponentChangedEventHandler(OnComponentChanged);
                         cs.ComponentRemoved -= new ComponentEventHandler(OnComponentRemoved);
                     }
 
-                    if (undoEngine != null)
+                    if (undoEngine is not null)
                     {
                         undoEngine.Undoing -= new EventHandler(OnUndoing);
                         undoEngine.Undone -= new EventHandler(OnUndone);
                     }
 
-                    if (toolboxCreator != null)
+                    if (toolboxCreator is not null)
                     {
                         IToolboxService toolbox = (IToolboxService)GetService(typeof(IToolboxService));
-                        Debug.Assert(toolbox != null, "No toolbox service available");
-                        if (toolbox != null)
+                        Debug.Assert(toolbox is not null, "No toolbox service available");
+                        if (toolbox is not null)
                         {
                             Debug.WriteLineIf(AxToolSwitch.TraceVerbose, "Removing DocumentDesigner as CLSID ToolboxItemCreator");
                             toolbox.RemoveCreator(AxClipFormat, host);
@@ -466,26 +466,26 @@ namespace System.Windows.Forms.Design
                 }
 
                 ISelectionService ss = (ISelectionService)GetService(typeof(ISelectionService));
-                if (ss != null)
+                if (ss is not null)
                 {
                     ss.SelectionChanged -= new EventHandler(OnSelectionChanged);
                 }
 
-                if (behaviorService != null)
+                if (behaviorService is not null)
                 {
                     behaviorService.Dispose();
                     behaviorService = null;
                 }
 
-                if (selectionManager != null)
+                if (selectionManager is not null)
                 {
                     selectionManager.Dispose();
                     selectionManager = null;
                 }
 
-                if (componentTray != null)
+                if (componentTray is not null)
                 {
-                    if (host != null)
+                    if (host is not null)
                     {
                         ISplitWindowService sws = (ISplitWindowService)GetService(typeof(ISplitWindowService));
                         sws?.RemoveSplitWindow(componentTray);
@@ -495,40 +495,40 @@ namespace System.Windows.Forms.Design
                     componentTray = null;
                 }
 
-                if (pbrsFwd != null)
+                if (pbrsFwd is not null)
                 {
                     pbrsFwd.Dispose();
                     pbrsFwd = null;
                 }
 
-                if (frame != null)
+                if (frame is not null)
                 {
                     frame.Dispose();
                     frame = null;
                 }
 
-                if (commandSet != null)
+                if (commandSet is not null)
                 {
                     commandSet.Dispose();
                     commandSet = null;
                 }
 
-                if (inheritanceService != null)
+                if (inheritanceService is not null)
                 {
                     inheritanceService.Dispose();
                     inheritanceService = null;
                 }
 
-                if (inheritanceUI != null)
+                if (inheritanceUI is not null)
                 {
                     inheritanceUI.Dispose();
                     inheritanceUI = null;
                 }
 
-                if (designBindingValueUIHandler != null)
+                if (designBindingValueUIHandler is not null)
                 {
                     IPropertyValueUIService pvUISvc = (IPropertyValueUIService)GetService(typeof(IPropertyValueUIService));
-                    if (pvUISvc != null)
+                    if (pvUISvc is not null)
                     {
                         pvUISvc.RemovePropertyValueUIHandler(new PropertyValueUIHandler(designBindingValueUIHandler.OnGetUIValueItem));
                         pvUISvc = null;
@@ -538,7 +538,7 @@ namespace System.Windows.Forms.Design
                     designBindingValueUIHandler = null;
                 }
 
-                if (designerExtenders != null)
+                if (designerExtenders is not null)
                 {
                     designerExtenders.Dispose();
                     designerExtenders = null;
@@ -546,7 +546,7 @@ namespace System.Windows.Forms.Design
 
                 axTools?.Clear();
 
-                if (host != null)
+                if (host is not null)
                 {
                     host.RemoveService(typeof(BehaviorService));
                     host.RemoveService(typeof(ToolStripAdornerWindowService));
@@ -581,21 +581,21 @@ namespace System.Windows.Forms.Design
 
                 bool locked = false;
                 PropertyDescriptor prop = TypeDescriptor.GetProperties(Component)["Locked"];
-                if (prop != null)
+                if (prop is not null)
                 {
                     locked = (bool)prop.GetValue(Component);
                 }
 
                 bool autoSize = false;
                 prop = TypeDescriptor.GetProperties(Component)["AutoSize"];
-                if (prop != null)
+                if (prop is not null)
                 {
                     autoSize = (bool)prop.GetValue(Component);
                 }
 
                 AutoSizeMode mode = AutoSizeMode.GrowOnly;
                 prop = TypeDescriptor.GetProperties(Component)["AutoSizeMode"];
-                if (prop != null)
+                if (prop is not null)
                 {
                     mode = (AutoSizeMode)prop.GetValue(Component);
                 }
@@ -655,7 +655,7 @@ namespace System.Windows.Forms.Design
             ISelectionService s = (ISelectionService)GetService(typeof(ISelectionService));
             ParentControlDesigner parentControlDesigner = null;
 
-            if (s != null)
+            if (s is not null)
             {
                 // We first try the primary selection.  If that is null
                 // or isn't a Control, we then walk the set of selected
@@ -679,7 +679,7 @@ namespace System.Windows.Forms.Design
                     }
                 }
 
-                if (sel != null)
+                if (sel is not null)
                 {
                     // Now that we have our currently selected component
                     // we can walk up the parent chain looking for a frame
@@ -690,13 +690,13 @@ namespace System.Windows.Forms.Design
 
                     IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
 
-                    if (host != null)
+                    if (host is not null)
                     {
-                        while (c != null)
+                        while (c is not null)
                         {
                             ParentControlDesigner designer = host.GetDesigner(c) as ParentControlDesigner;
 
-                            if (designer != null)
+                            if (designer is not null)
                             {
                                 parentControlDesigner = designer;
                                 break;
@@ -740,19 +740,19 @@ namespace System.Windows.Forms.Design
             // back color.
             //
             PropertyDescriptor backProp = TypeDescriptor.GetProperties(Component.GetType())["BackColor"];
-            if (backProp != null && backProp.PropertyType == typeof(Color) && !backProp.ShouldSerializeValue(Component))
+            if (backProp is not null && backProp.PropertyType == typeof(Color) && !backProp.ShouldSerializeValue(Component))
             {
                 Control.BackColor = SystemColors.Control;
             }
 
             IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
             IExtenderProviderService exps = (IExtenderProviderService)GetService(typeof(IExtenderProviderService));
-            if (exps != null)
+            if (exps is not null)
             {
                 designerExtenders = new DesignerExtenders(exps);
             }
 
-            if (host != null)
+            if (host is not null)
             {
                 host.Activated += new EventHandler(OnDesignerActivate);
                 host.Deactivated += new EventHandler(OnDesignerDeactivate);
@@ -783,7 +783,7 @@ namespace System.Windows.Forms.Design
                 // And component add and remove events for our tray
                 //
                 IComponentChangeService cs = (IComponentChangeService)GetService(typeof(IComponentChangeService));
-                if (cs != null)
+                if (cs is not null)
                 {
                     cs.ComponentAdded += new ComponentEventHandler(OnComponentAdded);
                     cs.ComponentChanged += new ComponentChangedEventHandler(OnComponentChanged);
@@ -815,7 +815,7 @@ namespace System.Windows.Forms.Design
 
                 IPropertyValueUIService pvUISvc = (IPropertyValueUIService)component.Site.GetService(typeof(IPropertyValueUIService));
 
-                if (pvUISvc != null)
+                if (pvUISvc is not null)
                 {
                     designBindingValueUIHandler = new DesignBindingValueUIHandler();
                     pvUISvc.AddPropertyValueUIHandler(new PropertyValueUIHandler(designBindingValueUIHandler.OnGetUIValueItem));
@@ -824,7 +824,7 @@ namespace System.Windows.Forms.Design
                 // Add the DocumentDesigner as a creator of CLSID toolbox items.
                 //
                 IToolboxService toolbox = (IToolboxService)host.GetService(typeof(IToolboxService));
-                if (toolbox != null)
+                if (toolbox is not null)
                 {
                     Debug.WriteLineIf(AxToolSwitch.TraceVerbose, "Adding DocumentDesigner as CLSID ToolboxItemCreator");
                     toolboxCreator = new ToolboxItemCreatorCallback(OnCreateToolboxItem);
@@ -842,7 +842,7 @@ namespace System.Windows.Forms.Design
 
             // Setup our menu command structure.
             //
-            Debug.Assert(component.Site != null, "Designer host should have given us a site by now.");
+            Debug.Assert(component.Site is not null, "Designer host should have given us a site by now.");
             commandSet = new ControlCommandSet(component.Site);
 
             // Finally hook the designer view into the frame.  We do this last because the frame may
@@ -871,7 +871,7 @@ namespace System.Windows.Forms.Design
             {
                 string controlKey = "CLSID\\" + clsid + "\\Control";
                 key = Registry.ClassesRoot.OpenSubKey(controlKey);
-                if (key != null)
+                if (key is not null)
                 {
                     // ASURT 36817:
                     // We are not going to support design-time controls for this revision. We use the guids under
@@ -896,7 +896,7 @@ namespace System.Windows.Forms.Design
         private void OnUndone(object source, EventArgs e)
         {
             //resume all suspended comps we found earlier
-            if (suspendedComponents != null)
+            if (suspendedComponents is not null)
             {
                 foreach (Control c in suspendedComponents)
                 {
@@ -913,7 +913,7 @@ namespace System.Windows.Forms.Design
             if (GetService(typeof(IDesignerHost)) is IDesignerHost host)
             {
                 IContainer container = host.Container;
-                if (container != null)
+                if (container is not null)
                 {
                     suspendedComponents = new(container.Components.Count + 1);
 
@@ -932,7 +932,7 @@ namespace System.Windows.Forms.Design
                     if (host.RootComponent is Control root)
                     {
                         Control rootParent = root.Parent;
-                        if (rootParent != null)
+                        if (rootParent is not null)
                         {
                             rootParent.SuspendLayout();
                             suspendedComponents.Add(rootParent);
@@ -950,7 +950,7 @@ namespace System.Windows.Forms.Design
         private void OnComponentAdded(object source, ComponentEventArgs ce)
         {
             IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
-            if (host != null)
+            if (host is not null)
             {
                 IComponent component = ce.Component;
 
@@ -970,7 +970,7 @@ namespace System.Windows.Forms.Design
                 if (td is null)
                 {
                     ControlDesigner cd = host.GetDesigner(component) as ControlDesigner;
-                    if (cd != null)
+                    if (cd is not null)
                     {
                         Form form = cd.Control as Form;
                         if (form is null || !form.TopLevel)
@@ -986,7 +986,7 @@ namespace System.Windows.Forms.Design
                     if (componentTray is null)
                     {
                         ISplitWindowService sws = (ISplitWindowService)GetService(typeof(ISplitWindowService));
-                        if (sws != null)
+                        if (sws is not null)
                         {
                             componentTray = new ComponentTray(this, Component.Site);
                             sws.AddSplitWindow(componentTray);
@@ -999,7 +999,7 @@ namespace System.Windows.Forms.Design
                         }
                     }
 
-                    if (componentTray != null)
+                    if (componentTray is not null)
                     {
                         // Suspend the layout of the tray through the loading
                         // process. This way, we won't continuously try to layout
@@ -1007,7 +1007,7 @@ namespace System.Windows.Forms.Design
                         // the controls restore themselves to their persisted state
                         // and then let auto-arrange kick in once.
                         //
-                        if (host != null && host.Loading && !trayLayoutSuspended)
+                        if (host is not null && host.Loading && !trayLayoutSuspended)
                         {
                             trayLayoutSuspended = true;
                             componentTray.SuspendLayout();
@@ -1028,14 +1028,14 @@ namespace System.Windows.Forms.Design
         {
             // ToolStrip is designableAsControl but has a ComponentTray Entry ... so special case it out.
             bool designableAsControl = (ce.Component is Control && !(ce.Component is ToolStrip)) && !(ce.Component is Form && ((Form)ce.Component).TopLevel);
-            if (!designableAsControl && componentTray != null)
+            if (!designableAsControl && componentTray is not null)
             {
                 componentTray.RemoveComponent(ce.Component);
 
                 if (componentTray.ComponentCount == 0)
                 {
                     ISplitWindowService sws = (ISplitWindowService)GetService(typeof(ISplitWindowService));
-                    if (sws != null)
+                    if (sws is not null)
                     {
                         sws.RemoveSplitWindow(componentTray);
                         IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
@@ -1055,10 +1055,10 @@ namespace System.Windows.Forms.Design
         protected override void OnContextMenu(int x, int y)
         {
             IMenuCommandService mcs = (IMenuCommandService)GetService(typeof(IMenuCommandService));
-            if (mcs != null)
+            if (mcs is not null)
             {
                 ISelectionService selSvc = (ISelectionService)GetService(typeof(ISelectionService));
-                if (selSvc != null)
+                if (selSvc is not null)
                 {
                     // Here we check to see if we're the only component selected.  If not, then
                     // we'll display the standard component menu.
@@ -1072,13 +1072,13 @@ namespace System.Windows.Forms.Design
                     else
                     {
                         Component selComp = selSvc.PrimarySelection as Component;
-                        if (selComp != null)
+                        if (selComp is not null)
                         {
                             IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
-                            if (host != null)
+                            if (host is not null)
                             {
                                 ComponentDesigner compDesigner = host.GetDesigner(selComp) as ComponentDesigner;
-                                if (compDesigner != null)
+                                if (compDesigner is not null)
                                 {
                                     compDesigner.ShowContextMenu(x, y);
                                     return;
@@ -1098,7 +1098,7 @@ namespace System.Windows.Forms.Design
         protected override void OnCreateHandle()
         {
             // Don't call base unless our inheritance service is already running.
-            if (inheritanceService != null)
+            if (inheritanceService is not null)
             {
                 base.OnCreateHandle();
             }
@@ -1167,7 +1167,7 @@ namespace System.Windows.Forms.Design
             if (undoEngine is null)
             {
                 undoEngine = GetService(typeof(UndoEngine)) as UndoEngine;
-                if (undoEngine != null)
+                if (undoEngine is not null)
                 {
                     undoEngine.Undoing += new EventHandler(OnUndoing);
                     undoEngine.Undone += new EventHandler(OnUndone);
@@ -1200,13 +1200,13 @@ namespace System.Windows.Forms.Design
 
             // Restore the tray layout.
             //
-            if (trayLayoutSuspended && componentTray != null)
+            if (trayLayoutSuspended && componentTray is not null)
                 componentTray.ResumeLayout();
 
             // Select this component.
             //
             ISelectionService ss = (ISelectionService)GetService(typeof(ISelectionService));
-            if (ss != null)
+            if (ss is not null)
             {
                 ss.SelectionChanged += new EventHandler(OnSelectionChanged);
                 ss.SetSelectedComponents(new object[] { Component }, SelectionTypes.Replace);
@@ -1217,7 +1217,7 @@ namespace System.Windows.Forms.Design
         private void OnComponentChanged(object sender, ComponentChangedEventArgs e)
         {
             Control ctrl = e.Component as Control;
-            if (ctrl != null && ctrl.IsHandleCreated)
+            if (ctrl is not null && ctrl.IsHandleCreated)
             {
                 User32.NotifyWinEvent((int)AccessibleEvents.LocationChange, new HandleRef(ctrl, ctrl.Handle), User32.OBJID.CLIENT, 0);
                 if (frame.Focused)
@@ -1234,7 +1234,7 @@ namespace System.Windows.Forms.Design
         private void OnSelectionChanged(object sender, EventArgs e)
         {
             ISelectionService svc = (ISelectionService)GetService(typeof(ISelectionService));
-            if (svc != null)
+            if (svc is not null)
             {
                 ICollection selComponents = svc.GetSelectedComponents();
 
@@ -1244,7 +1244,7 @@ namespace System.Windows.Forms.Design
                 foreach (object selObj in selComponents)
                 {
                     Control c = selObj as Control;
-                    if (c != null)
+                    if (c is not null)
                     {
                         Debug.WriteLineIf(CompModSwitches.MSAA.TraceInfo, "MSAA: SelectionAdd, control = " + c.ToString());
                         User32.NotifyWinEvent((int)AccessibleEvents.SelectionAdd, new HandleRef(c, c.Handle), User32.OBJID.CLIENT, 0);
@@ -1252,7 +1252,7 @@ namespace System.Windows.Forms.Design
                 }
 
                 Control primary = svc.PrimarySelection as Control;
-                if (primary != null)
+                if (primary is not null)
                 {
                     Debug.WriteLineIf(CompModSwitches.MSAA.TraceInfo, "MSAA: Focus, control = " + primary.ToString());
                     User32.NotifyWinEvent((int)AccessibleEvents.Focus, new HandleRef(primary, primary.Handle), User32.OBJID.CLIENT, 0);
@@ -1263,7 +1263,7 @@ namespace System.Windows.Forms.Design
                 //
                 IHelpService hs = (IHelpService)GetService(typeof(IHelpService));
 
-                if (hs != null)
+                if (hs is not null)
                 {
                     ushort type = 0;
                     string[] types = new string[]
@@ -1362,20 +1362,20 @@ namespace System.Windows.Forms.Design
             for (int i = 0; i < shadowProps.Length; i++)
             {
                 prop = (PropertyDescriptor)properties[shadowProps[i]];
-                if (prop != null)
+                if (prop is not null)
                 {
                     properties[shadowProps[i]] = TypeDescriptor.CreateProperty(typeof(DocumentDesigner), prop, empty);
                 }
             }
 
             prop = (PropertyDescriptor)properties["AutoScaleDimensions"];
-            if (prop != null)
+            if (prop is not null)
             {
                 properties["AutoScaleDimensions"] = TypeDescriptor.CreateProperty(typeof(DocumentDesigner), prop, DesignerSerializationVisibilityAttribute.Visible);
             }
 
             prop = (PropertyDescriptor)properties["AutoScaleMode"];
-            if (prop != null)
+            if (prop is not null)
             {
                 properties["AutoScaleMode"] = TypeDescriptor.CreateProperty(typeof(DocumentDesigner), prop, DesignerSerializationVisibilityAttribute.Visible, BrowsableAttribute.Yes);
             }
@@ -1383,7 +1383,7 @@ namespace System.Windows.Forms.Design
             for (int i = 0; i < noBrowseProps.Length; i++)
             {
                 prop = (PropertyDescriptor)properties[noBrowseProps[i]];
-                if (prop != null)
+                if (prop is not null)
                 {
                     properties[noBrowseProps[i]] = TypeDescriptor.CreateProperty(prop.ComponentType, prop, BrowsableAttribute.No, DesignerSerializationVisibilityAttribute.Hidden);
                 }
@@ -1451,10 +1451,10 @@ namespace System.Windows.Forms.Design
             // If the tab order UI is showing, don't allow us to place a tool.
             //
             IMenuCommandService mcs = (IMenuCommandService)GetService(typeof(IMenuCommandService));
-            if (mcs != null)
+            if (mcs is not null)
             {
                 MenuCommand cmd = mcs.FindCommand(StandardCommands.TabOrder);
-                if (cmd != null && cmd.Checked)
+                if (cmd is not null && cmd.Checked)
                 {
                     return;
                 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/EditorServiceContext.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/EditorServiceContext.cs
@@ -31,13 +31,13 @@ namespace System.Windows.Forms.Design
             if (prop is null)
             {
                 prop = TypeDescriptor.GetDefaultProperty(designer.Component);
-                if (prop != null && typeof(ICollection).IsAssignableFrom(prop.PropertyType))
+                if (prop is not null && typeof(ICollection).IsAssignableFrom(prop.PropertyType))
                 {
                     _targetProperty = prop;
                 }
             }
 
-            Debug.Assert(_targetProperty != null, "Need PropertyDescriptor for ICollection property to associate collection editor with.");
+            Debug.Assert(_targetProperty is not null, "Need PropertyDescriptor for ICollection property to associate collection editor with.");
         }
 
         internal EditorServiceContext(ComponentDesigner designer, PropertyDescriptor prop, string newVerbText) : this(designer, prop)
@@ -91,7 +91,7 @@ namespace System.Windows.Forms.Design
         {
             get
             {
-                if (_designer.Component.Site != null)
+                if (_designer.Component.Site is not null)
                 {
                     return _designer.Component.Site.Container;
                 }
@@ -129,7 +129,7 @@ namespace System.Windows.Forms.Design
                 return this;
             }
 
-            if (_designer.Component != null && _designer.Component.Site != null)
+            if (_designer.Component is not null && _designer.Component.Site is not null)
             {
                 return _designer.Component.Site.GetService(serviceType);
             }
@@ -153,7 +153,7 @@ namespace System.Windows.Forms.Design
         DialogResult IWindowsFormsEditorService.ShowDialog(Form dialog)
         {
             IUIService uiSvc = (IUIService)((IServiceProvider)this).GetService(typeof(IUIService));
-            if (uiSvc != null)
+            if (uiSvc is not null)
             {
                 return uiSvc.ShowDialog(dialog);
             }
@@ -176,7 +176,7 @@ namespace System.Windows.Forms.Design
 
             CollectionEditor itemsEditor = TypeDescriptor.GetEditor(propertyValue, typeof(UITypeEditor)) as CollectionEditor;
 
-            Debug.Assert(itemsEditor != null, "Didn't get a collection editor for type '" + _targetProperty.PropertyType.FullName + "'");
+            Debug.Assert(itemsEditor is not null, "Didn't get a collection editor for type '" + _targetProperty.PropertyType.FullName + "'");
             itemsEditor?.EditValue(this, this, propertyValue);
         }
     }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/EventHandlerService.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/EventHandlerService.cs
@@ -59,7 +59,7 @@ namespace System.Windows.Forms.Design
 
             object handler = _handlers.FirstOrDefault(handlerType.IsInstanceOfType);
 
-            if (handler != null)
+            if (handler is not null)
             {
                 _lastHandler = handler;
                 _lastHandlerType = handlerType;
@@ -76,7 +76,7 @@ namespace System.Windows.Forms.Design
             ArgumentNullException.ThrowIfNull(handler);
 
             var node = _handlers.Find(handler);
-            if (node != null)
+            if (node is not null)
             {
                 _handlers.Remove(node);
                 _lastHandler = null;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FolderNameEditor.FolderBrowser.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FolderNameEditor.FolderBrowser.cs
@@ -53,7 +53,7 @@ namespace System.Windows.Forms.Design
             public unsafe DialogResult ShowDialog(IWin32Window owner)
             {
                 // Get/find an owner HWND for this dialog.
-                HWND hWndOwner = owner != null ? (HWND)owner.Handle : PInvoke.GetActiveWindow();
+                HWND hWndOwner = owner is not null ? (HWND)owner.Handle : PInvoke.GetActiveWindow();
 
                 // Get the IDL for the specific start location.
                 PInvoke.SHGetSpecialFolderLocation(hWndOwner, (int)StartLocation, out ITEMIDLIST* listHandle);

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FormDocumentDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FormDocumentDesigner.cs
@@ -191,13 +191,13 @@ namespace System.Windows.Forms.Design
                 }
 
                 // if the padding has not been set - then we'll auto-add padding to form - this is a Usability request
-                if (Control.Padding == Padding.Empty && snapLines != null)
+                if (Control.Padding == Padding.Empty && snapLines is not null)
                 {
                     int paddingsFound = 0; // used to short-circuit once we find 4 paddings
                     for (int i = 0; i < snapLines.Count; i++)
                     {
                         // remove previous padding snaplines
-                        if (snapLines[i] is SnapLine snapLine && snapLine.Filter != null && snapLine.Filter.StartsWith(SnapLine.Padding))
+                        if (snapLines[i] is SnapLine snapLine && snapLine.Filter is not null && snapLine.Filter.StartsWith(SnapLine.Padding))
                         {
                             if (snapLine.Filter.Equals(SnapLine.PaddingLeft) || snapLine.Filter.Equals(SnapLine.PaddingTop))
                             {
@@ -283,9 +283,9 @@ namespace System.Windows.Forms.Design
             if (disposing)
             {
                 IDesignerHost host = GetService<IDesignerHost>();
-                Debug.Assert(host != null, "Must have a designer host on dispose");
+                Debug.Assert(host is not null, "Must have a designer host on dispose");
 
-                if (host != null)
+                if (host is not null)
                 {
                     host.LoadComplete -= new EventHandler(OnLoadComplete);
                     host.Activated -= new EventHandler(OnDesignerActivate);
@@ -293,7 +293,7 @@ namespace System.Windows.Forms.Design
                 }
 
                 IComponentChangeService cs = (IComponentChangeService)GetService(typeof(IComponentChangeService));
-                if (cs != null)
+                if (cs is not null)
                 {
                     cs.ComponentAdded -= new ComponentEventHandler(OnComponentAdded);
                     cs.ComponentRemoved -= new ComponentEventHandler(OnComponentRemoved);
@@ -316,7 +316,7 @@ namespace System.Windows.Forms.Design
         {
             // We have to shadow the WindowState before we call base.Initialize
             PropertyDescriptor windowStateProp = TypeDescriptor.GetProperties(component.GetType())["WindowState"];
-            if (windowStateProp != null && windowStateProp.PropertyType == typeof(FormWindowState))
+            if (windowStateProp is not null && windowStateProp.PropertyType == typeof(FormWindowState))
             {
                 WindowState = (FormWindowState)windowStateProp.GetValue(component);
             }
@@ -329,7 +329,7 @@ namespace System.Windows.Forms.Design
             Debug.Assert(component is Form, "FormDocumentDesigner expects its component to be a form.");
 
             IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
-            if (host != null)
+            if (host is not null)
             {
                 host.LoadComplete += new EventHandler(OnLoadComplete);
                 host.Activated += new EventHandler(OnDesignerActivate);
@@ -344,7 +344,7 @@ namespace System.Windows.Forms.Design
             // Monitor component/remove add events for our tray
             //
             IComponentChangeService cs = (IComponentChangeService)GetService(typeof(IComponentChangeService));
-            if (cs != null)
+            if (cs is not null)
             {
                 cs.ComponentAdded += new ComponentEventHandler(OnComponentAdded);
                 cs.ComponentRemoved += new ComponentEventHandler(OnComponentRemoved);
@@ -369,7 +369,7 @@ namespace System.Windows.Forms.Design
         /// </summary>
         private void OnComponentRemoved(object source, ComponentEventArgs ce)
         {
-            if (ce.Component is ToolStrip && _toolStripAdornerWindowService != null)
+            if (ce.Component is ToolStrip && _toolStripAdornerWindowService is not null)
             {
                 _toolStripAdornerWindowService = null;
             }
@@ -457,7 +457,7 @@ namespace System.Windows.Forms.Design
             for (int i = 0; i < shadowProps.Length; i++)
             {
                 prop = (PropertyDescriptor)properties[shadowProps[i]];
-                if (prop != null)
+                if (prop is not null)
                 {
                     properties[shadowProps[i]] = TypeDescriptor.CreateProperty(typeof(FormDocumentDesigner), prop, empty);
                 }
@@ -465,14 +465,14 @@ namespace System.Windows.Forms.Design
 
             // Mark auto scale base size as serializable again so we can monitor it for backwards compat.
             prop = (PropertyDescriptor)properties["AutoScaleBaseSize"];
-            if (prop != null)
+            if (prop is not null)
             {
                 properties["AutoScaleBaseSize"] = TypeDescriptor.CreateProperty(typeof(FormDocumentDesigner), prop, DesignerSerializationVisibilityAttribute.Visible);
             }
 
             // And set the new default value attribute for client base size, and shadow it as well.
             prop = (PropertyDescriptor)properties["ClientSize"];
-            if (prop != null)
+            if (prop is not null)
             {
                 properties["ClientSize"] = TypeDescriptor.CreateProperty(typeof(FormDocumentDesigner), prop, new DefaultValueAttribute(new Size(-1, -1)));
             }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FormatControl.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FormatControl.cs
@@ -36,7 +36,7 @@ namespace System.Windows.Forms.Design
             {
                 FormatTypeClass formatType = formatTypeListBox.SelectedItem as FormatTypeClass;
 
-                if (formatType != null)
+                if (formatType is not null)
                 {
                     return formatType.ToString();
                 }
@@ -436,11 +436,11 @@ namespace System.Windows.Forms.Design
             FormatStringDialog fsd = null;
             Control ctl = Parent;
 
-            while (ctl != null)
+            while (ctl is not null)
             {
                 fsd = ctl as FormatStringDialog;
 
-                if (fsd != null)
+                if (fsd is not null)
                 {
                     break;
                 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FormatStringDialog.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FormatStringDialog.cs
@@ -100,7 +100,7 @@ namespace System.Windows.Forms.Design
         {
             int result = ctl.Width;
 
-            while (ctl != null)
+            while (ctl is not null)
             {
                 result += ctl.Left;
                 ctl = ctl.Parent;
@@ -112,7 +112,7 @@ namespace System.Windows.Forms.Design
         private void FormatStringDialog_Load(object sender, EventArgs e)
         {
             // make a reasonable guess what user control should be shown
-            string formatString = _dgvCellStyle != null ? _dgvCellStyle.Format : _listControl.FormatString;
+            string formatString = _dgvCellStyle is not null ? _dgvCellStyle.Format : _listControl.FormatString;
             object nullValue = _dgvCellStyle?.NullValue;
             string formatType = string.Empty;
 
@@ -123,13 +123,13 @@ namespace System.Windows.Forms.Design
 
             // the null value text box should be enabled only when editing DataGridViewCellStyle
             // when we are editing ListControl, it should be disabled
-            if (_dgvCellStyle != null)
+            if (_dgvCellStyle is not null)
             {
                 _formatControl1.NullValueTextBoxEnabled = true;
             }
             else
             {
-                Debug.Assert(_listControl != null, "we check this everywhere, but it does not hurt to check it again");
+                Debug.Assert(_listControl is not null, "we check this everywhere, but it does not hurt to check it again");
                 _formatControl1.NullValueTextBoxEnabled = false;
             }
 
@@ -138,7 +138,7 @@ namespace System.Windows.Forms.Design
             // push the information from FormatString/FormatInfo/NullValue into the FormattingUserControl
             FormatControl.FormatTypeClass formatTypeItem = _formatControl1.FormatTypeItem;
 
-            if (formatTypeItem != null)
+            if (formatTypeItem is not null)
             {
                 // parsing the FormatString uses the CultureInfo. So push the CultureInfo before push the FormatString.
                 formatTypeItem.PushFormatStringIntoFormatType(formatString);
@@ -149,7 +149,7 @@ namespace System.Windows.Forms.Design
                 _formatControl1.FormatType = SR.BindingFormattingDialogFormatTypeNoFormatting;
             }
 
-            _formatControl1.NullValue = nullValue != null ? nullValue.ToString() : "";
+            _formatControl1.NullValue = nullValue is not null ? nullValue.ToString() : "";
         }
 
         public static void End()
@@ -264,7 +264,7 @@ namespace System.Windows.Forms.Design
                 return;
             }
 
-            if (_dgvCellStyle != null)
+            if (_dgvCellStyle is not null)
             {
                 _dgvCellStyle.Format = formatTypeItem.FormatString;
                 _dgvCellStyle.NullValue = _formatControl1.NullValue;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/GroupBoxDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/GroupBoxDesigner.cs
@@ -88,7 +88,7 @@ namespace System.Windows.Forms.Design
             {
                 inheritanceUI ??= (InheritanceUI)GetService(typeof(InheritanceUI));
 
-                if (inheritanceUI != null)
+                if (inheritanceUI is not null)
                 {
                     pe.Graphics.DrawImage(InheritanceUI.InheritanceGlyph, 0, 0);
                 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ImageCollectionCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ImageCollectionCodeDomSerializer.cs
@@ -47,7 +47,7 @@ namespace System.Windows.Forms.Design
             object codeObject = baseSerializer.Serialize(manager, value);
             ImageList imageList = value as ImageList;
 
-            if (imageList != null)
+            if (imageList is not null)
             {
                 StringCollection imageKeys = imageList.Images.Keys;
 
@@ -55,15 +55,15 @@ namespace System.Windows.Forms.Design
                 {
                     CodeExpression imageListObject = GetExpression(manager, value);
 
-                    if (imageListObject != null)
+                    if (imageListObject is not null)
                     {
                         CodeExpression imageListImagesProperty = new CodePropertyReferenceExpression(imageListObject, "Images");
 
-                        if (imageListImagesProperty != null)
+                        if (imageListImagesProperty is not null)
                         {
                             for (int i = 0; i < imageKeys.Count; i++)
                             {
-                                if ((imageKeys[i] != null) || (imageKeys[i].Length != 0))
+                                if ((imageKeys[i] is not null) || (imageKeys[i].Length != 0))
                                 {
                                     CodeMethodInvokeExpression setNameMethodCall
                                         = new(imageListImagesProperty, "SetKeyName",

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/InheritanceUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/InheritanceUI.cs
@@ -98,7 +98,7 @@ namespace System.Windows.Forms.Design
         /// </summary>
         public void RemoveInheritedControl(Control c)
         {
-            if (_tooltip != null && _tooltip.GetToolTip(c).Length > 0)
+            if (_tooltip is not null && _tooltip.GetToolTip(c).Length > 0)
             {
                 _tooltip.SetToolTip(c, null);
                 // Also, set all of its non-sited children

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/LabelDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/LabelDesigner.cs
@@ -37,7 +37,7 @@ namespace System.Windows.Forms.Design
                 PropertyDescriptor prop;
                 PropertyDescriptorCollection props = TypeDescriptor.GetProperties(Component);
 
-                if ((prop = props["TextAlign"]) != null)
+                if ((prop = props["TextAlign"]) is not null)
                 {
                     alignment = (ContentAlignment)prop.GetValue(Component);
                 }
@@ -45,13 +45,13 @@ namespace System.Windows.Forms.Design
                 //a single text-baseline for the label (and linklabel) control
                 int baseline = DesignerUtils.GetTextBaseline(Control, alignment);
 
-                if ((prop = props["AutoSize"]) != null)
+                if ((prop = props["AutoSize"]) is not null)
                 {
                     if ((bool)prop.GetValue(Component) == false)
                     {
                         //Only adjust if AutoSize is false
                         BorderStyle borderStyle = BorderStyle.None;
-                        if ((prop = props["BorderStyle"]) != null)
+                        if ((prop = props["BorderStyle"]) is not null)
                         {
                             borderStyle = (BorderStyle)prop.GetValue(Component);
                         }
@@ -64,13 +64,13 @@ namespace System.Windows.Forms.Design
 
                 // VSWhidbey# 414468
                 Label label = Control as Label;
-                if (label != null && label.BorderStyle == BorderStyle.None)
+                if (label is not null && label.BorderStyle == BorderStyle.None)
                 {
                     Type type = Type.GetType("System.Windows.Forms.Label");
-                    if (type != null)
+                    if (type is not null)
                     {
                         MethodInfo info = type.GetMethod("GetLeadingTextPaddingFromTextFormatFlags", BindingFlags.Instance | BindingFlags.NonPublic);
-                        if (info != null)
+                        if (info is not null)
                         {
                             int offset = (int)info.Invoke(Component, null);
                             bool rtl = (label.RightToLeft == RightToLeft.Yes);
@@ -79,7 +79,7 @@ namespace System.Windows.Forms.Design
                             {
                                 // remove previous padding snaplines
                                 SnapLine snapLine = snapLines[i] as SnapLine;
-                                if (snapLine != null && snapLine.SnapLineType == (rtl ? SnapLineType.Right : SnapLineType.Left))
+                                if (snapLine is not null && snapLine.SnapLineType == (rtl ? SnapLineType.Right : SnapLineType.Left))
                                 {
                                     snapLine.AdjustOffset(rtl ? -offset : offset);
                                     break;
@@ -147,7 +147,7 @@ namespace System.Windows.Forms.Design
                 object component = Component;
 
                 PropertyDescriptor propAutoSize = TypeDescriptor.GetProperties(component)["AutoSize"];
-                if (propAutoSize != null)
+                if (propAutoSize is not null)
                 {
                     bool autoSize = (bool)propAutoSize.GetValue(component);
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ListBoxDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ListBoxDesigner.cs
@@ -68,13 +68,13 @@ namespace System.Windows.Forms.Design
         protected override void PreFilterProperties(IDictionary properties)
         {
             PropertyDescriptor integralHeightProp = (PropertyDescriptor)properties["IntegralHeight"];
-            if (integralHeightProp != null)
+            if (integralHeightProp is not null)
             {
                 properties["IntegralHeight"] = TypeDescriptor.CreateProperty(typeof(ListBoxDesigner), integralHeightProp, Array.Empty<Attribute>());
             }
 
             PropertyDescriptor dockProp = (PropertyDescriptor)properties["Dock"];
-            if (dockProp != null)
+            if (dockProp is not null)
             {
                 properties["Dock"] = TypeDescriptor.CreateProperty(typeof(ListBoxDesigner), dockProp, Array.Empty<Attribute>());
             }
@@ -93,7 +93,7 @@ namespace System.Windows.Forms.Design
                 // list box.
                 //
                 IComponentChangeService cs = (IComponentChangeService)GetService(typeof(IComponentChangeService));
-                if (cs != null)
+                if (cs is not null)
                 {
                     cs.ComponentRename -= new ComponentRenameEventHandler(OnComponentRename);
                     cs.ComponentChanged -= new ComponentChangedEventHandler(OnComponentChanged);
@@ -111,7 +111,7 @@ namespace System.Windows.Forms.Design
             base.Initialize(component);
 
             ListBox listBox = component as ListBox;
-            if (null != listBox)
+            if (listBox is not null)
                 IntegralHeight = listBox.IntegralHeight;
 
             AutoResizeHandles = true;
@@ -120,7 +120,7 @@ namespace System.Windows.Forms.Design
             // list box.
             //
             IComponentChangeService cs = (IComponentChangeService)GetService(typeof(IComponentChangeService));
-            if (cs != null)
+            if (cs is not null)
             {
                 cs.ComponentRename += new ComponentRenameEventHandler(OnComponentRename);
                 cs.ComponentChanged += new ComponentChangedEventHandler(OnComponentChanged);
@@ -138,7 +138,7 @@ namespace System.Windows.Forms.Design
             // OnCreateHandle so let's set it here again. We need to keep setting the text in
             // OnCreateHandle, otherwise we introduce VSWhidbey 498162.
             PropertyDescriptor nameProp = TypeDescriptor.GetProperties(Component)["Name"];
-            if (nameProp != null)
+            if (nameProp is not null)
             {
                 UpdateControlName(nameProp.GetValue(Component).ToString());
             }
@@ -162,10 +162,10 @@ namespace System.Windows.Forms.Design
         /// </summary>
         private void OnComponentChanged(object sender, ComponentChangedEventArgs e)
         {
-            if (e.Component == Component && e.Member != null && e.Member.Name == "Items")
+            if (e.Component == Component && e.Member is not null && e.Member.Name == "Items")
             {
                 PropertyDescriptor nameProp = TypeDescriptor.GetProperties(Component)["Name"];
-                if (nameProp != null)
+                if (nameProp is not null)
                 {
                     UpdateControlName(nameProp.GetValue(Component).ToString());
                 }
@@ -179,7 +179,7 @@ namespace System.Windows.Forms.Design
         {
             base.OnCreateHandle();
             PropertyDescriptor nameProp = TypeDescriptor.GetProperties(Component)["Name"];
-            if (nameProp != null)
+            if (nameProp is not null)
             {
                 UpdateControlName(nameProp.GetValue(Component).ToString());
             }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ListViewDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ListViewDesigner.cs
@@ -30,7 +30,7 @@ namespace System.Windows.Forms.Design
             get
             {
                 ListView lv = Control as ListView;
-                if (lv != null)
+                if (lv is not null)
                 {
                     return lv.Columns;
                 }
@@ -114,14 +114,14 @@ namespace System.Windows.Forms.Design
         {
             PropertyDescriptor ownerDrawProp = (PropertyDescriptor)properties["OwnerDraw"];
 
-            if (ownerDrawProp != null)
+            if (ownerDrawProp is not null)
             {
                 properties["OwnerDraw"] = TypeDescriptor.CreateProperty(typeof(ListViewDesigner), ownerDrawProp, Array.Empty<Attribute>());
             }
 
             PropertyDescriptor viewProp = (PropertyDescriptor)properties["View"];
 
-            if (viewProp != null)
+            if (viewProp is not null)
             {
                 properties["View"] = TypeDescriptor.CreateProperty(typeof(ListViewDesigner), viewProp, Array.Empty<Attribute>());
             }
@@ -186,7 +186,7 @@ namespace System.Windows.Forms.Design
 
         private static void ShowErrorDialog(IUIService uiService, Exception ex, Control control)
         {
-            if (uiService != null)
+            if (uiService is not null)
             {
                 uiService.ShowError(ex);
             }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskDescriptor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskDescriptor.cs
@@ -92,13 +92,13 @@ namespace System.Windows.Forms.Design
 
             if (maskedTextBox.Tag is null) // Sample was added successfully (MaskInputRejected event handler did not change the maskedTextBox tag).
             {
-                if (maskDescriptor.ValidatingType != null)
+                if (maskDescriptor.ValidatingType is not null)
                 {
                     maskedTextBox.ValidateText();
                 }
             }
 
-            if (maskedTextBox.Tag != null) // Validation failed.
+            if (maskedTextBox.Tag is not null) // Validation failed.
             {
                 validationErrorDescription = maskedTextBox.Tag.ToString();
             }
@@ -147,7 +147,7 @@ namespace System.Windows.Forms.Design
         {
             string hash = Mask;
 
-            if (ValidatingType != null)
+            if (ValidatingType is not null)
             {
                 hash += ValidatingType.ToString();
             }
@@ -161,7 +161,7 @@ namespace System.Windows.Forms.Design
                 GetType(),
                 Name ?? "null",
                 Mask ?? "null",
-                ValidatingType != null ? ValidatingType.ToString() : "null");
+                ValidatingType is not null ? ValidatingType.ToString() : "null");
         }
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskDescriptorComparer.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskDescriptorComparer.cs
@@ -68,7 +68,7 @@ namespace System.Windows.Forms.Design
 
         public static int GetHashCode(MaskDescriptor maskDescriptor)
         {
-            if (maskDescriptor != null)
+            if (maskDescriptor is not null)
             {
                 return maskDescriptor.GetHashCode();
             }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskDescriptorTemplate.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskDescriptorTemplate.cs
@@ -311,7 +311,7 @@ namespace System.Windows.Forms.Design
             /// </summary>
             public void Add(MaskDescriptorTemplate maskDescriptorTemplate)
             {
-                if (maskDescriptorTemplate.Mask != null)
+                if (maskDescriptorTemplate.Mask is not null)
                 {
                     List.Add(maskDescriptorTemplate);
                 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskDesignerDialog.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskDesignerDialog.cs
@@ -326,11 +326,11 @@ namespace System.Windows.Forms.Design
         /// </summary>
         private bool ContainsMaskDescriptor(MaskDescriptor maskDescriptor)
         {
-            Debug.Assert(maskDescriptor != null, "Null mask descriptor.");
+            Debug.Assert(maskDescriptor is not null, "Null mask descriptor.");
 
             foreach (MaskDescriptor descriptor in _maskDescriptors)
             {
-                Debug.Assert(descriptor != null, "Null mask descriptor in the collection.");
+                Debug.Assert(descriptor is not null, "Null mask descriptor in the collection.");
 
                 if (maskDescriptor.Equals(descriptor) || maskDescriptor.Name.Trim() == descriptor.Name.Trim())
                 {
@@ -494,7 +494,7 @@ namespace System.Windows.Forms.Design
 
                 foreach (MaskDescriptor maskDescriptor in _maskDescriptors)
                 {
-                    string validatingType = maskDescriptor.ValidatingType != null ? maskDescriptor.ValidatingType.Name : nullEntry;
+                    string validatingType = maskDescriptor.ValidatingType is not null ? maskDescriptor.ValidatingType.Name : nullEntry;
 
                     // Make sure the sample displays literals.
                     MaskedTextProvider mtp = new MaskedTextProvider(maskDescriptor.Mask, maskDescriptor.Culture);
@@ -510,7 +510,7 @@ namespace System.Windows.Forms.Design
                 _maskDescriptors.Add(_customMaskDescriptor);
                 _listViewCannedMasks.Items.Add(new ListViewItem(new string[] { _customMaskDescriptor.Name, "", nullEntry }));
 
-                if (selectedMaskDex != null)
+                if (selectedMaskDex is not null)
                 {
                     SetSelectedMaskDescriptor(selectedMaskDex);
                 }
@@ -586,7 +586,7 @@ namespace System.Windows.Forms.Design
         /// </summary>
         private void listViewCannedMasks_Enter(object sender, EventArgs e)
         {
-            if (_listViewCannedMasks.FocusedItem != null || _listViewCannedMasks.Items.Count <= 0)
+            if (_listViewCannedMasks.FocusedItem is not null || _listViewCannedMasks.Items.Count <= 0)
             {
                 return;
             }
@@ -648,7 +648,7 @@ namespace System.Windows.Forms.Design
         /// </summary>
         private void ShowHelp()
         {
-            if (_helpService != null)
+            if (_helpService is not null)
             {
                 _helpService.ShowHelpFromKeyword(HelpTopic);
             }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskedTextBoxDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskedTextBoxDesigner.cs
@@ -171,7 +171,7 @@ namespace System.Windows.Forms.Design
             for (int i = 0; i < shadowProps.Length; i++)
             {
                 prop = (PropertyDescriptor)properties[shadowProps[i]];
-                if (prop != null)
+                if (prop is not null)
                 {
                     properties[shadowProps[i]] = TypeDescriptor.CreateProperty(typeof(MaskedTextBoxDesigner), prop, empty);
                 }
@@ -204,7 +204,7 @@ namespace System.Windows.Forms.Design
             get
             {
                 MaskedTextBox maskedTextBox = Control as MaskedTextBox;
-                Debug.Assert(maskedTextBox != null, "Designed control is not a MaskedTextBox.");
+                Debug.Assert(maskedTextBox is not null, "Designed control is not a MaskedTextBox.");
 
                 if (maskedTextBox.UseSystemPasswordChar)
                 {
@@ -222,7 +222,7 @@ namespace System.Windows.Forms.Design
             set
             {
                 MaskedTextBox maskedTextBox = Control as MaskedTextBox;
-                Debug.Assert(maskedTextBox != null, "Designed control is not a MaskedTextBox.");
+                Debug.Assert(maskedTextBox is not null, "Designed control is not a MaskedTextBox.");
 
                 maskedTextBox.PasswordChar = value;
             }
@@ -241,7 +241,7 @@ namespace System.Windows.Forms.Design
             {
                 // Return text w/o literals or prompt.
                 MaskedTextBox maskedTextBox = Control as MaskedTextBox;
-                Debug.Assert(maskedTextBox != null, "Designed control is not a MaskedTextBox.");
+                Debug.Assert(maskedTextBox is not null, "Designed control is not a MaskedTextBox.");
 
                 // Text w/o prompt or literals.
                 if (string.IsNullOrEmpty(maskedTextBox.Mask))
@@ -254,7 +254,7 @@ namespace System.Windows.Forms.Design
             set
             {
                 MaskedTextBox maskedTextBox = Control as MaskedTextBox;
-                Debug.Assert(maskedTextBox != null, "Designed control is not a MaskedTextBox.");
+                Debug.Assert(maskedTextBox is not null, "Designed control is not a MaskedTextBox.");
 
                 if (string.IsNullOrEmpty(maskedTextBox.Mask))
                 {

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/NewItemsContextMenuStrip.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/NewItemsContextMenuStrip.cs
@@ -39,7 +39,7 @@ namespace System.Windows.Forms.Design
                 Groups["StandardList"].Items.Add(item);
                 if (_convertTo)
                 {
-                    if (item is ItemTypeToolStripMenuItem toolItem && _currentItem != null && toolItem.ItemType == _currentItem.GetType())
+                    if (item is ItemTypeToolStripMenuItem toolItem && _currentItem is not null && toolItem.ItemType == _currentItem.GetType())
                     {
                         toolItem.Enabled = false;
                     }
@@ -51,7 +51,7 @@ namespace System.Windows.Forms.Design
                 Groups["CustomList"].Items.Add(item);
                 if (_convertTo)
                 {
-                    if (item is ItemTypeToolStripMenuItem toolItem && _currentItem != null && toolItem.ItemType == _currentItem.GetType())
+                    if (item is ItemTypeToolStripMenuItem toolItem && _currentItem is not null && toolItem.ItemType == _currentItem.GetType())
                     {
                         toolItem.Enabled = false;
                     }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/OleDragDropHandler.CfCodeToolboxItem.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/OleDragDropHandler.CfCodeToolboxItem.cs
@@ -50,7 +50,7 @@ namespace System.Windows.Forms.Design
             protected override void Serialize(SerializationInfo info, StreamingContext context)
             {
                 base.Serialize(info, context);
-                if (_serializationData != null)
+                if (_serializationData is not null)
                 {
                     info.AddValue("CfCodeToolboxItem.serializationData", _serializationData);
                 }
@@ -88,7 +88,7 @@ namespace System.Windows.Forms.Design
                 ArrayList components = new ArrayList();
                 foreach (object obj in objects)
                 {
-                    if (obj != null && obj is IComponent)
+                    if (obj is not null && obj is IComponent)
                     {
                         components.Add(obj);
                     }
@@ -101,10 +101,10 @@ namespace System.Windows.Forms.Design
                 //
                 defaultValues ??= new Hashtable();
                 Control parentControl = defaultValues["Parent"] as Control;
-                if (parentControl != null)
+                if (parentControl is not null)
                 {
                     ParentControlDesigner parentControlDesigner = host.GetDesigner(parentControl) as ParentControlDesigner;
-                    if (parentControlDesigner != null)
+                    if (parentControlDesigner is not null)
                     {
                         // Determine bounds of all controls
                         //
@@ -114,7 +114,7 @@ namespace System.Windows.Forms.Design
                         {
                             Control childControl = component as Control;
 
-                            if (childControl != null && childControl != parentControl && childControl.Parent is null)
+                            if (childControl is not null && childControl != parentControl && childControl.Parent is null)
                             {
                                 if (bounds.IsEmpty)
                                 {
@@ -132,8 +132,8 @@ namespace System.Windows.Forms.Design
                         {
                             Control childControl = component as Control;
                             Form form = childControl as Form;
-                            if (childControl != null
-                                && !(form != null && form.TopLevel) // Don't add top-level forms
+                            if (childControl is not null 
+                                && !(form is not null && form.TopLevel) // Don't add top-level forms
                                 && childControl.Parent is null)
                             {
                                 defaultValues["Offset"] = new Size(childControl.Bounds.X - bounds.X, childControl.Bounds.Y - bounds.Y);
@@ -150,7 +150,7 @@ namespace System.Windows.Forms.Design
                 //
                 ComponentTray tray = (ComponentTray)host.GetService(typeof(ComponentTray));
                 List<Control> trayComponents = null;
-                if (tray != null)
+                if (tray is not null)
                 {
                     foreach (IComponent component in componentsArray)
                     {
@@ -164,7 +164,7 @@ namespace System.Windows.Forms.Design
                         }
                     }
 
-                    if (trayComponents != null)
+                    if (trayComponents is not null)
                     {
                         tray.UpdatePastePositions(trayComponents);
                     }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/OleDragDropHandler.CfCodeToolboxItem.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/OleDragDropHandler.CfCodeToolboxItem.cs
@@ -132,7 +132,7 @@ namespace System.Windows.Forms.Design
                         {
                             Control childControl = component as Control;
                             Form form = childControl as Form;
-                            if (childControl is not null 
+                            if (childControl is not null
                                 && !(form is not null && form.TopLevel) // Don't add top-level forms
                                 && childControl.Parent is null)
                             {

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/OleDragDropHandler.ComponentDataObject.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/OleDragDropHandler.ComponentDataObject.cs
@@ -45,10 +45,10 @@ namespace System.Windows.Forms.Design
             {
                 get
                 {
-                    if (serializationStream is null && Components != null)
+                    if (serializationStream is null && Components is not null)
                     {
                         IDesignerSerializationService ds = (IDesignerSerializationService)serviceProvider.GetService(typeof(IDesignerSerializationService));
-                        if (ds != null)
+                        if (ds is not null)
                         {
                             object[] comps = new object[components.Length];
                             for (int i = 0; i < components.Length; i++)
@@ -75,7 +75,7 @@ namespace System.Windows.Forms.Design
             {
                 get
                 {
-                    if (components is null && (serializationStream != null || serializationData != null))
+                    if (components is null && (serializationStream is not null || serializationData is not null))
                     {
                         Deserialize(null, false);
                         if (components is null)
@@ -126,7 +126,7 @@ namespace System.Windows.Forms.Design
                     selectedComponents = new ArrayList(components);
 
                 IDesignerHost host = (IDesignerHost)serviceProvider.GetService(typeof(IDesignerHost));
-                if (host != null)
+                if (host is not null)
                 {
                     ArrayList copySelection = new ArrayList();
                     foreach (IComponent comp in selectedComponents)
@@ -248,14 +248,14 @@ namespace System.Windows.Forms.Design
 #pragma warning restore SYSLIB0011 // Type or member is obsolete
                     }
 
-                    if (removeCurrentComponents && components != null)
+                    if (removeCurrentComponents && components is not null)
                     {
                         foreach (IComponent removeComp in components)
                         {
-                            if (host is null && removeComp.Site != null)
+                            if (host is null && removeComp.Site is not null)
                             {
                                 host = (IDesignerHost)removeComp.Site.GetService(typeof(IDesignerHost));
-                                if (host != null)
+                                if (host is not null)
                                 {
                                     trans = host.CreateTransaction(string.Format(SR.DragDropMoveComponents, components.Length));
                                 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/OleDragDropHandler.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/OleDragDropHandler.cs
@@ -108,7 +108,7 @@ namespace System.Windows.Forms.Design
 
         protected virtual bool CanDropDataObject(IDataObject dataObj)
         {
-            if (dataObj != null)
+            if (dataObj is not null)
             {
                 if (dataObj is ComponentDataObjectWrapper)
                 {
@@ -217,7 +217,7 @@ namespace System.Windows.Forms.Design
             {
                 try
                 {
-                    if (host != null)
+                    if (host is not null)
                         trans = host.CreateTransaction(string.Format(SR.DesignerBatchCreateTool, tool.ToString()));
                 }
                 catch (CheckoutException cxe)
@@ -235,7 +235,7 @@ namespace System.Windows.Forms.Design
                         // First check if we are currently in localization mode (i.e., language is non-default).
                         // If so, we should not permit addition of new components. This is an intentional
                         // change from Everett - see VSWhidbey #292249.
-                        if (host != null && CurrentlyLocalizing(host.RootComponent))
+                        if (host is not null && CurrentlyLocalizing(host.RootComponent))
                         {
                             IUIService uiService = (IUIService)GetService(typeof(IUIService));
                             uiService?.ShowMessage(SR.LocalizingCannotAdd);
@@ -247,12 +247,12 @@ namespace System.Windows.Forms.Design
                         // Create a dictionary of default values that the designer can
                         // use to initialize a control with.
                         Hashtable defaultValues = new Hashtable();
-                        if (parent != null)
+                        if (parent is not null)
                             defaultValues["Parent"] = parent;
 
                         // adjust the location if we are in a mirrored parent. That is because the origin
                         // will then be in the upper right rather than upper left.
-                        if (parent != null && parent.IsMirrored)
+                        if (parent is not null && parent.IsMirrored)
                         {
                             x += width;
                         }
@@ -262,7 +262,7 @@ namespace System.Windows.Forms.Design
                         if (hasSize)
                             defaultValues["Size"] = new Size(width, height);
                         //store off extra behavior drag/drop information
-                        if (e != null)
+                        if (e is not null)
                             defaultValues["ToolboxSnapDragDropEventArgs"] = e;
 
                         comps = tool.CreateComponents(host, defaultValues);
@@ -288,7 +288,7 @@ namespace System.Windows.Forms.Design
                         IUIService uiService = (IUIService)GetService(typeof(IUIService));
 
                         string exceptionMessage = string.Empty;
-                        if (ex.InnerException != null)
+                        if (ex.InnerException is not null)
                         {
                             exceptionMessage = ex.InnerException.ToString();
                         }
@@ -303,7 +303,7 @@ namespace System.Windows.Forms.Design
                             exceptionMessage = ex.Message;
                         }
 
-                        if (uiService != null)
+                        if (uiService is not null)
                         {
                             uiService.ShowError(ex, string.Format(SR.FailedToCreateComponent, tool.DisplayName, exceptionMessage));
                         }
@@ -317,7 +317,7 @@ namespace System.Windows.Forms.Design
                 }
                 finally
                 {
-                    if (toolboxSvc != null && tool.Equals(toolboxSvc.GetSelectedToolboxItem(host)))
+                    if (toolboxSvc is not null && tool.Equals(toolboxSvc.GetSelectedToolboxItem(host)))
                     {
                         toolboxSvc.SelectedToolboxItemUsed();
                     }
@@ -332,7 +332,7 @@ namespace System.Windows.Forms.Design
 
             // Finally, select the newly created components.
             //
-            if (selSvc != null && comps.Length > 0)
+            if (selSvc is not null && comps.Length > 0)
             {
                 host?.Activate();
 
@@ -358,11 +358,11 @@ namespace System.Windows.Forms.Design
         /// </summary>
         private static bool CurrentlyLocalizing(IComponent rootComponent)
         {
-            if (rootComponent != null)
+            if (rootComponent is not null)
             {
                 PropertyDescriptor prop = TypeDescriptor.GetProperties(rootComponent)["Language"];
 
-                if (prop != null && prop.PropertyType == typeof(Globalization.CultureInfo))
+                if (prop is not null && prop.PropertyType == typeof(Globalization.CultureInfo))
                 {
                     Globalization.CultureInfo ci = (Globalization.CultureInfo)prop.GetValue(rootComponent);
                     if (!ci.Equals(Globalization.CultureInfo.InvariantCulture))
@@ -379,7 +379,7 @@ namespace System.Windows.Forms.Design
         {
             foreach (Control c in controls)
             {
-                if (c != null)
+                if (c is not null)
                 {
                     if (c.AllowDrop)
                     {
@@ -437,7 +437,7 @@ namespace System.Windows.Forms.Design
                 bool readOnlyLocation = true;
 
                 PropertyDescriptor loc = TypeDescriptor.GetProperties(comps[i])["Location"];
-                if (loc != null)
+                if (loc is not null)
                 {
                     readOnlyLocation = loc.IsReadOnly;
                 }
@@ -597,7 +597,7 @@ namespace System.Windows.Forms.Design
             foreach (object comp in components)
             {
                 Control ctl = comp as Control;
-                if (ctl != null && ctl.HasChildren)
+                if (ctl is not null && ctl.HasChildren)
                 {
                     DisableDragDropChildren(ctl.Controls, allowDropChanged);
                 }
@@ -606,7 +606,7 @@ namespace System.Windows.Forms.Design
             DragDropEffects effect = DragDropEffects.None;
             IDesignerHost host = GetService(typeof(IDesignerHost)) as IDesignerHost;
             DesignerTransaction trans = null;
-            if (host != null)
+            if (host is not null)
             {
                 trans = host.CreateTransaction(string.Format(SR.DragDropDragComponents, components.Length));
             }
@@ -629,7 +629,7 @@ namespace System.Windows.Forms.Design
 
                 freezePainting = oldFreezePainting;
 
-                if (trans != null)
+                if (trans is not null)
                 {
                     ((IDisposable)trans).Dispose();
                 }
@@ -641,9 +641,9 @@ namespace System.Windows.Forms.Design
             bool isLocalMove = isMove && localDragInside;
 
             ISelectionUIService selectionUISvc = (ISelectionUIService)GetService(typeof(ISelectionUIService));
-            Debug.Assert(selectionUISvc != null, "Unable to get selection ui service when adding child control");
+            Debug.Assert(selectionUISvc is not null, "Unable to get selection ui service when adding child control");
 
-            if (selectionUISvc != null)
+            if (selectionUISvc is not null)
             {
                 // We must check to ensure that UI service is still in drag mode.  It is
                 // possible that the user hit escape, which will cancel drag mode.
@@ -840,9 +840,9 @@ namespace System.Windows.Forms.Design
                     // now we need to offset the components locations from the drop mouse
                     // point to the parent, since their current locations are relative
                     // the mouse pointer
-                    if (components != null && components.Length > 0)
+                    if (components is not null && components.Length > 0)
                     {
-                        Debug.Assert(container != null, "Didn't get a container from the site!");
+                        Debug.Assert(container is not null, "Didn't get a container from the site!");
                         string name;
                         IComponent comp = null;
 
@@ -886,7 +886,7 @@ namespace System.Windows.Forms.Design
                                     // it didn't, so let's check for the regular Location
                                     loc ??= TypeDescriptor.GetProperties(comp)["Location"];
 
-                                    if (loc != null && !loc.IsReadOnly)
+                                    if (loc is not null && !loc.IsReadOnly)
                                     {
                                         Rectangle bounds = default(Rectangle);
                                         Point pt = (Point)loc.GetValue(comp);
@@ -914,7 +914,7 @@ namespace System.Windows.Forms.Design
                                     if (updateLocation)
                                     {
                                         ParentControlDesigner parentDesigner = client as ParentControlDesigner;
-                                        if (parentDesigner != null)
+                                        if (parentDesigner is not null)
                                         {
                                             Control c = client.GetControlForComponent(comp);
                                             dropPt = parentDesigner.GetSnappedPoint(c.Location);
@@ -963,9 +963,9 @@ namespace System.Windows.Forms.Design
                 if (localDragInside)
                 {
                     ISelectionUIService selectionUISvc = (ISelectionUIService)GetService(typeof(ISelectionUIService));
-                    Debug.Assert(selectionUISvc != null, "Unable to get selection ui service when adding child control");
+                    Debug.Assert(selectionUISvc is not null, "Unable to get selection ui service when adding child control");
 
-                    if (selectionUISvc != null)
+                    if (selectionUISvc is not null)
                     {
                         // We must check to ensure that UI service is still in drag mode.  It is
                         // possible that the user hit escape, which will cancel drag mode.
@@ -1148,7 +1148,7 @@ namespace System.Windows.Forms.Design
             }
 
             e.UseDefaultCursors = ((!localDragInside && !forceDrawFrames) || ((e.Effect & (DragDropEffects.Copy)) != 0)) || e.Effect == DragDropEffects.None;
-            if (!e.UseDefaultCursors && selectionHandler != null)
+            if (!e.UseDefaultCursors && selectionHandler is not null)
             {
                 selectionHandler.SetCursor();
             }
@@ -1198,11 +1198,11 @@ namespace System.Windows.Forms.Design
             foreach (object comp in compList)
             {
                 Control c = comp as Control;
-                if (c is null && comp != null)
+                if (c is null && comp is not null)
                 {
                     topLevel.Add(comp);
                 }
-                else if (c != null)
+                else if (c is not null)
                 {
                     if (c.Parent is null || !compList.Contains(c.Parent))
                     {

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ParentControlDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ParentControlDesigner.cs
@@ -182,7 +182,7 @@ namespace System.Windows.Forms.Design
                     //our grid/snap setting from it - instead of our options page
                     //
                     ParentControlDesigner parent = GetParentControlDesignerOfParent();
-                    if (parent != null)
+                    if (parent is not null)
                     {
                         _drawGrid = parent.DrawGrid;
                     }
@@ -223,7 +223,7 @@ namespace System.Windows.Forms.Design
                     // 'cause they might to change along with us, unless the user has explicitly set
                     // those values...
                     IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
-                    if (host != null)
+                    if (host is not null)
                     {
                         // for (int i = 0; i < children.Length; i++) {
                         foreach (Control child in Control.Controls)
@@ -271,7 +271,7 @@ namespace System.Windows.Forms.Design
                     //our grid/snap setting from it - instead of our options page
                     //
                     ParentControlDesigner parent = GetParentControlDesignerOfParent();
-                    if (parent != null)
+                    if (parent is not null)
                     {
                         _gridSize = parent.GridSize;
                     }
@@ -316,7 +316,7 @@ namespace System.Windows.Forms.Design
                 // 'cause they might to change along with us, unless the user has explicitly set
                 // those values...
                 IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
-                if (host != null)
+                if (host is not null)
                 {
                     foreach (Control child in Control.Controls)
                     {
@@ -405,7 +405,7 @@ namespace System.Windows.Forms.Design
         {
             get
             {
-                if (Component != null)
+                if (Component is not null)
                 {
                     return Component.Site;
                 }
@@ -435,14 +435,14 @@ namespace System.Windows.Forms.Design
                     //our grid/snap setting from it - instead of our options page
                     //
                     ParentControlDesigner parent = GetParentControlDesignerOfParent();
-                    if (parent != null)
+                    if (parent is not null)
                     {
                         _gridSnap = parent.SnapToGrid;
                     }
                     else
                     {
                         object optionValue = DesignerUtils.GetOptionValue(ServiceProvider, "SnapToGrid");
-                        if (optionValue != null && optionValue is bool)
+                        if (optionValue is not null && optionValue is bool)
                         {
                             _gridSnap = (bool)optionValue;
                         }
@@ -471,7 +471,7 @@ namespace System.Windows.Forms.Design
                     // 'cause they might to change along with us, unless the user has explicitly set
                     // those values...
                     IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
-                    if (host != null)
+                    if (host is not null)
                     {
                         foreach (Control child in Control.Controls)
                         {
@@ -503,14 +503,14 @@ namespace System.Windows.Forms.Design
             Point location = Point.Empty;
             Size size = Size.Empty;
             Size offset = new Size(0, 0);
-            bool hasLocation = (defaultValues != null && defaultValues.Contains("Location"));
-            bool hasSize = (defaultValues != null && defaultValues.Contains("Size"));
+            bool hasLocation = (defaultValues is not null && defaultValues.Contains("Location"));
+            bool hasSize = (defaultValues is not null && defaultValues.Contains("Size"));
 
             if (hasLocation)
                 location = (Point)defaultValues["Location"];
             if (hasSize)
                 size = (Size)defaultValues["Size"];
-            if (defaultValues != null && defaultValues.Contains("Offset"))
+            if (defaultValues is not null && defaultValues.Contains("Offset"))
             {
                 offset = (Size)defaultValues["Offset"];
             }
@@ -522,11 +522,8 @@ namespace System.Windows.Forms.Design
             // Otherwise, proceed with the parenting and locating.
             //
             IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
-            if (host != null
-                && newChild != null
-                && !Control.Contains(newChild)
-                && (host.GetDesigner(newChild) as ControlDesigner) != null
-                && !(newChild is Form && ((Form)newChild).TopLevel))
+            if (host is not null && newChild is not null && !Control.Contains(newChild)
+                && (host.GetDesigner(newChild) as ControlDesigner) is not null && !(newChild is Form && ((Form)newChild).TopLevel))
             {
                 Rectangle bounds = default(Rectangle);
 
@@ -546,7 +543,7 @@ namespace System.Windows.Forms.Design
                     ISelectionService selSvc = (ISelectionService)GetService(typeof(ISelectionService));
                     object primarySelection = selSvc.PrimarySelection;
                     Control selectedControl = null;
-                    if (primarySelection != null)
+                    if (primarySelection is not null)
                     {
                         selectedControl = ((IOleDragClient)this).GetControlForComponent(primarySelection);
                     }
@@ -554,7 +551,7 @@ namespace System.Windows.Forms.Design
                     // If the resulting control that came back isn't sited, it's not part of the
                     // design surface and should not be used as a marker.
                     //
-                    if (selectedControl != null && selectedControl.Site is null)
+                    if (selectedControl is not null && selectedControl.Site is null)
                     {
                         selectedControl = null;
                     }
@@ -619,10 +616,10 @@ namespace System.Windows.Forms.Design
 
                 //check to see if we have additional information for bounds from
                 //the behaviorservice dragdrop logic
-                if (defaultValues != null && defaultValues.Contains("ToolboxSnapDragDropEventArgs"))
+                if (defaultValues is not null && defaultValues.Contains("ToolboxSnapDragDropEventArgs"))
                 {
                     ToolboxSnapDragDropEventArgs e = defaultValues["ToolboxSnapDragDropEventArgs"] as ToolboxSnapDragDropEventArgs;
-                    Debug.Assert(e != null, "Why can't we get a ToolboxSnapDragDropEventArgs object out of our default values?");
+                    Debug.Assert(e is not null, "Why can't we get a ToolboxSnapDragDropEventArgs object out of our default values?");
 
                     Rectangle snappedBounds = DesignerUtils.GetBoundsFromToolboxSnapDragDropInfo(e, bounds, Control.IsMirrored);
 
@@ -632,7 +629,7 @@ namespace System.Windows.Forms.Design
                     //never properly adjust the snap drag info.  This cause the control to be added @ 0,0 w.r.t.
                     //the adorner window.
                     Control rootControl = host.RootComponent as Control;
-                    if (rootControl != null && snappedBounds.IntersectsWith(rootControl.ClientRectangle))
+                    if (rootControl is not null && snappedBounds.IntersectsWith(rootControl.ClientRectangle))
                     {
                         bounds = snappedBounds;
                     }
@@ -650,7 +647,7 @@ namespace System.Windows.Forms.Design
                 // these values if it does.
                 //
                 PropertyDescriptorCollection props = TypeDescriptor.GetProperties(newChild);
-                if (props != null)
+                if (props is not null)
                 {
                     PropertyDescriptor prop = props["Size"];
                     prop?.SetValue(newChild, new Size(bounds.Width, bounds.Height));
@@ -664,7 +661,7 @@ namespace System.Windows.Forms.Design
 
                     Point pt = new Point(bounds.X, bounds.Y);
                     ScrollableControl p = newChild.Parent as ScrollableControl;
-                    if (p != null)
+                    if (p is not null)
                     {
                         Point ptScroll = p.AutoScrollPosition;
                         pt.Offset(-ptScroll.X, -ptScroll.Y); //always want to add the control below/right of the AutoScrollPosition
@@ -688,7 +685,7 @@ namespace System.Windows.Forms.Design
         {
             Control control = GetControl(component);
 
-            if (control != null)
+            if (control is not null)
             {
                 Control parent = control;
 
@@ -703,10 +700,10 @@ namespace System.Windows.Forms.Design
                     childSite = ((IComponent)children[i]).Site;
 
                     IContainer childContainer;
-                    if (childSite != null)
+                    if (childSite is not null)
                     {
                         name = childSite.Name;
-                        if (container.Components[name] != null)
+                        if (container.Components[name] is not null)
                         {
                             name = null;
                         }
@@ -726,7 +723,7 @@ namespace System.Windows.Forms.Design
 
                     childContainer?.Remove(children[i]);
 
-                    if (name != null)
+                    if (name is not null)
                     {
                         container.Add(children[i], name);
                     }
@@ -785,7 +782,7 @@ namespace System.Windows.Forms.Design
                 }
 
                 IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
-                if (host != null)
+                if (host is not null)
                 {
                     _changeService.ComponentRemoving -= new ComponentEventHandler(OnComponentRemoving);
                     _changeService.ComponentRemoved -= new ComponentEventHandler(OnComponentRemoved);
@@ -972,7 +969,7 @@ namespace System.Windows.Forms.Design
                 container = DesignerUtils.CheckForNestedContainer(container); // ...necessary to support SplitterPanel components
 
                 if (child.Visible && ((containRect && rect.Contains(bounds)) || (!containRect && bounds.IntersectsWith(rect))) &&
-                    child.Site != null && child.Site.Container == container)
+                    child.Site is not null && child.Site.Container == container)
                 {
                     list.Add(child);
                 }
@@ -987,13 +984,13 @@ namespace System.Windows.Forms.Design
         protected Control GetControl(object component)
         {
             IComponent comp = component as IComponent;
-            if (comp != null)
+            if (comp is not null)
             {
                 IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
-                if (host != null)
+                if (host is not null)
                 {
                     ControlDesigner cd = host.GetDesigner(comp) as ControlDesigner;
-                    if (cd != null)
+                    if (cd is not null)
                     {
                         return cd.Control;
                     }
@@ -1034,7 +1031,7 @@ namespace System.Windows.Forms.Design
             PropertyDescriptor prop = TypeDescriptor.GetProperties(component)["AutoSize"];
 
             Size size;
-            if (prop != null &&
+            if (prop is not null &&
                 !(prop.Attributes.Contains(DesignerSerializationVisibilityAttribute.Hidden) ||
                   prop.Attributes.Contains(BrowsableAttribute.No)))
             {
@@ -1042,7 +1039,7 @@ namespace System.Windows.Forms.Design
                 if (autoSize)
                 {
                     prop = TypeDescriptor.GetProperties(component)["PreferredSize"];
-                    if (prop != null)
+                    if (prop is not null)
                     {
                         size = (Size)prop.GetValue(component);
                         if (size != Size.Empty)
@@ -1057,7 +1054,7 @@ namespace System.Windows.Forms.Design
             //
             prop = TypeDescriptor.GetProperties(component)["Size"];
 
-            if (prop != null)
+            if (prop is not null)
             {
                 // first, let's see if we can get a valid size...
                 size = (Size)prop.GetValue(component);
@@ -1066,7 +1063,7 @@ namespace System.Windows.Forms.Design
                 if (size.Width <= 0 || size.Height <= 0)
                 {
                     var sizeAttr = (DefaultValueAttribute)prop.Attributes[typeof(DefaultValueAttribute)];
-                    if (sizeAttr != null)
+                    if (sizeAttr is not null)
                     {
                         return ((Size)sizeAttr.Value);
                     }
@@ -1096,7 +1093,7 @@ namespace System.Windows.Forms.Design
             Control parent = Control.Parent;
             IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
 
-            if (parent != null && host != null && host.RootComponent != Component)
+            if (parent is not null && host is not null && host.RootComponent != Component)
             {
                 Rectangle parentRect = BehaviorService.ControlRectInAdornerWindow(parent);
                 Rectangle nonClipRect = Rectangle.Intersect(parentRect, controlRect);
@@ -1172,7 +1169,7 @@ namespace System.Windows.Forms.Design
         {
             Control parent = Control.Parent;
             IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
-            if (parent != null && host != null)
+            if (parent is not null && host is not null)
             {
                 return (host.GetDesigner(parent) as ParentControlDesigner);
             }
@@ -1313,10 +1310,10 @@ namespace System.Windows.Forms.Design
             // connect these up.
             //
             IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
-            if (host != null)
+            if (host is not null)
             {
                 _changeService = (IComponentChangeService)host.GetService(typeof(IComponentChangeService));
-                if (_changeService != null)
+                if (_changeService is not null)
                 {
                     _changeService.ComponentRemoving += new ComponentEventHandler(OnComponentRemoving);
                     _changeService.ComponentRemoved += new ComponentEventHandler(OnComponentRemoved);
@@ -1338,7 +1335,7 @@ namespace System.Windows.Forms.Design
                 return;
             }
 
-            if (defaultValues != null && defaultValues["Size"] != null && defaultValues["Location"] != null && defaultValues["Parent"] != null)
+            if (defaultValues is not null && defaultValues["Size"] is not null && defaultValues["Location"] is not null && defaultValues["Parent"] is not null)
             {
                 //build our rect that may have covered some child controls
                 Rectangle bounds = new Rectangle((Point)defaultValues["Location"], (Size)defaultValues["Size"]);
@@ -1418,7 +1415,7 @@ namespace System.Windows.Forms.Design
                 defaultValue = DesignerUtils.GetOptionValue(ServiceProvider, optionName);
             }
 
-            if (defaultValue != null)
+            if (defaultValue is not null)
             {
                 return defaultValue.Equals(value);
             }
@@ -1433,7 +1430,7 @@ namespace System.Windows.Forms.Design
         private void OnComponentRemoving(object sender, ComponentEventArgs e)
         {
             Control comp = e.Component as Control;
-            if (comp != null && comp.Parent != null && comp.Parent == Control)
+            if (comp is not null && comp.Parent is not null && comp.Parent == Control)
             {
                 _pendingRemoveControl = comp;
                 //We suspend Component Changing Events for bulk operations to avoid unnecessary serialization\deserialization for undo
@@ -1498,7 +1495,7 @@ namespace System.Windows.Forms.Design
             }
 
             DropSourceBehavior.BehaviorDataObject data = de.Data as DropSourceBehavior.BehaviorDataObject;
-            if (data != null)
+            if (data is not null)
             {
                 data.Target = Component;
                 data.EndDragDrop(AllowSetChildIndexOnDrop);
@@ -1510,13 +1507,13 @@ namespace System.Windows.Forms.Design
             else if (_mouseDragTool is null && data is null)
             {
                 OleDragDropHandler ddh = GetOleDragHandler();
-                if (ddh != null)
+                if (ddh is not null)
                 {
                     IOleDragClient target = ddh.Destination;
-                    if (target != null && target.Component != null && target.Component.Site != null)
+                    if (target is not null && target.Component is not null && target.Component.Site is not null)
                     {
                         IContainer container = target.Component.Site.Container;
-                        if (container != null)
+                        if (container is not null)
                         {
                             object[] dragComps = OleDragDropHandler.GetDraggingObjects(de);
                             for (int i = 0; i < dragComps.Length; i++)
@@ -1529,7 +1526,7 @@ namespace System.Windows.Forms.Design
                 }
             }
 
-            if (_mouseDragTool != null)
+            if (_mouseDragTool is not null)
             {
                 IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
                 host?.Activate();
@@ -1572,7 +1569,7 @@ namespace System.Windows.Forms.Design
 
             DropSourceBehavior.BehaviorDataObject behDataObject = null;
             DropSourceBehavior.BehaviorDataObject data = de.Data as DropSourceBehavior.BehaviorDataObject;
-            if (data != null)
+            if (data is not null)
             {
                 behDataObject = data;
                 behDataObject.Target = Component;
@@ -1584,10 +1581,10 @@ namespace System.Windows.Forms.Design
             // dropped here.
             //
             IMenuCommandService ms = (IMenuCommandService)GetService(typeof(IMenuCommandService));
-            if (ms != null)
+            if (ms is not null)
             {
                 MenuCommand tabCommand = ms.FindCommand(StandardCommands.TabOrder);
-                if (tabCommand != null && tabCommand.Checked)
+                if (tabCommand is not null && tabCommand.Checked)
                 {
                     de.Effect = DragDropEffects.None;
                     return;
@@ -1597,7 +1594,7 @@ namespace System.Windows.Forms.Design
             // Get the objects that are being dragged
             //
             object[] dragComps;
-            if (behDataObject != null && behDataObject.DragComponents != null)
+            if (behDataObject is not null && behDataObject.DragComponents is not null)
             {
                 dragComps = new object[behDataObject.DragComponents.Count];
                 behDataObject.DragComponents.CopyTo(dragComps, 0);
@@ -1611,10 +1608,10 @@ namespace System.Windows.Forms.Design
             Control draggedControl = null;
 
             IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
-            if (host != null)
+            if (host is not null)
             {
                 DocumentDesigner parentDesigner = host.GetDesigner(host.RootComponent) as DocumentDesigner;
-                if (parentDesigner != null)
+                if (parentDesigner is not null)
                 {
                     if (!parentDesigner.CanDropComponents(de))
                     {
@@ -1624,7 +1621,7 @@ namespace System.Windows.Forms.Design
                 }
             }
 
-            if (dragComps != null)
+            if (dragComps is not null)
             {
                 if (data is null)
                 {
@@ -1646,7 +1643,7 @@ namespace System.Windows.Forms.Design
                         // If we are dropping on a new target, then check to see if any of the components
                         // are inherited. If so, don't allow them to be moved.
                         InheritanceAttribute attr = (InheritanceAttribute)TypeDescriptor.GetAttributes(comp)[typeof(InheritanceAttribute)];
-                        if (attr != null && !attr.Equals(InheritanceAttribute.NotInherited) && !attr.Equals(InheritanceAttribute.InheritedReadOnly))
+                        if (attr is not null && !attr.Equals(InheritanceAttribute.NotInherited) && !attr.Equals(InheritanceAttribute.InheritedReadOnly))
                         {
                             de.Effect = DragDropEffects.None;
                             return;
@@ -1662,7 +1659,7 @@ namespace System.Windows.Forms.Design
                     }
 
                     Control ctrl = dragComps[i] as Control;
-                    if (draggedControl is null && ctrl != null)
+                    if (draggedControl is null && ctrl is not null)
                     {
                         draggedControl = ctrl;
                     }
@@ -1705,13 +1702,13 @@ namespace System.Windows.Forms.Design
 
             // Only assume the items came from the ToolBox if dragComps == null
             //
-            if (_toolboxService != null && dragComps is null)
+            if (_toolboxService is not null && dragComps is null)
             {
                 _mouseDragTool = _toolboxService.DeserializeToolboxItem(de.Data, host);
 
                 //If we have a valid toolbox item to drag and
                 //we haven't pushed our behavior, then do so now...
-                if ((_mouseDragTool != null) && BehaviorService != null && BehaviorService.UseSnapLines)
+                if ((_mouseDragTool is not null) && BehaviorService is not null && BehaviorService.UseSnapLines)
                 {
                     //demand create
                     _toolboxItemSnapLineBehavior ??= new ToolboxItemSnapLineBehavior(Component.Site, BehaviorService, this, AllowGenericDragBox);
@@ -1723,7 +1720,7 @@ namespace System.Windows.Forms.Design
                     }
                 }
 
-                if (_mouseDragTool != null)
+                if (_mouseDragTool is not null)
                 {
                     PerformDragEnter(de, host);
                 }
@@ -1768,7 +1765,7 @@ namespace System.Windows.Forms.Design
         protected override void OnDragLeave(EventArgs e)
         {
             //if we're dragging around our generic snapline box - let's remove it here
-            if (_toolboxItemSnapLineBehavior != null && _toolboxItemSnapLineBehavior.IsPushed)
+            if (_toolboxItemSnapLineBehavior is not null && _toolboxItemSnapLineBehavior.IsPushed)
             {
                 BehaviorService.PopBehavior(_toolboxItemSnapLineBehavior);
                 _toolboxItemSnapLineBehavior.IsPushed = false;
@@ -1783,7 +1780,7 @@ namespace System.Windows.Forms.Design
         protected override void OnDragOver(DragEventArgs de)
         {
             DropSourceBehavior.BehaviorDataObject data = de.Data as DropSourceBehavior.BehaviorDataObject;
-            if (data != null)
+            if (data is not null)
             {
                 data.Target = Component;
                 de.Effect = (Control.ModifierKeys == Keys.Control) ? DragDropEffects.Copy : DragDropEffects.Move;
@@ -1795,11 +1792,11 @@ namespace System.Windows.Forms.Design
             // dropped here.
             //
             IMenuCommandService ms = (IMenuCommandService)GetService(typeof(IMenuCommandService));
-            if (ms != null)
+            if (ms is not null)
             {
                 MenuCommand tabCommand = ms.FindCommand(StandardCommands.TabOrder);
-                Debug.Assert(tabCommand != null, "Missing tab order command");
-                if (tabCommand != null && tabCommand.Checked)
+                Debug.Assert(tabCommand is not null, "Missing tab order command");
+                if (tabCommand is not null && tabCommand.Checked)
                 {
                     de.Effect = DragDropEffects.None;
                     return;
@@ -1807,10 +1804,10 @@ namespace System.Windows.Forms.Design
             }
 
             IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
-            if (host != null)
+            if (host is not null)
             {
                 DocumentDesigner parentDesigner = host.GetDesigner(host.RootComponent) as DocumentDesigner;
-                if (parentDesigner != null)
+                if (parentDesigner is not null)
                 {
                     if (!parentDesigner.CanDropComponents(de))
                     {
@@ -1820,7 +1817,7 @@ namespace System.Windows.Forms.Design
                 }
             }
 
-            if (_mouseDragTool != null)
+            if (_mouseDragTool is not null)
             {
                 Debug.Assert(0 != (de.AllowedEffect & DragDropEffects.Copy), "DragDropEffect.Move isn't allowed?");
                 de.Effect = DragDropEffects.Copy;
@@ -1854,7 +1851,7 @@ namespace System.Windows.Forms.Design
             {
                 _toolboxService ??= (IToolboxService)GetService(typeof(IToolboxService));
 
-                if (_toolboxService != null)
+                if (_toolboxService is not null)
                 {
                     _mouseDragTool = _toolboxService.GetSelectedToolboxItem((IDesignerHost)GetService(typeof(IDesignerHost)));
                 }
@@ -1880,7 +1877,7 @@ namespace System.Windows.Forms.Design
             //UNDONE: Behavior Work
             //Debug.Assert(escapeHandler == null, "Why is there already an escape handler?");
 
-            if (eventSvc != null && _escapeHandler is null)
+            if (eventSvc is not null && _escapeHandler is null)
             {
                 _escapeHandler = new EscapeHandler(this);
                 eventSvc.PushHandler(_escapeHandler);
@@ -1921,7 +1918,7 @@ namespace System.Windows.Forms.Design
             Cursor.Clip = Rectangle.Empty;
 
             // Clear out the drag frame.
-            if (!offset.IsEmpty && _graphics != null)
+            if (!offset.IsEmpty && _graphics is not null)
             {
                 Rectangle frameRect = new Rectangle(offset.X - _adornerWindowToScreenOffset.X,
                                                      offset.Y - _adornerWindowToScreenOffset.Y,
@@ -1939,14 +1936,14 @@ namespace System.Windows.Forms.Design
                 _graphics.ResetClip();
             }
 
-            if (_graphics != null)
+            if (_graphics is not null)
             {
                 _graphics.Dispose();
                 _graphics = null;
             }
 
             //destroy the snapline engine (if we used it)
-            if (_dragManager != null)
+            if (_dragManager is not null)
             {
                 _dragManager.OnMouseUp();
                 _dragManager = null;
@@ -1955,14 +1952,14 @@ namespace System.Windows.Forms.Design
             // Get the event handler service and pop our handler.
             //
             IEventHandlerService eventSvc = (IEventHandlerService)GetService(typeof(IEventHandlerService));
-            if (eventSvc != null && _escapeHandler != null)
+            if (eventSvc is not null && _escapeHandler is not null)
             {
                 eventSvc.PopHandler(_escapeHandler);
                 _escapeHandler = null;
             }
 
             // Set Status Information - but only if the offset is not empty, if it is, the user didn't move the mouse
-            if (_statusCommandUI != null && !offset.IsEmpty)
+            if (_statusCommandUI is not null && !offset.IsEmpty)
             {
                 Point location = new(baseVar.X, baseVar.Y);
                 location = Control.PointToClient(location);
@@ -1973,7 +1970,7 @@ namespace System.Windows.Forms.Design
             if (offset.IsEmpty && !cancel)
             {
                 // BUT, if we have a selected tool, create it here
-                if (tool != null)
+                if (tool is not null)
                 {
                     try
                     {
@@ -2005,7 +2002,7 @@ namespace System.Windows.Forms.Design
 
             // If we have a valid toolbox item, create the tool
             //
-            if (tool != null)
+            if (tool is not null)
             {
                 try
                 {
@@ -2043,7 +2040,7 @@ namespace System.Windows.Forms.Design
                 // select them.
                 //
                 var selSvc = (ISelectionService)GetService(typeof(ISelectionService));
-                if (selSvc != null)
+                if (selSvc is not null)
                 {
                     object[] selection = GetComponentsInRect(offset, true, false /*component does not need to be fully contained*/);
                     if (selection.Length > 0)
@@ -2063,7 +2060,7 @@ namespace System.Windows.Forms.Design
         {
             //if we pushed a snapline behavior during a drag operation - make sure we have popped it
             //if we're now receiving mouse move messages.
-            if (_toolboxItemSnapLineBehavior != null && _toolboxItemSnapLineBehavior.IsPushed)
+            if (_toolboxItemSnapLineBehavior is not null && _toolboxItemSnapLineBehavior.IsPushed)
             {
                 BehaviorService.PopBehavior(_toolboxItemSnapLineBehavior);
                 _toolboxItemSnapLineBehavior.IsPushed = false;
@@ -2090,12 +2087,12 @@ namespace System.Windows.Forms.Design
             //and use it when the user drags a reversible rect -- but only if the
             //parentcontroldesigner wants to allow Snaplines
 
-            if (_dragManager is null && ParticipatesWithSnapLines && _mouseDragTool != null && BehaviorService.UseSnapLines)
+            if (_dragManager is null && ParticipatesWithSnapLines && _mouseDragTool is not null && BehaviorService.UseSnapLines)
             {
                 _dragManager = new DragAssistanceManager(Component.Site);
             }
 
-            if (_dragManager != null)
+            if (_dragManager is not null)
             {
                 //here, we build up our new rect (offset by the adorner window)
                 //and ask the snapline engine to adjust our coords
@@ -2123,7 +2120,7 @@ namespace System.Windows.Forms.Design
             // If we're dragging out a new component, update the drag rectangle
             // to use snaps, if they're set.
             //
-            if (_mouseDragTool != null)
+            if (_mouseDragTool is not null)
             {
                 // To snap properly, we must snap in client coordinates.  So, convert, snap
                 // and re-convert.
@@ -2136,7 +2133,7 @@ namespace System.Windows.Forms.Design
             _graphics ??= BehaviorService.AdornerWindowGraphics;
 
             // And draw the new drag frame
-            if (!_mouseDragOffset.IsEmpty && _graphics != null)
+            if (!_mouseDragOffset.IsEmpty && _graphics is not null)
             {
                 Rectangle frameRect = new Rectangle(_mouseDragOffset.X - _adornerWindowToScreenOffset.X,
                                                      _mouseDragOffset.Y - _adornerWindowToScreenOffset.Y,
@@ -2179,7 +2176,7 @@ namespace System.Windows.Forms.Design
             }
 
             // We are looking at the primary control
-            if (_statusCommandUI != null)
+            if (_statusCommandUI is not null)
             {
                 Point offset = new(_mouseDragOffset.X, _mouseDragOffset.Y);
                 offset = Control.PointToClient(offset);
@@ -2311,7 +2308,7 @@ namespace System.Windows.Forms.Design
                 //get the location of our parent - so we can correctly offset the new lasso'd controls
                 //once they are re-parented
                 Point parentLoc = Point.Empty;
-                if (locationProp != null)
+                if (locationProp is not null)
                 {
                     parentLoc = (Point)locationProp.GetValue(newParent);
                 }
@@ -2328,20 +2325,20 @@ namespace System.Windows.Forms.Design
 
                     //do not want to reparent any control that is inherited readonly
                     InheritanceAttribute inheritanceAttribute = (InheritanceAttribute)TypeDescriptor.GetAttributes(control)[typeof(InheritanceAttribute)];
-                    if (inheritanceAttribute != null && inheritanceAttribute == InheritanceAttribute.InheritedReadOnly)
+                    if (inheritanceAttribute is not null && inheritanceAttribute == InheritanceAttribute.InheritedReadOnly)
                     {
                         continue;
                     }
 
                     //get the current location of the control
                     PropertyDescriptor locProp = TypeDescriptor.GetProperties(control)["Location"];
-                    if (locProp != null)
+                    if (locProp is not null)
                     {
                         controlLoc = (Point)locProp.GetValue(control);
                     }
 
                     //fire comp changing on parent and control
-                    if (oldParent != null)
+                    if (oldParent is not null)
                     {
                         changeService?.OnComponentChanging(oldParent, controlsProp);
 
@@ -2357,7 +2354,7 @@ namespace System.Windows.Forms.Design
                     //this condition will determine which way we need to 'offset' our control location
                     //based on whether we are moving controls into a child or bringing them out to
                     //a parent
-                    if (oldParent != null)
+                    if (oldParent is not null)
                     {
                         if (oldParent.Controls.Contains(newParent))
                         {
@@ -2373,7 +2370,7 @@ namespace System.Windows.Forms.Design
                     locProp.SetValue(control, newLoc);
 
                     //fire our comp changed events
-                    if (changeService != null && oldParent != null)
+                    if (changeService is not null && oldParent is not null)
                     {
                         changeService.OnComponentChanged(oldParent, controlsProp);
                     }
@@ -2396,7 +2393,7 @@ namespace System.Windows.Forms.Design
             //setting...
             //
             ParentControlDesigner parent = GetParentControlDesignerOfParent();
-            if (parent != null)
+            if (parent is not null)
             {
                 return !(DrawGrid == parent.DrawGrid);
             }
@@ -2416,7 +2413,7 @@ namespace System.Windows.Forms.Design
             //setting...
             //
             ParentControlDesigner parent = GetParentControlDesignerOfParent();
-            if (parent != null)
+            if (parent is not null)
             {
                 return !(SnapToGrid == parent.SnapToGrid);
             }
@@ -2436,7 +2433,7 @@ namespace System.Windows.Forms.Design
             //setting...
             //
             ParentControlDesigner parent = GetParentControlDesignerOfParent();
-            if (parent != null)
+            if (parent is not null)
             {
                 return !(GridSize.Equals(parent.GridSize));
             }
@@ -2495,7 +2492,7 @@ namespace System.Windows.Forms.Design
             if (!firstAdd)
             {
                 // just a move, so reparent
-                if (component.Site != null)
+                if (component.Site is not null)
                 {
                     oldContainer = component.Site.Container;
                     containerMove = container != oldContainer;
@@ -2509,13 +2506,13 @@ namespace System.Windows.Forms.Design
                 {
                     // check if there's already a component by this name in the
                     // container
-                    if (name != null && container.Components[name] != null)
+                    if (name is not null && container.Components[name] is not null)
                     {
                         name = null;
                     }
 
                     // add it back
-                    if (name != null)
+                    if (name is not null)
                     {
                         container.Add(component, name);
                     }
@@ -2535,7 +2532,7 @@ namespace System.Windows.Forms.Design
                 {
                     IUIService uiSvc = (IUIService)GetService(typeof(IUIService));
                     string error = string.Format(SR.DesignerCantParentType, component.GetType().Name, Component.GetType().Name);
-                    if (uiSvc != null)
+                    if (uiSvc is not null)
                     {
                         uiSvc.ShowError(error);
                     }
@@ -2573,7 +2570,7 @@ namespace System.Windows.Forms.Design
             //
             Control c = GetControl(component);
 
-            if (c != null)
+            if (c is not null)
             {
                 // set it's handler to this
                 Control parent = GetParentForComponent(component);
@@ -2587,7 +2584,7 @@ namespace System.Windows.Forms.Design
                         // we want to insert rather than add it, so we add then move
                         // to the beginning
 
-                        if (c.Parent != null)
+                        if (c.Parent is not null)
                         {
                             Control cParent = c.Parent;
                             _changeService?.OnComponentChanging(cParent, controlsProp);
@@ -2596,7 +2593,7 @@ namespace System.Windows.Forms.Design
                             _changeService?.OnComponentChanged(cParent, controlsProp, cParent.Controls, cParent.Controls);
                         }
 
-                        if (_suspendChanging == 0 && _changeService != null)
+                        if (_suspendChanging == 0 && _changeService is not null)
                         {
                             _changeService.OnComponentChanging(parent, controlsProp);
                         }
@@ -2621,7 +2618,7 @@ namespace System.Windows.Forms.Design
                 c.Invalidate(true);
             }
 
-            if (localDesignerHost != null && containerMove)
+            if (localDesignerHost is not null && containerMove)
             {
                 // sburke -- looks like we always want to do this to ensure that sited children get
                 // handled properly.  if we respected the boolean before, the ui selection handlers
@@ -2656,7 +2653,7 @@ namespace System.Windows.Forms.Design
         {
             IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
 
-            if (host != null)
+            if (host is not null)
             {
                 IDesigner designer = host.GetDesigner(component);
                 bool disposeDesigner = false;
@@ -2666,7 +2663,7 @@ namespace System.Windows.Forms.Design
                 {
                     designer = TypeDescriptor.CreateDesigner(component, typeof(IDesigner));
                     ControlDesigner cd = designer as ControlDesigner;
-                    if (cd != null)
+                    if (cd is not null)
                     {
                         //Make sure the component doesn't get set to Visible
                         cd.ForceVisible = false;
@@ -2679,12 +2676,12 @@ namespace System.Windows.Forms.Design
                 try
                 {
                     ComponentDesigner cd = designer as ComponentDesigner;
-                    if (cd != null)
+                    if (cd is not null)
                     {
                         if (cd.CanBeAssociatedWith(this))
                         {
                             ControlDesigner controlDesigner = cd as ControlDesigner;
-                            if (controlDesigner != null)
+                            if (controlDesigner is not null)
                             {
                                 return CanParent(controlDesigner);
                             }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/PictureBoxDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/PictureBoxDesigner.cs
@@ -86,7 +86,7 @@ namespace System.Windows.Forms.Design
                 object component = Component;
 
                 PropertyDescriptor propSizeMode = TypeDescriptor.GetProperties(Component)["SizeMode"];
-                if (propSizeMode != null)
+                if (propSizeMode is not null)
                 {
                     PictureBoxSizeMode sizeMode = (PictureBoxSizeMode)propSizeMode.GetValue(component);
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/RadioButtonDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/RadioButtonDesigner.cs
@@ -20,7 +20,7 @@ namespace System.Windows.Forms.Design
 
             // In Whidbey, default the TabStop to true.
             PropertyDescriptor prop = TypeDescriptor.GetProperties(Component)["TabStop"];
-            if (prop != null && prop.PropertyType == typeof(bool) && !prop.IsReadOnly && prop.IsBrowsable)
+            if (prop is not null && prop.PropertyType == typeof(bool) && !prop.IsReadOnly && prop.IsBrowsable)
             {
                 prop.SetValue(Component, true);
             }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/RichTextBoxDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/RichTextBoxDesigner.cs
@@ -29,7 +29,7 @@ namespace System.Windows.Forms.Design
             // CONSIDER: Is this the correct function for doing this?
             Control control = Control;
 
-            if (control != null && control.Handle != IntPtr.Zero)
+            if (control is not null && control.Handle != IntPtr.Zero)
             {
                 PInvoke.RevokeDragDrop((HWND)control.Handle);
                 // DragAcceptFiles(control.Handle, false);
@@ -77,7 +77,7 @@ namespace System.Windows.Forms.Design
             for (int i = 0; i < shadowProps.Length; i++)
             {
                 prop = (PropertyDescriptor)properties[shadowProps[i]];
-                if (prop != null)
+                if (prop is not null)
                 {
                     properties[shadowProps[i]] = TypeDescriptor.CreateProperty(typeof(RichTextBoxDesigner), prop, empty);
                 }
@@ -97,7 +97,7 @@ namespace System.Windows.Forms.Design
             set
             {
                 string oldText = Control.Text;
-                if (value != null)
+                if (value is not null)
                 {
                     value = value.Replace("\r\n", "\n");
                 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/SelectionUIHandler.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/SelectionUIHandler.cs
@@ -47,7 +47,7 @@ namespace System.Windows.Forms.Design
             {
                 Debug.Assert(components[i] is IComponent, "Selection UI handler only deals with IComponents");
                 dragControls[i] = GetControl((IComponent)components[i]);
-                Debug.Assert(dragControls[i] != null, "Everyone must have a control");
+                Debug.Assert(dragControls[i] is not null, "Everyone must have a control");
             }
 
             // allow the cliprect to go just beyond the window by one grid.  This helps with round off
@@ -73,7 +73,7 @@ namespace System.Windows.Forms.Design
                 Rectangle containerRect = containerControl.RectangleToScreen(containerControl.ClientRectangle);
                 containerRect.Inflate(snapSize.Width, snapSize.Height);
                 ScrollableControl sc = GetControl() as ScrollableControl;
-                if (sc != null && sc.AutoScroll)
+                if (sc is not null && sc.AutoScroll)
                 {
                     Rectangle screen = SystemInformation.VirtualScreen;
                     containerRect.Width = screen.Width;
@@ -90,7 +90,7 @@ namespace System.Windows.Forms.Design
         /// </summary>
         private static void CancelControlMove(Control[] controls, BoundsInfo[] bounds)
         {
-            Debug.Assert(bounds != null && controls != null && bounds.Length == controls.Length, "bounds->controls mismatch");
+            Debug.Assert(bounds is not null && controls is not null && bounds.Length == controls.Length, "bounds->controls mismatch");
 
             Rectangle b = default(Rectangle);
 
@@ -131,7 +131,7 @@ namespace System.Windows.Forms.Design
         {
             dragOffset = offset;
             MoveControls(components, false, false);
-            Debug.Assert(originalCoords != null, "We are keying off of originalCoords, but MoveControls didn't set it");
+            Debug.Assert(originalCoords is not null, "We are keying off of originalCoords, but MoveControls didn't set it");
         }
 
         /// <summary>
@@ -329,7 +329,7 @@ namespace System.Windows.Forms.Design
                 //
 
                 IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
-                Debug.Assert(host != null, "No designer host");
+                Debug.Assert(host is not null, "No designer host");
                 if (controls[i] == host.RootComponent)
                 {
                     targetX = 0;
@@ -388,7 +388,7 @@ namespace System.Windows.Forms.Design
                     //
                     PropertyDescriptor boundsProp = TypeDescriptor.GetProperties(components[i])["Bounds"];
 
-                    if (boundsProp != null && !boundsProp.IsReadOnly)
+                    if (boundsProp is not null && !boundsProp.IsReadOnly)
                     {
                         if (finalMove)
                         {
@@ -418,7 +418,7 @@ namespace System.Windows.Forms.Design
 
                     PropertyDescriptor trayProp = TypeDescriptor.GetProperties(components[i])["TrayLocation"];
 
-                    if (trayProp != null && !trayProp.IsReadOnly)
+                    if (trayProp is not null && !trayProp.IsReadOnly)
                     {
                         trayProp.SetValue(components[i], adjustedLoc);
                     }
@@ -430,7 +430,7 @@ namespace System.Windows.Forms.Design
                         //
                         PropertyDescriptor leftProp = TypeDescriptor.GetProperties(components[i])["Left"];
                         PropertyDescriptor topProp = TypeDescriptor.GetProperties(components[i])["Top"];
-                        if (topProp != null && !topProp.IsReadOnly)
+                        if (topProp is not null && !topProp.IsReadOnly)
                         {
                             if (finalMove)
                             {
@@ -443,7 +443,7 @@ namespace System.Windows.Forms.Design
                             }
                         }
 
-                        if (leftProp != null && !leftProp.IsReadOnly)
+                        if (leftProp is not null && !leftProp.IsReadOnly)
                         {
                             if (finalMove)
                             {
@@ -459,7 +459,7 @@ namespace System.Windows.Forms.Design
                         if (leftProp is null || topProp is null)
                         {
                             PropertyDescriptor locationProp = TypeDescriptor.GetProperties(components[i])["Location"];
-                            if (locationProp != null && !locationProp.IsReadOnly)
+                            if (locationProp is not null && !locationProp.IsReadOnly)
                             {
                                 locationProp.SetValue(components[i], adjustedLoc);
                             }
@@ -481,7 +481,7 @@ namespace System.Windows.Forms.Design
                     PropertyDescriptor widthProp = TypeDescriptor.GetProperties(components[i])["Width"];
                     PropertyDescriptor heightProp = TypeDescriptor.GetProperties(components[i])["Height"];
 
-                    if (widthProp != null && !widthProp.IsReadOnly && size.Width != (int)widthProp.GetValue(components[i]))
+                    if (widthProp is not null && !widthProp.IsReadOnly && size.Width != (int)widthProp.GetValue(components[i]))
                     {
                         if (finalMove)
                         {
@@ -494,7 +494,7 @@ namespace System.Windows.Forms.Design
                         }
                     }
 
-                    if (heightProp != null && !heightProp.IsReadOnly && size.Height != (int)heightProp.GetValue(components[i]))
+                    if (heightProp is not null && !heightProp.IsReadOnly && size.Height != (int)heightProp.GetValue(components[i]))
                     {
                         if (finalMove)
                         {
@@ -515,7 +515,7 @@ namespace System.Windows.Forms.Design
             {
                 Control parent = controls[i].Parent;
 
-                if (parent != null)
+                if (parent is not null)
                 {
                     parent.ResumeLayout();
                     parent.Update();
@@ -533,18 +533,18 @@ namespace System.Windows.Forms.Design
         public bool QueryBeginDrag(object[] components, SelectionRules rules, int initialX, int initialY)
         {
             IComponentChangeService cs = (IComponentChangeService)GetService(typeof(IComponentChangeService));
-            if (cs != null)
+            if (cs is not null)
             {
                 try
                 {
-                    if (components != null && components.Length > 0)
+                    if (components is not null && components.Length > 0)
                     {
                         foreach (object c in components)
                         {
                             cs.OnComponentChanging(c, TypeDescriptor.GetProperties(c)["Location"]);
                             PropertyDescriptor sizeProp = TypeDescriptor.GetProperties(c)["Size"];
 
-                            if (sizeProp != null && sizeProp.Attributes.Contains(DesignerSerializationVisibilityAttribute.Hidden))
+                            if (sizeProp is not null && sizeProp.Attributes.Contains(DesignerSerializationVisibilityAttribute.Hidden))
                             {
                                 sizeProp = TypeDescriptor.GetProperties(c)["ClientSize"];
                             }
@@ -577,7 +577,7 @@ namespace System.Windows.Forms.Design
                 }
             }
 
-            return components != null && components.Length > 0;
+            return components is not null && components.Length > 0;
         }
 
         /// <summary>
@@ -628,7 +628,7 @@ namespace System.Windows.Forms.Design
                 Size sz;
                 Point loc;
 
-                if (sizeProp != null)
+                if (sizeProp is not null)
                 {
                     sz = (Size)sizeProp.GetValue(control);
                 }
@@ -637,7 +637,7 @@ namespace System.Windows.Forms.Design
                     sz = control.Size;
                 }
 
-                if (locProp != null)
+                if (locProp is not null)
                 {
                     loc = (Point)locProp.GetValue(control);
                 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/SelectionUIService.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/SelectionUIService.cs
@@ -64,7 +64,7 @@ namespace System.Windows.Forms.Design
             Text = "SelectionUIOverlay";
 
             _selSvc = (ISelectionService)host.GetService(typeof(ISelectionService));
-            if (_selSvc != null)
+            if (_selSvc is not null)
             {
                 _selSvc.SelectionChanged += new EventHandler(OnSelectionChanged);
             }
@@ -116,7 +116,7 @@ namespace System.Windows.Forms.Design
         private void DisplayError(Exception e)
         {
             IUIService uis = (IUIService)_host.GetService(typeof(IUIService));
-            if (uis != null)
+            if (uis is not null)
             {
                 uis.ShowError(e);
             }
@@ -139,12 +139,12 @@ namespace System.Windows.Forms.Design
         {
             if (disposing)
             {
-                if (_selSvc != null)
+                if (_selSvc is not null)
                 {
                     _selSvc.SelectionChanged -= new EventHandler(OnSelectionChanged);
                 }
 
-                if (_host != null)
+                if (_host is not null)
                 {
                     _host.TransactionOpened -= new EventHandler(OnTransactionOpened);
                     _host.TransactionClosed -= new DesignerTransactionCloseEventHandler(OnTransactionClosed);
@@ -254,7 +254,7 @@ namespace System.Windows.Forms.Design
                     string name = string.Empty;
                     if (objects.Length > 0)
                     {
-                        if (objects[0] is IComponent comp && comp.Site != null)
+                        if (objects[0] is IComponent comp && comp.Site is not null)
                         {
                             name = comp.Site.Name;
                         }
@@ -278,7 +278,7 @@ namespace System.Windows.Forms.Design
                     string name = string.Empty;
                     if (objects.Length > 0)
                     {
-                        if (objects[0] is IComponent comp && comp.Site != null)
+                        if (objects[0] is IComponent comp && comp.Site is not null)
                         {
                             name = comp.Site.Name;
                         }
@@ -385,7 +385,7 @@ namespace System.Windows.Forms.Design
             {
                 object existingItem = _selectionItems[comp];
                 bool create = true;
-                if (existingItem != null)
+                if (existingItem is not null)
                 {
                     if (existingItem is ContainerSelectionUIItem item)
                     {
@@ -474,11 +474,11 @@ namespace System.Windows.Forms.Design
         protected override void OnDoubleClick(EventArgs devent)
         {
             base.OnDoubleClick(devent);
-            if (_selSvc != null)
+            if (_selSvc is not null)
             {
                 object selComp = _selSvc.PrimarySelection;
-                Debug.Assert(selComp != null, "Illegal selection on double-click");
-                if (selComp != null)
+                Debug.Assert(selComp is not null, "Illegal selection on double-click");
+                if (selComp is not null)
                 {
                     ISelectionUIHandler handler = GetHandler(selComp);
                     handler?.OnSelectionDoubleClick((IComponent)selComp);
@@ -492,7 +492,7 @@ namespace System.Windows.Forms.Design
         // Standard 'catch all - rethrow critical' exception pattern
         protected override void OnMouseDown(MouseEventArgs me)
         {
-            if (_dragHandler is null && _selSvc != null)
+            if (_dragHandler is null && _selSvc is not null)
             {
                 try
                 {
@@ -591,7 +591,7 @@ namespace System.Windows.Forms.Design
             Point screenCoord = PointToScreen(new Point(me.X, me.Y));
             HitTestInfo hti = GetHitTest(screenCoord, HITTEST_CONTAINER_SELECTOR);
             int hitTest = hti.hitTest;
-            if (hitTest != SelectionUIItem.CONTAINER_SELECTOR && hti.selectionUIHit != null)
+            if (hitTest != SelectionUIItem.CONTAINER_SELECTOR && hti.selectionUIHit is not null)
             {
                 OnContainerSelectorActive(new ContainerSelectorActiveEventArgs(hti.selectionUIHit._component));
             }
@@ -701,7 +701,7 @@ namespace System.Windows.Forms.Design
             try
             {
                 Point screenCoord = PointToScreen(new Point(me.X, me.Y));
-                if (_ctrlSelect && !_mouseDragging && _selSvc != null)
+                if (_ctrlSelect && !_mouseDragging && _selSvc is not null)
                 {
                     HitTestInfo hti = GetHitTest(screenCoord, HITTEST_DEFAULT);
                     _selSvc.SetSelectedComponents(new object[] { hti.selectionUIHit._component }, SelectionTypes.Primary);
@@ -717,7 +717,7 @@ namespace System.Windows.Forms.Design
                         ((ISelectionUIService)this).EndDrag(false);
                     }
 
-                    if (me.Button == MouseButtons.Right && oldContainerDrag != null && !oldDragMoved)
+                    if (me.Button == MouseButtons.Right && oldContainerDrag is not null && !oldDragMoved)
                     {
                         OnContainerSelectorActive(new ContainerSelectorActiveEventArgs(oldContainerDrag, ContainerSelectorActiveEventArgsType.Contextmenu));
                     }
@@ -785,7 +785,7 @@ namespace System.Windows.Forms.Design
                 }
 
                 Cursor cursor = item.GetCursorAtPoint(clientCoords);
-                if (cursor != null)
+                if (cursor is not null)
                 {
                     if (cursor == Cursors.Default)
                     {
@@ -805,7 +805,7 @@ namespace System.Windows.Forms.Design
                 if (item is ContainerSelectionUIItem)
                 {
                     Cursor cursor = item.GetCursorAtPoint(clientCoords);
-                    if (cursor != null)
+                    if (cursor is not null)
                     {
                         if (cursor == Cursors.Default)
                         {
@@ -876,7 +876,7 @@ namespace System.Windows.Forms.Design
         /// </summary>
         bool ISelectionUIService.Dragging
         {
-            get => _dragHandler != null;
+            get => _dragHandler is not null;
         }
 
         /// <summary>
@@ -903,7 +903,7 @@ namespace System.Windows.Forms.Design
         void ISelectionUIService.AssignSelectionUIHandler(object component, ISelectionUIHandler handler)
         {
             ISelectionUIHandler oldHandler = (ISelectionUIHandler)_selectionHandlers[component];
-            if (oldHandler != null)
+            if (oldHandler is not null)
             {
                 // The collection editors do not dispose objects from the collection before setting a new collection. This causes items that are common to the old and new collections to come through this code path  again, causing the exception to fire. So, we check to see if the SelectionUIHandler is same, and bail out in that case.
                 if (handler == oldHandler)
@@ -917,7 +917,7 @@ namespace System.Windows.Forms.Design
 
             _selectionHandlers[component] = handler;
             // If this component is selected, create a new UI handler for it.
-            if (_selSvc != null && _selSvc.GetComponentSelected(component))
+            if (_selSvc is not null && _selSvc.GetComponentSelected(component))
             {
                 SelectionUIItem item = new SelectionUIItem(this, component);
                 _selectionItems[component] = item;
@@ -941,7 +941,7 @@ namespace System.Windows.Forms.Design
         // Standard 'catch all - rethrow critical' exception pattern
         bool ISelectionUIService.BeginDrag(SelectionRules rules, int initialX, int initialY)
         {
-            if (_dragHandler != null)
+            if (_dragHandler is not null)
             {
                 Debug.Fail("Caller is starting a drag, but there is already one in progress -- we cannot nest these!");
                 return false;
@@ -972,7 +972,7 @@ namespace System.Windows.Forms.Design
             // We allow all components with the same UI handler as the primary selection to participate in the drag.
             ISelectionUIHandler primaryHandler = null;
             object primary = _selSvc.PrimarySelection;
-            if (primary != null)
+            if (primary is not null)
             {
                 primaryHandler = GetHandler(primary);
             }
@@ -1013,7 +1013,7 @@ namespace System.Windows.Forms.Design
             {
                 if (primaryHandler.QueryBeginDrag(objects, rules, initialX, initialY))
                 {
-                    if (_dragHandler != null)
+                    if (_dragHandler is not null)
                     {
                         try
                         {
@@ -1036,7 +1036,7 @@ namespace System.Windows.Forms.Design
                     _dragHandler = null;
 
                     // Always commit this -- BeginDrag returns false for our drags because it is a complete operation.
-                    if (_dragTransaction != null)
+                    if (_dragTransaction is not null)
                     {
                         _dragTransaction.Commit();
                         _dragTransaction = null;
@@ -1058,7 +1058,7 @@ namespace System.Windows.Forms.Design
                 throw new Exception(SR.DesignerBeginDragNotCalled);
             }
 
-            Debug.Assert(_dragComponents != null, "We should have a set of drag controls here");
+            Debug.Assert(_dragComponents is not null, "We should have a set of drag controls here");
             if ((_dragRules & SelectionRules.Moveable) == SelectionRules.None && (_dragRules & (SelectionRules.TopSizeable | SelectionRules.LeftSizeable)) == SelectionRules.None)
             {
                 newOffset = new Rectangle(0, 0, offset.Width, offset.Height);
@@ -1109,13 +1109,13 @@ namespace System.Windows.Forms.Design
             try
             {
                 IComponent comp = components[0] as IComponent;
-                if (components.Length > 1 || (components.Length == 1 && comp != null && comp.Site is null))
+                if (components.Length > 1 || (components.Length == 1 && comp is not null && comp.Site is null))
                 {
                     trans = _host.CreateTransaction(string.Format(SR.DragDropMoveComponents, components.Length));
                 }
                 else if (components.Length == 1)
                 {
-                    if (comp != null)
+                    if (comp is not null)
                     {
                         trans = _host.CreateTransaction(string.Format(SR.DragDropMoveComponent, comp.Site.Name));
                     }
@@ -1137,7 +1137,7 @@ namespace System.Windows.Forms.Design
                 // Reset the selection.  This will re-display our selection.
                 Visible = _savedVisible;
                 ((ISelectionUIService)this).SyncSelection();
-                if (_dragTransaction != null)
+                if (_dragTransaction is not null)
                 {
                     _dragTransaction.Commit();
                     _dragTransaction = null;
@@ -1166,7 +1166,7 @@ namespace System.Windows.Forms.Design
                 foreach (object comp in components)
                 {
                     SelectionUIItem item = (SelectionUIItem)_selectionItems[comp];
-                    if (item != null && !(item is ContainerSelectionUIItem))
+                    if (item is not null && !(item is ContainerSelectionUIItem))
                     {
                         if ((item.GetRules() & selectionRules) == selectionRules)
                         {
@@ -1206,7 +1206,7 @@ namespace System.Windows.Forms.Design
         /// <summary>
         ///  Determines if the component is currently "container" selected. Container selection is a visual aid for selecting containers. It doesn't affect the normal "component" selection.
         /// </summary>
-        bool ISelectionUIService.GetContainerSelected(object component) => (component != null && _selectionItems[component] is ContainerSelectionUIItem);
+        bool ISelectionUIService.GetContainerSelected(object component) => (component is not null && _selectionItems[component] is ContainerSelectionUIItem);
 
         /// <summary>
         ///  Retrieves a set of flags that define rules for the selection.  Selection rules indicate if the given component can be moved or sized, for example.
@@ -1278,13 +1278,13 @@ namespace System.Windows.Forms.Design
         void ISelectionUIService.SetSelectionStyle(object component, SelectionStyles style)
         {
             SelectionUIItem selUI = (SelectionUIItem)_selectionItems[component];
-            if (_selSvc != null && _selSvc.GetComponentSelected(component))
+            if (_selSvc is not null && _selSvc.GetComponentSelected(component))
             {
                 selUI = new SelectionUIItem(this, component);
                 _selectionItems[component] = selUI;
             }
 
-            if (selUI != null)
+            if (selUI is not null)
             {
                 selUI.Style = style;
                 UpdateWindowRegion();
@@ -1441,7 +1441,7 @@ namespace System.Windows.Forms.Design
                     if (value != _selectionStyle)
                     {
                         _selectionStyle = value;
-                        if (_region != null)
+                        if (_region is not null)
                         {
                             _region.Dispose();
                             _region = null;
@@ -1463,7 +1463,7 @@ namespace System.Windows.Forms.Design
                 }
 
                 bool fActive = false;
-                if (_selUIsvc._selSvc != null)
+                if (_selUIsvc._selSvc is not null)
                 {
                     fActive = _component == _selUIsvc._selSvc.PrimarySelection;
                     // Office rules:  If this is a multi-select, reverse the colors for active / inactive.
@@ -1475,7 +1475,7 @@ namespace System.Windows.Forms.Design
                 Rectangle outer = _outerRect;
                 Region oldClip = gr.Clip;
                 Color borderColor = SystemColors.Control;
-                if (_control != null && _control.Parent != null)
+                if (_control is not null && _control.Parent is not null)
                 {
                     Control parent = _control.Parent;
                     borderColor = parent.BackColor;
@@ -1675,7 +1675,7 @@ namespace System.Windows.Forms.Design
                         _region = new Region(new Rectangle(0, 0, 0, 0));
                     }
 
-                    if (_handler != null)
+                    if (_handler is not null)
                     {
                         Rectangle handlerClip = _handler.GetSelectionClipRect(_component);
                         if (!handlerClip.IsEmpty)
@@ -1695,7 +1695,7 @@ namespace System.Windows.Forms.Design
 
             public void Dispose()
             {
-                if (_region != null)
+                if (_region is not null)
                 {
                     _region.Dispose();
                     _region = null;
@@ -1856,7 +1856,7 @@ namespace System.Windows.Forms.Design
 
                         _outerRect = rcOuterNew;
                         Invalidate();
-                        if (_region != null)
+                        if (_region is not null)
                         {
                             _region.Dispose();
                             _region = null;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/StandardCommandToolStripMenuItem.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/StandardCommandToolStripMenuItem.cs
@@ -43,7 +43,7 @@ namespace System.Windows.Forms.Design
 
         public void RefreshItem()
         {
-            if (_menuCommand != null)
+            if (_menuCommand is not null)
             {
                 Visible = _menuCommand.Visible;
                 Enabled = _menuCommand.Enabled;
@@ -75,7 +75,7 @@ namespace System.Windows.Forms.Design
                     _cachedImage = true;
                     try
                     {
-                        if (_name != null)
+                        if (_name is not null)
                         {
                             _image = new Icon(typeof(ToolStripMenuItem), _name).ToBitmap();
                         }
@@ -102,11 +102,11 @@ namespace System.Windows.Forms.Design
 
         protected override void OnClick(EventArgs e)
         {
-            if (_menuCommand != null)
+            if (_menuCommand is not null)
             {
                 _menuCommand.Invoke();
             }
-            else if (MenuService != null)
+            else if (MenuService is not null)
             {
                 if (MenuService.GlobalInvoke(_menuID))
                 {

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/StandardMenuStripVerb.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/StandardMenuStripVerb.cs
@@ -27,7 +27,7 @@ namespace System.Windows.Forms.Design
         /// </summary>
         internal StandardMenuStripVerb(ToolStripDesigner designer)
         {
-            Debug.Assert(designer != null, "Can't have a StandardMenuStripVerb without an associated designer");
+            Debug.Assert(designer is not null, "Can't have a StandardMenuStripVerb without an associated designer");
             _designer = designer;
             _provider = designer.Component.Site;
             _host = (IDesignerHost)_provider.GetService(typeof(IDesignerHost));
@@ -92,7 +92,7 @@ namespace System.Windows.Forms.Design
                 new Keys[] { /*Help*/Keys.None, /*Contents*/Keys.None, /*Index*/Keys.None, /*Search*/Keys.None, /*Separator*/Keys.None, /*About*/Keys.None }
             };
 
-            Debug.Assert(host != null, "can't create standard menu without designer _host.");
+            Debug.Assert(host is not null, "can't create standard menu without designer _host.");
             if (host is null)
             {
                 return;
@@ -109,9 +109,9 @@ namespace System.Windows.Forms.Design
                 string name = defaultName;
                 int index = 1;
 
-                if (host != null)
+                if (host is not null)
                 {
-                    while (_host.Container.Components[name] != null)
+                    while (_host.Container.Components[name] is not null)
                     {
                         name = defaultName + (index++).ToString(CultureInfo.InvariantCulture);
                     }
@@ -171,10 +171,10 @@ namespace System.Windows.Forms.Design
                                 // eat the exception.. as you may not find image for all MenuItems.
                             }
 
-                            if (image != null)
+                            if (image is not null)
                             {
                                 PropertyDescriptor imageProperty = TypeDescriptor.GetProperties(item)["Image"];
-                                Debug.Assert(imageProperty != null, "Could not find 'Image' property in ToolStripItem.");
+                                Debug.Assert(imageProperty is not null, "Could not find 'Image' property in ToolStripItem.");
                                 imageProperty?.SetValue(item, image);
 
                                 item.ImageTransparentColor = Color.Magenta;
@@ -223,7 +223,7 @@ namespace System.Windows.Forms.Design
                     uiService.ShowError(e.Message);
                 }
 
-                if (createMenu != null)
+                if (createMenu is not null)
                 {
                     createMenu.Cancel();
                     createMenu = null;
@@ -232,7 +232,7 @@ namespace System.Windows.Forms.Design
             finally
             {
                 ToolStripDesigner.s_autoAddNewItems = true;
-                if (createMenu != null)
+                if (createMenu is not null)
                 {
                     createMenu.Commit();
                     createMenu = null;
@@ -264,7 +264,7 @@ namespace System.Windows.Forms.Design
 
             // build a image list mapping one-one the above menuItems list... this is required so that the in LOCALIZED build we don't use the Localized item string.
             string[] menuItemImageNames = new string[] { "new", "open", "save", "print", "-", "cut", "copy", "paste", "-", "help" };
-            Debug.Assert(host != null, "can't create standard menu without designer _host.");
+            Debug.Assert(host is not null, "can't create standard menu without designer _host.");
 
             if (host is null)
             {
@@ -281,9 +281,9 @@ namespace System.Windows.Forms.Design
                 string defaultName = "standardMainToolStrip";
                 string name = defaultName;
                 int index = 1;
-                if (host != null)
+                if (host is not null)
                 {
-                    while (_host.Container.Components[name] != null)
+                    while (_host.Container.Components[name] is not null)
                     {
                         name = defaultName + (index++).ToString(CultureInfo.InvariantCulture);
                     }
@@ -320,11 +320,11 @@ namespace System.Windows.Forms.Design
                         }
 
                         PropertyDescriptor displayStyleProperty = TypeDescriptor.GetProperties(item)["DisplayStyle"];
-                        Debug.Assert(displayStyleProperty != null, "Could not find 'Text' property in ToolStripItem.");
+                        Debug.Assert(displayStyleProperty is not null, "Could not find 'Text' property in ToolStripItem.");
                         displayStyleProperty?.SetValue(item, ToolStripItemDisplayStyle.Image);
 
                         PropertyDescriptor textProperty = TypeDescriptor.GetProperties(item)["Text"];
-                        Debug.Assert(textProperty != null, "Could not find 'Text' property in ToolStripItem.");
+                        Debug.Assert(textProperty is not null, "Could not find 'Text' property in ToolStripItem.");
                         textProperty?.SetValue(item, itemText);
 
                         Bitmap image = null;
@@ -337,10 +337,10 @@ namespace System.Windows.Forms.Design
                             // eat the exception.. as you may not find image for all MenuItems.
                         }
 
-                        if (image != null)
+                        if (image is not null)
                         {
                             PropertyDescriptor imageProperty = TypeDescriptor.GetProperties(item)["Image"];
-                            Debug.Assert(imageProperty != null, "Could not find 'Image' property in ToolStripItem.");
+                            Debug.Assert(imageProperty is not null, "Could not find 'Image' property in ToolStripItem.");
                             imageProperty?.SetValue(item, image);
 
                             item.ImageTransparentColor = Color.Magenta;
@@ -365,7 +365,7 @@ namespace System.Windows.Forms.Design
                     uiService.ShowError(e.Message);
                 }
 
-                if (createMenu != null)
+                if (createMenu is not null)
                 {
                     createMenu.Cancel();
                     createMenu = null;
@@ -375,7 +375,7 @@ namespace System.Windows.Forms.Design
             {
                 //Reset the AutoAdd state
                 ToolStripDesigner.s_autoAddNewItems = true;
-                if (createMenu != null)
+                if (createMenu is not null)
                 {
                     createMenu.Commit();
                     createMenu = null;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TabOrder.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TabOrder.cs
@@ -48,7 +48,7 @@ namespace System.Windows.Forms.Design
             // Determine a font for us to use.
             //
             IUIService uisvc = (IUIService)host.GetService(typeof(IUIService));
-            if (uisvc != null)
+            if (uisvc is not null)
             {
                 tabFont = (Font)uisvc.Styles["DialogFont"];
             }
@@ -72,7 +72,7 @@ namespace System.Windows.Forms.Design
             // The decimal separator
             //
             NumberFormatInfo formatInfo = (NumberFormatInfo)CultureInfo.CurrentCulture.GetFormat(typeof(NumberFormatInfo));
-            if (formatInfo != null)
+            if (formatInfo is not null)
             {
                 decimalSep = formatInfo.NumberDecimalSeparator;
             }
@@ -91,7 +91,7 @@ namespace System.Windows.Forms.Design
             // We're an overlay on top of the form
             //
             IOverlayService os = (IOverlayService)host.GetService(typeof(IOverlayService));
-            Debug.Assert(os != null, "No overlay service -- tab order UI cannot be shown");
+            Debug.Assert(os is not null, "No overlay service -- tab order UI cannot be shown");
             os?.PushOverlay(this);
 
             // Push a help keyword so the help system knows we're in place.
@@ -133,7 +133,7 @@ namespace System.Windows.Forms.Design
             };
 
             IMenuCommandService mcs = (IMenuCommandService)host.GetService(typeof(IMenuCommandService));
-            if (mcs != null)
+            if (mcs is not null)
             {
                 foreach (MenuCommand mc in newCommands)
                 {
@@ -151,7 +151,7 @@ namespace System.Windows.Forms.Design
             // form may pull on us.
             //
             IComponentChangeService cs = (IComponentChangeService)host.GetService(typeof(IComponentChangeService));
-            if (cs != null)
+            if (cs is not null)
             {
                 cs.ComponentAdded += new ComponentEventHandler(OnComponentAddRemove);
                 cs.ComponentRemoved += new ComponentEventHandler(OnComponentAddRemove);
@@ -166,13 +166,13 @@ namespace System.Windows.Forms.Design
         {
             if (disposing)
             {
-                if (region != null)
+                if (region is not null)
                 {
                     region.Dispose();
                     region = null;
                 }
 
-                if (host != null)
+                if (host is not null)
                 {
                     IOverlayService os = (IOverlayService)host.GetService(typeof(IOverlayService));
                     os?.RemoveOverlay(this);
@@ -181,7 +181,7 @@ namespace System.Windows.Forms.Design
                     ehs?.PopHandler(this);
 
                     IMenuCommandService mcs = (IMenuCommandService)host.GetService(typeof(IMenuCommandService));
-                    if (mcs != null)
+                    if (mcs is not null)
                     {
                         foreach (MenuCommand mc in newCommands)
                         {
@@ -193,7 +193,7 @@ namespace System.Windows.Forms.Design
                     // form may pull on us.
                     //
                     IComponentChangeService cs = (IComponentChangeService)host.GetService(typeof(IComponentChangeService));
-                    if (cs != null)
+                    if (cs is not null)
                     {
                         cs.ComponentAdded -= new ComponentEventHandler(OnComponentAddRemove);
                         cs.ComponentRemoved -= new ComponentEventHandler(OnComponentAddRemove);
@@ -230,7 +230,7 @@ namespace System.Windows.Forms.Design
                 region = new Region(new Rectangle(0, 0, 0, 0));
             }
 
-            if (ctlHover != null)
+            if (ctlHover is not null)
             {
                 Rectangle ctlInner = GetConvertedBounds(ctlHover);
                 Rectangle ctlOuter = ctlInner;
@@ -270,7 +270,7 @@ namespace System.Windows.Forms.Design
                 parent = GetSitedParent(ctl);
                 Control baseControl = (Control)host.RootComponent;
 
-                while (parent != baseControl && parent != null)
+                while (parent != baseControl && parent is not null)
                 {
                     drawString.Insert(0, decimalSep);
                     drawString.Insert(0, parent.TabIndex.ToString(CultureInfo.CurrentCulture));
@@ -409,19 +409,19 @@ namespace System.Windows.Forms.Design
         {
             Control parent = child.Parent;
 
-            while (parent != null)
+            while (parent is not null)
             {
                 ISite site = parent.Site;
                 IContainer container = null;
 
-                if (site != null)
+                if (site is not null)
                 {
                     container = site.Container;
                 }
 
                 container = DesignerUtils.CheckForNestedContainer(container); // ...necessary to support SplitterPanel components
 
-                if (site != null && container == host)
+                if (site is not null && container == host)
                 {
                     break;
                 }
@@ -450,7 +450,7 @@ namespace System.Windows.Forms.Design
             {
                 ctlTab = ctl.Controls[i];
 
-                if (null != GetSitedParent(ctlTab) && GetTabbable(ctlTab))
+                if (GetSitedParent(ctlTab) is not null && GetTabbable(ctlTab))
                 {
                     tabs.Add(ctlTab);
                 }
@@ -467,7 +467,7 @@ namespace System.Windows.Forms.Design
         /// </summary>
         private bool GetTabbable(Control control)
         {
-            for (Control c = control; c != null; c = c.Parent)
+            for (Control c = control; c is not null; c = c.Parent)
             {
                 if (!c.Visible)
                     return false;
@@ -504,7 +504,7 @@ namespace System.Windows.Forms.Design
 
             tabNext?.Clear();
 
-            if (region != null)
+            if (region is not null)
             {
                 region.Dispose();
                 region = null;
@@ -521,7 +521,7 @@ namespace System.Windows.Forms.Design
         {
             tabControls = null;
             tabGlyphs = null;
-            if (region != null)
+            if (region is not null)
             {
                 region.Dispose();
                 region = null;
@@ -536,11 +536,11 @@ namespace System.Windows.Forms.Design
         private void OnKeyCancel(object sender, EventArgs e)
         {
             IMenuCommandService mcs = (IMenuCommandService)host.GetService(typeof(IMenuCommandService));
-            Debug.Assert(mcs != null, "No menu command service, can't get out of tab order UI");
-            if (mcs != null)
+            Debug.Assert(mcs is not null, "No menu command service, can't get out of tab order UI");
+            if (mcs is not null)
             {
                 MenuCommand mc = mcs.FindCommand(StandardCommands.TabOrder);
-                Debug.Assert(mc != null, "No tab order menu command, can't get out of tab order UI");
+                Debug.Assert(mc is not null, "No tab order menu command, can't get out of tab order UI");
                 mc?.Invoke();
             }
         }
@@ -550,7 +550,7 @@ namespace System.Windows.Forms.Design
         /// </summary>
         private void OnKeyDefault(object sender, EventArgs e)
         {
-            if (ctlHover != null)
+            if (ctlHover is not null)
             {
                 SetNextTabIndex(ctlHover);
                 RotateControls(true);
@@ -589,7 +589,7 @@ namespace System.Windows.Forms.Design
         /// </summary>
         public virtual void OnMouseDown(IComponent component, MouseButtons button, int x, int y)
         {
-            if (ctlHover != null)
+            if (ctlHover is not null)
             {
                 SetNextTabIndex(ctlHover);
             }
@@ -603,7 +603,7 @@ namespace System.Windows.Forms.Design
         protected override void OnMouseDown(MouseEventArgs e)
         {
             base.OnMouseDown(e);
-            if (ctlHover != null)
+            if (ctlHover is not null)
             {
                 SetNextTabIndex(ctlHover);
             }
@@ -622,7 +622,7 @@ namespace System.Windows.Forms.Design
         /// </summary>
         public virtual void OnMouseMove(IComponent component, int x, int y)
         {
-            if (tabControls != null)
+            if (tabControls is not null)
             {
                 Control ctl = GetControlAtPoint(tabControls, x, y);
                 SetNewHover(ctl);
@@ -638,7 +638,7 @@ namespace System.Windows.Forms.Design
         {
             base.OnMouseMove(e);
 
-            if (tabGlyphs != null)
+            if (tabGlyphs is not null)
             {
                 Control ctl = null;
 
@@ -668,7 +668,7 @@ namespace System.Windows.Forms.Design
 
         private void SetAppropriateCursor()
         {
-            if (ctlHover != null)
+            if (ctlHover is not null)
             {
                 Cursor.Current = Cursors.Cross;
             }
@@ -772,7 +772,7 @@ namespace System.Windows.Forms.Design
 
             ctl ??= form;
 
-            while (null != (ctl = form.GetNextControl(ctl, forward)))
+            while ((ctl = form.GetNextControl(ctl, forward)) is not null)
             {
                 if (GetTabbable(ctl))
                     break;
@@ -788,9 +788,9 @@ namespace System.Windows.Forms.Design
         {
             if (ctlHover != ctl)
             {
-                if (null != ctlHover)
+                if (ctlHover is not null)
                 {
-                    if (region != null)
+                    if (region is not null)
                     {
                         region.Dispose();
                         region = null;
@@ -803,9 +803,9 @@ namespace System.Windows.Forms.Design
 
                 ctlHover = ctl;
 
-                if (null != ctlHover)
+                if (ctlHover is not null)
                 {
-                    if (region != null)
+                    if (region is not null)
                     {
                         region.Dispose();
                         region = null;
@@ -824,7 +824,7 @@ namespace System.Windows.Forms.Design
         // Standard 'catch all - rethrow critical' exception pattern
         private void SetNextTabIndex(Control ctl)
         {
-            if (tabControls != null)
+            if (tabControls is not null)
             {
                 int index, max;
                 Control parent = GetSitedParent(ctl);
@@ -833,7 +833,7 @@ namespace System.Windows.Forms.Design
                 if (tabComplete.IndexOf(ctl) == -1)
                     tabComplete.Add(ctl);
 
-                if (null != nextIndex)
+                if (nextIndex is not null)
                     index = (int)nextIndex;
                 else
                     index = 0;
@@ -841,7 +841,7 @@ namespace System.Windows.Forms.Design
                 try
                 {
                     PropertyDescriptor prop = (PropertyDescriptor)tabProperties[ctl];
-                    if (prop != null)
+                    if (prop is not null)
                     {
                         int newIndex = index + 1;
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TableLayoutControlCollectionCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TableLayoutControlCollectionCodeDomSerializer.cs
@@ -31,14 +31,14 @@ namespace System.Windows.Forms.Design
                 bool isTargetInherited = false;
                 ExpressionContext ctx = manager.Context[typeof(ExpressionContext)] as ExpressionContext;
 
-                if (ctx != null && ctx.Expression == targetExpression)
+                if (ctx is not null && ctx.Expression == targetExpression)
                 {
                     IComponent comp = ctx.Owner as IComponent;
 
-                    if (comp != null)
+                    if (comp is not null)
                     {
                         InheritanceAttribute ia = (InheritanceAttribute)TypeDescriptor.GetAttributes(comp)[typeof(InheritanceAttribute)];
-                        isTargetInherited = (ia != null && ia.InheritanceLevel == InheritanceLevel.Inherited);
+                        isTargetInherited = (ia is not null && ia.InheritanceLevel == InheritanceLevel.Inherited);
                     }
                 }
 
@@ -50,7 +50,7 @@ namespace System.Windows.Forms.Design
                     {
                         InheritanceAttribute ia = (InheritanceAttribute)TypeDescriptor.GetAttributes(o)[typeof(InheritanceAttribute)];
 
-                        if (ia != null)
+                        if (ia is not null)
                         {
                             if (ia.InheritanceLevel == InheritanceLevel.InheritedReadOnly)
                                 genCode = false;
@@ -71,12 +71,12 @@ namespace System.Windows.Forms.Design
                         statement.Method = methodRef;
                         CodeExpression serializedObj = SerializeToExpression(manager, o);
 
-                        if (serializedObj != null && !typeof(Control).IsAssignableFrom(o.GetType()))
+                        if (serializedObj is not null && !typeof(Control).IsAssignableFrom(o.GetType()))
                         {
                             serializedObj = new CodeCastExpression(typeof(Control), serializedObj);
                         }
 
-                        if (serializedObj != null)
+                        if (serializedObj is not null)
                         {
                             int col, row;
                             col = tableCollection.Container.GetColumn((Control)o);

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TableLayoutPanelCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TableLayoutPanelCodeDomSerializer.cs
@@ -41,9 +41,9 @@ namespace System.Windows.Forms.Design
             // Now push our layout settings stuff into the resx if we are not inherited read only and
             // are in a localizable Form.
             TableLayoutPanel tlp = value as TableLayoutPanel;
-            Debug.Assert(tlp != null, "Huh? We were expecting to be serializing a TableLayoutPanel here.");
+            Debug.Assert(tlp is not null, "Huh? We were expecting to be serializing a TableLayoutPanel here.");
 
-            if (tlp != null)
+            if (tlp is not null)
             {
                 InheritanceAttribute ia = (InheritanceAttribute)TypeDescriptor.GetAttributes(tlp)[typeof(InheritanceAttribute)];
 
@@ -56,7 +56,7 @@ namespace System.Windows.Forms.Design
                         PropertyDescriptor lsProp = TypeDescriptor.GetProperties(tlp)[LayoutSettingsPropName];
                         object val = lsProp?.GetValue(tlp);
 
-                        if (val != null)
+                        if (val is not null)
                         {
                             string key = manager.GetName(tlp) + "." + LayoutSettingsPropName;
                             SerializeResourceInvariant(manager, key, val);
@@ -70,11 +70,11 @@ namespace System.Windows.Forms.Design
 
         private static bool IsLocalizable(IDesignerHost host)
         {
-            if (host != null)
+            if (host is not null)
             {
                 PropertyDescriptor prop = TypeDescriptor.GetProperties(host.RootComponent)["Localizable"];
 
-                if (prop != null && prop.PropertyType == typeof(bool))
+                if (prop is not null && prop.PropertyType == typeof(bool))
                 {
                     return (bool)prop.GetValue(host.RootComponent);
                 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TemplateNodeCustomMenuItemCollection.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TemplateNodeCustomMenuItemCollection.cs
@@ -63,7 +63,7 @@ namespace System.Windows.Forms.Design
         private void InsertToolStripItem(Type t)
         {
             IDesignerHost designerHost = (IDesignerHost)_serviceProvider.GetService(typeof(IDesignerHost));
-            Debug.Assert(designerHost != null, "Why didn't we get a designer host?");
+            Debug.Assert(designerHost is not null, "Why didn't we get a designer host?");
             ToolStrip parent = ParentTool;
             int dummyIndex = parent.Items.IndexOf(_currentItem);
             DesignerTransaction newItemTransaction = designerHost.CreateTransaction(SR.ToolStripAddingItem);
@@ -96,18 +96,18 @@ namespace System.Windows.Forms.Design
                     }
 
                     PropertyDescriptor imageProperty = TypeDescriptor.GetProperties(component)["Image"];
-                    Debug.Assert(imageProperty != null, "Could not find 'Image' property in ToolStripItem.");
-                    if (imageProperty != null && image != null)
+                    Debug.Assert(imageProperty is not null, "Could not find 'Image' property in ToolStripItem.");
+                    if (imageProperty is not null && image is not null)
                     {
                         imageProperty.SetValue(component, image);
                     }
 
                     PropertyDescriptor dispProperty = TypeDescriptor.GetProperties(component)["DisplayStyle"];
-                    Debug.Assert(dispProperty != null, "Could not find 'DisplayStyle' property in ToolStripItem.");
+                    Debug.Assert(dispProperty is not null, "Could not find 'DisplayStyle' property in ToolStripItem.");
                     dispProperty?.SetValue(component, ToolStripItemDisplayStyle.Image);
 
                     PropertyDescriptor imageTransProperty = TypeDescriptor.GetProperties(component)["ImageTransparentColor"];
-                    Debug.Assert(imageTransProperty != null, "Could not find 'DisplayStyle' property in ToolStripItem.");
+                    Debug.Assert(imageTransProperty is not null, "Could not find 'DisplayStyle' property in ToolStripItem.");
                     imageTransProperty?.SetValue(component, Color.Magenta);
                 }
 
@@ -119,7 +119,7 @@ namespace System.Windows.Forms.Design
             }
             catch (Exception ex)
             {
-                if (newItemTransaction != null)
+                if (newItemTransaction is not null)
                 {
                     newItemTransaction.Cancel();
                     newItemTransaction = null;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TextBoxBaseDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TextBoxBaseDesigner.cs
@@ -34,7 +34,7 @@ namespace System.Windows.Forms.Design
 
                 BorderStyle borderStyle = BorderStyle.Fixed3D;
                 PropertyDescriptor prop = TypeDescriptor.GetProperties(Component)["BorderStyle"];
-                if (prop != null)
+                if (prop is not null)
                 {
                     borderStyle = (BorderStyle)prop.GetValue(Component);
                 }
@@ -100,7 +100,7 @@ namespace System.Windows.Forms.Design
             base.InitializeNewComponent(defaultValues);
 
             PropertyDescriptor textProp = TypeDescriptor.GetProperties(Component)["Text"];
-            if (textProp != null && textProp.PropertyType == typeof(string) && !textProp.IsReadOnly && textProp.IsBrowsable)
+            if (textProp is not null && textProp.PropertyType == typeof(string) && !textProp.IsReadOnly && textProp.IsBrowsable)
             {
                 textProp.SetValue(Component, "");
             }
@@ -124,7 +124,7 @@ namespace System.Windows.Forms.Design
             for (int i = 0; i < shadowProps.Length; i++)
             {
                 prop = (PropertyDescriptor)properties[shadowProps[i]];
-                if (prop != null)
+                if (prop is not null)
                 {
                     properties[shadowProps[i]] = TypeDescriptor.CreateProperty(typeof(TextBoxBaseDesigner), prop, empty);
                 }
@@ -146,13 +146,13 @@ namespace System.Windows.Forms.Design
                 rules |= SelectionRules.AllSizeable;
 
                 PropertyDescriptor prop = TypeDescriptor.GetProperties(component)["Multiline"];
-                if (prop != null)
+                if (prop is not null)
                 {
                     object value = prop.GetValue(component);
                     if (value is bool && (bool)value == false)
                     {
                         PropertyDescriptor propAuto = TypeDescriptor.GetProperties(component)["AutoSize"];
-                        if (propAuto != null)
+                        if (propAuto is not null)
                         {
                             object auto = propAuto.GetValue(component);
                             if (auto is bool && (bool)auto)

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TextBoxDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TextBoxDesigner.cs
@@ -57,7 +57,7 @@ namespace System.Windows.Forms.Design
             for (int i = 0; i < shadowProps.Length; i++)
             {
                 prop = (PropertyDescriptor)properties[shadowProps[i]];
-                if (prop != null)
+                if (prop is not null)
                 {
                     properties[shadowProps[i]] = TypeDescriptor.CreateProperty(typeof(TextBoxDesigner), prop, empty);
                 }
@@ -75,7 +75,7 @@ namespace System.Windows.Forms.Design
             get
             {
                 TextBox tb = Control as TextBox;
-                Debug.Assert(tb != null, "Designed control is not a TextBox.");
+                Debug.Assert(tb is not null, "Designed control is not a TextBox.");
 
                 if (tb.UseSystemPasswordChar)
                 {
@@ -89,7 +89,7 @@ namespace System.Windows.Forms.Design
             set
             {
                 TextBox tb = Control as TextBox;
-                Debug.Assert(tb != null, "Designed control is not a TextBox.");
+                Debug.Assert(tb is not null, "Designed control is not a TextBox.");
 
                 passwordChar = value;
                 tb.PasswordChar = value;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripActionList.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripActionList.cs
@@ -66,8 +66,8 @@ namespace System.Windows.Forms.Design
         private object GetProperty(string propertyName)
         {
             PropertyDescriptor getProperty = TypeDescriptor.GetProperties(_toolStrip)[propertyName];
-            Debug.Assert(getProperty != null, "Could not find given property in control.");
-            if (getProperty != null)
+            Debug.Assert(getProperty is not null, "Could not find given property in control.");
+            if (getProperty is not null)
             {
                 return getProperty.GetValue(_toolStrip);
             }
@@ -79,7 +79,7 @@ namespace System.Windows.Forms.Design
         private void ChangeProperty(string propertyName, object value)
         {
             PropertyDescriptor changingProperty = TypeDescriptor.GetProperties(_toolStrip)[propertyName];
-            Debug.Assert(changingProperty != null, "Could not find given property in control.");
+            Debug.Assert(changingProperty is not null, "Could not find given property in control.");
             changingProperty?.SetValue(_toolStrip, value);
         }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripAdornerWindowService.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripAdornerWindowService.cs
@@ -75,13 +75,13 @@ namespace System.Windows.Forms.Design
             _overlayService?.RemoveOverlay(_toolStripAdornerWindow);
 
             _toolStripAdornerWindow.Dispose();
-            if (_behaviorService != null)
+            if (_behaviorService is not null)
             {
                 _behaviorService.Adorners.Remove(_dropDownAdorner);
                 _behaviorService = null;
             }
 
-            if (_dropDownAdorner != null)
+            if (_dropDownAdorner is not null)
             {
                 _dropDownAdorner.Glyphs.Clear();
                 _dropDownAdorner = null;
@@ -208,7 +208,7 @@ namespace System.Windows.Forms.Design
             {
                 if (disposing)
                 {
-                    if (_designerFrame != null)
+                    if (_designerFrame is not null)
                     {
                         _designerFrame = null;
                     }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripCodeDomSerializer.cs
@@ -26,12 +26,12 @@ namespace System.Windows.Forms.Design
 
             foreach (ToolStripItem item in toolStrip.Items)
             {
-                if (item.Site != null && toolStrip.Site != null && item.Site.Container == toolStrip.Site.Container)
+                if (item.Site is not null && toolStrip.Site is not null && item.Site.Container == toolStrip.Site.Container)
                 {
                     // We only emit Size/Location information for controls that are sited and not inherited readonly.
                     InheritanceAttribute ia = (InheritanceAttribute)TypeDescriptor.GetAttributes(item)[typeof(InheritanceAttribute)];
 
-                    if (ia != null && ia.InheritanceLevel != InheritanceLevel.InheritedReadOnly)
+                    if (ia is not null && ia.InheritanceLevel != InheritanceLevel.InheritedReadOnly)
                     {
                         return true;
                     }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripDesigner.cs
@@ -74,7 +74,7 @@ namespace System.Windows.Forms.Design
 
                 // First add the verbs for this component there...
                 DesignerVerbCollection verbs = Verbs;
-                if (verbs != null && verbs.Count != 0)
+                if (verbs is not null && verbs.Count != 0)
                 {
                     DesignerVerb[] verbsArray = new DesignerVerb[verbs.Count];
                     verbs.CopyTo(verbsArray, 0);
@@ -478,10 +478,10 @@ namespace System.Windows.Forms.Design
         /// </summary>
         private void AddItemBodyGlyph(ToolStripItem item)
         {
-            if (item != null)
+            if (item is not null)
             {
                 ToolStripItemDesigner dropDownItemDesigner = (ToolStripItemDesigner)_host.GetDesigner(item);
-                if (dropDownItemDesigner != null)
+                if (dropDownItemDesigner is not null)
                 {
                     Rectangle bounds = dropDownItemDesigner.GetGlyphBounds();
                     Behavior.Behavior toolStripBehavior = new ToolStripItemBehavior();
@@ -500,7 +500,7 @@ namespace System.Windows.Forms.Design
         /// </summary>
         private ToolStripItem AddNewItem(Type t)
         {
-            Debug.Assert(_host != null, "Why didn't we get a designer host?");
+            Debug.Assert(_host is not null, "Why didn't we get a designer host?");
             NewItemTransaction = _host.CreateTransaction(SR.ToolStripCreatingNewItemTransaction);
             IComponent component = null;
             try
@@ -522,7 +522,7 @@ namespace System.Windows.Forms.Design
                 }
                 finally
                 {
-                    if (designer != null)
+                    if (designer is not null)
                     {
                         designer.InternalCreate = false;
                     }
@@ -533,7 +533,7 @@ namespace System.Windows.Forms.Design
             }
             catch (Exception e)
             {
-                if (NewItemTransaction != null)
+                if (NewItemTransaction is not null)
                 {
                     NewItemTransaction.Cancel();
                     NewItemTransaction = null;
@@ -556,7 +556,7 @@ namespace System.Windows.Forms.Design
         // Standard 'catch all - rethrow critical' exception pattern
         internal ToolStripItem AddNewItem(Type t, string text, bool enterKeyPressed, bool tabKeyPressed)
         {
-            Debug.Assert(_host != null, "Why didn't we get a designer host?");
+            Debug.Assert(_host is not null, "Why didn't we get a designer host?");
             Debug.Assert(_pendingTransaction is null, "Adding item with pending transaction?");
             DesignerTransaction outerTransaction = _host.CreateTransaction(string.Format(SR.ToolStripAddingItem, t.Name));
             ToolStripItem item = null;
@@ -588,11 +588,11 @@ namespace System.Windows.Forms.Design
 
                 //Set the Text and Image..
                 item = component as ToolStripItem;
-                if (item != null)
+                if (item is not null)
                 {
                     PropertyDescriptor textProperty = TypeDescriptor.GetProperties(item)["Text"];
-                    Debug.Assert(textProperty != null, "Could not find 'Text' property in ToolStripItem.");
-                    if (textProperty != null && !string.IsNullOrEmpty(text))
+                    Debug.Assert(textProperty is not null, "Could not find 'Text' property in ToolStripItem.");
+                    if (textProperty is not null && !string.IsNullOrEmpty(text))
                     {
                         textProperty.SetValue(item, text);
                     }
@@ -614,18 +614,18 @@ namespace System.Windows.Forms.Design
                         }
 
                         PropertyDescriptor imageProperty = TypeDescriptor.GetProperties(item)["Image"];
-                        Debug.Assert(imageProperty != null, "Could not find 'Image' property in ToolStripItem.");
-                        if (imageProperty != null && image != null)
+                        Debug.Assert(imageProperty is not null, "Could not find 'Image' property in ToolStripItem.");
+                        if (imageProperty is not null && image is not null)
                         {
                             imageProperty.SetValue(item, image);
                         }
 
                         PropertyDescriptor dispProperty = TypeDescriptor.GetProperties(item)["DisplayStyle"];
-                        Debug.Assert(dispProperty != null, "Could not find 'DisplayStyle' property in ToolStripItem.");
+                        Debug.Assert(dispProperty is not null, "Could not find 'DisplayStyle' property in ToolStripItem.");
                         dispProperty?.SetValue(item, ToolStripItemDisplayStyle.Image);
 
                         PropertyDescriptor imageTransProperty = TypeDescriptor.GetProperties(item)["ImageTransparentColor"];
-                        Debug.Assert(imageTransProperty != null, "Could not find 'DisplayStyle' property in ToolStripItem.");
+                        Debug.Assert(imageTransProperty is not null, "Could not find 'DisplayStyle' property in ToolStripItem.");
                         imageTransProperty?.SetValue(item, Color.Magenta);
                     }
                 }
@@ -638,7 +638,7 @@ namespace System.Windows.Forms.Design
                     {
                         if (!designer.SetSelection(enterKeyPressed))
                         {
-                            if (KeyboardHandlingService != null)
+                            if (KeyboardHandlingService is not null)
                             {
                                 KeyboardHandlingService.SelectedDesignerControl = _editorNode;
                                 SelectionService.SetSelectedComponents(null, SelectionTypes.Replace);
@@ -655,14 +655,14 @@ namespace System.Windows.Forms.Design
                 }
                 else
                 {
-                    if (_keyboardHandlingService != null)
+                    if (_keyboardHandlingService is not null)
                     {
                         KeyboardHandlingService.SelectedDesignerControl = _editorNode;
                         SelectionService.SetSelectedComponents(null, SelectionTypes.Replace);
                     }
                 }
 
-                if (designer != null && item.Placement != ToolStripItemPlacement.Overflow)
+                if (designer is not null && item.Placement != ToolStripItemPlacement.Overflow)
                 {
                     Rectangle bounds = designer.GetGlyphBounds();
                     Behavior.Behavior toolStripBehavior = new ToolStripItemBehavior();
@@ -671,7 +671,7 @@ namespace System.Windows.Forms.Design
                     // Add ItemGlyph to the Collection
                     GetService<SelectionManager>().BodyGlyphAdorner.Glyphs.Insert(0, bodyGlyphForItem);
                 }
-                else if (designer != null && item.Placement == ToolStripItemPlacement.Overflow)
+                else if (designer is not null && item.Placement == ToolStripItemPlacement.Overflow)
                 {
                     // Add Glyphs for overflow...
                     RemoveBodyGlyphsForOverflow();
@@ -682,13 +682,13 @@ namespace System.Windows.Forms.Design
             {
                 // ResumeLayout on ToolStrip.
                 ToolStrip.ResumeLayout();
-                if (_pendingTransaction != null)
+                if (_pendingTransaction is not null)
                 {
                     _pendingTransaction.Cancel();
                     _pendingTransaction = null;
                 }
 
-                if (outerTransaction != null)
+                if (outerTransaction is not null)
                 {
                     outerTransaction.Cancel();
                     outerTransaction = null;
@@ -701,7 +701,7 @@ namespace System.Windows.Forms.Design
             }
             finally
             {
-                if (_pendingTransaction != null)
+                if (_pendingTransaction is not null)
                 {
                     _pendingTransaction.Cancel();
                     _pendingTransaction = null;
@@ -776,14 +776,14 @@ namespace System.Windows.Forms.Design
                         if (item.IsOnDropDown && item.Placement != ToolStripItemPlacement.Overflow)
                         {
                             ToolStripDropDown dropDown = (ToolStripDropDown)((DesignerToolStripControlHost)comp).GetCurrentParent();
-                            if (dropDown != null)
+                            if (dropDown is not null)
                             {
                                 ToolStripItem ownerItem = dropDown.OwnerItem;
                                 ToolStripMenuItemDesigner itemDesigner = (ToolStripMenuItemDesigner)_host.GetDesigner(ownerItem);
                                 ToolStripDropDown topmost = ToolStripItemDesigner.GetFirstDropDown((ToolStripDropDownItem)(ownerItem));
                                 ToolStripItem topMostItem = (topmost is null) ? ownerItem : topmost.OwnerItem;
 
-                                if (topMostItem != null && topMostItem.Owner == ToolStrip)
+                                if (topMostItem is not null && topMostItem.Owner == ToolStrip)
                                 {
                                     showToolStrip = true;
                                 }
@@ -793,11 +793,11 @@ namespace System.Windows.Forms.Design
                     else if (item.IsOnDropDown && item.Placement != ToolStripItemPlacement.Overflow)
                     {
                         ToolStripItem parentItem = ((ToolStripDropDown)(item.Owner)).OwnerItem;
-                        if (parentItem != null)
+                        if (parentItem is not null)
                         {
                             ToolStripDropDown topmost = ToolStripMenuItemDesigner.GetFirstDropDown((ToolStripDropDownItem)parentItem);
                             ToolStripItem topMostItem = (topmost is null) ? parentItem : topmost.OwnerItem;
-                            if (topMostItem != null && topMostItem.Owner == ToolStrip)
+                            if (topMostItem is not null && topMostItem.Owner == ToolStrip)
                             {
                                 showToolStrip = true;
                             }
@@ -814,7 +814,7 @@ namespace System.Windows.Forms.Design
         /// </summary>
         internal bool Commit()
         {
-            if (_tn != null && _tn.Active)
+            if (_tn is not null && _tn.Active)
             {
                 _tn.Commit(false, false);
                 _editorNode.Width = _tn.EditorToolStrip.Width;
@@ -831,7 +831,7 @@ namespace System.Windows.Forms.Design
                 }
                 else
                 {
-                    if (KeyboardHandlingService != null)
+                    if (KeyboardHandlingService is not null)
                     {
                         if (KeyboardHandlingService.SelectedDesignerControl is ToolStripItem designerItem && designerItem.IsOnDropDown)
                         {
@@ -852,7 +852,7 @@ namespace System.Windows.Forms.Design
                             if (SelectionService.PrimarySelection is ToolStripItem toolItem)
                             {
                                 ToolStripItemDesigner itemDesigner = (ToolStripItemDesigner)_host.GetDesigner(toolItem);
-                                if (itemDesigner != null && itemDesigner.IsEditorActive)
+                                if (itemDesigner is not null && itemDesigner.IsEditorActive)
                                 {
                                     itemDesigner.Editor.Commit(false, false);
                                     return true;
@@ -931,7 +931,7 @@ namespace System.Windows.Forms.Design
             }
             catch
             {
-                if (_pendingTransaction != null)
+                if (_pendingTransaction is not null)
                 {
                     _pendingTransaction.Cancel();
                     _pendingTransaction = null;
@@ -940,7 +940,7 @@ namespace System.Windows.Forms.Design
             }
             finally
             {
-                if (_pendingTransaction != null)
+                if (_pendingTransaction is not null)
                 {
                     _pendingTransaction.Commit();
                     _pendingTransaction = null;
@@ -954,7 +954,7 @@ namespace System.Windows.Forms.Design
         /// </summary>
         private void ComponentChangeSvc_ComponentAdding(object sender, ComponentEventArgs e)
         {
-            if (KeyboardHandlingService != null && KeyboardHandlingService.CopyInProgress)
+            if (KeyboardHandlingService is not null && KeyboardHandlingService.CopyInProgress)
             {
                 return;
             }
@@ -963,7 +963,7 @@ namespace System.Windows.Forms.Design
             object selectedItem = SelectionService.PrimarySelection;
             if (selectedItem is null)
             {
-                if (_keyboardHandlingService != null)
+                if (_keyboardHandlingService is not null)
                 {
                     selectedItem = KeyboardHandlingService.SelectedDesignerControl;
                 }
@@ -976,7 +976,7 @@ namespace System.Windows.Forms.Design
 
             // we'll be adding a child item if the component is a ToolStrip item and we've currently got this ToolStrip or one of it's items selected. we do this so things like paste and undo automagically work.
             ToolStripItem addingItem = e.Component as ToolStripItem;
-            if (addingItem != null && addingItem.Owner != null)
+            if (addingItem is not null && addingItem.Owner is not null)
             {
                 if (addingItem.Owner.Site is null)
                 {
@@ -985,13 +985,13 @@ namespace System.Windows.Forms.Design
                 }
             }
 
-            if (_insertMenuItemTransaction is null && s_autoAddNewItems && addingItem != null && !_addingItem && IsToolStripOrItemSelected && !EditingCollection)
+            if (_insertMenuItemTransaction is null && s_autoAddNewItems && addingItem is not null && !_addingItem && IsToolStripOrItemSelected && !EditingCollection)
             {
                 _addingItem = true;
 
                 if (_pendingTransaction is null)
                 {
-                    Debug.Assert(_host != null, "Why didn't we get a designer host?");
+                    Debug.Assert(_host is not null, "Why didn't we get a designer host?");
                     _insertMenuItemTransaction = _pendingTransaction = _host.CreateTransaction(SR.ToolStripDesignerTransactionAddingItem);
                 }
             }
@@ -1005,7 +1005,7 @@ namespace System.Windows.Forms.Design
             if (e.Component is ToolStripItem changingItem)
             {
                 ToolStrip parent = changingItem.Owner;
-                if (parent == ToolStrip && e.Member != null && e.Member.Name == "Overflow")
+                if (parent == ToolStrip && e.Member is not null && e.Member.Name == "Overflow")
                 {
                     ToolStripItemOverflow oldValue = (ToolStripItemOverflow)e.OldValue;
                     ToolStripItemOverflow newValue = (ToolStripItemOverflow)e.NewValue;
@@ -1041,7 +1041,7 @@ namespace System.Windows.Forms.Design
                 }
                 finally
                 {
-                    if (_pendingTransaction != null)
+                    if (_pendingTransaction is not null)
                     {
                         _pendingTransaction.Commit();
                         _pendingTransaction = null;
@@ -1069,7 +1069,7 @@ namespace System.Windows.Forms.Design
                     AddBodyGlyphsForOverflow();
                 }
 
-                if (_toolStripAdornerWindowService != null && _boundsToInvalidate != Rectangle.Empty)
+                if (_toolStripAdornerWindowService is not null && _boundsToInvalidate != Rectangle.Empty)
                 {
                     _toolStripAdornerWindowService.Invalidate(_boundsToInvalidate);
                     BehaviorService.Invalidate(_boundsToInvalidate);
@@ -1079,11 +1079,11 @@ namespace System.Windows.Forms.Design
                 {
                     IComponent targetSelection = (itemIndex == -1) ? ToolStrip : ToolStrip.Items[itemIndex];
                     // if the TemplateNode becomes the targetSelection, then set the targetSelection to null.
-                    if (targetSelection != null)
+                    if (targetSelection is not null)
                     {
                         if (targetSelection is DesignerToolStripControlHost)
                         {
-                            if (KeyboardHandlingService != null)
+                            if (KeyboardHandlingService is not null)
                             {
                                 KeyboardHandlingService.SelectedDesignerControl = targetSelection;
                             }
@@ -1106,7 +1106,7 @@ namespace System.Windows.Forms.Design
         {
             if (e.Component is ToolStripItem && ((ToolStripItem)e.Component).Owner == Component)
             {
-                Debug.Assert(_host != null, "Why didn't we get a designer host?");
+                Debug.Assert(_host is not null, "Why didn't we get a designer host?");
                 Debug.Assert(_pendingTransaction is null, "Removing item with pending transaction?");
                 try
                 {
@@ -1120,7 +1120,7 @@ namespace System.Windows.Forms.Design
                 }
                 catch
                 {
-                    if (_pendingTransaction != null)
+                    if (_pendingTransaction is not null)
                     {
                         _pendingTransaction.Cancel();
                         _pendingTransaction = null;
@@ -1137,26 +1137,26 @@ namespace System.Windows.Forms.Design
             if (disposing)
             {
                 _disposed = true;
-                if (_items != null)
+                if (_items is not null)
                 {
                     _items = null;
                 }
 
-                if (_selectionService != null)
+                if (_selectionService is not null)
                 {
                     _selectionService = null;
                 }
 
                 EnableDragDrop(false);
                 //Dispose of the EditManager
-                if (_editManager != null)
+                if (_editManager is not null)
                 {
                     ToolStripEditorManager.CloseManager();
                     _editManager = null;
                 }
 
                 //tear down the TemplateNode
-                if (_tn != null)
+                if (_tn is not null)
                 {
                     _tn.RollBack();
                     _tn.CloseEditor();
@@ -1164,21 +1164,21 @@ namespace System.Windows.Forms.Design
                 }
 
                 // teardown the add item button.
-                if (_miniToolStrip != null)
+                if (_miniToolStrip is not null)
                 {
                     _miniToolStrip.Dispose();
                     _miniToolStrip = null;
                 }
 
                 //tearDown the EditorNode..
-                if (_editorNode != null)
+                if (_editorNode is not null)
                 {
                     _editorNode.Dispose();
                     _editorNode = null;
                 }
 
                 // tear off the ContextMenu..
-                if (_toolStripContextMenu != null)
+                if (_toolStripContextMenu is not null)
                 {
                     _toolStripContextMenu.Dispose();
                     _toolStripContextMenu = null;
@@ -1192,7 +1192,7 @@ namespace System.Windows.Forms.Design
                     ToolStrip.OverflowButton.HideDropDown();
                 }
 
-                if (_toolStripAdornerWindowService != null)
+                if (_toolStripAdornerWindowService is not null)
                 {
                     _toolStripAdornerWindowService = null;
                 }
@@ -1212,7 +1212,7 @@ namespace System.Windows.Forms.Design
                 IComponent selectedItem = SelectionService.PrimarySelection as IComponent;
                 if (selectedItem is null)
                 {
-                    if (KeyboardHandlingService != null)
+                    if (KeyboardHandlingService is not null)
                     {
                         selectedItem = (IComponent)KeyboardHandlingService.SelectedDesignerControl;
                     }
@@ -1221,10 +1221,10 @@ namespace System.Windows.Forms.Design
                 // if one of the sub-items is selected, delegate to it.
                 if (selectedItem is ToolStripItem)
                 {
-                    if (_host != null)
+                    if (_host is not null)
                     {
                         IDesigner itemDesigner = _host.GetDesigner(selectedItem);
-                        if (itemDesigner != null)
+                        if (itemDesigner is not null)
                         {
                             itemDesigner.DoDefaultAction();
                             return;
@@ -1247,7 +1247,7 @@ namespace System.Windows.Forms.Design
                 return null;
             }
 
-            if (TryGetService(out SelectionManager selectionManager) && ToolStrip != null && CanAddItems && ToolStrip.Visible)
+            if (TryGetService(out SelectionManager selectionManager) && ToolStrip is not null && CanAddItems && ToolStrip.Visible)
             {
                 object primarySelection = SelectionService.PrimarySelection;
                 Behavior.Behavior toolStripBehavior = new ToolStripItemBehavior();
@@ -1260,12 +1260,12 @@ namespace System.Windows.Forms.Design
                     ToolStrip.Items.CopyTo(items, 0);
                     foreach (ToolStripItem toolItem in items)
                     {
-                        if (toolItem != null)
+                        if (toolItem is not null)
                         {
                             ToolStripItemDesigner itemDesigner = (ToolStripItemDesigner)_host.GetDesigner(toolItem);
                             bool isPrimary = (toolItem == primarySelection);
                             if (!isPrimary &&
-                                itemDesigner != null &&
+                                itemDesigner is not null &&
                                 itemDesigner.IsEditorActive)
                             {
                                 itemDesigner.Editor.Commit(false, false);
@@ -1286,7 +1286,7 @@ namespace System.Windows.Forms.Design
                     if (item.Placement == ToolStripItemPlacement.Main)
                     {
                         ToolStripItemDesigner itemDesigner = (ToolStripItemDesigner)_host.GetDesigner(item);
-                        if (itemDesigner != null)
+                        if (itemDesigner is not null)
                         {
                             bool isPrimary = (item == primarySelection);
                             if (isPrimary)
@@ -1297,7 +1297,7 @@ namespace System.Windows.Forms.Design
                             // Get Back the Current Bounds if current selection is not  a primary selection
                             if (!isPrimary)
                             {
-                                item.AutoSize = (itemDesigner != null) ? itemDesigner.AutoSize : true;
+                                item.AutoSize = (itemDesigner is not null) ? itemDesigner.AutoSize : true;
                             }
 
                             Rectangle itemBounds = itemDesigner.GetGlyphBounds();
@@ -1372,7 +1372,7 @@ namespace System.Windows.Forms.Design
             // convert to client coords.
             point = Control.PointToClient(point);
 
-            if (_miniToolStrip != null && _miniToolStrip.Visible && AddItemRect.Contains(point))
+            if (_miniToolStrip is not null && _miniToolStrip.Visible && AddItemRect.Contains(point))
             {
                 return true;
             }
@@ -1434,7 +1434,7 @@ namespace System.Windows.Forms.Design
             // ToolStrip is selected...
             _toolStripSelected = true;
             // Reset the TemplateNode Selection if any...
-            if (_keyboardHandlingService != null)
+            if (_keyboardHandlingService is not null)
             {
                 KeyboardHandlingService.SelectedDesignerControl = null;
             }
@@ -1448,7 +1448,7 @@ namespace System.Windows.Forms.Design
             Control parent = defaultValues["Parent"] as Control;
             Form parentForm = _host.RootComponent as Form;
             FormDocumentDesigner parentFormDesigner = null;
-            if (parentForm != null)
+            if (parentForm is not null)
             {
                 parentFormDesigner = _host.GetDesigner(parentForm) as FormDocumentDesigner;
             }
@@ -1468,20 +1468,20 @@ namespace System.Windows.Forms.Design
                 base.InitializeNewComponent(defaultValues);
             }
 
-            if (parentFormDesigner != null)
+            if (parentFormDesigner is not null)
             {
                 //Set MainMenuStrip property
                 if (ToolStrip is MenuStrip)
                 {
                     PropertyDescriptor mainMenuStripProperty = TypeDescriptor.GetProperties(parentForm)["MainMenuStrip"];
-                    if (mainMenuStripProperty != null && mainMenuStripProperty.GetValue(parentForm) is null)
+                    if (mainMenuStripProperty is not null && mainMenuStripProperty.GetValue(parentForm) is null)
                     {
                         mainMenuStripProperty.SetValue(parentForm, ToolStrip as MenuStrip);
                     }
                 }
             }
 
-            if (parentPanel != null)
+            if (parentPanel is not null)
             {
                 if (!(ToolStrip is MenuStrip))
                 {
@@ -1495,7 +1495,7 @@ namespace System.Windows.Forms.Design
 
                     //Try to fire ComponentChange on the Location Property for ToolStrip.
                     PropertyDescriptor locationProp = TypeDescriptor.GetProperties(ToolStrip)["Location"];
-                    if (_componentChangeSvc != null)
+                    if (_componentChangeSvc is not null)
                     {
                         _componentChangeSvc.OnComponentChanging(ToolStrip, locationProp);
                         _componentChangeSvc.OnComponentChanged(ToolStrip, locationProp);
@@ -1504,7 +1504,7 @@ namespace System.Windows.Forms.Design
             }
 
             // If we are added to any container other than ToolStripPanel.
-            else if (parent != null)
+            else if (parent is not null)
             {
                 // If we are adding the MenuStrip ... put it at the Last in the Controls Collection so it gets laid out first.
                 if (ToolStrip is MenuStrip)
@@ -1540,7 +1540,7 @@ namespace System.Windows.Forms.Design
                             return;
                         }
 
-                        if (menu != null)
+                        if (menu is not null)
                         {
                             index = parent.Controls.IndexOf(c);
                             break;
@@ -1588,12 +1588,12 @@ namespace System.Windows.Forms.Design
         private static bool ItemParentIsOverflow(ToolStripItem item)
         {
             ToolStripDropDown topmost = item.Owner as ToolStripDropDown;
-            if (topmost != null)
+            if (topmost is not null)
             {
                 // walk back up the chain of windows to get the topmost
-                while (topmost != null && !(topmost is ToolStripOverflow))
+                while (topmost is not null && !(topmost is ToolStripOverflow))
                 {
-                    if (topmost.OwnerItem != null)
+                    if (topmost.OwnerItem is not null)
                     {
                         topmost = topmost.OwnerItem.GetCurrentParent() as ToolStripDropDown;
                     }
@@ -1647,7 +1647,7 @@ namespace System.Windows.Forms.Design
             INameCreationService nameCreate = serviceProvider.GetService(typeof(INameCreationService)) as INameCreationService;
             IContainer container = (IContainer)serviceProvider.GetService(typeof(IContainer));
             string defaultName;
-            if (nameCreate != null && container != null)
+            if (nameCreate is not null && container is not null)
             {
                 defaultName = nameCreate.CreateName(container, componentType);
             }
@@ -1656,7 +1656,7 @@ namespace System.Windows.Forms.Design
                 return null;
             }
 
-            Debug.Assert(defaultName != null && defaultName.Length > 0, "Couldn't create default name for item");
+            Debug.Assert(defaultName is not null && defaultName.Length > 0, "Couldn't create default name for item");
 
             if (text is null || text.Length == 0 || text == "-")
             {
@@ -1742,7 +1742,7 @@ namespace System.Windows.Forms.Design
             {
                 // start appending numbers.
                 string newName = baseName;
-                for (int indexer = 1; !nameCreate.IsValidName(newName) || container.Components[newName] != null; indexer++)
+                for (int indexer = 1; !nameCreate.IsValidName(newName) || container.Components[newName] is not null; indexer++)
                 {
                     newName = baseName + indexer.ToString(CultureInfo.InvariantCulture);
                 }
@@ -1847,18 +1847,18 @@ namespace System.Windows.Forms.Design
                 if (copy)
                 {
                     // Remember the primary selection if we had one
-                    if (primaryItem != null)
+                    if (primaryItem is not null)
                     {
                         primaryIndex = components.IndexOf(primaryItem);
                     }
 
-                    if (KeyboardHandlingService != null)
+                    if (KeyboardHandlingService is not null)
                     {
                         KeyboardHandlingService.CopyInProgress = true;
                     }
 
                     components = DesignerUtils.CopyDragObjects(components, Component.Site) as ArrayList;
-                    if (KeyboardHandlingService != null)
+                    if (KeyboardHandlingService is not null)
                     {
                         KeyboardHandlingService.CopyInProgress = false;
                     }
@@ -1902,7 +1902,7 @@ namespace System.Windows.Forms.Design
                 // Fire extra changing/changed events so that the order is "restored" after undo/redo
                 if (copy)
                 {
-                    if (changeService != null)
+                    if (changeService is not null)
                     {
                         changeService.OnComponentChanging(parentToolStrip, TypeDescriptor.GetProperties(parentToolStrip)["Items"]);
                         changeService.OnComponentChanged(parentToolStrip, TypeDescriptor.GetProperties(parentToolStrip)["Items"]);
@@ -1915,7 +1915,7 @@ namespace System.Windows.Forms.Design
 
             catch
             {
-                if (changeParent != null)
+                if (changeParent is not null)
                 {
                     changeParent.Cancel();
                     changeParent = null;
@@ -1932,7 +1932,7 @@ namespace System.Windows.Forms.Design
         /// </summary>
         private void OnItemAdded(object sender, ToolStripItemEventArgs e)
         {
-            if (_editorNode != null && (e.Item != _editorNode))
+            if (_editorNode is not null && (e.Item != _editorNode))
             {
                 int currentIndexOfEditor = ToolStrip.Items.IndexOf(_editorNode);
                 if (currentIndexOfEditor == -1 || currentIndexOfEditor != ToolStrip.Items.Count - 1)
@@ -1972,7 +1972,7 @@ namespace System.Windows.Forms.Design
         /// </summary>
         private void OnOverFlowDropDownClosed(object sender, EventArgs e)
         {
-            if (_toolStripAdornerWindowService != null && sender is ToolStripDropDownItem ddi)
+            if (_toolStripAdornerWindowService is not null && sender is ToolStripDropDownItem ddi)
             {
                 _toolStripAdornerWindowService.Invalidate(ddi.DropDown.Bounds);
                 RemoveBodyGlyphsForOverflow();
@@ -1982,7 +1982,7 @@ namespace System.Windows.Forms.Design
             if (SelectionService.PrimarySelection is ToolStripItem curSel && curSel.IsOnOverflow)
             {
                 ToolStripItem nextItem = ToolStrip.GetNextItem(ToolStrip.OverflowButton, ArrowDirection.Left);
-                if (nextItem != null)
+                if (nextItem is not null)
                 {
                     SelectionService.SetSelectedComponents(new IComponent[] { nextItem }, SelectionTypes.Replace);
                 }
@@ -1995,24 +1995,24 @@ namespace System.Windows.Forms.Design
         private void OnOverFlowDropDownOpened(object sender, EventArgs e)
         {
             //Show the TemplateNode
-            if (_editorNode != null)
+            if (_editorNode is not null)
             {
                 _editorNode.Control.Visible = true;
                 _editorNode.Visible = true;
             }
 
             ToolStripDropDownItem ddi = sender as ToolStripDropDownItem;
-            if (ddi != null)
+            if (ddi is not null)
             {
                 RemoveBodyGlyphsForOverflow();
                 AddBodyGlyphsForOverflow();
             }
 
             //select the last item on the parent toolStrip if the current selection is on the DropDown.
-            if (!(SelectionService.PrimarySelection is ToolStripItem curSel) || (curSel != null && !curSel.IsOnOverflow))
+            if (!(SelectionService.PrimarySelection is ToolStripItem curSel) || (curSel is not null && !curSel.IsOnOverflow))
             {
                 ToolStripItem nextItem = ddi.DropDown.GetNextItem(null, ArrowDirection.Down);
-                if (nextItem != null)
+                if (nextItem is not null)
                 {
                     SelectionService.SetSelectedComponents(new IComponent[] { nextItem }, SelectionTypes.Replace);
                     BehaviorService.Invalidate(BehaviorService.ControlRectInAdornerWindow(ToolStrip));
@@ -2053,7 +2053,7 @@ namespace System.Windows.Forms.Design
                 ddi.DropDown.TopLevel = false;
             }
 
-            if (_toolStripAdornerWindowService != null)
+            if (_toolStripAdornerWindowService is not null)
             {
                 ToolStrip.SuspendLayout();
                 ddi.DropDown.Parent = _toolStripAdornerWindowService.ToolStripAdornerWindowControl;
@@ -2074,7 +2074,7 @@ namespace System.Windows.Forms.Design
                 AddBodyGlyphsForOverflow();
             }
 
-            if (_toolStripAdornerWindowService != null && dropDown != null)
+            if (_toolStripAdornerWindowService is not null && dropDown is not null)
             {
                 _toolStripAdornerWindowService.Invalidate();
             }
@@ -2100,7 +2100,7 @@ namespace System.Windows.Forms.Design
         /// </summary>
         private void OnUndone(object source, EventArgs e)
         {
-            if (_editorNode != null && (ToolStrip.Items.IndexOf(_editorNode) == -1))
+            if (_editorNode is not null && (ToolStrip.Items.IndexOf(_editorNode) == -1))
             {
                 ToolStrip.Items.Add(_editorNode);
             }
@@ -2188,7 +2188,7 @@ namespace System.Windows.Forms.Design
             for (int i = 0; i < shadowProps.Length; i++)
             {
                 prop = (PropertyDescriptor)properties[shadowProps[i]];
-                if (prop != null)
+                if (prop is not null)
                 {
                     properties[shadowProps[i]] = TypeDescriptor.CreateProperty(typeof(ToolStripDesigner), prop, empty);
                 }
@@ -2212,10 +2212,10 @@ namespace System.Windows.Forms.Design
                 if (item.Placement == ToolStripItemPlacement.Overflow)
                 {
                     ToolStripItemDesigner dropDownItemDesigner = (ToolStripItemDesigner)_host.GetDesigner(item);
-                    if (dropDownItemDesigner != null)
+                    if (dropDownItemDesigner is not null)
                     {
                         ControlBodyGlyph glyph = dropDownItemDesigner.bodyGlyph;
-                        if (glyph != null && _toolStripAdornerWindowService != null && _toolStripAdornerWindowService.DropDownAdorner.Glyphs.Contains(glyph))
+                        if (glyph is not null && _toolStripAdornerWindowService is not null && _toolStripAdornerWindowService.DropDownAdorner.Glyphs.Contains(glyph))
                         {
                             _toolStripAdornerWindowService.DropDownAdorner.Glyphs.Remove(glyph);
                         }
@@ -2229,7 +2229,7 @@ namespace System.Windows.Forms.Design
         /// </summary>
         internal void RollBack()
         {
-            if (_tn != null)
+            if (_tn is not null)
             {
                 _tn.RollBack();
                 _editorNode.Width = _tn.EditorToolStrip.Width;
@@ -2270,7 +2270,7 @@ namespace System.Windows.Forms.Design
             if (_toolStripSelected)
             {
                 // first commit the node
-                if (_tn != null && _tn.Active)
+                if (_tn is not null && _tn.Active)
                 {
                     _tn.Commit(false, false);
                 }
@@ -2293,7 +2293,7 @@ namespace System.Windows.Forms.Design
                 }
 
                 //Always Hide the EditorNode if the ToolStrip Is Not Selected...
-                if (_editorNode != null)
+                if (_editorNode is not null)
                 {
                     _editorNode.Visible = false;
                 }
@@ -2309,7 +2309,7 @@ namespace System.Windows.Forms.Design
         /// </summary>
         private void SelSvc_SelectionChanged(object sender, EventArgs e)
         {
-            if (_miniToolStrip != null && _host != null)
+            if (_miniToolStrip is not null && _host is not null)
             {
                 bool itemSelected = CheckIfItemSelected();
                 bool showToolStrip = itemSelected || SelectionService.GetComponentSelected(ToolStrip);
@@ -2344,7 +2344,7 @@ namespace System.Windows.Forms.Design
                     }
 
                     //Always Show the EditorNode if the ToolStripIsSelected and is PrimarySelection or one of item is selected.
-                    if (_editorNode != null && (SelectionService.PrimarySelection == ToolStrip || itemSelected))
+                    if (_editorNode is not null && (SelectionService.PrimarySelection == ToolStrip || itemSelected))
                     {
                         bool originalSyncSelection = FireSyncSelection;
                         ToolStripPanel parent = ToolStrip.Parent as ToolStripPanel;
@@ -2362,7 +2362,7 @@ namespace System.Windows.Forms.Design
                     // REQUIRED FOR THE REFRESH OF GLYPHS BUT TRY TO BE SMART ABOUT THE REGION TO INVALIDATE....
                     if (!(SelectionService.PrimarySelection is ToolStripItem selectedItem))
                     {
-                        if (KeyboardHandlingService != null)
+                        if (KeyboardHandlingService is not null)
                         {
                             selectedItem = KeyboardHandlingService.SelectedDesignerControl as ToolStripItem;
                         }
@@ -2402,7 +2402,7 @@ namespace System.Windows.Forms.Design
                 try
                 {
                     ToolStripItem newItem = AddNewItem(typeof(ToolStripMenuItem));
-                    if (newItem != null)
+                    if (newItem is not null)
                     {
                         if (_host.GetDesigner(newItem) is ToolStripItemDesigner newItemDesigner)
                         {
@@ -2469,7 +2469,7 @@ namespace System.Windows.Forms.Design
         {
             if (!_addingDummyItem && !_disposed && (CheckIfItemSelected() || SelectionService.GetComponentSelected(ToolStrip)))
             {
-                if (_miniToolStrip != null && _miniToolStrip.Visible)
+                if (_miniToolStrip is not null && _miniToolStrip.Visible)
                 {
                     LayoutToolStrip();
                 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripDesignerUtils.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripDesignerUtils.cs
@@ -155,7 +155,7 @@ namespace System.Windows.Forms.Design
 
             // check to see if we've got a toolbox item, and use it.
             ToolboxItem tbxItem = GetCachedToolboxItem(itemType);
-            if (tbxItem != null)
+            if (tbxItem is not null)
             {
                 return tbxItem.Bitmap;
             }
@@ -171,7 +171,7 @@ namespace System.Windows.Forms.Design
         {
             string currentName = null;
             ToolboxItem tbxItem = GetCachedToolboxItem(itemType);
-            if (tbxItem != null)
+            if (tbxItem is not null)
             {
                 currentName = tbxItem.DisplayName;
             }
@@ -206,7 +206,7 @@ namespace System.Windows.Forms.Design
                 return s_newItemTypesForStatusStrip;
             }
 
-            Debug.Assert(toolStrip != null, "why werent we handed a toolstrip here? returning default list");
+            Debug.Assert(toolStrip is not null, "why werent we handed a toolstrip here? returning default list");
             return s_newItemTypesForToolStrip;
         }
 
@@ -236,7 +236,7 @@ namespace System.Windows.Forms.Design
         public static Type[] GetCustomItemTypes(IComponent component, IServiceProvider serviceProvider)
         {
             ITypeDiscoveryService discoveryService = null;
-            if (serviceProvider != null)
+            if (serviceProvider is not null)
             {
                 discoveryService = serviceProvider.GetService(typeof(ITypeDiscoveryService)) as ITypeDiscoveryService;
             }
@@ -246,7 +246,7 @@ namespace System.Windows.Forms.Design
 
         public static Type[] GetCustomItemTypes(IComponent component, ITypeDiscoveryService discoveryService)
         {
-            if (discoveryService != null)
+            if (discoveryService is not null)
             {
                 // fish out all types which derive from toolstrip item
                 ICollection itemTypes = discoveryService.GetTypes(s_toolStripItemType, false /*excludeGlobalTypes*/);
@@ -285,7 +285,7 @@ namespace System.Windows.Forms.Design
 
                         // if the visibility matches the current toolstrip type,  add it to the list of possible types to create.
                         ToolStripItemDesignerAvailabilityAttribute visibilityAttribute = (ToolStripItemDesignerAvailabilityAttribute)TypeDescriptor.GetAttributes(t)[typeof(ToolStripItemDesignerAvailabilityAttribute)];
-                        if (visibilityAttribute != null && ((visibilityAttribute.ItemAdditionVisibility & currentToolStripVisibility) == currentToolStripVisibility))
+                        if (visibilityAttribute is not null && ((visibilityAttribute.ItemAdditionVisibility & currentToolStripVisibility) == currentToolStripVisibility))
                         {
                             bool isStockType = false;
                             // PERF: consider a dictionary - but this list will usually be 3-7 items.
@@ -332,7 +332,7 @@ namespace System.Windows.Forms.Design
                 {
                     ConvertTo = convertTo
                 };
-                if (onClick != null)
+                if (onClick is not null)
                 {
                     item.Click += onClick;
                 }
@@ -356,7 +356,7 @@ namespace System.Windows.Forms.Design
                 {
                     ConvertTo = convertTo
                 };
-                if (onClick != null)
+                if (onClick is not null)
                 {
                     item.Click += onClick;
                 }
@@ -381,7 +381,7 @@ namespace System.Windows.Forms.Design
                 contextMenu.Groups["StandardList"].Items.Add(item);
                 if (convertTo)
                 {
-                    if (item is ItemTypeToolStripMenuItem toolItem && currentItem != null && toolItem.ItemType == currentItem.GetType())
+                    if (item is ItemTypeToolStripMenuItem toolItem && currentItem is not null && toolItem.ItemType == currentItem.GetType())
                     {
                         toolItem.Enabled = false;
                     }
@@ -414,7 +414,7 @@ namespace System.Windows.Forms.Design
                 contextMenu.Groups["CustomList"].Items.Add(item);
                 if (convertTo)
                 {
-                    if (item is ItemTypeToolStripMenuItem toolItem && currentItem != null && toolItem.ItemType == currentItem.GetType())
+                    if (item is ItemTypeToolStripMenuItem toolItem && currentItem is not null && toolItem.ItemType == currentItem.GetType())
                     {
                         toolItem.Enabled = false;
                     }
@@ -445,7 +445,7 @@ namespace System.Windows.Forms.Design
                 Rectangle invalidateBounds = Rectangle.Empty;
                 IDesignerHost designerHost = (IDesignerHost)provider.GetService(typeof(IDesignerHost));
 
-                if (designerHost != null)
+                if (designerHost is not null)
                 {
                     foreach (Component comp in originalSelComps)
                     {
@@ -457,7 +457,7 @@ namespace System.Windows.Forms.Design
                             {
                                 // finally Invalidate the selection rect ...
                                 designer = designerHost.GetDesigner(selItem) as ToolStripItemDesigner;
-                                if (designer != null)
+                                if (designer is not null)
                                 {
                                     invalidateBounds = designer.GetGlyphBounds();
                                     GetAdjustedBounds(selItem, ref invalidateBounds);
@@ -482,19 +482,19 @@ namespace System.Windows.Forms.Design
                     }
                 }
 
-                if (invalidateRegion != null || templateNodeSelected || shiftPressed)
+                if (invalidateRegion is not null || templateNodeSelected || shiftPressed)
                 {
                     BehaviorService behaviorService = (BehaviorService)provider.GetService(typeof(BehaviorService));
-                    if (behaviorService != null)
+                    if (behaviorService is not null)
                     {
-                        if (invalidateRegion != null)
+                        if (invalidateRegion is not null)
                         {
                             behaviorService.Invalidate(invalidateRegion);
                         }
 
                         // When a ToolStripItem is PrimarySelection, the glyph bounds are not invalidated  through the SelectionManager so we have to do this.
                         designer = designerHost.GetDesigner(nextSelection) as ToolStripItemDesigner;
-                        if (designer != null)
+                        if (designer is not null)
                         {
                             invalidateBounds = designer.GetGlyphBounds();
                             GetAdjustedBounds(nextSelection, ref invalidateBounds);

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripDropDownDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripDropDownDesigner.cs
@@ -55,14 +55,14 @@ namespace System.Windows.Forms.Design
                 DesignerActionListCollection actionLists = new DesignerActionListCollection();
                 actionLists.AddRange(base.ActionLists);
                 ContextMenuStripActionList cmActionList = new ContextMenuStripActionList(this);
-                if (cmActionList != null)
+                if (cmActionList is not null)
                 {
                     actionLists.Add(cmActionList);
                 }
 
                 // finally add the verbs for this component there...
                 DesignerVerbCollection cmVerbs = Verbs;
-                if (cmVerbs != null && cmVerbs.Count != 0)
+                if (cmVerbs is not null && cmVerbs.Count != 0)
                 {
                     DesignerVerb[] cmverbsArray = new DesignerVerb[cmVerbs.Count];
                     cmVerbs.CopyTo(cmverbsArray, 0);
@@ -129,7 +129,7 @@ namespace System.Windows.Forms.Design
             get => dropDown.RightToLeft;
             set
             {
-                if (menuItem != null && designMenu != null && value != RightToLeft)
+                if (menuItem is not null && designMenu is not null && value != RightToLeft)
                 {
                     Rectangle bounds = Rectangle.Empty;
                     try
@@ -162,12 +162,12 @@ namespace System.Windows.Forms.Design
             {
                 if (string.IsNullOrEmpty((string)ShadowProperties[SettingsKeyName]))
                 {
-                    if (Component is IPersistComponentSettings persistableComponent && host != null)
+                    if (Component is IPersistComponentSettings persistableComponent && host is not null)
                     {
                         if (persistableComponent.SettingsKey is null)
                         {
                             IComponent rootComponent = host.RootComponent;
-                            if (rootComponent != null && rootComponent != persistableComponent)
+                            if (rootComponent is not null && rootComponent != persistableComponent)
                             {
                                 ShadowProperties[SettingsKeyName] = string.Format(CultureInfo.CurrentCulture, "{0}.{1}", rootComponent.Site.Name, Component.Site.Name);
                             }
@@ -234,25 +234,25 @@ namespace System.Windows.Forms.Design
             if (disposing)
             {
                 // Unhook our services
-                if (_selectionService != null)
+                if (_selectionService is not null)
                 {
                     _selectionService.SelectionChanged -= new EventHandler(OnSelectionChanged);
                     _selectionService.SelectionChanging -= new EventHandler(OnSelectionChanging);
                 }
 
                 DisposeMenu();
-                if (designMenu != null)
+                if (designMenu is not null)
                 {
                     designMenu.Dispose();
                     designMenu = null;
                 }
 
-                if (dummyToolStripGlyph != null)
+                if (dummyToolStripGlyph is not null)
                 {
                     dummyToolStripGlyph = null;
                 }
 
-                if (_undoEngine != null)
+                if (_undoEngine is not null)
                 {
                     _undoEngine.Undone -= new EventHandler(OnUndone);
                 }
@@ -269,14 +269,14 @@ namespace System.Windows.Forms.Design
             HideMenu();
             if (host.RootComponent is Control form)
             {
-                if (designMenu != null)
+                if (designMenu is not null)
                 {
                     form.Controls.Remove(designMenu);
                 }
 
-                if (menuItem != null)
+                if (menuItem is not null)
                 {
-                    if (_nestedContainer != null)
+                    if (_nestedContainer is not null)
                     {
                         _nestedContainer.Dispose();
                         _nestedContainer = null;
@@ -317,7 +317,7 @@ namespace System.Windows.Forms.Design
             // Query for the Behavior Service and Remove Glyph....
             if (TryGetService(out BehaviorService _))
             {
-                if (dummyToolStripGlyph != null && TryGetService(out SelectionManager selectionManager))
+                if (dummyToolStripGlyph is not null && TryGetService(out SelectionManager selectionManager))
                 {
                     if (selectionManager.BodyGlyphAdorner.Glyphs.Contains(dummyToolStripGlyph))
                     {
@@ -331,7 +331,7 @@ namespace System.Windows.Forms.Design
             }
 
             // Unhook all the events for DesignMenuItem
-            if (menuItem != null)
+            if (menuItem is not null)
             {
                 if (host.GetDesigner(menuItem) is ToolStripMenuItemDesigner itemDesigner)
                 {
@@ -367,7 +367,7 @@ namespace System.Windows.Forms.Design
             if (TryGetService(out _selectionService))
             {
                 // first select the rootComponent and then hook on the events... but not if we are loading - VSWhidbey #484576
-                if (host != null && !host.Loading)
+                if (host is not null && !host.Loading)
                 {
                     _selectionService.SetSelectedComponents(new IComponent[] { host.RootComponent }, SelectionTypes.Replace);
                 }
@@ -395,7 +395,7 @@ namespace System.Windows.Forms.Design
                     BackColor = SystemColors.Window,
                     Name = Component.Site.Name
                 };
-                menuItem.Text = (dropDown != null) ? dropDown.GetType().Name : menuItem.Name;
+                menuItem.Text = (dropDown is not null) ? dropDown.GetType().Name : menuItem.Name;
                 designMenu.Items.Add(menuItem);
                 form.Controls.Add(designMenu);
                 designMenu.SendToBack();
@@ -445,7 +445,7 @@ namespace System.Windows.Forms.Design
                 else
                 {
                     ToolStripMenuItemDesigner itemDesigner = (ToolStripMenuItemDesigner)host.GetDesigner(comp);
-                    if (itemDesigner != null)
+                    if (itemDesigner is not null)
                     {
                         topmost = ToolStripItemDesigner.GetFirstDropDown(currentItem);
                     }
@@ -459,17 +459,17 @@ namespace System.Windows.Forms.Design
                     parent = ((ToolStripItem)comp).Owner as ToolStripDropDown;
                 }
 
-                if (parent != null && parent.Visible)
+                if (parent is not null && parent.Visible)
                 {
                     ToolStripItem ownerItem = parent.OwnerItem;
-                    if (ownerItem != null && ownerItem == menuItem)
+                    if (ownerItem is not null && ownerItem == menuItem)
                     {
                         topmost = menuItem.DropDown;
                     }
                     else
                     {
                         ToolStripMenuItemDesigner itemDesigner = (ToolStripMenuItemDesigner)host.GetDesigner(ownerItem);
-                        if (itemDesigner != null)
+                        if (itemDesigner is not null)
                         {
                             topmost = ToolStripItemDesigner.GetFirstDropDown((ToolStripDropDownItem)ownerItem);
                         }
@@ -477,7 +477,7 @@ namespace System.Windows.Forms.Design
                 }
             }
 
-            if (topmost != null)
+            if (topmost is not null)
             {
                 ToolStripItem topMostItem = topmost.OwnerItem;
                 if (topMostItem == menuItem)
@@ -538,7 +538,7 @@ namespace System.Windows.Forms.Design
                 // Selection change would remove our Glyph from the BodyGlyph Collection.
                 if (TryGetService(out SelectionManager selectionManager))
                 {
-                    if (dummyToolStripGlyph != null)
+                    if (dummyToolStripGlyph is not null)
                     {
                         selectionManager.BodyGlyphAdorner.Glyphs.Insert(0, dummyToolStripGlyph);
                     }
@@ -561,7 +561,7 @@ namespace System.Windows.Forms.Design
             for (int i = 0; i < shadowProps.Length; i++)
             {
                 prop = (PropertyDescriptor)properties[shadowProps[i]];
-                if (prop != null)
+                if (prop is not null)
                 {
                     properties[shadowProps[i]] = TypeDescriptor.CreateProperty(typeof(ToolStripDropDownDesigner), prop, empty);
                 }
@@ -655,7 +655,7 @@ namespace System.Windows.Forms.Design
             menuItem.Visible = true;
 
             // Check if this is a design-time DropDown
-            if (currentParent != null && currentParent != menuItem)
+            if (currentParent is not null && currentParent != menuItem)
             {
                 if (host.GetDesigner(currentParent) is ToolStripMenuItemDesigner ownerItemDesigner)
                 {
@@ -683,7 +683,7 @@ namespace System.Windows.Forms.Design
             if (TryGetService(out BehaviorService behaviorService))
             {
                 // Show the contextMenu only if the dummy menuStrip is contained in the Form. Refer to VsWhidbey 484317 for more details.
-                if (itemDesigner != null && parent != null)
+                if (itemDesigner is not null && parent is not null)
                 {
                     Rectangle parentBounds = behaviorService.ControlRectInAdornerWindow(parent);
                     Rectangle menuBounds = behaviorService.ControlRectInAdornerWindow(designMenu);
@@ -702,7 +702,7 @@ namespace System.Windows.Forms.Design
                     GetService<SelectionManager>()?.BodyGlyphAdorner.Glyphs.Insert(0, dummyToolStripGlyph);
                 }
 
-                if (selectedItem != null)
+                if (selectedItem is not null)
                 {
                     GetService<ToolStripKeyboardHandlingService>().SelectedDesignerControl = selectedItem;
                 }
@@ -710,7 +710,7 @@ namespace System.Windows.Forms.Design
         }
 
         // Should the designer serialize the settings?
-        private bool ShouldSerializeSettingsKey() => (Component is IPersistComponentSettings persistableComponent && persistableComponent.SaveSettings && SettingsKey != null);
+        private bool ShouldSerializeSettingsKey() => (Component is IPersistComponentSettings persistableComponent && persistableComponent.SaveSettings && SettingsKey is not null);
 
         /// <summary>
         /// Since we're shadowing ToolStripDropDown AutoClose, we get called here to determine whether or not to serialize
@@ -732,7 +732,7 @@ namespace System.Windows.Forms.Design
         /// </summary>
         private void OnUndone(object source, EventArgs e)
         {
-            if (_selectionService != null && Component.Equals(_selectionService.PrimarySelection))
+            if (_selectionService is not null && Component.Equals(_selectionService.PrimarySelection))
             {
                 HideMenu();
                 ShowMenu();

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripEditorManager.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripEditorManager.cs
@@ -47,7 +47,7 @@ namespace System.Windows.Forms.Design
             if (item != _currentItem)
             {
                 // Remove old editor
-                if (_editor != null)
+                if (_editor is not null)
                 {
                     _behaviorService.AdornerWindowControl.Controls.Remove(_editor);
                     _behaviorService.Invalidate(_editor.Bounds);
@@ -57,24 +57,24 @@ namespace System.Windows.Forms.Design
                     _itemDesigner.IsEditorActive = false;
 
                     // Show the previously edited glyph
-                    if (_currentItem != null)
+                    if (_currentItem is not null)
                     {
                         _currentItem = null;
                     }
                 }
 
-                if (item != null)
+                if (item is not null)
                 {
                     // Add new editor from the item...
                     _currentItem = item;
-                    if (_designerHost != null)
+                    if (_designerHost is not null)
                     {
                         _itemDesigner = (ToolStripItemDesigner)_designerHost.GetDesigner(_currentItem);
                     }
 
                     _editorUI = _itemDesigner.Editor;
                     // If we got an editor, position and focus it.
-                    if (_editorUI != null)
+                    if (_editorUI is not null)
                     {
                         // Hide this glyph while it's being edited
                         _itemDesigner.IsEditorActive = true;
@@ -105,7 +105,7 @@ namespace System.Windows.Forms.Design
         {
             // THIS IS CURRENTLY DISABLE !!!!! TO DO !! SHOULD WE SUPPORT AUTOSIZED INSITU ?????
             _behaviorService.Invalidate(_lastKnownEditorBounds);
-            if (_editor != null)
+            if (_editor is not null)
             {
                 _lastKnownEditorBounds = _editor.Bounds;
             }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripInSituService.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripInSituService.cs
@@ -27,12 +27,12 @@ namespace System.Windows.Forms.Design
         {
             _sp = provider;
             _designerHost = (IDesignerHost)provider.GetService(typeof(IDesignerHost));
-            Debug.Assert(_designerHost != null, "ToolStripKeyboardHandlingService relies on the selection service, which is unavailable.");
+            Debug.Assert(_designerHost is not null, "ToolStripKeyboardHandlingService relies on the selection service, which is unavailable.");
             _designerHost?.AddService(typeof(ISupportInSituService), this);
 
             _componentChangeSvc = (IComponentChangeService)_designerHost.GetService(typeof(IComponentChangeService));
-            Debug.Assert(_componentChangeSvc != null, "ToolStripKeyboardHandlingService relies on the componentChange service, which is unavailable.");
-            if (_componentChangeSvc != null)
+            Debug.Assert(_componentChangeSvc is not null, "ToolStripKeyboardHandlingService relies on the componentChange service, which is unavailable.");
+            if (_componentChangeSvc is not null)
             {
                 _componentChangeSvc.ComponentRemoved += new ComponentEventHandler(OnComponentRemoved);
             }
@@ -43,19 +43,19 @@ namespace System.Windows.Forms.Design
         /// </summary>
         public void Dispose()
         {
-            if (_toolDesigner != null)
+            if (_toolDesigner is not null)
             {
                 _toolDesigner.Dispose();
                 _toolDesigner = null;
             }
 
-            if (_toolItemDesigner != null)
+            if (_toolItemDesigner is not null)
             {
                 _toolItemDesigner.Dispose();
                 _toolItemDesigner = null;
             }
 
-            if (_componentChangeSvc != null)
+            if (_componentChangeSvc is not null)
             {
                 _componentChangeSvc.ComponentRemoved -= new ComponentEventHandler(OnComponentRemoved);
                 _componentChangeSvc = null;
@@ -81,14 +81,14 @@ namespace System.Windows.Forms.Design
             {
                 ISelectionService selectionService = (ISelectionService)_sp.GetService(typeof(ISelectionService));
                 IDesignerHost host = (IDesignerHost)_sp.GetService(typeof(IDesignerHost));
-                if (selectionService != null && host != null)
+                if (selectionService is not null && host is not null)
                 {
                     if (!(selectionService.PrimarySelection is IComponent comp))
                     {
                         comp = (IComponent)ToolStripKeyBoardService.SelectedDesignerControl;
                     }
 
-                    if (comp != null)
+                    if (comp is not null)
                     {
                         if (comp is DesignerToolStripControlHost c)
                         {
@@ -103,7 +103,7 @@ namespace System.Windows.Forms.Design
                                     else
                                     {
                                         _toolItemDesigner = host.GetDesigner(parentItem) as ToolStripMenuItemDesigner;
-                                        if (_toolItemDesigner != null)
+                                        if (_toolItemDesigner is not null)
                                         {
                                             _toolDesigner = null;
                                             return true;
@@ -116,7 +116,7 @@ namespace System.Windows.Forms.Design
                                 if (c.GetCurrentParent() is MenuStrip tool)
                                 {
                                     _toolDesigner = host.GetDesigner(tool) as ToolStripDesigner;
-                                    if (_toolDesigner != null)
+                                    if (_toolDesigner is not null)
                                     {
                                         _toolItemDesigner = null;
                                         return true;
@@ -129,10 +129,10 @@ namespace System.Windows.Forms.Design
                             if (host.GetDesigner(comp) is ToolStripDropDownDesigner designer)
                             {
                                 ToolStripMenuItem toolItem = designer.DesignerMenuItem;
-                                if (toolItem != null)
+                                if (toolItem is not null)
                                 {
                                     _toolItemDesigner = host.GetDesigner(toolItem) as ToolStripItemDesigner;
-                                    if (_toolItemDesigner != null)
+                                    if (_toolItemDesigner is not null)
                                     {
                                         _toolDesigner = null;
                                         return true;
@@ -143,7 +143,7 @@ namespace System.Windows.Forms.Design
                         else if (comp is MenuStrip)
                         {
                             _toolDesigner = host.GetDesigner(comp) as ToolStripDesigner;
-                            if (_toolDesigner != null)
+                            if (_toolDesigner is not null)
                             {
                                 _toolItemDesigner = null;
                                 return true;
@@ -152,7 +152,7 @@ namespace System.Windows.Forms.Design
                         else if (comp is ToolStripMenuItem)
                         {
                             _toolItemDesigner = host.GetDesigner(comp) as ToolStripItemDesigner;
-                            if (_toolItemDesigner != null)
+                            if (_toolItemDesigner is not null)
                             {
                                 _toolDesigner = null;
                                 return true;
@@ -170,24 +170,24 @@ namespace System.Windows.Forms.Design
         /// </summary>
         public void HandleKeyChar()
         {
-            if (_toolDesigner != null || _toolItemDesigner != null)
+            if (_toolDesigner is not null || _toolItemDesigner is not null)
             {
-                if (_toolDesigner != null)
+                if (_toolDesigner is not null)
                 {
                     _toolDesigner.ShowEditNode(false);
                 }
-                else if (_toolItemDesigner != null)
+                else if (_toolItemDesigner is not null)
                 {
                     if (_toolItemDesigner is ToolStripMenuItemDesigner menuDesigner)
                     {
                         ISelectionService selService = (ISelectionService)_sp.GetService(typeof(ISelectionService));
-                        if (selService != null)
+                        if (selService is not null)
                         {
                             object comp = selService.PrimarySelection;
                             comp ??= ToolStripKeyBoardService.SelectedDesignerControl;
 
                             DesignerToolStripControlHost designerItem = comp as DesignerToolStripControlHost;
-                            if (designerItem != null || comp is ToolStripDropDown)
+                            if (designerItem is not null || comp is ToolStripDropDown)
                             {
                                 menuDesigner.EditTemplateNode(false);
                             }
@@ -211,11 +211,11 @@ namespace System.Windows.Forms.Design
         public IntPtr GetEditWindow()
         {
             IntPtr hWnd = IntPtr.Zero;
-            if (_toolDesigner != null && _toolDesigner.Editor != null && _toolDesigner.Editor.EditBox != null)
+            if (_toolDesigner is not null && _toolDesigner.Editor is not null && _toolDesigner.Editor.EditBox is not null)
             {
                 hWnd = (_toolDesigner.Editor.EditBox.Visible) ? _toolDesigner.Editor.EditBox.Handle : hWnd;
             }
-            else if (_toolItemDesigner != null && _toolItemDesigner.Editor != null && _toolItemDesigner.Editor.EditBox != null)
+            else if (_toolItemDesigner is not null && _toolItemDesigner.Editor is not null && _toolItemDesigner.Editor.EditBox is not null)
             {
                 hWnd = (_toolItemDesigner.Editor.EditBox.Visible) ? _toolItemDesigner.Editor.EditBox.Handle : hWnd;
             }
@@ -240,7 +240,7 @@ namespace System.Windows.Forms.Design
             if (!toolStripPresent)
             {
                 ToolStripInSituService inSituService = (ToolStripInSituService)_sp.GetService(typeof(ISupportInSituService));
-                if (inSituService != null)
+                if (inSituService is not null)
                 {
                     //since we are going away .. restore the old commands.
                     _designerHost.RemoveService(typeof(ISupportInSituService));

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripItemBehavior.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripItemBehavior.cs
@@ -64,16 +64,16 @@ namespace System.Windows.Forms.Design
 
             // Don't paint any "MouseOver" glyphs if TemplateNode is ACTIVE !
             ToolStripKeyboardHandlingService keyService = GetKeyBoardHandlingService(item);
-            if (keyService != null && keyService.TemplateNodeActive)
+            if (keyService is not null && keyService.TemplateNodeActive)
             {
                 return;
             }
 
             // stuff away the lastInsertionMarkRect  and clear it out _before_ we call paint OW the call to invalidate won't help as it will get repainted.
-            if (item != null && item.Site != null)
+            if (item is not null && item.Site is not null)
             {
                 IDesignerHost designerHost = (IDesignerHost)item.Site.GetService(typeof(IDesignerHost));
-                if (designerHost != null)
+                if (designerHost is not null)
                 {
                     Rectangle bounds = GetPaintingBounds(designerHost, item);
                     bounds.Inflate(GLYPHBORDER, GLYPHBORDER);
@@ -83,7 +83,7 @@ namespace System.Windows.Forms.Design
                         bounds.Inflate(-GLYPHINSET, -GLYPHINSET);
                         rgn.Exclude(bounds);
                         BehaviorService bSvc = GetBehaviorService(item);
-                        if (bSvc != null && bounds != Rectangle.Empty)
+                        if (bSvc is not null && bounds != Rectangle.Empty)
                         {
                             bSvc.Invalidate(rgn);
                         }
@@ -99,7 +99,7 @@ namespace System.Windows.Forms.Design
         // Tries to put the item in the Insitu edit mode after the double click timer has ticked
         private static void EnterInSituMode(ToolStripItemGlyph glyph)
         {
-            if (glyph.ItemDesigner != null && !glyph.ItemDesigner.IsEditorActive)
+            if (glyph.ItemDesigner is not null && !glyph.ItemDesigner.IsEditorActive)
             {
                 glyph.ItemDesigner.ShowEditNode(false);
             }
@@ -108,11 +108,11 @@ namespace System.Windows.Forms.Design
         // Gets the Selection Service.
         private static ISelectionService GetSelectionService(ToolStripItem item)
         {
-            Debug.Assert(item != null, "Item passed is null, SelectionService cannot be obtained");
-            if (item.Site != null)
+            Debug.Assert(item is not null, "Item passed is null, SelectionService cannot be obtained");
+            if (item.Site is not null)
             {
                 ISelectionService selSvc = (ISelectionService)item.Site.GetService(typeof(ISelectionService));
-                Debug.Assert(selSvc != null, "Failed to get Selection Service!");
+                Debug.Assert(selSvc is not null, "Failed to get Selection Service!");
                 return selSvc;
             }
 
@@ -122,11 +122,11 @@ namespace System.Windows.Forms.Design
         // Gets the Behavior Service.
         private static BehaviorService GetBehaviorService(ToolStripItem item)
         {
-            Debug.Assert(item != null, "Item passed is null, BehaviorService cannot be obtained");
-            if (item.Site != null)
+            Debug.Assert(item is not null, "Item passed is null, BehaviorService cannot be obtained");
+            if (item.Site is not null)
             {
                 BehaviorService behaviorSvc = (BehaviorService)item.Site.GetService(typeof(BehaviorService));
-                Debug.Assert(behaviorSvc != null, "Failed to get Behavior Service!");
+                Debug.Assert(behaviorSvc is not null, "Failed to get Behavior Service!");
                 return behaviorSvc;
             }
 
@@ -136,11 +136,11 @@ namespace System.Windows.Forms.Design
         // Gets the ToolStripKeyBoardHandling Service.
         private static ToolStripKeyboardHandlingService GetKeyBoardHandlingService(ToolStripItem item)
         {
-            Debug.Assert(item != null, "Item passed is null, ToolStripKeyBoardHandlingService cannot be obtained");
-            if (item.Site != null)
+            Debug.Assert(item is not null, "Item passed is null, ToolStripKeyBoardHandlingService cannot be obtained");
+            if (item.Site is not null)
             {
                 ToolStripKeyboardHandlingService keyBoardSvc = (ToolStripKeyboardHandlingService)item.Site.GetService(typeof(ToolStripKeyboardHandlingService));
-                Debug.Assert(keyBoardSvc != null, "Failed to get ToolStripKeyboardHandlingService!");
+                Debug.Assert(keyBoardSvc is not null, "Failed to get ToolStripKeyboardHandlingService!");
                 return keyBoardSvc;
             }
 
@@ -170,25 +170,25 @@ namespace System.Windows.Forms.Design
             IMouseHandler mouseHandler = null;
             _eventSvc ??= (IEventHandlerService)item.Site.GetService(typeof(IEventHandlerService));
 
-            if (_eventSvc != null)
+            if (_eventSvc is not null)
             {
                 mouseHandler = (IMouseHandler)_eventSvc.GetHandler(typeof(IMouseHandler));
             }
 
-            return (mouseHandler != null);
+            return (mouseHandler is not null);
         }
 
         // Occurs when the timer ticks after user has doubleclicked an item
         private void OnDoubleClickTimerTick(object sender, EventArgs e)
         {
-            if (_timer != null)
+            if (_timer is not null)
             {
                 _timer.Enabled = false;
                 _timer.Tick -= new EventHandler(OnDoubleClickTimerTick);
                 _timer.Dispose();
                 _timer = null;
                 // Enter Insitu ...
-                if (_selectedGlyph != null && _selectedGlyph.Item is ToolStripMenuItem)
+                if (_selectedGlyph is not null && _selectedGlyph.Item is ToolStripMenuItem)
                 {
                     EnterInSituMode(_selectedGlyph);
                 }
@@ -219,7 +219,7 @@ namespace System.Windows.Forms.Design
             SetParentDesignerValuesForDragDrop(glyphItem, false, Point.Empty);
             if (_doubleClickFired)
             {
-                if (glyph != null && button == MouseButtons.Left)
+                if (glyph is not null && button == MouseButtons.Left)
                 {
                     ISelectionService selSvc = GetSelectionService(glyphItem);
                     if (selSvc is null)
@@ -232,7 +232,7 @@ namespace System.Windows.Forms.Design
                     if (selectedItem == glyphItem)
                     {
                         // If timer != null.. we are in DoubleClick before the "InSitu Timer" so KILL IT.
-                        if (_timer != null)
+                        if (_timer is not null)
                         {
                             _timer.Enabled = false;
                             _timer.Tick -= new EventHandler(OnDoubleClickTimerTick);
@@ -241,10 +241,10 @@ namespace System.Windows.Forms.Design
                         }
 
                         // If the Selecteditem is already in editmode ... bail out
-                        if (selectedItem != null)
+                        if (selectedItem is not null)
                         {
                             ToolStripItemDesigner selectedItemDesigner = glyph.ItemDesigner;
-                            if (selectedItemDesigner != null && selectedItemDesigner.IsEditorActive)
+                            if (selectedItemDesigner is not null && selectedItemDesigner.IsEditorActive)
                             {
                                 return false;
                             }
@@ -273,7 +273,7 @@ namespace System.Windows.Forms.Design
             ISelectionService selSvc = GetSelectionService(glyphItem);
             BehaviorService bSvc = GetBehaviorService(glyphItem);
             ToolStripKeyboardHandlingService keyService = GetKeyBoardHandlingService(glyphItem);
-            if ((button == MouseButtons.Left) && (keyService != null) && (keyService.TemplateNodeActive))
+            if ((button == MouseButtons.Left) && (keyService is not null) && (keyService.TemplateNodeActive))
             {
                 if (keyService.ActiveTemplateNode.IsSystemContextMenuDisplayed)
                 {
@@ -283,11 +283,11 @@ namespace System.Windows.Forms.Design
             }
 
             IDesignerHost designerHost = (IDesignerHost)glyphItem.Site.GetService(typeof(IDesignerHost));
-            Debug.Assert(designerHost != null, "Invalid DesignerHost");
+            Debug.Assert(designerHost is not null, "Invalid DesignerHost");
 
             //Cache original selection
             ICollection originalSelComps = null;
-            if (selSvc != null)
+            if (selSvc is not null)
             {
                 originalSelComps = selSvc.GetSelectedComponents();
             }
@@ -296,13 +296,13 @@ namespace System.Windows.Forms.Design
             ArrayList origSel = new ArrayList(originalSelComps);
             if (origSel.Count == 0)
             {
-                if (keyService != null && keyService.SelectedDesignerControl != null)
+                if (keyService is not null && keyService.SelectedDesignerControl is not null)
                 {
                     origSel.Add(keyService.SelectedDesignerControl);
                 }
             }
 
-            if (keyService != null)
+            if (keyService is not null)
             {
                 keyService.SelectedDesignerControl = null;
                 if (keyService.TemplateNodeActive)
@@ -322,19 +322,19 @@ namespace System.Windows.Forms.Design
                 return false;
             }
 
-            if (glyph != null && button == MouseButtons.Left)
+            if (glyph is not null && button == MouseButtons.Left)
             {
                 ToolStripItem selectedItem = selSvc.PrimarySelection as ToolStripItem;
                 // Always set the Drag-Rect for Drag-Drop...
                 SetParentDesignerValuesForDragDrop(glyphItem, true, mouseLoc);
                 // Check if this item is already selected ...
-                if (selectedItem != null && selectedItem == glyphItem)
+                if (selectedItem is not null && selectedItem == glyphItem)
                 {
                     // If the Selecteditem is already in editmode ... bail out
-                    if (selectedItem != null)
+                    if (selectedItem is not null)
                     {
                         ToolStripItemDesigner selectedItemDesigner = glyph.ItemDesigner;
-                        if (selectedItemDesigner != null && selectedItemDesigner.IsEditorActive)
+                        if (selectedItemDesigner is not null && selectedItemDesigner.IsEditorActive)
                         {
                             return false;
                         }
@@ -377,7 +377,7 @@ namespace System.Windows.Forms.Design
                         _doubleClickFired = false;
                         //Implementing Shift + Click....
                         // we have 2 items, namely, selectedItem (current PrimarySelection) and glyphItem (item which has received mouseDown) FIRST check if they have common parent...  IF YES then get the indices of the two and SELECT all items from LOWER index to the HIGHER index.
-                        if (shiftPressed && (selectedItem != null && CommonParent(selectedItem, glyphItem)))
+                        if (shiftPressed && (selectedItem is not null && CommonParent(selectedItem, glyphItem)))
                         {
                             ToolStrip parent = null;
                             if (glyphItem.IsOnOverflow)
@@ -427,7 +427,7 @@ namespace System.Windows.Forms.Design
                         }
 
                         // Set the appropriate object.
-                        if (keyService != null)
+                        if (keyService is not null)
                         {
                             keyService.ShiftPrimaryItem = glyphItem;
                         }
@@ -441,7 +441,7 @@ namespace System.Windows.Forms.Design
                 }
             }
 
-            if (glyph != null && button == MouseButtons.Right)
+            if (glyph is not null && button == MouseButtons.Right)
             {
                 if (!selSvc.GetComponentSelected(glyphItem))
                 {
@@ -468,7 +468,7 @@ namespace System.Windows.Forms.Design
                 }
 
                 ISelectionService selSvc = GetSelectionService(glyphItem);
-                if (selSvc != null)
+                if (selSvc is not null)
                 {
                     if (!selSvc.GetComponentSelected(glyphItem))
                     {
@@ -494,7 +494,7 @@ namespace System.Windows.Forms.Design
                 }
 
                 ISelectionService selSvc = GetSelectionService(glyphItem);
-                if (selSvc != null)
+                if (selSvc is not null)
                 {
                     if (!selSvc.GetComponentSelected(glyphItem))
                     {
@@ -526,11 +526,11 @@ namespace System.Windows.Forms.Design
                 retVal = false;
             }
 
-            if (button == MouseButtons.Left && glyph != null && glyph.ItemDesigner != null && !glyph.ItemDesigner.IsEditorActive)
+            if (button == MouseButtons.Left && glyph is not null && glyph.ItemDesigner is not null && !glyph.ItemDesigner.IsEditorActive)
             {
                 Rectangle dragBox = Rectangle.Empty;
                 IDesignerHost designerHost = (IDesignerHost)glyphItem.Site.GetService(typeof(IDesignerHost));
-                Debug.Assert(designerHost != null, "Invalid DesignerHost");
+                Debug.Assert(designerHost is not null, "Invalid DesignerHost");
                 if (glyphItem.Placement == ToolStripItemPlacement.Overflow || (glyphItem.Placement == ToolStripItemPlacement.Main && !(glyphItem.IsOnDropDown)))
                 {
                     ToolStripItemDesigner itemDesigner = glyph.ItemDesigner;
@@ -556,7 +556,7 @@ namespace System.Windows.Forms.Design
                 // If the mouse moves outside the rectangle, start the drag.
                 if (dragBox != Rectangle.Empty && !dragBox.Contains(mouseLoc.X, mouseLoc.Y))
                 {
-                    if (_timer != null)
+                    if (_timer is not null)
                     {
                         _timer.Enabled = false;
                         _timer.Tick -= new EventHandler(OnDoubleClickTimerTick);
@@ -626,15 +626,15 @@ namespace System.Windows.Forms.Design
         {
             ToolStripItem currentDropItem = ToolStripDesigner.s_dragItem;
             // Ensure that the list item index is contained in the data.
-            if (e.Data is ToolStripItemDataObject && currentDropItem != null)
+            if (e.Data is ToolStripItemDataObject && currentDropItem is not null)
             {
                 ToolStripItemDataObject data = (ToolStripItemDataObject)e.Data;
                 // Get the PrimarySelection before the Drag operation...
                 ToolStripItem selectedItem = data.PrimarySelection;
                 IDesignerHost designerHost = (IDesignerHost)currentDropItem.Site.GetService(typeof(IDesignerHost));
-                Debug.Assert(designerHost != null, "Invalid DesignerHost");
+                Debug.Assert(designerHost is not null, "Invalid DesignerHost");
                 //Do DragDrop only if currentDropItem has changed.
-                if (currentDropItem != selectedItem && designerHost != null)
+                if (currentDropItem != selectedItem && designerHost is not null)
                 {
                     ArrayList components = data.DragComponents;
                     ToolStrip parentToolStrip = currentDropItem.GetCurrentParent();
@@ -676,19 +676,19 @@ namespace System.Windows.Forms.Design
                         if (copy)
                         {
                             // Remember the primary selection if we had one
-                            if (selectedItem != null)
+                            if (selectedItem is not null)
                             {
                                 primaryIndex = components.IndexOf(selectedItem);
                             }
 
                             ToolStripKeyboardHandlingService keyboardHandlingService = GetKeyBoardHandlingService(selectedItem);
-                            if (keyboardHandlingService != null)
+                            if (keyboardHandlingService is not null)
                             {
                                 keyboardHandlingService.CopyInProgress = true;
                             }
 
                             components = DesignerUtils.CopyDragObjects(components, currentDropItem.Site) as ArrayList;
-                            if (keyboardHandlingService != null)
+                            if (keyboardHandlingService is not null)
                             {
                                 keyboardHandlingService.CopyInProgress = false;
                             }
@@ -702,7 +702,7 @@ namespace System.Windows.Forms.Design
                         if (e.Effect == DragDropEffects.Move || copy)
                         {
                             ISelectionService selSvc = GetSelectionService(currentDropItem);
-                            if (selSvc != null)
+                            if (selSvc is not null)
                             {
                                 // Insert the item.
                                 if (parentToolStrip is ToolStripOverflow)
@@ -714,7 +714,7 @@ namespace System.Windows.Forms.Design
                                 if (indexOfItemUnderMouseToDrop != -1)
                                 {
                                     int indexOfPrimarySelection = 0;
-                                    if (selectedItem != null)
+                                    if (selectedItem is not null)
                                     {
                                         indexOfPrimarySelection = parentToolStrip.Items.IndexOf(selectedItem);
                                     }
@@ -734,10 +734,10 @@ namespace System.Windows.Forms.Design
                             }
                         }
 
-                        if (changeService != null)
+                        if (changeService is not null)
                         {
                             ToolStripDropDown dropDown = parentToolStrip as ToolStripDropDown;
-                            if (dropDown != null)
+                            if (dropDown is not null)
                             {
                                 ToolStripItem ownerItem = dropDown.OwnerItem;
                                 changeService.OnComponentChanged(ownerItem, TypeDescriptor.GetProperties(ownerItem)["DropDownItems"]);
@@ -750,7 +750,7 @@ namespace System.Windows.Forms.Design
                             //fire extra changing/changed events.
                             if (copy)
                             {
-                                if (dropDown != null)
+                                if (dropDown is not null)
                                 {
                                     ToolStripItem ownerItem = dropDown.OwnerItem;
                                     changeService.OnComponentChanging(ownerItem, TypeDescriptor.GetProperties(ownerItem)["DropDownItems"]);
@@ -794,7 +794,7 @@ namespace System.Windows.Forms.Design
                     }
                     catch (Exception ex)
                     {
-                        if (designerTransaction != null)
+                        if (designerTransaction is not null)
                         {
                             designerTransaction.Cancel();
                             designerTransaction = null;
@@ -881,21 +881,21 @@ namespace System.Windows.Forms.Design
 
             // Don't paint any "MouseOver" glyphs if TemplateNode is ACTIVE !
             ToolStripKeyboardHandlingService keyService = GetKeyBoardHandlingService(item);
-            if (keyService != null && keyService.TemplateNodeActive)
+            if (keyService is not null && keyService.TemplateNodeActive)
             {
                 return;
             }
 
             //Start from fresh State...
-            if (item != null && item.Site != null)
+            if (item is not null && item.Site is not null)
             {
                 ToolStripDesigner.s_lastCursorPosition = Cursor.Position;
                 IDesignerHost designerHost = (IDesignerHost)item.Site.GetService(typeof(IDesignerHost));
-                if (designerHost != null)
+                if (designerHost is not null)
                 {
                     Rectangle bounds = GetPaintingBounds(designerHost, item);
                     BehaviorService bSvc = GetBehaviorService(item);
-                    if (bSvc != null)
+                    if (bSvc is not null)
                     {
                         Graphics g = bSvc.AdornerWindowGraphics;
                         try
@@ -950,7 +950,7 @@ namespace System.Windows.Forms.Design
             Size dragSize = new Size(1, 1);
 
             IDesignerHost designerHost = (IDesignerHost)glyphItem.Site.GetService(typeof(IDesignerHost));
-            Debug.Assert(designerHost != null, "Invalid DesignerHost");
+            Debug.Assert(designerHost is not null, "Invalid DesignerHost");
 
             // implement Drag Drop for individual ToolStrip Items While this item is getting selected.. Get the index of the item the mouse is below.
             if (glyphItem.Placement == ToolStripItemPlacement.Overflow || (glyphItem.Placement == ToolStripItemPlacement.Main && !(glyphItem.IsOnDropDown)))

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripItemCustomMenuItemCollection.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripItemCustomMenuItemCollection.cs
@@ -202,7 +202,7 @@ namespace System.Windows.Forms.Design
             if (currentItem is ToolStripDropDownItem)
             {
                 IDesignerHost _designerHost = (IDesignerHost)serviceProvider.GetService(typeof(IDesignerHost));
-                if (_designerHost != null)
+                if (_designerHost is not null)
                 {
                     if (_designerHost.GetDesigner(currentItem) is ToolStripItemDesigner itemDesigner)
                     {
@@ -228,7 +228,7 @@ namespace System.Windows.Forms.Design
         private void OnImageToolStripMenuItemClick(object sender, EventArgs e)
         {
             IDesignerHost _designerHost = (IDesignerHost)serviceProvider.GetService(typeof(IDesignerHost));
-            if (_designerHost != null)
+            if (_designerHost is not null)
             {
                 if (_designerHost.GetDesigner(currentItem) is ToolStripItemDesigner itemDesigner)
                 {
@@ -249,12 +249,12 @@ namespace System.Windows.Forms.Design
         private void OnBooleanValueChanged(object sender, EventArgs e)
         {
             ToolStripItem item = sender as ToolStripItem;
-            Debug.Assert(item != null, "Why is item null?");
-            if (item != null)
+            Debug.Assert(item is not null, "Why is item null?");
+            if (item is not null)
             {
                 string propertyName = item.Tag as string;
-                Debug.Assert(propertyName != null, "Why is propertyName null?");
-                if (propertyName != null)
+                Debug.Assert(propertyName is not null, "Why is propertyName null?");
+                if (propertyName is not null)
                 {
                     bool currentValue = (bool)GetProperty(propertyName);
                     ChangeProperty(propertyName, !currentValue);
@@ -265,12 +265,12 @@ namespace System.Windows.Forms.Design
         private void OnEnumValueChanged(object sender, EventArgs e)
         {
             ToolStripItem item = sender as ToolStripItem;
-            Debug.Assert(item != null, "Why is item null?");
-            if (item != null)
+            Debug.Assert(item is not null, "Why is item null?");
+            if (item is not null)
             {
                 EnumValueDescription desc = item.Tag as EnumValueDescription;
-                Debug.Assert(desc != null, "Why is desc null?");
-                if (desc != null && !string.IsNullOrEmpty(desc.PropertyName))
+                Debug.Assert(desc is not null, "Why is desc null?");
+                if (desc is not null && !string.IsNullOrEmpty(desc.PropertyName))
                 {
                     ChangeProperty(desc.PropertyName, desc.Value);
                 }
@@ -348,7 +348,7 @@ namespace System.Windows.Forms.Design
 
         private static void TryCancelTransaction(ref DesignerTransaction transaction)
         {
-            if (transaction != null)
+            if (transaction is not null)
             {
                 try
                 {
@@ -367,9 +367,9 @@ namespace System.Windows.Forms.Design
         private void InsertIntoDropDown(ToolStripDropDown parent, Type t)
         {
             IDesignerHost designerHost = (IDesignerHost)serviceProvider.GetService(typeof(IDesignerHost));
-            Debug.Assert(designerHost != null, "Why didn't we get a designer host?");
+            Debug.Assert(designerHost is not null, "Why didn't we get a designer host?");
             int dummyIndex = parent.Items.IndexOf(currentItem);
-            if (parent != null)
+            if (parent is not null)
             {
                 if (parent.OwnerItem is ToolStripDropDownItem ownerItem)
                 {
@@ -399,7 +399,7 @@ namespace System.Windows.Forms.Design
             catch (Exception ex)
             {
                 // We need to cancel the ToolStripDesigner's nested MenuItemTransaction; otherwise, we can't cancel our Transaction and the Designer will be left in an unusable state
-                if ((parent != null) && (parent.OwnerItem != null) && (parent.OwnerItem.Owner != null))
+                if ((parent is not null) && (parent.OwnerItem is not null) && (parent.OwnerItem.Owner is not null))
                 {
                     if (designerHost.GetDesigner(parent.OwnerItem.Owner) is ToolStripDesigner toolStripDesigner)
                     {
@@ -427,7 +427,7 @@ namespace System.Windows.Forms.Design
         private void InsertIntoMainMenu(MenuStrip parent, Type t)
         {
             IDesignerHost designerHost = (IDesignerHost)serviceProvider.GetService(typeof(IDesignerHost));
-            Debug.Assert(designerHost != null, "Why didn't we get a designer host?");
+            Debug.Assert(designerHost is not null, "Why didn't we get a designer host?");
             int dummyIndex = parent.Items.IndexOf(currentItem);
             DesignerTransaction newItemTransaction = designerHost.CreateTransaction(SR.ToolStripAddingItem);
             try
@@ -466,7 +466,7 @@ namespace System.Windows.Forms.Design
         private void InsertIntoStatusStrip(StatusStrip parent, Type t)
         {
             IDesignerHost designerHost = (IDesignerHost)serviceProvider.GetService(typeof(IDesignerHost));
-            Debug.Assert(designerHost != null, "Why didn't we get a designer host?");
+            Debug.Assert(designerHost is not null, "Why didn't we get a designer host?");
             int dummyIndex = parent.Items.IndexOf(currentItem);
             DesignerTransaction newItemTransaction = designerHost.CreateTransaction(SR.ToolStripAddingItem);
             try
@@ -505,7 +505,7 @@ namespace System.Windows.Forms.Design
         private void InsertToolStripItem(Type t)
         {
             IDesignerHost designerHost = (IDesignerHost)serviceProvider.GetService(typeof(IDesignerHost));
-            Debug.Assert(designerHost != null, "Why didn't we get a designer host?");
+            Debug.Assert(designerHost is not null, "Why didn't we get a designer host?");
             ToolStrip parent = ParentTool;
             int dummyIndex = parent.Items.IndexOf(currentItem);
             DesignerTransaction newItemTransaction = designerHost.CreateTransaction(SR.ToolStripAddingItem);
@@ -548,7 +548,7 @@ namespace System.Windows.Forms.Design
             }
             catch (Exception ex)
             {
-                if (newItemTransaction != null)
+                if (newItemTransaction is not null)
                 {
                     newItemTransaction.Cancel();
                     newItemTransaction = null;
@@ -569,8 +569,8 @@ namespace System.Windows.Forms.Design
         private bool IsPropertyBrowsable(string propertyName)
         {
             PropertyDescriptor getProperty = TypeDescriptor.GetProperties(currentItem)[propertyName];
-            Debug.Assert(getProperty != null, "Could not find given property in control.");
-            if (getProperty != null)
+            Debug.Assert(getProperty is not null, "Could not find given property in control.");
+            if (getProperty is not null)
             {
                 if (getProperty.Attributes[typeof(BrowsableAttribute)] is BrowsableAttribute attribute)
                 {
@@ -585,8 +585,8 @@ namespace System.Windows.Forms.Design
         private object GetProperty(string propertyName)
         {
             PropertyDescriptor getProperty = TypeDescriptor.GetProperties(currentItem)[propertyName];
-            Debug.Assert(getProperty != null, "Could not find given property in control.");
-            if (getProperty != null)
+            Debug.Assert(getProperty is not null, "Could not find given property in control.");
+            if (getProperty is not null)
             {
                 return getProperty.GetValue(currentItem);
             }
@@ -603,7 +603,7 @@ namespace System.Windows.Forms.Design
         protected void ChangeProperty(IComponent target, string propertyName, object value)
         {
             PropertyDescriptor changingProperty = TypeDescriptor.GetProperties(target)[propertyName];
-            Debug.Assert(changingProperty != null, "Could not find given property in control.");
+            Debug.Assert(changingProperty is not null, "Could not find given property in control.");
             try
             {
                 changingProperty?.SetValue(target, value);

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripItemDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripItemDesigner.cs
@@ -152,7 +152,7 @@ namespace System.Windows.Forms.Design
         {
             get
             {
-                if (ToolStripItem != null)
+                if (ToolStripItem is not null)
                 {
                     ToolStrip parent = ToolStripItem.GetCurrentParent();
                     return parent ?? ToolStripItem.Owner;
@@ -199,7 +199,7 @@ namespace System.Windows.Forms.Design
         {
             get
             {
-                if (ToolStripItem != null)
+                if (ToolStripItem is not null)
                 {
                     if (ToolStripItem.IsOnDropDown && !ToolStripItem.IsOnOverflow)
                     {
@@ -278,7 +278,7 @@ namespace System.Windows.Forms.Design
                             if (item.Owner is ToolStripDropDown parentDropDown)
                             {
                                 ToolStripItem ownerItem = parentDropDown.OwnerItem;
-                                if (ownerItem != null)
+                                if (ownerItem is not null)
                                 {
                                     parentControls.Add(ownerItem);
                                     startComp = ownerItem;
@@ -288,7 +288,7 @@ namespace System.Windows.Forms.Design
                     }
                     else
                     {
-                        if (item.Owner.Site != null)
+                        if (item.Owner.Site is not null)
                         {
                             parentControls.Add(item.Owner);
                         }
@@ -300,7 +300,7 @@ namespace System.Windows.Forms.Design
                 {
                     Control selectedControl = startComp as Control;
                     Control parentControl = selectedControl.Parent;
-                    if (parentControl.Site != null)
+                    if (parentControl.Site is not null)
                     {
                         parentControls.Add(parentControl);
                     }
@@ -361,7 +361,7 @@ namespace System.Windows.Forms.Design
                     }
                     finally
                     {
-                        if (designer.NewItemTransaction != null)
+                        if (designer.NewItemTransaction is not null)
                         {
                             designer.NewItemTransaction.Commit();
                             designer.NewItemTransaction = null;
@@ -377,19 +377,19 @@ namespace System.Windows.Forms.Design
                         //Change the Text...
                         PropertyDescriptor textProp = TypeDescriptor.GetProperties(ToolStripItem)["Text"];
                         string oldValue = (string)textProp.GetValue(ToolStripItem);
-                        if (textProp != null && text != oldValue)
+                        if (textProp is not null && text != oldValue)
                         {
                             textProp.SetValue(ToolStripItem, text);
                         }
 
-                        if (enterKeyPressed && _selectionService != null)
+                        if (enterKeyPressed && _selectionService is not null)
                         {
                             SelectNextItem(_selectionService, enterKeyPressed, designer);
                         }
                     }
                     catch (Exception e)
                     {
-                        if (designerTransaction != null)
+                        if (designerTransaction is not null)
                         {
                             designerTransaction.Cancel();
                             designerTransaction = null;
@@ -419,7 +419,7 @@ namespace System.Windows.Forms.Design
                     dummyItemAdded = false;
                     RemoveItem();
 
-                    if (designer.NewItemTransaction != null)
+                    if (designer.NewItemTransaction is not null)
                     {
                         designer.NewItemTransaction.Cancel();
                         designer.NewItemTransaction = null;
@@ -428,7 +428,7 @@ namespace System.Windows.Forms.Design
             }
 
             immediateParent.ResumeLayout();
-            if (newItem != null && !newItem.IsOnDropDown)
+            if (newItem is not null && !newItem.IsOnDropDown)
             {
                 if (newItem is ToolStripDropDownItem dropDown)
                 {
@@ -436,7 +436,7 @@ namespace System.Windows.Forms.Design
                     Rectangle itemBounds = itemDesigner.GetGlyphBounds();
                     if (designerHost.RootComponent is Control parent)
                     {
-                        if (behaviorService != null)
+                        if (behaviorService is not null)
                         {
                             Rectangle parentBounds = behaviorService.ControlRectInAdornerWindow(parent);
                             if (!ToolStripDesigner.IsGlyphTotallyVisible(itemBounds, parentBounds))
@@ -459,13 +459,13 @@ namespace System.Windows.Forms.Design
         {
             if (disposing)
             {
-                if (_editorNode != null)
+                if (_editorNode is not null)
                 {
                     _editorNode.CloseEditor();
                     _editorNode = null;
                 }
 
-                if (ToolStripItem != null)
+                if (ToolStripItem is not null)
                 {
                     ToolStripItem.Paint -= new PaintEventHandler(OnItemPaint);
                 }
@@ -476,21 +476,20 @@ namespace System.Windows.Forms.Design
                     cs.ComponentRename -= new ComponentRenameEventHandler(OnComponentRename);
                 }
 
-                if (_selectionService != null)
+                if (_selectionService is not null)
                 {
                     _selectionService.SelectionChanged -= new EventHandler(OnSelectionChanged);
                 }
 
                 // Clean up the ToolStripItem Glyph if Any
-                if (bodyGlyph != null
-                    && TryGetService(out ToolStripAdornerWindowService toolStripAdornerWindowService)
+                if (bodyGlyph is not null && TryGetService(out ToolStripAdornerWindowService toolStripAdornerWindowService)
                     && toolStripAdornerWindowService.DropDownAdorner.Glyphs.Contains(bodyGlyph))
                 {
                     toolStripAdornerWindowService.DropDownAdorner.Glyphs.Remove(bodyGlyph);
                 }
 
                 // Remove the Collection
-                if (toolStripItemCustomMenuItemCollection != null && toolStripItemCustomMenuItemCollection.Count > 0)
+                if (toolStripItemCustomMenuItemCollection is not null && toolStripItemCustomMenuItemCollection.Count > 0)
                 {
                     foreach (ToolStripItem item in toolStripItemCustomMenuItemCollection)
                     {
@@ -516,7 +515,7 @@ namespace System.Windows.Forms.Design
         public Rectangle GetGlyphBounds()
         {
             Rectangle r = Rectangle.Empty;
-            if (TryGetService(out BehaviorService b) && ImmediateParent != null)
+            if (TryGetService(out BehaviorService b) && ImmediateParent is not null)
             {
                 Point loc = b.ControlToAdornerWindow((Control)ImmediateParent);
                 r = ToolStripItem.Bounds;
@@ -534,7 +533,7 @@ namespace System.Windows.Forms.Design
                 return;
             }
 
-            if (TryGetService(out IComponentChangeService changeService) && parent.Site != null)
+            if (TryGetService(out IComponentChangeService changeService) && parent.Site is not null)
             {
                 changeService.OnComponentChanging(parent, TypeDescriptor.GetProperties(parent)["DropDownItems"]);
             }
@@ -556,7 +555,7 @@ namespace System.Windows.Forms.Design
                 return;
             }
 
-            if (TryGetService(out IComponentChangeService changeService) && parent.Site != null)
+            if (TryGetService(out IComponentChangeService changeService) && parent.Site is not null)
             {
                 changeService.OnComponentChanged(parent, TypeDescriptor.GetProperties(parent)["DropDownItems"]);
             }
@@ -589,7 +588,7 @@ namespace System.Windows.Forms.Design
                     ToolStrip parent = ToolStripItem.GetCurrentParent();
                     parent ??= ToolStripItem.Owner;
 
-                    if (parent != null && parent.Visible)
+                    if (parent is not null && parent.Visible)
                     {
                         glyphs.Add(new MiniLockedBorderGlyph(r, SelectionBorderGlyphType.Top, standardBehavior, true));
                         glyphs.Add(new MiniLockedBorderGlyph(r, SelectionBorderGlyphType.Bottom, standardBehavior, true));
@@ -616,7 +615,7 @@ namespace System.Windows.Forms.Design
             {
                 ToolStripDropDown topmost = currentItem.Owner as ToolStripDropDown;
                 // walk back up the chain of windows to get the topmost
-                while (topmost.OwnerItem != null && (topmost.OwnerItem.Owner is ToolStripDropDown))
+                while (topmost.OwnerItem is not null && (topmost.OwnerItem.Owner is ToolStripDropDown))
                 {
                     topmost = topmost.OwnerItem.Owner as ToolStripDropDown;
                 }
@@ -633,7 +632,7 @@ namespace System.Windows.Forms.Design
         private void HideDummyNode()
         {
             ToolStripItem.AutoSize = AutoSize;
-            if (_editorNode != null)
+            if (_editorNode is not null)
             {
                 _editorNode.CloseEditor();
                 _editorNode = null;
@@ -680,7 +679,7 @@ namespace System.Windows.Forms.Design
             if (!internalCreate)
             {
                 ISite site = Component.Site;
-                if (site != null && Component is ToolStripDropDownItem)
+                if (site is not null && Component is ToolStripDropDownItem)
                 {
                     defaultValues ??= new Hashtable();
 
@@ -688,7 +687,7 @@ namespace System.Windows.Forms.Design
                     IComponent component = Component;
                     PropertyDescriptor pd = TypeDescriptor.GetProperties(ToolStripItem)["Text"];
 
-                    if (pd != null && pd.PropertyType.Equals(typeof(string)))
+                    if (pd is not null && pd.PropertyType.Equals(typeof(string)))
                     {
                         string current = (string)pd.GetValue(component);
                         if (current is null || current.Length == 0)
@@ -704,7 +703,7 @@ namespace System.Windows.Forms.Design
             if (Component is ToolStripTextBox || Component is ToolStripComboBox)
             {
                 PropertyDescriptor textProp = TypeDescriptor.GetProperties(Component)["Text"];
-                if (textProp != null && textProp.PropertyType == typeof(string) && !textProp.IsReadOnly && textProp.IsBrowsable)
+                if (textProp is not null && textProp.PropertyType == typeof(string) && !textProp.IsReadOnly && textProp.IsBrowsable)
                 {
                     textProp.SetValue(Component, "");
                 }
@@ -744,7 +743,7 @@ namespace System.Windows.Forms.Design
                 if (ImmediateParent is ToolStripDropDown parentDropDown)
                 {
                     ownerItem = parentDropDown.OwnerItem;
-                    if (ownerItem != null)
+                    if (ownerItem is not null)
                     {
                         ownerItemDesigner = (ToolStripMenuItemDesigner)host.GetDesigner(ownerItem);
                     }
@@ -768,7 +767,7 @@ namespace System.Windows.Forms.Design
                 //Serialize all the DropDownItems for this Item....
                 SerializationStore _serializedDataForDropDownItems = null;
                 ToolStripDropDownItem dropDownItem = ToolStripItem as ToolStripDropDownItem;
-                if (dropDownItem != null && typeof(ToolStripDropDownItem).IsAssignableFrom(t))
+                if (dropDownItem is not null && typeof(ToolStripDropDownItem).IsAssignableFrom(t))
                 {
                     // Hide the DropDown.
                     dropDownItem.HideDropDown();
@@ -784,11 +783,11 @@ namespace System.Windows.Forms.Design
                 // Remove the currentItem that is getting morphed..
                 if (TryGetService(out IComponentChangeService changeService))
                 {
-                    if (parent.Site != null)
+                    if (parent.Site is not null)
                     {
                         changeService.OnComponentChanging(parent, TypeDescriptor.GetProperties(parent)["Items"]);
                     }
-                    else if (ownerItem != null)
+                    else if (ownerItem is not null)
                     {
                         changeService.OnComponentChanging(ownerItem, TypeDescriptor.GetProperties(ownerItem)["DropDownItems"]);
                         changeService.OnComponentChanged(ownerItem, TypeDescriptor.GetProperties(ownerItem)["DropDownItems"]);
@@ -803,7 +802,7 @@ namespace System.Windows.Forms.Design
                 //Since destroying the original item took away its DropDownItems. We need to Deserialize the items again...
                 if (component is ToolStripDropDownItem)
                 {
-                    if (_serializedDataForDropDownItems != null)
+                    if (_serializedDataForDropDownItems is not null)
                     {
                         serializationService.Deserialize(_serializedDataForDropDownItems);
                     }
@@ -830,29 +829,29 @@ namespace System.Windows.Forms.Design
                     }
 
                     PropertyDescriptor imageProperty = TypeDescriptor.GetProperties(newItem)["Image"];
-                    Debug.Assert(imageProperty != null, "Could not find 'Image' property in ToolStripItem.");
-                    if (imageProperty != null && image != null)
+                    Debug.Assert(imageProperty is not null, "Could not find 'Image' property in ToolStripItem.");
+                    if (imageProperty is not null && image is not null)
                     {
                         imageProperty.SetValue(newItem, image);
                     }
 
                     PropertyDescriptor dispProperty = TypeDescriptor.GetProperties(newItem)["DisplayStyle"];
-                    Debug.Assert(dispProperty != null, "Could not find 'DisplayStyle' property in ToolStripItem.");
+                    Debug.Assert(dispProperty is not null, "Could not find 'DisplayStyle' property in ToolStripItem.");
                     dispProperty?.SetValue(newItem, ToolStripItemDisplayStyle.Image);
 
                     PropertyDescriptor imageTransProperty = TypeDescriptor.GetProperties(newItem)["ImageTransparentColor"];
-                    Debug.Assert(imageTransProperty != null, "Could not find 'DisplayStyle' property in ToolStripItem.");
+                    Debug.Assert(imageTransProperty is not null, "Could not find 'DisplayStyle' property in ToolStripItem.");
                     imageTransProperty?.SetValue(newItem, Color.Magenta);
                 }
 
                 parent.Items.Insert(dummyIndex, newItem);
-                if (changeService != null)
+                if (changeService is not null)
                 {
-                    if (parent.Site != null)
+                    if (parent.Site is not null)
                     {
                         changeService.OnComponentChanged(parent, TypeDescriptor.GetProperties(parent)["Items"]);
                     }
-                    else if (ownerItem != null)
+                    else if (ownerItem is not null)
                     {
                         changeService.OnComponentChanging(ownerItem, TypeDescriptor.GetProperties(ownerItem)["DropDownItems"]);
                         changeService.OnComponentChanged(ownerItem, TypeDescriptor.GetProperties(ownerItem)["DropDownItems"]);
@@ -861,7 +860,7 @@ namespace System.Windows.Forms.Design
 
                 FireComponentChanged(dropDownItem);
                 // Add the Glyph for the DropDown ... We are responsible for the Glyph Addition since BodyGlyphs for DropDownItems are added by us.
-                if (newItem.IsOnDropDown && ownerItemDesigner != null)
+                if (newItem.IsOnDropDown && ownerItemDesigner is not null)
                 {
                     ownerItemDesigner.RemoveItemBodyGlyph(newItem);
                     ownerItemDesigner.AddItemBodyGlyph(newItem);
@@ -870,7 +869,7 @@ namespace System.Windows.Forms.Design
                 // re start the ComponentAdding/Added events
                 ToolStripDesigner.s_autoAddNewItems = true;
                 //Invalidate the AdornerWindow to refresh selectionglyphs.
-                if (newItem != null)
+                if (newItem is not null)
                 {
                     if (newItem is ToolStripSeparator)
                     {
@@ -891,7 +890,7 @@ namespace System.Windows.Forms.Design
             {
                 host.Container.Add(ToolStripItem);
                 parent.Items.Insert(dummyIndex, ToolStripItem);
-                if (designerTransaction != null)
+                if (designerTransaction is not null)
                 {
                     designerTransaction.Cancel();
                     designerTransaction = null;
@@ -922,8 +921,7 @@ namespace System.Windows.Forms.Design
         private void OnItemPaint(object sender, PaintEventArgs e)
         {
             if (ToolStripItem.GetCurrentParent() is ToolStripDropDown
-                && _selectionService != null
-                && !IsEditorActive
+                && _selectionService is not null && !IsEditorActive
                 && ToolStripItem.Equals(_selectionService.PrimarySelection)
                 && TryGetService(out BehaviorService behaviorService))
             {
@@ -958,13 +956,13 @@ namespace System.Windows.Forms.Design
                 {
                     ToolStrip owner = ImmediateParent as ToolStrip;
                     int focusIndex = 0;
-                    if (owner != null)
+                    if (owner is not null)
                     {
                         focusIndex = owner.Items.IndexOf(currentSelection);
                     }
 
                     acc.AddState(AccessibleStates.Selected);
-                    if (tool != null)
+                    if (tool is not null)
                     {
                         Debug.WriteLineIf(CompModSwitches.MSAA.TraceInfo, "MSAA: SelectionAdd, tool = " + tool.ToString());
                         User32.NotifyWinEvent((uint)AccessibleEvents.SelectionAdd, new HandleRef(owner, owner.Handle), User32.OBJID.CLIENT, focusIndex + 1);
@@ -973,7 +971,7 @@ namespace System.Windows.Forms.Design
                     if (currentSelection == ToolStripItem)
                     {
                         acc.AddState(AccessibleStates.Focused);
-                        if (tool != null)
+                        if (tool is not null)
                         {
                             User32.NotifyWinEvent((uint)AccessibleEvents.Focus, new HandleRef(owner, owner.Handle), User32.OBJID.CLIENT, focusIndex + 1);
                         }
@@ -981,7 +979,7 @@ namespace System.Windows.Forms.Design
                 }
             }
 
-            if (currentSelection != null && currentSelection.Equals(ToolStripItem) && !(ToolStripItem is ToolStripMenuItem))
+            if (currentSelection is not null && currentSelection.Equals(ToolStripItem) && !(ToolStripItem is ToolStripMenuItem))
             {
                 if (currentSelection.IsOnDropDown)
                 {
@@ -1016,7 +1014,7 @@ namespace System.Windows.Forms.Design
                         }
                     }
                 }
-                else if (currentSelection.Owner != null)
+                else if (currentSelection.Owner is not null)
                 {
                     // The selected item could be in a MenuStrip, StatusStrip or ToolStrip. Need invalidate the
                     // BehaviorService to reflect the selection change.
@@ -1042,7 +1040,7 @@ namespace System.Windows.Forms.Design
             for (int i = 0; i < shadowProps.Length; i++)
             {
                 prop = (PropertyDescriptor)properties[shadowProps[i]];
-                if (prop != null)
+                if (prop is not null)
                 {
                     properties[shadowProps[i]] = TypeDescriptor.CreateProperty(typeof(ToolStripItemDesigner), prop, empty);
                 }
@@ -1168,7 +1166,7 @@ namespace System.Windows.Forms.Design
                 if (!currentVisible)
                 {
                     ToolStripItem.Visible = true;
-                    if (designer != null && !designer.FireSyncSelection)
+                    if (designer is not null && !designer.FireSyncSelection)
                     {
                         designer.FireSyncSelection = true;
                     }
@@ -1193,12 +1191,12 @@ namespace System.Windows.Forms.Design
         /// <summary>
         /// Since we're shadowing autosize, we get called here to determine whether or not to serialize
         /// </summary>
-        private bool ShouldSerializeAccessibleName() => (ShadowProperties[nameof(AccessibleName)] != null);
+        private bool ShouldSerializeAccessibleName() => (ShadowProperties[nameof(AccessibleName)] is not null);
 
         /// <summary>
         /// Since we're Overflow Size, we get called here to determine whether or not to serialize
         /// </summary>
-        private bool ShouldSerializeOverflow() => (ShadowProperties[nameof(Overflow)] != null);
+        private bool ShouldSerializeOverflow() => (ShadowProperties[nameof(Overflow)] is not null);
 
         /// <summary>
         ///  This Function is called thru the ToolStripEditorManager which is listening for the  F2 command.
@@ -1215,8 +1213,8 @@ namespace System.Windows.Forms.Design
 
                 IDesignerHost designerHost = (IDesignerHost)Component.Site.GetService(typeof(IDesignerHost));
                 ToolStrip parent = ImmediateParent as ToolStrip;
-                Debug.Assert(parent != null, "ImmediateParent is null for the current ToolStripItem !!");
-                if (parent != null)
+                Debug.Assert(parent is not null, "ImmediateParent is null for the current ToolStripItem !!");
+                if (parent is not null)
                 {
                     ToolStripDesigner parentDesigner = (ToolStripDesigner)designerHost.GetDesigner(parent);
                     BehaviorService behaviorService = GetService<BehaviorService>();
@@ -1267,13 +1265,13 @@ namespace System.Windows.Forms.Design
                         behaviorService.Invalidate(boundsInAdornerWindow);
 
                         // PLEASE DON'T CHANGE THIS ORDER !!!
-                        if (parentDesigner != null && parentDesigner.EditManager != null)
+                        if (parentDesigner is not null && parentDesigner.EditManager is not null)
                         {
                             parentDesigner.EditManager.ActivateEditor(ToolStripItem, clicked);
                         }
 
                         SelectionManager selectionManager = GetService<SelectionManager>();
-                        if (bodyGlyph != null)
+                        if (bodyGlyph is not null)
                         {
                             selectionManager.BodyGlyphAdorner.Glyphs.Remove(bodyGlyph);
                         }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripMenuItemCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripMenuItemCodeDomSerializer.cs
@@ -41,7 +41,7 @@ namespace System.Windows.Forms.Design
             ToolStrip parent = item.GetCurrentParent();
 
             // Don't Serialize if we are Dummy Item ...
-            if ((item != null) && !(item.IsOnDropDown) && (parent != null) && (parent.Site is null))
+            if ((item is not null) && !(item.IsOnDropDown) && (parent is not null) && (parent.Site is null))
             {
                 //don't serialize anything...
                 return null;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripMenuItemDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripMenuItemDesigner.cs
@@ -121,7 +121,7 @@ namespace System.Windows.Forms.Design
                 }
 
                 // Check if DropDown Exists .. and if yes then Close the DropDown
-                if (MenuItem.DropDown != null)
+                if (MenuItem.DropDown is not null)
                 {
                     RemoveTypeHereNode(MenuItem);
 
@@ -162,7 +162,7 @@ namespace System.Windows.Forms.Design
                 //Set the Shadow Property
                 customDropDown = value;
                 // If DropDown is Set to null and we have valid serializedData, then use it to recreate Items.
-                if (value is null && !dropDownSet && serializedDataForDropDownItems != null)
+                if (value is null && !dropDownSet && serializedDataForDropDownItems is not null)
                 {
                     try
                     {
@@ -202,12 +202,12 @@ namespace System.Windows.Forms.Design
         {
             get
             {
-                if (base.Editor != null)
+                if (base.Editor is not null)
                 {
                     return base.Editor;
                 }
 
-                if (commitedTemplateNode != null)
+                if (commitedTemplateNode is not null)
                 {
                     return commitedTemplateNode;
                 }
@@ -225,7 +225,7 @@ namespace System.Windows.Forms.Design
             get
             {
                 ToolStrip mainStrip = GetMainToolStrip();
-                if (mainStrip != null && mainStrip.Site != null && !(mainStrip is ContextMenuStrip))
+                if (mainStrip is not null && mainStrip.Site is not null && !(mainStrip is ContextMenuStrip))
                 {
                     return false;
                 }
@@ -250,13 +250,13 @@ namespace System.Windows.Forms.Design
             get
             {
                 // check to see if the primary selection is the ToolStrip or one of it's children.
-                if (_selectionService != null)
+                if (_selectionService is not null)
                 {
                     object selectedItem = _selectionService.PrimarySelection;
                     ToolStripItem toolItem;
                     if (selectedItem is null)
                     {
-                        if (KeyboardHandlingService != null)
+                        if (KeyboardHandlingService is not null)
                         {
                             selectedItem = KeyboardHandlingService.SelectedDesignerControl;
                         }
@@ -268,10 +268,10 @@ namespace System.Windows.Forms.Design
                         toolItem = selectedItem as ToolStripItem;
                     }
 
-                    if (toolItem != null)
+                    if (toolItem is not null)
                     {
                         // We always need to return the current selection if we are adding a DummyNode...
-                        if (_designerHost != null)
+                        if (_designerHost is not null)
                         {
                             if (_designerHost.GetDesigner(toolItem) is ToolStripItemDesigner designer)
                             {
@@ -315,7 +315,7 @@ namespace System.Windows.Forms.Design
         {
             get
             {
-                if (ToolStripItem != null)
+                if (ToolStripItem is not null)
                 {
                     if (!ToolStripItem.IsOnOverflow && ToolStripItem.IsOnDropDown)
                     {
@@ -354,7 +354,7 @@ namespace System.Windows.Forms.Design
                 }
             }
 
-            if (typeHereNode != null)
+            if (typeHereNode is not null)
             {
                 dropDown.Items.Remove(typeHereNode);
             }
@@ -372,10 +372,10 @@ namespace System.Windows.Forms.Design
         // used by morphing in ToolStripItemDesigner ... hence internal method.
         internal void AddItemBodyGlyph(ToolStripItem item)
         {
-            if (item != null)
+            if (item is not null)
             {
                 ToolStripItemDesigner dropDownItemDesigner = (ToolStripItemDesigner)_designerHost.GetDesigner(item);
-                if (dropDownItemDesigner != null)
+                if (dropDownItemDesigner is not null)
                 {
                     Rectangle bounds = dropDownItemDesigner.GetGlyphBounds();
                     Behavior.Behavior toolStripBehavior = new ToolStripItemBehavior();
@@ -392,10 +392,10 @@ namespace System.Windows.Forms.Design
         // Add individual item Body Glyphs
         private void AddBodyGlyphs(ToolStripDropDownItem item)
         {
-            if (item != null)
+            if (item is not null)
             {
                 ToolStripMenuItemDesigner itemDesigner = (ToolStripMenuItemDesigner)_designerHost.GetDesigner(item);
-                if (itemDesigner != null)
+                if (itemDesigner is not null)
                 {
                     foreach (ToolStripItem ddItem in item.DropDownItems)
                     {
@@ -411,7 +411,7 @@ namespace System.Windows.Forms.Design
         internal override void CommitEdit(Type type, string text, bool commit, bool enterKeyPressed, bool tabKeyPressed)
         {
             IsEditorActive = false;
-            if (!(MenuItem.Owner is ToolStripDropDown) && base.Editor != null) //we are on Base Menustrip !!
+            if (!(MenuItem.Owner is ToolStripDropDown) && base.Editor is not null) //we are on Base Menustrip !!
             {
                 base.CommitEdit(type, text, commit, enterKeyPressed, tabKeyPressed);
             }
@@ -421,7 +421,7 @@ namespace System.Windows.Forms.Design
                 dummyItemAdded = false;
                 MenuItem.DropDown.SuspendLayout();
                 int index;
-                if (commitedEditorNode != null)
+                if (commitedEditorNode is not null)
                 {
                     // This means we have a valid node and we just changed some properties.
                     index = MenuItem.DropDownItems.IndexOf(commitedEditorNode);
@@ -429,13 +429,13 @@ namespace System.Windows.Forms.Design
                     // Remove TemplateNode
                     MenuItem.DropDown.Items.Remove(commitedEditorNode);
                     // Get rid of the templateNode...
-                    if (commitedTemplateNode != null)
+                    if (commitedTemplateNode is not null)
                     {
                         commitedTemplateNode.CloseEditor();
                         commitedTemplateNode = null;
                     }
 
-                    if (commitedEditorNode != null)
+                    if (commitedEditorNode is not null)
                     {
                         commitedEditorNode.Dispose();
                         commitedEditorNode = null;
@@ -454,7 +454,7 @@ namespace System.Windows.Forms.Design
                             }
                             catch
                             {
-                                if (newMenuItemTransaction != null)
+                                if (newMenuItemTransaction is not null)
                                 {
                                     try
                                     {
@@ -469,7 +469,7 @@ namespace System.Windows.Forms.Design
                             }
                             finally
                             {
-                                if (newMenuItemTransaction != null)
+                                if (newMenuItemTransaction is not null)
                                 {
                                     newMenuItemTransaction.Commit();
                                     newMenuItemTransaction = null;
@@ -495,7 +495,7 @@ namespace System.Windows.Forms.Design
                             }
                             catch
                             {
-                                if (newMenuItemTransaction != null)
+                                if (newMenuItemTransaction is not null)
                                 {
                                     try
                                     {
@@ -510,7 +510,7 @@ namespace System.Windows.Forms.Design
                             }
                             finally
                             {
-                                if (newMenuItemTransaction != null)
+                                if (newMenuItemTransaction is not null)
                                 {
                                     newMenuItemTransaction.Commit();
                                     newMenuItemTransaction = null;
@@ -531,14 +531,14 @@ namespace System.Windows.Forms.Design
                                 //Change the properties
                                 PropertyDescriptor textProp = TypeDescriptor.GetProperties(editedItem)["Text"];
                                 string oldValue = (string)textProp.GetValue(editedItem);
-                                if (textProp != null && text != oldValue)
+                                if (textProp is not null && text != oldValue)
                                 {
                                     textProp.SetValue(editedItem, text);
                                 }
                             }
                             catch
                             {
-                                if (designerTransaction != null)
+                                if (designerTransaction is not null)
                                 {
                                     designerTransaction.Cancel();
                                     designerTransaction = null;
@@ -575,7 +575,7 @@ namespace System.Windows.Forms.Design
                 //Reset the Glyphs after Item addition...
                 ResetGlyphs(MenuItem);
                 //set the selection to our new item only if item was commited via ENTER KEY in the Insitu Mode.
-                if (_selectionService != null)
+                if (_selectionService is not null)
                 {
                     if (enterKeyPressed)
                     {
@@ -590,9 +590,9 @@ namespace System.Windows.Forms.Design
                             nextItem = MenuItem.DropDownItems[index + 1];
                         }
 
-                        if (KeyboardHandlingService != null)
+                        if (KeyboardHandlingService is not null)
                         {
-                            if (nextItem != null)
+                            if (nextItem is not null)
                             {
                                 if (MenuItem.DropDownItems[index] is ToolStripDropDownItem currentItem)
                                 {
@@ -622,7 +622,7 @@ namespace System.Windows.Forms.Design
             else
             {
                 // We come here if we have not committed so revert our state.
-                if (commitedEditorNode != null)
+                if (commitedEditorNode is not null)
                 {
                     // We just changed some properties which we want to revert.
                     MenuItem.DropDown.SuspendLayout();
@@ -633,13 +633,13 @@ namespace System.Windows.Forms.Design
                     MenuItem.DropDown.Items.Remove(commitedEditorNode);
                     // put the item back...
                     editedItem.Visible = true;
-                    if (commitedTemplateNode != null)
+                    if (commitedTemplateNode is not null)
                     {
                         commitedTemplateNode.CloseEditor();
                         commitedTemplateNode = null;
                     }
 
-                    if (commitedEditorNode != null)
+                    if (commitedEditorNode is not null)
                     {
                         commitedEditorNode.Dispose();
                         commitedEditorNode = null;
@@ -654,7 +654,7 @@ namespace System.Windows.Forms.Design
                         }
                         catch
                         {
-                            if (newMenuItemTransaction != null)
+                            if (newMenuItemTransaction is not null)
                             {
                                 try
                                 {
@@ -675,7 +675,7 @@ namespace System.Windows.Forms.Design
                     MenuItem.DropDown.ResumeLayout();
 
                     // Remove the Glyphs so that Mouse Message go to the Editor
-                    if (editedItem != null)
+                    if (editedItem is not null)
                     {
                         AddItemBodyGlyph(editedItem);
                     }
@@ -686,7 +686,7 @@ namespace System.Windows.Forms.Design
                         // set SelectionManager.NeedRefresh to false so that it doesnt refresh,
                         // when the transaction is cancelled.
                         GetService<SelectionManager>().NeedRefresh = false;
-                        if (newMenuItemTransaction != null)
+                        if (newMenuItemTransaction is not null)
                         {
                             try
                             {
@@ -725,7 +725,7 @@ namespace System.Windows.Forms.Design
                     MenuItem.DropDown.Text = MenuItem.Name + ".DropDown";
                 }
             }
-            else if (typeHereNode != null && MenuItem.DropDownItems.IndexOf(typeHereNode) == -1)
+            else if (typeHereNode is not null && MenuItem.DropDownItems.IndexOf(typeHereNode) == -1)
             {
                 MenuItem.DropDown.Items.Add(typeHereNode);
                 typeHereNode.Visible = true;
@@ -810,7 +810,7 @@ namespace System.Windows.Forms.Design
             {
                 CommitInsertTransaction(commit: false);
 
-                if (newMenuItemTransaction != null)
+                if (newMenuItemTransaction is not null)
                 {
                     newMenuItemTransaction.Cancel();
                     newMenuItemTransaction = null;
@@ -885,11 +885,11 @@ namespace System.Windows.Forms.Design
                 }
 
                 //Set the Text and Image..
-                if (newItem != null)
+                if (newItem is not null)
                 {
                     PropertyDescriptor textProperty = TypeDescriptor.GetProperties(newItem)["Text"];
-                    Debug.Assert(textProperty != null, "Could not find 'Text' property in ToolStripItem.");
-                    if (textProperty != null && !string.IsNullOrEmpty(newText))
+                    Debug.Assert(textProperty is not null, "Could not find 'Text' property in ToolStripItem.");
+                    if (textProperty is not null && !string.IsNullOrEmpty(newText))
                     {
                         textProperty.SetValue(newItem, newText);
                     }
@@ -899,7 +899,7 @@ namespace System.Windows.Forms.Design
             {
                 //There might be scenarios where the ComponentAdding is fired but the Added doesnt get fired. Is such cases the InsertTransaction might be still active...  So we need to cancel that too here.
                 CommitInsertTransaction(false);
-                if (outerTransaction != null)
+                if (outerTransaction is not null)
                 {
                     outerTransaction.Cancel();
                     outerTransaction = null;
@@ -923,7 +923,7 @@ namespace System.Windows.Forms.Design
         /// </summary>
         private static bool CheckSameOwner(ToolStripDropDownItem lastSelected, ToolStripDropDownItem currentSelected)
         {
-            if (lastSelected != null && currentSelected != null)
+            if (lastSelected is not null && currentSelected is not null)
             {
                 if (lastSelected.Owner is ToolStripDropDown && currentSelected.Owner is ToolStripDropDown)
                 {
@@ -939,7 +939,7 @@ namespace System.Windows.Forms.Design
         // internal method to commit any node.
         internal void Commit()
         {
-            if (commitedTemplateNode != null && commitedTemplateNode.Active)
+            if (commitedTemplateNode is not null && commitedTemplateNode.Active)
             {
                 //Get Index of the CommitedItem..
                 int index = MenuItem.DropDownItems.IndexOf(commitedEditorNode);
@@ -952,17 +952,17 @@ namespace System.Windows.Forms.Design
                     }
                 }
             }
-            else if (typeHereTemplateNode != null && typeHereTemplateNode.Active)
+            else if (typeHereTemplateNode is not null && typeHereTemplateNode.Active)
             {
                 typeHereTemplateNode.Commit(false, false);
             }
 
             // COMMIT ALL THE THE PARENT CHAIN ....
             ToolStripDropDownItem currentItem = MenuItem;
-            while (currentItem != null && currentItem.Owner is ToolStripDropDown)
+            while (currentItem is not null && currentItem.Owner is ToolStripDropDown)
             {
                 currentItem = (ToolStripDropDownItem)((ToolStripDropDown)(currentItem.Owner)).OwnerItem;
-                if (currentItem != null)
+                if (currentItem is not null)
                 {
                     ToolStripMenuItemDesigner itemDesigner = (ToolStripMenuItemDesigner)_designerHost.GetDesigner(currentItem);
                     itemDesigner?.Commit();
@@ -978,56 +978,56 @@ namespace System.Windows.Forms.Design
             if (disposing)
             {
                 //clean up
-                if (_selectionService != null)
+                if (_selectionService is not null)
                 {
                     _selectionService.SelectionChanged -= new EventHandler(OnSelectionChanged);
                 }
 
-                if (_undoEngine != null)
+                if (_undoEngine is not null)
                 {
                     _undoEngine.Undoing -= new EventHandler(OnUndoing);
                     _undoEngine.Undone -= new EventHandler(OnUndone);
                 }
 
-                if (MenuItem != null && MenuItem.HasDropDown)
+                if (MenuItem is not null && MenuItem.HasDropDown)
                 {
                     MenuItem.DropDown.Hide();
                     //Unhook the events...
                     UnHookEvents();
                 }
 
-                if (_toolStripAdornerWindowService != null)
+                if (_toolStripAdornerWindowService is not null)
                 {
                     _toolStripAdornerWindowService = null;
                 }
 
-                if (typeHereTemplateNode != null)
+                if (typeHereTemplateNode is not null)
                 {
                     typeHereTemplateNode.RollBack();
                     typeHereTemplateNode.CloseEditor();
                     typeHereTemplateNode = null;
                 }
 
-                if (typeHereNode != null)
+                if (typeHereNode is not null)
                 {
                     typeHereNode.Dispose();
                     typeHereNode = null;
                 }
 
-                if (commitedTemplateNode != null)
+                if (commitedTemplateNode is not null)
                 {
                     commitedTemplateNode.RollBack();
                     commitedTemplateNode.CloseEditor();
                     commitedTemplateNode = null;
                 }
 
-                if (commitedEditorNode != null)
+                if (commitedEditorNode is not null)
                 {
                     commitedEditorNode.Dispose();
                     commitedEditorNode = null;
                 }
 
-                if (parentItem != null)
+                if (parentItem is not null)
                 {
                     parentItem = null;
                 }
@@ -1040,7 +1040,7 @@ namespace System.Windows.Forms.Design
         private void DropDownClick(object sender, EventArgs e)
         {
             // Commit any InsituEdit Node.
-            if (KeyboardHandlingService != null && KeyboardHandlingService.TemplateNodeActive)
+            if (KeyboardHandlingService is not null && KeyboardHandlingService.TemplateNodeActive)
             {
                 // If templateNode Active .. commit and Select it
                 KeyboardHandlingService.ActiveTemplateNode.CommitAndSelect();
@@ -1051,7 +1051,7 @@ namespace System.Windows.Forms.Design
         private void DropDownPaint(object sender, PaintEventArgs e)
         {
             //Select All requires the repaint of glyphs after the DropDown receives paint message.
-            if (_selectionService != null && MenuItem != null)
+            if (_selectionService is not null && MenuItem is not null)
             {
                 foreach (ToolStripItem item in MenuItem.DropDownItems)
                 {
@@ -1092,7 +1092,7 @@ namespace System.Windows.Forms.Design
         private void DropDownItem_DropDownOpening(object sender, EventArgs e)
         {
             ToolStripDropDownItem ddi = sender as ToolStripDropDownItem;
-            if (_toolStripAdornerWindowService != null)
+            if (_toolStripAdornerWindowService is not null)
             {
                 ddi.DropDown.TopLevel = false;
                 ddi.DropDown.Parent = _toolStripAdornerWindowService.ToolStripAdornerWindowControl;
@@ -1104,14 +1104,14 @@ namespace System.Windows.Forms.Design
         {
             //Add Glyphs...
             ToolStripDropDownItem ddi = sender as ToolStripDropDownItem;
-            if (ddi != null)
+            if (ddi is not null)
             {
                 ResetGlyphs(ddi);
             }
 
             // finally add Glyph for the "DropDown"
             Control rootControl = ddi.DropDown;
-            if (rootControl != null)
+            if (rootControl is not null)
             {
                 if (_designerHost.GetDesigner(_designerHost.RootComponent) is ControlDesigner designer)
                 {
@@ -1128,9 +1128,9 @@ namespace System.Windows.Forms.Design
             if (sender is ToolStripDropDownItem ddi)
             {
                 //Invalidate the ToolStripWindow.... for clearing the dropDowns
-                if (_toolStripAdornerWindowService != null)
+                if (_toolStripAdornerWindowService is not null)
                 {
-                    if (rootControlGlyph != null && _toolStripAdornerWindowService.DropDownAdorner.Glyphs.Contains(rootControlGlyph))
+                    if (rootControlGlyph is not null && _toolStripAdornerWindowService.DropDownAdorner.Glyphs.Contains(rootControlGlyph))
                     {
                         _toolStripAdornerWindowService.DropDownAdorner.Glyphs.Remove(rootControlGlyph);
                     }
@@ -1142,7 +1142,7 @@ namespace System.Windows.Forms.Design
                 initialized = false;
                 UnHookEvents();
                 // Check if this is a Sited-DropDown
-                if (ddi.DropDown.Site != null || ddi.DropDownItems.Count == 1)
+                if (ddi.DropDown.Site is not null || ddi.DropDownItems.Count == 1)
                 {
                     //Get Designer ... and call Remove on that Designer.
                     RemoveTypeHereNode(ddi);
@@ -1157,11 +1157,10 @@ namespace System.Windows.Forms.Design
             ToolStripDropDown dropDown = sender as ToolStripDropDown;
             if (!dummyItemAdded)
             {
-                if (dropDown != null && dropDown.Visible)
+                if (dropDown is not null && dropDown.Visible)
                 {
                     // Invalidate only if new Size is LESS than old Size...
-                    if (_toolStripAdornerWindowService != null
-                        && (dropDown.Width < dropDownSizeToInvalidate.Width || dropDown.Size.Height < dropDownSizeToInvalidate.Height))
+                    if (_toolStripAdornerWindowService is not null && (dropDown.Width < dropDownSizeToInvalidate.Width || dropDown.Size.Height < dropDownSizeToInvalidate.Height))
                     {
                         using Region invalidatingRegion = new Region(dropDownSizeToInvalidate);
                         invalidatingRegion.Exclude(dropDown.Bounds);
@@ -1172,9 +1171,9 @@ namespace System.Windows.Forms.Design
                     }
                 }
 
-                if (_toolStripAdornerWindowService != null)
+                if (_toolStripAdornerWindowService is not null)
                 {
-                    if (rootControlGlyph != null && _toolStripAdornerWindowService.DropDownAdorner.Glyphs.Contains(rootControlGlyph))
+                    if (rootControlGlyph is not null && _toolStripAdornerWindowService.DropDownAdorner.Glyphs.Contains(rootControlGlyph))
                     {
                         _toolStripAdornerWindowService.DropDownAdorner.Glyphs.Remove(rootControlGlyph);
                     }
@@ -1205,7 +1204,7 @@ namespace System.Windows.Forms.Design
             // Refresh the state of the 'TypeHere' node to NotSelected state
             typeHereNode.RefreshSelectionGlyph();
             // Commit any InsituEdit Node.
-            if (KeyboardHandlingService != null && KeyboardHandlingService.TemplateNodeActive)
+            if (KeyboardHandlingService is not null && KeyboardHandlingService.TemplateNodeActive)
             {
                 // If templateNode Active .. commit and Select it
                 KeyboardHandlingService.ActiveTemplateNode.CommitAndSelect();
@@ -1234,7 +1233,7 @@ namespace System.Windows.Forms.Design
 
             // Hide the DropDown of any previous Selection.. First get the SelectedItem...
             ToolStripDropDownItem selectedItem = null;
-            if (_selectionService.PrimarySelection is null && KeyboardHandlingService != null)
+            if (_selectionService.PrimarySelection is null && KeyboardHandlingService is not null)
             {
                 if (KeyboardHandlingService.SelectedDesignerControl is ToolStripItem item)
                 {
@@ -1247,7 +1246,7 @@ namespace System.Windows.Forms.Design
             }
 
             // Now Hide the DropDown and Refresh Glyphs...
-            if (selectedItem != null && selectedItem != MenuItem)
+            if (selectedItem is not null && selectedItem != MenuItem)
             {
                 HideSiblingDropDowns(selectedItem);
             }
@@ -1267,7 +1266,7 @@ namespace System.Windows.Forms.Design
                 {
                     CommitInsertTransaction(/*commit=*/ false);
 
-                    if (newMenuItemTransaction != null)
+                    if (newMenuItemTransaction is not null)
                     {
                         newMenuItemTransaction.Cancel();
                         newMenuItemTransaction = null;
@@ -1280,12 +1279,12 @@ namespace System.Windows.Forms.Design
             }
             finally
             {
-                dummyItemAdded = (newDummyItem != null);
+                dummyItemAdded = (newDummyItem is not null);
                 addingDummyItem = false;
             }
 
             MenuItem.DropDown.ResumeLayout();
-            if (newDummyItem != null)
+            if (newDummyItem is not null)
             {
                 if (_designerHost.GetDesigner(newDummyItem) is ToolStripMenuItemDesigner newItemDesigner)
                 {
@@ -1305,7 +1304,7 @@ namespace System.Windows.Forms.Design
             {
                 ToolStripItem ownerItem = ((ToolStripDropDown)(MenuItem.Owner)).OwnerItem;
                 //need to inform the owner tha we want to enter insitu mode
-                if (_designerHost != null)
+                if (_designerHost is not null)
                 {
                     IDesigner designer = _designerHost.GetDesigner(ownerItem);
                     if (designer is ToolStripMenuItemDesigner)
@@ -1353,7 +1352,7 @@ namespace System.Windows.Forms.Design
             commitedTemplateNode?.FocusEditor(toolItem);
 
             ToolStripDropDownItem dropDownItem = toolItem as ToolStripDropDownItem;
-            if (!(dropDownItem.Owner is ToolStripDropDownMenu) && dropDownItem != null && dropDownItem.Bounds.Width < commitedEditorNode.Bounds.Width)
+            if (!(dropDownItem.Owner is ToolStripDropDownMenu) && dropDownItem is not null && dropDownItem.Bounds.Width < commitedEditorNode.Bounds.Width)
             {
                 dropDownItem.Width = commitedEditorNode.Width;
                 dropDownItem.DropDown.Location = new Point(dropDownItem.DropDown.Location.X + commitedEditorNode.Bounds.Width - dropDownItem.Bounds.Width, dropDownItem.DropDown.Location.Y);
@@ -1393,7 +1392,7 @@ namespace System.Windows.Forms.Design
         {
             ToolStripDropDown topmost = GetFirstDropDown(MenuItem);
             ToolStripItem topMostItem = topmost?.OwnerItem;
-            if (topMostItem != null)
+            if (topMostItem is not null)
             {
                 return topMostItem.Owner;
             }
@@ -1474,7 +1473,7 @@ namespace System.Windows.Forms.Design
         /// </summary>
         internal void HookEvents()
         {
-            if (MenuItem != null)
+            if (MenuItem is not null)
             {
                 MenuItem.DropDown.Closing += new ToolStripDropDownClosingEventHandler(OnDropDownClosing);
                 MenuItem.DropDownOpening += new EventHandler(DropDownItem_DropDownOpening);
@@ -1540,10 +1539,10 @@ namespace System.Windows.Forms.Design
             ToolStrip main = GetMainToolStrip();
             // Check if the TopMostItem is on normal dropdown or on the overflow.
             ToolStripDropDown firstDropDown = GetFirstDropDown(MenuItem);
-            if (firstDropDown != null)
+            if (firstDropDown is not null)
             {
                 ToolStripItem topMostItem = firstDropDown.OwnerItem;
-                if ((topMostItem != null && topMostItem.GetCurrentParent() is ToolStripOverflow) && !main.CanOverflow)
+                if ((topMostItem is not null && topMostItem.GetCurrentParent() is ToolStripOverflow) && !main.CanOverflow)
                 {
                     return;
                 }
@@ -1564,7 +1563,7 @@ namespace System.Windows.Forms.Design
                 }
 
                 // Check if this is a Sited-DropDown
-                if (MenuItem.DropDown.Site != null)
+                if (MenuItem.DropDown.Site is not null)
                 {
                     if (_designerHost.GetDesigner(MenuItem.DropDown) is ToolStripDropDownDesigner designer)
                     {
@@ -1597,10 +1596,10 @@ namespace System.Windows.Forms.Design
 
         private bool IsParentDropDown(ToolStripDropDown currentDropDown)
         {
-            if (currentDropDown != null)
+            if (currentDropDown is not null)
             {
                 ToolStripDropDown startDropDown = MenuItem.Owner as ToolStripDropDown;
-                while (startDropDown != null && startDropDown != currentDropDown)
+                while (startDropDown is not null && startDropDown != currentDropDown)
                 {
                     if (startDropDown.OwnerItem is ToolStripDropDownItem ownerItem)
                     {
@@ -1656,9 +1655,9 @@ namespace System.Windows.Forms.Design
                 componentAddingFired = false;
                 try
                 {
-                    if (IsOnContextMenu && MenuItem.DropDown.Site != null)
+                    if (IsOnContextMenu && MenuItem.DropDown.Site is not null)
                     {
-                        if (changeService != null)
+                        if (changeService is not null)
                         {
                             MemberDescriptor member = TypeDescriptor.GetProperties(MenuItem.DropDown)["Items"];
                             changeService.OnComponentChanging(MenuItem.DropDown, member);
@@ -1675,7 +1674,7 @@ namespace System.Windows.Forms.Design
                     // In Cut / Copy and Paste the 'indexToInsertNewItem' is not Set and hence is -1... so check for that value...
                     if (indexToInsertNewItem != -1)
                     {
-                        if (IsOnContextMenu && MenuItem.DropDown.Site != null)
+                        if (IsOnContextMenu && MenuItem.DropDown.Site is not null)
                         {
                             MenuItem.DropDown.Items.Insert(indexToInsertNewItem, newItem);
                         }
@@ -1693,7 +1692,7 @@ namespace System.Windows.Forms.Design
                             if (MenuItem.DropDownDirection == ToolStripDropDownDirection.AboveLeft || MenuItem.DropDownDirection == ToolStripDropDownDirection.AboveRight)
                             {
                                 // Add at the next Index in case of "Up-Directed" dropDown.
-                                if (IsOnContextMenu && MenuItem.DropDown.Site != null)
+                                if (IsOnContextMenu && MenuItem.DropDown.Site is not null)
                                 {
                                     MenuItem.DropDown.Items.Insert(index + 1, newItem);
                                 }
@@ -1704,7 +1703,7 @@ namespace System.Windows.Forms.Design
                             }
                             else
                             {
-                                if (IsOnContextMenu && MenuItem.DropDown.Site != null)
+                                if (IsOnContextMenu && MenuItem.DropDown.Site is not null)
                                 {
                                     MenuItem.DropDown.Items.Insert(index, newItem);
                                 }
@@ -1721,7 +1720,7 @@ namespace System.Windows.Forms.Design
                                 if (MenuItem.DropDownDirection != ToolStripDropDownDirection.AboveLeft && MenuItem.DropDownDirection != ToolStripDropDownDirection.AboveRight)
                                 {
                                     // ADD at Last but one, the last one being the TemplateNode always...
-                                    if (IsOnContextMenu && MenuItem.DropDown.Site != null)
+                                    if (IsOnContextMenu && MenuItem.DropDown.Site is not null)
                                     {
                                         MenuItem.DropDown.Items.Insert(count - 1, newItem);
                                     }
@@ -1733,7 +1732,7 @@ namespace System.Windows.Forms.Design
                             }
                             else //count == 0
                             {
-                                if (IsOnContextMenu && MenuItem.DropDown.Site != null)
+                                if (IsOnContextMenu && MenuItem.DropDown.Site is not null)
                                 {
                                     MenuItem.DropDown.Items.Add(newItem);
                                 }
@@ -1759,9 +1758,9 @@ namespace System.Windows.Forms.Design
                 }
                 finally
                 {
-                    if (IsOnContextMenu && MenuItem.DropDown.Site != null)
+                    if (IsOnContextMenu && MenuItem.DropDown.Site is not null)
                     {
-                        if (changeService != null)
+                        if (changeService is not null)
                         {
                             MemberDescriptor member = TypeDescriptor.GetProperties(MenuItem.DropDown)["Items"];
                             changeService.OnComponentChanged(MenuItem.DropDown, member);
@@ -1782,7 +1781,7 @@ namespace System.Windows.Forms.Design
             if (!IsOnContextMenu)
             {
                 ToolStrip mainStrip = GetMainToolStrip();
-                if (_designerHost.GetDesigner(mainStrip) is ToolStripDesigner mainStripDesigner && mainStripDesigner.InsertTransaction != null)
+                if (_designerHost.GetDesigner(mainStrip) is ToolStripDesigner mainStripDesigner && mainStripDesigner.InsertTransaction is not null)
                 {
                     if (commit)
                     {
@@ -1798,7 +1797,7 @@ namespace System.Windows.Forms.Design
             }
             else
             {
-                if (insertMenuItemTransaction != null)
+                if (insertMenuItemTransaction is not null)
                 {
                     if (commit)
                     {
@@ -1820,7 +1819,7 @@ namespace System.Windows.Forms.Design
         private void ComponentChangeSvc_ComponentAdding(object sender, ComponentEventArgs e)
         {
             // Don't do anything if CopyInProgress is true
-            if (KeyboardHandlingService != null && KeyboardHandlingService.CopyInProgress)
+            if (KeyboardHandlingService is not null && KeyboardHandlingService.CopyInProgress)
             {
                 return;
             }
@@ -1833,7 +1832,7 @@ namespace System.Windows.Forms.Design
                     if (_designerHost.GetDesigner(mainStrip) is ToolStripDesigner mainStripDesigner && !mainStripDesigner.EditingCollection && mainStripDesigner.InsertTransaction is null)
                     {
                         componentAddingFired = true;
-                        Debug.Assert(_designerHost != null, "Why didn't we get a designer host?");
+                        Debug.Assert(_designerHost is not null, "Why didn't we get a designer host?");
                         mainStripDesigner.InsertTransaction = _designerHost.CreateTransaction(SR.ToolStripInsertingIntoDropDownTransaction);
                     }
                 }
@@ -1842,7 +1841,7 @@ namespace System.Windows.Forms.Design
                     if (e.Component is ToolStripItem itemAdding && itemAdding.Owner is null)
                     {
                         componentAddingFired = true;
-                        Debug.Assert(_designerHost != null, "Why didn't we get a designer host?");
+                        Debug.Assert(_designerHost is not null, "Why didn't we get a designer host?");
                         insertMenuItemTransaction = _designerHost.CreateTransaction(SR.ToolStripInsertingIntoDropDownTransaction);
                     }
                 }
@@ -1860,7 +1859,7 @@ namespace System.Windows.Forms.Design
                 {
                     //Get the ownerItem
                     ToolStripDropDownItem ownerItem = (ToolStripDropDownItem)((ToolStripDropDown)(itemToBeDeleted.Owner)).OwnerItem;
-                    if (ownerItem != null && ownerItem == MenuItem)
+                    if (ownerItem is not null && ownerItem == MenuItem)
                     {
                         int itemIndex = ownerItem.DropDownItems.IndexOf(itemToBeDeleted);
                         // send notifications.
@@ -1874,7 +1873,7 @@ namespace System.Windows.Forms.Design
                         }
                         finally
                         {
-                            if (_pendingTransaction != null)
+                            if (_pendingTransaction is not null)
                             {
                                 _pendingTransaction.Commit();
                                 _pendingTransaction = null;
@@ -1895,7 +1894,7 @@ namespace System.Windows.Forms.Design
                         }
 
                         // Looks like we need to invalidate the entire
-                        if (_toolStripAdornerWindowService != null && boundsToInvalidateOnRemove != Rectangle.Empty)
+                        if (_toolStripAdornerWindowService is not null && boundsToInvalidateOnRemove != Rectangle.Empty)
                         {
                             using (Region regionToInvalidate = new Region(boundsToInvalidateOnRemove))
                             {
@@ -1906,9 +1905,9 @@ namespace System.Windows.Forms.Design
                         }
 
                         // Select the item only if Cut/Delete is pressed.
-                        if (KeyboardHandlingService != null && KeyboardHandlingService.CutOrDeleteInProgress)
+                        if (KeyboardHandlingService is not null && KeyboardHandlingService.CutOrDeleteInProgress)
                         {
-                            if (_selectionService != null && !dummyItemAdded)
+                            if (_selectionService is not null && !dummyItemAdded)
                             {
                                 IComponent targetSelection = (itemIndex == -1) ? ownerItem : ownerItem.DropDownItems[itemIndex];
                                 // if the TemplateNode becomes the targetSelection, then set the targetSelection to null.
@@ -1945,7 +1944,7 @@ namespace System.Windows.Forms.Design
                 {
                     //Get the ownerItem
                     ToolStripDropDownItem ownerItem = (ToolStripDropDownItem)((ToolStripDropDown)(itemToBeDeleted.Owner)).OwnerItem;
-                    if (ownerItem != null && ownerItem == MenuItem)
+                    if (ownerItem is not null && ownerItem == MenuItem)
                     {
                         RemoveItemBodyGlyph(itemToBeDeleted);
                         InitializeBodyGlyphsForItems(false, ownerItem);
@@ -1956,7 +1955,7 @@ namespace System.Windows.Forms.Design
                             boundsToInvalidateOnRemove = Rectangle.Union(boundsToInvalidateOnRemove, dropDownItem.DropDown.Bounds);
                         }
 
-                        Debug.Assert(_designerHost != null, "Why didn't we get a designer host?");
+                        Debug.Assert(_designerHost is not null, "Why didn't we get a designer host?");
                         Debug.Assert(_pendingTransaction is null, "Adding item with pending transaction?");
                         try
                         {
@@ -1965,7 +1964,7 @@ namespace System.Windows.Forms.Design
                         }
                         catch
                         {
-                            if (_pendingTransaction != null)
+                            if (_pendingTransaction is not null)
                             {
                                 _pendingTransaction.Cancel();
                                 _pendingTransaction = null;
@@ -1990,9 +1989,9 @@ namespace System.Windows.Forms.Design
         /// </summary>
         private void OnDropDownDisposed(object sender, EventArgs e)
         {
-            if (MenuItem != null)
+            if (MenuItem is not null)
             {
-                if (MenuItem.DropDown != null)
+                if (MenuItem.DropDown is not null)
                 {
                     MenuItem.DropDown.Disposed -= new EventHandler(OnDropDownDisposed);
                 }
@@ -2010,7 +2009,7 @@ namespace System.Windows.Forms.Design
             // Reshuffle the TemplateNode only for "Downward" dropdowns...
             if (MenuItem.DropDownDirection != ToolStripDropDownDirection.AboveLeft && MenuItem.DropDownDirection != ToolStripDropDownDirection.AboveRight)
             {
-                if (typeHereNode != null && (e.Item != typeHereNode))
+                if (typeHereNode is not null && (e.Item != typeHereNode))
                 {
                     int currentIndexOfEditor = MenuItem.DropDown.Items.IndexOf(typeHereNode);
                     if (currentIndexOfEditor >= 0 && currentIndexOfEditor < MenuItem.DropDown.Items.Count - 1)
@@ -2056,7 +2055,7 @@ namespace System.Windows.Forms.Design
                 }
 
                 // since the dropDown is closed during UnDoing .. we need to re-open the dropDown in Undone.
-                if (MenuItem != null && _selectionService.GetComponentSelected(MenuItem))
+                if (MenuItem is not null && _selectionService.GetComponentSelected(MenuItem))
                 {
                     InitializeDropDown();
                     MenuItem.DropDown.PerformLayout();
@@ -2114,18 +2113,18 @@ namespace System.Windows.Forms.Design
             }
 
             ISelectionService selectionSvc = sender as ISelectionService;
-            Debug.Assert(selectionSvc != null, "No Selection Service !!");
+            Debug.Assert(selectionSvc is not null, "No Selection Service !!");
             if (selectionSvc is null)
             {
                 return;
             }
 
             //ALWAYS COMMIT!!!
-            if (commitedTemplateNode != null && commitedTemplateNode.Active)
+            if (commitedTemplateNode is not null && commitedTemplateNode.Active)
             {
                 commitedTemplateNode.Commit(false, false);
             }
-            else if (typeHereTemplateNode != null && typeHereTemplateNode.Active)
+            else if (typeHereTemplateNode is not null && typeHereTemplateNode.Active)
             {
                 typeHereTemplateNode.Commit(false, false);
             }
@@ -2133,7 +2132,7 @@ namespace System.Windows.Forms.Design
             if (MenuItem.Equals(selectionSvc.PrimarySelection))
             {
                 ArrayList origSel = ToolStripDesignerUtils.originalSelComps;
-                if (origSel != null)
+                if (origSel is not null)
                 {
                     ToolStripDesignerUtils.InvalidateSelection(origSel, MenuItem, MenuItem.Site, false /*shift pressed*/);
                 }
@@ -2155,7 +2154,7 @@ namespace System.Windows.Forms.Design
 
                 //Cache original selection
                 ICollection originalSelComps = null;
-                if (_selectionService != null)
+                if (_selectionService is not null)
                 {
                     originalSelComps = selectionSvc.GetSelectedComponents();
                 }
@@ -2164,7 +2163,7 @@ namespace System.Windows.Forms.Design
                 origSel = new ArrayList(originalSelComps);
                 if (origSel.Count == 0)
                 {
-                    if (KeyboardHandlingService != null && KeyboardHandlingService.SelectedDesignerControl != null)
+                    if (KeyboardHandlingService is not null && KeyboardHandlingService.SelectedDesignerControl is not null)
                     {
                         origSel.Add(KeyboardHandlingService.SelectedDesignerControl);
                     }
@@ -2180,7 +2179,7 @@ namespace System.Windows.Forms.Design
                 object selectedObj = ((ISelectionService)sender).PrimarySelection;
                 if (selectedObj is null)
                 {
-                    if (KeyboardHandlingService != null)
+                    if (KeyboardHandlingService is not null)
                     {
                         selectedObj = KeyboardHandlingService.SelectedDesignerControl;
                     }
@@ -2189,7 +2188,7 @@ namespace System.Windows.Forms.Design
                 if (selectedObj is ToolStripItem currentSelection)
                 {
                     ToolStripDropDown parent = currentSelection.Owner as ToolStripDropDown;
-                    while (parent != null)
+                    while (parent is not null)
                     {
                         if (parent.OwnerItem == MenuItem || parent.OwnerItem is null)
                         {
@@ -2215,7 +2214,7 @@ namespace System.Windows.Forms.Design
                         if (selectedObj is ToolStripItem item)
                         {
                             ToolStripDropDown parent = item.Owner as ToolStripDropDown;
-                            while (parent != null)
+                            while (parent is not null)
                             {
                                 if (parent == MenuItem.DropDown)
                                 {
@@ -2251,7 +2250,7 @@ namespace System.Windows.Forms.Design
             for (int i = 0; i < shadowProps.Length; i++)
             {
                 prop = (PropertyDescriptor)properties[shadowProps[i]];
-                if (prop != null)
+                if (prop is not null)
                 {
                     properties[shadowProps[i]] = TypeDescriptor.CreateProperty(typeof(ToolStripMenuItemDesigner), prop, empty);
                 }
@@ -2295,14 +2294,14 @@ namespace System.Windows.Forms.Design
                 ownerItem.DropDownItems.RemoveAt(0);
             }
 
-            if (typeHereTemplateNode != null && typeHereTemplateNode.Active)
+            if (typeHereTemplateNode is not null && typeHereTemplateNode.Active)
             {
                 typeHereTemplateNode.RollBack();
                 typeHereTemplateNode.CloseEditor();
                 typeHereTemplateNode = null;
             }
 
-            if (typeHereNode != null)
+            if (typeHereNode is not null)
             {
                 typeHereNode.Dispose();
                 typeHereNode = null;
@@ -2316,25 +2315,25 @@ namespace System.Windows.Forms.Design
         /// </summary>
         private void RollBack()
         {
-            if (commitedEditorNode != null)
+            if (commitedEditorNode is not null)
             {
                 int index = MenuItem.DropDownItems.IndexOf(commitedEditorNode);
                 Debug.Assert(index != -1, "Invalid Index");
                 ToolStripDropDownItem editedItem = (ToolStripDropDownItem)MenuItem.DropDownItems[index + 1];
-                if (editedItem != null)
+                if (editedItem is not null)
                 {
                     editedItem.Visible = true;
                 }
 
                 MenuItem.DropDown.Items.Remove(commitedEditorNode);
-                if (commitedTemplateNode != null)
+                if (commitedTemplateNode is not null)
                 {
                     commitedTemplateNode.RollBack();
                     commitedTemplateNode.CloseEditor();
                     commitedTemplateNode = null;
                 }
 
-                if (commitedEditorNode != null)
+                if (commitedEditorNode is not null)
                 {
                     commitedEditorNode.Dispose();
                     commitedEditorNode = null;
@@ -2347,15 +2346,15 @@ namespace System.Windows.Forms.Design
         /// </summary>
         private void RemoveBodyGlyphs(ToolStripDropDownItem item)
         {
-            if (item != null)
+            if (item is not null)
             {
                 foreach (ToolStripItem ddItem in item.DropDownItems)
                 {
                     ToolStripItemDesigner dropDownItemDesigner = (ToolStripItemDesigner)_designerHost.GetDesigner(ddItem);
-                    if (dropDownItemDesigner != null)
+                    if (dropDownItemDesigner is not null)
                     {
                         ControlBodyGlyph glyph = dropDownItemDesigner.bodyGlyph;
-                        if (glyph != null && _toolStripAdornerWindowService != null && _toolStripAdornerWindowService.DropDownAdorner.Glyphs.Contains(glyph))
+                        if (glyph is not null && _toolStripAdornerWindowService is not null && _toolStripAdornerWindowService.DropDownAdorner.Glyphs.Contains(glyph))
                         {
                             _toolStripAdornerWindowService.DropDownAdorner.Glyphs.Remove(glyph);
                             dropDownItemDesigner.bodyGlyph = null;
@@ -2370,13 +2369,13 @@ namespace System.Windows.Forms.Design
         /// </summary>
         internal void RemoveItemBodyGlyph(ToolStripItem item)
         {
-            if (item != null)
+            if (item is not null)
             {
                 ToolStripItemDesigner itemDesigner = (ToolStripItemDesigner)_designerHost.GetDesigner(item);
-                if (itemDesigner != null)
+                if (itemDesigner is not null)
                 {
                     ControlBodyGlyph glyph = itemDesigner.bodyGlyph;
-                    if (glyph != null && _toolStripAdornerWindowService != null && _toolStripAdornerWindowService.DropDownAdorner.Glyphs.Contains(glyph))
+                    if (glyph is not null && _toolStripAdornerWindowService is not null && _toolStripAdornerWindowService.DropDownAdorner.Glyphs.Contains(glyph))
                     {
                         _toolStripAdornerWindowService.DropDownAdorner.Glyphs.Remove(glyph);
                         itemDesigner.bodyGlyph = null;
@@ -2411,9 +2410,9 @@ namespace System.Windows.Forms.Design
                 }
 
                 //set the selection to our new item
-                if (_selectionService != null)
+                if (_selectionService is not null)
                 {
-                    if (KeyboardHandlingService != null)
+                    if (KeyboardHandlingService is not null)
                     {
                         int count = 0;
                         if (MenuItem.DropDownDirection != ToolStripDropDownDirection.AboveLeft && MenuItem.DropDownDirection != ToolStripDropDownDirection.AboveRight)
@@ -2451,7 +2450,7 @@ namespace System.Windows.Forms.Design
         /// <summary>
         ///  Returns true if the CheckOnClick property should be persisted in code gen.
         /// </summary>
-        private bool ShouldSerializeDropDown() => (customDropDown != null);
+        private bool ShouldSerializeDropDown() => (customDropDown is not null);
 
         /// <summary>
         ///  Returns true if the visible property should be persisted in code gen.
@@ -2474,7 +2473,7 @@ namespace System.Windows.Forms.Design
                 {
                     parentItem = ((ToolStripDropDown)(MenuItem.Owner)).OwnerItem;
                     //need to inform the owner tha we want to enter insitu mode
-                    if (_designerHost != null)
+                    if (_designerHost is not null)
                     {
                         IDesigner designer = _designerHost.GetDesigner(parentItem);
                         if (designer is ToolStripMenuItemDesigner)
@@ -2530,11 +2529,11 @@ namespace System.Windows.Forms.Design
         internal void ShowOwnerDropDown(ToolStripDropDownItem currentSelection)
         {
             //  We MIGHT HAVE TO START TOP - DOWN Instead of BOTTOM-UP.  Sometimes we DON'T get the Owner POPUP and hence all the popup are parented to Wrong guy.
-            while (currentSelection != null && currentSelection.Owner is ToolStripDropDown)
+            while (currentSelection is not null && currentSelection.Owner is ToolStripDropDown)
             {
                 ToolStripDropDown currentDropDown = (ToolStripDropDown)(currentSelection.Owner);
                 currentSelection = (ToolStripDropDownItem)currentDropDown.OwnerItem;
-                if (currentSelection != null && !currentSelection.DropDown.Visible)
+                if (currentSelection is not null && !currentSelection.DropDown.Visible)
                 {
                     if (_designerHost.GetDesigner(currentSelection) is ToolStripMenuItemDesigner currentSelectionDesigner)
                     {
@@ -2555,7 +2554,7 @@ namespace System.Windows.Forms.Design
         /// </summary>
         internal void UnHookEvents()
         {
-            if (MenuItem != null)
+            if (MenuItem is not null)
             {
                 MenuItem.DropDown.Closing -= new ToolStripDropDownClosingEventHandler(OnDropDownClosing);
                 MenuItem.DropDownOpening -= new EventHandler(DropDownItem_DropDownOpening);
@@ -2657,13 +2656,13 @@ namespace System.Windows.Forms.Design
                     IDesignerHost host = (IDesignerHost)primaryItem.Site.GetService(typeof(IDesignerHost));
                     ToolStripDropDown parentToolStrip = primaryItem.GetCurrentParent() as ToolStripDropDown;
                     ToolStripDropDownItem ownerItem = null;
-                    if (parentToolStrip != null)
+                    if (parentToolStrip is not null)
                     {
                         ownerItem = parentToolStrip.OwnerItem as ToolStripDropDownItem;
                     }
 
-                    Debug.Assert(ownerItem != null, "How can ownerItem be null for a menu item on a dropdown?");
-                    if (ownerItem != null && host != null)
+                    Debug.Assert(ownerItem is not null, "How can ownerItem be null for a menu item on a dropdown?");
+                    if (ownerItem is not null && host is not null)
                     {
                         string transDesc;
                         ArrayList components = data.DragComponents;
@@ -2695,20 +2694,20 @@ namespace System.Windows.Forms.Design
                             if (copy)
                             {
                                 // Remember the primary selection if we had one
-                                if (primaryItem != null)
+                                if (primaryItem is not null)
                                 {
                                     primaryIndex = components.IndexOf(primaryItem);
                                 }
 
                                 ToolStripKeyboardHandlingService keyboardHandlingService = (ToolStripKeyboardHandlingService)primaryItem.Site.GetService(typeof(ToolStripKeyboardHandlingService));
-                                if (keyboardHandlingService != null)
+                                if (keyboardHandlingService is not null)
                                 {
                                     keyboardHandlingService.CopyInProgress = true;
                                 }
 
                                 components = DesignerUtils.CopyDragObjects(components, primaryItem.Site) as ArrayList;
 
-                                if (keyboardHandlingService != null)
+                                if (keyboardHandlingService is not null)
                                 {
                                     keyboardHandlingService.CopyInProgress = false;
                                 }
@@ -2753,7 +2752,7 @@ namespace System.Windows.Forms.Design
                             }
 
                             //If Parent is DropDown... we have to manage the Glyphs ....
-                            if (ownerItem != null)
+                            if (ownerItem is not null)
                             {
                                 if (host.GetDesigner(ownerItem) is ToolStripMenuItemDesigner ownerDesigner)
                                 {
@@ -2768,7 +2767,7 @@ namespace System.Windows.Forms.Design
                         }
                         catch
                         {
-                            if (changeParent != null)
+                            if (changeParent is not null)
                             {
                                 changeParent.Cancel();
                                 changeParent = null;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripTemplateNode.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripTemplateNode.cs
@@ -113,7 +113,7 @@ namespace System.Windows.Forms.Design
             _designerHost = (IDesignerHost)component.Site.GetService(typeof(IDesignerHost));
             _designer = _designerHost.GetDesigner(component);
             _designSurface = (DesignSurface)component.Site.GetService(typeof(DesignSurface));
-            if (_designSurface != null)
+            if (_designSurface is not null)
             {
                 _designSurface.Flushed += new EventHandler(OnLoaderFlushed);
             }
@@ -154,7 +154,7 @@ namespace System.Windows.Forms.Design
                 {
                     _active = value;
 
-                    if (KeyboardService != null)
+                    if (KeyboardService is not null)
                     {
                         KeyboardService.TemplateNodeActive = value;
                     }
@@ -163,22 +163,22 @@ namespace System.Windows.Forms.Design
                     {
                         //Active.. Fire Activated
                         OnActivated(new EventArgs());
-                        if (KeyboardService != null)
+                        if (KeyboardService is not null)
                         {
                             KeyboardService.ActiveTemplateNode = this;
                         }
 
                         IMenuCommandService menuService = (IMenuCommandService)_component.Site.GetService(typeof(IMenuCommandService));
-                        if (menuService != null)
+                        if (menuService is not null)
                         {
                             _oldUndoCommand = menuService.FindCommand(StandardCommands.Undo);
-                            if (_oldUndoCommand != null)
+                            if (_oldUndoCommand is not null)
                             {
                                 menuService.RemoveCommand(_oldUndoCommand);
                             }
 
                             _oldRedoCommand = menuService.FindCommand(StandardCommands.Redo);
-                            if (_oldRedoCommand != null)
+                            if (_oldRedoCommand is not null)
                             {
                                 menuService.RemoveCommand(_oldRedoCommand);
                             }
@@ -198,13 +198,13 @@ namespace System.Windows.Forms.Design
                     else
                     {
                         OnDeactivated(new EventArgs());
-                        if (KeyboardService != null)
+                        if (KeyboardService is not null)
                         {
                             KeyboardService.ActiveTemplateNode = null;
                         }
 
                         IMenuCommandService menuService = (IMenuCommandService)_component.Site.GetService(typeof(IMenuCommandService));
-                        if (menuService != null)
+                        if (menuService is not null)
                         {
                             for (int i = 0; i < _addCommands.Length; i++)
                             {
@@ -212,12 +212,12 @@ namespace System.Windows.Forms.Design
                             }
                         }
 
-                        if (_oldUndoCommand != null)
+                        if (_oldUndoCommand is not null)
                         {
                             menuService.AddCommand(_oldUndoCommand);
                         }
 
-                        if (_oldRedoCommand != null)
+                        if (_oldRedoCommand is not null)
                         {
                             menuService.AddCommand(_oldRedoCommand);
                         }
@@ -308,7 +308,7 @@ namespace System.Windows.Forms.Design
         /// </summary>
         internal TextBox EditBox
         {
-            get => (_centerTextBox != null) ? (TextBox)_centerTextBox.Control : null;
+            get => (_centerTextBox is not null) ? (TextBox)_centerTextBox.Control : null;
         }
 
         /// <summary>
@@ -389,18 +389,18 @@ namespace System.Windows.Forms.Design
         private void AddNewItemClick(object sender, EventArgs e)
         {
             // Close the DropDown.. Important for Morphing ....
-            if (_addItemButton != null)
+            if (_addItemButton is not null)
             {
                 _addItemButton.DropDown.Visible = false;
             }
 
-            if (_component is ToolStrip && SelectionService != null)
+            if (_component is ToolStrip && SelectionService is not null)
             {
                 // Stop the Designer from closing the Overflow if its open
                 ToolStripDesigner designer = _designerHost.GetDesigner(_component) as ToolStripDesigner;
                 try
                 {
-                    if (designer != null)
+                    if (designer is not null)
                     {
                         designer.DontCloseOverflow = true;
                     }
@@ -409,7 +409,7 @@ namespace System.Windows.Forms.Design
                 }
                 finally
                 {
-                    if (designer != null)
+                    if (designer is not null)
                     {
                         designer.DontCloseOverflow = false;
                     }
@@ -417,7 +417,7 @@ namespace System.Windows.Forms.Design
             }
 
             ItemTypeToolStripMenuItem senderItem = (ItemTypeToolStripMenuItem)sender;
-            if (_lastSelection != null)
+            if (_lastSelection is not null)
             {
                 _lastSelection.Checked = false;
             }
@@ -440,7 +440,7 @@ namespace System.Windows.Forms.Design
                 CommitEditor(true, false, false);
             }
 
-            if (KeyboardService != null)
+            if (KeyboardService is not null)
             {
                 KeyboardService.TemplateNodeActive = false;
             }
@@ -455,18 +455,18 @@ namespace System.Windows.Forms.Design
             if (e.Button == MouseButtons.Right)
             {
                 // Don't show the DesignerContextMenu if there is any active templateNode.
-                if (KeyboardService != null && KeyboardService.TemplateNodeActive)
+                if (KeyboardService is not null && KeyboardService.TemplateNodeActive)
                 {
                     return;
                 }
 
-                if (KeyboardService != null)
+                if (KeyboardService is not null)
                 {
                     KeyboardService.SelectedDesignerControl = _controlHost;
                 }
 
                 SelectionService.SetSelectedComponents(null, SelectionTypes.Replace);
-                if (BehaviorService != null)
+                if (BehaviorService is not null)
                 {
                     Point loc = BehaviorService.ControlToAdornerWindow(_miniToolStrip);
                     loc = BehaviorService.AdornerWindowPointToScreen(loc);
@@ -478,7 +478,7 @@ namespace System.Windows.Forms.Design
             {
                 if (_hotRegion.Contains(e.Location) && !KeyboardService.TemplateNodeActive)
                 {
-                    if (KeyboardService != null)
+                    if (KeyboardService is not null)
                     {
                         KeyboardService.SelectedDesignerControl = _controlHost;
                     }
@@ -486,7 +486,7 @@ namespace System.Windows.Forms.Design
                     SelectionService.SetSelectedComponents(null, SelectionTypes.Replace);
                     ToolStripDropDown oldContextMenu = _contextMenu;
                     // PERF: Consider refresh mechanism for the derived items.
-                    if (oldContextMenu != null)
+                    if (oldContextMenu is not null)
                     {
                         oldContextMenu.Closed -= new ToolStripDropDownClosedEventHandler(OnContextMenuClosed);
                         oldContextMenu.Closing -= OnContextMenuClosing;
@@ -547,14 +547,14 @@ namespace System.Windows.Forms.Design
                             }
                         }
 
-                        if (_designer != null)
+                        if (_designer is not null)
                         {
                             ((ToolStripMenuItemDesigner)_designer).EditTemplateNode(true);
                         }
                         else
                         {
                             ISelectionService cachedSelSvc = (ISelectionService)svcProvider.GetService(typeof(ISelectionService));
-                            if (cachedSelSvc.PrimarySelection is ToolStripItem selectedItem && _designerHost != null)
+                            if (cachedSelSvc.PrimarySelection is ToolStripItem selectedItem && _designerHost is not null)
                             {
                                 if (_designerHost.GetDesigner(selectedItem) is ToolStripMenuItemDesigner itemDesigner)
                                 {
@@ -583,7 +583,7 @@ namespace System.Windows.Forms.Design
         /// </summary>
         private void CenterLabelMouseEnter(object sender, EventArgs e)
         {
-            if (_renderer != null && !KeyboardService.TemplateNodeActive)
+            if (_renderer is not null && !KeyboardService.TemplateNodeActive)
             {
                 if (_renderer.State != (int)TemplateNodeSelectionState.HotRegionSelected)
                 {
@@ -598,7 +598,7 @@ namespace System.Windows.Forms.Design
         /// </summary>
         private void CenterLabelMouseMove(object sender, MouseEventArgs e)
         {
-            if (_renderer != null && !KeyboardService.TemplateNodeActive)
+            if (_renderer is not null && !KeyboardService.TemplateNodeActive)
             {
                 if (_renderer.State != (int)TemplateNodeSelectionState.HotRegionSelected)
                 {
@@ -621,14 +621,14 @@ namespace System.Windows.Forms.Design
         /// </summary>
         private void CenterLabelMouseLeave(object sender, EventArgs e)
         {
-            if (_renderer != null && !KeyboardService.TemplateNodeActive)
+            if (_renderer is not null && !KeyboardService.TemplateNodeActive)
             {
                 if (_renderer.State != (int)TemplateNodeSelectionState.HotRegionSelected)
                 {
                     _renderer.State = (int)TemplateNodeSelectionState.None;
                 }
 
-                if (KeyboardService != null && KeyboardService.SelectedDesignerControl == _controlHost)
+                if (KeyboardService is not null && KeyboardService.SelectedDesignerControl == _controlHost)
                 {
                     _renderer.State = (int)TemplateNodeSelectionState.TemplateNodeSelected;
                 }
@@ -642,7 +642,7 @@ namespace System.Windows.Forms.Design
         /// </summary>
         private void CenterTextBoxMouseEnter(object sender, EventArgs e)
         {
-            if (_renderer != null)
+            if (_renderer is not null)
             {
                 _renderer.State = (int)TemplateNodeSelectionState.TemplateNodeSelected;
                 _miniToolStrip.Invalidate();
@@ -654,7 +654,7 @@ namespace System.Windows.Forms.Design
         /// </summary>
         private void CenterTextBoxMouseLeave(object sender, EventArgs e)
         {
-            if (_renderer != null && !Active)
+            if (_renderer is not null && !Active)
             {
                 _renderer.State = (int)TemplateNodeSelectionState.None;
                 _miniToolStrip.Invalidate();
@@ -666,10 +666,10 @@ namespace System.Windows.Forms.Design
         /// </summary>
         internal void CloseEditor()
         {
-            if (_miniToolStrip != null)
+            if (_miniToolStrip is not null)
             {
                 Active = false;
-                if (_lastSelection != null)
+                if (_lastSelection is not null)
                 {
                     _lastSelection.Dispose();
                     _lastSelection = null;
@@ -687,7 +687,7 @@ namespace System.Windows.Forms.Design
                     }
                 }
 
-                if (_centerLabel != null)
+                if (_centerLabel is not null)
                 {
                     _centerLabel.MouseUp -= new MouseEventHandler(CenterLabelClick);
                     _centerLabel.MouseEnter -= new EventHandler(CenterLabelMouseEnter);
@@ -697,7 +697,7 @@ namespace System.Windows.Forms.Design
                     _centerLabel = null;
                 }
 
-                if (_addItemButton != null)
+                if (_addItemButton is not null)
                 {
                     _addItemButton.MouseMove -= new MouseEventHandler(OnMouseMove);
                     _addItemButton.MouseUp -= new MouseEventHandler(OnMouseUp);
@@ -708,7 +708,7 @@ namespace System.Windows.Forms.Design
                     _addItemButton = null;
                 }
 
-                if (_contextMenu != null)
+                if (_contextMenu is not null)
                 {
                     _contextMenu.Closed -= new ToolStripDropDownClosedEventHandler(OnContextMenuClosed);
                     _contextMenu.Closing -= OnContextMenuClosing;
@@ -720,7 +720,7 @@ namespace System.Windows.Forms.Design
                 _miniToolStrip.Dispose();
                 _miniToolStrip = null;
                 // Surface can be null. VS Whidbey #572862
-                if (_designSurface != null)
+                if (_designSurface is not null)
                 {
                     _designSurface.Flushed -= new EventHandler(OnLoaderFlushed);
                     _designSurface = null;
@@ -737,7 +737,7 @@ namespace System.Windows.Forms.Design
         internal void Commit(bool enterKeyPressed, bool tabKeyPressed)
         {
             // Commit only if we are still available !!
-            if (_miniToolStrip != null && _inSituMode)
+            if (_miniToolStrip is not null && _inSituMode)
             {
                 string text = ((TextBox)(_centerTextBox.Control)).Text;
                 if (string.IsNullOrEmpty(text))
@@ -770,7 +770,7 @@ namespace System.Windows.Forms.Design
                     ToolStripItemType = typeof(ToolStripSeparator);
                 }
 
-                if (ToolStripItemType != null)
+                if (ToolStripItemType is not null)
                 {
                     selectedType = ToolStripItemType;
                     ToolStripItemType = null;
@@ -804,14 +804,14 @@ namespace System.Windows.Forms.Design
             // After the node is commited the templateNode gets the selection. But the original selection is not invalidated. consider following case
             // FOO -> BAR -> TEMPLATENODE node
             // When the TemplateNode is committed "FOO" is selected but after the commit is complete, The TemplateNode gets the selection but "FOO" is never invalidated and hence retains selection. So we get the selection and then invalidate it at the end of this function. Get the currentSelection to invalidate
-            string text = (_centerTextBox != null) ? ((TextBox)(_centerTextBox.Control)).Text : string.Empty;
+            string text = (_centerTextBox is not null) ? ((TextBox)(_centerTextBox.Control)).Text : string.Empty;
             ExitInSituEdit();
             FocusForm();
             CommitTextToDesigner(text, commit, enterKeyPressed, tabKeyPressed);
             // finally Invalidate the selection rect ...
             if (SelectionService.PrimarySelection is ToolStripItem curSel)
             {
-                if (_designerHost != null)
+                if (_designerHost is not null)
                 {
                     if (_designerHost.GetDesigner(curSel) is ToolStripItemDesigner designer)
                     {
@@ -844,7 +844,7 @@ namespace System.Windows.Forms.Design
                     Active = true;
                     _inSituMode = true;
                     // set the renderer state to Selected...
-                    if (_renderer != null)
+                    if (_renderer is not null)
                     {
                         _renderer.State = (int)TemplateNodeSelectionState.TemplateNodeSelected;
                     }
@@ -909,7 +909,7 @@ namespace System.Windows.Forms.Design
         private void ExitInSituEdit()
         {
             // put the ToolStripTemplateNode back into "non edit state"
-            if (_centerTextBox != null && _inSituMode)
+            if (_centerTextBox is not null && _inSituMode)
             {
                 _miniToolStrip.Parent?.SuspendLayout();
 
@@ -951,7 +951,7 @@ namespace System.Windows.Forms.Design
         /// </summary>
         internal void FocusEditor(ToolStripItem currentItem)
         {
-            if (currentItem != null)
+            if (currentItem is not null)
             {
                 _centerLabel.Text = currentItem.Text;
             }
@@ -994,7 +994,7 @@ namespace System.Windows.Forms.Design
         /// </summary>
         private void OnContextMenuClosed(object sender, ToolStripDropDownClosedEventArgs e)
         {
-            if (_renderer != null)
+            if (_renderer is not null)
             {
                 _renderer.State = (int)TemplateNodeSelectionState.TemplateNodeSelected;
                 _miniToolStrip.Invalidate();
@@ -1015,7 +1015,7 @@ namespace System.Windows.Forms.Design
         private void OnContextMenuOpened(object sender, EventArgs e)
         {
             // Disable All Commands .. the Commands would be reenabled by AddNewItemClick call.
-            if (KeyboardService != null)
+            if (KeyboardService is not null)
             {
                 KeyboardService.TemplateNodeContextMenuOpen = true;
             }
@@ -1095,8 +1095,8 @@ namespace System.Windows.Forms.Design
         {
             //exit Insitu with committing....
             Active = false;
-            Debug.Assert(_centerTextBox.Control != null, "The TextBox is null");
-            if (_centerTextBox.Control != null)
+            Debug.Assert(_centerTextBox.Control is not null, "The TextBox is null");
+            if (_centerTextBox.Control is not null)
             {
                 string text = ((TextBox)(_centerTextBox.Control)).Text;
                 if (string.IsNullOrEmpty(text))
@@ -1124,7 +1124,7 @@ namespace System.Windows.Forms.Design
         {
             if (e.Button == MouseButtons.Right)
             {
-                if (BehaviorService != null)
+                if (BehaviorService is not null)
                 {
                     Point loc = BehaviorService.ControlToAdornerWindow(_miniToolStrip);
                     loc = BehaviorService.AdornerWindowPointToScreen(loc);
@@ -1139,7 +1139,7 @@ namespace System.Windows.Forms.Design
         /// </summary>
         private void OnMouseDown(object sender, MouseEventArgs e)
         {
-            if (KeyboardService != null)
+            if (KeyboardService is not null)
             {
                 KeyboardService.SelectedDesignerControl = _controlHost;
             }
@@ -1153,9 +1153,9 @@ namespace System.Windows.Forms.Design
         private void OnMouseMove(object sender, MouseEventArgs e)
         {
             _renderer.State = (int)TemplateNodeSelectionState.None;
-            if (_renderer != null)
+            if (_renderer is not null)
             {
-                if (_addItemButton != null)
+                if (_addItemButton is not null)
                 {
                     if (_addItemButton.ButtonBounds.Contains(e.Location))
                     {
@@ -1176,14 +1176,14 @@ namespace System.Windows.Forms.Design
         /// </summary>
         private void OnMouseLeave(object sender, EventArgs e)
         {
-            if (SelectionService != null)
+            if (SelectionService is not null)
             {
-                if (SelectionService.PrimarySelection is ToolStripItem && _renderer != null && _renderer.State != (int)TemplateNodeSelectionState.HotRegionSelected)
+                if (SelectionService.PrimarySelection is ToolStripItem && _renderer is not null && _renderer.State != (int)TemplateNodeSelectionState.HotRegionSelected)
                 {
                     _renderer.State = (int)TemplateNodeSelectionState.None;
                 }
 
-                if (KeyboardService != null && KeyboardService.SelectedDesignerControl == _controlHost)
+                if (KeyboardService is not null && KeyboardService.SelectedDesignerControl == _controlHost)
                 {
                     _renderer.State = (int)TemplateNodeSelectionState.TemplateNodeSelected;
                 }
@@ -1248,7 +1248,7 @@ namespace System.Windows.Forms.Design
         internal void RollBack()
         {
             // RollBack only iff we are still available !!
-            if (_miniToolStrip != null && _inSituMode)
+            if (_miniToolStrip is not null && _inSituMode)
             {
                 CommitEditor(false, false, false);
             }
@@ -1261,7 +1261,7 @@ namespace System.Windows.Forms.Design
 
         internal void ShowDropDownMenu()
         {
-            if (_addItemButton != null)
+            if (_addItemButton is not null)
             {
                 if (!_isPopulated)
                 {
@@ -1273,7 +1273,7 @@ namespace System.Windows.Forms.Design
             }
             else
             {
-                if (BehaviorService != null)
+                if (BehaviorService is not null)
                 {
                     Point loc = BehaviorService.ControlToAdornerWindow(_miniToolStrip);
                     loc = BehaviorService.AdornerWindowPointToScreen(loc);
@@ -1309,7 +1309,7 @@ namespace System.Windows.Forms.Design
 
                     _contextMenu.Show(translatedBounds.X, translatedBounds.Y + translatedBounds.Height);
                     _contextMenu.Focus();
-                    if (_renderer != null)
+                    if (_renderer is not null)
                     {
                         _renderer.State = (int)TemplateNodeSelectionState.HotRegionSelected;
                         _miniToolStrip.Invalidate();
@@ -1994,7 +1994,7 @@ namespace System.Windows.Forms.Design
             protected override void OnRenderItemText(ToolStripItemTextRenderEventArgs e)
             {
                 ToolStripItem item = e.Item as ToolStripLabel;
-                if (item != null && string.Equals(item.Name, CenterLabelName, StringComparison.InvariantCulture) && SystemInformation.HighContrast)
+                if (item is not null && string.Equals(item.Name, CenterLabelName, StringComparison.InvariantCulture) && SystemInformation.HighContrast)
                 {
                     // "Type Here" node always has white background, text should be painted in black
                     e.TextColor = Color.Black;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TreeViewDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TreeViewDesigner.cs
@@ -33,7 +33,7 @@ namespace System.Windows.Forms.Design
         {
             if (disposing)
             {
-                if (_treeView != null)
+                if (_treeView is not null)
                 {
                     _treeView.AfterExpand -= TreeViewInvalidate;
                     _treeView.AfterCollapse -= TreeViewInvalidate;
@@ -62,8 +62,8 @@ namespace System.Windows.Forms.Design
         {
             base.Initialize(component);
             _treeView = component as TreeView;
-            Debug.Assert(_treeView != null, "TreeView is null in TreeViewDesigner");
-            if (_treeView != null)
+            Debug.Assert(_treeView is not null, "TreeView is null in TreeViewDesigner");
+            if (_treeView is not null)
             {
                 _treeView.AfterExpand += TreeViewInvalidate;
                 _treeView.AfterCollapse += TreeViewInvalidate;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/UpDownBaseDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/UpDownBaseDesigner.cs
@@ -48,7 +48,7 @@ namespace System.Windows.Forms.Design
 
                 BorderStyle borderStyle = BorderStyle.Fixed3D;
                 PropertyDescriptor prop = TypeDescriptor.GetProperties(Component)["BorderStyle"];
-                if (prop != null)
+                if (prop is not null)
                 {
                     borderStyle = (BorderStyle)prop.GetValue(Component);
                 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/UserControlDocumentDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/UserControlDocumentDesigner.cs
@@ -63,7 +63,7 @@ namespace System.Windows.Forms.Design
             for (int i = 0; i < shadowProps.Length; i++)
             {
                 prop = (PropertyDescriptor)properties[shadowProps[i]];
-                if (prop != null)
+                if (prop is not null)
                 {
                     properties[shadowProps[i]] = TypeDescriptor.CreateProperty(typeof(UserControlDocumentDesigner), prop, empty);
                 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/WindowsFormsDesignerOptionService.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/WindowsFormsDesignerOptionService.cs
@@ -21,13 +21,13 @@ namespace System.Windows.Forms.Design
         /// </summary>
         protected override void PopulateOptionCollection(DesignerOptionCollection options)
         {
-            if (options is null || options.Parent != null)
+            if (options is null || options.Parent is not null)
             {
                 return;
             }
 
             DesignerOptions designerOptions = CompatibilityOptions;
-            if (designerOptions != null)
+            if (designerOptions is not null)
             {
                 CreateOptionCollection(options, "DesignerOptions", designerOptions);
             }


### PR DESCRIPTION
Refactors `System.Windows.Forms.Design` to use `is not null` instead of `!= null` using [CSharpIsNull](https://github.com/AArnott/CSharpIsNull) analyzer code fix.

Related: #3459

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8239)