### PR TITLE
Fix `LinkLabel` truncate when programmatically disabled and `UseCompatibleTextRendering=false`

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.cs
@@ -703,7 +703,7 @@ namespace System.Windows.Forms
 
                         Rectangle visualRectangle = new Rectangle(clientRectWithPadding.X + iLeftMargin,
                                                                   clientRectWithPadding.Y,
-                                                                  textSize.Width - iRightMargin - iLeftMargin,
+                                                                  textSize.Width + iRightMargin + iLeftMargin,
                                                                   textSize.Height);
                         visualRectangle = CalcTextRenderBounds(visualRectangle /*textRect*/, clientRectWithPadding /*clientRect*/, RtlTranslateContent(TextAlign));
 


### PR DESCRIPTION
Fixes #7341

Before:
![image](https://user-images.githubusercontent.com/2433737/207186226-fd67025e-37dd-4faf-81cc-ec915414c080.png)

After:
![image](https://user-images.githubusercontent.com/2433737/207186353-0742a050-ed55-476a-a53a-5231d104afe6.png)

Original comment: https://github.com/dotnet/winforms/issues/7341#issuecomment-1345829400

> This comment pointed me in the right direction.
> https://github.com/dotnet/winforms/issues/3780#issuecomment-855463125
> 
> When setting `UseCompatibleTextRendering=false`, it causes the issue.
> 
> The most basic reproduction is:
> ```csharp
> using Form form = new();
> using LinkLabel linkLabel = new()
> {
>     Text = "linkLabel12345",
>     Enabled = false,
>     UseCompatibleTextRendering = false,
>     AutoSize = true
> };
> form.Controls.Add(linkLabel);
> form.ShowDialog();
> ```
> 
> The issue stems from how `OnPaint` functions when `Enabled` and `UseCompatibleTextRendering`. The key here is around `Graphics.ExcludeClip` vs `Graphics.IntersectClip` and how Margins are included in the `_textRegion` in `EnsureRun`.
> 
> When `Enabled` is `true`, a manual paint is done via `PaintLink` and then `Graphics.ExcludeClip(_textRegion)` is called to avoid rendering that part of the graphics.
> 
> When `Enabled` is `false`, `Graphics.IntersectClip(_textRegion)` is called and then depending on `UseCompatibleTextRendering` we call a different overload of `ControlPaint.DrawStringDisabled`. `UseCompatibleTextRendering=true` will result in a `graphics.DrawString` call, where as `UseCompatibleTextRendering=false` results in a `User32.DrawTextExW` call.
> 
> When `UseCompatibleTextRendering=true` it uses `Graphics.MeasureCharacterRanges` to set the `_textRegion`. When `UseCompatibleTextRendering=false`, it uses the `ClientRectWithPadding` and then the margins returned from `hfont.GetTextMargins()`. The margins returned are then **SUBTRACTED** from the width to create a new rectangle. This is the bug, they should be ADDED to the width to account for the extra space required for the text.
> 
> https://github.com/dotnet/winforms/blob/b0e5f5b7c4698d3b39424c22d09dbce01e0ce544/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.cs#L704-L707
> 
> By changing the code to the following the behaviour was fixed in all scenarios.
> ```csharp
> Rectangle visualRectangle = new Rectangle(clientRectWithPadding.X + iLeftMargin,
>                                                                   clientRectWithPadding.Y,
>                                                                   textSize.Width + iRightMargin + iLeftMargin,
>                                                                   textSize.Height);
> ```
> Calling _textRegion.GetBounds(g); when UseCompatibleTextRendering=true gets Width = 81 Height = 16.
> 
> When UseCompatibleTextRendering=false
> With Changes:
> visualRectangle has Width = 91 Height = 15. Which is then changed to Width = 84 Height = 15 after the call to CalcTextRenderBounds which narrows it to the clientRectWithPadding.
> 
> Without Changes:
> visualRectangle has Width = 77 Height = 15.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8368)