### PR TITLE
Fix issues in `KeysConverter.ConvertTo` introduced in #8255

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Keys.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Keys.cs
@@ -12,7 +12,7 @@ namespace System.Windows.Forms
     /// </summary>
     [Flags]
     [TypeConverter(typeof(KeysConverter))]
-    [Editor("System.Windows.Forms.Design.ShortcutKeysEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
+    [Editor($"System.Windows.Forms.Design.ShortcutKeysEditor, {AssemblyRef.SystemDesign}", typeof(UITypeEditor))]
     public enum Keys
     {
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/KeysConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/KeysConverter.cs
@@ -240,7 +240,7 @@ namespace System.Windows.Forms
                 {
                     string keyString = DisplayOrder[i];
                     Keys keyValue = _keyNames[keyString];
-                    if (keyValue.HasFlag(modifiers))
+                    if (modifiers.HasFlag(keyValue))
                     {
                         termKeys.Add(keyValue);
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/KeysConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/KeysConverter.cs
@@ -285,7 +285,7 @@ namespace System.Windows.Forms
                 {
                     string keyString = DisplayOrder[i];
                     Keys keyValue = _keyNames[keyString];
-                    if (keyValue.HasFlag(modifiers))
+                    if (modifiers.HasFlag(keyValue))
                     {
                         termStrings.Append(keyString).Append('+');
                     }
@@ -313,7 +313,7 @@ namespace System.Windows.Forms
                 // of the enum.
                 if (!foundKey && Enum.IsDefined(typeof(Keys), (int)keyOnly))
                 {
-                    termStrings.Append(keyOnly.ToString());
+                    termStrings.Append(Enum.GetName(keyOnly));
                 }
 
                 return termStrings.ToString();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/KeysConverterTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/KeysConverterTests.cs
@@ -19,5 +19,17 @@ namespace System.Windows.Forms.Tests
 
             Assert.Equal(keys, result);
         }
+
+        [Theory]
+        [InlineData(Keys.None, "None")]
+        [InlineData(Keys.S, "S")]
+        [InlineData(Keys.Control | Keys.C, "Ctrl+C")]
+        [InlineData(Keys.Control | Keys.Alt | Keys.D, "Ctrl+Alt+D")]
+        public void ConvertToString_ShouldConvertKeys(Keys keys, string expectedResult)
+        {
+            KeysConverter converter = new();
+            var result = converter.ConvertToString(keys);
+            Assert.Equal(expectedResult, result);
+        }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/KeysConverterTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/KeysConverterTests.cs
@@ -9,14 +9,16 @@ namespace System.Windows.Forms.Tests
     public class KeysConverterTests
     {
         [Theory]
+        [InlineData("Ctrl+Alt+Shift+A", Keys.Control | Keys.Alt | Keys.Shift | Keys.A)]
+        [InlineData("Ctrl+Alt+Shift+F1", Keys.Control | Keys.Alt | Keys.Shift | Keys.F1)]
+        [InlineData("Ctrl+Alt+D", Keys.Control | Keys.Alt | Keys.D)]
         [InlineData("Ctrl + N", Keys.Control | Keys.N)]
         [InlineData("G", Keys.G)]
+        [InlineData("None", Keys.None)]
         public void ConvertFrom_ShouldConvertKeys(string input, Keys keys)
         {
             KeysConverter converter = new();
-
             var result = (Keys)converter.ConvertFrom(input);
-
             Assert.Equal(keys, result);
         }
 
@@ -24,7 +26,10 @@ namespace System.Windows.Forms.Tests
         [InlineData(Keys.None, "None")]
         [InlineData(Keys.S, "S")]
         [InlineData(Keys.Control | Keys.C, "Ctrl+C")]
+        [InlineData(Keys.Control | Keys.Add, "Ctrl+Add")]
         [InlineData(Keys.Control | Keys.Alt | Keys.D, "Ctrl+Alt+D")]
+        [InlineData(Keys.Control | Keys.Alt | Keys.Shift | Keys.A, "Ctrl+Alt+Shift+A")]
+        [InlineData(Keys.Control | Keys.Alt | Keys.Shift | Keys.F1, "Ctrl+Alt+Shift+F1")]
         public void ConvertToString_ShouldConvertKeys(Keys keys, string expectedResult)
         {
             KeysConverter converter = new();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/KeysConverterTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/KeysConverterTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Globalization;
 using Xunit;
 
 namespace System.Windows.Forms.Tests

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/KeysConverterTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/KeysConverterTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Globalization;
 using Xunit;
 
 namespace System.Windows.Forms.Tests
@@ -34,6 +35,26 @@ namespace System.Windows.Forms.Tests
         {
             KeysConverter converter = new();
             var result = converter.ConvertToString(keys);
+            Assert.Equal(expectedResult, result);
+        }
+
+        public static IEnumerable<object[]> ConvertToEnumArray_ShouldConvertKeys_TestData()
+        {
+            yield return new object[] { Keys.None, new Enum[] { Keys.None } };
+            yield return new object[] { Keys.S, new Enum[] { Keys.S } };
+            yield return new object[] { Keys.Control | Keys.C, new Enum[] { Keys.Control, Keys.C } };
+            yield return new object[] { Keys.Control | Keys.Add, new Enum[] { Keys.Control, Keys.Add } };
+            yield return new object[] { Keys.Control | Keys.Alt | Keys.D, new Enum[] { Keys.Control, Keys.Alt, Keys.D } };
+            yield return new object[] { Keys.Control | Keys.Alt | Keys.Shift | Keys.A, new Enum[] { Keys.Control, Keys.Alt, Keys.Shift, Keys.A } };
+            yield return new object[] { Keys.Control | Keys.Alt | Keys.Shift | Keys.F1, new Enum[] { Keys.Control, Keys.Alt, Keys.Shift, Keys.F1 } };
+        }
+
+        [Theory]
+        [MemberData(nameof(ConvertToEnumArray_ShouldConvertKeys_TestData))]
+        public void ConvertToEnumArray_ShouldConvertKeys(Keys keys, Enum[] expectedResult)
+        {
+            KeysConverter converter = new();
+            var result = converter.ConvertTo(keys, typeof(Enum[]));
             Assert.Equal(expectedResult, result);
         }
     }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripMenuItemTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripMenuItemTests.cs
@@ -134,6 +134,9 @@ namespace System.Windows.Forms.Tests
 
 		[WinFormsTheory]
         [InlineData(Keys.A)]
+        [InlineData(Keys.Control)]
+        [InlineData(Keys.Control | Keys.Alt)]
+        [InlineData(Keys.Control | Keys.Alt | Keys.Shift)]
         public void ToolStripMenuItem_SetShortcutKeys_ThrowsInvalidEnumArgumentException(Keys keys)
         {
             using var item = new SubToolStripMenuItem();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripMenuItemTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripMenuItemTests.cs
@@ -121,10 +121,12 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
+        [InlineData(Keys.F1)]
         [InlineData(Keys.None)]
+        [InlineData(Keys.Control | Keys.Add)]
+        [InlineData(Keys.Control | Keys.Alt | Keys.D)]
         [InlineData(Keys.Control | Keys.Alt | Keys.Shift | Keys.A)]
         [InlineData(Keys.Control | Keys.Alt | Keys.Shift | Keys.F1)]
-        [InlineData(Keys.F1)]
         public void ToolStripMenuItem_SetShortcutKeys(Keys keys)
         {
             using var item = new SubToolStripMenuItem();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripMenuItemTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripMenuItemTests.cs
@@ -120,6 +120,26 @@ namespace System.Windows.Forms.Tests
             Assert.NotNull(bitmap);
         }
 
+        [WinFormsTheory]
+        [InlineData(Keys.None)]
+        [InlineData(Keys.Control | Keys.Alt | Keys.Shift | Keys.A)]
+        [InlineData(Keys.Control | Keys.Alt | Keys.Shift | Keys.F1)]
+        [InlineData(Keys.F1)]
+        public void ToolStripMenuItem_SetShortcutKeys(Keys keys)
+        {
+            using var item = new SubToolStripMenuItem();
+            item.ShortcutKeys=keys;
+            Assert.Equal(keys, item.ShortcutKeys);
+        }
+
+		[WinFormsTheory]
+        [InlineData(Keys.A)]
+        public void ToolStripMenuItem_SetShortcutKeys_ThrowsInvalidEnumArgumentException(Keys keys)
+        {
+            using var item = new SubToolStripMenuItem();
+            Assert.Throws<InvalidEnumArgumentException>(() => item.ShortcutKeys=keys);
+        }
+
         private class SubToolStripMenuItem : ToolStripMenuItem
         {
             public SubToolStripMenuItem() : base()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripMenuItemTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripMenuItemTests.cs
@@ -130,11 +130,11 @@ namespace System.Windows.Forms.Tests
         public void ToolStripMenuItem_SetShortcutKeys(Keys keys)
         {
             using var item = new SubToolStripMenuItem();
-            item.ShortcutKeys=keys;
+            item.ShortcutKeys = keys;
             Assert.Equal(keys, item.ShortcutKeys);
         }
 
-		[WinFormsTheory]
+        [WinFormsTheory]
         [InlineData(Keys.A)]
         [InlineData(Keys.Control)]
         [InlineData(Keys.Control | Keys.Alt)]
@@ -142,7 +142,7 @@ namespace System.Windows.Forms.Tests
         public void ToolStripMenuItem_SetShortcutKeys_ThrowsInvalidEnumArgumentException(Keys keys)
         {
             using var item = new SubToolStripMenuItem();
-            Assert.Throws<InvalidEnumArgumentException>(() => item.ShortcutKeys=keys);
+            Assert.Throws<InvalidEnumArgumentException>(() => item.ShortcutKeys = keys);
         }
 
         private class SubToolStripMenuItem : ToolStripMenuItem


### PR DESCRIPTION
Also added some tests to better cover the KeysConverter.

Fixes #8456

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8485)