### PR TITLE
Adding the ToolStripMenuItem checked state announcement

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripMenuItem.ToolStripMenuItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripMenuItem.ToolStripMenuItemAccessibleObject.cs
@@ -52,6 +52,43 @@ namespace System.Windows.Forms
                     UiaCore.UIA.AcceleratorKeyPropertyId => _owningToolStripMenuItem.GetShortcutText(),
                     _ => base.GetPropertyValue(propertyID)
                 };
+
+            public override string DefaultAction
+            {
+                get
+                {
+                    string? defaultAction = Owner.AccessibleDefaultActionDescription;
+                    return defaultAction
+                        ?? (_owningToolStripMenuItem.CheckOnClick ? SR.AccessibleActionCheck : base.DefaultAction);
+                }
+            }
+
+            internal override bool IsPatternSupported(UiaCore.UIA patternId) =>
+                patternId switch
+                {
+                    UiaCore.UIA.TogglePatternId => _owningToolStripMenuItem.CheckOnClick || _owningToolStripMenuItem.Checked,
+                    _ => base.IsPatternSupported(patternId)
+                };
+
+            #region Toggle Pattern
+
+            internal override void Toggle()
+            {
+                if (_owningToolStripMenuItem.CheckOnClick)
+                {
+                    _owningToolStripMenuItem.Checked = !_owningToolStripMenuItem.Checked;
+                }
+            }
+
+            internal override UiaCore.ToggleState ToggleState =>
+                _owningToolStripMenuItem.CheckState switch
+                {
+                    CheckState.Checked => UiaCore.ToggleState.On,
+                    CheckState.Unchecked => UiaCore.ToggleState.Off,
+                    _ => UiaCore.ToggleState.Indeterminate
+                };
+
+            #endregion
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripMenuItem.ToolStripMenuItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripMenuItem.ToolStripMenuItemAccessibleObject.cs
@@ -57,8 +57,7 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    string? defaultAction = Owner.AccessibleDefaultActionDescription;
-                    return defaultAction
+                    return Owner.AccessibleDefaultActionDescription
                         ?? (_owningToolStripMenuItem.CheckOnClick ? SR.AccessibleActionCheck : base.DefaultAction);
                 }
             }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripMenuItem.ToolStripMenuItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripMenuItem.ToolStripMenuItemAccessibleObjectTests.cs
@@ -68,5 +68,66 @@ namespace System.Windows.Forms.Tests
 
             Assert.Equal(expected, actual);
         }
+
+        [WinFormsTheory]
+        [InlineData(true, CheckState.Checked, true)]
+        [InlineData(true, CheckState.Unchecked, true)]
+        [InlineData(true, CheckState.Indeterminate, true)]
+        [InlineData(false, CheckState.Checked, true)]
+        [InlineData(false, CheckState.Unchecked, false)]
+        [InlineData(false, CheckState.Indeterminate, true)]
+        public void ToolStripMenuItemAccessibleObject_IsTogglePatternSupported_ReturnExpected(bool checkOnClick, CheckState checkState, bool expected)
+        {
+            using ToolStripMenuItem toolStripMenuItem = new()
+            {
+                CheckOnClick = checkOnClick,
+                CheckState = checkState
+            };
+
+            object actual = toolStripMenuItem.AccessibilityObject.IsPatternSupported(UiaCore.UIA.TogglePatternId);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [WinFormsTheory]
+        [InlineData(CheckState.Checked, (int)UiaCore.ToggleState.On)]
+        [InlineData(CheckState.Unchecked, (int)UiaCore.ToggleState.Off)]
+        [InlineData(CheckState.Indeterminate, (int)UiaCore.ToggleState.Indeterminate)]
+        public void ToolStripMenuItemAccessibleObject_ToggleState_ReturnsExpected(CheckState checkState, int expectedToggleState)
+        {
+            using ToolStripMenuItem toolStripMenuItem = new()
+            {
+                CheckState = checkState
+            };
+
+            object actual = toolStripMenuItem.AccessibilityObject.ToggleState;
+
+            Assert.Equal((UiaCore.ToggleState)expectedToggleState, actual);
+        }
+
+        [WinFormsFact]
+        public void ToolStripMenuItemAccessibleObject_Toggle_Invoke()
+        {
+            using ToolStripMenuItem toolStripMenuItem = new()
+            {
+                CheckOnClick = true
+            };
+
+            int clickCounter = 0;
+
+            toolStripMenuItem.Click += (s, e) => { clickCounter++; };
+
+            Assert.Equal(UiaCore.ToggleState.Off, toolStripMenuItem.AccessibilityObject.ToggleState);
+
+            toolStripMenuItem.AccessibilityObject.Toggle();
+
+            Assert.Equal(UiaCore.ToggleState.On, toolStripMenuItem.AccessibilityObject.ToggleState);
+
+            toolStripMenuItem.AccessibilityObject.Toggle();
+
+            Assert.Equal(UiaCore.ToggleState.Off, toolStripMenuItem.AccessibilityObject.ToggleState);
+
+            Assert.Equal(0, clickCounter);
+        }
     }
 }


### PR DESCRIPTION
Fixes #8307

## Proposed changes

- Added Toggle pattern support for menu items with CheckOnClick set to true and pre-checked menu items
- Added unit tests for ToolStripMenuItemAccessibleObject to verify pattern implementation

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Narrator announces checked state of checkable menu item
- Checkable menu item can be checked or unchecked using UI Automation API

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

No checked state announcement:
![before](https://user-images.githubusercontent.com/113603457/205697530-113681dc-a84d-4ba3-a40d-52c36c665866.png)

No toggle pattern support:
![before - no toggle pattern](https://user-images.githubusercontent.com/113603457/205700251-9431495a-667b-4fa0-b3ec-acbbe055a553.png)

### After

Checked state announcement:
![after](https://user-images.githubusercontent.com/113603457/205697563-fd558998-6dd3-460c-945c-e3037ae6a1a6.png)

Toggle pattern support: 
![after - toggle pattern](https://user-images.githubusercontent.com/113603457/205700318-5e630dfc-6fb4-473c-9180-4fae387e9ac7.png)


## Accessibility testing

- Accessibility Insights for Windows

## Test environment(s) <!-- Remove any that don't apply -->

- 7.0.0


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8329)