### PR TITLE
Use interpolated strings in System.Windows.Forms.Design

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.cs
@@ -412,7 +412,7 @@ namespace System.Windows.Forms.Design.Behavior
             int index = _behaviorStack.IndexOf(behavior);
             if (index == -1)
             {
-                Debug.Assert(false, "Could not find the behavior to pop - did it already get popped off? " + behavior.ToString());
+                Debug.Assert(false, $"Could not find the behavior to pop - did it already get popped off? {behavior}");
                 return null;
             }
 
@@ -791,10 +791,7 @@ namespace System.Windows.Forms.Design.Behavior
             string snapLineInfo = string.Empty;
             if (_testHook_RecentSnapLines is not null)
             {
-                foreach (string line in _testHook_RecentSnapLines)
-                {
-                    snapLineInfo += line + "\n";
-                }
+                snapLineInfo = string.Join('\n', _testHook_RecentSnapLines) + "\n";
             }
 
             TestHook_SetText(ref m, snapLineInfo);
@@ -846,7 +843,7 @@ namespace System.Windows.Forms.Design.Behavior
                 {
                     foreach (SnapLine line in designer.SnapLines)
                     {
-                        snapLineInfo += line.ToString() + "\tAssociated Control = " + designer.Control.Name + ":::";
+                        snapLineInfo += $"{line}\tAssociated Control = {designer.Control.Name}:::";
                     }
                 }
             }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.cs
@@ -791,7 +791,7 @@ namespace System.Windows.Forms.Design.Behavior
             string snapLineInfo = string.Empty;
             if (_testHook_RecentSnapLines is not null)
             {
-                snapLineInfo = string.Join('\n', _testHook_RecentSnapLines) + "\n";
+                snapLineInfo = string.Join(Environment.NewLine, _testHook_RecentSnapLines) + Environment.NewLine;
             }
 
             TestHook_SetText(ref m, snapLineInfo);

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DragAssistanceManager.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DragAssistanceManager.cs
@@ -1174,7 +1174,7 @@ namespace System.Windows.Forms.Design.Behavior
 
             public override string ToString()
             {
-                return "Line, type = " + _lineType + ", dims =(" + x1 + ", " + y1 + ")->(" + x2 + ", " + y2 + ")";
+                return $"Line, type = {_lineType}, dims =({x1}, {y1})->({x2}, {y2})";
             }
         }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/ResizeBehavior.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/ResizeBehavior.cs
@@ -221,7 +221,7 @@ namespace System.Windows.Forms.Design.Behavior
                     }
                     else
                     {
-                        Debug.Fail("Initiating resize. Could not get the designer for " + _resizeComponents[i].resizeControl.ToString());
+                        Debug.Fail($"Initiating resize. Could not get the designer for {_resizeComponents[i].resizeControl}");
                         _resizeComponents[i].resizeRules = SelectionRules.None;
                     }
                 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/SnapLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/SnapLine.cs
@@ -181,7 +181,7 @@ namespace System.Windows.Forms.Design.Behavior
         /// </summary>
         public override string ToString()
         {
-            return "SnapLine: {type = " + SnapLineType + ", offset = " + Offset + ", priority = " + Priority + ", filter = " + (Filter is null ? "<null>" : Filter) + "}";
+            return $"SnapLine: {{type = {SnapLineType}, offset = {Offset}, priority = {Priority}, filter = {Filter ?? "<null>"}}}";
         }
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/CollectionEditVerbManager.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/CollectionEditVerbManager.cs
@@ -195,7 +195,7 @@ namespace System.Windows.Forms.Design
             }
 
             CollectionEditor itemsEditor = TypeDescriptor.GetEditor(propertyValue, typeof(UITypeEditor)) as CollectionEditor;
-            Debug.Assert(itemsEditor is not null, "Didn't get a collection editor for type '" + _targetProperty.PropertyType.FullName + "'");
+            Debug.Assert(itemsEditor is not null, $"Didn't get a collection editor for type '{_targetProperty.PropertyType.FullName}'");
             itemsEditor?.EditValue(this, this, propertyValue);
         }
     }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/CommandSet.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/CommandSet.cs
