### PR TITLE
Fix scaling anchors in PMv2 applications.

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DefaultLayout.AnchorInfo.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DefaultLayout.AnchorInfo.cs
@@ -15,12 +15,13 @@ namespace System.Windows.Forms.Layout
             public int Right;
             public int Bottom;
 
-            // In PermonV2 mode applications, when moved from one monitor to the other, Form/Container is scaled with scale
-            // factor computed with respect to new DPI on the monitor. However, scaling ratio between non-client and client
-            // area is not linear. This is causing few pixels variance when anchors are also scaled with same scale factor.
-            // Anchors are relative to display rectangle.Hence, making change to computing anchor scale factor with respect
-            // to change in DisplayRect instead of change in the bounds (a.k.a: scale factor computed with respect to new DPI).
-            public Rectangle DisplayRect;
+            // In PerMonitorV2 mode applications, when moved from one monitor to the other, Form/Container bounds are scaled with scale
+            // factor computed with respect to new DPI on the monitor. However, scaling ratio between non-client and client area is not linear.
+            // Window chrome (adorners) are scaled by Windows following their heuristics, leaving non client area fit to rest of the bounds.
+            // This is causing few pixels variance when anchors are also scaled with same scale factor but are relative to display rectangle.
+            // Hence, making change to computing anchor scale factor with respect to change in display rectangle instead of change in the
+            // bounds (a.k.a: scale factor computed with respect to new DPI).
+            public Rectangle DisplayRectangle;
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DefaultLayout.AnchorInfo.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DefaultLayout.AnchorInfo.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Drawing;
+
 namespace System.Windows.Forms.Layout
 {
     internal partial class DefaultLayout
@@ -12,6 +14,9 @@ namespace System.Windows.Forms.Layout
             public int Top;
             public int Right;
             public int Bottom;
+
+            // Display rectangle of the parent/container used in computing child control's anchors.
+            public Rectangle DisplayRect;
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DefaultLayout.AnchorInfo.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DefaultLayout.AnchorInfo.cs
@@ -15,7 +15,11 @@ namespace System.Windows.Forms.Layout
             public int Right;
             public int Bottom;
 
-            // Display rectangle of the parent/container used in computing child control's anchors.
+            // In PermonV2 mode applications, when moved from one monitor to the other, Form/Container is scaled with scale
+            // factor computed with respect to new DPI on the monitor. However, scaling ratio between non-client and client
+            // area is not linear. This is causing few pixels variance when anchors are also scaled with same scale factor.
+            // Anchors are relative to display rectangle.Hence, making change to computing anchor scale factor with respect
+            // to change in DisplayRect instead of change in the bounds (a.k.a: scale factor computed with respect to new DPI).
             public Rectangle DisplayRect;
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DefaultLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DefaultLayout.cs
@@ -168,9 +168,9 @@ namespace System.Windows.Forms.Layout
                 : ComputeAnchoredBounds(element, displayRect, measureOnly);
         }
 
-        private static Rectangle ComputeAnchoredBoundsV2(IArrangedElement element, Rectangle displayRect)
+        private static Rectangle ComputeAnchoredBoundsV2(IArrangedElement element, Rectangle displayRectangle)
         {
-            if (displayRect.IsEmpty)
+            if (displayRectangle.IsEmpty)
             {
                 return element.Bounds;
             }
@@ -184,7 +184,7 @@ namespace System.Windows.Forms.Layout
             Rectangle elementBounds = element.Bounds;
             int width = elementBounds.Width;
             int height = elementBounds.Height;
-            anchorInfo.DisplayRect = displayRect;
+            anchorInfo.DisplayRectangle = displayRectangle;
 
             Debug.WriteLineIf(width < 0 || height < 0, $"\t\t'{element}' destination bounds resulted in negative");
 
@@ -196,7 +196,7 @@ namespace System.Windows.Forms.Layout
                 // the parent's width.
                 if (IsAnchored(anchors, AnchorStyles.Right))
                 {
-                    width = displayRect.Width - (anchorInfo.Right + anchorInfo.Left);
+                    width = displayRectangle.Width - (anchorInfo.Right + anchorInfo.Left);
                 }
             }
             else
@@ -205,13 +205,13 @@ namespace System.Windows.Forms.Layout
                 // to the parent's width.
                 if (IsAnchored(anchors, AnchorStyles.Right))
                 {
-                    anchorInfo.Left = displayRect.Width - elementBounds.Width - anchorInfo.Right;
+                    anchorInfo.Left = displayRectangle.Width - elementBounds.Width - anchorInfo.Right;
                 }
                 else
                 {
                     // The control neither anchored Right nor Left but anchored Top or Bottom, the control's
                     // X-coordinate should be adjusted according to the parent's width.
-                    int growOrShrink = (displayRect.Width - (anchorInfo.Left + anchorInfo.Right + elementBounds.Width)) / 2;
+                    int growOrShrink = (displayRectangle.Width - (anchorInfo.Left + anchorInfo.Right + elementBounds.Width)) / 2;
                     anchorInfo.Left += growOrShrink;
                     anchorInfo.Right += growOrShrink;
                 }
@@ -223,7 +223,7 @@ namespace System.Windows.Forms.Layout
                 {
                     // If anchored both Top and Bottom, the control's height should be adjusted according to
                     // the parent's height.
-                    height = displayRect.Height - (anchorInfo.Bottom + anchorInfo.Top);
+                    height = displayRectangle.Height - (anchorInfo.Bottom + anchorInfo.Top);
                 }
             }
             else
