### PR TITLE
Fixed FragmentNavigate issue in ToolStripAccessibleObject

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/StatusStrip.StatusStripAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/StatusStrip.StatusStripAccessibleObject.cs
@@ -28,45 +28,6 @@ namespace System.Windows.Forms
                 }
             }
 
-            internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
-            {
-                if (Owner is not StatusStrip statusStrip || statusStrip.Items.Count == 0)
-                {
-                    return base.FragmentNavigate(direction);
-                }
-
-                switch (direction)
-                {
-                    case UiaCore.NavigateDirection.FirstChild:
-                        AccessibleObject? firstChild;
-                        for (int i = 0; i < GetChildCount(); i++)
-                        {
-                            firstChild = GetChild(i);
-                            if (firstChild is not null && firstChild is not ControlAccessibleObject)
-                            {
-                                return firstChild;
-                            }
-                        }
-
-                        return null;
-
-                    case UiaCore.NavigateDirection.LastChild:
-                        AccessibleObject? lastChild;
-                        for (int i = GetChildCount() - 1; i >= 0; i--)
-                        {
-                            lastChild = GetChild(i);
-                            if (lastChild is not null && lastChild is not ControlAccessibleObject)
-                            {
-                                return lastChild;
-                            }
-                        }
-
-                        return null;
-                }
-
-                return base.FragmentNavigate(direction);
-            }
-
             internal override UiaCore.IRawElementProviderFragment? ElementProviderFromPoint(double x, double y)
                 => Owner.IsHandleCreated ? HitTest((int)x, (int)y) : null;
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripAccessibleObjectTests.cs
@@ -23,6 +23,8 @@ namespace System.Windows.Forms.Tests
         public void ToolStripAccessibleObject_FragmentNavigate_FirstChild_ThumbButton()
         {
             using ToolStrip toolStrip = new ToolStrip();
+            toolStrip.CreateControl();
+
             var accessibleObject = toolStrip.AccessibilityObject;
 
             UiaCore.IRawElementProviderFragment firstChild = accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.FirstChild);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripScrollButton.ToolStripScrollButtonAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripScrollButton.ToolStripScrollButtonAccessibleObjectTests.cs
@@ -43,6 +43,17 @@ namespace System.Windows.Forms.Tests
             dropDownMenu.UpdateDisplayedItems();
 
             AccessibleObject accessibleObject = dropDownMenu.AccessibilityObject;
+
+            Assert.Null(accessibleObject.FragmentNavigate(NavigateDirection.FirstChild));
+            Assert.Null(accessibleObject.FragmentNavigate(NavigateDirection.LastChild));
+
+            if (!createControl)
+            {
+                return;
+            }
+
+            dropDownMenu.CreateControl(fIgnoreVisible: true);
+
             AccessibleObject upScrollButtonAccessibleObject = dropDownMenu.UpScrollButton.AccessibilityObject;
             AccessibleObject itemAccessibleObject1 = dropDownMenu.Items[0].AccessibilityObject;
             AccessibleObject itemAccessibleObject2 = dropDownMenu.Items[1].AccessibilityObject;
@@ -94,6 +105,17 @@ namespace System.Windows.Forms.Tests
             dropDownMenu.UpdateDisplayedItems();
 
             AccessibleObject accessibleObject = dropDownMenu.AccessibilityObject;
+
+            Assert.Null(accessibleObject.FragmentNavigate(NavigateDirection.FirstChild));
+            Assert.Null(accessibleObject.FragmentNavigate(NavigateDirection.LastChild));
+
+            if (!createControl)
+            {
+                return;
+            }
+
+            dropDownMenu.CreateControl(fIgnoreVisible: true);
+
             AccessibleObject itemAccessibleObject1 = dropDownMenu.Items[0].AccessibilityObject;
             AccessibleObject itemAccessibleObject2 = dropDownMenu.Items[1].AccessibilityObject;
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #8033


## Proposed changes

- Removed duplicate items reordering in GetChildFragment and GetChildFragmentIndex methods
- Modified FragmentNavigate to return null if ToolStrip's handle is not created
- Modified unit tests to properly follow handle creation


## Screenshots

Before
![before](https://user-images.githubusercontent.com/113603457/203341899-db7bd315-163b-4f3c-83fa-4b06be0682c7.png)

After
![after](https://user-images.githubusercontent.com/113603457/203341910-7ca6c5f7-0df9-4c35-aca4-80904dbc8f2c.png)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8248)