### PR TITLE
Refactor `ToolStripControlHost.Control` property to throw `ObjectDisposedException` if null

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripControlHost.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripControlHost.cs
@@ -86,7 +86,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Overridden to return value from Control.CanSelect.
         /// </summary>
-        public override bool CanSelect => _control is not null ? DesignMode || Control.CanSelect : false;
+        public override bool CanSelect => _control is not null && (DesignMode || _control.CanSelect);
 
         [SRCategory(nameof(SR.CatFocus))]
         [DefaultValue(true)]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripControlHost.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripControlHost.cs
@@ -6,6 +6,7 @@
 
 using System.ComponentModel;
 using System.Drawing;
+using System.Runtime.CompilerServices;
 using System.Windows.Forms.Layout;
 
 namespace System.Windows.Forms
@@ -126,6 +127,7 @@ namespace System.Windows.Forms
         /// </summary>
         private Control ControlInternal
         {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
                 ObjectDisposedException.ThrowIf(_control is null, _control);
@@ -806,7 +808,7 @@ namespace System.Windows.Forms
         private void SyncControlParent()
         {
             ReadOnlyControlCollection newControls = GetControlCollection(ParentInternal);
-            newControls?.AddInternal(ControlInternal);
+            newControls?.AddInternal(_control);
         }
 
         protected virtual void OnHostedControlResize(EventArgs e)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripControlHost.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripControlHost.cs
@@ -123,7 +123,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                ObjectDisposedException.ThrowIf(_control is null, nameof(Control));
+                ObjectDisposedException.ThrowIf(_control is null, Control);
                 return _control;
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripControlHost.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripControlHost.cs
@@ -86,18 +86,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Overriden to return value from Control.CanSelect.
         /// </summary>
-        public override bool CanSelect
-        {
-            get
-            {
-                if (_control is not null)
-                {
-                    return (DesignMode || Control.CanSelect);
-                }
-
-                return false;
-            }
-        }
+        public override bool CanSelect => _control is not null ? DesignMode || Control.CanSelect : false;
 
         [SRCategory(nameof(SR.CatFocus))]
         [DefaultValue(true)]
@@ -130,7 +119,14 @@ namespace System.Windows.Forms
         /// </summary>
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public Control Control => _control;
+        public Control Control
+        {
+            get
+            {
+                ObjectDisposedException.ThrowIf(_control is null, nameof(Control));
+                return _control;
+            }
+        }
 
         internal AccessibleObject ControlAccessibilityObject => Control?.AccessibilityObject;
 
@@ -323,19 +319,16 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (_control is not null)
-                {
-                    return _control.RightToLeft;
-                }
-
-                return base.RightToLeft;
+                return _control is not null ? _control.RightToLeft : base.RightToLeft;
             }
             set
             {
-                if (_control is not null)
+                if (_control is null)
                 {
-                    _control.RightToLeft = value;
+                    return;
                 }
+
+                _control.RightToLeft = value;
             }
         }
 
@@ -476,12 +469,9 @@ namespace System.Windows.Forms
 
         public override Size GetPreferredSize(Size constrainingSize)
         {
-            if (_control is not null)
-            {
-                return Control.GetPreferredSize(constrainingSize - Padding.Size) + Padding.Size;
-            }
-
-            return base.GetPreferredSize(constrainingSize);
+            return _control is not null
+                ? Control.GetPreferredSize(constrainingSize - Padding.Size) + Padding.Size
+                : base.GetPreferredSize(constrainingSize);
         }
 
         ///  Handle* wrappers:
