### PR TITLE
Changed type of the `handle` parameter from `IntPtr` to  `HWND` in the `Control.ReleaseUiaProvider` method

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/UiaCore/Interop.UiaReturnRawElementProvider.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/UiaCore/Interop.UiaReturnRawElementProvider.cs
@@ -9,7 +9,7 @@ internal partial class Interop
     internal static partial class UiaCore
     {
         [DllImport(Libraries.UiaCore, CharSet = CharSet.Unicode)]
-        public static extern nint UiaReturnRawElementProvider(IntPtr hwnd, nint wParam, nint lParam, IRawElementProviderSimple? el);
+        public static extern nint UiaReturnRawElementProvider(HWND hwnd, nint wParam, nint lParam, IRawElementProviderSimple? el);
 
         public static nint UiaReturnRawElementProvider(IHandle<HWND> hwnd, WPARAM wParam, LPARAM lParam, IRawElementProviderSimple? el)
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildNativeWindow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildNativeWindow.cs
@@ -61,7 +61,7 @@ namespace System.Windows.Forms
                         {
                             if (Handle != IntPtr.Zero)
                             {
-                                UiaCore.UiaReturnRawElementProvider(Handle, wParam: 0, lParam: 0, el: null);
+                                UiaCore.UiaReturnRawElementProvider(HWND, wParam: 0, lParam: 0, el: null);
                             }
 
                             if (OsVersion.IsWindows8OrGreater())

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -3228,7 +3228,7 @@ namespace System.Windows.Forms
             }
         }
 
-        internal override void ReleaseUiaProvider(IntPtr handle)
+        internal override void ReleaseUiaProvider(HWND handle)
         {
             if (!IsAccessibilityObjectCreated)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -2511,6 +2511,8 @@ namespace System.Windows.Forms
 
         internal IntPtr HandleInternal => _window.Handle;
 
+        internal HWND HWNDInternal => _window.HWND;
+
         /// <summary>
         ///  True if this control has child controls in its collection.  This
         ///  is more efficient than checking for Controls.Count > 0, but has the
@@ -10076,9 +10078,9 @@ namespace System.Windows.Forms
         ///  Releases UI Automation provider for specified window.
         /// </summary>
         /// <param name="handle">The window handle.</param>
-        internal virtual void ReleaseUiaProvider(IntPtr handle)
+        internal virtual void ReleaseUiaProvider(HWND handle)
         {
-            if (handle != IntPtr.Zero)
+            if (!handle.IsNull)
             {
                 // When a window that previously returned providers has been destroyed,
                 // you should notify UI Automation by calling the UiaReturnRawElementProvider
@@ -12222,7 +12224,7 @@ namespace System.Windows.Forms
 
             if (SupportsUiaProviders)
             {
-                ReleaseUiaProvider(HandleInternal);
+                ReleaseUiaProvider(HWNDInternal);
             }
 
             OnHandleDestroyed(EventArgs.Empty);
@@ -14525,7 +14527,6 @@ namespace System.Windows.Forms
         HWND IHandle<HWND>.Handle => HWND;
 
         internal HWND HWND => (HWND)Handle;
-        internal HWND HWNDInternal => (HWND)HandleInternal;
 
         internal virtual bool AllowsChildrenToShowToolTips() => true;
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
@@ -26104,7 +26104,7 @@ namespace System.Windows.Forms
             Capture = false;
         }
 
-        internal override void ReleaseUiaProvider(IntPtr handle)
+        internal override void ReleaseUiaProvider(HWND handle)
         {
             if (!IsAccessibilityObjectCreated)
             {
@@ -26129,7 +26129,7 @@ namespace System.Windows.Forms
                     column.HeaderCell.ReleaseUiaProvider();
                 }
 
-                _editingPanel?.ReleaseUiaProvider(IntPtr.Zero);
+                _editingPanel?.ReleaseUiaProvider(HWND.Null);
                 _editingPanelAccessibleObject = null;
                 _topLeftHeaderCell?.ReleaseUiaProvider();
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxCell.cs
@@ -2549,7 +2549,7 @@ namespace System.Windows.Forms
 
         internal override void ReleaseUiaProvider()
         {
-            EditingComboBox?.ReleaseUiaProvider(IntPtr.Zero);
+            EditingComboBox?.ReleaseUiaProvider(HWND.Null);
 
             base.ReleaseUiaProvider();
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxEditingControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxEditingControl.cs
@@ -169,7 +169,7 @@ namespace System.Windows.Forms
             }
         }
 
-        internal override void ReleaseUiaProvider(nint handle)
+        internal override void ReleaseUiaProvider(HWND handle)
         {
             if (TryGetAccessibilityObject(out AccessibleObject accessibleObject))
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxEditingControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxEditingControl.cs
@@ -285,7 +285,7 @@ namespace System.Windows.Forms
             return base.ProcessKeyEventArgs(ref m);
         }
 
-        internal override void ReleaseUiaProvider(nint handle)
+        internal override void ReleaseUiaProvider(HWND handle)
         {
             if (TryGetAccessibilityObject(out AccessibleObject? accessibleObject))
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
@@ -2083,7 +2083,7 @@ namespace System.Windows.Forms
             Items.SetItemInternal(index, Items[index]);
         }
 
-        internal override void ReleaseUiaProvider(IntPtr handle)
+        internal override void ReleaseUiaProvider(HWND handle)
         {
             ClearListItemAccessibleObjects();
             base.ReleaseUiaProvider(handle);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -5139,7 +5139,7 @@ namespace System.Windows.Forms
             }
         }
 
-        internal override void ReleaseUiaProvider(nint handle)
+        internal override void ReleaseUiaProvider(HWND handle)
         {
             if (!OsVersion.IsWindows8OrGreater() || !IsAccessibilityObjectCreated)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewLabelEditNativeWindow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewLabelEditNativeWindow.cs
@@ -79,7 +79,7 @@ namespace System.Windows.Forms
                 // you should notify UI Automation by calling the UiaReturnRawElementProvider
                 // as follows: UiaReturnRawElementProvider(hwnd, 0, 0, NULL). This call tells
                 // UI Automation that it can safely remove all map entries that refer to the specified window.
-                UiaCore.UiaReturnRawElementProvider(Handle, wParam: 0, lParam: 0, el: null);
+                UiaCore.UiaReturnRawElementProvider(HWND, wParam: 0, lParam: 0, el: null);
             }
 
             if (OsVersion.IsWindows8OrGreater())

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.cs
@@ -1580,7 +1580,7 @@ namespace System.Windows.Forms
             _onRightToLeftLayoutChanged?.Invoke(this, e);
         }
 
