### PR TITLE
Fix InvalidCastException when adding a second ToolStrip in ToolStripPanel

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanelRow.ToolStripPanelRowControlCollection.ToolStripPanelCellToControlEnumerator.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanelRow.ToolStripPanelRowControlCollection.ToolStripPanelCellToControlEnumerator.cs
@@ -18,9 +18,9 @@ namespace System.Windows.Forms
             {
                 private readonly IEnumerator _arrayListEnumerator;
 
-                internal ToolStripPanelCellToControlEnumerator(IEnumerable<ToolStripPanelCell> list)
+                internal ToolStripPanelCellToControlEnumerator(IEnumerator enumerator)
                 {
-                    _arrayListEnumerator = list.GetEnumerator();
+                    _arrayListEnumerator = enumerator;
                 }
 
                 public virtual object? Current

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanelRow.ToolStripPanelRowControlCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanelRow.ToolStripPanelRowControlCollection.cs
@@ -145,7 +145,7 @@ namespace System.Windows.Forms
                 }
             }
 
-            public override IEnumerator GetEnumerator() { return new ToolStripPanelCellToControlEnumerator((IEnumerable<ToolStripPanelCell>)InnerList); }
+            public override IEnumerator GetEnumerator() { return new ToolStripPanelCellToControlEnumerator(InnerList.GetEnumerator()); }
 
             private Control GetControl(int index)
             {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripPanelTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripPanelTests.cs
@@ -344,9 +344,9 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void ToolStripPanel_AddTwoToolStrips_DoesNotThrowInvalidCastException()
         {
-            ToolStripContainer toolStripContainer = new();
-            ToolStrip toolStrip1 = new();
-            ToolStrip toolStrip2 = new();
+            using ToolStripContainer toolStripContainer = new();
+            using ToolStrip toolStrip1 = new();
+            using ToolStrip toolStrip2 = new();
 
             toolStripContainer.TopToolStripPanel.Controls.Add(toolStrip1);
             var exception = Record.Exception(() => toolStripContainer.TopToolStripPanel.Controls.Add(toolStrip2));

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripPanelTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripPanelTests.cs
@@ -341,6 +341,19 @@ namespace System.Windows.Forms.Tests
             Assert.False(control.GetTopLevel());
         }
 
+        [WinFormsFact]
+        public void ToolStripPanel_AddTwoToolStrips_DoesNotThrowInvalidCastException()
+        {
+            ToolStripContainer toolStripContainer = new();
+            ToolStrip toolStrip1 = new();
+            ToolStrip toolStrip2 = new();
+
+            toolStripContainer.TopToolStripPanel.Controls.Add(toolStrip1);
+            var exception = Record.Exception(() => toolStripContainer.TopToolStripPanel.Controls.Add(toolStrip2));
+
+            Assert.Null(exception);
+        }
+
         private class SubToolStripPanel : ToolStripPanel
         {
             public new SizeF AutoScaleFactor => base.AutoScaleFactor;


### PR DESCRIPTION
Fixes #8415


## Proposed changes

- Add simple test.
- Pass enumerator as parameter to fix the exception.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8419)