@@ -852,7 +852,7 @@ namespace System.Windows.Forms.Design
                             }
                             else
                             {
-                                Debug.Fail("Unknown command mapped to OnKeyMove: " + cmd.ToString());
+                                Debug.Fail($"Unknown command mapped to OnKeyMove: {cmd}");
                             }
 
                             DesignerTransaction trans = selSvc.SelectionCount > 1
@@ -1182,7 +1182,7 @@ namespace System.Windows.Forms.Design
                         }
                         else
                         {
-                            Debug.Fail("Unrecognized command: " + id.ToString());
+                            Debug.Fail($"Unrecognized command: {id}");
                         }
 
                         if (firstTry && !CanCheckout(comp))

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ComponentTray.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ComponentTray.cs
@@ -251,7 +251,7 @@ namespace System.Windows.Forms.Design
                     Control c = TrayControl.FromComponent(component);
                     if (c is not null)
                     {
-                        Debug.WriteLineIf(CompModSwitches.MSAA.TraceInfo, "MSAA: SelectionAdd, traycontrol = " + c.ToString());
+                        Debug.WriteLineIf(CompModSwitches.MSAA.TraceInfo, $"MSAA: SelectionAdd, traycontrol = {c}");
                         User32.NotifyWinEvent((uint)AccessibleEvents.SelectionAdd, new HandleRef(c, c.Handle), User32.OBJID.CLIENT, 0);
                     }
                 }
