### PR TITLE
Update to the latest CsWin32.

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -46,7 +46,7 @@
       Microsoft.NET.Sdk.IL.targets requires definition of MicrosoftNETCoreILAsmVersion
     -->
     <MicrosoftNETCoreILAsmVersion>$(MicrosoftNETCoreILAsmPackageVersion)</MicrosoftNETCoreILAsmVersion>
-    <MicrosoftWindowsCsWin32PackageVersion>0.2.138-beta</MicrosoftWindowsCsWin32PackageVersion>
+    <MicrosoftWindowsCsWin32PackageVersion>0.2.162-beta</MicrosoftWindowsCsWin32PackageVersion>
   </PropertyGroup>
   <!-- Docs / Intellisense -->
   <PropertyGroup>

--- a/src/System.Windows.Forms.Primitives/src/Interop/OleAut32/Interop.VARIANT.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/OleAut32/Interop.VARIANT.cs
@@ -218,7 +218,7 @@ internal unsafe partial struct VARIANT : IDisposable
     private static Type GetRecordElementType(IRecordInfo* record)
     {
         Guid guid;
-        record->GetGuid(&guid).ThrowOnFailure();
+        record->GetGuid(&guid);
 
         Type? t = global::System.Type.GetTypeFromCLSID(guid);
         if (t is null || !t.IsValueType)

--- a/src/System.Windows.Forms.Primitives/src/NativeMethods.json
+++ b/src/System.Windows.Forms.Primitives/src/NativeMethods.json
@@ -1,5 +1,20 @@
 {
   "$schema": "https://aka.ms/CsWin32.schema.json",
   "allowMarshaling": false,
-  "useSafeHandles": false
+  "useSafeHandles": false,
+  "comInterop": {
+    "preserveSigMethods": [
+      "IAutoComplete2.SetOptions",
+      "IDispatch.Invoke",
+      "IFileDialog.Show",
+      "IFileDialog.GetResult",
+      "IFileOpenDialog.GetResults",
+      "IFileOpenDialog.Show",
+      "IGlobalInterfaceTable.GetInterfaceFromGlobal",
+      "IGlobalInterfaceTable.RevokeInterfaceFromGlobal",
+      "IStorage.CreateStream",
+      "IStorage.OpenStream",
+      "IUnknown.QueryInterface"
+    ]
+  }
 }

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/FileDialogCustomPlacesCollection.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/FileDialogCustomPlacesCollection.cs
@@ -16,7 +16,7 @@ namespace System.Windows.Forms
                 using ComScope<IShellItem> shellItem = new(customPlace.GetNativePath());
                 if (!shellItem.IsNull)
                 {
-                    dialog->AddPlace(shellItem, 0).ThrowOnFailure();
+                    dialog->AddPlace(shellItem, 0);
                 }
             }
         }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/Foundation/GlobalInterfaceTable.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/Foundation/GlobalInterfaceTable.cs
@@ -40,7 +40,7 @@ namespace Windows.Win32.Foundation
             s_globalInterfaceTable->RegisterInterfaceInGlobal(
                 (IUnknown*)@interface,
                 IID.Get<TInterface>(),
-                &cookie).ThrowOnFailure();
+                &cookie);
             return cookie;
         }
 

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Ole/IPicture.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Ole/IPicture.cs
@@ -48,7 +48,7 @@ internal unsafe partial struct IPicture
             PICTYPE type = (PICTYPE)picture->Type;
             if (type == PICTYPE.PICTYPE_BITMAP)
             {
-                picture->get_hPal(&paletteHandle).ThrowOnFailure();
+                paletteHandle = picture->hPal;
             }
 
             return OLE_HANDLE.OleHandleToImage(picture->Handle, type, paletteHandle, picture->Width, picture->Height);

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/Interop/Oleaut32/IDispatchTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/Interop/Oleaut32/IDispatchTests.cs
@@ -27,8 +27,7 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.Oleaut32
                 fixed (int* pRgDispId = rgDispId)
                 fixed (PWSTR* pRgszNames = rgszNames)
                 {
-                    HRESULT hr = picture.Value->GetIDsOfNames(&riid, pRgszNames, (uint)rgszNames.Length, PInvoke.GetThreadLocale(), pRgDispId);
-                    Assert.Equal(HRESULT.S_OK, hr);
+                    picture.Value->GetIDsOfNames(&riid, pRgszNames, (uint)rgszNames.Length, PInvoke.GetThreadLocale(), pRgDispId);
                     Assert.Equal(new PWSTR[] { width, other }, rgszNames);
                     
                     Assert.Equal(new int[] { (int)PInvoke.DISPID_PICT_WIDTH, PInvoke.DISPID_UNKNOWN }, rgDispId);
@@ -44,8 +43,7 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.Oleaut32
             Assert.False(picture.IsNull);
 
             using ComScope<ITypeInfo> typeInfo = new(null);
-            HRESULT hr = picture.Value->GetTypeInfo(0, PInvoke.GetThreadLocale(), typeInfo);
-            Assert.Equal(HRESULT.S_OK, hr);
+            picture.Value->GetTypeInfo(0, PInvoke.GetThreadLocale(), typeInfo);
         }
 
         [StaFact]
