### PR TITLE
Use TryGetObject instead of ContainsObject and GetObject

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -766,9 +766,9 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (Properties.ContainsObject(s_autoScrollOffsetProperty))
+                if (Properties.TryGetObject(s_autoScrollOffsetProperty, out Point point))
                 {
-                    return (Point)Properties.GetObject(s_autoScrollOffsetProperty)!;
+                    return point;
                 }
 
                 return Point.Empty;
@@ -860,9 +860,9 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (Properties.ContainsObject(s_dataContextProperty))
+                if (Properties.TryGetObject(s_dataContextProperty, out object? value))
                 {
-                    return Properties.GetObject(s_dataContextProperty);
+                    return value;
                 }
 
                 return ParentInternal?.DataContext;
@@ -1014,15 +1014,12 @@ namespace System.Windows.Forms
         {
             get
             {
-                bool found = Properties.ContainsObject(s_backgroundImageLayoutProperty);
-                if (!found)
+                if (Properties.TryGetObject(s_backgroundImageLayoutProperty, out ImageLayout imageLayout))
                 {
-                    return ImageLayout.Tile;
+                    return imageLayout;
                 }
-                else
-                {
-                    return (ImageLayout)Properties.GetObject(s_backgroundImageLayoutProperty)!;
-                }
+
+                return ImageLayout.Tile;
             }
             set
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -764,15 +764,9 @@ namespace System.Windows.Forms
         [DefaultValue(typeof(Point), "0, 0")]
         public virtual Point AutoScrollOffset
         {
-            get
-            {
-                if (Properties.TryGetObject(s_autoScrollOffsetProperty, out Point point))
-                {
-                    return point;
-                }
-
-                return Point.Empty;
-            }
+            get => Properties.TryGetObject(s_autoScrollOffsetProperty, out Point point)
+                    ? point
+                    : Point.Empty;
             set
             {
                 if (AutoScrollOffset != value)
@@ -858,15 +852,9 @@ namespace System.Windows.Forms
         [Bindable(true)]
         public virtual object? DataContext
         {
-            get
-            {
-                if (Properties.TryGetObject(s_dataContextProperty, out object? value))
-                {
-                    return value;
-                }
-
-                return ParentInternal?.DataContext;
-            }
+            get => Properties.TryGetObject(s_dataContextProperty, out object? value)
+                    ? value
+                    : ParentInternal?.DataContext;
             set
             {
                 if (Equals(value, DataContext))
@@ -1012,15 +1000,9 @@ namespace System.Windows.Forms
         [SRDescription(nameof(SR.ControlBackgroundImageLayoutDescr))]
         public virtual ImageLayout BackgroundImageLayout
         {
-            get
-            {
-                if (Properties.TryGetObject(s_backgroundImageLayoutProperty, out ImageLayout imageLayout))
-                {
-                    return imageLayout;
-                }
-
-                return ImageLayout.Tile;
-            }
+            get => Properties.TryGetObject(s_backgroundImageLayoutProperty, out ImageLayout imageLayout)
+                    ? imageLayout
+                    : ImageLayout.Tile;
             set
             {
                 if (BackgroundImageLayout != value)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.cs
@@ -3130,21 +3130,18 @@ namespace System.Windows.Forms
         {
             get
             {
-                ToolTip toolTip;
-                if (!Properties.ContainsObject(s_propToolTip))
+                if (Properties.TryGetObject(s_propToolTip, out ToolTip toolTip))
                 {
-                    toolTip = new ToolTip
-                    {
-                        ReshowDelay = 500,
-                        InitialDelay = 500
-                    };
+                    return toolTip;
+                }
 
-                    Properties.SetObject(s_propToolTip, toolTip);
-                }
-                else
+                toolTip = new ToolTip
                 {
-                    toolTip = (ToolTip)Properties.GetObject(s_propToolTip);
-                }
+                    ReshowDelay = 500,
+                    InitialDelay = 500
+                };
+
+                Properties.SetObject(s_propToolTip, toolTip);
 
                 return toolTip;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewBand.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewBand.cs
@@ -254,17 +254,17 @@ namespace System.Windows.Forms
         [Browsable(false)]
         public bool HasDefaultCellStyle
         {
-            get => Properties.ContainsObject(s_propDefaultCellStyle) && Properties.GetObject(s_propDefaultCellStyle) is not null;
+            get => Properties.TryGetObject(s_propDefaultCellStyle, out object? value) && value is not null;
         }
 
         internal bool HasDefaultHeaderCellType
         {
-            get => Properties.ContainsObject(s_propDefaultHeaderCellType) && Properties.GetObject(s_propDefaultHeaderCellType) is not null;
+            get => Properties.TryGetObject(s_propDefaultHeaderCellType, out object? value) && value is not null;
         }
 
         internal bool HasHeaderCell
         {
-            get => Properties.ContainsObject(s_propHeaderCell) && Properties.GetObject(s_propHeaderCell) is not null;
+            get => Properties.TryGetObject(s_propHeaderCell, out object? value) && value is not null;
         }
 
         [Browsable(false)]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
@@ -357,37 +357,19 @@ namespace System.Windows.Forms
 
         private bool HasErrorText
         {
-            get => Properties.ContainsObject(s_propCellErrorText) && Properties.GetObject(s_propCellErrorText) is not null;
+            get => Properties.TryGetObject(s_propCellErrorText, out object value) && value is not null;
         }
 
         [Browsable(false)]
-        public bool HasStyle
-        {
-            get
-            {
-                return Properties.ContainsObject(s_propCellStyle) && Properties.GetObject(s_propCellStyle) is not null;
-            }
-        }
+        public bool HasStyle => Properties.TryGetObject(s_propCellStyle, out object value) && value is not null;
 
-        internal bool HasToolTipText
-        {
-            get
-            {
-                return Properties.ContainsObject(s_propCellToolTipText) && Properties.GetObject(s_propCellToolTipText) is not null;
-            }
-        }
+        internal bool HasToolTipText => Properties.TryGetObject(s_propCellToolTipText, out object value) && value is not null;
 
-        internal bool HasValue
-        {
-            get
-            {
-                return Properties.ContainsObject(s_propCellValue) && Properties.GetObject(s_propCellValue) is not null;
-            }
-        }
+        internal bool HasValue => Properties.TryGetObject(s_propCellValue, out object value) && value is not null;
 
         private protected virtual bool HasValueType
         {
-            get => Properties.ContainsObject(s_propCellValueType) && Properties.GetObject(s_propCellValueType) is not null;
+            get => Properties.TryGetObject(s_propCellValueType, out object value) && value is not null;
         }
 
         #region IKeyboardToolTip implementation

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellStyle.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellStyle.cs
@@ -148,12 +148,12 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (Properties.ContainsObject(PropDataSourceNullValue))
+                if (Properties.TryGetObject(PropDataSourceNullValue, out object value))
                 {
-                    return Properties.GetObject(PropDataSourceNullValue);
+                    return value;
                 }
 
-                return System.DBNull.Value;
+                return DBNull.Value;
             }
             set
             {
@@ -295,12 +295,12 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (!Properties.ContainsObject(PropDataSourceNullValue))
+                if (!Properties.TryGetObject(PropDataSourceNullValue, out object value))
                 {
                     return true;
                 }
 
-                return Properties.GetObject(PropDataSourceNullValue) == System.DBNull.Value;
+                return value == DBNull.Value;
             }
         }
 
@@ -320,12 +320,11 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (!Properties.ContainsObject(PropNullValue))
+                if (!Properties.TryGetObject(PropNullValue, out object nullValue))
                 {
                     return true;
                 }
 
-                object nullValue = Properties.GetObject(PropNullValue);
                 return nullValue is string nullValueString && nullValueString.Length == 0;
             }
         }
@@ -337,9 +336,9 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (Properties.ContainsObject(PropNullValue))
+                if (Properties.TryGetObject(PropNullValue, out object value))
                 {
-                    return Properties.GetObject(PropNullValue);
+                    return value;
                 }
 
                 return string.Empty;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellStyle.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellStyle.cs
@@ -146,15 +146,9 @@ namespace System.Windows.Forms
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public object DataSourceNullValue
         {
-            get
-            {
-                if (Properties.TryGetObject(PropDataSourceNullValue, out object value))
-                {
-                    return value;
-                }
-
-                return DBNull.Value;
-            }
+            get => Properties.TryGetObject(PropDataSourceNullValue, out object value)
+                ? value
+                : DBNull.Value;
             set
             {
                 object oldDataSourceNullValue = DataSourceNullValue;
@@ -334,15 +328,9 @@ namespace System.Windows.Forms
         [SRCategory(nameof(SR.CatData))]
         public object NullValue
         {
-            get
-            {
-                if (Properties.TryGetObject(PropNullValue, out object value))
-                {
-                    return value;
-                }
-
-                return string.Empty;
-            }
+            get => Properties.TryGetObject(PropNullValue, out object value)
+                ? value
+                : string.Empty;
             set
             {
                 object oldNullValue = NullValue;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxCell.cs
@@ -509,13 +509,7 @@ namespace System.Windows.Forms
             }
         }
 
-        internal bool HasItems
-        {
-            get
-            {
-                return Properties.ContainsObject(s_propComboBoxCellItems) && Properties.GetObject(s_propComboBoxCellItems) is not null;
-            }
-        }
+        internal bool HasItems => Properties.TryGetObject(s_propComboBoxCellItems, out object value) && value is not null;
 
         [Browsable(false)]
         public virtual ObjectCollection Items

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewHeaderCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewHeaderCell.cs
@@ -150,7 +150,7 @@ namespace System.Windows.Forms
 
         private protected override bool HasValueType
         {
-            get => Properties.ContainsObject(s_propValueType) && Properties.GetObject(s_propValueType) is not null;
+            get => Properties.TryGetObject(s_propValueType, out object value) && value is not null;
         }
 
         [Browsable(false)]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewLinkCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewLinkCell.cs
@@ -50,9 +50,9 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (Properties.ContainsObject(s_propLinkCellActiveLinkColor))
+                if (Properties.TryGetObject(s_propLinkCellActiveLinkColor, out Color color))
                 {
-                    return (Color)Properties.GetObject(s_propLinkCellActiveLinkColor);
+                    return color;
                 }
                 else if (SystemInformation.HighContrast)
                 {
@@ -174,9 +174,9 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (Properties.ContainsObject(s_propLinkCellLinkColor))
+                if (Properties.TryGetObject(s_propLinkCellLinkColor, out Color color))
                 {
-                    return (Color)Properties.GetObject(s_propLinkCellLinkColor);
+                    return color;
                 }
                 else if (SystemInformation.HighContrast)
                 {
@@ -371,9 +371,9 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (Properties.ContainsObject(s_propLinkCellVisitedLinkColor))
+                if (Properties.TryGetObject(s_propLinkCellVisitedLinkColor, out Color color))
                 {
-                    return (Color)Properties.GetObject(s_propLinkCellVisitedLinkColor);
+                    return color;
                 }
                 else if (SystemInformation.HighContrast)
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.cs
@@ -198,7 +198,7 @@ namespace System.Windows.Forms
 
         private bool HasErrorText
         {
-            get => Properties.ContainsObject(s_propRowErrorText) && Properties.GetObject(s_propRowErrorText) is not null;
+            get => Properties.TryGetObject(s_propRowErrorText, out object value) && value is not null;
         }
 
         [Browsable(false)]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -1127,9 +1127,9 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (Properties.ContainsObject(PropMdiChildFocusable))
+                if (Properties.TryGetObject(PropMdiChildFocusable, out bool value))
                 {
-                    return (bool)Properties.GetObject(PropMdiChildFocusable)!;
+                    return value;
                 }
 
                 return false;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -1125,15 +1125,9 @@ namespace System.Windows.Forms
         // so that WM_SETFOCUS sent to MDIClient does not activate that child. (See MdiClient.WndProc).
         internal bool IsMdiChildFocusable
         {
-            get
-            {
-                if (Properties.TryGetObject(PropMdiChildFocusable, out bool value))
-                {
-                    return value;
-                }
-
-                return false;
-            }
+            get => Properties.TryGetObject(PropMdiChildFocusable, out bool value)
+                ? value
+                : false;
             set
             {
                 if (value != IsMdiChildFocusable)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
@@ -1477,11 +1477,7 @@ namespace System.Windows.Forms
                 ToolStripPanelCell? toolStripPanelCell = null;
                 if (!IsDropDown && !IsDisposed)
                 {
-                    if (Properties.ContainsObject(ToolStrip.s_propToolStripPanelCell))
-                    {
-                        toolStripPanelCell = (ToolStripPanelCell?)Properties.GetObject(ToolStrip.s_propToolStripPanelCell);
-                    }
-                    else
+                    if (!Properties.TryGetObject(ToolStrip.s_propToolStripPanelCell, out toolStripPanelCell))
                     {
                         toolStripPanelCell = new ToolStripPanelCell(this);
                         Properties.SetObject(ToolStrip.s_propToolStripPanelCell, toolStripPanelCell);
@@ -1771,15 +1767,10 @@ namespace System.Windows.Forms
         {
             get
             {
-                ToolTip toolTip;
-                if (!Properties.ContainsObject(ToolStrip.s_propToolTip))
+                if (!Properties.TryGetObject(ToolStrip.s_propToolTip, out ToolTip toolTip))
                 {
                     toolTip = new ToolTip();
                     Properties.SetObject(ToolStrip.s_propToolTip, toolTip);
-                }
-                else
-                {
-                    toolTip = (ToolTip)Properties.GetObject(ToolStrip.s_propToolTip);
                 }
 
                 return toolTip;
@@ -1794,9 +1785,9 @@ namespace System.Windows.Forms
             get
             {
                 ToolStripTextDirection textDirection = ToolStripTextDirection.Inherit;
-                if (Properties.ContainsObject(ToolStrip.s_propTextDirection))
+                if (Properties.TryGetObject(ToolStrip.s_propTextDirection, out ToolStripTextDirection direction))
                 {
-                    textDirection = (ToolStripTextDirection)Properties.GetObject(ToolStrip.s_propTextDirection);
+                    textDirection = direction;
                 }
 
                 if (textDirection == ToolStripTextDirection.Inherit)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
@@ -516,15 +516,9 @@ namespace System.Windows.Forms
         [SRDescription(nameof(SR.ControlBackgroundImageLayoutDescr))]
         public virtual ImageLayout BackgroundImageLayout
         {
-            get
-            {
-                if (Properties.TryGetObject(s_backgroundImageLayoutProperty, out ImageLayout imageLayout))
-                {
-                    return imageLayout;
-                }
-
-                return ImageLayout.Tile;
-            }
+            get => Properties.TryGetObject(s_backgroundImageLayoutProperty, out ImageLayout imageLayout)
+                ? imageLayout
+                : ImageLayout.Tile;
             set
             {
                 if (BackgroundImageLayout != value)
@@ -1890,15 +1884,7 @@ namespace System.Windows.Forms
         [TypeConverter(typeof(StringConverter))]
         public object? Tag
         {
-            get
-            {
-                if (Properties.TryGetObject(ToolStripItem.s_tagProperty, out object? tag))
-                {
-                    return tag;
-                }
-
-                return null;
-            }
+            get => Properties.TryGetObject(ToolStripItem.s_tagProperty, out object? tag) ? tag : null;
             set => Properties.SetObject(ToolStripItem.s_tagProperty, value);
         }
 
@@ -1911,15 +1897,9 @@ namespace System.Windows.Forms
         [SRDescription(nameof(SR.ToolStripItemTextDescr))]
         public virtual string? Text
         {
-            get
-            {
-                if (Properties.TryGetObject(ToolStripItem.s_textProperty, out string? text))
-                {
-                    return text;
-                }
-
-                return string.Empty;
-            }
+            get => Properties.TryGetObject(ToolStripItem.s_textProperty, out string? text)
+                ? text
+                : string.Empty;
             set
             {
                 if (value != Text)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
@@ -518,13 +518,12 @@ namespace System.Windows.Forms
         {
             get
             {
-                bool found = Properties.ContainsObject(s_backgroundImageLayoutProperty);
-                if (!found)
+                if (Properties.TryGetObject(s_backgroundImageLayoutProperty, out ImageLayout imageLayout))
                 {
-                    return ImageLayout.Tile;
+                    return imageLayout;
                 }
 
-                return (ImageLayout)Properties.GetObject(s_backgroundImageLayoutProperty)!;
+                return ImageLayout.Tile;
             }
             set
             {
@@ -1893,9 +1892,9 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (Properties.ContainsObject(ToolStripItem.s_tagProperty))
+                if (Properties.TryGetObject(ToolStripItem.s_tagProperty, out object? tag))
                 {
-                    return Properties.GetObject(ToolStripItem.s_tagProperty);
+                    return tag;
                 }
 
                 return null;
@@ -1914,9 +1913,9 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (Properties.ContainsObject(ToolStripItem.s_textProperty))
+                if (Properties.TryGetObject(ToolStripItem.s_textProperty, out string? text))
                 {
-                    return (string?)Properties.GetObject(ToolStripItem.s_textProperty);
+                    return text;
                 }
 
                 return string.Empty;
@@ -1968,9 +1967,9 @@ namespace System.Windows.Forms
             get
             {
                 ToolStripTextDirection textDirection = ToolStripTextDirection.Inherit;
-                if (Properties.ContainsObject(ToolStripItem.s_textDirectionProperty))
+                if (Properties.TryGetObject(ToolStripItem.s_textDirectionProperty, out ToolStripTextDirection direction))
                 {
-                    textDirection = (ToolStripTextDirection)Properties.GetObject(ToolStripItem.s_textDirectionProperty)!;
+                    textDirection = direction;
                 }
 
                 if (textDirection == ToolStripTextDirection.Inherit)
@@ -3062,9 +3061,9 @@ namespace System.Windows.Forms
         internal void OnOwnerTextDirectionChanged()
         {
             ToolStripTextDirection textDirection = ToolStripTextDirection.Inherit;
-            if (Properties.ContainsObject(ToolStripItem.s_textDirectionProperty))
+            if (Properties.TryGetObject(ToolStripItem.s_textDirectionProperty, out ToolStripTextDirection direction))
             {
-                textDirection = (ToolStripTextDirection)Properties.GetObject(ToolStripItem.s_textDirectionProperty)!;
+                textDirection = direction;
             }
 
             if (textDirection == ToolStripTextDirection.Inherit)
@@ -3457,9 +3456,9 @@ namespace System.Windows.Forms
         private bool ShouldSerializeTextDirection()
         {
             ToolStripTextDirection textDirection = ToolStripTextDirection.Inherit;
-            if (Properties.ContainsObject(ToolStripItem.s_textDirectionProperty))
+            if (Properties.TryGetObject(ToolStripItem.s_textDirectionProperty, out ToolStripTextDirection direction))
             {
-                textDirection = (ToolStripTextDirection)Properties.GetObject(ToolStripItem.s_textDirectionProperty)!;
+                textDirection = direction;
             }
 
             return textDirection != ToolStripTextDirection.Inherit;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripMenuItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripMenuItem.cs
@@ -598,7 +598,7 @@ namespace System.Windows.Forms
         internal static MenuTimer MenuTimer => s_menuTimer;
 
         /// <summary> Tag property for internal use </summary>
-        internal Form? MdiForm => Properties.ContainsObject(s_propMdiForm) ? Properties.GetObject(s_propMdiForm) as Form : null;
+        internal Form? MdiForm => Properties.TryGetObject(s_propMdiForm, out Form? form) ? form : null;
 
         internal ToolStripMenuItem Clone()
         {


### PR DESCRIPTION
## Proposed changes

- Use TryGetObject instead of ContainsObject and GetObject.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8575)