### PR TITLE
Fix spelling of debug message

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewControl.cs
@@ -447,7 +447,7 @@ namespace System.Windows.Forms
 
                 document.Print();
                 pageInfo = previewController.GetPreviewPageInfo();
-                Debug.Assert(pageInfo is not null, "PreviewPrintController did not give us preview info");
+                Debug.Assert(pageInfo is not null, $"{nameof(PreviewPrintController)} did not give us preview info.");
 
                 document.PrintController = oldController;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewControl.cs
@@ -447,7 +447,7 @@ namespace System.Windows.Forms
 
                 document.Print();
                 pageInfo = previewController.GetPreviewPageInfo();
-                Debug.Assert(pageInfo is not null, "ReviewPrintController did not give us preview info");
+                Debug.Assert(pageInfo is not null, "PreviewPrintController did not give us preview info");
 
                 document.PrintController = oldController;
             }


### PR DESCRIPTION
## Proposed changes

The name of the class `PreviewPrintController` is misspelled in a debug message.
If a developer is searching the debug output for messages related to this class, this may not be found.

## Customer Impact

- None

## Regression? 

- No

## Risk

- None

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8621)