### PR TITLE
Use interpolated strings in DataGridView

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.HitTestInfo.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.HitTestInfo.cs
@@ -4,8 +4,6 @@
 
 #nullable disable
 
-using System.Globalization;
-
 namespace System.Windows.Forms
 {
     public partial class DataGridView
@@ -119,7 +117,7 @@ namespace System.Windows.Forms
             /// </summary>
             public override string ToString()
             {
-                return "{ Type:" + _type.ToString() + ", Column:" + _col.ToString(CultureInfo.CurrentCulture) + ", Row:" + _row.ToString(CultureInfo.CurrentCulture) + " }";
+                return $"{{ Type:{_type}, Column:{_col}, Row:{_row} }}";
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.LayoutData.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.LayoutData.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Drawing;
-using System.Text;
 
 namespace System.Windows.Forms
 {
@@ -56,37 +55,18 @@ namespace System.Windows.Forms
 
             public override string ToString()
             {
-                StringBuilder sb = new StringBuilder(100);
-                sb.Append(base.ToString());
-                sb.Append(" { \n");
-                sb.Append("ClientRectangle = ");
-                sb.Append(ClientRectangle.ToString());
-                sb.Append('\n');
-                sb.Append("Inside = ");
-                sb.Append(Inside.ToString());
-                sb.Append('\n');
-                sb.Append("TopLeftHeader = ");
-                sb.Append(TopLeftHeader.ToString());
-                sb.Append('\n');
-                sb.Append("ColumnHeaders = ");
-                sb.Append(ColumnHeaders.ToString());
-                sb.Append('\n');
-                sb.Append("RowHeaders = ");
-                sb.Append(RowHeaders.ToString());
-                sb.Append('\n');
-                sb.Append("Data = ");
-                sb.Append(Data.ToString());
-                sb.Append('\n');
-                sb.Append("ResizeBoxRect = ");
-                sb.Append(ResizeBoxRect.ToString());
-                sb.Append('\n');
-                sb.Append("ColumnHeadersVisible = ");
-                sb.Append(ColumnHeadersVisible);
-                sb.Append('\n');
-                sb.Append("RowHeadersVisible = ");
-                sb.Append(RowHeadersVisible);
-                sb.Append(" }");
-                return sb.ToString();
+                return $$"""
+                    {{base.ToString()}} {
+                    ClientRectangle = {{ClientRectangle}}
+                    Inside = {{Inside}}
+                    TopLeftHeader = {{TopLeftHeader}}
+                    ColumnHeaders = {{ColumnHeaders}}
+                    RowHeaders = {{RowHeaders}}
+                    Data = {{Data}}
+                    ResizeBoxRect = {{ResizeBoxRect}}
+                    ColumnHeadersVisible = {{ColumnHeadersVisible}}
+                    RowHeadersVisible = {{RowHeadersVisible}} }
+                    """;
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
@@ -3724,7 +3724,7 @@ namespace System.Windows.Forms
 
         private bool ColumnEditable(int columnIndex)
         {
-            Debug.Assert(columnIndex >= 0 && columnIndex < Columns.Count, "Invalid columnIndex: " + columnIndex);
+            Debug.Assert(columnIndex >= 0 && columnIndex < Columns.Count, $"Invalid columnIndex: {columnIndex}");
             if (Columns[columnIndex].IsDataBound &&
                 DataConnection is not null &&
                 !DataConnection.AllowEdit)
@@ -17252,9 +17252,8 @@ namespace System.Windows.Forms
             }
             catch (Exception ex)
             {
-#if DEBUG
-                Debug.Fail("DataGridView.OnPaint exception: " + ex.Message + " stack trace " + ex.StackTrace);
-#endif
+                Debug.Fail($"DataGridView.OnPaint exception: {ex.Message} stack trace {ex.StackTrace}");
+
                 if (ClientUtils.IsCriticalException(ex))
                 {
                     throw;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.cs
@@ -12,11 +12,11 @@ using System.Windows.Forms.Layout;
 
 namespace System.Windows.Forms
 {
-    [Designer("System.Windows.Forms.Design.DataGridViewDesigner, " + AssemblyRef.SystemDesign)]
+    [Designer($"System.Windows.Forms.Design.DataGridViewDesigner, {AssemblyRef.SystemDesign}")]
     [DefaultEvent(nameof(CellContentClick))]
     [ComplexBindingProperties(nameof(DataSource), nameof(DataMember))]
     [Docking(DockingBehavior.Ask)]
-    [Editor("System.Windows.Forms.Design.DataGridViewComponentEditor, " + AssemblyRef.SystemDesign, typeof(ComponentEditor))]
+    [Editor($"System.Windows.Forms.Design.DataGridViewComponentEditor, {AssemblyRef.SystemDesign}", typeof(ComponentEditor))]
     [SRDescription(nameof(SR.DescriptionDataGridView))]
     public partial class DataGridView : Control, ISupportInitialize
     {
@@ -1198,7 +1198,7 @@ namespace System.Windows.Forms
             {
                 bool canEnable = false;
 
-                Debug.WriteLineIf(CompModSwitches.ImeMode.Level >= TraceLevel.Info, "Inside get_CanEnableIme(), this = " + this);
+                Debug.WriteLineIf(CompModSwitches.ImeMode.Level >= TraceLevel.Info, $"Inside get_CanEnableIme(), this = {this}");
                 Debug.Indent();
 
                 if (_ptCurrentCell.X != -1 && ColumnEditable(_ptCurrentCell.X))
@@ -1212,7 +1212,7 @@ namespace System.Windows.Forms
                     }
                 }
 
-                Debug.WriteLineIf(CompModSwitches.ImeMode.Level >= TraceLevel.Info, "Value = " + canEnable);
+                Debug.WriteLineIf(CompModSwitches.ImeMode.Level >= TraceLevel.Info, $"Value = {canEnable}");
                 Debug.Unindent();
 
                 return canEnable;
@@ -1792,7 +1792,7 @@ namespace System.Windows.Forms
             }
         }
 
-        [Editor("System.Windows.Forms.Design.DataGridViewColumnCollectionEditor, " + AssemblyRef.SystemDesign, typeof(Drawing.Design.UITypeEditor))]
+        [Editor($"System.Windows.Forms.Design.DataGridViewColumnCollectionEditor, {AssemblyRef.SystemDesign}", typeof(Drawing.Design.UITypeEditor))]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         [MergableProperty(false)]
         public DataGridViewColumnCollection Columns
@@ -1982,7 +1982,7 @@ namespace System.Windows.Forms
 
         [DefaultValue("")]
         [SRCategory(nameof(SR.CatData))]
-        [Editor("System.Windows.Forms.Design.DataMemberListEditor, " + AssemblyRef.SystemDesign, typeof(Drawing.Design.UITypeEditor))]
+        [Editor($"System.Windows.Forms.Design.DataMemberListEditor, {AssemblyRef.SystemDesign}", typeof(Drawing.Design.UITypeEditor))]
         [SRDescription(nameof(SR.DataGridViewDataMemberDescr))]
         public string DataMember
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewAdvancedBorderStyle.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewAdvancedBorderStyle.cs
@@ -292,7 +292,7 @@ namespace System.Windows.Forms
 
         public override string ToString()
         {
-            return "DataGridViewAdvancedBorderStyle { All=" + All.ToString() + ", Left=" + Left.ToString() + ", Right=" + Right.ToString() + ", Top=" + Top.ToString() + ", Bottom=" + Bottom.ToString() + " }";
+            return $"DataGridViewAdvancedBorderStyle {{ All={All}, Left={Left}, Right={Right}, Top={Top}, Bottom={Bottom} }}";
         }
 
         object ICloneable.Clone()

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewBand.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewBand.cs
@@ -5,7 +5,6 @@
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Text;
 
 namespace System.Windows.Forms
 {
@@ -923,11 +922,7 @@ namespace System.Windows.Forms
 
         public override string ToString()
         {
-            var builder = new StringBuilder(36);
-            builder.Append("DataGridViewBand { Index=");
-            builder.Append(Index);
-            builder.Append(" }");
-            return builder.ToString();
+            return $"DataGridViewBand {{ Index={Index} }}";
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewButtonCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewButtonCell.cs
@@ -8,7 +8,6 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
-using System.Globalization;
 using System.Windows.Forms.ButtonInternal;
 using System.Windows.Forms.VisualStyles;
 
@@ -1044,7 +1043,7 @@ namespace System.Windows.Forms
 
         public override string ToString()
         {
-            return "DataGridViewButtonCell { ColumnIndex=" + ColumnIndex.ToString(CultureInfo.CurrentCulture) + ", RowIndex=" + RowIndex.ToString(CultureInfo.CurrentCulture) + " }";
+            return $"DataGridViewButtonCell {{ ColumnIndex={ColumnIndex}, RowIndex={RowIndex} }}";
         }
 
         private void UpdateButtonState(ButtonState newButtonState, int rowIndex)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewButtonColumn.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewButtonColumn.cs
@@ -7,8 +7,6 @@
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
-using System.Globalization;
-using System.Text;
 
 namespace System.Windows.Forms
 {
@@ -220,13 +218,7 @@ namespace System.Windows.Forms
 
         public override string ToString()
         {
-            StringBuilder sb = new StringBuilder(64);
-            sb.Append("DataGridViewButtonColumn { Name=");
-            sb.Append(Name);
-            sb.Append(", Index=");
-            sb.Append(Index.ToString(CultureInfo.CurrentCulture));
-            sb.Append(" }");
-            return sb.ToString();
+            return $"DataGridViewButtonColumn {{ Name={Name}, Index={Index} }}";
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
@@ -28,8 +28,6 @@ namespace System.Windows.Forms
         private const int HighContrastThreshold = 2000;
         private const int MaxToolTipLength = 288;
         private const int MaxToolTipCutOff = 256;
-        private const int ToolTipEllipsisLength = 3;
-        private const string ToolTipEllipsis = "...";
         private const byte FlagAreaNotSet = 0x00;
         private const byte FlagDataArea = 0x01;
         private const byte FlagErrorArea = 0x02;
@@ -4154,16 +4152,14 @@ namespace System.Windows.Forms
         /// </summary>
         public override string ToString()
         {
-            return "DataGridViewCell { ColumnIndex=" + ColumnIndex.ToString(CultureInfo.CurrentCulture) + ", RowIndex=" + RowIndex.ToString(CultureInfo.CurrentCulture) + " }";
+            return $"DataGridViewCell {{ ColumnIndex={ColumnIndex}, RowIndex={RowIndex} }}";
         }
 
         private static string TruncateToolTipText(string toolTipText)
         {
             if (toolTipText.Length > MaxToolTipLength)
             {
-                StringBuilder sb = new StringBuilder(toolTipText.Substring(0, MaxToolTipCutOff), MaxToolTipCutOff + ToolTipEllipsisLength);
-                sb.Append(ToolTipEllipsis);
-                return sb.ToString();
+                return $"{toolTipText.AsSpan(0, MaxToolTipCutOff)}...";
             }
 
             return toolTipText;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellStyle.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellStyle.cs
@@ -13,7 +13,7 @@ using System.Text;
 namespace System.Windows.Forms
 {
     [TypeConverter(typeof(DataGridViewCellStyleConverter))]
-    [Editor("System.Windows.Forms.Design.DataGridViewCellStyleEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
+    [Editor($"System.Windows.Forms.Design.DataGridViewCellStyleEditor, {AssemblyRef.SystemDesign}", typeof(UITypeEditor))]
     public class DataGridViewCellStyle : ICloneable
     {
         private static readonly int PropAlignment = PropertyStore.CreateKey();
@@ -224,7 +224,7 @@ namespace System.Windows.Forms
         }
 
         [DefaultValue("")]
-        [Editor("System.Windows.Forms.Design.FormatStringEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
+        [Editor($"System.Windows.Forms.Design.FormatStringEditor, {AssemblyRef.SystemDesign}", typeof(UITypeEditor))]
         [SRCategory(nameof(SR.CatBehavior))]
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         public string Format

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellStyle.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellStyle.cs
@@ -722,7 +722,7 @@ namespace System.Windows.Forms
             bool firstPropAdded = true;
             if (BackColor != Color.Empty)
             {
-                sb.Append(" BackColor=" + BackColor.ToString());
+                sb.Append($" BackColor={BackColor}");
                 firstPropAdded = false;
             }
 
@@ -733,7 +733,7 @@ namespace System.Windows.Forms
                     sb.Append(',');
                 }
 
-                sb.Append(" ForeColor=" + ForeColor.ToString());
+                sb.Append($" ForeColor={ForeColor}");
                 firstPropAdded = false;
             }
 
@@ -744,7 +744,7 @@ namespace System.Windows.Forms
                     sb.Append(',');
                 }
 
-                sb.Append(" SelectionBackColor=" + SelectionBackColor.ToString());
+                sb.Append($" SelectionBackColor={SelectionBackColor}");
                 firstPropAdded = false;
             }
 
@@ -755,7 +755,7 @@ namespace System.Windows.Forms
                     sb.Append(',');
                 }
 
-                sb.Append(" SelectionForeColor=" + SelectionForeColor.ToString());
+                sb.Append($" SelectionForeColor={SelectionForeColor}");
                 firstPropAdded = false;
             }
 
@@ -766,7 +766,7 @@ namespace System.Windows.Forms
                     sb.Append(',');
                 }
 
-                sb.Append(" Font=" + Font.ToString());
+                sb.Append($" Font={Font}");
                 firstPropAdded = false;
             }
 
@@ -777,7 +777,7 @@ namespace System.Windows.Forms
                     sb.Append(',');
                 }
 
-                sb.Append(" NullValue=" + NullValue.ToString());
+                sb.Append($" NullValue={NullValue}");
                 firstPropAdded = false;
             }
 
@@ -788,7 +788,7 @@ namespace System.Windows.Forms
                     sb.Append(',');
                 }
 
-                sb.Append(" DataSourceNullValue=" + DataSourceNullValue.ToString());
+                sb.Append($" DataSourceNullValue={DataSourceNullValue}");
                 firstPropAdded = false;
             }
 
@@ -799,7 +799,7 @@ namespace System.Windows.Forms
                     sb.Append(',');
                 }
 
-                sb.Append(" Format=" + Format);
+                sb.Append($" Format={Format}");
                 firstPropAdded = false;
             }
 
@@ -810,7 +810,7 @@ namespace System.Windows.Forms
                     sb.Append(',');
                 }
 
