### PR TITLE
Enable nullability in MenuCommandsChangedEventArgs

### DIFF
--- a/src/System.Windows.Forms.Design/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms.Design/src/PublicAPI.Shipped.txt
@@ -324,8 +324,8 @@
 ~System.ComponentModel.Design.InheritanceService.GetInheritanceAttribute(System.ComponentModel.IComponent component) -> System.ComponentModel.InheritanceAttribute
 ~System.ComponentModel.Design.LoadedEventArgs.Errors.get -> System.Collections.ICollection
 ~System.ComponentModel.Design.LoadedEventArgs.LoadedEventArgs(bool succeeded, System.Collections.ICollection errors) -> void
-~System.ComponentModel.Design.MenuCommandsChangedEventArgs.Command.get -> System.ComponentModel.Design.MenuCommand
-~System.ComponentModel.Design.MenuCommandsChangedEventArgs.MenuCommandsChangedEventArgs(System.ComponentModel.Design.MenuCommandsChangedType changeType, System.ComponentModel.Design.MenuCommand command) -> void
+System.ComponentModel.Design.MenuCommandsChangedEventArgs.Command.get -> System.ComponentModel.Design.MenuCommand?
+System.ComponentModel.Design.MenuCommandsChangedEventArgs.MenuCommandsChangedEventArgs(System.ComponentModel.Design.MenuCommandsChangedType changeType, System.ComponentModel.Design.MenuCommand? command) -> void
 ~System.ComponentModel.Design.MenuCommandService.FindCommand(System.ComponentModel.Design.CommandID commandID) -> System.ComponentModel.Design.MenuCommand
 ~System.ComponentModel.Design.MenuCommandService.FindCommand(System.Guid guid, int id) -> System.ComponentModel.Design.MenuCommand
 ~System.ComponentModel.Design.MenuCommandService.GetCommandList(System.Guid guid) -> System.Collections.ICollection

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/MenuCommandsChangedEventArgs.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/MenuCommandsChangedEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.ComponentModel.Design
 {
     /// <summary>
@@ -18,7 +16,7 @@ namespace System.ComponentModel.Design
         ///  and the remaining commands left for the object.  "command" can be null
         ///  to signify multiple commands changed at once.
         /// </summary>
-        public MenuCommandsChangedEventArgs(MenuCommandsChangedType changeType, MenuCommand command)
+        public MenuCommandsChangedEventArgs(MenuCommandsChangedType changeType, MenuCommand? command)
         {
             ChangeType = changeType;
             Command = command;
@@ -33,6 +31,6 @@ namespace System.ComponentModel.Design
         /// <summary>
         ///  The command that was added/removed/changed.  This can be null if more than one command changed at once.
         /// </summary>
-        public MenuCommand Command { get; }
+        public MenuCommand? Command { get; }
     }
 }


### PR DESCRIPTION
## Proposed changes

- Enable nullability in MenuCommandsChangedEventArgs.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8380)