### PR TITLE
Fixed memory leaking of PropertyGrid

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
@@ -1866,6 +1866,24 @@ namespace System.Windows.Forms
             base.Dispose(disposing);
         }
 
+        internal override void ReleaseUiaProvider(HWND handle)
+        {
+            if (_viewTabProperties?.Count > 0)
+            {
+                foreach (GridEntry gridEntry in _viewTabProperties.Values)
+                {
+                    gridEntry.ReleaseUiaProvider();
+                }
+            }
+
+            _helpPane?.ReleaseUiaProvider(HWND.Null);
+            _commandsPane?.ReleaseUiaProvider(HWND.Null);
+            _toolStrip?.ReleaseUiaProvider(HWND.Null);
+            _rootEntry?.ReleaseUiaProvider();
+
+            base.ReleaseUiaProvider(handle);
+        }
+
         private void DividerDraw(int y)
         {
             if (y == -1)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.cs
@@ -997,12 +997,30 @@ namespace System.Windows.Forms.PropertyGridInternal
             _cacheItems = null;
             _typeConverter = null;
             Editor = null;
-            _accessibleObject = null;
+            ReleaseUiaProvider();
 
             if (disposing)
             {
                 DisposeChildren();
             }
+        }
+
+        internal void ReleaseUiaProvider()
+        {
+            if (_children?.Count > 0)
+            {
+                foreach (GridEntry gridEntry in _children)
+                {
+                    gridEntry.ReleaseUiaProvider();
+                }
+            }
+
+            if (OsVersion.IsWindows8OrGreater() && _accessibleObject is not null)
+            {
+                UiaCore.UiaDisconnectProvider(_accessibleObject);
+            }
+
+            _accessibleObject = null;
         }
 
         public virtual void DisposeChildren()

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewListBoxAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewListBoxAccessibleObject.cs
@@ -36,8 +36,12 @@ namespace System.Windows.Forms.PropertyGridInternal
             /// <returns>Returns the element in the specified direction.</returns>
             internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
             {
-                if (!_owningPropertyGridView.DropDownVisible || _owningPropertyGridView.SelectedGridEntry is null
-                    || _owningPropertyGridView.DropDownControlHolder.Component != Owner)
+                if (!_owningPropertyGridView.DropDownVisible
+                    || _owningPropertyGridView.SelectedGridEntry is null
+                    || _owningPropertyGridView.DropDownControlHolder.Component != Owner
+                    // Created is set to false in WM_DESTROY, but the window Handle is released on NCDESTROY, which comes after DESTROY.
+                    // But between these calls, AccessibleObject can be recreated and might cause memory leaks.
+                    || !_owningPropertyGridView.OwnerGrid.Created)
                 {
                     return null;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewTextBox.GridViewTextBoxAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewTextBox.GridViewTextBoxAccessibleObject.cs
@@ -46,6 +46,9 @@ namespace System.Windows.Forms.PropertyGridInternal
                 internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
                 {
                     if (!_owningPropertyGridView.IsEditTextBoxCreated
+                        // Created is set to false in WM_DESTROY, but the window Handle is released on NCDESTROY, which comes after DESTROY.
+                        // But between these calls, AccessibleObject can be recreated and might cause memory leaks.
+                        || !_owningPropertyGridView.OwnerGrid.Created
                         || _owningPropertyGridView.SelectedGridEntry?.AccessibilityObject is not PropertyDescriptorGridEntryAccessibleObject parent)
                     {
                         return null;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.PropertyGridViewAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.PropertyGridViewAccessibleObject.cs
@@ -50,6 +50,9 @@ namespace System.Windows.Forms.PropertyGridInternal
             internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
             {
                 if (_parentPropertyGrid.IsHandleCreated &&
+                    // Created is set to false in WM_DESTROY, but the window Handle is released on NCDESTROY, which comes after DESTROY.
+                    // But between these calls, AccessibleObject can be recreated and might cause memory leaks.
+                    _parentPropertyGrid.Created &&
                     _parentPropertyGrid.AccessibilityObject is PropertyGrid.PropertyGridAccessibleObject propertyGridAccessibleObject)
                 {
                     UiaCore.IRawElementProviderFragment? navigationTarget = propertyGridAccessibleObject.ChildFragmentNavigate(this, direction);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -1054,6 +1054,9 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 _toolTip?.Dispose();
                 _toolTip = null;
+
+                _selectedGridEntry?.Dispose();
+                _selectedGridEntry = null;
             }
 
             base.Dispose(disposing);
@@ -4919,6 +4922,26 @@ namespace System.Windows.Forms.PropertyGridInternal
             SetCommitError(ErrorState.None);
 
             return CommitValue(value);
+        }
+
+        internal override void ReleaseUiaProvider(HWND handle)
+        {
+            if (_allGridEntries?.Count > 0)
+            {
+                foreach (GridEntry gridEntry in _allGridEntries)
+                {
+                    gridEntry.ReleaseUiaProvider();
+                }
+            }
+
+            _scrollBar?.ReleaseUiaProvider(HWND.Null);
+            _listBox?.ReleaseUiaProvider(HWND.Null);
+            _dropDownHolder?.ReleaseUiaProvider(HWND.Null);
+            _editTextBox?.ReleaseUiaProvider(HWND.Null);
+            _dropDownButton?.ReleaseUiaProvider(HWND.Null);
+            _dialogButton?.ReleaseUiaProvider(HWND.Null);
+
+            base.ReleaseUiaProvider(handle);
         }
 
         internal void ReverseFocus()


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #6943 (except cases when leaking is caused by `UiaTextRange`)


## Proposed changes

- Added `ReleaseUiaProvider` method to `GridEntry` to release it and its children.
- Override `ReleaseUiaProvider` method in `PropertyGrid` and `PropertyGridView` classes to release their items too.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Fewer leaks in memory when `PropertyGrid` is used.

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![Screenshot 2022-12-13 110035](https://user-images.githubusercontent.com/109065597/207292611-e9e065dc-f401-4f52-8ce3-c55034ca37d2.png)

### After

![Screenshot 2022-12-13 104756](https://user-images.githubusercontent.com/109065597/207292646-015b4592-4fb4-4724-910a-d2cf3705ab5d.png)


## Test methodology <!-- How did you ensure quality? -->

- Manualy utilizing WinDbg 

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

- Inspect
- AI
- Narrator


 

## Test environment(s) <!-- Remove any that don't apply -->

.NET SDK:
 Version:   8.0.100-alpha.1.22512.5
 Commit:    1b80461e45

Runtime Environment:
 OS Name:     Windows
 OS Version:  10.0.22621


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8375)