### PR TITLE
Dispose Cursor only if it is owned by the creator.

### DIFF
--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/Interop/Mocks/MockCursor.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/Interop/Mocks/MockCursor.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.ComponentModel;
 using System.Drawing;
+using System.Runtime.InteropServices;
 
 namespace System.Windows.Forms.Primitives.Tests.Interop.Mocks
 {
@@ -18,37 +20,23 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.Mocks
             _ownHandle = false;
             _resourceId = nResourceId;
             _handle = PInvoke.LoadCursor(HINSTANCE.Null, nResourceId);
+            if (_handle.IsNull)
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
         }
 
         public void Dispose()
         {
-            if (!_handle.IsNull)
+            if (!_handle.IsNull && _ownHandle)
             {
-                if (_ownHandle)
-                {
-                    PInvoke.DestroyCursor(_handle);
-                }
-
+                PInvoke.DestroyCursor(_handle);
                 _handle = HCURSOR.Null;
             }
         }
 
-        internal HCURSOR Handle
-        {
-            get
-            {
-                if (_handle.IsNull)
-                {
-                    throw new ObjectDisposedException(nameof(MockCursor));
-                }
+        internal HCURSOR Handle => _handle.IsNull ? throw new ObjectDisposedException(nameof(MockCursor)) : _handle;
 
-                return _handle;
-            }
-        }
-
-        public Size Size
-        {
-            get => SystemInformation.CursorSize;
-        }
+        public Size Size => SystemInformation.CursorSize;
     }
 }

--- a/src/System.Windows.Forms/src/Resources/SR.resx
+++ b/src/System.Windows.Forms/src/Resources/SR.resx
@@ -6961,4 +6961,7 @@ Stack trace where the illegal operation occurred was:
   <data name="InvalidArgumentType" xml:space="preserve">
     <value>Argument '{0}' must be of type '{1}'.</value>
   </data>
+  <data name="FailedToLoadCursor" xml:space="preserve">
+    <value>Failed to load cursor. Error '{1}'.</value>
+  </data>
 </root>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
@@ -5021,6 +5021,11 @@ Pokud kliknete na Pokračovat, aplikace bude tuto chybu ignorovat a pokusí se p
         <target state="translated">Určuje, zda dialogové okno zajišťuje, že názvy souborů neobsahují neplatné znaky nebo posloupnosti.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToLoadCursor">
+        <source>Failed to load cursor. Error '{1}'.</source>
+        <target state="new">Failed to load cursor. Error '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FileDialogAddToRecentDescr">
         <source>Controls whether to add the file being opened or saved to the recent list.</source>
         <target state="translated">Určuje, jestli se má soubor, který se otevírá nebo ukládá, přidat do seznamu posledních souborů.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
@@ -5021,6 +5021,11 @@ Wenn Sie auf "Weiter" klicken, ignoriert die Anwendung den Fehler und setzt den 
         <target state="translated">Steuert, ob das Dialogfeld sicherstellt, dass Dateinamen keine ungültigen Zeichen oder Sequenzen enthalten.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToLoadCursor">
+        <source>Failed to load cursor. Error '{1}'.</source>
+        <target state="new">Failed to load cursor. Error '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FileDialogAddToRecentDescr">
         <source>Controls whether to add the file being opened or saved to the recent list.</source>
         <target state="translated">Steuert, ob die Datei, die geöffnet oder gespeichert wird, zur Liste zuletzt verwendeten Elemente hinzugefügt wird.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
@@ -5021,6 +5021,11 @@ Si hace clic en Continuar, la aplicación pasará por alto este error e intentar
         <target state="translated">Controla si el cuadro de diálogo comprueba que los nombres de archivo no contienen caracteres o secuencias no válidas.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToLoadCursor">
+        <source>Failed to load cursor. Error '{1}'.</source>
+        <target state="new">Failed to load cursor. Error '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FileDialogAddToRecentDescr">
         <source>Controls whether to add the file being opened or saved to the recent list.</source>
         <target state="translated">Controla si se va a agregar el archivo que se va a abrir o guardar en la lista reciente.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
@@ -5021,6 +5021,11 @@ Si vous cliquez sur Continuer, l'application va ignorer cette erreur et tenter d
         <target state="translated">Contrôle si la boîte de dialogue s'assure que les noms de fichiers ne contiennent pas de caractères ou de séquences non valides.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToLoadCursor">
+        <source>Failed to load cursor. Error '{1}'.</source>
+        <target state="new">Failed to load cursor. Error '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FileDialogAddToRecentDescr">
         <source>Controls whether to add the file being opened or saved to the recent list.</source>
         <target state="translated">Contrôle s'il faut ajouter le fichier en cours d'ouverture ou d'enregistrement à la liste récente.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
