### PR TITLE
[RUS] The ‘Details’ button text overlaps its drop down arrow in unhandled exception dialog

### DIFF
--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
@@ -4914,7 +4914,7 @@ If you click Continue, the application will ignore this error and attempt to con
       </trans-unit>
       <trans-unit id="ExDlgShowDetails">
         <source>&amp;Details</source>
-        <target state="translated">&amp;Подробности</target>
+        <target state="translated">&amp;сведения</target>
         <note />
       </trans-unit>
       <trans-unit id="ExDlgWarningText">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
@@ -4914,7 +4914,7 @@ If you click Continue, the application will ignore this error and attempt to con
       </trans-unit>
       <trans-unit id="ExDlgShowDetails">
         <source>&amp;Details</source>
-        <target state="translated">&amp;сведения</target>
+        <target state="translated">&amp;Подробности</target>
         <note />
       </trans-unit>
       <trans-unit id="ExDlgWarningText">

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ThreadExceptionDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ThreadExceptionDialog.cs
@@ -30,9 +30,9 @@ namespace System.Windows.Forms
         private const int BUTTONDETAILS_LEFTPADDING = 8;
         private const int MESSAGE_TOPPADDING = 8;
         private const int HEIGHTPADDING = 8;
-        private const int BUTTONWIDTH = 100;
+        private const int BUTTONWIDTH = 130;
         private const int BUTTONHEIGHT = 23;
-        private const int BUTTONALIGNMENTWIDTH = 105;
+        private const int BUTTONALIGNMENTWIDTH = 135;
         private const int BUTTONALIGNMENTPADDING = 5;
         private const int DETAILSWIDTHPADDING = 16;
         private const int DETAILSHEIGHT = 154;
@@ -307,7 +307,7 @@ namespace System.Windows.Forms
             _helpButton.FlatStyle = FlatStyle.Standard;
             _helpButton.DialogResult = DialogResult.Yes;
 
-            _detailsButton.Text = SR.ExDlgShowDetails;
+            _detailsButton.Text = "&Подробности";
             _detailsButton.FlatStyle = FlatStyle.Standard;
             _detailsButton.Click += new EventHandler(DetailsClick);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ThreadExceptionDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ThreadExceptionDialog.cs
@@ -307,7 +307,7 @@ namespace System.Windows.Forms
             _helpButton.FlatStyle = FlatStyle.Standard;
             _helpButton.DialogResult = DialogResult.Yes;
 
-            _detailsButton.Text = "&Подробности";
+            _detailsButton.Text = SR.ExDlgShowDetails;
             _detailsButton.FlatStyle = FlatStyle.Standard;
             _detailsButton.Click += new EventHandler(DetailsClick);
 


### PR DESCRIPTION
Fixes #6490

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8488)