### PR TITLE
Enable nullability in ColorPaletteAccessibleObject and ControlDesignerAccessibleObject

### DIFF
--- a/src/System.Windows.Forms.Design/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms.Design/src/PublicAPI.Shipped.txt
@@ -84,15 +84,15 @@
 ~override System.Windows.Forms.Design.ComponentTray.OnMouseUp(System.Windows.Forms.MouseEventArgs e) -> void
 ~override System.Windows.Forms.Design.ComponentTray.OnPaint(System.Windows.Forms.PaintEventArgs pe) -> void
 ~override System.Windows.Forms.Design.ControlDesigner.AssociatedComponents.get -> System.Collections.ICollection
-~override System.Windows.Forms.Design.ControlDesigner.ControlDesignerAccessibleObject.DefaultAction.get -> string
-~override System.Windows.Forms.Design.ControlDesigner.ControlDesignerAccessibleObject.Description.get -> string
-~override System.Windows.Forms.Design.ControlDesigner.ControlDesignerAccessibleObject.GetChild(int index) -> System.Windows.Forms.AccessibleObject
-~override System.Windows.Forms.Design.ControlDesigner.ControlDesignerAccessibleObject.GetFocused() -> System.Windows.Forms.AccessibleObject
-~override System.Windows.Forms.Design.ControlDesigner.ControlDesignerAccessibleObject.GetSelected() -> System.Windows.Forms.AccessibleObject
-~override System.Windows.Forms.Design.ControlDesigner.ControlDesignerAccessibleObject.HitTest(int x, int y) -> System.Windows.Forms.AccessibleObject
-~override System.Windows.Forms.Design.ControlDesigner.ControlDesignerAccessibleObject.Name.get -> string
-~override System.Windows.Forms.Design.ControlDesigner.ControlDesignerAccessibleObject.Parent.get -> System.Windows.Forms.AccessibleObject
-~override System.Windows.Forms.Design.ControlDesigner.ControlDesignerAccessibleObject.Value.get -> string
+override System.Windows.Forms.Design.ControlDesigner.ControlDesignerAccessibleObject.DefaultAction.get -> string!
+override System.Windows.Forms.Design.ControlDesigner.ControlDesignerAccessibleObject.Description.get -> string?
+override System.Windows.Forms.Design.ControlDesigner.ControlDesignerAccessibleObject.GetChild(int index) -> System.Windows.Forms.AccessibleObject?
+override System.Windows.Forms.Design.ControlDesigner.ControlDesignerAccessibleObject.GetFocused() -> System.Windows.Forms.AccessibleObject?
+override System.Windows.Forms.Design.ControlDesigner.ControlDesignerAccessibleObject.GetSelected() -> System.Windows.Forms.AccessibleObject?
+override System.Windows.Forms.Design.ControlDesigner.ControlDesignerAccessibleObject.HitTest(int x, int y) -> System.Windows.Forms.AccessibleObject?
+override System.Windows.Forms.Design.ControlDesigner.ControlDesignerAccessibleObject.Name.get -> string!
+override System.Windows.Forms.Design.ControlDesigner.ControlDesignerAccessibleObject.Parent.get -> System.Windows.Forms.AccessibleObject?
+override System.Windows.Forms.Design.ControlDesigner.ControlDesignerAccessibleObject.Value.get -> string?
 ~override System.Windows.Forms.Design.ControlDesigner.InheritanceAttribute.get -> System.ComponentModel.InheritanceAttribute
 ~override System.Windows.Forms.Design.ControlDesigner.Initialize(System.ComponentModel.IComponent component) -> void
 ~override System.Windows.Forms.Design.ControlDesigner.InitializeExistingComponent(System.Collections.IDictionary defaultValues) -> void
@@ -455,7 +455,7 @@
 ~System.Windows.Forms.Design.ComponentTray.SetTrayLocation(System.ComponentModel.IComponent receiver, System.Drawing.Point location) -> void
 ~System.Windows.Forms.Design.ControlDesigner.accessibilityObj -> System.Windows.Forms.AccessibleObject
 ~System.Windows.Forms.Design.ControlDesigner.BehaviorService.get -> System.Windows.Forms.Design.Behavior.BehaviorService
-~System.Windows.Forms.Design.ControlDesigner.ControlDesignerAccessibleObject.ControlDesignerAccessibleObject(System.Windows.Forms.Design.ControlDesigner designer, System.Windows.Forms.Control control) -> void
+System.Windows.Forms.Design.ControlDesigner.ControlDesignerAccessibleObject.ControlDesignerAccessibleObject(System.Windows.Forms.Design.ControlDesigner! designer, System.Windows.Forms.Control! control) -> void
 ~System.Windows.Forms.Design.ControlDesigner.DisplayError(System.Exception e) -> void
 ~System.Windows.Forms.Design.ControlDesigner.EnableDesignMode(System.Windows.Forms.Control child, string name) -> bool
 ~System.Windows.Forms.Design.ControlDesigner.HookChildControls(System.Windows.Forms.Control firstChild) -> void

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/ColorEditor.ColorPalette.ColorPaletteAccessibleObject.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/ColorEditor.ColorPalette.ColorPaletteAccessibleObject.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Windows.Forms;
 
 namespace System.Drawing.Design
