### PR TITLE
Adding UIA's PositionInSet and SizeOfSet properties to ToolStripMenuItemAccessibleObject

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripMenuItem.ToolStripMenuItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripMenuItem.ToolStripMenuItemAccessibleObject.cs
@@ -50,8 +50,70 @@ namespace System.Windows.Forms
                 propertyID switch
                 {
                     UiaCore.UIA.AcceleratorKeyPropertyId => _owningToolStripMenuItem.GetShortcutText(),
+                    UiaCore.UIA.PositionInSetPropertyId => GetPositionInSet(),
+                    UiaCore.UIA.SizeOfSetPropertyId => GetSizeOfSet(),
                     _ => base.GetPropertyValue(propertyID)
                 };
+
+            /// <summary>
+            /// Gets <see cref="UiaCore.UIA.PositionInSetPropertyId"/> property value.
+            /// </summary>
+            private int? GetPositionInSet()
+            {
+                ToolStripItemCollection? displayedItems = _owningToolStripMenuItem.ParentInternal?.DisplayedItems;
+
+                if (displayedItems is null)
+                {
+                    return null;
+                }
+
+                int index = displayedItems.IndexOf(_owningToolStripMenuItem);
+
+                if (index < 0)
+                {
+                    return null;
+                }
+
+                foreach (ToolStripItem item in displayedItems)
+                {
+                    if (item == _owningToolStripMenuItem)
+                    {
+                        break;
+                    }
+
+                    if (item is ToolStripSeparator)
+                    {
+                        index--;
+                    }
+                }
+
+                return index + 1; // UIA_PositionInSet is 1-based
+            }
+
+            /// <summary>
+            /// Gets <see cref="UiaCore.UIA.SizeOfSetPropertyId"/> property value.
+            /// </summary>
+            private int? GetSizeOfSet()
+            {
+                ToolStripItemCollection? displayedItems = _owningToolStripMenuItem.ParentInternal?.DisplayedItems;
+
+                if (displayedItems is null)
+                {
+                    return null;
+                }
+
+                int sizeOfSet = displayedItems.Count;
+
+                foreach (ToolStripItem item in displayedItems)
+                {
+                    if (item is ToolStripSeparator)
+                    {
+                        sizeOfSet--;
+                    }
+                }
+
+                return sizeOfSet;
+            }
 
             public override string DefaultAction
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripMenuItem.ToolStripMenuItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripMenuItem.ToolStripMenuItemAccessibleObject.cs
@@ -91,7 +91,7 @@ namespace System.Windows.Forms
             }
 
             /// <summary>
-            /// Gets <see cref="UiaCore.UIA.SizeOfSetPropertyId"/> property value.
+            ///  Gets <see cref="UiaCore.UIA.SizeOfSetPropertyId"/> property value.
             /// </summary>
             private int? GetSizeOfSet()
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripMenuItem.ToolStripMenuItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripMenuItem.ToolStripMenuItemAccessibleObject.cs
@@ -56,7 +56,7 @@ namespace System.Windows.Forms
                 };
 
             /// <summary>
-            /// Gets <see cref="UiaCore.UIA.PositionInSetPropertyId"/> property value.
+            ///  Gets <see cref="UiaCore.UIA.PositionInSetPropertyId"/> property value.
             /// </summary>
             private int? GetPositionInSet()
             {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripMenuItem.ToolStripMenuItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripMenuItem.ToolStripMenuItemAccessibleObjectTests.cs
@@ -69,6 +69,86 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expected, actual);
         }
 
