### PR TITLE
Port DateTimePickerDesigner to runtime

### DIFF
--- a/src/System.Design/src/System.Design.Forwards.cs
+++ b/src/System.Design/src/System.Design.Forwards.cs
@@ -35,6 +35,7 @@ using System.Runtime.CompilerServices;
 // internal designers
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.ButtonBaseDesigner))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.ComboBoxDesigner))]
+[assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.DateTimePickerDesigner))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.FormDocumentDesigner))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.GroupBoxDesigner))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.LabelDesigner))]

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DateTimePickerDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DateTimePickerDesigner.cs
@@ -18,18 +18,18 @@ namespace System.Windows.Forms.Design
         /// <summary>
         ///  Adds a baseline SnapLine to the list of SnapLines related to this control.
         /// </summary>
-        public override IList? SnapLines
+        public override IList SnapLines
         {
             get
             {
-                ArrayList? snapLines = base.SnapLines as ArrayList;
+                IList snapLines = base.SnapLines;
 
                 // A single text-baseline for the label (and linklabel) control.
                 int baseline = DesignerUtils.GetTextBaseline(Control, ContentAlignment.MiddleLeft);
 
                 // DateTimePicker doesn't have an alignment, so we use MiddleLeft and add a fudge-factor.
                 baseline += 2;
-                snapLines?.Add(new SnapLine(SnapLineType.Baseline, baseline, SnapLinePriority.Medium));
+                snapLines.Add(new SnapLine(SnapLineType.Baseline, baseline, SnapLinePriority.Medium));
 
                 return snapLines;
             }
@@ -41,13 +41,6 @@ namespace System.Windows.Forms.Design
         ///  provides rules for a component, the component will not get any UI services.
         /// </summary>
         public override SelectionRules SelectionRules
-        {
-            get
-            {
-                SelectionRules rules = base.SelectionRules;
-                rules &= ~(SelectionRules.TopSizeable | SelectionRules.BottomSizeable);
-                return rules;
-            }
-        }
+            => base.SelectionRules & ~(SelectionRules.TopSizeable | SelectionRules.BottomSizeable);
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DateTimePickerDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DateTimePickerDesigner.cs
@@ -1,0 +1,53 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Drawing;
+using System.Windows.Forms.Design.Behavior;
+
+namespace System.Windows.Forms.Design
+{
+    internal class DateTimePickerDesigner : ControlDesigner
+    {
+        public DateTimePickerDesigner()
+        {
+            AutoResizeHandles = true;
+        }
+
+        /// <summary>
+        ///  Adds a baseline SnapLine to the list of SnapLines related to this control.
+        /// </summary>
+        public override IList? SnapLines
+        {
+            get
+            {
+                ArrayList? snapLines = base.SnapLines as ArrayList;
+
+                // A single text-baseline for the label (and linklabel) control.
+                int baseline = DesignerUtils.GetTextBaseline(Control, ContentAlignment.MiddleLeft);
+
+                // DateTimePicker doesn't have an alignment, so we use MiddleLeft and add a fudge-factor.
+                baseline += 2;
+                snapLines?.Add(new SnapLine(SnapLineType.Baseline, baseline, SnapLinePriority.Medium));
+
+                return snapLines;
+            }
+        }
+
+        /// <summary>
+        ///  Retrieves a set of rules concerning the movement capabilities of a component.
+        ///  This should be one or more flags from the SelectionRules class.  If no designer
+        ///  provides rules for a component, the component will not get any UI services.
+        /// </summary>
+        public override SelectionRules SelectionRules
+        {
+            get
+            {
+                SelectionRules rules = base.SelectionRules;
+                rules &= ~(SelectionRules.TopSizeable | SelectionRules.BottomSizeable);
+                return rules;
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/MainForm.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/MainForm.cs
@@ -134,6 +134,8 @@ namespace TestConsole
                             pb1.Image = new Icon("painter.ico").ToBitmap();
 
                             ContextMenuStrip cm1 = surface.CreateComponent<ContextMenuStrip>();
+
+                            surface.CreateControl<DateTimePicker>(new Size(200, 23), new Point(172, 150));
                         }
 
                         break;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Design/DesignerAttributeTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Design/DesignerAttributeTests.cs
@@ -31,7 +31,6 @@ namespace System.Windows.Forms.Design.Tests
             "System.Windows.Forms.Design.DataGridViewColumnDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
             "System.Windows.Forms.Design.DataGridViewComboBoxColumnDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
             "System.Windows.Forms.Design.DataGridViewDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
-            "System.Windows.Forms.Design.DateTimePickerDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
             "System.Windows.Forms.Design.FlowLayoutPanelDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
             "System.Windows.Forms.Design.FolderBrowserDialogDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
             "System.Windows.Forms.Design.ImageListDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",


### PR DESCRIPTION
Related to #8501, #8508, #2411


## Proposed changes

- Port DateTimePickerDesigner to runtime

## Customer Impact

- DateTimePicker can be designed in runtime

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before<!-- TODO -->
![Screenshot 2023-02-01 133438](https://user-images.githubusercontent.com/102954094/216074806-9d027654-285f-4e2f-bee9-0d7a8c828d37.png)

DateTimePicker is not available in runtime designer scenario

### After

![datetimepickerdesigner](https://user-images.githubusercontent.com/102954094/216074839-e6cc5584-7c3a-4c7a-b9b3-ded613aaedc0.gif)

DateTimePicker can be designed in runtime

## Test methodology <!-- How did you ensure quality? -->

- Manually (added DateTimePicker to DemoConsole test app)

 

## Test environment(s) <!-- Remove any that don't apply -->

- .NET 8.0.0-alpha.1.23067.11
- Windows 10.0.22621


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8549)