### PR TITLE
Removed the DefaultValue attribute from ListBox.ItemHeight property

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
@@ -62,8 +62,9 @@ namespace System.Windows.Forms
         private SelectedIndexCollection? _selectedIndices;
         private ObjectCollection? _itemsCollection;
 
-        private int _itemHeight = DefaultItemHeight;
+        private int _itemHeight = DefaultListBoxItemHeight;
         private int _columnWidth;
+        private static int s_defaultListBoxItemHeight = -1;
         private int _requestedHeight;
         private int _topIndex;
         private int _horizontalExtent;
@@ -389,6 +390,19 @@ namespace System.Windows.Forms
             }
         }
 
+        private static int DefaultListBoxItemHeight
+        {
+            get
+            {
+                if (s_defaultListBoxItemHeight == -1)
+                {
+                    s_defaultListBoxItemHeight = DefaultFont.Height;
+                }
+
+                return s_defaultListBoxItemHeight;
+            }
+        }
+
         protected override Size DefaultSize
         {
             get
@@ -586,7 +600,6 @@ namespace System.Windows.Forms
         ///  the height of an item in an owner-draw list box.
         /// </summary>
         [SRCategory(nameof(SR.CatBehavior))]
-        [DefaultValue(DefaultItemHeight)]
         [Localizable(true)]
         [SRDescription(nameof(SR.ListBoxItemHeightDescr))]
         [RefreshProperties(RefreshProperties.Repaint)]
@@ -2107,9 +2120,10 @@ namespace System.Windows.Forms
             base.ResetForeColor();
         }
 
+        // ShouldSerialize and Reset Methods are being used by Designer via reflection.
         private void ResetItemHeight()
         {
-            _itemHeight = DefaultItemHeight;
+            _itemHeight = DefaultListBoxItemHeight;
         }
 
         protected override void ScaleControl(SizeF factor, BoundsSpecified specified)
@@ -2206,6 +2220,12 @@ namespace System.Windows.Forms
 
             SelectedItems.Dirty();
             OnSelectedIndexChanged(EventArgs.Empty);
+        }
+
+        // ShouldSerialize and Reset Methods are being used by Designer via reflection.
+        private bool ShouldSerializeItemHeight()
+        {
+            return ItemHeight != DefaultListBoxItemHeight;
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListBoxTests.cs
@@ -86,7 +86,7 @@ namespace System.Windows.Forms.Tests
             Assert.True(control.IntegralHeight);
             Assert.False(control.IsAccessible);
             Assert.False(control.IsMirrored);
-            Assert.Equal(13, control.ItemHeight);
+            Assert.Equal(Control.DefaultFont.Height, control.ItemHeight);
             Assert.Empty(control.Items);
             Assert.Same(control.Items, control.Items);
             Assert.NotNull(control.LayoutEngine);
@@ -100,7 +100,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(Padding.Empty, control.Padding);
             Assert.Null(control.Parent);
             Assert.Equal("Microsoft\u00AE .NET", control.ProductName);
-            Assert.Equal(13 + SystemInformation.BorderSize.Height * 4 + 3, control.PreferredHeight);
+            Assert.Equal(Control.DefaultFont.Height + SystemInformation.BorderSize.Height * 4 + 3, control.PreferredHeight);
             Assert.Equal(new Size(120, 96), control.PreferredSize);
             Assert.False(control.RecreatingHandle);
             Assert.Null(control.Region);
@@ -1742,13 +1742,13 @@ namespace System.Windows.Forms.Tests
             foreach (bool integralHeight in new bool[] { true, false })
             {
                 yield return new object[] { DrawMode.Normal, integralHeight, 1, 0 };
-                yield return new object[] { DrawMode.Normal, integralHeight, 13, 0 };
+                yield return new object[] { DrawMode.Normal, integralHeight, Control.DefaultFont.Height, 0 };
                 yield return new object[] { DrawMode.Normal, integralHeight, 255, 0 };
                 yield return new object[] { DrawMode.OwnerDrawFixed, integralHeight, 1, 1 };
-                yield return new object[] { DrawMode.OwnerDrawFixed, integralHeight, 13, 0 };
+                yield return new object[] { DrawMode.OwnerDrawFixed, integralHeight, Control.DefaultFont.Height, 0 };
                 yield return new object[] { DrawMode.OwnerDrawFixed, integralHeight, 255, 1 };
                 yield return new object[] { DrawMode.OwnerDrawVariable, integralHeight, 1, 0 };
-                yield return new object[] { DrawMode.OwnerDrawVariable, integralHeight, 13, 0 };
+                yield return new object[] { DrawMode.OwnerDrawVariable, integralHeight, Control.DefaultFont.Height, 0 };
                 yield return new object[] { DrawMode.OwnerDrawVariable, integralHeight, 255, 0 };
             }
         }