-        internal override void ReleaseUiaProvider(nint handle)
+        internal override void ReleaseUiaProvider(HWND handle)
         {
             if (OsVersion.IsWindows8OrGreater() && IsAccessibilityObjectCreated)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.TabPageCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.TabPageCollection.cs
@@ -342,7 +342,7 @@ namespace System.Windows.Forms
                 _owner.Controls.Remove(value);
                 if (value.IsHandleCreated)
                 {
-                    value.ReleaseUiaProvider(value.HandleInternal);
+                    value.ReleaseUiaProvider(value.HWNDInternal);
                 }
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.cs
@@ -620,7 +620,7 @@ namespace System.Windows.Forms
             }
         }
 
-        internal override void ReleaseUiaProvider(IntPtr handle)
+        internal override void ReleaseUiaProvider(HWND handle)
         {
             if (OsVersion.IsWindows8OrGreater())
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
@@ -4166,7 +4166,7 @@ namespace System.Windows.Forms
             return null;
         }
 
-        internal override void ReleaseUiaProvider(IntPtr handle)
+        internal override void ReleaseUiaProvider(HWND handle)
         {
             if (!IsAccessibilityObjectCreated)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripControlHost.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripControlHost.cs
@@ -872,7 +872,7 @@ namespace System.Windows.Forms
 
         internal override void ReleaseUiaProvider()
         {
-            _control?.ReleaseUiaProvider(IntPtr.Zero);
+            _control?.ReleaseUiaProvider(HWND.Null);
             base.ReleaseUiaProvider();
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownItem.cs
@@ -617,7 +617,7 @@ namespace System.Windows.Forms
 
         internal override void ReleaseUiaProvider()
         {
-            _dropDown?.ReleaseUiaProvider(IntPtr.Zero);
+            _dropDown?.ReleaseUiaProvider(HWND.Null);
             base.ReleaseUiaProvider();
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
@@ -177,7 +177,7 @@ namespace System.Windows.Forms
             SetStyle(ControlStyles.UseTextForAccessibility, false);
         }
 
-        internal override void ReleaseUiaProvider(IntPtr handle)
+        internal override void ReleaseUiaProvider(HWND handle)
         {
             foreach (TreeNode rootNode in Nodes)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.UpDownButtons.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.UpDownButtons.cs
@@ -337,7 +337,7 @@ namespace System.Windows.Forms
             protected virtual void OnUpDown(UpDownEventArgs upevent)
                 => _upDownEventHandler?.Invoke(this, upevent);
 
-            internal override void ReleaseUiaProvider(IntPtr handle)
+            internal override void ReleaseUiaProvider(HWND handle)
             {
                 if (IsAccessibilityObjectCreated
                     && OsVersion.IsWindows8OrGreater()

--- a/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.cs
@@ -457,14 +457,14 @@ namespace System.Windows.Forms
             return base.ApplyBoundsConstraints(suggestedX, suggestedY, proposedWidth, PreferredHeight);
         }
 
-        internal override void ReleaseUiaProvider(IntPtr handle)
+        internal override void ReleaseUiaProvider(HWND handle)
         {
             // UpDownEdit as TextBox is a control, that should disconnect its accessible object itself,
             // but if it supports Uia providers. If no, force disconnecting for UpDownEdit accessible object
             // as a part of UIA tree of Domain/NumericUpDown controls.
             if (!_upDownEdit.SupportsUiaProviders)
             {
-                _upDownEdit.ReleaseUiaProvider(_upDownEdit.HandleInternal);
+                _upDownEdit.ReleaseUiaProvider(_upDownEdit.HWNDInternal);
             }
 
             base.ReleaseUiaProvider(handle);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ColumnHeader.ListViewColumnHeaderAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ColumnHeader.ListViewColumnHeaderAccessibleObjectTests.cs
@@ -48,7 +48,7 @@ namespace System.Windows.Forms.Tests
             EnforceAccessibleObjectCreation(columnHeader);
             _ = listView.AccessibilityObject;
 
-            listView.ReleaseUiaProvider(listView.Handle);
+            listView.ReleaseUiaProvider(listView.HWND);
 
             Assert.Null(columnHeader.TestAccessor().Dynamic._accessibilityObject);
             Assert.True(listView.IsHandleCreated);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBox.ComboBoxAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBox.ComboBoxAccessibleObjectTests.cs
@@ -418,7 +418,7 @@ namespace System.Windows.Forms.Tests
 
             Assert.Equal(comboBox.Items.Count, accessibleObject.ItemAccessibleObjects.Count);
 
-            comboBox.ReleaseUiaProvider(comboBox.Handle);
+            comboBox.ReleaseUiaProvider(comboBox.HWND);
 
             Assert.Equal(0, accessibleObject.ItemAccessibleObjects.Count);
             Assert.True(comboBox.IsHandleCreated);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListBoxAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListBoxAccessibleObjectTests.cs
@@ -100,7 +100,7 @@ namespace System.Windows.Forms.Tests
             using ListBox listBox = CreateListBoxWithItems();
             ListBoxAccessibleObject accessibleObject = InitListBoxItemsAccessibleObjects(listBox);
 
-            listBox.ReleaseUiaProvider(listBox.Handle);
+            listBox.ReleaseUiaProvider(listBox.HWND);
 
             Assert.Equal(0, accessibleObject.TestAccessor().Dynamic._itemAccessibleObjects.Count);
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObjectTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -1353,7 +1353,7 @@ namespace System.Windows.Forms.Tests
             EnforceAccessibleObjectCreation(group);
             EnforceAccessibleObjectCreation(listView.DefaultGroup);
 
-            listView.ReleaseUiaProvider(listView.Handle);
+            listView.ReleaseUiaProvider(listView.HWND);
 
             Assert.Null(group.TestAccessor().Dynamic._accessibilityObject);
             Assert.Null(listView.DefaultGroup.TestAccessor().Dynamic._accessibilityObject);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemAccessibleObjectTests.cs
@@ -1846,7 +1846,7 @@ namespace System.Windows.Forms.Tests
             listView.Items.Add(item);
             EnforceAccessibleObjectCreation(item);
 
-            listView.ReleaseUiaProvider(listView.Handle);
+            listView.ReleaseUiaProvider(listView.HWND);
 
             Assert.Null(item.TestAccessor().Dynamic._accessibilityObject);
             Assert.True(listView.IsHandleCreated);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObjectTests.cs
@@ -1061,7 +1061,7 @@ namespace System.Windows.Forms.Tests
             listView.Items.Add(listViewItem);
             EnforceAccessibleObjectCreation(listViewItem);
 
-            listView.ReleaseUiaProvider(listView.Handle);
+            listView.ReleaseUiaProvider(listView.HWND);
 
             Assert.Null(listViewSubItem.TestAccessor().Dynamic._accessibilityObject);
             Assert.True(listView.IsHandleCreated);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
@@ -5745,7 +5745,7 @@ namespace System.Windows.Forms.Tests
             using ListView listView = new();
             _ = listView.AccessibilityObject;
 
-            listView.ReleaseUiaProvider(listView.Handle);
+            listView.ReleaseUiaProvider(listView.HWND);
 
             Assert.Null(listView.TestAccessor().Dynamic._defaultGroup);
             Assert.True(listView.IsHandleCreated);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabPage.TabAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabPage.TabAccessibleObjectTests.cs
@@ -39,7 +39,7 @@ namespace System.Windows.Forms.Tests
             using TabPage tabPage = new();
             EnforceTabAccessibilityObjectCreation(tabPage);
 
-            tabPage.ReleaseUiaProvider(tabPage.Handle);
+            tabPage.ReleaseUiaProvider(tabPage.HWND);
 
             Assert.Null(tabPage.TestAccessor().Dynamic._tabAccessibilityObject);
             Assert.True(tabPage.IsHandleCreated);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripItemTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripItemTests.cs
@@ -7076,7 +7076,7 @@ namespace System.Windows.Forms.Tests
             _ = toolStrip.AccessibilityObject;
             Assert.True(toolStrip.IsAccessibilityObjectCreated);
 
-            toolStrip.ReleaseUiaProvider(toolStrip.Handle);
+            toolStrip.ReleaseUiaProvider(toolStrip.HWND);
 
             Assert.Equal(1, toolStrip.Disconnects);
             Assert.True(toolStripDropDownItem1.IsAccessibleObjectCleared());
@@ -15574,7 +15574,7 @@ namespace System.Windows.Forms.Tests
 
             public int Disconnects { get; private set; }
 
-            internal new void ReleaseUiaProvider(IntPtr handle)
+            internal new void ReleaseUiaProvider(HWND handle)
             {
                 base.ReleaseUiaProvider(handle);
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNode.TreeNodeAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNode.TreeNodeAccessibleObjectTests.cs
@@ -501,7 +501,7 @@ namespace System.Windows.Forms.Tests
             secondLevelNode.Nodes.Add(thirdLevelNode);
             control.CreateControl();
 
-            control.ReleaseUiaProvider(control.Handle);
+            control.ReleaseUiaProvider(control.HWND);
 
             Assert.True(firstLevelNode.IsAccessibilityObjectDisconnected);
             Assert.True(secondLevelNode.IsAccessibilityObjectDisconnected);


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #8217


## Proposed changes

- Changed type to `HWND`.
- Refactored `Control.HWNDInternal` property to remove extra convert.
- Used `HWND` value instead of `Handle`.
- Used `HWND.Null` value instead of `IntPtr.Zero`.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Method becomes more clear and an argument type is unified.

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Test methodology <!-- How did you ensure quality? -->

- Manual
- Unit tests

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

- Inspect 

## Test environment(s) <!-- Remove any that don't apply -->

.NET SDK:
 Version:   8.0.100-alpha.1.22512.5
 Commit:    1b80461e45

Runtime Environment:
 OS Name:     Windows
 OS Version:  10.0.22621


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8351)