### PR TITLE
Fixing runtime crash if an application contains `ToolStripMenuItem` with configured shortcut and launched in other locales.

### DIFF
--- a/src/System.Windows.Forms/src/Resources/SR.resx
+++ b/src/System.Windows.Forms/src/Resources/SR.resx
@@ -6963,4 +6963,7 @@ Stack trace where the illegal operation occurred was:
   <data name="FailedToLoadCursor" xml:space="preserve">
     <value>Failed to load cursor. Error '{1}'.</value>
   </data>
+  <data name="ResourceValueNotFound" xml:space="preserve">
+    <value>The resource value '{0}' was not found.</value>
+  </data>
 </root>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
@@ -8624,6 +8624,11 @@ Trasování zásobníku, kde došlo k neplatné operaci:
         <target state="translated">Modul pro zápis prostředků byl uložen. Pravděpodobně jej nebudete moci upravovat.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourceValueNotFound">
+        <source>The resource value '{0}' was not found.</source>
+        <target state="new">The resource value '{0}' was not found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RestartNotSupported">
         <source>Restart method is not supported for this application type.</source>
         <target state="translated">Metoda Restart není pro tento typ aplikace podporována.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
@@ -8624,6 +8624,11 @@ Stapelüberwachung, in der der unzulässige Vorgang auftrat:
         <target state="translated">Der Ressourcenwriter wurde gespeichert. Sie können ihn nicht bearbeiten.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourceValueNotFound">
+        <source>The resource value '{0}' was not found.</source>
+        <target state="new">The resource value '{0}' was not found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RestartNotSupported">
         <source>Restart method is not supported for this application type.</source>
         <target state="translated">Die Restart-Methode wird für diesen Anwendungstyp nicht unterstützt.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
@@ -8624,6 +8624,11 @@ El seguimiento de la pila donde tuvo lugar la operación no válida fue:
         <target state="translated">El sistema de escritura de recursos se ha guardado. No se puede editar.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourceValueNotFound">
+        <source>The resource value '{0}' was not found.</source>
+        <target state="new">The resource value '{0}' was not found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RestartNotSupported">
         <source>Restart method is not supported for this application type.</source>
         <target state="translated">Este tipo de aplicación no admite el método Restart.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
@@ -8624,6 +8624,11 @@ Cette opération non conforme s'est produite sur la trace de la pile :
         <target state="translated">Le writer de ressource a été enregistré. Vous ne pouvez pas le modifier.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourceValueNotFound">
+        <source>The resource value '{0}' was not found.</source>
+        <target state="new">The resource value '{0}' was not found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RestartNotSupported">
         <source>Restart method is not supported for this application type.</source>
         <target state="translated">La méthode Restart n'est pas prise en charge pour ce type d'application.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
@@ -8624,6 +8624,11 @@ Traccia dello stack da cui si è verificata l'operazione non valida:
         <target state="translated">Il writer della risorsa è già stato salvato e non può più essere modificato.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourceValueNotFound">
+        <source>The resource value '{0}' was not found.</source>
+        <target state="new">The resource value '{0}' was not found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RestartNotSupported">
         <source>Restart method is not supported for this application type.</source>
         <target state="translated">Il metodo Restart non è supportato per questo tipo di applicazione.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
@@ -8624,6 +8624,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">リソース ライターは保存されています。  編集できません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourceValueNotFound">
+        <source>The resource value '{0}' was not found.</source>
+        <target state="new">The resource value '{0}' was not found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RestartNotSupported">
         <source>Restart method is not supported for this application type.</source>
         <target state="translated">Restart メソッドはこのアプリケーションの種類に対してサポートされていません。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
@@ -8624,6 +8624,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">리소스 작성기가 저장되었으므로 편집할 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourceValueNotFound">
+        <source>The resource value '{0}' was not found.</source>
+        <target state="new">The resource value '{0}' was not found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RestartNotSupported">
         <source>Restart method is not supported for this application type.</source>
         <target state="translated">Restart 메서드는 이 애플리케이션 종류에서 지원되지 않습니다.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
