### PR TITLE
Change default `ImageList.ColorDepth` to 32bit

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.cs
@@ -19,11 +19,11 @@ namespace System.Windows.Forms
     ///  Toolbar. You can add either bitmaps or Icons to the ImageList, and the
     ///  other controls will be able to use the Images as they desire.
     /// </summary>
-    [Designer("System.Windows.Forms.Design.ImageListDesigner, " + AssemblyRef.SystemDesign)]
+    [Designer($"System.Windows.Forms.Design.ImageListDesigner, {AssemblyRef.SystemDesign}")]
     [ToolboxItemFilter("System.Windows.Forms")]
     [DefaultProperty(nameof(Images))]
     [TypeConverter(typeof(ImageListConverter))]
-    [DesignerSerializer("System.Windows.Forms.Design.ImageListCodeDomSerializer, " + AssemblyRef.SystemDesign, "System.ComponentModel.Design.Serialization.CodeDomSerializer, " + AssemblyRef.SystemDesign)]
+    [DesignerSerializer($"System.Windows.Forms.Design.ImageListCodeDomSerializer, {AssemblyRef.SystemDesign}", "System.ComponentModel.Design.Serialization.CodeDomSerializer, " + AssemblyRef.SystemDesign)]
     [SRDescription(nameof(SR.DescriptionImageList))]
     public sealed partial class ImageList : Component, IHandle, IHandle<HIMAGELIST>
     {
@@ -37,7 +37,7 @@ namespace System.Windows.Forms
 
         private NativeImageList? _nativeImageList;
 
-        private ColorDepth _colorDepth = ColorDepth.Depth8Bit;
+        private ColorDepth _colorDepth = ColorDepth.Depth32Bit;
         private Size _imageSize = s_defaultImageSize;
 
         private ImageCollection? _imageCollection;
@@ -103,7 +103,7 @@ namespace System.Windows.Forms
 
         private bool ShouldSerializeColorDepth() => Images.Count == 0;
 
-        private void ResetColorDepth() => ColorDepth = ColorDepth.Depth8Bit;
+        private void ResetColorDepth() => ColorDepth = ColorDepth.Depth32Bit;
 
         /// <summary>
         ///  The handle of the ImageList object. This corresponds to a win32
@@ -794,15 +794,9 @@ namespace System.Windows.Forms
         ///  Returns a string representation for this control.
         /// </summary>
         public override string ToString()
-        {
-            string s = base.ToString();
-            if (Images is not null)
-            {
-                return s + " Images.Count: " + Images.Count.ToString(CultureInfo.CurrentCulture) + ", ImageSize: " + ImageSize.ToString();
-            }
-
-            return s;
-        }
+            => Images is null
+            ? base.ToString()
+            : $"{base.ToString()} Images.Count: {Images.Count.ToString(CultureInfo.CurrentCulture)}, ImageSize: {ImageSize}";
 
         HIMAGELIST IHandle<HIMAGELIST>.Handle => HIMAGELIST;
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ImageListTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ImageListTests.cs
@@ -17,7 +17,7 @@ namespace System.Windows.Forms.Tests
         public void ImageList_Ctor_Default()
         {
             using var list = new ImageList();
-            Assert.Equal(ColorDepth.Depth8Bit, list.ColorDepth);
+            Assert.Equal(ColorDepth.Depth32Bit, list.ColorDepth);
             Assert.Null(list.Container);
             Assert.Empty(list.Images);
             Assert.Same(list.Images, list.Images);
@@ -35,7 +35,7 @@ namespace System.Windows.Forms.Tests
         {
             var container = new Container();
             using var list = new ImageList(container);
-            Assert.Equal(ColorDepth.Depth8Bit, list.ColorDepth);
+            Assert.Equal(ColorDepth.Depth32Bit, list.ColorDepth);
             Assert.Same(container, list.Container);
             Assert.Empty(list.Images);
             Assert.Same(list.Images, list.Images);
@@ -171,15 +171,15 @@ namespace System.Windows.Forms.Tests
         {
             PropertyDescriptor property = TypeDescriptor.GetProperties(typeof(ImageList))[nameof(ImageList.ColorDepth)];
             using var list = new ImageList();
-            Assert.Equal(ColorDepth.Depth8Bit, list.ColorDepth);
-            Assert.True(property.CanResetValue(list));
-
-            list.ColorDepth = ColorDepth.Depth32Bit;
             Assert.Equal(ColorDepth.Depth32Bit, list.ColorDepth);
             Assert.True(property.CanResetValue(list));
 
-            property.ResetValue(list);
+            list.ColorDepth = ColorDepth.Depth8Bit;
             Assert.Equal(ColorDepth.Depth8Bit, list.ColorDepth);
+            Assert.True(property.CanResetValue(list));
+
+            property.ResetValue(list);
+            Assert.Equal(ColorDepth.Depth32Bit, list.ColorDepth);
             Assert.True(property.CanResetValue(list));
         }
 
@@ -188,15 +188,15 @@ namespace System.Windows.Forms.Tests
         {
             PropertyDescriptor property = TypeDescriptor.GetProperties(typeof(ImageList))[nameof(ImageList.ColorDepth)];
             using var list = new ImageList();
-            Assert.Equal(ColorDepth.Depth8Bit, list.ColorDepth);
-            Assert.True(property.ShouldSerializeValue(list));
-
-            list.ColorDepth = ColorDepth.Depth32Bit;
             Assert.Equal(ColorDepth.Depth32Bit, list.ColorDepth);
             Assert.True(property.ShouldSerializeValue(list));
 
-            property.ResetValue(list);
+            list.ColorDepth = ColorDepth.Depth8Bit;
             Assert.Equal(ColorDepth.Depth8Bit, list.ColorDepth);
+            Assert.True(property.ShouldSerializeValue(list));
+
+            property.ResetValue(list);
+            Assert.Equal(ColorDepth.Depth32Bit, list.ColorDepth);
             Assert.True(property.ShouldSerializeValue(list));
 
             // With images.
@@ -506,7 +506,7 @@ namespace System.Windows.Forms.Tests
             {
                 ImageStream = stream
             };
-            Assert.Equal(ColorDepth.Depth8Bit, list.ColorDepth);
+            Assert.Equal(ColorDepth.Depth32Bit, list.ColorDepth);
             Assert.Empty(list.Images);
             Assert.Equal(new Size(16, 16), list.ImageSize);
             Assert.False(list.HandleCreated);
@@ -531,7 +531,7 @@ namespace System.Windows.Forms.Tests
             {
                 ImageStream = stream
             };
-            Assert.Equal(ColorDepth.Depth8Bit, list.ColorDepth);
+            Assert.Equal(ColorDepth.Depth32Bit, list.ColorDepth);
             Assert.Empty(list.Images);
             Assert.Equal(new Size(16, 16), list.ImageSize);
             Assert.False(list.HandleCreated);
@@ -556,7 +556,7 @@ namespace System.Windows.Forms.Tests
             Assert.NotEqual(IntPtr.Zero, list.Handle);
 
             list.ImageStream = stream;
-            Assert.Equal(ColorDepth.Depth8Bit, list.ColorDepth);
+            Assert.Equal(ColorDepth.Depth32Bit, list.ColorDepth);
             Assert.Empty(list.Images);
             Assert.Equal(new Size(16, 16), list.ImageSize);
             Assert.True(list.HandleCreated);
@@ -580,7 +580,7 @@ namespace System.Windows.Forms.Tests
             {
                 ImageStream = stream
             };
-            Assert.Equal(ColorDepth.Depth8Bit, list.ColorDepth);
+            Assert.Equal(ColorDepth.Depth32Bit, list.ColorDepth);
             Assert.Empty(list.Images);
             Assert.Equal(new Size(16, 16), list.ImageSize);
             Assert.False(list.HandleCreated);
@@ -604,7 +604,7 @@ namespace System.Windows.Forms.Tests
             Assert.NotEqual(IntPtr.Zero, list.Handle);
 
             list.ImageStream = stream;
-            Assert.Equal(ColorDepth.Depth8Bit, list.ColorDepth);
+            Assert.Equal(ColorDepth.Depth32Bit, list.ColorDepth);
             Assert.Empty(list.Images);
             Assert.Equal(new Size(16, 16), list.ImageSize);
             Assert.True(list.HandleCreated);


### PR DESCRIPTION
Fixes #7021

In the linked issue, the suggestion was to change the default `ColorDepth` to `32bit`. Thus having the best looking image by default. For modern applications this makes a lot of sense.

Side effects from this include a branch in `GetBitmap` which checks the alpha information, which may decrease performance slightly when interacting with the `ImageCollection`. It could also result in higher memory usage. But I cannot see any documentation on whether the `ColorDepth` setting reduces the image quality to save on memory. It's just a hunch.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8366)