### PR TITLE
Enable nullability in IComPropertyBrowser and ICom2PropertyPageDisplayService

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -862,9 +862,9 @@ System.Windows.Forms.BindingMemberInfo.BindingPath.get -> string!
 ~System.Windows.Forms.ComboBox.SelectedItem.set -> void
 ~System.Windows.Forms.ComboBox.SelectedText.get -> string
 ~System.Windows.Forms.ComboBox.SelectedText.set -> void
-~System.Windows.Forms.ComponentModel.Com2Interop.ICom2PropertyPageDisplayService.ShowPropertyPage(string title, object component, int dispid, System.Guid pageGuid, nint parentHandle) -> void
-~System.Windows.Forms.ComponentModel.Com2Interop.IComPropertyBrowser.LoadState(Microsoft.Win32.RegistryKey key) -> void
-~System.Windows.Forms.ComponentModel.Com2Interop.IComPropertyBrowser.SaveState(Microsoft.Win32.RegistryKey key) -> void
+System.Windows.Forms.ComponentModel.Com2Interop.ICom2PropertyPageDisplayService.ShowPropertyPage(string! title, object? component, int dispid, System.Guid pageGuid, nint parentHandle) -> void
+System.Windows.Forms.ComponentModel.Com2Interop.IComPropertyBrowser.LoadState(Microsoft.Win32.RegistryKey? key) -> void
+System.Windows.Forms.ComponentModel.Com2Interop.IComPropertyBrowser.SaveState(Microsoft.Win32.RegistryKey? key) -> void
 System.Windows.Forms.Control.InvokeGotFocus(System.Windows.Forms.Control? toInvoke, System.EventArgs! e) -> void
 System.Windows.Forms.Control.InvokeLostFocus(System.Windows.Forms.Control? toInvoke, System.EventArgs! e) -> void
 System.Windows.Forms.Control.InvokeOnClick(System.Windows.Forms.Control? toInvoke, System.EventArgs! e) -> void
@@ -5685,7 +5685,7 @@ System.Windows.Forms.ComponentModel.Com2Interop.Com2Variant
 System.Windows.Forms.ComponentModel.Com2Interop.Com2Variant.Com2Variant() -> void
 System.Windows.Forms.ComponentModel.Com2Interop.ICom2PropertyPageDisplayService
 System.Windows.Forms.ComponentModel.Com2Interop.IComPropertyBrowser
-System.Windows.Forms.ComponentModel.Com2Interop.IComPropertyBrowser.ComComponentNameChanged -> System.ComponentModel.Design.ComponentRenameEventHandler
+System.Windows.Forms.ComponentModel.Com2Interop.IComPropertyBrowser.ComComponentNameChanged -> System.ComponentModel.Design.ComponentRenameEventHandler?
 System.Windows.Forms.ComponentModel.Com2Interop.IComPropertyBrowser.DropDownDone() -> void
 System.Windows.Forms.ComponentModel.Com2Interop.IComPropertyBrowser.EnsurePendingChangesCommitted() -> bool
 System.Windows.Forms.ComponentModel.Com2Interop.IComPropertyBrowser.HandleF4() -> void

--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -862,7 +862,7 @@ System.Windows.Forms.BindingMemberInfo.BindingPath.get -> string!
 ~System.Windows.Forms.ComboBox.SelectedItem.set -> void
 ~System.Windows.Forms.ComboBox.SelectedText.get -> string
 ~System.Windows.Forms.ComboBox.SelectedText.set -> void
-System.Windows.Forms.ComponentModel.Com2Interop.ICom2PropertyPageDisplayService.ShowPropertyPage(string! title, object? component, int dispid, System.Guid pageGuid, nint parentHandle) -> void
+System.Windows.Forms.ComponentModel.Com2Interop.ICom2PropertyPageDisplayService.ShowPropertyPage(string! title, object! component, int dispid, System.Guid pageGuid, nint parentHandle) -> void
 System.Windows.Forms.ComponentModel.Com2Interop.IComPropertyBrowser.LoadState(Microsoft.Win32.RegistryKey? key) -> void
 System.Windows.Forms.ComponentModel.Com2Interop.IComPropertyBrowser.SaveState(Microsoft.Win32.RegistryKey? key) -> void
 System.Windows.Forms.Control.InvokeGotFocus(System.Windows.Forms.Control? toInvoke, System.EventArgs! e) -> void

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyPageUITypeConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyPageUITypeConverter.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Drawing.Design;
 using System.Runtime.InteropServices;
 using System.Windows.Forms.Design;
