### PR TITLE
Fix disabled text label rendering.

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Label.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Label.cs
@@ -63,7 +63,7 @@ namespace System.Windows.Forms
         /// </summary>
         public Label() : base()
         {
-            // this class overrides GetPreferredSizeCore, let Control automatically cache the result
+            // This class overrides GetPreferredSizeCore, let Control automatically cache the result.
             SetExtendedState(ExtendedStates.UserPreferredSizeCache, true);
 
             SetStyle(ControlStyles.UserPaint |
@@ -134,25 +134,27 @@ namespace System.Windows.Forms
             get => _labelState[s_stateAutoEllipsis] != 0;
             set
             {
-                if (AutoEllipsis != value)
+                if (AutoEllipsis == value)
                 {
-                    _labelState[s_stateAutoEllipsis] = value ? 1 : 0;
-                    MeasureTextCache.InvalidateCache();
-
-                    OnAutoEllipsisChanged(/*EventArgs.Empty*/);
-
-                    if (value)
-                    {
-                        _textToolTip ??= new ToolTip();
-                    }
-
-                    if (ParentInternal is not null)
-                    {
-                        LayoutTransaction.DoLayoutIf(AutoSize, ParentInternal, this, PropertyNames.AutoEllipsis);
-                    }
-
-                    Invalidate();
+                    return;
                 }
+
+                _labelState[s_stateAutoEllipsis] = value ? 1 : 0;
+                MeasureTextCache.InvalidateCache();
+
+                OnAutoEllipsisChanged();
+
+                if (value)
+                {
+                    _textToolTip ??= new ToolTip();
+                }
+
+                if (ParentInternal is not null)
+                {
+                    LayoutTransaction.DoLayoutIf(AutoSize, ParentInternal, this, PropertyNames.AutoEllipsis);
+                }
+
+                Invalidate();
             }
         }
 
@@ -323,31 +325,33 @@ namespace System.Windows.Forms
                 //valid values are 0x0 to 0x3
                 SourceGenerated.EnumValidator.Validate(value);
 
-                if (_labelState[s_stateFlatStyle] != (int)value)
+                if (_labelState[s_stateFlatStyle] == (int)value)
                 {
-                    bool needRecreate = (_labelState[s_stateFlatStyle] == (int)FlatStyle.System) || (value == FlatStyle.System);
+                    return;
+                }
 
-                    _labelState[s_stateFlatStyle] = (int)value;
+                bool needRecreate = (_labelState[s_stateFlatStyle] == (int)FlatStyle.System) || (value == FlatStyle.System);
 
-                    SetStyle(ControlStyles.UserPaint
-                             | ControlStyles.SupportsTransparentBackColor
-                             | ControlStyles.OptimizedDoubleBuffer, OwnerDraw);
+                _labelState[s_stateFlatStyle] = (int)value;
 
-                    if (needRecreate)
+                SetStyle(ControlStyles.UserPaint
+                    | ControlStyles.SupportsTransparentBackColor
+                    | ControlStyles.OptimizedDoubleBuffer, OwnerDraw);
+
+                if (needRecreate)
+                {
+                    // This will clear the preferred size cache - it's OK if the parent is null - it would be a NOP.
+                    LayoutTransaction.DoLayoutIf(AutoSize, ParentInternal, this, PropertyNames.BorderStyle);
+                    if (AutoSize)
                     {
-                        // this will clear the preferred size cache - it's OK if the parent is null - it would be a NOP.
-                        LayoutTransaction.DoLayoutIf(AutoSize, ParentInternal, this, PropertyNames.BorderStyle);
-                        if (AutoSize)
-                        {
-                            AdjustSize();
-                        }
+                        AdjustSize();
+                    }
 
-                        RecreateHandle();
-                    }
-                    else
-                    {
-                        Refresh();
-                    }
+                    RecreateHandle();
+                }
+                else
+                {
+                    Refresh();
                 }
             }
         }
@@ -447,9 +451,8 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Gets or sets the key accessor for the image list.  This specifies the image
-        ///   from the image list to display on
-        ///  <see cref="Label"/>.
+        ///  Gets or sets the key accessor for the image list. This specifies the image
+        ///  from the image list to display on the <see cref="Label"/>.
         /// </summary>
         [TypeConverter(typeof(ImageKeyConverter))]
         [Editor($"System.Windows.Forms.Design.ImageIndexEditor, {AssemblyRef.SystemDesign}", typeof(UITypeEditor))]
@@ -552,12 +555,7 @@ namespace System.Windows.Forms
             get
             {
                 int imageAlign = Properties.GetInteger(s_propImageAlign, out bool found);
-                if (found)
-                {
-                    return (ContentAlignment)imageAlign;
-                }
-
-                return ContentAlignment.MiddleCenter;
+                return found ? (ContentAlignment)imageAlign : ContentAlignment.MiddleCenter;
             }
             set
             {
@@ -651,8 +649,7 @@ namespace System.Windows.Forms
         public virtual int PreferredHeight => PreferredSize.Height;
 
         /// <summary>
-        ///  Gets the width of the control (in pixels), assuming a single line
-        ///  of text is displayed.
+        ///  Gets the width of the control (in pixels), assuming a single line of text is displayed.
         /// </summary>
         [SRCategory(nameof(SR.CatLayout))]
         [Browsable(false)]
@@ -675,8 +672,7 @@ namespace System.Windows.Forms
         private bool SelfSizing => CommonProperties.ShouldSelfSize(this);
 
         /// <summary>
-        ///  Gets or sets a value indicating whether the user can tab to the
-        ///  <see cref="Label"/>.
+        ///  Gets or sets a value indicating whether the user can tab to the <see cref="Label"/>.
         /// </summary>
         [DefaultValue(false)]
         [Browsable(false)]
@@ -696,8 +692,7 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Gets or sets the
-        ///  horizontal alignment of the text in the control.
+        ///  Gets or sets the horizontal alignment of the text in the control.
         /// </summary>
         [SRDescription(nameof(SR.LabelTextAlignDescr))]
         [Localizable(true)]
@@ -708,12 +703,7 @@ namespace System.Windows.Forms
             get
             {
                 int textAlign = Properties.GetInteger(s_propTextAlign, out bool found);
-                if (found)
-                {
-                    return (ContentAlignment)textAlign;
-                }
-
-                return ContentAlignment.TopLeft;
+                return found ? (ContentAlignment)textAlign : ContentAlignment.TopLeft;
             }
             set
             {
@@ -739,8 +729,7 @@ namespace System.Windows.Forms
         ///  Gets or sets the text in the Label. Since we can have multiline support
         ///  this property just overrides the base to pluck in the Multiline editor.
         /// </summary>
-        [Editor($"System.ComponentModel.Design.MultilineStringEditor, {AssemblyRef.SystemDesign}", typeof(UITypeEditor)),
-        SettingsBindable(true)]
+        [Editor($"System.ComponentModel.Design.MultilineStringEditor, {AssemblyRef.SystemDesign}", typeof(UITypeEditor)), SettingsBindable(true)]
         [AllowNull]
         public override string Text
         {
@@ -753,7 +742,6 @@ namespace System.Windows.Forms
         public event EventHandler? TextAlignChanged
         {
             add => Events.AddHandler(s_eventTextAlignChanged, value);
-
             remove => Events.RemoveHandler(s_eventTextAlignChanged, value);
         }
 
@@ -785,11 +773,6 @@ namespace System.Windows.Forms
             }
         }
 
-        /// <summary>
-        ///  Determines whether the control supports rendering text using GDI+ and GDI. This is provided for container
-        ///  controls to iterate through its children to set <see cref="UseCompatibleTextRendering"/> to the same value
-        ///  if the child control supports it.
-        /// </summary>
         internal override bool SupportsUseCompatibleTextRendering => true;
 
         /// <summary>
@@ -949,12 +932,11 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Get TextFormatFlags flags for rendering text using GDI (TextRenderer).
         /// </summary>
-        internal virtual TextFormatFlags CreateTextFormatFlags(Size constrainingSize)
+        private protected TextFormatFlags CreateTextFormatFlags(Size constrainingSize)
         {
             // PREFERRED SIZE CACHING:
             //
-            // Please read if you're adding a new TextFormatFlag.
-            // whenever something can change the TextFormatFlags used
+            // Please read if you're adding a new TextFormatFlag. Whenever something can change the TextFormatFlags used
             // MeasureTextCache.InvalidateCache() should be called so we can appropriately clear.
 
             TextFormatFlags flags = ControlPaint.CreateTextFormatFlags(this, TextAlign, AutoEllipsis, UseMnemonic);
@@ -1176,9 +1158,6 @@ namespace System.Windows.Forms
             }
         }
 
-        /// <summary>
-        ///  Specifies whether the control is willing to process mnemonics when hosted in an container ActiveX (Ax Sourcing).
-        /// </summary>
         internal override bool IsMnemonicsListenerAxSourced => true;
 
         /// <summary>
@@ -1189,9 +1168,6 @@ namespace System.Windows.Forms
         /// </summary>
         private bool IsOwnerDraw() => FlatStyle != FlatStyle.System;
 
-        /// <summary>
-        ///  Raises the <see cref="Control.OnMouseEnter"/> event.
-        /// </summary>
         protected override void OnMouseEnter(EventArgs e)
         {
             if (!_controlToolTip && !DesignMode && AutoEllipsis && _showToolTip && _textToolTip is not null)
@@ -1210,9 +1186,6 @@ namespace System.Windows.Forms
             base.OnMouseEnter(e);
         }
 
-        /// <summary>
-        ///  Raises the <see cref="Control.OnMouseLeave"/> event.
-        /// </summary>
         protected override void OnMouseLeave(EventArgs e)
         {
             if (!_controlToolTip && _textToolTip is not null && _textToolTip.GetHandleCreated())
@@ -1349,7 +1322,7 @@ namespace System.Windows.Forms
                 }
                 else
                 {
-                    //Theme specs -- if the backcolor is darker than Control, we use
+                    // Theme specs -- if the backcolor is darker than Control, we use
                     // ControlPaint.Dark(backcolor).  Otherwise we use ControlDark.
 
                     Color disabledTextForeColor = TextRenderer.DisabledTextColor(BackColor);
@@ -1378,8 +1351,7 @@ namespace System.Windows.Forms
             base.OnParentChanged(e);
             if (SelfSizing)
             {
-                // In the case of SelfSizing
-                // we don't know what size to be until we're parented
+                // In the case of SelfSizing we don't know what size to be until we're parented.
                 AdjustSize();
             }
 
@@ -1407,10 +1379,6 @@ namespace System.Windows.Forms
             ControlPaint.PrintBorder(g, new Rectangle(Point.Empty, Size), BorderStyle, Border3DStyle.SunkenOuter);
         }
 
-        /// <summary>
-        ///  Overrides Control. This is called when the user has pressed an Alt-CHAR key combination and determines if
-        ///  that combination is an interesting mnemonic for this control.
-        /// </summary>
         protected internal override bool ProcessMnemonic(char charCode)
         {
             if (UseMnemonic && IsMnemonic(charCode, Text) && CanProcessMnemonic())
@@ -1430,9 +1398,6 @@ namespace System.Windows.Forms
             return false;
         }
 