@@ -651,7 +641,7 @@ namespace System.Windows.Forms
         /// </summary>
         protected override void OnBoundsChanged()
         {
-            if (!(_control is IArrangedElement element))
+            if (_control is not IArrangedElement element)
             {
                 return;
             }
@@ -827,14 +817,7 @@ namespace System.Windows.Forms
         protected internal override bool ProcessCmdKey(ref Message m, Keys keyData) => false;
 
         protected internal override bool ProcessMnemonic(char charCode)
-        {
-            if (_control is not null)
-            {
-                return _control.ProcessMnemonic(charCode);
-            }
-
-            return base.ProcessMnemonic(charCode);
-        }
+            => _control is not null ? _control.ProcessMnemonic(charCode) : base.ProcessMnemonic(charCode);
 
         protected internal override bool ProcessDialogKey(Keys keyData) => false;
 
@@ -879,44 +862,16 @@ namespace System.Windows.Forms
         private void ResumeSizeSync() => _suspendSyncSizeCount--;
 
         internal override bool ShouldSerializeBackColor()
-        {
-            if (_control is not null)
-            {
-                return _control.ShouldSerializeBackColor();
-            }
-
-            return base.ShouldSerializeBackColor();
-        }
+            => _control is not null ? _control.ShouldSerializeBackColor() : base.ShouldSerializeBackColor();
 
         internal override bool ShouldSerializeForeColor()
-        {
-            if (_control is not null)
-            {
-                return _control.ShouldSerializeForeColor();
-            }
-
-            return base.ShouldSerializeForeColor();
-        }
+            => _control is not null ? _control.ShouldSerializeForeColor() : base.ShouldSerializeForeColor();
 
         internal override bool ShouldSerializeFont()
-        {
-            if (_control is not null)
-            {
-                return _control.ShouldSerializeFont();
-            }
-
-            return base.ShouldSerializeFont();
-        }
+            => _control is not null ? _control.ShouldSerializeFont() : base.ShouldSerializeFont();
 
         internal override bool ShouldSerializeRightToLeft()
-        {
-            if (_control is not null)
-            {
-                return _control.ShouldSerializeRightToLeft();
-            }
-
-            return base.ShouldSerializeRightToLeft();
-        }
+            => _control is not null ? _control.ShouldSerializeRightToLeft() : base.ShouldSerializeRightToLeft();
 
         internal override void OnKeyboardToolTipHook(ToolTip toolTip)
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripControlHost.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripControlHost.cs
@@ -124,8 +124,6 @@ namespace System.Windows.Forms
         /// <summary>
         ///  The control that this item is hosting.
         /// </summary>
-        [Browsable(false)]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         private Control ControlInternal
         {
             get
@@ -135,7 +133,7 @@ namespace System.Windows.Forms
             }
         }
 
-        internal AccessibleObject ControlAccessibilityObject => _control?.AccessibilityObject;
+        internal AccessibleObject? ControlAccessibilityObject => _control?.AccessibilityObject;
 
         /// <summary>
         ///  Deriving classes can override this to configure a default size for their control.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripControlHost.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripControlHost.cs
@@ -56,8 +56,8 @@ namespace System.Windows.Forms
 
         public override Color BackColor
         {
-            get => Control.BackColor;
-            set => Control.BackColor = value;
+            get => ControlInternal.BackColor;
+            set => ControlInternal.BackColor = value;
         }
 
         /// <summary>
@@ -69,8 +69,8 @@ namespace System.Windows.Forms
         [DefaultValue(null)]
         public override Image BackgroundImage
         {
-            get => Control.BackgroundImage;
-            set => Control.BackgroundImage = value;
+            get => ControlInternal.BackgroundImage;
+            set => ControlInternal.BackgroundImage = value;
         }
 
         [SRCategory(nameof(SR.CatAppearance))]
@@ -79,12 +79,12 @@ namespace System.Windows.Forms
         [SRDescription(nameof(SR.ControlBackgroundImageLayoutDescr))]
         public override ImageLayout BackgroundImageLayout
         {
-            get => Control.BackgroundImageLayout;
-            set => Control.BackgroundImageLayout = value;
+            get => ControlInternal.BackgroundImageLayout;
+            set => ControlInternal.BackgroundImageLayout = value;
         }
 
         /// <summary>
-        ///  Overriden to return value from Control.CanSelect.
+        ///  Overridden to return value from Control.CanSelect.
         /// </summary>
         public override bool CanSelect => _control is not null ? DesignMode || Control.CanSelect : false;
 
@@ -93,8 +93,8 @@ namespace System.Windows.Forms
         [SRDescription(nameof(SR.ControlCausesValidationDescr))]
         public bool CausesValidation
         {
-            get => Control.CausesValidation;
-            set => Control.CausesValidation = value;
+            get => ControlInternal.CausesValidation;
+            set => ControlInternal.CausesValidation = value;
         }
 
         [DefaultValue(ContentAlignment.MiddleCenter)]
@@ -119,7 +119,14 @@ namespace System.Windows.Forms
         /// </summary>
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public Control Control
+        public Control Control => _control;
+
+        /// <summary>
+        ///  The control that this item is hosting.
+        /// </summary>
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        private Control ControlInternal
         {
             get
             {
@@ -128,7 +135,7 @@ namespace System.Windows.Forms
             }
         }
 
