### PR TITLE
Add interpolated string handler to TraceSwitchExtensions.TraceVerbose

### DIFF
--- a/src/Common/src/TraceSwitchExtensions.cs
+++ b/src/Common/src/TraceSwitchExtensions.cs
@@ -109,62 +109,16 @@ namespace System.Windows.Forms
             public void AppendFormatted<T>(T value, string? format) => _stringBuilderHandler.AppendFormatted(value, format);
 
             /// <summary>
-            ///   Writes the specified value to the handler.
-            /// </summary>
-            /// <param name="value">The value to write.</param>
-            /// <param name="alignment">Minimum number of characters that should be written for this value.  If the
-            /// value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
-            /// <typeparam name="T">The type of the value to write.</typeparam>
-            public void AppendFormatted<T>(T value, int alignment) => _stringBuilderHandler.AppendFormatted(value, alignment);
-
-            /// <summary>
-            ///   Writes the specified value to the handler.
-            /// </summary>
-            /// <param name="value">The value to write.</param>
-            /// <param name="format">The format string.</param>
-            /// <param name="alignment">Minimum number of characters that should be written for this value.  If the
-            /// value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
-            /// <typeparam name="T">The type of the value to write.</typeparam>
-            public void AppendFormatted<T>(T value, int alignment, string? format) => _stringBuilderHandler.AppendFormatted(value, alignment, format);
-
-            /// <summary>
             ///   Writes the specified character span to the handler.
             /// </summary>
             /// <param name="value">The span to write.</param>
             public void AppendFormatted(ReadOnlySpan<char> value) => _stringBuilderHandler.AppendFormatted(value);
 
             /// <summary>
-            ///   Writes the specified string of chars to the handler.
-            /// </summary>
-            /// <param name="value">The span to write.</param>
-            /// <param name="alignment">Minimum number of characters that should be written for this value.  If the
-            /// value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
-            /// <param name="format">The format string.</param>
-            public void AppendFormatted(ReadOnlySpan<char> value, int alignment = 0, string? format = null) => _stringBuilderHandler.AppendFormatted(value, alignment, format);
-
-            /// <summary>
             ///   Writes the specified character span to the handler.
             /// </summary>
             /// <param name="value">The value to write.</param>
             public void AppendFormatted(string? value) => _stringBuilderHandler.AppendFormatted(value);
-
-            /// <summary>
-            ///   Writes the specified character span to the handler.
-            /// </summary>
-            /// <param name="value">The value to write.</param>
-            /// <param name="alignment">Minimum number of characters that should be written for this value.  If the
-            /// value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
-            /// <param name="format">The format string.</param>
-            public void AppendFormatted(string? value, int alignment = 0, string? format = null) => _stringBuilderHandler.AppendFormatted(value, alignment, format);
-
-            /// <summary>
-            ///   Writes the specified character span to the handler.
-            /// </summary>
-            /// <param name="value">The value to write.</param>
-            /// <param name="alignment">Minimum number of characters that should be written for this value.  If the
-            /// value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
-            /// <param name="format">The format string.</param>
-            public void AppendFormatted(object? value, int alignment = 0, string? format = null) => _stringBuilderHandler.AppendFormatted(value, alignment, format);
         }
     }
 }

--- a/src/Common/src/TraceSwitchExtensions.cs
+++ b/src/Common/src/TraceSwitchExtensions.cs
@@ -29,25 +29,37 @@ namespace System.Windows.Forms
             }
         }
 