-        /// <summary>
-        ///  Overrides Control.setBoundsCore to enforce autoSize.
-        /// </summary>
         protected override void SetBoundsCore(int x, int y, int width, int height, BoundsSpecified specified)
         {
             if ((specified & BoundsSpecified.Height) != BoundsSpecified.None)
@@ -1462,9 +1427,6 @@ namespace System.Windows.Forms
 
         private bool ShouldSerializeImage() => Properties.ContainsObjectThatIsNotNull(s_propImage);
 
-        /// <summary>
-        ///  Called by ToolTip to poke in that Tooltip into this ComCtl so that the Native ChildToolTip is not exposed.
-        /// </summary>
         internal override void SetToolTip(ToolTip toolTip)
         {
             if (toolTip is null || _controlToolTip)
@@ -1472,10 +1434,8 @@ namespace System.Windows.Forms
                 return;
             }
 
-            // Label now has its own Tooltip for AutoEllipsis.
-            // So this control too falls in special casing.
-            // We need to disable the LABEL AutoEllipsis tooltip and show
-            // this tooltip always.
+            // Label now has its own Tooltip for AutoEllipsis. So this control too falls in special casing.
+            // We need to disable the LABEL AutoEllipsis tooltip and show this tooltip always.
             _controlToolTip = true;
         }
 
@@ -1484,15 +1444,8 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Returns a string representation for this control.
         /// </summary>
-        public override string ToString()
-        {
-            string s = base.ToString();
-            return $"{s}, Text: {Text}";
-        }
+        public override string ToString() => $"{base.ToString()}, Text: {Text}";
 
-        /// <summary>
-        ///  Overrides Control. This processes certain messages that the Win32 STATIC class would normally override.
-        /// </summary>
         protected override void WndProc(ref Message m)
         {
             switch ((User32.WM)m.Msg)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.cs
@@ -56,11 +56,12 @@ namespace System.Windows.Forms
         public LinkLabel() : base()
         {
             SetStyle(ControlStyles.AllPaintingInWmPaint
-                     | ControlStyles.OptimizedDoubleBuffer
-                     | ControlStyles.Opaque
-                     | ControlStyles.UserPaint
-                     | ControlStyles.StandardClick
-                     | ControlStyles.ResizeRedraw, true);
+                | ControlStyles.OptimizedDoubleBuffer
+                | ControlStyles.Opaque
+                | ControlStyles.UserPaint
+                | ControlStyles.StandardClick
+                | ControlStyles.ResizeRedraw,
+                value: true);
             ResetLinkArea();
         }
 