@@ -1743,7 +1743,7 @@ namespace System.Windows.Forms.Design
 
         private void PositionControl(TrayControl c)
         {
-            Debug.Assert(c.Visible, "TrayControl for " + c.Component + " should not be positioned");
+            Debug.Assert(c.Visible, $"TrayControl for {c.Component} should not be positioned");
             if (!autoArrange)
             {
                 if (mouseDropLocation != InvalidPoint)
@@ -1797,7 +1797,7 @@ namespace System.Windows.Forms.Design
         internal void RearrangeInAutoSlots(Control c, Point pos)
         {
             Debug.Assert(controls.IndexOf(c) != -1, "Add control to the list of controls before autoarranging.!!!");
-            Debug.Assert(Visible == c.Visible, "TrayControl for " + ((TrayControl)c).Component + " should not be positioned");
+            Debug.Assert(Visible == c.Visible, $"TrayControl for {((TrayControl)c).Component} should not be positioned");
 
             TrayControl tc = (TrayControl)c;
             tc.Positioned = true;
@@ -1806,7 +1806,7 @@ namespace System.Windows.Forms.Design
 
         private bool PositionInNextAutoSlot(TrayControl c, Control prevCtl, bool dirtyDesigner)
         {
-            Debug.Assert(c.Visible, "TrayControl for " + c.Component + " should not be positioned");
+            Debug.Assert(c.Visible, $"TrayControl for {c.Component} should not be positioned");
             if (whiteSpace.IsEmpty)
             {
                 Debug.Assert(selectionUISvc is not null, "No SelectionUIService available for tray.");
@@ -2417,7 +2417,7 @@ namespace System.Windows.Forms.Design
                 base.SetVisibleCore(value);
             }
 
-            public override string ToString() => "ComponentTray: " + _component.ToString();
+            public override string ToString() => $"ComponentTray: {_component}";
 
             internal void UpdateIconInfo()
             {

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlCodeDomSerializer.cs
@@ -271,8 +271,8 @@ namespace System.Windows.Forms.Design
 
                         if (componentName is not null)
                         {
-                            SerializeResourceInvariant(manager, ">>" + componentName + ".Name", componentName);
-                            SerializeResourceInvariant(manager, ">>" + componentName + ".Type", componentTypeName);
+                            SerializeResourceInvariant(manager, $">>{componentName}.Name", componentName);
+                            SerializeResourceInvariant(manager, $">>{componentName}.Type", componentTypeName);
                         }
                     }
                 }
@@ -288,10 +288,10 @@ namespace System.Windows.Forms.Design
                     }
                 }
 
-                SerializeResourceInvariant(manager, ">>" + name + ".Name", manager.GetName(value));
+                SerializeResourceInvariant(manager, $">>{name}.Name", manager.GetName(value));
 
                 // Object type
-                SerializeResourceInvariant(manager, ">>" + name + ".Type", mthelperSvc is null ? control.GetType().AssemblyQualifiedName : mthelperSvc.GetAssemblyQualifiedName(control.GetType()));
+                SerializeResourceInvariant(manager, $">>{name}.Type", mthelperSvc is null ? control.GetType().AssemblyQualifiedName : mthelperSvc.GetAssemblyQualifiedName(control.GetType()));
 
                 // Parent
                 Control parent = control.Parent;
@@ -311,7 +311,7 @@ namespace System.Windows.Forms.Design
 
                     if (parentName is not null)
                     {
-                        SerializeResourceInvariant(manager, ">>" + name + ".Parent", parentName);
+                        SerializeResourceInvariant(manager, $">>{name}.Parent", parentName);
                     }
 
                     // Z-Order
@@ -319,7 +319,7 @@ namespace System.Windows.Forms.Design
                     {
                         if (parent.Controls[i] == control)
                         {
-                            SerializeResourceInvariant(manager, ">>" + name + ".ZOrder", i.ToString(CultureInfo.InvariantCulture));
+                            SerializeResourceInvariant(manager, $">>{name}.ZOrder", i.ToString(CultureInfo.InvariantCulture));
                             break;
                         }
                     }
@@ -355,10 +355,10 @@ namespace System.Windows.Forms.Design
         /// </summary>
         private void SerializeMethodInvocation(IDesignerSerializationManager manager, CodeStatementCollection statements, object control, string methodName, CodeExpressionCollection parameters, Type[] paramTypes, StatementOrdering ordering)
         {
-            using (TraceScope("ControlCodeDomSerializer::SerializeMethodInvocation(" + methodName + ")"))
+            using (TraceScope($"ControlCodeDomSerializer::SerializeMethodInvocation({methodName})"))
             {
                 string name = manager.GetName(control);
-                Trace(name + "." + methodName);
+                Trace("{0}.{1}", name, methodName);
 
                 // Use IReflect to see if this method name exists on the control.
                 paramTypes = ToTargetTypes(control, paramTypes);
@@ -387,7 +387,7 @@ namespace System.Windows.Forms.Design
                             statement.UserData["statement-ordering"] = "end";
                             break;
                         default:
-                            Debug.Fail("Unsupported statement ordering: " + ordering);
+                            Debug.Fail($"Unsupported statement ordering: {ordering}");
                             break;
                     }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlCommandSet.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlCommandSet.cs
@@ -595,7 +595,7 @@ namespace System.Windows.Forms.Design
                             }
                             else
                             {
-                                Debug.Fail("Unknown command mapped to OnKeySize: " + cmd.ToString());
+                                Debug.Fail($"Unknown command mapped to OnKeySize: {cmd}");
                             }
 
                             DesignerTransaction trans;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
@@ -11,7 +11,6 @@ using System.ComponentModel.Design.Serialization;
 using System.Diagnostics;
 using System.Drawing;
 using System.Drawing.Design;
-using System.Globalization;
 using System.Windows.Forms.Design.Behavior;
 using static Interop;
 
@@ -2502,16 +2501,9 @@ namespace System.Windows.Forms.Design
             _thrownException = exception;
             owner ??= Control;
 
-            string stack = string.Empty;
             string[] exceptionLines = exception.StackTrace.Split('\r', '\n');
             string typeName = owner.GetType().FullName;
-            foreach (string line in exceptionLines)
-            {
-                if (line.IndexOf(typeName) != -1)
-                {
-                    stack = string.Format(CultureInfo.CurrentCulture, "{0}\r\n{1}", stack, line);
-                }
-            }
+            string stack = string.Join("\r\n", exceptionLines.Where(l => l.Contains(typeName)));
 
             Exception wrapper = new Exception(
                 string.Format(SR.ControlDesigner_WndProcException, typeName, exception.Message, stack),

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
@@ -2503,7 +2503,7 @@ namespace System.Windows.Forms.Design
 
             string[] exceptionLines = exception.StackTrace.Split('\r', '\n');
             string typeName = owner.GetType().FullName;
-            string stack = string.Join("\r\n", exceptionLines.Where(l => l.Contains(typeName)));
+            string stack = string.Join(Environment.NewLine, exceptionLines.Where(l => l.Contains(typeName)));
 
             Exception wrapper = new Exception(
                 string.Format(SR.ControlDesigner_WndProcException, typeName, exception.Message, stack),

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignBindingValueUIHandler.LocalUIItem.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignBindingValueUIHandler.LocalUIItem.cs
@@ -44,8 +44,7 @@ namespace System.Windows.Forms.Design
                     name = "(List)";
                 }
 
-                name += " - " + binding.BindingMemberInfo.BindingMember;
-                return name;
+                return $"{name} - {binding.BindingMemberInfo.BindingMember}";
             }
         }
     }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerUtils.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerUtils.cs
