### PR TITLE
Refactor CodeDomSerializerBase.Trace methods for string interpolation

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomComponentSerializationService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomComponentSerializationService.cs
@@ -760,7 +760,7 @@ namespace System.ComponentModel.Design.Serialization
                                 PropertyDescriptor prop = props[propName];
                                 if (prop is not null && prop.CanResetValue(comp))
                                 {
-                                    Trace("Resetting default for {0}.{1}", name, propName);
+                                    Trace(TraceLevel.Verbose, $"Resetting default for {name}.{propName}");
                                     // If there is a member relationship setup for this property, we should disconnect it first. This makes sense, since if there was a previous relationship, we would have serialized it and not come here at all.
                                     if (manager.GetService(typeof(MemberRelationshipService)) is MemberRelationshipService relationships && relationships[comp, prop] != MemberRelationship.Empty)
                                     {
@@ -888,7 +888,7 @@ namespace System.ComponentModel.Design.Serialization
                             Type type = manager.GetType(typeName);
                             if (type is null)
                             {
-                                TraceError("Type does not exist: {0}", typeName);
+                                Trace(TraceLevel.Error, $"Type does not exist: {typeName}");
                                 manager.ReportError(new CodeDomSerializerException(string.Format(SR.SerializerTypeNotFound, typeName), manager));
                             }
                             else
@@ -899,14 +899,17 @@ namespace System.ComponentModel.Design.Serialization
                                     if (serializer is null)
                                     {
                                         // We report this as an error.  This indicates that there are code statements in initialize component that we do not know how to load.
-                                        TraceError("Type referenced in init method has no serializer: {0}", type.Name);
+                                        Trace(TraceLevel.Error, $"Type referenced in init method has no serializer: {type.Name}");
                                         manager.ReportError(new CodeDomSerializerException(string.Format(SR.SerializerNoSerializerForComponent, type.FullName), manager));
                                     }
                                     else
                                     {
-                                        Trace("--------------------------------------------------------------------");
-                                        Trace("     Beginning deserialization of {0}", name);
-                                        Trace("--------------------------------------------------------------------");
+                                        Trace(TraceLevel.Verbose,
+                                            $"""
+                                                --------------------------------------------------------------------
+                                                     Beginning deserialization of {name}
+                                                --------------------------------------------------------------------
+                                                """);
                                         try
                                         {
                                             object instance = serializer.Deserialize(manager, statements);
@@ -1229,7 +1232,7 @@ namespace System.ComponentModel.Design.Serialization
                                         {
                                             defaultPropList ??= new ArrayList(data.Members.Count);
 
-                                            Trace("Adding default for {0}.{1}", data._name, prop.Name);
+                                            Trace(TraceLevel.Verbose, $"Adding default for {data._name}.{prop.Name}");
                                             defaultPropList.Add(prop.Name);
                                         }
                                     }
@@ -1271,7 +1274,7 @@ namespace System.ComponentModel.Design.Serialization
                                         {
                                             defaultPropList ??= new ArrayList(data.Members.Count);
 
-                                            Trace("Adding default for {0}.{1}", data._name, prop.Name);
+                                            Trace(TraceLevel.Verbose, $"Adding default for {data._name}.{prop.Name}");
                                             defaultPropList.Add(prop.Name);
                                         }
                                     }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializer.cs
@@ -128,14 +128,14 @@ namespace System.ComponentModel.Design.Serialization
             {
                 if (assign.Left is CodeFieldReferenceExpression fieldRef)
                 {
-                    Trace("Assigning instance to field {0}", fieldRef.FieldName);
+                    Trace(TraceLevel.Verbose, $"Assigning instance to field {fieldRef.FieldName}");
                     instance = DeserializeExpression(manager, fieldRef.FieldName, assign.Right);
                 }
                 else
                 {
                     if (assign.Left is CodeVariableReferenceExpression varRef)
                     {
-                        Trace("Assigning instance to variable {0}", varRef.VariableName);
+                        Trace(TraceLevel.Verbose, $"Assigning instance to variable {varRef.VariableName}");
                         instance = DeserializeExpression(manager, varRef.VariableName, assign.Right);
                     }
                     else
@@ -146,7 +146,7 @@ namespace System.ComponentModel.Design.Serialization
             }
             else if (statement is CodeVariableDeclarationStatement varDecl && varDecl.InitExpression is not null)
             {
-                Trace("Initializing variable declaration for variable {0}", varDecl.Name);
+                Trace(TraceLevel.Verbose, $"Initializing variable declaration for variable {varDecl.Name}");
                 instance = DeserializeExpression(manager, varDecl.Name, varDecl.InitExpression);
             }
             else
@@ -169,7 +169,7 @@ namespace System.ComponentModel.Design.Serialization
 
             using (TraceScope($"CodeDomSerializer::{nameof(Serialize)}"))
             {
-                Trace("Type: {0}", value.GetType().Name);
+                Trace(TraceLevel.Verbose, $"Type: {value.GetType().Name}");
 
                 if (value is Type)
                 {
@@ -196,13 +196,13 @@ namespace System.ComponentModel.Design.Serialization
                         isPreset = false;
                     }
 
-                    TraceIf(expression is null, "Unable to create object; aborting.");
+                    TraceIf(TraceLevel.Verbose, expression is null, "Unable to create object; aborting.");
                     // Short circuit common cases
                     if (expression is not null)
                     {
                         if (isComplete)
                         {
-                            Trace("Single expression : {0}", expression);
+                            Trace(TraceLevel.Verbose, $"Single expression : {expression}");
                             result = expression;
                         }
                         else
@@ -221,7 +221,7 @@ namespace System.ComponentModel.Design.Serialization
                                 string varTypeName = TypeDescriptor.GetClassName(value);
 
                                 CodeVariableDeclarationStatement varDecl = new CodeVariableDeclarationStatement(varTypeName, varName);
-                                Trace("Generating local : {0}", varName);
+                                Trace(TraceLevel.Verbose, $"Generating local : {varName}");
                                 varDecl.InitExpression = expression;
                                 statements.Add(varDecl);
                                 variableReference = new CodeVariableReferenceExpression(varName);
@@ -358,7 +358,7 @@ namespace System.ComponentModel.Design.Serialization
 
                     if (name is not null)
                     {
-                        Trace("Object is reference ({0}) Creating reference expression", name);
+                        Trace(TraceLevel.Verbose, $"Object is reference ({name}) Creating reference expression");
                         // Check to see if this is a reference to the root component.  If it is, then use "this".
                         RootContext root = (RootContext)manager.Context[typeof(RootContext)];
                         if (root is not null && root.Value == value)

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializerBase.TraceIfInterpolatedStringHandler.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializerBase.TraceIfInterpolatedStringHandler.cs
@@ -1,0 +1,147 @@
+﻿using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace System.ComponentModel.Design.Serialization
+{
+    public abstract partial class CodeDomSerializerBase
+    {
+        /// <summary>
+        ///  Provides an interpolated string handler for <see
+        ///  cref="CodeDomSerializerBase.TraceIf(System.Diagnostics.TraceLevel,bool,ref System.ComponentModel.Design.Serialization.CodeDomSerializerBase.TraceIfInterpolatedStringHandler)"
+        ///  /> that only performs formatting if the condition applies and tracing is set to verbose.</summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [InterpolatedStringHandler]
+        internal struct TraceIfInterpolatedStringHandler
+        {
+            /// <summary>
+            ///  The handler we use to perform the formatting.
+            /// </summary>
+            private StringBuilder.AppendInterpolatedStringHandler _stringBuilderHandler;
+
+            /// <summary>
+            ///  The underlying <see cref="StringBuilder"/> instance used by <see cref="_stringBuilderHandler"/>, if any.
+            /// </summary>
+            private StringBuilder? _builder;
+
+            /// <summary>
+            ///  Creates an instance of the handler..
+            /// </summary>
+            /// <param name="literalLength">The number of constant characters outside of interpolation expressions in
+            /// the interpolated string.</param>
+            /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
+            /// <param name="condition">The condition Boolean passed to the <see cref="Debug"/> method.</param>
+            /// <param name="level">The trace level of the message.</param>
+            /// <param name="shouldAppend">A value indicating whether formatting should proceed.</param>
+            /// <remarks>
+            ///  This is intended to be called only by compiler-generated code. Arguments are not validated as they'd
+            ///  otherwise be for members intended to be used directly.
+            /// </remarks>
+            public TraceIfInterpolatedStringHandler(int literalLength, int formattedCount, bool condition, TraceLevel level, out bool shouldAppend)
+            {
+                if (condition && traceSerialization.Level >= level)
+                {
+                    _builder = new StringBuilder();
+                    _stringBuilderHandler = new StringBuilder.AppendInterpolatedStringHandler(literalLength, formattedCount,
+                        _builder);
+                    shouldAppend = true;
+                }
+                else
+                {
+                    _stringBuilderHandler = default;
+                    _builder = null;
+                    shouldAppend = false;
+                }
+            }
+
+            /// <summary>
+            ///  Extracts the built string from the handler.
+            /// </summary>
+            internal string ToStringAndClear()
+            {
+                string s = _builder?.ToString() ?? string.Empty;
+                _stringBuilderHandler = default;
+                return s;
+            }
+
+            /// <summary>
+            ///  Writes the specified string to the handler.
+            /// </summary>
+            /// <param name="value">The string to write.</param>
+            public void AppendLiteral(string value) => _stringBuilderHandler.AppendLiteral(value);
+
+            /// <summary>
+            ///  Writes the specified value to the handler.
+            /// </summary>
+            /// <param name="value">The value to write.</param>
+            /// <typeparam name="T">The type of the value to write.</typeparam>
+            public void AppendFormatted<T>(T value) => _stringBuilderHandler.AppendFormatted(value);
+
+            /// <summary>
+            ///  Writes the specified value to the handler.
+            /// </summary>
+            /// <param name="value">The value to write.</param>
+            /// <param name="format">The format string.</param>
+            /// <typeparam name="T">The type of the value to write.</typeparam>
+            public void AppendFormatted<T>(T value, string? format) => _stringBuilderHandler.AppendFormatted(value, format);
+
+            /// <summary>
+            ///  Writes the specified value to the handler.
+            /// </summary>
+            /// <param name="value">The value to write.</param>
+            /// <param name="alignment">Minimum number of characters that should be written for this value. If the value
+            /// is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
+            /// <typeparam name="T">The type of the value to write.</typeparam>
+            public void AppendFormatted<T>(T value, int alignment) => _stringBuilderHandler.AppendFormatted(value, alignment);
+
+            /// <summary>
+            ///  Writes the specified value to the handler.
+            /// </summary>
+            /// <param name="value">The value to write.</param>
+            /// <param name="format">The format string.</param>
+            /// <param name="alignment">Minimum number of characters that should be written for this value. If the value
+            /// is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
+            /// <typeparam name="T">The type of the value to write.</typeparam>
+            public void AppendFormatted<T>(T value, int alignment, string? format) => _stringBuilderHandler.AppendFormatted(value, alignment, format);
+
+            /// <summary>
+            ///  Writes the specified character span to the handler.
+            /// </summary>
+            /// <param name="value">The span to write.</param>
+            public void AppendFormatted(ReadOnlySpan<char> value) => _stringBuilderHandler.AppendFormatted(value);
+
+            /// <summary>
+            ///  Writes the specified string of chars to the handler.
+            /// </summary>
+            /// <param name="value">The span to write.</param>
+            /// <param name="alignment">Minimum number of characters that should be written for this value. If the value
+            /// is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
+            /// <param name="format">The format string.</param>
+            public void AppendFormatted(ReadOnlySpan<char> value, int alignment = 0, string? format = null) => _stringBuilderHandler.AppendFormatted(value, alignment, format);
+
+            /// <summary>
+            ///  Writes the specified value to the handler.
+            /// </summary>
+            /// <param name="value">The value to write.</param>
+            public void AppendFormatted(string? value) => _stringBuilderHandler.AppendFormatted(value);
+
+            /// <summary>
+            ///  Writes the specified value to the handler.
+            /// </summary>
+            /// <param name="value">The value to write.</param>
+            /// <param name="alignment">Minimum number of characters that should be written for this value. If the value
+            /// is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
+            /// <param name="format">The format string.</param>
+            public void AppendFormatted(string? value, int alignment = 0, string? format = null) => _stringBuilderHandler.AppendFormatted(value, alignment, format);
+
+            /// <summary>
+            ///  Writes the specified value to the handler.
+            /// </summary>
+            /// <param name="value">The value to write.</param>
+            /// <param name="alignment">Minimum number of characters that should be written for this value. If the value
+            /// is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
+            /// <param name="format">The format string.</param>
+            public void AppendFormatted(object? value, int alignment = 0, string? format = null) => _stringBuilderHandler.AppendFormatted(value, alignment, format);
+        }
+    }
+}

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializerBase.TraceIfInterpolatedStringHandler.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializerBase.TraceIfInterpolatedStringHandler.cs
@@ -93,59 +93,7 @@ namespace System.ComponentModel.Design.Serialization
             ///  Writes the specified value to the handler.
             /// </summary>
             /// <param name="value">The value to write.</param>
-            /// <param name="alignment">Minimum number of characters that should be written for this value. If the value
-            /// is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
-            /// <typeparam name="T">The type of the value to write.</typeparam>
-            public void AppendFormatted<T>(T value, int alignment) => _stringBuilderHandler.AppendFormatted(value, alignment);
-
-            /// <summary>
-            ///  Writes the specified value to the handler.
-            /// </summary>
-            /// <param name="value">The value to write.</param>
-            /// <param name="format">The format string.</param>
-            /// <param name="alignment">Minimum number of characters that should be written for this value. If the value
-            /// is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
-            /// <typeparam name="T">The type of the value to write.</typeparam>
-            public void AppendFormatted<T>(T value, int alignment, string? format) => _stringBuilderHandler.AppendFormatted(value, alignment, format);
-
-            /// <summary>
-            ///  Writes the specified character span to the handler.
-            /// </summary>
-            /// <param name="value">The span to write.</param>
-            public void AppendFormatted(ReadOnlySpan<char> value) => _stringBuilderHandler.AppendFormatted(value);
-
-            /// <summary>
-            ///  Writes the specified string of chars to the handler.
-            /// </summary>
-            /// <param name="value">The span to write.</param>
-            /// <param name="alignment">Minimum number of characters that should be written for this value. If the value
-            /// is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
-            /// <param name="format">The format string.</param>
-            public void AppendFormatted(ReadOnlySpan<char> value, int alignment = 0, string? format = null) => _stringBuilderHandler.AppendFormatted(value, alignment, format);
-
-            /// <summary>
-            ///  Writes the specified value to the handler.
-            /// </summary>
-            /// <param name="value">The value to write.</param>
             public void AppendFormatted(string? value) => _stringBuilderHandler.AppendFormatted(value);
-
-            /// <summary>
-            ///  Writes the specified value to the handler.
-            /// </summary>
-            /// <param name="value">The value to write.</param>
-            /// <param name="alignment">Minimum number of characters that should be written for this value. If the value
-            /// is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
-            /// <param name="format">The format string.</param>
-            public void AppendFormatted(string? value, int alignment = 0, string? format = null) => _stringBuilderHandler.AppendFormatted(value, alignment, format);
-
-            /// <summary>
-            ///  Writes the specified value to the handler.
-            /// </summary>
-            /// <param name="value">The value to write.</param>
-            /// <param name="alignment">Minimum number of characters that should be written for this value. If the value
-            /// is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
-            /// <param name="format">The format string.</param>
-            public void AppendFormatted(object? value, int alignment = 0, string? format = null) => _stringBuilderHandler.AppendFormatted(value, alignment, format);
         }
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializerBase.TraceIfInterpolatedStringHandler.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializerBase.TraceIfInterpolatedStringHandler.cs
@@ -13,7 +13,9 @@ namespace System.ComponentModel.Design.Serialization
         /// <summary>
         ///  Provides an interpolated string handler for <see
         ///  cref="CodeDomSerializerBase.TraceIf(System.Diagnostics.TraceLevel,bool,ref System.ComponentModel.Design.Serialization.CodeDomSerializerBase.TraceIfInterpolatedStringHandler)"
-        ///  /> that only performs formatting if the condition applies and tracing is set to verbose.</summary>
+        ///  /> that only performs formatting if the condition applies and tracing is set to a level higher or equal to
+        ///  the level of the message.
+        /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [InterpolatedStringHandler]
         internal struct TraceIfInterpolatedStringHandler
@@ -29,7 +31,7 @@ namespace System.ComponentModel.Design.Serialization
             private StringBuilder? _builder;
 
             /// <summary>
-            ///  Creates an instance of the handler..
+            ///  Creates an instance of the handler.
             /// </summary>
             /// <param name="literalLength">The number of constant characters outside of interpolation expressions in
             /// the interpolated string.</param>

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializerBase.TraceIfInterpolatedStringHandler.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializerBase.TraceIfInterpolatedStringHandler.cs
@@ -1,4 +1,8 @@
-﻿using System.Diagnostics;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Text;
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializerBase.TraceInterpolatedStringHandler.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializerBase.TraceInterpolatedStringHandler.cs
@@ -13,7 +13,7 @@ namespace System.ComponentModel.Design.Serialization
         /// <summary>
         ///  Provides an interpolated string handler for <see
         ///  cref="CodeDomSerializerBase.Trace(TraceLevel, ref CodeDomSerializerBase.TraceInterpolatedStringHandler)"/>
-        ///  that only performs formatting if trecing is set to verbose.
+        ///  that only performs formatting if tracing is set to a level higher or equal to the level of the message.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [InterpolatedStringHandler]
@@ -30,7 +30,7 @@ namespace System.ComponentModel.Design.Serialization
             private StringBuilder? _builder;
 
             /// <summary>
-            ///  Creates an instance of the handler..
+            ///  Creates an instance of the handler.
             /// </summary>
             /// <param name="literalLength">The number of constant characters outside of interpolation expressions in the
             /// interpolated string.</param>

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializerBase.TraceInterpolatedStringHandler.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializerBase.TraceInterpolatedStringHandler.cs
@@ -1,0 +1,147 @@
+﻿using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace System.ComponentModel.Design.Serialization
+{
+    public abstract partial class CodeDomSerializerBase
+    {
+        /// <summary>
+        ///  Provides an interpolated string handler for <see
+        ///  cref="CodeDomSerializerBase.Trace(TraceLevel, ref CodeDomSerializerBase.TraceInterpolatedStringHandler)"/>
+        ///  that only performs formatting if trecing is set to verbose.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [InterpolatedStringHandler]
+        internal struct TraceInterpolatedStringHandler
+        {
+            /// <summary>
+            ///  The handler we use to perform the formatting.
+            /// </summary>
+            private StringBuilder.AppendInterpolatedStringHandler _stringBuilderHandler;
+
+            /// <summary>
+            ///  The underlying <see cref="StringBuilder"/> instance used by <see cref="_stringBuilderHandler"/>, if any.
+            /// </summary>
+            private StringBuilder? _builder;
+
+            /// <summary>
+            ///  Creates an instance of the handler..
+            /// </summary>
+            /// <param name="literalLength">The number of constant characters outside of interpolation expressions in the
+            /// interpolated string.</param>
+            /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
+            /// <param name="level">The trace level of the message.</param>
+            /// <param name="shouldAppend">A value indicating whether formatting should proceed.</param>
+            /// <remarks>
+            ///  This is intended to be called only by compiler-generated code. Arguments are not validated as they'd
+            ///  otherwise be for members intended to be used directly.
+            /// </remarks>
+            public TraceInterpolatedStringHandler(int literalLength, int formattedCount, TraceLevel level, out bool shouldAppend)
+            {
+                if (traceSerialization.Level >= level)
+                {
+                    _builder = new StringBuilder();
+                    _stringBuilderHandler = new StringBuilder.AppendInterpolatedStringHandler(literalLength, formattedCount,
+                        _builder);
+                    shouldAppend = true;
+                }
+                else
+                {
+                    _stringBuilderHandler = default;
+                    _builder = null;
+                    shouldAppend = false;
+                }
+            }
+
+            /// <summary>
+            ///  Extracts the built string from the handler.
+            /// </summary>
+            internal string ToStringAndClear()
+            {
+                string s = _builder?.ToString() ?? string.Empty;
+                _stringBuilderHandler = default;
+                return s;
+            }
+
+            /// <summary>
+            ///  Writes the specified string to the handler.
+            /// </summary>
+            /// <param name="value">The string to write.</param>
+            public void AppendLiteral(string value) => _stringBuilderHandler.AppendLiteral(value);
+
+            /// <summary>
+            ///  Writes the specified value to the handler.
+            /// </summary>
+            /// <param name="value">The value to write.</param>
+            /// <typeparam name="T">The type of the value to write.</typeparam>
+            public void AppendFormatted<T>(T value) => _stringBuilderHandler.AppendFormatted(value);
+
+            /// <summary>
+            ///  Writes the specified value to the handler.
+            /// </summary>
+            /// <param name="value">The value to write.</param>
+            /// <param name="format">The format string.</param>
+            /// <typeparam name="T">The type of the value to write.</typeparam>
+            public void AppendFormatted<T>(T value, string? format) => _stringBuilderHandler.AppendFormatted(value, format);
+
+            /// <summary>
+            ///  Writes the specified value to the handler.
+            /// </summary>
+            /// <param name="value">The value to write.</param>
+            /// <param name="alignment">Minimum number of characters that should be written for this value. If the value
+            /// is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
+            /// <typeparam name="T">The type of the value to write.</typeparam>
+            public void AppendFormatted<T>(T value, int alignment) => _stringBuilderHandler.AppendFormatted(value, alignment);
+
+            /// <summary>
+            ///  Writes the specified value to the handler.
+            /// </summary>
+            /// <param name="value">The value to write.</param>
+            /// <param name="format">The format string.</param>
+            /// <param name="alignment">Minimum number of characters that should be written for this value. If the value
+            /// is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
+            /// <typeparam name="T">The type of the value to write.</typeparam>
+            public void AppendFormatted<T>(T value, int alignment, string? format) => _stringBuilderHandler.AppendFormatted(value, alignment, format);
+
+            /// <summary>
+            ///  Writes the specified character span to the handler.
+            /// </summary>
+            /// <param name="value">The span to write.</param>
+            public void AppendFormatted(ReadOnlySpan<char> value) => _stringBuilderHandler.AppendFormatted(value);
+
+            /// <summary>
+            ///  Writes the specified string of chars to the handler.
+            /// </summary>
+            /// <param name="value">The span to write.</param>
+            /// <param name="alignment">Minimum number of characters that should be written for this value. If the value
+            /// is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
+            /// <param name="format">The format string.</param>
+            public void AppendFormatted(ReadOnlySpan<char> value, int alignment = 0, string? format = null) => _stringBuilderHandler.AppendFormatted(value, alignment, format);
+
+            /// <summary>
+            ///  Writes the specified value to the handler.
+            /// </summary>
+            /// <param name="value">The value to write.</param>
+            public void AppendFormatted(string? value) => _stringBuilderHandler.AppendFormatted(value);
+
+            /// <summary>
+            ///  Writes the specified value to the handler.
+            /// </summary>
+            /// <param name="value">The value to write.</param>
+            /// <param name="alignment">Minimum number of characters that should be written for this value. If the value
+            /// is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
+            /// <param name="format">The format string.</param>
+            public void AppendFormatted(string? value, int alignment = 0, string? format = null) => _stringBuilderHandler.AppendFormatted(value, alignment, format);
+
+            /// <summary>
+            ///  Writes the specified value to the handler.
+            /// </summary>
+            /// <param name="value">The value to write.</param>
+            /// <param name="alignment">Minimum number of characters that should be written for this value. If the value
+            /// is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
+            /// <param name="format">The format string.</param>
+            public void AppendFormatted(object? value, int alignment = 0, string? format = null) => _stringBuilderHandler.AppendFormatted(value, alignment, format);
+        }
+    }
+}

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializerBase.TraceInterpolatedStringHandler.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializerBase.TraceInterpolatedStringHandler.cs
@@ -93,59 +93,7 @@ namespace System.ComponentModel.Design.Serialization
             ///  Writes the specified value to the handler.
             /// </summary>
             /// <param name="value">The value to write.</param>
-            /// <param name="alignment">Minimum number of characters that should be written for this value. If the value
-            /// is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
-            /// <typeparam name="T">The type of the value to write.</typeparam>
-            public void AppendFormatted<T>(T value, int alignment) => _stringBuilderHandler.AppendFormatted(value, alignment);
-
-            /// <summary>
-            ///  Writes the specified value to the handler.
-            /// </summary>
-            /// <param name="value">The value to write.</param>
-            /// <param name="format">The format string.</param>
-            /// <param name="alignment">Minimum number of characters that should be written for this value. If the value
-            /// is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
-            /// <typeparam name="T">The type of the value to write.</typeparam>
-            public void AppendFormatted<T>(T value, int alignment, string? format) => _stringBuilderHandler.AppendFormatted(value, alignment, format);
-
-            /// <summary>
-            ///  Writes the specified character span to the handler.
-            /// </summary>
-            /// <param name="value">The span to write.</param>
-            public void AppendFormatted(ReadOnlySpan<char> value) => _stringBuilderHandler.AppendFormatted(value);
-
-            /// <summary>
-            ///  Writes the specified string of chars to the handler.
-            /// </summary>
-            /// <param name="value">The span to write.</param>
-            /// <param name="alignment">Minimum number of characters that should be written for this value. If the value
-            /// is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
-            /// <param name="format">The format string.</param>
-            public void AppendFormatted(ReadOnlySpan<char> value, int alignment = 0, string? format = null) => _stringBuilderHandler.AppendFormatted(value, alignment, format);
-
-            /// <summary>
-            ///  Writes the specified value to the handler.
-            /// </summary>
-            /// <param name="value">The value to write.</param>
             public void AppendFormatted(string? value) => _stringBuilderHandler.AppendFormatted(value);
-
-            /// <summary>
-            ///  Writes the specified value to the handler.
-            /// </summary>
-            /// <param name="value">The value to write.</param>
-            /// <param name="alignment">Minimum number of characters that should be written for this value. If the value
-            /// is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
-            /// <param name="format">The format string.</param>
-            public void AppendFormatted(string? value, int alignment = 0, string? format = null) => _stringBuilderHandler.AppendFormatted(value, alignment, format);
-
-            /// <summary>
-            ///  Writes the specified value to the handler.
-            /// </summary>
-            /// <param name="value">The value to write.</param>
-            /// <param name="alignment">Minimum number of characters that should be written for this value. If the value
-            /// is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
-            /// <param name="format">The format string.</param>
-            public void AppendFormatted(object? value, int alignment = 0, string? format = null) => _stringBuilderHandler.AppendFormatted(value, alignment, format);
         }
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializerBase.TraceInterpolatedStringHandler.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializerBase.TraceInterpolatedStringHandler.cs
@@ -1,4 +1,8 @@
-﻿using System.Diagnostics;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Text;
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializerBase.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializerBase.cs
@@ -1885,7 +1885,7 @@ namespace System.ComponentModel.Design.Serialization
                         $"""
                             ***************************************************
                             *** WARNING :{message}
-                            *** SCOPE :{TraceScopeAsString()}
+                            *** SCOPE :{GetTraceScopeAsString()}
                             ***************************************************
                             """);
                     break;
@@ -1895,17 +1895,17 @@ namespace System.ComponentModel.Design.Serialization
                         $"""
                             ***************************************************
                             *** ERROR :{message}
-                            *** SCOPE :{TraceScopeAsString()}
+                            *** SCOPE :{GetTraceScopeAsString()}
                             ***************************************************
                             """);
                     break;
 
                 default:
-                    throw new ArgumentOutOfRangeException(nameof(level), level, null);
+                    throw new InvalidEnumArgumentException(nameof(level), (int)level, typeof(TraceLevel));
             }
         }
 
