### PR TITLE
Refactor `DesignerSerializationManager` dictionary usage to use `TryGetValue`

### DIFF
--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/Serialization/DesignerSerializationManagerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/Serialization/DesignerSerializationManagerTests.cs
@@ -1394,6 +1394,9 @@ namespace System.ComponentModel.Design.Serialization.Tests
 
             // Call again.
             Assert.Null(iManager.GetSerializer(objectType, typeof(int)));
+
+            // Call unrelated object type
+            Assert.Null(iManager.GetSerializer(typeof(object), typeof(int)));
         }
 
         [Fact]


### PR DESCRIPTION
Refactor dictionary usage to use `TryGetValue`.

Addresses feedback from:
https://github.com/dotnet/winforms/pull/8353#issuecomment-1443195430

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8702)