### PR TITLE
Add Serialization Tests for AxHost

### DIFF
--- a/src/Common/tests/TestUtilities/CustomConverter.cs
+++ b/src/Common/tests/TestUtilities/CustomConverter.cs
@@ -15,7 +15,7 @@ public static class CustomConverter
     public static RegistrationScope RegisterConverter(Type type, TypeConverter converter)
     {
         TypeDescriptionProvider parentProvider = TypeDescriptor.GetProvider(type);
-        TypeDescriptionProvider newProvider = new CustomTypeDescriptionProvider(parentProvider, converter);
+        CustomTypeDescriptionProvider newProvider = new(parentProvider, converter);
         TypeDescriptor.AddProvider(newProvider, type);
         return new RegistrationScope(type, newProvider);
     }
@@ -25,26 +25,18 @@ public static class CustomConverter
     ///  This is meant to be utilized in a <see langword="using"/> statement to ensure
     ///  <see cref="TypeDescriptor.RemoveProvider(TypeDescriptionProvider, Type)"/> is called when going out of scope with the using.
     /// </summary>
-    public ref struct RegistrationScope
+    public readonly ref struct RegistrationScope
     {
         private readonly Type _type;
         private readonly TypeDescriptionProvider _provider;
-        private TypeConverter _converter;
 
         public RegistrationScope(Type type, TypeDescriptionProvider provider)
         {
             _type = type;
             _provider = provider;
-            _converter = TypeDescriptor.GetConverter(type);
         }
 
-        public TypeConverter Converter => _converter;
-
-        public void Dispose()
-        {
-            TypeDescriptor.RemoveProvider(_provider, _type);
-            _converter = null;
-        }
+        public void Dispose() => TypeDescriptor.RemoveProvider(_provider, _type);
     }
 
     public class CustomTypeDescriptionProvider : TypeDescriptionProvider

--- a/src/Common/tests/TestUtilities/CustomConverter.cs
+++ b/src/Common/tests/TestUtilities/CustomConverter.cs
@@ -1,0 +1,67 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+
+namespace System;
+
+public static class CustomConverter
+{
+    /// <summary>
+    ///  Registers a TypeConverter with the specified type.
+    /// </summary>
+    public static RegistrationScope RegisterConverter(Type type, TypeConverter converter)
+    {
+        TypeDescriptionProvider parentProvider = TypeDescriptor.GetProvider(type);
+        TypeDescriptionProvider newProvider = new CustomTypeDescriptionProvider(parentProvider, converter);
+        TypeDescriptor.AddProvider(newProvider, type);
+        return new RegistrationScope(type, newProvider);
+    }
+
+    /// <summary>
+    ///  Manages the registration lifetime of a TypeConverter to a type.
+    ///  This is meant to be utilized in a <see langword="using"/> statement to ensure
+    ///  <see cref="TypeDescriptor.RemoveProvider(TypeDescriptionProvider, Type)"/> is called when going out of scope with the using.
+    /// </summary>
+    public readonly ref struct RegistrationScope
+    {
+        private readonly Type _type;
+        private readonly TypeDescriptionProvider _provider;
+
+        public RegistrationScope(Type type, TypeDescriptionProvider provider)
+        {
+            _type = type;
+            _provider = provider;
+        }
+
+        public void Dispose() => TypeDescriptor.RemoveProvider(_provider, _type);
+    }
+
+    public class CustomTypeDescriptionProvider : TypeDescriptionProvider
+    {
+        private TypeConverter _converter;
+
+        public CustomTypeDescriptionProvider(TypeDescriptionProvider parent, TypeConverter converter) : base(parent)
+        {
+            _converter = converter;
+        }
+
+        public override ICustomTypeDescriptor GetTypeDescriptor(
+            [DynamicallyAccessedMembers((DynamicallyAccessedMemberTypes)(-1))] Type objectType,
+            object instance) => new TypeConverterProvider(base.GetTypeDescriptor(objectType, instance), _converter);
+
+        private class TypeConverterProvider : CustomTypeDescriptor
+        {
+            private static TypeConverter _converter;
+
+            public TypeConverterProvider(ICustomTypeDescriptor parent, TypeConverter converter) : base(parent)
+            {
+                _converter = converter;
+            }
+
+            public override TypeConverter GetConverter() => _converter;
+        }
+    }
+}