@@ -5021,6 +5021,11 @@ Se si sceglie Continua, l'errore verrà ignorato e l'applicazione proverà a con
         <target state="translated">Determina se la finestra di dialogo ha il compito di verificare che i nomi di file non contengano caratteri o sequenze non valide.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToLoadCursor">
+        <source>Failed to load cursor. Error '{1}'.</source>
+        <target state="new">Failed to load cursor. Error '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FileDialogAddToRecentDescr">
         <source>Controls whether to add the file being opened or saved to the recent list.</source>
         <target state="translated">Controlla se aggiungere il file aperto o salvato nell'elenco degli elementi recenti.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
@@ -5021,6 +5021,11 @@ If you click Continue, the application will ignore this error and attempt to con
         <target state="translated">無効な文字やシーケンスがファイル名に含まれていないことをダイアログ ボックスが確認するかどうかを設定します。</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToLoadCursor">
+        <source>Failed to load cursor. Error '{1}'.</source>
+        <target state="new">Failed to load cursor. Error '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FileDialogAddToRecentDescr">
         <source>Controls whether to add the file being opened or saved to the recent list.</source>
         <target state="translated">開いているファイルを追加するか、最近使用したリストに保存するかを制御します。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
@@ -5021,6 +5021,11 @@ If you click Continue, the application will ignore this error and attempt to con
         <target state="translated">대화 상자에서 파일 이름에 잘못된 문자나 시퀀스가 없는지 확인할지 여부를 제어합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToLoadCursor">
+        <source>Failed to load cursor. Error '{1}'.</source>
+        <target state="new">Failed to load cursor. Error '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FileDialogAddToRecentDescr">
         <source>Controls whether to add the file being opened or saved to the recent list.</source>
         <target state="translated">연 파일 또는 저장한 파일을 최근 목록에 추가할지를 제어합니다.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
@@ -5021,6 +5021,11 @@ Jeśli klikniesz pozycję Kontynuuj, aplikacja zignoruje ten błąd i będzie pr
         <target state="translated">Kontroluje, czy w oknie dialogowym nazwy plików nie zawierają nieprawidłowych znaków ani sekwencji.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToLoadCursor">
+        <source>Failed to load cursor. Error '{1}'.</source>
+        <target state="new">Failed to load cursor. Error '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FileDialogAddToRecentDescr">
         <source>Controls whether to add the file being opened or saved to the recent list.</source>
         <target state="translated">Określa, czy dodać otwierany lub zapisywany plik do listy ostatnio używanych.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
@@ -5021,6 +5021,11 @@ Se você clicar em Continuar, o aplicativo ignorará esse erro e tentará contin
         <target state="translated">Controla se a caixa de diálogo assegura que os nomes de arquivos não contém cadeias ou caracteres inválidos.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToLoadCursor">
+        <source>Failed to load cursor. Error '{1}'.</source>
+        <target state="new">Failed to load cursor. Error '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FileDialogAddToRecentDescr">
         <source>Controls whether to add the file being opened or saved to the recent list.</source>
         <target state="translated">Controla se o arquivo que está sendo aberto ou salvo na lista recente deve ser adicionado.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
@@ -5022,6 +5022,11 @@ If you click Continue, the application will ignore this error and attempt to con
         <target state="translated">Определяет, проверяет ли диалоговое окно имена файлов на наличие недопустимых символов или последовательностей.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToLoadCursor">
+        <source>Failed to load cursor. Error '{1}'.</source>
+        <target state="new">Failed to load cursor. Error '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FileDialogAddToRecentDescr">
         <source>Controls whether to add the file being opened or saved to the recent list.</source>
         <target state="translated">Определяет, следует ли добавлять открываемый или сохраненный файл в список "Последние".</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
@@ -5021,6 +5021,11 @@ Devam'a tıkladığınızda uygulama bu hatayı yoksayar ve işlemi sürdürmeye
         <target state="translated">İletişim kutusunun dosya adlarında geçersiz karakterler ve sıralar içermediğinden emin olup olmayacağını denetler.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToLoadCursor">
+        <source>Failed to load cursor. Error '{1}'.</source>
+        <target state="new">Failed to load cursor. Error '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FileDialogAddToRecentDescr">
         <source>Controls whether to add the file being opened or saved to the recent list.</source>
         <target state="translated">Açılmakta olan veya kaydedilen dosyanın son listeye eklenip eklenmeyeceğini kontrol eder.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
@@ -5021,6 +5021,11 @@ If you click Continue, the application will ignore this error and attempt to con
         <target state="translated">控制对话框是否确保文件名中不包含无效的字符或序列。</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToLoadCursor">
