### PR TITLE
Refactor `SerializationResourceManager` to use `Dictionary` instead of `HashTable`

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ResourceCodeDomSerializer.SerializationResourceManager.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ResourceCodeDomSerializer.SerializationResourceManager.cs
@@ -225,7 +225,6 @@ namespace System.ComponentModel.Design.Serialization
                 Debug.Assert(culture.Parent != culture, "should have returned when culture = InvariantCulture");
                 CultureInfo parent = culture.Parent;
                 Dictionary<string, object> resourceSet = GetResourceSet(culture);
-                bool contains = (resourceSet is null) ? false : resourceSet.ContainsKey(name);
                 if (resourceSet is not null && resourceSet.TryGetValue(name, out object parentValue))
                 {
                     return !parentValue.Equals(value) || parentValue is null ? CompareValue.Different : CompareValue.Same;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ResourceCodeDomSerializer.SerializationResourceManager.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ResourceCodeDomSerializer.SerializationResourceManager.cs
@@ -455,7 +455,7 @@ namespace System.ComponentModel.Design.Serialization
             /// <summary>
             ///  Override of GetResourceSet from ResourceManager.
             /// </summary>
-            public override ResourceSet? GetResourceSet(CultureInfo culture, bool createIfNotExists, bool tryParents)
+            public override ResourceSet GetResourceSet(CultureInfo culture, bool createIfNotExists, bool tryParents)
             {
                 ArgumentNullException.ThrowIfNull(culture);
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ResourceCodeDomSerializer.SerializationResourceManager.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ResourceCodeDomSerializer.SerializationResourceManager.cs
@@ -275,13 +275,14 @@ namespace System.ComponentModel.Design.Serialization
             }
 
             /// <summary>
-            ///  This returns a dictionary enumerator for metadata on the invariant culture.  If no metadata  can be found this will return null..
+            ///  This returns a dictionary enumerator for metadata on the invariant culture.
+            ///  If no metadata can be found this will return null.
             /// </summary>
             public IDictionaryEnumerator GetMetadataEnumerator()
             {
                 if (_mergedMetadata is not null)
                 {
-                    return _mergedMetadata?.GetEnumerator();
+                    return _mergedMetadata.GetEnumerator();
                 }
 
                 Dictionary<string, object> metaData = GetMetadata();
@@ -300,7 +301,7 @@ namespace System.ComponentModel.Design.Serialization
                     _mergedMetadata = metaData;
                 }
 
-                return _mergedMetadata?.GetEnumerator();
+                return _mergedMetadata.GetEnumerator();
             }
 
             /// <summary>
@@ -390,7 +391,7 @@ namespace System.ComponentModel.Design.Serialization
             private Dictionary<string, object> GetResourceSet(CultureInfo culture)
             {
                 Debug.Assert(culture is not null, "null parameter");
-                Dictionary<string, object> rs = null;
+                Dictionary<string, object> resourceSet = null;
                 object objRs = ResourceTable[culture];
                 if (objRs is null)
                 {
@@ -403,14 +404,14 @@ namespace System.ComponentModel.Design.Serialization
                         {
                             try
                             {
-                                rs = CreateResourceSet(reader, culture);
+                                resourceSet = CreateResourceSet(reader, culture);
                             }
                             finally
                             {
                                 reader.Close();
                             }
 
-                            ResourceTable[culture] = rs;
+                            ResourceTable[culture] = resourceSet;
                         }
                         else
                         {
@@ -422,15 +423,15 @@ namespace System.ComponentModel.Design.Serialization
                 }
                 else
                 {
-                    rs = objRs as Dictionary<string, object>;
-                    if (rs is null)
+                    resourceSet = objRs as Dictionary<string, object>;
+                    if (resourceSet is null)
                     {
                         // the resourceSets hash table may contain our "this" pointer as a sentinel value
                         Debug.Assert(objRs == s_resourceSetSentinel, $"unknown object in resourceSets: {objRs}");
                     }
                 }
 
-                return rs;
+                return resourceSet;
             }
 
             /// <summary>

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ResourceCodeDomSerializer.SerializationResourceManager.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ResourceCodeDomSerializer.SerializationResourceManager.cs
@@ -745,17 +745,17 @@ namespace System.ComponentModel.Design.Serialization
 
                     CodeExpression expression = tree.Expression;
                     string expressionName;
-                    if (expression is CodePropertyReferenceExpression)
+                    if (expression is CodePropertyReferenceExpression codeProperty)
                     {
-                        expressionName = ((CodePropertyReferenceExpression)expression).PropertyName;
+                        expressionName = codeProperty.PropertyName;
                     }
-                    else if (expression is CodeFieldReferenceExpression)
+                    else if (expression is CodeFieldReferenceExpression codeField)
                     {
-                        expressionName = ((CodeFieldReferenceExpression)expression).FieldName;
+                        expressionName = codeField.FieldName;
                     }
-                    else if (expression is CodeMethodReferenceExpression)
+                    else if (expression is CodeMethodReferenceExpression codeMethod)
                     {
-                        expressionName = ((CodeMethodReferenceExpression)expression).MethodName;
+                        expressionName = codeMethod.MethodName;
                         if (expressionName.StartsWith("Set", StringComparison.InvariantCulture))
                         {
                             expressionName = expressionName[3..];

--- a/src/System.Windows.Forms/src/System/Resources/ResXResourceReader.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResXResourceReader.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections;
-using System.Collections.Specialized;
 using System.ComponentModel.Design;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -31,8 +30,8 @@ namespace System.Resources
         private readonly ITypeResolutionService? _typeResolver;
         private readonly IAliasResolver _aliasResolver;
 
-        private ListDictionary? _resData;
-        private ListDictionary? _resMetadata;
+        private Dictionary<string, object>? _resData;
+        private Dictionary<string, object>? _resMetadata;
 #pragma warning disable IDE0052 // Remove unread private members - for diagnostics
         private string? _resHeaderVersion;
 #pragma warning restore IDE0052
@@ -243,8 +242,8 @@ namespace System.Resources
 
             Debug.Assert(_resData is null && _resMetadata is null);
 
-            _resData = new ListDictionary();
-            _resMetadata = new ListDictionary();
+            _resData = new();
+            _resMetadata = new();
 
             XmlTextReader? contentReader = null;
 
@@ -314,7 +313,7 @@ namespace System.Resources
         {
             _isReaderDirty = true;
             EnsureResData();
-            return _resData.GetEnumerator();
+            return ((IDictionary)_resData).GetEnumerator();
         }
 
         /// <summary>
@@ -323,7 +322,7 @@ namespace System.Resources
         public IDictionaryEnumerator GetMetadataEnumerator()
         {
             EnsureResData();
-            return _resMetadata.GetEnumerator();
+            return ((IDictionary)_resMetadata).GetEnumerator();
         }
 
         /// <summary>


### PR DESCRIPTION
- Refactored `ResourceCodeDomSerializer.SerializationResourceManager` to replace usages of `Hashtable`. 
- Refactored `ResXResourceReader` to use `Dictionary` instead of `ListDictionary`

Related: #8143

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8332)