@@ -56,8 +54,7 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.Oleaut32
             Assert.False(picture.IsNull);
 
             uint ctInfo = uint.MaxValue;
-            HRESULT hr = picture.Value->GetTypeInfoCount(&ctInfo);
-            Assert.Equal(HRESULT.S_OK, hr);
+            picture.Value->GetTypeInfoCount(&ctInfo);
             Assert.Equal(1u, ctInfo);
         }
 

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/Interop/Oleaut32/ITypeInfoTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/Interop/Oleaut32/ITypeInfoTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Drawing;
+using System.Runtime.InteropServices;
 using Windows.Win32.System.Com;
 using Windows.Win32.System.Ole;
 
@@ -18,12 +19,20 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.Oleaut32
             using var iPictureDisp = IPictureDisp.CreateFromImage(image);
             Assert.False(iPictureDisp.IsNull);
             using ComScope<ITypeInfo> typeInfo = new(null);
-            HRESULT hr = ((IDispatch*)iPictureDisp.Value)->GetTypeInfo(0, PInvoke.GetThreadLocale(), typeInfo);
-            Assert.Equal(HRESULT.S_OK, hr);
+            ((IDispatch*)iPictureDisp.Value)->GetTypeInfo(0, PInvoke.GetThreadLocale(), typeInfo);
 
-            void* pv;
-            hr = typeInfo.Value->AddressOfMember(6, INVOKEKIND.INVOKE_FUNC, &pv);
-            Assert.Equal(HRESULT.TYPE_E_BADMODULEKIND, hr);
+            try
+            {
+                void* pvObj;
+                typeInfo.Value->AddressOfMember(6, INVOKEKIND.INVOKE_FUNC, &pvObj);
+            }
+            catch (COMException ex)
+            {
+                Assert.Equal((int)HRESULT.TYPE_E_BADMODULEKIND, ex.HResult);
+                return;
+            }
+
+            Assert.Fail("Exception was not thrown");
         }
 
         [StaFact]
@@ -33,12 +42,20 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.Oleaut32
             using var iPictureDisp = IPictureDisp.CreateFromImage(image);
             Assert.False(iPictureDisp.IsNull);
             using ComScope<ITypeInfo> typeInfo = new(null);
-            HRESULT hr = ((IDispatch*)iPictureDisp.Value)->GetTypeInfo(0, PInvoke.GetThreadLocale(), typeInfo);
-            Assert.Equal(HRESULT.S_OK, hr);
+            ((IDispatch*)iPictureDisp.Value)->GetTypeInfo(0, PInvoke.GetThreadLocale(), typeInfo);
 
-            void* pvObj = null;
-            hr = typeInfo.Value->CreateInstance(null, IID.Get<IPictureDisp>(), &pvObj);
-            Assert.Equal(HRESULT.TYPE_E_BADMODULEKIND, hr);
+            try
+            {
+                void* pvObj;
+                typeInfo.Value->CreateInstance(null, IID.Get<IPictureDisp>(), &pvObj);
+            }
+            catch (COMException ex)
+            {
+                Assert.Equal((int)HRESULT.TYPE_E_BADMODULEKIND, ex.HResult);
+                return;
+            }
+
+            Assert.Fail("Exception was not thrown");
         }
 
         [StaFact]
@@ -48,14 +65,12 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.Oleaut32
             using var iPictureDisp = IPictureDisp.CreateFromImage(image);
             Assert.False(iPictureDisp.IsNull);
             using ComScope<ITypeInfo> typeInfo = new(null);
-            HRESULT hr = ((IDispatch*)iPictureDisp.Value)->GetTypeInfo(0, PInvoke.GetThreadLocale(), typeInfo);
-            Assert.Equal(HRESULT.S_OK, hr);
+            ((IDispatch*)iPictureDisp.Value)->GetTypeInfo(0, PInvoke.GetThreadLocale(), typeInfo);
 
             using ComScope<ITypeLib> typeLib = new(null);
             uint index = uint.MaxValue;
-            hr = typeInfo.Value->GetContainingTypeLib(typeLib, &index);
+            typeInfo.Value->GetContainingTypeLib(typeLib, &index);
 
-            Assert.Equal(HRESULT.S_OK, hr);
             Assert.NotEqual(0u, index);
         }
 
@@ -66,17 +81,26 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.Oleaut32
             using var iPictureDisp = IPictureDisp.CreateFromImage(image);
             Assert.False(iPictureDisp.IsNull);
             using ComScope<ITypeInfo> typeInfo = new(null);
