### PR TITLE
Fix ToolStrip/MenuStrip/StatusStrip arrow keys navigation

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
@@ -2181,7 +2181,7 @@ namespace System.Windows.Forms
                 case ArrowDirection.Right:
                     return GetNextItemHorizontal(start, forward: true);
                 case ArrowDirection.Left:
-                    bool forward = LastKeyData == Keys.Tab || TabStop;
+                    bool forward = LastKeyData == Keys.Tab || (TabStop && start is null);
                     return GetNextItemHorizontal(start, forward);
                 case ArrowDirection.Down:
                     return GetNextItemVertical(start, down: true);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripTests.cs
@@ -4752,20 +4752,35 @@ namespace System.Windows.Forms.Tests
             Assert.Throws<InvalidEnumArgumentException>("direction", () => toolStrip.GetNextItem(null, direction));
         }
 
-        [WinFormsTheory]
-        [InlineData(RightToLeft.No)]
-        [InlineData(RightToLeft.Yes)]
-        public void ToolStrip_GetNextItem_ReturnsForwardItem(RightToLeft rightToLeft)
+        public static IEnumerable<object[]> ToolStrip_GetNextItem_TestData()
         {
-            using ToolStrip toolStrip = new()
+            foreach (RightToLeft rtl in Enum.GetValues(typeof(RightToLeft)))
             {
-                RightToLeft = rightToLeft,
-                TabStop = false
-            };
+                foreach (bool tabStop in new bool[] { true, false })
+                {
+                    foreach (bool useTabKey in new bool[] { true, false })
+                    {
+                        yield return new object[] { rtl, tabStop, useTabKey };
+                    }
+                }
+            }
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ToolStrip_GetNextItem_TestData))]
+        public void ToolStrip_GetNextItem_ReturnsForwardItem(RightToLeft rightToLeft, bool tabStop, bool useTabKey)
+        {
+            using ToolStrip toolStrip = new() { RightToLeft = rightToLeft, TabStop = tabStop };
             using ToolStripButton toolStripButton1 = new();
             using ToolStripButton toolStripButton2 = new();
             using ToolStripButton toolStripButton3 = new();
             toolStrip.Items.AddRange(new ToolStripItem[] { toolStripButton1, toolStripButton2, toolStripButton3 });
+
+            if (useTabKey)
+            {
+                toolStrip.TestAccessor().Dynamic.LastKeyData = Keys.Tab;
+            }
+
             ToolStripItem actual = toolStrip.GetNextItem(toolStrip.Items[0], ArrowDirection.Right);
 
             Assert.Equal(toolStripButton2, actual);
@@ -4773,15 +4788,20 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
-        [InlineData(RightToLeft.No)]
-        [InlineData(RightToLeft.Yes)]
-        public void ToolStrip_GetNextItem_CyclesForwardExpected(RightToLeft rightToLeft)
+        [MemberData(nameof(ToolStrip_GetNextItem_TestData))]
+        public void ToolStrip_GetNextItem_CyclesForwardExpected(RightToLeft rightToLeft, bool tabStop, bool useTabKey)
         {
-            using ToolStrip toolStrip = new() { RightToLeft = rightToLeft, TabStop = false };
+            using ToolStrip toolStrip = new() { RightToLeft = rightToLeft, TabStop = tabStop };
             using ToolStripButton toolStripButton1 = new();
             using ToolStripButton toolStripButton2 = new();
             using ToolStripButton toolStripButton3 = new();
             toolStrip.Items.AddRange(new ToolStripItem[] { toolStripButton1, toolStripButton2, toolStripButton3 });
+
+            if (useTabKey)
+            {
+                toolStrip.TestAccessor().Dynamic.LastKeyData = Keys.Tab;
+            }
+
             ToolStripItem nextToolStripItem1 = toolStrip.GetNextItem(toolStripButton1, ArrowDirection.Right);
             ToolStripItem nextToolStripItem2 = toolStrip.GetNextItem(toolStripButton2, ArrowDirection.Right);
             ToolStripItem nextToolStripItem3 = toolStrip.GetNextItem(toolStripButton3, ArrowDirection.Right);
@@ -4793,20 +4813,20 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
-        [InlineData(RightToLeft.No)]
-        [InlineData(RightToLeft.Yes)]
-        public void ToolStrip_GetNextItem_ReturnsBackwardItem(RightToLeft rightToLeft)
+        [MemberData(nameof(ToolStrip_GetNextItem_TestData))]
+        public void ToolStrip_GetNextItem_ReturnsBackwardItem(RightToLeft rightToLeft, bool tabStop, bool useTabKey)
         {
-            using ToolStrip toolStrip = new()
-            {
-                RightToLeft = rightToLeft,
-                TabStop = false
-            };
+            using ToolStrip toolStrip = new() { RightToLeft = rightToLeft, TabStop = tabStop };
             using ToolStripButton toolStripButton1 = new();
             using ToolStripButton toolStripButton2 = new();
             using ToolStripButton toolStripButton3 = new();
             toolStrip.Items.AddRange(new ToolStripItem[] { toolStripButton1, toolStripButton2, toolStripButton3 });
-            toolStrip.TestAccessor().Dynamic.LastKeyData = Keys.Shift | Keys.Tab;
+
+            if (useTabKey)
+            {
+                toolStrip.TestAccessor().Dynamic.LastKeyData = Keys.Shift | Keys.Tab;
+            }
+
             ToolStripItem actual = toolStrip.GetNextItem(toolStrip.Items[0], ArrowDirection.Left);
 
             Assert.Equal(toolStripButton3, actual);
@@ -4814,16 +4834,20 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
-        [InlineData(RightToLeft.No)]
-        [InlineData(RightToLeft.Yes)]
-        public void ToolStrip_GetNextItem_CyclesBackwardExpected(RightToLeft rightToLeft)
+        [MemberData(nameof(ToolStrip_GetNextItem_TestData))]
+        public void ToolStrip_GetNextItem_CyclesBackwardExpected(RightToLeft rightToLeft, bool tabStop, bool useTabKey)
         {
-            using ToolStrip toolStrip = new() { RightToLeft = rightToLeft, TabStop = false };
+            using ToolStrip toolStrip = new() { RightToLeft = rightToLeft, TabStop = tabStop };
             using ToolStripButton toolStripButton1 = new();
             using ToolStripButton toolStripButton2 = new();
             using ToolStripButton toolStripButton3 = new();
             toolStrip.Items.AddRange(new ToolStripItem[] { toolStripButton1, toolStripButton2, toolStripButton3 });
-            toolStrip.TestAccessor().Dynamic.LastKeyData = Keys.Shift | Keys.Tab;
+
+            if (useTabKey)
+            {
+                toolStrip.TestAccessor().Dynamic.LastKeyData = Keys.Shift | Keys.Tab;
+            }
+
             ToolStripItem previousToolStripItem1 = toolStrip.GetNextItem(toolStripButton1, ArrowDirection.Left);
             ToolStripItem previousToolStripItem2 = toolStrip.GetNextItem(toolStripButton3, ArrowDirection.Left);
             ToolStripItem previousToolStripItem3 = toolStrip.GetNextItem(toolStripButton2, ArrowDirection.Left);


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #8587


## Proposed changes

- Fix ToolsStrip.TabStop property value handling in calculating the next ToolStripItem to switch to.
- Modify unit tests to ensure GetNextItem method handles TabStop true value correctly.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Arrow keys work correctly when navigation ToolStrip/MenuStrip/StatusStrip items from keyboard.

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Focus goes *right* on both Left and Right keys:

https://user-images.githubusercontent.com/113603457/217533909-e7af42f1-b48c-40e8-b670-bce1797ccac1.mp4

### After

Focus goes *left* on Left key and *right* on the Right key:

https://user-images.githubusercontent.com/113603457/217534004-530e0969-86f0-4470-a9d9-60dd8a06362a.mp4

Tab and Shift+Tab navigation is not affected:

https://user-images.githubusercontent.com/113603457/217534084-6c900fa3-001e-4f39-8c21-6ba12f3df049.mp4


## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- .NET 8.0.0-alpha.1.23057.5


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8588)