@@ -1825,7 +1825,7 @@ namespace System.Windows.Forms.Tests
             Assert.True(property.CanResetValue(control));
 
             property.ResetValue(control);
-            Assert.Equal(13, control.ItemHeight);
+            Assert.Equal(Control.DefaultFont.Height, control.ItemHeight);
             Assert.False(property.CanResetValue(control));
         }
 
@@ -1841,7 +1841,7 @@ namespace System.Windows.Forms.Tests
             Assert.True(property.ShouldSerializeValue(control));
 
             property.ResetValue(control);
-            Assert.Equal(13, control.ItemHeight);
+            Assert.Equal(Control.DefaultFont.Height, control.ItemHeight);
             Assert.False(property.ShouldSerializeValue(control));
         }
 
@@ -2050,13 +2050,13 @@ namespace System.Windows.Forms.Tests
         public static IEnumerable<object[]> PreferredHeight_GetEmpty_TestData()
         {
             int extra = SystemInformation.BorderSize.Height * 4 + 3;
-            yield return new object[] { DrawMode.Normal, BorderStyle.Fixed3D, 13 + extra };
-            yield return new object[] { DrawMode.Normal, BorderStyle.FixedSingle, 13 + extra };
-            yield return new object[] { DrawMode.Normal, BorderStyle.None, 13 };
+            yield return new object[] { DrawMode.Normal, BorderStyle.Fixed3D, Control.DefaultFont.Height + extra };
+            yield return new object[] { DrawMode.Normal, BorderStyle.FixedSingle, Control.DefaultFont.Height + extra };
+            yield return new object[] { DrawMode.Normal, BorderStyle.None, Control.DefaultFont.Height };
 
-            yield return new object[] { DrawMode.OwnerDrawFixed, BorderStyle.Fixed3D, 13 + extra };
-            yield return new object[] { DrawMode.OwnerDrawFixed, BorderStyle.FixedSingle, 13 + extra };
-            yield return new object[] { DrawMode.OwnerDrawFixed, BorderStyle.None, 13 };
+            yield return new object[] { DrawMode.OwnerDrawFixed, BorderStyle.Fixed3D, Control.DefaultFont.Height + extra };
+            yield return new object[] { DrawMode.OwnerDrawFixed, BorderStyle.FixedSingle, Control.DefaultFont.Height + extra };
+            yield return new object[] { DrawMode.OwnerDrawFixed, BorderStyle.None, Control.DefaultFont.Height };
 
             yield return new object[] { DrawMode.OwnerDrawVariable, BorderStyle.Fixed3D, extra };
             yield return new object[] { DrawMode.OwnerDrawVariable, BorderStyle.FixedSingle, extra };
@@ -2079,17 +2079,17 @@ namespace System.Windows.Forms.Tests
         public static IEnumerable<object[]> PreferredHeight_GetNotEmpty_TestData()
         {
             int extra = SystemInformation.BorderSize.Height * 4 + 3;
-            yield return new object[] { DrawMode.Normal, BorderStyle.Fixed3D, 26 + extra };
-            yield return new object[] { DrawMode.Normal, BorderStyle.FixedSingle, 26 + extra };
-            yield return new object[] { DrawMode.Normal, BorderStyle.None, 26 };
+            yield return new object[] { DrawMode.Normal, BorderStyle.Fixed3D, (Control.DefaultFont.Height * 2) + extra };
+            yield return new object[] { DrawMode.Normal, BorderStyle.FixedSingle, (Control.DefaultFont.Height * 2) + extra };
+            yield return new object[] { DrawMode.Normal, BorderStyle.None, (Control.DefaultFont.Height * 2) };
 
-            yield return new object[] { DrawMode.OwnerDrawFixed, BorderStyle.Fixed3D, 26 + extra };
-            yield return new object[] { DrawMode.OwnerDrawFixed, BorderStyle.FixedSingle, 26 + extra };
-            yield return new object[] { DrawMode.OwnerDrawFixed, BorderStyle.None, 26 };
+            yield return new object[] { DrawMode.OwnerDrawFixed, BorderStyle.Fixed3D, (Control.DefaultFont.Height * 2) + extra };
+            yield return new object[] { DrawMode.OwnerDrawFixed, BorderStyle.FixedSingle, (Control.DefaultFont.Height * 2) + extra };
+            yield return new object[] { DrawMode.OwnerDrawFixed, BorderStyle.None, (Control.DefaultFont.Height * 2) };
 
-            yield return new object[] { DrawMode.OwnerDrawVariable, BorderStyle.Fixed3D, 26 + extra };
-            yield return new object[] { DrawMode.OwnerDrawVariable, BorderStyle.FixedSingle, 26 + extra };
-            yield return new object[] { DrawMode.OwnerDrawVariable, BorderStyle.None, 26 };
+            yield return new object[] { DrawMode.OwnerDrawVariable, BorderStyle.Fixed3D, (Control.DefaultFont.Height * 2) + extra };
+            yield return new object[] { DrawMode.OwnerDrawVariable, BorderStyle.FixedSingle, (Control.DefaultFont.Height * 2) + extra };
+            yield return new object[] { DrawMode.OwnerDrawVariable, BorderStyle.None, (Control.DefaultFont.Height * 2) };
         }
 
         [WinFormsTheory]
@@ -5148,7 +5148,7 @@ namespace System.Windows.Forms.Tests
             {
                 DrawMode = drawMode
             };
-            Assert.Equal(13, control.GetItemHeight(0));
+            Assert.Equal(Control.DefaultFont.Height, control.GetItemHeight(0));
             Assert.False(control.IsHandleCreated);
         }
 
