### PR TITLE
inverted `langVersion` conditions in C# templates

### DIFF
--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-CSharp/.template.config/template.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-CSharp/.template.config/template.json
@@ -85,14 +85,18 @@
       "description": "Whether to enable nullable reference types for this project.",
       "displayName": "Enable nullable"
     },
-    "csharp10orLater": {
+    "csharp9orOlder": {
       "type": "generated",
       "generator": "regexMatch",
       "datatype": "bool",
       "parameters": {
-        "pattern": "^(|10\\.0|10|11.\\0|11|preview|latest|default|latestMajor)$",
+        "pattern": "^(ISO-1|ISO-2|[1-7]|[8-9]|[8-9]\\.0|7\\.[0-3])$",
         "source": "langVersion"
       }
+    },
+    "csharp10orLater": {
+      "type": "computed",
+      "value": "!csharp9orOlder"
     },
     "csharpFeature_ImplicitUsings": {
       "type": "computed",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-CSharp/.template.config/template.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-CSharp/.template.config/template.json
@@ -85,14 +85,18 @@
       "description": "Whether to enable nullable reference types for this project.",
       "displayName": "Enable nullable"
     },
-    "csharp10orLater": {
+    "csharp9orOlder": {
       "type": "generated",
       "generator": "regexMatch",
       "datatype": "bool",
       "parameters": {
-        "pattern": "^(|10\\.0|10|11.\\0|11|preview|latest|default|latestMajor)$",
+        "pattern": "^(ISO-1|ISO-2|[1-7]|[8-9]|[8-9]\\.0|7\\.[0-3])$",
         "source": "langVersion"
       }
+    },
+    "csharp10orLater": {
+      "type": "computed",
+      "value": "!csharp9orOlder"
     },
     "csharpFeature_ImplicitUsings": {
       "type": "computed",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-CSharp/.template.config/template.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-CSharp/.template.config/template.json
@@ -85,14 +85,18 @@
       "description": "Whether to enable nullable reference types for this project.",
       "displayName": "Enable nullable"
     },
-    "csharp10orLater": {
+    "csharp9orOlder": {
       "type": "generated",
       "generator": "regexMatch",
       "datatype": "bool",
       "parameters": {
-        "pattern": "^(|10\\.0|10|11.\\0|11|preview|latest|default|latestMajor)$",
+        "pattern": "^(ISO-1|ISO-2|[1-7]|[8-9]|[8-9]\\.0|7\\.[0-3])$",
         "source": "langVersion"
       }
+    },
+    "csharp10orLater": {
+      "type": "computed",
+      "value": "!csharp9orOlder"
     },
     "csharpFeature_ImplicitUsings": {
       "type": "computed",


### PR DESCRIPTION
## Proposed changes
Inverted `langVersion` conditions in C# templates
Background: the new language version is released each year, and it is easy to change regex in template definition.
Inversion of condition doesn't need an update with new  `langVersion`  released.

This was already done in Common and WPF templates.

Related to: https://github.com/dotnet/templating/issues/5668

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8404)