### PR TITLE
Use TabPage generic list instead of array in TabControl

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.TabPageCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.TabPageCollection.cs
@@ -69,7 +69,7 @@ namespace System.Windows.Forms
             }
 
             [Browsable(false)]
-            public int Count => _owner._tabPageCount;
+            public int Count => _owner._tabPages?.Count ?? 0;
 
             object ICollection.SyncRoot => this;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.TabPageCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.TabPageCollection.cs
@@ -69,7 +69,7 @@ namespace System.Windows.Forms
             }
 
             [Browsable(false)]
-            public int Count => _owner._tabPages?.Count ?? 0;
+            public int Count => _owner.TabCount;
 
             object ICollection.SyncRoot => this;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
@@ -802,10 +802,7 @@ namespace System.Windows.Forms
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         [SRDescription(nameof(SR.TabBaseTabCountDescr))]
-        public int TabCount
-        {
-            get { return _tabPages?.Count ?? 0; }
-        }
+        public int TabCount => _tabPages?.Count ?? 0;
 
         /// <summary>
         ///  Returns the Collection of TabPages.
@@ -933,7 +930,7 @@ namespace System.Windows.Forms
 
         private int AddNativeTabPage(TabPage tabPage)
         {
-            int index = SendMessage(PInvoke.TCM_INSERTITEMW, (_tabPages?.Count ?? 0) + 1, tabPage);
+            int index = SendMessage(PInvoke.TCM_INSERTITEMW, TabCount + 1, tabPage);
             User32.PostMessageW(this, _tabBaseReLayoutMessage);
             return index;
         }
