### PR TITLE
Made ListBox.DefaultItemHeight property obsolete.

### DIFF
--- a/docs/list-of-diagnostics.md
+++ b/docs/list-of-diagnostics.md
@@ -38,6 +38,7 @@ The acceptance criteria for adding an obsoletion includes:
 |  __`WFDEV001`__ | Casting to/from IntPtr is unsafe, use `ResultInternal`. |
 |  __`WFDEV002`__ | `DomainUpDown.DomainUpDownAccessibleObject` is no longer used to provide accessible support for `DomainUpDown` controls. Use `ControlAccessibleObject` instead. |
 |  __`WFDEV003`__ | `DomainUpDown.DomainItemAccessibleObject` is no longer used to provide accessible support for `DomainUpDown` items. |
+|  __`WFDEV004`__ | `ListBox.DefaultItemHeight` constant is no longer used as the default item height. Default item height is now scaled according to the application default font. |
 
 
 ## Analyzer Warnings

--- a/src/Common/src/Obsoletions.cs
+++ b/src/Common/src/Obsoletions.cs
@@ -21,4 +21,9 @@ internal static class Obsoletions
     internal const string DomainItemAccessibleObjectMessage = $"{nameof(DomainUpDown.DomainItemAccessibleObject)} is no longer used to provide accessible support for {nameof(DomainUpDown)} items.";
 #pragma warning restore WFDEV003 // Type or member is obsolete
     internal const string DomainItemAccessibleObjectDiagnosticId = "WFDEV003";
+
+#pragma warning disable WFDEV004
+    internal const string ListBoxDefaultItemHeightMessage = $"{nameof(ListBox)}.{nameof(ListBox.DefaultItemHeight)} constant is no longer used as the default item height. Default item height is now scaled according to the default font.";
+#pragma warning restore WFDEV004
+    internal const string ListBoxDefaultItemHeightDiagnosticId = "WFDEV004";
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
@@ -52,6 +52,11 @@ namespace System.Windows.Forms
         ///  The default item height for an owner-draw ListBox. The ListBox's non-ownerdraw
         ///  item height is 13 for the default font on Windows.
         /// </summary>
+        [Obsolete(
+            Obsoletions.ListBoxDefaultItemHeightMessage,
+            error: false,
+            DiagnosticId = Obsoletions.ListBoxDefaultItemHeightDiagnosticId,
+            UrlFormat = Obsoletions.SharedUrlFormat)]
         public const int DefaultItemHeight = 13;
 
         private static readonly object EVENT_SELECTEDINDEXCHANGED = new object();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListBoxTests.cs
@@ -1382,6 +1382,39 @@ namespace System.Windows.Forms.Tests
             }
         }
 
+        [WinFormsFact]
+        public void ListBox_ItemHeight_EqualsDefaultHeight_IfDefaultFontIsChanged()
+        {
+            PropertyDescriptor property = TypeDescriptor.GetProperties(typeof(ListBox))[nameof(ListBox.ItemHeight)];
+            using ListBox listBox = new();
+            using Font font = new("Times New Roman", 12);
+
+            var applicationTestAccessor = typeof(Application).TestAccessor().Dynamic;
+            var listBoxTestAccessor = typeof(ListBox).TestAccessor().Dynamic;
+
+            try
+            {
+                // Application.DefaultFont is being changed.
+                // ListBox.DefaultListBoxItemHeight and Control.DefaultFont are being cleared to pick up Application.DefaultFont value.
+                // ListBox.ItemHeight is being reset to a new default value.
+                applicationTestAccessor.s_defaultFont = font;
+                listBoxTestAccessor.s_defaultListBoxItemHeight = -1;
+                listBoxTestAccessor.s_defaultFont = null;
+                property.ResetValue(listBox);
+
+                // ListBox.ItemHeight equals the new default value now.
+                Assert.Equal(Control.DefaultFont.Height - 1, listBox.ItemHeight);
+                Assert.Equal(Control.DefaultFont.Height - 1, listBoxTestAccessor.DefaultListBoxItemHeight);
+            }
+            finally
+            {
+                applicationTestAccessor.s_defaultFont = null;
+                applicationTestAccessor.s_defaultFontScaled = null;
+                listBoxTestAccessor.s_defaultListBoxItemHeight = -1;
+                listBoxTestAccessor.s_defaultFont = null;
+            }
+        }
+
         [WinFormsTheory]
         [MemberData(nameof(HorizontalExtent_Set_TestData))]
         public void ListBox_HorizontalExtent_Set_GetReturnsExpected(bool multiColumn, bool horizontalScrollBar, int value)


### PR DESCRIPTION
Fixes #4463 (partially, see also #8755)

## Proposed changes

- The ListBox.DefaultItemHeight constant marked as obsolete since the `ListBox.ItemHeight` after #8518 will be depended on actual `DefaultFont.Height` value.
- New unit test `ListBox_Height_IsEqualDefaultHeight_IfDefaultFontIsChanged` is added.
- Take note: it should be merged after the #8755 

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Made property obsolete. Made changes to documentation and obsoletion inside the project.

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Test methodology

- Manual (Issue can be tested via substitution of dlls, complete restart of the VS recommended)

## Test environment(s) <!-- Remove any that don't apply -->

- dotnet 8.0.100-alpha.1.22607.6


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8518)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8640)