### PR TITLE
Add ContainsObjectThatIsNotNull method in PropertyStore and use it where possible

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewBand.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewBand.cs
@@ -254,17 +254,17 @@ namespace System.Windows.Forms
         [Browsable(false)]
         public bool HasDefaultCellStyle
         {
-            get => Properties.TryGetObject(s_propDefaultCellStyle, out object? value) && value is not null;
+            get => Properties.ContainsObjectThatIsNotNull(s_propDefaultCellStyle);
         }
 
         internal bool HasDefaultHeaderCellType
         {
-            get => Properties.TryGetObject(s_propDefaultHeaderCellType, out object? value) && value is not null;
+            get => Properties.ContainsObjectThatIsNotNull(s_propDefaultHeaderCellType);
         }
 
         internal bool HasHeaderCell
         {
-            get => Properties.TryGetObject(s_propHeaderCell, out object? value) && value is not null;
+            get => Properties.ContainsObjectThatIsNotNull(s_propHeaderCell);
         }
 
         [Browsable(false)]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
@@ -357,19 +357,19 @@ namespace System.Windows.Forms
 
         private bool HasErrorText
         {
-            get => Properties.TryGetObject(s_propCellErrorText, out object value) && value is not null;
+            get => Properties.ContainsObjectThatIsNotNull(s_propCellErrorText);
         }
 
         [Browsable(false)]
-        public bool HasStyle => Properties.TryGetObject(s_propCellStyle, out object value) && value is not null;
+        public bool HasStyle => Properties.ContainsObjectThatIsNotNull(s_propCellStyle);
 
-        internal bool HasToolTipText => Properties.TryGetObject(s_propCellToolTipText, out object value) && value is not null;
+        internal bool HasToolTipText => Properties.ContainsObjectThatIsNotNull(s_propCellToolTipText);
 
-        internal bool HasValue => Properties.TryGetObject(s_propCellValue, out object value) && value is not null;
+        internal bool HasValue => Properties.ContainsObjectThatIsNotNull(s_propCellValue);
 
         private protected virtual bool HasValueType
         {
-            get => Properties.TryGetObject(s_propCellValueType, out object value) && value is not null;
+            get => Properties.ContainsObjectThatIsNotNull(s_propCellValueType);
         }
 
         #region IKeyboardToolTip implementation

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxCell.cs
@@ -509,7 +509,7 @@ namespace System.Windows.Forms
             }
         }
 
-        internal bool HasItems => Properties.TryGetObject(s_propComboBoxCellItems, out object value) && value is not null;
+        internal bool HasItems => Properties.ContainsObjectThatIsNotNull(s_propComboBoxCellItems);
 
         [Browsable(false)]
         public virtual ObjectCollection Items

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewHeaderCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewHeaderCell.cs
@@ -150,7 +150,7 @@ namespace System.Windows.Forms
 
         private protected override bool HasValueType
         {
-            get => Properties.TryGetObject(s_propValueType, out object value) && value is not null;
+            get => Properties.ContainsObjectThatIsNotNull(s_propValueType);
         }
 
         [Browsable(false)]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.cs
@@ -198,7 +198,7 @@ namespace System.Windows.Forms
 
         private bool HasErrorText
         {
-            get => Properties.TryGetObject(s_propRowErrorText, out object value) && value is not null;
+            get => Properties.ContainsObjectThatIsNotNull(s_propRowErrorText);
         }
 
         [Browsable(false)]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyStore.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyStore.cs
@@ -194,6 +194,12 @@ namespace System.Windows.Forms
             return found;
         }
 
+        public bool ContainsObjectThatIsNotNull(int key)
+        {
+            object? entry = GetObject(key, out bool found);
+            return found && entry is not null;
+        }
+
         /// <summary>
         ///  Retrieves an object value from our property list.
         ///  This will set value to null and return false if the


### PR DESCRIPTION
## Proposed changes

- Add ContainsObjectThatIsNotNull method in PropertyStore and use it where possible
- Addresses https://github.com/dotnet/winforms/pull/8575#discussion_r1099644647

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8594)