### PR TITLE
Enabling nullability annotations to `System.Windows.Forms.Design` classes

### DIFF
--- a/src/System.Windows.Forms.Design/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms.Design/src/PublicAPI.Shipped.txt
@@ -317,7 +317,7 @@ System.ComponentModel.Design.DesignerCommandSet.Verbs.get -> System.ComponentMod
 ~System.ComponentModel.Design.DesignSurfaceManager.ServiceContainer.get -> System.ComponentModel.Design.ServiceContainer
 ~System.ComponentModel.Design.EventBindingService.EventBindingService(System.IServiceProvider provider) -> void
 ~System.ComponentModel.Design.EventBindingService.GetService(System.Type serviceType) -> object
-System.ComponentModel.Design.ExceptionCollection.ExceptionCollection(System.Collections.ArrayList! exceptions) -> void
+System.ComponentModel.Design.ExceptionCollection.ExceptionCollection(System.Collections.ArrayList? exceptions) -> void
 System.ComponentModel.Design.ExceptionCollection.Exceptions.get -> System.Collections.ArrayList?
 System.ComponentModel.Design.IMultitargetHelperService.GetAssemblyQualifiedName(System.Type! type) -> string!
 ~System.ComponentModel.Design.InheritanceService.AddInheritedComponents(System.ComponentModel.IComponent component, System.ComponentModel.IContainer container) -> void
@@ -424,8 +424,8 @@ System.Drawing.Design.IToolboxItemProvider.Items.get -> System.Drawing.Design.To
 ~System.Drawing.Design.IToolboxService.SetSelectedToolboxItem(System.Drawing.Design.ToolboxItem toolboxItem) -> void
 ~System.Drawing.Design.IToolboxUser.GetToolSupported(System.Drawing.Design.ToolboxItem tool) -> bool
 ~System.Drawing.Design.IToolboxUser.ToolPicked(System.Drawing.Design.ToolboxItem tool) -> void
-System.Drawing.Design.ToolboxComponentsCreatedEventArgs.Components.get -> System.ComponentModel.IComponent![]!
-System.Drawing.Design.ToolboxComponentsCreatedEventArgs.ToolboxComponentsCreatedEventArgs(System.ComponentModel.IComponent![]! components) -> void
+System.Drawing.Design.ToolboxComponentsCreatedEventArgs.Components.get -> System.ComponentModel.IComponent![]?
+System.Drawing.Design.ToolboxComponentsCreatedEventArgs.ToolboxComponentsCreatedEventArgs(System.ComponentModel.IComponent![]? components) -> void
 ~System.Drawing.Design.ToolboxComponentsCreatingEventArgs.DesignerHost.get -> System.ComponentModel.Design.IDesignerHost
 ~System.Drawing.Design.ToolboxComponentsCreatingEventArgs.ToolboxComponentsCreatingEventArgs(System.ComponentModel.Design.IDesignerHost host) -> void
 ~System.Drawing.Design.ToolboxItem.AssemblyName.get -> System.Reflection.AssemblyName

--- a/src/System.Windows.Forms.Design/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms.Design/src/PublicAPI.Shipped.txt
@@ -339,8 +339,8 @@ System.ComponentModel.Design.MenuCommandsChangedEventArgs.MenuCommandsChangedEve
 ~System.ComponentModel.Design.ObjectSelectorEditor.Selector.Selector(System.ComponentModel.Design.ObjectSelectorEditor editor) -> void
 ~System.ComponentModel.Design.ObjectSelectorEditor.Selector.SetSelection(object value, System.Windows.Forms.TreeNodeCollection nodes) -> bool
 ~System.ComponentModel.Design.ObjectSelectorEditor.Selector.Start(System.Windows.Forms.Design.IWindowsFormsEditorService edSvc, object value) -> void
-System.ComponentModel.Design.ObjectSelectorEditor.SelectorNode.SelectorNode(string! label, object! value) -> void
-System.ComponentModel.Design.ObjectSelectorEditor.SelectorNode.value -> object!
+System.ComponentModel.Design.ObjectSelectorEditor.SelectorNode.SelectorNode(string! label, object? value) -> void
+System.ComponentModel.Design.ObjectSelectorEditor.SelectorNode.value -> object?
 System.ComponentModel.Design.ProjectTargetFrameworkAttribute.ProjectTargetFrameworkAttribute(string! targetFrameworkMoniker) -> void
 System.ComponentModel.Design.ProjectTargetFrameworkAttribute.TargetFrameworkMoniker.get -> string!
 ~System.ComponentModel.Design.Serialization.BasicDesignerLoader.GetService(System.Type serviceType) -> object

--- a/src/System.Windows.Forms.Design/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms.Design/src/PublicAPI.Shipped.txt
@@ -269,9 +269,9 @@ System.ComponentModel.Design.DesignerActionItemCollection.this[int index].set ->
 ~System.ComponentModel.Design.DesignerActionMethodItem.DesignerActionMethodItem(System.ComponentModel.Design.DesignerActionList actionList, string memberName, string displayName, string category, string description, bool includeAsDesignerVerb) -> void
 ~System.ComponentModel.Design.DesignerActionMethodItem.RelatedComponent.get -> System.ComponentModel.IComponent
 ~System.ComponentModel.Design.DesignerActionMethodItem.RelatedComponent.set -> void
-System.ComponentModel.Design.DesignerActionPropertyItem.DesignerActionPropertyItem(string! memberName, string! displayName) -> void
-System.ComponentModel.Design.DesignerActionPropertyItem.DesignerActionPropertyItem(string! memberName, string! displayName, string? category) -> void
-System.ComponentModel.Design.DesignerActionPropertyItem.DesignerActionPropertyItem(string! memberName, string! displayName, string? category, string? description) -> void
+System.ComponentModel.Design.DesignerActionPropertyItem.DesignerActionPropertyItem(string! memberName, string? displayName) -> void
+System.ComponentModel.Design.DesignerActionPropertyItem.DesignerActionPropertyItem(string! memberName, string? displayName, string? category) -> void
+System.ComponentModel.Design.DesignerActionPropertyItem.DesignerActionPropertyItem(string! memberName, string? displayName, string? category, string? description) -> void
 System.ComponentModel.Design.DesignerActionPropertyItem.MemberName.get -> string!
 System.ComponentModel.Design.DesignerActionPropertyItem.RelatedComponent.get -> System.ComponentModel.IComponent?
 System.ComponentModel.Design.DesignerActionPropertyItem.RelatedComponent.set -> void
@@ -283,7 +283,7 @@ System.ComponentModel.Design.DesignerActionPropertyItem.RelatedComponent.set -> 
 ~System.ComponentModel.Design.DesignerActionService.Remove(System.ComponentModel.Design.DesignerActionList actionList) -> void
 ~System.ComponentModel.Design.DesignerActionService.Remove(System.ComponentModel.IComponent comp) -> void
 ~System.ComponentModel.Design.DesignerActionService.Remove(System.ComponentModel.IComponent comp, System.ComponentModel.Design.DesignerActionList actionList) -> void
-System.ComponentModel.Design.DesignerActionTextItem.DesignerActionTextItem(string? displayName, string! category) -> void
+System.ComponentModel.Design.DesignerActionTextItem.DesignerActionTextItem(string? displayName, string? category) -> void
 ~System.ComponentModel.Design.DesignerActionUIService.HideUI(System.ComponentModel.IComponent component) -> void
 ~System.ComponentModel.Design.DesignerActionUIService.Refresh(System.ComponentModel.IComponent component) -> void
 ~System.ComponentModel.Design.DesignerActionUIService.ShouldAutoShow(System.ComponentModel.IComponent component) -> bool

--- a/src/System.Windows.Forms.Design/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms.Design/src/PublicAPI.Shipped.txt
@@ -31,7 +31,7 @@
 ~override System.ComponentModel.Design.DateTimeEditor.EditValue(System.ComponentModel.ITypeDescriptorContext context, System.IServiceProvider provider, object value) -> object
 ~override System.ComponentModel.Design.DateTimeEditor.GetEditStyle(System.ComponentModel.ITypeDescriptorContext context) -> System.Drawing.Design.UITypeEditorEditStyle
 ~override System.ComponentModel.Design.DesignerActionListCollection.OnValidate(object value) -> void
-~override System.ComponentModel.Design.ExceptionCollection.GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
+override System.ComponentModel.Design.ExceptionCollection.GetObjectData(System.Runtime.Serialization.SerializationInfo! info, System.Runtime.Serialization.StreamingContext context) -> void
 ~override System.ComponentModel.Design.MultilineStringEditor.EditValue(System.ComponentModel.ITypeDescriptorContext context, System.IServiceProvider provider, object value) -> object
 ~override System.ComponentModel.Design.MultilineStringEditor.GetEditStyle(System.ComponentModel.ITypeDescriptorContext context) -> System.Drawing.Design.UITypeEditorEditStyle
 ~override System.ComponentModel.Design.MultilineStringEditor.GetPaintValueSupported(System.ComponentModel.ITypeDescriptorContext context) -> bool