-        private static string TraceScopeAsString() =>
+        private static string GetTraceScopeAsString() =>
             traceScope is not null ? string.Join('/', traceScope.Reverse()) : string.Empty;
 
         private bool DeserializePropertyAssignStatement(IDesignerSerializationManager manager, CodeAssignStatement statement,

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializerBase.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializerBase.cs
@@ -9,6 +9,7 @@ using System.Collections;
 using System.Diagnostics;
 using System.Globalization;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace System.ComponentModel.Design.Serialization
@@ -437,7 +438,7 @@ namespace System.ComponentModel.Design.Serialization
                         if (passFilter)
                         {
                             object resourceObject = de.Value;
-                            Trace("Resource: {0}, value: {1}", resourceName, (resourceObject ?? "(null)"));
+                            Trace(TraceLevel.Verbose, $"Resource: {resourceName}, value: {(resourceObject ?? "(null)")}");
                             try
                             {
                                 property.SetValue(value, resourceObject);
@@ -452,49 +453,238 @@ namespace System.ComponentModel.Design.Serialization
             }
         }
 
+#nullable enable
+        /// <summary>Provides an interpolated string handler for <see cref="CodeDomSerializerBase.Trace(TraceLevel, ref CodeDomSerializerBase.TraceInterpolatedStringHandler)"/> that only performs formatting if trecing is set to verbose.</summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [InterpolatedStringHandler]
+        internal struct TraceInterpolatedStringHandler
+        {
+            /// <summary>The handler we use to perform the formatting.</summary>
+            private StringBuilder.AppendInterpolatedStringHandler _stringBuilderHandler;
+
+            /// <summary>
+            /// The underlying <see cref="StringBuilder"/> instance used by <see cref="_stringBuilderHandler"/>, if any.
+            /// </summary>
+            private StringBuilder? _builder;
+
+            /// <summary>Creates an instance of the handler..</summary>
+            /// <param name="literalLength">The number of constant characters outside of interpolation expressions in the interpolated string.</param>
+            /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
+            /// <param name="level">The trace level of the message.</param>
+            /// <param name="shouldAppend">A value indicating whether formatting should proceed.</param>
+            /// <remarks>This is intended to be called only by compiler-generated code. Arguments are not validated as they'd otherwise be for members intended to be used directly.</remarks>
+            public TraceInterpolatedStringHandler(int literalLength, int formattedCount, TraceLevel level, out bool shouldAppend)
+            {
+                if (traceSerialization.Level >= level)
+                {
+                    _builder = new StringBuilder();
+                    _stringBuilderHandler = new StringBuilder.AppendInterpolatedStringHandler(literalLength, formattedCount,
+                        _builder);
+                    shouldAppend = true;
+                }
+                else
+                {
+                    _stringBuilderHandler = default;
+                    _builder = null;
+                    shouldAppend = false;
+                }
+            }
+
+            /// <summary>Extracts the built string from the handler.</summary>
+            internal string ToStringAndClear()
+            {
+                string s = _builder?.ToString() ?? string.Empty;
+                _stringBuilderHandler = default;
+                return s;
+            }
+
+            /// <summary>Writes the specified string to the handler.</summary>
+            /// <param name="value">The string to write.</param>
+            public void AppendLiteral(string value) => _stringBuilderHandler.AppendLiteral(value);
+
+            /// <summary>Writes the specified value to the handler.</summary>
+            /// <param name="value">The value to write.</param>
+            /// <typeparam name="T">The type of the value to write.</typeparam>
+            public void AppendFormatted<T>(T value) => _stringBuilderHandler.AppendFormatted(value);
+
+            /// <summary>Writes the specified value to the handler.</summary>
+            /// <param name="value">The value to write.</param>
+            /// <param name="format">The format string.</param>
+            /// <typeparam name="T">The type of the value to write.</typeparam>
+            public void AppendFormatted<T>(T value, string? format) => _stringBuilderHandler.AppendFormatted(value, format);
+
+            /// <summary>Writes the specified value to the handler.</summary>
+            /// <param name="value">The value to write.</param>
+            /// <param name="alignment">Minimum number of characters that should be written for this value.  If the value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
+            /// <typeparam name="T">The type of the value to write.</typeparam>
+            public void AppendFormatted<T>(T value, int alignment) => _stringBuilderHandler.AppendFormatted(value, alignment);
+
+            /// <summary>Writes the specified value to the handler.</summary>
+            /// <param name="value">The value to write.</param>
+            /// <param name="format">The format string.</param>
+            /// <param name="alignment">Minimum number of characters that should be written for this value.  If the value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
+            /// <typeparam name="T">The type of the value to write.</typeparam>
+            public void AppendFormatted<T>(T value, int alignment, string? format) => _stringBuilderHandler.AppendFormatted(value, alignment, format);
+
+            /// <summary>Writes the specified character span to the handler.</summary>
+            /// <param name="value">The span to write.</param>
+            public void AppendFormatted(ReadOnlySpan<char> value) => _stringBuilderHandler.AppendFormatted(value);
+
+            /// <summary>Writes the specified string of chars to the handler.</summary>
+            /// <param name="value">The span to write.</param>
+            /// <param name="alignment">Minimum number of characters that should be written for this value.  If the value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
+            /// <param name="format">The format string.</param>
+            public void AppendFormatted(ReadOnlySpan<char> value, int alignment = 0, string? format = null) => _stringBuilderHandler.AppendFormatted(value, alignment, format);
+
+            /// <summary>Writes the specified value to the handler.</summary>
+            /// <param name="value">The value to write.</param>
+            public void AppendFormatted(string? value) => _stringBuilderHandler.AppendFormatted(value);
+
+            /// <summary>Writes the specified value to the handler.</summary>
+            /// <param name="value">The value to write.</param>
+            /// <param name="alignment">Minimum number of characters that should be written for this value.  If the value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
+            /// <param name="format">The format string.</param>
+            public void AppendFormatted(string? value, int alignment = 0, string? format = null) => _stringBuilderHandler.AppendFormatted(value, alignment, format);
+
+            /// <summary>Writes the specified value to the handler.</summary>
+            /// <param name="value">The value to write.</param>
+            /// <param name="alignment">Minimum number of characters that should be written for this value.  If the value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
+            /// <param name="format">The format string.</param>
+            public void AppendFormatted(object? value, int alignment = 0, string? format = null) => _stringBuilderHandler.AppendFormatted(value, alignment, format);
+        }
+
+        /// <summary>Provides an interpolated string handler for <see cref="CodeDomSerializerBase.TraceIf(System.Diagnostics.TraceLevel,bool,ref System.ComponentModel.Design.Serialization.CodeDomSerializerBase.TraceIfInterpolatedStringHandler)"/> that only performs formatting if the condition applies and tracing is set to verbose.</summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [InterpolatedStringHandler]
+        internal struct TraceIfInterpolatedStringHandler
+        {
+            /// <summary>The handler we use to perform the formatting.</summary>
+            private StringBuilder.AppendInterpolatedStringHandler _stringBuilderHandler;
+
+            /// <summary>
+            /// The underlying <see cref="StringBuilder"/> instance used by <see cref="_stringBuilderHandler"/>, if any.
+            /// </summary>
+            private StringBuilder? _builder;
+
+            /// <summary>Creates an instance of the handler..</summary>
+            /// <param name="literalLength">The number of constant characters outside of interpolation expressions in the interpolated string.</param>
+            /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
+            /// <param name="condition">The condition Boolean passed to the <see cref="Debug"/> method.</param>
+            /// <param name="level">The trace level of the message.</param>
+            /// <param name="shouldAppend">A value indicating whether formatting should proceed.</param>
+            /// <remarks>This is intended to be called only by compiler-generated code. Arguments are not validated as they'd otherwise be for members intended to be used directly.</remarks>
+            public TraceIfInterpolatedStringHandler(int literalLength, int formattedCount, bool condition, TraceLevel level, out bool shouldAppend)
+            {
+                if (condition && traceSerialization.Level >= level)
+                {
+                    _builder = new StringBuilder();
+                    _stringBuilderHandler = new StringBuilder.AppendInterpolatedStringHandler(literalLength, formattedCount,
+                        _builder);
+                    shouldAppend = true;
+                }
+                else
+                {
+                    _stringBuilderHandler = default;
+                    _builder = null;
+                    shouldAppend = false;
+                }
+            }
+
+            /// <summary>Extracts the built string from the handler.</summary>
+            internal string ToStringAndClear()
+            {
+                string s = _builder?.ToString() ?? string.Empty;
+                _stringBuilderHandler = default;
+                return s;
+            }
+
+            /// <summary>Writes the specified string to the handler.</summary>
+            /// <param name="value">The string to write.</param>
+            public void AppendLiteral(string value) => _stringBuilderHandler.AppendLiteral(value);
+
+            /// <summary>Writes the specified value to the handler.</summary>
+            /// <param name="value">The value to write.</param>
+            /// <typeparam name="T">The type of the value to write.</typeparam>
+            public void AppendFormatted<T>(T value) => _stringBuilderHandler.AppendFormatted(value);
+
+            /// <summary>Writes the specified value to the handler.</summary>
+            /// <param name="value">The value to write.</param>
+            /// <param name="format">The format string.</param>
+            /// <typeparam name="T">The type of the value to write.</typeparam>
+            public void AppendFormatted<T>(T value, string? format) => _stringBuilderHandler.AppendFormatted(value, format);
+
+            /// <summary>Writes the specified value to the handler.</summary>
+            /// <param name="value">The value to write.</param>
+            /// <param name="alignment">Minimum number of characters that should be written for this value.  If the value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
+            /// <typeparam name="T">The type of the value to write.</typeparam>
+            public void AppendFormatted<T>(T value, int alignment) => _stringBuilderHandler.AppendFormatted(value, alignment);
+
+            /// <summary>Writes the specified value to the handler.</summary>
+            /// <param name="value">The value to write.</param>
+            /// <param name="format">The format string.</param>
+            /// <param name="alignment">Minimum number of characters that should be written for this value.  If the value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
+            /// <typeparam name="T">The type of the value to write.</typeparam>
+            public void AppendFormatted<T>(T value, int alignment, string? format) => _stringBuilderHandler.AppendFormatted(value, alignment, format);
+
+            /// <summary>Writes the specified character span to the handler.</summary>
+            /// <param name="value">The span to write.</param>
+            public void AppendFormatted(ReadOnlySpan<char> value) => _stringBuilderHandler.AppendFormatted(value);
+
+            /// <summary>Writes the specified string of chars to the handler.</summary>
+            /// <param name="value">The span to write.</param>
+            /// <param name="alignment">Minimum number of characters that should be written for this value.  If the value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
+            /// <param name="format">The format string.</param>
+            public void AppendFormatted(ReadOnlySpan<char> value, int alignment = 0, string? format = null) => _stringBuilderHandler.AppendFormatted(value, alignment, format);
+
+            /// <summary>Writes the specified value to the handler.</summary>
+            /// <param name="value">The value to write.</param>
+            public void AppendFormatted(string? value) => _stringBuilderHandler.AppendFormatted(value);
+
+            /// <summary>Writes the specified value to the handler.</summary>
+            /// <param name="value">The value to write.</param>
+            /// <param name="alignment">Minimum number of characters that should be written for this value.  If the value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
+            /// <param name="format">The format string.</param>
+            public void AppendFormatted(string? value, int alignment = 0, string? format = null) => _stringBuilderHandler.AppendFormatted(value, alignment, format);
+
+            /// <summary>Writes the specified value to the handler.</summary>
+            /// <param name="value">The value to write.</param>
+            /// <param name="alignment">Minimum number of characters that should be written for this value.  If the value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
+            /// <param name="format">The format string.</param>
+            public void AppendFormatted(object? value, int alignment = 0, string? format = null) => _stringBuilderHandler.AppendFormatted(value, alignment, format);
+        }
+#nullable disable
+
         internal static IDisposable TraceScope(string name)
         {
 #if DEBUG
-            traceScope ??= new ();
+            traceScope ??= new Stack<string>();
 
-            Trace(name);
+            Trace(TraceLevel.Verbose, name);
             traceScope.Push(name);
 #endif
             return default(TracingScope);
         }
 
         [Conditional("DEBUG")]
-        internal static void TraceIf(bool condition, string message, params object[] values)
+        internal static void TraceIf(TraceLevel level, bool condition, string message)
         {
             if (condition)
             {
-                Trace(message, values);
+                Trace(level, message);
             }
         }
 
         [Conditional("DEBUG")]
-        internal static void Trace(string message, params object[] values)
+        internal static void TraceIf(TraceLevel level, bool condition, [InterpolatedStringHandlerArgument(nameof(condition), nameof(level))]
+            ref TraceIfInterpolatedStringHandler message)
         {
-            if (traceSerialization.TraceVerbose)
-            {
-                int indent = 0;
-                int oldIndent = Debug.IndentLevel;
+            TraceIf(level, condition, message.ToStringAndClear());
+        }
 
-                if (traceScope is not null)
-                {
-                    indent = traceScope.Count;
-                }
-
-                try
-                {
-                    Debug.IndentLevel = indent;
-                    Debug.WriteLine(string.Format(CultureInfo.CurrentCulture, message, values));
-                }
-                finally
-                {
-                    Debug.IndentLevel = oldIndent;
-                }
-            }
+        [Conditional("DEBUG")]
+        internal static void Trace(TraceLevel level, [InterpolatedStringHandlerArgument(nameof(level))] ref TraceInterpolatedStringHandler message)
+        {
+            Trace(level, message.ToStringAndClear());
         }
 
         private struct TracingScope : IDisposable
@@ -513,7 +703,7 @@ namespace System.ComponentModel.Design.Serialization
         {
             using (TraceScope($"CodeDomSerializerBase::{nameof(DeserializeStatement)}"))
             {
-                Trace("Statement : {0}", statement.GetType().Name);
+                Trace(TraceLevel.Verbose, $"Statement : {statement.GetType().Name}");
 
                 // Push this statement onto the context stack.  This allows any serializers handling an expression to know what it was connected to.
                 manager.Context.Push(statement);
@@ -568,7 +758,7 @@ namespace System.ComponentModel.Design.Serialization
                                             }
                                             else
                                             {
-                                                TraceWarning("Unrecognized statement type: {0}", statement.GetType().Name);
+                                                Trace(TraceLevel.Warning, $"Unrecognized statement type: {statement.GetType().Name}");
                                             }
                                         }
                                     }
