### PR TITLE
Fixes the removal of the DefaultValue attribute from ListBox.ItemHeight property

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
@@ -394,7 +394,7 @@ public partial class ListBox : ListControl
         {
             if (s_defaultListBoxItemHeight == -1)
             {
-                s_defaultListBoxItemHeight = DefaultFont.Height;
+                s_defaultListBoxItemHeight = DefaultFont.Height - 1;
             }
 
             return s_defaultListBoxItemHeight;
@@ -2113,7 +2113,7 @@ public partial class ListBox : ListControl
     // ShouldSerialize and Reset Methods are being used by Designer via reflection.
     private void ResetItemHeight()
     {
-        _itemHeight = DefaultListBoxItemHeight;
+        ItemHeight = DefaultListBoxItemHeight;
     }
 
     protected override void ScaleControl(SizeF factor, BoundsSpecified specified)


### PR DESCRIPTION
Fixes #4463 


## Proposed changes

- Changed the value of the DefaultListBoxItemHeight property. It is affected by the DPI.
- Therefore finishes #8518 

## Customer Impact

- Fixes the Issue which impacts user experience, breaks DPI and Font scaling. For the newly created control at 100% scaling, designer should generate the same value as is defined by the Default. There is no extra code.


## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/15823268/104525385-e63a8080-55b4-11eb-8018-1cd886b658a0.png)

### After

![image](https://user-images.githubusercontent.com/102961955/223371358-5d3f24a5-49c1-4554-b21e-77b1382560d7.png)


## Test methodology <!-- How did you ensure quality? -->

- Manual (Issue can be tested via substitution of dlls, complete restart of the VS recommended)
- Unit test

## Test environment(s) <!-- Remove any that don't apply -->

- dotnet 8.0.100-alpha.1.22607.6


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8755)