### PR TITLE
Fix Control COM interface serialization

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.PropertyBagStream.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.PropertyBagStream.cs
@@ -2,88 +2,85 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections;
 using System.Runtime.Serialization.Formatters.Binary;
 using Windows.Win32.System.Com;
 using Windows.Win32.System.Com.StructuredStorage;
 
-namespace System.Windows.Forms
+namespace System.Windows.Forms;
+
+public abstract unsafe partial class AxHost
 {
-    public abstract unsafe partial class AxHost
+    internal class PropertyBagStream : IPropertyBag.Interface
     {
-        internal class PropertyBagStream : IPropertyBag.Interface
+        private Hashtable _bag = new();
+
+        internal void Read(Stream stream)
         {
-            private Hashtable _bag = new();
-
-            internal void Read(Stream stream)
+            BinaryFormatter formatter = new();
+            try
             {
-                BinaryFormatter formatter = new BinaryFormatter();
-                try
-                {
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
-                    _bag = (Hashtable)formatter.Deserialize(stream);
-#pragma warning restore SYSLIB0011 // Type or member is obsolete
-                }
-                catch
-                {
-                    // Error reading.  Just init an empty hashtable.
-                    _bag = new Hashtable();
-                }
-            }
-
-            HRESULT IPropertyBag.Interface.Read(PCWSTR pszPropName, VARIANT* pVar, IErrorLog* pErrorLog)
-            {
-                if (pVar is null)
-                {
-                    return HRESULT.E_POINTER;
-                }
-
-                s_axHTraceSwitch.TraceVerbose($"Reading property {pszPropName} from OCXState propertybag.");
-
-                if (!_bag.Contains(pszPropName))
-                {
-                    *pVar = default;
-                    return HRESULT.E_INVALIDARG;
-                }
-
-                *pVar = (VARIANT)_bag[pszPropName];
-                s_axHTraceSwitch.TraceVerbose($"\tValue={*pVar}");
-
-                // The EE returns a VT_EMPTY for a null. The problem is that visual basic6 expects the caller to respect the
-                // "hint" it gives in the VariantType. For eg., for a VT_BSTR, it expects that the callee will null
-                // out the BSTR field of the variant. Since, the EE or us cannot do anything about this, we will return
-                // a E_INVALIDARG rather than let visual basic6 crash.
-
-                return (*pVar).Equals(default(VARIANT)) ? HRESULT.E_INVALIDARG : HRESULT.S_OK;
-            }
-
-            HRESULT IPropertyBag.Interface.Write(PCWSTR pszPropName, VARIANT* pVar)
-            {
-                if (pVar is null)
-                {
-                    return HRESULT.E_POINTER;
-                }
-
-                s_axHTraceSwitch.TraceVerbose($"Writing property {pszPropName} [{*pVar}] into OCXState propertybag.");
-                if (!pVar->GetType().IsSerializable)
-                {
-                    s_axHTraceSwitch.TraceVerbose($"\t {pVar->GetType().FullName} is not serializable.");
-                    return HRESULT.S_OK;
-                }
-
-                _bag[pszPropName] = *pVar;
-                return HRESULT.S_OK;
-            }
-
-            internal void Write(Stream stream)
-            {
-                BinaryFormatter formatter = new BinaryFormatter();
-#pragma warning disable SYSLIB0011 // Type or member is obsolete
-                formatter.Serialize(stream, _bag);
+                _bag = (Hashtable)formatter.Deserialize(stream);
 #pragma warning restore SYSLIB0011 // Type or member is obsolete
             }
+            catch
+            {
+                // Error reading.  Just init an empty hashtable.
+                _bag = new Hashtable();
+            }
+        }
+
+        HRESULT IPropertyBag.Interface.Read(PCWSTR pszPropName, VARIANT* pVar, IErrorLog* pErrorLog)
+        {
+            if (pVar is null || pszPropName.Value is null)
+            {
+                return HRESULT.E_POINTER;
+            }
+
+            string name = pszPropName.ToString();
+
+            s_axHTraceSwitch.TraceVerbose($"Reading property {name} from OCXState propertybag.");
+
+            if (!_bag.Contains(name))
+            {
+                *pVar = default;
+                return HRESULT.E_INVALIDARG;
+            }
+
+            object? value = _bag[name];
+            *pVar = VARIANT.FromObject(value);
+            s_axHTraceSwitch.TraceVerbose($"\tValue={value ?? "<null>"}");
+
+            // The EE returns a VT_EMPTY for a null. The problem is that Visual Basic 6 expects the caller to respect
+            // the "hint" it gives in the VariantType. For eg., for a VT_BSTR, it expects that the callee will null
+            // out the BSTR field of the variant. Since the EE or us cannot do anything about this, we will return
+            // a E_INVALIDARG rather than let Visual Basic 6 crash.
+
+            return (*pVar).Equals(default(VARIANT)) ? HRESULT.E_INVALIDARG : HRESULT.S_OK;
+        }
+
+        HRESULT IPropertyBag.Interface.Write(PCWSTR pszPropName, VARIANT* pVar)
+        {
+            if (pVar is null || pszPropName.Value is null)
+            {
+                return HRESULT.E_POINTER;
+            }
+
+            string name = pszPropName.ToString();
+            object? value = pVar->ToObject();
+
+            s_axHTraceSwitch.TraceVerbose($"Writing property {name} [{*pVar}] into OCXState propertybag.");
+            _bag[name] = value;
+            return HRESULT.S_OK;
+        }
+
+        internal void Write(Stream stream)
+        {
+            BinaryFormatter formatter = new();
+#pragma warning disable SYSLIB0011 // Type or member is obsolete
+            formatter.Serialize(stream, _bag);
+#pragma warning restore SYSLIB0011 // Type or member is obsolete
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.PropertyBagStream.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.PropertyBagStream.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections;
+using System.Diagnostics;
 using System.Runtime.Serialization.Formatters.Binary;
 using Windows.Win32.System.Com;
 using Windows.Win32.System.Com.StructuredStorage;
@@ -67,29 +68,32 @@ public partial class Control
 
             HRESULT IPropertyBag.Interface.Read(PCWSTR pszPropName, VARIANT* pVar, IErrorLog* pErrorLog)
             {
-                if (pVar is null)
+                if (pVar is null || pszPropName.Value is null)
                 {
                     return HRESULT.E_POINTER;
                 }
 
-                if (!_bag.Contains(pszPropName))
+                string name = pszPropName.ToString();
+                if (!_bag.Contains(name))
                 {
                     *pVar = default;
                     return HRESULT.E_INVALIDARG;
                 }
 
-                *pVar = (VARIANT)_bag[pszPropName]!;
+                Debug.Assert(_bag[name] is string);
+                *pVar = VARIANT.FromObject(_bag[name]);
                 return HRESULT.S_OK;
             }
 
             HRESULT IPropertyBag.Interface.Write(PCWSTR pszPropName, VARIANT* pVar)
             {
-                if (pVar is null)
+                if (pVar is null || pszPropName.Value is null)
                 {
                     return HRESULT.E_POINTER;
                 }
 
-                _bag[pszPropName] = *pVar;
+                Debug.Assert(pVar->vt == VARENUM.VT_BSTR);
+                _bag[pszPropName.ToString()] = pVar->ToObject();
                 return HRESULT.S_OK;
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.PropertyBagStream.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.PropertyBagStream.cs
@@ -19,7 +19,7 @@ public partial class Control
         /// </summary>
         private class PropertyBagStream : IPropertyBag.Interface, IManagedWrapper<IPropertyBag>
         {
-            private Hashtable _bag = new Hashtable();
+            private Hashtable _bag = new();
 
             internal void Read(IStream* istream)
             {
@@ -47,7 +47,7 @@ public partial class Control
 
                 MemoryStream stream = new(streamData);
 
-                BinaryFormatter formatter = new BinaryFormatter();
+                BinaryFormatter formatter = new();
                 try
                 {
 #pragma warning disable SYSLIB0011 // Type or member is obsolete

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AxHost.PropertyBagStreamTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AxHost.PropertyBagStreamTests.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Windows.Win32.System.Com;
+using Xunit;
+
+namespace System.Windows.Forms.Tests;
+
+public unsafe class AxHost_PropertyBagStreamTests : IClassFixture<ThreadExceptionFixture>
+{
+    [WinFormsFact]
+    public void PropertyBagStream_WriteReadRoundTrip()
+    {
+        AxHost.PropertyBagStream bag = new();
+        HRESULT hr = bag.Write("Integer", (VARIANT)42);
+        Assert.True(hr.Succeeded);
+        NameClass obj = new() { Name = "Hamlet" };
+        hr = bag.Write("Object", VARIANT.FromObject(obj));
+        Assert.True(hr.Succeeded);
+
+        using MemoryStream stream = new();
+        bag.Write(stream);
+        Assert.NotEqual(0, stream.Length);
+        stream.Position = 0;
+
+        AxHost.PropertyBagStream newBag = new();
+        newBag.Read(stream);
+
+        VARIANT integer = new();
+        hr = newBag.Read("Integer", ref integer, null);
+        Assert.True(hr.Succeeded);
+        Assert.Equal(42, (int)integer);
+
+        VARIANT dispatch = new();
+        hr = newBag.Read("Object", ref dispatch, null);
+        Assert.True(hr.Succeeded);
+        Assert.Equal(obj.Name, ((NameClass)dispatch.ToObject()).Name);
+    }
+
+    [Serializable]
+    private class NameClass
+    {
+        public string Name { get; set; }
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ActiveXImplTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ActiveXImplTests.cs
@@ -46,7 +46,7 @@ public unsafe class Control_ActiveXImplTests : IClassFixture<ThreadExceptionFixt
         using var istream = ComHelpers.GetComScope<IStream>(new GPStream(memoryStream));
         HRESULT hr = persistStream.Save(istream.Value, fClearDirty: BOOL.FALSE);
         Assert.True(hr.Succeeded);
-        control.DataContext = null;
+        control.SerializableValue = default;
 
         istream.Value->Seek(0, SeekOrigin.Begin);
         hr = persistStream.Load(istream.Value);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ActiveXImplTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ActiveXImplTests.cs
@@ -1,0 +1,77 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Drawing;
+using System.Runtime.Serialization;
+using Windows.Win32.System.Com;
+using Xunit;
+using static Interop.Ole32;
+
+namespace System.Windows.Forms.Tests;
+
+public unsafe class Control_ActiveXImplTests : IClassFixture<ThreadExceptionFixture>
+{
+    [WinFormsFact]
+    public void ActiveXImpl_SaveLoad_RoundTrip()
+    {
+        using Control control = new();
+        control.BackColor = Color.Bisque;
+        IPersistStreamInit.Interface persistStream = control;
+
+        using MemoryStream memoryStream = new();
+        using var istream = ComHelpers.GetComScope<IStream>(new GPStream(memoryStream));
+        HRESULT hr = persistStream.Save(istream.Value, fClearDirty: BOOL.FALSE);
+        Assert.True(hr.Succeeded);
+        control.BackColor = Color.Honeydew;
+
+        istream.Value->Seek(0, SeekOrigin.Begin);
+        hr = persistStream.Load(istream.Value);
+        Assert.True(hr.Succeeded);
+        Assert.Equal(Color.Bisque, control.BackColor);
+    }
+
+    [WinFormsFact]
+    public void ActiveXImpl_SaveLoad_BinaryFormatterProperty()
+    {
+        using MyControl control = new();
+
+        // We need to have a type that doesn't have a TypeConverter that implements ISerializable to hit the
+        // BinaryFormatter code path.
+        SerializableStruct myValue = new() { Value = "HelloThere" };
+        control.SerializableValue = myValue;
+        IPersistStreamInit.Interface persistStream = control;
+
+        using MemoryStream memoryStream = new();
+        using var istream = ComHelpers.GetComScope<IStream>(new GPStream(memoryStream));
+        HRESULT hr = persistStream.Save(istream.Value, fClearDirty: BOOL.FALSE);
+        Assert.True(hr.Succeeded);
+        control.DataContext = null;
+
+        istream.Value->Seek(0, SeekOrigin.Begin);
+        hr = persistStream.Load(istream.Value);
+        Assert.True(hr.Succeeded);
+        Assert.Equal(myValue, control.SerializableValue);
+    }
+
+    private class MyControl : Control
+    {
+        public SerializableStruct SerializableValue { get; set; }
+    }
+
+    [Serializable]
+    public struct SerializableStruct : ISerializable
+    {
+        public string Value { get; set; }
+
+        public void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            info.AddValue(nameof(Value), Value, typeof(string));
+        }
+
+        private SerializableStruct(SerializationInfo serializationInfo, StreamingContext streamingContext)
+        {
+            Value = (string)serializationInfo.GetValue(nameof(Value), typeof(string));
+        }
+    }
+}


### PR DESCRIPTION
`PropertyBagStream` wasn't converting it's values correctly to/from string/object.

Also reinstate `BinaryFormatter` property handling which I removed under the misunderstanding that `BinaryFormatter` would be completely removed.

Add tests.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8597)