### PR TITLE
Fix exception caused by `ToolStripMenuItem.DropDownClosed` hiding itself.

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
@@ -845,13 +845,13 @@ namespace System.Windows.Forms
             get
             {
                 _toolStripGrip ??= new ToolStripGrip
-                    {
-                        Overflow = ToolStripItemOverflow.Never,
-                        Visible = _toolStripGripStyle == ToolStripGripStyle.Visible,
-                        AutoSize = false,
-                        ParentInternal = this,
-                        Margin = DefaultGripMargin
-                    };
+                {
+                    Overflow = ToolStripItemOverflow.Never,
+                    Visible = _toolStripGripStyle == ToolStripGripStyle.Visible,
+                    AutoSize = false,
+                    ParentInternal = this,
+                    Margin = DefaultGripMargin
+                };
 
                 return _toolStripGrip;
             }
@@ -1914,29 +1914,32 @@ namespace System.Windows.Forms
             Rectangle regionRect = (item is null) ? Rectangle.Empty : item.Bounds;
             Region region = null;
 
+            // Copy displayed items collection so it doesn't mutate when we begin to hide items.
+            ToolStripItem[] displayedItems = new ToolStripItem[DisplayedItems.Count];
+            DisplayedItems.CopyTo(displayedItems, 0);
+
             try
             {
-                for (int i = 0; i < DisplayedItems.Count; i++)
+                for (int i = 0; i < displayedItems.Length; i++)
                 {
-                    if (DisplayedItems[i] == item)
+                    if (displayedItems[i] == item)
                     {
                         continue;
                     }
-                    else if (item is not null && DisplayedItems[i].Pressed)
-                    {
-                        //
 
-                        if (DisplayedItems[i] is ToolStripDropDownItem dropDownItem && dropDownItem.HasDropDownItems)
-                        {
-                            dropDownItem.AutoHide(item);
-                        }
+                    if (item is not null
+                        && displayedItems[i] is ToolStripDropDownItem dropDownItem
+                        && dropDownItem.Pressed
+                        && dropDownItem.HasDropDownItems)
+                    {
+                        dropDownItem.AutoHide(item);
                     }
 
                     bool invalidate = false;
-                    if (DisplayedItems[i].Selected)
+                    if (displayedItems[i].Selected)
                     {
-                        DisplayedItems[i].Unselect();
-                        s_selectionDebug.TraceVerbose($"[SelectDBG ClearAllSelectionsExcept] Unselecting {DisplayedItems[i].Text}");
+                        displayedItems[i].Unselect();
+                        s_selectionDebug.TraceVerbose($"[SelectDBG ClearAllSelectionsExcept] Unselecting {displayedItems[i].Text}");
                         invalidate = true;
                     }
 
@@ -1944,8 +1947,7 @@ namespace System.Windows.Forms
                     {
                         // since regions are heavy weight - only use if we need it.
                         region ??= new Region(regionRect);
-
-                        region.Union(DisplayedItems[i].Bounds);
+                        region.Union(displayedItems[i].Bounds);
                     }
                 }
 
@@ -1969,7 +1971,7 @@ namespace System.Windows.Forms
             // fire accessibility
             if (IsHandleCreated && item is not null)
             {
-                int focusIndex = DisplayedItems.IndexOf(item);
+                int focusIndex = Array.IndexOf(displayedItems, item);
                 AccessibilityNotifyClients(AccessibleEvents.Focus, focusIndex);
             }
         }

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/ToolStripTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/ToolStripTests.cs
@@ -61,5 +61,31 @@ namespace System.Windows.Forms.UITests
                 Assert.Single(sharedImageList.Images);
             }
         }
+
+        // Regression test for https://github.com/dotnet/winforms/issues/7884
+        [WinFormsFact]
+        public void ToolStrip_Hiding_ToolStripMenuItem_OnDropDownClosed_ShouldNotThrow()
+        {
+            using Form form = new();
+
+            using ToolStripMenuItem menu1 = new("Menu1");
+            using ToolStripMenuItem menu1Item1 = new("Item1");
+            menu1.DropDownItems.Add(menu1Item1);
+
+            using ToolStripMenuItem hiddenMenu = new("hiddenMenu");
+            using ToolStripMenuItem menu2Item1 = new("Item1");
+            hiddenMenu.DropDownItems.Add(menu2Item1);
+            hiddenMenu.DropDownClosed += (object? sender, EventArgs e) => { hiddenMenu.Visible = false; };
+
+            using MenuStrip menuStrip = new();
+            menuStrip.Items.Add(menu1);
+            menuStrip.Items.Add(hiddenMenu);
+
+            form.Controls.Add(menuStrip);
+            form.MainMenuStrip = menuStrip;
+            form.Show();
+            hiddenMenu.ShowDropDown();
+            menu1.Select();
+        }
     }
 }

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/ToolStripTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/ToolStripTests.cs
@@ -73,8 +73,8 @@ namespace System.Windows.Forms.UITests
             menu1.DropDownItems.Add(menu1Item1);
 
             using ToolStripMenuItem hiddenMenu = new("hiddenMenu");
-            using ToolStripMenuItem menu2Item1 = new("Item1");
-            hiddenMenu.DropDownItems.Add(menu2Item1);
+            using ToolStripMenuItem hiddenMenuItem1 = new("hiddenMenuItem1");
+            hiddenMenu.DropDownItems.Add(hiddenMenuItem1);
             hiddenMenu.DropDownClosed += (object? sender, EventArgs e) => { hiddenMenu.Visible = false; };
 
             using MenuStrip menuStrip = new();


### PR DESCRIPTION
Fixes #7884

First commit contains the test to prove the failure. Thus proving the subsequent fix actually fixes it.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8454)