@@ -71,17 +72,7 @@ namespace System.Windows.Forms
         [SRDescription(nameof(SR.LinkLabelActiveLinkColorDescr))]
         public Color ActiveLinkColor
         {
-            get
-            {
-                if (_activeLinkColor.IsEmpty)
-                {
-                    return IEActiveLinkColor;
-                }
-                else
-                {
-                    return _activeLinkColor;
-                }
-            }
+            get => _activeLinkColor.IsEmpty ? IEActiveLinkColor : _activeLinkColor;
             set
             {
                 if (_activeLinkColor != value)
@@ -99,17 +90,7 @@ namespace System.Windows.Forms
         [SRDescription(nameof(SR.LinkLabelDisabledLinkColorDescr))]
         public Color DisabledLinkColor
         {
-            get
-            {
-                if (_disabledLinkColor.IsEmpty)
-                {
-                    return IEDisabledLinkColor;
-                }
-                else
-                {
-                    return _disabledLinkColor;
-                }
-            }
+            get => _disabledLinkColor.IsEmpty ? IEDisabledLinkColor : _disabledLinkColor;
             set
             {
                 if (_disabledLinkColor != value)
@@ -122,10 +103,7 @@ namespace System.Windows.Forms
 
         private Link? FocusLink
         {
-            get
-            {
-                return _focusLink;
-            }
+            get => _focusLink;
             set
             {
                 if (_focusLink != value)
@@ -147,29 +125,11 @@ namespace System.Windows.Forms
             }
         }
 
-        private static Color IELinkColor
-        {
-            get
-            {
-                return LinkUtilities.IELinkColor;
-            }
-        }
+        private static Color IELinkColor => LinkUtilities.IELinkColor;
 
-        private static Color IEActiveLinkColor
-        {
-            get
-            {
-                return LinkUtilities.IEActiveLinkColor;
-            }
-        }
+        private static Color IEActiveLinkColor => LinkUtilities.IEActiveLinkColor;
 
-        private static Color IEVisitedLinkColor
-        {
-            get
-            {
-                return LinkUtilities.IEVisitedLinkColor;
-            }
-        }
+        private static Color IEVisitedLinkColor => LinkUtilities.IEVisitedLinkColor;
 
         private Color IEDisabledLinkColor
         {
@@ -184,13 +144,7 @@ namespace System.Windows.Forms
             }
         }
 
-        private Rectangle ClientRectWithPadding
-        {
-            get
-            {
-                return LayoutUtils.DeflateRect(ClientRectangle, Padding);
-            }
-        }
+        private Rectangle ClientRectWithPadding => LayoutUtils.DeflateRect(ClientRectangle, Padding);
 
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -203,22 +157,16 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Gets or sets the range in the text that is treated as a link.
         /// </summary>
-        [Editor("System.Windows.Forms.Design.LinkAreaEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
+        [Editor($"System.Windows.Forms.Design.LinkAreaEditor, {AssemblyRef.SystemDesign}", typeof(UITypeEditor))]
         [RefreshProperties(RefreshProperties.Repaint)]
         [Localizable(true)]
         [SRCategory(nameof(SR.CatBehavior))]
         [SRDescription(nameof(SR.LinkLabelLinkAreaDescr))]
         public LinkArea LinkArea
         {
-            get
-            {
-                if (_links.Count == 0)
-                {
-                    return new LinkArea(0, 0);
-                }
-
-                return new LinkArea(_links[0].Start, _links[0].Length);
-            }
+            get => _links.Count == 0
+                ? new LinkArea(0, 0)
+                : new LinkArea(_links[0].Start, _links[0].Length);
             set
             {
                 LinkArea pt = LinkArea;
@@ -253,7 +201,7 @@ namespace System.Windows.Forms
                 {
                     InvalidateTextLayout();
                     LayoutTransaction.DoLayout(ParentInternal, this, PropertyNames.LinkArea);
-                    base.AdjustSize();
+                    AdjustSize();
                     Invalidate();
                 }
             }
@@ -267,13 +215,10 @@ namespace System.Windows.Forms
         [SRDescription(nameof(SR.LinkLabelLinkBehaviorDescr))]
         public LinkBehavior LinkBehavior
         {
-            get
-            {
-                return _linkBehavior;
-            }
+            get => _linkBehavior;
             set
             {
-                //valid values are 0x0 to 0x3
+                // Valid values are 0x0 to 0x3
                 SourceGenerated.EnumValidator.Validate(value);
                 if (value != _linkBehavior)
                 {
@@ -291,22 +236,9 @@ namespace System.Windows.Forms
         [SRDescription(nameof(SR.LinkLabelLinkColorDescr))]
         public Color LinkColor
         {
-            get
-            {
-                if (_linkColor.IsEmpty)
-                {
-                    if (SystemInformation.HighContrast)
-                    {
-                        return SystemColors.HotTrack;
-                    }
-
-                    return IELinkColor;
-                }
-                else
-                {
-                    return _linkColor;
-                }
-            }
+            get => _linkColor.IsEmpty
+                ? SystemInformation.HighContrast ? SystemColors.HotTrack : IELinkColor
+                : _linkColor;
             set
             {
                 if (_linkColor != value)
@@ -322,15 +254,7 @@ namespace System.Windows.Forms
         /// </summary>
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public LinkCollection Links
-        {
-            get
-            {
-                _linkCollection ??= new LinkCollection(this);
-
-                return _linkCollection;
-            }
-        }
+        public LinkCollection Links => _linkCollection ??= new LinkCollection(this);
 
         /// <summary>
         ///  Gets or sets a value indicating whether the link should be displayed as if it was visited.
@@ -340,17 +264,7 @@ namespace System.Windows.Forms
         [SRDescription(nameof(SR.LinkLabelLinkVisitedDescr))]
         public bool LinkVisited
         {
-            get
-            {
-                if (_links.Count == 0)
-                {
-                    return false;
-                }
-                else
-                {
-                    return _links[0].Visited;
-                }
-            }
+            get => _links.Count == 0 ? false : _links[0].Visited;
             set
             {
                 if (value != LinkVisited)
@@ -365,15 +279,7 @@ namespace System.Windows.Forms
             }
         }
 
-        // link labels must always ownerdraw
-        //
-        internal override bool OwnerDraw
-        {
-            get
-            {
-                return true;
-            }
-        }
+        internal override bool OwnerDraw => true;
 
         protected Cursor? OverrideCursor
         {
@@ -401,7 +307,6 @@ namespace System.Windows.Forms
             }
         }
 
-        // Make this event visible through the property browser.
         [Browsable(true)]
         [EditorBrowsable(EditorBrowsableState.Always)]
         public new event EventHandler? TabStopChanged
@@ -440,22 +345,9 @@ namespace System.Windows.Forms
         [SRDescription(nameof(SR.LinkLabelVisitedLinkColorDescr))]
         public Color VisitedLinkColor
         {
-            get
-            {
-                if (_visitedLinkColor.IsEmpty)
-                {
-                    if (SystemInformation.HighContrast)
-                    {
-                        return LinkUtilities.GetVisitedLinkColor();
-                    }
-
-                    return IEVisitedLinkColor;
-                }
-                else
-                {
-                    return _visitedLinkColor;
-                }
-            }
+            get => _visitedLinkColor.IsEmpty
+                ? SystemInformation.HighContrast ? LinkUtilities.GetVisitedLinkColor() : IEVisitedLinkColor
+                : _visitedLinkColor;
             set
             {
                 if (_visitedLinkColor != value)
@@ -531,61 +423,41 @@ namespace System.Windows.Forms
             return new Rectangle(xLoc, yLoc, width, height);
         }
 
-        /// <summary>
-        ///  Constructs the new instance of the accessibility object for this control. Subclasses
-        ///  should not call base.CreateAccessibilityObject.
-        /// </summary>
-        protected override AccessibleObject CreateAccessibilityInstance()
-        {
-            return new LinkLabelAccessibleObject(this);
-        }
+        protected override AccessibleObject CreateAccessibilityInstance() => new LinkLabelAccessibleObject(this);
 
-        /// <summary>
-        ///  Creates a handle for this control. This method is called by the framework,
-        ///  this should not be called directly. Inheriting classes should always call
-        ///  <c>base.CreateHandle</c> when overriding this method.
-        /// </summary>
         protected override void CreateHandle()
         {
             base.CreateHandle();
             InvalidateTextLayout();
         }
 
-        /// <summary>
-        ///  Determines whether the current state of the control allows for rendering text using
-        ///  TextRenderer (GDI).
-        ///  The Gdi library doesn't currently have a way to calculate character ranges so we cannot
-        ///  use it for painting link(s) within the text, but if the link are is null or covers the
-        ///  entire text we are ok since it is just one area with the same size of the text binding
-        ///  area.
-        /// </summary>
         internal override bool CanUseTextRenderer
         {
             get
             {
-                // If no link or the LinkArea is one and covers the entire text, we can support UseCompatibleTextRendering = false.
-                // Observe that LinkArea refers to the first link always.
-                StringInfo stringInfo = new StringInfo(Text);
-                return LinkArea.Start == 0 && (LinkArea.IsEmpty || LinkArea.Length == stringInfo.LengthInTextElements);
+                // The Gdi library doesn't currently have a way to calculate character ranges so we cannot use it for
+                // painting link(s) within the text, but if the link are is null or covers the entire text we are ok
+                // since it is just one area with the same size of the text binding area.
+
+                return LinkArea.Start == 0 && (LinkArea.IsEmpty || LinkArea.Length == new StringInfo(Text).LengthInTextElements);
             }
         }
 
-        internal override bool UseGDIMeasuring()
-        {
-            return !UseCompatibleTextRendering;
-        }
+        internal override bool UseGDIMeasuring() => !UseCompatibleTextRendering;
 
         /// <summary>
-        ///  Converts the character index into char index of the string
-        ///  This method is copied in LinkCollectionEditor.cs. Update the other
-        ///  one as well if you change this method.
-        ///  This method mainly deal with surrogate. Suppose we
-        ///  have a string consisting of 3 surrogates, and we want the
-        ///  second character, then the index we need should be 2 instead of
-        ///  1, and this method returns the correct index.
+        ///  Converts the character index into char index of the string.
         /// </summary>
+        /// <remarks>
+        ///  <para>
+        ///   This method mainly deal with surrogate. Suppose we have a string consisting of 3 surrogates, and we want the
+        ///   second character, then the index we need should be 2 instead of 1, and this method returns the correct index.
+        ///  </para>
+        /// </remarks>
         private static int ConvertToCharIndex(int index, string text)
         {
+            // This method is copied in LinkCollectionEditor. Update the other one as well if you change this method.
+
             if (index <= 0)
             {
                 return 0;
@@ -594,47 +466,45 @@ namespace System.Windows.Forms
             if (string.IsNullOrEmpty(text))
             {
                 Debug.Assert(text is not null, "string should not be null");
-                //do no conversion, just return the original value passed in
+
+                // Do no conversion, just return the original value passed in.
                 return index;
             }
 
-            //Dealing with surrogate characters
-            //in some languages, characters can expand over multiple
-            //chars, using StringInfo lets us properly deal with it.
-            StringInfo stringInfo = new StringInfo(text);
+            // Dealing with surrogate characters in some languages, characters can expand over multiple
+            // chars, using StringInfo lets us properly deal with it.
+            StringInfo stringInfo = new(text);
             int numTextElements = stringInfo.LengthInTextElements;
 
-            //index is greater than the length of the string
             if (index > numTextElements)
             {
-                return index - numTextElements + text.Length;  //pretend all the characters after are ASCII characters
+                // Pretend all the characters after are ASCII characters
+                return index - numTextElements + text.Length;
             }
 
-            //return the length of the substring which has specified number of characters
+            // Return the length of the substring which has specified number of characters.
             string sub = stringInfo.SubstringByTextElements(0, index);
             return sub.Length;
         }
 
         /// <summary>
-        ///  Ensures that we have analyzed the text run so that we can render each segment
-        ///  and link.
+        ///  Ensures that we have analyzed the text run so that we can render each segment and link.
         /// </summary>
         private void EnsureRun(Graphics g)
         {
-            // bail early if everything is valid!
+            Debug.Assert(g is not null);
+
             if (_textLayoutValid)
             {
                 return;
             }
 
-            if (_textRegion is not null)
-            {
-                _textRegion.Dispose();
-                _textRegion = null;
-            }
+            _textRegion?.Dispose();
+            _textRegion = null;
 
-            // bail early for no text
-            if (Text.Length == 0)
+            string text = Text;
+
+            if (text.Length == 0)
             {
                 Links.Clear();
                 Links.Add(new Link(0, -1));   // default 'magic' link.
@@ -642,93 +512,76 @@ namespace System.Windows.Forms
                 return;
             }
 
-            StringFormat textFormat = CreateStringFormat();
-            string text = Text;
-            try
+            using StringFormat textFormat = CreateStringFormat();
+
+            using Font alwaysUnderlined = new Font(Font, Font.Style | FontStyle.Underline);
+
+            if (UseCompatibleTextRendering)
             {
-                Font alwaysUnderlined = new Font(Font, Font.Style | FontStyle.Underline);
-                Graphics? created = null;
+                Region[] textRegions = g.MeasureCharacterRanges(text, alwaysUnderlined, ClientRectWithPadding, textFormat);
 
-                try
+                int regionIndex = 0;
+
+                for (int i = 0; i < Links.Count; i++)
                 {
-                    g ??= created = CreateGraphicsInternal();
-
-                    if (UseCompatibleTextRendering)
+                    Link link = Links[i];
+                    int charStart = ConvertToCharIndex(link.Start, text);
+                    int charEnd = ConvertToCharIndex(link.Start + link.Length, text);
+                    if (LinkInText(charStart, charEnd - charStart))
                     {
-                        Region[] textRegions = g.MeasureCharacterRanges(text, alwaysUnderlined, ClientRectWithPadding, textFormat);
-
-                        int regionIndex = 0;
-
-                        for (int i = 0; i < Links.Count; i++)
-                        {
-                            Link link = Links[i];
-                            int charStart = ConvertToCharIndex(link.Start, text);
-                            int charEnd = ConvertToCharIndex(link.Start + link.Length, text);
-                            if (LinkInText(charStart, charEnd - charStart))
-                            {
-                                Links[i].VisualRegion = textRegions[regionIndex];
-                                regionIndex++;
-                            }
-                        }
-
-                        Debug.Assert(regionIndex == (textRegions.Length - 1), "Failed to consume all link label visual regions");
-                        _textRegion = textRegions[textRegions.Length - 1];
-                    }
-                    else
-                    {
-                        // use TextRenderer.MeasureText to see the size of the text
-                        Rectangle clientRectWithPadding = ClientRectWithPadding;
-                        Size clientSize = new Size(clientRectWithPadding.Width, clientRectWithPadding.Height);
-                        TextFormatFlags flags = CreateTextFormatFlags(clientSize);
-                        Size textSize = TextRenderer.MeasureText(text, alwaysUnderlined, clientSize, flags);
-
-                        // We need to take into account the padding that GDI adds around the text.
-                        int iLeftMargin, iRightMargin;
-
-                        TextPaddingOptions padding = default;
-                        if ((flags & TextFormatFlags.NoPadding) == TextFormatFlags.NoPadding)
-                        {
-                            padding = TextPaddingOptions.NoPadding;
-                        }
-                        else if ((flags & TextFormatFlags.LeftAndRightPadding) == TextFormatFlags.LeftAndRightPadding)
-                        {
-                            padding = TextPaddingOptions.LeftAndRightPadding;
-                        }
-
-                        using var hfont = GdiCache.GetHFONT(Font);
-                        User32.DRAWTEXTPARAMS dtParams = hfont.GetTextMargins(padding);
-
-                        iLeftMargin = dtParams.iLeftMargin;
-                        iRightMargin = dtParams.iRightMargin;
-
-                        Rectangle visualRectangle = new Rectangle(clientRectWithPadding.X + iLeftMargin,
-                                                                  clientRectWithPadding.Y,
-                                                                  textSize.Width - iRightMargin - iLeftMargin,
-                                                                  textSize.Height);
-                        visualRectangle = CalcTextRenderBounds(visualRectangle /*textRect*/, clientRectWithPadding /*clientRect*/, RtlTranslateContent(TextAlign));
-
-                        Region visualRegion = new Region(visualRectangle);
-                        if (_links is not null && _links.Count == 1)
-                        {
-                            Links[0].VisualRegion = visualRegion;
-                        }
-
-                        _textRegion = visualRegion;
+                        Links[i].VisualRegion = textRegions[regionIndex];
+                        regionIndex++;
                     }
                 }
-                finally
-                {
-                    alwaysUnderlined.Dispose();
 
-                    created?.Dispose();
+                Debug.Assert(regionIndex == (textRegions.Length - 1), "Failed to consume all link label visual regions");
+                _textRegion = textRegions[^1];
+            }
+            else
+            {
+                // Use TextRenderer.MeasureText to see the size of the text
+                Rectangle clientRectWithPadding = ClientRectWithPadding;
+                Size clientSize = new Size(clientRectWithPadding.Width, clientRectWithPadding.Height);
+                TextFormatFlags flags = CreateTextFormatFlags(clientSize);
+                Size textSize = TextRenderer.MeasureText(text, alwaysUnderlined, clientSize, flags);
+
+                // We need to take into account the padding that GDI adds around the text.
+                int iLeftMargin, iRightMargin;
+
+                TextPaddingOptions padding = default;
+                if ((flags & TextFormatFlags.NoPadding) == TextFormatFlags.NoPadding)
+                {
+                    padding = TextPaddingOptions.NoPadding;
+                }
+                else if ((flags & TextFormatFlags.LeftAndRightPadding) == TextFormatFlags.LeftAndRightPadding)
+                {
+                    padding = TextPaddingOptions.LeftAndRightPadding;
                 }
 
-                _textLayoutValid = true;
+                using var hfont = GdiCache.GetHFONT(Font);
+                User32.DRAWTEXTPARAMS dtParams = hfont.GetTextMargins(padding);
+
+                iLeftMargin = dtParams.iLeftMargin;
+                iRightMargin = dtParams.iRightMargin;
+
+                Rectangle visualRectangle = new(
+                    clientRectWithPadding.X + iLeftMargin,
+                    clientRectWithPadding.Y,
+                    textSize.Width - iRightMargin - iLeftMargin,
+                    textSize.Height);
+
+                visualRectangle = CalcTextRenderBounds(visualRectangle, clientRectWithPadding, RtlTranslateContent(TextAlign));
+
+                Region visualRegion = new Region(visualRectangle);
+                if (_links is not null && _links.Count == 1)
+                {
+                    Links[0].VisualRegion = visualRegion;
+                }
+
+                _textRegion = visualRegion;
             }
-            finally
-            {
-                textFormat.Dispose();
-            }
+
+            _textLayoutValid = true;
         }
 
         internal override StringFormat CreateStringFormat()
@@ -767,7 +620,7 @@ namespace System.Windows.Forms
                 int charEnd = ConvertToCharIndex(link.Start + link.Length, text);
                 if (LinkInText(charStart, charEnd - charStart))
                 {
-                    int length = (int)Math.Min(link.Length, textLen - link.Start);
+                    int length = Math.Min(link.Length, textLen - link.Start);
                     ranges.Add(new CharacterRange(charStart, ConvertToCharIndex(link.Start + length, text) - charStart));
                 }
             }
@@ -779,7 +632,7 @@ namespace System.Windows.Forms
 
         /// <summary>
         ///  Determines whether the whole link label contains only one link,
-        ///  and the link runs from the beginning of the label to the end of it
+        ///  and the link runs from the beginning of the label to the end of it.
         /// </summary>
         private bool IsOneLink()
         {
@@ -798,37 +651,29 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Determines if the given client coordinates is contained within a portion
-        ///  of a link area.
+        ///  Determines if the given client coordinates is contained within a portion of a link area.
         /// </summary>
         protected Link? PointInLink(int x, int y)
         {
-            Graphics g = CreateGraphicsInternal();
+            using Graphics g = CreateGraphicsInternal();
             Link? hit = null;
-            try
+
+            EnsureRun(g);
+            foreach (Link link in _links)
             {
-                EnsureRun(g);
-                foreach (Link link in _links)
+                if (link.VisualRegion is not null && link.VisualRegion.IsVisible(x, y, g))
                 {
-                    if (link.VisualRegion is not null && link.VisualRegion.IsVisible(x, y, g))
-                    {
-                        hit = link;
-                        break;
-                    }
+                    hit = link;
+                    break;
                 }
-            }
-            finally
-            {
-                g.Dispose();
             }
 
             return hit;
         }
 
         /// <summary>
-        ///  Invalidates only the portions of the text that is linked to
-        ///  the specified link. If link is null, then all linked text
-        ///  is invalidated.
+        ///  Invalidates only the portions of the text that is linked to the specified link. If link is null, then
+        ///  all linked text is invalidated.
         /// </summary>
         private void InvalidateLink(Link? link)
         {
@@ -846,8 +691,7 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Invalidates the current set of fonts we use when painting
-        ///  links.  The fonts will be recreated when needed.
+        ///  Invalidates the current set of fonts we use when painting links. The fonts will be recreated when needed.
         /// </summary>
         private void InvalidateLinkFonts()
         {
@@ -862,31 +706,19 @@ namespace System.Windows.Forms
             _hoverLinkFont = null;
         }
 
-        private void InvalidateTextLayout()
-        {
-            _textLayoutValid = false;
-        }
+        private void InvalidateTextLayout() => _textLayoutValid = false;
 
-        private bool LinkInText(int start, int length)
-        {
-            return (start >= 0 && start < Text.Length && length > 0);
-        }
+        private bool LinkInText(int start, int length) => start >= 0 && start < Text.Length && length > 0;
 
         /// <summary>
-        ///  Gets or sets a value that is returned to the
-        ///  parent form when the link label.
-        ///  is clicked.
+        ///  Gets or sets a value that is returned to the parent form when the link label is clicked.
         /// </summary>
         DialogResult IButtonControl.DialogResult
         {
-            get
-            {
-                return _dialogResult;
-            }
-
+            get => _dialogResult;
             set
             {
-                //valid values are 0x0 to 0x7
+                // Valid values are 0x0 to 0x7
                 SourceGenerated.EnumValidator.Validate(value);
 
                 _dialogResult = value;
@@ -897,9 +729,6 @@ namespace System.Windows.Forms
         {
         }
 
-        /// <summary>
-        ///  Raises the <see cref="Control.GotFocus"/> event.
-        /// </summary>
         protected override void OnGotFocus(EventArgs e)
         {
             if (!_processingOnGotFocus)
@@ -915,7 +744,7 @@ namespace System.Windows.Forms
                 {
                     // Set focus on first link.
                     // This will raise the OnGotFocus event again but it will not be processed because processingOnGotFocus is true.
-                    Select(true /*directed*/, true /*forward*/);
+                    Select(directed: true, forward: true);
                 }
                 else
                 {
@@ -932,10 +761,6 @@ namespace System.Windows.Forms
             }
         }
 
-        /// <summary>
-        ///  Raises the <see cref="Control.LostFocus"/>
-        ///  event.
-        /// </summary>
         protected override void OnLostFocus(EventArgs e)
         {
             base.OnLostFocus(e);
@@ -946,10 +771,6 @@ namespace System.Windows.Forms
             }
         }
 
-        /// <summary>
-        ///  Raises the <see cref="Control.OnKeyDown"/>
-        ///  event.
-        /// </summary>
         protected override void OnKeyDown(KeyEventArgs e)
         {
             base.OnKeyDown(e);
@@ -963,10 +784,6 @@ namespace System.Windows.Forms
             }
         }
 
-        /// <summary>
-        ///  Raises the <see cref="Control.OnMouseLeave"/>
-        ///  event.
-        /// </summary>
         protected override void OnMouseLeave(EventArgs e)
         {
             base.OnMouseLeave(e);
@@ -993,10 +810,6 @@ namespace System.Windows.Forms
             }
         }
 
-        /// <summary>
-        ///  Raises the <see cref="Control.OnMouseDown"/>
-        ///  event.
-        /// </summary>
         protected override void OnMouseDown(MouseEventArgs e)
         {
             base.OnMouseDown(e);
@@ -1026,10 +839,6 @@ namespace System.Windows.Forms
             }
         }
 
-        /// <summary>
-        ///  Raises the <see cref="Control.OnMouseUp"/>
-        ///  event.
-        /// </summary>
         protected override void OnMouseUp(MouseEventArgs e)
         {
             base.OnMouseUp(e);
@@ -1063,10 +872,6 @@ namespace System.Windows.Forms
             }
         }
 
-        /// <summary>
-        ///  Raises the <see cref="Control.OnMouseMove"/>
-        ///  event.
-        /// </summary>
         protected override void OnMouseMove(MouseEventArgs e)
         {
             base.OnMouseMove(e);
@@ -1137,13 +942,10 @@ namespace System.Windows.Forms
             InvalidateTextLayout();
         }
 
-        /// <summary>
-        ///  Raises the <see cref="Control.OnPaint"/>
-        ///  event.
-        /// </summary>
         protected override void OnPaint(PaintEventArgs e)
         {
-            RectangleF finalrect = RectangleF.Empty;   //the focus rectangle if there is only one link
+            // The focus rectangle if there is only one link
+            RectangleF finalrect = RectangleF.Empty;
             Animate();
 
             ImageAnimator.UpdateFrames(Image);
@@ -1154,7 +956,6 @@ namespace System.Windows.Forms
 
             if (Text.Length == 0)
             {
-                // bail early for no text
                 PaintLinkBackground(g);
             }
             else
@@ -1164,7 +965,7 @@ namespace System.Windows.Forms
                 {
                     Rectangle clientRect = ClientRectWithPadding;
                     Size preferredSize = GetPreferredSize(new Size(clientRect.Width, clientRect.Height));
-                    _showToolTip = (clientRect.Width < preferredSize.Width || clientRect.Height < preferredSize.Height);
+                    _showToolTip = clientRect.Width < preferredSize.Width || clientRect.Height < preferredSize.Height;
                 }
                 else
                 {
@@ -1175,119 +976,110 @@ namespace System.Windows.Forms
                 {
                     // Control.Enabled not to be confused with Link.Enabled
                     bool optimizeBackgroundRendering = !GetStyle(ControlStyles.OptimizedDoubleBuffer);
-                    var foreBrush = ForeColor.GetCachedSolidBrushScope();
-                    var linkBrush = LinkColor.GetCachedSolidBrushScope();
+                    using var foreBrush = ForeColor.GetCachedSolidBrushScope();
+                    using var linkBrush = LinkColor.GetCachedSolidBrushScope();
+
+                    if (!optimizeBackgroundRendering)
+                    {
+                        PaintLinkBackground(g);
+                    }
+
+                    LinkUtilities.EnsureLinkFonts(Font, LinkBehavior, ref _linkFont, ref _hoverLinkFont);
+
+                    Region originalClip = g.Clip;
 
                     try
                     {
-                        if (!optimizeBackgroundRendering)
+                        if (IsOneLink())
                         {
-                            PaintLinkBackground(g);
+                            // Exclude the area to draw the focus rectangle.
+                            g.Clip = originalClip;
+                            RectangleF[]? rects = _links[0].VisualRegion?.GetRegionScans(e.GraphicsInternal.Transform);
+                            if (rects is not null && rects.Length > 0)
+                            {
+                                if (UseCompatibleTextRendering)
+                                {
+                                    finalrect = new RectangleF(rects[0].Location, SizeF.Empty);
+                                    foreach (RectangleF rect in rects)
+                                    {
+                                        finalrect = RectangleF.Union(finalrect, rect);
+                                    }
+                                }
+                                else
+                                {
+                                    finalrect = ClientRectWithPadding;
+                                    Size finalRectSize = finalrect.Size.ToSize();
+
+                                    Size requiredSize = MeasureTextCache.GetTextSize(Text, Font, finalRectSize, CreateTextFormatFlags(finalRectSize));
+
+                                    finalrect.Width = requiredSize.Width;
+
+                                    if (requiredSize.Height < finalrect.Height)
+                                    {
+                                        finalrect.Height = requiredSize.Height;
+                                    }
+
+                                    finalrect = CalcTextRenderBounds(Rectangle.Round(finalrect), ClientRectWithPadding, RtlTranslateContent(TextAlign));
+                                }
+
+                                using (Region region = new Region(finalrect))
+                                {
+                                    g.ExcludeClip(region);
+                                }
+                            }
                         }
-
-                        LinkUtilities.EnsureLinkFonts(Font, LinkBehavior, ref _linkFont, ref _hoverLinkFont);
-
-                        Region originalClip = g.Clip;
-
-                        try
+                        else
                         {
-                            if (IsOneLink())
-                            {
-                                //exclude the area to draw the focus rectangle
-                                g.Clip = originalClip;
-                                RectangleF[]? rects = _links[0].VisualRegion?.GetRegionScans(e.GraphicsInternal.Transform);
-                                if (rects is not null && rects.Length > 0)
-                                {
-                                    if (UseCompatibleTextRendering)
-                                    {
-                                        finalrect = new RectangleF(rects[0].Location, SizeF.Empty);
-                                        foreach (RectangleF rect in rects)
-                                        {
-                                            finalrect = RectangleF.Union(finalrect, rect);
-                                        }
-                                    }
-                                    else
-                                    {
-                                        finalrect = ClientRectWithPadding;
-                                        Size finalRectSize = finalrect.Size.ToSize();
-
-                                        Size requiredSize = MeasureTextCache.GetTextSize(Text, Font, finalRectSize, CreateTextFormatFlags(finalRectSize));
-
-                                        finalrect.Width = requiredSize.Width;
-
-                                        if (requiredSize.Height < finalrect.Height)
-                                        {
-                                            finalrect.Height = requiredSize.Height;
-                                        }
-
-                                        finalrect = CalcTextRenderBounds(Rectangle.Round(finalrect) /*textRect*/, ClientRectWithPadding /*clientRect*/, RtlTranslateContent(TextAlign));
-                                    }
-
-                                    using (Region region = new Region(finalrect))
-                                    {
-                                        g.ExcludeClip(region);
-                                    }
-                                }
-                            }
-                            else
-                            {
-                                foreach (Link link in _links)
-                                {
-                                    if (link.VisualRegion is not null)
-                                    {
-                                        g.ExcludeClip(link.VisualRegion);
-                                    }
-                                }
-                            }
-
-                            // When there is only one link in link label,
-                            // it's not necessary to paint with foreBrush first
-                            // as it will be overlapped by linkBrush in the following steps
-
-                            if (!IsOneLink())
-                            {
-                                PaintLink(
-                                    e,
-                                    link: null,
-                                    foreBrush,
-                                    linkBrush,
-                                    _linkFont,
-                                    _hoverLinkFont,
-                                    optimizeBackgroundRendering,
-                                    finalrect);
-                            }
-
                             foreach (Link link in _links)
                             {
-                                PaintLink(
-                                    e,
-                                    link,
-                                    foreBrush,
-                                    linkBrush,
-                                    _linkFont,
-                                    _hoverLinkFont,
-                                    optimizeBackgroundRendering,
-                                    finalrect);
-                            }
-
-                            if (optimizeBackgroundRendering)
-                            {
-                                g.Clip = originalClip;
-
-                                // Because the code has been like that since long time, we assume that _textRegion is not null.
-                                g.ExcludeClip(_textRegion!);
-                                PaintLinkBackground(g);
+                                if (link.VisualRegion is not null)
+                                {
+                                    g.ExcludeClip(link.VisualRegion);
+                                }
                             }
                         }
-                        finally
+
+                        // When there is only one link in link label, it's not necessary to paint with foreBrush
+                        // first as it will be overlapped by linkBrush in the following steps.
+
+                        if (!IsOneLink())
+                        {
+                            PaintLink(
+                                e,
+                                link: null,
+                                foreBrush,
+                                linkBrush,
+                                _linkFont,
+                                _hoverLinkFont,
+                                optimizeBackgroundRendering,
+                                finalrect);
+                        }
+
+                        foreach (Link link in _links)
+                        {
+                            PaintLink(
+                                e,
+                                link,
+                                foreBrush,
+                                linkBrush,
+                                _linkFont,
+                                _hoverLinkFont,
+                                optimizeBackgroundRendering,
+                                finalrect);
+                        }
+
+                        if (optimizeBackgroundRendering)
                         {
                             g.Clip = originalClip;
+
+                            // This shouldn't be null, but it would require significant refactoring to encapsulate.
+                            g.ExcludeClip(_textRegion!);
+                            PaintLinkBackground(g);
                         }
                     }
                     finally
                     {
-                        foreBrush.Dispose();
-                        linkBrush.Dispose();
+                        g.Clip = originalClip;
                     }
                 }
                 else
@@ -1302,13 +1094,12 @@ namespace System.Windows.Forms
 
                         PaintLinkBackground(g);
 
-                        // Because the code has been like that since long time, we assume that _textRegion is not null.
-                        g.IntersectClip(_textRegion!);
-
                         if (UseCompatibleTextRendering)
                         {
-                            // APPCOMPAT: Use DisabledColor because Everett used DisabledColor.
-                            // (ie, don't use Graphics.GetNearestColor(DisabledColor.)
+                            // The clipping only applies when rendering through GDI+. The region shouldn't be null, but
+                            // it would require significant refactoring to encapsulate.
+                            g.IntersectClip(_textRegion!);
+
                             StringFormat stringFormat = CreateStringFormat();
                             ControlPaint.DrawStringDisabled(g, Text, Font, DisabledColor, ClientRectWithPadding, stringFormat);
                         }
@@ -1393,12 +1184,9 @@ namespace System.Windows.Forms
             InvalidateTextLayout();
         }
 
-        /// <summary>
-        ///  Overriden by LinkLabel.
-        /// </summary>
         internal override void OnAutoEllipsisChanged()
         {
-            base.OnAutoEllipsisChanged(/*e*/);
+            base.OnAutoEllipsisChanged();
             InvalidateTextLayout();
         }
 
@@ -1444,7 +1232,6 @@ namespace System.Windows.Forms
             bool optimizeBackgroundRendering,
             RectangleF finalrect)
         {
-            // link = null means paint the whole text
             Graphics g = e.GraphicsInternal;
 
             Debug.Assert(g is not null, "Must pass valid graphics");
@@ -1455,133 +1242,134 @@ namespace System.Windows.Forms
 
             if (link is not null)
             {
-                if (link.VisualRegion is not null)
+                if (link.VisualRegion is null)
                 {
-                    Color brushColor = Color.Empty;
-                    LinkState linkState = link.State;
-
-                    font = (linkState & LinkState.Hover) == LinkState.Hover ? hoverLinkFont : linkFont;
-
-                    if (link.Enabled)
-                    {
-                        // Not to be confused with Control.Enabled.
-                        if ((linkState & LinkState.Active) == LinkState.Active)
-                        {
-                            brushColor = ActiveLinkColor;
-                        }
-                        else if ((linkState & LinkState.Visited) == LinkState.Visited)
-                        {
-                            brushColor = VisitedLinkColor;
-                        }
-                    }
-                    else
-                    {
-                        brushColor = DisabledLinkColor;
-                    }
-
-                    g.Clip = IsOneLink() ? new Region(finalrect) : link.VisualRegion;
-
-                    if (optimizeBackgroundRendering)
-                    {
-                        PaintLinkBackground(g);
-                    }
-
-                    if (brushColor == Color.Empty)
-                    {
-                        brushColor = linkBrush.Color;
-                    }
-
-                    if (UseCompatibleTextRendering)
-                    {
-                        using var useBrush = brushColor.GetCachedSolidBrushScope();
-                        StringFormat stringFormat = CreateStringFormat();
-                        g.DrawString(Text, font, useBrush, ClientRectWithPadding, stringFormat);
-                    }
-                    else
-                    {
-                        brushColor = g.FindNearestColor(brushColor);
-
-                        Rectangle clientRectWithPadding = ClientRectWithPadding;
-
-#pragma warning disable SA1009 // Closing parenthesis should be spaced correctly
-                        TextRenderer.DrawText(
-                            g,
-                            Text,
-                            font,
-                            clientRectWithPadding,
-                            brushColor,
-                            CreateTextFormatFlags(clientRectWithPadding.Size)
-#if DEBUG
-                            // Skip the asserts in TextRenderer because the DC has been modified
-                            | TextRenderer.SkipAssertFlag
-#endif
-                            );
-#pragma warning restore SA1009 // Closing parenthesis should be spaced correctly
-                    }
-
-                    if (Focused && ShowFocusCues && FocusLink == link)
-                    {
-                        // Get the rectangles making up the visual region, and draw each one.
-                        RectangleF[] rects = link.VisualRegion.GetRegionScans(g.Transform);
-                        if (rects is not null && rects.Length > 0)
-                        {
-                            Rectangle focusRect;
-
-                            if (IsOneLink())
-                            {
-                                // Draw one merged focus rectangle
-                                focusRect = Rectangle.Ceiling(finalrect);
-                                Debug.Assert(finalrect != RectangleF.Empty, "finalrect should be initialized");
-
-                                ControlPaint.DrawFocusRectangle(g, focusRect, ForeColor, BackColor);
-                            }
-                            else
-                            {
-                                foreach (RectangleF rect in rects)
-                                {
-                                    ControlPaint.DrawFocusRectangle(g, Rectangle.Ceiling(rect), ForeColor, BackColor);
-                                }
-                            }
-                        }
-                    }
+                    // Don't paint anything if we are given a link with no visual region.
+                    return;
                 }
 
-                // no else clause... we don't paint anything if we are given a link with no visual region.
-            }
-            else
-            {
-                // Painting with no link.
-                // Because the code has been like that since long time, we assume that _textRegion is not null.
-                g.IntersectClip(_textRegion!);
+                Color brushColor = Color.Empty;
+                LinkState linkState = link.State;
+
+                font = (linkState & LinkState.Hover) == LinkState.Hover ? hoverLinkFont : linkFont;
+
+                if (link.Enabled)
+                {
+                    // Not to be confused with Control.Enabled.
+                    if ((linkState & LinkState.Active) == LinkState.Active)
+                    {
+                        brushColor = ActiveLinkColor;
+                    }
+                    else if ((linkState & LinkState.Visited) == LinkState.Visited)
+                    {
+                        brushColor = VisitedLinkColor;
+                    }
+                }
+                else
+                {
+                    brushColor = DisabledLinkColor;
+                }
+
+                g.Clip = IsOneLink() ? new Region(finalrect) : link.VisualRegion;
 
                 if (optimizeBackgroundRendering)
                 {
                     PaintLinkBackground(g);
                 }
 
+                if (brushColor == Color.Empty)
+                {
+                    brushColor = linkBrush.Color;
+                }
+
                 if (UseCompatibleTextRendering)
                 {
+                    using var useBrush = brushColor.GetCachedSolidBrushScope();
                     StringFormat stringFormat = CreateStringFormat();
-                    g.DrawString(Text, font, foreBrush, ClientRectWithPadding, stringFormat);
+                    g.DrawString(Text, font, useBrush, ClientRectWithPadding, stringFormat);
                 }
                 else
                 {
-                    Color color;
-                    using (var hdc = new DeviceContextHdcScope(g, applyGraphicsState: false))
-                    {
-                        color = ColorTranslator.FromWin32(
-                            (int)PInvoke.GetNearestColor(hdc, (COLORREF)(uint)ColorTranslator.ToWin32(foreBrush.Color)).Value);
-                    }
+                    brushColor = g.FindNearestColor(brushColor);
 
                     Rectangle clientRectWithPadding = ClientRectWithPadding;
+
+#pragma warning disable SA1009 // Closing parenthesis should be spaced correctly
                     TextRenderer.DrawText(
                         g,
                         Text,
                         font,
                         clientRectWithPadding,
-                        color,
-                        CreateTextFormatFlags(clientRectWithPadding.Size));
+                        brushColor,
+                        CreateTextFormatFlags(clientRectWithPadding.Size)
+#if DEBUG
+                        // Skip the asserts in TextRenderer because the DC has been modified
+                        | TextRenderer.SkipAssertFlag
+#endif
+                        );
+#pragma warning restore SA1009
                 }
+
+                if (Focused && ShowFocusCues && FocusLink == link)
+                {
+                    // Get the rectangles making up the visual region, and draw each one.
+                    RectangleF[] rects = link.VisualRegion.GetRegionScans(g.Transform);
+                    if (rects is not null && rects.Length > 0)
+                    {
+                        Rectangle focusRect;
+
+                        if (IsOneLink())
+                        {
+                            // Draw one merged focus rectangle
+                            focusRect = Rectangle.Ceiling(finalrect);
+                            Debug.Assert(finalrect != RectangleF.Empty, "finalrect should be initialized");
+
+                            ControlPaint.DrawFocusRectangle(g, focusRect, ForeColor, BackColor);
+                        }
+                        else
+                        {
+                            foreach (RectangleF rect in rects)
+                            {
+                                ControlPaint.DrawFocusRectangle(g, Rectangle.Ceiling(rect), ForeColor, BackColor);
+                            }
+                        }
+                    }
+                }
+
+                return;
+            }
+
+            // Painting with no link.
+            // Because the code has been like that since long time, we assume that _textRegion is not null.
+            g.IntersectClip(_textRegion!);
+
+            if (optimizeBackgroundRendering)
+            {
+                PaintLinkBackground(g);
+            }
+
+            if (UseCompatibleTextRendering)
+            {
+                StringFormat stringFormat = CreateStringFormat();
+                g.DrawString(Text, font, foreBrush, ClientRectWithPadding, stringFormat);
+            }
+            else
+            {
+                Color color;
+                using (var hdc = new DeviceContextHdcScope(g, applyGraphicsState: false))
+                {
+                    color = ColorTranslator.FromWin32(
+                        (int)PInvoke.GetNearestColor(hdc, (COLORREF)(uint)ColorTranslator.ToWin32(foreBrush.Color)).Value);
+                }
+
+                Rectangle clientRectWithPadding = ClientRectWithPadding;
+                TextRenderer.DrawText(
+                    g,
+                    Text,
+                    font,
+                    clientRectWithPadding,
+                    color,
+                    CreateTextFormatFlags(clientRectWithPadding.Size));
             }
         }
 
@@ -1595,7 +1383,7 @@ namespace System.Windows.Forms
 
         void IButtonControl.PerformClick()
         {
-            // If a link is not currently focused, focus on the first link
+            // If a link is not currently focused, focus on the first link.
             if (FocusLink is null && Links.Count > 0)
             {
                 string text = Text;
@@ -1611,25 +1399,13 @@ namespace System.Windows.Forms
                 }
             }
 
-            // Act as if the focused link was clicked
+            // Act as if the focused link was clicked.
             if (FocusLink is not null)
             {
                 OnLinkClicked(new LinkLabelLinkClickedEventArgs(FocusLink));
             }
         }
 
-        /// <summary>
-        ///  Processes a dialog key. This method is called during message pre-processing
-        ///  to handle dialog characters, such as TAB, RETURN, ESCAPE, and arrow keys. This
-        ///  method is called only if the isInputKey() method indicates that the control
-        ///  isn't interested in the key. processDialogKey() simply sends the character to
-        ///  the parent's processDialogKey() method, or returns false if the control has no
-        ///  parent. The Form class overrides this method to perform actual processing
-        ///  of dialog keys. When overriding processDialogKey(), a control should return true
-        ///  to indicate that it has processed the key. For keys that aren't processed by the
-        ///  control, the result of "base.processDialogChar()" should be returned. Controls
-        ///  will seldom, if ever, need to override this method.
-        /// </summary>
         protected override bool ProcessDialogKey(Keys keyData)
         {
             if ((keyData & (Keys.Alt | Keys.Control)) != Keys.Alt)
@@ -1723,8 +1499,8 @@ namespace System.Windows.Forms
                     }
                 }
                 while (test is not null
-                         && !test.Enabled
-                         && LinkInText(charStart, charEnd - charStart));
+                    && !test.Enabled
+                    && LinkInText(charStart, charEnd - charStart));
             }
             else
             {
@@ -1743,34 +1519,18 @@ namespace System.Windows.Forms
                     }
                 }
                 while (test is not null
-                         && !test.Enabled
-                         && LinkInText(charStart, charEnd - charStart));
+                    && !test.Enabled
+                    && LinkInText(charStart, charEnd - charStart));
             }
 
-            if (focusIndex < 0 || focusIndex >= _links.Count)
-            {
-                return -1;
-            }
-            else
-            {
-                return focusIndex;
-            }
+            return focusIndex < 0 || focusIndex >= _links.Count ? -1 : focusIndex;
         }
 
-        private void ResetLinkArea()
-        {
-            LinkArea = new LinkArea(0, -1);
-        }
+        private void ResetLinkArea() => LinkArea = new LinkArea(0, -1);
 
-        internal void ResetActiveLinkColor()
-        {
-            _activeLinkColor = Color.Empty;
-        }
+        internal void ResetActiveLinkColor() => _activeLinkColor = Color.Empty;
 
-        internal void ResetDisabledLinkColor()
-        {
-            _disabledLinkColor = Color.Empty;
-        }
+        internal void ResetDisabledLinkColor() => _disabledLinkColor = Color.Empty;
 
         internal void ResetLinkColor()
         {
@@ -1778,22 +1538,13 @@ namespace System.Windows.Forms
             InvalidateLink(null);
         }
 
-        private void ResetVisitedLinkColor()
-        {
-            _visitedLinkColor = Color.Empty;
-        }
+        private void ResetVisitedLinkColor() => _visitedLinkColor = Color.Empty;
 
-        /// <summary>
-        ///  Performs the work of setting the bounds of this control. Inheriting classes
-        ///  can override this function to add size restrictions. Inheriting classes must call
-        ///  base.setBoundsCore to actually cause the bounds of the control to change.
-        /// </summary>
         protected override void SetBoundsCore(int x, int y, int width, int height, BoundsSpecified specified)
         {
-            // we cache too much state to try and optimize this (regions, etc)... it is best
-            // to always relayout here... If we want to resurrect this code in the future,
-            // remember that we need to handle a word wrapped top aligned text that
-            // will become newly exposed (and therefore layed out) when we resize...
+            // We cache too much state to try and optimize this (regions, etc). It is best to always relayout here.
+            // If we want to resurrect this code in the future, remember that we need to handle a word wrapped top
+            // aligned text that will become newly exposed (and therefore layed out) when we resize.
             InvalidateTextLayout();
             Invalidate();
 
@@ -1802,42 +1553,38 @@ namespace System.Windows.Forms
 
         protected override void Select(bool directed, bool forward)
         {
-            if (directed)
+            // In a multi-link label, if the tab came from another control, we want to keep the currently
+            // focused link, otherwise, we set the focus to the next link.
+            if (directed && _links.Count > 0)
             {
-                // In a multi-link label, if the tab came from another control, we want to keep the currently
-                // focused link, otherwise, we set the focus to the next link.
-                if (_links.Count > 0)
+                // Find which link is currently focused
+                int focusIndex = -1;
+                if (FocusLink is not null)
                 {
-                    // Find which link is currently focused
-                    //
-                    int focusIndex = -1;
-                    if (FocusLink is not null)
-                    {
-                        focusIndex = _links.IndexOf(FocusLink);
-                    }
+                    focusIndex = _links.IndexOf(FocusLink);
+                }
 
-                    // We could be getting focus from ourself, so we must
-                    // invalidate each time.
-                    //
-                    FocusLink = null;
+                // We could be getting focus from ourself, so we must invalidate each time.
+                FocusLink = null;
 
-                    int newFocus = GetNextLinkIndex(focusIndex, forward);
-                    if (newFocus == -1)
+                int newFocus = GetNextLinkIndex(focusIndex, forward);
+                if (newFocus == -1)
+                {
+                    if (forward)
                     {
-                        if (forward)
-                        {
-                            newFocus = GetNextLinkIndex(-1, forward); // -1, so "next" will be 0
-                        }
-                        else
-                        {
-                            newFocus = GetNextLinkIndex(_links.Count, forward); // Count, so "next" will be Count-1
-                        }
+                        // -1, so "next" will be 0
+                        newFocus = GetNextLinkIndex(-1, forward);
                     }
+                    else
+                    {
+                        // Count, so "next" will be Count-1
+                        newFocus = GetNextLinkIndex(_links.Count, forward);
+                    }
+                }
 
-                    if (newFocus != -1)
-                    {
-                        FocusLink = _links[newFocus];
-                    }
+                if (newFocus != -1)
+                {
+                    FocusLink = _links[newFocus];
                 }
             }
 
@@ -1847,18 +1594,12 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Determines if the color for active links should remain the same.
         /// </summary>
-        internal bool ShouldSerializeActiveLinkColor()
-        {
-            return !_activeLinkColor.IsEmpty;
-        }
+        internal bool ShouldSerializeActiveLinkColor() => !_activeLinkColor.IsEmpty;
 
         /// <summary>
         ///  Determines if the color for disabled links should remain the same.
         /// </summary>
-        internal bool ShouldSerializeDisabledLinkColor()
-        {
-            return !_disabledLinkColor.IsEmpty;
-        }
+        internal bool ShouldSerializeDisabledLinkColor() => !_disabledLinkColor.IsEmpty;
 
         /// <summary>
         ///  Determines if the range in text that is treated as a link should remain the same.
@@ -1877,10 +1618,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Determines if the color of links in normal cases should remain the same.
         /// </summary>
-        internal bool ShouldSerializeLinkColor()
-        {
-            return !_linkColor.IsEmpty;
-        }
+        internal bool ShouldSerializeLinkColor() => !_linkColor.IsEmpty;
 
         /// <summary>
         ///  Determines whether designer should generate code for setting the UseCompatibleTextRendering or not.
@@ -1895,10 +1633,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Determines if the color of links that have been visited should remain the same.
         /// </summary>
-        private bool ShouldSerializeVisitedLinkColor()
-        {
-            return !_visitedLinkColor.IsEmpty;
-        }
+        private bool ShouldSerializeVisitedLinkColor() => !_visitedLinkColor.IsEmpty;
 
         /// <summary>
         ///  Update accessibility with the currently focused link.
@@ -1975,7 +1710,6 @@ namespace System.Windows.Forms
             else
             {
                 // If a link is currently focused, de-select it
-                //
                 if (FocusLink is not null)
                 {
                     FocusLink = null;
@@ -1987,9 +1721,6 @@ namespace System.Windows.Forms
             SetStyle(ControlStyles.Selectable, selectable);
         }
 
-        /// <summary>
-        ///  Determines whether to use compatible text rendering engine (GDI+) or not (GDI).
-        /// </summary>
         [RefreshProperties(RefreshProperties.Repaint)]
         [SRCategory(nameof(SR.CatBehavior))]
         [SRDescription(nameof(SR.UseCompatibleTextRenderingDescr))]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewControl.cs
@@ -534,10 +534,10 @@ namespace System.Windows.Forms
                 if (pageInfo is not null || exceptionPrinting)
                 {
                     // Calculate formats
-                    using StringFormat format = new StringFormat
+                    using StringFormat format = new()
                     {
-                        Alignment = ControlPaint.TranslateAlignment(ContentAlignment.MiddleCenter),
-                        LineAlignment = ControlPaint.TranslateLineAlignment(ContentAlignment.MiddleCenter)
+                        Alignment = StringAlignment.Center,
+                        LineAlignment = StringAlignment.Center
                     };
 
                     // Do actual drawing

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBox.cs
@@ -879,8 +879,7 @@ namespace System.Windows.Forms
         /// </summary>
         private void DrawPlaceholderText(HDC hdc)
         {
-            TextFormatFlags flags = TextFormatFlags.NoPadding | TextFormatFlags.Top |
-                                    TextFormatFlags.EndEllipsis;
+            TextFormatFlags flags = TextFormatFlags.NoPadding | TextFormatFlags.Top | TextFormatFlags.EndEllipsis;
             Rectangle rectangle = ClientRectangle;
 
             if (RightToLeft == RightToLeft.Yes)
@@ -925,11 +924,6 @@ namespace System.Windows.Forms
             TextRenderer.DrawTextInternal(hdc, PlaceholderText, Font, rectangle, SystemColors.GrayText, TextRenderer.DefaultQuality, flags);
         }
 
-        /// <summary>
-        ///  The edits window procedure.  Inheriting classes can override this
-        ///  to add extra functionality, but should not forget to call
-        ///  base.wndProc(m); to ensure the combo continues to function properly.
-        /// </summary>
         protected override unsafe void WndProc(ref Message m)
         {
             switch ((User32.WM)m.Msg)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextExtensions.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextExtensions.cs
@@ -7,297 +7,296 @@ using System.Drawing;
 using System.Windows.Forms.Internal;
 using static Interop;
 
-namespace System.Windows.Forms
+namespace System.Windows.Forms;
+
+internal static class TextExtensions
 {
-    internal static class TextExtensions
+    // The value of the ItalicPaddingFactor comes from several tests using different fonts & drawing
+    // flags and some benchmarking with GDI+.
+    private const float ItalicPaddingFactor = 1 / 2f;
+
+    // Used to clear TextRenderer specific flags from TextFormatFlags
+    internal const int GdiUnsupportedFlagMask = unchecked((int)0xFF000000);
+
+    [Conditional("DEBUG")]
+    private static void ValidateFlags(User32.DT flags)
     {
-        // The value of the ItalicPaddingFactor comes from several tests using different fonts & drawing
-        // flags and some benchmarking with GDI+.
-        private const float ItalicPaddingFactor = 1 / 2f;
+        Debug.Assert(((uint)flags & GdiUnsupportedFlagMask) == 0,
+            "Some custom flags were left over and are not GDI compliant!");
+    }
 
-        // Used to clear TextRenderer specific flags from TextFormatFlags
-        internal const int GdiUnsupportedFlagMask = (unchecked((int)0xFF000000));
-
-        [Conditional("DEBUG")]
-        private static void ValidateFlags(User32.DT flags)
+    private static (User32.DT Flags, TextPaddingOptions Padding) SplitTextFormatFlags(TextFormatFlags flags)
+    {
+        if (((uint)flags & GdiUnsupportedFlagMask) == 0)
         {
-            Debug.Assert(((uint)flags & GdiUnsupportedFlagMask) == 0,
-                "Some custom flags were left over and are not GDI compliant!");
+            return ((User32.DT)flags, TextPaddingOptions.GlyphOverhangPadding);
         }
 
-        private static (User32.DT Flags, TextPaddingOptions Padding) SplitTextFormatFlags(TextFormatFlags flags)
+        // Clear TextRenderer custom flags.
+        User32.DT windowsGraphicsSupportedFlags = (User32.DT)((uint)flags & ~GdiUnsupportedFlagMask);
+
+        TextPaddingOptions padding = flags.HasFlag(TextFormatFlags.LeftAndRightPadding)
+            ? TextPaddingOptions.LeftAndRightPadding
+            : flags.HasFlag(TextFormatFlags.NoPadding)
+                ? TextPaddingOptions.NoPadding
+                : TextPaddingOptions.GlyphOverhangPadding;
+
+        return (windowsGraphicsSupportedFlags, padding);
+    }
+
+    /// <summary>
+    ///  Draws the given <paramref name="text"/> text in the given <paramref name="hdc"/>.
+    /// </summary>
+    /// <param name="backColor">If <see cref="Color.Empty"/>, the hdc current background color is used.</param>
+    /// <param name="foreColor">If <see cref="Color.Empty"/>, the hdc current foreground color is used.</param>
+    public static void DrawText(
+        this HDC hdc,
+        ReadOnlySpan<char> text,
+        FontCache.Scope font,
+        Rectangle bounds,
+        Color foreColor,
+        TextFormatFlags flags,
+        Color backColor = default)
+    {
+        if (text.IsEmpty || foreColor == Color.Transparent)
         {
-            if (((uint)flags & GdiUnsupportedFlagMask) == 0)
-            {
-                return ((User32.DT)flags, TextPaddingOptions.GlyphOverhangPadding);
-            }
-
-            // Clear TextRenderer custom flags.
-            User32.DT windowsGraphicsSupportedFlags = (User32.DT)((uint)flags & ~GdiUnsupportedFlagMask);
-
-            TextPaddingOptions padding = flags.HasFlag(TextFormatFlags.LeftAndRightPadding)
-                ? TextPaddingOptions.LeftAndRightPadding
-                : flags.HasFlag(TextFormatFlags.NoPadding)
-                    ? TextPaddingOptions.NoPadding
-                    : TextPaddingOptions.GlyphOverhangPadding;
-
-            return (windowsGraphicsSupportedFlags, padding);
+            return;
         }
 
-        /// <summary>
-        ///  Draws the text in the given bounds, using the given Font, foreColor and backColor, and according to the specified
-        ///  TextFormatFlags flags.
-        ///
-        ///  If font is null, the font currently selected in the hdc is used.
-        ///
-        ///  If foreColor and/or backColor are Color.Empty, the hdc current text and/or background color are used.
-        /// </summary>
-        public static void DrawText(
-            this HDC hdc,
-            ReadOnlySpan<char> text,
-            FontCache.Scope font,
-            Rectangle bounds,
-            Color foreColor,
-            TextFormatFlags flags,
-            Color backColor = default)
+        (User32.DT dt, TextPaddingOptions padding) = SplitTextFormatFlags(flags);
+
+        // DrawText requires default text alignment.
+        using PInvoke.SetTextAlignmentScope alignment = new(hdc, default);
+
+        // Color empty means use the one currently selected in the dc.
+        using var textColor = foreColor.IsEmpty ? default : new PInvoke.SetTextColorScope(hdc, foreColor);
+        using PInvoke.SelectObjectScope fontSelection = new(hdc, (HFONT)font);
+
+        BACKGROUND_MODE newBackGroundMode = (backColor.IsEmpty || backColor == Color.Transparent)
+            ? BACKGROUND_MODE.TRANSPARENT
+            : BACKGROUND_MODE.OPAQUE;
+
+        using PInvoke.SetBkModeScope backgroundMode = new(hdc, newBackGroundMode);
+        using var backgroundColor = newBackGroundMode != BACKGROUND_MODE.TRANSPARENT
+            ? new PInvoke.SetBackgroundColorScope(hdc, backColor)
+            : default;
+
+        User32.DRAWTEXTPARAMS dtparams = GetTextMargins(font, padding);
+
+        bounds = AdjustForVerticalAlignment(hdc, text, bounds, dt, ref dtparams);
+
+        // Adjust unbounded rect to avoid overflow.
+        if (bounds.Width == int.MaxValue)
         {
-            if (text.IsEmpty || foreColor == Color.Transparent)
-                return;
-
-            (User32.DT dt, TextPaddingOptions padding) = SplitTextFormatFlags(flags);
-
-            // DrawText requires default text alignment.
-            using PInvoke.SetTextAlignmentScope alignment = new(hdc, default);
-
-            // Color empty means use the one currently selected in the dc.
-            using var textColor = foreColor.IsEmpty ? default : new PInvoke.SetTextColorScope(hdc, foreColor);
-            using PInvoke.SelectObjectScope fontSelection = new(hdc, (HFONT)font);
-
-            BACKGROUND_MODE newBackGroundMode = (backColor.IsEmpty || backColor == Color.Transparent) ?
-                BACKGROUND_MODE.TRANSPARENT :
-                BACKGROUND_MODE.OPAQUE;
-
-            using PInvoke.SetBkModeScope backgroundMode = new(hdc, newBackGroundMode);
-            using var backgroundColor = newBackGroundMode != BACKGROUND_MODE.TRANSPARENT
-                ? new PInvoke.SetBackgroundColorScope(hdc, backColor)
-                : default;
-
-            User32.DRAWTEXTPARAMS dtparams = GetTextMargins(font, padding);
-
-            bounds = AdjustForVerticalAlignment(hdc, text, bounds, dt, ref dtparams);
-
-            // Adjust unbounded rect to avoid overflow since Rectangle ctr does not do param validation.
-            if (bounds.Width == TextRenderer.MaxSize.Width)
-            {
-                bounds.Width -= bounds.X;
-            }
-
-            if (bounds.Height == TextRenderer.MaxSize.Height)
-            {
-                bounds.Height -= bounds.Y;
-            }
-
-            RECT rect = bounds;
-            User32.DrawTextExW(hdc, text, ref rect, dt, ref dtparams);
+            bounds.Width -= bounds.X;
         }
 
-        /// <summary>
-        ///  Get the bounding box internal text padding to be used when drawing text.
-        /// </summary>
-        public static User32.DRAWTEXTPARAMS GetTextMargins(
-            this FontCache.Scope font,
-            TextPaddingOptions padding = default)
+        if (bounds.Height == int.MaxValue)
         {
-            // DrawText(Ex) adds a small space at the beginning of the text bounding box but not at the end,
-            // this is more noticeable when the font has the italic style.  We compensate with this factor.
-
-            int leftMargin = 0;
-            int rightMargin = 0;
-            float overhangPadding;
-
-            switch (padding)
-            {
-                case TextPaddingOptions.GlyphOverhangPadding:
-                    // [overhang padding][Text][overhang padding][italic padding]
-                    overhangPadding = font.Data.Height / 6f;
-                    leftMargin = (int)Math.Ceiling(overhangPadding);
-                    rightMargin = (int)Math.Ceiling(overhangPadding * (1 + ItalicPaddingFactor));
-                    break;
-
-                case TextPaddingOptions.LeftAndRightPadding:
-                    // [2 * overhang padding][Text][2 * overhang padding][italic padding]
-                    overhangPadding = font.Data.Height / 6f;
-                    leftMargin = (int)Math.Ceiling(2 * overhangPadding);
-                    rightMargin = (int)Math.Ceiling(overhangPadding * (2 + ItalicPaddingFactor));
-                    break;
-
-                case TextPaddingOptions.NoPadding:
-                default:
-                    break;
-            }
-
-            return new User32.DRAWTEXTPARAMS
-            {
-                iLeftMargin = leftMargin,
-                iRightMargin = rightMargin
-            };
+            bounds.Height -= bounds.Y;
         }
 
-        /// <summary>
-        ///  The GDI DrawText does not do multiline alignment when User32.DT.SINGLELINE is not set. This
-        ///  adjustment is to workaround that limitation. We don't want to duplicate SelectObject calls here,
-        ///  so put your Font in the dc before calling this.
-        ///
-        ///  AdjustForVerticalAlignment is only used when the text is multiline and it fits inside the bounds passed in.
-        ///  In that case we want the horizontal center of the multiline text to be at the horizontal center of the bounds.
-        ///
-        ///  If the text is multiline and it does not fit inside the bounds passed in, then return the bounds that were passed in.
-        ///  This way we paint the top of the text at the top of the bounds passed in.
-        /// </summary>
-        public static Rectangle AdjustForVerticalAlignment(
-            this HDC hdc,
-            ReadOnlySpan<char> text,
-            Rectangle bounds,
-            User32.DT flags,
-            ref User32.DRAWTEXTPARAMS dtparams)
+        RECT rect = bounds;
+        User32.DrawTextExW(hdc, text, ref rect, dt, ref dtparams);
+    }
+
+    /// <summary>
+    ///  Get the bounding box internal text padding to be used when drawing text.
+    /// </summary>
+    public static User32.DRAWTEXTPARAMS GetTextMargins(
+        this FontCache.Scope font,
+        TextPaddingOptions padding = default)
+    {
+        // DrawText(Ex) adds a small space at the beginning of the text bounding box but not at the end,
+        // this is more noticeable when the font has the italic style.  We compensate with this factor.
+
+        int leftMargin = 0;
+        int rightMargin = 0;
+        float overhangPadding;
+
+        switch (padding)
         {
-            ValidateFlags(flags);
+            case TextPaddingOptions.GlyphOverhangPadding:
+                // [overhang padding][Text][overhang padding][italic padding]
+                overhangPadding = font.Data.Height / 6f;
+                leftMargin = (int)Math.Ceiling(overhangPadding);
+                rightMargin = (int)Math.Ceiling(overhangPadding * (1 + ItalicPaddingFactor));
+                break;
 
-            // Ok if any Top (Cannot test User32.DT.Top because it is 0), single line text or measuring text.
-            bool isTop = (flags & User32.DT.BOTTOM) == 0 && (flags & User32.DT.VCENTER) == 0;
-            if (isTop || ((flags & User32.DT.SINGLELINE) != 0) || ((flags & User32.DT.CALCRECT) != 0))
-            {
-                return bounds;
-            }
+            case TextPaddingOptions.LeftAndRightPadding:
+                // [2 * overhang padding][Text][2 * overhang padding][italic padding]
+                overhangPadding = font.Data.Height / 6f;
+                leftMargin = (int)Math.Ceiling(2 * overhangPadding);
+                rightMargin = (int)Math.Ceiling(overhangPadding * (2 + ItalicPaddingFactor));
+                break;
 
-            RECT rect = bounds;
-
-            // Get the text bounds.
-            flags |= User32.DT.CALCRECT;
-            int textHeight = User32.DrawTextExW(hdc, text, ref rect, flags, ref dtparams);
-
-            // if the text does not fit inside the bounds then return the bounds that were passed in
-            if (textHeight > bounds.Height)
-            {
-                return bounds;
-            }
-
-            Rectangle adjustedBounds = bounds;
-
-            if ((flags & User32.DT.VCENTER) != 0)
-            {
-                // Middle
-                adjustedBounds.Y = adjustedBounds.Top + adjustedBounds.Height / 2 - textHeight / 2;
-            }
-            else
-            {
-                // Bottom
-                adjustedBounds.Y = adjustedBounds.Bottom - textHeight;
-            }
-
-            return adjustedBounds;
+            case TextPaddingOptions.NoPadding:
+            default:
+                break;
         }
 
-        /// <summary>
-        ///  Returns the Size in logical units of the given text using the given Font, and according to the formatting flags.
-        ///  The proposed size is used to create a bounding rectangle as follows:
-        ///  - If there are multiple lines of text, DrawText uses the width of the rectangle pointed to by
-        ///  the lpRect parameter and extends the base of the rectangle to bound the last line of text.
-        ///  - If the largest word is wider than the rectangle, the width is expanded.
-        ///  - If the text is less than the width of the rectangle, the width is reduced.
-        ///  - If there is only one line of text, DrawText modifies the right side of the rectangle so that
-        ///  it bounds the last character in the line.
-        ///  If the font is null, the hdc's current font will be used.
-        ///
-        ///  Note for vertical fonts (if ever supported): DrawTextEx uses GetTextExtentPoint32 for measuring the text and this
-        ///  function has the following limitation (from MSDN):
-        ///  - This function assumes that the text is horizontal, that is, that the escapement is always 0. This is true for both
-        ///  the horizontal and vertical measurements of the text.  The application must convert it explicitly.
-        /// </summary>
-        public static Size MeasureText(
-            this HDC hdc,
-            ReadOnlySpan<char> text,
-            FontCache.Scope font,
-            Size proposedSize,
-            TextFormatFlags flags)
+        return new User32.DRAWTEXTPARAMS
         {
-            (User32.DT dt, TextPaddingOptions padding) = SplitTextFormatFlags(flags);
+            iLeftMargin = leftMargin,
+            iRightMargin = rightMargin
+        };
+    }
 
-            if (text.IsEmpty)
-            {
-                return Size.Empty;
-            }
+    /// <summary>
+    ///  Adjusts <paramref name="bounds"/> to allow for vertical alignment.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   The GDI DrawText does not do multiline alignment when User32.DT.SINGLELINE is not set. This
+    ///   adjustment is to workaround that limitation.
+    ///  </para>
+    /// </remarks>
+    public static Rectangle AdjustForVerticalAlignment(
+        this HDC hdc,
+        ReadOnlySpan<char> text,
+        Rectangle bounds,
+        User32.DT flags,
+        ref User32.DRAWTEXTPARAMS dtparams)
+    {
+        ValidateFlags(flags);
 
-            // DrawText returns a rectangle useful for aligning, but not guaranteed to encompass all
-            // pixels (its not a FitBlackBox, if the text is italicized, it will overhang on the right.)
-            // So we need to account for this.
-
-            User32.DRAWTEXTPARAMS dtparams = GetTextMargins(font, padding);
-
-            // If Width / Height are < 0, we need to make them larger or DrawText will return
-            // an unbounded measurement when we actually trying to make it very narrow.
-            int minWidth = 1 + dtparams.iLeftMargin + dtparams.iRightMargin;
-
-            if (proposedSize.Width <= minWidth)
-            {
-                proposedSize.Width = minWidth;
-            }
-
-            if (proposedSize.Height <= 0)
-            {
-                proposedSize.Height = 1;
-            }
-
-            RECT rect = new(proposedSize);
-
-            using PInvoke.SelectObjectScope fontSelection = new(hdc, font.Object);
-
-            // If proposedSize.Height >= MaxSize.Height it is assumed bounds needed.  If flags contain SINGLELINE and
-            // VCENTER or BOTTOM options, DrawTextEx does not bind the rectangle to the actual text height since
-            // it assumes the text is to be vertically aligned; we need to clear the VCENTER and BOTTOM flags to
-            // get the actual text bounds.
-            if (proposedSize.Height >= TextRenderer.MaxSize.Height && (dt & User32.DT.SINGLELINE) != 0)
-            {
-                // Clear vertical-alignment flags.
-                dt &= ~(User32.DT.BOTTOM | User32.DT.VCENTER);
-            }
-
-            if (proposedSize.Width == TextRenderer.MaxSize.Width)
-            {
-                // PERF: No constraining width means no word break.
-                // in this case, we don't care about word wrapping - there should be enough room to fit it all
-                dt &= ~(User32.DT.WORDBREAK);
-            }
-
-            dt |= User32.DT.CALCRECT;
-            User32.DrawTextExW(hdc, text, ref rect, dt, ref dtparams);
-
-            return rect.Size;
+        // No need to do anything if TOP (Cannot test DT_TOP because it is 0), single line text or measuring text.
+        bool isTop = !flags.HasFlag(User32.DT.BOTTOM) && !flags.HasFlag(User32.DT.VCENTER);
+        if (isTop || flags.HasFlag(User32.DT.SINGLELINE) || flags.HasFlag(User32.DT.CALCRECT))
+        {
+            return bounds;
         }
 
-        /// <summary>
-        ///  Returns the Size of the given text using the specified font if not null, otherwise the font currently
-        ///  set in the dc is used.
-        ///  This method is used to get the size in points of a line of text; it uses GetTextExtentPoint32 function
-        ///  which computes the width and height of the text ignoring TAB\CR\LF characters.
-        ///  A text extent is the distance between the beginning of the space and a character that will fit in the space.
-        /// </summary>
-        public static unsafe Size GetTextExtent(this HDC hdc, string? text, HFONT hfont)
+        RECT rect = bounds;
+
+        // Get the text bounds.
+        flags |= User32.DT.CALCRECT;
+        int textHeight = User32.DrawTextExW(hdc, text, ref rect, flags, ref dtparams);
+
+        // If the text does not fit inside the bounds then return the bounds that were passed in.
+        // This way we paint the top of the text at the top of the bounds passed in.
+        if (textHeight > bounds.Height)
         {
-            if (string.IsNullOrEmpty(text))
-            {
-                return Size.Empty;
-            }
-
-            Size size = default;
-            using PInvoke.SelectObjectScope selectFont = new(hdc, hfont);
-
-            fixed (char* pText = text)
-            {
-                PInvoke.GetTextExtentPoint32W(hdc, pText, text.Length, (SIZE*)(void*)&size);
-            }
-
-            return size;
+            return bounds;
         }
+
+        Rectangle adjustedBounds = bounds;
+
+        if (flags.HasFlag(User32.DT.VCENTER))
+        {
+            // Middle
+            adjustedBounds.Y = adjustedBounds.Top + adjustedBounds.Height / 2 - textHeight / 2;
+        }
+        else
+        {
+            // Bottom
+            adjustedBounds.Y = adjustedBounds.Bottom - textHeight;
+        }
+
+        return adjustedBounds;
+    }
+
+    /// <summary>
+    ///  Returns the bounds in logical units of the given <paramref name="text"/>.
+    /// </summary>
+    /// <param name="proposedSize">
+    ///  <para>
+    ///   The desired bounds. It will be modified as follows:
+    ///  </para>
+    ///  <list type="bullet">
+    ///   <item><description>The base is extended to fit multiple lines of text.</description></item>
+    ///   <item><description>The width is extended to fit the largest word.</description></item>
+    ///   <item><description>The width is reduced if the text is smaller than the requested width.</description></item>
+    ///   <item><description>The width is extended to fit a single line of text.</description></item>
+    ///  </list>
+    /// </param>
+    public static Size MeasureText(
+        this HDC hdc,
+        ReadOnlySpan<char> text,
+        FontCache.Scope font,
+        Size proposedSize,
+        TextFormatFlags flags)
+    {
+        (User32.DT dt, TextPaddingOptions padding) = SplitTextFormatFlags(flags);
+
+        if (text.IsEmpty)
+        {
+            return Size.Empty;
+        }
+
+        // DrawText returns a rectangle useful for aligning, but not guaranteed to encompass all
+        // pixels (its not a FitBlackBox, if the text is italicized, it will overhang on the right.)
+        // So we need to account for this.
+
+        User32.DRAWTEXTPARAMS dtparams = GetTextMargins(font, padding);
+
+        // If Width / Height are < 0, we need to make them larger or DrawText will return
+        // an unbounded measurement when we actually trying to make it very narrow.
+        int minWidth = 1 + dtparams.iLeftMargin + dtparams.iRightMargin;
+
+        if (proposedSize.Width <= minWidth)
+        {
+            proposedSize.Width = minWidth;
+        }
+
+        if (proposedSize.Height <= 0)
+        {
+            proposedSize.Height = 1;
+        }
+
+        RECT rect = new(proposedSize);
+
+        using PInvoke.SelectObjectScope fontSelection = new(hdc, font.Object);
+
+        // If proposedSize.Height == int.MaxValue it is assumed bounds are needed. If flags contain SINGLELINE and
+        // VCENTER or BOTTOM options, DrawTextEx does not bind the rectangle to the actual text height since
+        // it assumes the text is to be vertically aligned; we need to clear the VCENTER and BOTTOM flags to
+        // get the actual text bounds.
+        if (proposedSize.Height == int.MaxValue && dt.HasFlag(User32.DT.SINGLELINE))
+        {
+            // Clear vertical-alignment flags.
+            dt &= ~(User32.DT.BOTTOM | User32.DT.VCENTER);
+        }
+
+        if (proposedSize.Width == int.MaxValue)
+        {
+            // If there is no constraining width, there should be no need to calculate word breaks.
+            dt &= ~(User32.DT.WORDBREAK);
+        }
+
+        dt |= User32.DT.CALCRECT;
+        User32.DrawTextExW(hdc, text, ref rect, dt, ref dtparams);
+
+        return rect.Size;
+    }
+
+    /// <summary>
+    ///  Returns the dimensions the of the given <paramref name="text"/>.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   This method is used to get the size in logical units of a line of text; it uses GetTextExtentPoint32 function
+    ///   which computes the width and height of the text ignoring TAB\CR\LF characters.
+    ///  </para>
+    ///  <para>
+    ///   A text extent is the distance between the beginning of the space and a character that will fit in the space.
+    ///  </para>
+    /// </remarks>
+    public static unsafe Size GetTextExtent(this HDC hdc, string? text, HFONT hfont)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return Size.Empty;
+        }
+
+        Size size = default;
+        using PInvoke.SelectObjectScope selectFont = new(hdc, hfont);
+
+        fixed (char* pText = text)
+        {
+            PInvoke.GetTextExtentPoint32W(hdc, pText, text.Length, (SIZE*)(void*)&size);
+        }
+
+        return size;
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextFormatFlags.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextFormatFlags.cs
@@ -9,9 +9,6 @@ namespace System.Windows.Forms
     /// <summary>
     ///  Specifies the display and layout information for text strings.
     /// </summary>
-    /// <remarks>
-    ///  This is a public enum wrapping the internal <see cref="User32.DT"/>.
-    /// </remarks>
     [Flags]
     public enum TextFormatFlags
     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.ToolStripItemInternalLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.ToolStripItemInternalLayout.cs
@@ -81,7 +81,7 @@ namespace System.Windows.Forms
                 }
             }
 
-            internal static TextFormatFlags ContentAlignToTextFormat(ContentAlignment alignment, bool rightToLeft)
+            internal static TextFormatFlags ContentAlignmentToTextFormat(ContentAlignment alignment, bool rightToLeft)
             {
                 TextFormatFlags textFormat = TextFormatFlags.Default;
                 if (rightToLeft)
@@ -91,8 +91,7 @@ namespace System.Windows.Forms
                 }
 
                 // Calculate Text Positioning
-                textFormat |= ControlPaint.TranslateAlignmentForGDI(alignment);
-                textFormat |= ControlPaint.TranslateLineAlignmentForGDI(alignment);
+                textFormat |= ControlPaint.ConvertAlignmentToTextFormat(alignment);
                 return textFormat;
             }
 
@@ -126,7 +125,7 @@ namespace System.Windows.Forms
                 layoutOptions.DotNetOneButtonCompat = false;
 
                 // Support RTL
-                layoutOptions.GdiTextFormatFlags = ContentAlignToTextFormat(Owner.TextAlign, Owner.RightToLeft == RightToLeft.Yes);
+                layoutOptions.GdiTextFormatFlags = ContentAlignmentToTextFormat(Owner.TextAlign, Owner.RightToLeft == RightToLeft.Yes);
 
                 // Hide underlined &File unless ALT is pressed
                 layoutOptions.GdiTextFormatFlags = Owner.ShowKeyboardCues ? layoutOptions.GdiTextFormatFlags : layoutOptions.GdiTextFormatFlags | TextFormatFlags.HidePrefix;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItemTextRenderEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItemTextRenderEventArgs.cs
@@ -56,7 +56,7 @@ namespace System.Windows.Forms
             TextRectangle = textRectangle;
             DefaultTextColor = textColor;
             TextFont = textFont;
-            TextFormat = ToolStripItem.ToolStripItemInternalLayout.ContentAlignToTextFormat(textAlign, item.RightToLeft == RightToLeft.Yes);
+            TextFormat = ToolStripItem.ToolStripItemInternalLayout.ContentAlignmentToTextFormat(textAlign, item.RightToLeft == RightToLeft.Yes);
             TextFormat = (item.ShowKeyboardCues) ? TextFormat : TextFormat | TextFormatFlags.HidePrefix;
             TextDirection = item.TextDirection;
         }


### PR DESCRIPTION
The problem was actually in ControlPaint.DrawStringDisabled that takes an IDeviceContext. In the big refactoring it lost the application of TextFormatFlags to decide whether or not to apply Graphics state. LinkLabel never set those flags historically so it didn't get the clipping it applied to the Graphics object applied to the HDC. Fix is to apply the flags properly.

I've also cleaned up the LinkLabel code and did a thorough pass of the TextExtensions to bring the code up to snuff.

Fixes https://github.com/dotnet/winforms/issues/7341

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8771)