### PR TITLE
Close ServerManager window on build agents and save screenshot in UI test failures.

### DIFF
--- a/eng/custom-cibuild.ps1
+++ b/eng/custom-cibuild.ps1
@@ -11,7 +11,7 @@ function _kill($processName) {
         # when there are no instances of the process
         & cmd /c "taskkill /T /F /IM ${processName} 2>&1"
     } catch {
-        Write-Host "Failed to kill ${processName}: $_"
+        Write-Host "Either failed to kill ${processName} or process was not running."
     }
 }
 

--- a/eng/custom-cibuild.ps1
+++ b/eng/custom-cibuild.ps1
@@ -4,6 +4,20 @@ Param(
     [Parameter(ValueFromRemainingArguments=$true)][String[]]$properties
 )
 
+function _kill($processName) {
+    Write-Host "killing process ${processName}."
+    try {
+        # Redirect stderr to stdout to avoid big red blocks of output in Azure Pipeline logging
+        # when there are no instances of the process
+        & cmd /c "taskkill /T /F /IM ${processName} 2>&1"
+    } catch {
+        Write-Host "Failed to kill ${processName}: $_"
+    }
+}
+
+# kill server manager process if running on build agents.
+_kill severmanager.exe
+
 # How long to wait before we consider a build/test run to be unresponsive
 $WaitSeconds = 900 # 15 min
 

--- a/eng/custom-cibuild.ps1
+++ b/eng/custom-cibuild.ps1
@@ -11,7 +11,7 @@ function _kill($processName) {
         # when there are no instances of the process
         & cmd /c "taskkill /T /F /IM ${processName} 2>&1"
     } catch {
-        Write-Host "Either failed to kill ${processName} or process was not running."
+        Write-Host "Failed to kill ${processName}."
     }
 }
 

--- a/src/System.Windows.Forms.Primitives/src/NativeMethods.txt
+++ b/src/System.Windows.Forms.Primitives/src/NativeMethods.txt
@@ -591,7 +591,6 @@ StgCreateDocfileOnILockBytes
 StgOpenStorageOnILockBytes
 STGTY
 StretchDIBits
-SwitchToThisWindow
 SystemParametersInfo
 SystemParametersInfoForDpi
 SYSTEMTIME

--- a/src/System.Windows.Forms.Primitives/src/NativeMethods.txt
+++ b/src/System.Windows.Forms.Primitives/src/NativeMethods.txt
@@ -591,6 +591,7 @@ StgCreateDocfileOnILockBytes
 StgOpenStorageOnILockBytes
 STGTY
 StretchDIBits
+SwitchToThisWindow
 SystemParametersInfo
 SystemParametersInfoForDpi
 SYSTEMTIME

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Infra/ControlTestBase.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Infra/ControlTestBase.cs
@@ -21,6 +21,7 @@ namespace System.Windows.Forms.UITests
         private static string? _logPath;
         private readonly string _testName;
         private static bool s_disableServerManager;
+        private static int k;
 
         private bool _clientAreaAnimation;
         private DenyExecutionSynchronizationContext? _denyExecutionSynchronizationContext;
@@ -35,7 +36,7 @@ namespace System.Windows.Forms.UITests
 
             // Build agents might be running on server OS and ServerManager window is opened on logon.
             // Closing this window to avoid any interference with Winforms UI tests.
-            // CloseServerManagerWindow();
+            CloseServerManagerWindow();
 
             Application.EnableVisualStyles();
 
@@ -93,6 +94,7 @@ namespace System.Windows.Forms.UITests
 
                         if (process.MainWindowHandle != IntPtr.Zero)
                         {
+                            TestOutputHelper.WriteLine($"ServerManager window found. Closing.");
                             process.CloseMainWindow();
                         }
 
@@ -315,6 +317,11 @@ namespace System.Windows.Forms.UITests
                 try
                 {
                     await testDriverAsync(dialog!, control!);
+                    if(k == 0)
+                    {
+                        TrySaveScreenshot();
+                        k++;
+                    }
                 }
                 catch
                 {
@@ -326,6 +333,11 @@ namespace System.Windows.Forms.UITests
                     dialog!.Close();
                     dialog.Dispose();
                     dialog = null;
+
+                    if(s_disableServerManager)
+                    {
+                        TestOutputHelper.WriteLine("ServerManagerWindow closed.");
+                    }
                 }
             });
 
@@ -355,6 +367,11 @@ namespace System.Windows.Forms.UITests
                 try
                 {
                     await testDriverAsync(dialog!);
+                    if (k == 0)
+                    {
+                        k++;
+                        TrySaveScreenshot();
+                    }
                 }
                 catch
                 {
@@ -366,6 +383,11 @@ namespace System.Windows.Forms.UITests
                     dialog!.Close();
                     dialog.Dispose();
                     dialog = null;
+
+                    if (s_disableServerManager)
+                    {
+                        TestOutputHelper.WriteLine("ServerManagerWindow closed.");
+                    }
                 }
             });
 

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Infra/ControlTestBase.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Infra/ControlTestBase.cs
@@ -35,7 +35,7 @@ namespace System.Windows.Forms.UITests
 
             // Build agents might be running on server OS and ServerManager window is opened on logon.
             // Closing this window to avoid any interference with Winforms UI tests.
-            CloseServerManagerWindow();
+            // CloseServerManagerWindow();
 
             Application.EnableVisualStyles();
 


### PR DESCRIPTION
- Close ServerManager window on build agents that may interfere with UI tests.
- Take screenshots and save them in case any UI test fails.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8875)