### PR TITLE
Refactor `BindingManagerBase` and related classes to replace `ArrayList`

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -375,7 +375,6 @@ override System.Windows.Forms.MonthCalendar.ToString() -> string!
 ~override System.Windows.Forms.PropertyGrid.Text.get -> string
 ~override System.Windows.Forms.PropertyGrid.Text.set -> void
 ~override System.Windows.Forms.PropertyManager.Current.get -> object
-~override System.Windows.Forms.PropertyManager.GetListName(System.Collections.ArrayList listAccessors) -> string
 ~override System.Windows.Forms.PropertyManager.OnCurrentChanged(System.EventArgs ea) -> void
 ~override System.Windows.Forms.PropertyManager.OnCurrentItemChanged(System.EventArgs ea) -> void
 ~override System.Windows.Forms.RichTextBox.BackgroundImage.get -> System.Drawing.Image
@@ -2254,7 +2253,6 @@ abstract System.Windows.Forms.BindingManagerBase.CancelCurrentEdit() -> void
 abstract System.Windows.Forms.BindingManagerBase.Count.get -> int
 abstract System.Windows.Forms.BindingManagerBase.Current.get -> object!
 abstract System.Windows.Forms.BindingManagerBase.EndCurrentEdit() -> void
-abstract System.Windows.Forms.BindingManagerBase.GetListName(System.Collections.ArrayList? listAccessors) -> string!
 abstract System.Windows.Forms.BindingManagerBase.OnCurrentChanged(System.EventArgs! e) -> void
 abstract System.Windows.Forms.BindingManagerBase.OnCurrentItemChanged(System.EventArgs! e) -> void
 abstract System.Windows.Forms.BindingManagerBase.Position.get -> int

--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -3,6 +3,7 @@ System.Windows.Forms.PrintPreviewControl.TabStop.get -> bool
 System.Windows.Forms.PrintPreviewControl.TabStop.set -> void
 System.Windows.Forms.PrintPreviewControl.TabStopChanged -> System.EventHandler?
 *REMOVED*override System.Windows.Forms.ToolStripButton.CanSelect.get -> bool
+abstract System.Windows.Forms.BindingManagerBase.GetListName(System.Collections.Generic.List<System.ComponentModel.PropertyDescriptor!>? listAccessors) -> string!
 override System.Windows.Forms.MaskedTextBox.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject!
 override System.Windows.Forms.MaskedTextBox.OnGotFocus(System.EventArgs! e) -> void
 override System.Windows.Forms.MaskedTextBox.OnMouseDown(System.Windows.Forms.MouseEventArgs! e) -> void
@@ -12,3 +13,4 @@ virtual System.Windows.Forms.AxHost.State.Dispose(bool disposing) -> void
 *REMOVED*override System.Windows.Forms.DomainUpDown.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject!
 virtual System.Windows.Forms.NativeWindow.WmDpiChangedAfterParent(ref System.Windows.Forms.Message m) -> void
 virtual System.Windows.Forms.NativeWindow.WmDpiChangedBeforeParent(ref System.Windows.Forms.Message m) -> void
+~override System.Windows.Forms.PropertyManager.GetListName(System.Collections.Generic.List<System.ComponentModel.PropertyDescriptor> listAccessors) -> string

--- a/src/System.Windows.Forms/src/System/Windows/Forms/BindingManagerBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/BindingManagerBase.cs
@@ -224,7 +224,7 @@ namespace System.Windows.Forms
 
         protected abstract void UpdateIsBinding();
 
-        protected internal abstract string GetListName(ArrayList? listAccessors);
+        protected internal abstract string GetListName(List<PropertyDescriptor>? listAccessors);
 
         public abstract void SuspendBinding();
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/CurrencyManager.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CurrencyManager.cs
@@ -623,26 +623,19 @@ namespace System.Windows.Forms
         /// </summary>
         internal override string GetListName()
         {
-            if (list is ITypedList)
-            {
-                return ((ITypedList)list).GetListName(null);
-            }
-            else
-            {
-                return finalType.Name;
-            }
+            return list is ITypedList typedList ? typedList.GetListName(null) : finalType.Name;
         }
 
         /// <summary>
         ///  Gets the name of the specified list.
         /// </summary>
-        protected internal override string GetListName(ArrayList listAccessors)
+        protected internal override string GetListName(List<PropertyDescriptor> listAccessors)
         {
-            if (list is ITypedList)
+            if (list is ITypedList typedList)
             {
                 PropertyDescriptor[] properties = new PropertyDescriptor[listAccessors.Count];
                 listAccessors.CopyTo(properties, 0);
-                return ((ITypedList)list).GetListName(properties);
+                return typedList.GetListName(properties);
             }
 
             return "";

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyManager.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyManager.cs
@@ -4,7 +4,6 @@
 
 #nullable disable
 
-using System.Collections;
 using System.ComponentModel;
 
 namespace System.Windows.Forms
@@ -120,7 +119,7 @@ namespace System.Windows.Forms
         ///  Gets the name of the list supplying the data for the binding.
         /// </summary>
         /// <returns>Always returns an empty string.</returns>
-        protected internal override string GetListName(ArrayList listAccessors) => string.Empty;
+        protected internal override string GetListName(List<PropertyDescriptor> listAccessors) => string.Empty;
 
         /// <summary>
         ///  Cancels the current edit.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RelatedCurrencyManager.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RelatedCurrencyManager.cs
@@ -109,19 +109,14 @@ namespace System.Windows.Forms
         /// </summary>
         internal override string GetListName()
         {
-            string name = GetListName(new ArrayList());
-            if (name.Length > 0)
-            {
-                return name;
-            }
-
-            return base.GetListName();
+            string name = GetListName(new());
+            return name.Length > 0 ? name : base.GetListName();
         }
 
         /// <summary>
         ///  Gets the name of the specified list.
         /// </summary>
-        protected internal override string GetListName(ArrayList listAccessors)
+        protected internal override string GetListName(List<PropertyDescriptor> listAccessors)
         {
             listAccessors.Insert(0, fieldInfo);
             return parentManager.GetListName(listAccessors);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RelatedPropertyManager.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RelatedPropertyManager.cs
@@ -4,7 +4,6 @@
 
 #nullable disable
 
-using System.Collections;
 using System.ComponentModel;
 using System.Diagnostics;
 
@@ -38,16 +37,11 @@ namespace System.Windows.Forms
 
         internal override string GetListName()
         {
-            string name = GetListName(new ArrayList());
-            if (name.Length > 0)
-            {
-                return name;
-            }
-
-            return base.GetListName();
+            string name = GetListName(new());
+            return name.Length > 0 ? name : base.GetListName();
         }
 
-        protected internal override string GetListName(ArrayList listAccessors)
+        protected internal override string GetListName(List<PropertyDescriptor> listAccessors)
         {
             listAccessors.Insert(0, fieldInfo);
             return parentManager.GetListName(listAccessors);


### PR DESCRIPTION
Related: #8140, #8357

@merriemcgaw I think this is a breaking API change. But if the `ArrayList` contains anything but `PropertyDescriptor` it will cause an exception in `CurrencyManager.GetListName`.

CC: @KlausLoeffelmann because this relates to binding.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8651)