### PR TITLE
Minor clean-up from Drawing migration

### DIFF
--- a/src/System.Drawing.Common/src/System.Drawing.Common.csproj
+++ b/src/System.Drawing.Common/src/System.Drawing.Common.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- net6.0 TFM isn't buildable as it depends on LibraryImportAttribute which isn't availble. -->
-    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks>$(NetCurrent);$(NetPrevious);$(NetMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
     <TargetFramework />
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <WarningsNotAsErrors>CS0618</WarningsNotAsErrors>
@@ -12,6 +11,7 @@
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <IsPackable>true</IsPackable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <!-- This should point to the last stable released version of this package. -->
     <PackageValidationBaselineVersion>7.0.0</PackageValidationBaselineVersion>
     <AddXamarinPlaceholderFilesToPackage>true</AddXamarinPlaceholderFilesToPackage>
     <PackageDescription>Provides access to GDI+ graphics functionality.

--- a/src/System.Drawing.Common/src/packaging.targets
+++ b/src/System.Drawing.Common/src/packaging.targets
@@ -8,6 +8,10 @@
     <DisablePackageBaselineValidation Condition="'$(IsShipping)' == 'false' or
                                                  '$(SuppressFinalPackageVersion)' == 'true' or
                                                  '$(DotNetBuildFromSource)' == 'true'">true</DisablePackageBaselineValidation>
+    <!-- Optional rules -->
+    <ApiCompatEnableRuleCannotChangeParameterName>true</ApiCompatEnableRuleCannotChangeParameterName>
+    <ApiCompatEnableRuleAttributesMustMatch>true</ApiCompatEnableRuleAttributesMustMatch>
+
     <BeforePack>$(BeforePack);AddNETStandardCompatErrorFileForPackaging</BeforePack>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <LicenseFile>$(RepoRoot)LICENSE.TXT</LicenseFile>
@@ -54,13 +58,13 @@
        than the minimum supported one. -->
   <ItemGroup>
     <NETStandardCompatError Include="netcoreapp2.0"
-                            Supported="net6.0"
+                            Supported="$(NetMinimum)"
                             Condition="$(TargetFrameworks.Contains('netstandard2.')) and
-                                       ($(TargetFrameworks.Contains('net6.0')) or $(TargetFrameworks.Contains('net7.0')) or $(TargetFrameworks.Contains('net8.0')))" />
+                                       ($(TargetFrameworks.Contains('$(NetMinimum)')) or $(TargetFrameworks.Contains('$(NetPrevious)')) or $(TargetFrameworks.Contains('$(NetCurrent)')))" />
     <NETStandardCompatError Include="net461"
-                            Supported="net462"
+                            Supported="$(NetFrameworkMinimum)"
                             Condition="$(TargetFrameworks.Contains('netstandard2.0')) and
-                                       ($(TargetFrameworks.Contains('net462')) or $(TargetFrameworks.Contains('net47')) or $(TargetFrameworks.Contains('net48')))" />
+                                       ($(TargetFrameworks.Contains('$(NetFrameworkMinimum)')) or $(TargetFrameworks.Contains('net47')) or $(TargetFrameworks.Contains('net48')))" />
   </ItemGroup>
 
   <!-- Add targets file that marks a .NETStandard applicable tfm as unsupported. -->


### PR DESCRIPTION
Use the floating TFM properties defined in Arcade
Enable ApiCompat's optional rules
Remove obsolete commentMinor clean-up from Drawing migration


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8861)