-            HRESULT hr = ((IDispatch*)iPictureDisp.Value)->GetTypeInfo(0, PInvoke.GetThreadLocale(), typeInfo);
-            Assert.Equal(HRESULT.S_OK, hr);
+            ((IDispatch*)iPictureDisp.Value)->GetTypeInfo(0, PInvoke.GetThreadLocale(), typeInfo);
 
             using BSTR dllName = new("DllName");
             using BSTR name = new("Name");
             ushort wOrdinal = ushort.MaxValue;
-            hr = typeInfo.Value->GetDllEntry(6, INVOKEKIND.INVOKE_FUNC, &dllName, &name, &wOrdinal);
-            Assert.Equal(HRESULT.TYPE_E_BADMODULEKIND, hr);
-            Assert.True(dllName.Length == 0);
-            Assert.True(name.Length == 0);
-            Assert.Equal(0u, wOrdinal);
+
+            try
+            {
+                typeInfo.Value->GetDllEntry(6, INVOKEKIND.INVOKE_FUNC, &dllName, &name, &wOrdinal);
+            }
+            catch (COMException ex)
+            {
+                Assert.Equal((int)HRESULT.TYPE_E_BADMODULEKIND, ex.HResult);
+                Assert.True(dllName.Length == 0);
+                Assert.True(name.Length == 0);
+                Assert.Equal(0u, wOrdinal);
+                return;
+            }
+
+            Assert.Fail("Exception was not thrown");
         }
 
         [StaFact]
@@ -86,15 +110,13 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.Oleaut32
             using var iPictureDisp = IPictureDisp.CreateFromImage(image);
             Assert.False(iPictureDisp.IsNull);
             using ComScope<ITypeInfo> typeInfo = new(null);
-            HRESULT hr = ((IDispatch*)iPictureDisp.Value)->GetTypeInfo(0, PInvoke.GetThreadLocale(), typeInfo);
-            Assert.Equal(HRESULT.S_OK, hr);
+            ((IDispatch*)iPictureDisp.Value)->GetTypeInfo(0, PInvoke.GetThreadLocale(), typeInfo);
 
             using BSTR name = new("Name");
             using BSTR docString = new("DocString");
             uint dwHelpContext = uint.MaxValue;
             using BSTR helpFile = new("HelpFile");
-            hr = typeInfo.Value->GetDocumentation(4, &name, &docString, &dwHelpContext, &helpFile);
-            Assert.Equal(HRESULT.S_OK, hr);
+            typeInfo.Value->GetDocumentation(4, &name, &docString, &dwHelpContext, &helpFile);
             Assert.Equal("Width", name.ToString());
             Assert.True(docString.Length == 0);
             Assert.Equal(0u, dwHelpContext);
@@ -108,14 +130,12 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.Oleaut32
             using var iPictureDisp = IPictureDisp.CreateFromImage(image);
             Assert.False(iPictureDisp.IsNull);
             using ComScope<ITypeInfo> typeInfo = new(null);
-            HRESULT hr = ((IDispatch*)iPictureDisp.Value)->GetTypeInfo(0, PInvoke.GetThreadLocale(), typeInfo);
-            Assert.Equal(HRESULT.S_OK, hr);
+            ((IDispatch*)iPictureDisp.Value)->GetTypeInfo(0, PInvoke.GetThreadLocale(), typeInfo);
 
             FUNCDESC* pFuncDesc = null;
             try
             {
-                hr = typeInfo.Value->GetFuncDesc(0, &pFuncDesc);
-                Assert.Equal(HRESULT.S_OK, hr);
+                typeInfo.Value->GetFuncDesc(0, &pFuncDesc);
                 Assert.Equal(6, pFuncDesc->memid);
                 Assert.True(pFuncDesc->lprgscode is null);
                 Assert.NotEqual(IntPtr.Zero, (IntPtr)pFuncDesc->lprgelemdescParam);
@@ -144,8 +164,7 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.Oleaut32
             using var iPictureDisp = IPictureDisp.CreateFromImage(image);
             Assert.False(iPictureDisp.IsNull);
             using ComScope<ITypeInfo> typeInfo = new(null);
-            HRESULT hr = ((IDispatch*)iPictureDisp.Value)->GetTypeInfo(0, PInvoke.GetThreadLocale(), typeInfo);
-            Assert.Equal(HRESULT.S_OK, hr);
+            ((IDispatch*)iPictureDisp.Value)->GetTypeInfo(0, PInvoke.GetThreadLocale(), typeInfo);
 
             fixed (char* width = "Width")
             fixed (char* other = "Other")
@@ -155,8 +174,7 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.Oleaut32
                 fixed (PWSTR* pRgszNames = rgszNames)
                 fixed (int* pRgDispId = rgDispId)
                 {
-                    hr = typeInfo.Value->GetIDsOfNames(pRgszNames, (uint)rgszNames.Length, pRgDispId);
-                    Assert.Equal(HRESULT.S_OK, hr);
+                    typeInfo.Value->GetIDsOfNames(pRgszNames, (uint)rgszNames.Length, pRgDispId);
                     Assert.Equal(new PWSTR[] { width, other }, rgszNames);
                     Assert.Equal(new int[] { (int)PInvoke.DISPID_PICT_WIDTH, PInvoke.DISPID_UNKNOWN }, rgDispId);
                 }
@@ -170,12 +188,10 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.Oleaut32
             using var iPictureDisp = IPictureDisp.CreateFromImage(image);
             Assert.False(iPictureDisp.IsNull);
             using ComScope<ITypeInfo> typeInfo = new(null);
-            HRESULT hr = ((IDispatch*)iPictureDisp.Value)->GetTypeInfo(0, PInvoke.GetThreadLocale(), typeInfo);
-            Assert.Equal(HRESULT.S_OK, hr);
+            ((IDispatch*)iPictureDisp.Value)->GetTypeInfo(0, PInvoke.GetThreadLocale(), typeInfo);
 
             int implTypeFlags = -1;
-            hr = typeInfo.Value->GetImplTypeFlags(0, &implTypeFlags);
-            Assert.Equal(HRESULT.S_OK, hr);
+            typeInfo.Value->GetImplTypeFlags(0, &implTypeFlags);
             Assert.NotEqual((int)IMPLTYPEFLAGS.IMPLTYPEFLAG_FDEFAULT, implTypeFlags);
         }
 