--- a/src/Common/tests/TestUtilities/CustomConverter.cs
+++ b/src/Common/tests/TestUtilities/CustomConverter.cs
@@ -25,18 +25,26 @@ public static class CustomConverter
     ///  This is meant to be utilized in a <see langword="using"/> statement to ensure
     ///  <see cref="TypeDescriptor.RemoveProvider(TypeDescriptionProvider, Type)"/> is called when going out of scope with the using.
     /// </summary>
-    public readonly ref struct RegistrationScope
+    public ref struct RegistrationScope
     {
         private readonly Type _type;
         private readonly TypeDescriptionProvider _provider;
+        private TypeConverter _converter;
 
         public RegistrationScope(Type type, TypeDescriptionProvider provider)
         {
             _type = type;
             _provider = provider;
+            _converter = TypeDescriptor.GetConverter(type);
         }
 
-        public void Dispose() => TypeDescriptor.RemoveProvider(_provider, _type);
+        public TypeConverter Converter => _converter;
+
+        public void Dispose()
+        {
+            TypeDescriptor.RemoveProvider(_provider, _type);
+            _converter = null;
+        }
     }
 
     public class CustomTypeDescriptionProvider : TypeDescriptionProvider
@@ -44,9 +52,7 @@ public static class CustomConverter
         private TypeConverter _converter;
 
         public CustomTypeDescriptionProvider(TypeDescriptionProvider parent, TypeConverter converter) : base(parent)
-        {
-            _converter = converter;
-        }
+            => _converter = converter;
 
         public override ICustomTypeDescriptor GetTypeDescriptor(
             [DynamicallyAccessedMembers((DynamicallyAccessedMemberTypes)(-1))] Type objectType,
@@ -57,9 +63,7 @@ public static class CustomConverter
             private static TypeConverter _converter;
 
             public TypeConverterProvider(ICustomTypeDescriptor parent, TypeConverter converter) : base(parent)
-            {
-                _converter = converter;
-            }
+                => _converter = converter;
 
             public override TypeConverter GetConverter() => _converter;
         }

--- a/src/System.Windows.Forms.Design/tests/UnitTests/Properties/launchSettings.json
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "System.Windows.Forms.Design.Tests": {
+      "commandName": "Project",
+      "nativeDebugging": true
+    }
+  }
+}

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System.Windows.Forms.Design.Tests.csproj
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System.Windows.Forms.Design.Tests.csproj
@@ -51,4 +51,13 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <Reference Include="AxInterop.WMPLib">
+      <HintPath>$(ArtifactsBinDir)\AxHosts\$(Configuration)\net472\AxInterop.WMPLib.dll</HintPath>
+    </Reference>
+    <Reference Include="Interop.WMPLib">
+      <HintPath>$(ArtifactsBinDir)\AxHosts\$(Configuration)\net472\Interop.WMPLib.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
 </Project>

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Resources/Tools/StronglyTypedResourceBuilderTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Resources/Tools/StronglyTypedResourceBuilderTests.cs
@@ -626,24 +626,6 @@ public partial class StronglyTypedResourceBuilderTests
         Assert.Equal(expectedUrl, mediaPlayer.URL);
     }
 
-    public class AxHostStateTypeDescriptionProvider : TypeDescriptionProvider
-    {
-        public AxHostStateTypeDescriptionProvider(TypeDescriptionProvider parent) : base(parent)
-        {
-        }
-
-        public override ICustomTypeDescriptor GetTypeDescriptor(
-            [DynamicallyAccessedMembers((DynamicallyAccessedMemberTypes)(-1))] Type objectType,
-            object instance) => new TypeConverterProvider(base.GetTypeDescriptor(objectType, instance));
-
-        private class TypeConverterProvider : CustomTypeDescriptor
-        {
-            private static TypeConverter s_converter = new AxHost.StateConverter();
-            public TypeConverterProvider(ICustomTypeDescriptor parent) : base(parent) { }
-            public override TypeConverter GetConverter() => s_converter;
-        }
-    }
-
     // Utilizes ResourceWriter to save the resources and gets the specified
     // PropertyInfo.
     private static PropertyInfo CompileAndGetPropertyInfo(

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Resources/Tools/StronglyTypedResourceBuilderTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Resources/Tools/StronglyTypedResourceBuilderTests.cs
@@ -335,7 +335,7 @@ public partial class StronglyTypedResourceBuilderTests
             out _);
 
         using ResXResourceReader reader = new(temp.Path);
