### PR TITLE
Use interpolated strings in System.ComponentModel.Design

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ComponentDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ComponentDesigner.cs
@@ -7,7 +7,6 @@
 using System.Collections;
 using System.Configuration;
 using System.Diagnostics;
-using System.Globalization;
 using System.Windows.Forms.Design;
 
 namespace System.ComponentModel.Design
@@ -466,7 +465,7 @@ namespace System.ComponentModel.Design
                         {
                             if (rootComponent is not null && rootComponent != persistableComponent)
                             {
-                                ShadowProperties[SettingsKeyName] = string.Format(CultureInfo.CurrentCulture, "{0}.{1}", rootComponent.Site.Name, Component.Site.Name);
+                                ShadowProperties[SettingsKeyName] = $"{rootComponent.Site.Name}.{Component.Site.Name}";
                             }
                             else
                             {

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignSurface.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignSurface.cs
@@ -435,7 +435,7 @@ namespace System.ComponentModel.Design
                 return new TypeDescriptorFilterService();
             }
 
-            Debug.Assert(serviceType == typeof(IReferenceService), "Demand created service not supported: " + serviceType.Name);
+            Debug.Assert(serviceType == typeof(IReferenceService), $"Demand created service not supported: {serviceType.Name}");
             return new ReferenceService(container);
         }
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignSurfaceManager.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignSurfaceManager.cs
@@ -361,7 +361,7 @@ namespace System.ComponentModel.Design
                 return new DesignerEventService();
             }
 
-            Debug.Fail("Demand created service not supported: " + serviceType.Name);
+            Debug.Fail($"Demand created service not supported: {serviceType.Name}");
             return null;
         }
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.MethodLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.MethodLine.cs
@@ -24,7 +24,7 @@ namespace System.ComponentModel.Design
 
             public sealed override string FocusId
             {
-                get => "METHOD:" + _actionList.GetType().FullName + "." + _methodItem.MemberName;
+                get => $"METHOD:{_actionList.GetType().FullName}.{_methodItem.MemberName}";
             }
 
             protected override void AddControls(List<Control> controls)

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.PropertyLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.PropertyLine.cs
@@ -27,7 +27,7 @@ namespace System.ComponentModel.Design
 
             public sealed override string FocusId
             {
-                get => "PROPERTY:" + _actionList.GetType().FullName + "." + _propertyItem.MemberName;
+                get => $"PROPERTY:{_actionList.GetType().FullName}.{_propertyItem.MemberName}";
             }
 
             protected PropertyDescriptor PropertyDescriptor

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionUI.DesignerActionToolStripDropDown.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionUI.DesignerActionToolStripDropDown.cs
@@ -29,7 +29,7 @@ namespace System.ComponentModel.Design
             }
 
             public DesignerActionPanel CurrentPanel
-                => _panel is not null ? _panel.Control as DesignerActionPanel : null;
+                => _panel?.Control as DesignerActionPanel;
 
             // we're not topmost because we can show modal editors above us.
             protected override bool TopMost
@@ -162,10 +162,10 @@ namespace System.ComponentModel.Design
                     }
                 }
 
-                Debug.WriteLineIf(DropDownVisibilityDebug.TraceVerbose, "[DesignerActionToolStripDropDown.OnClosing] calling base.OnClosing with e.Cancel: " + e.Cancel.ToString());
+                Debug.WriteLineIf(DropDownVisibilityDebug.TraceVerbose, $"[DesignerActionToolStripDropDown.OnClosing] calling base.OnClosing with e.Cancel: {e.Cancel}");
                 base.OnClosing(e);
                 Debug.Unindent();
-                Debug.WriteLineIf(DropDownVisibilityDebug.TraceVerbose, "_____________________________End OnClose e.Cancel: " + e.Cancel.ToString());
+                Debug.WriteLineIf(DropDownVisibilityDebug.TraceVerbose, $"_____________________________End OnClose e.Cancel: {e.Cancel}");
             }
 
             public void SetDesignerActionPanel(DesignerActionPanel panel, Glyph relatedGlyph)
