### PR TITLE
[release/7.0] Fix setting Form.Owner in Form.Show/ShowDialog(IWin32Window owner) if owner is a Control 

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -5178,7 +5178,7 @@ namespace System.Windows.Forms
                 throw new InvalidOperationException(SR.CantShowModalOnNonInteractive);
             }
 
-            if ((owner is not null) && owner.GetExtendedStyle().HasFlag(User32.WS_EX.TOPMOST))
+            if ((owner is not null) && !owner.GetExtendedStyle().HasFlag(User32.WS_EX.TOPMOST))
             {
                 // It's not the top-most window
                 if (owner is Control ownerControl)
@@ -5253,7 +5253,7 @@ namespace System.Windows.Forms
                 throw new InvalidOperationException(SR.CantShowModalOnNonInteractive);
             }
 
-            if ((owner is not null) && owner.GetExtendedStyle().HasFlag(User32.WS_EX.TOPMOST))
+            if ((owner is not null) && !owner.GetExtendedStyle().HasFlag(User32.WS_EX.TOPMOST))
             {
                 // It's not the top-most window
                 if (owner is Control ownerControl)

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FormTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FormTests.cs
@@ -2572,6 +2572,49 @@ namespace System.Windows.Forms.Tests
             Assert.True(control.IsHandleCreated);
         }
 
+        [WinFormsFact]
+        public void Form_Show_SetsOwnerToTopLevelForm_WhenShownWithControlAsOwner()
+        {
+            using Form parent = new();
+            using Control control = new();
+            parent.Controls.Add(control);
+            parent.Show();
+            using Form form = new();
+            Form owner = null;
+            form.Load += (object sender, EventArgs e) =>
+            {
+                owner = ((Form)sender).Owner;
+                form.Close();
+            };
+
+            form.Show(owner: control);
+
+            Assert.Same(owner, parent);
+            Assert.False(form.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void Form_ShowDialog_SetsOwnerToTopLevelForm_WhenShownWithControlAsOwner()
+        {
+            using Form parent = new();
+            using Control control = new();
+            parent.Controls.Add(control);
+            parent.Show();
+
+            using Form form = new();
+            Form owner = null;
+            form.Load += (object sender, EventArgs e) =>
+            {
+                owner = ((Form)sender).Owner;
+                form.Close();
+            };
+
+            form.ShowDialog(owner: control);
+
+            Assert.Same(owner, parent);
+            Assert.False(form.IsHandleCreated);
+        }
+
         public class SubForm : Form
         {
             public new const int ScrollStateAutoScrolling = Form.ScrollStateAutoScrolling;


### PR DESCRIPTION
Backport of https://github.com/dotnet/winforms/pull/8283 to release/7.0
Fixes #8280

Form.Show/ShowDialog(IWin32Window owner) method should set form's Owner property, however this logic had been inadvertently inverted for not TOPLEVEL windows during refactoring (#5791) and form owner property would be `null`. This fix restores the previous logic.

## Servicing reasons

- `null` owner property might lead to window shown on an incorrect desktop or in the wrong place.
- This regression may cause serious UI issues described in https://github.com/dotnet/winforms/issues/8280, to the point of being a ship blocker.

## Proposed changes

- Check if owner doesn't have a `TOPMOST` style to correctly initialize it with a top-level Control in this case

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Owner property will be correctly set for a form if it was shown with a Control as owner

## Regression? 

- Yes in 7.0 Preview1

## Risk

- Minimal - restores previous behavior and customer confirmed it resolves their issue

<!-- end TELL-MODE -->


## Test methodology <!-- How did you ensure quality? -->

- Unit test
- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- .NET 7.0


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8289)