@@ -12,7 +12,6 @@ using System.Diagnostics;
 using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
-using System.Globalization;
 using System.Windows.Forms.Design.Behavior;
 using static Interop;
 
@@ -692,7 +691,7 @@ namespace System.Windows.Forms.Design
                 string nameN = name;
                 for (int i = 1; !nameCreationService.IsValidName(nameN); ++i)
                 {
-                    nameN = name + i.ToString(CultureInfo.InvariantCulture);
+                    nameN = $"{name}{i}";
                 }
 
                 return nameN;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DocumentDesigner.AxToolboxItem.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DocumentDesigner.AxToolboxItem.cs
@@ -194,13 +194,13 @@ namespace System.Windows.Forms.Design
 
                 FileInfo file = new FileInfo(path);
                 string fullPath = file.FullName;
-                Debug.WriteLineIf(AxToolSwitch.TraceVerbose, "Checking: " + fullPath);
+                Debug.WriteLineIf(AxToolSwitch.TraceVerbose, $"Checking: {fullPath}");
 
                 ITypeResolutionService trs = (ITypeResolutionService)host.GetService(typeof(ITypeResolutionService));
                 Debug.Assert(trs is not null, "No type resolution service found.");
 
                 Assembly a = trs.GetAssembly(AssemblyName.GetAssemblyName(fullPath));
-                Debug.Assert(a is not null, "No assembly found at " + fullPath);
+                Debug.Assert(a is not null, $"No assembly found at {fullPath}");
 
                 return GetAxTypeFromAssembly(a);
             }
@@ -222,7 +222,7 @@ namespace System.Windows.Forms.Design
                     }
 
                     object[] attrs = t.GetCustomAttributes(typeof(AxHost.ClsidAttribute), false);
-                    Debug.Assert(attrs is not null && attrs.Length == 1, "Invalid number of GuidAttributes found on: " + t.FullName);
+                    Debug.Assert(attrs is not null && attrs.Length == 1, $"Invalid number of GuidAttributes found on: {t.FullName}");
 
                     AxHost.ClsidAttribute guid = (AxHost.ClsidAttribute)attrs[0];
                     if (string.Equals(guid.Value, clsid, StringComparison.OrdinalIgnoreCase))
