### PR TITLE
Fix ToolStripItems_FontScaling tests

### DIFF
--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Dpi/ToolStripItemTests.Dpi.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Dpi/ToolStripItemTests.Dpi.cs
@@ -50,7 +50,7 @@ namespace System.Windows.Forms.UITests.Dpi
                 form.Show();
 
                 DpiMessageHelper.TriggerDpiMessage(User32.WM.DPICHANGED_BEFOREPARENT, toolStrip, newDpi);
-                var factor = newDpi / DpiHelper.LogicalDpi;
+                var factor = (float)newDpi / form.DeviceDpi;
 
                 Assert.Equal((float)initialFont.Size * factor, toolStrip.Font.Size, precision: 1);
                 form.Close();


### PR DESCRIPTION
## Proposed changes

- Locally, the tests are failing for me and it looks like it is because we are using `DpiHelper.LogicalDpi` which is always `96.0`. I used `Form.DeviceDpi` instead.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8783)