### PR TITLE
Enable CheckCertificateRevocationList Under a Switch

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
@@ -15,13 +15,14 @@ namespace System.Windows.Forms.Primitives
         // for more details on how to enable these switches in the application.
         private const string ScaleTopLevelFormMinMaxSizeForDpiSwitchName = "System.Windows.Forms.ScaleTopLevelFormMinMaxSizeForDpi";
         internal const string AnchorLayoutV2SwitchName = "System.Windows.Forms.AnchorLayoutV2";
-        internal const string ServicePointManagerCheckCRLSwitchName = "System.Windows.Forms.ServicePointManagerCheckCRL";
+        internal const string ServicePointManagerCheckCrlSwitchName = "System.Windows.Forms.ServicePointManagerCheckCrl";
         internal const string TrackBarModernRenderingSwitchName = "System.Windows.Forms.TrackBarModernRendering";
         private static int s_AnchorLayoutV2;
         private static int s_scaleTopLevelFormMinMaxSizeForDpi;
-        private static int s_servicePointManagerCheckCRL;
+        private static int s_servicePointManagerCheckCrl;
         private static int s_trackBarModernRendering;
         private static FrameworkName? s_targetFrameworkName;
+        private static Version? s_minimumSupportVersion;
 
         /// <summary>
         ///  The <see cref="TargetFrameworkAttribute"/> value for the entry assembly, if any.
@@ -32,6 +33,18 @@ namespace System.Windows.Forms.Primitives
             {
                 s_targetFrameworkName ??= AppContext.TargetFrameworkName is { } name ? new(name) : null;
                 return s_targetFrameworkName;
+            }
+        }
+
+        /// <summary>
+        ///  The earliest <see cref="Version"/> switches are supported in.
+        /// </summary>
+        private static Version MinimumSupportVersion
+        {
+            get
+            {
+                s_minimumSupportVersion ??= new("8.0");
+                return s_minimumSupportVersion;
             }
         }
 
@@ -82,7 +95,7 @@ namespace System.Windows.Forms.Primitives
 
                 // We are introducing switch defaults in .NET 8.0+ and support matrix for this product is
                 // limited to Windows 10 and above versions.
-                if (OsVersion.IsWindows10_1703OrGreater() && TargetFrameworkName!.Version.CompareTo(new Version("8.0")) >= 0)
+                if (OsVersion.IsWindows10_1703OrGreater() && TargetFrameworkName?.Version.CompareTo(MinimumSupportVersion) >= 0)
                 {
                     if (switchName == ScaleTopLevelFormMinMaxSizeForDpiSwitchName)
                     {
@@ -99,7 +112,7 @@ namespace System.Windows.Forms.Primitives
                         return true;
                     }
 
-                    if (switchName == ServicePointManagerCheckCRLSwitchName)
+                    if (switchName == ServicePointManagerCheckCrlSwitchName)
                     {
                         return true;
                     }
@@ -137,13 +150,13 @@ namespace System.Windows.Forms.Primitives
 
         /// <summary>
         ///  Indicates whether certificates are checked against the certificate authority revocation list.
-        ///  If true, revoked certificates will be accepted by WebRequests and WebClients as invalid.
+        ///  If true, revoked certificates will not be accepted by WebRequests and WebClients as valid.
         ///  Otherwise, revoked certificates will be accepted as valid.
         /// </summary>
-        public static bool ServicePointManagerCheckCRL
+        public static bool ServicePointManagerCheckCrl
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => GetCachedSwitchValue(ServicePointManagerCheckCRLSwitchName, ref s_servicePointManagerCheckCRL);
+            get => GetCachedSwitchValue(ServicePointManagerCheckCrlSwitchName, ref s_servicePointManagerCheckCrl);
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
@@ -15,9 +15,11 @@ namespace System.Windows.Forms.Primitives
         // for more details on how to enable these switches in the application.
         private const string ScaleTopLevelFormMinMaxSizeForDpiSwitchName = "System.Windows.Forms.ScaleTopLevelFormMinMaxSizeForDpi";
         internal const string AnchorLayoutV2SwitchName = "System.Windows.Forms.AnchorLayoutV2";
+        internal const string ServicePointManagerCheckCRLSwitchName = "System.Windows.Forms.ServicePointManagerCheckCRL";
         internal const string TrackBarModernRenderingSwitchName = "System.Windows.Forms.TrackBarModernRendering";
         private static int s_AnchorLayoutV2;
         private static int s_scaleTopLevelFormMinMaxSizeForDpi;
+        private static int s_servicePointManagerCheckCRL;
         private static int s_trackBarModernRendering;
         private static FrameworkName? s_targetFrameworkName;
 
@@ -112,6 +114,11 @@ namespace System.Windows.Forms.Primitives
                         {
                             return true;
                         }
+
+                        if (switchName == ServicePointManagerCheckCRLSwitchName)
+                        {
+                            return true;
+                        }
                     }
                 }
 