-        internal AccessibleObject ControlAccessibilityObject => Control?.AccessibilityObject;
+        internal AccessibleObject ControlAccessibilityObject => _control?.AccessibilityObject;
 
         /// <summary>
         ///  Deriving classes can override this to configure a default size for their control.
@@ -138,11 +145,11 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (Control is not null)
+                if (_control is not null)
                 {
                     // When you create the control - it sets up its size as its default size.
                     // Since the property is protected we don't know for sure, but this is a pretty good guess.
-                    return Control.Size;
+                    return _control.Size;
                 }
 
                 return base.DefaultSize;
@@ -182,14 +189,14 @@ namespace System.Windows.Forms
 
         public override Font Font
         {
-            get => Control.Font;
-            set => Control.Font = value;
+            get => ControlInternal.Font;
+            set => ControlInternal.Font = value;
         }
 
         public override bool Enabled
         {
-            get => Control.Enabled;
-            set => Control.Enabled = value;
+            get => ControlInternal.Enabled;
+            set => ControlInternal.Enabled = value;
         }
 
         [SRCategory(nameof(SR.CatFocus))]
@@ -202,12 +209,12 @@ namespace System.Windows.Forms
 
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Always)]
-        public virtual bool Focused => Control.Focused;
+        public virtual bool Focused => ControlInternal.Focused;
 
         public override Color ForeColor
         {
-            get => Control.ForeColor;
-            set => Control.ForeColor = value;
+            get => ControlInternal.ForeColor;
+            set => ControlInternal.ForeColor = value;
         }
 
         [SRCategory(nameof(SR.CatFocus))]
@@ -341,7 +348,7 @@ namespace System.Windows.Forms
             set => base.RightToLeftAutoMirrorImage = value;
         }
 
-        public override bool Selected => Control is not null && Control.Focused;
+        public override bool Selected => _control is not null && _control.Focused;
 
         public override Size Size
         {
@@ -373,7 +380,8 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Overriden to set the Site for the control hosted. This is set at DesignTime when the component is added to the Container.
+        ///  Overridden to set the Site for the control hosted.
+        ///  This is set at DesignTime when the component is added to the Container.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         public override ISite Site
@@ -382,25 +390,20 @@ namespace System.Windows.Forms
             set
             {
                 base.Site = value;
-                if (value is not null)
-                {
-                    Control.Site = new StubSite(Control, this);
-                }
-                else
-                {
-                    Control.Site = null;
-                }
+                ControlInternal.Site = value is not null
+                    ? new StubSite(ControlInternal, this)
+                    : (ISite)null;
             }
         }
 
         /// <summary>
-        ///  Overriden to modify hosted control's text.
+        ///  Overridden to modify hosted control's text.
         /// </summary>
         [DefaultValue("")]
         public override string Text
         {
-            get => Control.Text;
-            set => Control.Text = value;
+            get => ControlInternal.Text;
+            set => ControlInternal.Text = value;
         }
 
         [Browsable(false)]
@@ -454,23 +457,23 @@ namespace System.Windows.Forms
             // will be correctly unparented before being disposed.
             base.Dispose(disposing);
 
-            if (disposing && Control is not null)
+            if (disposing && _control is not null)
             {
-                OnUnsubscribeControlEvents(Control);
+                OnUnsubscribeControlEvents(_control);
 
                 // we only call control.Dispose if we are NOT being disposed in the finalizer.
-                Control.Dispose();
+                _control.Dispose();
                 _control = null;
             }
         }
 
         [EditorBrowsable(EditorBrowsableState.Advanced)]
-        public void Focus() => Control.Focus();
+        public void Focus() => ControlInternal.Focus();
 
         public override Size GetPreferredSize(Size constrainingSize)
         {
             return _control is not null
-                ? Control.GetPreferredSize(constrainingSize - Padding.Size) + Padding.Size
+                ? _control.GetPreferredSize(constrainingSize - Padding.Size) + Padding.Size
                 : base.GetPreferredSize(constrainingSize);
         }
 
@@ -580,12 +583,12 @@ namespace System.Windows.Forms
             // check the STATE_VISIBLE flag rather than using Control.Visible.
             // if we check while it's unparented it will return visible false.
             // the easiest way to do this is to use ParticipatesInLayout.
-            bool controlVisibleStateFlag = ((IArrangedElement)Control).ParticipatesInLayout;
+            bool controlVisibleStateFlag = ((IArrangedElement)ControlInternal).ParticipatesInLayout;
             bool itemVisibleStateFlag = ((IArrangedElement)(this)).ParticipatesInLayout;
 
             if (itemVisibleStateFlag != controlVisibleStateFlag)
             {
-                Visible = Control.Visible;
+                Visible = ControlInternal.Visible;
                 // this should fire the OnVisibleChanged and raise events appropriately.
             }
         }
