### PR TITLE
Enable nullability in HtmlHistory

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -1178,9 +1178,9 @@ System.Windows.Forms.ErrorProvider.Tag.set -> void
 ~System.Windows.Forms.HtmlElementEventArgs.EventType.get -> string
 ~System.Windows.Forms.HtmlElementEventArgs.FromElement.get -> System.Windows.Forms.HtmlElement
 ~System.Windows.Forms.HtmlElementEventArgs.ToElement.get -> System.Windows.Forms.HtmlElement
-~System.Windows.Forms.HtmlHistory.DomHistory.get -> object
-~System.Windows.Forms.HtmlHistory.Go(string urlString) -> void
-~System.Windows.Forms.HtmlHistory.Go(System.Uri url) -> void
+System.Windows.Forms.HtmlHistory.DomHistory.get -> object!
+System.Windows.Forms.HtmlHistory.Go(string! urlString) -> void
+System.Windows.Forms.HtmlHistory.Go(System.Uri! url) -> void
 ~System.Windows.Forms.HtmlWindow.Alert(string message) -> void
 ~System.Windows.Forms.HtmlWindow.AttachEventHandler(string eventName, System.EventHandler eventHandler) -> void
 ~System.Windows.Forms.HtmlWindow.Confirm(string message) -> bool

--- a/src/System.Windows.Forms/src/System/Windows/Forms/HtmlHistory.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/HtmlHistory.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Diagnostics;
 using static Interop.Mshtml;
 
@@ -31,7 +29,7 @@ namespace System.Windows.Forms
 
         public void Dispose()
         {
-            htmlHistory = null;
+            htmlHistory = null!;
             disposed = true;
             GC.SuppressFinalize(this);
         }


### PR DESCRIPTION
## Proposed changes

- Enable nullability in HtmlHistory.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8427)