@@ -232,13 +232,13 @@ namespace System.Windows.Forms.Layout
                 // the parent's height.
                 if (IsAnchored(anchors, AnchorStyles.Bottom))
                 {
-                    anchorInfo.Top = displayRect.Height - elementBounds.Height - anchorInfo.Bottom;
+                    anchorInfo.Top = displayRectangle.Height - elementBounds.Height - anchorInfo.Bottom;
                 }
                 else
                 {
                     // The control neither anchored Top or Bottom but anchored Right or Left, the control's
                     // Y-coordinate is adjusted accoring to the parent's height.
-                    int growOrShrink = (displayRect.Height - (anchorInfo.Bottom + anchorInfo.Top + elementBounds.Height)) / 2;
+                    int growOrShrink = (displayRectangle.Height - (anchorInfo.Bottom + anchorInfo.Top + elementBounds.Height)) / 2;
                     anchorInfo.Top += growOrShrink;
                     anchorInfo.Bottom += growOrShrink;
                 }
@@ -910,17 +910,17 @@ namespace System.Windows.Forms.Layout
                 SetAnchorInfo(control, anchorInfo);
             }
 
-            Rectangle displayRect = control.Parent.DisplayRectangle;
+            Rectangle displayRectange = control.Parent.DisplayRectangle;
             Rectangle elementBounds = control.Bounds;
             int x = elementBounds.X;
             int y = elementBounds.Y;
 
-            anchorInfo.DisplayRect = displayRect;
+            anchorInfo.DisplayRectangle = displayRectange;
             anchorInfo.Left = x;
             anchorInfo.Top = y;
 
-            anchorInfo.Right = displayRect.Width - (x + elementBounds.Width);
-            anchorInfo.Bottom = displayRect.Height - (y + elementBounds.Height);
+            anchorInfo.Right = displayRectange.Width - (x + elementBounds.Width);
+            anchorInfo.Bottom = displayRectange.Height - (y + elementBounds.Height);
 
             // Walk through parent hierarchy and check if scaling due to DPI change is in progress.
             static bool DpiScalingInProgress(Control control, Control parent)
@@ -1041,9 +1041,9 @@ namespace System.Windows.Forms.Layout
                     // So, compute factor with respect to the change in DisplayRectangle and apply it to scale anchors.
                     // See https://github.com/dotnet/winforms/issues/8266 for more information.
                     Rectangle displayRect = element.Container.DisplayRectangle;
-                    heightFactor = ((double)displayRect.Height) / anchorInfo.DisplayRect.Height;
-                    widthFactor = ((double)displayRect.Width) / anchorInfo.DisplayRect.Width;
-                    anchorInfo.DisplayRect = displayRect;
+                    heightFactor = ((double)displayRect.Height) / anchorInfo.DisplayRectangle.Height;
+                    widthFactor = ((double)displayRect.Width) / anchorInfo.DisplayRectangle.Width;
+                    anchorInfo.DisplayRectangle = displayRect;
                 }
 
                 anchorInfo.Left = (int)Math.Round(anchorInfo.Left * widthFactor);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DefaultLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DefaultLayout.cs
@@ -1032,23 +1032,24 @@ namespace System.Windows.Forms.Layout
             // some controls don't have AnchorInfo, i.e. Panels
             if (anchorInfo is not null)
             {
-                float heightFactor = factor.Height;
-                float widthFactor = factor.Width;
+                double heightFactor = factor.Height;
+                double widthFactor = factor.Width;
 
                 if (UseAnchorLayoutV2(element))
                 {
-                    // AutoscaleFactor is not alligned with Window's SuggestedRectangle applied on top-level window/Form.
+                    // AutoScaleFactor is not alligned with Window's SuggestedRectangle applied on top-level window/Form.
                     // So, compute factor with respect to the change in DisplayRectangle and apply it to scale anchors.
-                    // See dotnet/winforms#8266 for more information.
-                    heightFactor = ((float)element.Container.DisplayRectangle.Height) / anchorInfo.DisplayRect.Height;
-                    widthFactor = ((float)element.Container.DisplayRectangle.Width) / anchorInfo.DisplayRect.Width;
-                    anchorInfo.DisplayRect = element.Container.DisplayRectangle;
+                    // See https://github.com/dotnet/winforms/issues/8266 for more information.
+                    Rectangle displayRect = element.Container.DisplayRectangle;
+                    heightFactor = ((double)displayRect.Height) / anchorInfo.DisplayRect.Height;
+                    widthFactor = ((double)displayRect.Width) / anchorInfo.DisplayRect.Width;
+                    anchorInfo.DisplayRect = displayRect;
                 }
 
-                anchorInfo.Left = (int)(anchorInfo.Left * widthFactor);
-                anchorInfo.Top = (int)(anchorInfo.Top * heightFactor);
-                anchorInfo.Right = (int)(anchorInfo.Right * widthFactor);
-                anchorInfo.Bottom = (int)(anchorInfo.Bottom * heightFactor);
+                anchorInfo.Left = (int)Math.Round(anchorInfo.Left * widthFactor);
+                anchorInfo.Top = (int)Math.Round(anchorInfo.Top * heightFactor);
+                anchorInfo.Right = (int)Math.Round(anchorInfo.Right * widthFactor);
+                anchorInfo.Bottom = (int)Math.Round(anchorInfo.Bottom * heightFactor);
 
                 SetAnchorInfo(element, anchorInfo);
             }


### PR DESCRIPTION
Fixes #8266.

In PermonV2 mode applications, when moved from one monitor to the other, Form/Container is scaled with scale factor computed with respect to new DPI on the monitor. However, scaling ratio between non-client and client area is not linear. This is causing few pixels variance when anchors are also scaled with same scale factor.
Anchors are relative to display rectangle. Hence, making change to computing anchor scale factor with respect to change in DisplayRect instead of change in the bounds (a.k.a: scale factor computed with respect to new DPI).

This PR follows #8201.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8349)