### PR TITLE
Enable nullability in TableLayoutPanelCellPosition and TableLayoutPanelCellPositionTypeConverter

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -417,8 +417,8 @@ override System.Windows.Forms.StatusStrip.OnPaintBackground(System.Windows.Forms
 ~override System.Windows.Forms.TabControl.Text.get -> string
 ~override System.Windows.Forms.TabControl.Text.set -> void
 ~override System.Windows.Forms.TabControl.ToString() -> string
-~override System.Windows.Forms.TableLayoutPanelCellPosition.Equals(object other) -> bool
-~override System.Windows.Forms.TableLayoutPanelCellPosition.ToString() -> string
+override System.Windows.Forms.TableLayoutPanelCellPosition.Equals(object? other) -> bool
+override System.Windows.Forms.TableLayoutPanelCellPosition.ToString() -> string!
 override System.Windows.Forms.ToolStrip.BindingContext.get -> System.Windows.Forms.BindingContext?
 override System.Windows.Forms.ToolStrip.BindingContext.set -> void
 ~override System.Windows.Forms.ToolStrip.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutPanelCellPosition.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutPanelCellPosition.cs
@@ -4,11 +4,7 @@
 
 #nullable disable
 
-using System.Collections;
 using System.ComponentModel;
-using System.ComponentModel.Design.Serialization;
-using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 
 namespace System.Windows.Forms
 {
@@ -61,111 +57,5 @@ namespace System.Windows.Forms
         public override string ToString() => $"{Column},{Row}";
 
         public override int GetHashCode() => HashCode.Combine(Row, Column);
-    }
-
-    internal class TableLayoutPanelCellPositionTypeConverter : TypeConverter
-    {
-        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
-        {
-            if (destinationType == typeof(InstanceDescriptor))
-            {
-                return true;
-            }
-
-            return base.CanConvertTo(context, destinationType);
-        }
-
-        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
-        {
-            if (sourceType == typeof(string))
-            {
-                return true;
-            }
-
-            return base.CanConvertFrom(context, sourceType);
-        }
-
-        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
-        {
-            if (value is string stringValue)
-            {
-                stringValue = stringValue.Trim();
-                if (stringValue.Length == 0)
-                {
-                    return null;
-                }
-
-                // Parse 2 integer values.
-                culture ??= CultureInfo.CurrentCulture;
-
-                string[] tokens = stringValue.Split(new char[] { culture.TextInfo.ListSeparator[0] });
-                int[] values = new int[tokens.Length];
-
-                if (values.Length != 2)
-                {
-                    throw new ArgumentException(
-                        string.Format(
-                            SR.TextParseFailedFormat,
-                            stringValue,
-                            "column, row"),
-                        nameof(value));
-                }
-
-                TypeConverter intConverter = TypeDescriptor.GetConverter(typeof(int));
-                for (int i = 0; i < values.Length; i++)
-                {
-                    // Note: ConvertFromString will raise exception if value cannot be converted.
-                    values[i] = (int)intConverter.ConvertFromString(context, culture, tokens[i]);
-                }
-
-                return new TableLayoutPanelCellPosition(values[0], values[1]);
-            }
-
-            return base.ConvertFrom(context, culture, value);
-        }
-
-        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
-        {
-            if (destinationType == typeof(InstanceDescriptor) && value is TableLayoutPanelCellPosition cellPosition)
-            {
-                return new InstanceDescriptor(
-                    typeof(TableLayoutPanelCellPosition).GetConstructor(new Type[] { typeof(int), typeof(int) }),
-                    new object[] { cellPosition.Column, cellPosition.Row });
-            }
-
-            return base.ConvertTo(context, culture, value, destinationType);
-        }
-
-        public override object CreateInstance(ITypeDescriptorContext context, IDictionary propertyValues)
-        {
-            ArgumentNullException.ThrowIfNull(propertyValues);
-
-            try
-            {
-                return new TableLayoutPanelCellPosition(
-                    (int)propertyValues[nameof(TableLayoutPanelCellPosition.Column)],
-                    (int)propertyValues[nameof(TableLayoutPanelCellPosition.Row)]);
-            }
-            catch (InvalidCastException invalidCast)
-            {
-                throw new ArgumentException(SR.PropertyValueInvalidEntry, nameof(propertyValues), invalidCast);
-            }
-            catch (NullReferenceException nullRef)
-            {
-                throw new ArgumentException(SR.PropertyValueInvalidEntry, nameof(propertyValues), nullRef);
-            }
-        }
-
-        public override bool GetCreateInstanceSupported(ITypeDescriptorContext context) => true;
-
-        [RequiresUnreferencedCode(TrimmingConstants.TypeOrValueNotDiscoverableMessage)]
-        [DynamicDependency(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.PublicFields, typeof(BrowsableAttribute))]
-        public override PropertyDescriptorCollection GetProperties(ITypeDescriptorContext context, object value, Attribute[] attributes)
-        {
-            PropertyDescriptorCollection props = TypeDescriptor.GetProperties(typeof(TableLayoutPanelCellPosition), attributes);
-            return props.Sort(new string[] { nameof(TableLayoutPanelCellPosition.Column), nameof(TableLayoutPanelCellPosition.Row) });
-        }
-
-        public override bool GetPropertiesSupported(ITypeDescriptorContext context) => true;
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutPanelCellPosition.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutPanelCellPosition.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 
 namespace System.Windows.Forms
@@ -31,7 +29,7 @@ namespace System.Windows.Forms
 
         public int Column { get; set; }
 
-        public override bool Equals(object other)
+        public override bool Equals(object? other)
         {
             if (other is not TableLayoutPanelCellPosition otherCellPosition)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutPanelCellPositionTypeConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutPanelCellPositionTypeConverter.cs
@@ -1,0 +1,120 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+using System.Collections;
+using System.ComponentModel;
+using System.ComponentModel.Design.Serialization;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+
+namespace System.Windows.Forms
+{
+    internal class TableLayoutPanelCellPositionTypeConverter : TypeConverter
+    {
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+        {
+            if (destinationType == typeof(InstanceDescriptor))
+            {
+                return true;
+            }
+
+            return base.CanConvertTo(context, destinationType);
+        }
+
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            if (sourceType == typeof(string))
+            {
+                return true;
+            }
+
+            return base.CanConvertFrom(context, sourceType);
+        }
+
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        {
+            if (value is string stringValue)
+            {
+                stringValue = stringValue.Trim();
+                if (stringValue.Length == 0)
+                {
+                    return null;
+                }
+
+                // Parse 2 integer values.
+                culture ??= CultureInfo.CurrentCulture;
+
+                string[] tokens = stringValue.Split(new char[] { culture.TextInfo.ListSeparator[0] });
+                int[] values = new int[tokens.Length];
+
+                if (values.Length != 2)
+                {
+                    throw new ArgumentException(
+                        string.Format(
+                            SR.TextParseFailedFormat,
+                            stringValue,
+                            "column, row"),
+                        nameof(value));
+                }
+
+                TypeConverter intConverter = TypeDescriptor.GetConverter(typeof(int));
+                for (int i = 0; i < values.Length; i++)
+                {
+                    // Note: ConvertFromString will raise exception if value cannot be converted.
+                    values[i] = (int)intConverter.ConvertFromString(context, culture, tokens[i]);
+                }
+
+                return new TableLayoutPanelCellPosition(values[0], values[1]);
+            }
+
+            return base.ConvertFrom(context, culture, value);
+        }
+
+        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+        {
+            if (destinationType == typeof(InstanceDescriptor) && value is TableLayoutPanelCellPosition cellPosition)
+            {
+                return new InstanceDescriptor(
+                    typeof(TableLayoutPanelCellPosition).GetConstructor(new Type[] { typeof(int), typeof(int) }),
+                    new object[] { cellPosition.Column, cellPosition.Row });
+            }
+
+            return base.ConvertTo(context, culture, value, destinationType);
+        }
+
+        public override object CreateInstance(ITypeDescriptorContext context, IDictionary propertyValues)
+        {
+            ArgumentNullException.ThrowIfNull(propertyValues);
+
+            try
+            {
+                return new TableLayoutPanelCellPosition(
+                    (int)propertyValues[nameof(TableLayoutPanelCellPosition.Column)],
+                    (int)propertyValues[nameof(TableLayoutPanelCellPosition.Row)]);
+            }
+            catch (InvalidCastException invalidCast)
+            {
+                throw new ArgumentException(SR.PropertyValueInvalidEntry, nameof(propertyValues), invalidCast);
+            }
+            catch (NullReferenceException nullRef)
+            {
+                throw new ArgumentException(SR.PropertyValueInvalidEntry, nameof(propertyValues), nullRef);
+            }
+        }
+
+        public override bool GetCreateInstanceSupported(ITypeDescriptorContext context) => true;
+
+        [RequiresUnreferencedCode(TrimmingConstants.TypeOrValueNotDiscoverableMessage)]
+        [DynamicDependency(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.PublicFields, typeof(BrowsableAttribute))]
+        public override PropertyDescriptorCollection GetProperties(ITypeDescriptorContext context, object value, Attribute[] attributes)
+        {
+            PropertyDescriptorCollection props = TypeDescriptor.GetProperties(typeof(TableLayoutPanelCellPosition), attributes);
+            return props.Sort(new string[] { nameof(TableLayoutPanelCellPosition.Column), nameof(TableLayoutPanelCellPosition.Row) });
+        }
+
+        public override bool GetPropertiesSupported(ITypeDescriptorContext context) => true;
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutPanelCellPositionTypeConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutPanelCellPositionTypeConverter.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections;
 using System.ComponentModel;
 using System.ComponentModel.Design.Serialization;
@@ -14,7 +12,7 @@ namespace System.Windows.Forms
 {
     internal class TableLayoutPanelCellPositionTypeConverter : TypeConverter
     {
-        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+        public override bool CanConvertTo(ITypeDescriptorContext? context, Type? destinationType)
         {
             if (destinationType == typeof(InstanceDescriptor))
             {
@@ -24,7 +22,7 @@ namespace System.Windows.Forms
             return base.CanConvertTo(context, destinationType);
         }
 
-        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType)
         {
             if (sourceType == typeof(string))
             {
@@ -34,7 +32,7 @@ namespace System.Windows.Forms
             return base.CanConvertFrom(context, sourceType);
         }
 
-        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        public override object? ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object value)
         {
             if (value is string stringValue)
             {
@@ -64,7 +62,7 @@ namespace System.Windows.Forms
                 for (int i = 0; i < values.Length; i++)
                 {
                     // Note: ConvertFromString will raise exception if value cannot be converted.
-                    values[i] = (int)intConverter.ConvertFromString(context, culture, tokens[i]);
+                    values[i] = (int)intConverter.ConvertFromString(context, culture, tokens[i])!;
                 }
 
                 return new TableLayoutPanelCellPosition(values[0], values[1]);
@@ -73,7 +71,7 @@ namespace System.Windows.Forms
             return base.ConvertFrom(context, culture, value);
         }
 
-        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+        public override object? ConvertTo(ITypeDescriptorContext? context, CultureInfo? culture, object? value, Type destinationType)
         {
             if (destinationType == typeof(InstanceDescriptor) && value is TableLayoutPanelCellPosition cellPosition)
             {
@@ -85,15 +83,15 @@ namespace System.Windows.Forms
             return base.ConvertTo(context, culture, value, destinationType);
         }
 
-        public override object CreateInstance(ITypeDescriptorContext context, IDictionary propertyValues)
+        public override object? CreateInstance(ITypeDescriptorContext? context, IDictionary propertyValues)
         {
             ArgumentNullException.ThrowIfNull(propertyValues);
 
             try
             {
                 return new TableLayoutPanelCellPosition(
-                    (int)propertyValues[nameof(TableLayoutPanelCellPosition.Column)],
-                    (int)propertyValues[nameof(TableLayoutPanelCellPosition.Row)]);
+                    (int)propertyValues[nameof(TableLayoutPanelCellPosition.Column)]!,
+                    (int)propertyValues[nameof(TableLayoutPanelCellPosition.Row)]!);
             }
             catch (InvalidCastException invalidCast)
             {
@@ -105,16 +103,16 @@ namespace System.Windows.Forms
             }
         }
 
-        public override bool GetCreateInstanceSupported(ITypeDescriptorContext context) => true;
+        public override bool GetCreateInstanceSupported(ITypeDescriptorContext? context) => true;
 
         [RequiresUnreferencedCode(TrimmingConstants.TypeOrValueNotDiscoverableMessage)]
         [DynamicDependency(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.PublicFields, typeof(BrowsableAttribute))]
-        public override PropertyDescriptorCollection GetProperties(ITypeDescriptorContext context, object value, Attribute[] attributes)
+        public override PropertyDescriptorCollection? GetProperties(ITypeDescriptorContext? context, object value, Attribute[]? attributes)
         {
             PropertyDescriptorCollection props = TypeDescriptor.GetProperties(typeof(TableLayoutPanelCellPosition), attributes);
             return props.Sort(new string[] { nameof(TableLayoutPanelCellPosition.Column), nameof(TableLayoutPanelCellPosition.Row) });
         }
 
-        public override bool GetPropertiesSupported(ITypeDescriptorContext context) => true;
+        public override bool GetPropertiesSupported(ITypeDescriptorContext? context) => true;
     }
 }


### PR DESCRIPTION
## Proposed changes

- Enable nullability in TableLayoutPanelCellPosition and TableLayoutPanelCellPositionTypeConverter

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8627)