@@ -8624,6 +8624,11 @@ Stos śledzenia, w którym wystąpiła zabroniona operacja:
         <target state="translated">Zapisywarka zasobów została zapisana. Nie można jej edytować.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourceValueNotFound">
+        <source>The resource value '{0}' was not found.</source>
+        <target state="new">The resource value '{0}' was not found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RestartNotSupported">
         <source>Restart method is not supported for this application type.</source>
         <target state="translated">Metoda Restart nie jest obsługiwana w aplikacji tego typu.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
@@ -8624,6 +8624,11 @@ Rastreamento de pilha em que a operação ilegal ocorreu:
         <target state="translated">O gravador de recurso foi salvo. Talvez você não possa editá-lo.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourceValueNotFound">
+        <source>The resource value '{0}' was not found.</source>
+        <target state="new">The resource value '{0}' was not found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RestartNotSupported">
         <source>Restart method is not supported for this application type.</source>
         <target state="translated">Não há suporte para o método de reinicialização para este tipo de aplicativo.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
@@ -8625,6 +8625,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">Объект, выполняющий запись ресурсов, сохранен.  Редактирование запрещено.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourceValueNotFound">
+        <source>The resource value '{0}' was not found.</source>
+        <target state="new">The resource value '{0}' was not found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RestartNotSupported">
         <source>Restart method is not supported for this application type.</source>
         <target state="translated">Метод Restart не поддерживается для данного типа приложения.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
@@ -8624,6 +8624,11 @@ Geçersiz işlemin gerçekleştiği yığın izi:
         <target state="translated">Kaynak yazıcısı kaydedildi. Düzenleyemezsiniz.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourceValueNotFound">
+        <source>The resource value '{0}' was not found.</source>
+        <target state="new">The resource value '{0}' was not found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RestartNotSupported">
         <source>Restart method is not supported for this application type.</source>
         <target state="translated">Bu uygulama türü için yeniden başlatma metodu desteklenmiyor.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
@@ -8624,6 +8624,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">已保存资源编写器。  不能对其进行编辑。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourceValueNotFound">
+        <source>The resource value '{0}' was not found.</source>
+        <target state="new">The resource value '{0}' was not found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RestartNotSupported">
         <source>Restart method is not supported for this application type.</source>
         <target state="translated">此应用程序类型不支持 Restart 方法。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
@@ -8624,6 +8624,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">已儲存資源寫入器。您無法再進行編輯。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ResourceValueNotFound">
+        <source>The resource value '{0}' was not found.</source>
+        <target state="new">The resource value '{0}' was not found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="RestartNotSupported">
         <source>Restart method is not supported for this application type.</source>
         <target state="translated">這種應用程式類型不支援 Restart 方法。</target>

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/KeysConverterTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/KeysConverterTests.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Globalization;
+
 namespace System.Windows.Forms.Tests;
 
 public class KeysConverterTests
@@ -21,18 +23,46 @@ public class KeysConverterTests
     }
 
     [Theory]
-    [InlineData(Keys.None, "None")]
+    [InlineData("fr-FR", "(aucun)", Keys.None)]
+    [InlineData("nb-NO", "None", Keys.None)]
+    [InlineData("de-DE", "Beenden", Keys.End)]
+    public void ConvertFrom_ShouldConvertKeys_Localization(string cultureName, string localizedKeyName, Keys expectedKey)
+    {
+        CultureInfo culture = CultureInfo.GetCultureInfo(cultureName);
+
+        KeysConverter converter = new();
+        var result = (Keys?)converter.ConvertFrom(null, culture, localizedKeyName);
+
+        Assert.Equal(expectedKey, result);
+    }
+
+    [Theory]
+    [InlineData(Keys.None, "(none)")]
     [InlineData(Keys.S, "S")]
     [InlineData(Keys.Control | Keys.C, "Ctrl+C")]
     [InlineData(Keys.Control | Keys.Add, "Ctrl+Add")]
     [InlineData(Keys.Control | Keys.Alt | Keys.D, "Ctrl+Alt+D")]
     [InlineData(Keys.Control | Keys.Alt | Keys.Shift | Keys.A, "Ctrl+Alt+Shift+A")]
     [InlineData(Keys.Control | Keys.Alt | Keys.Shift | Keys.F1, "Ctrl+Alt+Shift+F1")]
