### PR TITLE
Enable nullability in WindowsFormsSynchronizationContext

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -580,9 +580,9 @@ override System.Windows.Forms.ToolStripTextBox.OnUnsubscribeControlEvents(System
 ~override System.Windows.Forms.WebBrowserBase.Site.set -> void
 ~override System.Windows.Forms.WebBrowserBase.Text.get -> string
 ~override System.Windows.Forms.WebBrowserBase.Text.set -> void
-~override System.Windows.Forms.WindowsFormsSynchronizationContext.CreateCopy() -> System.Threading.SynchronizationContext
-~override System.Windows.Forms.WindowsFormsSynchronizationContext.Post(System.Threading.SendOrPostCallback d, object state) -> void
-~override System.Windows.Forms.WindowsFormsSynchronizationContext.Send(System.Threading.SendOrPostCallback d, object state) -> void
+override System.Windows.Forms.WindowsFormsSynchronizationContext.CreateCopy() -> System.Threading.SynchronizationContext!
+override System.Windows.Forms.WindowsFormsSynchronizationContext.Post(System.Threading.SendOrPostCallback! d, object? state) -> void
+override System.Windows.Forms.WindowsFormsSynchronizationContext.Send(System.Threading.SendOrPostCallback! d, object? state) -> void
 static readonly System.Resources.ResXResourceWriter.BinSerializedObjectMimeType -> string!
 static readonly System.Resources.ResXResourceWriter.ByteArraySerializedObjectMimeType -> string!
 static readonly System.Resources.ResXResourceWriter.DefaultSerializedObjectMimeType -> string!

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WindowsFormsSynchronizationContext.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WindowsFormsSynchronizationContext.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 using System.Diagnostics;
 
@@ -15,7 +13,7 @@ namespace System.Windows.Forms
     public sealed class WindowsFormsSynchronizationContext : SynchronizationContext, IDisposable
     {
         private Control controlToSendTo;
-        private WeakReference destinationThreadRef;
+        private WeakReference? destinationThreadRef;
 
         //ThreadStatics won't get initialized per thread: easiest to just invert the value.
         [ThreadStatic]
@@ -25,7 +23,7 @@ namespace System.Windows.Forms
         private static bool inSyncContextInstallation;
 
         [ThreadStatic]
-        private static SynchronizationContext previousSyncContext;
+        private static SynchronizationContext? previousSyncContext;
 
         public WindowsFormsSynchronizationContext()
         {
@@ -34,7 +32,7 @@ namespace System.Windows.Forms
             Debug.Assert(controlToSendTo.IsHandleCreated, "Marshaling control should have created its handle in its ctor.");
         }
 
-        private WindowsFormsSynchronizationContext(Control marshalingControl, Thread destinationThread)
+        private WindowsFormsSynchronizationContext(Control marshalingControl, Thread? destinationThread)
         {
             controlToSendTo = marshalingControl;
             DestinationThread = destinationThread;
@@ -42,7 +40,7 @@ namespace System.Windows.Forms
         }
 
         // Directly holding onto the Thread can prevent ThreadStatics from finalizing.
-        private Thread DestinationThread
+        private Thread? DestinationThread
         {
             get
             {
@@ -71,25 +69,25 @@ namespace System.Windows.Forms
                     controlToSendTo.Dispose();
                 }
 
-                controlToSendTo = null;
+                controlToSendTo = null!;
             }
         }
 
         // This is never called because we decide whether to Send or Post and we always post
-        public override void Send(SendOrPostCallback d, object state)
+        public override void Send(SendOrPostCallback d, object? state)
         {
-            Thread destinationThread = DestinationThread;
+            Thread? destinationThread = DestinationThread;
             if (destinationThread is null || !destinationThread.IsAlive)
             {
                 throw new InvalidAsynchronousStateException(SR.ThreadNoLongerValid);
             }
 
-            controlToSendTo?.Invoke(d, new object[] { state });
+            controlToSendTo?.Invoke(d, new object?[] { state });
         }
 
-        public override void Post(SendOrPostCallback d, object state)
+        public override void Post(SendOrPostCallback d, object? state)
         {
-            controlToSendTo?.BeginInvoke(d, new object[] { state });
+            controlToSendTo?.BeginInvoke(d, new object?[] { state });
         }
 
         public override SynchronizationContext CreateCopy()

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WindowsFormsSynchronizationContext.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WindowsFormsSynchronizationContext.cs
@@ -42,15 +42,9 @@ namespace System.Windows.Forms
         // Directly holding onto the Thread can prevent ThreadStatics from finalizing.
         private Thread? DestinationThread
         {
-            get
-            {
-                if ((_destinationThreadRef is not null) && (_destinationThreadRef.IsAlive))
-                {
-                    return _destinationThreadRef.Target as Thread;
-                }
-
-                return null;
-            }
+            get => _destinationThreadRef?.IsAlive == true
+                ? _destinationThreadRef.Target as Thread
+                : null;
             set
             {
                 if (value is not null)


### PR DESCRIPTION
## Proposed changes

- Enable nullability in WindowsFormsSynchronizationContext.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8622)