### PR TITLE
Enable `SA1131` and use analyzer refactor

### DIFF
--- a/eng/CodeAnalysis.src.globalconfig
+++ b/eng/CodeAnalysis.src.globalconfig
@@ -1047,7 +1047,7 @@ dotnet_diagnostic.SA1129.severity = warning
 dotnet_diagnostic.SA1130.severity = none
 
 # SA1131: Constant values should appear on the right-hand side of comparisons
-dotnet_diagnostic.SA1131.severity = none
+dotnet_diagnostic.SA1131.severity = warning
 
 # SA1132: Do not combine fields
 dotnet_diagnostic.SA1132.severity = none

--- a/eng/CodeAnalysis.test.globalconfig
+++ b/eng/CodeAnalysis.test.globalconfig
@@ -1042,7 +1042,7 @@ dotnet_diagnostic.SA1129.severity = none
 dotnet_diagnostic.SA1130.severity = none
 
 # SA1131: Constant values should appear on the right-hand side of comparisons
-dotnet_diagnostic.SA1131.severity = none
+dotnet_diagnostic.SA1131.severity = suggestion
 
 # SA1132: Do not combine fields
 dotnet_diagnostic.SA1132.severity = none

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/MenuCommandService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/MenuCommandService.cs
@@ -525,7 +525,7 @@ namespace System.ComponentModel.Design
                 if (_commandGroups.TryGetValue(command.CommandID.Guid, out List<MenuCommand> commands))
                 {
                     int index = commands.IndexOf(command);
-                    if (-1 != index)
+                    if (index != -1)
                     {
                         commands.RemoveAt(index);
                         // If there are no more commands in this command group, remove the group

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/SelectionService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/SelectionService.cs
@@ -410,7 +410,7 @@ namespace System.ComponentModel.Design
             object requestedPrimary = null;
             int primaryIndex;
 
-            if (fPrimary && 1 == components.Count)
+            if (fPrimary && components.Count == 1)
             {
                 foreach (object o in components)
                 {

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ComponentTray.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ComponentTray.cs
@@ -1110,7 +1110,7 @@ namespace System.Windows.Forms.Design
 
                 if (mouseDragTool is not null)
                 {
-                    Debug.Assert(0 != (de.AllowedEffect & (DragDropEffects.Move | DragDropEffects.Copy)), "DragDropEffect.Move | .Copy isn't allowed?");
+                    Debug.Assert((de.AllowedEffect & (DragDropEffects.Move | DragDropEffects.Copy)) != 0, "DragDropEffect.Move | .Copy isn't allowed?");
                     if ((de.AllowedEffect & DragDropEffects.Move) != 0)
                     {
                         de.Effect = DragDropEffects.Move;
@@ -1144,7 +1144,7 @@ namespace System.Windows.Forms.Design
         {
             if (mouseDragTool is not null)
             {
-                Debug.Assert(0 != (de.AllowedEffect & DragDropEffects.Copy), "DragDropEffect.Move isn't allowed?");
+                Debug.Assert((de.AllowedEffect & DragDropEffects.Copy) != 0, "DragDropEffect.Move isn't allowed?");
                 de.Effect = DragDropEffects.Copy;
             }
             else

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ParentControlDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ParentControlDesigner.cs
@@ -1736,7 +1736,7 @@ namespace System.Windows.Forms.Design
         {
             host?.Activate();
 
-            Debug.Assert(0 != (de.AllowedEffect & (DragDropEffects.Move | DragDropEffects.Copy)), "DragDropEffect.Move | .Copy isn't allowed?");
+            Debug.Assert((de.AllowedEffect & (DragDropEffects.Move | DragDropEffects.Copy)) != 0, "DragDropEffect.Move | .Copy isn't allowed?");
             if ((de.AllowedEffect & DragDropEffects.Move) != 0)
             {
                 de.Effect = DragDropEffects.Move;
@@ -1819,7 +1819,7 @@ namespace System.Windows.Forms.Design
 
             if (_mouseDragTool is not null)
             {
-                Debug.Assert(0 != (de.AllowedEffect & DragDropEffects.Copy), "DragDropEffect.Move isn't allowed?");
+                Debug.Assert((de.AllowedEffect & DragDropEffects.Copy) != 0, "DragDropEffect.Move isn't allowed?");
                 de.Effect = DragDropEffects.Copy;
                 return;
             }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/SelectionUIService.SelectionUIItem.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/SelectionUIService.SelectionUIItem.cs
@@ -198,7 +198,7 @@ namespace System.Windows.Forms.Design
                         nOffset = GetHandleIndexOfPoint(pt);
                     }
 
-                    if (-1 == nOffset)
+                    if (nOffset == -1)
                     {
                         if ((GetRules() & SelectionRules.Moveable) == SelectionRules.None)
                         {
@@ -232,7 +232,7 @@ namespace System.Windows.Forms.Design
                 // Which index in the array is this?
                 int nOffset = GetHandleIndexOfPoint(pt);
                 // If no index, the user has picked on the hatch
-                if (-1 == nOffset || _sizes[nOffset] == 0)
+                if (nOffset == -1 || _sizes[nOffset] == 0)
                 {
                     return ((GetRules() & SelectionRules.Moveable) == SelectionRules.None ? 0 : MOVE_X | MOVE_Y);
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/ButtonBaseAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/ButtonBaseAdapter.cs
@@ -591,7 +591,7 @@ namespace System.Windows.Forms.ButtonInternal
                 TextAlign = textAlign,
                 HintTextUp = false,
                 ShadowedText = !enabled,
-                LayoutRTL = RightToLeft.Yes == rtl,
+                LayoutRTL = rtl == RightToLeft.Yes,
                 TextImageRelation = TextImageRelation.Overlay,
                 UseCompatibleTextRendering = false
             };
@@ -621,7 +621,7 @@ namespace System.Windows.Forms.ButtonInternal
                 TextAlign = Control.TextAlign,
                 HintTextUp = false,
                 ShadowedText = !Control.Enabled,
-                LayoutRTL = RightToLeft.Yes == Control.RightToLeft,
+                LayoutRTL = Control.RightToLeft == RightToLeft.Yes,
                 TextImageRelation = Control.TextImageRelation,
                 UseCompatibleTextRendering = Control.UseCompatibleTextRendering
             };

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/CheckBoxBaseAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/CheckBoxBaseAdapter.cs
@@ -358,7 +358,7 @@ namespace System.Windows.Forms.ButtonInternal
             layout.CheckAlign = Control.CheckAlign;
             layout.TextOffset = false;
             layout.ShadowedText = !Control.Enabled;
-            layout.LayoutRTL = RightToLeft.Yes == Control.RightToLeft;
+            layout.LayoutRTL = Control.RightToLeft == RightToLeft.Yes;
 
             return layout;
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2Enum.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2Enum.cs
@@ -61,7 +61,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                     return _values[i];
                 }
 
-                if (bestMatch == -1 && 0 == string.Compare(_names[i], value, true, CultureInfo.InvariantCulture))
+                if (bestMatch == -1 && string.Compare(_names[i], value, true, CultureInfo.InvariantCulture) == 0)
                 {
                     bestMatch = i;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyDescriptor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyDescriptor.cs
@@ -753,7 +753,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
 
             // If this is a object, get the value and attempt to create the correct value editor based on that value.
             // We don't do this if the state came from an attribute.
-            if (0 == (_refreshState & Com2PropertyDescriptorRefresh.TypeConverterAttr) && PropertyType == typeof(Com2Variant))
+            if ((_refreshState & Com2PropertyDescriptorRefresh.TypeConverterAttr) == 0 && PropertyType == typeof(Com2Variant))
             {
                 Type editorType = PropertyType;
                 object? value = GetValue(TargetObject);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.AdviseHelper.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.AdviseHelper.cs
@@ -157,7 +157,7 @@ namespace System.Windows.Forms
                         {
                             if (!IsClosed)
                             {
-                                return (IntPtr.Zero == handle);
+                                return (handle == IntPtr.Zero);
                             }
 
                             return true;
@@ -171,7 +171,7 @@ namespace System.Windows.Forms
                     {
                         IntPtr ptr1 = handle;
                         handle = IntPtr.Zero;
-                        if (IntPtr.Zero != ptr1)
+                        if (ptr1 != IntPtr.Zero)
                         {
                             Marshal.Release(ptr1);
                         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -11360,13 +11360,13 @@ namespace System.Windows.Forms
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         protected HorizontalAlignment RtlTranslateHorizontal(HorizontalAlignment align)
         {
-            if (RightToLeft.Yes == RightToLeft)
+            if (RightToLeft == RightToLeft.Yes)
             {
-                if (HorizontalAlignment.Left == align)
+                if (align == HorizontalAlignment.Left)
                 {
                     return HorizontalAlignment.Right;
                 }
-                else if (HorizontalAlignment.Right == align)
+                else if (align == HorizontalAlignment.Right)
                 {
                     return HorizontalAlignment.Left;
                 }
@@ -11378,13 +11378,13 @@ namespace System.Windows.Forms
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         protected LeftRightAlignment RtlTranslateLeftRight(LeftRightAlignment align)
         {
-            if (RightToLeft.Yes == RightToLeft)
+            if (RightToLeft == RightToLeft.Yes)
             {
-                if (LeftRightAlignment.Left == align)
+                if (align == LeftRightAlignment.Left)
                 {
                     return LeftRightAlignment.Right;
                 }
-                else if (LeftRightAlignment.Right == align)
+                else if (align == LeftRightAlignment.Right)
                 {
                     return LeftRightAlignment.Left;
                 }
@@ -11396,7 +11396,7 @@ namespace System.Windows.Forms
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         protected internal ContentAlignment RtlTranslateContent(ContentAlignment align)
         {
-            if (RightToLeft.Yes == RightToLeft)
+            if (RightToLeft == RightToLeft.Yes)
             {
                 if ((align & WindowsFormsUtils.AnyTopAlign) != 0)
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
@@ -3328,7 +3328,7 @@ namespace System.Windows.Forms
                             {
                                 if (!IsColumnOutOfBounds(oldCurrentCellX) && Columns[oldCurrentCellX].Visible)
                                 {
-                                    Debug.Assert(0 == Rows.GetFirstRow(DataGridViewElementStates.Visible));
+                                    Debug.Assert(Rows.GetFirstRow(DataGridViewElementStates.Visible) == 0);
                                     // Setting the current cell to the current column in the first row
                                     // will create the new row if the user was editing the cell.
                                     SetAndSelectCurrentCellAddress(oldCurrentCellX,
@@ -14400,7 +14400,7 @@ namespace System.Windows.Forms
                                         success = SetCurrentCellAddressCore(hti._col, rowIndex, !isShiftDown, false, true);
                                         Debug.Assert(success);
                                     }
-                                    else if (-1 != _ptCurrentCell.X)
+                                    else if (_ptCurrentCell.X != -1)
                                     {
                                         // Potentially have to give focus back to the current edited cell.
                                         bool success = SetCurrentCellAddressCore(_ptCurrentCell.X, _ptCurrentCell.Y, false /*setAnchorCellAddress*/, false /*validateCurrentCell*/, false /*throughMouseClick*/);
@@ -18711,7 +18711,7 @@ namespace System.Windows.Forms
                                         success = SetCurrentCellAddressCore(dataGridViewColumn.Index, hti._row, !selectRowRange, false, true);
                                         Debug.Assert(success);
                                     }
-                                    else if (-1 != _ptCurrentCell.Y)
+                                    else if (_ptCurrentCell.Y != -1)
                                     {
                                         // Potentially have to give focus back to the current edited cell.
                                         bool success = SetCurrentCellAddressCore(_ptCurrentCell.X, _ptCurrentCell.Y,
@@ -19322,7 +19322,7 @@ namespace System.Windows.Forms
 
         internal void OnRowUnshared(DataGridViewRow dataGridViewRow)
         {
-            if (-1 != _ptCurrentCell.X && dataGridViewRow.Index == _ptCurrentCell.Y && EditingControl is not null)
+            if (_ptCurrentCell.X != -1 && dataGridViewRow.Index == _ptCurrentCell.Y && EditingControl is not null)
             {
                 CurrentCellInternal.CacheEditingControl();
             }
@@ -19479,7 +19479,7 @@ namespace System.Windows.Forms
                 InvalidateGridFocusOnScroll(newValue - oldValue, orientation);
             }
 
-            if (ScrollOrientation.VerticalScroll == orientation)
+            if (orientation == ScrollOrientation.VerticalScroll)
             {
                 if (se.NewValue != newValue)
                 {
@@ -19615,7 +19615,7 @@ namespace System.Windows.Forms
             if (MultiSelect)
             {
                 SelectAll();
-                if (-1 != _ptCurrentCell.X)
+                if (_ptCurrentCell.X != -1)
                 {
                     // Potentially have to give focus back to the current edited cell.
                     bool success = SetCurrentCellAddressCore(_ptCurrentCell.X, _ptCurrentCell.Y,
@@ -28726,7 +28726,7 @@ namespace System.Windows.Forms
                     int rowVFIndex = Rows.GetFirstRow(DataGridViewElementStates.Visible | DataGridViewElementStates.Frozen);
                     Debug.Assert(rowVFIndex != -1);
                     Rows.SetRowState(rowVFIndex, DataGridViewElementStates.Frozen, false);
-                    Debug.Assert(0 == Rows.GetRowCount(DataGridViewElementStates.Visible | DataGridViewElementStates.Frozen));
+                    Debug.Assert(Rows.GetRowCount(DataGridViewElementStates.Visible | DataGridViewElementStates.Frozen) == 0);
                 }
 
                 if (SortedColumn is not null &&

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.cs
@@ -1704,7 +1704,7 @@ namespace System.Windows.Forms
 
         private bool ShouldSerializeColumnHeadersHeight()
         {
-            return ColumnHeadersHeightSizeMode != DataGridViewColumnHeadersHeightSizeMode.AutoSize && DefaultColumnHeadersHeight != ColumnHeadersHeight;
+            return ColumnHeadersHeightSizeMode != DataGridViewColumnHeadersHeightSizeMode.AutoSize && ColumnHeadersHeight != DefaultColumnHeadersHeight;
         }
 
         /// <summary>
@@ -1904,7 +1904,7 @@ namespace System.Windows.Forms
                 Debug.Assert(_ptCurrentCell.Y != -1);
 
                 bool previousVisibleColumnExists = (Columns.GetPreviousColumn(Columns[_ptCurrentCell.X], DataGridViewElementStates.Visible, DataGridViewElementStates.None) is not null);
-                bool previousVisibleRowExists = (-1 != Rows.GetPreviousRow(_ptCurrentCell.Y, DataGridViewElementStates.Visible));
+                bool previousVisibleRowExists = (Rows.GetPreviousRow(_ptCurrentCell.Y, DataGridViewElementStates.Visible) != -1);
 
                 return !previousVisibleColumnExists && !previousVisibleRowExists;
             }
@@ -1922,7 +1922,7 @@ namespace System.Windows.Forms
                 Debug.Assert(_ptCurrentCell.Y != -1);
 
                 bool nextVisibleColumnExists = (Columns.GetNextColumn(Columns[_ptCurrentCell.X], DataGridViewElementStates.Visible, DataGridViewElementStates.None) is not null);
-                bool nextVisibleRowExists = (-1 != Rows.GetNextRow(_ptCurrentCell.Y, DataGridViewElementStates.Visible));
+                bool nextVisibleRowExists = (Rows.GetNextRow(_ptCurrentCell.Y, DataGridViewElementStates.Visible) != -1);
 
                 return !nextVisibleColumnExists && !nextVisibleRowExists;
             }
@@ -3661,7 +3661,7 @@ namespace System.Windows.Forms
         private bool ShouldSerializeRowHeadersWidth()
         {
             return (_rowHeadersWidthSizeMode == DataGridViewRowHeadersWidthSizeMode.EnableResizing || _rowHeadersWidthSizeMode == DataGridViewRowHeadersWidthSizeMode.DisableResizing) &&
-                   DefaultRowHeadersWidth != RowHeadersWidth;
+                   RowHeadersWidth != DefaultRowHeadersWidth;
         }
 
         /// <summary>
@@ -4439,7 +4439,7 @@ namespace System.Windows.Forms
                     return false;
                 }
 
-                return -1 != Rows.GetFirstRow(DataGridViewElementStates.Visible);
+                return Rows.GetFirstRow(DataGridViewElementStates.Visible) != -1;
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnCollection.cs
@@ -377,7 +377,7 @@ namespace System.Windows.Forms
             {
                 DataGridViewColumn dataGridViewColumn = _items[i];
                 // NOTE: case-insensitive
-                if (0 == string.Compare(dataGridViewColumn.Name, columnName, true, CultureInfo.InvariantCulture))
+                if (string.Compare(dataGridViewColumn.Name, columnName, true, CultureInfo.InvariantCulture) == 0)
                 {
                     return true;
                 }
@@ -1065,7 +1065,7 @@ namespace System.Windows.Forms
             {
                 DataGridViewColumn dataGridViewColumn = _items[i];
                 // NOTE: case-insensitive
-                if (0 == string.Compare(dataGridViewColumn.Name, columnName, true, CultureInfo.InvariantCulture))
+                if (string.Compare(dataGridViewColumn.Name, columnName, true, CultureInfo.InvariantCulture) == 0)
                 {
                     RemoveAt(i);
                     return;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnHeaderCell.DataGridViewColumnHeaderCellRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnHeaderCell.DataGridViewColumnHeaderCellRenderer.cs
@@ -26,7 +26,7 @@ namespace System.Windows.Forms
             public static void DrawHeader(Graphics g, Rectangle bounds, int headerState)
             {
                 Rectangle rectClip = Rectangle.Truncate(g.ClipBounds);
-                if ((int)HeaderItemState.Hot == headerState)
+                if (headerState == (int)HeaderItemState.Hot)
                 {
                     // Workaround for a
                     VisualStyleRenderer.SetParameters(s_headerElement);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -2294,7 +2294,7 @@ namespace System.Windows.Forms
                 // it won't send a WM_SHOWWINDOW the first time it's called.
                 // when WM_SHOWWINDOW gets called, we'll flip this bit to true
                 //
-                if (0 == _formState[FormStateSWCalled])
+                if (_formState[FormStateSWCalled] == 0)
                 {
                     PInvoke.SendMessage(this, User32.WM.SHOWWINDOW, (WPARAM)(BOOL)value);
                 }
@@ -3307,7 +3307,7 @@ namespace System.Windows.Forms
 
                 GC.KeepAlive(_ctlClient);
             }
-            else if (0 != _formStateEx[FormStateExUseMdiChildProc])
+            else if (_formStateEx[FormStateExUseMdiChildProc] != 0)
             {
                 m.ResultInternal = PInvoke.DefMDIChildProc(m.HWND, (uint)m.Msg, m.WParamInternal, m.LParamInternal);
             }
@@ -3520,7 +3520,7 @@ namespace System.Windows.Forms
                     // several times when a window is shown, we'll need to force the location
                     // each time for MdiChild windows that are docked so that the window will
                     // be created in the correct location and scroll bars will not be displayed.
-                    if (IsMdiChild && DockStyle.None != Dock)
+                    if (IsMdiChild && Dock != DockStyle.None)
                     {
                         break;
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.cs
@@ -869,7 +869,7 @@ namespace System.Windows.Forms
 
         private bool LinkInText(int start, int length)
         {
-            return (0 <= start && start < Text.Length && 0 < length);
+            return (start >= 0 && start < Text.Length && length > 0);
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
@@ -450,7 +450,7 @@ namespace System.Windows.Forms
             {
                 base.Font = value;
 
-                if (false == _integralHeight)
+                if (_integralHeight == false)
                 {
                     // Refresh the list to force the scroll bars to display
                     // when the integral height is false.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ColumnHeaderCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ColumnHeaderCollection.cs
@@ -524,7 +524,7 @@ namespace System.Windows.Forms
                 if (_owner.IsHandleCreated && _owner.View != View.Tile)
                 {
                     int retval = (int)PInvoke.SendMessage(_owner, (User32.WM)PInvoke.LVM_DELETECOLUMN, (WPARAM)index);
-                    if (0 == retval)
+                    if (retval == 0)
                     {
                         throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -3921,7 +3921,7 @@ namespace System.Windows.Forms
 
             // First column must be left aligned
 
-            if (-1 == idx)
+            if (idx == -1)
             {
                 throw new InvalidOperationException(SR.ListViewAddColumnFailed);
             }
@@ -4298,7 +4298,7 @@ namespace System.Windows.Forms
                         _onItemCheck = oldOnItemCheck;
                     }
 
-                    if (-1 == insertIndex)
+                    if (insertIndex == -1)
                     {
                         throw new InvalidOperationException(SR.ListViewAddItemFailed);
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObject.cs
@@ -164,11 +164,11 @@ namespace System.Windows.Forms
                     return false;
                 }
 
-                return LIST_VIEW_GROUP_STATE_FLAGS.LVGS_FOCUSED == (LIST_VIEW_GROUP_STATE_FLAGS)(uint)PInvoke.SendMessage(
+                return (LIST_VIEW_GROUP_STATE_FLAGS)(uint)PInvoke.SendMessage(
                     _owningListView,
                     (User32.WM)PInvoke.LVM_GETGROUPSTATE,
                     (WPARAM)nativeGroupId,
-                    (LPARAM)(uint)LIST_VIEW_GROUP_STATE_FLAGS.LVGS_FOCUSED);
+                    (LPARAM)(uint)LIST_VIEW_GROUP_STATE_FLAGS.LVGS_FOCUSED) == LIST_VIEW_GROUP_STATE_FLAGS.LVGS_FOCUSED;
             }
 
             private int GetNativeGroupId()

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OpenFileDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OpenFileDialog.cs
@@ -183,7 +183,7 @@ namespace System.Windows.Forms
             get
             {
                 string[] fullPaths = FileNames;
-                if (fullPaths is null || 0 == fullPaths.Length)
+                if (fullPaths is null || fullPaths.Length == 0)
                 {
                     return Array.Empty<string>();
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
@@ -603,7 +603,7 @@ namespace System.Windows.Forms
             {
                 if (value && IsHandleCreated && Visible)
                 {
-                    if (0 == _paintFrozen++)
+                    if (_paintFrozen++ == 0)
                     {
                         PInvoke.SendMessage(this, User32.WM.SETREDRAW, (WPARAM)(BOOL)false);
                     }
@@ -616,7 +616,7 @@ namespace System.Windows.Forms
                         return;
                     }
 
-                    if (0 == --_paintFrozen)
+                    if (--_paintFrozen == 0)
                     {
                         PInvoke.SendMessage(this, User32.WM.SETREDRAW, (WPARAM)(BOOL)true);
                         Invalidate(true);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -1773,7 +1773,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                     // Check real values against string values.
                     itemTextValue = gridEntry.TypeConverter.ConvertToString(currentValue);
-                    if (value == currentValue || 0 == string.Compare(textValue, itemTextValue, true, CultureInfo.InvariantCulture))
+                    if (value == currentValue || string.Compare(textValue, itemTextValue, true, CultureInfo.InvariantCulture) == 0)
                     {
                         stringMatch = i;
                     }
@@ -2521,7 +2521,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 if (!equal && value is string @string && currentValue is not null)
                 {
-                    equal = 0 == string.Compare(@string, currentValue.ToString(), true, CultureInfo.CurrentCulture);
+                    equal = string.Compare(@string, currentValue.ToString(), true, CultureInfo.CurrentCulture) == 0;
                 }
 
                 if (!equal)
@@ -5097,11 +5097,11 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             if (TryGetService(out IUIService uiService))
             {
-                revert = DialogResult.Cancel == uiService.ShowDialog(ErrorDialog);
+                revert = uiService.ShowDialog(ErrorDialog) == DialogResult.Cancel;
             }
             else
             {
-                revert = DialogResult.Cancel == ShowDialog(ErrorDialog);
+                revert = ShowDialog(ErrorDialog) == DialogResult.Cancel;
             }
 
             EditTextBox.DisableMouseHook = false;
@@ -5174,11 +5174,11 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             if (TryGetService(out IUIService uiService))
             {
-                revert = DialogResult.Cancel == uiService.ShowDialog(ErrorDialog);
+                revert = uiService.ShowDialog(ErrorDialog) == DialogResult.Cancel;
             }
             else
             {
-                revert = DialogResult.Cancel == ShowDialog(ErrorDialog);
+                revert = ShowDialog(ErrorDialog) == DialogResult.Cancel;
             }
 
             EditTextBox.DisableMouseHook = false;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
@@ -338,7 +338,7 @@ namespace System.Windows.Forms
 
                 // Remove the WS_BORDER style from the control, if we're trying to set it,
                 // to prevent the control from displaying the single point rectangle around the 3D border
-                if (BorderStyle.FixedSingle == BorderStyle && ((cp.Style & (int)WINDOW_STYLE.WS_BORDER) != 0))
+                if (BorderStyle == BorderStyle.FixedSingle && ((cp.Style & (int)WINDOW_STYLE.WS_BORDER) != 0))
                 {
                     cp.Style &= ~(int)WINDOW_STYLE.WS_BORDER;
                     cp.ExStyle |= (int)WINDOW_EX_STYLE.WS_EX_CLIENTEDGE;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
@@ -736,7 +736,7 @@ namespace System.Windows.Forms
                     return null;
                 }
 
-                Debug.Assert(0 <= index && index < _tabPages.Length, "SelectedIndex returned an invalid index");
+                Debug.Assert(index >= 0 && index < _tabPages.Length, "SelectedIndex returned an invalid index");
                 return _tabPages[index];
             }
             set
@@ -998,7 +998,7 @@ namespace System.Windows.Forms
             TabPage t = GetTabPage(index);
             if (SelectedTab == t)
             {
-                if (0 <= index && index < TabPages.Count - 1)
+                if (index >= 0 && index < TabPages.Count - 1)
                 {
                     SelectedTab = GetTabPage(++index);
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
@@ -4515,7 +4515,7 @@ namespace System.Windows.Forms
 
             if (LayoutEngine is ToolStripSplitStackLayout)
             {
-                if (ToolStripGripStyle.Visible == GripStyle)
+                if (GripStyle == ToolStripGripStyle.Visible)
                 {
                     DisplayedItems.Add(Grip);
                     SetupGrip();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.ToolStripItemInternalLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.ToolStripItemInternalLayout.cs
@@ -119,7 +119,7 @@ namespace System.Windows.Forms
                 layoutOptions.TextAlign = Owner.TextAlign;
                 layoutOptions.HintTextUp = false;
                 layoutOptions.ShadowedText = !_ownerItem.Enabled;
-                layoutOptions.LayoutRTL = RightToLeft.Yes == Owner.RightToLeft;
+                layoutOptions.LayoutRTL = Owner.RightToLeft == RightToLeft.Yes;
                 layoutOptions.TextImageRelation = Owner.TextImageRelation;
                 // Set textImageInset to 0 since we don't draw 3D border for ToolStripItems.
                 layoutOptions.TextImageInset = 0;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripManager.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripManager.cs
@@ -767,7 +767,7 @@ namespace System.Windows.Forms
         internal static bool IsMenuKey(Keys keyData)
         {
             Keys keyCode = keyData & Keys.KeyCode;
-            return (Keys.Menu == keyCode || Keys.F10 == keyCode);
+            return (keyCode == Keys.Menu || keyCode == Keys.F10);
         }
 
         public static bool IsShortcutDefined(Keys shortcut)

--- a/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DesignSurfaceExt/DesignSurfaceExt.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DesignSurfaceExt/DesignSurfaceExt.cs
@@ -14,7 +14,7 @@ namespace DesignSurfaceExt
 
         public void SwitchTabOrder()
         {
-            if (false == IsTabOrderMode)
+            if (IsTabOrderMode == false)
             {
                 InvokeTabOrder();
             }

--- a/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DesignSurfaceExt/NameCreationServiceImp.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DesignSurfaceExt/NameCreationServiceImp.cs
@@ -48,7 +48,7 @@ namespace DesignSurfaceExt
                 i++;
             } //end_while
 
-            if (0 == count)
+            if (count == 0)
             {
                 return type.Name + "1";
             }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/HtmlDocumentTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/HtmlDocumentTests.cs
@@ -1811,7 +1811,7 @@ namespace System.Windows.Forms.Tests
 
             Assert.True(document == document);
             Assert.False(document == newDocument);
-            Assert.False((HtmlDocument)null == document);
+            Assert.False(document == (HtmlDocument)null);
             Assert.False(document == (HtmlDocument)null);
             Assert.True((HtmlDocument)null == (HtmlDocument)null);
         }
@@ -1831,7 +1831,7 @@ namespace System.Windows.Forms.Tests
 
             Assert.False(document != document);
             Assert.True(document != newDocument);
-            Assert.True((HtmlDocument)null != document);
+            Assert.True(document != (HtmlDocument)null);
             Assert.True(document != (HtmlDocument)null);
             Assert.False((HtmlDocument)null != (HtmlDocument)null);
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/HtmlElementTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/HtmlElementTests.cs
@@ -2338,7 +2338,7 @@ namespace System.Windows.Forms.Tests
             Assert.True(element1 == element1);
             Assert.True(element1 == element2);
             Assert.False(element1 == element3);
-            Assert.False((HtmlElement)null == element1);
+            Assert.False(element1 == (HtmlElement)null);
             Assert.False(element1 == (HtmlElement)null);
             Assert.True((HtmlElement)null == (HtmlElement)null);
         }
@@ -2361,7 +2361,7 @@ namespace System.Windows.Forms.Tests
             Assert.False(element1 != element1);
             Assert.False(element1 != element2);
             Assert.True(element1 != element3);
-            Assert.True((HtmlElement)null != element1);
+            Assert.True(element1 != (HtmlElement)null);
             Assert.True(element1 != (HtmlElement)null);
             Assert.False((HtmlElement)null != (HtmlElement)null);
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObjectTests.cs
@@ -559,7 +559,7 @@ namespace System.Windows.Forms.Tests
                 foreach (View view in Enum.GetValues(typeof(View)))
                 {
                     // View.Tile is not supported by ListView in virtual mode
-                    if (virtualMode && View.Tile == view)
+                    if (virtualMode && view == View.Tile)
                     {
                         continue;
                     }
@@ -636,7 +636,7 @@ namespace System.Windows.Forms.Tests
                 foreach (View view in Enum.GetValues(typeof(View)))
                 {
                     // View.Tile is not supported by ListView in virtual mode
-                    if (virtualMode && View.Tile == view)
+                    if (virtualMode && view == View.Tile)
                     {
                         continue;
                     }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemAccessibleObjectTests.cs
@@ -735,7 +735,7 @@ namespace System.Windows.Forms.Tests
                 foreach (View view in Enum.GetValues(typeof(View)))
                 {
                     // View.Tile is not supported by ListView in virtual mode
-                    if (virtualMode && View.Tile == view)
+                    if (virtualMode && view == View.Tile)
                     {
                         continue;
                     }
@@ -809,7 +809,7 @@ namespace System.Windows.Forms.Tests
             foreach (View view in Enum.GetValues(typeof(View)))
             {
                 // View.Tile does not support enabled CheckBoxes
-                if (View.Tile == view)
+                if (view == View.Tile)
                 {
                     continue;
                 }
@@ -860,7 +860,7 @@ namespace System.Windows.Forms.Tests
             foreach (View view in Enum.GetValues(typeof(View)))
             {
                 // View.Tile does not support enabled CheckBoxes
-                if (View.Tile == view)
+                if (view == View.Tile)
                 {
                     continue;
                 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
@@ -4633,7 +4633,7 @@ namespace System.Windows.Forms.Tests
                 foreach (View view in Enum.GetValues(typeof(View)))
                 {
                     // View.Tile is not supported by ListView in virtual mode
-                    if (virtualMode && View.Tile == view)
+                    if (virtualMode && view == View.Tile)
                     {
                         continue;
                     }
@@ -4699,7 +4699,7 @@ namespace System.Windows.Forms.Tests
                 foreach (View view in Enum.GetValues(typeof(View)))
                 {
                     // View.Tile is not supported by ListView in virtual mode
-                    if (virtualMode && View.Tile == view)
+                    if (virtualMode && view == View.Tile)
                     {
                         continue;
                     }


### PR DESCRIPTION
Enable [SA1131](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1131.md) Constant values should appear on the right-hand side of comparisons. Use solution wide analyzer refactor to fix code base.

Fixes #8334

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8336)