### PR TITLE
Fix control select and exception when moving controls

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.AdornerWindow.MouseHook.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.AdornerWindow.MouseHook.cs
@@ -178,8 +178,7 @@ namespace System.Windows.Forms.Design.Behavior
                             try
                             {
                                 _processingMessage = true;
-                                var pt = new Point(x, y);
-                                adornerWindow.PointToClient(pt);
+                                Point pt = adornerWindow.PointToClient(new Point(x, y));
                                 Message m = Message.Create(hwnd, msg, 0u, PARAM.FromLowHigh(pt.Y, pt.X));
 
                                 // No one knows why we get an extra click here from VS. As a workaround, we check the TimeStamp and discard it.

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DropSourceBehavior.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DropSourceBehavior.cs
@@ -887,7 +887,7 @@ namespace System.Windows.Forms.Design.Behavior
         /// </summary>
         private void InitiateDrag(Point initialMouseLocation, ICollection dragComps)
         {
-            dragObjects = (List<IComponent>)dragComps;
+            dragObjects = dragComps.Cast<IComponent>().ToList();
             DisableAdorners(serviceProviderSource, behaviorServiceSource, false);
             Control primaryControl = dragObjects[0] as Control;
             Control primaryParent = primaryControl?.Parent;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/SelectionUIService.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/SelectionUIService.cs
@@ -236,7 +236,8 @@ namespace System.Windows.Forms.Design
             return new HitTestInfo(SelectionUIItem.NOHIT, null);
         }
 
-        private ISelectionUIHandler GetHandler(object component) => _selectionHandlers[component];
+        private ISelectionUIHandler GetHandler(object component)
+            => _selectionHandlers.TryGetValue(component, out ISelectionUIHandler value) ? value : null;
 
         /// <summary>
         ///  This method returns a well-formed name for a drag transaction based on the rules it is given.
@@ -915,7 +916,7 @@ namespace System.Windows.Forms.Design
             _selectionHandlers.TryGetValue(component, out ISelectionUIHandler oldHandler);
             if (oldHandler == handler)
             {
-                _selectionHandlers[component] = null;
+                _selectionHandlers.Remove(component);
             }
         }
 


### PR DESCRIPTION
Related: #8515

I have fixed the exceptions in `DropSourceBehavior` and `SelectionUIService`. But the resize via the editor still doesn't work.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8522)