+        [WinFormsFact]
+        public void ToolStripMenuItemAccessibleObject_GetPropertyValue_PositionInSet_ReturnsExpected_IfNoParent()
+        {
+            using ToolStripMenuItem toolStripMenuItem = new();
+
+            AccessibleObject accessibilityObject = toolStripMenuItem.AccessibilityObject;
+
+            Assert.Null(accessibilityObject.GetPropertyValue(UiaCore.UIA.PositionInSetPropertyId));
+        }
+
+        [WinFormsFact]
+        public void ToolStripMenuItemAccessibleObject_GetPropertyValue_PositionInSet_ReturnsExpected()
+        {
+            using MenuStrip menuStrip = new();
+
+            using ToolStripMenuItem item1 = new();
+            menuStrip.Items.Add(item1);
+            menuStrip.PerformLayout();
+
+            Assert.Equal(1, menuStrip.Items.Count);
+            Assert.Equal(1, item1.AccessibilityObject.GetPropertyValue(UiaCore.UIA.PositionInSetPropertyId));
+
+            using ToolStripSeparator separator = new();
+            menuStrip.Items.Add(separator);
+            menuStrip.PerformLayout();
+
+            Assert.Equal(2, menuStrip.Items.Count);
+            Assert.Equal(1, item1.AccessibilityObject.GetPropertyValue(UiaCore.UIA.PositionInSetPropertyId));
+            Assert.Null(separator.AccessibilityObject.GetPropertyValue(UiaCore.UIA.PositionInSetPropertyId));
+
+            using ToolStripMenuItem item2 = new();
+            menuStrip.Items.Add(item2);
+            menuStrip.PerformLayout();
+
+            Assert.Equal(3, menuStrip.Items.Count);
+            Assert.Equal(1, item1.AccessibilityObject.GetPropertyValue(UiaCore.UIA.PositionInSetPropertyId));
+            Assert.Null(separator.AccessibilityObject.GetPropertyValue(UiaCore.UIA.PositionInSetPropertyId));
+            Assert.Equal(2, item2.AccessibilityObject.GetPropertyValue(UiaCore.UIA.PositionInSetPropertyId));
+        }
+
+        [WinFormsFact]
+        public void ToolStripMenuItemAccessibleObject_GetPropertyValue_SizeOfSet_ReturnsExpected_IfNoParent()
+        {
+            using ToolStripMenuItem toolStripMenuItem = new();
+
+            AccessibleObject accessibilityObject = toolStripMenuItem.AccessibilityObject;
+
+            Assert.Null(accessibilityObject.GetPropertyValue(UiaCore.UIA.SizeOfSetPropertyId));
+        }
+
+        [WinFormsFact]
+        public void ToolStripMenuItemAccessibleObject_GetPropertyValue_SizeOfSet_ReturnsExpected()
+        {
+            using MenuStrip menuStrip = new();
+
+            using ToolStripMenuItem item1 = new();
+            menuStrip.Items.Add(item1);
+            menuStrip.PerformLayout();
+
+            Assert.Equal(1, menuStrip.Items.Count);
+            Assert.Equal(1, item1.AccessibilityObject.GetPropertyValue(UiaCore.UIA.SizeOfSetPropertyId));
+
+            using ToolStripSeparator separator = new();
+            menuStrip.Items.Add(separator);
+            menuStrip.PerformLayout();
+
+            Assert.Equal(2, menuStrip.Items.Count);
+            Assert.Equal(1, item1.AccessibilityObject.GetPropertyValue(UiaCore.UIA.SizeOfSetPropertyId));
+            Assert.Null(separator.AccessibilityObject.GetPropertyValue(UiaCore.UIA.SizeOfSetPropertyId));
+
+            using ToolStripMenuItem item2 = new();
+            menuStrip.Items.Add(item2);
+            menuStrip.PerformLayout();
+
+            Assert.Equal(3, menuStrip.Items.Count);
+            Assert.Equal(2, item1.AccessibilityObject.GetPropertyValue(UiaCore.UIA.SizeOfSetPropertyId));
+            Assert.Null(separator.AccessibilityObject.GetPropertyValue(UiaCore.UIA.SizeOfSetPropertyId));
+            Assert.Equal(2, item2.AccessibilityObject.GetPropertyValue(UiaCore.UIA.SizeOfSetPropertyId));
+        }
+
         [WinFormsTheory]
         [InlineData(true, CheckState.Checked, true)]
         [InlineData(true, CheckState.Unchecked, true)]


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #3471


## Proposed changes

- Added UIA's PositionInSet and SizeOfSet properties to ToolStripMenuItemAccessibleObject

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Screen readers can announce menu items order information 

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
![3471 before](https://user-images.githubusercontent.com/113603457/208908079-3d6e6348-8b47-401f-ab42-ad2b8153c3fe.png)

<!-- TODO -->

### After
![3471 after](https://user-images.githubusercontent.com/113603457/208908100-aea2822a-c795-4f04-8f76-476d72fb6d32.png)

<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- Manually
 

## Test environment(s) <!-- Remove any that don't apply -->

- .NET 7.0.1
- Windows 11


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8408)