@@ -129,6 +136,17 @@ namespace System.Windows.Forms.Primitives
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => GetCachedSwitchValue(TrackBarModernRenderingSwitchName, ref s_trackBarModernRendering);
+        }
+
+        /// <summary>
+        ///  Indicates whether certificates are checked against the certificate authority revocation list.
+        ///  If true, revoked certificates will be accepted by WebRequests and WebClients as invalid.
+        ///  Otherwise, revoked certificates will be accepted as valid.
+        /// </summary>
+        public static bool ServicePointManagerCheckCRL
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => GetCachedSwitchValue(ServicePointManagerCheckCRLSwitchName, ref s_servicePointManagerCheckCRL);
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
@@ -40,20 +40,6 @@ namespace System.Windows.Forms.Primitives
         /// </summary>
         public static bool IsNetCoreApp => string.Equals(TargetFrameworkName?.Identifier, ".NETCoreApp");
 
-        /// <summary>
-        ///  Indicates whether AnchorLayoutV2 feature is enabled.
-        /// </summary>
-        /// <devdoc>
-        ///  Returns AnchorLayoutV2 switch value from runtimeconfig.json. Defaults to true if application is targeting .NET 8.0 and beyond.
-        ///  Refer to
-        ///  https://github.com/dotnet/winforms/blob/tree/main/docs/design/anchor-layout-changes-in-net80.md for more details.
-        /// </devdoc>
-        public static bool AnchorLayoutV2
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => GetCachedSwitchValue(AnchorLayoutV2SwitchName, ref s_AnchorLayoutV2);
-        }
-
         private static bool GetCachedSwitchValue(string switchName, ref int cachedSwitchValue)
         {
             // The cached switch value has 3 states: 0 - unknown, 1 - true, -1 - false
@@ -96,34 +82,46 @@ namespace System.Windows.Forms.Primitives
 
                 // We are introducing switch defaults in .NET 8.0+ and support matrix for this product is
                 // limited to Windows 10 and above versions.
-                if (OsVersion.IsWindows10_1703OrGreater())
+                if (OsVersion.IsWindows10_1703OrGreater() && TargetFrameworkName!.Version.CompareTo(new Version("8.0")) >= 0)
                 {
-                    if (TargetFrameworkName!.Version.CompareTo(new Version("8.0")) >= 0)
+                    if (switchName == ScaleTopLevelFormMinMaxSizeForDpiSwitchName)
                     {
-                        if (switchName == ScaleTopLevelFormMinMaxSizeForDpiSwitchName)
-                        {
-                            return true;
-                        }
-
-                        if (switchName == AnchorLayoutV2SwitchName)
-                        {
-                            return true;
-                        }
-
-                        if (switchName == TrackBarModernRenderingSwitchName)
-                        {
-                            return true;
-                        }
-
-                        if (switchName == ServicePointManagerCheckCRLSwitchName)
-                        {
-                            return true;
-                        }
+                        return true;
                     }
+
+                    if (switchName == AnchorLayoutV2SwitchName)
+                    {
+                        return true;
+                    }
+
+                    if (switchName == TrackBarModernRenderingSwitchName)
+                    {
+                        return true;
+                    }
+
+                    if (switchName == ServicePointManagerCheckCRLSwitchName)
+                    {
+                        return true;
+                    }
+
                 }
 
                 return false;
             }