@@ -186,12 +202,10 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.Oleaut32
             using var iPictureDisp = IPictureDisp.CreateFromImage(image);
             Assert.False(iPictureDisp.IsNull);
             using ComScope<ITypeInfo> typeInfo = new(null);
-            HRESULT hr = ((IDispatch*)iPictureDisp.Value)->GetTypeInfo(0, PInvoke.GetThreadLocale(), typeInfo);
-            Assert.Equal(HRESULT.S_OK, hr);
+            ((IDispatch*)iPictureDisp.Value)->GetTypeInfo(0, PInvoke.GetThreadLocale(), typeInfo);
 
             using BSTR mops = new("Mops");
-            hr = typeInfo.Value->GetMops(4, &mops);
-            Assert.Equal(HRESULT.S_OK, hr);
+            typeInfo.Value->GetMops(4, &mops);
             Assert.True(mops.Length == 0);
         }
 
@@ -202,15 +216,13 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.Oleaut32
             using var iPictureDisp = IPictureDisp.CreateFromImage(image);
             Assert.False(iPictureDisp.IsNull);
             using ComScope<ITypeInfo> typeInfo = new(null);
-            HRESULT hr = ((IDispatch*)iPictureDisp.Value)->GetTypeInfo(0, PInvoke.GetThreadLocale(), typeInfo);
-            Assert.Equal(HRESULT.S_OK, hr);
+            ((IDispatch*)iPictureDisp.Value)->GetTypeInfo(0, PInvoke.GetThreadLocale(), typeInfo);
 
             BSTR* rgszNames = stackalloc BSTR[2];
             rgszNames[0] = new BSTR("Name1");
             rgszNames[1] = new BSTR("Name2");
             uint cNames = 0;
-            hr = typeInfo.Value->GetNames(4, rgszNames, 2u, &cNames);
-            Assert.Equal(HRESULT.S_OK, hr);
+            typeInfo.Value->GetNames(4, rgszNames, 2u, &cNames);
             Assert.Equal("Width", rgszNames[0].ToString());
             Assert.Equal("Name2", rgszNames[1].ToString());
             Assert.Equal(1u, cNames);
@@ -226,17 +238,14 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.Oleaut32
             using var iPictureDisp = IPictureDisp.CreateFromImage(image);
             Assert.False(iPictureDisp.IsNull);
             using ComScope<ITypeInfo> typeInfo = new(null);
-            HRESULT hr = ((IDispatch*)iPictureDisp.Value)->GetTypeInfo(0, PInvoke.GetThreadLocale(), typeInfo);
-            Assert.Equal(HRESULT.S_OK, hr);
+            ((IDispatch*)iPictureDisp.Value)->GetTypeInfo(0, PInvoke.GetThreadLocale(), typeInfo);
 
             uint refType = uint.MaxValue;
-            hr = typeInfo.Value->GetRefTypeOfImplType(0, &refType);
-            Assert.Equal(HRESULT.S_OK, hr);
+            typeInfo.Value->GetRefTypeOfImplType(0, &refType);
             Assert.NotEqual(0u, refType);
 
             using ComScope<ITypeInfo> refTypeInfo = new(null);
-            hr = typeInfo.Value->GetRefTypeInfo(refType, refTypeInfo);
-            Assert.Equal(HRESULT.S_OK, hr);
+            typeInfo.Value->GetRefTypeInfo(refType, refTypeInfo);
         }
 
         [StaFact]
@@ -246,12 +255,10 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.Oleaut32
             using var iPictureDisp = IPictureDisp.CreateFromImage(image);
             Assert.False(iPictureDisp.IsNull);
             using ComScope<ITypeInfo> typeInfo = new(null);
