### PR TITLE
Fix: Do not use fixed index in the TreeNode.PrevNode if the TreeView is sorted

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeNode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeNode.cs
@@ -859,7 +859,11 @@ namespace System.Windows.Forms
 
                 if (fixedInd > 0)
                 {
-                    currentInd = fixedInd;
+                    TreeView tv = TreeView;
+                    if (tv is null || !tv.Sorted)
+                    {
+                        currentInd = fixedInd;
+                    }
                 }
 
                 if (currentInd > 0 && currentInd <= parent.Nodes.Count)


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #8768

This corresponds to the following check in `TreeNodeCollection.AddInternal`, that results in the fixed index not being used for node insertion:

```
if (tv is not null && tv.Sorted)
{
    return owner.AddSorted(node);
}
```
## Regression? 

- No

<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8774)