### PR TITLE
Fix menu item without sub menu leaking focus on arrow keys

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownItem.cs
@@ -542,18 +542,18 @@ namespace System.Windows.Forms
         {
             Keys keyCode = (Keys)keyData & Keys.KeyCode;
 
+            // Items on the overflow should have the same kind of keyboard handling as a toplevel.
+            bool isTopLevel = (!IsOnDropDown || IsOnOverflow);
+
             if (HasDropDownItems)
             {
-                // Items on the overflow should have the same kind of keyboard handling as a toplevel
-                bool isToplevel = (!IsOnDropDown || IsOnOverflow);
-
-                if (isToplevel && (keyCode == Keys.Down || keyCode == Keys.Up || keyCode == Keys.Enter || (SupportsSpaceKey && keyCode == Keys.Space)))
+                if (isTopLevel && (keyCode == Keys.Down || keyCode == Keys.Up || keyCode == Keys.Enter || (SupportsSpaceKey && keyCode == Keys.Space)))
                 {
                     ToolStrip.s_selectionDebug.TraceVerbose("[SelectDBG ProcessDialogKey] open submenu from toplevel item");
 
                     if (Enabled || DesignMode)
                     {
-                        // |__[ * File ]_____|  * is where you are.  Up or down arrow hit should expand menu
+                        // |__[ * File ]_____|  * is where you are.  Up or down arrow hit should expand menu.
                         ShowDropDown();
                         KeyboardToolTipStateMachine.Instance.NotifyAboutLostFocus(this);
                         DropDown.SelectNextToolStripItem(null, true);
@@ -561,7 +561,7 @@ namespace System.Windows.Forms
 
                     return true;
                 }
-                else if (!isToplevel)
+                else if (!isTopLevel)
                 {
                     // if we're on a DropDown - then cascade out.
                     bool menusCascadeRight = (((int)DropDownDirection & 0x0001) == 0);
@@ -581,6 +581,14 @@ namespace System.Windows.Forms
 
                         return true;
                     }
+                }
+            }
+            else
+            {
+                // For a top-level item without sub-items: do nothing on Up/Down.
+                if (isTopLevel && (keyCode == Keys.Down || keyCode == Keys.Up))
+                {
+                    return true;
                 }
             }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #8591


## Proposed changes

- Handle Up and Down keys in ToolStripDropDownItem class in case when item has no sub-items.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Screen readers do not announce other controls when a user tries to open menu item without sub menu.

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

When empty menu item is focused, Down key switches focus to form button:

https://user-images.githubusercontent.com/113603457/217564499-a7878c2e-ec87-4d39-ab1d-94eb4976b001.mp4

### After

When empty menu item is focused, Down key does nothing, menu is still focused:

https://user-images.githubusercontent.com/113603457/217564561-48b9c782-3251-4aae-a9be-a7d976ac82c9.mp4


## Test methodology <!-- How did you ensure quality? -->

- Manual


## Test environment(s) <!-- Remove any that don't apply -->

- .NET 8.0.0-alpha.1.23057.5


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8592)