### PR TITLE
Fix keyboard layout name returned from System.Windows.Forms.InputLanguage.LayoutName

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/InputLanguage.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/InputLanguage.cs
@@ -116,6 +116,7 @@ namespace System.Windows.Forms
         ///  Returns the KLID string for provided HKL handle.
         ///  Same as GetKeyboardLayoutName API but for any HKL.
         ///  See https://learn.microsoft.com/windows-hardware/manufacture/desktop/windows-language-pack-default-values
+        ///  for a list of possible KLID values.
         /// </summary>
         internal static string GetKeyboardLayoutNameForHKL(IntPtr hkl)
         {
@@ -124,20 +125,20 @@ namespace System.Windows.Forms
             // language; setting and resetting the current input language would generate
             // spurious InputLanguageChanged events.
             //
-            // According to the docs of GetKeyboardLayout API function high word of HKL
-            // contains a device handle to the physical layout of the keyboard
-            // but exact format of this handle is not documented.
+            // According to the GetKeyboardLayout API function docs low word of HKL
+            // contains input language but same keyboard can be installed more than once
+            // under different languages in Windows and it would give us wrong results
+            // in cases where for example French keyboard is installed under US input
+            // language etc.
             //
-            // We may try to use low word of HKL which contains input language but same
-            // keyboard can be installed more than once under different languages in Windows
-            // and it would give us wrong results in cases where French keyboard is
-            // installed under US input language etc.
+            // High word of HKL contains a device handle to the physical layout of
+            // the keyboard but exact format of this handle is not documented.
             //
-            // For older keyboards layouts device handle seems contain keyboard layout
-            // language which we can use as KLID without issues.
+            // For older keyboard layouts device handle seems contain keyboard layout
+            // language which we can use as KLID without any issues.
             int device = PARAM.HIWORD(hkl);
 
-            // But for newer keyboards layouts device handle contains layout id
+            // But for newer keyboard layouts device handle contains layout id
             // if its high nibble is 0xF. This id may be used to search for keyboard layout
             // under registry.
             // NOTE: this logic may break in future versions of Windows since its not documented.
@@ -164,6 +165,7 @@ namespace System.Windows.Forms
                         if (layoutId == Convert.ToInt32(subKeyLayoutId, 16))
                         {
                             Debug.Assert(subKeyName.Length == 8, "unexpected key length in registry: " + subKey.Name);
+                            // We don't care what is exact format of KLID here
                             return subKeyName;
                         }
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/InputLanguage.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/InputLanguage.cs
@@ -29,7 +29,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Returns the culture of the current input language.
         /// </summary>
-        public CultureInfo Culture => new CultureInfo(PARAM.ToInt(_handle) & 0xFFFF);
+        public CultureInfo Culture => new CultureInfo(PARAM.LOWORD(_handle));
 
         /// <summary>
         ///  Gets or sets the input language for the current thread.
@@ -132,15 +132,14 @@ namespace System.Windows.Forms
             // High word of HKL contains a device handle to the physical layout
             // of the keyboard but exact format of this handle is not
             // documented. For older keyboard layouts device handle seems
-            // contain keyboard layout language which we can use as KLID without
-            // any issues.
+            // contains keyboard layout language which we can use as KLID.
             int device = PARAM.HIWORD(hkl);
 
             // But for newer keyboard layouts device handle contains layout id
             // if its high nibble is 0xF. This id may be used to search for
             // keyboard layout under registry.
             // NOTE: this logic may break in future versions of Windows since
-            // its not documented.
+            // it is not documented.
             if ((device & 0xF000) == 0xF000)
             {
                 // Extract layout id from the device handle

--- a/src/System.Windows.Forms/src/System/Windows/Forms/InputLanguage.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/InputLanguage.cs
@@ -124,16 +124,16 @@ namespace System.Windows.Forms
             // GetKeyboardLayoutName does what we want, but only for the current input
             // language; setting and resetting the current input language would generate
             // spurious InputLanguageChanged events.
-            //
+
             // According to the GetKeyboardLayout API function docs low word of HKL
             // contains input language but same keyboard can be installed more than once
             // under different languages in Windows and it would give us wrong results
             // in cases where for example French keyboard is installed under US input
             // language etc.
-            //
+            int language = PARAM.LOWORD(hkl);
+
             // High word of HKL contains a device handle to the physical layout of
             // the keyboard but exact format of this handle is not documented.
-            //
             // For older keyboard layouts device handle seems contain keyboard layout
             // language which we can use as KLID without any issues.
             int device = PARAM.HIWORD(hkl);
@@ -171,15 +171,17 @@ namespace System.Windows.Forms
                     }
                 }
             }
-
-            // Fallback to input language if keyboard language is not available
-            if (device == 0)
+            else
             {
-                device = PARAM.LOWORD(hkl);
+                // Keyboard layout language overrides input language if available
+                if (device != 0)
+                {
+                    language = device;
+                }
             }
 
             // Pad with zeros to its left to produce arbitrary length KLID string