+    [InlineData(Keys.F2 | Keys.Shift | Keys.Alt | Keys.Control, "Ctrl+Alt+Shift+F2")]
     public void ConvertToString_ShouldConvertKeys(Keys keys, string expectedResult)
     {
         KeysConverter converter = new();
-        var result = converter.ConvertToString(keys);
+        var result = converter.ConvertToString(null, CultureInfo.InvariantCulture, keys);
         Assert.Equal(expectedResult, result);
+    }
+
+    [Theory]
+    [InlineData("fr-FR", Keys.None, "(aucun)")]
+    [InlineData("de-DE", Keys.End, "Beenden")]
+    public void ConvertToString_ShouldConvertKeys_Localization(string cultureName, Keys key, string expectedLocalizedKeyName)
+    {
+        CultureInfo culture = CultureInfo.GetCultureInfo(cultureName);
+
+        KeysConverter converter = new();
+        string result = converter.ConvertToString(null, culture, key);
+
+        Assert.Equal(expectedLocalizedKeyName, result);
     }
 
     public static IEnumerable<object[]> ConvertToEnumArray_ShouldConvertKeys_TestData()


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #2886 


## Proposed changes

- Added support for the `culture` parameter in `ConvertFrom` and `ConvertTo` methods.
- Dictionaries with localization are loaded per request.
- `KeysConverter` becomes more independent and doesn't contain the logic of choosing the "right" locale. 

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- No crashes when an application is run in different locales.
- A developer's locale doesn't impact values in the .resx file.
- The placeholder when the shortcut isn't set becomes more apparent.

## Regression? 

- Yes (after migration to .net core).

## Risk

- Old applications that contain localized values of `ShortcutKeys` (e.g. Strg for de-DE) are crashed.
- `ShortcutKeysEditor` seems inconsistent due to `KeysConverter` receiving `CultureInfo.CurrentCulture` while `ShortcutKeysUI` is localized with `CultureInfo.CurrentUICulture`.

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![Screenshot 2022-12-19 142918](https://user-images.githubusercontent.com/109065597/208414409-0e09c0e7-1cf6-4a5b-a2d7-183b9e6ed4d6.png)
![Screenshot 2022-12-19 142011](https://user-images.githubusercontent.com/109065597/208414376-07ab0ebf-6517-46da-94fe-660e82ee552d.png)
![image](https://user-images.githubusercontent.com/109065597/209143143-3ef303be-e19f-4f1e-983a-d2eb7f01f269.png)


### After

![image](https://user-images.githubusercontent.com/109065597/209142559-dac8c3b7-d3af-48a4-b781-649c31c7414d.png)
![image](https://user-images.githubusercontent.com/109065597/209142472-77baa5d6-7e01-4384-acb1-8f00a50e24d6.png)
![Screenshot 2022-12-22 171839](https://user-images.githubusercontent.com/109065597/209143161-78b98e64-9db7-4673-9a81-6db17f313b8d.png)


## Test methodology <!-- How did you ensure quality? -->

- Manually 
 

## Test environment(s) <!-- Remove any that don't apply -->

.NET SDK:
 Version:   8.0.100-alpha.1.22512.5
 Commit:    1b80461e45

Runtime Environment:
 OS Name:     Windows
 OS Version:  10.0.22621


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8401)