@@ -222,7 +222,7 @@ namespace System.ComponentModel.Design
 
             protected override void SetVisibleCore(bool visible)
             {
-                Debug.WriteLineIf(DropDownVisibilityDebug.TraceVerbose, "[DesignerActionToolStripDropDown.SetVisibleCore] setting dropdown visible=" + visible.ToString());
+                Debug.WriteLineIf(DropDownVisibilityDebug.TraceVerbose, $"[DesignerActionToolStripDropDown.SetVisibleCore] setting dropdown visible={visible}");
                 base.SetVisibleCore(visible);
                 if (visible)
                 {
@@ -238,16 +238,13 @@ namespace System.ComponentModel.Design
             {
                 Debug.WriteLineIf(
                     DropDownVisibilityDebug.TraceVerbose,
-                    $"[WindowOwnsWindow] Testing if {hWndOwner.Value.ToString("x")} is a owned by {hWndDescendant.Value.ToString("x")}... ");
-#if DEBUG
-                if (DropDownVisibilityDebug.TraceVerbose)
-                {
-                    Debug.WriteLine("\t\tOWNER: " + GetControlInformation(hWndOwner));
-                    Debug.WriteLine("\t\tOWNEE: " + GetControlInformation(hWndDescendant));
-                    IntPtr claimedOwnerHwnd = PInvoke.GetWindowLong(hWndDescendant, WINDOW_LONG_PTR_INDEX.GWL_HWNDPARENT);
-                    Debug.WriteLine("OWNEE's CLAIMED OWNER: " + GetControlInformation(claimedOwnerHwnd));
-                }
-#endif
+                    $"""
+                        [WindowOwnsWindow] Testing if {hWndOwner.Value:x} is a owned by {hWndDescendant.Value:x}...
+                        		OWNER: {GetControlInformation(hWndOwner)}
+                        		OWNEE: {GetControlInformation(hWndDescendant)}
+                        OWNEE's CLAIMED OWNER: {GetControlInformation(PInvoke.GetWindowLong(hWndDescendant, WINDOW_LONG_PTR_INDEX.GWL_HWNDPARENT))}
+                        """);
+
                 if (hWndDescendant == hWndOwner)
                 {
                     Debug.WriteLineIf(DropDownVisibilityDebug.TraceVerbose, "they match, YES.");
@@ -306,13 +303,16 @@ namespace System.ComponentModel.Design
                         {
                             if (dd.OwnerItem is not null)
                             {
-                                nameOfControl += "OwnerItem: [" + dd.OwnerItem.ToString() + "]";
+                                nameOfControl += $"OwnerItem: [{dd.OwnerItem}]";
                             }
                         }
                     }
                 }
 
-                return windowText + "\r\n\t\t\tType: [" + typeOfControl + "] Name: [" + nameOfControl + "]";
+                return $"""
+                    {windowText}
+                    			Type: [{typeOfControl}] Name: [{nameOfControl}]
+                    """;
 #else
             return string.Empty;
 #endif
@@ -333,7 +333,7 @@ namespace System.ComponentModel.Design
                     if (WindowOwnsWindow((HWND)Handle, hwndActivating))
                     {
                         Debug.WriteLineIf(DropDownVisibilityDebug.TraceVerbose, "[DesignerActionUI WmActivate] setting cancel close true because WindowsOwnWindow");
-                        Debug.WriteLineIf(DropDownVisibilityDebug.TraceVerbose, "[DesignerActionUI WmActivate] checking the focus... " + GetControlInformation(PInvoke.GetFocus()));
+                        Debug.WriteLineIf(DropDownVisibilityDebug.TraceVerbose, $"[DesignerActionUI WmActivate] checking the focus... {GetControlInformation(PInvoke.GetFocus())}");
                         _cancelClose = true;
                     }
                     else

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionUI.cs
@@ -596,13 +596,13 @@ namespace System.ComponentModel.Design
             if (e.CloseReason == ToolStripDropDownCloseReason.ItemClicked)
             {
                 e.Cancel = true;
-                Debug.WriteLineIf(DropDownVisibilityDebug.TraceVerbose, "[DesignerActionUI.toolStripDropDown_Closing] ItemClicked: e.Cancel set to: " + e.Cancel.ToString());
+                Debug.WriteLineIf(DropDownVisibilityDebug.TraceVerbose, $"[DesignerActionUI.toolStripDropDown_Closing] ItemClicked: e.Cancel set to: {e.Cancel}");
             }
 
             if (e.CloseReason == ToolStripDropDownCloseReason.Keyboard)
             {
                 e.Cancel = false;
-                Debug.WriteLineIf(DropDownVisibilityDebug.TraceVerbose, "[DesignerActionUI.toolStripDropDown_Closing] Keyboard: e.Cancel set to: " + e.Cancel.ToString());
+                Debug.WriteLineIf(DropDownVisibilityDebug.TraceVerbose, $"[DesignerActionUI.toolStripDropDown_Closing] Keyboard: e.Cancel set to: {e.Cancel}");
             }
 
             if (e.Cancel == false)

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/InheritanceService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/InheritanceService.cs
@@ -6,7 +6,6 @@
 
 using System.ComponentModel.Design.Serialization;
 using System.Diagnostics;
-using System.Globalization;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Windows.Forms.Design;
@@ -68,7 +67,7 @@ namespace System.ComponentModel.Design
                 return;
             }
 