-        var imagePropertyInfo = compileAndGetPropertyInfo(reader.GetEnumerator(), compileUnit, "Image1");
+        var imagePropertyInfo = CompileAndGetPropertyInfo(reader.GetEnumerator(), compileUnit, "Image1");
         using Bitmap expected = (Bitmap)Image.FromFile(@"Resources\Image1.png");
         ValidateResultBitmap(imagePropertyInfo, expected, TypeDescriptor.GetConverter(typeof(Bitmap)));
     }
@@ -364,7 +364,7 @@ public partial class StronglyTypedResourceBuilderTests
             out _);
 
         using ResXResourceReader reader = new(temp.Path);
-        var imagePropertyInfo = compileAndGetPropertyInfo(reader.GetEnumerator(), compileUnit, "Image1");
+        var imagePropertyInfo = CompileAndGetPropertyInfo(reader.GetEnumerator(), compileUnit, "Image1");
         ValidateResultBitmap(imagePropertyInfo, bitmap, converter);
     }
 
@@ -391,7 +391,7 @@ public partial class StronglyTypedResourceBuilderTests
         resxWriter.Generate();
         resxStream.Position = 0;
         using ResXResourceReader reader = new(resxStream);
-        var imagePropertyInfo = compileAndGetPropertyInfo(reader.GetEnumerator(), compileUnit, "Image1");
+        var imagePropertyInfo = CompileAndGetPropertyInfo(reader.GetEnumerator(), compileUnit, "Image1");
         using Bitmap expected = (Bitmap)Image.FromFile(@"Resources\Image1.png");
         ValidateResultBitmap(imagePropertyInfo, expected, TypeDescriptor.GetConverter(typeof(Bitmap)));
     }
@@ -416,7 +416,7 @@ public partial class StronglyTypedResourceBuilderTests
             out _);
 
         using ResXResourceReader reader = new(temp.Path);
-        var iconPropertyInfo = compileAndGetPropertyInfo(reader.GetEnumerator(), compileUnit, "Icon1");
+        var iconPropertyInfo = CompileAndGetPropertyInfo(reader.GetEnumerator(), compileUnit, "Icon1");
         using Icon expected = new(@"Resources\Icon1.ico");
         ValidateResultIcon(iconPropertyInfo, expected, TypeDescriptor.GetConverter(typeof(Icon)));
     }
@@ -444,7 +444,7 @@ public partial class StronglyTypedResourceBuilderTests
             out _);
 
         using ResXResourceReader reader = new(temp.Path);
-        var iconPropertyInfo = compileAndGetPropertyInfo(reader.GetEnumerator(), compileUnit, "Icon1");
+        var iconPropertyInfo = CompileAndGetPropertyInfo(reader.GetEnumerator(), compileUnit, "Icon1");
         ValidateResultIcon(iconPropertyInfo, icon, converter);
     }
 
@@ -471,7 +471,7 @@ public partial class StronglyTypedResourceBuilderTests
         resxWriter.Generate();
         resxStream.Position = 0;
         using ResXResourceReader reader = new(resxStream);
-        var iconPropertyInfo = compileAndGetPropertyInfo(reader.GetEnumerator(), compileUnit, "Icon1");
+        var iconPropertyInfo = CompileAndGetPropertyInfo(reader.GetEnumerator(), compileUnit, "Icon1");
         using Icon expected = new(@"Resources\Icon1.ico");
         ValidateResultIcon(iconPropertyInfo, expected, TypeDescriptor.GetConverter(typeof(Icon)));
     }
@@ -497,7 +497,7 @@ public partial class StronglyTypedResourceBuilderTests
             out _);
 
         using ResXResourceReader reader = new(temp.Path);