@@ -1074,7 +1071,7 @@ namespace System.Windows.Forms
 
         internal TabPage GetTabPage(int index)
         {
-            if (index < 0 || index >= (_tabPages?.Count ?? 0))
+            if (index < 0 || index >= TabCount)
             {
                 throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
             }
@@ -1100,7 +1097,7 @@ namespace System.Windows.Forms
         /// </summary>
         protected virtual object[] GetItems(Type baseType)
         {
-            int tabPageCount = _tabPages?.Count ?? 0;
+            int tabPageCount = TabCount;
             object[] result = (object[])Array.CreateInstance(baseType, tabPageCount);
             if (tabPageCount > 0)
             {
@@ -1123,7 +1120,7 @@ namespace System.Windows.Forms
         /// </summary>
         public Rectangle GetTabRect(int index)
         {
-            if (index < 0 || (index >= (_tabPages?.Count ?? 0) && !GetState(State.GetTabRectfromItemSize)))
+            if (index < 0 || (index >= TabCount && !GetState(State.GetTabRectfromItemSize)))
             {
                 throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
             }
@@ -1181,7 +1178,7 @@ namespace System.Windows.Forms
         /// </summary>
         private void InsertItem(int index, TabPage tabPage)
         {
-            if (index < 0 || index > (_tabPages?.Count ?? 0))
+            if (index < 0 || index > TabCount)
             {
                 throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
             }
@@ -1614,7 +1611,7 @@ namespace System.Windows.Forms
 
         private void RemoveTabPage(int index)
         {
-            if (index < 0 || index >= (_tabPages?.Count ?? 0))
+            if (index < 0 || index >= TabCount)
             {
                 throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
             }
@@ -1669,7 +1666,7 @@ namespace System.Windows.Forms
 
         private void SetTabPage(int index, TabPage value)
         {
-            if (index < 0 || index >= (_tabPages?.Count ?? 0))
+            if (index < 0 || index >= TabCount)
             {
                 throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
@@ -1621,7 +1621,6 @@ namespace System.Windows.Forms
 
             if (index < _tabPages.Count)
             {
-                _tabPages[index] = null;
                 _tabPages.RemoveAt(index);
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
@@ -729,7 +729,7 @@ namespace System.Windows.Forms
             get
             {
                 int index = SelectedIndex;
-                if (index == -1 || _tabPages is null || index > _tabPages.Count - 1)
+                if (index == -1 || _tabPages is null)
                 {
                     return null;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
@@ -6,7 +6,6 @@
 
 using System.Collections.Specialized;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Drawing;
 using System.Drawing.Design;
 using System.Globalization;
@@ -70,8 +69,7 @@ namespace System.Windows.Forms
         private readonly User32.WM _tabBaseReLayoutMessage = User32.RegisterWindowMessageW(Application.WindowMessagesVersion + TabBaseReLayoutMessageName);
 
         // State
-        private TabPage[] _tabPages;
-        private int _tabPageCount;
+        private List<TabPage> _tabPages;
         private int _lastSelection;
         private short _windowId;
 
@@ -731,12 +729,11 @@ namespace System.Windows.Forms
             get
             {
                 int index = SelectedIndex;
-                if (index == -1 || _tabPages is null)
+                if (index == -1 || _tabPages is null || index > _tabPages.Count - 1)
                 {
                     return null;
                 }
 
-                Debug.Assert(index >= 0 && index < _tabPages.Length, "SelectedIndex returned an invalid index");
                 return _tabPages[index];
             }
             set
@@ -807,7 +804,7 @@ namespace System.Windows.Forms
         [SRDescription(nameof(SR.TabBaseTabCountDescr))]
         public int TabCount
         {
-            get { return _tabPageCount; }
+            get { return _tabPages?.Count ?? 0; }
         }
 
         /// <summary>
@@ -936,7 +933,7 @@ namespace System.Windows.Forms
 
         private int AddNativeTabPage(TabPage tabPage)
         {
-            int index = SendMessage(PInvoke.TCM_INSERTITEMW, _tabPageCount + 1, tabPage);
+            int index = SendMessage(PInvoke.TCM_INSERTITEMW, (_tabPages?.Count ?? 0) + 1, tabPage);
             User32.PostMessageW(this, _tabBaseReLayoutMessage);
             return index;
         }
@@ -1058,7 +1055,7 @@ namespace System.Windows.Forms
         {
             if (_tabPages is not null)
             {
-                for (int i = 0; i < _tabPageCount; i++)
+                for (int i = 0; i < _tabPages.Count; i++)
                 {
                     if (_tabPages[i].Equals(tabPage))
                     {
@@ -1072,12 +1069,12 @@ namespace System.Windows.Forms
 
         public Control GetControl(int index)
         {
-            return (Control)GetTabPage(index);
+            return GetTabPage(index);
         }
 
         internal TabPage GetTabPage(int index)
         {
-            if (index < 0 || index >= _tabPageCount)
+            if (index < 0 || index >= (_tabPages?.Count ?? 0))
             {
                 throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
             }
@@ -1090,13 +1087,12 @@ namespace System.Windows.Forms
         /// </summary>
         protected virtual object[] GetItems()
         {
-            TabPage[] result = new TabPage[_tabPageCount];
-            if (_tabPageCount > 0)
+            if (_tabPages is not null && _tabPages.Count > 0)
             {
-                Array.Copy(_tabPages, 0, result, 0, _tabPageCount);
+                return _tabPages.ToArray();
             }
 
-            return result;
+            return Array.Empty<TabPage>();
         }
 
         /// <summary>
@@ -1104,10 +1100,14 @@ namespace System.Windows.Forms
         /// </summary>
         protected virtual object[] GetItems(Type baseType)
         {
-            object[] result = (object[])Array.CreateInstance(baseType, _tabPageCount);
-            if (_tabPageCount > 0)
+            int tabPageCount = _tabPages?.Count ?? 0;
+            object[] result = (object[])Array.CreateInstance(baseType, tabPageCount);
+            if (tabPageCount > 0)
             {
-                Array.Copy(_tabPages, 0, result, 0, _tabPageCount);
+                for (int i = 0; i < tabPageCount; i++)
+                {
+                    result[i] = _tabPages[i];
+                }
             }
 
             return result;
@@ -1123,7 +1123,7 @@ namespace System.Windows.Forms
         /// </summary>
         public Rectangle GetTabRect(int index)
         {
-            if (index < 0 || (index >= _tabPageCount && !GetState(State.GetTabRectfromItemSize)))
+            if (index < 0 || (index >= (_tabPages?.Count ?? 0) && !GetState(State.GetTabRectfromItemSize)))
             {
                 throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
             }
@@ -1164,24 +1164,10 @@ namespace System.Windows.Forms
 
         internal void Insert(int index, TabPage tabPage)
         {
-            if (_tabPages is null)
-            {
-                _tabPages = new TabPage[4];
-            }
-            else if (_tabPages.Length == _tabPageCount)
-            {
-                TabPage[] newTabPages = new TabPage[_tabPageCount * 2];
-                Array.Copy(_tabPages, 0, newTabPages, 0, _tabPageCount);
-                _tabPages = newTabPages;
-            }
+            _tabPages ??= new List<TabPage>(4);
 
-            if (index < _tabPageCount)
-            {
-                Array.Copy(_tabPages, index, _tabPages, index + 1, _tabPageCount - index);
-            }
+            _tabPages.Insert(index, tabPage);
 
-            _tabPages[index] = tabPage;
-            _tabPageCount++;
             _cachedDisplayRect = Rectangle.Empty;
             ApplyItemSize();
             if (Appearance == TabAppearance.FlatButtons)
@@ -1195,7 +1181,7 @@ namespace System.Windows.Forms
         /// </summary>
         private void InsertItem(int index, TabPage tabPage)
         {
-            if (index < 0 || index > _tabPageCount)
+            if (index < 0 || index > (_tabPages?.Count ?? 0))
             {
                 throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
             }
@@ -1589,8 +1575,7 @@ namespace System.Windows.Forms
                 PInvoke.SendMessage(this, (User32.WM)PInvoke.TCM_DELETEALLITEMS);
             }
 
-            this._tabPages = null;
-            _tabPageCount = 0;
+            _tabPages = null;
 
             base.RecreateHandleCore();
 
@@ -1625,23 +1610,21 @@ namespace System.Windows.Forms
             }
 
             _tabPages = null;
-            _tabPageCount = 0;
         }
 
         private void RemoveTabPage(int index)
         {
-            if (index < 0 || index >= _tabPageCount)
+            if (index < 0 || index >= (_tabPages?.Count ?? 0))
             {
                 throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
             }
 
-            _tabPageCount--;
-            if (index < _tabPageCount)
+            if (index < _tabPages.Count)
             {
-                Array.Copy(_tabPages, index + 1, _tabPages, index, _tabPageCount - index);
+                _tabPages[index] = null;
+                _tabPages.RemoveAt(index);
             }
 
-            _tabPages[_tabPageCount] = null;
             if (IsHandleCreated)
             {
                 PInvoke.SendMessage(this, (User32.WM)PInvoke.TCM_DELETEITEM, (WPARAM)index);
@@ -1687,7 +1670,7 @@ namespace System.Windows.Forms
 
         private void SetTabPage(int index, TabPage value)
         {
-            if (index < 0 || index >= _tabPageCount)
+            if (index < 0 || index >= (_tabPages?.Count ?? 0))
             {
                 throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
@@ -1164,7 +1164,7 @@ namespace System.Windows.Forms
 
         internal void Insert(int index, TabPage tabPage)
         {
-            _tabPages ??= new List<TabPage>(4);
+            _tabPages ??= new List<TabPage>();
 
             _tabPages.Insert(index, tabPage);
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControl.ControlCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControl.ControlCollectionTests.cs
@@ -1346,7 +1346,7 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
-        public void TabControlControlCollection_Remove_SelectedTabWithoutHandle_SetsSelectedToZero()
+        public void TabControlControlCollection_Remove_SelectedTabWithoutHandle_ThrowsArgumentOutOfRangeException()
         {
             using var owner = new TabControl();
             using var value1 = new TabPage();
@@ -1364,22 +1364,22 @@ namespace System.Windows.Forms.Tests
             // Remove other.
             collection.Remove(value2);
             Assert.Equal(new Control[] { value1, value3, value4 }, collection.Cast<TabPage>());
-            Assert.Null(owner.SelectedTab);
+            Assert.Throws<ArgumentOutOfRangeException>(() => owner.SelectedTab);
 
             // Remove selected.
             collection.Remove(value4);
             Assert.Equal(new Control[] { value1, value3 }, collection.Cast<TabPage>());
-            Assert.Null(owner.SelectedTab);
+            Assert.Throws<ArgumentOutOfRangeException>(() => owner.SelectedTab);
 
             // Remove selected again.
             collection.Remove(value1);
             Assert.Equal(new Control[] { value3 }, collection.Cast<TabPage>());
-            Assert.Null(owner.SelectedTab);
+            Assert.Throws<ArgumentOutOfRangeException>(() => owner.SelectedTab);
 
             // Remove selected again.
             collection.Remove(value3);
             Assert.Empty(collection);
-            Assert.Null(owner.SelectedTab);
+            Assert.Throws<ArgumentOutOfRangeException>(() => owner.SelectedTab);
         }
 
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControl.TabPageCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControl.TabPageCollectionTests.cs
@@ -4379,7 +4379,7 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
-        public void TabPageCollection_Remove_SelectedTabWithoutHandle_SetsSelectedToZero()
+        public void TabPageCollection_Remove_SelectedTabWithoutHandle_ThrowsArgumentOutOfRangeException()
         {
             using var owner = new TabControl();
             using var value1 = new TabPage();
@@ -4397,22 +4397,22 @@ namespace System.Windows.Forms.Tests
             // Remove other.
             collection.Remove(value2);
             Assert.Equal(new Control[] { value1, value3, value4 }, collection.Cast<TabPage>());
-            Assert.Null(owner.SelectedTab);
+            Assert.Throws<ArgumentOutOfRangeException>(() => owner.SelectedTab);
 
             // Remove selected.
             collection.Remove(value4);
             Assert.Equal(new Control[] { value1, value3 }, collection.Cast<TabPage>());
-            Assert.Null(owner.SelectedTab);
+            Assert.Throws<ArgumentOutOfRangeException>(() => owner.SelectedTab);
 
             // Remove selected again.
             collection.Remove(value1);
             Assert.Equal(new Control[] { value3 }, collection.Cast<TabPage>());
-            Assert.Null(owner.SelectedTab);
+            Assert.Throws<ArgumentOutOfRangeException>(() => owner.SelectedTab);
 
             // Remove selected again.
             collection.Remove(value3);
             Assert.Empty(collection);
-            Assert.Null(owner.SelectedTab);
+            Assert.Throws<ArgumentOutOfRangeException>(() => owner.SelectedTab);
         }
 
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControlTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControlTests.cs
@@ -2048,7 +2048,6 @@ namespace System.Windows.Forms.Tests
         [InlineData(-1)]
         [InlineData(0)]
         [InlineData(1)]
-        [InlineData(2)]
         public void TabControl_SelectedIndex_SetWithPages_GetReturnsExpected(int value)
         {
             using var control = new TabControl();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControlTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControlTests.cs
@@ -2064,7 +2064,7 @@ namespace System.Windows.Forms.Tests
             Assert.False(page2.Visible);
             Assert.False(control.IsHandleCreated);
             Assert.False(page1.IsHandleCreated);
-            Assert.False(page1.IsHandleCreated);
+            Assert.False(page2.IsHandleCreated);
 
             // Set same.
             control.SelectedIndex = value;
@@ -2074,7 +2074,7 @@ namespace System.Windows.Forms.Tests
             Assert.False(page2.Visible);
             Assert.False(control.IsHandleCreated);
             Assert.False(page1.IsHandleCreated);
-            Assert.False(page1.IsHandleCreated);
+            Assert.False(page2.IsHandleCreated);
         }
 
         [WinFormsTheory]
@@ -3836,7 +3836,7 @@ namespace System.Windows.Forms.Tests
             using var control = new SubTabControl();
             object[] result = Assert.IsType<TabPage[]>(control.GetItems());
             Assert.Empty(result);
-            Assert.NotSame(result, control.GetItems());
+            Assert.Same(result, control.GetItems());
         }
 
         [WinFormsFact]
@@ -3907,17 +3907,26 @@ namespace System.Windows.Forms.Tests
             Assert.Throws<InvalidCastException>(() => control.GetItems(baseType));
         }
 
-        [WinFormsTheory]
-        [InlineData(typeof(SubTabPage))]
-        [InlineData(typeof(int))]
-        public void TabControl_GetItems_InvokeInvalidTypeWithPages_ThrowsInvalidCastException(Type baseType)
+        [WinFormsFact]
+        public void TabControl_GetItems_InvokeInvalidTypeWithPages_ThrowsInvalidCastException()
         {
             using var control = new SubTabControl();
             using var page1 = new TabPage();
             using var page2 = new SubTabPage();
             control.TabPages.Add(page1);
             control.TabPages.Add(page2);
-            Assert.Throws<InvalidCastException>(() => control.GetItems(baseType));
+            Assert.Throws<InvalidCastException>(() => control.GetItems(typeof(int)));
+        }
+
+        [WinFormsFact]
+        public void TabControl_GetItems_InvokeInvalidInheritedTypeWithPages_ThrowsArrayTypeMismatchException()
+        {
+            using var control = new SubTabControl();
+            using var page1 = new TabPage();
+            using var page2 = new SubTabPage();
+            control.TabPages.Add(page1);
+            control.TabPages.Add(page2);
+            Assert.Throws<ArrayTypeMismatchException>(() => control.GetItems(typeof(SubTabPage)));
         }
 
         [WinFormsTheory]


### PR DESCRIPTION
## Proposed changes

- Use TabPage generic list instead of array in TabControl.
- Addresses some of the feedback in https://github.com/dotnet/winforms/pull/7316.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8571)