### PR TITLE
Fix announcing ComboBox item change by arrows in NVDA when DropDownStyle set as "DropDown"

### DIFF
--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ToolStripTests.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ToolStripTests.Designer.cs
@@ -38,6 +38,7 @@ namespace WinformsControlsTest
             this.toolStripProgressBar1 = new System.Windows.Forms.ToolStripProgressBar();
             this.toolStripLabel1 = new System.Windows.Forms.ToolStripLabel();
             this.toolStripTextBox1 = new System.Windows.Forms.ToolStripTextBox();
+            this.toolStripComboBox1 = new System.Windows.Forms.ToolStripComboBox();
             this.toolStripProgressBar2 = new System.Windows.Forms.ToolStripProgressBar();
             this.toolStripStatusLabel1 = new System.Windows.Forms.ToolStripStatusLabel();
             this.toolStrip2 = new System.Windows.Forms.ToolStrip();
@@ -62,7 +63,8 @@ namespace WinformsControlsTest
             this.toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripProgressBar1,
             this.toolStripLabel1,
-            this.toolStripTextBox1 });
+            this.toolStripTextBox1,
+            this.toolStripComboBox1 });
             this.toolStrip1.Location = new System.Drawing.Point(0, 0);
             this.toolStrip1.Name = "toolStrip1";
             this.toolStrip1.Size = new System.Drawing.Size(481, 22);
@@ -209,6 +211,12 @@ namespace WinformsControlsTest
             this.toolStripTextBox1.Size = new System.Drawing.Size(100, 22);
             this.toolStripTextBox1.Text = "ToolStripTextBox";
             // 
+            // toolStripComboBox1
+            //
+            this.toolStripComboBox1.Name = "toolStripComboBox1";
+            this.toolStripComboBox1.Size = new System.Drawing.Size(100, 22);
+            this.toolStripComboBox1.Items.AddRange(new object[] { "1", "2", "3", "4", "5" });
+            // 
             // toolStripProgressBar2
             // 
             this.toolStripProgressBar2.Name = "toolStripProgressBar2";
@@ -250,6 +258,7 @@ namespace WinformsControlsTest
         private System.Windows.Forms.ToolStripProgressBar toolStripProgressBar1;
         private System.Windows.Forms.StatusStrip statusStrip1;
         private System.Windows.Forms.ToolStripTextBox toolStripTextBox1;
+        private System.Windows.Forms.ToolStripComboBox toolStripComboBox1;
         private System.Windows.Forms.ToolStripStatusLabel toolStripStatusLabel1;
         private System.Windows.Forms.ToolStripProgressBar toolStripProgressBar2;
         private System.Windows.Forms.Label label1;


### PR DESCRIPTION
Fixes #8395


## Proposed changes

- Set MSAA focus on edit field when dropdown is closed for ComboBox with 'DropDown' style. If focus is set to the ComboBox itself, NVDA will not announce changes to the edit field, e.g. when selecting items by arrows. Focus on edit field also matches the focus when ComboBox is selected by Tab key.
- Add ToolStripComboBox to WinformsControlsTest app

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- NVDA will announce item changes by arrows after dropdown is closed.

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

* For `ComboBox`:

![A screenshot showing that NVDA does not announce item change by arrows after dropdown is closed for a ComboBox](https://user-images.githubusercontent.com/102954094/211023634-8b231e50-c0c5-4fcf-8b6a-a6f790faf035.png)
> combo box  collapsed
> ComboBox  edit  blank
> 1
> list
> 1
> ComboBox  1 collapsed

* For `ToolStripComboBox`:

Same issue is present:
![A screenshot showing that NVDA does not announce item change by arrows after dropdown is closed for a ToolStripComboBox](https://user-images.githubusercontent.com/102954094/211335916-9d2f8e34-37d5-4914-9a77-f03465525f15.png)

> combo box  collapsed
> ComboBox  edit  blank
> list
> 1
> ComboBox  1 collapsed

* For `DataGridViewComboBoxCell` there is no issue because its own `ComboBox` has `DropDownList` style without an option to set `DropDown`.

### After

![A screenshot showing that NVDA announces item change by arrows after dropdown is closed for ComboBox](https://user-images.githubusercontent.com/102954094/211023884-f8f45afa-adbe-40c1-bd27-a805a3081df1.png)

> combo box  collapsed
> ComboBox  edit  blank
> 1
> list
> 1
> ComboBox  edit  selected 1
> 2
> 3

* For `ToolStripComboBox`:

![A screenshot showing that NVDA announces item change by arrows after dropdown is closed for ToolStripComboBox](https://user-images.githubusercontent.com/102954094/211339191-4c450f87-9d5c-41ff-bd89-f918e4d15de2.png)
> combo box  collapsed
> ComboBox  edit  blank
> list
> 1
> ComboBox  edit  selected 1
> 2
> 3

## Test methodology <!-- How did you ensure quality? -->

- Manual test

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

- Fixed in NVDA
- No changes in Narrator, it didn't have the issue

## Test environment(s) <!-- Remove any that don't apply -->

- .NET 8.0.0-alpha.1.23054.18
- NVDA 2022.4 (2022.4.0.27401)
- Windows 11


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8465)