### PR TITLE
Fix InvalidCastException in ErrorProvider

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections;
 using System.ComponentModel;
 using System.ComponentModel.Design;
 using System.Diagnostics;
@@ -513,11 +512,9 @@ namespace System.Windows.Forms
                 controlError[dataBinding.Control] = outputError;
             }
 
-            IEnumerator enumerator = controlError.GetEnumerator();
-            while (enumerator.MoveNext())
+            foreach (KeyValuePair<Control, string> entry in controlError)
             {
-                DictionaryEntry entry = (DictionaryEntry)enumerator.Current;
-                SetError((Control)entry.Key, (string?)entry.Value);
+                SetError(entry.Key, entry.Value);
             }
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ErrorProviderTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ErrorProviderTests.cs
@@ -1244,6 +1244,26 @@ namespace System.Windows.Forms.Tests
             Assert.False(provider.HasErrors);
         }
 
+        [WinFormsFact]
+        public void ErrorProvider_CustomDataSource_DoesNotThrowInvalidCastException()
+        {
+            using Form form = new();
+            CustomDataSource customDataSource = new();
+            form.DataBindings.Add("Text", customDataSource, "Error");
+            using ErrorProvider errorProvider = new(form);
+
+            var exception = Record.Exception(() => errorProvider.DataSource = customDataSource);
+
+            Assert.Null(exception);
+        }
+
+        private class CustomDataSource : IDataErrorInfo
+        {
+            public string this[string columnName] => string.Empty;
+
+            public string Error => string.Empty;
+        }
+
         private class SubErrorProvider : ErrorProvider
         {
             public SubErrorProvider() : base()


### PR DESCRIPTION
Fixes #8424


## Proposed changes

- Add simple test.
- Fix InvalidCastException in ErrorProvider

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8425)