### PR TITLE
Dispose Cursor in tests

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AxHostTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AxHostTests.cs
@@ -1570,7 +1570,7 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public unsafe void AxHost_GetIPictureFromCursor_Invoke_Roundtrips()
         {
-            var original = new Cursor("bitmaps/cursor.cur");
+            using var original = new Cursor("bitmaps/cursor.cur");
             IPicture.Interface iPicture = (IPicture.Interface)SubAxHost.GetIPictureFromCursor(original);
             Assert.NotNull(iPicture);
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CursorConverterTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CursorConverterTests.cs
@@ -130,7 +130,7 @@ namespace System.Windows.Forms.Tests
             var converter = new CursorConverter();
             byte[] data = File.ReadAllBytes(Path.Combine("bitmaps", "10x16_one_entry_32bit.ico"));
             using var stream = new MemoryStream(data);
-            var sourceCursor = new Cursor(stream);
+            using var sourceCursor = new Cursor(stream);
             Assert.Equal(data, converter.ConvertTo(sourceCursor, typeof(byte[])));
         }
 
@@ -140,7 +140,7 @@ namespace System.Windows.Forms.Tests
             var converter = new CursorConverter();
             string fileName = Path.Combine("bitmaps", "10x16_one_entry_32bit.ico");
             byte[] data = File.ReadAllBytes(fileName);
-            var sourceCursor = new Cursor(fileName);
+            using var sourceCursor = new Cursor(fileName);
             Assert.Equal(data, converter.ConvertTo(sourceCursor, typeof(byte[])));
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CursorTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CursorTests.cs
@@ -33,7 +33,7 @@ public class CursorTests
     public void Cursor_Ctor_IntPtr()
     {
         Cursor sourceCursor = Cursors.AppStarting;
-        var cursor = new Cursor(sourceCursor.Handle);
+        using var cursor = new Cursor(sourceCursor.Handle);
         Assert.Equal(sourceCursor.Handle, cursor.Handle);
         Assert.Equal(sourceCursor.HotSpot, cursor.HotSpot);
         Assert.Equal(sourceCursor.Size, cursor.Size);
@@ -43,7 +43,7 @@ public class CursorTests
     [Fact]
     public void Cursor_Ctor_IntPtr_Invalid()
     {
-        var cursor = new Cursor(-1000);
+        using var cursor = new Cursor(-1000);
         Assert.Equal(-1000, cursor.Handle);
         Assert.Equal(new Point(0, 0), cursor.HotSpot);
         Assert.True(cursor.Size == new Size(32, 32) || cursor.Size == new Size(64, 64));
@@ -155,7 +155,7 @@ public class CursorTests
     [Fact]
     public void Cursor_Ctor_Type_String()
     {
-        var cursor = new Cursor(typeof(PropertyTabTests), "CustomPropertyTab");
+        using var cursor = new Cursor(typeof(PropertyTabTests), "CustomPropertyTab");
         Assert.NotEqual(IntPtr.Zero, cursor.Handle);
         Assert.Equal(new Point(5, 8), cursor.HotSpot);
         Assert.True(cursor.Size == new Size(32, 32) || cursor.Size == new Size(64, 64));
@@ -313,7 +313,7 @@ public class CursorTests
     [CommonMemberData(typeof(CommonTestHelper), nameof(CommonTestHelper.GetStringWithNullTheoryData))]
     public void Cursor_Tag_Set_GetReturnsExpected(object value)
     {
-        var cursor = new Cursor(2)
+        using var cursor = new Cursor(2)
         {
             Tag = value
         };
@@ -332,7 +332,7 @@ public class CursorTests
         Assert.NotEqual(IntPtr.Zero, handle);
         Assert.NotEqual(sourceCursor.Handle, handle);
 
-        var cursor = new Cursor(sourceCursor.Handle);
+        using var cursor = new Cursor(sourceCursor.Handle);
         Assert.Equal(sourceCursor.Handle, cursor.Handle);
         Assert.Equal(sourceCursor.HotSpot, cursor.HotSpot);
         Assert.Equal(sourceCursor.Size, cursor.Size);
@@ -391,7 +391,7 @@ public class CursorTests
     [MemberData(nameof(Draw_TestData))]
     public void Cursor_Draw_InvokeInvalidCursor_Success(Rectangle rectangle)
     {
-        var cursor = new Cursor(-1000);
+        using var cursor = new Cursor(-1000);
         using var image = new Bitmap(10, 10);
         using Graphics graphics = Graphics.FromImage(image);
         cursor.Draw(graphics, rectangle);
@@ -428,7 +428,7 @@ public class CursorTests
     [MemberData(nameof(Draw_TestData))]
     public void Cursor_DrawStretched_InvokeInvalidCursor_Success(Rectangle rectangle)
     {
-        var cursor = new Cursor(-1000);
+        using var cursor = new Cursor(-1000);
         using var image = new Bitmap(10, 10);
         using Graphics graphics = Graphics.FromImage(image);
         cursor.DrawStretched(graphics, rectangle);
@@ -510,7 +510,7 @@ public class CursorTests
     [Fact]
     public void Cursor_ToString_InvalidCursor_ThrowsFormatException()
     {
-        var cursor = new Cursor(2);
+        using var cursor = new Cursor(2);
         Assert.Throws<FormatException>(() => cursor.ToString());
     }
 }


### PR DESCRIPTION
## Proposed changes

- Dispose Cursor in tests.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8793)