### PR TITLE
Removed DefaultValue attribute from the RowTemplate.Height property

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.cs
@@ -19,6 +19,7 @@ namespace System.Windows.Forms
     public partial class DataGridViewRow : DataGridViewBand
     {
         private static readonly Type s_rowType = typeof(DataGridViewRow);
+        private static int s_defaultHeight = -1;
         private static readonly int s_propRowErrorText = PropertyStore.CreateKey();
         private static readonly int s_propRowAccessibilityObject = PropertyStore.CreateKey();
 
@@ -34,7 +35,7 @@ namespace System.Windows.Forms
         public DataGridViewRow() : base()
         {
             MinimumThickness = DefaultMinRowThickness;
-            Thickness = Control.DefaultFont.Height + 9;
+            Thickness = DefaultHeight;
         }
 
         [Browsable(false)]
@@ -151,6 +152,19 @@ namespace System.Windows.Forms
             set => ErrorTextInternal = value;
         }
 
+        private static int DefaultHeight
+        {
+            get
+            {
+                if (s_defaultHeight == -1)
+                {
+                    s_defaultHeight = Control.DefaultFont.Height + 9;
+                }
+
+                return s_defaultHeight;
+            }
+        }
+
         private string ErrorTextInternal
         {
             get
@@ -209,7 +223,6 @@ namespace System.Windows.Forms
             set => base.HeaderCellCore = value;
         }
 
-        [DefaultValue(22)]
         [NotifyParentProperty(true)]
         [SRCategory(nameof(SR.CatAppearance))]
         [SRDescription(nameof(SR.DataGridView_RowHeightDescr))]
@@ -1730,6 +1743,12 @@ namespace System.Windows.Forms
             }
         }
 
+        // ShouldSerialize and Reset Methods are being used by Designer via reflection.
+        private void ResetHeight()
+        {
+            Height = DefaultHeight;
+        }
+
         internal void ReleaseUiaProvider()
         {
             if (!IsAccessibilityObjectCreated)
@@ -1807,6 +1826,12 @@ namespace System.Windows.Forms
             }
 
             return setResult && values.Length <= cellCount;
+        }
+
+        // ShouldSerialize and Reset Methods are being used by Designer via reflection.
+        private bool ShouldSerializeHeight()
+        {
+            return Height != DefaultHeight;
         }
 
         public override string ToString()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewRowTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewRowTests.cs
@@ -2020,6 +2020,30 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
+        public void DataGridViewRow_Height_IsEqualDefaultHeight_IfDefaultFontIsChanged()
+        {
+            var oldApplicationDefaultFont = Application.DefaultFont;
+            using var font = new Font("Times New Roman", 12);
+            using var row = new TestDataGridViewRow();
+            var applicationTestAccessor = typeof(Application).TestAccessor().Dynamic;
+
+            try
+            {
+                applicationTestAccessor.s_defaultFont = font;
+                Assert.NotEqual(oldApplicationDefaultFont, Application.DefaultFont);
+
+                var rowDefaultHeight = row.GetDefaultHeight();
+                Assert.Equal(Control.DefaultFont.Height + 9, rowDefaultHeight);
+                Assert.Equal(Control.DefaultFont.Height + 9, row.Height);
+            }
+            finally
+            {
+                applicationTestAccessor.s_defaultFont = null;
+                applicationTestAccessor.s_defaultFontScaled = null;
+            }
+        }
+
+        [WinFormsFact]
         public void DataGridViewRow_Height_SetShared_ThrowsInvalidOperationException()
         {
             using var control = new DataGridView
@@ -5791,6 +5815,14 @@ namespace System.Windows.Forms.Tests
                 DataGridViewRowAccessibleObject accessibilityObject = Assert.IsType<DataGridViewRowAccessibleObject>(CreateAccessibilityInstance());
                 Assert.Equal(this, accessibilityObject.Owner);
             }
+        }
+    }
+
+    internal class TestDataGridViewRow : DataGridViewRow
+    {
+        internal int GetDefaultHeight()
+        {
+            return this.TestAccessor().Dynamic.DefaultHeight;
         }
     }
 }


### PR DESCRIPTION
Fixes #4461


## Proposed changes

- Introduces a new private property `DefaultHeight` with **the intended value** (by default in Winforms Control.DefaultFont is **Segoe UI, Size 9, Height 16** which gives us **default Row height = 25**).
- Removes the DefaultValue attribute from the `DataGridViewRow.Height` property;
- Implements `ResetHeight` and `ShouldSerializeHeight` methods ([see more](https://learn.microsoft.com/en-us/dotnet/desktop/winforms/controls/defining-default-values-with-the-shouldserialize-and-reset-methods?view=netframeworkdesktop-4.8)).
- The `DataGridViewRow.Height` property still returns the value of the  `Thickness` property.
- Existing unit tests weren't changed.
- New unit test `DataGridViewRow_Height_NotEqualDefaultHeight_IfDefaultFontIsChanged` is added.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Fixes the Issue which impacts user experience,  breaks DPI and Font scaling. For the _newly created_ control at 100% scaling, designer should generate the same value as is defined by the Default. There is no extra code.

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/15823268/104521807-77f4be80-55b2-11eb-9f38-b7e32eff005d.png)

### After

![image](https://user-images.githubusercontent.com/15823268/104521910-b5f1e280-55b2-11eb-804e-5a05b8b8a195.png)


## Test methodology

- Manual (Issue can be tested via substitution of dlls, complete restart of the VS recommended)
- Unit test


 

## Test environment(s) <!-- Remove any that don't apply -->

- dotnet 8.0.100-alpha.1.22607.6


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8474)