### PR TITLE
Obsolete `ExceptionCollection` and replace with `AggregateException`

### DIFF
--- a/docs/list-of-diagnostics.md
+++ b/docs/list-of-diagnostics.md
@@ -38,7 +38,7 @@ The acceptance criteria for adding an obsoletion includes:
 |  __`WFDEV001`__ | Casting to/from IntPtr is unsafe, use `ResultInternal`. |
 |  __`WFDEV002`__ | `DomainUpDown.DomainUpDownAccessibleObject` is no longer used to provide accessible support for `DomainUpDown` controls. Use `ControlAccessibleObject` instead. |
 |  __`WFDEV003`__ | `DomainUpDown.DomainItemAccessibleObject` is no longer used to provide accessible support for `DomainUpDown` items. |
-|  __`WFDEV004`__ | `ExceptionCollection` has been deprecated. Use `AggregateException` instead. |
+|  __`WFDEV004`__ | `ExceptionCollection` is Obsolete. Use `AggregateException` instead. |
 
 
 ## Analyzer Warnings

--- a/docs/list-of-diagnostics.md
+++ b/docs/list-of-diagnostics.md
@@ -38,6 +38,7 @@ The acceptance criteria for adding an obsoletion includes:
 |  __`WFDEV001`__ | Casting to/from IntPtr is unsafe, use `ResultInternal`. |
 |  __`WFDEV002`__ | `DomainUpDown.DomainUpDownAccessibleObject` is no longer used to provide accessible support for `DomainUpDown` controls. Use `ControlAccessibleObject` instead. |
 |  __`WFDEV003`__ | `DomainUpDown.DomainItemAccessibleObject` is no longer used to provide accessible support for `DomainUpDown` items. |
+|  __`WFDEV004`__ | `ExceptionCollection` has been deprecated. Use `AggregateException` instead. |
 
 
 ## Analyzer Warnings

--- a/src/Common/src/Obsoletions.cs
+++ b/src/Common/src/Obsoletions.cs
@@ -22,6 +22,6 @@ internal static class Obsoletions
 #pragma warning restore WFDEV003 // Type or member is obsolete
     internal const string DomainItemAccessibleObjectDiagnosticId = "WFDEV003";
 
-    internal const string ExceptionCollectionMessage = $"ExceptionCollection has been deprecated. Use {nameof(AggregateException)} instead.";
+    internal const string ExceptionCollectionMessage = $"Use {nameof(AggregateException)} instead.";
     internal const string ExceptionCollectionDiagnosticId = "WFDEV004";
 }

--- a/src/Common/src/Obsoletions.cs
+++ b/src/Common/src/Obsoletions.cs
@@ -21,4 +21,7 @@ internal static class Obsoletions
     internal const string DomainItemAccessibleObjectMessage = $"{nameof(DomainUpDown.DomainItemAccessibleObject)} is no longer used to provide accessible support for {nameof(DomainUpDown)} items.";
 #pragma warning restore WFDEV003 // Type or member is obsolete
     internal const string DomainItemAccessibleObjectDiagnosticId = "WFDEV003";
+
+    internal const string ExceptionCollectionMessage = $"ExceptionCollection has been deprecated. Use {nameof(AggregateException)} instead.";
+    internal const string ExceptionCollectionDiagnosticId = "WFDEV004";
 }

--- a/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
+++ b/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
@@ -70,6 +70,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\Common\src\Obsoletions.cs" Link="Common\Obsoletions.cs" />
     <Compile Include="..\..\Common\src\RTLAwareMessageBox.cs" Link="Common\RTLAwareMessageBox.cs" />
   </ItemGroup>
   

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerHost.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerHost.cs
@@ -704,7 +704,7 @@ namespace System.ComponentModel.Design
             // Now remove all the designers and their components.  We save the root for last.  Note that we eat any exceptions that components or their designers generate.  A bad component or designer should not prevent an unload from happening.  We do all of this in a transaction to help reduce the number of events we generate.
             _state[s_stateUnloading] = true;
             DesignerTransaction t = ((IDesignerHost)this).CreateTransaction();
-            ArrayList exceptions = new ArrayList();
+            List<Exception> exceptions = new();
             try
             {
                 IComponent[] components = new IComponent[Components.Count];
@@ -788,7 +788,7 @@ namespace System.ComponentModel.Design
 
             if (exceptions.Count > 0)
             {
-                throw new ExceptionCollection(exceptions);
+                throw new AggregateException(exceptions);
             }
         }
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ExceptionCollection.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ExceptionCollection.cs
@@ -9,6 +9,11 @@ using System.Runtime.Serialization;
 
 namespace System.ComponentModel.Design
 {
+    [Obsolete(
+            Obsoletions.ExceptionCollectionMessage,
+            error: false,
+            DiagnosticId = Obsoletions.ExceptionCollectionDiagnosticId,
+            UrlFormat = Obsoletions.SharedUrlFormat)]
     public sealed class ExceptionCollection : Exception
     {
         private readonly ArrayList _exceptions;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/ExceptionCollectionTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/ExceptionCollectionTests.cs
@@ -22,7 +22,9 @@ namespace System.ComponentModel.Design.Tests
         [MemberData(nameof(Ctor_ArrayList_TestData))]
         public void ExceptionCollection_Ctor_ArrayList(ArrayList exceptions)
         {
+#pragma warning disable WFDEV004 // Type or member is obsolete
             var collection = new ExceptionCollection(exceptions);
+#pragma warning restore WFDEV004 // Type or member is obsolete
             if (exceptions is null)
             {
                 Assert.Null(collection.Exceptions);
@@ -42,7 +44,9 @@ namespace System.ComponentModel.Design.Tests
             using (var stream = new MemoryStream())
             {
                 var formatter = new BinaryFormatter();
+#pragma warning disable WFDEV004 // Type or member is obsolete
                 var collection = new ExceptionCollection(new ArrayList());
+#pragma warning restore WFDEV004 // Type or member is obsolete
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
                 Assert.Throws<SerializationException>(() => formatter.Serialize(stream, collection));
 #pragma warning restore SYSLIB0011 // Type or member is obsolete
@@ -52,7 +56,9 @@ namespace System.ComponentModel.Design.Tests
         [Fact]
         public void ExceptionCollection_GetObjectData_ThrowsPlatformNotSupportedException()
         {
+#pragma warning disable WFDEV004 // Type or member is obsolete
             var collection = new ExceptionCollection(new ArrayList());
+#pragma warning restore WFDEV004 // Type or member is obsolete
             Assert.Throws<PlatformNotSupportedException>(() => collection.GetObjectData(null, new StreamingContext()));
         }
     }


### PR DESCRIPTION
Based on feedback in #8413, this PR marks the `ExceptionCollection` as obsolete and replaces winforms usage with `AggregateException`.

## Customer Impact

- Anyone relying on catching `ExceptionCollection` will run into compile warnings and told to replace their usage
- 

## Regression? 

- Yes / No

## Risk

- Low risk, diagnostic should help customers migrate quite easily and provide better usability.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8449)