@@ -610,7 +800,7 @@ namespace System.ComponentModel.Design.Serialization
             {
                 if (statement.InitExpression is not null)
                 {
-                    Trace("Processing init expression");
+                    Trace(TraceLevel.Verbose, "Processing init expression");
                     DeserializeExpression(manager, statement.Name, statement.InitExpression);
                 }
             }
@@ -621,19 +811,19 @@ namespace System.ComponentModel.Design.Serialization
             using (TraceScope($"CodeDomSerializerBase::{nameof(DeserializeDetachEventStatement)}"))
             {
                 object eventListener = DeserializeExpression(manager, null, statement.Listener);
-                TraceErrorIf(!(eventListener is CodeDelegateCreateExpression), "Unable to simplify event attach RHS to a delegate create.");
+                TraceIf(TraceLevel.Error, eventListener is not CodeDelegateCreateExpression, "Unable to simplify event attach RHS to a delegate create.");
                 if (eventListener is CodeDelegateCreateExpression delegateCreate)
                 {
                     // We only support binding methods to the root object.
                     object eventAttachObject = DeserializeExpression(manager, null, delegateCreate.TargetObject);
                     RootContext rootExp = (RootContext)manager.Context[typeof(RootContext)];
                     bool isRoot = rootExp is null || (rootExp is not null && rootExp.Value == eventAttachObject);
-                    TraceWarningIf(!isRoot, "Event is bound to an object other than the root.  We do not support this.");
+                    TraceIf(TraceLevel.Warning, !isRoot, "Event is bound to an object other than the root.  We do not support this.");
                     if (isRoot)
                     {
                         // Now deserialize the LHS of the event attach to discover the guy whose event we are attaching.
                         object targetObject = DeserializeExpression(manager, null, statement.Event.TargetObject);
-                        TraceErrorIf(targetObject is CodeExpression, "Unable to simplify event attach LHS to an object reference.");
+                        TraceIf(TraceLevel.Error, targetObject is CodeExpression, "Unable to simplify event attach LHS to an object reference.");
                         if (!(targetObject is CodeExpression))
                         {
                             EventDescriptor evt = GetEventsHelper(manager, targetObject, null)[statement.Event.EventName];
@@ -648,7 +838,7 @@ namespace System.ComponentModel.Design.Serialization
                             }
                             else
                             {
-                                TraceError("Object {0} does not have a event {1}", targetObject.GetType().Name, statement.Event.EventName);
+                                Trace(TraceLevel.Error, $"Object {targetObject.GetType().Name} does not have a event {statement.Event.EventName}");
                                 Error(manager, string.Format(SR.SerializerNoSuchEvent, targetObject.GetType().FullName, statement.Event.EventName), SR.SerializerNoSuchEvent);
                             }
                         }
@@ -665,14 +855,14 @@ namespace System.ComponentModel.Design.Serialization
                 //Perf: is -> as changes, change ordering based on possibility of occurrence
                 CodeExpression expression = statement.Left;
 
-                Trace("Processing LHS");
+                Trace(TraceLevel.Verbose, "Processing LHS");
                 if (expression is CodePropertyReferenceExpression propertyReferenceEx)
                 {
                     DeserializePropertyAssignStatement(manager, statement, propertyReferenceEx, true);
                 }
                 else if (expression is CodeFieldReferenceExpression fieldReferenceEx)
                 {
-                    Trace("LHS is field : {0}", fieldReferenceEx.FieldName);
+                    Trace(TraceLevel.Verbose, $"LHS is field : {fieldReferenceEx.FieldName}");
                     object lhs = DeserializeExpression(manager, fieldReferenceEx.FieldName, fieldReferenceEx.TargetObject);
                     if (lhs is not null)
                     {
@@ -680,11 +870,11 @@ namespace System.ComponentModel.Design.Serialization
 
                         if (root is not null && root.Value == lhs)
                         {
-                            Trace("Processing RHS");
+                            Trace(TraceLevel.Verbose, "Processing RHS");
                             object rhs = DeserializeExpression(manager, fieldReferenceEx.FieldName, statement.Right);
                             if (rhs is CodeExpression)
                             {
-                                TraceError("Unable to simplify statement to anything better than: {0}", rhs.GetType().Name);
+                                Trace(TraceLevel.Error, $"Unable to simplify statement to anything better than: {rhs.GetType().Name}");
                                 return;
                             }
                         }
@@ -707,11 +897,11 @@ namespace System.ComponentModel.Design.Serialization
 
                             if (f is not null)
                             {
-                                Trace("Processing RHS");
+                                Trace(TraceLevel.Verbose, "Processing RHS");
                                 object rhs = DeserializeExpression(manager, fieldReferenceEx.FieldName, statement.Right);
                                 if (rhs is CodeExpression)
                                 {
-                                    TraceError("Unable to simplify statement to anything better than: {0}", rhs.GetType().Name);
+                                    Trace(TraceLevel.Error, $"Unable to simplify statement to anything better than: {rhs.GetType().Name}");
                                     return;
                                 }
 
@@ -752,7 +942,7 @@ namespace System.ComponentModel.Design.Serialization
                                 };
                                 if (!DeserializePropertyAssignStatement(manager, statement, propRef, false))
                                 {
-                                    TraceError("Object {0} does not have a field {1}", lhs.GetType().Name, fieldReferenceEx.FieldName);
+                                    Trace(TraceLevel.Error, $"Object {lhs.GetType().Name} does not have a field {fieldReferenceEx.FieldName}");
                                     Error(manager, string.Format(SR.SerializerNoSuchField, lhs.GetType().FullName, fieldReferenceEx.FieldName), SR.SerializerNoSuchField);
                                 }
                             }
@@ -760,17 +950,17 @@ namespace System.ComponentModel.Design.Serialization
                     }
                     else
                     {
-                        TraceWarning("Could not find target object for field {0}", fieldReferenceEx.FieldName);
+                        Trace(TraceLevel.Warning, $"Could not find target object for field {fieldReferenceEx.FieldName}");
                     }
                 }
                 else if (expression is CodeVariableReferenceExpression variableReferenceEx)
                 {
                     // This is the easiest.  Just relate the RHS object to the name of the variable.
-                    Trace("Processing RHS");
+                    Trace(TraceLevel.Verbose, "Processing RHS");
                     object rhs = DeserializeExpression(manager, variableReferenceEx.VariableName, statement.Right);
                     if (rhs is CodeExpression)
                     {
-                        TraceError("Unable to simplify statement to anything better than: {0}", rhs.GetType().Name);
+                        Trace(TraceLevel.Error, $"Unable to simplify statement to anything better than: {rhs.GetType().Name}");
                         return;
                     }
 
@@ -779,7 +969,7 @@ namespace System.ComponentModel.Design.Serialization
                 else if (expression is CodeArrayIndexerExpression arrayIndexerEx)
                 {
                     int[] indexes = new int[arrayIndexerEx.Indices.Count];
-                    Trace("LHS is Array Indexer with dims {0}", indexes.Length);
+                    Trace(TraceLevel.Verbose, $"LHS is Array Indexer with dims {indexes.Length}");
                     object array = DeserializeExpression(manager, null, arrayIndexerEx.TargetObject);
                     bool indexesOK = true;
 
@@ -790,11 +980,11 @@ namespace System.ComponentModel.Design.Serialization
                         if (index is IConvertible ic)
                         {
                             indexes[i] = ic.ToInt32(null);
-                            Trace("[{0}] == {1}", i, indexes[i]);
+                            Trace(TraceLevel.Verbose, $"[{i}] == {indexes[i]}");
                         }
                         else
                         {
-                            TraceWarning("Index {0} could not be converted to int.  Type: {1}", i, (index is null ? "(null)" : index.GetType().Name));
+                            Trace(TraceLevel.Warning, $"Index {i} could not be converted to int.  Type: {(index is null ? "(null)" : index.GetType().Name)}");
                             indexesOK = false;
                             break;
                         }
@@ -802,11 +992,11 @@ namespace System.ComponentModel.Design.Serialization
 
                     if (array is Array arr && indexesOK)
                     {
-                        Trace("Processing RHS");
+                        Trace(TraceLevel.Verbose, "Processing RHS");
                         object rhs = DeserializeExpression(manager, null, statement.Right);
                         if (rhs is CodeExpression)
                         {
-                            TraceError("Unable to simplify statement to anything better than: {0}", rhs.GetType().Name);
+                            Trace(TraceLevel.Error, $"Unable to simplify statement to anything better than: {rhs.GetType().Name}");
                             return;
                         }
 
@@ -814,24 +1004,10 @@ namespace System.ComponentModel.Design.Serialization
                     }
                     else
                     {
-                        TraceErrorIf(!(array is Array), "Array resolved to something other than an array: {0}", (array is null ? "(null)" : array.GetType().Name));
-                        TraceErrorIf(!indexesOK, "Indexes to array could not be converted to int32.");
+                        TraceIf(TraceLevel.Error, array is not Array, $"Array resolved to something other than an array: {(array is null ? "(null)" : array.GetType().Name)}");
+                        TraceIf(TraceLevel.Error, !indexesOK, "Indexes to array could not be converted to int32.");
                     }
                 }
-            }
-        }
-
-        [Conditional("DEBUG")]
-        internal static void TraceError(string message, params object[] values)
-        {
-            if (traceSerialization.TraceError)
-            {
-                string scope = traceScope is not null ? string.Join('/', traceScope.Reverse()) : string.Empty;
-
-                Debug.WriteLine("***************************************************");
-                Debug.WriteLine($"*** ERROR :{string.Format(CultureInfo.CurrentCulture, message, values)}");
-                Debug.WriteLine($"*** SCOPE :{scope}");
-                Debug.WriteLine("***************************************************");
             }
         }
 