-        /// <summary>Provides an interpolated string handler for <see cref="TraceSwitchExtensions.TraceVerbose(TraceSwitch?, ref TraceSwitchExtensions.TraceVerboseInterpolatedStringHandler)"/> that only performs formatting if the condition applies.</summary>
+        /// <summary>
+        ///   Provides an interpolated string handler for <see
+        ///   cref="TraceSwitchExtensions.TraceVerbose(TraceSwitch?, ref TraceSwitchExtensions.TraceVerboseInterpolatedStringHandler)"
+        ///   /> that only performs formatting if the condition applies.
+        /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [InterpolatedStringHandler]
         public struct TraceVerboseInterpolatedStringHandler
         {
-            /// <summary>The handler we use to perform the formatting.</summary>
+            /// <summary>
+            ///   The handler we use to perform the formatting.
+            /// </summary>
             private StringBuilder.AppendInterpolatedStringHandler _stringBuilderHandler;
 
             /// <summary>
-            /// The underlying <see cref="StringBuilder"/> instance used by <see cref="_stringBuilderHandler"/>, if any.
+            ///   The underlying <see cref="StringBuilder"/> instance used by <see cref="_stringBuilderHandler"/>,
+            ///   if any.
             /// </summary>
             private StringBuilder? _builder;
 
-            /// <summary>Creates an instance of the handler..</summary>
+            /// <summary>
+            ///   Creates an instance of the handler.
+            /// </summary>
             /// <param name="literalLength">The number of constant characters outside of interpolation expressions in the interpolated string.</param>
             /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
             /// <param name="traceSwitch">The TraceSwitch passed to the <see cref="TraceSwitchExtensions"/> method.</param>
             /// <param name="shouldAppend">A value indicating whether formatting should proceed.</param>
-            /// <remarks>This is intended to be called only by compiler-generated code. Arguments are not validated as they'd otherwise be for members intended to be used directly.</remarks>
+            /// <remarks>
+            ///   This is intended to be called only by compiler-generated code. Arguments are not validated as they'd
+            ///   otherwise be for members intended to be used directly.
+            /// </remarks>
             public TraceVerboseInterpolatedStringHandler(int literalLength, int formattedCount, TraceSwitch? traceSwitch, out bool shouldAppend)
             {
                 if (traceSwitch is not null && traceSwitch.TraceVerbose)
@@ -64,7 +76,9 @@ namespace System.Windows.Forms
                 }
             }
 
-            /// <summary>Extracts the built string from the handler.</summary>
+            /// <summary>
+            ///   Extracts the built string from the handler.
+            /// </summary>
             internal string ToStringAndClear()
             {
                 string s = _builder?.ToString() ?? string.Empty;
@@ -73,57 +87,82 @@ namespace System.Windows.Forms
                 return s;
             }
 
-            /// <summary>Writes the specified string to the handler.</summary>
+            /// <summary>
+            ///   Writes the specified string to the handler.
+            /// </summary>
             /// <param name="value">The string to write.</param>
             public void AppendLiteral(string value) => _stringBuilderHandler.AppendLiteral(value);
 
-            /// <summary>Writes the specified value to the handler.</summary>
+            /// <summary>
+            ///   Writes the specified value to the handler.
+            /// </summary>
             /// <param name="value">The value to write.</param>
             /// <typeparam name="T">The type of the value to write.</typeparam>
             public void AppendFormatted<T>(T value) => _stringBuilderHandler.AppendFormatted(value);
 
-            /// <summary>Writes the specified value to the handler.</summary>
+            /// <summary>
+            ///   Writes the specified value to the handler.
+            /// </summary>
             /// <param name="value">The value to write.</param>
             /// <param name="format">The format string.</param>
             /// <typeparam name="T">The type of the value to write.</typeparam>
             public void AppendFormatted<T>(T value, string? format) => _stringBuilderHandler.AppendFormatted(value, format);
 
-            /// <summary>Writes the specified value to the handler.</summary>
+            /// <summary>
+            ///   Writes the specified value to the handler.
+            /// </summary>
             /// <param name="value">The value to write.</param>
-            /// <param name="alignment">Minimum number of characters that should be written for this value.  If the value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
+            /// <param name="alignment">Minimum number of characters that should be written for this value.  If the
+            /// value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
             /// <typeparam name="T">The type of the value to write.</typeparam>
             public void AppendFormatted<T>(T value, int alignment) => _stringBuilderHandler.AppendFormatted(value, alignment);
 
-            /// <summary>Writes the specified value to the handler.</summary>
+            /// <summary>
+            ///   Writes the specified value to the handler.
+            /// </summary>
             /// <param name="value">The value to write.</param>
             /// <param name="format">The format string.</param>
-            /// <param name="alignment">Minimum number of characters that should be written for this value.  If the value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
+            /// <param name="alignment">Minimum number of characters that should be written for this value.  If the
+            /// value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
             /// <typeparam name="T">The type of the value to write.</typeparam>
             public void AppendFormatted<T>(T value, int alignment, string? format) => _stringBuilderHandler.AppendFormatted(value, alignment, format);
 
-            /// <summary>Writes the specified character span to the handler.</summary>
+            /// <summary>
+            ///   Writes the specified character span to the handler.
+            /// </summary>
             /// <param name="value">The span to write.</param>
             public void AppendFormatted(ReadOnlySpan<char> value) => _stringBuilderHandler.AppendFormatted(value);
 
