### PR TITLE
Removed designer-added tags from the project file

### DIFF
--- a/src/System.Windows.Forms/src/System.Windows.Forms.csproj
+++ b/src/System.Windows.Forms/src/System.Windows.Forms.csproj
@@ -654,51 +654,6 @@
     </EmbeddedResource>
   </ItemGroup>
 
-  <ItemGroup>
-    <Compile Update="System\Windows\Forms\ComboBox.ChildAccessibleObject.cs">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Update="System\Windows\Forms\ComboBox.ObjectCollection.cs">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Update="System\Windows\Forms\ComboBox.FlatComboAdapter.cs">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Update="System\Windows\Forms\ComboBox.AutoCompleteDropDownFinder.cs">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Update="System\Windows\Forms\ComboBox.ACNativeWindow.cs">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Update="System\Windows\Forms\ComboBox.ComboBoxChildDropDownButtonUiaProvider.cs">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Update="System\Windows\Forms\ComboBox.ComboBoxChildTextUiaProvider.cs">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Update="System\Windows\Forms\ComboBox.ComboBoxChildListUiaProvider.cs">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Update="System\Windows\Forms\ComboBox.ComboBoxChildEditUiaProvider.cs">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Update="System\Windows\Forms\ComboBox.ComboBoxAccessibleObject.cs">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Update="System\Windows\Forms\ComboBox.ComboBoxItemAccessibleObjectCollection.cs">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Update="System\Windows\Forms\ComboBox.ComboBoxItemAccessibleObject.cs">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Update="System\Windows\Forms\ComboBox.ItemComparer.cs">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Update="System\Windows\Forms\ComboBox.ComboBoxChildNativeWindow.cs">
-      <SubType>Component</SubType>
-    </Compile>
-  </ItemGroup>
-
   <ItemGroup Condition="Exists('comctl32.dll')">
     <None Update="comctl32.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
These were added by the designer when nested classes were [split into the dedicated files](https://github.com/dotnet/winforms/commit/d0974fc45e7be195721091b4a8d09caf7394397b). Subtype informs the IDE what file view to use with these files, however it would had deduced this information from the type and visual designer does not work with these files. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8374)