### PR TITLE
Enable nullable reference types for `System.Windows.Forms.Design`

### DIFF
--- a/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
+++ b/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
@@ -5,6 +5,7 @@
     <CLSCompliant>true</CLSCompliant>
     <Deterministic>true</Deterministic>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Nullable>enable</Nullable>
     <!--the obsolete usage in public surface can't be removed-->
     <NoWarn>$(NoWarn);618</NoWarn>
     <!-- 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ActiveDesignSurfaceChangedEventArgs.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ActiveDesignSurfaceChangedEventArgs.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.ComponentModel.Design
 {
     /// <summary>

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ArrayEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ArrayEditor.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.ComponentModel.Design
 {
     /// <summary>

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/BinaryEditor.BinaryUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/BinaryEditor.BinaryUI.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Drawing;
 using System.Windows.Forms;
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/BinaryEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/BinaryEditor.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Diagnostics;
 using System.Drawing.Design;
 using System.Text;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ByteViewer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ByteViewer.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Drawing;
 using System.Globalization;
 using System.Text;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CodeMarkers.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CodeMarkers.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Microsoft.Win32;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CollectionEditor.CollectionEditorCollectionForm.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CollectionEditor.CollectionEditorCollectionForm.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.Diagnostics;
 using System.Drawing;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CollectionEditor.CollectionForm.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CollectionEditor.CollectionForm.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.Windows.Forms;
 using System.Windows.Forms.Design;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CollectionEditor.FilterListBox.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CollectionEditor.FilterListBox.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Windows.Forms;
 using static Interop;
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CollectionEditor.PropertyGridSite.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CollectionEditor.PropertyGridSite.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.ComponentModel.Design
 {
     public partial class CollectionEditor

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CollectionEditor.SplitButton.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CollectionEditor.SplitButton.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Drawing;
 using System.Windows.Forms;
 using System.Windows.Forms.VisualStyles;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CollectionEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CollectionEditor.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.Drawing.Design;
 using System.Reflection;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ComponentDesigner.ShadowPropertyCollection.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ComponentDesigner.ShadowPropertyCollection.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.ComponentModel.Design
 {
     public partial class ComponentDesigner

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ComponentDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ComponentDesigner.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.Configuration;
 using System.Diagnostics;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DateTimeEditor.DateTimeUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DateTimeEditor.DateTimeUI.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Windows.Forms;
 using System.Windows.Forms.Design;
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DateTimeEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DateTimeEditor.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Drawing.Design;
 using System.Windows.Forms.Design;
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignSurface.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignSurface.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.ComponentModel.Design.Serialization;
 using System.Diagnostics;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignSurfaceCollection.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignSurfaceCollection.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 
 namespace System.ComponentModel.Design

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignSurfaceEvent.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignSurfaceEvent.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Windows.Forms;
 
 namespace System.ComponentModel.Design

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignSurfaceManager.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignSurfaceManager.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Diagnostics;
 
 namespace System.ComponentModel.Design

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignSurfaceServiceContainer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignSurfaceServiceContainer.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.ComponentModel.Design
 {
     /// <summary>

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionHeaderItem.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionHeaderItem.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.ComponentModel.Design
 {
     public sealed class DesignerActionHeaderItem : DesignerActionTextItem

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionItem.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionItem.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.Collections.Specialized;
 using System.Text.RegularExpressions;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionItemCollection.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionItemCollection.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 
 namespace System.ComponentModel.Design

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionList.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionList.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Reflection;
 
 namespace System.ComponentModel.Design

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionListCollection.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionListCollection.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 
 namespace System.ComponentModel.Design

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionListsChangedEventArgs.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionListsChangedEventArgs.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.ComponentModel.Design
 {
     /// <summary>

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionMethodItem.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionMethodItem.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Reflection;
 
 namespace System.ComponentModel.Design

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.CheckBoxPropertyLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.CheckBoxPropertyLine.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Drawing;
 using System.Windows.Forms;
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.DesignerActionPanelHeaderItem.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.DesignerActionPanelHeaderItem.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.ComponentModel.Design
 {
     internal sealed partial class DesignerActionPanel

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.EditorPropertyLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.EditorPropertyLine.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Drawing;
 using System.Drawing.Design;
 using System.Drawing.Imaging;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.Line.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.Line.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Drawing;
 using System.Windows.Forms;
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.MethodLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.MethodLine.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Diagnostics;
 using System.Drawing;
 using System.Reflection;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.PanelHeaderLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.PanelHeaderLine.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Diagnostics;
 using System.Drawing;
 using System.Windows.Forms;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.PropertyLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.PropertyLine.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Globalization;
 using System.Reflection;
 using System.Windows.Forms;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.TextBoxPropertyLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.TextBoxPropertyLine.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Drawing;
 using System.Windows.Forms;
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.TextLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.TextLine.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Diagnostics;
 using System.Drawing;
 using System.Windows.Forms;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.TypeDescriptorContext.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.TypeDescriptorContext.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.ComponentModel.Design
 {
     internal sealed partial class DesignerActionPanel

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.cs
@@ -1,6 +1,8 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+
+#nullable disable
 
 using System.Collections;
 using System.Collections.Specialized;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPropertyItem.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPropertyItem.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.ComponentModel.Design
 {
     public sealed class DesignerActionPropertyItem : DesignerActionItem

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionService.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Windows.Forms.Design;
 
 namespace System.ComponentModel.Design

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionTextItem.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionTextItem.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.ComponentModel.Design
 {
     public class DesignerActionTextItem : DesignerActionItem

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionUI.DesignerActionToolStripDropDown.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionUI.DesignerActionToolStripDropDown.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Diagnostics;
 using System.Drawing;
 using System.Windows.Forms;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionUI.cs
@@ -4,7 +4,6 @@
 
 #nullable disable
 
-using System.Collections;
 using System.Diagnostics;
 using System.Drawing;
 using System.Windows.Forms;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionUI.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
+using System.Collections;
 using System.Diagnostics;
 using System.Drawing;
 using System.Windows.Forms;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionUIService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionUIService.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Diagnostics;
 using System.Windows.Forms.Design.Behavior;
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionUIStateChangeEventArgs.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionUIStateChangeEventArgs.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.ComponentModel.Design
 {
     /// <summary>

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerCommandSet.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerCommandSet.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 
 namespace System.ComponentModel.Design

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerEventService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerEventService.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Diagnostics;
 
 namespace System.ComponentModel.Design

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerHost.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerHost.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.Collections.Specialized;
 using System.ComponentModel.Design.Serialization;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/EventBindingService.EventPropertyDescriptor.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/EventBindingService.EventPropertyDescriptor.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.Globalization;
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/EventBindingService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/EventBindingService.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.Diagnostics;
 using System.Reflection;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ExceptionCollection.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ExceptionCollection.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.Runtime.Serialization;
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ExtenderProviderService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ExtenderProviderService.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.ComponentModel.Design
 {
     /// <summary>

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/HostDesigntimeLicenseContext.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/HostDesigntimeLicenseContext.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.ComponentModel.Design
 {
     /// <summary>

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/IMultitargetHelperService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/IMultitargetHelperService.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.ComponentModel.Design
 {
     /// <summary>

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/InheritanceService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/InheritanceService.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel.Design.Serialization;
 using System.Diagnostics;
 using System.Globalization;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/InheritedPropertyDescriptor.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/InheritedPropertyDescriptor.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.Diagnostics;
 using System.Drawing.Design;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/LoadedEventArgs.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/LoadedEventArgs.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 
 namespace System.ComponentModel.Design

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/MenuCommandService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/MenuCommandService.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.Diagnostics;
 using System.Globalization;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/MenuCommandsChangedEventArgs.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/MenuCommandsChangedEventArgs.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.ComponentModel.Design
 {
     /// <summary>

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/MultilineStringEditor.MultilineStringEditorUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/MultilineStringEditor.MultilineStringEditorUI.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Diagnostics;
 using System.Drawing;
 using System.Globalization;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/MultilineStringEditor.OleCallback.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/MultilineStringEditor.OleCallback.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Diagnostics;
 using System.Globalization;
 using System.Windows.Forms;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/MultilineStringEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/MultilineStringEditor.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Drawing.Design;
 using System.Windows.Forms.Design;
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ObjectSelectorEditor.Selector.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ObjectSelectorEditor.Selector.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Windows.Forms;
 using System.Windows.Forms.Design;
 using static Interop;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ObjectSelectorEditor.SelectorNode.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ObjectSelectorEditor.SelectorNode.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Windows.Forms;
 
 namespace System.ComponentModel.Design

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ObjectSelectorEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ObjectSelectorEditor.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Drawing.Design;
 using System.Windows.Forms;
 using System.Windows.Forms.Design;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ProjectTargetFrameworkAttribute.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ProjectTargetFrameworkAttribute.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.ComponentModel.Design
 {
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Struct)]

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ReferenceService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ReferenceService.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Diagnostics;
 using System.Globalization;
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/SelectionService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/SelectionService.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.Collections.Specialized;
 using System.Diagnostics;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/BasicDesignerLoader.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/BasicDesignerLoader.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.Collections.Specialized;
 using System.Diagnostics;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomComponentSerializationService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomComponentSerializationService.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.CodeDom;
 using System.Collections;
 using System.Diagnostics;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomDesignerLoader.ModifierConverter.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomDesignerLoader.ModifierConverter.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.CodeDom;
 using System.CodeDom.Compiler;
 using System.Collections;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomDesignerLoader.ModifiersExtenderProvider.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomDesignerLoader.ModifiersExtenderProvider.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.CodeDom;
 using System.Windows.Forms;
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomDesignerLoader.ModifiersInheritedExtenderProvider.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomDesignerLoader.ModifiersInheritedExtenderProvider.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.CodeDom;
 using System.Diagnostics;
 using System.Reflection;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomDesignerLoader.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomDesignerLoader.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.CodeDom;
 using System.CodeDom.Compiler;
 using System.Collections;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomLocalizationProvider.LanguageCultureInfoConverter.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomLocalizationProvider.LanguageCultureInfoConverter.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Globalization;
 
 namespace System.ComponentModel.Design.Serialization

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomLocalizationProvider.LanguageExtenders.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomLocalizationProvider.LanguageExtenders.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Globalization;
 using System.Windows.Forms;
 using System.Windows.Forms.Design;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomLocalizationProvider.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomLocalizationProvider.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.Globalization;
 using System.Resources;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializationProvider.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializationProvider.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.Resources;
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializer.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.CodeDom;
 using System.Diagnostics;
 using System.Globalization;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializerBase.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializerBase.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.CodeDom;
 using System.Collections;
 using System.Diagnostics;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializerException.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializerException.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.CodeDom;
 using System.Runtime.Serialization;
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeMethodMap.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeMethodMap.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.CodeDom;
 
 namespace System.ComponentModel.Design.Serialization

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CollectionCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CollectionCodeDomSerializer.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.CodeDom;
 using System.Collections;
 using System.Collections.Specialized;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ComponentCache.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ComponentCache.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.CodeDom;
 
 namespace System.ComponentModel.Design.Serialization

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ComponentCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ComponentCodeDomSerializer.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.CodeDom;
 using System.Configuration;
 using System.Diagnostics;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ComponentTypeCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ComponentTypeCodeDomSerializer.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.CodeDom;
 
 namespace System.ComponentModel.Design.Serialization

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ContainerCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ContainerCodeDomSerializer.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.CodeDom;
 
 namespace System.ComponentModel.Design.Serialization

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/DesignerSerializationManager.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/DesignerSerializationManager.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.Reflection;
 using System.Runtime.Serialization;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/EnumCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/EnumCodeDomSerializer.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.CodeDom;
 using System.Diagnostics;
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/EventMemberCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/EventMemberCodeDomSerializer.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.CodeDom;
 using System.Reflection;
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ExpressionContext.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ExpressionContext.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.CodeDom;
 using System.Windows.Forms;
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ExpressionTable.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ExpressionTable.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.CodeDom;
 
 namespace System.ComponentModel.Design.Serialization

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ICodeDomDesignerReload.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ICodeDomDesignerReload.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.CodeDom;
 
 namespace System.ComponentModel.Design.Serialization

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/LocalizationCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/LocalizationCodeDomSerializer.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.CodeDom;
 using System.Collections;
 using System.Diagnostics;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/MemberCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/MemberCodeDomSerializer.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.CodeDom;
 
 namespace System.ComponentModel.Design.Serialization

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/PrimitiveCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/PrimitiveCodeDomSerializer.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.CodeDom;
 
 namespace System.ComponentModel.Design.Serialization

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/PropertyMemberCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/PropertyMemberCodeDomSerializer.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.CodeDom;
 using System.Diagnostics;
 using System.Reflection;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ResourceCodeDomSerializer.SerializationResourceManager.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ResourceCodeDomSerializer.SerializationResourceManager.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.CodeDom;
 using System.Collections;
 using System.Diagnostics;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ResourceCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ResourceCodeDomSerializer.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.CodeDom;
 using System.Collections;
 using System.Diagnostics;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ResourcePropertyMemberCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ResourcePropertyMemberCodeDomSerializer.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.CodeDom;
 using System.Diagnostics;
 using System.Globalization;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/RootContext.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/RootContext.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.CodeDom;
 using System.Windows.Forms;
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/SerializeAbsoluteContext.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/SerializeAbsoluteContext.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.ComponentModel.Design.Serialization
 {
     /// <summary>

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/StatementContext.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/StatementContext.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.CodeDom;
 using System.Collections;
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/TypeCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/TypeCodeDomSerializer.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.CodeDom;
 using System.CodeDom.Compiler;
 using System.Collections;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/SiteNestedContainer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/SiteNestedContainer.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.ComponentModel.Design
 {
     /// <summary>

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/TypeDescriptorFilterService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/TypeDescriptorFilterService.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 
 namespace System.ComponentModel.Design

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/UndoEngine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/UndoEngine.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.ComponentModel.Design.Serialization;
 using System.Diagnostics;

--- a/src/System.Windows.Forms.Design/src/System/Drawing/BitmapSelector.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/BitmapSelector.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Configuration;
 using System.Drawing.Configuration;
 using System.Reflection;

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/BitmapEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/BitmapEditor.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.Drawing.Design
 {
     /// <summary>

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/ColorEditor.ColorPalette.ColorPaletteAccessibleObject.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/ColorEditor.ColorPalette.ColorPaletteAccessibleObject.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Windows.Forms;
 
 namespace System.Drawing.Design

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/ColorEditor.ColorPalette.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/ColorEditor.ColorPalette.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
 using static Interop.User32;

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/ColorEditor.ColorUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/ColorEditor.ColorUI.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.Reflection;
 using System.Windows.Forms;

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/ColorEditor.CustomColorDialog.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/ColorEditor.CustomColorDialog.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.InteropServices;

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/ColorEditor.StandardColorComparer.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/ColorEditor.StandardColorComparer.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 
 namespace System.Drawing.Design

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/ColorEditor.SystemColorComparer.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/ColorEditor.SystemColorComparer.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.Globalization;
 

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/ColorEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/ColorEditor.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.Windows.Forms;
 using System.Windows.Forms.Design;

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/ContentAlignmentEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/ContentAlignmentEditor.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.Windows.Forms.Design;
 

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/CursorEditor.CursorUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/CursorEditor.CursorUI.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Windows.Forms;

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/CursorEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/CursorEditor.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.Windows.Forms.Design;
 

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/FontEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/FontEditor.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.Windows.Forms;
 using System.Windows.Forms.Design;

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/FontNameEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/FontNameEditor.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 
 namespace System.Drawing.Design

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/IToolboxItemProvider.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/IToolboxItemProvider.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.Drawing.Design
 {
     public interface IToolboxItemProvider

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/IToolboxService.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/IToolboxService.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.ComponentModel.Design;
 using System.Runtime.InteropServices;

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/IToolboxUser.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/IToolboxUser.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.Drawing.Design
 {
     /// <summary>

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/IconEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/IconEditor.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Windows.Forms;

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/ImageEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/ImageEditor.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.ComponentModel;
 using System.Reflection;

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/MetafileEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/MetafileEditor.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Drawing.Imaging;
 
 namespace System.Drawing.Design

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/SelectionPanelBase.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/SelectionPanelBase.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Windows.Forms;
 using System.Windows.Forms.Design;
 

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/ToolboxComponentsCreatedEventArgs.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/ToolboxComponentsCreatedEventArgs.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 
 namespace System.Drawing.Design

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/ToolboxComponentsCreatingEventArgs.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/ToolboxComponentsCreatingEventArgs.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel.Design;
 
 namespace System.Drawing.Design

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/ToolboxItem.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/ToolboxItem.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.ComponentModel;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/ToolboxItemCollection.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/ToolboxItemCollection.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 
 namespace System.Drawing.Design

--- a/src/System.Windows.Forms.Design/src/System/Resources/Tools/ITargetAwareCodeDomProvider.cs
+++ b/src/System.Windows.Forms.Design/src/System/Resources/Tools/ITargetAwareCodeDomProvider.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 
 namespace System.Resources.Tools

--- a/src/System.Windows.Forms.Design/src/System/Resources/Tools/StronglyTypedResourceBuilder.cs
+++ b/src/System.Windows.Forms.Design/src/System/Resources/Tools/StronglyTypedResourceBuilder.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.CodeDom;
 using System.Reflection;

--- a/src/System.Windows.Forms.Design/src/System/Runtime/InteropServices/UCOMITypeLib.cs
+++ b/src/System.Windows.Forms.Design/src/System/Runtime/InteropServices/UCOMITypeLib.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Runtime.InteropServices.ComTypes;
 
 namespace System.Runtime.InteropServices

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/AnchorEditor.AnchorUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/AnchorEditor.AnchorUI.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Drawing;
 
 namespace System.Windows.Forms.Design

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/AnchorEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/AnchorEditor.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.Drawing.Design;
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/AxImporter.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/AxImporter.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Reflection;
 using System.Runtime.InteropServices;
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/BaseContextMenuStrip.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/BaseContextMenuStrip.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.ComponentModel;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/Adorner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/Adorner.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Drawing;
 
 namespace System.Windows.Forms.Design.Behavior

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/AdornerCollection.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/AdornerCollection.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 
 namespace System.Windows.Forms.Design.Behavior

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/Behavior.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/Behavior.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System.ComponentModel.Design;
 using System.Drawing;
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorDragDropEventArgs.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorDragDropEventArgs.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 
 namespace System.Windows.Forms.Design.Behavior

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.AdornerWindow.MouseHook.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.AdornerWindow.MouseHook.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel.Design;
 using System.Diagnostics;
 using System.Drawing;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.AdornerWindow.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.AdornerWindow.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Drawing;
 using static Interop;
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.MenuCommandHandler.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.MenuCommandHandler.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel.Design;
 
 namespace System.Windows.Forms.Design.Behavior

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.ComponentModel;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorServiceAdornerCollectionEnumerator.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorServiceAdornerCollectionEnumerator.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 
 namespace System.Windows.Forms.Design.Behavior

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/ComponentGlyph.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/ComponentGlyph.cs
@@ -1,8 +1,6 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
-
-#nullable enable
 
 using System.ComponentModel;
 using System.Drawing;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/ContainerSelectorBehavior.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/ContainerSelectorBehavior.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.ComponentModel;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/ContainerSelectorGlyph.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/ContainerSelectorGlyph.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System.Diagnostics;
 using System.Drawing;
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/ControlBodyGlyph.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/ControlBodyGlyph.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DesignerActionBehavior.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DesignerActionBehavior.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.ComponentModel.Design;
 using System.Diagnostics;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DesignerActionGlyph.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DesignerActionGlyph.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System.ComponentModel;
 using System.Drawing;
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DesignerActionKeyboardBehavior.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DesignerActionKeyboardBehavior.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel.Design;
 using System.Diagnostics;
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DragAssistanceManager.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DragAssistanceManager.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.ComponentModel;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DropSourceBehavior.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DropSourceBehavior.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.ComponentModel;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/Glyph.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/Glyph.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Drawing;
 
 namespace System.Windows.Forms.Design.Behavior

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/GlyphCollection.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/GlyphCollection.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 
 namespace System.Windows.Forms.Design.Behavior

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/GrabHandleGlyph.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/GrabHandleGlyph.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System.Diagnostics;
 using System.Drawing;
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/LockedBorderGlyph.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/LockedBorderGlyph.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
+#nullable disable
 
 using System.Drawing;
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/LockedBorderGlyph.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/LockedBorderGlyph.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Drawing;
 
 namespace System.Windows.Forms.Design.Behavior

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/LockedHandleGlyph.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/LockedHandleGlyph.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
+#nullable disable
 
 using System.Drawing;
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/LockedHandleGlyph.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/LockedHandleGlyph.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Drawing;
 
 namespace System.Windows.Forms.Design.Behavior

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/MiniLockedBorderGlyph.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/MiniLockedBorderGlyph.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System.Drawing;
 
 namespace System.Windows.Forms.Design.Behavior

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/NoResizeHandleGlyph.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/NoResizeHandleGlyph.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System.Drawing;
 
 namespace System.Windows.Forms.Design.Behavior

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/NoResizeSelectionBorderGlyph.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/NoResizeSelectionBorderGlyph.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System.Drawing;
 
 namespace System.Windows.Forms.Design.Behavior

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/ResizeBehavior.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/ResizeBehavior.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.ComponentModel;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/SelectionBorderGlyph.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/SelectionBorderGlyph.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System.Drawing;
 
 namespace System.Windows.Forms.Design.Behavior

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/SelectionGlyphBase.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/SelectionGlyphBase.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System.Drawing;
 
 namespace System.Windows.Forms.Design.Behavior

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/SelectionManager.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/SelectionManager.cs
@@ -1,6 +1,8 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+
+#nullable disable
 
 using System.Collections;
 using System.ComponentModel;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/SnapLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/SnapLine.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.Windows.Forms.Design.Behavior
 {
     /// <summary>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/ToolboxItemSnapLineBehavior.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/ToolboxItemSnapLineBehavior.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.ComponentModel.Design;
 using System.Drawing;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/BorderSidesEditor.BorderSidesEditorUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/BorderSidesEditor.BorderSidesEditorUI.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/BorderSidesEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/BorderSidesEditor.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.Drawing.Design;
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ButtonBaseDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ButtonBaseDesigner.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.ComponentModel;
 using System.Diagnostics;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ChangeToolStripParentVerb.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ChangeToolStripParentVerb.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.ComponentModel.Design;
 using System.Diagnostics;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/CollectionEditVerbManager.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/CollectionEditVerbManager.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.ComponentModel;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ColumnHeaderCollectionEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ColumnHeaderCollectionEditor.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.ComponentModel.Design;
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ComboBoxDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ComboBoxDesigner.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel.Design;
 using System.ComponentModel;
 using System.Collections;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/CommandSet.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/CommandSet.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Runtime.Serialization.Formatters.Binary;
 using System.ComponentModel;
 using System.Diagnostics;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ComponentTray.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ComponentTray.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.ComponentModel;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/CompositionDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/CompositionDesigner.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.ComponentModel;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ContextMenuStripActionList.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ContextMenuStripActionList.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.ComponentModel.Design;
 using System.Diagnostics;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ContextMenuStripGroup.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ContextMenuStripGroup.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.Windows.Forms.Design
 {
     internal class ContextMenuStripGroup

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ContextMenuStripGroupCollection.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ContextMenuStripGroupCollection.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 
 namespace System.Windows.Forms.Design

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlCodeDomSerializer.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.CodeDom;
 using System.ComponentModel;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlCommandSet.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlCommandSet.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Collections;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.CanResetSizePropertyDescriptor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.CanResetSizePropertyDescriptor.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 
 namespace System.Windows.Forms.Design

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.ChildSubClass.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.ChildSubClass.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Diagnostics;
 using static Interop;
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.ControlDesignerAccessibleObject.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.ControlDesignerAccessibleObject.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.ComponentModel.Design;
 using System.Diagnostics;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.DesignerControlCollection.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.DesignerControlCollection.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.ComponentModel;
 using System.ComponentModel.Design.Serialization;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.DesignerWindowTarget.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.DesignerWindowTarget.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.Windows.Forms.Design
 {
     public partial class ControlDesigner

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.DockingActionList.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.DockingActionList.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.ComponentModel.Design;
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.TransparentBehavior.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.TransparentBehavior.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Drawing;
 using System.Windows.Forms.Design.Behavior;
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.ComponentModel;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewCellStyleBuilder.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewCellStyleBuilder.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.ComponentModel.Design;
 using System.Diagnostics;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewCellStyleEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewCellStyleEditor.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.Drawing;
 using System.Drawing.Design;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewComponentPropertyGridSite.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewComponentPropertyGridSite.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 
 namespace System.Windows.Forms.Design

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewRowCollectionCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewRowCollectionCodeDomSerializer.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.CodeDom;
 using System.Collections;
 using System.ComponentModel.Design.Serialization;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataMemberFieldConverter.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataMemberFieldConverter.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.Globalization;
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignBindingValueUIHandler.LocalUIItem.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignBindingValueUIHandler.LocalUIItem.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.Drawing.Design;
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignBindingValueUIHandler.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignBindingValueUIHandler.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.ComponentModel;
 using System.Drawing.Design;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerExtenders.NameExtenderProvider.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerExtenders.NameExtenderProvider.cs
@@ -1,6 +1,8 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+
+#nullable disable
 
 using System.ComponentModel;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerExtenders.NameInheritedExtenderProvider.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerExtenders.NameInheritedExtenderProvider.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 
 namespace System.Windows.Forms.Design

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerExtenders.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerExtenders.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.ComponentModel.Design;
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerFrame.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerFrame.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.ComponentModel;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerToolStripControlHost.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerToolStripControlHost.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.Drawing;
 using System.Windows.Forms.Design.Behavior;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerUtils.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerUtils.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.ComponentModel;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DockEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DockEditor.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.Drawing.Design;
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DocumentDesigner.AxToolboxItem.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DocumentDesigner.AxToolboxItem.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.ComponentModel.Design;
 using System.Diagnostics;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DocumentDesigner.DocumentInheritanceService.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DocumentDesigner.DocumentInheritanceService.cs
@@ -1,6 +1,8 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+
+#nullable disable
 
 using System.ComponentModel;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DocumentDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DocumentDesigner.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.ComponentModel;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/EditorServiceContext.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/EditorServiceContext.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.ComponentModel;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/EventHandlerService.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/EventHandlerService.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Diagnostics;
 
 namespace System.Windows.Forms.Design

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FileNameEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FileNameEditor.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.Drawing.Design;
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FolderNameEditor.FolderBrowser.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FolderNameEditor.FolderBrowser.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Buffers;
 using System.ComponentModel;
 using Windows.Win32.UI.Shell.Common;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FolderNameEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FolderNameEditor.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.Drawing.Design;
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FormDocumentDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FormDocumentDesigner.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.ComponentModel;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FormatControl.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FormatControl.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Diagnostics;
 using System.Globalization;
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FormatStringDialog.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FormatStringDialog.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.ComponentModel.Design;
 using System.Diagnostics;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FormatStringEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FormatStringEditor.cs
@@ -1,6 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+
+#nullable disable
+
 using System.ComponentModel;
 using System.ComponentModel.Design;
 using System.Diagnostics;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/GroupBoxDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/GroupBoxDesigner.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Drawing;
 using static Interop;
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/GroupedContextMenuStrip.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/GroupedContextMenuStrip.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections.Specialized;
 using System.ComponentModel;
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/IContainsThemedScrollbarWindows.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/IContainsThemedScrollbarWindows.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 
 namespace System.Windows.Forms.Design

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ImageCollectionCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ImageCollectionCodeDomSerializer.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.CodeDom;
 using System.Collections.Specialized;
 using System.ComponentModel;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ImageCollectionEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ImageCollectionEditor.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.ComponentModel;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ImageIndexEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ImageIndexEditor.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ImageListImage.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ImageListImage.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.Drawing;
 using System.Drawing.Design;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ImageListImageEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ImageListImageEditor.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.ComponentModel;
 using System.Drawing.Design;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/InheritanceUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/InheritanceUI.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ItemTypeToolStripMenuItem.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ItemTypeToolStripMenuItem.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Drawing;
 using System.Drawing.Design;
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/LabelDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/LabelDesigner.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.ComponentModel;
 using System.Diagnostics;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/LinkAreaEditor.LinkAreaUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/LinkAreaEditor.LinkAreaUI.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.ComponentModel.Design;
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/LinkAreaEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/LinkAreaEditor.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.ComponentModel.Design;
 using System.Drawing.Design;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ListBoxDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ListBoxDesigner.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel.Design;
 using System.ComponentModel;
 using System.Collections;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ListControlStringCollectionEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ListControlStringCollectionEditor.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 
 namespace System.Windows.Forms.Design

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ListViewActionList.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ListViewActionList.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel.Design;
 using System.ComponentModel;
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ListViewDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ListViewDesigner.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel.Design;
 using System.ComponentModel;
 using System.Collections;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ListViewGroupCollectionEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ListViewGroupCollectionEditor.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.ComponentModel.Design;
 using System.ComponentModel.Design.Serialization;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ListViewItemCollectionEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ListViewItemCollectionEditor.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.ComponentModel.Design;
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ListViewSubItemCollectionEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ListViewSubItemCollectionEditor.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.ComponentModel;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskDescriptor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskDescriptor.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.Globalization;
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskDescriptorComparer.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskDescriptorComparer.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Diagnostics;
 
 namespace System.Windows.Forms.Design

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskDescriptorTemplate.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskDescriptorTemplate.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Globalization;
 
 namespace System.Windows.Forms.Design

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskDesignerDialog.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskDesignerDialog.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.ComponentModel;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskPropertyEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskPropertyEditor.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel.Design;
 using System.Diagnostics;
 using System.Drawing.Design;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskedTextBoxDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskedTextBoxDesigner.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.ComponentModel;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskedTextBoxDesignerActionList.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskedTextBoxDesignerActionList.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.ComponentModel.Design;
 using System.Diagnostics;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskedTextBoxTextEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskedTextBoxTextEditor.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.Drawing.Design;
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskedTextBoxTextEditorDropDown.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskedTextBoxTextEditorDropDown.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.Windows.Forms.Design
 {
     internal class MaskedTextBoxTextEditorDropDown : UserControl

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MenuCommands.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MenuCommands.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel.Design;
 
 namespace System.Windows.Forms.Design

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/NewItemsContextMenuStrip.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/NewItemsContextMenuStrip.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 
 namespace System.Windows.Forms.Design

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/OleDragDropHandler.CfCodeToolboxItem.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/OleDragDropHandler.CfCodeToolboxItem.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.ComponentModel;
 using System.ComponentModel.Design.Serialization;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/OleDragDropHandler.ComponentDataObject.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/OleDragDropHandler.ComponentDataObject.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.ComponentModel.Design.Serialization;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/OleDragDropHandler.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/OleDragDropHandler.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.ComponentModel;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ParentControlDesigner.EscapeHandler.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ParentControlDesigner.EscapeHandler.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel.Design;
 
 namespace System.Windows.Forms.Design

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ParentControlDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ParentControlDesigner.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.ComponentModel;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/PbrsForward.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/PbrsForward.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel.Design;
 using static Interop;
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/PictureBoxActionList.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/PictureBoxActionList.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel.Design;
 using System.ComponentModel;
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/PictureBoxDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/PictureBoxDesigner.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel.Design;
 using System.ComponentModel;
 using System.Drawing;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/RadioButtonDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/RadioButtonDesigner.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.ComponentModel;
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/RichTextBoxDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/RichTextBoxDesigner.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel.Design;
 using System.ComponentModel;
 using System.Collections;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ScrollableControlDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ScrollableControlDesigner.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Drawing;
 using System.Windows.Forms.Design.Behavior;
 using static Interop;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/SelectionUIHandler.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/SelectionUIHandler.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.ComponentModel.Design;
 using System.Diagnostics;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/SelectionUIService.ContainerSelectionUIItem.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/SelectionUIService.ContainerSelectionUIItem.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Drawing;
 
 namespace System.Windows.Forms.Design

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/SelectionUIService.HitTestInfo.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/SelectionUIService.HitTestInfo.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.Windows.Forms.Design
 {
     internal sealed partial class SelectionUIService

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/SelectionUIService.SelectionUIItem.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/SelectionUIService.SelectionUIItem.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/SelectionUIService.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/SelectionUIService.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.ComponentModel;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ServiceProviderExtensions.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ServiceProviderExtensions.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.Windows.Forms.Design
 {
     internal static class ServiceProviderExtensions

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ShortcutKeysEditor.ShortcutKeysUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ShortcutKeysEditor.ShortcutKeysUI.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ShortcutKeysEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ShortcutKeysEditor.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.Drawing;
 using System.Drawing.Design;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/StandardCommandToolStripMenuItem.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/StandardCommandToolStripMenuItem.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel.Design;
 using System.Drawing;
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/StandardMenuStripVerb.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/StandardMenuStripVerb.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.ComponentModel.Design;
 using System.ComponentModel.Design.Serialization;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/StatusCommandUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/StatusCommandUI.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.ComponentModel.Design;
 using System.Drawing;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/StringArrayEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/StringArrayEditor.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.Windows.Forms.Design
 {
     /// <summary>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/StringCollectionEditor.StringCollectionForm.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/StringCollectionEditor.StringCollectionForm.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.ComponentModel.Design;
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TabOrder.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TabOrder.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.ComponentModel;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TabPageCollectionEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TabPageCollectionEditor.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel.Design;
 
 namespace System.Windows.Forms.Design

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TableLayoutControlCollectionCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TableLayoutControlCollectionCodeDomSerializer.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.CodeDom;
 using System.Collections;
 using System.ComponentModel;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TableLayoutPanelCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TableLayoutPanelCodeDomSerializer.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.ComponentModel.Design;
 using System.ComponentModel.Design.Serialization;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TemplateNodeCustomMenuItemCollection.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TemplateNodeCustomMenuItemCollection.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.ComponentModel.Design;
 using System.Diagnostics;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TextBoxActionList.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TextBoxActionList.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.ComponentModel.Design;
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TextBoxBaseDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TextBoxBaseDesigner.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.ComponentModel;
 using System.Diagnostics;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TextBoxDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TextBoxDesigner.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.ComponentModel;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripActionList.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripActionList.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.ComponentModel.Design;
 using System.Diagnostics;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripAdornerWindowService.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripAdornerWindowService.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.Drawing;
 using System.Windows.Forms.Design.Behavior;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripCodeDomSerializer.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.Diagnostics;
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripDesigner.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.ComponentModel;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripDesignerUtils.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripDesignerUtils.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.ComponentModel;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripDropDownDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripDropDownDesigner.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.ComponentModel;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripEditorManager.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripEditorManager.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.ComponentModel.Design;
 using System.Drawing;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripInSituService.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripInSituService.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.ComponentModel.Design;
 using System.Diagnostics;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripItemBehavior.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripItemBehavior.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.ComponentModel;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripItemCustomMenuItemCollection.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripItemCustomMenuItemCollection.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.ComponentModel.Design;
 using System.Diagnostics;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripItemDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripItemDesigner.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.ComponentModel;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripItemGlyph.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripItemGlyph.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Drawing;
 using System.Windows.Forms.Design.Behavior;
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripKeyboardHandlingService.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripKeyboardHandlingService.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.ComponentModel;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripMenuItemCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripMenuItemCodeDomSerializer.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.ComponentModel.Design.Serialization;
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripMenuItemDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripMenuItemDesigner.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.ComponentModel;
 using System.ComponentModel.Design;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripTemplateNode.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripTemplateNode.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.ComponentModel.Design;
 using System.Diagnostics;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TreeViewActionList.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TreeViewActionList.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.ComponentModel.Design;
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TreeViewDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TreeViewDesigner.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.ComponentModel.Design;
 using System.Drawing;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/UpDownBaseDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/UpDownBaseDesigner.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel;
 using System.Collections;
 using System.Windows.Forms.Design.Behavior;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/UserControlDocumentDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/UserControlDocumentDesigner.cs
@@ -1,6 +1,8 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+
+#nullable disable
 
 using System.ComponentModel;
 using System.Collections;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/WindowsFormsDesignerOptionService.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/WindowsFormsDesignerOptionService.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.ComponentModel.Design;
 
 namespace System.Windows.Forms.Design


### PR DESCRIPTION
PR enables nullability at the project level and sets the nullable annotation context to disabled where the code does not compile without warnings.

- Files were manually changed to add the `#nullable disable` annotation.
- Some files were changed to remove `#nullable enable` annotation.
- No other changes were made.


Related: #8342, #1107

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8343)