+        <source>Failed to load cursor. Error '{1}'.</source>
+        <target state="new">Failed to load cursor. Error '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FileDialogAddToRecentDescr">
         <source>Controls whether to add the file being opened or saved to the recent list.</source>
         <target state="translated">控制是否将打开或保存的文件添加到最近使用项列表中。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
@@ -5021,6 +5021,11 @@ If you click Continue, the application will ignore this error and attempt to con
         <target state="translated">控制對話方塊是否要確認檔名並未包含無效的字元或逸出字元。</target>
         <note />
       </trans-unit>
+      <trans-unit id="FailedToLoadCursor">
+        <source>Failed to load cursor. Error '{1}'.</source>
+        <target state="new">Failed to load cursor. Error '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FileDialogAddToRecentDescr">
         <source>Controls whether to add the file being opened or saved to the recent list.</source>
         <target state="translated">控制是否新增開啟或儲存至最近使用之清單的檔案。</target>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Cursor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Cursor.cs
@@ -466,6 +466,8 @@ namespace System.Windows.Forms
             return (byte[])_cursorData.Clone();
         }
 
+        internal bool IsValid() => _handle != IntPtr.Zero;
+
         /// <summary>
         ///  Displays the cursor. For every call to Cursor.show() there must have been
         ///  a previous call to Cursor.hide().

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Cursor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Cursor.cs
@@ -39,6 +39,10 @@ namespace System.Windows.Forms
             _ownHandle = false;
             _resourceId = nResourceId;
             _handle = PInvoke.LoadCursor((HINSTANCE)0, nResourceId);
+            if (_handle.IsNull)
+            {
+                throw new Win32Exception(string.Format(SR.FailedToLoadCursor, Marshal.GetLastWin32Error()));
+            }
         }
 
         /// <summary>
@@ -222,13 +226,9 @@ namespace System.Windows.Forms
 
         private void Dispose(bool disposing)
         {
-            if (!_handle.IsNull)
+            if (!_handle.IsNull && _ownHandle)
             {
-                if (_ownHandle)
-                {
-                    PInvoke.DestroyCursor(_handle);
-                }
-
+                PInvoke.DestroyCursor(_handle);
                 _handle = HCURSOR.Null;
             }
         }
@@ -429,6 +429,11 @@ namespace System.Windows.Forms
                         picSize.Width,
                         picSize.Height,
                         IMAGE_FLAGS.LR_DEFAULTCOLOR).Value;
+
+                    if (_handle.IsNull)
+                    {
+                        throw new Win32Exception(string.Format(SR.FailedToLoadCursor, Marshal.GetLastWin32Error()));
+                    }
 
                     _ownHandle = true;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Cursors.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Cursors.cs