-            HRESULT hr = ((IDispatch*)iPictureDisp.Value)->GetTypeInfo(0, PInvoke.GetThreadLocale(), typeInfo);
-            Assert.Equal(HRESULT.S_OK, hr);
+            ((IDispatch*)iPictureDisp.Value)->GetTypeInfo(0, PInvoke.GetThreadLocale(), typeInfo);
 
             uint refType = uint.MaxValue;
-            hr = typeInfo.Value->GetRefTypeOfImplType(0, &refType);
-            Assert.Equal(HRESULT.S_OK, hr);
+            typeInfo.Value->GetRefTypeOfImplType(0, &refType);
             Assert.NotEqual(0u, refType);
         }
 
@@ -262,14 +269,12 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.Oleaut32
             using var iPictureDisp = IPictureDisp.CreateFromImage(image);
             Assert.False(iPictureDisp.IsNull);
             using ComScope<ITypeInfo> typeInfo = new(null);
-            HRESULT hr = ((IDispatch*)iPictureDisp.Value)->GetTypeInfo(0, PInvoke.GetThreadLocale(), typeInfo);
-            Assert.Equal(HRESULT.S_OK, hr);
+            ((IDispatch*)iPictureDisp.Value)->GetTypeInfo(0, PInvoke.GetThreadLocale(), typeInfo);
 
             TYPEATTR* pTypeAttr = null;
             try
             {
-                hr = typeInfo.Value->GetTypeAttr(&pTypeAttr);
-                Assert.Equal(HRESULT.S_OK, hr);
+                typeInfo.Value->GetTypeAttr(&pTypeAttr);
                 Assert.Equal(typeof(IPictureDisp).GUID, pTypeAttr->guid);
                 Assert.Equal(0u, pTypeAttr->lcid);
                 Assert.Equal(0u, pTypeAttr->dwReserved);
@@ -303,12 +308,10 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.Oleaut32
             using var iPictureDisp = IPictureDisp.CreateFromImage(image);
             Assert.False(iPictureDisp.IsNull);
             using ComScope<ITypeInfo> typeInfo = new(null);
-            HRESULT hr = ((IDispatch*)iPictureDisp.Value)->GetTypeInfo(0, PInvoke.GetThreadLocale(), typeInfo);
-            Assert.Equal(HRESULT.S_OK, hr);
+            ((IDispatch*)iPictureDisp.Value)->GetTypeInfo(0, PInvoke.GetThreadLocale(), typeInfo);
 
-            ITypeComp* typeComp;
-            hr = typeInfo.Value->GetTypeComp(&typeComp);
-            Assert.Equal(HRESULT.S_OK, hr);
+            using ComScope<ITypeComp> typeComp = new(null);
+            typeInfo.Value->GetTypeComp(typeComp);
         }
 
         [StaFact]
@@ -318,14 +321,12 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.Oleaut32
             using var iPictureDisp = IPictureDisp.CreateFromImage(image);
             Assert.False(iPictureDisp.IsNull);
             using ComScope<ITypeInfo> typeInfo = new(null);