@@ -245,8 +245,7 @@ namespace System.Windows.Forms.Design
             {
                 Debug.Assert(host is not null, "Null Designer Host");
 
-                Type type;
-                type = Type.GetType("EnvDTE.ProjectItem, " + AssemblyRef.EnvDTE);
+                Type type = Type.GetType($"EnvDTE.ProjectItem, {AssemblyRef.EnvDTE}");
 
                 if (type is null)
                 {
@@ -260,13 +259,13 @@ namespace System.Windows.Forms.Design
                 string name = ext.GetType().InvokeMember("Name", BindingFlags.GetProperty | BindingFlags.Public | BindingFlags.Instance, null, ext, null, CultureInfo.InvariantCulture).ToString();
 
                 object project = ext.GetType().InvokeMember("ContainingProject", BindingFlags.GetProperty | BindingFlags.Public | BindingFlags.Instance, null, ext, null, CultureInfo.InvariantCulture);
-                Debug.Assert(project is not null, "No DTE Project for the current project item: " + name);
+                Debug.Assert(project is not null, $"No DTE Project for the current project item: {name}");
 
                 object vsproject = project.GetType().InvokeMember("Object", BindingFlags.GetProperty | BindingFlags.Public | BindingFlags.Instance, null, project, null, CultureInfo.InvariantCulture);
-                Debug.Assert(vsproject is not null, "No VS Project for the current project item: " + name);
+                Debug.Assert(vsproject is not null, $"No VS Project for the current project item: {name}");
 
                 object references = vsproject.GetType().InvokeMember("References", BindingFlags.GetProperty | BindingFlags.Public | BindingFlags.Instance, null, vsproject, null, CultureInfo.InvariantCulture);
-                Debug.Assert(references is not null, "No References for the current project item: " + name);
+                Debug.Assert(references is not null, $"No References for the current project item: {name}");
 
                 return references;
             }
@@ -281,7 +280,7 @@ namespace System.Windows.Forms.Design
                 if (key is null)
                 {
                     if (AxToolSwitch.TraceVerbose)
-                        Debug.WriteLine("No registry key found for: " + controlKey);
+                        Debug.WriteLine($"No registry key found for: {controlKey}");
                     throw new ArgumentException(string.Format(SR.AXNotRegistered, controlKey.ToString()));
                 }
 
@@ -380,7 +379,7 @@ namespace System.Windows.Forms.Design
             protected override void Serialize(SerializationInfo info, StreamingContext context)
             {
                 if (AxToolSwitch.TraceVerbose)
-                    Debug.WriteLine("Serializing AxToolboxItem:" + clsid);
+                    Debug.WriteLine($"Serializing AxToolboxItem:{clsid}");
                 base.Serialize(info, context);
                 info.AddValue("Clsid", clsid);
             }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DocumentDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DocumentDesigner.cs
@@ -353,8 +353,7 @@ namespace System.Windows.Forms.Design
             // Look to see if we have already cached the ToolboxItem.
             if (axTools is not null && axTools.TryGetValue(clsid, out AxToolboxItem tool))
             {
-                if (AxToolSwitch.TraceVerbose)
-                    Debug.WriteLine("Found AxToolboxItem in tool cache");
+                Debug.WriteLineIf(AxToolSwitch.TraceVerbose, "Found AxToolboxItem in tool cache");
                 return tool;
             }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/EditorServiceContext.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/EditorServiceContext.cs
@@ -178,7 +178,7 @@ namespace System.Windows.Forms.Design
 
             CollectionEditor itemsEditor = TypeDescriptor.GetEditor(propertyValue, typeof(UITypeEditor)) as CollectionEditor;
 
-            Debug.Assert(itemsEditor is not null, "Didn't get a collection editor for type '" + _targetProperty.PropertyType.FullName + "'");
+            Debug.Assert(itemsEditor is not null, $"Didn't get a collection editor for type '{_targetProperty.PropertyType.FullName}'");
             itemsEditor?.EditValue(this, this, propertyValue);
         }
     }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskDescriptor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskDescriptor.cs
@@ -147,23 +147,13 @@ namespace System.Windows.Forms.Design
 
         public override int GetHashCode()
         {
-            string hash = Mask;
-
-            if (ValidatingType is not null)
-            {
-                hash += ValidatingType.ToString();
-            }
-
+            string hash = string.Concat(Mask, ValidatingType?.ToString());
             return hash.GetHashCode();
         }
 
         public override string ToString()
         {
-            return string.Format(CultureInfo.CurrentCulture, "{0}<Name={1}, Mask={2}, ValidatingType={3}",
-                GetType(),
-                Name ?? "null",
-                Mask ?? "null",
-                ValidatingType is not null ? ValidatingType.ToString() : "null");
+            return $"{GetType()}<Name={Name ?? "null"}, Mask={Mask ?? "null"}, ValidatingType={(ValidatingType is not null ? ValidatingType.ToString() : "null")}";
         }
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/OleDragDropHandler.CfCodeToolboxItem.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/OleDragDropHandler.CfCodeToolboxItem.cs
@@ -8,7 +8,6 @@ using System.ComponentModel.Design;
 using System.ComponentModel.Design.Serialization;
 using System.Drawing;
 using System.Drawing.Design;
-using System.Globalization;
 using System.Runtime.Serialization;
 
 namespace System.Windows.Forms.Design
@@ -39,7 +38,7 @@ namespace System.Windows.Forms.Design
                 if (!_displayNameSet)
                 {
                     _displayNameSet = true;
-                    DisplayName = "Template" + (++s_template).ToString(CultureInfo.CurrentCulture);
+                    DisplayName = $"Template{++s_template}";
                 }
             }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/OleDragDropHandler.ComponentDataObject.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/OleDragDropHandler.ComponentDataObject.cs