@@ -95,7 +95,7 @@ namespace System.Windows.Forms
 
         private static Cursor GetCursor(ref Cursor? cursor, string resource)
         {
-            return cursor is not null && cursor.Handle != IntPtr.Zero
+            return cursor is not null && cursor.IsValid()
                 ? cursor
                 : (cursor = new Cursor(typeof(Cursor), resource));
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Cursors.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Cursors.cs
@@ -65,33 +65,39 @@ namespace System.Windows.Forms
         public static Cursor WaitCursor => s_wait ??= new Cursor(PInvoke.IDC_WAIT);
 
         public static Cursor Help => s_help ??= new Cursor(PInvoke.IDC_HELP);
-
-        public static Cursor HSplit => s_hSplit ??= new Cursor(typeof(Cursor), "hsplit.cur");
-
-        public static Cursor VSplit => s_vSplit ??= new Cursor(typeof(Cursor), "vsplit.cur");
-
-        public static Cursor NoMove2D => s_noMove2D ??= new Cursor(typeof(Cursor), "nomove2d.cur");
-
-        public static Cursor NoMoveHoriz => s_noMoveHoriz ??= new Cursor(typeof(Cursor), "nomoveh.cur");
-
-        public static Cursor NoMoveVert => s_noMoveVert ??= new Cursor(typeof(Cursor), "nomovev.cur");
-
-        public static Cursor PanEast => s_panEast ??= new Cursor(typeof(Cursor), "east.cur");
-
-        public static Cursor PanNE => s_panNE ??= new Cursor(typeof(Cursor), "ne.cur");
-
-        public static Cursor PanNorth => s_panNorth ??= new Cursor(typeof(Cursor), "north.cur");
-
-        public static Cursor PanNW => s_panNW ??= new Cursor(typeof(Cursor), "nw.cur");
-
-        public static Cursor PanSE => s_panSE ??= new Cursor(typeof(Cursor), "se.cur");
-
-        public static Cursor PanSouth => s_panSouth ??= new Cursor(typeof(Cursor), "south.cur");
-
-        public static Cursor PanSW => s_panSW ??= new Cursor(typeof(Cursor), "sw.cur");
-
-        public static Cursor PanWest => s_panWest ??= new Cursor(typeof(Cursor), "west.cur");
-
         public static Cursor Hand => s_hand ??= new Cursor(PInvoke.IDC_HAND);
+
+        public static Cursor HSplit => GetCursor(ref s_hSplit, "hsplit.cur");
+
+        public static Cursor VSplit => GetCursor(ref s_vSplit, "vsplit.cur");
+
+        public static Cursor NoMove2D => GetCursor(ref s_noMove2D, "nomove2d.cur");
+
+        public static Cursor NoMoveHoriz => GetCursor(ref s_noMoveHoriz, "nomoveh.cur");
+
+        public static Cursor NoMoveVert => GetCursor(ref s_noMoveVert, "nomovev.cur");
+
+        public static Cursor PanEast => GetCursor(ref s_panEast, "east.cur");
+
+        public static Cursor PanNE => GetCursor(ref s_panNE, "ne.cur");
+
+        public static Cursor PanNorth => GetCursor(ref s_panNorth, "north.cur");
+
+        public static Cursor PanNW => GetCursor(ref s_panNW, "nw.cur");
+
+        public static Cursor PanSE => GetCursor(ref s_panSE, "se.cur");
+
+        public static Cursor PanSouth => GetCursor(ref s_panSouth, "south.cur");
+
+        public static Cursor PanSW => GetCursor(ref s_panSW, "sw.cur");
+
+        public static Cursor PanWest => GetCursor(ref s_panWest, "west.cur");
+
+        private static Cursor GetCursor(ref Cursor? cursor, string resource)
+        {
+            return cursor is not null && cursor.Handle != IntPtr.Zero
+                ? cursor
+                : (cursor = new Cursor(typeof(Cursor), resource));
+        }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Cursors.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Cursors.cs
@@ -94,10 +94,8 @@ namespace System.Windows.Forms
         public static Cursor PanWest => GetCursor(ref s_panWest, "west.cur");
 
         private static Cursor GetCursor(ref Cursor? cursor, string resource)
-        {
-            return cursor is not null && cursor.IsValid()
+            => cursor is not null && cursor.IsValid()
                 ? cursor
-                : (cursor = new Cursor(typeof(Cursor), resource));
-        }
+                : cursor = new Cursor(typeof(Cursor), resource);
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CursorTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CursorTests.cs
@@ -358,12 +358,8 @@ public class CursorTests
         var cursor = new Cursor(2);
         cursor.Dispose();
 
-        Assert.Throws<ObjectDisposedException>(() => cursor.Handle);
-        Assert.Throws<ObjectDisposedException>(() => cursor.HotSpot);
-
-        cursor.Dispose();
-        Assert.Throws<ObjectDisposedException>(() => cursor.Handle);
-        Assert.Throws<ObjectDisposedException>(() => cursor.HotSpot);
+        // Cursors not owned should not be disposed.
+        Assert.NotEqual(IntPtr.Zero, cursor.Handle);
     }
 
     public static IEnumerable<object[]> Draw_TestData()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CursorsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CursorsTests.cs
@@ -22,7 +22,7 @@ namespace System.Windows.Forms.Tests
             yield return new object[] { I(() => Cursors.Default) };
             yield return new object[] { I(() => Cursors.Hand) };
             yield return new object[] { I(() => Cursors.Help) };
-            // yield return new object[] { I(() => Cursors.HSplit) }; Tracking issue: https://github.com/dotnet/winforms/issues/8810.
+            yield return new object[] { I(() => Cursors.HSplit) };
             yield return new object[] { I(() => Cursors.IBeam) };
             yield return new object[] { I(() => Cursors.No) };
             yield return new object[] { I(() => Cursors.NoMove2D) };
@@ -42,7 +42,7 @@ namespace System.Windows.Forms.Tests
             yield return new object[] { I(() => Cursors.SizeNWSE) };
             yield return new object[] { I(() => Cursors.SizeWE) };
             yield return new object[] { I(() => Cursors.UpArrow) };
-            // yield return new object[] { I(() => Cursors.VSplit) }; Tracking issue: https://github.com/dotnet/winforms/issues/8810.
+            yield return new object[] { I(() => Cursors.VSplit) };
             yield return new object[] { I(() => Cursors.WaitCursor) };
         }
 


### PR DESCRIPTION
While investigating flaky tests, found that Cursor Handle is being set to null even if the cursor is not owned by the specific scope. This has been the case since .NET framework. Disposing handle only if owned by creator. 

Some static Cursors in WinForms are incorrectly categorized as `owned`. Making any change around `owned` flag on these could break existing applications. In this change, we are recreating static cursors if their handle is disposed.

Related #8810 

fixes #8373 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8865)