@@ -868,7 +1044,7 @@ namespace System.ComponentModel.Design.Serialization
                 {
                     if (result is CodePrimitiveExpression primitiveEx)
                     {
-                        Trace("Primitive.  Value: {0}", (primitiveEx.Value ?? "(null)"));
+                        Trace(TraceLevel.Verbose, $"Primitive.  Value: {(primitiveEx.Value ?? "(null)")}");
                         result = primitiveEx.Value;
                         break;
                     }
@@ -879,7 +1055,7 @@ namespace System.ComponentModel.Design.Serialization
                     }
                     else if (result is CodeThisReferenceExpression)
                     { //(is -> as doesn't help here, since the cast is different)
-                        Trace("'this' reference");
+                        Trace(TraceLevel.Verbose, "'this' reference");
                         RootContext rootExp = (RootContext)manager.Context[typeof(RootContext)];
                         if (rootExp is not null)
                         {
@@ -896,7 +1072,7 @@ namespace System.ComponentModel.Design.Serialization
 
                         if (result is null)
                         {
-                            TraceError("CodeThisReferenceExpression not handled because there is no root context or the root context did not contain an instance.");
+                            Trace(TraceLevel.Error, "CodeThisReferenceExpression not handled because there is no root context or the root context did not contain an instance.");
                             Error(manager, SR.SerializerNoRootExpression, SR.SerializerNoRootExpression);
                         }
 
@@ -904,13 +1080,13 @@ namespace System.ComponentModel.Design.Serialization
                     }
                     else if ((typeReferenceEx = result as CodeTypeReferenceExpression) is not null)
                     {
-                        Trace("TypeReference : {0}", typeReferenceEx.Type.BaseType);
+                        Trace(TraceLevel.Verbose, $"TypeReference : {typeReferenceEx.Type.BaseType}");
                         result = manager.GetType(GetTypeNameFromCodeTypeReference(manager, typeReferenceEx.Type));
                         break;
                     }
                     else if ((objectCreateEx = result as CodeObjectCreateExpression) is not null)
                     {
-                        Trace("Object create");
+                        Trace(TraceLevel.Verbose, "Object create");
                         result = null;
                         Type type = manager.GetType(GetTypeNameFromCodeTypeReference(manager, objectCreateEx.CreateType));
                         if (type is not null)
@@ -970,7 +1146,7 @@ namespace System.ComponentModel.Design.Serialization
                         }
                         else
                         {
-                            TraceError("Type {0} could not be loaded", objectCreateEx.CreateType.BaseType);
+                            Trace(TraceLevel.Error, $"Type {objectCreateEx.CreateType.BaseType} could not be loaded");
                             Error(manager, string.Format(SR.SerializerTypeNotFound, objectCreateEx.CreateType.BaseType), SR.SerializerTypeNotFound);
                         }
 
@@ -978,11 +1154,11 @@ namespace System.ComponentModel.Design.Serialization
                     }
                     else if ((argumentReferenceEx = result as CodeArgumentReferenceExpression) is not null)
                     {
-                        Trace("Named argument reference : {0}", argumentReferenceEx.ParameterName);
+                        Trace(TraceLevel.Verbose, $"Named argument reference : {argumentReferenceEx.ParameterName}");
                         result = manager.GetInstance(argumentReferenceEx.ParameterName);
                         if (result is null)
                         {
-                            TraceError("Parameter {0} does not exist", argumentReferenceEx.ParameterName);
+                            Trace(TraceLevel.Error, "Parameter {argumentReferenceEx.ParameterName} does not exist");
                             Error(manager, string.Format(SR.SerializerUndeclaredName, argumentReferenceEx.ParameterName), SR.SerializerUndeclaredName);
                         }
 
@@ -990,7 +1166,7 @@ namespace System.ComponentModel.Design.Serialization
                     }
                     else if ((fieldReferenceEx = result as CodeFieldReferenceExpression) is not null)
                     {
-                        Trace("Field reference : {0}", fieldReferenceEx.FieldName);
+                        Trace(TraceLevel.Verbose, $"Field reference : {fieldReferenceEx.FieldName}");
                         object target = DeserializeExpression(manager, null, fieldReferenceEx.TargetObject);
                         if (target is not null && !(target is CodeExpression))
                         {
@@ -1005,7 +1181,7 @@ namespace System.ComponentModel.Design.Serialization
                                 }
                                 else
                                 {
-                                    TraceError("Field {0} could not be resolved", fieldReferenceEx.FieldName);
+                                    Trace(TraceLevel.Error, "Field {fieldReferenceEx.FieldName} could not be resolved");
                                     Error(manager, string.Format(SR.SerializerUndeclaredName, fieldReferenceEx.FieldName), SR.SerializerUndeclaredName);
                                 }
                             }