+        }
+
+        /// <summary>
+        ///  Indicates whether AnchorLayoutV2 feature is enabled.
+        /// </summary>
+        /// <devdoc>
+        ///  Returns AnchorLayoutV2 switch value from runtimeconfig.json. Defaults to true if application is targeting .NET 8.0 and beyond.
+        ///  Refer to
+        ///  https://github.com/dotnet/winforms/blob/tree/main/docs/design/anchor-layout-changes-in-net80.md for more details.
+        /// </devdoc>
+        public static bool AnchorLayoutV2
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => GetCachedSwitchValue(AnchorLayoutV2SwitchName, ref s_AnchorLayoutV2);
         }
 
         public static bool ScaleTopLevelFormMinMaxSizeForDpi

--- a/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
@@ -22,7 +22,6 @@ namespace System.Windows.Forms.Primitives
         private static int s_servicePointManagerCheckCrl;
         private static int s_trackBarModernRendering;
         private static FrameworkName? s_targetFrameworkName;
-        private static Version? s_minimumSupportVersion;
 
         /// <summary>
         ///  The <see cref="TargetFrameworkAttribute"/> value for the entry assembly, if any.
@@ -33,18 +32,6 @@ namespace System.Windows.Forms.Primitives
             {
                 s_targetFrameworkName ??= AppContext.TargetFrameworkName is { } name ? new(name) : null;
                 return s_targetFrameworkName;
-            }
-        }
-
-        /// <summary>
-        ///  The earliest <see cref="Version"/> switches are supported in.
-        /// </summary>
-        private static Version MinimumSupportVersion
-        {
-            get
-            {
-                s_minimumSupportVersion ??= new("8.0");
-                return s_minimumSupportVersion;
             }
         }
 
@@ -93,23 +80,31 @@ namespace System.Windows.Forms.Primitives
                     return false;
                 }
 
-                // We are introducing switch defaults in .NET 8.0+ and support matrix for this product is
-                // limited to Windows 10 and above versions.
-                if (OsVersion.IsWindows10_1703OrGreater() && TargetFrameworkName?.Version.CompareTo(MinimumSupportVersion) >= 0)
+                if (TargetFrameworkName is not { } framework)
                 {
-                    if (switchName == ScaleTopLevelFormMinMaxSizeForDpiSwitchName)
-                    {
-                        return true;
-                    }
+                    return false;
+                }
 
-                    if (switchName == AnchorLayoutV2SwitchName)
+                // Switches added in .NET 8.
+                if (framework.Version.Major >= 8)
+                {
+                    // The support matrix for these switches is limited to Windows 10 and above versions.
+                    if (OsVersion.IsWindows10_1703OrGreater())
                     {
-                        return true;
-                    }
+                        if (switchName == ScaleTopLevelFormMinMaxSizeForDpiSwitchName)
+                        {
+                            return true;
+                        }
 
-                    if (switchName == TrackBarModernRenderingSwitchName)
-                    {
-                        return true;
+                        if (switchName == AnchorLayoutV2SwitchName)
+                        {
+                            return true;
+                        }
+
+                        if (switchName == TrackBarModernRenderingSwitchName)
+                        {
+                            return true;
+                        }
                     }
 
                     if (switchName == ServicePointManagerCheckCrlSwitchName)

--- a/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
@@ -103,7 +103,6 @@ namespace System.Windows.Forms.Primitives
                     {
                         return true;
                     }
-
                 }
 
                 return false;

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/LocalAppContextSwitchesTest.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/LocalAppContextSwitchesTest.cs
@@ -15,24 +15,26 @@ namespace System.Windows.Forms.Tests
             testAccessor.s_AnchorLayoutV2 = 0;
             testAccessor.s_scaleTopLevelFormMinMaxSizeForDpi = 0;
             testAccessor.s_trackBarModernRendering = 0;
