### PR TITLE
Improve `Cursor` `Stream` constructor to be more robust

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Cursor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Cursor.cs
@@ -82,6 +82,12 @@ namespace System.Windows.Forms
         {
             ArgumentNullException.ThrowIfNull(stream);
             MemoryStream memoryStream = new();
+            // reset stream position to start, there are no gaurantees it is at the start.
+            if (stream.CanSeek)
+            {
+                stream.Position = 0;
+            }
+
             stream.CopyTo(memoryStream);
             _cursorData = memoryStream.ToArray();
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CursorTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CursorTests.cs
@@ -58,6 +58,21 @@ namespace System.Windows.Forms.Tests
         }
 
         [Fact]
+        public void Cursor_Ctor_Stream_NonStartPosition()
+        {
+            using var stream = new MemoryStream(File.ReadAllBytes(Path.Combine("bitmaps", "cursor.cur")));
+            stream.Position = 5;
+            using var cursor = new Cursor(stream);
+            Assert.NotNull(cursor);
+        }
+
+        [Fact]
+        public void Cursor_Ctor_EmptyStream_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>("stream", () => new Cursor(new MemoryStream()));
+        }
+
+        [Fact]
         public void Cursor_Ctor_NullStream_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>("stream", () => new Cursor((Stream)null));


### PR DESCRIPTION
Change Cursor ctor to reset the stream parameters position ready for the copyTo call.

This is a guess on the fix, but would make sense.

Related: #8367, #8373

> Copying begins at the current position in the current stream, and does not reset the position of the destination stream after the copy operation is complete.
https://learn.microsoft.com/en-us/dotnet/api/system.io.stream.copyto?view=net-7.0

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8477)