@@ -55,7 +55,7 @@ namespace System.Windows.Forms.Design
                             object[] comps = new object[components.Length];
                             for (int i = 0; i < components.Length; i++)
                             {
-                                Debug.Assert(components[i] is IComponent, "Item " + components[i].GetType().Name + " is not an IComponent");
+                                Debug.Assert(components[i] is IComponent, $"Item {components[i].GetType().Name} is not an IComponent");
                                 comps[i] = (IComponent)components[i];
                             }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/OleDragDropHandler.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/OleDragDropHandler.cs
@@ -1067,7 +1067,7 @@ namespace System.Windows.Forms.Design
 
         public void DoOleDragOver(DragEventArgs de)
         {
-            Debug.WriteLineIf(CompModSwitches.DragDrop.TraceInfo, "\tOleDragDropHandler.OnDragOver: " + de.ToString());
+            Debug.WriteLineIf(CompModSwitches.DragDrop.TraceInfo, $"\tOleDragDropHandler.OnDragOver: {de}");
             if (!localDrag && !dragOk)
             {
                 de.Effect = DragDropEffects.None;
@@ -1109,7 +1109,7 @@ namespace System.Windows.Forms.Design
 
                 if (newOffset != localDragOffset)
                 {
-                    Debug.WriteLineIf(CompModSwitches.DragDrop.TraceInfo, "\tParentControlDesigner.OnDragOver: " + de.ToString());
+                    Debug.WriteLineIf(CompModSwitches.DragDrop.TraceInfo, $"\tParentControlDesigner.OnDragOver: {de}");
                     DrawDragFrames(dragComps, localDragOffset, localDragEffect,
                                    newOffset, de.Effect, forceDrawFrames);
                     localDragOffset = newOffset;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ParentControlDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ParentControlDesigner.cs
@@ -1781,14 +1781,13 @@ namespace System.Windows.Forms.Design
         /// </summary>
         protected override void OnDragOver(DragEventArgs de)
         {
-            DropSourceBehavior.BehaviorDataObject data = de.Data as DropSourceBehavior.BehaviorDataObject;
-            if (data is not null)
+            if (de.Data is DropSourceBehavior.BehaviorDataObject data)
             {
                 data.Target = Component;
                 de.Effect = (Control.ModifierKeys == Keys.Control) ? DragDropEffects.Copy : DragDropEffects.Move;
             }
 
-            Debug.WriteLineIf(CompModSwitches.DragDrop.TraceInfo, "\tParentControlDesigner.OnDragOver: " + de.ToString());
+            Debug.WriteLineIf(CompModSwitches.DragDrop.TraceInfo, $"\tParentControlDesigner.OnDragOver: {de}");
 
             // If tab order UI is being shown, then don't allow anything to be
             // dropped here.
@@ -1806,16 +1805,12 @@ namespace System.Windows.Forms.Design
             }
 
             IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
-            if (host is not null)
+            if (host?.GetDesigner(host.RootComponent) is DocumentDesigner parentDesigner)
             {
-                DocumentDesigner parentDesigner = host.GetDesigner(host.RootComponent) as DocumentDesigner;
-                if (parentDesigner is not null)
+                if (!parentDesigner.CanDropComponents(de))
                 {
-                    if (!parentDesigner.CanDropComponents(de))
-                    {
-                        de.Effect = DragDropEffects.None;
-                        return;
-                    }
+                    de.Effect = DragDropEffects.None;
+                    return;
                 }
             }
 
@@ -1826,7 +1821,7 @@ namespace System.Windows.Forms.Design
                 return;
             }
 
-            Debug.WriteLineIf(CompModSwitches.DragDrop.TraceInfo, "\tParentControlDesigner.OnDragOver: " + de.ToString());
+            Debug.WriteLineIf(CompModSwitches.DragDrop.TraceInfo, $"\tParentControlDesigner.OnDragOver: {de}");
         }
 
         /// <summary>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/StandardMenuStripVerb.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/StandardMenuStripVerb.cs
@@ -115,7 +115,7 @@ namespace System.Windows.Forms.Design
                 {
                     while (_host.Container.Components[name] is not null)
                     {
-                        name = defaultName + (index++).ToString(CultureInfo.InvariantCulture);
+                        name = $"{defaultName}{index++}";
                     }
                 }
 
@@ -287,7 +287,7 @@ namespace System.Windows.Forms.Design
                 {
                     while (_host.Container.Components[name] is not null)
                     {
-                        name = defaultName + (index++).ToString(CultureInfo.InvariantCulture);
+                        name = $"{defaultName}{index++}";
                     }
                 }
 
@@ -508,7 +508,7 @@ namespace System.Windows.Forms.Design
                 string newName = baseName;
                 for (int indexer = 1; !nameCreationService.IsValidName(newName); indexer++)
                 {
-                    newName = baseName + indexer.ToString(CultureInfo.InvariantCulture);
+                    newName = $"{baseName}{indexer}";
                 }
 
                 return newName;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TabOrder.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TabOrder.cs
@@ -7,7 +7,6 @@ using System.ComponentModel;
 using System.ComponentModel.Design;
 using System.Diagnostics;
 using System.Drawing;
-using System.Drawing.Design;
 using System.Globalization;
 using System.Text;
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TableLayoutPanelCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TableLayoutPanelCodeDomSerializer.cs
@@ -60,7 +60,7 @@ namespace System.Windows.Forms.Design
 
                         if (val is not null)
                         {
-                            string key = manager.GetName(tlp) + "." + LayoutSettingsPropName;
+                            string key = $"{manager.GetName(tlp)}.{LayoutSettingsPropName}";
                             SerializeResourceInvariant(manager, key, val);
                         }
                     }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripDesigner.cs
