### PR TITLE
Servicing:  Repopulate owner HWNDs correctly

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.EnumThreadWindowsCallback.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.EnumThreadWindowsCallback.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using static Interop;
 
 namespace System.Windows.Forms
@@ -31,7 +32,7 @@ namespace System.Windows.Forms
                     // Enumerated window is owned by this Form.
                     // Store it in a list for further treatment.
                     _ownedWindows ??= new();
-                    _ownedWindows.Add(parent);
+                    _ownedWindows.Add(hwnd);
                 }
 
                 return BOOL.TRUE;
@@ -44,7 +45,8 @@ namespace System.Windows.Forms
                 {
                     foreach (IntPtr hwnd in _ownedWindows)
                     {
-                        User32.SetWindowLong(hwnd, User32.GWL.HWNDPARENT, 0);
+                        nint oldValue = User32.SetWindowLong(hwnd, User32.GWL.HWNDPARENT, 0);
+                        Debug.Assert(oldValue == _formHandle);
                     }
                 }
             }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FormTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FormTests.cs
@@ -2615,6 +2615,44 @@ namespace System.Windows.Forms.Tests
             Assert.False(form.IsHandleCreated);
         }
 
+        [WinFormsFact]
+        public void Form_ParentThenSetShowInTaskbarToFalse()
+        {
+            // Regression test for https://github.com/dotnet/winforms/issues/8803
+            using ParentedForm form = new();
+            form.Show();
+        }
+
+        public partial class ParentedForm : Form
+        {
+            private ParentingForm _parentForm;
+
+            protected override void OnHandleCreated(EventArgs e)
+            {
+                base.OnHandleCreated(e);
+                _parentForm = new ParentingForm(this);
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                base.Dispose(disposing);
+
+                if (disposing)
+                {
+                    _parentForm?.Dispose();
+                }
+            }
+
+            public class ParentingForm : Form
+            {
+                public ParentingForm(Form targetForm)
+                {
+                    targetForm.Owner = this;
+                    RecreateHandle();
+                }
+            }
+        }
+
         public class SubForm : Form
         {
             public new const int ScrollStateAutoScrolling = Form.ScrollStateAutoScrolling;


### PR DESCRIPTION
Porting #8870 
  and
Fixes #8803

When a Form's handle is recreated it looks for child Windows so it can update them with the new handle. The list of child windows was mistakingly storing the parent handle instead of the child handle.

In the reported case, the parent form was created while the child form was still in CreateWindow. After parenting against the child a property was set that caused recreation of the parent's handle. As the handle reparenting logic was broken the child would be left with an invalid parent window handle, causing CreateWindow to return and error and WinForms would throw an unhandled exception.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8876)