-            Debug.WriteLineIf(s_inheritanceServiceSwitch.TraceVerbose, "Searching for inherited components on '" + type.FullName + "'.");
+            Debug.WriteLineIf(s_inheritanceServiceSwitch.TraceVerbose, $"Searching for inherited components on '{type.FullName}'.");
             Debug.Indent();
             ISite site = component.Site;
             IComponentChangeService cs = null;
@@ -90,7 +89,7 @@ namespace System.ComponentModel.Design
                 {
                     Type reflect = TypeDescriptor.GetReflectionType(type);
                     FieldInfo[] fields = reflect.GetFields(BindingFlags.Instance | BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.NonPublic);
-                    Debug.WriteLineIf(s_inheritanceServiceSwitch.TraceVerbose, "...found " + fields.Length.ToString(CultureInfo.InvariantCulture) + " fields.");
+                    Debug.WriteLineIf(s_inheritanceServiceSwitch.TraceVerbose, $"...found {fields.Length} fields.");
                     for (int i = 0; i < fields.Length; i++)
                     {
                         FieldInfo field = fields[i];
@@ -100,7 +99,7 @@ namespace System.ComponentModel.Design
                         Type reflectionType = GetReflectionTypeFromTypeHelper(field.FieldType);
                         if (!GetReflectionTypeFromTypeHelper(typeof(IComponent)).IsAssignableFrom(reflectionType))
                         {
-                            Debug.WriteLineIf(s_inheritanceServiceSwitch.TraceVerbose, "...skipping " + name + ": Not IComponent");
+                            Debug.WriteLineIf(s_inheritanceServiceSwitch.TraceVerbose, $"...skipping {name}: Not IComponent");
                             continue;
                         }
 
@@ -111,7 +110,7 @@ namespace System.ComponentModel.Design
                         object value = field.GetValue(component);
                         if (value is null)
                         {
-                            Debug.WriteLineIf(s_inheritanceServiceSwitch.TraceVerbose, "...skipping " + name + ": Contains NULL");
+                            Debug.WriteLineIf(s_inheritanceServiceSwitch.TraceVerbose, $"...skipping {name}: Contains NULL");
                             continue;
                         }
 
@@ -148,9 +147,9 @@ namespace System.ComponentModel.Design
                         bool ignoreMember = IgnoreInheritedMember(member, component);
 
                         // We now have an inherited member.  Gather some information about it and then add it to our list.  We must always add to our list, but we may not want to  add it to the container.  That is up to the IgnoreInheritedMember method. We add here because there are components in the world that, when sited, add their children to the container too. That's fine, but we want to make sure we account for them in the inheritance service too.
-                        Debug.WriteLineIf(s_inheritanceServiceSwitch.TraceVerbose, "...found inherited member '" + name + "'");
+                        Debug.WriteLineIf(s_inheritanceServiceSwitch.TraceVerbose, $"...found inherited member '{name}'");
                         Debug.Indent();
-                        Debug.WriteLineIf(s_inheritanceServiceSwitch.TraceVerbose, "Type: " + field.FieldType.FullName);
+                        Debug.WriteLineIf(s_inheritanceServiceSwitch.TraceVerbose, $"Type: {field.FieldType.FullName}");
 
                         InheritanceAttribute attr;
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/InheritedPropertyDescriptor.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/InheritedPropertyDescriptor.cs
@@ -28,7 +28,7 @@ namespace System.ComponentModel.Design
         /// </summary>
         public InheritedPropertyDescriptor(PropertyDescriptor propertyDescriptor, object component) : base(propertyDescriptor, Array.Empty<Attribute>())
         {
-            Debug.Assert(!(propertyDescriptor is InheritedPropertyDescriptor), "Recursive inheritance propertyDescriptor " + propertyDescriptor.ToString());
+            Debug.Assert(propertyDescriptor is not InheritedPropertyDescriptor, $"Recursive inheritance propertyDescriptor {propertyDescriptor}");
             this.propertyDescriptor = propertyDescriptor;
 
             InitInheritedDefaultValue(component);
@@ -150,7 +150,7 @@ namespace System.ComponentModel.Design
             }
             set
             {
-                Debug.Assert(!(value is InheritedPropertyDescriptor), "Recursive inheritance propertyDescriptor " + propertyDescriptor.ToString());
+                Debug.Assert(value is not InheritedPropertyDescriptor, $"Recursive inheritance propertyDescriptor {propertyDescriptor}");
                 propertyDescriptor = value;
             }
         }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/MenuCommandService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/MenuCommandService.cs
@@ -116,7 +116,7 @@ namespace System.ComponentModel.Design
             }
 
             command.CommandChanged += _commandChangedHandler;
