### PR TITLE
Dispose PaintEventArgs in tests

### DIFF
--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/ByteViewerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/ByteViewerTests.cs
@@ -427,7 +427,7 @@ namespace System.ComponentModel.Design.Tests
         {
             using var image = new Bitmap(10, 10);
             using Graphics graphics = Graphics.FromImage(image);
-            var eventArgs = new PaintEventArgs(graphics, Rectangle.Empty);
+            using var eventArgs = new PaintEventArgs(graphics, Rectangle.Empty);
 
             using var control = new SubByteViewer();
             int callCount = 0;
@@ -468,7 +468,7 @@ namespace System.ComponentModel.Design.Tests
         {
             using var image = new Bitmap(10, 10);
             using Graphics graphics = Graphics.FromImage(image);
-            var eventArgs = new PaintEventArgs(graphics, Rectangle.Empty);
+            using var eventArgs = new PaintEventArgs(graphics, Rectangle.Empty);
 
             using var control = new SubByteViewer();
             control.SetBytes(bytes);
@@ -513,7 +513,7 @@ namespace System.ComponentModel.Design.Tests
         {
             using var image = new Bitmap(10, 10);
             using Graphics graphics = Graphics.FromImage(image);
-            var eventArgs = new PaintEventArgs(graphics, Rectangle.Empty);
+            using var eventArgs = new PaintEventArgs(graphics, Rectangle.Empty);
 
             using var control = new SubByteViewer();
             int callCount = 0;
@@ -543,7 +543,7 @@ namespace System.ComponentModel.Design.Tests
         {
             using var image = new Bitmap(10, 10);
             using Graphics graphics = Graphics.FromImage(image);
-            var eventArgs = new PaintEventArgs(graphics, Rectangle.Empty);
+            using var eventArgs = new PaintEventArgs(graphics, Rectangle.Empty);
 
             using var control = new SubByteViewer();
             control.SetBytes(bytes);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.Handlers.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.Handlers.cs
@@ -3855,7 +3855,7 @@ namespace System.Windows.Forms.Tests
         {
             using var image = new Bitmap(10, 10);
             using Graphics graphics = Graphics.FromImage(image);
-            var eventArgs = new PaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
+            using var eventArgs = new PaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
 
             using var control = new SubControl();
             control.SetStyle(ControlStyles.SupportsTransparentBackColor, supportsTransparentBackColor);
@@ -3977,7 +3977,7 @@ namespace System.Windows.Forms.Tests
         {
             using var image = new Bitmap(10, 10);
             using Graphics graphics = Graphics.FromImage(image);
-            var eventArgs = new PaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
+            using var eventArgs = new PaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
 
             using var control = new SubControl
             {
@@ -4027,7 +4027,7 @@ namespace System.Windows.Forms.Tests
         {
             using var image = new Bitmap(10, 10);
             using Graphics graphics = Graphics.FromImage(image);
-            var eventArgs = new PaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
+            using var eventArgs = new PaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
 
             using var control = new SubControl();
             control.SetStyle(ControlStyles.SupportsTransparentBackColor, supportsTransparentBackColor);
@@ -4104,7 +4104,7 @@ namespace System.Windows.Forms.Tests
         {
             using var image = new Bitmap(10, 10);
             using Graphics graphics = Graphics.FromImage(image);
-            var eventArgs = new PaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
+            using var eventArgs = new PaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
 
             using var parent = new Control
             {
@@ -4637,7 +4637,7 @@ namespace System.Windows.Forms.Tests
 
             using var image = new Bitmap(10, 10);
             using Graphics graphics = Graphics.FromImage(image);
-            var eventArgs = new PaintEventArgs(graphics, Rectangle.Empty);
+            using var eventArgs = new PaintEventArgs(graphics, Rectangle.Empty);
             control.OnPrint(eventArgs);
             Assert.Equal(expectedPaintCallCount, paintCallCount);
             Assert.Equal(expectedIsHandleCreated, control.IsHandleCreated);
@@ -4656,7 +4656,7 @@ namespace System.Windows.Forms.Tests
 
             using var image = new Bitmap(10, 10);
             using Graphics graphics = Graphics.FromImage(image);
-            var eventArgs = new PaintEventArgs(graphics, Rectangle.Empty);
+            using var eventArgs = new PaintEventArgs(graphics, Rectangle.Empty);
             Assert.Throws<DivideByZeroException>(() => control.OnPrint(eventArgs));
             Assert.Equal(1, paintCallCount);
             Assert.False(control.IsHandleCreated);
@@ -4695,7 +4695,7 @@ namespace System.Windows.Forms.Tests
 
             using var image = new Bitmap(10, 10);
             using Graphics graphics = Graphics.FromImage(image);
-            var eventArgs = new PaintEventArgs(graphics, Rectangle.Empty);
+            using var eventArgs = new PaintEventArgs(graphics, Rectangle.Empty);
             control.OnPrint(eventArgs);
             Assert.Equal(expectedPaintCallCount, paintCallCount);
             Assert.True(control.IsHandleCreated);
@@ -4724,7 +4724,7 @@ namespace System.Windows.Forms.Tests
 
             using var image = new Bitmap(10, 10);
             using Graphics graphics = Graphics.FromImage(image);
-            var eventArgs = new PaintEventArgs(graphics, Rectangle.Empty);
+            using var eventArgs = new PaintEventArgs(graphics, Rectangle.Empty);
             Assert.Throws<DivideByZeroException>(() => control.OnPrint(eventArgs));
             Assert.Equal(1, paintCallCount);
             Assert.True(control.IsHandleCreated);
@@ -4760,7 +4760,7 @@ namespace System.Windows.Forms.Tests
 
             using var image = new Bitmap(10, 10);
             using Graphics graphics = Graphics.FromImage(image);
-            var eventArgs = new PaintEventArgs(graphics, Rectangle.Empty);
+            using var eventArgs = new PaintEventArgs(graphics, Rectangle.Empty);
             control.OnPrint(eventArgs);
             Assert.Equal(1, printCallCount);
             Assert.Empty(control.Text);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.Methods.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.Methods.cs
@@ -4298,7 +4298,7 @@ namespace System.Windows.Forms.Tests
             using var control = new SubControl();
             using var image = new Bitmap(10, 10);
             using Graphics graphics = Graphics.FromImage(image);
-            var eventArgs = new PaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
+            using var eventArgs = new PaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
             Assert.Throws<NullReferenceException>(() => control.InvokePaint(null, eventArgs));
         }
 
@@ -4307,7 +4307,7 @@ namespace System.Windows.Forms.Tests
         {
             using var image = new Bitmap(10, 10);
             using Graphics graphics = Graphics.FromImage(image);
-            var eventArgs = new PaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
+            using var eventArgs = new PaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
 
             using var otherControlParent = new Control();
             using var otherControl = new SubControl
@@ -4354,7 +4354,7 @@ namespace System.Windows.Forms.Tests
             using var control = new SubControl();
             using var image = new Bitmap(10, 10);
             using Graphics graphics = Graphics.FromImage(image);
-            var eventArgs = new PaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
+            using var eventArgs = new PaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
             Assert.Throws<NullReferenceException>(() => control.InvokePaintBackground(null, eventArgs));
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/GroupBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/GroupBoxTests.cs
@@ -1827,7 +1827,7 @@ namespace System.Windows.Forms.Tests
         {
             using var image = new Bitmap(10, 10);
             using Graphics graphics = Graphics.FromImage(image);
-            var eventArgs = new PaintEventArgs(graphics, Rectangle.Empty);
+            using var eventArgs = new PaintEventArgs(graphics, Rectangle.Empty);
 
             using var control = new SubGroupBox
             {
@@ -1865,7 +1865,7 @@ namespace System.Windows.Forms.Tests
         {
             using var image = new Bitmap(10, 10);
             using Graphics graphics = Graphics.FromImage(image);
-            var eventArgs = new PaintEventArgs(graphics, Rectangle.Empty);
+            using var eventArgs = new PaintEventArgs(graphics, Rectangle.Empty);
 
             using var control = new SubGroupBox
             {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PaintEventArgsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PaintEventArgsTests.cs
@@ -52,7 +52,7 @@ namespace System.Windows.Forms.Tests
         {
             using var image = new Bitmap(10, 10);
             using Graphics graphics = Graphics.FromImage(image);
-            var e = new SubPaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
+            using var e = new SubPaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
             e.DisposeEntry(disposing);
             e.DisposeEntry(disposing);
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ScrollableControlTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ScrollableControlTests.cs
@@ -1531,7 +1531,7 @@ namespace System.Windows.Forms.Tests
         {
             using var image = new Bitmap(10, 10);
             using Graphics graphics = Graphics.FromImage(image);
-            var eventArgs = new PaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
+            using var eventArgs = new PaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
 
             using var control = new SubScrollableControl
             {
@@ -1678,7 +1678,7 @@ namespace System.Windows.Forms.Tests
         {
             using var image = new Bitmap(10, 10);
             using Graphics graphics = Graphics.FromImage(image);
-            var eventArgs = new PaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
+            using var eventArgs = new PaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
 
             using var control = new SubScrollableControl
             {
@@ -1730,7 +1730,7 @@ namespace System.Windows.Forms.Tests
         {
             using var image = new Bitmap(10, 10);
             using Graphics graphics = Graphics.FromImage(image);
-            var eventArgs = new PaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
+            using var eventArgs = new PaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
 
             using var control = new SubScrollableControl
             {
@@ -1818,7 +1818,7 @@ namespace System.Windows.Forms.Tests
         {
             using var image = new Bitmap(10, 10);
             using Graphics graphics = Graphics.FromImage(image);
-            var eventArgs = new PaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
+            using var eventArgs = new PaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
 
             using var parent = new Control
             {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/StatusStripTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/StatusStripTests.cs
@@ -1210,7 +1210,7 @@ namespace System.Windows.Forms.Tests
         {
             using var image = new Bitmap(10, 10);
             using Graphics graphics = Graphics.FromImage(image);
-            var eventArgs = new PaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
+            using var eventArgs = new PaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
 
             using var control = new SubStatusStrip
             {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabPageTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabPageTests.cs
@@ -3978,7 +3978,7 @@ namespace System.Windows.Forms.Tests
         {
             using var image = new Bitmap(10, 10);
             using Graphics graphics = Graphics.FromImage(image);
-            var eventArgs = new PaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
+            using var eventArgs = new PaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
 
             using var control = new SubTabPage();
             control.SetStyle(ControlStyles.SupportsTransparentBackColor, supportsTransparentBackColor);
@@ -4048,7 +4048,7 @@ namespace System.Windows.Forms.Tests
         {
             using var image = new Bitmap(10, 10);
             using Graphics graphics = Graphics.FromImage(image);
-            var eventArgs = new PaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
+            using var eventArgs = new PaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
 
             using var parent = new TabControl
             {
@@ -4104,7 +4104,7 @@ namespace System.Windows.Forms.Tests
         {
             using var image = new Bitmap(10, 10);
             using Graphics graphics = Graphics.FromImage(image);
-            var eventArgs = new PaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
+            using var eventArgs = new PaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
 
             using var control = new SubTabPage();
             control.SetStyle(ControlStyles.SupportsTransparentBackColor, supportsTransparentBackColor);
@@ -4187,7 +4187,7 @@ namespace System.Windows.Forms.Tests
         {
             using var image = new Bitmap(10, 10);
             using Graphics graphics = Graphics.FromImage(image);
-            var eventArgs = new PaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
+            using var eventArgs = new PaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
 
             using var parent = new TabControl
             {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TableLayoutPanelTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TableLayoutPanelTests.cs
@@ -1431,7 +1431,7 @@ namespace System.Windows.Forms.Tests
         {
             using var image = new Bitmap(10, 10);
             using Graphics graphics = Graphics.FromImage(image);
-            var eventArgs = new PaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
+            using var eventArgs = new PaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
 
             using var control = new SubTableLayoutPanel
             {
@@ -1471,7 +1471,7 @@ namespace System.Windows.Forms.Tests
         {
             using var image = new Bitmap(10, 10);
             using Graphics graphics = Graphics.FromImage(image);
-            var eventArgs = new PaintEventArgs(graphics, new Rectangle(15, 2, 5, 20));
+            using var eventArgs = new PaintEventArgs(graphics, new Rectangle(15, 2, 5, 20));
 
             using var control = new SubTableLayoutPanel
             {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripButtonTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripButtonTests.cs
@@ -1284,7 +1284,7 @@ namespace System.Windows.Forms.Tests
         {
             using var image = new Bitmap(10, 10);
             using Graphics graphics = Graphics.FromImage(image);
-            var eventArgs = new PaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
+            using var eventArgs = new PaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
 
             var renderer = new SubToolStripRenderer();
             using var owner = new ToolStrip
@@ -1375,7 +1375,7 @@ namespace System.Windows.Forms.Tests
         {
             using var image = new Bitmap(10, 10);
             using Graphics graphics = Graphics.FromImage(image);
-            var eventArgs = new PaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
+            using var eventArgs = new PaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
 
             var renderer = new SubToolStripRenderer();
             using var owner = new ToolStrip

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripContentPanelTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripContentPanelTests.cs
@@ -1854,7 +1854,7 @@ namespace System.Windows.Forms.Tests
         {
             using var image = new Bitmap(10, 10);
             using Graphics graphics = Graphics.FromImage(image);
-            var eventArgs = new PaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
+            using var eventArgs = new PaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
 
             var renderer = new SubToolStripRenderer();
             using var control = new SubToolStripContentPanel

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripControlHostTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripControlHostTests.cs
@@ -4109,7 +4109,8 @@ namespace System.Windows.Forms.Tests
 
             using var image = new Bitmap(10, 10);
             var graphics = Graphics.FromImage(image);
-            c.OnPaint(new PaintEventArgs(graphics, new Rectangle(1, 2, 3, 4)));
+            using var eventArgs = new PaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
+            c.OnPaint(eventArgs);
             Assert.Equal(0, paintCallCount);
 
             c.OnResize(EventArgs.Empty);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripSeparatorTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripSeparatorTests.cs
@@ -1212,7 +1212,7 @@ namespace System.Windows.Forms.Tests
         {
             using var image = new Bitmap(10, 10);
             using Graphics graphics = Graphics.FromImage(image);
-            var eventArgs = new PaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
+            using var eventArgs = new PaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
 
             var renderer1 = new SubToolStripRenderer();
             var renderer2 = new SubToolStripRenderer();
@@ -1283,7 +1283,7 @@ namespace System.Windows.Forms.Tests
         {
             using var image = new Bitmap(10, 10);
             using Graphics graphics = Graphics.FromImage(image);
-            var eventArgs = new PaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
+            using var eventArgs = new PaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
 
             var renderer1 = new SubToolStripRenderer();
             var renderer2 = new SubToolStripRenderer();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripTests.Rendering.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripTests.Rendering.cs
@@ -29,7 +29,7 @@ namespace System.Windows.Forms.Tests
             DeviceContextState state = new DeviceContextState(emf);
 
             Rectangle bounds = toolStrip.Bounds;
-            PaintEventArgs e = new PaintEventArgs(emf, bounds);
+            using var e = new PaintEventArgs(emf, bounds);
             toolStrip.TestAccessor().Dynamic.OnPaintBackground(e);
 
             Rectangle bitBltBounds = new Rectangle(bounds.X, bounds.Y, bounds.Width - 1, bounds.Height - 1);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripTests.cs
@@ -5833,7 +5833,7 @@ namespace System.Windows.Forms.Tests
         {
             using var image = new Bitmap(10, 10);
             using Graphics graphics = Graphics.FromImage(image);
-            var eventArgs = new PaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
+            using var eventArgs = new PaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
 
             using var control = new SubToolStrip
             {
@@ -5980,7 +5980,7 @@ namespace System.Windows.Forms.Tests
         {
             using var image = new Bitmap(10, 10);
             using Graphics graphics = Graphics.FromImage(image);
-            var eventArgs = new PaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
+            using var eventArgs = new PaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
 
             using var control = new SubToolStrip
             {
@@ -6031,7 +6031,7 @@ namespace System.Windows.Forms.Tests
         {
             using var image = new Bitmap(10, 10);
             using Graphics graphics = Graphics.FromImage(image);
-            var eventArgs = new PaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
+            using var eventArgs = new PaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
 
             using var control = new SubToolStrip
             {
@@ -6118,7 +6118,7 @@ namespace System.Windows.Forms.Tests
         {
             using var image = new Bitmap(10, 10);
             using Graphics graphics = Graphics.FromImage(image);
-            var eventArgs = new PaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
+            using var eventArgs = new PaintEventArgs(graphics, new Rectangle(1, 2, 3, 4));
 
             using var parent = new Control
             {
@@ -6193,7 +6193,7 @@ namespace System.Windows.Forms.Tests
         {
             using var image = new Bitmap(10, 10);
             using Graphics graphics = Graphics.FromImage(image);
-            var eventArgs = new PaintEventArgs(graphics, Rectangle.Empty);
+            using var eventArgs = new PaintEventArgs(graphics, Rectangle.Empty);
 
             using var control = new SubToolStrip();
             int callCount = 0;
@@ -6222,7 +6222,7 @@ namespace System.Windows.Forms.Tests
         {
             using var image = new Bitmap(10, 10);
             using Graphics graphics = Graphics.FromImage(image);
-            var eventArgs = new PaintEventArgs(graphics, Rectangle.Empty);
+            using var eventArgs = new PaintEventArgs(graphics, Rectangle.Empty);
 
             using var control = new SubToolStrip();
             Assert.NotEqual(IntPtr.Zero, control.Handle);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/UpDownBaseTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/UpDownBaseTests.cs
@@ -2247,7 +2247,7 @@ namespace System.Windows.Forms.Tests
         {
             using var image = new Bitmap(10, 10);
             using Graphics graphics = Graphics.FromImage(image);
-            var eventArgs = new PaintEventArgs(graphics, Rectangle.Empty);
+            using var eventArgs = new PaintEventArgs(graphics, Rectangle.Empty);
 
             using var control = new SubUpDownBase
             {
@@ -2283,7 +2283,7 @@ namespace System.Windows.Forms.Tests
         {
             using var image = new Bitmap(10, 10);
             using Graphics graphics = Graphics.FromImage(image);
-            var eventArgs = new PaintEventArgs(graphics, Rectangle.Empty);
+            using var eventArgs = new PaintEventArgs(graphics, Rectangle.Empty);
 
             using var control = new SubUpDownBase
             {


### PR DESCRIPTION
## Proposed changes

- Dispose PaintEventArgs in tests.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8785)