+            testAccessor.s_servicePointManagerCheckCrl = 0;
         }
 
         [WinFormsTheory]
         [InlineData(".NETCoreApp,Version=v8.0", true)]
         [InlineData(".NETCoreApp,Version=v7.0", false)]
         [InlineData(".NET Framework,Version=v4.8", false)]
-        public void Validate_Default_Switch_Values(string tragetFrameworkName, bool expected)
+        public void Validate_Default_Switch_Values(string targetFrameworkName, bool expected)
         {
             FrameworkName? previousTestTargetFramework = LocalAppContextSwitches.TargetFrameworkName;
             dynamic testAccessor = typeof(LocalAppContextSwitches).TestAccessor().Dynamic;
 
             try
             {
-                testAccessor.s_targetFrameworkName = new FrameworkName(tragetFrameworkName);
+                testAccessor.s_targetFrameworkName = new FrameworkName(targetFrameworkName);
 
                 Assert.Equal(expected, LocalAppContextSwitches.TrackBarModernRendering);
                 Assert.Equal(expected, LocalAppContextSwitches.AnchorLayoutV2);
                 Assert.Equal(expected, LocalAppContextSwitches.ScaleTopLevelFormMinMaxSizeForDpi);
+                Assert.Equal(expected, LocalAppContextSwitches.ServicePointManagerCheckCrl);
             }
             finally
             {
@@ -46,14 +48,14 @@ namespace System.Windows.Forms.Tests
         [InlineData(".NETCoreApp,Version=v8.0", true)]
         [InlineData(".NETCoreApp,Version=v7.0", true)]
         [InlineData(".NET Framework,Version=v4.8", false)]
-        public void Validate_TargetFramework_Is_NETCore(string tragetFrameworkName, bool isNetCoreApp)
+        public void Validate_TargetFramework_Is_NETCore(string targetFrameworkName, bool isNetCoreApp)
         {
             FrameworkName? previousTestTargetFramework = LocalAppContextSwitches.TargetFrameworkName;
             dynamic testAccessor = typeof(LocalAppContextSwitches).TestAccessor().Dynamic;
 
             try
             {
-                testAccessor.s_targetFrameworkName = new FrameworkName(tragetFrameworkName);
+                testAccessor.s_targetFrameworkName = new FrameworkName(targetFrameworkName);
                 bool isCoreApplication = LocalAppContextSwitches.IsNetCoreApp;
                 Assert.Equal(isNetCoreApp, isCoreApplication);
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PictureBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PictureBox.cs
@@ -11,6 +11,7 @@ using System.Drawing;
 using System.Net;
 using System.Runtime.InteropServices;
 using System.Windows.Forms.Layout;
+using System.Windows.Forms.Primitives;
 
 namespace System.Windows.Forms
 {
@@ -509,8 +510,13 @@ namespace System.Windows.Forms
             }
             else
             {
+                if (LocalAppContextSwitches.ServicePointManagerCheckCRL)
+                {
+                    ServicePointManager.CheckCertificateRevocationList = true;
+                }
+
 #pragma warning disable SYSLIB0014 // Type or member is obsolete
-                using (WebClient wc = new WebClient())
+                using (WebClient wc = new WebClient()) // lgtm[cs/webrequest-checkcertrevlist-disabled] - Having ServicePointManager.CheckCertificateRevocationList set to true has a slim chance of resulting in failure. We have an opt-out for this rare event.
 #pragma warning restore SYSLIB0014 // Type or member is obsolete
                 {
                     _uriImageStream = wc.OpenRead(uri.ToString());

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PictureBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PictureBox.cs
@@ -516,10 +516,10 @@ namespace System.Windows.Forms
                 }
 
 #pragma warning disable SYSLIB0014 // Type or member is obsolete
-                using (WebClient wc = new WebClient()) // lgtm[cs/webrequest-checkcertrevlist-disabled] - Having ServicePointManager.CheckCertificateRevocationList set to true has a slim chance of resulting in failure. We have an opt-out for this rare event.
+                using (WebClient webClient = new()) // lgtm[cs/webrequest-checkcertrevlist-disabled] - Having ServicePointManager.CheckCertificateRevocationList set to true has a slim chance of resulting in failure. We have an opt-out for this rare event.
 #pragma warning restore SYSLIB0014 // Type or member is obsolete
                 {
-                    _uriImageStream = wc.OpenRead(uri.ToString());
+                    _uriImageStream = webClient.OpenRead(uri.ToString());
                     img = Image.FromStream(_uriImageStream);
                 }
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PictureBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PictureBox.cs
@@ -510,7 +510,7 @@ namespace System.Windows.Forms
             }
             else
             {
-                if (LocalAppContextSwitches.ServicePointManagerCheckCRL)
+                if (LocalAppContextSwitches.ServicePointManagerCheckCrl)
                 {
                     ServicePointManager.CheckCertificateRevocationList = true;
                 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PictureBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PictureBoxTests.cs
@@ -734,17 +734,22 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(PathImageLocation, pictureBox.ImageLocation);
         }
 
-        [WinFormsFact]
-        public void PictureBox_ImageLocation_SetValidWithWaitOnLoadTrueUri_ConfigSwitch_CheckCRL_Disabled_GetReturnsExpected()
+        [WinFormsTheory]
+        [CommonMemberData(typeof(CommonTestHelper), nameof(CommonTestHelper.GetBoolTheoryData))]
+        public void PictureBox_ImageLocation_SetValidWithWaitOnLoadTrueUri_ConfigSwitch_CheckCRL_GetReturnsExpected(bool switchValue)
         {
+            dynamic testAccessor = typeof(LocalAppContextSwitches).TestAccessor().Dynamic;
+
             try
             {
+                AppContext.SetSwitch(LocalAppContextSwitches.ServicePointManagerCheckCrlSwitchName, switchValue);
+                Assert.Equal(switchValue, LocalAppContextSwitches.ServicePointManagerCheckCrl);
+
                 using var pictureBox = new PictureBox
                 {
                     WaitOnLoad = true
                 };
 
-                AppContext.SetSwitch(LocalAppContextSwitches.ServicePointManagerCheckCRLSwitchName, false);
                 Size expectedImageSize = new(110, 100);
 
                 pictureBox.ImageLocation = UrlImageLocation;
@@ -760,33 +765,9 @@ namespace System.Windows.Forms.Tests
             {
                 // Swallow network errors.
             }
-        }
-
-        [WinFormsFact]
-        public void PictureBox_ImageLocation_SetValidWithWaitOnLoadTrueUri_ConfigSwitch_CheckCRL_Enabled_GetReturnsExpected()
-        {
-            try
+            finally
             {
-                using var pictureBox = new PictureBox
-                {
-                    WaitOnLoad = true
-                };
-
-                AppContext.SetSwitch(LocalAppContextSwitches.ServicePointManagerCheckCRLSwitchName, true);
-                Size expectedImageSize = new(110, 100);
-
-                pictureBox.ImageLocation = UrlImageLocation;
-                Assert.Equal(expectedImageSize, pictureBox.Image.Size);
-                Assert.Same(UrlImageLocation, pictureBox.ImageLocation);
-
-                // Set same.
-                pictureBox.ImageLocation = UrlImageLocation;
-                Assert.Equal(expectedImageSize, pictureBox.Image.Size);
-                Assert.Same(UrlImageLocation, pictureBox.ImageLocation);
-            }
-            catch
-            {
-                // Swallow network errors.
+                testAccessor.s_servicePointManagerCheckCrl = 0;
             }
         }
 
@@ -2023,17 +2004,22 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(new Size(110, 100), pictureBox.Image.Size);
         }
 
-        [WinFormsFact]
-        public void PictureBox_Load_UrlValidWithWaitOnLoadTrueUri_ConfigSwitch_CheckCRL_Disabled_GetReturnsExpected()
+        [WinFormsTheory]
+        [CommonMemberData(typeof(CommonTestHelper), nameof(CommonTestHelper.GetBoolTheoryData))]
+        public void PictureBox_Load_UrlValidWithWaitOnLoadTrueUri_ConfigSwitch_CheckCRL_GetReturnsExpected(bool switchValue)
         {
+            dynamic testAccessor = typeof(LocalAppContextSwitches).TestAccessor().Dynamic;
+
             try
             {
+                AppContext.SetSwitch(LocalAppContextSwitches.ServicePointManagerCheckCrlSwitchName, switchValue);
+                Assert.Equal(switchValue, LocalAppContextSwitches.ServicePointManagerCheckCrl);
+
                 using var pictureBox = new PictureBox
                 {
                     WaitOnLoad = true
                 };
 
-                AppContext.SetSwitch(LocalAppContextSwitches.ServicePointManagerCheckCRLSwitchName, false);
                 Size expectedImageSize = new(110, 100);
 
                 pictureBox.Load(UrlImageLocation);
@@ -2049,33 +2035,9 @@ namespace System.Windows.Forms.Tests
             {
                 // Swallow network errors.
             }
-        }
-
-        [WinFormsFact]
-        public void PictureBox_Load_UrlValidWithWaitOnLoadTrueUri_ConfigSwitch_CheckCRL_Enabled_GetReturnsExpected()
-        {
-            try
+            finally
             {
-                using var pictureBox = new PictureBox
-                {
-                    WaitOnLoad = true
-                };
-
-                AppContext.SetSwitch(LocalAppContextSwitches.ServicePointManagerCheckCRLSwitchName, true);
-                Size expectedImageSize = new(110, 100);
-
-                pictureBox.Load(UrlImageLocation);
-                Assert.Same(UrlImageLocation, pictureBox.ImageLocation);
-                Assert.Equal(expectedImageSize, pictureBox.Image.Size);
-
-                // Call again.
-                pictureBox.Load(UrlImageLocation);
-                Assert.Same(UrlImageLocation, pictureBox.ImageLocation);
-                Assert.Equal(expectedImageSize, pictureBox.Image.Size);
-            }
-            catch
-            {
-                // Swallow network errors.
+                testAccessor.s_servicePointManagerCheckCrl = 0;
             }
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PictureBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PictureBoxTests.cs
@@ -722,18 +722,20 @@ namespace System.Windows.Forms.Tests
                 WaitOnLoad = true
             };
 
+            Size expectedImageSize = new(110, 100);
+
             pictureBox.ImageLocation = PathImageLocation;
-            Assert.Equal(new Size(110, 100), pictureBox.Image.Size);
+            Assert.Equal(expectedImageSize, pictureBox.Image.Size);
             Assert.Equal(PathImageLocation, pictureBox.ImageLocation);
 
             // Set same.
             pictureBox.ImageLocation = PathImageLocation;
-            Assert.Equal(new Size(110, 100), pictureBox.Image.Size);
+            Assert.Equal(expectedImageSize, pictureBox.Image.Size);
             Assert.Equal(PathImageLocation, pictureBox.ImageLocation);
         }
 
         [WinFormsFact]
-        public void PictureBox_ImageLocation_SetValidWithWaitOnLoadTrueUri_GetReturnsExpected()
+        public void PictureBox_ImageLocation_SetValidWithWaitOnLoadTrueUri_ConfigSwitch_CheckCRL_Disabled_GetReturnsExpected()
         {
             try
             {
@@ -742,13 +744,44 @@ namespace System.Windows.Forms.Tests
                     WaitOnLoad = true
                 };
 
-                pictureBox.Load(UrlImageLocation);
-                Assert.Equal(new Size(110, 100), pictureBox.Image.Size);
+                AppContext.SetSwitch(LocalAppContextSwitches.ServicePointManagerCheckCRLSwitchName, false);
+                Size expectedImageSize = new(110, 100);
+
+                pictureBox.ImageLocation = UrlImageLocation;
+                Assert.Equal(expectedImageSize, pictureBox.Image.Size);
                 Assert.Same(UrlImageLocation, pictureBox.ImageLocation);
 
                 // Set same.
-                pictureBox.Load(UrlImageLocation);
-                Assert.Equal(new Size(110, 100), pictureBox.Image.Size);
+                pictureBox.ImageLocation = UrlImageLocation;
+                Assert.Equal(expectedImageSize, pictureBox.Image.Size);
+                Assert.Same(UrlImageLocation, pictureBox.ImageLocation);
+            }
+            catch
+            {
+                // Swallow network errors.
+            }
+        }
+
+        [WinFormsFact]
+        public void PictureBox_ImageLocation_SetValidWithWaitOnLoadTrueUri_ConfigSwitch_CheckCRL_Enabled_GetReturnsExpected()
+        {
+            try
+            {
+                using var pictureBox = new PictureBox
+                {
+                    WaitOnLoad = true
+                };
+
+                AppContext.SetSwitch(LocalAppContextSwitches.ServicePointManagerCheckCRLSwitchName, true);
+                Size expectedImageSize = new(110, 100);
+
+                pictureBox.ImageLocation = UrlImageLocation;
+                Assert.Equal(expectedImageSize, pictureBox.Image.Size);
+                Assert.Same(UrlImageLocation, pictureBox.ImageLocation);
+
+                // Set same.
+                pictureBox.ImageLocation = UrlImageLocation;
+                Assert.Equal(expectedImageSize, pictureBox.Image.Size);
                 Assert.Same(UrlImageLocation, pictureBox.ImageLocation);
             }
             catch
@@ -2003,12 +2036,12 @@ namespace System.Windows.Forms.Tests
                 AppContext.SetSwitch(LocalAppContextSwitches.ServicePointManagerCheckCRLSwitchName, false);
                 Size expectedImageSize = new(110, 100);
 
-                pictureBox.ImageLocation = UrlImageLocation;
+                pictureBox.Load(UrlImageLocation);
                 Assert.Same(UrlImageLocation, pictureBox.ImageLocation);
                 Assert.Equal(expectedImageSize, pictureBox.Image.Size);
 
                 // Call again.
-                pictureBox.ImageLocation = UrlImageLocation;
+                pictureBox.Load(UrlImageLocation);
                 Assert.Same(UrlImageLocation, pictureBox.ImageLocation);
                 Assert.Equal(expectedImageSize, pictureBox.Image.Size);
             }
@@ -2031,12 +2064,12 @@ namespace System.Windows.Forms.Tests
                 AppContext.SetSwitch(LocalAppContextSwitches.ServicePointManagerCheckCRLSwitchName, true);
                 Size expectedImageSize = new(110, 100);
 
-                pictureBox.ImageLocation = UrlImageLocation;
+                pictureBox.Load(UrlImageLocation);
                 Assert.Same(UrlImageLocation, pictureBox.ImageLocation);
                 Assert.Equal(expectedImageSize, pictureBox.Image.Size);
 
                 // Call again.
-                pictureBox.ImageLocation = UrlImageLocation;
+                pictureBox.Load(UrlImageLocation);
                 Assert.Same(UrlImageLocation, pictureBox.ImageLocation);
                 Assert.Equal(expectedImageSize, pictureBox.Image.Size);
             }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PictureBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PictureBoxTests.cs
@@ -4,8 +4,9 @@
 
 using System.ComponentModel;
 using System.Drawing;
-using Moq;
+using System.Windows.Forms.Primitives;
 using System.Windows.Forms.TestUtilities;
+using Moq;
 using Xunit;
 using Point = System.Drawing.Point;
 using Size = System.Drawing.Size;
@@ -15,7 +16,7 @@ namespace System.Windows.Forms.Tests
     public class PictureBoxTests : IClassFixture<ThreadExceptionFixture>
     {
         private const string PathImageLocation = "bitmaps/nature24bits.jpg";
-        private const string UrlImageLocation = "https://github.com/dotnet/runtime-assets/raw/master/src/System.Drawing.Common.TestData/bitmaps/nature24bits.jpg";
+        private const string UrlImageLocation = "https://github.com/dotnet/winforms/blob/main/src/System.Windows.Forms/tests/UnitTests/bitmaps/nature24bits.jpg?raw=true";
 
         [WinFormsFact]
         public void PictureBox_Ctor_Default()
@@ -1990,7 +1991,7 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
-        public void PictureBox_Load_UrlValidWithWaitOnLoadTrueUri_GetReturnsExpected()
+        public void PictureBox_Load_UrlValidWithWaitOnLoadTrueUri_ConfigSwitch_CheckCRL_Disabled_GetReturnsExpected()
         {
             try
             {
@@ -1999,14 +2000,45 @@ namespace System.Windows.Forms.Tests
                     WaitOnLoad = true
                 };
 
+                AppContext.SetSwitch(LocalAppContextSwitches.ServicePointManagerCheckCRLSwitchName, false);
+                Size expectedImageSize = new(110, 100);
+
                 pictureBox.ImageLocation = UrlImageLocation;
                 Assert.Same(UrlImageLocation, pictureBox.ImageLocation);
-                Assert.Equal(new Size(110, 100), pictureBox.Image.Size);
+                Assert.Equal(expectedImageSize, pictureBox.Image.Size);
 
                 // Call again.
                 pictureBox.ImageLocation = UrlImageLocation;
                 Assert.Same(UrlImageLocation, pictureBox.ImageLocation);
-                Assert.Equal(new Size(110, 100), pictureBox.Image.Size);
+                Assert.Equal(expectedImageSize, pictureBox.Image.Size);
+            }
+            catch
+            {
+                // Swallow network errors.
+            }
+        }
+
+        [WinFormsFact]
+        public void PictureBox_Load_UrlValidWithWaitOnLoadTrueUri_ConfigSwitch_CheckCRL_Enabled_GetReturnsExpected()
+        {
+            try
+            {
+                using var pictureBox = new PictureBox
+                {
+                    WaitOnLoad = true
+                };
+
+                AppContext.SetSwitch(LocalAppContextSwitches.ServicePointManagerCheckCRLSwitchName, true);
+                Size expectedImageSize = new(110, 100);
+
+                pictureBox.ImageLocation = UrlImageLocation;
+                Assert.Same(UrlImageLocation, pictureBox.ImageLocation);
+                Assert.Equal(expectedImageSize, pictureBox.Image.Size);
+
+                // Call again.
+                pictureBox.ImageLocation = UrlImageLocation;
+                Assert.Same(UrlImageLocation, pictureBox.ImageLocation);
+                Assert.Equal(expectedImageSize, pictureBox.Image.Size);
             }
             catch
             {


### PR DESCRIPTION
Related: [CodeQL](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1666879/) , https://github.com/dotnet/winforms/issues/8561
- Introduces a switch for turning on `ServicePointManager.CheckCertificateRevocationList`
- Fixes tests and adds test to check for same behavior when switch is both on and off
- Add CodeQL suppression in case it tries to reflag this because of the switch
- General clean up

**Background:**
Before creating a `WebClient` or `WebRequest`, it is best practice to set `ServicePointManager.CheckCertificateRevocationList` to `true` beforehand so that revoked certificates are not accepted by `WebClient`s or `WebRequest`s as valid. 
Now that we are checking certificate revocation list, the behavior should remain the same as before, however there is a rare case when it could fail which is if:
a) the certificate authority provides revocation only through a technology called CRL, 
b) the client has not recently enough cached the relevant CRL, and 
c) the client is operating on an egress-restricted network and the CRL location isn't on the egress allow-list.  
There may be some other corner cases, and a mild performance hit, hence why this is placed under a switch for user to have opportunity to opt out if they run into this.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8556)