### PR TITLE
Fix MenuStrip item focus announcement when opening/closing dropdown menu

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDown.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDown.cs
@@ -1418,7 +1418,7 @@ namespace System.Windows.Forms
 
             if (itemOnPreviousMenuToSelect is not null)
             {
-                itemOnPreviousMenuToSelect.Select();
+                itemOnPreviousMenuToSelect.Select(forceRaiseAccessibilityFocusChanged: true);
 
                 KeyboardToolTipStateMachine.Instance.NotifyAboutGotFocus(itemOnPreviousMenuToSelect);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownItem.cs
@@ -513,7 +513,7 @@ namespace System.Windows.Forms
                     DropDown.OwnerItem = null;
                 }
 
-                if (IsParentAccessibilityObjectCreated && AccessibilityObject is ToolStripItemAccessibleObject accessibleObject)
+                if (IsAccessibilityObjectCreated && AccessibilityObject is ToolStripItemAccessibleObject accessibleObject)
                 {
                     accessibleObject.RaiseFocusChanged();
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownItem.cs
@@ -512,6 +512,11 @@ namespace System.Windows.Forms
                 {
                     DropDown.OwnerItem = null;
                 }
+
+                if (IsParentAccessibilityObjectCreated && AccessibilityObject is ToolStripItemAccessibleObject accessibleObject)
+                {
+                    accessibleObject.RaiseFocusChanged();
+                }
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownItem.cs
@@ -512,11 +512,6 @@ namespace System.Windows.Forms
                 {
                     DropDown.OwnerItem = null;
                 }
-
-                if (IsAccessibilityObjectCreated && AccessibilityObject is ToolStripItemAccessibleObject accessibleObject)
-                {
-                    accessibleObject.RaiseFocusChanged();
-                }
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
@@ -193,6 +193,11 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
+        ///  Indicates whether or not this control has an accessible object associated with it.
+        /// </summary>
+        internal bool IsAccessibilityObjectCreated => Properties.GetObject(s_accessibilityProperty) is AccessibleObject;
+
+        /// <summary>
         ///  The Accessibility Object for this Control
         /// </summary>
         [Browsable(false)]
@@ -3243,7 +3248,19 @@ namespace System.Windows.Forms
 
                 KeyboardToolTipStateMachine.Instance.NotifyAboutGotFocus(this);
 
-                if (IsParentAccessibilityObjectCreated && AccessibilityObject is ToolStripItemAccessibleObject accessibleObject)
+                bool accessibilityIsOn = IsAccessibilityObjectCreated ||
+                    // When ToolStripItem is selected automatically for the first time
+                    // (for example, when menu bar gets focus or a sub menu is opened, its first item is selected automatically),
+                    // ToolStripItem's and parent sub menu's AccessibilityObjects might not be created yet.
+                    // AO tree is going to be constructed just after this first selection, if any accessibility client is on.
+                    // In this case, to be able to notify Accessibility of focus event right now
+                    // we determine Accessibility status by checking if parent AO instance is created.
+                    // If so, then we can force child AO creation.
+                    (IsOnDropDown
+                        ? OwnerItem?.IsAccessibilityObjectCreated ?? false
+                        : IsParentAccessibilityObjectCreated);
+
+                if (accessibilityIsOn && AccessibilityObject is ToolStripItemAccessibleObject accessibleObject)
                 {
                     accessibleObject.RaiseFocusChanged();
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
@@ -3204,6 +3204,11 @@ namespace System.Windows.Forms
 
         public void Select()
         {
+            Select(forceRaiseAccessibilityFocusChanged: false);
+        }
+
+        internal void Select(bool forceRaiseAccessibilityFocusChanged)
+        {
 #if DEBUG
             // let's not snap the stack trace unless we're debugging selection.
             if (ToolStrip.s_selectionDebug.TraceVerbose)
@@ -3248,6 +3253,11 @@ namespace System.Windows.Forms
 
                 KeyboardToolTipStateMachine.Instance.NotifyAboutGotFocus(this);
 
+                forceRaiseAccessibilityFocusChanged = true;
+            }
+
+            if (forceRaiseAccessibilityFocusChanged)
+            {
                 bool accessibilityIsOn = IsAccessibilityObjectCreated ||
                     // When ToolStripItem is selected automatically for the first time
                     // (for example, when menu bar gets focus or a sub menu is opened, its first item is selected automatically),


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #8432


## Proposed changes

- Fire AutomationFocusChanged UIA-event after dropdown is closed
- When dropdown menu is opened, it's first item is automatically selected and AutomationFocusChanged UIA-event is fired. At this moment, check MenuStrip's AccessibilityObject, not DropDown's, because it might not be created yet

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Screen readers announce menu item selection on drop down first opening
- Screen readers announce focus returning back to menu item after dropdown closing

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
https://user-images.githubusercontent.com/113603457/211337891-2b890e41-6d62-49cd-ba1a-e8251214c942.mp4

> .NET 8.0.0-alpha.1.23057.5 window, MenuStrip and CheckedListBox window, 
> Exit .NET 8.0.0-alpha.1.23057.5 window, Enter MenuStrip and CheckedListBox window, menuStrip1 menu bar, Project, menu item, collapsed, 
> Project, menu, 
> Check/UnCheck, menu item, checked, Ctrl+ C, 

Missing announcements:
- "New" menu item after opening "Project" menu
- "Project" menu item after closing "Project" menu

<!-- TODO -->

### After

https://user-images.githubusercontent.com/113603457/211337951-47c8384e-cfb6-4218-abba-622805667e0b.mp4

> .NET 8.0.0-alpha.1.23057.5 window, MenuStrip and CheckedListBox window, 
> Exit .NET 8.0.0-alpha.1.23057.5 window, Enter MenuStrip and CheckedListBox window, menuStrip1 menu bar, Project, menu item, collapsed, 
> Project, menu, 
> New, menu item, Ctrl+ N, 
> Project, menu, 
> Check/UnCheck, menu item, checked, Ctrl+ C, 
> Project, menu item, collapsed, 

<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- Manual

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->

Tested in Narrator, NVDA, JAWS
 

## Test environment(s) <!-- Remove any that don't apply -->

- .NET 8.0.0-alpha.1.23057.5
- Windows 11
- NVDA 2022.3.2
- JAWS 2022 2110.60 ILM


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8473)