### PR TITLE
Specify `Font` in `HH_POPUPW` when calling `ShowHTML10Help` in `Help.ShowPopup` to allow for unicode characters

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Help.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Help.cs
@@ -106,9 +106,17 @@ namespace System.Windows.Forms
                 clrForeground = new COLORREF(unchecked((uint)-1)),  // Ignore
                 clrBackground = SystemColors.Window
             };
-            fixed (char* pszText = caption)
+
+            Font font = parent?.Font ?? SystemFonts.StatusFont ?? SystemFonts.DefaultFont;
+            string captionFont = $"{font.Name}, {font.Size}, , " +
+                $"{(font.Bold ? "BOLD" : "")}" +
+                $"{(font.Italic ? "ITALIC" : "")}" +
+                $"{(font.Underline ? "UNDERLINE" : "")}";
+
+            fixed (char* pszText = caption, pszFont = captionFont)
             {
                 pop.pszText = pszText;
+                pop.pszFont = pszFont;
                 ShowHTML10Help(parent, null, HelpNavigator.Topic, pop);
             }
         }
@@ -155,15 +163,7 @@ namespace System.Windows.Forms
                 }
             }
 
-            HandleRef<HWND> handle;
-            if (parent is not null)
-            {
-                handle = new(parent);
-            }
-            else
-            {
-                handle = Control.GetHandleRef(PInvoke.GetActiveWindow());
-            }
+            HandleRef<HWND> handle = parent is not null ? (new(parent)) : Control.GetHandleRef(PInvoke.GetActiveWindow());
 
             object? htmlParam;
             if (param is string stringParam)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Help.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Help.cs
@@ -107,8 +107,8 @@ namespace System.Windows.Forms
                 clrBackground = SystemColors.Window
             };
 
-            Font font = parent?.Font ?? SystemFonts.StatusFont ?? SystemFonts.DefaultFont;
-            string captionFont = $"{font.Name}, {font.Size}, , " +
+            Font font = SystemFonts.StatusFont ?? SystemFonts.DefaultFont;
+            string captionFont = $"{font.Name}, {font.SizeInPoints}, , " +
                 $"{(font.Bold ? "BOLD" : "")}" +
                 $"{(font.Italic ? "ITALIC" : "")}" +
                 $"{(font.Underline ? "UNDERLINE" : "")}";


### PR DESCRIPTION
See issue for discussion on fix.

Fixes #4422

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8372)