-            Debug.WriteLineIf(MENUSERVICE.TraceVerbose, "Command added: " + command.ToString());
+            Debug.WriteLineIf(MENUSERVICE.TraceVerbose, $"Command added: {command}");
 
             // raise event
             OnCommandsChanged(new MenuCommandsChangedEventArgs(MenuCommandsChangedType.CommandAdded, command));
@@ -345,7 +345,7 @@ namespace System.ComponentModel.Design
         /// </summary>
         protected MenuCommand FindCommand(Guid guid, int id)
         {
-            Debug.WriteLineIf(MENUSERVICE.TraceVerbose, "MCS Searching for command: " + guid.ToString() + " : " + id.ToString(CultureInfo.CurrentCulture));
+            Debug.WriteLineIf(MENUSERVICE.TraceVerbose, $"MCS Searching for command: {guid} : {id}");
 
             // Search in the list of commands only if the command group is known
             List<MenuCommand> commands;
@@ -475,7 +475,7 @@ namespace System.ComponentModel.Design
         /// </summary>
         private void OnCommandChanged(object sender, EventArgs e)
         {
-            Debug.WriteLineIf(MENUSERVICE.TraceVerbose, "Command dirty: " + ((sender is not null) ? sender.ToString() : "(null sender)"));
+            Debug.WriteLineIf(MENUSERVICE.TraceVerbose, $"Command dirty: {((sender is not null) ? sender.ToString() : "(null sender)")}");
             OnCommandsChanged(new MenuCommandsChangedEventArgs(MenuCommandsChangedType.CommandChanged, (MenuCommand)sender));
         }
 
@@ -538,7 +538,7 @@ namespace System.ComponentModel.Design
 
                         command.CommandChanged -= _commandChangedHandler;
 
-                        Debug.WriteLineIf(MENUSERVICE.TraceVerbose, "Command removed: " + command.ToString());
+                        Debug.WriteLineIf(MENUSERVICE.TraceVerbose, $"Command removed: {command}");
 
                         // raise event
                         OnCommandsChanged(new MenuCommandsChangedEventArgs(MenuCommandsChangedType.CommandRemoved, command));
@@ -548,7 +548,7 @@ namespace System.ComponentModel.Design
                 }
             }
 
-            Debug.WriteLineIf(MENUSERVICE.TraceVerbose, "Unable to remove command: " + command.ToString());
+            Debug.WriteLineIf(MENUSERVICE.TraceVerbose, $"Unable to remove command: {command}");
         }
 
         /// <summary>

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ReferenceService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ReferenceService.cs
@@ -5,7 +5,6 @@
 #nullable disable
 
 using System.Diagnostics;
-using System.Globalization;
 
 namespace System.ComponentModel.Design
 {
@@ -54,7 +53,7 @@ namespace System.ComponentModel.Design
             {
                 if (property.IsReadOnly)
                 {
-                    CreateReferences(string.Format(CultureInfo.CurrentCulture, "{0}.{1}", trailingName, property.Name), property.GetValue(reference), sitedComponent);
+                    CreateReferences($"{trailingName}.{property.Name}", property.GetValue(reference), sitedComponent);
                 }
             }
         }
@@ -319,16 +318,12 @@ namespace System.ComponentModel.Design
 
                 Debug.Assert(trailingName is not null, "Expected a trailing name");
                 Debug.Assert(reference is not null, "Expected a reference");
-#if DEBUG
                 Debug.Assert(sitedComponent is not null, "Expected a sited component");
+#if DEBUG
                 if (sitedComponent is not null)
                 {
-                    Debug.Assert(sitedComponent.Site is not null, "Sited component is not really sited: " + sitedComponent.ToString());
-                }
-
-                if (sitedComponent is not null)
-                {
-                    Debug.Assert(TypeDescriptor.GetComponentName(sitedComponent) is not null, "Sited component has no name: " + sitedComponent.ToString());
+                    Debug.Assert(sitedComponent.Site is not null, $"Sited component is not really sited: {sitedComponent}");
+                    Debug.Assert(TypeDescriptor.GetComponentName(sitedComponent) is not null, $"Sited component has no name: {sitedComponent}");
                 }
 #endif // DEBUG
             }
@@ -355,12 +350,11 @@ namespace System.ComponentModel.Design
                             string siteName = TypeDescriptor.GetComponentName(_sitedComponent);
                             if (siteName is not null)
                             {
-                                _fullName = string.Format(CultureInfo.CurrentCulture, "{0}{1}", siteName, _trailingName);
+                                _fullName = $"{siteName}{_trailingName}";
                             }
