### PR TITLE
refactor all remaining `!= null` to `is not null`

### DIFF
--- a/src/Common/tests/TestUtilities/TestAccessor.cs
+++ b/src/Common/tests/TestUtilities/TestAccessor.cs
@@ -116,7 +116,7 @@ namespace System
                             modifiers: null);
                     }
 
-                    if (methodInfo != null || type == typeof(object))
+                    if (methodInfo is not null || type == typeof(object))
                     {
                         // Found something, or already at the top of the type heirarchy
                         break;
@@ -170,7 +170,7 @@ namespace System
                             memberName,
                             BindingFlags.Static | BindingFlags.Instance | BindingFlags.NonPublic);
 
-                    if (info != null || type == typeof(object))
+                    if (info is not null || type == typeof(object))
                     {
                         // Found something, or already at the top of the type heirarchy
                         break;

--- a/src/Microsoft.VisualBasic/tests/UnitTests/Microsoft/VisualBasic/ApplicationServices/UserTests.cs
+++ b/src/Microsoft.VisualBasic/tests/UnitTests/Microsoft/VisualBasic/ApplicationServices/UserTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualBasic.ApplicationServices.Tests
         {
             var user = new User();
             Assert.Equal(System.Threading.Thread.CurrentPrincipal, user.CurrentPrincipal);
-            if (user.CurrentPrincipal != null)
+            if (user.CurrentPrincipal is not null)
             {
                 Assert.Equal(System.Threading.Thread.CurrentPrincipal.Identity.Name, user.Name);
                 Assert.Equal(System.Threading.Thread.CurrentPrincipal.Identity.IsAuthenticated, user.IsAuthenticated);

--- a/src/System.Windows.Forms.Design/tests/UnitTests/CodeDomHelpers.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/CodeDomHelpers.cs
@@ -117,7 +117,7 @@ namespace System.Windows.Forms.TestUtilities
             string GetType(CodeTypeReference reference)
             {
                 Type result = Type.GetType(reference.BaseType);
-                if (result != null)
+                if (result is not null)
                 {
                     return $"typeof({result.Name})";
                 }

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignerHostTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignerHostTests.cs
@@ -2511,7 +2511,7 @@ namespace System.ComponentModel.Design.Tests
 
             // Replace placeholders for "this"
             ActiveDesignerEventArgs actualEventArgs = null;
-            if (eventArgs != null)
+            if (eventArgs is not null)
             {
                 IDesignerHost newDesigner = eventArgs.NewDesigner == s_placeholderHost ? host : eventArgs.NewDesigner;
                 IDesignerHost oldDesigner = eventArgs.OldDesigner == s_placeholderHost ? host : eventArgs.OldDesigner;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/SiteNestedContainerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/SiteNestedContainerTests.cs
@@ -93,7 +93,7 @@ namespace System.ComponentModel.Design.Tests
 
             // Add again.
             container.Add(component1, "newName");
-            if (component1.Site != null)
+            if (component1.Site is not null)
             {
                 Assert.Equal(componentName, component1.Site.Name);
             }

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/EmfValidator.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/EmfValidator.cs
@@ -57,7 +57,7 @@ namespace System.Windows.Forms.Metafiles
                 },
                 state);
 
-            if (currentValidator != null)
+            if (currentValidator is not null)
             {
                 Assert.False(
                     currentValidator.FailIfIncomplete,

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/Poly16Validator.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/Poly16Validator.cs
@@ -34,7 +34,7 @@ namespace System.Windows.Forms.Metafiles
                 Assert.Equal(_bounds.Value, (Rectangle)poly->rclBounds);
             }
 
-            if (_points != null)
+            if (_points is not null)
             {
                 Assert.Equal(_points.Length, (int)poly->cpts);
                 Assert.Equal(_points, poly->points.Transform<POINTS, Point>(p => p));

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/TextOutValidator.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/Validators/TextOutValidator.cs
@@ -37,7 +37,7 @@ namespace System.Windows.Forms.Metafiles
 
             EMREXTTEXTOUTW* textOut = record.ExtTextOutWRecord;
 
-            if (_text != null)
+            if (_text is not null)
             {
                 Assert.Equal(_text, textOut->emrtext.GetText().ToString());
             }

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/Automation/UiaTextRangeTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/Automation/UiaTextRangeTests.cs
@@ -411,7 +411,7 @@ this is the third line.";
 
             ITextRangeProvider? actual = ((ITextRangeProvider)textRange).FindText(textToSearch, backward, ignoreCase);
 
-            if (foundText != null)
+            if (foundText is not null)
             {
                 Assert.Equal(foundText, actual?.GetText(5000));
             }

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/SinglyLinkedListTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/SinglyLinkedListTests.cs
@@ -177,7 +177,7 @@ namespace System.Windows.Forms.Tests
         {
             List<T> list = new List<T>(linkedList.Count);
             var node = linkedList.First;
-            while (node != null)
+            while (node is not null)
             {
                 list.Add(node);
                 node = node.Next;

--- a/src/System.Windows.Forms/tests/AccessibilityTests/DataControls.cs
+++ b/src/System.Windows.Forms/tests/AccessibilityTests/DataControls.cs
@@ -37,7 +37,7 @@ namespace Accessibility_Core_App
             dataGridView1.CurrentCell = dataGridView1.Rows[0].Cells[0];
             dataGridView1.BeginEdit(false);
             DataGridViewComboBoxEditingControl cbox = dataGridView1.EditingControl as DataGridViewComboBoxEditingControl;
-            if (cbox != null)
+            if (cbox is not null)
                 cbox.DroppedDown = true;
         }
 

--- a/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/CustomControls/CustomButtonDesignerActionList.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/CustomControls/CustomButtonDesignerActionList.cs
@@ -31,7 +31,7 @@ namespace TestConsole
             get
             {
                 string name = string.Empty;
-                if (_control != null)
+                if (_control is not null)
                 {
                     CustomButton control = _control;
                     name = control.Name;
@@ -48,7 +48,7 @@ namespace TestConsole
         private string GetActionName()
         {
             PropertyDescriptor dockProp = TypeDescriptor.GetProperties(Component)[nameof(CustomButton.BackColor)];
-            if (dockProp != null)
+            if (dockProp is not null)
             {
                 Color backColor = (Color)dockProp.GetValue(Component);
                 if (backColor != Color.Yellow)

--- a/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/CustomControls/DesignerActionVerbItem.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/CustomControls/DesignerActionVerbItem.cs
@@ -9,7 +9,7 @@ namespace TestConsole
 
         public DesignerActionVerbItem(DesignerVerb verb) : base(null, null, null)
         {
-            Debug.Assert(verb != null, "All callers check whether the verb is null.");
+            Debug.Assert(verb is not null, "All callers check whether the verb is null.");
             _targetVerb = verb;
         }
 

--- a/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/MainForm.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/MainForm.cs
@@ -44,7 +44,7 @@ namespace TestConsole
             {
                 IDesignSurfaceExt isurf = _listOfDesignSurface[i];
                 _selectionService = (ISelectionService)(isurf.GetIDesignerHost().GetService(typeof(ISelectionService)));
-                if (null != _selectionService)
+                if (_selectionService is not null)
                     _selectionService.SelectionChanged += new System.EventHandler(OnSelectionChanged);
             }
         }
@@ -56,7 +56,7 @@ namespace TestConsole
                 return;
 
             IDesignSurfaceExt isurf = _listOfDesignSurface[tabControl1.SelectedIndex];
-            if (null != isurf)
+            if (isurf is not null)
             {
                 ISelectionService selectionService = isurf.GetIDesignerHost().GetService(typeof(ISelectionService)) as ISelectionService;
                 propertyGrid.SelectedObject = selectionService.PrimarySelection;
@@ -251,7 +251,7 @@ namespace TestConsole
         {
             //- find out the DesignSurfaceExt control hosted by the TabPage
             IDesignSurfaceExt isurf = _listOfDesignSurface[tabControl1.SelectedIndex];
-            if (null != isurf)
+            if (isurf is not null)
                 propertyGrid.SelectedObject = isurf.GetIDesignerHost().RootComponent;
         }
 

--- a/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DesignSurfaceExt/DesignSurfaceExt.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DesignSurfaceExt/DesignSurfaceExt.cs
@@ -28,7 +28,7 @@ namespace DesignSurfaceExt
         {
             IServiceContainer serviceProvider = GetService(typeof(IServiceContainer)) as IServiceContainer;
             DesignerOptionService opsService = serviceProvider.GetService(typeof(DesignerOptionService)) as DesignerOptionService;
-            if (null != opsService)
+            if (opsService is not null)
             {
                 serviceProvider.RemoveService(typeof(DesignerOptionService));
             }
@@ -41,7 +41,7 @@ namespace DesignSurfaceExt
         {
             IServiceContainer serviceProvider = GetService(typeof(IServiceContainer)) as IServiceContainer;
             DesignerOptionService opsService = serviceProvider.GetService(typeof(DesignerOptionService)) as DesignerOptionService;
-            if (null != opsService)
+            if (opsService is not null)
             {
                 serviceProvider.RemoveService(typeof(DesignerOptionService));
             }
@@ -54,7 +54,7 @@ namespace DesignSurfaceExt
         {
             IServiceContainer serviceProvider = GetService(typeof(IServiceContainer)) as IServiceContainer;
             DesignerOptionService opsService = serviceProvider.GetService(typeof(DesignerOptionService)) as DesignerOptionService;
-            if (null != opsService)
+            if (opsService is not null)
             {
                 serviceProvider.RemoveService(typeof(DesignerOptionService));
             }
@@ -67,7 +67,7 @@ namespace DesignSurfaceExt
         {
             IServiceContainer serviceProvider = GetService(typeof(IServiceContainer)) as IServiceContainer;
             DesignerOptionService opsService = serviceProvider.GetService(typeof(DesignerOptionService)) as DesignerOptionService;
-            if (null != opsService)
+            if (opsService is not null)
             {
                 serviceProvider.RemoveService(typeof(DesignerOptionService));
             }
@@ -95,7 +95,7 @@ namespace DesignSurfaceExt
                     return null;
                 //- check if the root component has already been set
                 //- if so then rollback (return without do nothing)
-                if (null != host.RootComponent)
+                if (host.RootComponent is not null)
                     return null;
                 //-
                 //-
@@ -320,7 +320,7 @@ namespace DesignSurfaceExt
             //-
             //- 1. NameCreationService
             _nameCreationService = new NameCreationServiceImp();
-            if (_nameCreationService != null)
+            if (_nameCreationService is not null)
             {
                 ServiceContainer.RemoveService(typeof(INameCreationService), false);
                 ServiceContainer.AddService(typeof(INameCreationService), _nameCreationService);
@@ -330,7 +330,7 @@ namespace DesignSurfaceExt
             //-
             //- 2. CodeDomComponentSerializationService
             _codeDomComponentSerializationService = new CodeDomComponentSerializationService(ServiceContainer);
-            if (_codeDomComponentSerializationService != null)
+            if (_codeDomComponentSerializationService is not null)
             {
                 //- the CodeDomComponentSerializationService is ready to be replaced
                 ServiceContainer.RemoveService(typeof(ComponentSerializationService), false);
@@ -341,7 +341,7 @@ namespace DesignSurfaceExt
             //-
             //- 3. IDesignerSerializationService
             _designerSerializationService = new DesignerSerializationServiceImpl(ServiceContainer);
-            if (_designerSerializationService != null)
+            if (_designerSerializationService is not null)
             {
                 //- the IDesignerSerializationService is ready to be replaced
                 ServiceContainer.RemoveService(typeof(IDesignerSerializationService), false);
@@ -354,7 +354,7 @@ namespace DesignSurfaceExt
             _undoEngine = new UndoEngineExt(ServiceContainer);
             //- disable the UndoEngine
             _undoEngine.Enabled = false;
-            if (_undoEngine != null)
+            if (_undoEngine is not null)
             {
                 //- the UndoEngine is ready to be replaced
                 ServiceContainer.RemoveService(typeof(UndoEngine), false);

--- a/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DesignSurfaceExt/DesignerOptionServiceExt.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DesignSurfaceExt/DesignerOptionServiceExt.cs
@@ -9,7 +9,7 @@ namespace DesignSurfaceExt
 
         protected override void PopulateOptionCollection(DesignerOptionCollection options)
         {
-            if (null != options.Parent)
+            if (options.Parent is not null)
                 return;
 
             DesignerOptions ops = new DesignerOptions();
@@ -28,7 +28,7 @@ namespace DesignSurfaceExt
 
         protected override void PopulateOptionCollection(DesignerOptionCollection options)
         {
-            if (null != options.Parent)
+            if (options.Parent is not null)
                 return;
 
             DesignerOptions ops = new DesignerOptions();
@@ -50,7 +50,7 @@ namespace DesignSurfaceExt
 
         protected override void PopulateOptionCollection(DesignerOptionCollection options)
         {
-            if (null != options.Parent)
+            if (options.Parent is not null)
                 return;
 
             DesignerOptions ops = new DesignerOptions();
@@ -70,7 +70,7 @@ namespace DesignSurfaceExt
 
         protected override void PopulateOptionCollection(DesignerOptionCollection options)
         {
-            if (null != options.Parent)
+            if (options.Parent is not null)
                 return;
 
             DesignerOptions ops = new DesignerOptions();

--- a/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DesignSurfaceExt/DesignerSerializationServiceImpl.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DesignSurfaceExt/DesignerSerializationServiceImpl.cs
@@ -16,7 +16,7 @@ namespace DesignSurfaceExt
         public System.Collections.ICollection Deserialize(object serializationData)
         {
             SerializationStore serializationStore = serializationData as SerializationStore;
-            if (serializationStore != null)
+            if (serializationStore is not null)
             {
                 ComponentSerializationService componentSerializationService = _serviceProvider.GetService(typeof(ComponentSerializationService)) as ComponentSerializationService;
                 ICollection collection = componentSerializationService.Deserialize(serializationStore);

--- a/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests/Mocks/MainObject.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests/Mocks/MainObject.cs
@@ -19,7 +19,7 @@ namespace System.Windows.Forms.IntegrationTests.Mocks
                 if (text != value)
                 {
                     text = value;
-                    if (_propertyChanged != null)
+                    if (_propertyChanged is not null)
                     {
                         _propertyChanged(this, new PropertyChangedEventArgs(nameof(Text)));
                     }
@@ -33,6 +33,6 @@ namespace System.Windows.Forms.IntegrationTests.Mocks
             remove => _propertyChanged -= value;
         }
 
-        public bool IsPropertyChangedAssigned { get { return _propertyChanged != null; } }
+        public bool IsPropertyChangedAssigned { get { return _propertyChanged is not null; } }
     }
 }

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Infra/ControlTestBase.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Infra/ControlTestBase.cs
@@ -62,7 +62,7 @@ namespace System.Windows.Forms.UITests
             await _joinableTaskCollection.JoinTillEmptyAsync();
             JoinableTaskContext = null!;
             JoinableTaskFactory = null!;
-            if (_denyExecutionSynchronizationContext != null)
+            if (_denyExecutionSynchronizationContext is not null)
             {
                 SynchronizationContext.SetSynchronizationContext(_denyExecutionSynchronizationContext.UnderlyingContext);
                 _denyExecutionSynchronizationContext.ThrowIfSwitchOccurred();

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/RichTextBoxTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/RichTextBoxTests.cs
@@ -276,7 +276,7 @@ This is hidden text preceeding a \v #link3#\v0 custom link.\par
                     {
                         // This method returns a COM object, thus increments the RCW reference count and we want to release it later.
                         var range = textDocument.Range(start, start + length);
-                        if (range != null)
+                        if (range is not null)
                         {
                             try
                             {
@@ -297,7 +297,7 @@ This is hidden text preceeding a \v #link3#\v0 custom link.\par
             finally
             {
                 // release RCW reference count
-                if (oleInterface != null)
+                if (oleInterface is not null)
                 {
                     Marshal.ReleaseComObject(oleInterface);
                 }

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/DataGridViewInVirtualModeTest.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/DataGridViewInVirtualModeTest.cs
@@ -135,7 +135,7 @@ namespace WinformsControlsTest
                 _customerInEdit = null;
                 _rowInEdit = -1;
             }
-            else if (_customerInEdit != null && e.RowIndex < _customers.Count)
+            else if (_customerInEdit is not null && e.RowIndex < _customers.Count)
             {
                 // Save the modified TestCustomer object in the data store
                 _customers[e.RowIndex] = _customerInEdit;

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MdiChild.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MdiChild.cs
@@ -93,7 +93,7 @@ namespace WinformsControlsTest
 
         private void chkRightToLeft_CheckedChanged(object sender, EventArgs e)
         {
-            if (MyParent.MainMenuStrip != null)
+            if (MyParent.MainMenuStrip is not null)
             {
                 MyParent.MainMenuStrip.RightToLeft = chkRightToLeft.Checked ? RightToLeft.Yes : RightToLeft.No;
             }

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/PictureBoxes.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/PictureBoxes.cs
@@ -53,7 +53,7 @@ namespace WinformsControlsTest
                 MessageBox.Show("Image loading cancelled");
             }
 
-            if (e.Error != null)
+            if (e.Error is not null)
             {
                 MessageBox.Show(e.Error.Message, $"{e.Error.GetType().FullName} occurred");
             }

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/UserControls/UserControlWithObjectCollectionEditor.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/UserControls/UserControlWithObjectCollectionEditor.cs
@@ -34,7 +34,7 @@ namespace WinformsControlsTest.UserControls
     {
         public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
         {
-            if (destinationType != null && destinationType.IsAssignableFrom(typeof(string)) && value != null && value is IList<int> list)
+            if (destinationType is not null && destinationType.IsAssignableFrom(typeof(string)) && value is not null && value is IList<int> list)
             {
                 var result = new StringBuilder("");
                 for (int i = 0; i < list.Count; i++)

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/BindingTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/BindingTests.cs
@@ -396,7 +396,7 @@ namespace System.Windows.Forms.Tests
 
             binding.BindingComplete += handler;
             Assert.Throws(exception.GetType(), () => binding.OnBindingComplete(eventArgs));
-            if (eventArgs != null)
+            if (eventArgs is not null)
             {
                 Assert.False(eventArgs.Cancel);
             }
@@ -428,7 +428,7 @@ namespace System.Windows.Forms.Tests
 
             binding.BindingComplete += handler;
             binding.OnBindingComplete(eventArgs);
-            if (eventArgs != null)
+            if (eventArgs is not null)
             {
                 Assert.True(eventArgs.Cancel);
             }
@@ -478,7 +478,7 @@ namespace System.Windows.Forms.Tests
             };
 
             binding.Format += handler;
-            if (eventArgs != null)
+            if (eventArgs is not null)
             {
                 eventArgs.Value = oldValue;
             }
@@ -489,7 +489,7 @@ namespace System.Windows.Forms.Tests
 
             // Should not call if the handler is removed.
             binding.Format -= handler;
-            if (eventArgs != null)
+            if (eventArgs is not null)
             {
                 eventArgs.Value = oldValue;
             }
@@ -523,7 +523,7 @@ namespace System.Windows.Forms.Tests
             };
 
             binding.Parse += handler;
-            if (eventArgs != null)
+            if (eventArgs is not null)
             {
                 eventArgs.Value = oldValue;
             }
@@ -534,7 +534,7 @@ namespace System.Windows.Forms.Tests
 
             // Should not call if the handler is removed.
             binding.Parse -= handler;
-            if (eventArgs != null)
+            if (eventArgs is not null)
             {
                 eventArgs.Value = oldValue;
             }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ControlAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ControlAccessibleObjectTests.cs
@@ -1129,7 +1129,7 @@ namespace System.Windows.Forms.Tests
             var accessibleObject = new Control.ControlAccessibleObject(ownerControl);
             Assert.Equal(createControl, ownerControl.IsHandleCreated);
             IAccessible iAccessible = accessibleObject;
-            Assert.Equal(createControl, iAccessible.accParent != null);
+            Assert.Equal(createControl, iAccessible.accParent is not null);
         }
 
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewRowTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewRowTests.cs
@@ -1480,7 +1480,7 @@ namespace System.Windows.Forms.Tests
             {
                 HeaderCell = value
             };
-            if (value != null)
+            if (value is not null)
             {
                 Assert.Same(value, row.HeaderCell);
             }
@@ -1493,7 +1493,7 @@ namespace System.Windows.Forms.Tests
 
             // Set same.
             row.HeaderCell = value;
-            if (value != null)
+            if (value is not null)
             {
                 Assert.Same(value, row.HeaderCell);
             }
@@ -1516,7 +1516,7 @@ namespace System.Windows.Forms.Tests
             };
             row.HeaderCell = value;
 
-            if (value != null)
+            if (value is not null)
             {
                 Assert.Same(value, row.HeaderCell);
             }
@@ -1529,7 +1529,7 @@ namespace System.Windows.Forms.Tests
 
             // Set same.
             row.HeaderCell = value;
-            if (value != null)
+            if (value is not null)
             {
                 Assert.Same(value, row.HeaderCell);
             }
@@ -1576,7 +1576,7 @@ namespace System.Windows.Forms.Tests
             DataGridViewRow row = control.Rows[0];
 
             row.HeaderCell = value;
-            if (value != null)
+            if (value is not null)
             {
                 Assert.Same(value, row.HeaderCell);
             }
@@ -1589,7 +1589,7 @@ namespace System.Windows.Forms.Tests
 
             // Set same.
             row.HeaderCell = value;
-            if (value != null)
+            if (value is not null)
             {
                 Assert.Same(value, row.HeaderCell);
             }
@@ -1616,7 +1616,7 @@ namespace System.Windows.Forms.Tests
 
             row.HeaderCell = value;
 
-            if (value != null)
+            if (value is not null)
             {
                 Assert.Same(value, row.HeaderCell);
             }
@@ -1629,7 +1629,7 @@ namespace System.Windows.Forms.Tests
 
             // Set same.
             row.HeaderCell = value;
-            if (value != null)
+            if (value is not null)
             {
                 Assert.Same(value, row.HeaderCell);
             }
@@ -1653,7 +1653,7 @@ namespace System.Windows.Forms.Tests
             DataGridViewRow row = control.Rows.SharedRow(0);
 
             row.HeaderCell = value;
-            if (value != null)
+            if (value is not null)
             {
                 Assert.Same(value, row.HeaderCell);
             }
@@ -1666,7 +1666,7 @@ namespace System.Windows.Forms.Tests
 
             // Set same.
             row.HeaderCell = value;
-            if (value != null)
+            if (value is not null)
             {
                 Assert.Same(value, row.HeaderCell);
             }
@@ -1693,7 +1693,7 @@ namespace System.Windows.Forms.Tests
 
             row.HeaderCell = value;
 
-            if (value != null)
+            if (value is not null)
             {
                 Assert.Same(value, row.HeaderCell);
             }
@@ -1706,7 +1706,7 @@ namespace System.Windows.Forms.Tests
 
             // Set same.
             row.HeaderCell = value;
-            if (value != null)
+            if (value is not null)
             {
                 Assert.Same(value, row.HeaderCell);
             }
@@ -2131,17 +2131,17 @@ namespace System.Windows.Forms.Tests
                 ColumnCount = 2
             };
 
-            if (rowsDefaultCellStyle != null)
+            if (rowsDefaultCellStyle is not null)
             {
                 control.RowsDefaultCellStyle = rowsDefaultCellStyle;
             }
 
-            if (alternatingRowsDefaultCellStyle != null)
+            if (alternatingRowsDefaultCellStyle is not null)
             {
                 control.AlternatingRowsDefaultCellStyle = alternatingRowsDefaultCellStyle;
             }
 
-            if (gridDefaultCellStyle != null)
+            if (gridDefaultCellStyle is not null)
             {
                 control.DefaultCellStyle = gridDefaultCellStyle;
             }
@@ -2150,7 +2150,7 @@ namespace System.Windows.Forms.Tests
             control.Rows.Add(new SubDataGridViewRow());
 
             DataGridViewRow row = control.Rows[index];
-            if (rowDefaultCellStyle != null)
+            if (rowDefaultCellStyle is not null)
             {
                 row.DefaultCellStyle = rowDefaultCellStyle;
             }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataObjectTests.cs
@@ -1536,18 +1536,18 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expectedCsvText, dataObject.GetData(DataFormats.CommaSeparatedValue, autoConvert: false));
 
             Assert.True(dataObject.ContainsText(format));
-            Assert.Equal(expectedUnicodeText != null, dataObject.GetDataPresent(DataFormats.UnicodeText, autoConvert: true));
-            Assert.Equal(expectedUnicodeText != null, dataObject.GetDataPresent(DataFormats.UnicodeText, autoConvert: false));
+            Assert.Equal(expectedUnicodeText is not null, dataObject.GetDataPresent(DataFormats.UnicodeText, autoConvert: true));
+            Assert.Equal(expectedUnicodeText is not null, dataObject.GetDataPresent(DataFormats.UnicodeText, autoConvert: false));
             Assert.False(dataObject.GetDataPresent(DataFormats.Text, autoConvert: true));
             Assert.False(dataObject.GetDataPresent(DataFormats.Text, autoConvert: false));
             Assert.False(dataObject.GetDataPresent(DataFormats.StringFormat, autoConvert: true));
             Assert.False(dataObject.GetDataPresent(DataFormats.StringFormat, autoConvert: false));
-            Assert.Equal(expectedRtfText != null, dataObject.GetDataPresent(DataFormats.Rtf, autoConvert: true));
-            Assert.Equal(expectedRtfText != null, dataObject.GetDataPresent(DataFormats.Rtf, autoConvert: false));
-            Assert.Equal(expectedHtmlText != null, dataObject.GetDataPresent(DataFormats.Html, autoConvert: true));
-            Assert.Equal(expectedHtmlText != null, dataObject.GetDataPresent(DataFormats.Html, autoConvert: false));
-            Assert.Equal(expectedCsvText != null, dataObject.GetDataPresent(DataFormats.CommaSeparatedValue, autoConvert: true));
-            Assert.Equal(expectedCsvText != null, dataObject.GetDataPresent(DataFormats.CommaSeparatedValue, autoConvert: false));
+            Assert.Equal(expectedRtfText is not null, dataObject.GetDataPresent(DataFormats.Rtf, autoConvert: true));
+            Assert.Equal(expectedRtfText is not null, dataObject.GetDataPresent(DataFormats.Rtf, autoConvert: false));
+            Assert.Equal(expectedHtmlText is not null, dataObject.GetDataPresent(DataFormats.Html, autoConvert: true));
+            Assert.Equal(expectedHtmlText is not null, dataObject.GetDataPresent(DataFormats.Html, autoConvert: false));
+            Assert.Equal(expectedCsvText is not null, dataObject.GetDataPresent(DataFormats.CommaSeparatedValue, autoConvert: true));
+            Assert.Equal(expectedCsvText is not null, dataObject.GetDataPresent(DataFormats.CommaSeparatedValue, autoConvert: false));
         }
 
         public static IEnumerable<object[]> SetText_StringTextDataFormatMocked_TestData()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/HtmlDocumentTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/HtmlDocumentTests.cs
@@ -1831,9 +1831,9 @@ namespace System.Windows.Forms.Tests
 
             Assert.False(document != document);
             Assert.True(document != newDocument);
-            Assert.True((HtmlDocument)null != document);
-            Assert.True(document != (HtmlDocument)null);
-            Assert.False((HtmlDocument)null != (HtmlDocument)null);
+            Assert.True(document is not null);
+            Assert.True((HtmlDocument)null is not null);
+            Assert.False((HtmlDocument)null is not null);
         }
 #pragma warning restore CS1718
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/HtmlDocumentTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/HtmlDocumentTests.cs
@@ -1795,7 +1795,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal("about:blank", newDocument.Url.OriginalString);
         }
 
-#pragma warning disable CS1718 // Disable "Comparison made to same variable" warning.
+#pragma warning disable CS1718, CSIsNull001, CSIsNull002 // Disable "Comparison made to same variable" warning.
         [WinFormsFact]
         public async Task HtmlDocument_OperatorEquals_Invoke_ReturnsExpected()
         {
@@ -1831,11 +1831,11 @@ namespace System.Windows.Forms.Tests
 
             Assert.False(document != document);
             Assert.True(document != newDocument);
-            Assert.True(document is not null);
-            Assert.True((HtmlDocument)null is not null);
-            Assert.False((HtmlDocument)null is not null);
+            Assert.True((HtmlDocument)null != document);
+            Assert.True(document != (HtmlDocument)null);
+            Assert.False((HtmlDocument)null != (HtmlDocument)null);
         }
-#pragma warning restore CS1718
+#pragma warning restore CS1718, CSIsNull001, CSIsNull002
 
         [WinFormsFact]
         public async Task HtmlDocument_Click_InvokeEvent_Success()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/HtmlDocumentTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/HtmlDocumentTests.cs
@@ -1795,7 +1795,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal("about:blank", newDocument.Url.OriginalString);
         }
 
-#pragma warning disable CS1718, CSIsNull001, CSIsNull002 // Disable "Comparison made to same variable" warning.
+#pragma warning disable CS1718 // Disable "Comparison made to same variable" warning.
         [WinFormsFact]
         public async Task HtmlDocument_OperatorEquals_Invoke_ReturnsExpected()
         {
@@ -1835,7 +1835,7 @@ namespace System.Windows.Forms.Tests
             Assert.True(document != (HtmlDocument)null);
             Assert.False((HtmlDocument)null != (HtmlDocument)null);
         }
-#pragma warning restore CS1718, CSIsNull001, CSIsNull002
+#pragma warning restore CS1718
 
         [WinFormsFact]
         public async Task HtmlDocument_Click_InvokeEvent_Success()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/HtmlElementTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/HtmlElementTests.cs
@@ -2319,7 +2319,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(HRESULT.DISP_E_UNKNOWNNAME, (HRESULT)ex.HResult);
         }
 
-#pragma warning disable CS1718, CSIsNull001, CSIsNull002 // Disable "Comparison made to same variable" warning.
+#pragma warning disable CS1718 // Disable "Comparison made to same variable" warning.
         [WinFormsFact]
         public async Task HtmlElement_OperatorEquals_Invoke_ReturnsExpected()
         {
@@ -2365,7 +2365,7 @@ namespace System.Windows.Forms.Tests
             Assert.True(element1 != (HtmlElement)null);
             Assert.False((HtmlElement)null != (HtmlElement)null);
         }
-#pragma warning restore CS1718, CSIsNull001, CSIsNull002
+#pragma warning restore CS1718
 
         [WinFormsFact]
         public async Task HtmlElement_Click_InvokeEvent_Success()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/HtmlElementTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/HtmlElementTests.cs
@@ -2319,7 +2319,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(HRESULT.DISP_E_UNKNOWNNAME, (HRESULT)ex.HResult);
         }
 
-#pragma warning disable CS1718 // Disable "Comparison made to same variable" warning.
+#pragma warning disable CS1718, CSIsNull001, CSIsNull002 // Disable "Comparison made to same variable" warning.
         [WinFormsFact]
         public async Task HtmlElement_OperatorEquals_Invoke_ReturnsExpected()
         {
@@ -2361,11 +2361,11 @@ namespace System.Windows.Forms.Tests
             Assert.False(element1 != element1);
             Assert.False(element1 != element2);
             Assert.True(element1 != element3);
-            Assert.True(element1 is not null);
-            Assert.True((HtmlElement)null is not null);
-            Assert.False((HtmlElement)null is not null);
+            Assert.True((HtmlElement)null != element1);
+            Assert.True(element1 != (HtmlElement)null);
+            Assert.False((HtmlElement)null != (HtmlElement)null);
         }
-#pragma warning restore CS1718
+#pragma warning restore CS1718, CSIsNull001, CSIsNull002
 
         [WinFormsFact]
         public async Task HtmlElement_Click_InvokeEvent_Success()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/HtmlElementTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/HtmlElementTests.cs
@@ -2361,9 +2361,9 @@ namespace System.Windows.Forms.Tests
             Assert.False(element1 != element1);
             Assert.False(element1 != element2);
             Assert.True(element1 != element3);
-            Assert.True((HtmlElement)null != element1);
-            Assert.True(element1 != (HtmlElement)null);
-            Assert.False((HtmlElement)null != (HtmlElement)null);
+            Assert.True(element1 is not null);
+            Assert.True((HtmlElement)null is not null);
+            Assert.False((HtmlElement)null is not null);
         }
 #pragma warning restore CS1718
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridTests.cs
@@ -3907,7 +3907,7 @@ namespace System.Windows.Forms.Tests
             object @object = new();
             propertyGrid.SelectedObject = @object;
             GridItem selectedItem = propertyGrid.SelectedGridItem;
-            Assert.True(selectedItem != null);
+            Assert.True(selectedItem is not null);
             Assert.Equal("System.Object", selectedItem.Label);
             Assert.IsAssignableFrom<IRootGridEntry>(selectedItem);
             SingleSelectRootGridEntry gridEntry = Assert.IsAssignableFrom<SingleSelectRootGridEntry>(selectedItem);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ScrollableControlTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ScrollableControlTests.cs
@@ -1585,7 +1585,7 @@ namespace System.Windows.Forms.Tests
                         {
                             foreach (ImageLayout backgroundImageLayout in Enum.GetValues(typeof(ImageLayout)))
                             {
-                                int expected = backgroundImage != null && (backgroundImageLayout == ImageLayout.Zoom || backgroundImageLayout == ImageLayout.Stretch || backgroundImageLayout == ImageLayout.Center) && (hScroll || vScroll) ? 0 : 1;
+                                int expected = backgroundImage is not null && (backgroundImageLayout == ImageLayout.Zoom || backgroundImageLayout == ImageLayout.Stretch || backgroundImageLayout == ImageLayout.Center) && (hScroll || vScroll) ? 0 : 1;
                                 yield return new object[] { parentFactory(), hScroll, vScroll, true, Color.Empty, backgroundImage, backgroundImageLayout, 0 };
                                 yield return new object[] { parentFactory(), hScroll, vScroll, true, Color.Red, backgroundImage, backgroundImageLayout, 0 };
                                 yield return new object[] { parentFactory(), hScroll, vScroll, true, Color.FromArgb(100, 50, 100, 150), backgroundImage, backgroundImageLayout, expected };
@@ -1636,8 +1636,7 @@ namespace System.Windows.Forms.Tests
 
                                 int expected = parentFactory == CreateTabPage
                                     ? 0
-                                    : backgroundImage != null
-                                        && (backgroundImageLayout == ImageLayout.Zoom || backgroundImageLayout == ImageLayout.Stretch || backgroundImageLayout == ImageLayout.Center)
+                                    : backgroundImage is not null && (backgroundImageLayout == ImageLayout.Zoom || backgroundImageLayout == ImageLayout.Stretch || backgroundImageLayout == ImageLayout.Center)
                                         && (hScroll || vScroll)
                                             ? 0
                                             : 1;
@@ -1786,7 +1785,7 @@ namespace System.Windows.Forms.Tests
                     {
                         foreach (ImageLayout backgroundImageLayout in Enum.GetValues(typeof(ImageLayout)))
                         {
-                            int expected = backgroundImage != null && (backgroundImageLayout == ImageLayout.Zoom || backgroundImageLayout == ImageLayout.Stretch || backgroundImageLayout == ImageLayout.Center) && (!hScroll && vScroll) ? 0 : 1;
+                            int expected = backgroundImage is not null && (backgroundImageLayout == ImageLayout.Zoom || backgroundImageLayout == ImageLayout.Stretch || backgroundImageLayout == ImageLayout.Center) && (!hScroll && vScroll) ? 0 : 1;
                             yield return new object[] { hScroll, vScroll, true, Color.Empty, backgroundImage, backgroundImageLayout, 0 };
                             yield return new object[] { hScroll, vScroll, true, Color.Red, backgroundImage, backgroundImageLayout, 0 };
                             yield return new object[] { hScroll, vScroll, true, Color.FromArgb(100, 50, 100, 150), backgroundImage, backgroundImageLayout, expected };

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripDropDownItemTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripDropDownItemTests.cs
@@ -306,7 +306,7 @@ namespace System.Windows.Forms.Tests
         public void ToolStripDropDownItem_Ctor_String_Image_ToolStripItemArray(string text, Image image, ToolStripItem[] dropDownItems, ToolStripItem[] expectedDropDownItems)
         {
             using var item = new SubToolStripDropDownItem(text, image, dropDownItems);
-            Assert.Equal(dropDownItems != null, item.HasDropDown);
+            Assert.Equal(dropDownItems is not null, item.HasDropDown);
             Assert.NotNull(item.AccessibilityObject);
             Assert.Null(item.AccessibleDefaultActionDescription);
             Assert.Null(item.AccessibleDescription);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripItemTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripItemTests.cs
@@ -4515,7 +4515,7 @@ namespace System.Windows.Forms.Tests
                 item.ImageIndex = value;
                 Assert.Equal(expected, item.ImageIndex);
                 Assert.Empty(item.ImageKey);
-                Assert.Equal(expectedHasImage, item.Image != null);
+                Assert.Equal(expectedHasImage, item.Image is not null);
                 Assert.Equal(1, ownerLayoutCallCount);
                 Assert.False(owner.IsHandleCreated);
 
@@ -4523,7 +4523,7 @@ namespace System.Windows.Forms.Tests
                 item.ImageIndex = value;
                 Assert.Equal(expected, item.ImageIndex);
                 Assert.Empty(item.ImageKey);
-                Assert.Equal(expectedHasImage, item.Image != null);
+                Assert.Equal(expectedHasImage, item.Image is not null);
                 Assert.Equal(2, ownerLayoutCallCount);
                 Assert.False(owner.IsHandleCreated);
             }
@@ -5017,7 +5017,7 @@ namespace System.Windows.Forms.Tests
                 item.ImageKey = value;
                 Assert.Equal(expected, item.ImageKey);
                 Assert.Equal(-1, item.ImageIndex);
-                Assert.Equal(expectedHasImage, item.Image != null);
+                Assert.Equal(expectedHasImage, item.Image is not null);
                 Assert.Equal(1, ownerLayoutCallCount);
                 Assert.False(owner.IsHandleCreated);
 
@@ -5025,7 +5025,7 @@ namespace System.Windows.Forms.Tests
                 item.ImageKey = value;
                 Assert.Equal(expected, item.ImageKey);
                 Assert.Equal(-1, item.ImageIndex);
-                Assert.Equal(expectedHasImage, item.Image != null);
+                Assert.Equal(expectedHasImage, item.Image is not null);
                 Assert.Equal(2, ownerLayoutCallCount);
                 Assert.False(owner.IsHandleCreated);
             }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripTests.cs
@@ -5864,7 +5864,7 @@ namespace System.Windows.Forms.Tests
                         {
                             foreach (ImageLayout backgroundImageLayout in Enum.GetValues(typeof(ImageLayout)))
                             {
-                                int expected = backgroundImage != null && (backgroundImageLayout == ImageLayout.Zoom || backgroundImageLayout == ImageLayout.Stretch || backgroundImageLayout == ImageLayout.Center) && (hScroll || vScroll) ? 0 : 1;
+                                int expected = backgroundImage is not null && (backgroundImageLayout == ImageLayout.Zoom || backgroundImageLayout == ImageLayout.Stretch || backgroundImageLayout == ImageLayout.Center) && (hScroll || vScroll) ? 0 : 1;
                                 yield return new object[] { parent, hScroll, vScroll, true, Color.Empty, backgroundImage, backgroundImageLayout, 0 };
                                 yield return new object[] { parent, hScroll, vScroll, true, Color.Red, backgroundImage, backgroundImageLayout, 0 };
                                 yield return new object[] { parent, hScroll, vScroll, true, Color.FromArgb(100, 50, 100, 150), backgroundImage, backgroundImageLayout, expected };
@@ -5923,8 +5923,7 @@ namespace System.Windows.Forms.Tests
 
                                 int expected = parent == tabPage
                                     ? 0
-                                    : backgroundImage != null
-                                        && (backgroundImageLayout == ImageLayout.Zoom || backgroundImageLayout == ImageLayout.Stretch || backgroundImageLayout == ImageLayout.Center)
+                                    : backgroundImage is not null && (backgroundImageLayout == ImageLayout.Zoom || backgroundImageLayout == ImageLayout.Stretch || backgroundImageLayout == ImageLayout.Center)
                                         && (hScroll || vScroll)
                                             ? 1
                                             : 2;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/WebBrowserTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/WebBrowserTests.cs
@@ -1779,13 +1779,13 @@ namespace System.Windows.Forms.Tests
                 ScrollBarsEnabled = value
             };
             Assert.Equal(value, control.ScrollBarsEnabled);
-            Assert.Equal(!value, control.ActiveXInstance != null);
+            Assert.Equal(!value, control.ActiveXInstance is not null);
             Assert.Equal(!value, control.IsHandleCreated);
 
             // Set same.
             control.ScrollBarsEnabled = value;
             Assert.Equal(value, control.ScrollBarsEnabled);
-            Assert.Equal(!value, control.ActiveXInstance != null);
+            Assert.Equal(!value, control.ActiveXInstance is not null);
             Assert.Equal(!value, control.IsHandleCreated);
 
             // Set different.
@@ -2141,7 +2141,7 @@ namespace System.Windows.Forms.Tests
             // Set different.
             control.Visible = !value;
             Assert.Equal(!value, control.Visible);
-            Assert.Equal(!value, control.ActiveXInstance != null);
+            Assert.Equal(!value, control.ActiveXInstance is not null);
             Assert.Equal(!value, control.IsHandleCreated);
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/TextBoxBaseTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/TextBoxBaseTests.cs
@@ -5799,7 +5799,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(1, callCount);
             Assert.Equal(0, clickCallCount);
             Assert.Equal(0, mouseClickCallCount);
-            Assert.Equal(eventArgs != null && eventArgs.Button == MouseButtons.Left, control.IsHandleCreated);
+            Assert.Equal(eventArgs is not null && eventArgs.Button == MouseButtons.Left, control.IsHandleCreated);
 
             // Remove handler.
             control.MouseUp -= handler;
@@ -5807,7 +5807,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(1, callCount);
             Assert.Equal(0, clickCallCount);
             Assert.Equal(0, mouseClickCallCount);
-            Assert.Equal(eventArgs != null && eventArgs.Button == MouseButtons.Left, control.IsHandleCreated);
+            Assert.Equal(eventArgs is not null && eventArgs.Button == MouseButtons.Left, control.IsHandleCreated);
         }
 
         [WinFormsTheory]


### PR DESCRIPTION
Refactors all remaining code to use `is not null` instead of `!= null` using [CSharpIsNull](https://github.com/AArnott/CSharpIsNull) analyzer code fix.

Related: #3459

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8242)