-            return device.ToString("x8");
+            return language.ToString("x8");
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/InputLanguage.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/InputLanguage.cs
@@ -150,25 +150,20 @@ namespace System.Windows.Forms
         internal static string GetKeyboardLayoutNameForHKL(IntPtr hkl)
         {
             // There is no good way to do this in Windows.
-            // GetKeyboardLayoutName does what we want, but only for the current
-            // input language; setting and resetting the current input language
-            // would generate spurious InputLanguageChanged events.
+            // GetKeyboardLayoutName does what we want, but only for the current input language; setting and resetting
+            // the current input language would generate spurious InputLanguageChanged events.
 
-            // According to the GetKeyboardLayout API function docs low word of
-            // HKL contains input language.
+            // According to the GetKeyboardLayout API function docs low word of HKL contains input language.
             int language = PARAM.LOWORD(hkl);
 
-            // High word of HKL contains a device handle to the physical layout
-            // of the keyboard but exact format of this handle is not
-            // documented. For older keyboard layouts device handle seems
-            // contains keyboard layout language which we can use as KLID.
+            // High word of HKL contains a device handle to the physical layout of the keyboard but exact format of this
+            // handle is not documented. For older keyboard layouts device handle seems contains keyboard layout
+            // language which we can use as KLID.
             int device = PARAM.HIWORD(hkl);
 
-            // But for newer keyboard layouts device handle contains layout id
-            // if its high nibble is 0xF. This id may be used to search for
-            // keyboard layout under registry.
-            // NOTE: this logic may break in future versions of Windows since
-            // it is not documented.
+            // But for newer keyboard layouts device handle contains layout id if its high nibble is 0xF. This id may be
+            // used to search for keyboard layout under registry.
+            // NOTE: this logic may break in future versions of Windows since it is not documented.
             if ((device & 0xF000) == 0xF000)
             {
                 // Extract layout id from the device handle
@@ -202,11 +197,9 @@ namespace System.Windows.Forms
             }
             else
             {
-                // Keyboard layout language overrides input language, if
-                // available. This is crucial in cases when keyboard is
-                // installed more than once or under different languages.
-                // For example when French keyboard is installed under US input
-                // language we need to return French keyboard name.
+                // Keyboard layout language overrides input language, if available. This is crucial in cases when
+                // keyboard is installed more than once or under different languages. For example when French keyboard
+                // is installed under US input language we need to return French keyboard name.
                 if (device != 0)
                 {
                     language = device;
@@ -250,8 +243,8 @@ namespace System.Windows.Forms
         {
             ArgumentNullException.ThrowIfNull(culture);
 
-            // KeyboardLayoutId is the LCID for built-in cultures, but it
-            // is the CU-preferred keyboard language for custom cultures.
+            // KeyboardLayoutId is the LCID for built-in cultures, but it is the CU-preferred keyboard language for
+            // custom cultures.
             int lcid = culture.KeyboardLayoutId;
 
             foreach (InputLanguage? lang in InstalledInputLanguages)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/InputLanguage.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/InputLanguage.cs
@@ -121,27 +121,26 @@ namespace System.Windows.Forms
         internal static string GetKeyboardLayoutNameForHKL(IntPtr hkl)
         {
             // There is no good way to do this in Windows.
-            // GetKeyboardLayoutName does what we want, but only for the current input
-            // language; setting and resetting the current input language would generate
-            // spurious InputLanguageChanged events.
+            // GetKeyboardLayoutName does what we want, but only for the current
+            // input language; setting and resetting the current input language
+            // would generate spurious InputLanguageChanged events.
 
-            // According to the GetKeyboardLayout API function docs low word of HKL
-            // contains input language but same keyboard can be installed more than once
-            // under different languages in Windows and it would give us wrong results
-            // in cases where for example French keyboard is installed under US input
-            // language etc.
+            // According to the GetKeyboardLayout API function docs low word of
+            // HKL contains input language.
             int language = PARAM.LOWORD(hkl);
 
-            // High word of HKL contains a device handle to the physical layout of
-            // the keyboard but exact format of this handle is not documented.
-            // For older keyboard layouts device handle seems contain keyboard layout
-            // language which we can use as KLID without any issues.
+            // High word of HKL contains a device handle to the physical layout
+            // of the keyboard but exact format of this handle is not
+            // documented. For older keyboard layouts device handle seems
+            // contain keyboard layout language which we can use as KLID without
+            // any issues.
             int device = PARAM.HIWORD(hkl);
 
             // But for newer keyboard layouts device handle contains layout id
-            // if its high nibble is 0xF. This id may be used to search for keyboard layout
-            // under registry.
-            // NOTE: this logic may break in future versions of Windows since its not documented.
+            // if its high nibble is 0xF. This id may be used to search for
+            // keyboard layout under registry.
+            // NOTE: this logic may break in future versions of Windows since
+            // its not documented.
             if ((device & 0xF000) == 0xF000)
             {
                 // Extract layout id from the device handle
@@ -173,7 +172,11 @@ namespace System.Windows.Forms
             }
             else
             {
-                // Keyboard layout language overrides input language if available
+                // Keyboard layout language overrides input language, if
+                // available. This is crucial in cases when keyboard is
+                // installed more than once or under different languages.
+                // For example when French keyboard is installed under US input
+                // language we need to return French keyboard name.
                 if (device != 0)
                 {
                     language = device;
@@ -192,8 +195,9 @@ namespace System.Windows.Forms
         {
             if (KeyboardLayoutsRegistryKey?.OpenSubKey(layoutName) is RegistryKey key)
             {
-                // Obtain localizable string resource associated with the keyboard layout
-                // that should be passed to SHLoadIndirectString API.
+                // Obtain localizable string resource associated with the
+                // keyboard layout that should be passed to SHLoadIndirectString
+                // API.
                 if (key.GetValue("Layout Display Name") is string layoutDisplayName)
                 {
                     unsafe

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/InputLanguageTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/InputLanguageTests.cs
@@ -113,6 +113,7 @@ namespace System.Windows.Forms.Tests
 
         public static IEnumerable<object[]> GetKeyboardLayoutNameForHKL_TestData()
         {
+            yield return new object[] { unchecked((nint)0x0000000000000409), "00000409" }; // US
             yield return new object[] { unchecked((nint)0x0000000004090409), "00000409" }; // US
             yield return new object[] { unchecked((nint)0x00000000040c0409), "0000040c" }; // French
             yield return new object[] { unchecked((nint)0xfffffffff0200409), "00011009" }; // Canadian Multilingual Standard
@@ -121,9 +122,9 @@ namespace System.Windows.Forms.Tests
 
         [Theory]
         [MemberData(nameof(GetKeyboardLayoutNameForHKL_TestData))]
-        public void InputLanguage_GetKeyboardLayoutNameForHKL_Invoke_ReturnsExpected(IntPtr handle, string keyboardLayoutId)
+        public void InputLanguage_GetKeyboardLayoutNameForHKL_Invoke_ReturnsExpected(IntPtr handle, string keyboardName)
         {
-            Assert.Equal(keyboardLayoutId, InputLanguage.GetKeyboardLayoutNameForHKL(handle));
+            Assert.Equal(keyboardName, InputLanguage.GetKeyboardLayoutNameForHKL(handle));
         }
 
         private static void VerifyInputLanguage(InputLanguage language)

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/InputLanguageTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/InputLanguageTests.cs
@@ -113,10 +113,10 @@ namespace System.Windows.Forms.Tests
 
         public static IEnumerable<object[]> GetKeyboardLayoutNameForHKL_TestData()
         {
-            yield return new object[] { (unchecked((nint)0x0000000004090409)), "00000409" }; // US
-            yield return new object[] { (unchecked((nint)0x00000000040c0409)), "0000040c" }; // French
-            yield return new object[] { (unchecked((nint)0xfffffffff0200409)), "00011009" }; // Canadian Multilingual Standard
-            yield return new object[] { (unchecked((nint)0xfffffffff0b42400)), "000c0c00" }; // Gothic
+            yield return new object[] { unchecked((nint)0x0000000004090409), "00000409" }; // US
+            yield return new object[] { unchecked((nint)0x00000000040c0409), "0000040c" }; // French
+            yield return new object[] { unchecked((nint)0xfffffffff0200409), "00011009" }; // Canadian Multilingual Standard
+            yield return new object[] { unchecked((nint)0xfffffffff0b42400), "000c0c00" }; // Gothic
         }
 
         [Theory]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/InputLanguageTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/InputLanguageTests.cs
@@ -111,6 +111,21 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(language.GetHashCode(), language.GetHashCode());
         }
 
+        public static IEnumerable<object[]> GetKeyboardLayoutNameForHKL_TestData()
+        {
+            yield return new object[] { (unchecked((nint)0x0000000004090409)), "00000409" }; // US
+            yield return new object[] { (unchecked((nint)0x00000000040c0409)), "0000040c" }; // French
+            yield return new object[] { (unchecked((nint)0xfffffffff0200409)), "00011009" }; // Canadian Multilingual Standard
+            yield return new object[] { (unchecked((nint)0xfffffffff0b42400)), "000c0c00" }; // Gothic
+        }
+
+        [Theory]
+        [MemberData(nameof(GetKeyboardLayoutNameForHKL_TestData))]
+        public void InputLanguage_GetKeyboardLayoutNameForHKL_Invoke_ReturnsExpected(IntPtr handle, string keyboardLayoutId)
+        {
+            Assert.Equal(keyboardLayoutId, InputLanguage.GetKeyboardLayoutNameForHKL(handle));
+        }
+
         private static void VerifyInputLanguage(InputLanguage language)
         {
             Assert.NotEqual(IntPtr.Zero, language.Handle);


### PR DESCRIPTION
Properly convert HKL to KLID string according to the comment from Windows team at https://github.com/dotnet/winforms/issues/4345#issuecomment-759161693

Don't need to look at `HKEY_CURRENT_USER\Keyboard Layout\Substitutes` at all since HKL is already have all needed information.

Fixes #4345 


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8439)