@@ -1746,7 +1746,7 @@ namespace System.Windows.Forms.Design
                 string newName = baseName;
                 for (int indexer = 1; !nameCreate.IsValidName(newName) || container.Components[newName] is not null; indexer++)
                 {
-                    newName = baseName + indexer.ToString(CultureInfo.InvariantCulture);
+                    newName = $"{baseName}{indexer}";
                 }
 
                 return newName;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripDropDownDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripDropDownDesigner.cs
@@ -9,7 +9,6 @@ using System.ComponentModel;
 using System.ComponentModel.Design;
 using System.Configuration;
 using System.Drawing;
-using System.Globalization;
 using System.Windows.Forms.Design.Behavior;
 
 namespace System.Windows.Forms.Design
@@ -171,7 +170,7 @@ namespace System.Windows.Forms.Design
                             IComponent rootComponent = host.RootComponent;
                             if (rootComponent is not null && rootComponent != persistableComponent)
                             {
-                                ShadowProperties[SettingsKeyName] = string.Format(CultureInfo.CurrentCulture, "{0}.{1}", rootComponent.Site.Name, Component.Site.Name);
+                                ShadowProperties[SettingsKeyName] = $"{rootComponent.Site.Name}.{Component.Site.Name}";
                             }
                             else
                             {

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripItemDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripItemDesigner.cs
@@ -966,7 +966,7 @@ namespace System.Windows.Forms.Design
                     acc.AddState(AccessibleStates.Selected);
                     if (tool is not null)
                     {
-                        Debug.WriteLineIf(CompModSwitches.MSAA.TraceInfo, "MSAA: SelectionAdd, tool = " + tool.ToString());
+                        Debug.WriteLineIf(CompModSwitches.MSAA.TraceInfo, $"MSAA: SelectionAdd, tool = {tool}");
                         User32.NotifyWinEvent((uint)AccessibleEvents.SelectionAdd, new HandleRef(owner, owner.Handle), User32.OBJID.CLIENT, focusIndex + 1);
                     }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripMenuItemDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripMenuItemDesigner.cs
@@ -724,7 +724,7 @@ namespace System.Windows.Forms.Design
                 //Add Text for Debugging Non Sited DropDown..
                 if (MenuItem.DropDown.Site is null)
                 {
-                    MenuItem.DropDown.Text = MenuItem.Name + ".DropDown";
+                    MenuItem.DropDown.Text = $"{MenuItem.Name}.DropDown";
                 }
             }
             else if (typeHereNode is not null && MenuItem.DropDownItems.IndexOf(typeHereNode) == -1)


### PR DESCRIPTION
Contributes to #8203

Changes encompass all files in src/System.Windows.Forms.Design/src/System/Windows/Forms/Design

## Test methodology

Static code analysis, CI

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8713)