### PR TITLE
`System.Windows.Forms.Design` Refactor `== null` to `is null`

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Drawing/BitmapSelector.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/BitmapSelector.cs
@@ -26,7 +26,7 @@ namespace System.Drawing
         {
             get
             {
-                if (_suffix == null)
+                if (_suffix is null)
                 {
                     _suffix = string.Empty;
                     var section = ConfigurationManager.GetSection("system.drawing") as SystemDrawingSection;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/Behavior.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/Behavior.cs
@@ -29,7 +29,7 @@ namespace System.Windows.Forms.Design.Behavior
         /// </param>
         protected Behavior(bool callParentBehavior, BehaviorService? behaviorService)
         {
-            if ((callParentBehavior) && (behaviorService == null))
+            if ((callParentBehavior) && (behaviorService is null))
             {
                 throw new ArgumentException(null, nameof(behaviorService));
             }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ComboBoxDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ComboBoxDesigner.cs
@@ -125,7 +125,7 @@ namespace System.Windows.Forms.Design
         {
             get
             {
-                if (_actionLists == null)
+                if (_actionLists is null)
                 {
                     _actionLists = new DesignerActionListCollection();
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/CommandSet.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/CommandSet.cs
@@ -290,7 +290,7 @@ namespace System.Windows.Forms.Design
         {
             get
             {
-                if (snapLineTimer == null)
+                if (snapLineTimer is null)
                 {
                     //instantiate our snapline timer
                     snapLineTimer = new Timer
@@ -320,7 +320,7 @@ namespace System.Windows.Forms.Design
                     }
 
                     ComponentEditor editor = (ComponentEditor)TypeDescriptor.GetEditor(obj, typeof(ComponentEditor));
-                    if (editor == null)
+                    if (editor is null)
                     {
                         return false;
                     }
@@ -508,7 +508,7 @@ namespace System.Windows.Forms.Design
         /// </summary>
         private IComponent[] FilterSelection(IComponent[] components, SelectionRules selectionRules)
         {
-            if (components == null)
+            if (components is null)
                 return Array.Empty<IComponent>();
 
             // Mask off any selection object that doesn't adhere to the given ruleset.
@@ -805,7 +805,7 @@ namespace System.Windows.Forms.Design
                     if (host != null)
                     {
                         PropertyDescriptor lockedProp = TypeDescriptor.GetProperties(comp)["Locked"];
-                        if (lockedProp == null || (lockedProp.PropertyType == typeof(bool) && ((bool)lockedProp.GetValue(comp))) == false)
+                        if (lockedProp is null || (lockedProp.PropertyType == typeof(bool) && ((bool)lockedProp.GetValue(comp))) == false)
                         {
                             CommandID cmd = ((MenuCommand)sender).CommandID;
                             bool invertSnap = false;
@@ -1046,7 +1046,7 @@ namespace System.Windows.Forms.Design
             Point primaryLocation = GetLocation(primarySelection);
             Size primarySize = GetSize(primarySelection);
 
-            if (SelectionService == null)
+            if (SelectionService is null)
             {
                 return;
             }
@@ -1108,7 +1108,7 @@ namespace System.Windows.Forms.Design
 
                         // Skip all components that don't have a location property
                         //
-                        if (locProp == null || locProp.IsReadOnly)
+                        if (locProp is null || locProp.IsReadOnly)
                         {
                             continue;
                         }
@@ -1121,7 +1121,7 @@ namespace System.Windows.Forms.Design
                             id.Equals(StandardCommands.AlignVerticalCenters) ||
                             id.Equals(StandardCommands.AlignRight))
                         {
-                            if (sizeProp == null || sizeProp.IsReadOnly)
+                            if (sizeProp is null || sizeProp.IsReadOnly)
                             {
                                 continue;
                             }
@@ -1212,7 +1212,7 @@ namespace System.Windows.Forms.Design
             Size gridSize = Size.Empty;
             int delta;
 
-            if (SelectionService == null)
+            if (SelectionService is null)
             {
                 return;
             }
@@ -1241,7 +1241,7 @@ namespace System.Windows.Forms.Design
                                 gridSize = (Size)prop.GetValue(baseComponent);
                             }
 
-                            if (prop == null || gridSize.IsEmpty)
+                            if (prop is null || gridSize.IsEmpty)
                             {
                                 //bail silently here
                                 return;
@@ -1276,7 +1276,7 @@ namespace System.Windows.Forms.Design
                         PropertyDescriptor locProp = GetProperty(comp, "Location");
 
                         // get the current value
-                        if (locProp == null || locProp.IsReadOnly)
+                        if (locProp is null || locProp.IsReadOnly)
                         {
                             continue;
                         }
@@ -1336,7 +1336,7 @@ namespace System.Windows.Forms.Design
             MenuCommand cmd = (MenuCommand)sender;
             CommandID cmdID = cmd.CommandID;
 
-            if (SelectionService == null)
+            if (SelectionService is null)
             {
                 return;
             }
@@ -1386,7 +1386,7 @@ namespace System.Windows.Forms.Design
 
                             // Skip all components that don't have location and size properties
                             //
-                            if (locProp == null || sizeProp == null || locProp.IsReadOnly || sizeProp.IsReadOnly)
+                            if (locProp is null || sizeProp is null || locProp.IsReadOnly || sizeProp.IsReadOnly)
                             {
                                 continue;
                             }
@@ -1419,7 +1419,7 @@ namespace System.Windows.Forms.Design
 
                     //if we never found a viewParent (some read-only inherited scenarios
                     //then simply bail
-                    if (viewParent == null)
+                    if (viewParent is null)
                     {
                         return;
                     }
@@ -1511,7 +1511,7 @@ namespace System.Windows.Forms.Design
         /// </summary>
         protected void OnMenuCopy(object sender, EventArgs e)
         {
-            if (SelectionService == null)
+            if (SelectionService is null)
             {
                 return;
             }
@@ -1557,7 +1557,7 @@ namespace System.Windows.Forms.Design
         /// </summary>
         protected void OnMenuCut(object sender, EventArgs e)
         {
-            if (SelectionService == null)
+            if (SelectionService is null)
             {
                 return;
             }
@@ -1652,7 +1652,7 @@ namespace System.Windows.Forms.Design
                                     //Cannot use idx = 1 to check (see diff) due to the call to PrependComponentNames, which
                                     //adds non IComponent objects to the beginning of selectedComponents. Thus when we finally get
                                     //here idx would be > 1.
-                                    if (commonParent == null && c != null)
+                                    if (commonParent is null && c != null)
                                     {
                                         commonParent = c.Parent;
                                     }
@@ -1693,7 +1693,7 @@ namespace System.Windows.Forms.Design
                             {
                                 SelectionService.SetSelectedComponents(new object[] { commonParent }, SelectionTypes.Replace);
                             }
-                            else if (SelectionService.PrimarySelection == null)
+                            else if (SelectionService.PrimarySelection is null)
                             {
                                 SelectionService.SetSelectedComponents(new object[] { host.RootComponent }, SelectionTypes.Replace);
                             }
@@ -1725,7 +1725,7 @@ namespace System.Windows.Forms.Design
                     IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
                     Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || host != null, "IDesignerHost not found");
 
-                    if (SelectionService == null)
+                    if (SelectionService is null)
                     {
                         return;
                     }
@@ -1747,7 +1747,7 @@ namespace System.Windows.Forms.Design
                             SelectionService.SetSelectedComponents(Array.Empty<object>(), SelectionTypes.Replace);
                             foreach (object obj in comps)
                             {
-                                if (obj is not IComponent comp || comp.Site == null)
+                                if (obj is not IComponent comp || comp.Site is null)
                                 {
                                     continue;
                                 }
@@ -1775,7 +1775,7 @@ namespace System.Windows.Forms.Design
                                 // If it's not a component, we can't delete it.  It also may have already been deleted
                                 // as part of a parent operation, so we skip it.
                                 //
-                                if (obj is not IComponent c || c.Site == null)
+                                if (obj is not IComponent c || c.Site is null)
                                 {
                                     continue;
                                 }
@@ -1914,7 +1914,7 @@ namespace System.Windows.Forms.Design
                             }
                         }
 
-                        if (commonParent != null && SelectionService.PrimarySelection == null)
+                        if (commonParent != null && SelectionService.PrimarySelection is null)
                         {
                             if (host.GetDesigner(commonParent) is ITreeDesigner commonParentDesigner && commonParentDesigner.Children != null)
                             {
@@ -1940,7 +1940,7 @@ namespace System.Windows.Forms.Design
 
                                     // 126240 -- make sure we've got a sited thing.
                                     //
-                                    while (controlCommonParent != null && controlCommonParent.Site == null)
+                                    while (controlCommonParent != null && controlCommonParent.Site is null)
                                     {
                                         controlCommonParent = controlCommonParent.Parent;
                                     }
@@ -1960,7 +1960,7 @@ namespace System.Windows.Forms.Design
                         }
                         else
                         {
-                            if (SelectionService.PrimarySelection == null)
+                            if (SelectionService.PrimarySelection is null)
                             {
                                 SelectionService.SetSelectedComponents(new object[] { host.RootComponent }, SelectionTypes.Replace);
                             }
@@ -1993,7 +1993,7 @@ namespace System.Windows.Forms.Design
 
                 IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
                 Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || host != null, "IDesignerHost not found");
-                if (host == null)
+                if (host is null)
                     return;   // nothing we can do here!
 
                 bool clipboardOperationSuccessful = ExecuteSafely(Clipboard.GetDataObject, false, out IDataObject dataObj);
@@ -2122,7 +2122,7 @@ namespace System.Windows.Forms.Design
                                 }
                                 else
                                 {
-                                    if (componentNames == null && obj is string[] sa)
+                                    if (componentNames is null && obj is string[] sa)
                                     {
                                         componentNames = sa;
                                         idx = 0;
@@ -2138,7 +2138,7 @@ namespace System.Windows.Forms.Design
                                         // If we couldn't find a property for this event, or of the property is read only, then
                                         // abort.
                                         //
-                                        if (pd == null || pd.IsReadOnly)
+                                        if (pd is null || pd.IsReadOnly)
                                         {
                                             continue;
                                         }
@@ -2204,7 +2204,7 @@ namespace System.Windows.Forms.Design
                                         }
                                     }
 
-                                    if (parentComp == null || !(associatedComps.Contains(curComp)))
+                                    if (parentComp is null || !(associatedComps.Contains(curComp)))
                                     {
                                         if (parentComp != null)
                                         {
@@ -2379,7 +2379,7 @@ namespace System.Windows.Forms.Design
                 if (site != null)
                 {
                     Debug.Assert(SelectionService != null, "We need the SelectionService, but we can't find it!");
-                    if (SelectionService == null)
+                    if (SelectionService is null)
                     {
                         return;
                     }
@@ -2391,7 +2391,7 @@ namespace System.Windows.Forms.Design
                     {
                         ComponentCollection components = host.Container.Components;
                         object[] selComps;
-                        if (components == null || components.Count == 0)
+                        if (components is null || components.Count == 0)
                         {
                             selComps = Array.Empty<IComponent>();
                         }
@@ -2465,7 +2465,7 @@ namespace System.Windows.Forms.Design
             MenuCommand cmd = (MenuCommand)sender;
             CommandID cmdID = cmd.CommandID;
 
-            if (SelectionService == null)
+            if (SelectionService is null)
             {
                 return;
             }
@@ -2489,7 +2489,7 @@ namespace System.Windows.Forms.Design
                 if (selPrimary is IComponent component)
                 {
                     sizeProp = GetProperty(component, "Size");
-                    if (sizeProp == null)
+                    if (sizeProp is null)
                     {
                         //if we couldn't get a valid size for our primary selection, we'll fail silently
                         return;
@@ -2498,7 +2498,7 @@ namespace System.Windows.Forms.Design
                     primarySize = (Size)sizeProp.GetValue(component);
                 }
 
-                if (selPrimary == null)
+                if (selPrimary is null)
                 {
                     return;
                 }
@@ -2537,7 +2537,7 @@ namespace System.Windows.Forms.Design
 
                         // Skip all components that don't have a size property
                         //
-                        if (sizeProp == null || sizeProp.IsReadOnly)
+                        if (sizeProp is null || sizeProp.IsReadOnly)
                         {
                             continue;
                         }
@@ -2575,7 +2575,7 @@ namespace System.Windows.Forms.Design
         /// </summary>
         protected void OnMenuSizeToGrid(object sender, EventArgs e)
         {
-            if (SelectionService == null)
+            if (SelectionService is null)
             {
                 return;
             }
@@ -2623,7 +2623,7 @@ namespace System.Windows.Forms.Design
                     {
                         IComponent comp = obj as IComponent;
 
-                        if (obj == null)
+                        if (obj is null)
                         {
                             continue;
                         }
@@ -2634,7 +2634,7 @@ namespace System.Windows.Forms.Design
                         Debug.Assert(sizeProp != null, "No size property on component");
                         Debug.Assert(locProp != null, "No location property on component");
 
-                        if (sizeProp == null || locProp == null || sizeProp.IsReadOnly || locProp.IsReadOnly)
+                        if (sizeProp is null || locProp is null || sizeProp.IsReadOnly || locProp.IsReadOnly)
                         {
                             continue;
                         }
@@ -2732,7 +2732,7 @@ namespace System.Windows.Forms.Design
             CommandID cmdID = cmd.CommandID;
             DesignerTransaction trans = null;
 
-            if (SelectionService == null)
+            if (SelectionService is null)
             {
                 return;
             }
@@ -2854,7 +2854,7 @@ namespace System.Windows.Forms.Design
                         if (curComp != null)
                         {
                             // only get the descriptors if we've changed component types
-                            if (lastComp == null || curComp.GetType() != lastComp.GetType())
+                            if (lastComp is null || curComp.GetType() != lastComp.GetType())
                             {
                                 curSizeDesc = GetProperty(curComp, "Size");
                                 curLocDesc = GetProperty(curComp, "Location");
@@ -2893,7 +2893,7 @@ namespace System.Windows.Forms.Design
                         if (curComp != null)
                         {
                             // only get the descriptors if we've changed component types
-                            if (lastComp == null || curComp.GetType() != lastComp.GetType())
+                            if (lastComp is null || curComp.GetType() != lastComp.GetType())
                             {
                                 curSizeDesc = GetProperty(curComp, "Size");
                                 curLocDesc = GetProperty(curComp, "Location");
@@ -2964,7 +2964,7 @@ namespace System.Windows.Forms.Design
                         continue; // locked property of our component is true, so don't move it
                     }
 
-                    if (lastComp == null || lastComp.GetType() != curComp.GetType())
+                    if (lastComp is null || lastComp.GetType() != curComp.GetType())
                     {
                         curSizeDesc = props["Size"];
                         curLocDesc = props["Location"];
@@ -3115,7 +3115,7 @@ namespace System.Windows.Forms.Design
         /// </summary>
         protected void OnSelectionChanged(object sender, EventArgs e)
         {
-            if (SelectionService == null/*: UNDONE: BehaviorWork  || SelectionUIService == null*/)
+            if (SelectionService is null)
             {
                 return;
             }
@@ -3290,7 +3290,7 @@ namespace System.Windows.Forms.Design
                         {
                             // if the object is not sited to the same thing as the host container
                             // then don't allow delete. VSWhidbey# 275790
-                            if (obj is IComponent comp && (comp.Site == null || (comp.Site != null && comp.Site.Container != host.Container)))
+                            if (obj is IComponent comp && (comp.Site is null || (comp.Site != null && comp.Site.Container != host.Container)))
                             {
                                 cmd.Enabled = false;
                                 return;
@@ -3692,7 +3692,7 @@ namespace System.Windows.Forms.Design
 
         private static void UpdatePasteTabIndex(Control componentControl, Control parentControl)
         {
-            if (parentControl == null || componentControl == null)
+            if (parentControl is null || componentControl is null)
             {
                 return;
             }
@@ -4117,11 +4117,11 @@ namespace System.Windows.Forms.Design
         {
             public int Compare(object p, object q)
             {
-                if (p == null)
+                if (p is null)
                 {
                     return -1;
                 }
-                else if (q == null)
+                else if (q is null)
                 {
                     return 1;
                 }
@@ -4148,7 +4148,7 @@ namespace System.Windows.Forms.Design
                     return 0;
                 }
 
-                return c1 == null ? -1 : c2 == null ? 1 : c1.TabIndex - c2.TabIndex;
+                return c1 is null ? -1 : c2 is null ? 1 : c1.TabIndex - c2.TabIndex;
             }
         }
     }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlCommandSet.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlCommandSet.cs
@@ -301,7 +301,7 @@ namespace System.Windows.Forms.Design
             {
                 Control c = obj as Control;
 
-                if (c == null || c.Site == null)
+                if (c is null || c.Site is null)
                 {
                     return false;
                 }
@@ -318,7 +318,7 @@ namespace System.Windows.Forms.Design
             {
                 Control c = component as Control;
 
-                if (c == null || c.Site == null)
+                if (c is null || c.Site is null)
                 {
                     return false;
                 }
@@ -395,7 +395,7 @@ namespace System.Windows.Forms.Design
             if (ctrl != null)
             {
                 Control c = ctrl.Parent;
-                while (c != null && currentSnapComponent == null)
+                while (c != null && currentSnapComponent is null)
                 {
                     props = TypeDescriptor.GetProperties(c);
                     currentSnapProp = props["SnapToGrid"];
@@ -419,7 +419,7 @@ namespace System.Windows.Forms.Design
 
             props = TypeDescriptor.GetProperties(currentSnapComponent);
 
-            if (currentSnapProp == null)
+            if (currentSnapProp is null)
             {
                 currentSnapProp = props["SnapToGrid"];
                 if (currentSnapProp != null && currentSnapProp.PropertyType != typeof(bool))
@@ -428,7 +428,7 @@ namespace System.Windows.Forms.Design
                 }
             }
 
-            if (gridSizeProp == null)
+            if (gridSizeProp is null)
             {
                 gridSizeProp = props["GridSize"];
                 if (gridSizeProp != null && gridSizeProp.PropertyType != typeof(Size))
@@ -885,7 +885,7 @@ namespace System.Windows.Forms.Design
                             {
                                 PropertyDescriptor prop = GetProperty(comp, "Locked");
                                 //check to see the prop is not null & not readonly
-                                if (prop == null)
+                                if (prop is null)
                                 {
                                     continue;
                                 }
@@ -984,7 +984,7 @@ namespace System.Windows.Forms.Design
 
             Debug.Assert(SelectionService != null, "Need SelectionService for sizing command");
 
-            if (SelectionService == null)
+            if (SelectionService is null)
             {
                 return;
             }
@@ -1189,7 +1189,7 @@ namespace System.Windows.Forms.Design
         {
             MenuCommand cmd = (MenuCommand)sender;
 
-            if (baseControl == null)
+            if (baseControl is null)
             {
                 cmd.Enabled = false;
                 return;
@@ -1209,7 +1209,7 @@ namespace System.Windows.Forms.Design
 
             IDesignerHost host = (IDesignerHost)site.GetService(typeof(IDesignerHost));
 
-            if (host == null)
+            if (host is null)
             {
                 return;
             }
@@ -1344,7 +1344,7 @@ namespace System.Windows.Forms.Design
                 {
                     Debug.Assert(SelectionService != null, "Need SelectionService for sizing command");
 
-                    if (SelectionService == null)
+                    if (SelectionService is null)
                     {
                         return;
                     }
@@ -1408,7 +1408,7 @@ namespace System.Windows.Forms.Design
             ISelectionService selSvc = SelectionService;
             IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
 
-            if (selSvc == null || host == null || !(host.RootComponent is Control))
+            if (selSvc is null || host is null || !(host.RootComponent is Control))
             {
                 return;
             }
@@ -1452,7 +1452,7 @@ namespace System.Windows.Forms.Design
                         controlSiteContainer = DesignerUtils.CheckForNestedContainer(nextControl.Site.Container); // ...necessary to support SplitterPanel components
                     }
 
-                    if (nextControl == null || nextControl.Site == null || controlSiteContainer != container)
+                    if (nextControl is null || nextControl.Site is null || controlSiteContainer != container)
                     {
                         next = current;
                     }
@@ -1475,7 +1475,7 @@ namespace System.Windows.Forms.Design
 
             ISelectionService selSvc = SelectionService;
             IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
-            if (selSvc == null || host == null || !(host.RootComponent is Control))
+            if (selSvc is null || host is null || !(host.RootComponent is Control))
             {
                 return;
             }
@@ -1492,7 +1492,7 @@ namespace System.Windows.Forms.Design
             currentSelection = selSvc.PrimarySelection;
             ctl = currentSelection as Control;
 
-            if (targetSelection == null && ctl != null && (baseCtl.Contains(ctl) || baseCtl == currentSelection))
+            if (targetSelection is null && ctl != null && (baseCtl.Contains(ctl) || baseCtl == currentSelection))
             {
                 // Our current selection is a control.  Select the next control in
                 // the z-order.
@@ -1508,7 +1508,7 @@ namespace System.Windows.Forms.Design
                 targetSelection = ctl;
             }
 
-            if (targetSelection == null)
+            if (targetSelection is null)
             {
                 ComponentTray tray = (ComponentTray)GetService(typeof(ComponentTray));
                 if (tray != null)
@@ -1557,7 +1557,7 @@ namespace System.Windows.Forms.Design
                     //
                     for (int c = 0; c < ctlControls.Count; c++)
                     {
-                        if (found == null || found.TabIndex > ctlControls[c].TabIndex)
+                        if (found is null || found.TabIndex > ctlControls[c].TabIndex)
                         {
                             found = ctlControls[c];
                         }
@@ -1603,7 +1603,7 @@ namespace System.Windows.Forms.Design
                                 // Check to see if this control replaces the "best match" we've already
                                 // found.
                                 //
-                                if (found == null || found.TabIndex > parentControls[c].TabIndex)
+                                if (found is null || found.TabIndex > parentControls[c].TabIndex)
                                 {
                                     // Finally, check to make sure that if this tab index is the same as ctl,
                                     // that we've already encountered ctl in the z-order.  If it isn't the same,
@@ -1671,7 +1671,7 @@ namespace System.Windows.Forms.Design
                                 // Check to see if this control replaces the "best match" we've already
                                 // found.
                                 //
-                                if (found == null || found.TabIndex < parentControls[c].TabIndex)
+                                if (found is null || found.TabIndex < parentControls[c].TabIndex)
                                 {
                                     // Finally, check to make sure that if this tab index is the same as ctl,
                                     // that we've already encountered ctl in the z-order.  If it isn't the same,
@@ -1726,7 +1726,7 @@ namespace System.Windows.Forms.Design
                     //
                     for (int c = ctlControls.Count - 1; c >= 0; c--)
                     {
-                        if (found == null || found.TabIndex < ctlControls[c].TabIndex)
+                        if (found is null || found.TabIndex < ctlControls[c].TabIndex)
                         {
                             found = ctlControls[c];
                         }
@@ -1773,7 +1773,7 @@ namespace System.Windows.Forms.Design
                     if (cX.Parent == cY.Parent)
                     {
                         Control parent = cX.Parent;
-                        if (parent == null)
+                        if (parent is null)
                         {
                             return 0;
                         }
@@ -1786,11 +1786,11 @@ namespace System.Windows.Forms.Design
                             return 1;
                         }
                     }
-                    else if (cX.Parent == null || cX.Contains(cY))
+                    else if (cX.Parent is null || cX.Contains(cY))
                     {
                         return 1;
                     }
-                    else if (cY.Parent == null || cY.Contains(cX))
+                    else if (cY.Parent is null || cY.Contains(cX))
                     {
                         return -1;
                     }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
@@ -180,7 +180,7 @@ namespace System.Windows.Forms.Design
             {
                 // don't do anything here during loading, if a refactor changed it we don't want to do anything
                 IDesignerHost host = GetService(typeof(IDesignerHost)) as IDesignerHost;
-                if (host == null || (host != null && !host.Loading))
+                if (host is null || (host != null && !host.Loading))
                 {
                     Component.Site.Name = value;
                 }
@@ -881,7 +881,7 @@ namespace System.Windows.Forms.Design
         {
             foreach (Control child in firstChild.Controls)
             {
-                if (child == null || _host == null || _host.GetDesigner(child) is ControlDesigner)
+                if (child is null || _host is null || _host.GetDesigner(child) is ControlDesigner)
                 {
                     continue;
                 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignBindingValueUIHandler.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignBindingValueUIHandler.cs
@@ -20,7 +20,7 @@ namespace System.Windows.Forms.Design
         {
             get
             {
-                if (dataBitmap == null)
+                if (dataBitmap is null)
                 {
                     dataBitmap = new Bitmap(typeof(DesignBindingValueUIHandler), "BoundProperty.bmp");
                     dataBitmap.MakeTransparent();

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerExtenders.NameExtenderProvider.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerExtenders.NameExtenderProvider.cs
@@ -27,7 +27,7 @@ namespace System.Windows.Forms.Design
 
             protected IComponent GetBaseComponent(object o)
             {
-                if (baseComponent == null)
+                if (baseComponent is null)
                 {
                     ISite site = ((IComponent)o).Site;
                     if (site != null)

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DocumentDesigner.AxToolboxItem.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DocumentDesigner.AxToolboxItem.cs
@@ -121,10 +121,10 @@ namespace System.Windows.Forms.Design
                     }
                 }
 
-                if (axctlType == null)
+                if (axctlType is null)
                 {
                     IUIService uiSvc = (IUIService)host.GetService(typeof(IUIService));
-                    if (uiSvc == null)
+                    if (uiSvc is null)
                     {
                         RTLAwareMessageBox.Show(null, SR.AxImportFailed, null, MessageBoxButtons.OK, MessageBoxIcon.Error,
                                         MessageBoxDefaultButton.Button1, 0);
@@ -173,7 +173,7 @@ namespace System.Windows.Forms.Design
 
                 // Missing reference will show up as an empty string.
                 //
-                if (path == null || path.Length <= 0)
+                if (path is null || path.Length <= 0)
                 {
                     return null;
                 }
@@ -234,13 +234,13 @@ namespace System.Windows.Forms.Design
                 Type type;
                 type = Type.GetType("EnvDTE.ProjectItem, " + AssemblyRef.EnvDTE);
 
-                if (type == null)
+                if (type is null)
                 {
                     return null;
                 }
 
                 object ext = host.GetService(type);
-                if (ext == null)
+                if (ext is null)
                     return null;
 
                 string name = ext.GetType().InvokeMember("Name", BindingFlags.GetProperty | BindingFlags.Public | BindingFlags.Instance, null, ext, null, CultureInfo.InvariantCulture).ToString();
@@ -264,7 +264,7 @@ namespace System.Windows.Forms.Design
             {
                 string controlKey = "CLSID\\" + clsid;
                 RegistryKey key = Registry.ClassesRoot.OpenSubKey(controlKey);
-                if (key == null)
+                if (key is null)
                 {
                     if (AxToolSwitch.TraceVerbose)
                         Debug.WriteLine("No registry key found for: " + controlKey);
@@ -331,7 +331,7 @@ namespace System.Windows.Forms.Design
                 //
                 // If that fails, try to load the TLB based on the TypeLib guid key.
                 //
-                if (pTLB == null)
+                if (pTLB is null)
                 {
                     RegistryKey inprocServerKey = key.OpenSubKey("InprocServer32");
                     if (inprocServerKey != null)

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DocumentDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DocumentDesigner.cs
@@ -292,7 +292,7 @@ namespace System.Windows.Forms.Design
         internal virtual bool CanDropComponents(DragEventArgs de)
         {
             // If there is no tray we bail.
-            if (componentTray == null)
+            if (componentTray is null)
                 return true;
 
             // Figure out if any of the components in the drag-drop are children
@@ -307,7 +307,7 @@ namespace System.Windows.Forms.Design
                 for (int i = 0; i < dragComps.Length; i++)
                 {
                     IComponent comp = dragComps[i] as IComponent;
-                    if (host == null || dragComps[i] == null || comp == null)
+                    if (host is null || dragComps[i] is null || comp is null)
                     {
                         continue;
                     }
@@ -663,7 +663,7 @@ namespace System.Windows.Forms.Design
                 //
                 object sel = s.PrimarySelection;
 
-                if (sel == null || !(sel is Control))
+                if (sel is null || !(sel is Control))
                 {
                     sel = null;
 
@@ -880,7 +880,7 @@ namespace System.Windows.Forms.Design
                     //
                     string category = "CLSID\\" + clsid + "\\Implemented Categories\\{" + htmlDesignTime.ToString() + "}";
                     designtimeKey = Registry.ClassesRoot.OpenSubKey(category);
-                    return (designtimeKey == null);
+                    return (designtimeKey is null);
                 }
 
                 return false;
@@ -967,13 +967,13 @@ namespace System.Windows.Forms.Design
                 //
                 ToolStripDesigner td = host.GetDesigner(component) as ToolStripDesigner;
 
-                if (td == null)
+                if (td is null)
                 {
                     ControlDesigner cd = host.GetDesigner(component) as ControlDesigner;
                     if (cd != null)
                     {
                         Form form = cd.Control as Form;
-                        if (form == null || !form.TopLevel)
+                        if (form is null || !form.TopLevel)
                         {
                             addControl = false;
                         }
@@ -983,7 +983,7 @@ namespace System.Windows.Forms.Design
                 if (addControl &&
                     TypeDescriptor.GetAttributes(component).Contains(DesignTimeVisibleAttribute.Yes))
                 {
-                    if (componentTray == null)
+                    if (componentTray is null)
                     {
                         ISplitWindowService sws = (ISplitWindowService)GetService(typeof(ISplitWindowService));
                         if (sws != null)
@@ -1134,7 +1134,7 @@ namespace System.Windows.Forms.Design
 
             IDataObject dataObject = serializedData as IDataObject;
 
-            if (dataObject == null)
+            if (dataObject is null)
             {
                 Debug.Fail("Toolbox service didn't pass us a data object; that should never happen");
                 return null;
@@ -1164,7 +1164,7 @@ namespace System.Windows.Forms.Design
         /// </summary>
         private void OnDesignerActivate(object source, EventArgs evevent)
         {
-            if (undoEngine == null)
+            if (undoEngine is null)
             {
                 undoEngine = GetService(typeof(UndoEngine)) as UndoEngine;
                 if (undoEngine != null)

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ImageIndexEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ImageIndexEditor.cs
@@ -42,7 +42,7 @@ namespace System.Windows.Forms.Design
             object instance = context.Instance;
 
             // We would not know what to do in this case anyway (i.e. multiple selection of objects)
-            if (instance is object[] || (index < 0 && key == null))
+            if (instance is object[] || (index < 0 && key is null))
             {
                 return null;
             }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ListBoxDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ListBoxDesigner.cs
@@ -203,7 +203,7 @@ namespace System.Windows.Forms.Design
         {
             get
             {
-                if (_actionLists == null)
+                if (_actionLists is null)
                 {
                     _actionLists = new DesignerActionListCollection();
                     if (Component is CheckedListBox)

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ListViewDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ListViewDesigner.cs
@@ -174,7 +174,7 @@ namespace System.Windows.Forms.Design
         {
             get
             {
-                if (_actionLists == null)
+                if (_actionLists is null)
                 {
                     _actionLists = new DesignerActionListCollection();
                     _actionLists.Add(new ListViewActionList(this));
@@ -193,7 +193,7 @@ namespace System.Windows.Forms.Design
             else
             {
                 string message = ex.Message;
-                if (message == null || message.Length == 0)
+                if (message is null || message.Length == 0)
                 {
                     message = ex.ToString();
                 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/OleDragDropHandler.CfCodeToolboxItem.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/OleDragDropHandler.CfCodeToolboxItem.cs
@@ -77,7 +77,7 @@ namespace System.Windows.Forms.Design
             protected override IComponent[] CreateComponentsCore(IDesignerHost host, IDictionary defaultValues)
             {
                 IDesignerSerializationService ds = (IDesignerSerializationService)host.GetService(typeof(IDesignerSerializationService));
-                if (ds == null)
+                if (ds is null)
                 {
                     return null;
                 }
@@ -114,7 +114,7 @@ namespace System.Windows.Forms.Design
                         {
                             Control childControl = component as Control;
 
-                            if (childControl != null && childControl != parentControl && childControl.Parent == null)
+                            if (childControl != null && childControl != parentControl && childControl.Parent is null)
                             {
                                 if (bounds.IsEmpty)
                                 {
@@ -134,7 +134,7 @@ namespace System.Windows.Forms.Design
                             Form form = childControl as Form;
                             if (childControl != null
                                 && !(form != null && form.TopLevel) // Don't add top-level forms
-                                && childControl.Parent == null)
+                                && childControl.Parent is null)
                             {
                                 defaultValues["Offset"] = new Size(childControl.Bounds.X - bounds.X, childControl.Bounds.Y - bounds.Y);
                                 parentControlDesigner.AddControl(childControl, defaultValues);

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/OleDragDropHandler.ComponentDataObject.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/OleDragDropHandler.ComponentDataObject.cs
@@ -45,7 +45,7 @@ namespace System.Windows.Forms.Design
             {
                 get
                 {
-                    if (serializationStream == null && Components != null)
+                    if (serializationStream is null && Components != null)
                     {
                         IDesignerSerializationService ds = (IDesignerSerializationService)serviceProvider.GetService(typeof(IDesignerSerializationService));
                         if (ds != null)
@@ -75,10 +75,10 @@ namespace System.Windows.Forms.Design
             {
                 get
                 {
-                    if (components == null && (serializationStream != null || serializationData != null))
+                    if (components is null && (serializationStream != null || serializationData != null))
                     {
                         Deserialize(null, false);
-                        if (components == null)
+                        if (components is null)
                         {
                             return Array.Empty<object>();
                         }
@@ -107,20 +107,20 @@ namespace System.Windows.Forms.Design
             /// </summary>
             private object[] GetComponentList(object[] components, ArrayList list, int index)
             {
-                if (serviceProvider == null)
+                if (serviceProvider is null)
                 {
                     return components;
                 }
 
                 ISelectionService selSvc = (ISelectionService)serviceProvider.GetService(typeof(ISelectionService));
 
-                if (selSvc == null)
+                if (selSvc is null)
                 {
                     return components;
                 }
 
                 ICollection selectedComponents;
-                if (components == null)
+                if (components is null)
                     selectedComponents = selSvc.GetSelectedComponents();
                 else
                     selectedComponents = new ArrayList(components);
@@ -146,7 +146,7 @@ namespace System.Windows.Forms.Design
             private void GetAssociatedComponents(IComponent component, IDesignerHost host, ArrayList list)
             {
                 ComponentDesigner designer = host.GetDesigner(component) as ComponentDesigner;
-                if (designer == null)
+                if (designer is null)
                 {
                     return;
                 }
@@ -240,7 +240,7 @@ namespace System.Windows.Forms.Design
 
                 try
                 {
-                    if (serializationData == null)
+                    if (serializationData is null)
                     {
                         BinaryFormatter formatter = new BinaryFormatter();
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
@@ -252,7 +252,7 @@ namespace System.Windows.Forms.Design
                     {
                         foreach (IComponent removeComp in components)
                         {
-                            if (host == null && removeComp.Site != null)
+                            if (host is null && removeComp.Site != null)
                             {
                                 host = (IDesignerHost)removeComp.Site.GetService(typeof(IDesignerHost));
                                 if (host != null)
@@ -287,7 +287,7 @@ namespace System.Windows.Forms.Design
                     {
                         if (components[i] is Control c)
                         {
-                            if (c.Parent == null)
+                            if (c.Parent is null)
                             {
                                 topComps.Add(components[i]);
                             }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/OleDragDropHandler.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/OleDragDropHandler.cs
@@ -78,7 +78,7 @@ namespace System.Windows.Forms.Design
 
         private static IComponent GetDragOwnerComponent(IDataObject data)
         {
-            if (currentDrags == null || !currentDrags.Contains(data))
+            if (currentDrags is null || !currentDrags.Contains(data))
             {
                 return null;
             }
@@ -113,7 +113,7 @@ namespace System.Windows.Forms.Design
                 if (dataObj is ComponentDataObjectWrapper)
                 {
                     object[] dragObjs = GetDraggingObjects(dataObj, true);
-                    if (dragObjs == null)
+                    if (dragObjs is null)
                     {
                         return false;
                     }
@@ -131,13 +131,13 @@ namespace System.Windows.Forms.Design
                 {
                     object serializationData = dataObj.GetData(DataFormat, false);
 
-                    if (serializationData == null)
+                    if (serializationData is null)
                     {
                         return false;
                     }
 
                     IDesignerSerializationService ds = (IDesignerSerializationService)GetService(typeof(IDesignerSerializationService));
-                    if (ds == null)
+                    if (ds is null)
                     {
                         return false;
                     }
@@ -403,13 +403,13 @@ namespace System.Windows.Forms.Design
             Control comp;
             Control parentControl = client.GetDesignerControl();
 
-            if (selectionHandler == null)
+            if (selectionHandler is null)
             {
                 Debug.Fail("selectionHandler should not be null");
                 return Point.Empty;
             }
 
-            if (comps == null)
+            if (comps is null)
             {
                 return Point.Empty;
             }
@@ -718,7 +718,7 @@ namespace System.Windows.Forms.Design
             //
             freezePainting = false;
 
-            if (selectionHandler == null)
+            if (selectionHandler is null)
             {
                 Debug.Fail("selectionHandler should not be null");
                 de.Effect = DragDropEffects.None;
@@ -799,7 +799,7 @@ namespace System.Windows.Forms.Design
                         // to make sure we pick up design time props, etc.
                         //
                         IComponent dragOwner = GetDragOwnerComponent(de.Data);
-                        bool newContainer = dragOwner == null || client.Component == null || dragOwner.Site.Container != client.Component.Site.Container;
+                        bool newContainer = dragOwner is null || client.Component is null || dragOwner.Site.Container != client.Component.Site.Container;
                         bool collapseChildren = false;
                         if (de.Effect == DragDropEffects.Copy || newContainer)
                         {
@@ -824,7 +824,7 @@ namespace System.Windows.Forms.Design
                     {
                         object serializationData = dataObj.GetData(DataFormat, true);
 
-                        if (serializationData == null)
+                        if (serializationData is null)
                         {
                             Debug.Fail("data object didn't return any data, so how did we allow the drop?");
                             components = Array.Empty<IComponent>();
@@ -862,7 +862,7 @@ namespace System.Windows.Forms.Design
                             {
                                 comp = components[i] as IComponent;
 
-                                if (comp == null)
+                                if (comp is null)
                                 {
                                     comp = null;
                                     continue;
@@ -905,7 +905,7 @@ namespace System.Windows.Forms.Design
                                     else
                                     {
                                         // make sure the component was added to this client
-                                        if (client.GetControlForComponent(comp) == null)
+                                        if (client.GetControlForComponent(comp) is null)
                                         {
                                             updateLocation = false;
                                         }
@@ -1142,7 +1142,7 @@ namespace System.Windows.Forms.Design
 
         public void DoOleGiveFeedback(GiveFeedbackEventArgs e)
         {
-            if (selectionHandler == null)
+            if (selectionHandler is null)
             {
                 Debug.Fail("selectionHandler should not be null");
             }
@@ -1166,7 +1166,7 @@ namespace System.Windows.Forms.Design
                 components = cdo.Components;
             }
 
-            if (!topLevelOnly || components == null)
+            if (!topLevelOnly || components is null)
             {
                 return components;
             }
@@ -1198,13 +1198,13 @@ namespace System.Windows.Forms.Design
             foreach (object comp in compList)
             {
                 Control c = comp as Control;
-                if (c == null && comp != null)
+                if (c is null && comp != null)
                 {
                     topLevel.Add(comp);
                 }
                 else if (c != null)
                 {
-                    if (c.Parent == null || !compList.Contains(c.Parent))
+                    if (c.Parent is null || !compList.Contains(c.Parent))
                     {
                         topLevel.Add(comp);
                     }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/PanelDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/PanelDesigner.cs
@@ -29,7 +29,7 @@ namespace System.Windows.Forms.Design
         protected virtual void DrawBorder(Graphics graphics)
         {
             Panel panel = (Panel)Component; // if the panel is invisible, bail now
-            if (panel == null || !panel.Visible)
+            if (panel is null || !panel.Visible)
             {
                 return;
             }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ParentControlDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ParentControlDesigner.cs
@@ -390,7 +390,7 @@ namespace System.Windows.Forms.Design
             {
                 ArrayList snapLines = base.SnapLines as ArrayList;
 
-                if (snapLines == null)
+                if (snapLines is null)
                 {
                     Debug.Fail("why did base.SnapLines return null?");
                     snapLines = new ArrayList(4);
@@ -554,7 +554,7 @@ namespace System.Windows.Forms.Design
                     // If the resulting control that came back isn't sited, it's not part of the
                     // design surface and should not be used as a marker.
                     //
-                    if (selectedControl != null && selectedControl.Site == null)
+                    if (selectedControl != null && selectedControl.Site is null)
                     {
                         selectedControl = null;
                     }
@@ -562,7 +562,7 @@ namespace System.Windows.Forms.Design
                     // if the currently selected container is this parent
                     // control, default to 0,0
                     //
-                    if (primarySelection == Component || selectedControl == null)
+                    if (primarySelection == Component || selectedControl is null)
                     {
                         bounds.X = DefaultControlLocation.X;
                         bounds.Y = DefaultControlLocation.Y;
@@ -1345,21 +1345,21 @@ namespace System.Windows.Forms.Design
 
                 //ask the parent to give us the comps within this rect
                 IComponent parent = defaultValues["Parent"] as IComponent;
-                if (parent == null)
+                if (parent is null)
                 {
                     Debug.Fail("Couldn't get the parent instance from 'defaultValues'");
                     return;
                 }
 
                 IDesignerHost host = GetService(typeof(IDesignerHost)) as IDesignerHost;
-                if (host == null)
+                if (host is null)
                 {
                     Debug.Fail("Failed to IDesignerHost");
                     return;
                 }
 
                 ParentControlDesigner parentDesigner = host.GetDesigner(parent) as ParentControlDesigner;
-                if (parentDesigner == null)
+                if (parentDesigner is null)
                 {
                     Debug.Fail("Could not get ParentControlDesigner for " + parent);
                     return;
@@ -1367,7 +1367,7 @@ namespace System.Windows.Forms.Design
 
                 object[] comps = parentDesigner.GetComponentsInRect(bounds, true, true /* component should be fully contained*/);
 
-                if (comps == null || comps.Length == 0)
+                if (comps is null || comps.Length == 0)
                 {
                     //no comps to re-parent
                     return;
@@ -1398,7 +1398,7 @@ namespace System.Windows.Forms.Design
 
             object defaultValue = null;
 
-            if (optSvc == null)
+            if (optSvc is null)
             {
                 if (optionName.Equals("ShowGrid"))
                 {
@@ -1424,7 +1424,7 @@ namespace System.Windows.Forms.Design
             }
             else
             {
-                return value == null;
+                return value is null;
             }
         }
 
@@ -1507,7 +1507,7 @@ namespace System.Windows.Forms.Design
             }
 
             // this should only occur when D&Ding between component trays on two separate forms.
-            else if (_mouseDragTool == null && data == null)
+            else if (_mouseDragTool is null && data is null)
             {
                 OleDragDropHandler ddh = GetOleDragHandler();
                 if (ddh != null)
@@ -1626,7 +1626,7 @@ namespace System.Windows.Forms.Design
 
             if (dragComps != null)
             {
-                if (data == null)
+                if (data is null)
                 {
                     // This should only be true, when moving a component from the Tray,
                     // to a new form. In this case, we are moving targets.
@@ -1636,7 +1636,7 @@ namespace System.Windows.Forms.Design
                 for (int i = 0; i < dragComps.Length; i++)
                 {
                     IComponent comp = dragComps[i] as IComponent;
-                    if (host == null || comp == null)
+                    if (host is null || comp is null)
                     {
                         continue;
                     }
@@ -1662,14 +1662,14 @@ namespace System.Windows.Forms.Design
                     }
 
                     Control ctrl = dragComps[i] as Control;
-                    if (draggedControl == null && ctrl != null)
+                    if (draggedControl is null && ctrl != null)
                     {
                         draggedControl = ctrl;
                     }
 
                     // oh well, it's not a control so it doesn't matter
                     //
-                    if (draggedControl == null)
+                    if (draggedControl is null)
                     {
                         continue;
                     }
@@ -1695,7 +1695,7 @@ namespace System.Windows.Forms.Design
 
                 // should only occur when dragging and dropping
                 // from the component tray.
-                if (data == null)
+                if (data is null)
                 {
                     PerformDragEnter(de, host);
                 }
@@ -1705,7 +1705,7 @@ namespace System.Windows.Forms.Design
 
             // Only assume the items came from the ToolBox if dragComps == null
             //
-            if (_toolboxService != null && dragComps == null)
+            if (_toolboxService != null && dragComps is null)
             {
                 _mouseDragTool = _toolboxService.DeserializeToolboxItem(de.Data, host);
 
@@ -1863,7 +1863,7 @@ namespace System.Windows.Forms.Design
             // Set the mouse capture and clipping to this control.
             control.Capture = true;
 
-            _mouseDragFrame = (_mouseDragTool == null) ? FrameStyle.Dashed : FrameStyle.Thick;
+            _mouseDragFrame = (_mouseDragTool is null) ? FrameStyle.Dashed : FrameStyle.Thick;
 
             // Setting this non-null signifies that we are dragging with the mouse.
             _mouseDragBase = new Point(x, y);
@@ -1880,7 +1880,7 @@ namespace System.Windows.Forms.Design
             //UNDONE: Behavior Work
             //Debug.Assert(escapeHandler == null, "Why is there already an escape handler?");
 
-            if (eventSvc != null && _escapeHandler == null)
+            if (eventSvc != null && _escapeHandler is null)
             {
                 _escapeHandler = new EscapeHandler(this);
                 eventSvc.PushHandler(_escapeHandler);
@@ -1901,7 +1901,7 @@ namespace System.Windows.Forms.Design
             //
             if (_mouseDragBase == InvalidPoint)
             {
-                Debug.Assert(_graphics == null);
+                Debug.Assert(_graphics is null);
                 // make sure we force the drag end
                 base.OnMouseDragEnd(cancel);
                 return;
@@ -2090,7 +2090,7 @@ namespace System.Windows.Forms.Design
             //and use it when the user drags a reversible rect -- but only if the
             //parentcontroldesigner wants to allow Snaplines
 
-            if (_dragManager == null && ParticipatesWithSnapLines && _mouseDragTool != null && BehaviorService.UseSnapLines)
+            if (_dragManager is null && ParticipatesWithSnapLines && _mouseDragTool != null && BehaviorService.UseSnapLines)
             {
                 _dragManager = new DragAssistanceManager(Component.Site);
             }
@@ -2238,7 +2238,7 @@ namespace System.Windows.Forms.Design
 
             try
             {
-                if (_toolboxService == null || !_toolboxService.SetCursor() || InheritanceAttribute.Equals(InheritanceAttribute.InheritedReadOnly))
+                if (_toolboxService is null || !_toolboxService.SetCursor() || InheritanceAttribute.Equals(InheritanceAttribute.InheritedReadOnly))
                 {
                     Cursor.Current = Cursors.Default;
                 }
@@ -2579,7 +2579,7 @@ namespace System.Windows.Forms.Design
                 Control parent = GetParentForComponent(component);
                 Form form = c as Form;
 
-                if (form == null || !form.TopLevel)
+                if (form is null || !form.TopLevel)
                 {
                     if (c.Parent != parent)
                     {
@@ -2662,7 +2662,7 @@ namespace System.Windows.Forms.Design
                 bool disposeDesigner = false;
 
                 // we need to create one then
-                if (designer == null)
+                if (designer is null)
                 {
                     designer = TypeDescriptor.CreateDesigner(component, typeof(IDesigner));
                     ControlDesigner cd = designer as ControlDesigner;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/PbrsForward.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/PbrsForward.cs
@@ -85,7 +85,7 @@ namespace System.Windows.Forms.Design
             {
                 case WM_PRIVATE_POSTCHAR:
 
-                    if (bufferedChars == null)
+                    if (bufferedChars is null)
                     {
                         return;
                     }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/PictureBoxDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/PictureBoxDesigner.cs
@@ -104,7 +104,7 @@ namespace System.Windows.Forms.Design
         {
             get
             {
-                if (_actionLists == null)
+                if (_actionLists is null)
                 {
                     _actionLists = new DesignerActionListCollection();
                     _actionLists.Add(new PictureBoxActionList(this));

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/RichTextBoxDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/RichTextBoxDesigner.cs
@@ -40,7 +40,7 @@ namespace System.Windows.Forms.Design
         {
             get
             {
-                if (_actionLists == null)
+                if (_actionLists is null)
                 {
                     _actionLists = new DesignerActionListCollection();
                     _actionLists.Add(new RichTextBoxActionList(this));

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/SelectionUIHandler.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/SelectionUIHandler.cs
@@ -248,7 +248,7 @@ namespace System.Windows.Forms.Design
             // the user cancels out of moving them.  So, we create a "BoundsInfo" object for
             // each control that saves this state.
             //
-            if (originalCoords == null && !finalMove)
+            if (originalCoords is null && !finalMove)
             {
                 originalCoords = new BoundsInfo[controls.Length];
                 for (int i = 0; i < controls.Length; i++)
@@ -456,7 +456,7 @@ namespace System.Windows.Forms.Design
                             }
                         }
 
-                        if (leftProp == null || topProp == null)
+                        if (leftProp is null || topProp is null)
                         {
                             PropertyDescriptor locationProp = TypeDescriptor.GetProperties(components[i])["Location"];
                             if (locationProp != null && !locationProp.IsReadOnly)

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TabOrder.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TabOrder.cs
@@ -474,14 +474,14 @@ namespace System.Windows.Forms.Design
             }
 
             ISite site = control.Site;
-            if (site == null || site.Container != host)
+            if (site is null || site.Container != host)
             {
                 return false;
             }
 
             PropertyDescriptor prop = TypeDescriptor.GetProperties(control)["TabIndex"];
 
-            if (prop == null || !prop.IsBrowsable)
+            if (prop is null || !prop.IsBrowsable)
             {
                 return false;
             }
@@ -694,24 +694,24 @@ namespace System.Windows.Forms.Design
         {
             base.OnPaint(e);
 
-            if (null == tabControls)
+            if (tabControls is null)
             {
                 tabControls = new ArrayList();
                 GetTabbing((Control)host.RootComponent, tabControls);
                 tabGlyphs = new Rectangle[tabControls.Count];
             }
 
-            if (null == tabComplete)
+            if (tabComplete is null)
             {
                 tabComplete = new ArrayList();
             }
 
-            if (null == tabNext)
+            if (tabNext is null)
             {
                 tabNext = new Hashtable();
             }
 
-            if (null == region)
+            if (region is null)
             {
                 DrawTabs(tabControls, e.Graphics, true);
             }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TabOrder.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TabOrder.cs
@@ -701,15 +701,8 @@ namespace System.Windows.Forms.Design
                 tabGlyphs = new Rectangle[tabControls.Count];
             }
 
-            if (tabComplete is null)
-            {
-                tabComplete = new ArrayList();
-            }
-
-            if (tabNext is null)
-            {
-                tabNext = new Hashtable();
-            }
+            tabComplete ??= new ArrayList();
+            tabNext ??= new Hashtable();
 
             if (region is null)
             {

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TextBoxDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TextBoxDesigner.cs
@@ -22,7 +22,7 @@ namespace System.Windows.Forms.Design
         {
             get
             {
-                if (_actionLists == null)
+                if (_actionLists is null)
                 {
                     _actionLists = new DesignerActionListCollection();
                     _actionLists.Add(new TextBoxActionList(this));

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripItemDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripItemDesigner.cs
@@ -256,7 +256,7 @@ namespace System.Windows.Forms.Design
 
             IComponent root = designerHost.RootComponent;
             Component startComp = ToolStripItem;
-            if (startComp == null || root == null)
+            if (startComp is null || root is null)
             {
                 return parentControls;
             }
@@ -529,7 +529,7 @@ namespace System.Windows.Forms.Design
         // Need to Fire ComponentChanging on all the DropDownItems. Please see "MorphToolStripItem" function for more details.
         private void FireComponentChanging(ToolStripDropDownItem parent)
         {
-            if (parent == null)
+            if (parent is null)
             {
                 return;
             }
@@ -551,7 +551,7 @@ namespace System.Windows.Forms.Design
 
         private void FireComponentChanged(ToolStripDropDownItem parent)
         {
-            if (parent == null)
+            if (parent is null)
             {
                 return;
             }
@@ -573,7 +573,7 @@ namespace System.Windows.Forms.Design
 
         public void GetGlyphs(ref GlyphCollection glyphs, Behavior.Behavior standardBehavior)
         {
-            if (ImmediateParent == null)
+            if (ImmediateParent is null)
             {
                 return;
             }


### PR DESCRIPTION
Refactors `System.Windows.Forms.Design` to use `is null` instead of `== null` using [CSharpIsNull](https://github.com/AArnott/CSharpIsNull) analyzer code fix.

Related: https://github.com/dotnet/winforms/issues/3459

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8240)