-            HRESULT hr = ((IDispatch*)iPictureDisp.Value)->GetTypeInfo(0, PInvoke.GetThreadLocale(), typeInfo);
-            Assert.Equal(HRESULT.S_OK, hr);
+            ((IDispatch*)iPictureDisp.Value)->GetTypeInfo(0, PInvoke.GetThreadLocale(), typeInfo);
 
             VARDESC* pVarDesc = null;
             try
             {
-                hr = typeInfo.Value->GetVarDesc(3, &pVarDesc);
-                Assert.Equal(HRESULT.S_OK, hr);
+                typeInfo.Value->GetVarDesc(3, &pVarDesc);
                 Assert.Equal(4, pVarDesc->memid);
                 Assert.True(pVarDesc->lpstrSchema.IsNull);
                 Assert.True(pVarDesc->Anonymous.lpvarValue  is null);
@@ -349,24 +350,33 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.Oleaut32
             using var iPictureDisp = IPictureDisp.CreateFromImage(image);
             Assert.False(iPictureDisp.IsNull);
             using ComScope<ITypeInfo> typeInfo = new(null);
-            HRESULT hr = ((IDispatch*)iPictureDisp.Value)->GetTypeInfo(0, PInvoke.GetThreadLocale(), typeInfo);
-            Assert.Equal(HRESULT.S_OK, hr);
+            ((IDispatch*)iPictureDisp.Value)->GetTypeInfo(0, PInvoke.GetThreadLocale(), typeInfo);
 
             DISPPARAMS dispParams = default;
             VARIANT varResult = default;
             EXCEPINFO excepInfo = default;
             uint argErr = 0;
-            hr = typeInfo.Value->Invoke(
-                iPictureDisp,
-                (int)PInvoke.DISPID_PICT_WIDTH,
-                DISPATCH_FLAGS.DISPATCH_PROPERTYGET,
-                &dispParams,
-                &varResult,
-                &excepInfo,
-                &argErr);
-            Assert.Equal(HRESULT.DISP_E_MEMBERNOTFOUND, hr);
-            Assert.Equal(default, varResult);
-            Assert.Equal(0u, argErr);
+
+            try
+            {
+                typeInfo.Value->Invoke(
+                    iPictureDisp,
+                    (int)PInvoke.DISPID_PICT_WIDTH,
+                    DISPATCH_FLAGS.DISPATCH_PROPERTYGET,
+                    &dispParams,
+                    &varResult,
+                    &excepInfo,
+                    &argErr);
+            }
+            catch (COMException ex)
+            {
+                Assert.Equal((int)HRESULT.DISP_E_MEMBERNOTFOUND, ex.HResult);
+                Assert.Equal(default, varResult);
+                Assert.Equal(0u, argErr);
+                return;
+            }
+
+            Assert.Fail("Exception was not thrown");
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.State.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.State.cs
@@ -258,14 +258,14 @@ namespace System.Windows.Forms
 
                 using var storage = _storage.GetInterface();
                 iPersistStorage.Save(storage, fSameAsLoad: true).ThrowOnFailure();
-                storage.Value->Commit(0).ThrowOnFailure();
+                storage.Value->Commit(0);
                 iPersistStorage.HandsOffStorage().ThrowOnFailure();
                 try
                 {
                     _buffer = null;
                     _memoryStream = null;
                     using var lockBytes = _lockBytes.GetInterface();
-                    lockBytes.Value->Stat(out STATSTG stat, STATFLAG.STATFLAG_NONAME).ThrowOnFailure();
+                    lockBytes.Value->Stat(out STATSTG stat, STATFLAG.STATFLAG_NONAME);
                     _length = (int)stat.cbSize;
                     _buffer = new byte[_length];
                     PInvoke.GetHGlobalFromILockBytes(lockBytes, out nint hglobal).ThrowOnFailure();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.Vista.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.Vista.cs
@@ -45,7 +45,7 @@ namespace System.Windows.Forms
 
             Debug.Assert(success);
 
-            dialog->Advise(events, out uint eventCookie).ThrowOnFailure();
+            dialog->Advise(events, out uint eventCookie);
             try
             {
                 returnValue = dialog->Show(hWndOwner) == HRESULT.S_OK;
@@ -53,7 +53,7 @@ namespace System.Windows.Forms
             }
             finally
             {
-                dialog->Unadvise(eventCookie).ThrowOnFailure();
+                dialog->Unadvise(eventCookie);
                 uint count = events->Release();
                 Debug.Assert(count == 0);
             }
@@ -65,24 +65,24 @@ namespace System.Windows.Forms
             {
                 // IFileDialog::SetClientGuid should be called immediately after creation of the dialog object.
                 // https://learn.microsoft.com/windows/win32/api/shobjidl_core/nf-shobjidl_core-ifiledialog-setclientguid#remarks
-                dialog->SetClientGuid(in clientGuid).ThrowOnFailure();
+                dialog->SetClientGuid(in clientGuid);
             }
 
-            dialog->SetDefaultExtension(DefaultExt).ThrowOnFailure();
-            dialog->SetFileName(FileName).ThrowOnFailure();
+            dialog->SetDefaultExtension(DefaultExt);
+            dialog->SetFileName(FileName);
 
             if (!string.IsNullOrEmpty(InitialDirectory))
             {
                 using ComScope<IShellItem> initialDirectory = new(PInvoke.SHCreateShellItem(InitialDirectory));
                 if (!initialDirectory.IsNull)
                 {
-                    dialog->SetDefaultFolder(initialDirectory).ThrowOnFailure();
-                    dialog->SetFolder(initialDirectory).ThrowOnFailure();
+                    dialog->SetDefaultFolder(initialDirectory);
+                    dialog->SetFolder(initialDirectory);
                 }
             }
 
-            dialog->SetTitle(Title).ThrowOnFailure();
-            dialog->SetOptions(GetOptions()).ThrowOnFailure();
+            dialog->SetTitle(Title);
+            dialog->SetOptions(GetOptions());
             SetFileTypes(dialog);
 
             _customPlaces.Apply(dialog);
@@ -144,7 +144,7 @@ namespace System.Windows.Forms
             try
             {
                 Thread.MemoryBarrier();
-                dialog->GetFileTypeIndex(out uint filterIndexTemp).ThrowOnFailure();
+                dialog->GetFileTypeIndex(out uint filterIndexTemp);
                 FilterIndex = unchecked((int)filterIndexTemp);
                 _fileNames = ProcessVistaFiles(dialog);
                 if (ProcessFileNames(_fileNames))
@@ -200,10 +200,10 @@ namespace System.Windows.Forms
             {
                 fixed (COMDLG_FILTERSPEC* fi = filterItems)
                 {
-                    dialog->SetFileTypes((uint)filterItems.Length, fi).ThrowOnFailure();
+                    dialog->SetFileTypes((uint)filterItems.Length, fi);
                 }
 
-                dialog->SetFileTypeIndex(unchecked((uint)FilterIndex)).ThrowOnFailure();
+                dialog->SetFileTypeIndex(unchecked((uint)FilterIndex));
             }
         }
 
@@ -250,9 +250,7 @@ namespace System.Windows.Forms
 
         private protected static unsafe string GetFilePathFromShellItem(IShellItem* item)
         {
-            HRESULT hr = item->GetDisplayName(SIGDN.SIGDN_DESKTOPABSOLUTEPARSING, out PWSTR ppszName);
-            hr.ThrowOnFailure();
-
+            item->GetDisplayName(SIGDN.SIGDN_DESKTOPABSOLUTEPARSING, out PWSTR ppszName);
             return ppszName.ToStringAndCoTaskMemFree()!;
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FolderBrowserDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FolderBrowserDialog.cs
@@ -250,17 +250,17 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Displays a folder browser dialog box.
         /// </summary>
-        /// <param name="hWndOwner">A handle to the window that owns the folder browser dialog.</param>
+        /// <param name="hwndOwner">A handle to the window that owns the folder browser dialog.</param>
         /// <returns>
         ///  <see langword="true" /> if the folder browser dialog was successfully run; otherwise, <see langword="false" />.
         /// </returns>
-        protected override bool RunDialog(IntPtr hWndOwner) =>
+        protected override bool RunDialog(IntPtr hwndOwner) =>
 
             // If running the Vista dialog fails (e.g. on Server Core), we fall back to the
             // legacy dialog.
-            UseVistaDialogInternal && TryRunDialogVista((HWND)hWndOwner, out bool returnValue)
+            UseVistaDialogInternal && TryRunDialogVista((HWND)hwndOwner, out bool returnValue)
                 ? returnValue
-                : RunDialogOld((HWND)hWndOwner);
+                : RunDialogOld((HWND)hwndOwner);
 
         private unsafe bool TryRunDialogVista(HWND owner, out bool returnValue)
         {
@@ -312,7 +312,7 @@ namespace System.Windows.Forms
             {
                 // IFileDialog::SetClientGuid should be called immediately after creation of the dialog object.
                 // https://docs.microsoft.com/windows/win32/api/shobjidl_core/nf-shobjidl_core-ifiledialog-setclientguid#remarks
-                dialog->SetClientGuid(in clientGuid).ThrowOnFailure();
+                dialog->SetClientGuid(in clientGuid);
             }
 
             // Description
@@ -320,27 +320,27 @@ namespace System.Windows.Forms
             {
                 if (UseDescriptionForTitle)
                 {
-                    dialog->SetTitle(_descriptionText).ThrowOnFailure();
+                    dialog->SetTitle(_descriptionText);
                 }
                 else
                 {
                     using ComScope<IFileDialogCustomize> customize = new(null);
                     if (dialog->QueryInterface(IID.Get<IFileDialogCustomize>(), customize).Succeeded)
                     {
-                        customize.Value->AddText(0, _descriptionText).ThrowOnFailure();
+                        customize.Value->AddText(0, _descriptionText);
                     }
                 }
             }
 
-            dialog->SetOptions(_options).ThrowOnFailure();
+            dialog->SetOptions(_options);
 
             if (!string.IsNullOrEmpty(_initialDirectory))
             {
                 using ComScope<IShellItem> initialDirectory = new(PInvoke.SHCreateShellItem(_initialDirectory));
                 if (!initialDirectory.IsNull)
                 {
-                    dialog->SetDefaultFolder(initialDirectory).ThrowOnFailure();
-                    dialog->SetFolder(initialDirectory).ThrowOnFailure();
+                    dialog->SetDefaultFolder(initialDirectory);
+                    dialog->SetFolder(initialDirectory);
                 }
             }
 
@@ -349,13 +349,13 @@ namespace System.Windows.Forms
                 string? parent = Path.GetDirectoryName(_selectedPath);
                 if (parent is null || !string.IsNullOrEmpty(_initialDirectory) || !Directory.Exists(parent))
                 {
-                    dialog->SetFileName(_selectedPath).ThrowOnFailure();
+                    dialog->SetFileName(_selectedPath);
                 }
                 else
                 {
                     string folder = Path.GetFileName(_selectedPath);
-                    dialog->SetFolder(PInvoke.SHCreateItemFromParsingName(parent)).ThrowOnFailure();
-                    dialog->SetFileName(folder).ThrowOnFailure();
+                    dialog->SetFolder(PInvoke.SHCreateItemFromParsingName(parent));
+                    dialog->SetFileName(folder);
                 }
             }
         }
@@ -380,10 +380,10 @@ namespace System.Windows.Forms
         private unsafe void GetResult(IFileOpenDialog* dialog)
         {
             using ComScope<IShellItem> item = new(null);
-            dialog->GetResult(item).ThrowOnFailure();
+            dialog->GetResult(item);
             if (!item.IsNull)
             {
-                item.Value->GetDisplayName(SIGDN.SIGDN_FILESYSPATH, out PWSTR ppszName).ThrowOnFailure();
+                item.Value->GetDisplayName(SIGDN.SIGDN_FILESYSPATH, out PWSTR ppszName);
                 _selectedPath = new(ppszName);
                 Marshal.FreeCoTaskMem((nint)(void*)ppszName);
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OpenFileDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OpenFileDialog.cs
@@ -149,12 +149,12 @@ namespace System.Windows.Forms
                 return Array.Empty<string>();
             }
 
-            items.Value->GetCount(out uint count).ThrowOnFailure();
+            items.Value->GetCount(out uint count);
             string[] files = new string[count];
             for (uint i = 0; i < count; ++i)
             {
                 using ComScope<IShellItem> item = new(null);
-                items.Value->GetItemAt(i, item).ThrowOnFailure();
+                items.Value->GetItemAt(i, item);
                 files[i] = GetFilePathFromShellItem(item);
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SaveFileDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SaveFileDialog.cs
@@ -158,7 +158,7 @@ namespace System.Windows.Forms
         private protected override unsafe string[] ProcessVistaFiles(IFileDialog* dialog)
         {
             using ComScope<IShellItem> item = new(null);
-            dialog->GetResult(item).ThrowOnFailure();
+            dialog->GetResult(item);
             return item.IsNull ? Array.Empty<string>() : new string[] { GetFilePathFromShellItem(item) };
         }
 
@@ -168,7 +168,7 @@ namespace System.Windows.Forms
                 in CLSID.FileSaveDialog,
                 pUnkOuter: null,
                 CLSCTX.CLSCTX_INPROC_SERVER | CLSCTX.CLSCTX_LOCAL_SERVER | CLSCTX.CLSCTX_REMOTE_SERVER,
-                out IFileDialog* fileDialog).ThrowOnFailure();
+                out IFileDialog* fileDialog);
 
             return fileDialog;
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/StringSource.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/StringSource.cs
@@ -56,9 +56,9 @@ namespace System.Windows.Forms
 
             bool result = ComHelpers.TryGetComPointer(this, out IEnumString* pEnumString);
             Debug.Assert(result);
-            HRESULT hr = _autoComplete2->Init(edit.Handle, (IUnknown*)pEnumString, (PCWSTR)null, (PCWSTR)null).ThrowOnFailure();
+            _autoComplete2->Init(edit.Handle, (IUnknown*)pEnumString, (PCWSTR)null, (PCWSTR)null);
             GC.KeepAlive(edit.Wrapper);
-            return hr.Succeeded;
+            return true;
         }
 
         public void ReleaseAutoComplete()

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SystemInformation.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SystemInformation.cs
@@ -7,7 +7,6 @@ using System.Drawing;
 using System.Runtime.InteropServices;
 using Microsoft.Win32;
 using Windows.Win32.System.StationsAndDesktops;
-using Windows.Win32.System.SystemServices;
 using Windows.Win32.UI.Accessibility;
 using static Windows.Win32.UI.WindowsAndMessaging.SYSTEM_METRICS_INDEX;
 using static Windows.Win32.UI.WindowsAndMessaging.SYSTEM_PARAMETERS_INFO_ACTION;
@@ -465,7 +464,7 @@ namespace System.Windows.Forms
             {
                 if (MultiMonitorSupport)
                 {
-                    return new (PInvoke.GetSystemMetrics(SM_XVIRTUALSCREEN),
+                    return new(PInvoke.GetSystemMetrics(SM_XVIRTUALSCREEN),
                         PInvoke.GetSystemMetrics(SM_YVIRTUALSCREEN),
                         PInvoke.GetSystemMetrics(SM_CXVIRTUALSCREEN),
                         PInvoke.GetSystemMetrics(SM_CYVIRTUALSCREEN));
@@ -826,7 +825,7 @@ namespace System.Windows.Forms
             {
                 // Try to open the input desktop. If it fails with access denied assume
                 // the app is running on a secure desktop.
-                HDESK desktop = PInvoke.OpenInputDesktop(0, false, (uint)DESKTOP_ACCESS_FLAGS.DESKTOP_SWITCHDESKTOP);
+                HDESK desktop = PInvoke.OpenInputDesktop(0, false, DESKTOP_ACCESS_FLAGS.DESKTOP_SWITCHDESKTOP);
                 if (desktop.IsNull)
                 {
                     return Marshal.GetLastWin32Error() == (int)WIN32_ERROR.ERROR_ACCESS_DENIED;


### PR DESCRIPTION
The default behavior now in CsWin32 is to not PreserveSig. Individual opt-outs are in NativeMethods.json.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8314)