### PR TITLE
[CSY] ‘Details’ and ‘Continue’ have the same hotkey "P" in unhandled exception

### DIFF
--- a/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
@@ -4913,7 +4913,7 @@ Pokud kliknete na Pokračovat, aplikace bude tuto chybu ignorovat a pokusí se p
       </trans-unit>
       <trans-unit id="ExDlgShowDetails">
         <source>&amp;Details</source>
-        <target state="translated">&amp;Podrobnosti</target>
+        <target state="translated">Po&amp;drobnosti</target>
         <note />
       </trans-unit>
       <trans-unit id="ExDlgWarningText">


### PR DESCRIPTION
Fixes #6496

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8487)