### PR TITLE
Update to the latest CsWin32

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -46,7 +46,7 @@
       Microsoft.NET.Sdk.IL.targets requires definition of MicrosoftNETCoreILAsmVersion
     -->
     <MicrosoftNETCoreILAsmVersion>$(MicrosoftNETCoreILAsmPackageVersion)</MicrosoftNETCoreILAsmVersion>
-    <MicrosoftWindowsCsWin32PackageVersion>0.2.162-beta</MicrosoftWindowsCsWin32PackageVersion>
+    <MicrosoftWindowsCsWin32PackageVersion>0.2.176-beta</MicrosoftWindowsCsWin32PackageVersion>
   </PropertyGroup>
   <!-- Docs / Intellisense -->
   <PropertyGroup>

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/ComHelpers.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/ComHelpers.cs
@@ -5,9 +5,9 @@
 using System.Runtime.InteropServices;
 using Windows.Win32.System.Com;
 
-namespace Windows.Win32.Foundation
+namespace Windows.Win32
 {
-    internal static unsafe class ComHelpers
+    internal static unsafe partial class ComHelpers
     {
         // Note that ComScope<T> needs to be the return value to faciliate using in a `using`.
         //

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/Foundation/IVTable.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/Foundation/IVTable.cs
@@ -23,9 +23,9 @@ internal unsafe interface IVTable<TComInterface, TVTable> : IVTable
     private static sealed TVTable* VTable { get; set; }
 
     /// <summary>
-    ///  Populate <paramref name="vtable"/> with function pointers specific to the COM Interface.
+    ///  Populate <paramref name="vtable"/> with function pointers.
     /// </summary>
-    private protected static abstract void PopulateComInterfaceVTable(TVTable* vtable);
+    private protected static abstract void PopulateVTable(TVTable* vtable);
 
     static IUnknown.Vtbl* IVTable.GetVTable()
     {
@@ -34,7 +34,7 @@ internal unsafe interface IVTable<TComInterface, TVTable> : IVTable
             TVTable* vtable = (TVTable*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(TVTable), sizeof(TVTable));
             Interop.WinFormsComWrappers.PopulateIUnknownVTable((IUnknown.Vtbl*)vtable);
             VTable = vtable;
-            TComInterface.PopulateComInterfaceVTable(VTable);
+            TComInterface.PopulateVTable(VTable);
         }
 
         return (IUnknown.Vtbl*)VTable;

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Com/IDataObject.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Com/IDataObject.cs
@@ -2,60 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using ComWrappers = Interop.WinFormsComWrappers;
-
 namespace Windows.Win32.System.Com;
 
 internal unsafe partial struct IDataObject : IVTable<IDataObject, IDataObject.Vtbl>
 {
-    static void IVTable<IDataObject, Vtbl>.PopulateComInterfaceVTable(Vtbl* vtable)
-    {
-        vtable->GetData_4 = &GetData;
-        vtable->GetDataHere_5 = &GetDataHere;
-        vtable->QueryGetData_6 = &QueryGetData;
-        vtable->GetCanonicalFormatEtc_7 = &GetCanonicalFormatEtc;
-        vtable->SetData_8 = &SetData;
-        vtable->EnumFormatEtc_9 = &EnumFormatEtc;
-        vtable->DAdvise_10 = &DAdvise;
-        vtable->DUnadvise_11 = &DUnadvise;
-        vtable->EnumDAdvise_12 = &EnumDAdvise;
-    }
-
-    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
-    private static HRESULT GetData(IDataObject* @this, FORMATETC* format, STGMEDIUM* pMedium)
-        => ComWrappers.UnwrapAndInvoke<IDataObject, Interface>(@this, o => o.GetData(format, pMedium));
-
-    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
-    private static unsafe HRESULT GetDataHere(IDataObject* @this, FORMATETC* format, STGMEDIUM* pMedium)
-        => ComWrappers.UnwrapAndInvoke<IDataObject, Interface>(@this, o => o.GetDataHere(format, pMedium));
-
-    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
-    private static unsafe HRESULT QueryGetData(IDataObject* @this, FORMATETC* format)
-        => ComWrappers.UnwrapAndInvoke<IDataObject, Interface>(@this, o => o.QueryGetData(format));
-
-    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
-    private static unsafe HRESULT GetCanonicalFormatEtc(IDataObject* @this, FORMATETC* formatIn, FORMATETC* formatOut)
-        => ComWrappers.UnwrapAndInvoke<IDataObject, Interface>(@this, o => o.GetCanonicalFormatEtc(formatIn, formatOut));
-
-    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
-    private static HRESULT SetData(IDataObject* @this, FORMATETC* format, STGMEDIUM* pMedium, BOOL release)
-        => ComWrappers.UnwrapAndInvoke<IDataObject, Interface>(@this, o => o.SetData(format, pMedium, release));
-
-    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
-    private static HRESULT EnumFormatEtc(IDataObject* @this, uint direction, IEnumFORMATETC** pEnumFormatC)
-        => ComWrappers.UnwrapAndInvoke<IDataObject, Interface>(@this, o => o.EnumFormatEtc(direction, pEnumFormatC));
-
-    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
-    private static unsafe HRESULT DAdvise(IDataObject* @this, FORMATETC* pFormatetc, uint advf, IAdviseSink* pAdviseSink, uint* connection)
-        => ComWrappers.UnwrapAndInvoke<IDataObject, Interface>(@this, o => o.DAdvise(pFormatetc, advf, pAdviseSink, connection));
-
-    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
-    private static unsafe HRESULT DUnadvise(IDataObject* @this, uint connection)
-        => ComWrappers.UnwrapAndInvoke<IDataObject, Interface>(@this, o => o.DUnadvise(connection));
-
-    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
-    private static unsafe HRESULT EnumDAdvise(IDataObject* @this, IEnumSTATDATA** pEnumAdvise)
-        => ComWrappers.UnwrapAndInvoke<IDataObject, Interface>(@this, o => o.EnumDAdvise(pEnumAdvise));
 }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Com/IDispatch.Interface.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Com/IDispatch.Interface.cs
@@ -10,7 +10,7 @@ namespace Windows.Win32.System.Com;
 
 internal unsafe partial struct IDispatch : IVTable<IDispatch, IDispatch.Vtbl>
 {
-    static void IVTable<IDispatch, Vtbl>.PopulateComInterfaceVTable(Vtbl* vtable)
+    static void IVTable<IDispatch, Vtbl>.PopulateVTable(Vtbl* vtable)
     {
         vtable->GetTypeInfoCount_4 = &GetTypeInfoCount;
         vtable->GetTypeInfo_5 = &GetTypeInfo;

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Com/IEnumFORMATETC.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Com/IEnumFORMATETC.cs
@@ -2,35 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using ComWrappers = Interop.WinFormsComWrappers;
-
 namespace Windows.Win32.System.Com;
 
 internal unsafe partial struct IEnumFORMATETC : IVTable<IEnumFORMATETC, IEnumFORMATETC.Vtbl>
 {
-    static void IVTable<IEnumFORMATETC, Vtbl>.PopulateComInterfaceVTable(Vtbl* vtable)
-    {
-        vtable->Next_4 = &Next;
-        vtable->Skip_5 = &Skip;
-        vtable->Reset_6 = &Reset;
-        vtable->Clone_7 = &Clone;
-    }
-
-    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
-    private static HRESULT Next(IEnumFORMATETC* @this, uint celt, FORMATETC* rgelt, uint* pceltFetched)
-        => ComWrappers.UnwrapAndInvoke<IEnumFORMATETC, Interface>(@this, o => o.Next(celt, rgelt, pceltFetched));
-
-    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
-    private static HRESULT Skip(IEnumFORMATETC* @this, uint celt)
-        => ComWrappers.UnwrapAndInvoke<IEnumFORMATETC, Interface>(@this, o => o.Skip(celt));
-
-    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
-    private static HRESULT Reset(IEnumFORMATETC* @this)
-        => ComWrappers.UnwrapAndInvoke<IEnumFORMATETC, Interface>(@this, o => o.Reset());
-
-    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
-    private static HRESULT Clone(IEnumFORMATETC* @this, IEnumFORMATETC** ppenum)
-        => ComWrappers.UnwrapAndInvoke<IEnumFORMATETC, Interface>(@this, o => o.Clone(ppenum));
 }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Com/IEnumString.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Com/IEnumString.cs
@@ -2,36 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using ComWrappers = Interop.WinFormsComWrappers;
-
 namespace Windows.Win32.System.Com
 {
     internal unsafe partial struct IEnumString : IVTable<IEnumString, IEnumString.Vtbl>
     {
-        static void IVTable<IEnumString, Vtbl>.PopulateComInterfaceVTable(Vtbl* vtable)
-        {
-            vtable->Next_4 = &Next;
-            vtable->Skip_5 = &Skip;
-            vtable->Reset_6 = &Reset;
-            vtable->Clone_7 = &Clone;
-        }
-
-        [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
-        private static HRESULT Next(IEnumString* @this, uint celt, PWSTR* rgelt, uint* pceltFetched) =>
-            ComWrappers.UnwrapAndInvoke<IEnumString, Interface>(@this, o => o.Next(celt, rgelt, pceltFetched));
-
-        [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
-        private static HRESULT Skip(IEnumString* @this, uint celt) =>
-            ComWrappers.UnwrapAndInvoke<IEnumString, Interface>(@this, o => o.Skip(celt));
-
-        [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
-        private static HRESULT Reset(IEnumString* @this) =>
-            ComWrappers.UnwrapAndInvoke<IEnumString, Interface>(@this, o => o.Reset());
-
-        [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
-        private static HRESULT Clone(IEnumString* @this, IEnumString** ppenum) =>
-            ComWrappers.UnwrapAndInvoke<IEnumString, Interface>(@this, o => o.Clone(ppenum));
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Com/ISequentialStream.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Com/ISequentialStream.cs
@@ -2,25 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using ComWrappers = Interop.WinFormsComWrappers;
-
 namespace Windows.Win32.System.Com;
 
 internal unsafe partial struct ISequentialStream : IVTable<ISequentialStream, ISequentialStream.Vtbl>
 {
-    static void IVTable<ISequentialStream, Vtbl>.PopulateComInterfaceVTable(Vtbl* vtable)
-    {
-        vtable->Read_4 = &Read;
-        vtable->Write_5 = &Write;
-    }
-
-    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
-    private static HRESULT Read(ISequentialStream* @this, void* pv, uint cb, uint* pcbRead)
-            => ComWrappers.UnwrapAndInvoke<ISequentialStream, Interface>(@this, o => o.Read(pv, cb, pcbRead));
-
-    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
-    private static HRESULT Write(ISequentialStream* @this, void* pv, uint cb, uint* pcbWritten)
-        => ComWrappers.UnwrapAndInvoke<ISequentialStream, Interface>(@this, o => o.Write(pv, cb, pcbWritten));
 }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Com/IStream.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Com/IStream.cs
@@ -2,71 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using ComWrappers = Interop.WinFormsComWrappers;
-
 namespace Windows.Win32.System.Com
 {
     internal unsafe partial struct IStream : IVTable<IStream, IStream.Vtbl>
     {
-        static void IVTable<IStream, Vtbl>.PopulateComInterfaceVTable(Vtbl* vtable)
-        {
-            vtable->Read_4 = &Read;
-            vtable->Write_5 = &Write;
-            vtable->Seek_6 = &Seek;
-            vtable->SetSize_7 = &SetSize;
-            vtable->CopyTo_8 = &CopyTo;
-            vtable->Commit_9 = &Commit;
-            vtable->Revert_10 = &Revert;
-            vtable->LockRegion_11 = &LockRegion;
-            vtable->UnlockRegion_12 = &UnlockRegion;
-            vtable->Stat_13 = &Stat;
-            vtable->Clone_14 = &Clone;
-        }
-
-        [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
-        private static HRESULT Read(IStream* @this, void* pv, uint cb, uint* pcbRead)
-            => ComWrappers.UnwrapAndInvoke<IStream, Interface>(@this, o => o.Read(pv, cb, pcbRead));
-
-        [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
-        private static HRESULT Write(IStream* @this, void* pv, uint cb, uint* pcbWritten)
-            => ComWrappers.UnwrapAndInvoke<IStream, Interface>(@this, o => o.Write(pv, cb, pcbWritten));
-
-        [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
-        private static HRESULT Seek(IStream* @this, long dlibMove, SeekOrigin dwOrigin, ulong* plibNewPosition)
-            => ComWrappers.UnwrapAndInvoke<IStream, Interface>(@this, o => o.Seek(dlibMove, dwOrigin, plibNewPosition));
-
-        [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
-        private static HRESULT SetSize(IStream* @this, ulong libNewSize)
-            => ComWrappers.UnwrapAndInvoke<IStream, Interface>(@this, o => o.SetSize(libNewSize));
-
-        [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
-        private static HRESULT CopyTo(IStream* @this, IStream* pstm, ulong cb, ulong* pcbRead, ulong* pcbWritten)
-            => ComWrappers.UnwrapAndInvoke<IStream, Interface>(@this, o => o.CopyTo(pstm, cb, pcbRead, pcbWritten));
-
-        [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
-        private static HRESULT Commit(IStream* @this, STGC grfCommitFlags)
-            => ComWrappers.UnwrapAndInvoke<IStream, Interface>(@this, o => o.Commit(grfCommitFlags));
-
-        [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
-        private static HRESULT Revert(IStream* @this)
-            => ComWrappers.UnwrapAndInvoke<IStream, Interface>(@this, o => o.Revert());
-
-        [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
-        private static HRESULT LockRegion(IStream* @this, ulong libOffset, ulong cb, LOCKTYPE dwLockType)
-            => ComWrappers.UnwrapAndInvoke<IStream, Interface>(@this, o => o.LockRegion(libOffset, cb, dwLockType));
-
-        [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
-        private static HRESULT UnlockRegion(IStream* @this, ulong libOffset, ulong cb, uint dwLockType)
-            => ComWrappers.UnwrapAndInvoke<IStream, Interface>(@this, o => o.UnlockRegion(libOffset, cb, dwLockType));
-
-        [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
-        private static HRESULT Stat(IStream* @this, STATSTG* pstatstg, STATFLAG grfStatFlag)
-            => ComWrappers.UnwrapAndInvoke<IStream, Interface>(@this, o => o.Stat(pstatstg, grfStatFlag));
-
-        [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
-        private static HRESULT Clone(IStream* @this, IStream** ppstm)
-            => ComWrappers.UnwrapAndInvoke<IStream, Interface>(@this, o => o.Clone(ppstm));
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Com/IUnknown.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Com/IUnknown.cs
@@ -2,20 +2,19 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace Windows.Win32.System.Com
-{
-    internal partial struct IUnknown
-    {
-        // https://github.com/microsoft/CsWin32/issues/724
-        internal interface Interface
-        {
-            // Can't do this yet as the generated members aren't public. Creating it anyway to help constrain our
-            // helpers a bit more.
-            // https://github.com/microsoft/CsWin32/issues/723
+namespace Windows.Win32.System.Com;
 
-            //internal unsafe HRESULT QueryInterface(Guid* riid, void** ppvObject);
-            //internal uint AddRef();
-            //internal uint Release();
-        }
+internal unsafe partial struct IUnknown
+{
+    // https://github.com/microsoft/CsWin32/issues/724
+    internal interface Interface
+    {
+        // Can't do this yet as the generated members aren't public. Creating it anyway to help constrain our
+        // helpers a bit more.
+        // https://github.com/microsoft/CsWin32/issues/723
+
+        //internal unsafe HRESULT QueryInterface(Guid* riid, void** ppvObject);
+        //internal uint AddRef();
+        //internal uint Release();
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Ole/IDropSource.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Ole/IDropSource.cs
@@ -2,26 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using Windows.Win32.System.SystemServices;
-using ComWrappers = Interop.WinFormsComWrappers;
-
 namespace Windows.Win32.System.Ole;
 
 internal unsafe partial struct IDropSource : IVTable<IDropSource, IDropSource.Vtbl>
 {
-    static void IVTable<IDropSource, Vtbl>.PopulateComInterfaceVTable(Vtbl* vtable)
-    {
-        vtable->QueryContinueDrag_4 = &QueryContinueDrag;
-        vtable->GiveFeedback_5 = &GiveFeedback;
-    }
-
-    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
-    private static HRESULT QueryContinueDrag(IDropSource* @this, BOOL fEscapePressed, MODIFIERKEYS_FLAGS grfKeyState)
-        => ComWrappers.UnwrapAndInvoke<IDropSource, Interface>(@this, o => o.QueryContinueDrag(fEscapePressed, grfKeyState));
-
-    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
-    private static HRESULT GiveFeedback(IDropSource* @this, DROPEFFECT dwEffect)
-        => ComWrappers.UnwrapAndInvoke<IDropSource, Interface>(@this, o => o.GiveFeedback(dwEffect));
 }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Ole/IDropSourceNotify.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Ole/IDropSourceNotify.cs
@@ -2,25 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using ComWrappers = Interop.WinFormsComWrappers;
-
 namespace Windows.Win32.System.Ole;
 
 internal unsafe partial struct IDropSourceNotify : IVTable<IDropSourceNotify, IDropSourceNotify.Vtbl>
 {
-    static void IVTable<IDropSourceNotify, Vtbl>.PopulateComInterfaceVTable(Vtbl* vtable)
-    {
-        vtable->DragEnterTarget_4 = &DragEnterTarget;
-        vtable->DragLeaveTarget_5 = &DragLeaveTarget;
-    }
-
-    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
-    private static HRESULT DragEnterTarget(IDropSourceNotify* @this, HWND hwndTarget)
-        => ComWrappers.UnwrapAndInvoke<IDropSourceNotify, Interface>(@this, o => o.DragEnterTarget(hwndTarget));
-
-    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
-    private static HRESULT DragLeaveTarget(IDropSourceNotify* @this)
-        => ComWrappers.UnwrapAndInvoke<IDropSourceNotify, Interface>(@this, o => o.DragLeaveTarget());
 }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Ole/IDropTarget.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Ole/IDropTarget.cs
@@ -2,37 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using Windows.Win32.System.Com;
-using Windows.Win32.System.SystemServices;
-using ComWrappers = Interop.WinFormsComWrappers;
-
 namespace Windows.Win32.System.Ole;
 
 internal unsafe partial struct IDropTarget : IVTable<IDropTarget, IDropTarget.Vtbl>
 {
-    static void IVTable<IDropTarget, Vtbl>.PopulateComInterfaceVTable(Vtbl* vtable)
-    {
-        vtable->DragEnter_4 = &DragEnter;
-        vtable->DragOver_5 = &DragOver;
-        vtable->DragLeave_6 = &DragLeave;
-        vtable->Drop_7 = &Drop;
-    }
-
-    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
-    private static HRESULT DragEnter(IDropTarget* @this, IDataObject* pDataObj, MODIFIERKEYS_FLAGS grfKeyState, POINTL pt, DROPEFFECT* pdwEffect)
-        => ComWrappers.UnwrapAndInvoke<IDropTarget, Interface>(@this, o => o.DragEnter(pDataObj, grfKeyState, pt, pdwEffect));
-
-    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
-    private static HRESULT DragOver(IDropTarget* @this, MODIFIERKEYS_FLAGS grfKeyState, POINTL pt, DROPEFFECT* pdwEffect)
-        => ComWrappers.UnwrapAndInvoke<IDropTarget, Interface>(@this, o => o.DragOver(grfKeyState, pt, pdwEffect));
-
-    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
-    private static HRESULT DragLeave(IDropTarget* @this)
-        => ComWrappers.UnwrapAndInvoke<IDropTarget, Interface>(@this, o => o.DragLeave());
-
-    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
-    private static HRESULT Drop(IDropTarget* @this, IDataObject* pDataObj, MODIFIERKEYS_FLAGS grfKeyState, POINTL pt, DROPEFFECT* pdwEffect)
-        => ComWrappers.UnwrapAndInvoke<IDropTarget, Interface>(@this, o => o.Drop(pDataObj, grfKeyState, pt, pdwEffect));
 }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/UI/Shell/IFileDialogEvents.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/UI/Shell/IFileDialogEvents.cs
@@ -2,50 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using ComWrappers = Interop.WinFormsComWrappers;
-
 namespace Windows.Win32.UI.Shell;
 
 internal unsafe partial struct IFileDialogEvents : IVTable<IFileDialogEvents, IFileDialogEvents.Vtbl>
 {
-    static void IVTable<IFileDialogEvents, Vtbl>.PopulateComInterfaceVTable(Vtbl* vtable)
-    {
-        vtable->OnFileOk_4 = &OnFileOk;
-        vtable->OnFolderChanging_5 = &OnFolderChanging;
-        vtable->OnFolderChange_6 = &OnFolderChange;
-        vtable->OnSelectionChange_7 = &OnSelectionChange;
-        vtable->OnShareViolation_8 = &OnShareViolation;
-        vtable->OnTypeChange_9 = &OnTypeChange;
-        vtable->OnOverwrite_10 = &OnOverwrite;
-    }
-
-    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
-    private static HRESULT OnFileOk(IFileDialogEvents* @this, IFileDialog* pfd)
-        => ComWrappers.UnwrapAndInvoke<IFileDialogEvents, Interface>(@this, o => o.OnFileOk(pfd));
-
-    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
-    private static HRESULT OnFolderChanging(IFileDialogEvents* @this, IFileDialog* pfd, IShellItem* psiFolder)
-        => ComWrappers.UnwrapAndInvoke<IFileDialogEvents, Interface>(@this, o => o.OnFolderChanging(pfd, psiFolder));
-
-    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
-    private static HRESULT OnFolderChange(IFileDialogEvents* @this, IFileDialog* pfd)
-        => ComWrappers.UnwrapAndInvoke<IFileDialogEvents, Interface>(@this, o => o.OnFolderChange(pfd));
-
-    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
-    private static HRESULT OnSelectionChange(IFileDialogEvents* @this, IFileDialog* pfd)
-        => ComWrappers.UnwrapAndInvoke<IFileDialogEvents, Interface>(@this, o => o.OnSelectionChange(pfd));
-
-    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
-    private static HRESULT OnShareViolation(IFileDialogEvents* @this, IFileDialog* pfd, IShellItem* psi, FDE_SHAREVIOLATION_RESPONSE* pResponse)
-        => ComWrappers.UnwrapAndInvoke<IFileDialogEvents, Interface>(@this, o => o.OnShareViolation(pfd, psi, pResponse));
-
-    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
-    private static HRESULT OnTypeChange(IFileDialogEvents* @this, IFileDialog* pfd)
-        => ComWrappers.UnwrapAndInvoke<IFileDialogEvents, Interface>(@this, o => o.OnTypeChange(pfd));
-
-    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
-    private static HRESULT OnOverwrite(IFileDialogEvents* @this, IFileDialog* pfd, IShellItem* psi, FDE_OVERWRITE_RESPONSE* pResponse)
-        => ComWrappers.UnwrapAndInvoke<IFileDialogEvents, Interface>(@this, o => o.OnOverwrite(pfd, psi, pResponse));
 }


### PR DESCRIPTION
This drop adds CCW generation, which removes a good chunk of our boilerplate and will facilitate additional progress on moving to ComWrappers.