@@ -596,22 +599,22 @@ namespace System.Windows.Forms
 
         internal override void OnAccessibleDescriptionChanged(EventArgs e)
         {
-            Control.AccessibleDescription = AccessibleDescription;
+            ControlInternal.AccessibleDescription = AccessibleDescription;
         }
 
         internal override void OnAccessibleNameChanged(EventArgs e)
         {
-            Control.AccessibleName = AccessibleName;
+            ControlInternal.AccessibleName = AccessibleName;
         }
 
         internal override void OnAccessibleDefaultActionDescriptionChanged(EventArgs e)
         {
-            Control.AccessibleDefaultActionDescription = AccessibleDefaultActionDescription;
+            ControlInternal.AccessibleDefaultActionDescription = AccessibleDefaultActionDescription;
         }
 
         internal override void OnAccessibleRoleChanged(EventArgs e)
         {
-            Control.AccessibleRole = AccessibleRole;
+            ControlInternal.AccessibleRole = AccessibleRole;
         }
 
 #pragma warning disable CA2252 // Suppress 'Opt in to preview features' (https://aka.ms/dotnet-warnings/preview-features)
@@ -683,13 +686,13 @@ namespace System.Windows.Forms
         /// </summary>
         protected override void OnParentChanged(ToolStrip oldParent, ToolStrip newParent)
         {
-            if (oldParent is not null && Owner is null && newParent is null && Control is not null)
+            if (oldParent is not null && Owner is null && newParent is null && _control is not null)
             {
                 // if we've really been removed from the item collection,
                 // politely remove ourselves from the control collection
                 ReadOnlyControlCollection oldControlCollection
-                                = GetControlCollection(Control.ParentInternal as ToolStrip);
-                oldControlCollection?.RemoveInternal(Control);
+                                = GetControlCollection(_control.ParentInternal as ToolStrip);
+                oldControlCollection?.RemoveInternal(_control);
             }
             else
             {
@@ -805,13 +808,13 @@ namespace System.Windows.Forms
         private void SyncControlParent()
         {
             ReadOnlyControlCollection newControls = GetControlCollection(ParentInternal);
-            newControls?.AddInternal(Control);
+            newControls?.AddInternal(ControlInternal);
         }
 
         protected virtual void OnHostedControlResize(EventArgs e)
         {
             // support for syncing the wrapper when the control size has changed
-            Size = Control.Size;
+            Size = ControlInternal.Size;
         }
 
         protected internal override bool ProcessCmdKey(ref Message m, Keys keyData) => false;
@@ -831,14 +834,14 @@ namespace System.Windows.Forms
             }
 
             _inSetVisibleCore = true;
-            Control.SuspendLayout();
+            ControlInternal.SuspendLayout();
             try
             {
-                Control.Visible = visible;
+                ControlInternal.Visible = visible;
             }
             finally
             {
-                Control.ResumeLayout(false);
+                ControlInternal.ResumeLayout(false);
                 // this will go ahead and perform layout.
                 base.SetVisibleCore(visible);
                 _inSetVisibleCore = false;
@@ -846,10 +849,10 @@ namespace System.Windows.Forms
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public override void ResetBackColor() => Control.ResetBackColor();
+        public override void ResetBackColor() => ControlInternal.ResetBackColor();
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public override void ResetForeColor() => Control.ResetForeColor();
+        public override void ResetForeColor() => ControlInternal.ResetForeColor();
 
         private void SuspendSizeSync() => _suspendSyncSizeCount++;
 
@@ -877,14 +880,14 @@ namespace System.Windows.Forms
         {
             base.OnKeyboardToolTipHook(toolTip);
 
-            KeyboardToolTipStateMachine.Instance.Hook(Control, toolTip);
+            KeyboardToolTipStateMachine.Instance.Hook(ControlInternal, toolTip);
         }
 
         internal override void OnKeyboardToolTipUnhook(ToolTip toolTip)
         {
             base.OnKeyboardToolTipUnhook(toolTip);
 
-            KeyboardToolTipStateMachine.Instance.Unhook(Control, toolTip);
+            KeyboardToolTipStateMachine.Instance.Unhook(ControlInternal, toolTip);
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripControlHost.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripControlHost.cs
@@ -123,7 +123,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                ObjectDisposedException.ThrowIf(_control is null, Control);
+                ObjectDisposedException.ThrowIf(_control is null, _control);
                 return _control;
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripControlHost.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripControlHost.cs
@@ -133,7 +133,7 @@ namespace System.Windows.Forms
             }
         }
 
-        internal AccessibleObject? ControlAccessibilityObject => _control?.AccessibilityObject;
+        internal AccessibleObject ControlAccessibilityObject => _control?.AccessibilityObject;
 
         /// <summary>
         ///  Deriving classes can override this to configure a default size for their control.

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripControlHostTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripControlHostTests.cs
@@ -153,13 +153,13 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
-        public void ToolStripControlHost_AccessibleDefaultActionDescription_SetDisposed_ThrowsNullReferenceException()
+        public void ToolStripControlHost_AccessibleDefaultActionDescription_SetDisposed_ThrowsObjectDisposedException()
         {
             using var c = new Control();
             using var item = new ToolStripControlHost(c);
             item.Dispose();
 
-            Assert.Throws<NullReferenceException>(() => item.AccessibleDefaultActionDescription = "value");
+            Assert.Throws<ObjectDisposedException>(() => item.AccessibleDefaultActionDescription = "value");
         }
 
         [WinFormsTheory]
@@ -183,13 +183,13 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
-        public void ToolStripControlHost_AccessibleDescription_SetDisposed_ThrowsNullReferenceException()
+        public void ToolStripControlHost_AccessibleDescription_SetDisposed_ThrowsObjectDisposedException()
         {
             using var c = new Control();
             using var item = new ToolStripControlHost(c);
             item.Dispose();
 
-            Assert.Throws<NullReferenceException>(() => item.AccessibleDescription = "value");
+            Assert.Throws<ObjectDisposedException>(() => item.AccessibleDescription = "value");
         }
 
         [WinFormsTheory]
@@ -213,13 +213,13 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
-        public void ToolStripControlHost_AccessibleName_SetDisposed_ThrowsNullReferenceException()
+        public void ToolStripControlHost_AccessibleName_SetDisposed_ThrowsObjectDisposedException()
         {
             using var c = new Control();
             using var item = new ToolStripControlHost(c);
             item.Dispose();
 
-            Assert.Throws<NullReferenceException>(() => item.AccessibleName = "value");
+            Assert.Throws<ObjectDisposedException>(() => item.AccessibleName = "value");
         }
 
         [WinFormsTheory]
@@ -252,13 +252,13 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
-        public void ToolStripControlHost_BackColor_GetDisposed_ThrowsNullReferenceException()
+        public void ToolStripControlHost_BackColor_GetDisposed_ThrowsObjectDisposedException()
         {
             using var c = new Control();
             using var item = new ToolStripControlHost(c);
             item.Dispose();
 
-            Assert.Throws<NullReferenceException>(() => item.BackColor);
+            Assert.Throws<ObjectDisposedException>(() => item.BackColor);
         }
 
         [WinFormsTheory]
@@ -318,13 +318,13 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
-        public void ToolStripControlHost_BackColor_SetDisposed_ThrowsNullReferenceException()
+        public void ToolStripControlHost_BackColor_SetDisposed_ThrowsObjectDisposedException()
         {
             using var c = new Control();
             using var item = new ToolStripControlHost(c);
             item.Dispose();
 
-            Assert.Throws<NullReferenceException>(() => item.BackColor = Color.Red);
+            Assert.Throws<ObjectDisposedException>(() => item.BackColor = Color.Red);
         }
 
         [WinFormsFact]
@@ -345,7 +345,7 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
-        public void ToolStripControlHost_BackColor_ResetValueDisposed_ThrowsNullReferenceException()
+        public void ToolStripControlHost_BackColor_ResetValueDisposed_ThrowsObjectDisposedException()
         {
             PropertyDescriptor property = TypeDescriptor.GetProperties(typeof(ToolStripControlHost))[nameof(ToolStripControlHost.BackColor)];
             using var c = new Control();
@@ -354,7 +354,7 @@ namespace System.Windows.Forms.Tests
             Assert.False(property.CanResetValue(item));
 
             TargetInvocationException ex = Assert.Throws<TargetInvocationException>(() => property.ResetValue(item));
-            Assert.IsType<NullReferenceException>(ex.InnerException);
+            Assert.IsType<ObjectDisposedException>(ex.InnerException);
             Assert.False(property.CanResetValue(item));
         }
 
@@ -386,13 +386,13 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
-        public void ToolStripControlHost_BackgroundImage_GetDisposed_ThrowsNullReferenceException()
+        public void ToolStripControlHost_BackgroundImage_GetDisposed_ThrowsObjectDisposedException()
         {
             using var c = new Control();
             using var item = new ToolStripControlHost(c);
             item.Dispose();
 
-            Assert.Throws<NullReferenceException>(() => item.BackgroundImage);
+            Assert.Throws<ObjectDisposedException>(() => item.BackgroundImage);
         }
 
         public static IEnumerable<object[]> BackgroundImage_Set_TestData()
@@ -424,24 +424,24 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
-        public void ToolStripControlHost_BackgroundImage_SetDisposed_ThrowsNullReferenceException()
+        public void ToolStripControlHost_BackgroundImage_SetDisposed_ThrowsObjectDisposedException()
         {
             using var c = new Control();
             using var item = new ToolStripControlHost(c);
             item.Dispose();
 
             using var value = new Bitmap(10, 10);
-            Assert.Throws<NullReferenceException>(() => item.BackgroundImage = value);
+            Assert.Throws<ObjectDisposedException>(() => item.BackgroundImage = value);
         }
 
         [WinFormsFact]
-        public void ToolStripControlHost_BackgroundImageLayout_GetDisposed_ThrowsNullReferenceException()
+        public void ToolStripControlHost_BackgroundImageLayout_GetDisposed_ThrowsObjectDisposedException()
         {
             using var c = new Control();
             using var item = new ToolStripControlHost(c);
             item.Dispose();
 
-            Assert.Throws<NullReferenceException>(() => item.BackgroundImageLayout);
+            Assert.Throws<ObjectDisposedException>(() => item.BackgroundImageLayout);
         }
 
         [WinFormsTheory]
@@ -465,13 +465,13 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
-        public void ToolStripControlHost_BackgroundImageLayout_SetDisposed_ThrowsNullReferenceException()
+        public void ToolStripControlHost_BackgroundImageLayout_SetDisposed_ThrowsObjectDisposedException()
         {
             using var c = new Control();
             using var item = new ToolStripControlHost(c);
             item.Dispose();
 
-            Assert.Throws<NullReferenceException>(() => item.BackgroundImageLayout = ImageLayout.Zoom);
+            Assert.Throws<ObjectDisposedException>(() => item.BackgroundImageLayout = ImageLayout.Zoom);
         }
 
         [WinFormsTheory]
@@ -838,13 +838,13 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
-        public void ToolStripControlHost_Enabled_GetDisposed_ThrowsNullReferenceException()
+        public void ToolStripControlHost_Enabled_GetDisposed_ThrowsObjectDisposedException()
         {
             using var c = new Control();
             using var item = new ToolStripControlHost(c);
             item.Dispose();
 
-            Assert.Throws<NullReferenceException>(() => item.Enabled);
+            Assert.Throws<ObjectDisposedException>(() => item.Enabled);
         }
 
         public static IEnumerable<object[]> Enabled_Set_TestData()
@@ -923,33 +923,33 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
-        public void ToolStripControlHost_Enabled_SetDisposed_ThrowsNullReferenceException()
+        public void ToolStripControlHost_Enabled_SetDisposed_ThrowsObjectDisposedException()
         {
             using var c = new Control();
             using var item = new ToolStripControlHost(c);
             item.Dispose();
 
-            Assert.Throws<NullReferenceException>(() => item.Enabled = false);
+            Assert.Throws<ObjectDisposedException>(() => item.Enabled = false);
         }
 
         [WinFormsFact]
-        public void ToolStripControlHost_Focused_GetDisposed_ThrowsNullReferenceException()
+        public void ToolStripControlHost_Focused_GetDisposed_ThrowsObjectDisposedException()
         {
             using var c = new Control();
             using var item = new ToolStripControlHost(c);
             item.Dispose();
 
-            Assert.Throws<NullReferenceException>(() => item.Focused);
+            Assert.Throws<ObjectDisposedException>(() => item.Focused);
         }
 
         [WinFormsFact]
-        public void ToolStripControlHost_Font_GetDisposed_ThrowsNullReferenceException()
+        public void ToolStripControlHost_Font_GetDisposed_ThrowsObjectDisposedException()
         {
             using var c = new Control();
             using var item = new ToolStripControlHost(c);
             item.Dispose();
 
-            Assert.Throws<NullReferenceException>(() => item.Font);
+            Assert.Throws<ObjectDisposedException>(() => item.Font);
         }
 
         public static IEnumerable<object[]> Font_Set_TestData()
@@ -984,14 +984,14 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
-        public void ToolStripControlHost_Font_SetDisposed_ThrowsNullReferenceException()
+        public void ToolStripControlHost_Font_SetDisposed_ThrowsObjectDisposedException()
         {
             using var c = new Control();
             using var item = new ToolStripControlHost(c);
             item.Dispose();
 
             using var font = new Font("Arial", 8.25f);
-            Assert.Throws<NullReferenceException>(() => item.Font = font);
+            Assert.Throws<ObjectDisposedException>(() => item.Font = font);
         }
 
         [WinFormsFact]
@@ -1021,7 +1021,7 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
-        public void ToolStripControlHost_Font_ResetValueDisposed_ThrowsNullReferenceException()
+        public void ToolStripControlHost_Font_ResetValueDisposed_ThrowsObjectDisposedException()
         {
             PropertyDescriptor property = TypeDescriptor.GetProperties(typeof(ToolStripControlHost))[nameof(ToolStripControlHost.Font)];
             using var c = new Control();
@@ -1030,7 +1030,7 @@ namespace System.Windows.Forms.Tests
             Assert.False(property.CanResetValue(item));
 
             TargetInvocationException ex = Assert.Throws<TargetInvocationException>(() => property.ResetValue(item));
-            Assert.IsType<NullReferenceException>(ex.InnerException);
+            Assert.IsType<ObjectDisposedException>(ex.InnerException);
             Assert.False(property.CanResetValue(item));
         }
 
@@ -1071,13 +1071,13 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
-        public void ToolStripControlHost_ForeColor_GetDisposed_ThrowsNullReferenceException()
+        public void ToolStripControlHost_ForeColor_GetDisposed_ThrowsObjectDisposedException()
         {
             using var c = new Control();
             using var item = new ToolStripControlHost(c);
             item.Dispose();
 
-            Assert.Throws<NullReferenceException>(() => item.ForeColor);
+            Assert.Throws<ObjectDisposedException>(() => item.ForeColor);
         }
 
         [WinFormsTheory]
@@ -1137,13 +1137,13 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
-        public void ToolStripControlHost_ForeColor_SetDisposed_ThrowsNullReferenceException()
+        public void ToolStripControlHost_ForeColor_SetDisposed_ThrowsObjectDisposedException()
         {
             using var c = new Control();
             using var item = new ToolStripControlHost(c);
             item.Dispose();
 
-            Assert.Throws<NullReferenceException>(() => item.ForeColor = Color.Red);
+            Assert.Throws<ObjectDisposedException>(() => item.ForeColor = Color.Red);
         }
 
         [WinFormsFact]
@@ -1164,7 +1164,7 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
-        public void ToolStripControlHost_ForeColor_ResetValueDisposed_ThrowsNullReferenceException()
+        public void ToolStripControlHost_ForeColor_ResetValueDisposed_ThrowsObjectDisposedException()
         {
             PropertyDescriptor property = TypeDescriptor.GetProperties(typeof(ToolStripControlHost))[nameof(ToolStripControlHost.ForeColor)];
             using var c = new Control();
@@ -1173,7 +1173,7 @@ namespace System.Windows.Forms.Tests
             Assert.False(property.CanResetValue(item));
 
             TargetInvocationException ex = Assert.Throws<TargetInvocationException>(() => property.ResetValue(item));
-            Assert.IsType<NullReferenceException>(ex.InnerException);
+            Assert.IsType<ObjectDisposedException>(ex.InnerException);
             Assert.False(property.CanResetValue(item));
         }
 
@@ -1533,7 +1533,7 @@ namespace System.Windows.Forms.Tests
             using var item = new SubToolStripControlHost(c);
             item.Dispose();
 
-            Assert.Throws<NullReferenceException>(() => item.Parent = parent);
+            Assert.Throws<ObjectDisposedException>(() => item.Parent = parent);
             Assert.Same(parent, item.Parent);
             Assert.Same(parent, item.GetCurrentParent());
             Assert.Null(item.Owner);
@@ -2175,7 +2175,7 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
-        public void ToolStripControlHost_Site_SetDisposed_ThrowsNullReferenceException()
+        public void ToolStripControlHost_Site_SetDisposed_ThrowsObjectDisposedException()
         {
             using var c = new Control();
             using var item = new ToolStripControlHost(c);
@@ -2185,7 +2185,7 @@ namespace System.Windows.Forms.Tests
             mockSite
                 .Setup(s => s.Container)
                 .Returns((IContainer)null);
-            Assert.Throws<NullReferenceException>(() => item.Site = mockSite.Object);
+            Assert.Throws<ObjectDisposedException>(() => item.Site = mockSite.Object);
             Assert.Equal(mockSite.Object, item.Site);
         }
 
@@ -2698,13 +2698,13 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
-        public void ToolStripControlHost_Focus_InvokeDisposed_ThrowsNullReferenceException()
+        public void ToolStripControlHost_Focus_InvokeDisposed_ThrowsObjectDisposedException()
         {
             using var c = new Control();
             using var item = new ToolStripControlHost(c);
             item.Dispose();
 
-            Assert.Throws<NullReferenceException>(() => item.Focus());
+            Assert.Throws<ObjectDisposedException>(() => item.Focus());
         }
 
         public static IEnumerable<object[]> GetPreferredSize_TestData()
@@ -2751,16 +2751,16 @@ namespace System.Windows.Forms.Tests
 
         [WinFormsTheory]
         [MemberData(nameof(GetPreferredSize_TestData))]
-        public void ToolStripControlHost_GetPreferredSize_InvokeDisposed_ThrowsNullReferenceException(Size proposedSize)
+        public void ToolStripControlHost_GetPreferredSize_InvokeDisposed_ThrowsObjectDisposedException(Size proposedSize)
         {
             using var c = new Control();
             using var item = new ToolStripControlHost(c);
             item.Dispose();
 
-            Assert.Throws<NullReferenceException>(() => item.GetPreferredSize(proposedSize));
+            Assert.Throws<ObjectDisposedException>(() => item.GetPreferredSize(proposedSize));
 
             // Call again.
-            Assert.Throws<NullReferenceException>(() => item.GetPreferredSize(proposedSize));
+            Assert.Throws<ObjectDisposedException>(() => item.GetPreferredSize(proposedSize));
         }
 
         [WinFormsTheory]
@@ -4352,7 +4352,7 @@ namespace System.Windows.Forms.Tests
 
         [WinFormsTheory]
         [CommonMemberData(typeof(CommonTestHelper), nameof(CommonTestHelper.GetBoolTheoryData))]
-        public void ToolStripControlHost_ProcessMnemonic_InvokeDisposed_ThrowsNullReferenceException(bool enabled)
+        public void ToolStripControlHost_ProcessMnemonic_InvokeDisposed_ThrowsObjectDisposedException(bool enabled)
         {
             using var c = new Control();
             using var item = new SubToolStripControlHost(c)
@@ -4363,7 +4363,7 @@ namespace System.Windows.Forms.Tests
 
             int clickCallCount = 0;
             item.Click += (sender, e) => clickCallCount++;
-            Assert.Throws<NullReferenceException>(() => item.ProcessMnemonic('a'));
+            Assert.Throws<ObjectDisposedException>(() => item.ProcessMnemonic('a'));
             Assert.Equal(0, clickCallCount);
             Assert.False(item.Pressed);
         }
@@ -4407,13 +4407,13 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
-        public void ToolStripControlHost_ResetBackColor_InvokeDisposed_ThrowsNullReferenceException()
+        public void ToolStripControlHost_ResetBackColor_InvokeDisposed_ThrowsObjectDisposedException()
         {
             using var c = new Control();
             using var item = new SubToolStripControlHost(c);
             item.Dispose();
 
-            Assert.Throws<NullReferenceException>(() => item.ResetBackColor());
+            Assert.Throws<ObjectDisposedException>(() => item.ResetBackColor());
         }
 
         [WinFormsFact]
@@ -4440,13 +4440,13 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
-        public void ToolStripControlHost_ResetForeColor_InvokeDisposed_ThrowsNullReferenceException()
+        public void ToolStripControlHost_ResetForeColor_InvokeDisposed_ThrowsObjectDisposedException()
         {
             using var c = new Control();
             using var item = new SubToolStripControlHost(c);
             item.Dispose();
 
-            Assert.Throws<NullReferenceException>(() => item.ResetForeColor());
+            Assert.Throws<ObjectDisposedException>(() => item.ResetForeColor());
         }
 
         [WinFormsTheory]


### PR DESCRIPTION
Refactored `ToolStripControlHost.Control` property to throw `ObjectDisposedException` if null.
Also some minor refactoring using expression bodies

Fixes #2466

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8509)