-                sb.Append(" WrapMode=" + WrapMode.ToString());
+                sb.Append($" WrapMode={WrapMode}");
                 firstPropAdded = false;
             }
 
@@ -821,7 +821,7 @@ namespace System.Windows.Forms
                     sb.Append(',');
                 }
 
-                sb.Append(" Alignment=" + Alignment.ToString());
+                sb.Append($" Alignment={Alignment}");
                 firstPropAdded = false;
             }
 
@@ -832,7 +832,7 @@ namespace System.Windows.Forms
                     sb.Append(',');
                 }
 
-                sb.Append(" Padding=" + Padding.ToString());
+                sb.Append($" Padding={Padding}");
                 firstPropAdded = false;
             }
 
@@ -843,7 +843,7 @@ namespace System.Windows.Forms
                     sb.Append(',');
                 }
 
-                sb.Append(" Tag=" + Tag.ToString());
+                sb.Append($" Tag={Tag}");
                 firstPropAdded = false;
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCheckBoxCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCheckBoxCell.cs
@@ -8,7 +8,6 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
-using System.Globalization;
 using System.Windows.Forms.ButtonInternal;
 using System.Windows.Forms.VisualStyles;
 
@@ -1763,7 +1762,7 @@ namespace System.Windows.Forms
         /// </summary>
         public override string ToString()
         {
-            return "DataGridViewCheckBoxCell { ColumnIndex=" + ColumnIndex.ToString(CultureInfo.CurrentCulture) + ", RowIndex=" + RowIndex.ToString(CultureInfo.CurrentCulture) + " }";
+            return $"DataGridViewCheckBoxCell {{ ColumnIndex={ColumnIndex}, RowIndex={RowIndex} }}";
         }
 
         private void UpdateButtonState(ButtonState newButtonState, int rowIndex)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCheckBoxColumn.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCheckBoxColumn.cs
