### PR TITLE
Inline UndoEngine.Trace method

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/UndoEngine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/UndoEngine.cs
@@ -1160,9 +1160,9 @@ namespace System.ComponentModel.Design
                     _member = e.Member;
 
                     Debug.WriteLineIf(s_traceUndo.TraceVerbose, $"UndoEngine: ---> Creating change undo event for '{_componentName}'");
-                    Debug.WriteLineIf(s_traceUndo.TraceVerbose, $"UndoEngine: ---> Saving before snapshot for change to '{_componentName}'");
                     if (serializeBeforeState)
                     {
+                        Debug.WriteLineIf(s_traceUndo.TraceVerbose, $"UndoEngine: ---> Saving before snapshot for change to '{_componentName}'");
                         _before = Serialize(engine, _openComponent, _member);
                     }
                 }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/UndoEngine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/UndoEngine.cs
@@ -7,7 +7,6 @@
 using System.Collections;
 using System.ComponentModel.Design.Serialization;
 using System.Diagnostics;
-using System.Globalization;
 using System.Reflection;
 using System.Windows.Forms;
 


### PR DESCRIPTION
Contributes to #8203


## Proposed changes

It's the same story as in #8743. This time I'm inlining a lot more calls though, around 15, so we're paying a higher cost to make the most of interpolated strings.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8769)