-#if DEBUG
-                            Debug.Assert(_sitedComponent.Site is not null, "Sited component is not really sited: " + _sitedComponent.ToString());
-                            Debug.Assert(TypeDescriptor.GetComponentName(_sitedComponent) is not null, "Sited component has no name: " + _sitedComponent.ToString());
-#endif // DEBUG
+
+                            Debug.Assert(_sitedComponent.Site is not null, $"Sited component is not really sited: {_sitedComponent}");
+                            Debug.Assert(TypeDescriptor.GetComponentName(_sitedComponent) is not null, $"Sited component has no name: {_sitedComponent}");
                         }
 
                         _fullName = string.Empty;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomComponentSerializationService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomComponentSerializationService.cs
@@ -459,7 +459,7 @@ namespace System.ComponentModel.Design.Serialization
                         foreach (string name in _objectNames)
                         {
                             object instance = ((IDesignerSerializationManager)delegator.Manager).GetInstance(name);
-                            Debug.Assert(instance is not null, "Failed to deserialize object " + name);
+                            Debug.Assert(instance is not null, $"Failed to deserialize object {name}");
                             if (instance is not null)
                             {
                                 objects.Add(instance);
@@ -503,9 +503,12 @@ namespace System.ComponentModel.Design.Serialization
                 }
 
                 Guid guid = Guid.NewGuid();
-                string guidStr = guid.ToString();
-                guidStr = guidStr.Replace("-", "_");
-                return string.Format(CultureInfo.CurrentCulture, "object_{0}", guidStr);
+                string prefix = "object_";
+                Span<char> chars = stackalloc char[prefix.Length + 36];
+                prefix.CopyTo(chars);
+                guid.TryFormat(chars[prefix.Length..], out _);
+                chars[prefix.Length..].Replace('-', '_');
+                return chars.ToString();
             }
 
             /// <summary>
@@ -579,8 +582,8 @@ namespace System.ComponentModel.Design.Serialization
                 }
                 else
                 {
-                    sw.Write("Unknown code type: " + code.GetType().Name);
-                    sw.Write("\r\n");
+                    sw.Write("Unknown code type: ");
+                    sw.WriteLine(code.GetType().Name);
                 }
 
                 // spit this line by line so it respects the indent.
@@ -648,7 +651,7 @@ namespace System.ComponentModel.Design.Serialization
                     }
                     else
                     {
-                        Debug.Fail("No case for " + data.GetType().Name);
+                        Debug.Fail($"No case for {data.GetType().Name}");
                     }
                 }
 
@@ -856,7 +859,7 @@ namespace System.ComponentModel.Design.Serialization
                         }
                         else
                         {
-                            Debug.Fail("Unable to resolve nested component: " + name);
+                            Debug.Fail($"Unable to resolve nested component: {name}");
                         }
                     }
 
@@ -1017,7 +1020,7 @@ namespace System.ComponentModel.Design.Serialization
                         if (!(resolved || (!resolved && !canInvokeManager)))
                         {
                             manager.ReportError(new CodeDomSerializerException(string.Format(SR.CodeDomComponentSerializationServiceDeserializationError, name), manager));
-                            Debug.Fail("No statements or instance for name and no lone expressions: " + name);
+                            Debug.Fail($"No statements or instance for name and no lone expressions: {name}");
                         }
                     }
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomDesignerLoader.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomDesignerLoader.cs
@@ -146,7 +146,7 @@ namespace System.ComponentModel.Design.Serialization
             }
             catch (Exception ex)
             {
-                sw.WriteLine("Error during declaration dump: " + ex.Message);
+                sw.WriteLine($"Error during declaration dump: {ex.Message}");
             }
 
             // spit this line by line so it respects the indent.
@@ -817,7 +817,7 @@ namespace System.ComponentModel.Design.Serialization
 
             // Ask the serializer for the root component to serialize.  This should return
             // a CodeTypeDeclaration, which we will plug into our existing code DOM tree.
-            Debug.Assert(_rootSerializer is not null || _typeSerializer is not null, "What are we saving right now?  Base component has no serializer: " + LoaderHost.RootComponent.GetType().FullName);
+            Debug.Assert(_rootSerializer is not null || _typeSerializer is not null, $"What are we saving right now?  Base component has no serializer: {LoaderHost.RootComponent.GetType().FullName}");
 
             if (_rootSerializer is not null)
             {
@@ -895,8 +895,7 @@ namespace System.ComponentModel.Design.Serialization
             s_codemarkers.CodeMarker((int)CodeMarkerEvent.perfFXDeserializeEnd);
 
             // EndTimingMark("Deserialize document");
-            string baseComp = string.Format(CultureInfo.CurrentCulture, "{0}.{1}", _documentNamespace.Name, _documentType.Name);
-            SetBaseComponentClassName(baseComp);
+            SetBaseComponentClassName($"{_documentNamespace.Name}.{_documentType.Name}");
         }
 
         /// <summary>