@@ -7,8 +7,6 @@
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
-using System.Globalization;
-using System.Text;
 
 namespace System.Windows.Forms
 {
@@ -319,13 +317,7 @@ namespace System.Windows.Forms
 
         public override string ToString()
         {
-            StringBuilder sb = new StringBuilder(64);
-            sb.Append("DataGridViewCheckBoxColumn { Name=");
-            sb.Append(Name);
-            sb.Append(", Index=");
-            sb.Append(Index.ToString(CultureInfo.CurrentCulture));
-            sb.Append(" }");
-            return sb.ToString();
+            return $"DataGridViewCheckBoxColumn {{ Name={Name}, Index={Index} }}";
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumn.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumn.cs
@@ -8,7 +8,6 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-using System.Text;
 
 namespace System.Windows.Forms
 {
@@ -1118,13 +1117,7 @@ namespace System.Windows.Forms
 
         public override string ToString()
         {
-            StringBuilder sb = new StringBuilder(64);
-            sb.Append("DataGridViewColumn { Name=");
-            sb.Append(Name);
-            sb.Append(", Index=");
-            sb.Append(Index.ToString(CultureInfo.CurrentCulture));
-            sb.Append(" }");
-            return sb.ToString();
+            return $"DataGridViewColumn {{ Name={Name}, Index={Index} }}";
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumn.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumn.cs
@@ -14,7 +14,7 @@ namespace System.Windows.Forms
     /// <summary>
     ///  Base class for the columns in a data grid view.
     /// </summary>
-    [Designer("System.Windows.Forms.Design.DataGridViewColumnDesigner, " + AssemblyRef.SystemDesign)]
+    [Designer($"System.Windows.Forms.Design.DataGridViewColumnDesigner, {AssemblyRef.SystemDesign}")]
     [DesignTimeVisible(false)]
     [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
     [ToolboxItem(false)]
@@ -179,8 +179,8 @@ namespace System.Windows.Forms
 
         [Browsable(true)]
         [DefaultValue("")]
-        [TypeConverter("System.Windows.Forms.Design.DataMemberFieldConverter, " + AssemblyRef.SystemDesign)]
-        [Editor("System.Windows.Forms.Design.DataGridViewColumnDataPropertyNameEditor, " + AssemblyRef.SystemDesign, typeof(Drawing.Design.UITypeEditor))]
+        [TypeConverter($"System.Windows.Forms.Design.DataMemberFieldConverter, {AssemblyRef.SystemDesign}")]
+        [Editor($"System.Windows.Forms.Design.DataGridViewColumnDataPropertyNameEditor, {AssemblyRef.SystemDesign}", typeof(Drawing.Design.UITypeEditor))]
         [SRDescription(nameof(SR.DataGridView_ColumnDataPropertyNameDescr))]
         [SRCategory(nameof(SR.CatData))]
         public string DataPropertyName

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnHeaderCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnHeaderCell.cs
@@ -1226,7 +1226,7 @@ namespace System.Windows.Forms
         /// </summary>
         public override string ToString()
         {
-            return "DataGridViewColumnHeaderCell { ColumnIndex=" + ColumnIndex.ToString(CultureInfo.CurrentCulture) + " }";
+            return $"DataGridViewColumnHeaderCell {{ ColumnIndex={ColumnIndex} }}";
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxCell.cs
@@ -2553,7 +2553,7 @@ namespace System.Windows.Forms
         /// </summary>
         public override string ToString()
         {
-            return "DataGridViewComboBoxCell { ColumnIndex=" + ColumnIndex.ToString(CultureInfo.CurrentCulture) + ", RowIndex=" + RowIndex.ToString(CultureInfo.CurrentCulture) + " }";
+            return $"DataGridViewComboBoxCell {{ ColumnIndex={ColumnIndex}, RowIndex={RowIndex} }}";
         }
 
         private void UnwireDataSource()

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxColumn.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxColumn.cs
@@ -8,8 +8,6 @@ using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
 using System.Drawing.Design;
-using System.Globalization;
-using System.Text;
 
 namespace System.Windows.Forms
 {
@@ -514,13 +512,7 @@ namespace System.Windows.Forms
         /// </summary>
         public override string ToString()
         {
-            StringBuilder sb = new StringBuilder(64);
-            sb.Append("DataGridViewComboBoxColumn { Name=");
-            sb.Append(Name);
-            sb.Append(", Index=");
-            sb.Append(Index.ToString(CultureInfo.CurrentCulture));
-            sb.Append(" }");
-            return sb.ToString();
+            return $"DataGridViewComboBoxColumn {{ Name={Name}, Index={Index} }}";
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxColumn.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxColumn.cs
@@ -11,7 +11,7 @@ using System.Drawing.Design;
 
 namespace System.Windows.Forms
 {
-    [Designer("System.Windows.Forms.Design.DataGridViewComboBoxColumnDesigner, " + AssemblyRef.SystemDesign)]
+    [Designer($"System.Windows.Forms.Design.DataGridViewComboBoxColumnDesigner, {AssemblyRef.SystemDesign}")]
     [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
     [ToolboxBitmap(typeof(DataGridViewComboBoxColumn), "DataGridViewComboBoxColumn")]
     public class DataGridViewComboBoxColumn : DataGridViewColumn
@@ -134,8 +134,8 @@ namespace System.Windows.Forms
         [DefaultValue("")]
         [SRCategory(nameof(SR.CatData))]
         [SRDescription(nameof(SR.DataGridView_ComboBoxColumnDisplayMemberDescr))]
-        [TypeConverter("System.Windows.Forms.Design.DataMemberFieldConverter, " + AssemblyRef.SystemDesign)]
-        [Editor("System.Windows.Forms.Design.DataMemberFieldEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
+        [TypeConverter($"System.Windows.Forms.Design.DataMemberFieldConverter, {AssemblyRef.SystemDesign}")]
+        [Editor($"System.Windows.Forms.Design.DataMemberFieldEditor, {AssemblyRef.SystemDesign}", typeof(UITypeEditor))]
         public string DisplayMember
         {
             get
@@ -329,7 +329,7 @@ namespace System.Windows.Forms
             }
         }
 
-        [Editor("System.Windows.Forms.Design.StringCollectionEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
+        [Editor($"System.Windows.Forms.Design.StringCollectionEditor, {AssemblyRef.SystemDesign}", typeof(UITypeEditor))]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         [SRCategory(nameof(SR.CatData))]
         [SRDescription(nameof(SR.DataGridView_ComboBoxColumnItemsDescr))]
@@ -349,8 +349,8 @@ namespace System.Windows.Forms
         [DefaultValue("")]
         [SRCategory(nameof(SR.CatData))]
         [SRDescription(nameof(SR.DataGridView_ComboBoxColumnValueMemberDescr))]
-        [TypeConverter("System.Windows.Forms.Design.DataMemberFieldConverter, " + AssemblyRef.SystemDesign)]
-        [Editor("System.Windows.Forms.Design.DataMemberFieldEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
+        [TypeConverter($"System.Windows.Forms.Design.DataMemberFieldConverter, {AssemblyRef.SystemDesign}")]
+        [Editor($"System.Windows.Forms.Design.DataMemberFieldEditor, {AssemblyRef.SystemDesign}", typeof(UITypeEditor))]
         public string ValueMember
         {
             get

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewImageColumn.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewImageColumn.cs
@@ -8,8 +8,6 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
-using System.Globalization;
-using System.Text;
 
 namespace System.Windows.Forms
 {
@@ -309,13 +307,7 @@ namespace System.Windows.Forms
 
         public override string ToString()
         {
-            StringBuilder sb = new StringBuilder(64);
-            sb.Append("DataGridViewImageColumn { Name=");
-            sb.Append(Name);
-            sb.Append(", Index=");
-            sb.Append(Index.ToString(CultureInfo.CurrentCulture));
-            sb.Append(" }");
-            return sb.ToString();
+            return $"DataGridViewImageColumn {{ Name={Name}, Index={Index} }}";
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewLinkCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewLinkCell.cs
@@ -8,7 +8,6 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
-using System.Globalization;
 using System.Runtime.CompilerServices;
 
 namespace System.Windows.Forms
@@ -1148,7 +1147,7 @@ namespace System.Windows.Forms
 
         public override string ToString()
         {
-            return "DataGridViewLinkCell { ColumnIndex=" + ColumnIndex.ToString(CultureInfo.CurrentCulture) + ", RowIndex=" + RowIndex.ToString(CultureInfo.CurrentCulture) + " }";
+            return $"DataGridViewLinkCell {{ ColumnIndex={ColumnIndex}, RowIndex={RowIndex} }}";
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewLinkColumn.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewLinkColumn.cs
@@ -7,8 +7,6 @@
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
-using System.Globalization;
-using System.Text;
 
 namespace System.Windows.Forms
 {
@@ -363,13 +361,7 @@ namespace System.Windows.Forms
 
         public override string ToString()
         {
-            StringBuilder sb = new StringBuilder(64);
-            sb.Append("DataGridViewLinkColumn { Name=");
-            sb.Append(Name);
-            sb.Append(", Index=");
-            sb.Append(Index.ToString(CultureInfo.CurrentCulture));
-            sb.Append(" }");
-            return sb.ToString();
+            return $"DataGridViewLinkColumn {{ Name={Name}, Index={Index} }}";
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.cs
@@ -7,8 +7,6 @@
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
-using System.Globalization;
-using System.Text;
 
 namespace System.Windows.Forms
 {
@@ -1836,11 +1834,7 @@ namespace System.Windows.Forms
 
         public override string ToString()
         {
-            var sb = new StringBuilder(36);
-            sb.Append("DataGridViewRow { Index=");
-            sb.Append(Index.ToString(CultureInfo.CurrentCulture));
-            sb.Append(" }");
-            return sb.ToString();
+            return $"DataGridViewRow {{ Index={Index} }}";
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowCollection.cs
@@ -17,8 +17,8 @@ namespace System.Windows.Forms
     ///  <see cref="DataGridView"/> control.
     /// </summary>
     [ListBindable(false)]
-    [DesignerSerializer("System.Windows.Forms.Design.DataGridViewRowCollectionCodeDomSerializer, " + AssemblyRef.SystemDesign,
-                        "System.ComponentModel.Design.Serialization.CodeDomSerializer, " + AssemblyRef.SystemDesign)]
+    [DesignerSerializer($"System.Windows.Forms.Design.DataGridViewRowCollectionCodeDomSerializer, {AssemblyRef.SystemDesign}",
+        $"System.ComponentModel.Design.Serialization.CodeDomSerializer, {AssemblyRef.SystemDesign}")]
     public partial class DataGridViewRowCollection : ICollection, IList
     {
 #if DEBUG

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowHeaderCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowHeaderCell.cs
@@ -1142,7 +1142,7 @@ namespace System.Windows.Forms
         /// </summary>
         public override string ToString()
         {
-            return "DataGridViewRowHeaderCell { RowIndex=" + RowIndex.ToString(CultureInfo.CurrentCulture) + " }";
+            return $"DataGridViewRowHeaderCell {{ RowIndex={RowIndex} }}";
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxColumn.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxColumn.cs
@@ -4,8 +4,6 @@
 
 using System.ComponentModel;
 using System.Drawing;
-using System.Globalization;
-using System.Text;
 
 namespace System.Windows.Forms
 {
@@ -82,13 +80,7 @@ namespace System.Windows.Forms
 
         public override string ToString()
         {
-            StringBuilder sb = new StringBuilder(64);
-            sb.Append("DataGridViewTextBoxColumn { Name=");
-            sb.Append(Name);
-            sb.Append(", Index=");
-            sb.Append(Index.ToString(CultureInfo.CurrentCulture));
-            sb.Append(" }");
-            return sb.ToString();
+            return $"DataGridViewTextBoxColumn {{ Name={Name}, Index={Index} }}";
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewCellAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewCellAccessibleObjectTests.cs
@@ -1003,11 +1003,7 @@ namespace System.Windows.Forms.Tests
             dataGridView.Rows.Add(new DataGridViewRow());
 
             DataGridViewCellAccessibleObject dataGridViewCellAccessibleObject = new(dataGridView.Rows[0].Cells[0]);
-            string expected = string.Empty;
-            foreach (int runtimeIdPart in dataGridViewCellAccessibleObject.RuntimeId)
-            {
-                expected += runtimeIdPart.ToString();
-            }
+            string expected = string.Concat(dataGridViewCellAccessibleObject.RuntimeId);
 
             Assert.Equal(expected, dataGridViewCellAccessibleObject.GetPropertyValue(UiaCore.UIA.AutomationIdPropertyId));
             Assert.False(dataGridView.IsHandleCreated);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewCellStyleTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewCellStyleTests.cs
@@ -1074,7 +1074,7 @@ namespace System.Windows.Forms.Tests
             yield return new object[]
             {
                 new DataGridViewCellStyle { Font = SystemFonts.DefaultFont },
-                "DataGridViewCellStyle { Font=" + SystemFonts.DefaultFont.ToString() + " }"
+                $"DataGridViewCellStyle {{ Font={SystemFonts.DefaultFont} }}"
             };
             yield return new object[]
             {


### PR DESCRIPTION
Contributes to #8203

This changes span all the DataGridView-related files. A lot of the changes are about StringBuilder removal.
<!-- We are in TELL-MODE the following section must be completed -->

## Test methodology

static code analysis

## Test environment

8.0.100-preview.1.23115.2

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8699)