### PR TITLE
Fix read only static member evaluation order

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
@@ -31,9 +31,6 @@ namespace System.Windows.Forms.Primitives
                 s_targetFrameworkName ??= AppContext.TargetFrameworkName is { } name ? new(name) : null;
                 return s_targetFrameworkName;
             }
-
-            // Used in tests.
-            private set => s_targetFrameworkName = value;
         }
 
         /// <summary>

--- a/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
@@ -21,6 +21,9 @@ namespace System.Windows.Forms.Primitives
         private static int s_scaleTopLevelFormMinMaxSizeForDpi;
         private static int s_trackBarModernRendering;
 
+        private static readonly FrameworkName? s_targetFrameworkName = GetTargetFrameworkName();
+        private static readonly bool s_isNetCoreApp = (s_targetFrameworkName?.Identifier) == ".NETCoreApp";
+
         /// <summary>
         ///  Indicates whether AnchorLayoutV2 feature is enabled.
         /// </summary>
@@ -113,10 +116,6 @@ namespace System.Windows.Forms.Primitives
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => GetCachedSwitchValue(ScaleTopLevelFormMinMaxSizeForDpiSwitchName, ref s_scaleTopLevelFormMinMaxSizeForDpi);
         }
-
-        private static readonly bool s_isNetCoreApp = (s_targetFrameworkName?.Identifier) == ".NETCoreApp";
-
-        private static readonly FrameworkName? s_targetFrameworkName = GetTargetFrameworkName();
 
         public static bool TrackBarModernRendering
         {

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/LocalAppContextSwitchesTest.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/LocalAppContextSwitchesTest.cs
@@ -7,6 +7,7 @@ using System.Windows.Forms.Primitives;
 
 namespace System.Windows.Forms.Tests
 {
+    [Collection(nameof(SynchronousCollection))]
     public class LocalAppContextSwitchesTest
     {
         private void ResetLocalSwitches(dynamic testAccessor)

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/LocalAppContextSwitchesTest.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/LocalAppContextSwitchesTest.cs
@@ -1,0 +1,66 @@
+﻿// Licensed to the.NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.Versioning;
+using System.Windows.Forms.Primitives;
+
+namespace System.Windows.Forms.Tests
+{
+    public class LocalAppContextSwitchesTest
+    {
+        private void ResetLocalSwitches(dynamic testAccessor)
+        {
+            testAccessor.s_AnchorLayoutV2 = 0;
+            testAccessor.s_scaleTopLevelFormMinMaxSizeForDpi = 0;
+            testAccessor.s_trackBarModernRendering = 0;
+        }
+
+        [WinFormsTheory]
+        [InlineData(".NETCoreApp,Version=v8.0", true)]
+        [InlineData(".NETCoreApp,Version=v7.0", false)]
+        [InlineData(".NET Framework,Version=v4.8", false)]
+        public void Validate_Default_Switch_Values(string tragetFrameworkName, bool expected)
+        {
+            FrameworkName? previousTestTargetFramework = LocalAppContextSwitches.TargetFrameworkName;
+            dynamic testAccessor = typeof(LocalAppContextSwitches).TestAccessor().Dynamic;
+
+            try
+            {
+                testAccessor.s_targetFrameworkName = new FrameworkName(tragetFrameworkName);
+
+                Assert.Equal(expected, LocalAppContextSwitches.TrackBarModernRendering);
+                Assert.Equal(expected, LocalAppContextSwitches.AnchorLayoutV2);
+                Assert.Equal(expected, LocalAppContextSwitches.ScaleTopLevelFormMinMaxSizeForDpi);
+            }
+            finally
+            {
+                // Reset target framework name.
+                testAccessor.s_targetFrameworkName = previousTestTargetFramework;
+                ResetLocalSwitches(testAccessor);
+            }
+        }
+
+        [WinFormsTheory]
+        [InlineData(".NETCoreApp,Version=v8.0", true)]
+        [InlineData(".NETCoreApp,Version=v7.0", true)]
+        [InlineData(".NET Framework,Version=v4.8", false)]
+        public void Validate_TargetFramework_Is_NETCore(string tragetFrameworkName, bool isNetCoreApp)
+        {
+            FrameworkName? previousTestTargetFramework = LocalAppContextSwitches.TargetFrameworkName;
+            dynamic testAccessor = typeof(LocalAppContextSwitches).TestAccessor().Dynamic;
+
+            try
+            {
+                testAccessor.s_targetFrameworkName = new FrameworkName(tragetFrameworkName);
+                bool isCoreApplication = LocalAppContextSwitches.IsNetCoreApp;
+                Assert.Equal(isNetCoreApp, isCoreApplication);
+            }
+            finally
+            {
+                // Reset target framework name.
+                testAccessor.s_targetFrameworkName = previousTestTargetFramework;
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/SynchronousCollection.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/SynchronousCollection.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the.NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms.Tests
+{
+    [CollectionDefinition(nameof(SynchronousCollection), DisableParallelization = true)]
+    public class SynchronousCollection
+    {
+        // This class has no code, and is never created. Its purpose is simply
+        // to be the place to apply [CollectionDefinition]
+    }
+}


### PR DESCRIPTION
There is a problem with the parsing of the TargetFramework, which is causing an invalid value to be set. static nullable private property needs to be assigned before its use.

Because the AppContext flags are read-only for .NET apps, and the incorrect TargetFramework is bypassing the logic behind these flags.

Found while verifying #6381. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8467)