### PR TITLE
Replace Stack with Stack<T> across codebase

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerHost.DesignerHostTransaction.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerHost.DesignerHostTransaction.cs
@@ -4,8 +4,6 @@
 
 #nullable disable
 
-using System.Collections;
-
 namespace System.ComponentModel.Design
 {
     internal sealed partial class DesignerHost

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerHost.DesignerHostTransaction.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerHost.DesignerHostTransaction.cs
@@ -20,7 +20,7 @@ namespace System.ComponentModel.Design
             public DesignerHostTransaction(DesignerHost host, string description) : base(description)
             {
                 _host = host;
-                _host._transactions ??= new Stack();
+                _host._transactions ??= new Stack<DesignerTransaction>();
 
                 _host._transactions.Push(this);
                 _host.OnTransactionOpening(EventArgs.Empty);
@@ -36,7 +36,7 @@ namespace System.ComponentModel.Design
                 {
                     if (_host._transactions.Peek() != this)
                     {
-                        string nestedDescription = ((DesignerTransaction)_host._transactions.Peek()).Description;
+                        string nestedDescription = _host._transactions.Peek().Description;
                         throw new InvalidOperationException(string.Format(SR.DesignerHostNestedTransaction, Description, nestedDescription));
                     }
 
@@ -65,7 +65,7 @@ namespace System.ComponentModel.Design
                 {
                     if (_host._transactions.Peek() != this)
                     {
-                        string nestedDescription = ((DesignerTransaction)_host._transactions.Peek()).Description;
+                        string nestedDescription = _host._transactions.Peek().Description;
                         throw new InvalidOperationException(string.Format(SR.DesignerHostNestedTransaction, Description, nestedDescription));
                     }
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerHost.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerHost.cs
@@ -47,7 +47,7 @@ namespace System.ComponentModel.Design
         private BitVector32 _state; // state for this host
         private DesignSurface _surface; // the owning designer surface.
         private string _newComponentName; // transient value indicating the name of a component that is being created
-        private Stack<DesignerTransaction> _transactions; // stack of transactions.  Each entry in the stack is a DesignerTransaction
+        private Stack<DesignerTransaction> _transactions; // stack of transactions
         private IComponent _rootComponent; // the root of our design
         private string _rootComponentClassName; // class name of the root of our design
         private readonly Dictionary<IComponent, IDesigner> _designers;  // designer -> component mapping
@@ -919,18 +919,10 @@ namespace System.ComponentModel.Design
         /// <summary>
         ///  Gets the description of the current transaction.
         /// </summary>
-        string IDesignerHost.TransactionDescription
-        {
-            get
-            {
-                if (_transactions is not null && _transactions.TryPeek(out DesignerTransaction transaction))
-                {
-                    return transaction.Description;
-                }
-
-                return null;
-            }
-        }
+        string IDesignerHost.TransactionDescription =>
+            _transactions is not null && _transactions.TryPeek(out DesignerTransaction transaction)
+                ? transaction.Description
+                : null;
 
         /// <summary>
         ///  Adds an event handler for the <see cref="IDesignerHost.Activated"/> event.

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerHost.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerHost.cs
@@ -47,7 +47,7 @@ namespace System.ComponentModel.Design
         private BitVector32 _state; // state for this host
         private DesignSurface _surface; // the owning designer surface.
         private string _newComponentName; // transient value indicating the name of a component that is being created
-        private Stack _transactions; // stack of transactions.  Each entry in the stack is a DesignerTransaction
+        private Stack<DesignerTransaction> _transactions; // stack of transactions.  Each entry in the stack is a DesignerTransaction
         private IComponent _rootComponent; // the root of our design
         private string _rootComponentClassName; // class name of the root of our design
         private readonly Dictionary<IComponent, IDesigner> _designers;  // designer -> component mapping
@@ -777,9 +777,8 @@ namespace System.ComponentModel.Design
             if (_transactions is not null && _transactions.Count > 0)
             {
                 Debug.Fail("There are open transactions at unload");
-                while (_transactions.Count > 0)
+                while (_transactions.TryPeek(out DesignerTransaction trans))  // it'll get popped in the OnCommit for DesignerHostTransaction
                 {
-                    DesignerTransaction trans = (DesignerTransaction)_transactions.Peek(); // it'll get popped in the OnCommit for DesignerHostTransaction
                     trans.Commit();
                 }
             }
@@ -924,9 +923,9 @@ namespace System.ComponentModel.Design
         {
             get
             {
-                if (_transactions is not null && _transactions.Count > 0)
+                if (_transactions is not null && _transactions.TryPeek(out DesignerTransaction transaction))
                 {
-                    return ((DesignerTransaction)_transactions.Peek()).Description;
+                    return transaction.Description;
                 }
 
                 return null;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerHost.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerHost.cs
@@ -777,9 +777,9 @@ namespace System.ComponentModel.Design
             if (_transactions is not null && _transactions.Count > 0)
             {
                 Debug.Fail("There are open transactions at unload");
-                while (_transactions.TryPeek(out DesignerTransaction trans))  // it'll get popped in the OnCommit for DesignerHostTransaction
+                while (_transactions.TryPeek(out DesignerTransaction transaction))  // it'll get popped in the OnCommit for DesignerHostTransaction
                 {
-                    trans.Commit();
+                    transaction.Commit();
                 }
             }
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/UndoEngine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/UndoEngine.cs
@@ -68,18 +68,7 @@ namespace System.ComponentModel.Design
         /// <summary>
         ///  Retrieves the current unit from the stack.
         /// </summary>
-        private UndoUnit CurrentUnit
-        {
-            get
-            {
-                if (_unitStack.TryPeek(out UndoUnit current))
-                {
-                    return current;
-                }
-
-                return null;
-            }
-        }
+        private UndoUnit CurrentUnit => _unitStack.TryPeek(out UndoUnit current) ? current : null;
 
         /// <summary>
         ///  This property indicates if an undo is in progress.

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/UndoEngine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/UndoEngine.cs
@@ -26,7 +26,7 @@ namespace System.ComponentModel.Design
         private static readonly TraceSwitch s_traceUndo = new TraceSwitch("UndoEngine", "Trace UndoRedo");
 
         private IServiceProvider _provider;
-        private readonly Stack _unitStack; // the stack of active (non-committed) units.
+        private readonly Stack<UndoUnit> _unitStack; // the stack of active (non-committed) units.
         private UndoUnit _executingUnit; // the unit currently executing an undo.
         private readonly IDesignerHost _host;
         private readonly ComponentSerializationService _serializationService;
@@ -45,7 +45,7 @@ namespace System.ComponentModel.Design
         protected UndoEngine(IServiceProvider provider)
         {
             _provider = provider.OrThrowIfNull();
-            _unitStack = new Stack();
+            _unitStack = new Stack<UndoUnit>();
             _enabled = true;
 
             // Validate that all required services are available.  Because undo is a passive activity we must know up front if it is going to work or not.
@@ -72,9 +72,9 @@ namespace System.ComponentModel.Design
         {
             get
             {
-                if (_unitStack.Count > 0)
+                if (_unitStack.TryPeek(out UndoUnit current))
                 {
-                    return (UndoUnit)_unitStack.Peek();
+                    return current;
                 }
 
                 return null;
@@ -154,7 +154,7 @@ namespace System.ComponentModel.Design
             if (reason != PopUnitReason.Normal || !_host.InTransaction)
             {
                 Trace("Popping unit {0}.  Reason: {1}", _unitStack.Peek(), reason);
-                UndoUnit unit = (UndoUnit)_unitStack.Pop();
+                UndoUnit unit = _unitStack.Pop();
 
                 if (!unit.IsEmpty)
                 {

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/UndoEngine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/UndoEngine.cs
@@ -66,11 +66,6 @@ namespace System.ComponentModel.Design
         }
 
         /// <summary>
-        ///  Retrieves the current unit from the stack.
-        /// </summary>
-        private UndoUnit CurrentUnit => _unitStack.TryPeek(out UndoUnit current) ? current : null;
-
-        /// <summary>
         ///  This property indicates if an undo is in progress.
         /// </summary>
         public bool UndoInProgress
@@ -314,7 +309,7 @@ namespace System.ComponentModel.Design
                 unit.ComponentAdded(e);
             }
 
-            if (CurrentUnit is not null)
+            if (_unitStack.Count > 0)
             {
                 CheckPopUnit(PopUnitReason.Normal);
             }
@@ -352,7 +347,7 @@ namespace System.ComponentModel.Design
                 unit.ComponentChanged(e);
             }
 
-            if (CurrentUnit is not null)
+            if (_unitStack.Count > 0)
             {
                 CheckPopUnit(PopUnitReason.Normal);
             }
@@ -395,7 +390,7 @@ namespace System.ComponentModel.Design
                 unit.ComponentRemoved(e);
             }
 
-            if (CurrentUnit is not null)
+            if (_unitStack.Count > 0)
             {
                 CheckPopUnit(PopUnitReason.Normal);
             }
@@ -502,7 +497,7 @@ namespace System.ComponentModel.Design
 
         private void OnTransactionClosed(object sender, DesignerTransactionCloseEventArgs e)
         {
-            if (_executingUnit is null && CurrentUnit is not null)
+            if (_executingUnit is null && _unitStack.Count > 0)
             {
                 PopUnitReason reason = e.TransactionCommitted ? PopUnitReason.TransactionCommit : PopUnitReason.TransactionCancel;
                 CheckPopUnit(reason);


### PR DESCRIPTION
Fixes #8728


## Proposed changes

Convert `Stack` usage to `Stack<T>` in DesignerHost and UndoEngine

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8729)