### PR TITLE
Refactor `SelectionService` to replace `ArrayList` and enable Nullability

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/SelectionService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/SelectionService.cs
@@ -227,7 +227,7 @@ namespace System.ComponentModel.Design
                 }
             }
 
-            _contextAttributes = new(_selection.Count);
+            _contextAttributes = new();
 
             for (int i = 0; i < _selection.Count; i++)
             {

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/SelectionService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/SelectionService.cs
@@ -54,7 +54,7 @@ namespace System.ComponentModel.Design
         /// <summary>
         ///  Adds the given selection to our selection list.
         /// </summary>
-        internal void AddSelection(IComponent selection)
+        internal void AddSelection(IComponent? selection)
         {
             if (selection is null)
             {

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/SelectionService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/SelectionService.cs
@@ -54,7 +54,7 @@ namespace System.ComponentModel.Design
         /// <summary>
         ///  Adds the given selection to our selection list.
         /// </summary>
-        internal void AddSelection(IComponent sel)
+        internal void AddSelection(IComponent selection)
         {
             if (_selection is null)
             {
@@ -76,9 +76,9 @@ namespace System.ComponentModel.Design
                 }
             }
 
-            if (!_selection.Contains(sel))
+            if (!_selection.Contains(selection))
             {
-                _selection.Add(sel);
+                _selection.Add(selection);
             }
         }
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/SelectionService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/SelectionService.cs
@@ -35,7 +35,7 @@ namespace System.ComponentModel.Design
         private BitVector32 _state; // state of the selection service
         private readonly EventHandlerList _events; // the events we raise
         private List<IComponent>? _selection; // list of selected objects
-        private string?[]? _contextAttributes; // help context information we have pushed to the help service.
+        private List<string>? _contextAttributes; // help context information we have pushed to the help service.
         private short _contextKeyword; // the offset into the selection keywords for the current selection.
         private StatusCommandUI _statusCommandUI; // UI for setting the StatusBar Information..
 
@@ -54,12 +54,9 @@ namespace System.ComponentModel.Design
         /// <summary>
         ///  Adds the given selection to our selection list.
         /// </summary>
-        internal void AddSelection(IComponent? selection)
+        internal void AddSelection(IComponent selection)
         {
-            if (selection is null)
-            {
-                return;
-            }
+            ArgumentNullException.ThrowIfNull(selection, nameof(selection));
 
             if (_selection is null)
             {
@@ -205,12 +202,9 @@ namespace System.ComponentModel.Design
             // If there is an old set of context attributes, remove them.
             if (_contextAttributes is not null)
             {
-                foreach (string? helpContext in _contextAttributes)
+                foreach (string helpContext in _contextAttributes)
                 {
-                    if (helpContext is not null)
-                    {
-                        helpService.RemoveContextAttribute("Keyword", helpContext);
-                    }
+                    helpService.RemoveContextAttribute("Keyword", helpContext);
                 }
 
                 _contextAttributes = null;
@@ -233,7 +227,7 @@ namespace System.ComponentModel.Design
                 }
             }
 
-            _contextAttributes = new string?[_selection.Count];
+            _contextAttributes = new(_selection.Count);
 
             for (int i = 0; i < _selection.Count; i++)
             {
@@ -247,18 +241,15 @@ namespace System.ComponentModel.Design
 
                 if (helpContext is not null)
                 {
-                    _contextAttributes[i] = helpContext;
+                    _contextAttributes.Add(helpContext);
                 }
             }
 
             // And push them into the help context as keywords.
             HelpKeywordType selectionType = baseComponentSelected ? HelpKeywordType.GeneralKeyword : HelpKeywordType.F1Keyword;
-            foreach (string? helpContext in _contextAttributes)
+            foreach (string helpContext in _contextAttributes)
             {
-                if (helpContext is not null)
-                {
-                    helpService.AddContextAttribute("Keyword", helpContext, selectionType);
-                }
+                helpService.AddContextAttribute("Keyword", helpContext, selectionType);
             }
 
             // Now add the appropriate selection keyword.

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/SelectionService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/SelectionService.cs
@@ -35,7 +35,7 @@ namespace System.ComponentModel.Design
         private BitVector32 _state; // state of the selection service
         private readonly EventHandlerList _events; // the events we raise
         private List<IComponent>? _selection; // list of selected objects
-        private string[]? _contextAttributes; // help context information we have pushed to the help service.
+        private List<string>? _contextAttributes; // help context information we have pushed to the help service.
         private short _contextKeyword; // the offset into the selection keywords for the current selection.
         private StatusCommandUI _statusCommandUI; // UI for setting the StatusBar Information..
 
@@ -210,7 +210,7 @@ namespace System.ComponentModel.Design
                     helpService.RemoveContextAttribute("Keyword", s);
                 }
 
-                _contextAttributes = null;
+                _contextAttributes.Clear();
             }
 
             // Clear the selection keyword
@@ -230,11 +230,10 @@ namespace System.ComponentModel.Design
                 }
             }
 
