### PR TITLE
Fix `Cursor(Stream)` to avoid incomplete reads and possible exception

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Cursor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Cursor.cs
@@ -81,12 +81,12 @@ namespace System.Windows.Forms
         public Cursor(Stream stream)
         {
             ArgumentNullException.ThrowIfNull(stream);
-
-            int length = checked((int)stream.Length);
-            _cursorData = new byte[length];
-            stream.Read(_cursorData, 0, length);
+            MemoryStream memoryStream = new();
+            stream.CopyTo(memoryStream);
+            memoryStream.Position = 0;
+            _cursorData = memoryStream.ToArray();
             LoadPicture(
-                new Ole32.GPStream(new MemoryStream(_cursorData)),
+                new Ole32.GPStream(memoryStream),
                 nameof(stream));
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Cursor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Cursor.cs
@@ -83,8 +83,10 @@ namespace System.Windows.Forms
             ArgumentNullException.ThrowIfNull(stream);
             MemoryStream memoryStream = new();
             stream.CopyTo(memoryStream);
-            memoryStream.Position = 0;
             _cursorData = memoryStream.ToArray();
+
+            // stream.CopyTo causes both streams to advance. So reset it for LoadPicture.
+            memoryStream.Position = 0;
             LoadPicture(
                 new Ole32.GPStream(memoryStream),
                 nameof(stream));


### PR DESCRIPTION
Fixes #3492

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8367)