### PR TITLE
Fix double scaling for scrollbars

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -3268,7 +3268,6 @@ override System.Windows.Forms.ScrollBar.GetScaledBounds(System.Drawing.Rectangle
 override System.Windows.Forms.ScrollBar.OnEnabledChanged(System.EventArgs! e) -> void
 override System.Windows.Forms.ScrollBar.OnHandleCreated(System.EventArgs! e) -> void
 override System.Windows.Forms.ScrollBar.OnMouseWheel(System.Windows.Forms.MouseEventArgs! e) -> void
-override System.Windows.Forms.ScrollBar.RescaleConstantsForDpi(int deviceDpiOld, int deviceDpiNew) -> void
 override System.Windows.Forms.ScrollBar.Text.get -> string!
 override System.Windows.Forms.ScrollBar.Text.set -> void
 override System.Windows.Forms.ScrollBar.ToString() -> string!

--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -6,6 +6,7 @@ System.Windows.Forms.PrintPreviewControl.TabStopChanged -> System.EventHandler?
 override System.Windows.Forms.MaskedTextBox.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject!
 override System.Windows.Forms.MaskedTextBox.OnGotFocus(System.EventArgs! e) -> void
 override System.Windows.Forms.MaskedTextBox.OnMouseDown(System.Windows.Forms.MouseEventArgs! e) -> void
+override System.Windows.Forms.ScrollBar.ScaleControl(System.Drawing.SizeF factor, System.Windows.Forms.BoundsSpecified specified) -> void
 override System.Windows.Forms.TextBox.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject!
 virtual System.Windows.Forms.AxHost.State.Dispose(bool disposing) -> void
 *REMOVED*override System.Windows.Forms.DomainUpDown.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject!

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ScrollBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ScrollBar.cs
@@ -131,14 +131,15 @@ namespace System.Windows.Forms
 
         protected override Padding DefaultMargin => Padding.Empty;
 
-        protected override void RescaleConstantsForDpi(int deviceDpiOld, int deviceDpiNew)
+        protected override void ScaleControl(SizeF factor, BoundsSpecified specified)
         {
-            base.RescaleConstantsForDpi(deviceDpiOld, deviceDpiNew);
-
-            if (ScaleScrollBarForDpiChange)
+            // Skip scaling if opted out.
+            if (!ScaleScrollBarForDpiChange)
             {
-                Scale((float)deviceDpiNew / deviceDpiOld);
+                return;
             }
+
+            base.ScaleControl(factor, specified);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #8270

in .NET 6, we streamlined scaling of child controls to use `AutScaleFactor` in PMv2 mode applications. This is a change from .NET framework, where we were scaling child controls with DPI factor even when `AutoScaleMode` was `Font`. As a result, scaling is centralized under `OnParentFontChanged` event and any controls that were doing explicit scaling in `RescaleConstants` method become redundant in .NET.

When it comes to `ScrollBars`, we added public property in .NET Framework 4.8 to let developer's opt-in/out of DPI scaling for scroll bars. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8312)