@@ -46,6 +47,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                     }
                 }
 
+                Debug.Assert(instance is not null);
                 propertyPageService.ShowPropertyPage(_propertyDescriptor.Name, instance, (int)_propertyDescriptor.DISPID, _guid, hWndParent);
             }
             catch (Exception ex)
@@ -61,13 +63,8 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
 
         public override UITypeEditorEditStyle GetEditStyle(ITypeDescriptorContext? context) => UITypeEditorEditStyle.Modal;
 
-        public unsafe void ShowPropertyPage(string title, object? component, int dispid, Guid pageGuid, IntPtr parentHandle)
+        public unsafe void ShowPropertyPage(string title, object component, int dispid, Guid pageGuid, IntPtr parentHandle)
         {
-            if (component is null)
-            {
-                return;
-            }
-
             object[] objs = component.GetType().IsArray ? (object[])component : new object[] { component };
             IntPtr[] objAddrs = new IntPtr[objs.Length];
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyPageUITypeConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyPageUITypeConverter.cs
@@ -61,8 +61,13 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
 
         public override UITypeEditorEditStyle GetEditStyle(ITypeDescriptorContext? context) => UITypeEditorEditStyle.Modal;
 
-        public unsafe void ShowPropertyPage(string title, object component, int dispid, Guid pageGuid, IntPtr parentHandle)
+        public unsafe void ShowPropertyPage(string title, object? component, int dispid, Guid pageGuid, IntPtr parentHandle)
         {
+            if (component is null)
+            {
+                return;
+            }
+
             object[] objs = component.GetType().IsArray ? (object[])component : new object[] { component };
             IntPtr[] objAddrs = new IntPtr[objs.Length];
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/ICOM2PropertyPageDisplayService.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/ICOM2PropertyPageDisplayService.cs
@@ -2,12 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms.ComponentModel.Com2Interop
 {
     public interface ICom2PropertyPageDisplayService
     {
-        void ShowPropertyPage(string title, object component, int dispid, Guid pageGuid, IntPtr parentHandle);
+        void ShowPropertyPage(string title, object? component, int dispid, Guid pageGuid, IntPtr parentHandle);
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/ICOM2PropertyPageDisplayService.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/ICOM2PropertyPageDisplayService.cs
@@ -6,6 +6,6 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
 {
     public interface ICom2PropertyPageDisplayService
     {
-        void ShowPropertyPage(string title, object? component, int dispid, Guid pageGuid, IntPtr parentHandle);
+        void ShowPropertyPage(string title, object component, int dispid, Guid pageGuid, IntPtr parentHandle);
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/IComPropertyBrowser.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/IComPropertyBrowser.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel.Design;
 using Microsoft.Win32;
 
@@ -28,7 +26,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         /// <summary>
         ///  Occurs when the <see cref="PropertyGrid"/> control is browsing a COM object and the user renames the object.
         /// </summary>
-        event ComponentRenameEventHandler ComComponentNameChanged;
+        event ComponentRenameEventHandler? ComComponentNameChanged;
 
         /// <summary>
         ///  Commits all pending changes to the <see cref="PropertyGrid"/> control.
@@ -48,12 +46,12 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         ///  Loads user states from the registry into the <see cref="PropertyGrid"/> control.
         /// </summary>
         /// <param name="key">The registry key that contains the user states.</param>
-        void LoadState(RegistryKey key);
+        void LoadState(RegistryKey? key);
 
         /// <summary>
         ///  Saves user states from the <see cref="PropertyGrid"/> control to the registry.
         /// </summary>
         /// <param name="key">The registry key that contains the user states.</param>
-        void SaveState(RegistryKey key);
+        void SaveState(RegistryKey? key);
     }
 }


### PR DESCRIPTION
## Proposed changes

- Enable nullability in IComPropertyBrowser and ICom2PropertyPageDisplayService.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8347)