@@ -5171,7 +5171,7 @@ namespace System.Windows.Forms.Tests
             };
             control.Items.Add("Item1");
             control.Items.Add("Item2");
-            Assert.Equal(13, control.GetItemHeight(index));
+            Assert.Equal(Control.DefaultFont.Height, control.GetItemHeight(index));
             Assert.False(control.IsHandleCreated);
         }
 


### PR DESCRIPTION
Fixes #4463 (partially, see also #8640)

## Proposed changes

- Introduces a new private property `DefaultHeight` with **the intended value** equals Winforms Control.DefaultFont.Height (for example in Windows.Forms it is **Segoe UI, Size 9, Height 16** by default).
- Removes the DefaultValue attribute from the `ListBox.ItemHeight` property;
- Implements `ResetItemHeight` and `ShouldSerializeItemHeight` methods ([see more](https://learn.microsoft.com/en-us/dotnet/desktop/winforms/controls/defining-default-values-with-the-shouldserialize-and-reset-methods?view=netframeworkdesktop-4.8)).
- The ListBox.DefaultItemHeight constant marked as obsolete. The `ListBox.ItemHeight` is now depended on actual `DefaultFont.Height` value.
- The `ListBox.ItemHeight` property still returns the value of the  `_itemHeight` property as usual.
- Changed 9 ListBox unit tests

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Fixes the Issue which impacts user experience,  breaks DPI and Font scaling. For the _newly created_ control at 100% scaling, designer should generate the same value as is defined by the Default. There is no extra code.

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/15823268/104525385-e63a8080-55b4-11eb-8018-1cd886b658a0.png)

### After

![image](https://user-images.githubusercontent.com/15823268/104525352-d1f68380-55b4-11eb-9bf4-fafbf11c85f4.png)


## Test methodology

- Manual (Issue can be tested via substitution of dlls, complete restart of the VS recommended)
- Unit test


 

## Test environment(s) <!-- Remove any that don't apply -->

- dotnet 8.0.100-alpha.1.22607.6


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8518)