-        ValidateResultTxtFileContent(compileAndGetPropertyInfo(reader.GetEnumerator(), compileUnit, "TextFile1"));
+        ValidateResultTxtFileContent(CompileAndGetPropertyInfo(reader.GetEnumerator(), compileUnit, "TextFile1"));
     }
 
     [Fact]
@@ -527,7 +527,7 @@ public partial class StronglyTypedResourceBuilderTests
         resxWriter.Generate();
         resxStream.Position = 0;
         using ResXResourceReader reader = new(resxStream);
-        ValidateResultTxtFileContent(compileAndGetPropertyInfo(reader.GetEnumerator(), compileUnit, "TextFile1"));
+        ValidateResultTxtFileContent(CompileAndGetPropertyInfo(reader.GetEnumerator(), compileUnit, "TextFile1"));
     }
 
     [Fact]
@@ -550,7 +550,7 @@ public partial class StronglyTypedResourceBuilderTests
             out _);
 
         using ResXResourceReader reader = new(temp.Path);
-        ValidateResultAudio(compileAndGetPropertyInfo(reader.GetEnumerator(), compileUnit, "Audio1"));
+        ValidateResultAudio(CompileAndGetPropertyInfo(reader.GetEnumerator(), compileUnit, "Audio1"));
     }
 
     [Fact]
@@ -576,7 +576,7 @@ public partial class StronglyTypedResourceBuilderTests
         resxWriter.Generate();
         resxStream.Position = 0;
         using ResXResourceReader reader = new(resxStream);
-        ValidateResultAudio(compileAndGetPropertyInfo(reader.GetEnumerator(), compileUnit, "Audio1"));
+        ValidateResultAudio(CompileAndGetPropertyInfo(reader.GetEnumerator(), compileUnit, "Audio1"));
     }
 
     [WinFormsFact]
@@ -614,7 +614,7 @@ public partial class StronglyTypedResourceBuilderTests
             out _);
 
         using ResXResourceReader reader = new(temp.Path);
-        var mediaPlayerPropertyInfo = compileAndGetPropertyInfo(reader.GetEnumerator(), compileUnit, "MediaPlayer1");
+        var mediaPlayerPropertyInfo = CompileAndGetPropertyInfo(reader.GetEnumerator(), compileUnit, "MediaPlayer1");
         byte[] resourceByte = Assert.IsType<byte[]>(mediaPlayerPropertyInfo.GetValue(obj: null));
         AxHost.State state = Assert.IsType<AxHost.State>(scope.Converter.ConvertFrom(resourceByte));
 
@@ -646,7 +646,7 @@ public partial class StronglyTypedResourceBuilderTests
 
     // Utilizes ResourceWriter to save the resources and gets the specified
     // PropertyInfo.