@@ -1140,9 +1139,9 @@ namespace System.ComponentModel.Design.Serialization
                 {
                     idx++;
                     conflict = false;
-                    finalName = string.Format(CultureInfo.CurrentCulture, "{0}{1}", baseName, idx.ToString(CultureInfo.InvariantCulture));
+                    finalName = $"{baseName}{idx}";
 
-                    if (container is not null && container.Components[finalName] is not null)
+                    if (container.Components[finalName] is not null)
                     {
                         conflict = true;
                     }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializer.cs
@@ -6,7 +6,6 @@
 
 using System.CodeDom;
 using System.Diagnostics;
-using System.Globalization;
 
 namespace System.ComponentModel.Design.Serialization
 {
@@ -106,7 +105,7 @@ namespace System.ComponentModel.Design.Serialization
                         if (!(codeObject is CodeStatement statement))
                         {
                             Debug.Fail("CodeDomSerializer::Deserialize requires a CodeExpression, CodeStatement or CodeStatementCollection to parse");
-                            string supportedTypes = string.Format(CultureInfo.CurrentCulture, "{0}, {1}, {2}", nameof(CodeExpression), nameof(CodeStatement), nameof(CodeStatementCollection));
+                            string supportedTypes = $"{nameof(CodeExpression)}, {nameof(CodeStatement)}, {nameof(CodeStatementCollection)}";
                             throw new ArgumentException(string.Format(SR.SerializerBadElementTypes, codeObject.GetType().Name, supportedTypes));
                         }
                     }
@@ -168,7 +167,7 @@ namespace System.ComponentModel.Design.Serialization
             ArgumentNullException.ThrowIfNull(manager);
             ArgumentNullException.ThrowIfNull(value);
 
-            using (TraceScope("CodeDomSerializer::" + nameof(Serialize)))
+            using (TraceScope($"CodeDomSerializer::{nameof(Serialize)}"))
             {
                 Trace("Type: {0}", value.GetType().Name);
 
@@ -338,7 +337,7 @@ namespace System.ComponentModel.Design.Serialization
         protected CodeExpression SerializeToReferenceExpression(IDesignerSerializationManager manager, object value)
         {
             CodeExpression expression = null;
-            using (TraceScope("CodeDomSerializer::" + nameof(SerializeToReferenceExpression)))
+            using (TraceScope($"CodeDomSerializer::{nameof(SerializeToReferenceExpression)}"))
             {
                 // First - try GetExpression
                 expression = GetExpression(manager, value);

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CollectionCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CollectionCodeDomSerializer.cs
@@ -46,7 +46,7 @@ namespace System.ComponentModel.Design.Serialization
             IEnumerator modifiedEnum = modified.GetEnumerator();
             if (modifiedEnum is null)
             {
-                Debug.Fail("Collection of type " + modified.GetType().FullName + " doesn't return an enumerator");
+                Debug.Fail($"Collection of type {modified.GetType().FullName} doesn't return an enumerator");
                 return modified;
             }
 
@@ -145,7 +145,7 @@ namespace System.ComponentModel.Design.Serialization
             ArgumentNullException.ThrowIfNull(value);
 
             object result = null;
-            using (TraceScope("CollectionCodeDomSerializer::" + nameof(Serialize)))
+            using (TraceScope($"CollectionCodeDomSerializer::{nameof(Serialize)}"))
             {
                 // We serialize collections as follows:
                 //      If the collection is an array, we write out the array.
@@ -227,7 +227,7 @@ namespace System.ComponentModel.Design.Serialization
                 }
                 else
                 {
-                    Debug.Fail("Collection serializer invoked for non-collection: " + (value is null ? "(null)" : value.GetType().Name));
+                    Debug.Fail($"Collection serializer invoked for non-collection: {(value is null ? "(null)" : value.GetType().Name)}");
                     TraceError("Collection serializer invoked for non collection: {0}", (value is null ? "(null)" : value.GetType().Name));
                 }
             }
@@ -401,7 +401,7 @@ namespace System.ComponentModel.Design.Serialization
         private CodeArrayCreateExpression SerializeArray(IDesignerSerializationManager manager, Type targetType, ICollection array, ICollection valuesToSerialize)
         {
             CodeArrayCreateExpression result = null;
-            using (TraceScope("CollectionCodeDomSerializer::" + nameof(SerializeArray)))
+            using (TraceScope($"CollectionCodeDomSerializer::{nameof(SerializeArray)}"))
             {
                 if (((Array)array).Rank != 1)
                 {
@@ -489,7 +489,7 @@ namespace System.ComponentModel.Design.Serialization
             ICollection valuesToSerialize)
         {
             CodeStatementCollection statements = new CodeStatementCollection();
-            using (TraceScope("CollectionCodeDomSerializer::" + nameof(SerializeViaAdd)))
+            using (TraceScope($"CollectionCodeDomSerializer::{nameof(SerializeViaAdd)}"))
             {
                 Trace("Elements: {0}", valuesToSerialize.Count.ToString(CultureInfo.InvariantCulture));
                 // Here we need to invoke Add once for each and every item in the collection. We can re-use the property reference and method reference, but we will need to recreate the invoke statement each time.
@@ -582,7 +582,7 @@ namespace System.ComponentModel.Design.Serialization
             ICollection valuesToSerialize)
         {
             CodeStatementCollection statements = new CodeStatementCollection();
-            using (TraceScope("CollectionCodeDomSerializer::" + nameof(SerializeViaAddRange)))
+            using (TraceScope($"CollectionCodeDomSerializer::{nameof(SerializeViaAddRange)}"))
             {
                 Trace("Elements: {0}", valuesToSerialize.Count.ToString(CultureInfo.InvariantCulture));
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/EnumCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/EnumCodeDomSerializer.cs
@@ -36,7 +36,7 @@ namespace System.ComponentModel.Design.Serialization
         {
             CodeExpression expression = null;
 
-            using (TraceScope("EnumCodeDomSerializer::" + nameof(Serialize)))
+            using (TraceScope($"EnumCodeDomSerializer::{nameof(Serialize)}"))
             {
                 Trace("Type: {0}", (value is null ? "(null)" : value.GetType().Name));
                 if (value is Enum)

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/PrimitiveCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/PrimitiveCodeDomSerializer.cs
@@ -33,7 +33,7 @@ namespace System.ComponentModel.Design.Serialization
         /// </summary>
         public override object Serialize(IDesignerSerializationManager manager, object value)
         {
-            using (TraceScope("PrimitiveCodeDomSerializer::" + nameof(Serialize)))
+            using (TraceScope($"PrimitiveCodeDomSerializer::{nameof(Serialize)}"))
             {
                 Trace("Value: {0}", (value is null ? "(null)" : value.ToString()));
             }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/PropertyMemberCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/PropertyMemberCodeDomSerializer.cs
@@ -198,7 +198,7 @@ namespace System.ComponentModel.Design.Serialization
                             CodeDomSerializer.TraceWarningIf(extended is null, "Extended object {0} could not be serialized.", manager.GetName(value));
                             if (extender is not null && extended is not null)
                             {
-                                CodeMethodReferenceExpression methodRef = new CodeMethodReferenceExpression(extender, "Get" + property.Name);
+                                CodeMethodReferenceExpression methodRef = new CodeMethodReferenceExpression(extender, $"Get{property.Name}");
                                 CodeMethodInvokeExpression methodInvoke = new CodeMethodInvokeExpression
                                 {
                                     Method = methodRef
@@ -271,7 +271,7 @@ namespace System.ComponentModel.Design.Serialization
         {
             AttributeCollection attributes = property.Attributes;
 
-            using (CodeDomSerializer.TraceScope("PropertyMemberCodeDomSerializer::" + nameof(SerializeExtenderProperty)))
+            using (CodeDomSerializer.TraceScope($"PropertyMemberCodeDomSerializer::{nameof(SerializeExtenderProperty)}"))
             {
                 ExtenderProvidedPropertyAttribute exAttr = (ExtenderProvidedPropertyAttribute)attributes[typeof(ExtenderProvidedPropertyAttribute)];
 
@@ -284,7 +284,7 @@ namespace System.ComponentModel.Design.Serialization
                 CodeDomSerializer.TraceWarningIf(extended is null, "Extended object {0} could not be serialized.", manager.GetName(value));
                 if (extender is not null && extended is not null)
                 {
-                    CodeMethodReferenceExpression methodRef = new CodeMethodReferenceExpression(extender, "Set" + property.Name);
+                    CodeMethodReferenceExpression methodRef = new CodeMethodReferenceExpression(extender, $"Set{property.Name}");
                     object propValue = GetPropertyValue(manager, property, value, out bool validValue);
                     CodeExpression serializedPropertyValue = null;
 
@@ -335,7 +335,7 @@ namespace System.ComponentModel.Design.Serialization
         /// </summary>
         private void SerializeNormalProperty(IDesignerSerializationManager manager, object value, PropertyDescriptor property, CodeStatementCollection statements)
         {
-            using (CodeDomSerializer.TraceScope("CodeDomSerializer::" + nameof(SerializeProperty)))
+            using (CodeDomSerializer.TraceScope($"CodeDomSerializer::{nameof(SerializeProperty)}"))
             {
                 CodeExpression target = SerializeToExpression(manager, value);
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ResourceCodeDomSerializer.SerializationResourceManager.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ResourceCodeDomSerializer.SerializationResourceManager.cs
@@ -536,7 +536,7 @@ namespace System.ComponentModel.Design.Serialization
             {
                 if (value is not null && (!value.GetType().IsSerializable))
                 {
-                    Debug.Fail("Cannot save a non-serializable value into resources.  Add serializable to " + (value is null ? "(null)" : value.GetType().Name));
+                    Debug.Fail($"Cannot save a non-serializable value into resources.  Add serializable to {(value is null ? "(null)" : value.GetType().Name)}");
                     return;
                 }
 
@@ -617,7 +617,7 @@ namespace System.ComponentModel.Design.Serialization
                 // Values we are going to serialize must be serializable or else the resource writer will fail when we close it.
                 if (value is not null && (!value.GetType().IsSerializable))
                 {
-                    Debug.Fail("Cannot save a non-serializable value into resources.  Add serializable to " + (value is null ? "(null)" : value.GetType().Name));
+                    Debug.Fail($"Cannot save a non-serializable value into resources.  Add serializable to {(value is null ? "(null)" : value.GetType().Name)}");
                     return;
                 }
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ResourceCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ResourceCodeDomSerializer.cs
@@ -132,7 +132,7 @@ namespace System.ComponentModel.Design.Serialization
                         if (!(codeObject is CodeStatement statement))
                         {
                             Debug.Fail("ResourceCodeDomSerializer::Deserialize requires a CodeExpression, CodeStatement or CodeStatementCollection to parse");
-                            string supportedTypes = string.Format(CultureInfo.CurrentCulture, "{0}, {1}, {2}", nameof(CodeExpression), nameof(CodeStatement), nameof(CodeStatementCollection));
+                            string supportedTypes = $"{nameof(CodeExpression)}, {nameof(CodeStatement)}, {nameof(CodeStatementCollection)}";
                             throw new ArgumentException(string.Format(SR.SerializerBadElementTypes, codeObject.GetType().Name, supportedTypes));
                         }
                     }
@@ -389,7 +389,7 @@ namespace System.ComponentModel.Design.Serialization
         /// </summary>
         public void SerializeMetadata(IDesignerSerializationManager manager, string name, object value, bool shouldSerializeValue)
         {
-            using (TraceScope("ResourceCodeDomSerializer::" + nameof(SerializeMetadata)))
+            using (TraceScope($"ResourceCodeDomSerializer::{nameof(SerializeMetadata)}"))
             {
                 Trace("Name: {0}", name);
                 Trace("Value: {0}", (value is null ? "(null)" : value.ToString()));
@@ -417,7 +417,7 @@ namespace System.ComponentModel.Design.Serialization
         private static void SetValueUsingCommonTraceScope(IDesignerSerializationManager manager, string name, object value, string calleeName,
             bool forceInvariant, bool shouldSerializeInvariant, bool ensureInvariant, bool applyingCachedResources)
         {
-            using (TraceScope("ResourceCodeDomSerializer::" + calleeName))
+            using (TraceScope($"ResourceCodeDomSerializer::{calleeName}"))
             {
                 Trace("Name: {0}", name);
                 Trace("Value: {0}", (value is null ? "(null)" : value.ToString()));

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/UndoEngine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/UndoEngine.cs
@@ -788,7 +788,7 @@ namespace System.ComponentModel.Design
 
                         if (name is not null)
                         {
-                            Debug.WriteLineIf(s_traceUndo.TraceVerbose && hasChange, "Adding second ChangeEvent for " + name + " Member: " + memberName);
+                            Debug.WriteLineIf(s_traceUndo.TraceVerbose && hasChange, $"Adding second ChangeEvent for {name} Member: {memberName}");
                         }
                         else
                         {


### PR DESCRIPTION
Contributes to #8203

Changes encompass all files in src/System.Windows.Forms.Design/src/System/ComponentModel/Design

There are more string.Format usages in the [`CodeDomSerializerBase.Trace`](https://github.com/dotnet/winforms/blob/190f292dbcaca33edbc7a0d5ac48ddcf31cf4627/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializerBase.cs#L491) method that I can remove in a follow-up PR using a custom interpolated string handler.

## Test methodology

Static code analysis, CI


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8712)