### PR TITLE
Fix UIA tree structure for MenuStrip

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/MenuStrip.MenuStripAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MenuStrip.MenuStripAccessibleObject.cs
@@ -26,6 +26,14 @@ namespace System.Windows.Forms
                     return AccessibleRole.MenuBar;
                 }
             }
+
+            internal override object? GetPropertyValue(Interop.UiaCore.UIA propertyID) =>
+                propertyID switch
+                {
+                    Interop.UiaCore.UIA.IsControlElementPropertyId => true,
+                    Interop.UiaCore.UIA.IsContentElementPropertyId => false,
+                    _ => base.GetPropertyValue(propertyID)
+                };
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownMenu.ToolStripDropDownMenuAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownMenu.ToolStripDropDownMenuAccessibleObject.cs
@@ -20,6 +20,14 @@ namespace System.Windows.Forms
                         => menu.OwnerItem?.AccessibilityObject,
                     _ => base.FragmentNavigate(direction)
                 };
+
+            internal override object? GetPropertyValue(UiaCore.UIA propertyID) =>
+                propertyID switch
+                {
+                    UiaCore.UIA.IsControlElementPropertyId => true,
+                    UiaCore.UIA.IsContentElementPropertyId => Owner is ContextMenuStrip,
+                    _ => base.GetPropertyValue(propertyID)
+                };
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.ToolStripItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.ToolStripItemAccessibleObject.cs
@@ -113,6 +113,8 @@ namespace System.Windows.Forms
                     UiaCore.UIA.IsEnabledPropertyId => _ownerItem.Enabled,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId => _ownerItem.CanSelect,
                     UiaCore.UIA.IsOffscreenPropertyId => GetIsOffscreenPropertyValue(_ownerItem.Placement, Bounds),
+                    UiaCore.UIA.IsControlElementPropertyId => true,
+                    UiaCore.UIA.IsContentElementPropertyId => true,
                     _ => base.GetPropertyValue(propertyID)
                 };
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MenuStrip.MenuStripAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MenuStrip.MenuStripAccessibleObjectTests.cs
@@ -28,6 +28,26 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
+        public void MenuStripAccessibleObject_GetPropertyValue_IsControlElement_ReturnsExpected()
+        {
+            using MenuStrip menuStrip = new();
+
+            AccessibleObject accessibleObject = menuStrip.AccessibilityObject;
+
+            Assert.True((bool)accessibleObject.GetPropertyValue(UIA.IsControlElementPropertyId));
+        }
+
+        [WinFormsFact]
+        public void MenuStripAccessibleObject_GetPropertyValue_IsContentElement_ReturnsExpected()
+        {
+            using MenuStrip menuStrip = new();
+
+            AccessibleObject accessibleObject = menuStrip.AccessibilityObject;
+
+            Assert.False((bool)accessibleObject.GetPropertyValue(UIA.IsContentElementPropertyId));
+        }
+
+        [WinFormsFact]
         public void MenuStripAccessibleObject_IsPatternSupported_LegacyIAccessible_ReturnsTrue()
         {
             using var menuStrip = new MenuStrip();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripDropDownMenu.ToolStripDropDownMenuAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripDropDownMenu.ToolStripDropDownMenuAccessibleObjectTests.cs
@@ -256,5 +256,73 @@ namespace System.Windows.Forms.Tests
             parentItem1.ParentInternal = null;
             parentItem2.ParentInternal = null;
         }