@@ -1013,8 +1189,7 @@ namespace System.ComponentModel.Design.Serialization
                             {
                                 FieldInfo field;
                                 object instance;
-                                Type t = target as Type;
-                                if (t is not null)
+                                if (target is Type t)
                                 {
                                     instance = null;
                                     field = GetReflectionTypeFromTypeHelper(manager, t).GetField(fieldReferenceEx.FieldName, BindingFlags.GetField | BindingFlags.Static | BindingFlags.Public);
@@ -1051,12 +1226,12 @@ namespace System.ComponentModel.Design.Serialization
                             Error(manager, string.Format(SR.SerializerFieldTargetEvalFailed, fieldReferenceEx.FieldName), SR.SerializerFieldTargetEvalFailed);
                         }
 
-                        TraceWarningIf(result == fieldReferenceEx, "Could not resolve field {0} to an object instance.", fieldReferenceEx.FieldName);
+                        TraceIf(TraceLevel.Warning, result == fieldReferenceEx, $"Could not resolve field {fieldReferenceEx.FieldName} to an object instance.");
                         break;
                     }
                     else if ((methodInvokeEx = result as CodeMethodInvokeExpression) is not null)
                     {
-                        Trace("Method invoke : {0}", methodInvokeEx.Method.MethodName);
+                        Trace(TraceLevel.Verbose, $"Method invoke : {methodInvokeEx.Method.MethodName}");
 
                         object targetObject = DeserializeExpression(manager, null, methodInvokeEx.Method.TargetObject);
 
@@ -1137,11 +1312,11 @@ namespace System.ComponentModel.Design.Serialization
                     }
                     else if ((variableReferenceEx = result as CodeVariableReferenceExpression) is not null)
                     {
-                        Trace("Variable reference : {0}", variableReferenceEx.VariableName);
+                        Trace(TraceLevel.Verbose, $"Variable reference : {variableReferenceEx.VariableName}");
                         result = manager.GetInstance(variableReferenceEx.VariableName);
                         if (result is null)
                         {
-                            TraceError("Variable {0} does not exist", variableReferenceEx.VariableName);
+                            Trace(TraceLevel.Error, $"Variable {variableReferenceEx.VariableName} does not exist");
                             Error(manager, string.Format(SR.SerializerUndeclaredName, variableReferenceEx.VariableName), SR.SerializerUndeclaredName);
                         }
 
@@ -1149,7 +1324,7 @@ namespace System.ComponentModel.Design.Serialization
                     }
                     else if ((castEx = result as CodeCastExpression) is not null)
                     {
-                        Trace("Cast : {0}", castEx.TargetType.BaseType);
+                        Trace(TraceLevel.Verbose, $"Cast : {castEx.TargetType.BaseType}");
                         result = DeserializeExpression(manager, name, castEx.Expression);
                         if (result is IConvertible ic)
                         {
@@ -1178,7 +1353,7 @@ namespace System.ComponentModel.Design.Serialization
                     }
                     else if ((arrayCreateEx = result as CodeArrayCreateExpression) is not null)
                     {
-                        Trace("Array create : {0}", arrayCreateEx.CreateType.BaseType);
+                        Trace(TraceLevel.Verbose, $"Array create : {arrayCreateEx.CreateType.BaseType}");
                         Type arrayType = manager.GetType(GetTypeNameFromCodeTypeReference(manager, arrayCreateEx.CreateType));
                         Array array = null;
 
@@ -1186,7 +1361,7 @@ namespace System.ComponentModel.Design.Serialization
                         {
                             if (arrayCreateEx.Initializers.Count > 0)
                             {
-                                Trace("{0} initializers", arrayCreateEx.Initializers.Count);
+                                Trace(TraceLevel.Verbose, $"{arrayCreateEx.Initializers.Count} initializers");
                                 // Passed an array of initializers.  Use this to create the array.  Note that we use an  ArrayList here and add elements as we create them. It is possible that an element cannot be resolved. This is an error, but we do not want to tank the entire array.  If we kicked out the entire statement, a missing control would cause all controls on a form to vanish.
                                 ArrayList arrayList = new ArrayList(arrayCreateEx.Initializers.Count);
 
@@ -1223,19 +1398,19 @@ namespace System.ComponentModel.Design.Serialization
                                 if (o is IConvertible ic)
                                 {
                                     int size = ic.ToInt32(null);
-                                    Trace("Initialized with expression that simplified to {0}", size);
+                                    Trace(TraceLevel.Verbose, $"Initialized with expression that simplified to {size}");
                                     array = Array.CreateInstance(arrayType, size);
                                 }
                             }
                             else
                             {
-                                Trace("Initialized with size {0}", arrayCreateEx.Size);
+                                Trace(TraceLevel.Verbose, $"Initialized with size {arrayCreateEx.Size}");
                                 array = Array.CreateInstance(arrayType, arrayCreateEx.Size);
                             }
                         }
                         else
                         {
-                            TraceError("Type could not be resolved: {0}", arrayCreateEx.CreateType.BaseType);
+                            Trace(TraceLevel.Error, $"Type could not be resolved: {arrayCreateEx.CreateType.BaseType}");
                             Error(manager, string.Format(SR.SerializerTypeNotFound, arrayCreateEx.CreateType.BaseType), SR.SerializerTypeNotFound);
                         }
 
@@ -1249,7 +1424,7 @@ namespace System.ComponentModel.Design.Serialization
                     }
                     else if ((arrayIndexerEx = result as CodeArrayIndexerExpression) is not null)
                     {
-                        Trace("Array indexer");
+                        Trace(TraceLevel.Verbose, "Array indexer");
 
                         // For this, assume in any error we return a null.  The only errors
                         // here should come from a mal-formed expression.
@@ -1260,7 +1435,7 @@ namespace System.ComponentModel.Design.Serialization
                         {
                             int[] indexes = new int[arrayIndexerEx.Indices.Count];
 
-                            Trace("Dims: {0}", indexes.Length);
+                            Trace(TraceLevel.Verbose, $"Dims: {indexes.Length}");
 
                             bool indexesOK = true;
 
@@ -1274,11 +1449,11 @@ namespace System.ComponentModel.Design.Serialization
                                 if (index is not null)
                                 {
                                     indexes[i] = index.ToInt32(null);
-                                    Trace("[{0}] == {1}", i, indexes[i]);
+                                    Trace(TraceLevel.Verbose, $"[{i}] == {indexes[i]}");
                                 }
                                 else
                                 {
-                                    TraceWarning("Index {0} could not be converted to int.  Type: {1}", i, (index is null ? "(null)" : index.GetType().Name));
+                                    Trace(TraceLevel.Warning, $"Index {i} could not be converted to int.  Type: {(index is null ? "(null)" : index.GetType().Name)}");
                                     indexesOK = false;
                                     break;
                                 }
@@ -1294,7 +1469,7 @@ namespace System.ComponentModel.Design.Serialization
                     }
                     else if ((binaryOperatorEx = result as CodeBinaryOperatorExpression) is not null)
                     {
-                        Trace("Binary operator : {0}", binaryOperatorEx.Operator);
+                        Trace(TraceLevel.Verbose, $"Binary operator : {binaryOperatorEx.Operator}");
 
                         object left = DeserializeExpression(manager, null, binaryOperatorEx.Left);
                         object right = DeserializeExpression(manager, null, binaryOperatorEx.Right);
@@ -1310,14 +1485,14 @@ namespace System.ComponentModel.Design.Serialization
                         }
                         else
                         {
-                            TraceWarning("Could not simplify left and right binary operators to IConvertible.");
+                            Trace(TraceLevel.Warning, "Could not simplify left and right binary operators to IConvertible.");
                         }
 
                         break;
                     }
                     else if ((delegateInvokeEx = result as CodeDelegateInvokeExpression) is not null)
                     {
-                        Trace("Delegate invoke");
+                        Trace(TraceLevel.Verbose, "Delegate invoke");
                         object targetObject = DeserializeExpression(manager, null, delegateInvokeEx.TargetObject);
                         if (targetObject is Delegate del)
                         {
@@ -1335,7 +1510,7 @@ namespace System.ComponentModel.Design.Serialization
 
                             if (paramsOk)
                             {
-                                Trace("Invoking {0} with {1} parameters", targetObject.GetType().Name, parameters.Length);
+                                Trace(TraceLevel.Verbose, $"Invoking {targetObject.GetType().Name} with {parameters.Length} parameters");
                                 del.DynamicInvoke(parameters);
                             }
                         }
@@ -1344,27 +1519,27 @@ namespace System.ComponentModel.Design.Serialization
                     }
                     else if ((directionEx = result as CodeDirectionExpression) is not null)
                     {
-                        Trace("Direction operator");
+                        Trace(TraceLevel.Verbose, "Direction operator");
                         result = DeserializeExpression(manager, name, directionEx.Expression);
                         break;
                     }
                     else if ((indexerEx = result as CodeIndexerExpression) is not null)
                     {
-                        Trace("Indexer");
+                        Trace(TraceLevel.Verbose, "Indexer");
                         // For this, assume in any error we return a null.  The only errors here should come from a mal-formed expression.
                         result = null;
                         object targetObject = DeserializeExpression(manager, null, indexerEx.TargetObject);
                         if (targetObject is not null)
                         {
                             object[] indexes = new object[indexerEx.Indices.Count];
-                            Trace("Indexes: {0}", indexes.Length);
+                            Trace(TraceLevel.Verbose, $"Indexes: {indexes.Length}");
                             bool indexesOK = true;
                             for (int i = 0; i < indexes.Length; i++)
                             {
                                 indexes[i] = DeserializeExpression(manager, null, indexerEx.Indices[i]);
                                 if (indexes[i] is CodeExpression)
                                 {
-                                    TraceWarning("Index {0} could not be simplified to an object.", i);
+                                    Trace(TraceLevel.Warning, $"Index {i} could not be simplified to an object.");
                                     indexesOK = false;
                                     break;
                                 }
@@ -1380,19 +1555,19 @@ namespace System.ComponentModel.Design.Serialization
                     }
                     else if (result is CodeSnippetExpression)
                     {
-                        Trace("Snippet");
+                        Trace(TraceLevel.Verbose, "Snippet");
                         result = null;
                         break;
                     }
                     else if ((parameterDeclaration = result as CodeParameterDeclarationExpression) is not null)
                     {
-                        Trace("Parameter declaration");
+                        Trace(TraceLevel.Verbose, "Parameter declaration");
                         result = manager.GetType(GetTypeNameFromCodeTypeReference(manager, parameterDeclaration.Type));
                         break;
                     }
                     else if ((typeOfExpression = result as CodeTypeOfExpression) is not null)
                     {
-                        Trace("Typeof({0})", typeOfExpression.Type.BaseType);
+                        Trace(TraceLevel.Verbose, $"Typeof({typeOfExpression.Type.BaseType})");
                         string type = GetTypeNameFromCodeTypeReference(manager, typeOfExpression.Type);
                         // add the array ranks so we get the right type of this thing.
                         for (int i = 0; i < typeOfExpression.Type.ArrayRank; i++)
@@ -1403,7 +1578,7 @@ namespace System.ComponentModel.Design.Serialization
                         result = manager.GetType(type);
                         if (result is null)
                         {
-                            TraceError("Type could not be resolved: {0}", type);
+                            Trace(TraceLevel.Error, $"Type could not be resolved: {type}");
                             Error(manager, string.Format(SR.SerializerTypeNotFound, type), SR.SerializerTypeNotFound);
                         }
 
@@ -1475,19 +1650,19 @@ namespace System.ComponentModel.Design.Serialization
 
                 if (handlerMethodName is null)
                 {
-                    TraceError("Unable to retrieve handler method and object for delegate create.");
+                    Trace(TraceLevel.Error, "Unable to retrieve handler method and object for delegate create.");
                 }
                 else
                 {
                     // We only support binding methods to the root object.
                     //
-                    TraceWarningIf(!isRoot, "Event is bound to an object other than the root.  We do not support this.");
+                    TraceIf(TraceLevel.Warning, !isRoot, "Event is bound to an object other than the root.  We do not support this.");
                     if (isRoot)
                     {
                         // Now deserialize the LHS of the event attach to discover the guy whose
                         // event we are attaching.
                         //
-                        TraceErrorIf(targetObject is CodeExpression, "Unable to simplify event attach LHS to an object reference.");
+                        TraceIf(TraceLevel.Error, targetObject is CodeExpression, "Unable to simplify event attach LHS to an object reference.");
                         if (!(targetObject is CodeExpression))
                         {
                             EventDescriptor evt = GetEventsHelper(manager, targetObject, null)[eventName];
@@ -1501,12 +1676,12 @@ namespace System.ComponentModel.Design.Serialization
                                     PropertyDescriptor prop = evtSvc.GetEventProperty(evt);
 
                                     prop.SetValue(targetObject, handlerMethodName);
-                                    Trace("Attached event {0}.{1} to {2}", targetObject.GetType().Name, eventName, handlerMethodName);
+                                    Trace(TraceLevel.Verbose, $"Attached event {targetObject.GetType().Name}.{eventName} to {handlerMethodName}");
                                 }
                             }
                             else
                             {
-                                TraceError("Object {0} does not have a event {1}", targetObject.GetType().Name, eventName);
+                                Trace(TraceLevel.Error, $"Object {targetObject.GetType().Name} does not have a event {eventName}");
                                 Error(manager, string.Format(SR.SerializerNoSuchEvent, targetObject.GetType().FullName, eventName), SR.SerializerNoSuchEvent);
                             }
                         }
@@ -1839,7 +2014,7 @@ namespace System.ComponentModel.Design.Serialization
         private object DeserializePropertyReferenceExpression(IDesignerSerializationManager manager, CodePropertyReferenceExpression propertyReferenceEx, bool reportError)
         {
             object result = propertyReferenceEx;
-            Trace("Property reference : {0}", propertyReferenceEx.PropertyName);
+            Trace(TraceLevel.Verbose, $"Property reference : {propertyReferenceEx.PropertyName}");
             object target = DeserializeExpression(manager, null, propertyReferenceEx.TargetObject);
             if (target is not null && !(target is CodeExpression))
             {
@@ -1880,58 +2055,64 @@ namespace System.ComponentModel.Design.Serialization
                 }
             }
 
-            TraceWarningIf(result == propertyReferenceEx, "Could not resolve property {0} to an object instance.", propertyReferenceEx.PropertyName);
+            TraceIf(TraceLevel.Warning, result == propertyReferenceEx, $"Could not resolve property {propertyReferenceEx.PropertyName} to an object instance.");
             return result;
         }
 
         [Conditional("DEBUG")]
-        internal static void TraceErrorIf(bool condition, string message, params object[] values)
+        internal static void Trace(TraceLevel level, string message)
         {
-            if (condition)
-            {
-                TraceError(message, values);
-            }
-        }
+            if (traceSerialization.Level < level)
+                return;
 
-        [Conditional("DEBUG")]
-        internal static void TraceWarningIf(bool condition, string message, params object[] values)
-        {
-            if (condition)
+            switch (level)
             {
-                TraceWarning(message, values);
-            }
-        }
+                case TraceLevel.Verbose:
+                    int oldIndent = Debug.IndentLevel;
 
-        [Conditional("DEBUG")]
-        internal static void TraceWarning(string message, params object[] values)
-        {
-            if (traceSerialization.TraceWarning)
-            {
-                string scope = string.Empty;
-                if (traceScope is not null)
-                {
-                    foreach (string scopeName in traceScope)
+                    try
                     {
-                        if (scope.Length > 0)
-                        {
-                            scope = "/" + scope;
-                        }
-
-                        scope = scopeName + scope;
+                        Debug.IndentLevel = traceScope?.Count ?? 0;
+                        Debug.WriteLine(message);
                     }
-                }
+                    finally
+                    {
+                        Debug.IndentLevel = oldIndent;
+                    }
 
-                Debug.WriteLine("***************************************************");
-                Debug.WriteLine($"*** WARNING :{string.Format(CultureInfo.CurrentCulture, message, values)}");
-                Debug.WriteLine($"*** SCOPE :{scope}");
-                Debug.WriteLine("***************************************************");
+                    break;
+                case TraceLevel.Warning:
+                    Debug.WriteLine(
+                        $"""
+                            ***************************************************
+                            *** WARNING :{message}
+                            *** SCOPE :{TraceScopeAsString()}
+                            ***************************************************
+                            """);
+                    break;
+
+                case TraceLevel.Error:
+                    Debug.WriteLine(
+                        $"""
+                            ***************************************************
+                            *** ERROR :{message}
+                            *** SCOPE :{TraceScopeAsString()}
+                            ***************************************************
+                            """);
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(level), level, null);
             }
         }
+
+        private static string TraceScopeAsString() =>
+            traceScope is not null ? string.Join('/', traceScope.Reverse()) : string.Empty;
 
         private bool DeserializePropertyAssignStatement(IDesignerSerializationManager manager, CodeAssignStatement statement,
             CodePropertyReferenceExpression propertyReferenceEx, bool reportError)
         {
-            Trace("LHS is property : {0}", propertyReferenceEx.PropertyName);
+            Trace(TraceLevel.Verbose, $"LHS is property : {propertyReferenceEx.PropertyName}");
             object lhs = DeserializeExpression(manager, null, propertyReferenceEx.TargetObject);
 
             if (lhs is not null && !(lhs is CodeExpression))
@@ -1941,11 +2122,11 @@ namespace System.ComponentModel.Design.Serialization
                 PropertyDescriptor p = properties[propertyReferenceEx.PropertyName];
                 if (p is not null)
                 {
-                    Trace("Processing RHS");
+                    Trace(TraceLevel.Verbose, "Processing RHS");
                     object rhs = DeserializeExpression(manager, null, statement.Right);
                     if (rhs is CodeExpression)
                     {
-                        TraceError("Unable to simplify statement to anything better than: {0}", rhs.GetType().Name);
+                        Trace(TraceLevel.Error, $"Unable to simplify statement to anything better than: {rhs.GetType().Name}");
                         return false;
                     }
 
@@ -2033,14 +2214,14 @@ namespace System.ComponentModel.Design.Serialization
                 {
                     if (reportError)
                     {
-                        TraceError("Object {0} does not have a property {1}", lhs.GetType().Name, propertyReferenceEx.PropertyName);
+                        Trace(TraceLevel.Error, $"Object {lhs.GetType().Name} does not have a property {propertyReferenceEx.PropertyName}");
                         Error(manager, string.Format(SR.SerializerNoSuchProperty, lhs.GetType().FullName, propertyReferenceEx.PropertyName), SR.SerializerNoSuchProperty);
                     }
                 }
             }
             else
             {
-                TraceWarning("Could not find target object for property {0}", propertyReferenceEx.PropertyName);
+                Trace(TraceLevel.Warning, $"Could not find target object for property {propertyReferenceEx.PropertyName}");
             }
 
             return false;
@@ -2069,14 +2250,14 @@ namespace System.ComponentModel.Design.Serialization
             ArgumentNullException.ThrowIfNull(manager);
             ArgumentNullException.ThrowIfNull(value);
 
-            Trace("GetExpression called for object {0}", value.ToString());
+            Trace(TraceLevel.Verbose, $"GetExpression called for object {value.ToString()}");
 
             // Is the expression part of a prior SetExpression call?
 
             if (manager.Context[typeof(ExpressionTable)] is ExpressionTable table)
             {
                 expression = table.GetExpression(value);
-                TraceIf(expression is not null, "Resolved through expression table : {0}", expression);
+                TraceIf(TraceLevel.Verbose, expression is not null, $"Resolved through expression table : {expression}");
             }
 
             // Check to see if this object represents the root context.
@@ -2085,7 +2266,7 @@ namespace System.ComponentModel.Design.Serialization
                 if (manager.Context[typeof(RootContext)] is RootContext rootEx && ReferenceEquals(rootEx.Value, value))
                 {
                     expression = rootEx.Expression;
-                    TraceIf(expression is not null, "Resolved through root expression context : {0}", expression);
+                    TraceIf(TraceLevel.Verbose, expression is not null, $"Resolved through root expression context : {expression}");
                 }
             }
 
@@ -2104,7 +2285,7 @@ namespace System.ComponentModel.Design.Serialization
                         objectName = refSvc.GetName(value);
                         if (objectName is not null && objectName.IndexOf('.') != -1)
                         {
-                            Trace("Resolving through IReferenceService : {0}", objectName);
+                            Trace(TraceLevel.Verbose, $"Resolving through IReferenceService : {objectName}");
 
                             // This object name is built from sub objects.  Assemble the graph of sub objects.
                             string[] nameParts = objectName.Split('.');
@@ -2113,12 +2294,12 @@ namespace System.ComponentModel.Design.Serialization
 
                             object baseInstance = manager.GetInstance(nameParts[0]);
 
-                            TraceWarningIf(baseInstance is null, "Manager can't return an instance for object {0}", nameParts[0]);
+                            TraceIf(TraceLevel.Warning, baseInstance is null, $"Manager can't return an instance for object {nameParts[0]}");
                             if (baseInstance is not null)
                             {
                                 CodeExpression baseExpression = SerializeToExpression(manager, baseInstance);
 
-                                TraceWarningIf(baseExpression is null, "Unable to serialize object {0} to an expression.", baseInstance);
+                                TraceIf(TraceLevel.Warning, baseExpression is null, $"Unable to serialize object {baseInstance} to an expression.");
                                 if (baseExpression is not null)
                                 {
                                     for (int idx = 1; idx < nameParts.Length; idx++)
@@ -2294,7 +2475,7 @@ namespace System.ComponentModel.Design.Serialization
                 hasExpression = true;
             }
 
-            Trace("IsSerialized called for object {0} : {1}", value, hasExpression);
+            Trace(TraceLevel.Verbose, $"IsSerialized called for object {value} : {hasExpression}");
             return hasExpression;
         }
 
@@ -2340,7 +2521,7 @@ namespace System.ComponentModel.Design.Serialization
             if (GetReflectionTypeHelper(manager, value).IsSerializable && !(value is IComponent && ((IComponent)value).Site is not null))
             {
                 CodeExpression expression = SerializeToResourceExpression(manager, value);
-                TraceIf(expression is not null, "Serialized value as a resource.");
+                TraceIf(TraceLevel.Verbose, expression is not null, "Serialized value as a resource.");
                 if (expression is not null)
                 {
                     isComplete = true;
@@ -2365,7 +2546,7 @@ namespace System.ComponentModel.Design.Serialization
             CodeExpression expression = null;
             using (TraceScope("CodeDomSerializerBase::SerializeInstanceDescriptor"))
             {
-                Trace("Member : {0}, args : {1}", descriptor.MemberInfo.Name, descriptor.Arguments.Count);
+                Trace(TraceLevel.Verbose, $"Member : {descriptor.MemberInfo.Name}, args : {descriptor.Arguments.Count}");
                 // Serialize all of the arguments.
                 CodeExpression[] arguments = new CodeExpression[descriptor.Arguments.Count];
                 object[] argumentValues = new object[arguments.Length];
@@ -2374,8 +2555,7 @@ namespace System.ComponentModel.Design.Serialization
                 if (arguments.Length > 0)
                 {
                     descriptor.Arguments.CopyTo(argumentValues, 0);
-                    MethodBase mi = descriptor.MemberInfo as MethodBase;
-                    if (mi is not null)
+                    if (descriptor.MemberInfo is MethodBase mi)
                     {
                         parameters = mi.GetParameters();
                     }
@@ -2421,7 +2601,7 @@ namespace System.ComponentModel.Design.Serialization
                     }
                     else
                     {
-                        TraceWarning("Parameter {0} in instance descriptor call {1} could not be serialized.", i, descriptor.GetType().Name);
+                        Trace(TraceLevel.Warning, $"Parameter {i} in instance descriptor call {descriptor.GetType().Name} could not be serialized.");
                         paramsOk = false;
                         break;
                     }
@@ -2472,7 +2652,7 @@ namespace System.ComponentModel.Design.Serialization
 
                     if (!targetType.IsAssignableFrom(expressionType))
                     {
-                        Trace("Supplying cast from {0} to {1}.", expressionType.Name, targetType.Name);
+                        Trace(TraceLevel.Verbose, $"Supplying cast from {expressionType.Name} to {targetType.Name}.");
                         expression = new CodeCastExpression(targetType, expression);
                     }
                 }
@@ -2500,7 +2680,7 @@ namespace System.ComponentModel.Design.Serialization
                 string baseName;
                 Type targetType = GetReflectionTypeHelper(manager, value);
                 INameCreationService ns = manager.GetService(typeof(INameCreationService)) as INameCreationService;
-                TraceWarningIf(ns is null, "Need to generate a unique name but we have no name creation service.");
+                TraceIf(TraceLevel.Warning, ns is null, "Need to generate a unique name but we have no name creation service.");
                 if (ns is not null)
                 {
                     baseName = ns.CreateName(null, targetType);
@@ -2546,7 +2726,7 @@ namespace System.ComponentModel.Design.Serialization
 
             using (TraceScope($"CodeDomSerializerBase::{nameof(SerializeEvent)}"))
             {
-                Trace("Name: {0}", descriptor.Name);
+                Trace(TraceLevel.Verbose, $"Name: {descriptor.Name}");
                 // Now look for a MemberCodeDomSerializer for the property.  If we can't find one, then we can't serialize the property
                 manager.Context.Push(statements);
                 manager.Context.Push(descriptor);
@@ -2554,7 +2734,7 @@ namespace System.ComponentModel.Design.Serialization
                 {
                     MemberCodeDomSerializer memberSerializer = (MemberCodeDomSerializer)manager.GetSerializer(descriptor.GetType(), typeof(MemberCodeDomSerializer));
 
-                    TraceErrorIf(memberSerializer is null, "Event {0} cannot be serialized because it has no serializer.", descriptor.Name);
+                    TraceIf(TraceLevel.Error, memberSerializer is null, $"Event {descriptor.Name} cannot be serialized because it has no serializer.");
                     if (memberSerializer is not null && memberSerializer.ShouldSerialize(manager, value, descriptor))
                     {
                         memberSerializer.Serialize(manager, value, descriptor, statements);
@@ -2574,7 +2754,7 @@ namespace System.ComponentModel.Design.Serialization
         /// </summary>
         protected void SerializeEvents(IDesignerSerializationManager manager, CodeStatementCollection statements, object value, params Attribute[] filter)
         {
-            Trace("CodeDomSerializerBase::{0}", nameof(SerializeEvents));
+            Trace(TraceLevel.Verbose, $"CodeDomSerializerBase::{nameof(SerializeEvents)}");
             EventDescriptorCollection events = GetEventsHelper(manager, value, filter).Sort();
             foreach (EventDescriptor evt in events)
             {
@@ -2657,7 +2837,7 @@ namespace System.ComponentModel.Design.Serialization
                         CodePropertyReferenceExpression propertyRef = new CodePropertyReferenceExpression(target, string.Empty);
                         foreach (PropertyDescriptor property in props)
                         {
-                            TraceWarningIf(property.Attributes.Contains(DesignerSerializationVisibilityAttribute.Content), "PersistContents property {0} cannot be serialized to resources.", property.Name);
+                            TraceIf(TraceLevel.Warning, property.Attributes.Contains(DesignerSerializationVisibilityAttribute.Content), $"PersistContents property {property.Name} cannot be serialized to resources.");
                             ExpressionContext tree = new ExpressionContext(propertyRef, property.PropertyType, value);
                             manager.Context.Push(tree);
                             try
@@ -2665,7 +2845,7 @@ namespace System.ComponentModel.Design.Serialization
                                 if (property.Attributes.Contains(DesignerSerializationVisibilityAttribute.Visible))
                                 {
                                     propertyRef.PropertyName = property.Name;
-                                    Trace("Property : {0}", property.Name);
+                                    Trace(TraceLevel.Verbose, $"Property : {property.Name}");
 
                                     string name;
                                     if (target is CodeThisReferenceExpression)
@@ -2707,14 +2887,14 @@ namespace System.ComponentModel.Design.Serialization
             ArgumentNullException.ThrowIfNull(propertyToSerialize);
             ArgumentNullException.ThrowIfNull(statements);
 
-            Trace("CodeDomSerializerBase::{0} {1}", nameof(SerializeProperty), propertyToSerialize.Name);
+            Trace(TraceLevel.Verbose, $"CodeDomSerializerBase::{nameof(SerializeProperty)} {propertyToSerialize.Name}");
             // Now look for a MemberCodeDomSerializer for the property.  If we can't find one, then we can't serialize the property
             manager.Context.Push(statements);
             manager.Context.Push(propertyToSerialize);
             try
             {
                 MemberCodeDomSerializer memberSerializer = (MemberCodeDomSerializer)manager.GetSerializer(propertyToSerialize.GetType(), typeof(MemberCodeDomSerializer));
-                TraceErrorIf(memberSerializer is null, "Property {0} cannot be serialized because it has no serializer.", propertyToSerialize.Name);
+                TraceIf(TraceLevel.Error, memberSerializer is null, $"Property {propertyToSerialize.Name} cannot be serialized because it has no serializer.");
                 if (memberSerializer is not null && memberSerializer.ShouldSerialize(manager, value, propertyToSerialize))
                 {
                     memberSerializer.Serialize(manager, value, propertyToSerialize, statements);
@@ -2778,14 +2958,14 @@ namespace System.ComponentModel.Design.Serialization
                     if (IsSerialized(manager, value))
                     {
                         expression = GetExpression(manager, value);
-                        TraceIf(expression is not null, "Existing expression found : {0}", expression);
+                        TraceIf(TraceLevel.Verbose, expression is not null, $"Existing expression found : {expression}");
                     }
                     else
                     {
                         expression = GetLegacyExpression(manager, value);
                         if (expression is not null)
                         {
-                            TraceWarning("Using legacy expression guard to prevent recursion.  Serializer for {0} should be rewritten to handle GetExpression / SetExpression.", value);
+                            Trace(TraceLevel.Warning, $"Using legacy expression guard to prevent recursion.  Serializer for {value} should be rewritten to handle GetExpression / SetExpression.");
                             SetExpression(manager, value, expression);
                         }
                     }
@@ -2796,7 +2976,7 @@ namespace System.ComponentModel.Design.Serialization
                     CodeDomSerializer serializer = GetSerializer(manager, value);
                     if (serializer is not null)
                     {
-                        Trace("Invoking serializer {0}", serializer.GetType().Name);
+                        Trace(TraceLevel.Verbose, $"Invoking serializer {serializer.GetType().Name}");
                         CodeStatementCollection saveStatements = null;
                         if (value is not null)
                         {
@@ -2848,13 +3028,13 @@ namespace System.ComponentModel.Design.Serialization
 
                         if (statements is not null)
                         {
-                            Trace("Serialization produced additional statements");
+                            Trace(TraceLevel.Verbose, "Serialization produced additional statements");
                             // See if we have a place for these statements to be stored.  If not, then check the context.
                             saveStatements ??= manager.Context[typeof(CodeStatementCollection)] as CodeStatementCollection;
 
                             if (saveStatements is not null)
                             {
-                                Trace("Saving in context stack statement collection");
+                                Trace(TraceLevel.Verbose, "Saving in context stack statement collection");
                                 Debug.Assert(saveStatements != statements, "The serializer returned the same collection that exists on the context stack.");
                                 saveStatements.AddRange(statements);
                             }
@@ -2868,14 +3048,14 @@ namespace System.ComponentModel.Design.Serialization
                                     valueName ??= value.GetType().Name;
                                 }
 
-                                TraceError("Serialization produced a set of statements but there is no statement collection on the stack to receive them.");
+                                Trace(TraceLevel.Error, "Serialization produced a set of statements but there is no statement collection on the stack to receive them.");
                                 manager.ReportError(string.Format(SR.SerializerLostStatements, valueName));
                             }
                         }
                     }
                     else
                     {
-                        TraceError("No serializer for data type: {0}", (value is null ? "(null)" : value.GetType().Name));
+                        Trace(TraceLevel.Error, $"No serializer for data type: {(value is null ? "(null)" : value.GetType().Name)}");
                         manager.ReportError(string.Format(SR.SerializerNoSerializerForComponent, value.GetType().FullName));
                     }
                 }
@@ -2907,7 +3087,7 @@ namespace System.ComponentModel.Design.Serialization
 
                     if (name is not null)
                     {
-                        Trace("Object is reference ({0}) Creating reference expression", name);
+                        Trace(TraceLevel.Verbose, $"Object is reference ({name}) Creating reference expression");
                         // Check to see if this is a reference to the root component.  If it is, then use "this".
                         RootContext root = (RootContext)manager.Context[typeof(RootContext)];
                         if (root is not null)
@@ -3055,7 +3235,7 @@ namespace System.ComponentModel.Design.Serialization
                 manager.Context.Append(table);
             }
 
-            Trace("Set expression {0} for object {1}", expression, value);
+            Trace(TraceLevel.Verbose, $"Set expression {expression} for object {value}");
             // in debug builds, save off who performed this set expression.  It's very valuable to know.
 #if DEBUG
             if (traceSerialization.TraceVerbose)
@@ -3077,7 +3257,7 @@ namespace System.ComponentModel.Design.Serialization
                     stack = "unknown";
                 }
 
-                TraceWarning("Duplicate expression on context stack for value {0}.  Original expression callstack: {1}", value, stack);
+                Trace(TraceLevel.Warning, $"Duplicate expression on context stack for value {value}.  Original expression callstack: {stack}");
             }
 #endif
             table.SetExpression(value, expression, isPreset);
@@ -3098,27 +3278,27 @@ namespace System.ComponentModel.Design.Serialization
                     CodeExpression expression = null;
                     if (statement is CodeAssignStatement assign)
                     {
-                        Trace("Processing CodeAssignStatement");
+                        Trace(TraceLevel.Verbose, "Processing CodeAssignStatement");
                         expression = assign.Left;
                     }
                     else if (statement is CodeAttachEventStatement attachEvent)
                     {
-                        Trace("Processing CodeAttachEventStatement");
+                        Trace(TraceLevel.Verbose, "Processing CodeAttachEventStatement");
                         expression = attachEvent.Event;
                     }
                     else if (statement is CodeRemoveEventStatement removeEvent)
                     {
-                        Trace("Processing CodeRemoveEventStatement");
+                        Trace(TraceLevel.Verbose, "Processing CodeRemoveEventStatement");
                         expression = removeEvent.Event;
                     }
                     else if (statement is CodeExpressionStatement expressionStmt)
                     {
-                        Trace("Processing CodeExpressionStatement");
+                        Trace(TraceLevel.Verbose, "Processing CodeExpressionStatement");
                         expression = expressionStmt.Expression;
                     }
                     else if (statement is CodeVariableDeclarationStatement variableDecl)
                     {
-                        Trace("Processing CodeVariableDeclarationStatement");
+                        Trace(TraceLevel.Verbose, "Processing CodeVariableDeclarationStatement");
                         AddStatement(table, variableDecl.Name, variableDecl);
                         if (names is not null && variableDecl.Type is not null && !string.IsNullOrEmpty(variableDecl.Type.BaseType))
                         {
@@ -3147,42 +3327,42 @@ namespace System.ComponentModel.Design.Serialization
                         {
                             if (expression is CodeCastExpression castEx)
                             {
-                                Trace("Simplifying CodeCastExpression");
+                                Trace(TraceLevel.Verbose, "Simplifying CodeCastExpression");
                                 expression = castEx.Expression;
                             }
                             else if ((delegateCreateEx = expression as CodeDelegateCreateExpression) is not null)
                             {
-                                Trace("Simplifying CodeDelegateCreateExpression");
+                                Trace(TraceLevel.Verbose, "Simplifying CodeDelegateCreateExpression");
                                 expression = delegateCreateEx.TargetObject;
                             }
                             else if ((delegateInvokeEx = expression as CodeDelegateInvokeExpression) is not null)
                             {
-                                Trace("Simplifying CodeDelegateInvokeExpression");
+                                Trace(TraceLevel.Verbose, "Simplifying CodeDelegateInvokeExpression");
                                 expression = delegateInvokeEx.TargetObject;
                             }
                             else if ((directionEx = expression as CodeDirectionExpression) is not null)
                             {
-                                Trace("Simplifying CodeDirectionExpression");
+                                Trace(TraceLevel.Verbose, "Simplifying CodeDirectionExpression");
                                 expression = directionEx.Expression;
                             }
                             else if ((eventReferenceEx = expression as CodeEventReferenceExpression) is not null)
                             {
-                                Trace("Simplifying CodeEventReferenceExpression");
+                                Trace(TraceLevel.Verbose, "Simplifying CodeEventReferenceExpression");
                                 expression = eventReferenceEx.TargetObject;
                             }
                             else if ((methodInvokeEx = expression as CodeMethodInvokeExpression) is not null)
                             {
-                                Trace("Simplifying CodeMethodInvokeExpression");
+                                Trace(TraceLevel.Verbose, "Simplifying CodeMethodInvokeExpression");
                                 expression = methodInvokeEx.Method;
                             }
                             else if ((methodReferenceEx = expression as CodeMethodReferenceExpression) is not null)
                             {
-                                Trace("Simplifying CodeMethodReferenceExpression");
+                                Trace(TraceLevel.Verbose, "Simplifying CodeMethodReferenceExpression");
                                 expression = methodReferenceEx.TargetObject;
                             }
                             else if ((arrayIndexerEx = expression as CodeArrayIndexerExpression) is not null)
                             {
-                                Trace("Simplifying CodeArrayIndexerExpression");
+                                Trace(TraceLevel.Verbose, "Simplifying CodeArrayIndexerExpression");
                                 expression = arrayIndexerEx.TargetObject;
                             }
                             else if ((fieldReferenceEx = expression as CodeFieldReferenceExpression) is not null)
@@ -3216,7 +3396,7 @@ namespace System.ComponentModel.Design.Serialization
                                 }
                                 else
                                 {
-                                    Trace("Simplifying CodeFieldReferenceExpression");
+                                    Trace(TraceLevel.Verbose, "Simplifying CodeFieldReferenceExpression");
                                     expression = fieldReferenceEx.TargetObject;
                                 }
                             }
@@ -3230,7 +3410,7 @@ namespace System.ComponentModel.Design.Serialization
                                 }
                                 else
                                 {
-                                    Trace("Simplifying CodePropertyReferenceExpression");
+                                    Trace(TraceLevel.Verbose, "Simplifying CodePropertyReferenceExpression");
                                     expression = propertyReferenceEx.TargetObject;
                                 }
                             }
@@ -3262,7 +3442,7 @@ namespace System.ComponentModel.Design.Serialization
 
                                 if (!statementAdded)
                                 {
-                                    TraceError("Variable {0} used before it was declared.", variableReferenceEx.VariableName);
+                                    Trace(TraceLevel.Error, $"Variable {variableReferenceEx.VariableName} used before it was declared.");
                                     manager.ReportError(new CodeDomSerializerException(string.Format(SR.SerializerUndeclaredName, variableReferenceEx.VariableName), manager));
                                 }
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializerBase.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializerBase.cs
@@ -19,7 +19,7 @@ namespace System.ComponentModel.Design.Serialization
     ///  It is not meant to be publicly derived from.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public abstract class CodeDomSerializerBase
+    public abstract partial class CodeDomSerializerBase
     {
         private static readonly Attribute[] runTimeProperties = new Attribute[] { DesignOnlyAttribute.No };
         private static readonly TraceSwitch traceSerialization = new TraceSwitch("DesignerSerialization", "Trace design time serialization");
@@ -452,207 +452,6 @@ namespace System.ComponentModel.Design.Serialization
                 }
             }
         }
-
-#nullable enable
-        /// <summary>Provides an interpolated string handler for <see cref="CodeDomSerializerBase.Trace(TraceLevel, ref CodeDomSerializerBase.TraceInterpolatedStringHandler)"/> that only performs formatting if trecing is set to verbose.</summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        [InterpolatedStringHandler]
-        internal struct TraceInterpolatedStringHandler
-        {
-            /// <summary>The handler we use to perform the formatting.</summary>
-            private StringBuilder.AppendInterpolatedStringHandler _stringBuilderHandler;
-
-            /// <summary>
-            /// The underlying <see cref="StringBuilder"/> instance used by <see cref="_stringBuilderHandler"/>, if any.
-            /// </summary>
-            private StringBuilder? _builder;
-
-            /// <summary>Creates an instance of the handler..</summary>
-            /// <param name="literalLength">The number of constant characters outside of interpolation expressions in the interpolated string.</param>
-            /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
-            /// <param name="level">The trace level of the message.</param>
-            /// <param name="shouldAppend">A value indicating whether formatting should proceed.</param>
-            /// <remarks>This is intended to be called only by compiler-generated code. Arguments are not validated as they'd otherwise be for members intended to be used directly.</remarks>
-            public TraceInterpolatedStringHandler(int literalLength, int formattedCount, TraceLevel level, out bool shouldAppend)
-            {
-                if (traceSerialization.Level >= level)
-                {
-                    _builder = new StringBuilder();
-                    _stringBuilderHandler = new StringBuilder.AppendInterpolatedStringHandler(literalLength, formattedCount,
-                        _builder);
-                    shouldAppend = true;
-                }
-                else
-                {
-                    _stringBuilderHandler = default;
-                    _builder = null;
-                    shouldAppend = false;
-                }
-            }
-
-            /// <summary>Extracts the built string from the handler.</summary>
-            internal string ToStringAndClear()
-            {
-                string s = _builder?.ToString() ?? string.Empty;
-                _stringBuilderHandler = default;
-                return s;
-            }
-
-            /// <summary>Writes the specified string to the handler.</summary>
-            /// <param name="value">The string to write.</param>
-            public void AppendLiteral(string value) => _stringBuilderHandler.AppendLiteral(value);
-
-            /// <summary>Writes the specified value to the handler.</summary>
-            /// <param name="value">The value to write.</param>
-            /// <typeparam name="T">The type of the value to write.</typeparam>
-            public void AppendFormatted<T>(T value) => _stringBuilderHandler.AppendFormatted(value);
-
-            /// <summary>Writes the specified value to the handler.</summary>
-            /// <param name="value">The value to write.</param>
-            /// <param name="format">The format string.</param>
-            /// <typeparam name="T">The type of the value to write.</typeparam>
-            public void AppendFormatted<T>(T value, string? format) => _stringBuilderHandler.AppendFormatted(value, format);
-
-            /// <summary>Writes the specified value to the handler.</summary>
-            /// <param name="value">The value to write.</param>
-            /// <param name="alignment">Minimum number of characters that should be written for this value.  If the value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
-            /// <typeparam name="T">The type of the value to write.</typeparam>
-            public void AppendFormatted<T>(T value, int alignment) => _stringBuilderHandler.AppendFormatted(value, alignment);
-
-            /// <summary>Writes the specified value to the handler.</summary>
-            /// <param name="value">The value to write.</param>
-            /// <param name="format">The format string.</param>
-            /// <param name="alignment">Minimum number of characters that should be written for this value.  If the value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
-            /// <typeparam name="T">The type of the value to write.</typeparam>
-            public void AppendFormatted<T>(T value, int alignment, string? format) => _stringBuilderHandler.AppendFormatted(value, alignment, format);
-
-            /// <summary>Writes the specified character span to the handler.</summary>
-            /// <param name="value">The span to write.</param>
-            public void AppendFormatted(ReadOnlySpan<char> value) => _stringBuilderHandler.AppendFormatted(value);
-
-            /// <summary>Writes the specified string of chars to the handler.</summary>
-            /// <param name="value">The span to write.</param>
-            /// <param name="alignment">Minimum number of characters that should be written for this value.  If the value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
-            /// <param name="format">The format string.</param>
-            public void AppendFormatted(ReadOnlySpan<char> value, int alignment = 0, string? format = null) => _stringBuilderHandler.AppendFormatted(value, alignment, format);
-
-            /// <summary>Writes the specified value to the handler.</summary>
-            /// <param name="value">The value to write.</param>
-            public void AppendFormatted(string? value) => _stringBuilderHandler.AppendFormatted(value);
-
-            /// <summary>Writes the specified value to the handler.</summary>
-            /// <param name="value">The value to write.</param>
-            /// <param name="alignment">Minimum number of characters that should be written for this value.  If the value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
-            /// <param name="format">The format string.</param>
-            public void AppendFormatted(string? value, int alignment = 0, string? format = null) => _stringBuilderHandler.AppendFormatted(value, alignment, format);
-
-            /// <summary>Writes the specified value to the handler.</summary>
-            /// <param name="value">The value to write.</param>
-            /// <param name="alignment">Minimum number of characters that should be written for this value.  If the value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
-            /// <param name="format">The format string.</param>
-            public void AppendFormatted(object? value, int alignment = 0, string? format = null) => _stringBuilderHandler.AppendFormatted(value, alignment, format);
-        }
-
-        /// <summary>Provides an interpolated string handler for <see cref="CodeDomSerializerBase.TraceIf(System.Diagnostics.TraceLevel,bool,ref System.ComponentModel.Design.Serialization.CodeDomSerializerBase.TraceIfInterpolatedStringHandler)"/> that only performs formatting if the condition applies and tracing is set to verbose.</summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        [InterpolatedStringHandler]
-        internal struct TraceIfInterpolatedStringHandler
-        {
-            /// <summary>The handler we use to perform the formatting.</summary>
-            private StringBuilder.AppendInterpolatedStringHandler _stringBuilderHandler;
-
-            /// <summary>
-            /// The underlying <see cref="StringBuilder"/> instance used by <see cref="_stringBuilderHandler"/>, if any.
-            /// </summary>
-            private StringBuilder? _builder;
-
-            /// <summary>Creates an instance of the handler..</summary>
-            /// <param name="literalLength">The number of constant characters outside of interpolation expressions in the interpolated string.</param>
-            /// <param name="formattedCount">The number of interpolation expressions in the interpolated string.</param>
-            /// <param name="condition">The condition Boolean passed to the <see cref="Debug"/> method.</param>
-            /// <param name="level">The trace level of the message.</param>
-            /// <param name="shouldAppend">A value indicating whether formatting should proceed.</param>
-            /// <remarks>This is intended to be called only by compiler-generated code. Arguments are not validated as they'd otherwise be for members intended to be used directly.</remarks>
-            public TraceIfInterpolatedStringHandler(int literalLength, int formattedCount, bool condition, TraceLevel level, out bool shouldAppend)
-            {
-                if (condition && traceSerialization.Level >= level)
-                {
-                    _builder = new StringBuilder();
-                    _stringBuilderHandler = new StringBuilder.AppendInterpolatedStringHandler(literalLength, formattedCount,
-                        _builder);
-                    shouldAppend = true;
-                }
-                else
-                {
-                    _stringBuilderHandler = default;
-                    _builder = null;
-                    shouldAppend = false;
-                }
-            }
-
-            /// <summary>Extracts the built string from the handler.</summary>
-            internal string ToStringAndClear()
-            {
-                string s = _builder?.ToString() ?? string.Empty;
-                _stringBuilderHandler = default;
-                return s;
-            }
-
-            /// <summary>Writes the specified string to the handler.</summary>
-            /// <param name="value">The string to write.</param>
-            public void AppendLiteral(string value) => _stringBuilderHandler.AppendLiteral(value);
-
-            /// <summary>Writes the specified value to the handler.</summary>
-            /// <param name="value">The value to write.</param>
-            /// <typeparam name="T">The type of the value to write.</typeparam>
-            public void AppendFormatted<T>(T value) => _stringBuilderHandler.AppendFormatted(value);
-
-            /// <summary>Writes the specified value to the handler.</summary>
-            /// <param name="value">The value to write.</param>
-            /// <param name="format">The format string.</param>
-            /// <typeparam name="T">The type of the value to write.</typeparam>
-            public void AppendFormatted<T>(T value, string? format) => _stringBuilderHandler.AppendFormatted(value, format);
-
-            /// <summary>Writes the specified value to the handler.</summary>
-            /// <param name="value">The value to write.</param>
-            /// <param name="alignment">Minimum number of characters that should be written for this value.  If the value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
-            /// <typeparam name="T">The type of the value to write.</typeparam>
-            public void AppendFormatted<T>(T value, int alignment) => _stringBuilderHandler.AppendFormatted(value, alignment);
-
-            /// <summary>Writes the specified value to the handler.</summary>
-            /// <param name="value">The value to write.</param>
-            /// <param name="format">The format string.</param>
-            /// <param name="alignment">Minimum number of characters that should be written for this value.  If the value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
-            /// <typeparam name="T">The type of the value to write.</typeparam>
-            public void AppendFormatted<T>(T value, int alignment, string? format) => _stringBuilderHandler.AppendFormatted(value, alignment, format);
-
-            /// <summary>Writes the specified character span to the handler.</summary>
-            /// <param name="value">The span to write.</param>
-            public void AppendFormatted(ReadOnlySpan<char> value) => _stringBuilderHandler.AppendFormatted(value);
-
-            /// <summary>Writes the specified string of chars to the handler.</summary>
-            /// <param name="value">The span to write.</param>
-            /// <param name="alignment">Minimum number of characters that should be written for this value.  If the value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
-            /// <param name="format">The format string.</param>
-            public void AppendFormatted(ReadOnlySpan<char> value, int alignment = 0, string? format = null) => _stringBuilderHandler.AppendFormatted(value, alignment, format);
-
-            /// <summary>Writes the specified value to the handler.</summary>
-            /// <param name="value">The value to write.</param>
-            public void AppendFormatted(string? value) => _stringBuilderHandler.AppendFormatted(value);
-
-            /// <summary>Writes the specified value to the handler.</summary>
-            /// <param name="value">The value to write.</param>
-            /// <param name="alignment">Minimum number of characters that should be written for this value.  If the value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
-            /// <param name="format">The format string.</param>
-            public void AppendFormatted(string? value, int alignment = 0, string? format = null) => _stringBuilderHandler.AppendFormatted(value, alignment, format);
-
-            /// <summary>Writes the specified value to the handler.</summary>
-            /// <param name="value">The value to write.</param>
-            /// <param name="alignment">Minimum number of characters that should be written for this value.  If the value is negative, it indicates left-aligned and the required minimum is the absolute value.</param>
-            /// <param name="format">The format string.</param>
-            public void AppendFormatted(object? value, int alignment = 0, string? format = null) => _stringBuilderHandler.AppendFormatted(value, alignment, format);
-        }
-#nullable disable
 
         internal static IDisposable TraceScope(string name)
         {
@@ -2250,7 +2049,7 @@ namespace System.ComponentModel.Design.Serialization
             ArgumentNullException.ThrowIfNull(manager);
             ArgumentNullException.ThrowIfNull(value);
 
-            Trace(TraceLevel.Verbose, $"GetExpression called for object {value.ToString()}");
+            Trace(TraceLevel.Verbose, $"GetExpression called for object {value}");
 
             // Is the expression part of a prior SetExpression call?
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CollectionCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CollectionCodeDomSerializer.cs
@@ -128,7 +128,7 @@ namespace System.ComponentModel.Design.Serialization
                 DesignerSerializationVisibilityAttribute vis = (DesignerSerializationVisibilityAttribute)attrs[0];
                 if (vis is not null && vis.Visibility == DesignerSerializationVisibility.Hidden)
                 {
-                    Trace("Member {0} does not support serialization.", method.Name);
+                    Trace(TraceLevel.Verbose, $"Member {method.Name} does not support serialization.");
                     return false;
                 }
             }
@@ -159,7 +159,7 @@ namespace System.ComponentModel.Design.Serialization
                 {
                     // We only want to give out an expression target if  this is our context (we find this out by comparing types above) and if the context type is not an array.  If it is an array, we will  just return the array create expression.
                     target = ctx.Expression;
-                    Trace("Valid context and property descriptor found on context stack.");
+                    Trace(TraceLevel.Verbose, "Valid context and property descriptor found on context stack.");
                 }
                 else
                 {
@@ -167,7 +167,7 @@ namespace System.ComponentModel.Design.Serialization
                     target = null;
                     ctx = null;
                     prop = null;
-                    Trace("No valid context.  We can only serialize if this is an array.");
+                    Trace(TraceLevel.Verbose, "No valid context.  We can only serialize if this is an array.");
                 }
 
                 // If we have a target expression see if we can create a delta for the collection. We want to do this only if the property the collection is associated with is inherited, and if the collection is not an array.
@@ -228,7 +228,7 @@ namespace System.ComponentModel.Design.Serialization
                 else
                 {
                     Debug.Fail($"Collection serializer invoked for non-collection: {(value is null ? "(null)" : value.GetType().Name)}");
-                    TraceError("Collection serializer invoked for non collection: {0}", (value is null ? "(null)" : value.GetType().Name));
+                    Trace(TraceLevel.Error, $"Collection serializer invoked for non collection: {(value is null ? "(null)" : value.GetType().Name)}");
                 }
             }
 
@@ -312,7 +312,7 @@ namespace System.ComponentModel.Design.Serialization
             bool serialized = false;
             if (typeof(Array).IsAssignableFrom(targetType))
             {
-                Trace("Collection is array");
+                Trace(TraceLevel.Verbose, "Collection is array");
                 CodeArrayCreateExpression arrayCreate = SerializeArray(manager, targetType, originalCollection, valuesToSerialize);
                 if (arrayCreate is not null)
                 {
@@ -328,7 +328,7 @@ namespace System.ComponentModel.Design.Serialization
             }
             else if (valuesToSerialize.Count > 0)
             {
-                Trace("Searching for AddRange or Add");
+                Trace(TraceLevel.Verbose, "Searching for AddRange or Add");
                 // Use the TargetFrameworkProviderService to create a provider, or use the default for the collection if the service is not available.  Since TargetFrameworkProvider reflection types are not compatible with RuntimeTypes, they can only be used with other reflection types from the same provider.
                 TypeDescriptionProvider provider = GetTargetFrameworkProvider(manager, originalCollection);
                 provider ??= TypeDescriptor.GetProvider(originalCollection);
@@ -389,7 +389,7 @@ namespace System.ComponentModel.Design.Serialization
             }
             else
             {
-                Trace("Collection has no values to serialize.");
+                Trace(TraceLevel.Verbose, "Collection has no values to serialize.");
             }
 
             return result;
@@ -405,7 +405,7 @@ namespace System.ComponentModel.Design.Serialization
             {
                 if (((Array)array).Rank != 1)
                 {
-                    TraceError("Cannot serialize arrays with rank > 1.");
+                    Trace(TraceLevel.Error, "Cannot serialize arrays with rank > 1.");
                     manager.ReportError(string.Format(SR.SerializerInvalidArrayRank, ((Array)array).Rank.ToString(CultureInfo.InvariantCulture)));
                 }
                 else
@@ -413,8 +413,8 @@ namespace System.ComponentModel.Design.Serialization
                     // For an array, we need an array create expression.  First, get the array type
                     Type elementType = targetType.GetElementType();
                     CodeTypeReference elementTypeRef = new CodeTypeReference(elementType);
-                    Trace("Array type: {0}", elementType.Name);
-                    Trace("Count: {0}", valuesToSerialize.Count);
+                    Trace(TraceLevel.Verbose, $"Array type: {elementType.Name}");
+                    Trace(TraceLevel.Verbose, $"Count: {valuesToSerialize.Count}");
                     // Now create an ArrayCreateExpression, and fill its initializers.
                     CodeArrayCreateExpression arrayCreate = new CodeArrayCreateExpression
                     {
@@ -491,7 +491,7 @@ namespace System.ComponentModel.Design.Serialization
             CodeStatementCollection statements = new CodeStatementCollection();
             using (TraceScope($"CollectionCodeDomSerializer::{nameof(SerializeViaAdd)}"))
             {
-                Trace("Elements: {0}", valuesToSerialize.Count.ToString(CultureInfo.InvariantCulture));
+                Trace(TraceLevel.Verbose, $"Elements: {valuesToSerialize.Count.ToString(CultureInfo.InvariantCulture)}");
                 // Here we need to invoke Add once for each and every item in the collection. We can re-use the property reference and method reference, but we will need to recreate the invoke statement each time.
                 CodeMethodReferenceExpression methodRef = new CodeMethodReferenceExpression(targetExpression, "Add");
 
@@ -584,7 +584,7 @@ namespace System.ComponentModel.Design.Serialization
             CodeStatementCollection statements = new CodeStatementCollection();
             using (TraceScope($"CollectionCodeDomSerializer::{nameof(SerializeViaAddRange)}"))
             {
-                Trace("Elements: {0}", valuesToSerialize.Count.ToString(CultureInfo.InvariantCulture));
+                Trace(TraceLevel.Verbose, $"Elements: {valuesToSerialize.Count.ToString(CultureInfo.InvariantCulture)}");
 
                 if (valuesToSerialize.Count > 0)
                 {

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CollectionCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CollectionCodeDomSerializer.cs
@@ -491,7 +491,7 @@ namespace System.ComponentModel.Design.Serialization
             CodeStatementCollection statements = new CodeStatementCollection();
             using (TraceScope($"CollectionCodeDomSerializer::{nameof(SerializeViaAdd)}"))
             {
-                Trace(TraceLevel.Verbose, $"Elements: {valuesToSerialize.Count.ToString(CultureInfo.InvariantCulture)}");
+                Trace(TraceLevel.Verbose, $"Elements: {valuesToSerialize.Count}");
                 // Here we need to invoke Add once for each and every item in the collection. We can re-use the property reference and method reference, but we will need to recreate the invoke statement each time.
                 CodeMethodReferenceExpression methodRef = new CodeMethodReferenceExpression(targetExpression, "Add");
 
@@ -584,7 +584,7 @@ namespace System.ComponentModel.Design.Serialization
             CodeStatementCollection statements = new CodeStatementCollection();
             using (TraceScope($"CollectionCodeDomSerializer::{nameof(SerializeViaAddRange)}"))
             {
-                Trace(TraceLevel.Verbose, $"Elements: {valuesToSerialize.Count.ToString(CultureInfo.InvariantCulture)}");
+                Trace(TraceLevel.Verbose, $"Elements: {valuesToSerialize.Count}");
 
                 if (valuesToSerialize.Count > 0)
                 {

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ComponentCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ComponentCodeDomSerializer.cs
@@ -97,7 +97,7 @@ namespace System.ComponentModel.Design.Serialization
 
             if (instance is not null)
             {
-                Trace("Deserializing design time properties for {0}", manager.GetName(instance));
+                Trace(TraceLevel.Verbose, $"Deserializing design time properties for {manager.GetName(instance)}");
                 DeserializePropertiesFromResources(manager, instance, _designTimeFilter);
             }
 
@@ -134,7 +134,7 @@ namespace System.ComponentModel.Design.Serialization
 
                 // First, skip everything if we're privately inherited.  We cannot write any code that would affect this
                 // component.
-                TraceIf(inheritanceLevel == InheritanceLevel.InheritedReadOnly, "Skipping read only inherited component");
+                TraceIf(TraceLevel.Verbose, inheritanceLevel == InheritanceLevel.InheritedReadOnly, "Skipping read only inherited component");
                 if (inheritanceLevel != InheritanceLevel.InheritedReadOnly)
                 {
                     // Things we need to know:
@@ -165,7 +165,7 @@ namespace System.ComponentModel.Design.Serialization
 
                     if (assignLhs is not null)
                     {
-                        Trace("Existing expression for LHS of value");
+                        Trace(TraceLevel.Verbose, "Existing expression for LHS of value");
                         generateLocal = false;
                         generateField = false;
                         generateObject = false;
@@ -187,7 +187,7 @@ namespace System.ComponentModel.Design.Serialization
                     }
                     else
                     {
-                        Trace("Creating LHS expression");
+                        Trace(TraceLevel.Verbose, "Creating LHS expression");
                         if (inheritanceLevel == InheritanceLevel.NotInherited)
                         {
                             // See if there is a "GenerateMember" property.  If so,
@@ -196,7 +196,7 @@ namespace System.ComponentModel.Design.Serialization
                             PropertyDescriptor generateProp = props["GenerateMember"];
                             if (generateProp is not null && generateProp.PropertyType == typeof(bool) && !(bool)generateProp.GetValue(value))
                             {
-                                Trace("Object GenerateMember property wants a local variable");
+                                Trace(TraceLevel.Verbose, "Object GenerateMember property wants a local variable");
                                 generateLocal = true;
                                 generateField = false;
                             }
@@ -245,13 +245,13 @@ namespace System.ComponentModel.Design.Serialization
                                     }
                                     else
                                     {
-                                        TraceWarning("No Modifiers or DefaultModifiers property on component {0}. We must assume private.", name);
+                                        Trace(TraceLevel.Warning, $"No Modifiers or DefaultModifiers property on component {name}. We must assume private.");
                                         fieldAttrs = MemberAttributes.Private;
                                     }
 
                                     field.Attributes = fieldAttrs;
                                     typeDecl.Members.Add(field);
-                                    Trace("Field {0} {1} {2} created.", fieldAttrs, typeName, name);
+                                    Trace(TraceLevel.Verbose, $"Field {fieldAttrs} {typeName} {name} created.");
                                 }
 
                                 // Next, create a nice LHS for our pending assign statement, when we hook up the variable.
@@ -264,7 +264,7 @@ namespace System.ComponentModel.Design.Serialization
                                     CodeVariableDeclarationStatement local = new CodeVariableDeclarationStatement(typeName, name);
 
                                     statements.Add(local);
-                                    Trace("Local {0} {1} created.", typeName, name);
+                                    Trace(TraceLevel.Verbose, $"Local {typeName} {name} created.");
                                 }
 
                                 assignLhs = new CodeVariableReferenceExpression(name);
@@ -289,7 +289,7 @@ namespace System.ComponentModel.Design.Serialization
 
                             if (ctor is not null)
                             {
-                                Trace("Component has IContainer constructor.");
+                                Trace(TraceLevel.Verbose, "Component has IContainer constructor.");
                                 assignRhs = new CodeObjectCreateExpression(typeName, new CodeExpression[]
                                 {
                                     SerializeToExpression(manager, container)
@@ -302,7 +302,7 @@ namespace System.ComponentModel.Design.Serialization
                                 Debug.Assert(isCompleteOld == isComplete, "CCDS Differing");
                             }
 
-                            TraceErrorIf(assignRhs is null, "No RHS code assign for object {0}", value);
+                            TraceIf(TraceLevel.Error, assignRhs is null, $"No RHS code assign for object {value}");
                             if (assignRhs is not null)
                             {
                                 if (assignLhs is null)
@@ -316,7 +316,7 @@ namespace System.ComponentModel.Design.Serialization
                                     }
                                     else
                                     {
-                                        TraceError("Incomplete serialization of object, abandoning serialization.");
+                                        Trace(TraceLevel.Error, "Incomplete serialization of object, abandoning serialization.");
                                     }
                                 }
                                 else
@@ -378,7 +378,7 @@ namespace System.ComponentModel.Design.Serialization
 
                             if (supportInitialize)
                             {
-                                Trace("Object implements ISupportInitialize.");
+                                Trace(TraceLevel.Verbose, "Object implements ISupportInitialize.");
                                 SerializeSupportInitialize(manager, statements, assignLhs, value, "BeginInit");
                             }
 
@@ -537,7 +537,7 @@ namespace System.ComponentModel.Design.Serialization
         /// </summary>
         private static void SerializeLoadComponentSettings(IDesignerSerializationManager manager, CodeStatementCollection statements, CodeExpression valueExpression, object value)
         {
-            Trace("Emitting LoadComponentSettings");
+            Trace(TraceLevel.Verbose, "Emitting LoadComponentSettings");
 
             CodeTypeReference type = new CodeTypeReference(typeof(IPersistComponentSettings));
             CodeCastExpression castExp = new CodeCastExpression(type, valueExpression);
@@ -558,7 +558,7 @@ namespace System.ComponentModel.Design.Serialization
         /// </summary>
         private static void SerializeSupportInitialize(IDesignerSerializationManager manager, CodeStatementCollection statements, CodeExpression valueExpression, object value, string methodName)
         {
-            Trace("Emitting {0}", methodName);
+            Trace(TraceLevel.Verbose, $"Emitting {methodName}");
 
             CodeTypeReference type = new CodeTypeReference(typeof(ISupportInitialize));
             CodeCastExpression castExp = new CodeCastExpression(type, valueExpression);

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ContainerCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ContainerCodeDomSerializer.cs
@@ -5,6 +5,7 @@
 #nullable disable
 
 using System.CodeDom;
+using System.Diagnostics;
 
 namespace System.ComponentModel.Design.Serialization
 {
@@ -41,13 +42,13 @@ namespace System.ComponentModel.Design.Serialization
 
                 if (obj is not null)
                 {
-                    Trace("Returning IContainer service as container");
+                    Trace(TraceLevel.Verbose, "Returning IContainer service as container");
                     manager.SetName(obj, name);
                     return obj;
                 }
             }
 
-            Trace("No IContainer service, creating default container.");
+            Trace(TraceLevel.Verbose, "No IContainer service, creating default container.");
             return base.DeserializeInstance(manager, type, parameters, name, addToContainer);
         }
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/EnumCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/EnumCodeDomSerializer.cs
@@ -38,7 +38,7 @@ namespace System.ComponentModel.Design.Serialization
 
             using (TraceScope($"EnumCodeDomSerializer::{nameof(Serialize)}"))
             {
-                Trace("Type: {0}", (value is null ? "(null)" : value.GetType().Name));
+                Trace(TraceLevel.Verbose, $"Type: {(value is null ? "(null)" : value.GetType().Name)}");
                 if (value is Enum)
                 {
                     bool needCast = false;
@@ -64,8 +64,8 @@ namespace System.ComponentModel.Design.Serialization
                     // If names is of length 1, then this is a simple field reference. Otherwise,
                     // it is an or-d combination of expressions.
                     //
-                    TraceIf(values.Length == 1, "Single field entity.");
-                    TraceIf(values.Length > 1, "Multi field entity.");
+                    TraceIf(TraceLevel.Verbose, values.Length == 1, "Single field entity.");
+                    TraceIf(TraceLevel.Verbose, values.Length > 1, "Multi field entity.");
 
                     // We now need to serialize the enum terms as fields. We new up an EnumConverter to do
                     // that. We cannot use the type's own converter since it might have a different string
@@ -100,7 +100,7 @@ namespace System.ComponentModel.Design.Serialization
                 else
                 {
                     Debug.Fail("Enum serializer called for non-enum object.");
-                    TraceError("Enum serializer called for non-enum object {0}", (value is null ? "(null)" : value.GetType().Name));
+                    Trace(TraceLevel.Error, $"Enum serializer called for non-enum object {(value is null ? "(null)" : value.GetType().Name)}");
                 }
             }
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/EventMemberCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/EventMemberCodeDomSerializer.cs
@@ -5,6 +5,7 @@
 #nullable disable
 
 using System.CodeDom;
+using System.Diagnostics;
 using System.Reflection;
 
 namespace System.ComponentModel.Design.Serialization
@@ -53,9 +54,9 @@ namespace System.ComponentModel.Design.Serialization
 
                     if (methodName is not null)
                     {
-                        Trace("Event {0} bound to {1}", eventToSerialize.Name, methodName);
+                        Trace(TraceLevel.Verbose, $"Event {eventToSerialize.Name} bound to {methodName}");
                         CodeExpression eventTarget = SerializeToExpression(manager, value);
-                        TraceWarningIf(eventTarget is null, "Object has no name and no property ref in context so we cannot serialize events: {0}", value);
+                        TraceIf(TraceLevel.Warning, eventTarget is null, $"Object has no name and no property ref in context so we cannot serialize events: {value}");
                         if (eventTarget is not null)
                         {
                             CodeTypeReference delegateTypeRef = new CodeTypeReference(eventToSerialize.EventType);

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/PrimitiveCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/PrimitiveCodeDomSerializer.cs
@@ -5,6 +5,7 @@
 #nullable disable
 
 using System.CodeDom;
+using System.Diagnostics;
 
 namespace System.ComponentModel.Design.Serialization
 {
@@ -35,7 +36,7 @@ namespace System.ComponentModel.Design.Serialization
         {
             using (TraceScope($"PrimitiveCodeDomSerializer::{nameof(Serialize)}"))
             {
-                Trace("Value: {0}", (value is null ? "(null)" : value.ToString()));
+                Trace(TraceLevel.Verbose, $"Value: {(value is null ? "(null)" : value.ToString())}");
             }
 
             CodeExpression expression = new CodePrimitiveExpression(value);

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/PropertyMemberCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/PropertyMemberCodeDomSerializer.cs
@@ -116,7 +116,7 @@ namespace System.ComponentModel.Design.Serialization
                 bool isExtender = (exAttr is not null && exAttr.Provider is not null);
                 bool serializeContents = propertyToSerialize.Attributes.Contains(DesignerSerializationVisibilityAttribute.Content);
 
-                CodeDomSerializer.Trace("Serializing property {0}", propertyToSerialize.Name);
+                CodeDomSerializer.Trace(TraceLevel.Verbose, $"Serializing property {propertyToSerialize.Name}");
                 if (serializeContents)
                 {
                     SerializeContentProperty(manager, value, propertyToSerialize, isExtender, statements);
@@ -149,7 +149,7 @@ namespace System.ComponentModel.Design.Serialization
         /// </summary>
         private void SerializeContentProperty(IDesignerSerializationManager manager, object value, PropertyDescriptor property, bool isExtender, CodeStatementCollection statements)
         {
-            CodeDomSerializer.Trace("Property is marked as Visibility.Content.  Recursing.");
+            CodeDomSerializer.Trace(TraceLevel.Verbose, "Property is marked as Visibility.Content.  Recursing.");
 
             object propertyValue = GetPropertyValue(manager, property, value, out bool validValue);
 
@@ -158,7 +158,7 @@ namespace System.ComponentModel.Design.Serialization
             //
             if (propertyValue is null)
             {
-                CodeDomSerializer.TraceError("Property {0} is marked as Visibility.Content but it is returning null.", property.Name);
+                CodeDomSerializer.Trace(TraceLevel.Error, $"Property {property.Name} is marked as Visibility.Content but it is returning null.");
 
                 string name = manager.GetName(value);
 
@@ -178,7 +178,7 @@ namespace System.ComponentModel.Design.Serialization
 
                     if (target is null)
                     {
-                        CodeDomSerializer.TraceWarning("Unable to convert value to expression object");
+                        CodeDomSerializer.Trace(TraceLevel.Warning, "Unable to convert value to expression object");
                     }
                     else
                     {
@@ -186,7 +186,7 @@ namespace System.ComponentModel.Design.Serialization
 
                         if (isExtender)
                         {
-                            CodeDomSerializer.Trace("Content property is an extender.");
+                            CodeDomSerializer.Trace(TraceLevel.Verbose, "Content property is an extender.");
                             ExtenderProvidedPropertyAttribute exAttr = (ExtenderProvidedPropertyAttribute)property.Attributes[typeof(ExtenderProvidedPropertyAttribute)];
 
                             // Extender properties are method invokes on a target "extender" object.
@@ -194,8 +194,8 @@ namespace System.ComponentModel.Design.Serialization
                             CodeExpression extender = SerializeToExpression(manager, exAttr.Provider);
                             CodeExpression extended = SerializeToExpression(manager, value);
 
-                            CodeDomSerializer.TraceWarningIf(extender is null, "Extender object {0} could not be serialized.", manager.GetName(exAttr.Provider));
-                            CodeDomSerializer.TraceWarningIf(extended is null, "Extended object {0} could not be serialized.", manager.GetName(value));
+                            CodeDomSerializer.TraceIf(TraceLevel.Warning, extender is null, $"Extender object {manager.GetName(exAttr.Provider)} could not be serialized.");
+                            CodeDomSerializer.TraceIf(TraceLevel.Warning, extended is null, $"Extended object {manager.GetName(value)} could not be serialized.");
                             if (extender is not null && extended is not null)
                             {
                                 CodeMethodReferenceExpression methodRef = new CodeMethodReferenceExpression(extender, $"Get{property.Name}");
@@ -257,7 +257,7 @@ namespace System.ComponentModel.Design.Serialization
                 }
                 else
                 {
-                    CodeDomSerializer.TraceError("Property {0} is marked as Visibility.Content but there is no serializer for it.", property.Name);
+                    CodeDomSerializer.Trace(TraceLevel.Error, $"Property {property.Name} is marked as Visibility.Content but there is no serializer for it.");
 
                     manager.ReportError(new CodeDomSerializerException(string.Format(SR.SerializerNoSerializerForComponent, property.PropertyType.FullName), manager));
                 }
@@ -280,8 +280,8 @@ namespace System.ComponentModel.Design.Serialization
                 CodeExpression extender = SerializeToExpression(manager, exAttr.Provider);
                 CodeExpression extended = SerializeToExpression(manager, value);
 
-                CodeDomSerializer.TraceWarningIf(extender is null, "Extender object {0} could not be serialized.", manager.GetName(exAttr.Provider));
-                CodeDomSerializer.TraceWarningIf(extended is null, "Extended object {0} could not be serialized.", manager.GetName(value));
+                CodeDomSerializer.TraceIf(TraceLevel.Warning, extender is null, $"Extender object {manager.GetName(exAttr.Provider)} could not be serialized.");
+                CodeDomSerializer.TraceIf(TraceLevel.Warning, extended is null, $"Extended object {manager.GetName(value)} could not be serialized.");
                 if (extender is not null && extended is not null)
                 {
                     CodeMethodReferenceExpression methodRef = new CodeMethodReferenceExpression(extender, $"Set{property.Name}");
@@ -339,7 +339,7 @@ namespace System.ComponentModel.Design.Serialization
             {
                 CodeExpression target = SerializeToExpression(manager, value);
 
-                CodeDomSerializer.TraceWarningIf(target is null, "Unable to serialize target for property {0}", property.Name);
+                CodeDomSerializer.TraceIf(TraceLevel.Warning, target is null, $"Unable to serialize target for property {property.Name}");
                 if (target is not null)
                 {
                     CodeExpression propertyRef = new CodePropertyReferenceExpression(target, property.Name);

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ResourceCodeDomSerializer.SerializationResourceManager.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ResourceCodeDomSerializer.SerializationResourceManager.cs
@@ -397,7 +397,7 @@ namespace System.ComponentModel.Design.Serialization
                 if (objRs is null)
                 {
                     IResourceService resSvc = (IResourceService)_manager.GetService(typeof(IResourceService));
-                    TraceErrorIf(resSvc is null, "IResourceService is not available.  We will not be able to load resources.");
+                    TraceIf(TraceLevel.Error, resSvc is null, "IResourceService is not available.  We will not be able to load resources.");
                     if (resSvc is not null)
                     {
                         IResourceReader reader = resSvc.GetResourceReader(culture);

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ResourceCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ResourceCodeDomSerializer.cs
@@ -107,7 +107,7 @@ namespace System.ComponentModel.Design.Serialization
                             // We create the resource manager ourselves here because it's not just a straight parse of the code. Do special parsing of the resources statement
                             if (element is CodeVariableDeclarationStatement statement)
                             {
-                                TraceWarningIf(!statement.Name.Equals(ResourceManagerName), "WARNING: Resource manager serializer being invoked to deserialize a collection we didn't create.");
+                                TraceIf(TraceLevel.Warning, !statement.Name.Equals(ResourceManagerName), "WARNING: Resource manager serializer being invoked to deserialize a collection we didn't create.");
                                 if (statement.Name.Equals(ResourceManagerName))
                                 {
                                     instance = CreateResourceManager(manager);
@@ -144,9 +144,9 @@ namespace System.ComponentModel.Design.Serialization
 
         private static SerializationResourceManager CreateResourceManager(IDesignerSerializationManager manager)
         {
-            Trace("Variable is our resource manager.  Creating it");
+            Trace(TraceLevel.Verbose, "Variable is our resource manager.  Creating it");
             SerializationResourceManager sm = GetResourceManager(manager);
-            TraceWarningIf(sm.DeclarationAdded, "We have already created a resource manager.");
+            TraceIf(TraceLevel.Warning, sm.DeclarationAdded, "We have already created a resource manager.");
             if (!sm.DeclarationAdded)
             {
                 sm.DeclarationAdded = true;
@@ -209,7 +209,7 @@ namespace System.ComponentModel.Design.Serialization
             }
 
             // Object is null. Nothing we can do
-            TraceError("We need to supply a cast, but we cannot determine the cast type.");
+            Trace(TraceLevel.Error, "We need to supply a cast, but we cannot determine the cast type.");
             return null;
         }
 
@@ -291,7 +291,7 @@ namespace System.ComponentModel.Design.Serialization
                     {
                         sm.DeclarationAdded = true;
                         // If we have a root context, then we can write out a reasonable resource manager constructor. If not, then we're a bit hobbled because we have to guess at the resource name.
-                        TraceWarningIf(statements is null, "No CodeStatementCollection on serialization stack, we cannot serialize resource manager creation statements.");
+                        TraceIf(TraceLevel.Warning, statements is null, "No CodeStatementCollection on serialization stack, we cannot serialize resource manager creation statements.");
                         if (statements is not null)
                         {
                             CodeExpression[] parameters;
@@ -302,7 +302,7 @@ namespace System.ComponentModel.Design.Serialization
                             }
                             else
                             {
-                                TraceWarning("No root context, we can only assume the resource manager resource name.");
+                                Trace(TraceLevel.Warning, "No root context, we can only assume the resource manager resource name.");
                                 parameters = new CodeExpression[] { new CodePrimitiveExpression(ResourceManagerName) };
                             }
 
@@ -329,7 +329,7 @@ namespace System.ComponentModel.Design.Serialization
 
                 // Retrieve the ExpressionContext on the context stack, and save the value as a resource.
                 ExpressionContext tree = (ExpressionContext)manager.Context[typeof(ExpressionContext)];
-                TraceWarningIf(tree is null, "No ExpressionContext on stack.  We can serialize, but we cannot create a well-formed name.");
+                TraceIf(TraceLevel.Warning, tree is null, "No ExpressionContext on stack.  We can serialize, but we cannot create a well-formed name.");
                 string resourceName = sm.SetValue(manager, tree, value, forceInvariant, shouldSerializeInvariant, ensureInvariant, false);
                 // Now the next step is to discover the type of the given value.  If it is a string, we will invoke "GetString"  Otherwise, we will invoke "GetObject" and supply a cast to the proper value.
                 bool needCast;
@@ -347,7 +347,7 @@ namespace System.ComponentModel.Design.Serialization
                 }
 
                 // Finally, all we need to do is create a CodeExpression that represents the resource manager method invoke.
-                Trace("Creating method invoke to {0}.{1}", ResourceManagerName, methodName);
+                Trace(TraceLevel.Verbose, $"Creating method invoke to {ResourceManagerName}.{methodName}");
                 CodeMethodInvokeExpression methodInvoke = new CodeMethodInvokeExpression
                 {
                     Method = new CodeMethodReferenceExpression(new CodeVariableReferenceExpression(ResourceManagerName), methodName)
@@ -358,7 +358,7 @@ namespace System.ComponentModel.Design.Serialization
                     Type castTo = GetCastType(manager, value);
                     if (castTo is not null)
                     {
-                        Trace("Supplying cast to {0}", castTo.Name);
+                        Trace(TraceLevel.Verbose, $"Supplying cast to {castTo.Name}");
                         expression = new CodeCastExpression(castTo, methodInvoke);
                     }
                     else
@@ -391,8 +391,8 @@ namespace System.ComponentModel.Design.Serialization
         {
             using (TraceScope($"ResourceCodeDomSerializer::{nameof(SerializeMetadata)}"))
             {
-                Trace("Name: {0}", name);
-                Trace("Value: {0}", (value is null ? "(null)" : value.ToString()));
+                Trace(TraceLevel.Verbose, $"Name: {name}");
+                Trace(TraceLevel.Verbose, $"Value: {(value is null ? "(null)" : value.ToString())}");
                 SerializationResourceManager sm = GetResourceManager(manager);
                 sm.SetMetadata(manager, name, value, shouldSerializeValue, false);
             }
@@ -419,8 +419,8 @@ namespace System.ComponentModel.Design.Serialization
         {
             using (TraceScope($"ResourceCodeDomSerializer::{calleeName}"))
             {
-                Trace("Name: {0}", name);
-                Trace("Value: {0}", (value is null ? "(null)" : value.ToString()));
+                Trace(TraceLevel.Verbose, $"Name: {name}");
+                Trace(TraceLevel.Verbose, $"Value: {(value is null ? "(null)" : value.ToString())}");
                 SerializationResourceManager sm = GetResourceManager(manager);
                 sm.SetValue(manager, name, value, forceInvariant, shouldSerializeInvariant, ensureInvariant, applyingCachedResources);
             }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlCodeDomSerializer.cs
@@ -358,7 +358,7 @@ namespace System.Windows.Forms.Design
             using (TraceScope($"ControlCodeDomSerializer::SerializeMethodInvocation({methodName})"))
             {
                 string name = manager.GetName(control);
-                Trace("{0}.{1}", name, methodName);
+                Trace(TraceLevel.Verbose, $"{name}.{methodName}");
 
                 // Use IReflect to see if this method name exists on the control.
                 paramTypes = ToTargetTypes(control, paramTypes);


### PR DESCRIPTION
Contributes to #8203

## Proposed changes

This one is more involved than the previous ones. Here, we remove all the format-string overloads of the (internal) `CodeDomSerializerBase.Trace*` methods to replace them with interpolated-string-accepting ones.

If you think the changes are too big, I can add the new overloads and port the code to them over multiple PRs

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8736)