@@ -232,18 +232,18 @@ static System.Windows.Forms.Design.Behavior.SnapLine.ShouldSnap(System.Windows.F
 ~System.ComponentModel.Design.ComponentDesigner.ShadowPropertyCollection.Contains(string propertyName) -> bool
 ~System.ComponentModel.Design.ComponentDesigner.ShadowPropertyCollection.this[string propertyName].get -> object
 ~System.ComponentModel.Design.ComponentDesigner.ShadowPropertyCollection.this[string propertyName].set -> void
-~System.ComponentModel.Design.DesignerActionHeaderItem.DesignerActionHeaderItem(string displayName) -> void
-~System.ComponentModel.Design.DesignerActionHeaderItem.DesignerActionHeaderItem(string displayName, string category) -> void
-~System.ComponentModel.Design.DesignerActionItem.DesignerActionItem(string displayName, string category, string description) -> void
-~System.ComponentModel.Design.DesignerActionItem.Properties.get -> System.Collections.IDictionary
-~System.ComponentModel.Design.DesignerActionItemCollection.Add(System.ComponentModel.Design.DesignerActionItem value) -> int
-~System.ComponentModel.Design.DesignerActionItemCollection.Contains(System.ComponentModel.Design.DesignerActionItem value) -> bool
-~System.ComponentModel.Design.DesignerActionItemCollection.CopyTo(System.ComponentModel.Design.DesignerActionItem[] array, int index) -> void
-~System.ComponentModel.Design.DesignerActionItemCollection.IndexOf(System.ComponentModel.Design.DesignerActionItem value) -> int
-~System.ComponentModel.Design.DesignerActionItemCollection.Insert(int index, System.ComponentModel.Design.DesignerActionItem value) -> void
-~System.ComponentModel.Design.DesignerActionItemCollection.Remove(System.ComponentModel.Design.DesignerActionItem value) -> void
-~System.ComponentModel.Design.DesignerActionItemCollection.this[int index].get -> System.ComponentModel.Design.DesignerActionItem
-~System.ComponentModel.Design.DesignerActionItemCollection.this[int index].set -> void
+System.ComponentModel.Design.DesignerActionHeaderItem.DesignerActionHeaderItem(string! displayName) -> void
+System.ComponentModel.Design.DesignerActionHeaderItem.DesignerActionHeaderItem(string! displayName, string! category) -> void
+System.ComponentModel.Design.DesignerActionItem.DesignerActionItem(string? displayName, string? category, string? description) -> void
+System.ComponentModel.Design.DesignerActionItem.Properties.get -> System.Collections.IDictionary!
+System.ComponentModel.Design.DesignerActionItemCollection.Add(System.ComponentModel.Design.DesignerActionItem! value) -> int
+System.ComponentModel.Design.DesignerActionItemCollection.Contains(System.ComponentModel.Design.DesignerActionItem! value) -> bool
+System.ComponentModel.Design.DesignerActionItemCollection.CopyTo(System.ComponentModel.Design.DesignerActionItem![]! array, int index) -> void
+System.ComponentModel.Design.DesignerActionItemCollection.IndexOf(System.ComponentModel.Design.DesignerActionItem! value) -> int
+System.ComponentModel.Design.DesignerActionItemCollection.Insert(int index, System.ComponentModel.Design.DesignerActionItem! value) -> void
+System.ComponentModel.Design.DesignerActionItemCollection.Remove(System.ComponentModel.Design.DesignerActionItem! value) -> void
+System.ComponentModel.Design.DesignerActionItemCollection.this[int index].get -> System.ComponentModel.Design.DesignerActionItem!
+System.ComponentModel.Design.DesignerActionItemCollection.this[int index].set -> void
 ~System.ComponentModel.Design.DesignerActionList.Component.get -> System.ComponentModel.IComponent
 ~System.ComponentModel.Design.DesignerActionList.DesignerActionList(System.ComponentModel.IComponent component) -> void
 ~System.ComponentModel.Design.DesignerActionList.GetService(System.Type serviceType) -> object
@@ -269,12 +269,12 @@ static System.Windows.Forms.Design.Behavior.SnapLine.ShouldSnap(System.Windows.F
 ~System.ComponentModel.Design.DesignerActionMethodItem.DesignerActionMethodItem(System.ComponentModel.Design.DesignerActionList actionList, string memberName, string displayName, string category, string description, bool includeAsDesignerVerb) -> void
 ~System.ComponentModel.Design.DesignerActionMethodItem.RelatedComponent.get -> System.ComponentModel.IComponent
 ~System.ComponentModel.Design.DesignerActionMethodItem.RelatedComponent.set -> void
-~System.ComponentModel.Design.DesignerActionPropertyItem.DesignerActionPropertyItem(string memberName, string displayName) -> void
-~System.ComponentModel.Design.DesignerActionPropertyItem.DesignerActionPropertyItem(string memberName, string displayName, string category) -> void
-~System.ComponentModel.Design.DesignerActionPropertyItem.DesignerActionPropertyItem(string memberName, string displayName, string category, string description) -> void
-~System.ComponentModel.Design.DesignerActionPropertyItem.MemberName.get -> string
-~System.ComponentModel.Design.DesignerActionPropertyItem.RelatedComponent.get -> System.ComponentModel.IComponent
-~System.ComponentModel.Design.DesignerActionPropertyItem.RelatedComponent.set -> void
+System.ComponentModel.Design.DesignerActionPropertyItem.DesignerActionPropertyItem(string! memberName, string! displayName) -> void
+System.ComponentModel.Design.DesignerActionPropertyItem.DesignerActionPropertyItem(string! memberName, string! displayName, string? category) -> void
+System.ComponentModel.Design.DesignerActionPropertyItem.DesignerActionPropertyItem(string! memberName, string! displayName, string? category, string? description) -> void
+System.ComponentModel.Design.DesignerActionPropertyItem.MemberName.get -> string!
+System.ComponentModel.Design.DesignerActionPropertyItem.RelatedComponent.get -> System.ComponentModel.IComponent?
+System.ComponentModel.Design.DesignerActionPropertyItem.RelatedComponent.set -> void
 ~System.ComponentModel.Design.DesignerActionService.Add(System.ComponentModel.IComponent comp, System.ComponentModel.Design.DesignerActionList actionList) -> void
 ~System.ComponentModel.Design.DesignerActionService.Add(System.ComponentModel.IComponent comp, System.ComponentModel.Design.DesignerActionListCollection designerActionListCollection) -> void
 ~System.ComponentModel.Design.DesignerActionService.Contains(System.ComponentModel.IComponent comp) -> bool
@@ -283,15 +283,15 @@ static System.Windows.Forms.Design.Behavior.SnapLine.ShouldSnap(System.Windows.F
 ~System.ComponentModel.Design.DesignerActionService.Remove(System.ComponentModel.Design.DesignerActionList actionList) -> void
 ~System.ComponentModel.Design.DesignerActionService.Remove(System.ComponentModel.IComponent comp) -> void
 ~System.ComponentModel.Design.DesignerActionService.Remove(System.ComponentModel.IComponent comp, System.ComponentModel.Design.DesignerActionList actionList) -> void
-~System.ComponentModel.Design.DesignerActionTextItem.DesignerActionTextItem(string displayName, string category) -> void
+System.ComponentModel.Design.DesignerActionTextItem.DesignerActionTextItem(string? displayName, string! category) -> void
 ~System.ComponentModel.Design.DesignerActionUIService.HideUI(System.ComponentModel.IComponent component) -> void
 ~System.ComponentModel.Design.DesignerActionUIService.Refresh(System.ComponentModel.IComponent component) -> void
 ~System.ComponentModel.Design.DesignerActionUIService.ShouldAutoShow(System.ComponentModel.IComponent component) -> bool
 ~System.ComponentModel.Design.DesignerActionUIService.ShowUI(System.ComponentModel.IComponent component) -> void
 ~System.ComponentModel.Design.DesignerActionUIStateChangeEventArgs.DesignerActionUIStateChangeEventArgs(object relatedObject, System.ComponentModel.Design.DesignerActionUIStateChangeType changeType) -> void
 ~System.ComponentModel.Design.DesignerActionUIStateChangeEventArgs.RelatedObject.get -> object
-~System.ComponentModel.Design.DesignerCommandSet.ActionLists.get -> System.ComponentModel.Design.DesignerActionListCollection
-~System.ComponentModel.Design.DesignerCommandSet.Verbs.get -> System.ComponentModel.Design.DesignerVerbCollection
+System.ComponentModel.Design.DesignerCommandSet.ActionLists.get -> System.ComponentModel.Design.DesignerActionListCollection?
+System.ComponentModel.Design.DesignerCommandSet.Verbs.get -> System.ComponentModel.Design.DesignerVerbCollection?
 ~System.ComponentModel.Design.DesignSurface.BeginLoad(System.ComponentModel.Design.Serialization.DesignerLoader loader) -> void
 ~System.ComponentModel.Design.DesignSurface.BeginLoad(System.Type rootComponentType) -> void
 ~System.ComponentModel.Design.DesignSurface.ComponentContainer.get -> System.ComponentModel.IContainer
@@ -317,9 +317,9 @@ static System.Windows.Forms.Design.Behavior.SnapLine.ShouldSnap(System.Windows.F
 ~System.ComponentModel.Design.DesignSurfaceManager.ServiceContainer.get -> System.ComponentModel.Design.ServiceContainer
 ~System.ComponentModel.Design.EventBindingService.EventBindingService(System.IServiceProvider provider) -> void
 ~System.ComponentModel.Design.EventBindingService.GetService(System.Type serviceType) -> object
-~System.ComponentModel.Design.ExceptionCollection.ExceptionCollection(System.Collections.ArrayList exceptions) -> void
-~System.ComponentModel.Design.ExceptionCollection.Exceptions.get -> System.Collections.ArrayList
-~System.ComponentModel.Design.IMultitargetHelperService.GetAssemblyQualifiedName(System.Type type) -> string
+System.ComponentModel.Design.ExceptionCollection.ExceptionCollection(System.Collections.ArrayList! exceptions) -> void
+System.ComponentModel.Design.ExceptionCollection.Exceptions.get -> System.Collections.ArrayList?
+System.ComponentModel.Design.IMultitargetHelperService.GetAssemblyQualifiedName(System.Type! type) -> string!
 ~System.ComponentModel.Design.InheritanceService.AddInheritedComponents(System.ComponentModel.IComponent component, System.ComponentModel.IContainer container) -> void
 ~System.ComponentModel.Design.InheritanceService.GetInheritanceAttribute(System.ComponentModel.IComponent component) -> System.ComponentModel.InheritanceAttribute
 ~System.ComponentModel.Design.LoadedEventArgs.Errors.get -> System.Collections.ICollection
@@ -339,10 +339,10 @@ System.ComponentModel.Design.MenuCommandsChangedEventArgs.MenuCommandsChangedEve
 ~System.ComponentModel.Design.ObjectSelectorEditor.Selector.Selector(System.ComponentModel.Design.ObjectSelectorEditor editor) -> void
 ~System.ComponentModel.Design.ObjectSelectorEditor.Selector.SetSelection(object value, System.Windows.Forms.TreeNodeCollection nodes) -> bool
 ~System.ComponentModel.Design.ObjectSelectorEditor.Selector.Start(System.Windows.Forms.Design.IWindowsFormsEditorService edSvc, object value) -> void
-~System.ComponentModel.Design.ObjectSelectorEditor.SelectorNode.SelectorNode(string label, object value) -> void
-~System.ComponentModel.Design.ObjectSelectorEditor.SelectorNode.value -> object
-~System.ComponentModel.Design.ProjectTargetFrameworkAttribute.ProjectTargetFrameworkAttribute(string targetFrameworkMoniker) -> void
-~System.ComponentModel.Design.ProjectTargetFrameworkAttribute.TargetFrameworkMoniker.get -> string
+System.ComponentModel.Design.ObjectSelectorEditor.SelectorNode.SelectorNode(string! label, object! value) -> void
+System.ComponentModel.Design.ObjectSelectorEditor.SelectorNode.value -> object!
+System.ComponentModel.Design.ProjectTargetFrameworkAttribute.ProjectTargetFrameworkAttribute(string! targetFrameworkMoniker) -> void
+System.ComponentModel.Design.ProjectTargetFrameworkAttribute.TargetFrameworkMoniker.get -> string!
 ~System.ComponentModel.Design.Serialization.BasicDesignerLoader.GetService(System.Type serviceType) -> object
 ~System.ComponentModel.Design.Serialization.BasicDesignerLoader.LoaderHost.get -> System.ComponentModel.Design.Serialization.IDesignerLoaderHost
 ~System.ComponentModel.Design.Serialization.BasicDesignerLoader.PropertyProvider.get -> object
@@ -374,7 +374,7 @@ System.ComponentModel.Design.MenuCommandsChangedEventArgs.MenuCommandsChangedEve
 ~System.ComponentModel.Design.Serialization.ExpressionContext.ExpressionType.get -> System.Type
 ~System.ComponentModel.Design.Serialization.ExpressionContext.Owner.get -> object
 ~System.ComponentModel.Design.Serialization.ExpressionContext.PresetValue.get -> object
-~System.ComponentModel.Design.Serialization.ICodeDomDesignerReload.ShouldReloadDesigner(System.CodeDom.CodeCompileUnit newTree) -> bool
+System.ComponentModel.Design.Serialization.ICodeDomDesignerReload.ShouldReloadDesigner(System.CodeDom.CodeCompileUnit! newTree) -> bool
 ~System.ComponentModel.Design.Serialization.ObjectStatementCollection.ContainsKey(object statementOwner) -> bool
 ~System.ComponentModel.Design.Serialization.ObjectStatementCollection.GetEnumerator() -> System.Collections.IDictionaryEnumerator
 ~System.ComponentModel.Design.Serialization.ObjectStatementCollection.Populate(object owner) -> void
@@ -394,7 +394,7 @@ System.ComponentModel.Design.MenuCommandsChangedEventArgs.MenuCommandsChangedEve
 ~System.ComponentModel.Design.UndoEngine.UndoUnit.Name.get -> string
 ~System.ComponentModel.Design.UndoEngine.UndoUnit.UndoEngine.get -> System.ComponentModel.Design.UndoEngine
 ~System.ComponentModel.Design.UndoEngine.UndoUnit.UndoUnit(System.ComponentModel.Design.UndoEngine engine, string name) -> void
-~System.Drawing.Design.IToolboxItemProvider.Items.get -> System.Drawing.Design.ToolboxItemCollection
+System.Drawing.Design.IToolboxItemProvider.Items.get -> System.Drawing.Design.ToolboxItemCollection!
 ~System.Drawing.Design.IToolboxService.AddCreator(System.Drawing.Design.ToolboxItemCreatorCallback creator, string format) -> void
 ~System.Drawing.Design.IToolboxService.AddCreator(System.Drawing.Design.ToolboxItemCreatorCallback creator, string format, System.ComponentModel.Design.IDesignerHost host) -> void
 ~System.Drawing.Design.IToolboxService.AddLinkedToolboxItem(System.Drawing.Design.ToolboxItem toolboxItem, string category, System.ComponentModel.Design.IDesignerHost host) -> void
@@ -424,8 +424,8 @@ System.ComponentModel.Design.MenuCommandsChangedEventArgs.MenuCommandsChangedEve
 ~System.Drawing.Design.IToolboxService.SetSelectedToolboxItem(System.Drawing.Design.ToolboxItem toolboxItem) -> void
 ~System.Drawing.Design.IToolboxUser.GetToolSupported(System.Drawing.Design.ToolboxItem tool) -> bool
 ~System.Drawing.Design.IToolboxUser.ToolPicked(System.Drawing.Design.ToolboxItem tool) -> void
-~System.Drawing.Design.ToolboxComponentsCreatedEventArgs.Components.get -> System.ComponentModel.IComponent[]
-~System.Drawing.Design.ToolboxComponentsCreatedEventArgs.ToolboxComponentsCreatedEventArgs(System.ComponentModel.IComponent[] components) -> void
+System.Drawing.Design.ToolboxComponentsCreatedEventArgs.Components.get -> System.ComponentModel.IComponent![]!
+System.Drawing.Design.ToolboxComponentsCreatedEventArgs.ToolboxComponentsCreatedEventArgs(System.ComponentModel.IComponent![]! components) -> void
 ~System.Drawing.Design.ToolboxComponentsCreatingEventArgs.DesignerHost.get -> System.ComponentModel.Design.IDesignerHost
 ~System.Drawing.Design.ToolboxComponentsCreatingEventArgs.ToolboxComponentsCreatingEventArgs(System.ComponentModel.Design.IDesignerHost host) -> void
 ~System.Drawing.Design.ToolboxItem.AssemblyName.get -> System.Reflection.AssemblyName
@@ -549,7 +549,7 @@ System.Windows.Forms.Design.Behavior.SnapLine.SnapLine(System.Windows.Forms.Desi
 ~System.Windows.Forms.Design.FolderNameEditor.FolderBrowser.Description.set -> void
 ~System.Windows.Forms.Design.FolderNameEditor.FolderBrowser.DirectoryPath.get -> string
 ~System.Windows.Forms.Design.FolderNameEditor.FolderBrowser.ShowDialog(System.Windows.Forms.IWin32Window owner) -> System.Windows.Forms.DialogResult
-~System.Windows.Forms.Design.IContainsThemedScrollbarWindows.ThemedScrollbarWindows() -> System.Collections.IEnumerable
+System.Windows.Forms.Design.IContainsThemedScrollbarWindows.ThemedScrollbarWindows() -> System.Collections.IEnumerable!
 ~System.Windows.Forms.Design.ParentControlDesigner.AddPaddingSnapLines(ref System.Collections.ArrayList snapLines) -> void
 ~System.Windows.Forms.Design.ParentControlDesigner.CreateTool(System.Drawing.Design.ToolboxItem tool) -> void
 ~System.Windows.Forms.Design.ParentControlDesigner.CreateTool(System.Drawing.Design.ToolboxItem tool, System.Drawing.Point location) -> void
@@ -589,15 +589,15 @@ System.Windows.Forms.Design.Behavior.SnapLine.SnapLine(System.Windows.Forms.Desi
 ~virtual System.ComponentModel.Design.ComponentDesigner.PreFilterEvents(System.Collections.IDictionary events) -> void
 ~virtual System.ComponentModel.Design.ComponentDesigner.PreFilterProperties(System.Collections.IDictionary properties) -> void
 ~virtual System.ComponentModel.Design.ComponentDesigner.Verbs.get -> System.ComponentModel.Design.DesignerVerbCollection
-~virtual System.ComponentModel.Design.DesignerActionItem.Category.get -> string
-~virtual System.ComponentModel.Design.DesignerActionItem.Description.get -> string
-~virtual System.ComponentModel.Design.DesignerActionItem.DisplayName.get -> string
+virtual System.ComponentModel.Design.DesignerActionItem.Category.get -> string?
+virtual System.ComponentModel.Design.DesignerActionItem.Description.get -> string?
+virtual System.ComponentModel.Design.DesignerActionItem.DisplayName.get -> string?
 ~virtual System.ComponentModel.Design.DesignerActionList.GetSortedActionItems() -> System.ComponentModel.Design.DesignerActionItemCollection
 ~virtual System.ComponentModel.Design.DesignerActionMethodItem.MemberName.get -> string
 ~virtual System.ComponentModel.Design.DesignerActionService.GetComponentActions(System.ComponentModel.IComponent component, System.Windows.Forms.Design.ComponentActionsType type) -> System.ComponentModel.Design.DesignerActionListCollection
 ~virtual System.ComponentModel.Design.DesignerActionService.GetComponentDesignerActions(System.ComponentModel.IComponent component, System.ComponentModel.Design.DesignerActionListCollection actionLists) -> void
 ~virtual System.ComponentModel.Design.DesignerActionService.GetComponentServiceActions(System.ComponentModel.IComponent component, System.ComponentModel.Design.DesignerActionListCollection actionLists) -> void
-~virtual System.ComponentModel.Design.DesignerCommandSet.GetCommands(string name) -> System.Collections.ICollection
+virtual System.ComponentModel.Design.DesignerCommandSet.GetCommands(string! name) -> System.Collections.ICollection?
 ~virtual System.ComponentModel.Design.DesignSurface.CreateComponent(System.Type componentType) -> System.ComponentModel.IComponent
 ~virtual System.ComponentModel.Design.DesignSurface.CreateDesigner(System.ComponentModel.IComponent component, bool rootDesigner) -> System.ComponentModel.Design.IDesigner
 ~virtual System.ComponentModel.Design.DesignSurface.CreateInstance(System.Type type) -> object

--- a/src/System.Windows.Forms.Design/src/Resources/SR.resx
+++ b/src/System.Windows.Forms.Design/src/Resources/SR.resx
@@ -1314,4 +1314,7 @@ Press Ctrl+Enter to accept Text.</value>
   <data name="StringPropertyTruncatedComment" xml:space="preserve">
     <value> {0} [rest of string was truncated]";</value>
   </data>
+  <data name="ExceptionCollectionInvalidArgument" xml:space="preserve">
+    <value>Argument must only contain objects of type Exception.</value>
+  </data>
 </root>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.cs.xlf
@@ -1025,6 +1025,11 @@
         <target state="translated">Nastavit událost {0}.{1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExceptionCollectionInvalidArgument">
+        <source>Argument must only contain objects of type Exception.</source>
+        <target state="new">Argument must only contain objects of type Exception.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExtenderProviderServiceDuplicateProvider">
         <source>The extender provider {0} has already been added as an extender.  Adding another would result in duplicate properties.</source>
         <target state="translated">Zprostředkovatel rozšířeného objektu {0} již byl přidán jako rozšiřující objekt. V případě přidání dalšího by došlo k duplicitě vlastností.</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.de.xlf
@@ -1025,6 +1025,11 @@
         <target state="translated">{0}.{1}-Ereignis festlegen</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExceptionCollectionInvalidArgument">
+        <source>Argument must only contain objects of type Exception.</source>
+        <target state="new">Argument must only contain objects of type Exception.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExtenderProviderServiceDuplicateProvider">
         <source>The extender provider {0} has already been added as an extender.  Adding another would result in duplicate properties.</source>
         <target state="translated">Der Extenderanbieter {0} wurde bereits als Extender hinzugefügt. Wenn ein weiterer hinzugefügt wird, führt dies zu doppelten Eigenschaften.</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.es.xlf
@@ -1025,6 +1025,11 @@
         <target state="translated">Establezca el evento {0}.{1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExceptionCollectionInvalidArgument">
+        <source>Argument must only contain objects of type Exception.</source>
+        <target state="new">Argument must only contain objects of type Exception.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExtenderProviderServiceDuplicateProvider">
         <source>The extender provider {0} has already been added as an extender.  Adding another would result in duplicate properties.</source>
         <target state="translated">El proveedor extensor {0} ya se ha agregado como extensor. Si agrega otro habría propiedades duplicadas.</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.fr.xlf
@@ -1025,6 +1025,11 @@
         <target state="translated">Définir l'événement {0}.{1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExceptionCollectionInvalidArgument">
+        <source>Argument must only contain objects of type Exception.</source>
+        <target state="new">Argument must only contain objects of type Exception.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExtenderProviderServiceDuplicateProvider">
         <source>The extender provider {0} has already been added as an extender.  Adding another would result in duplicate properties.</source>
         <target state="translated">Le fournisseur d'extendeurs {0} a déjà été ajouté en tant qu'extendeur. L'ajout d'un autre créerait des propriétés en double.</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.it.xlf
@@ -1025,6 +1025,11 @@
         <target state="translated">Imposta evento {0}.{1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExceptionCollectionInvalidArgument">
+        <source>Argument must only contain objects of type Exception.</source>
+        <target state="new">Argument must only contain objects of type Exception.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExtenderProviderServiceDuplicateProvider">
         <source>The extender provider {0} has already been added as an extender.  Adding another would result in duplicate properties.</source>
         <target state="translated">Il provider di Extender {0} è già stato aggiunto come Extender. Aggiungendone un altro si creerebbero proprietà duplicate.</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.ja.xlf
@@ -1025,6 +1025,11 @@
         <target state="translated">{0}.{1} イベントを設定</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExceptionCollectionInvalidArgument">
+        <source>Argument must only contain objects of type Exception.</source>
+        <target state="new">Argument must only contain objects of type Exception.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExtenderProviderServiceDuplicateProvider">
         <source>The extender provider {0} has already been added as an extender.  Adding another would result in duplicate properties.</source>
         <target state="translated">拡張プロバイダー {0} はエクステンダーとして既に追加されています。  もう 1 つ追加すると、プロパティが重複します。</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.ko.xlf
@@ -1025,6 +1025,11 @@
         <target state="translated">{0}.{1} 이벤트 설정</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExceptionCollectionInvalidArgument">
+        <source>Argument must only contain objects of type Exception.</source>
+        <target state="new">Argument must only contain objects of type Exception.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExtenderProviderServiceDuplicateProvider">
         <source>The extender provider {0} has already been added as an extender.  Adding another would result in duplicate properties.</source>
         <target state="translated">Extender 공급자 {0}이(가) Extender로 이미 추가되었습니다. 다른 공급자를 추가하면 속성이 중복됩니다.</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.pl.xlf
@@ -1025,6 +1025,11 @@
         <target state="translated">Ustaw zdarzenie {0}.{1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExceptionCollectionInvalidArgument">
+        <source>Argument must only contain objects of type Exception.</source>
+        <target state="new">Argument must only contain objects of type Exception.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExtenderProviderServiceDuplicateProvider">
         <source>The extender provider {0} has already been added as an extender.  Adding another would result in duplicate properties.</source>
         <target state="translated">Dostawca rozszerzony {0} został już dodany jako rozszerzenie. Dodanie kolejnego dostawcy spowodowałoby zduplikowanie właściwości.</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.pt-BR.xlf
@@ -1025,6 +1025,11 @@
         <target state="translated">Definir evento {0}.{1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExceptionCollectionInvalidArgument">
+        <source>Argument must only contain objects of type Exception.</source>
+        <target state="new">Argument must only contain objects of type Exception.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExtenderProviderServiceDuplicateProvider">
         <source>The extender provider {0} has already been added as an extender.  Adding another would result in duplicate properties.</source>
         <target state="translated">O provedor do extensor {0} já foi adicionado como extensor. A inclusão de outro resultará em propriedades duplicadas.</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.ru.xlf
@@ -1025,6 +1025,11 @@
         <target state="translated">Задать {0}.{1} событие</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExceptionCollectionInvalidArgument">
+        <source>Argument must only contain objects of type Exception.</source>
+        <target state="new">Argument must only contain objects of type Exception.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExtenderProviderServiceDuplicateProvider">
         <source>The extender provider {0} has already been added as an extender.  Adding another would result in duplicate properties.</source>
         <target state="translated">Поставщик расширений {0} уже добавлен в качестве расширения.  Добавление другого поставщика приведет к появлению повторяющихся свойств.</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.tr.xlf
@@ -1025,6 +1025,11 @@
         <target state="translated">{0}.{1} olayını ayarla</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExceptionCollectionInvalidArgument">
+        <source>Argument must only contain objects of type Exception.</source>
+        <target state="new">Argument must only contain objects of type Exception.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExtenderProviderServiceDuplicateProvider">
         <source>The extender provider {0} has already been added as an extender.  Adding another would result in duplicate properties.</source>
         <target state="translated">{0} uzatma sağlayıcısı zaten bir uzatma olarak eklendi. Bir uzatma daha eklemek yinelenen özelliklere neden olabilir.</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.zh-Hans.xlf
@@ -1025,6 +1025,11 @@
         <target state="translated">设置 {0}.{1} 事件</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExceptionCollectionInvalidArgument">
+        <source>Argument must only contain objects of type Exception.</source>
+        <target state="new">Argument must only contain objects of type Exception.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExtenderProviderServiceDuplicateProvider">
         <source>The extender provider {0} has already been added as an extender.  Adding another would result in duplicate properties.</source>
         <target state="translated">扩展程序提供程序 {0} 已添加为扩展程序。添加其他扩展程序提供程序将导致重复的属性。</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.zh-Hant.xlf
@@ -1025,6 +1025,11 @@
         <target state="translated">設定 {0}.{1} 事件</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExceptionCollectionInvalidArgument">
+        <source>Argument must only contain objects of type Exception.</source>
+        <target state="new">Argument must only contain objects of type Exception.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExtenderProviderServiceDuplicateProvider">
         <source>The extender provider {0} has already been added as an extender.  Adding another would result in duplicate properties.</source>
         <target state="translated">已經將擴充性提供者 {0} 加入做為擴充項。加入另一個會產生重複的屬性。</target>

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ComponentDesigner.CDDesignerCommandSet.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ComponentDesigner.CDDesignerCommandSet.cs
@@ -17,7 +17,7 @@ namespace System.ComponentModel.Design
 
             public CDDesignerCommandSet(ComponentDesigner componentDesigner) => _componentDesigner = componentDesigner;
 
-            public override ICollection GetCommands(string name) => name switch
+            public override ICollection? GetCommands(string name) => name switch
             {
                 VerbsCommand => _componentDesigner.Verbs,
                 ActionListsCommand => _componentDesigner.ActionLists,

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionHeaderItem.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionHeaderItem.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.ComponentModel.Design
 {
     public sealed class DesignerActionHeaderItem : DesignerActionTextItem

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionItem.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionItem.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections;
 using System.Collections.Specialized;
 using System.Text.RegularExpressions;
@@ -17,9 +15,9 @@ namespace System.ComponentModel.Design
     /// </summary>
     public abstract partial class DesignerActionItem
     {
-        private IDictionary _properties;
+        private IDictionary? _properties;
 
-        public DesignerActionItem(string displayName, string category, string description)
+        public DesignerActionItem(string? displayName, string? category, string? description)
         {
             DisplayName = displayName is null ? null : SanitizeNameRegex().Replace(displayName, "");
             Category = category;
@@ -31,11 +29,11 @@ namespace System.ComponentModel.Design
 
         public bool AllowAssociate { get; set; }
 
-        public virtual string Category { get; }
+        public virtual string? Category { get; }
 
-        public virtual string Description { get; }
+        public virtual string? Description { get; }
 
-        public virtual string DisplayName { get; }
+        public virtual string? DisplayName { get; }
 
         public IDictionary Properties => _properties ??= new HybridDictionary();
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionItemCollection.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionItemCollection.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections;
 
 namespace System.ComponentModel.Design
@@ -12,7 +10,7 @@ namespace System.ComponentModel.Design
     {
         public DesignerActionItem this[int index]
         {
-            get => (DesignerActionItem)(List[index]);
+            get => (DesignerActionItem)List[index]!;
             set => List[index] = value;
         }
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.DesignerActionPanelHeaderItem.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.DesignerActionPanelHeaderItem.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.ComponentModel.Design
 {
     internal sealed partial class DesignerActionPanel

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPropertyItem.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPropertyItem.cs
@@ -6,18 +6,18 @@ namespace System.ComponentModel.Design
 {
     public sealed class DesignerActionPropertyItem : DesignerActionItem
     {
-        public DesignerActionPropertyItem(string memberName, string displayName, string? category, string? description)
+        public DesignerActionPropertyItem(string memberName, string? displayName, string? category, string? description)
             : base(displayName, category, description)
         {
             MemberName = memberName;
         }
 
-        public DesignerActionPropertyItem(string memberName, string displayName)
+        public DesignerActionPropertyItem(string memberName, string? displayName)
             : this(memberName, displayName, category: null, description: null)
         {
         }
 
-        public DesignerActionPropertyItem(string memberName, string displayName, string? category)
+        public DesignerActionPropertyItem(string memberName, string? displayName, string? category)
             : this(memberName, displayName, category, description: null)
         {
         }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPropertyItem.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPropertyItem.cs
@@ -2,13 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.ComponentModel.Design
 {
     public sealed class DesignerActionPropertyItem : DesignerActionItem
     {
-        public DesignerActionPropertyItem(string memberName, string displayName, string category, string description) : base(displayName, category, description)
+        public DesignerActionPropertyItem(string memberName, string displayName, string? category, string? description) : base(displayName, category, description)
         {
             MemberName = memberName;
         }
@@ -17,12 +15,12 @@ namespace System.ComponentModel.Design
         {
         }
 
-        public DesignerActionPropertyItem(string memberName, string displayName, string category) : this(memberName, displayName, category, null)
+        public DesignerActionPropertyItem(string memberName, string displayName, string? category) : this(memberName, displayName, category, null)
         {
         }
 
         public string MemberName { get; }
 
-        public IComponent RelatedComponent { get; set; }
+        public IComponent? RelatedComponent { get; set; }
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPropertyItem.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPropertyItem.cs
@@ -6,16 +6,19 @@ namespace System.ComponentModel.Design
 {
     public sealed class DesignerActionPropertyItem : DesignerActionItem
     {
-        public DesignerActionPropertyItem(string memberName, string displayName, string? category, string? description) : base(displayName, category, description)
+        public DesignerActionPropertyItem(string memberName, string displayName, string? category, string? description)
+            : base(displayName, category, description)
         {
             MemberName = memberName;
         }
 
-        public DesignerActionPropertyItem(string memberName, string displayName) : this(memberName, displayName, null, null)
+        public DesignerActionPropertyItem(string memberName, string displayName)
+            : this(memberName, displayName, category: null, description: null)
         {
         }
 
-        public DesignerActionPropertyItem(string memberName, string displayName, string? category) : this(memberName, displayName, category, null)
+        public DesignerActionPropertyItem(string memberName, string displayName, string? category)
+            : this(memberName, displayName, category, description: null)
         {
         }
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionTextItem.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionTextItem.cs
@@ -6,7 +6,7 @@ namespace System.ComponentModel.Design
 {
     public class DesignerActionTextItem : DesignerActionItem
     {
-        public DesignerActionTextItem(string? displayName, string? category) : base(displayName, category, null)
+        public DesignerActionTextItem(string? displayName, string? category) : base(displayName, category, description: null)
         {
         }
     }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionTextItem.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionTextItem.cs
@@ -2,13 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.ComponentModel.Design
 {
     public class DesignerActionTextItem : DesignerActionItem
     {
-        public DesignerActionTextItem(string displayName, string category) : base(displayName, category, null)
+        public DesignerActionTextItem(string? displayName, string category) : base(displayName, category, null)
         {
         }
     }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionTextItem.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionTextItem.cs
@@ -6,7 +6,7 @@ namespace System.ComponentModel.Design
 {
     public class DesignerActionTextItem : DesignerActionItem
     {
-        public DesignerActionTextItem(string? displayName, string category) : base(displayName, category, null)
+        public DesignerActionTextItem(string? displayName, string? category) : base(displayName, category, null)
         {
         }
     }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerCommandSet.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerCommandSet.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections;
 
 namespace System.ComponentModel.Design
@@ -13,10 +11,10 @@ namespace System.ComponentModel.Design
         private protected const string VerbsCommand = "Verbs";
         private protected const string ActionListsCommand = "ActionLists";
 
-        public virtual ICollection GetCommands(string name) => null;
+        public virtual ICollection? GetCommands(string name) => null;
 
-        public DesignerVerbCollection Verbs => (DesignerVerbCollection)GetCommands(VerbsCommand);
+        public DesignerVerbCollection? Verbs => (DesignerVerbCollection?)GetCommands(VerbsCommand);
 
-        public DesignerActionListCollection ActionLists => (DesignerActionListCollection)GetCommands(ActionListsCommand);
+        public DesignerActionListCollection? ActionLists => (DesignerActionListCollection?)GetCommands(ActionListsCommand);
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerHost.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerHost.cs
@@ -704,7 +704,7 @@ namespace System.ComponentModel.Design
             // Now remove all the designers and their components.  We save the root for last.  Note that we eat any exceptions that components or their designers generate.  A bad component or designer should not prevent an unload from happening.  We do all of this in a transaction to help reduce the number of events we generate.
             _state[s_stateUnloading] = true;
             DesignerTransaction t = ((IDesignerHost)this).CreateTransaction();
-            ArrayList exceptions = new ArrayList();
+            List<Exception> exceptions = new();
             try
             {
                 IComponent[] components = new IComponent[Components.Count];

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ExceptionCollection.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ExceptionCollection.cs
@@ -13,6 +13,16 @@ namespace System.ComponentModel.Design
 
         public ExceptionCollection(ArrayList? exceptions)
         {
+            if (exceptions is null)
+            {
+                return;
+            }
+
+            if (exceptions.ToArray().Any(e => e is not Exception))
+            {
+                throw new ArgumentException(SR.ExceptionCollectionInvalidArgument, nameof(exceptions));
+            }
+
             _exceptions = exceptions?.Cast<Exception>().ToList();
         }
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ExceptionCollection.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ExceptionCollection.cs
@@ -9,14 +9,19 @@ namespace System.ComponentModel.Design
 {
     public sealed class ExceptionCollection : Exception
     {
-        private readonly ArrayList? _exceptions;
+        private readonly List<Exception>? _exceptions;
 
         public ExceptionCollection(ArrayList? exceptions)
+        {
+            _exceptions = exceptions?.Cast<Exception>().ToList();
+        }
+
+        internal ExceptionCollection(List<Exception>? exceptions)
         {
             _exceptions = exceptions;
         }
 
-        public ArrayList? Exceptions => (ArrayList?)_exceptions?.Clone();
+        public ArrayList? Exceptions => _exceptions is null ? null : new ArrayList(_exceptions);
 
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ExceptionCollection.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ExceptionCollection.cs
@@ -9,14 +9,14 @@ namespace System.ComponentModel.Design
 {
     public sealed class ExceptionCollection : Exception
     {
-        private readonly ArrayList _exceptions;
+        private readonly ArrayList? _exceptions;
 
-        public ExceptionCollection(ArrayList exceptions)
+        public ExceptionCollection(ArrayList? exceptions)
         {
             _exceptions = exceptions;
         }
 
-        public ArrayList? Exceptions => (ArrayList)_exceptions.Clone();
+        public ArrayList? Exceptions => (ArrayList?)_exceptions?.Clone();
 
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ExceptionCollection.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ExceptionCollection.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections;
 using System.Runtime.Serialization;
 
@@ -18,7 +16,7 @@ namespace System.ComponentModel.Design
             _exceptions = exceptions;
         }
 
-        public ArrayList Exceptions => (ArrayList)_exceptions?.Clone();
+        public ArrayList? Exceptions => (ArrayList)_exceptions.Clone();
 
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/HostDesigntimeLicenseContext.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/HostDesigntimeLicenseContext.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.ComponentModel.Design
 {
     /// <summary>
@@ -19,6 +17,6 @@ namespace System.ComponentModel.Design
             _provider = provider;
         }
 
-        public override object GetService(Type serviceClass) => _provider.GetService(serviceClass);
+        public override object? GetService(Type serviceClass) => _provider.GetService(serviceClass);
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/IMultitargetHelperService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/IMultitargetHelperService.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.ComponentModel.Design
 {
     /// <summary>

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ObjectSelectorEditor.SelectorNode.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ObjectSelectorEditor.SelectorNode.cs
@@ -10,12 +10,12 @@ namespace System.ComponentModel.Design
     {
         public class SelectorNode : TreeNode
         {
-            public object value;
+            public object? value;
 
             /// <summary>
             ///  Sets label and value to given.
             /// </summary>
-            public SelectorNode(string label, object value) : base(label)
+            public SelectorNode(string label, object? value) : base(label)
             {
                 this.value = value;
             }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ObjectSelectorEditor.SelectorNode.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ObjectSelectorEditor.SelectorNode.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Windows.Forms;
 
 namespace System.ComponentModel.Design

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ProjectTargetFrameworkAttribute.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ProjectTargetFrameworkAttribute.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.ComponentModel.Design
 {
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Struct)]

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ICodeDomDesignerReload.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ICodeDomDesignerReload.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.CodeDom;
 
 namespace System.ComponentModel.Design.Serialization

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/ColorEditor.ColorUI.ColorEditorListBox.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/ColorEditor.ColorUI.ColorEditorListBox.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Windows.Forms;
+
+namespace System.Drawing.Design
+{
+    public partial class ColorEditor
+    {
+        private sealed partial class ColorUI
+        {
+            private sealed class ColorEditorListBox : ListBox
+            {
+                protected override bool IsInputKey(Keys keyData)
+                {
+                    return keyData switch
+                    {
+                        Keys.Return => true,
+                        _ => base.IsInputKey(keyData),
+                    };
+                }
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/ColorEditor.ColorUI.ColorEditorTabControl.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/ColorEditor.ColorUI.ColorEditorTabControl.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Windows.Forms;
+
+namespace System.Drawing.Design
+{
+    public partial class ColorEditor
+    {
+        private sealed partial class ColorUI
+        {
+            private sealed class ColorEditorTabControl : TabControl
+            {
+                public ColorEditorTabControl() : base()
+                {
+                }
+
+                protected override void OnGotFocus(EventArgs e)
+                {
+                    TabPage selectedTab = SelectedTab;
+                    if (selectedTab is not null && selectedTab.Controls.Count > 0)
+                    {
+                        selectedTab.Controls[0].Focus();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/ColorEditor.ColorUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/ColorEditor.ColorUI.cs
@@ -14,7 +14,7 @@ namespace System.Drawing.Design
         /// <summary>
         ///  Editor UI for the color editor.
         /// </summary>
-        private sealed class ColorUI : Control
+        private sealed partial class ColorUI : Control
         {
             private readonly ColorEditor editor;
             private IWindowsFormsEditorService? edSvc;
@@ -380,34 +380,6 @@ namespace System.Drawing.Design
                     }
 
                     tabControl.SelectedTab = selectedTab;
-                }
-            }
-
-            private sealed class ColorEditorListBox : ListBox
-            {
-                protected override bool IsInputKey(Keys keyData)
-                {
-                    return keyData switch
-                    {
-                        Keys.Return => true,
-                        _ => base.IsInputKey(keyData),
-                    };
-                }
-            }
-
-            private sealed class ColorEditorTabControl : TabControl
-            {
-                public ColorEditorTabControl() : base()
-                {
-                }
-
-                protected override void OnGotFocus(EventArgs e)
-                {
-                    TabPage selectedTab = SelectedTab;
-                    if (selectedTab is not null && selectedTab.Controls.Count > 0)
-                    {
-                        selectedTab.Controls[0].Focus();
-                    }
                 }
             }
         }

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/ColorEditor.ColorUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/ColorEditor.ColorUI.cs
@@ -2,9 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
-using System.Collections;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Windows.Forms;
 using System.Windows.Forms.Design;
@@ -16,11 +14,11 @@ namespace System.Drawing.Design
         /// <summary>
         ///  Editor UI for the color editor.
         /// </summary>
-        private class ColorUI : Control
+        private sealed class ColorUI : Control
         {
             private readonly ColorEditor editor;
-            private IWindowsFormsEditorService edSvc;
-            private object value;
+            private IWindowsFormsEditorService? edSvc;
+            private object? value;
             private ColorEditorTabControl tabControl;
             private TabPage systemTabPage;
             private TabPage commonTabPage;
@@ -28,9 +26,9 @@ namespace System.Drawing.Design
             private ListBox lbSystem;
             private ListBox lbCommon;
             private ColorPalette pal;
-            private object[] systemColorConstants;
-            private object[] colorConstants;
-            private Color[] customColors;
+            private Color[]? systemColorConstants;
+            private Color[]? colorConstants;
+            private Color[]? customColors;
             private bool commonHeightSet;
             private bool systemHeightSet;
 
@@ -44,7 +42,7 @@ namespace System.Drawing.Design
             /// <summary>
             ///  Array of standard colors.
             /// </summary>
-            private object[] ColorValues => colorConstants ??= GetConstants(typeof(Color));
+            private Color[] ColorValues => colorConstants ??= GetConstants(typeof(Color));
 
             /// <summary>
             ///  Retrieves the array of custom colors for our use.
@@ -64,25 +62,19 @@ namespace System.Drawing.Design
 
                     return customColors;
                 }
-
-                set
-                {
-                    customColors = value;
-                    pal = null;
-                }
             }
 
             /// <summary>
             ///  Allows someone else to close our dropdown.
             /// </summary>
-            public IWindowsFormsEditorService EditorService => edSvc;
+            public IWindowsFormsEditorService? EditorService => edSvc;
 
             /// <summary>
             ///  Array of system colors.
             /// </summary>
-            private object[] SystemColorValues => systemColorConstants ??= GetConstants(typeof(SystemColors));
+            private Color[] SystemColorValues => systemColorConstants ??= GetConstants(typeof(SystemColors));
 
-            public object Value => value;
+            public object? Value => value;
 
             public void End()
             {
@@ -93,7 +85,6 @@ namespace System.Drawing.Design
             private void AdjustColorUIHeight()
             {
                 // Compute the default size for the color UI
-                //
                 Size size = pal.Size;
                 Rectangle rectItemSize = tabControl.GetTabRect(0);
                 int CMARGIN = 0;
@@ -112,13 +103,13 @@ namespace System.Drawing.Design
             /// </summary>
             private Color GetBestColor(Color color)
             {
-                object[] colors = ColorValues;
+                Color[] colors = ColorValues;
                 int rgb = color.ToArgb();
                 for (int i = 0; i < colors.Length; i++)
                 {
-                    if (((Color)colors[i]).ToArgb() == rgb)
+                    if (colors[i].ToArgb() == rgb)
                     {
-                        return (Color)colors[i];
+                        return colors[i];
                     }
                 }
 
@@ -128,23 +119,26 @@ namespace System.Drawing.Design
             /// <summary>
             ///  Retrieves an array of color constants for the given object.
             /// </summary>
-            private static object[] GetConstants(Type enumType)
+            private static Color[] GetConstants(Type enumType)
             {
                 MethodAttributes attrs = MethodAttributes.Public | MethodAttributes.Static;
                 PropertyInfo[] props = enumType.GetProperties();
 
-                ArrayList colorList = new ArrayList();
+                List<Color> colorList = new();
 
                 for (int i = 0; i < props.Length; i++)
                 {
                     PropertyInfo prop = props[i];
                     if (prop.PropertyType == typeof(Color))
                     {
-                        MethodInfo method = prop.GetGetMethod();
+                        MethodInfo? method = prop.GetGetMethod();
                         if (method is not null && (method.Attributes & attrs) == attrs)
                         {
-                            object[] tempIndex = null;
-                            colorList.Add(prop.GetValue(null, tempIndex));
+                            object?[]? tempIndex = null;
+                            if (prop.GetValue(null, tempIndex) is Color outColor)
+                            {
+                                colorList.Add(outColor);
+                            }
                         }
                     }
                 }
@@ -152,6 +146,14 @@ namespace System.Drawing.Design
                 return colorList.ToArray();
             }
 
+            [MemberNotNull(
+                nameof(tabControl),
+                nameof(pal),
+                nameof(paletteTabPage),
+                nameof(commonTabPage),
+                nameof(systemTabPage),
+                nameof(lbSystem),
+                nameof(lbCommon))]
             private void InitializeComponent()
             {
                 paletteTabPage = new TabPage(SR.ColorEditorPaletteTab);
@@ -196,16 +198,16 @@ namespace System.Drawing.Design
                 lbCommon.Dock = DockStyle.Fill;
 
                 Array.Sort(ColorValues, new StandardColorComparer());
-                Array.Sort(SystemColorValues, new SystemColorComparer());
+                Array.Sort(SystemColorValues, comparer: new SystemColorComparer());
 
                 lbCommon.Items.Clear();
-                foreach (object color in ColorValues)
+                foreach (Color color in ColorValues)
                 {
                     lbCommon.Items.Add(color);
                 }
 
                 lbSystem.Items.Clear();
-                foreach (object color in SystemColorValues)
+                foreach (Color color in SystemColorValues)
                 {
                     lbSystem.Items.Add(color);
                 }
@@ -226,50 +228,51 @@ namespace System.Drawing.Design
                 OnTabControlSelChange(this, EventArgs.Empty);
             }
 
-            private void OnFontChanged(object sender, EventArgs e)
+            private void OnFontChanged(object? sender, EventArgs e)
             {
                 commonHeightSet = systemHeightSet = false;
             }
 
-            private void OnListClick(object sender, EventArgs e)
+            private void OnListClick(object? sender, EventArgs e)
             {
-                ListBox lb = (ListBox)sender;
-                if (lb.SelectedItem is not null)
+                if (sender is ListBox lb && lb.SelectedItem is Color selectedColor)
                 {
-                    value = (Color)lb.SelectedItem;
+                    value = selectedColor;
                 }
 
-                edSvc.CloseDropDown();
+                edSvc?.CloseDropDown();
             }
 
-            private void OnListDrawItem(object sender, DrawItemEventArgs die)
+            private void OnListDrawItem(object? sender, DrawItemEventArgs die)
             {
-                ListBox lb = (ListBox)sender;
-                object value = lb.Items[die.Index];
-                Font font = Font;
-
-                if (lb == lbCommon && !commonHeightSet)
+                if (sender is ListBox lb)
                 {
-                    lb.ItemHeight = lb.Font.Height;
-                    commonHeightSet = true;
-                }
-                else if (lb == lbSystem && !systemHeightSet)
-                {
-                    lb.ItemHeight = lb.Font.Height;
-                    systemHeightSet = true;
-                }
+                    Color value = (Color)lb.Items[die.Index];
+                    Font font = Font;
 
-                Graphics graphics = die.Graphics;
-                die.DrawBackground();
+                    if (lb == lbCommon && !commonHeightSet)
+                    {
+                        lb.ItemHeight = lb.Font.Height;
+                        commonHeightSet = true;
+                    }
+                    else if (lb == lbSystem && !systemHeightSet)
+                    {
+                        lb.ItemHeight = lb.Font.Height;
+                        systemHeightSet = true;
+                    }
 
-                editor.PaintValue(value, graphics, new Rectangle(die.Bounds.X + 2, die.Bounds.Y + 2, 22, die.Bounds.Height - 4));
-                graphics.DrawRectangle(SystemPens.WindowText, new Rectangle(die.Bounds.X + 2, die.Bounds.Y + 2, 22 - 1, die.Bounds.Height - 4 - 1));
-                Brush foreBrush = new SolidBrush(die.ForeColor);
-                graphics.DrawString(((Color)value).Name, font, foreBrush, die.Bounds.X + 26, die.Bounds.Y);
-                foreBrush.Dispose();
+                    Graphics graphics = die.Graphics;
+                    die.DrawBackground();
+
+                    editor.PaintValue(value, graphics, new Rectangle(die.Bounds.X + 2, die.Bounds.Y + 2, 22, die.Bounds.Height - 4));
+                    graphics.DrawRectangle(SystemPens.WindowText, new Rectangle(die.Bounds.X + 2, die.Bounds.Y + 2, 22 - 1, die.Bounds.Height - 4 - 1));
+                    Brush foreBrush = new SolidBrush(die.ForeColor);
+                    graphics.DrawString(value.Name, font, foreBrush, die.Bounds.X + 26, die.Bounds.Y);
+                    foreBrush.Dispose();
+                }
             }
 
-            private void OnListKeyDown(object sender, KeyEventArgs ke)
+            private void OnListKeyDown(object? sender, KeyEventArgs ke)
             {
                 if (ke.KeyCode == Keys.Return)
                 {
@@ -277,11 +280,11 @@ namespace System.Drawing.Design
                 }
             }
 
-            private void OnPalettePick(object sender, EventArgs e)
+            private void OnPalettePick(object? sender, EventArgs e)
             {
-                ColorPalette p = (ColorPalette)sender;
-                value = GetBestColor(p.SelectedColor);
-                edSvc.CloseDropDown();
+                ColorPalette? p = (ColorPalette?)sender;
+                value = p is null ? null : GetBestColor(p.SelectedColor);
+                edSvc?.CloseDropDown();
             }
 
             protected override void OnFontChanged(EventArgs e)
@@ -291,7 +294,7 @@ namespace System.Drawing.Design
                 AdjustColorUIHeight();
             }
 
-            private void OnTabControlResize(object sender, EventArgs e)
+            private void OnTabControlResize(object? sender, EventArgs e)
             {
                 Rectangle rectTabControl = tabControl.TabPages[0].ClientRectangle;
                 Rectangle rectItemSize = tabControl.GetTabRect(1);
@@ -305,7 +308,7 @@ namespace System.Drawing.Design
                 pal.Location = new Point(0, rectTabControl.Y);
             }
 
-            private void OnTabControlSelChange(object sender, EventArgs e)
+            private void OnTabControlSelChange(object? sender, EventArgs e)
             {
                 TabPage selectedPage = tabControl.SelectedTab;
 
@@ -330,17 +333,8 @@ namespace System.Drawing.Design
                     if (sel != -1)
                     {
                         int count = tabControl.TabPages.Count;
-                        if (forward)
-                        {
-                            sel = (sel + 1) % count;
-                        }
-                        else
-                        {
-                            sel = (sel + count - 1) % count;
-                        }
-
+                        sel = forward ? (sel + 1) % count : (sel + count - 1) % count;
                         tabControl.SelectedTab = tabControl.TabPages[sel];
-
                         return true;
                     }
                 }
@@ -356,10 +350,9 @@ namespace System.Drawing.Design
                 AdjustColorUIHeight();
 
                 // Now look for the current color so we can select the proper tab.
-                //
                 if (value is not null)
                 {
-                    object[] values = ColorValues;
+                    Color[] values = ColorValues;
                     TabPage selectedTab = paletteTabPage;
 
                     for (int i = 0; i < values.Length; i++)
@@ -390,21 +383,19 @@ namespace System.Drawing.Design
                 }
             }
 
-            private class ColorEditorListBox : ListBox
+            private sealed class ColorEditorListBox : ListBox
             {
                 protected override bool IsInputKey(Keys keyData)
                 {
-                    switch (keyData)
+                    return keyData switch
                     {
-                        case Keys.Return:
-                            return true;
-                    }
-
-                    return base.IsInputKey(keyData);
+                        Keys.Return => true,
+                        _ => base.IsInputKey(keyData),
+                    };
                 }
             }
 
-            private class ColorEditorTabControl : TabControl
+            private sealed class ColorEditorTabControl : TabControl
             {
                 public ColorEditorTabControl() : base()
                 {

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/ColorEditor.SystemColorComparer.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/ColorEditor.SystemColorComparer.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections;
 using System.Globalization;
 
@@ -16,10 +14,12 @@ namespace System.Drawing.Design
         /// </summary>
         private class SystemColorComparer : IComparer
         {
-            public int Compare(object x, object y)
-            {
-                return string.Compare(((Color)x).Name, ((Color)y).Name, false, CultureInfo.InvariantCulture);
-            }
+            public int Compare(object? x, object? y)
+                => string.Compare(
+                    x is null ? null : ((Color)x).Name,
+                    y is null ? null : ((Color)y).Name,
+                    false,
+                    CultureInfo.InvariantCulture);
         }
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/ColorEditor.SystemColorComparer.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/ColorEditor.SystemColorComparer.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections;
 using System.Globalization;
 
 namespace System.Drawing.Design
@@ -12,14 +11,10 @@ namespace System.Drawing.Design
         /// <summary>
         ///  Comparer for system colors.
         /// </summary>
-        private class SystemColorComparer : IComparer
+        private class SystemColorComparer : IComparer<Color>
         {
-            public int Compare(object? x, object? y)
-                => string.Compare(
-                    x is null ? null : ((Color)x).Name,
-                    y is null ? null : ((Color)y).Name,
-                    false,
-                    CultureInfo.InvariantCulture);
+            public int Compare(Color x, Color y)
+                => string.Compare(x.Name, y.Name, false, CultureInfo.InvariantCulture);
         }
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/IToolboxItemProvider.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/IToolboxItemProvider.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Drawing.Design
 {
     public interface IToolboxItemProvider

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/ToolboxComponentsCreatedEventArgs.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/ToolboxComponentsCreatedEventArgs.cs
@@ -12,12 +12,12 @@ namespace System.Drawing.Design
     /// </summary>
     public class ToolboxComponentsCreatedEventArgs : EventArgs
     {
-        private readonly IComponent[] _components;
+        private readonly IComponent[]? _components;
 
         /// <summary>
         ///  Initializes a new instance of the <see cref="ToolboxComponentsCreatedEventArgs"/>
         /// </summary>
-        public ToolboxComponentsCreatedEventArgs(IComponent[] components)
+        public ToolboxComponentsCreatedEventArgs(IComponent[]? components)
         {
             _components = components;
         }
@@ -25,6 +25,6 @@ namespace System.Drawing.Design
         /// <summary>
         ///  An array storing the toolbox components.
         /// </summary>
-        public IComponent[] Components => (IComponent[])_components.Clone();
+        public IComponent[]? Components => (IComponent[]?)_components?.Clone();
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/ToolboxComponentsCreatedEventArgs.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/ToolboxComponentsCreatedEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 
 namespace System.Drawing.Design
@@ -27,6 +25,6 @@ namespace System.Drawing.Design
         /// <summary>
         ///  An array storing the toolbox components.
         /// </summary>
-        public IComponent[] Components => (IComponent[])_components?.Clone();
+        public IComponent[] Components => (IComponent[])_components.Clone();
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ContextMenuStripGroup.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ContextMenuStripGroup.cs
@@ -2,13 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms.Design
 {
     internal class ContextMenuStripGroup
     {
-        private List<ToolStripItem> _items;
+        private List<ToolStripItem>? _items;
         private readonly string _name;
 
         public ContextMenuStripGroup(string name) => _name = name;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ContextMenuStripGroupCollection.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ContextMenuStripGroupCollection.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections;
 
 namespace System.Windows.Forms.Design
@@ -23,7 +21,7 @@ namespace System.Windows.Forms.Design
                     InnerHashtable[key] = new ContextMenuStripGroup(key);
                 }
 
-                return InnerHashtable[key] as ContextMenuStripGroup;
+                return (ContextMenuStripGroup)InnerHashtable[key]!;
             }
         }
 
@@ -32,9 +30,9 @@ namespace System.Windows.Forms.Design
             return InnerHashtable.ContainsKey(key);
         }
 
-        protected override void OnInsert(object key, object value)
+        protected override void OnInsert(object key, object? value)
         {
-            if (!(value is ContextMenuStripGroup))
+            if (value is not ContextMenuStripGroup)
             {
                 throw new NotSupportedException();
             }
@@ -42,9 +40,9 @@ namespace System.Windows.Forms.Design
             base.OnInsert(key, value);
         }
 
-        protected override void OnSet(object key, object oldValue, object newValue)
+        protected override void OnSet(object key, object? oldValue, object? newValue)
         {
-            if (!(newValue is ContextMenuStripGroup))
+            if (newValue is not ContextMenuStripGroup)
             {
                 throw new NotSupportedException();
             }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataMemberFieldConverter.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataMemberFieldConverter.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 using System.Globalization;
 
@@ -11,22 +9,21 @@ namespace System.Windows.Forms.Design
 {
     internal class DataMemberFieldConverter : TypeConverter
     {
-        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType)
         {
             return sourceType == typeof(string) ? true : base.CanConvertFrom(context, sourceType);
         }
 
-        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        public override object? ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object? value)
         {
             return value is not null && value.Equals(SR.None) ? string.Empty : value;
         }
 
-        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+        public override object? ConvertTo(ITypeDescriptorContext? context, CultureInfo? culture, object? value, Type destinationType)
         {
-            if (destinationType == typeof(string) && (value is null || value.Equals(string.Empty)))
-                return SR.None_lc;
-
-            return base.ConvertTo(context, culture, value, destinationType);
+            return destinationType == typeof(string) && (value is null || value.Equals(string.Empty))
+                ? SR.None_lc
+                : base.ConvertTo(context, culture, value, destinationType);
         }
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/IContainsThemedScrollbarWindows.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/IContainsThemedScrollbarWindows.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections;
 
 namespace System.Windows.Forms.Design

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ServiceProviderExtensions.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ServiceProviderExtensions.cs
@@ -2,13 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms.Design
 {
     internal static class ServiceProviderExtensions
     {
-        public static T GetService<T>(this IServiceProvider serviceProvider) where T : class
+        public static T? GetService<T>(this IServiceProvider serviceProvider) where T : class
             => serviceProvider.GetService(typeof(T)) as T;
     }
 }

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/ExceptionCollectionTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/ExceptionCollectionTests.cs
@@ -15,7 +15,7 @@ namespace System.ComponentModel.Design.Tests
         {
             yield return new object[] { null };
             yield return new object[] { new ArrayList() };
-            yield return new object[] { new ArrayList { 1, 2, 3 } };
+            yield return new object[] { new ArrayList { new Exception(), new Exception(), new Exception()} };
         }
 
         [Theory]
@@ -34,6 +34,13 @@ namespace System.ComponentModel.Design.Tests
                 Assert.Equal(collection.Exceptions, collection.Exceptions);
                 Assert.NotSame(collection.Exceptions, collection.Exceptions);
             }
+        }
+
+        [Fact]
+        public void ExceptionCollection_Ctor_ArguementException()
+        {
+            var exceptions = new ArrayList { 1, 2, 3 };
+            Assert.Throws<ArgumentException>(() => new ExceptionCollection(exceptions));
         }
 
         [Fact]


### PR DESCRIPTION
Enable Nullability in multiple Design classes.

This PR focuses on classes with low line counts to reduce the review burden.

Related: #8342

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8413)