### PR TITLE
Fixes `Form.Show(IWin32Window)` causing memory leaks by removing setting of `PropDialogOwner`

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -5235,7 +5235,6 @@ namespace System.Windows.Forms
 
             HWND activeHwnd = PInvoke.GetActiveWindow();
             HandleRef<HWND> ownerHwnd = owner is null ? GetHandleRef(activeHwnd) : GetSafeHandle(owner);
-            Properties.SetObject(PropDialogOwner, owner);
             Form? oldOwner = OwnerInternal;
             if (owner is Form ownerForm && owner != oldOwner)
             {

--- a/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests.Common/MainFormControlsTabOrder.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests.Common/MainFormControlsTabOrder.cs
@@ -41,6 +41,7 @@ namespace System.Windows.Forms.IntegrationTests.Common
         DockLayoutButton,
         DragAndDrop,
         TextBoxesButton,
-        MediaPlayerButton
+        MediaPlayerButton,
+        FormOwnerTestButton
     }
 }

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/FormOwnerTestForm.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/FormOwnerTestForm.cs
@@ -1,0 +1,60 @@
+﻿using System.Diagnostics;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace WinformsControlsTest
+{
+    internal class FormOwnerTestForm : Form
+    {
+        public FormOwnerTestForm()
+        {
+            this.Shown += (object sender, EventArgs e) => ShowMemoryTest();
+        }
+
+        private void ShowMemoryTest()
+        {
+            long a = Process.GetCurrentProcess().WorkingSet64;
+
+            var children = new List<Form>();
+            for (int i = 0; i < 500; i++)
+            {
+                MemoryTestParentForm parent = new MemoryTestParentForm();
+                parent.Show();
+                children.Add(parent.Yum());
+                parent.Close();
+            }
+
+            children.ForEach(cf => cf.Close());
+            children.Clear();
+
+            long b = Process.GetCurrentProcess().WorkingSet64;
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+            long c = Process.GetCurrentProcess().WorkingSet64;
+
+            Controls.Add(new Label()
+            {
+                Text = $"Memory Usage:\n{a:N0} bytes\n{b:N0} bytes\n{c:N0} bytes",
+                Dock = DockStyle.Fill,
+                TextAlign = ContentAlignment.MiddleCenter
+            });
+        }
+
+        public class MemoryTestParentForm : Form
+        {
+            private byte[] array;
+
+            public Form Yum()
+            {
+                this.array = new byte[1024 * 1024];
+                Array.Clear(array, 0, this.array.Length);
+
+                Form child = new Form();
+                child.Show(this);
+
+                return child;
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/FormOwnerTestForm.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/FormOwnerTestForm.cs
@@ -35,7 +35,7 @@ namespace WinformsControlsTest
 
             Controls.Add(new Label()
             {
-                Text = $"Memory Usage:\n{a:N0} bytes\n{b:N0} bytes\n{c:N0} bytes",
+                Text = $"Memory Usage:\nBefore: {a:N0} bytes\nDuring: {b:N0} bytes\nAfter: {c:N0} bytes",
                 Dock = DockStyle.Fill,
                 TextAlign = ContentAlignment.MiddleCenter
             });

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MainForm.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MainForm.cs
@@ -200,6 +200,10 @@ namespace WinformsControlsTest
             {
                 MainFormControlsTabOrder.MediaPlayerButton,
                 new InitInfo("MediaPlayer", (obj, e) => new MediaPlayer().Show(this))
+            },
+            {
+                MainFormControlsTabOrder.FormOwnerTestButton,
+                new InitInfo("FormOwnerTest", (obj, e) => new FormOwnerTestForm().Show(this))
             }
         };
 


### PR DESCRIPTION
Fixes #530

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8478)