-    private static PropertyInfo compileAndGetPropertyInfo(
+    private static PropertyInfo CompileAndGetPropertyInfo(
         IDictionaryEnumerator resources,
         CodeCompileUnit compileUnit,
         string propertyName)

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Resources/Tools/StronglyTypedResourceBuilderTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Resources/Tools/StronglyTypedResourceBuilderTests.cs
@@ -584,11 +584,9 @@ public partial class StronglyTypedResourceBuilderTests
     {
         // AxHost.StateConverter is not properly registered as a converter for AxHost.State.
         // Temporarily register StateConverter as State's converter and test serialization.
-        TypeConverter converter = TypeDescriptor.GetConverter(typeof(AxHost.State));
-        Assert.Equal(typeof(TypeConverter), converter.GetType());
+        Assert.Equal(typeof(TypeConverter), TypeDescriptor.GetConverter(typeof(AxHost.State)).GetType());
         using var scope = CustomConverter.RegisterConverter(typeof(AxHost.State), new AxHost.StateConverter());
-        converter = TypeDescriptor.GetConverter(typeof(AxHost.State));
-        Assert.Equal(typeof(AxHost.StateConverter), converter.GetType());
+        Assert.Equal(typeof(AxHost.StateConverter), scope.Converter.GetType());
 
         using Form form = new();
         using AxWindowsMediaPlayer mediaPlayer = new();
@@ -599,7 +597,7 @@ public partial class StronglyTypedResourceBuilderTests
         string expectedUrl = $"{Path.GetTempPath()}testurl1";
         mediaPlayer.URL = expectedUrl;
 
-        ResXDataNode node = new("MediaPlayer1", converter.ConvertTo(mediaPlayer.OcxState, typeof(byte[])));
+        ResXDataNode node = new("MediaPlayer1", scope.Converter.ConvertTo(mediaPlayer.OcxState, typeof(byte[])));
         using var temp = TempFile.Create();
         using (ResXResourceWriter resxWriter = new(temp.Path))
         {
@@ -618,7 +616,7 @@ public partial class StronglyTypedResourceBuilderTests
         using ResXResourceReader reader = new(temp.Path);
         var mediaPlayerPropertyInfo = compileAndGetPropertyInfo(reader.GetEnumerator(), compileUnit, "MediaPlayer1");
         byte[] resourceByte = Assert.IsType<byte[]>(mediaPlayerPropertyInfo.GetValue(obj: null));
-        AxHost.State state = Assert.IsType<AxHost.State>(converter.ConvertFrom(resourceByte));
+        AxHost.State state = Assert.IsType<AxHost.State>(scope.Converter.ConvertFrom(resourceByte));
 
         string changedUrl = $"{Path.GetTempPath()}testurl2";
         mediaPlayer.URL = changedUrl;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.State.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.State.cs
@@ -16,8 +16,8 @@ namespace System.Windows.Forms
     public abstract partial class AxHost
     {
         /// <summary>
-        ///  The class which encapsulates the persisted state of the underlying activeX control
-        ///  An instance of this class my be obtained either by calling getOcxState on an
+        ///  The class which encapsulates the persisted state of the underlying activeX control.
+        ///  An instance of this class my be obtained either by calling <see cref="OcxState"/> on an
         ///  AxHost object, or by reading in from a stream.
         /// </summary>
         [TypeConverter(typeof(TypeConverter))]
@@ -36,7 +36,7 @@ namespace System.Windows.Forms
             private const string PropertyBagSerializationName = "PropertyBagBinary";
             private const string DataSerializationName = "Data";
 
-            // Create on save from ipersist stream
+            // Create on save from IPersistStream.
             internal State(MemoryStream memoryStream, int storageType, AxHost control, PropertyBagStream propertyBag)
             {
                 Type = storageType;
@@ -48,10 +48,7 @@ namespace System.Windows.Forms
                 _licenseKey = control.GetLicenseKey();
             }
 
-            internal State(PropertyBagStream propertyBag)
-            {
-                _propertyBag = propertyBag;
-            }
+            internal State(PropertyBagStream propertyBag) => _propertyBag = propertyBag;
 
             // Construct State using StateConverter information.
             // We do not want to save the memoryStream since it contains
@@ -59,7 +56,7 @@ namespace System.Windows.Forms
             // occurs in deserialization constructor.
             internal State(MemoryStream memoryStream) => InitializeFromStream(memoryStream);
 
-            // create on init new w/ storage...
+            // Create on init new with storage.
             internal State(AxHost control)
             {
                 CreateStorage();
@@ -76,7 +73,7 @@ namespace System.Windows.Forms
                 _manualUpdate = manualUpdate;
                 _licenseKey = licKey;
 
-                InitializeBufferFromStream(ms);
+                InitializeFromStream(ms, initializeBufferOnly: true);
             }
 
             /// <summary>
@@ -90,7 +87,7 @@ namespace System.Windows.Forms
                     return;
                 }
 
-                for (; enumerator.MoveNext();)
+                while (enumerator.MoveNext())
                 {
                     if (string.Equals(enumerator.Name, DataSerializationName, StringComparison.InvariantCultureIgnoreCase))
                     {
@@ -99,8 +96,8 @@ namespace System.Windows.Forms
                             byte[]? data = enumerator.Value as byte[];
                             if (data is not null)
                             {
-                                using var datMemoryStream = new MemoryStream(data);
-                                InitializeFromStream(datMemoryStream);
+                                using MemoryStream memoryStream = new(data);
+                                InitializeFromStream(memoryStream);
                             }
                         }
                         catch (Exception e)
@@ -117,8 +114,8 @@ namespace System.Windows.Forms
                             if (data is not null)
                             {
                                 _propertyBag = new PropertyBagStream();
-                                using var datMemoryStream = new MemoryStream(data);
-                                _propertyBag.Read(datMemoryStream);
+                                using MemoryStream memoryStream = new(data);
+                                _propertyBag.Read(memoryStream);
                             }
                         }
                         catch (Exception e)
@@ -221,40 +218,32 @@ namespace System.Windows.Forms
                 return new Ole32.GPStream(_memoryStream);
             }
 
-            private void InitializeFromStream(Stream ids)
+            private void InitializeFromStream(Stream dataStream, bool initializeBufferOnly = false)
             {
-                using var br = new BinaryReader(ids);
+                using BinaryReader binaryReader = new(dataStream);
 
-                Type = br.ReadInt32();
-                int version = br.ReadInt32();
-                _manualUpdate = br.ReadBoolean();
-                int cc = br.ReadInt32();
-                if (cc != 0)
+                if (!initializeBufferOnly)
                 {
-                    _licenseKey = new string(br.ReadChars(cc));
+                    Type = binaryReader.ReadInt32();
+                    int version = binaryReader.ReadInt32();
+                    _manualUpdate = binaryReader.ReadBoolean();
+                    int cc = binaryReader.ReadInt32();
+                    if (cc != 0)
+                    {
+                        _licenseKey = new string(binaryReader.ReadChars(cc));
+                    }
+
+                    for (int skipUnits = binaryReader.ReadInt32(); skipUnits > 0; skipUnits--)
+                    {
+                        int lengthRead = binaryReader.ReadInt32();
+                        dataStream.Position += lengthRead;
+                    }
                 }
 
-                for (int skipUnits = br.ReadInt32(); skipUnits > 0; skipUnits--)
-                {
-                    int len = br.ReadInt32();
-                    ids.Position += len;
-                }
-
-                _length = br.ReadInt32();
+                _length = binaryReader.ReadInt32();
                 if (_length > 0)
                 {
-                    _buffer = br.ReadBytes(_length);
-                }
-            }
-
-            private void InitializeBufferFromStream(Stream ids)
-            {
-                using var br = new BinaryReader(ids);
-
-                _length = br.ReadInt32();
-                if (_length > 0)
-                {
-                    _buffer = br.ReadBytes(_length);
+                    _buffer = binaryReader.ReadBytes(_length);
                 }
             }
 
@@ -309,26 +298,26 @@ namespace System.Windows.Forms
 
             internal void Save(MemoryStream stream)
             {
-                using var bw = new BinaryWriter(stream);
+                using BinaryWriter binaryWriter = new(stream);
 
-                bw.Write(Type);
-                bw.Write(VERSION);
-                bw.Write(_manualUpdate);
+                binaryWriter.Write(Type);
+                binaryWriter.Write(VERSION);
+                binaryWriter.Write(_manualUpdate);
                 if (_licenseKey is not null)
                 {
-                    bw.Write(_licenseKey.Length);
-                    bw.Write(_licenseKey.ToCharArray());
+                    binaryWriter.Write(_licenseKey.Length);
+                    binaryWriter.Write(_licenseKey.ToCharArray());
                 }
                 else
                 {
-                    bw.Write(0);
+                    binaryWriter.Write(0);
                 }
 
-                bw.Write(0); // skip units
-                bw.Write(_length);
+                binaryWriter.Write(0); // skip units
+                binaryWriter.Write(_length);
                 if (_buffer is not null)
                 {
-                    bw.Write(_buffer);
+                    binaryWriter.Write(_buffer);
                 }
                 else if (_memoryStream is not null)
                 {
@@ -344,20 +333,20 @@ namespace System.Windows.Forms
             /// <summary>
             ///  ISerializable private implementation
             /// </summary>
-            void ISerializable.GetObjectData(SerializationInfo si, StreamingContext context)
+            void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
             {
-                using var stream = new MemoryStream();
+                using MemoryStream stream = new();
                 Save(stream);
 
-                si.AddValue(DataSerializationName, stream.ToArray());
+                info.AddValue(DataSerializationName, stream.ToArray());
 
                 if (_propertyBag is not null)
                 {
                     try
                     {
-                        using var propertyBagBinaryStream = new MemoryStream();
+                        using MemoryStream propertyBagBinaryStream = new();
                         _propertyBag.Write(propertyBagBinaryStream);
-                        si.AddValue(PropertyBagSerializationName, propertyBagBinaryStream.ToArray());
+                        info.AddValue(PropertyBagSerializationName, propertyBagBinaryStream.ToArray());
                     }
                     catch (Exception e)
                     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.State.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.State.cs
@@ -53,12 +53,11 @@ namespace System.Windows.Forms
                 _propertyBag = propertyBag;
             }
 
-            internal State(MemoryStream memoryStream)
-            {
-                _memoryStream = memoryStream;
-                _length = (int)memoryStream.Length;
-                InitializeFromStream(memoryStream);
-            }
+            // Construct State using StateConverter information.
+            // We do not want to save the memoryStream since it contains
+            // extra information to construct the State. This same scenario
+            // occurs in deserialization constructor.
+            internal State(MemoryStream memoryStream) => InitializeFromStream(memoryStream);
 
             // create on init new w/ storage...
             internal State(AxHost control)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.StateConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.StateConverter.cs
@@ -15,38 +15,15 @@ namespace System.Windows.Forms
         /// </summary>
         public class StateConverter : TypeConverter
         {
-            /// <summary>
-            ///  Gets a value indicating whether this converter can
-            ///  convert an object in the given source type to the native type of the converter
-            ///  using the context.
-            /// </summary>
+            /// <inheritdoc/>
             public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType)
-            {
-                if (sourceType == typeof(byte[]))
-                {
-                    return true;
-                }
+                => sourceType == typeof(byte[]) || base.CanConvertFrom(context, sourceType);
 
-                return base.CanConvertFrom(context, sourceType);
-            }
-
-            /// <summary>
-            ///  Gets a value indicating whether this converter can
-            ///  convert an object to the given destination type using the context.
-            /// </summary>
+            /// <inheritdoc/>
             public override bool CanConvertTo(ITypeDescriptorContext? context, Type? destinationType)
-            {
-                if (destinationType == typeof(byte[]))
-                {
-                    return true;
-                }
+                => destinationType == typeof(byte[]) || base.CanConvertTo(context, destinationType);
 
-                return base.CanConvertTo(context, destinationType);
-            }
-
-            /// <summary>
-            ///  Converts the given object to the converter's native type.
-            /// </summary>
+            /// <inheritdoc/>
             public override object? ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object value)
             {
                 if (value is byte[] valueAsBytes)
@@ -58,30 +35,24 @@ namespace System.Windows.Forms
                 return base.ConvertFrom(context, culture, value);
             }
 
-            /// <summary>
-            ///  Converts the given object to another type.  The most common types to convert
-            ///  are to and from a string object.  The default implementation will make a call
-            ///  to ToString on the object if the object is valid and if the destination
-            ///  type is string.  If this cannot convert to the destination type, this will
-            ///  throw a NotSupportedException.
-            /// </summary>
+            /// <inheritdoc/>
             public override object? ConvertTo(ITypeDescriptorContext? context, CultureInfo? culture, object? value, Type destinationType)
             {
                 ArgumentNullException.ThrowIfNull(destinationType);
 
                 if (destinationType == typeof(byte[]))
                 {
-                    if (value is not null)
-                    {
-                        using MemoryStream ms = new MemoryStream();
-                        State state = (State)value;
-                        state.Save(ms);
-                        ms.Close();
-                        return ms.ToArray();
-                    }
-                    else
+                    if (value is null)
                     {
                         return Array.Empty<byte>();
+                    }
+
+                    if (value is State state)
+                    {
+                        using MemoryStream memoryStream = new();
+                        state.Save(memoryStream);
+                        memoryStream.Close();
+                        return memoryStream.ToArray();
                     }
                 }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.StateConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.StateConverter.cs
@@ -47,13 +47,15 @@ namespace System.Windows.Forms
                         return Array.Empty<byte>();
                     }
 
-                    if (value is State state)
+                    if (value is not State state)
                     {
-                        using MemoryStream memoryStream = new();
-                        state.Save(memoryStream);
-                        memoryStream.Close();
-                        return memoryStream.ToArray();
+                        throw GetConvertToException(value, destinationType);
                     }
+
+                    using MemoryStream memoryStream = new();
+                    state.Save(memoryStream);
+                    memoryStream.Close();
+                    return memoryStream.ToArray();
                 }
 
                 return base.ConvertTo(context, culture, value, destinationType);

--- a/src/System.Windows.Forms/tests/UnitTests/System.Windows.Forms.Tests.csproj
+++ b/src/System.Windows.Forms/tests/UnitTests/System.Windows.Forms.Tests.csproj
@@ -36,6 +36,9 @@
     <Content Include="bitmaps\*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <None Include="..\AxHosts\AxHosts.resx" Link="Resources\AxHosts.resx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <EmbeddedResource Include="bitmaps\10x16_one_entry_32bit.ico">
       <LogicalName>System.Windows.Forms.Design.Tests.CustomPropertyTab</LogicalName>
     </EmbeddedResource>
@@ -54,6 +57,10 @@
     <Reference Include="Interop.WMPLib">
       <HintPath>$(ArtifactsBinDir)\AxHosts\$(Configuration)\net472\Interop.WMPLib.dll</HintPath>
     </Reference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Resources\" />
   </ItemGroup>
 
 </Project>

--- a/src/System.Windows.Forms/tests/UnitTests/System.Windows.Forms.Tests.csproj
+++ b/src/System.Windows.Forms/tests/UnitTests/System.Windows.Forms.Tests.csproj
@@ -47,4 +47,13 @@
     </EmbeddedResource>
   </ItemGroup>
 
+  <ItemGroup>
+    <Reference Include="AxInterop.WMPLib">
+      <HintPath>$(ArtifactsBinDir)\AxHosts\$(Configuration)\net472\AxInterop.WMPLib.dll</HintPath>
+    </Reference>
+    <Reference Include="Interop.WMPLib">
+      <HintPath>$(ArtifactsBinDir)\AxHosts\$(Configuration)\net472\Interop.WMPLib.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
 </Project>

--- a/src/System.Windows.Forms/tests/UnitTests/System/Resources/ResXResourceReaderTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Resources/ResXResourceReaderTests.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Windows.Forms;
+using Xunit;
+
+namespace System.Resources.Tests
+{
+    public class ResXResourceReaderTests : IClassFixture<ThreadExceptionFixture>
+    {
+        [Fact]
+        public void ResXResourceReader_Deserialize_AxHost_Success_ResourceWriter_Throws()
+        {
+            string resxPath = Path.GetFullPath(@".\Resources\AxHosts.resx");
+            using MemoryStream resourceStream = new();
+            // ResourceWriter Dispose calls Generate method which will throw.
+            Assert.Throws<PlatformNotSupportedException>(() =>
+            {
+                using ResourceWriter resourceWriter = new(resourceStream);
+                using ResXResourceReader resxReader = new(resxPath);
+                var enumerator = resxReader.GetEnumerator();
+
+                Assert.True(enumerator.MoveNext());
+                string key = enumerator.Key.ToString();
+                object value = enumerator.Value;
+                Assert.Equal("axWindowsMediaPlayer1.OcxState", key);
+                Assert.Equal(typeof(AxHost.State), value.GetType());
+                Assert.False(enumerator.MoveNext());
+
+                resourceWriter.AddResource(key, value);
+                // ResourceWriter no longer supports BinaryFormatter in core.
+                Assert.Throws<PlatformNotSupportedException>(resourceWriter.Generate);
+            });
+        }
+    }
+}


### PR DESCRIPTION
- Minor clean ups for `State` and `StateConverter`
- Add serialization test for `AxHost` using `BinaryFormatter`
- Add test for serializing `AxHost` using `StronglyTypedResourceBuilder`
    - `StateConverter` was never hooked up properly so manually register `StateConverter` as the `TypeConverter` for `State` using `CustomConverter` class
    - Fix `State` constructor utilized by `StateConverter` to not save the passed in stream since extra information to build the State is contained in it.
- Add test for `ResXResourceReader` verifying AxHosts can be deserialized from resx file

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8251)