### PR TITLE
Fix Incorrect Conditional Check in CreateControl()

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -4927,7 +4927,7 @@ namespace System.Windows.Forms
         {
             // Unless specified otherwise, only "create" the control if it is visible for performance. This has the
             // effect of delayed handle creation of hidden controls.
-            if (!ignoreVisible && !GetState(States.Created) && !Visible)
+            if (!ignoreVisible && (GetState(States.Created) || !Visible))
             {
                 return;
             }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.cs
@@ -1090,6 +1090,37 @@ namespace System.Windows.Forms.Tests
             }
         }
 
+        [WinFormsFact]
+        public void Control_OnCreateControl_Triggered_Once_Expected()
+        {
+            // regression test for https://github.com/dotnet/winforms/issues/8495 and https://github.com/dotnet/winforms/issues/8489
+            // In both issues CreateControl method was not exiting early when the control was already created
+            // causing various unexpected behavior. This test ensures that a control does not try to go through
+            // CreateControl more than expected.
+            using Form form = new();
+            using OnCreateControlCounter control = new();
+            form.Controls.Add(control);
+            form.Shown += (s, e) => { form.Close(); };
+
+            form.ShowDialog();
+
+            // Calling show on the form will cause the control to be created and trigger OnCreateControl. Once
+            // the control is created, another show message will dispatch, which should cause CreateControl method to
+            // exit early, avoiding another trigger to OnCreateControl.
+            Assert.Equal(1, control.OnCreateControlCount);
+        }
+
+        private class OnCreateControlCounter : Control
+        {
+            public int OnCreateControlCount { get; set; }
+
+            protected override void OnCreateControl()
+            {
+                base.OnCreateControl();
+                OnCreateControlCount++;
+            }
+        }
+
         private class SubControl : Control
         {
             public SubControl() : base()


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #8495 
Fixes #8489 

A condition check in Control.cs was incorrectly inverted. 
Originally the condition was : 
```c#
bool ready = !GetState(States.Created);
ready = ready && Visible;
if (ready || fIgnoreVisible)
{
    // code...
}
```

and incorrectly inverted to : 
```c#
if (!ignoreVisible && !GetState(States.Created) && !Visible)
{
    return;
}
// code...
```
Regression [commit](https://github.com/dotnet/winforms/pull/8398/commits/3fa23fdff157ff51402b3d591255549d153214d5#diff-07a0a87cedab0d76c974ce8b105912a1b986c87116c7ee0ac73d6d5d65e4b48a)

This meant that a control could go through `CreateControl()` codepath even though it is already created or visible leading to many unexpected behavior.

### Before
#8495 :  user control overrode `OnCreateControl()` with a call to `RecreateHandle()` (indirectly). This caused control to be recreated even though it was in the middle of its creation cycle, resulting in a Win32 exception being thrown.
![before2](https://user-images.githubusercontent.com/30007367/219829567-7a4a9939-f059-4738-a6b3-1473f7ac9ba5.gif)


#8489 : user control attaches an eventhandler in `OnLoad()`. A show message causes the user control to be created, which causes `OnLoad()` to be triggered. This attaches the handler once. When a control is created, another show message is dispatched. Due to the incorrect condition check, the control would go through `CreateControl()` once again, which will trigger `OnLoad()` again, thus eventhandler is mistakenly attached twice. In this case it caused form to 'reopen' after user closes it.
![before](https://user-images.githubusercontent.com/30007367/219829573-2fa1f35b-0b16-4630-8cd7-8266d12f63ef.gif)


### After

#8495 : No exception thrown
![after2](https://user-images.githubusercontent.com/30007367/219829576-4facfa2e-5954-440c-a5d5-79cc0f999b5a.gif)


#8489 : No 'reopening' behavior
![after](https://user-images.githubusercontent.com/30007367/219829579-362b4275-e5a1-4f8a-a21c-54a951244d20.gif)



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8659)