### PR TITLE
[Porting] Fix InvalidCastException in ErrorProvider

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.cs
@@ -4,7 +4,6 @@
 
 #nullable disable
 
-using System.Collections;
 using System.ComponentModel;
 using System.ComponentModel.Design;
 using System.Diagnostics;
@@ -509,11 +508,9 @@ namespace System.Windows.Forms
                 controlError[dataBinding.Control] = outputError;
             }
 
-            IEnumerator enumerator = controlError.GetEnumerator();
-            while (enumerator.MoveNext())
+            foreach (KeyValuePair<Control, string> entry in controlError)
             {
-                DictionaryEntry entry = (DictionaryEntry)enumerator.Current;
-                SetError((Control)entry.Key, (string)entry.Value);
+                SetError(entry.Key, entry.Value);
             }
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ErrorProviderTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ErrorProviderTests.cs
@@ -1244,6 +1244,26 @@ namespace System.Windows.Forms.Tests
             Assert.False(provider.HasErrors);
         }
 
+        [WinFormsFact]
+        public void ErrorProvider_CustomDataSource_DoesNotThrowInvalidCastException()
+        {
+            using Form form = new();
+            CustomDataSource customDataSource = new();
+            form.DataBindings.Add("Text", customDataSource, "Error");
+            using ErrorProvider errorProvider = new(form);
+
+            var exception = Record.Exception(() => errorProvider.DataSource = customDataSource);
+
+            Assert.Null(exception);
+        }
+
+        private class CustomDataSource : IDataErrorInfo
+        {
+            public string this[string columnName] => string.Empty;
+
+            public string Error => string.Empty;
+        }
+
         private class SubErrorProvider : ErrorProvider
         {
             public SubErrorProvider() : base()


### PR DESCRIPTION
Porting from main. Please refer  https://github.com/dotnet/winforms/pull/8425 for more details

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #8424 


## Proposed changes
- We are moving to generic collections across Winforms code base. This is a regression from that change resulting in exception with type cast.
- Add simple test.
- Fix InvalidCastException in ErrorProvider

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Will see exceptions with ErrorProvider usage.
- 

## Regression? 

- Yes 

## Risk

- Low.  Unit tests added.

<!-- end TELL-MODE -->


## Test methodology <!-- How did you ensure quality? -->

- Manul and Unit test.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8447)