-            _contextAttributes = new string[_selection.Count];
+            _contextAttributes ??= new(_selection.Count);
 
-            for (int i = 0; i < _selection.Count; i++)
+            foreach (IComponent component in _selection)
             {
-                object component = _selection[i];
                 string? helpContext = TypeDescriptor.GetClassName(component);
                 HelpKeywordAttribute? contextAttribute = (HelpKeywordAttribute?)TypeDescriptor.GetAttributes(component)[typeof(HelpKeywordAttribute)];
                 if (contextAttribute is not null && !contextAttribute.IsDefaultAttribute())
@@ -244,7 +243,7 @@ namespace System.ComponentModel.Design
 
                 if (helpContext is not null)
                 {
-                    _contextAttributes[i] = helpContext;
+                    _contextAttributes.Add(helpContext);
                 }
             }
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/SelectionService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/SelectionService.cs
@@ -13,9 +13,9 @@ namespace System.ComponentModel.Design
 {
     /// <summary>
     ///  The selection service handles selection within a form.
-    ///  There is one selection service for each designer host.
-    ///  A selection consists of an array of objects.
-    ///  One objects is designated the "primary" selection.
+    ///  There is one selection service for each <see cref="DesignerHost"/>.
+    ///  A selection consists of an list of <see cref="IComponent"/>.
+    ///  The first component in the list is designated the <see cref="PrimarySelection"/>.
     /// </summary>
     internal sealed class SelectionService : ISelectionService, IDisposable
     {
@@ -56,6 +56,11 @@ namespace System.ComponentModel.Design
         /// </summary>
         internal void AddSelection(IComponent selection)
         {
+            if (selection is null)
+            {
+                return;
+            }
+
             if (_selection is null)
             {
                 _selection = new();
@@ -164,15 +169,12 @@ namespace System.ComponentModel.Design
         /// </summary>
         private void OnTransactionOpened(object? sender, EventArgs e) => _state[s_stateTransaction] = true;
 
-        internal IComponent? PrimarySelection
-        {
-            get => _selection?.Count > 0 ? _selection[0] : null;
-        }
+        internal IComponent? PrimarySelection => _selection?.Count > 0 ? _selection[0] : null;
 
         /// <summary>
         ///  Removes the given selection from the selection list.
         /// </summary>
-        internal void RemoveSelection(IComponent sel) => _selection?.Remove(sel);
+        internal void RemoveSelection(IComponent selection) => _selection?.Remove(selection);
 
         private void ApplicationIdle(object? source, EventArgs args)
         {

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/SelectionService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/SelectionService.cs
@@ -189,13 +189,11 @@ namespace System.ComponentModel.Design
             {
                 if (tryLater)
                 {
-                    // we don't have an help service YET, we need to wait for it...
-                    // hook up to the application.idle event
-                    // yes this is UGLY but we don't have a choice.
-                    // vs is always returning a UserContext, so even if we manage to instantiate the HelpService
-                    // beforehand and class pushcontext on it
-                    // (trying to stack up help context in the helpservice to be flushed when we get the
-                    // documentactivation event we just don't know if that's going to work or not... so we just wait...) :(((
+                    // We don't have a HelpService yet, hook up to the ApplicationIdle event.
+                    // VS is always returning a UserContext, so instantiating the HelpService
+                    // beforehand and doing class pushcontext on it to try to
+                    // stack up help context in the HelpService to be flushed when we get the
+                    // documentation event may not work, so we need to wait for a HelpService instead.
                     Application.Idle += new EventHandler(ApplicationIdle);
                 }
 
@@ -301,7 +299,7 @@ namespace System.ComponentModel.Design
         ///  The primary selection has a slightly different UI look and is used as
         ///  a "key" when an operation is to be done on multiple components.
         /// </summary>
-        object? ISelectionService.PrimarySelection => _selection?.Count > 0 ? _selection[0] : null;
+        object? ISelectionService.PrimarySelection => PrimarySelection;
 
         /// <summary>
         ///  Retrieves the count of selected objects.


### PR DESCRIPTION
Refactored `ISelectionService` to replace `ArrayList` and enable Nullability.

I had to submit a PR to Runtime to fix the nullability on `ISelectionService.PrimarySelection`, this PR will need to be rebased to main once that change has been made available. Until then this will have build errors.
https://github.com/dotnet/runtime/pull/81254

Related: #8140

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8528)