+
+        [WinFormsFact]
+        public void ToolStripDropDownMenuAccessible_GetPropertyValue_IsControlElement_ReturnsExpected_InToolStripMenuItem()
+        {
+            using ToolStripMenuItem menuItem = new();
+
+            ToolStripDropDown dropDown = menuItem.DropDown;
+
+            ToolStripDropDownMenu.ToolStripDropDownMenuAccessibleObject accessibleObject = (ToolStripDropDownMenu.ToolStripDropDownMenuAccessibleObject)dropDown.AccessibilityObject;
+
+            Assert.True((bool)accessibleObject.GetPropertyValue(UIA.IsControlElementPropertyId));
+        }
+
+        [WinFormsFact]
+        public void ToolStripDropDownMenuAccessible_GetPropertyValue_IsControlElement_ReturnsExpected_InToolStripDropDownButton()
+        {
+            using ToolStripDropDownButton dropDownButton = new();
+
+            ToolStripDropDown dropDown = dropDownButton.DropDown;
+
+            ToolStripDropDownMenu.ToolStripDropDownMenuAccessibleObject accessibleObject = (ToolStripDropDownMenu.ToolStripDropDownMenuAccessibleObject)dropDown.AccessibilityObject;
+
+            Assert.True((bool)accessibleObject.GetPropertyValue(UIA.IsControlElementPropertyId));
+        }
+
+        [WinFormsFact]
+        public void ToolStripDropDownMenuAccessible_GetPropertyValue_IsControlElement_ReturnsExpected_InContextMenuStrip()
+        {
+            using ContextMenuStrip contextMenu = new();
+
+            ToolStripDropDownMenu.ToolStripDropDownMenuAccessibleObject accessibleObject = (ToolStripDropDownMenu.ToolStripDropDownMenuAccessibleObject)contextMenu.AccessibilityObject;
+
+            Assert.True((bool)accessibleObject.GetPropertyValue(UIA.IsControlElementPropertyId));
+        }
+
+        [WinFormsFact]
+        public void ToolStripDropDownMenuAccessible_GetPropertyValue_IsContentElement_ReturnsExpected_InToolStripMenuItem()
+        {
+            using ToolStripMenuItem menuItem = new();
+
+            ToolStripDropDown dropDown = menuItem.DropDown;
+
+            ToolStripDropDownMenu.ToolStripDropDownMenuAccessibleObject accessibleObject = (ToolStripDropDownMenu.ToolStripDropDownMenuAccessibleObject)dropDown.AccessibilityObject;
+
+            Assert.False((bool)accessibleObject.GetPropertyValue(UIA.IsContentElementPropertyId));
+        }
+
+        [WinFormsFact]
+        public void ToolStripDropDownMenuAccessible_GetPropertyValue_IsContentElement_ReturnsExpected_InToolStripDropDownButton()
+        {
+            using ToolStripDropDownButton dropDownButton = new();
+
+            ToolStripDropDown dropDown = dropDownButton.DropDown;
+
+            ToolStripDropDownMenu.ToolStripDropDownMenuAccessibleObject accessibleObject = (ToolStripDropDownMenu.ToolStripDropDownMenuAccessibleObject)dropDown.AccessibilityObject;
+
+            Assert.False((bool)accessibleObject.GetPropertyValue(UIA.IsContentElementPropertyId));
+        }
+
+        [WinFormsFact]
+        public void ToolStripDropDownMenuAccessible_GetPropertyValue_IsContentElement_ReturnsExpected_InContextMenuStrip()
+        {
+            using ContextMenuStrip contextMenu = new();
+
+            ToolStripDropDownMenu.ToolStripDropDownMenuAccessibleObject accessibleObject = (ToolStripDropDownMenu.ToolStripDropDownMenuAccessibleObject)contextMenu.AccessibilityObject;
+
+            Assert.True((bool)accessibleObject.GetPropertyValue(UIA.IsContentElementPropertyId));
+        }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripItemAccessibleObjectTests.cs
@@ -176,6 +176,26 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
+        public void ToolStripItemAccessibleObject_GetPropertyValue_IsControlElement_ReturnsExpected()
+        {
+            using ToolStripItem toolStripItem = new SubToolStripItem();
+
+            AccessibleObject accessibleObject = toolStripItem.AccessibilityObject;
+
+            Assert.True((bool)accessibleObject.GetPropertyValue(UIA.IsControlElementPropertyId));
+        }
+
+        [WinFormsFact]
+        public void ToolStripItemAccessibleObject_GetPropertyValue_IsContentElement_ReturnsExpected()
+        {
+            using ToolStripItem toolStripItem = new SubToolStripItem();
+
+            AccessibleObject accessibleObject = toolStripItem.AccessibilityObject;
+
+            Assert.True((bool)accessibleObject.GetPropertyValue(UIA.IsContentElementPropertyId));
+        }
+
+        [WinFormsFact]
         public void ToolStripItemAccessibleObject_FragmentNavigate_Parent_ReturnsExpected()
         {
             using ToolStrip toolStrip = new();


### PR DESCRIPTION
Fixes #8433


## Proposed changes

- Fix values of IsControlElementProperty and IsContentElementProperty properties in MenuStrip, ToolStripDropDown and ToolStripItem accessible objects as described in 
[UI Automation Support for the Menu Control Type](https://learn.microsoft.com/en-us/dotnet/framework/ui-automation/ui-automation-support-for-the-menu-control-type) and [UI Automation Support for the MenuItem Control Type](https://learn.microsoft.com/en-us/dotnet/framework/ui-automation/ui-automation-support-for-the-menuitem-control-type)

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- JAWS for Windows announces top-level menu item without adding "sub menu"

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![JAWS before](https://user-images.githubusercontent.com/113603457/209850305-31ce0e1d-f8b9-4e69-ad2f-ff479cdebbd0.png)

> Menu bar
> File sub menu
> To navigate press Left or Right Arrow.
> f
> Edit sub menu
> e
> Tools sub menu
> t
> menu
> Customize
> To move through items press up or down arrow.
> c
> Options sub menu
> o
> Settings...

### After

![JAWS after](https://user-images.githubusercontent.com/113603457/209850372-62440aa0-e5c8-4c9c-ae52-4672626e0875.png)

> Menu bar
> File
> To navigate press Left or Right Arrow.
> f
> Edit
> e
> Tools
> t
> menu
> Customize
> To move through items press up or down arrow.
> c
> Options sub menu
> o
> Settings...

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- .NET 7.0.1


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8434)