### PR TITLE
Prevent disposing Icons that are not owned by the caller.

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.cs
@@ -583,7 +583,6 @@ namespace System.Windows.Forms
             }
             set
             {
-                _icon.Dispose();
                 _icon = value.OrThrowIfNull();
                 DisposeRegion();
                 ErrorWindow[] array = _windows.Values.ToArray();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ErrorProviderTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ErrorProviderTests.cs
@@ -1274,7 +1274,7 @@ namespace System.Windows.Forms.Tests
 
             Assert.NotNull(provider.Icon);
 
-            // Make sure old icon that is not owned by us, is not disposed
+            // Make sure the old icon that is not owned by us, is not disposed
             Assert.Equal(handle, icon.Handle);
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ErrorProviderTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ErrorProviderTests.cs
@@ -1259,6 +1259,20 @@ namespace System.Windows.Forms.Tests
             Assert.Null(exception);
         }
 
+        [WinFormsFact]
+        public void ErrorProvider_Icon_NotDisposed_Unexpectedly()
+        {
+            // Unit test for https://github.com/dotnet/winforms/issues/8513.
+            using var provider = new SubErrorProvider();
+            var Icon = provider.Icon;
+            Assert.NotNull(Icon);
+            nint handle = Icon.Handle;
+
+            provider.Icon = new Icon(typeof(ErrorProvider), "Error");
+            Assert.NotNull(provider.Icon);
+            Assert.Equal(handle, Icon.Handle);
+        }
+
         private class CustomDataSource : IDataErrorInfo
         {
             public string this[string columnName] => string.Empty;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ErrorProviderTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ErrorProviderTests.cs
@@ -1264,13 +1264,18 @@ namespace System.Windows.Forms.Tests
         {
             // Unit test for https://github.com/dotnet/winforms/issues/8513.
             using var provider = new SubErrorProvider();
-            var Icon = provider.Icon;
-            Assert.NotNull(Icon);
-            nint handle = Icon.Handle;
+            var icon = provider.Icon;
 
-            provider.Icon = new Icon(typeof(ErrorProvider), "Error");
+            Assert.NotNull(icon);
+
+            nint handle = icon.Handle;
+            using Icon newIcon = new (typeof(ErrorProvider), "Error");
+            provider.Icon = newIcon;
+
             Assert.NotNull(provider.Icon);
-            Assert.Equal(handle, Icon.Handle);
+
+            // Make sure old icon that is not owned by us, is not disposed
+            Assert.Equal(handle, icon.Handle);
         }
 
         private class CustomDataSource : IDataErrorInfo

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ErrorProviderTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ErrorProviderTests.cs
@@ -1263,13 +1263,13 @@ namespace System.Windows.Forms.Tests
         public void ErrorProvider_Icon_NotDisposed_Unexpectedly()
         {
             // Unit test for https://github.com/dotnet/winforms/issues/8513.
-            using var provider = new SubErrorProvider();
+            using var provider = new ErrorProvider();
             var icon = provider.Icon;
 
             Assert.NotNull(icon);
 
             nint handle = icon.Handle;
-            using Icon newIcon = new (typeof(ErrorProvider), "Error");
+            using Icon newIcon = new("bitmaps/10x16_one_entry_32bit.ico");
             provider.Icon = newIcon;
 
             Assert.NotNull(provider.Icon);


### PR DESCRIPTION
We regressed this issue here: https://github.com/dotnet/winforms/pull/8486.

by accidentally disposing Icons that may not be owned or created by us. In this scenario, It was default Icon that is getting disposed.

Added unit test.

Fixes #8513.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8618)