### PR TITLE
Repopulate owner HWNDs correctly

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.EnumThreadWindowsCallback.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.EnumThreadWindowsCallback.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
+
 namespace System.Windows.Forms
 {
     public partial class Form
@@ -29,7 +31,7 @@ namespace System.Windows.Forms
                     // Enumerated window is owned by this Form.
                     // Store it in a list for further treatment.
                     _ownedWindows ??= new();
-                    _ownedWindows.Add(parent);
+                    _ownedWindows.Add(hwnd);
                 }
 
                 return true;
@@ -42,13 +44,14 @@ namespace System.Windows.Forms
                 {
                     foreach (HWND hwnd in _ownedWindows)
                     {
-                        PInvoke.SetWindowLong(hwnd, WINDOW_LONG_PTR_INDEX.GWL_HWNDPARENT, 0);
+                        nint oldValue = PInvoke.SetWindowLong(hwnd, WINDOW_LONG_PTR_INDEX.GWL_HWNDPARENT, 0);
+                        Debug.Assert(oldValue == _formHandle.Value);
                     }
                 }
             }
 
             // Sets the owner of the windows back to this Form after its handle recreation.
-            internal void SetOwners(IntPtr ownerHwnd)
+            internal void SetOwners(nint ownerHwnd)
             {
                 if (_ownedWindows is not null)
                 {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FormTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FormTests.cs
@@ -2620,6 +2620,44 @@ namespace System.Windows.Forms.Tests
             Assert.False(child.IsHandleCreated);
         }
 
+        [WinFormsFact]
+        public void Form_ParentThenSetShowInTaskbarToFalse()
+        {
+            // Regression test for https://github.com/dotnet/winforms/issues/8803
+            using ParentedForm form = new();
+            form.Show();
+        }
+
+        public partial class ParentedForm : Form
+        {
+            private ParentingForm _parentForm;
+
+            protected override void OnHandleCreated(EventArgs e)
+            {
+                base.OnHandleCreated(e);
+                _parentForm = new ParentingForm(this);
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                base.Dispose(disposing);
+
+                if (disposing)
+                {
+                    _parentForm?.Dispose();
+                }
+            }
+
+            public class ParentingForm : Form
+            {
+                public ParentingForm(Form targetForm)
+                {
+                    targetForm.Owner = this;
+                    RecreateHandle();
+                }
+            }
+        }
+
         public class SubForm : Form
         {
             public new const int ScrollStateAutoScrolling = Form.ScrollStateAutoScrolling;


### PR DESCRIPTION
Should be storing the child, not the parent.

Fixes #8803

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8870)