-            /// <summary>Writes the specified string of chars to the handler.</summary>
+            /// <summary>
+            ///   Writes the specified string of chars to the handler.
+            /// </summary>
             /// <param name="value">The span to write.</param>
-            /// <param name="alignment">Minimum number of characters that should be written for this value.  If the value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
+            /// <param name="alignment">Minimum number of characters that should be written for this value.  If the
+            /// value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
             /// <param name="format">The format string.</param>
             public void AppendFormatted(ReadOnlySpan<char> value, int alignment = 0, string? format = null) => _stringBuilderHandler.AppendFormatted(value, alignment, format);
 
-            /// <summary>Writes the specified value to the handler.</summary>
+            /// <summary>
+            ///   Writes the specified character span to the handler.
+            /// </summary>
             /// <param name="value">The value to write.</param>
             public void AppendFormatted(string? value) => _stringBuilderHandler.AppendFormatted(value);
 
-            /// <summary>Writes the specified value to the handler.</summary>
+            /// <summary>
+            ///   Writes the specified character span to the handler.
+            /// </summary>
             /// <param name="value">The value to write.</param>
-            /// <param name="alignment">Minimum number of characters that should be written for this value.  If the value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
+            /// <param name="alignment">Minimum number of characters that should be written for this value.  If the
+            /// value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
             /// <param name="format">The format string.</param>
             public void AppendFormatted(string? value, int alignment = 0, string? format = null) => _stringBuilderHandler.AppendFormatted(value, alignment, format);
 
-            /// <summary>Writes the specified value to the handler.</summary>
+            /// <summary>
+            ///   Writes the specified character span to the handler.
+            /// </summary>
             /// <param name="value">The value to write.</param>
-            /// <param name="alignment">Minimum number of characters that should be written for this value.  If the value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
+            /// <param name="alignment">Minimum number of characters that should be written for this value.  If the
+            /// value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
             /// <param name="format">The format string.</param>
             public void AppendFormatted(object? value, int alignment = 0, string? format = null) => _stringBuilderHandler.AppendFormatted(value, alignment, format);
         }