@@ -25,7 +23,7 @@ namespace System.Drawing.Design
 
                 public override int GetChildCount() => CellsAcross * CellsDown;
 
-                public override AccessibleObject GetChild(int id)
+                public override AccessibleObject? GetChild(int id)
                 {
                     if (id < 0 || id >= CellsAcross * CellsDown)
                     {
@@ -35,7 +33,7 @@ namespace System.Drawing.Design
                     return _cells[id] ??= new ColorCellAccessibleObject(this, ColorPalette.GetColorFromCell(id), id);
                 }
 
-                public override AccessibleObject HitTest(int x, int y)
+                public override AccessibleObject? HitTest(int x, int y)
                 {
                     if (!ColorPalette.IsHandleCreated)
                     {

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.ControlDesignerAccessibleObject.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.ControlDesignerAccessibleObject.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 using System.ComponentModel.Design;
 using System.Diagnostics;
@@ -17,8 +15,8 @@ namespace System.Windows.Forms.Design
         {
             private readonly ControlDesigner _designer;
             private readonly Control _control;
-            private IDesignerHost _host;
-            private ISelectionService _selectionService;
+            private IDesignerHost? _host;
+            private ISelectionService? _selectionService;
 
             public ControlDesignerAccessibleObject(ControlDesigner designer, Control control)
             {
@@ -28,7 +26,7 @@ namespace System.Windows.Forms.Design
 
             public override Rectangle Bounds => _control.AccessibilityObject.Bounds;
 
-            public override string Description => _control.AccessibilityObject.Description;
+            public override string? Description => _control.AccessibilityObject.Description;
 
             private IDesignerHost DesignerHost
                 => _host ??= (IDesignerHost)_designer.GetService(typeof(IDesignerHost));
@@ -37,7 +35,7 @@ namespace System.Windows.Forms.Design
 
             public override string Name => _control.Name;
 
-            public override AccessibleObject Parent => _control.AccessibilityObject.Parent;
+            public override AccessibleObject? Parent => _control.AccessibilityObject.Parent;
 
             public override AccessibleRole Role => _control.AccessibilityObject.Role;
 
@@ -67,9 +65,9 @@ namespace System.Windows.Forms.Design
                 }
             }
 
-            public override string Value => _control.AccessibilityObject.Value;
+            public override string? Value => _control.AccessibilityObject.Value;
 
-            public override AccessibleObject GetChild(int index)
+            public override AccessibleObject? GetChild(int index)
             {
                 Debug.WriteLineIf(
                     CompModSwitches.MSAA.TraceInfo,
@@ -77,7 +75,7 @@ namespace System.Windows.Forms.Design
 
                 if (_control.AccessibilityObject.GetChild(index) is Control.ControlAccessibleObject childAccObj)
                 {
-                    AccessibleObject cao = GetDesignerAccessibleObject(childAccObj);
+                    AccessibleObject? cao = GetDesignerAccessibleObject(childAccObj);
                     if (cao is not null)
                     {
                         return cao;
@@ -89,7 +87,7 @@ namespace System.Windows.Forms.Design
 
             public override int GetChildCount() => _control.AccessibilityObject.GetChildCount();
 
-            private AccessibleObject GetDesignerAccessibleObject(Control.ControlAccessibleObject cao)
+            private AccessibleObject? GetDesignerAccessibleObject(Control.ControlAccessibleObject cao)
             {
                 if (cao is null)
                 {
@@ -104,13 +102,13 @@ namespace System.Windows.Forms.Design
                 return null;
             }
 
-            public override AccessibleObject GetFocused()
+            public override AccessibleObject? GetFocused()
                 => (State & AccessibleStates.Focused) != 0 ? this : base.GetFocused();
 
-            public override AccessibleObject GetSelected()
+            public override AccessibleObject? GetSelected()
                 => (State & AccessibleStates.Selected) != 0 ? this : base.GetFocused();
 
-            public override AccessibleObject HitTest(int x, int y) => _control.AccessibilityObject.HitTest(x, y);
+            public override AccessibleObject? HitTest(int x, int y) => _control.AccessibilityObject.HitTest(x, y);
         }
     }
 }


### PR DESCRIPTION
## Proposed changes

- Enable nullability in ColorPaletteAccessibleObject and ControlDesignerAccessibleObject

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8765)