--- a/src/Common/src/TraceSwitchExtensions.cs
+++ b/src/Common/src/TraceSwitchExtensions.cs
@@ -2,7 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.ComponentModel;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Text;
 
 namespace System.Windows.Forms
 {
@@ -15,6 +18,114 @@ namespace System.Windows.Forms
             {
                 Debug.WriteLine(message);
             }
+        }
+
+        [Conditional("DEBUG")]
+        public static void TraceVerbose(this TraceSwitch? traceSwitch, [InterpolatedStringHandlerArgument(nameof(traceSwitch))] ref TraceVerboseInterpolatedStringHandler message)
+        {
+            if (traceSwitch is not null && traceSwitch.TraceVerbose)
+            {
+                Debug.WriteLine(message.ToStringAndClear());
+            }
+        }
+
+        /// <summary>Provides an interpolated string handler for <see cref="TraceSwitchExtensions.TraceVerbose(TraceSwitch?, ref TraceSwitchExtensions.TraceVerboseInterpolatedStringHandler)"/> that only performs formatting if the condition applies.</summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [InterpolatedStringHandler]
+        public struct TraceVerboseInterpolatedStringHandler
+        {
+            /// <summary>The handler we use to perform the formatting.</summary>
+            private StringBuilder.AppendInterpolatedStringHandler _stringBuilderHandler;
+
+            /// <summary>
+            /// The underlying <see cref="StringBuilder"/> instance used by <see cref="_stringBuilderHandler"/>, if any.
+            /// </summary>
+            private StringBuilder? _builder;
+
+            /// <summary>Creates an instance of the handler..</summary>
+            /// <param name="literalLength">The number of constant characters outside of interpolation expressions in the interpolated string.</param>
+            /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
+            /// <param name="traceSwitch">The TraceSwitch passed to the <see cref="TraceSwitchExtensions"/> method.</param>
+            /// <param name="shouldAppend">A value indicating whether formatting should proceed.</param>
+            /// <remarks>This is intended to be called only by compiler-generated code. Arguments are not validated as they'd otherwise be for members intended to be used directly.</remarks>
+            public TraceVerboseInterpolatedStringHandler(int literalLength, int formattedCount, TraceSwitch? traceSwitch, out bool shouldAppend)
+            {
+                if (traceSwitch is not null && traceSwitch.TraceVerbose)
+                {
+                    _builder = new StringBuilder();
+                    _stringBuilderHandler = new StringBuilder.AppendInterpolatedStringHandler(literalLength, formattedCount,
+                        _builder);
+                    shouldAppend = true;
+                }
+                else
+                {
+                    _stringBuilderHandler = default;
+                    shouldAppend = false;
+                }
+            }
+
+            /// <summary>Extracts the built string from the handler.</summary>
+            internal string ToStringAndClear()
+            {
+                string s = _builder?.ToString() ?? string.Empty;
+                _stringBuilderHandler = default;
+                _builder = null;
+                return s;
+            }
+
+            /// <summary>Writes the specified string to the handler.</summary>
+            /// <param name="value">The string to write.</param>
+            public void AppendLiteral(string value) => _stringBuilderHandler.AppendLiteral(value);
+
+            /// <summary>Writes the specified value to the handler.</summary>
+            /// <param name="value">The value to write.</param>
+            /// <typeparam name="T">The type of the value to write.</typeparam>
+            public void AppendFormatted<T>(T value) => _stringBuilderHandler.AppendFormatted(value);
+
+            /// <summary>Writes the specified value to the handler.</summary>
+            /// <param name="value">The value to write.</param>
+            /// <param name="format">The format string.</param>
+            /// <typeparam name="T">The type of the value to write.</typeparam>
+            public void AppendFormatted<T>(T value, string? format) => _stringBuilderHandler.AppendFormatted(value, format);
+
+            /// <summary>Writes the specified value to the handler.</summary>
+            /// <param name="value">The value to write.</param>
+            /// <param name="alignment">Minimum number of characters that should be written for this value.  If the value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
+            /// <typeparam name="T">The type of the value to write.</typeparam>
+            public void AppendFormatted<T>(T value, int alignment) => _stringBuilderHandler.AppendFormatted(value, alignment);
+
+            /// <summary>Writes the specified value to the handler.</summary>
+            /// <param name="value">The value to write.</param>
+            /// <param name="format">The format string.</param>
+            /// <param name="alignment">Minimum number of characters that should be written for this value.  If the value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
+            /// <typeparam name="T">The type of the value to write.</typeparam>
+            public void AppendFormatted<T>(T value, int alignment, string? format) => _stringBuilderHandler.AppendFormatted(value, alignment, format);
+
+            /// <summary>Writes the specified character span to the handler.</summary>
+            /// <param name="value">The span to write.</param>
+            public void AppendFormatted(ReadOnlySpan<char> value) => _stringBuilderHandler.AppendFormatted(value);
+
+            /// <summary>Writes the specified string of chars to the handler.</summary>
+            /// <param name="value">The span to write.</param>
+            /// <param name="alignment">Minimum number of characters that should be written for this value.  If the value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
+            /// <param name="format">The format string.</param>
+            public void AppendFormatted(ReadOnlySpan<char> value, int alignment = 0, string? format = null) => _stringBuilderHandler.AppendFormatted(value, alignment, format);
+
+            /// <summary>Writes the specified value to the handler.</summary>
+            /// <param name="value">The value to write.</param>
+            public void AppendFormatted(string? value) => _stringBuilderHandler.AppendFormatted(value);
+
+            /// <summary>Writes the specified value to the handler.</summary>
+            /// <param name="value">The value to write.</param>
+            /// <param name="alignment">Minimum number of characters that should be written for this value.  If the value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
+            /// <param name="format">The format string.</param>
+            public void AppendFormatted(string? value, int alignment = 0, string? format = null) => _stringBuilderHandler.AppendFormatted(value, alignment, format);
+
+            /// <summary>Writes the specified value to the handler.</summary>
+            /// <param name="value">The value to write.</param>
+            /// <param name="alignment">Minimum number of characters that should be written for this value.  If the value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
+            /// <param name="format">The format string.</param>
+            public void AppendFormatted(object? value, int alignment = 0, string? format = null) => _stringBuilderHandler.AppendFormatted(value, alignment, format);
         }
     }
 }


### PR DESCRIPTION
Contributes to #8203

## Proposed changes

As stated in #8715, TraceSwitchExtensions.TraceVerbose doesn't handle interpolated strings despite replacing code that does (`Debug.WriteLineIf`). This is a proposed fix. Note that unlike `Debug.WriteIfInterpolatedStringHandler`, which is an obvious inspiration to this PR, we don't pull (yet?) `StringBuilder` instances as the caching mechanism is internal to corelib.



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8719)