### PR TITLE
Add Span overloads for Graphics text methods

### DIFF
--- a/src/System.Drawing.Common/src/System/Drawing/GdiplusNative.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/GdiplusNative.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Drawing.Drawing2D;
@@ -2981,12 +2981,12 @@ namespace System.Drawing
 #endif
             HandleRef brush, Rectangle* rects, int count);
 
-            [LibraryImport(LibraryName,  SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+            [LibraryImport(LibraryName, SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
             internal static partial int GdipDrawString(
 #if NET7_0_OR_GREATER
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
-            HandleRef graphics, string textString, int length,
+            HandleRef graphics, ReadOnlySpan<char> textString, int length,
 #if NET7_0_OR_GREATER
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
@@ -3199,7 +3199,7 @@ namespace System.Drawing
 #if NET7_0_OR_GREATER
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
-            HandleRef graphics, string textString, int length,
+            HandleRef graphics, ReadOnlySpan<char> textString, int length,
 #if NET7_0_OR_GREATER
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
@@ -3214,7 +3214,7 @@ namespace System.Drawing
 #if NET7_0_OR_GREATER
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif
-            HandleRef graphics, string textString, int length,
+            HandleRef graphics, ReadOnlySpan<char> textString, int length,
 #if NET7_0_OR_GREATER
             [MarshalUsing(typeof(HandleRefMarshaller))]
 #endif

--- a/src/System.Drawing.Common/src/System/Drawing/Graphics.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Graphics.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel;
@@ -1645,33 +1645,175 @@ namespace System.Drawing
         }
 
         /// <summary>
-        /// Draws a string with the specified font.
+        ///  Draws the specified text at the specified location with the specified <see cref="Brush"/> and
+        ///  <see cref="Font"/> objects.
         /// </summary>
+        /// <param name="s">The text to draw.</param>
+        /// <param name="font"><see cref="Font"/> that defines the text format.</param>
+        /// <param name="brush"><see cref="Brush"/> that determines the color and texture of the drawn text.</param>
+        /// <param name="x">The x-coordinate of the upper-left corner of the drawn text.</param>
+        /// <param name="y">The y-coordinate of the upper-left corner of the drawn text.</param>
+        /// <exception cref="ArgumentNullException">
+        ///  <paramref name="brush"/> is <see langword="null"/>. -or- <paramref name="font"/> is <see langword="null"/>.
+        /// </exception>
         public void DrawString(string? s, Font font, Brush brush, float x, float y)
         {
             DrawString(s, font, brush, new RectangleF(x, y, 0, 0), null);
         }
 
+#if NET8_0_OR_GREATER
+        /// <inheritdoc cref="DrawString(string?, Font, Brush, float, float)"/>
+        public void DrawString(ReadOnlySpan<char> s, Font font, Brush brush, float x, float y)
+        {
+            DrawString(s, font, brush, new RectangleF(x, y, 0, 0), null);
+        }
+#endif
+
+        /// <summary>
+        ///  Draws the specified text at the specified location with the specified <see cref="Brush"/> and
+        ///  <see cref="Font"/> objects.
+        /// </summary>
+        /// <param name="s">The text to draw.</param>
+        /// <param name="font"><see cref="Font"/> that defines the text format.</param>
+        /// <param name="brush"><see cref="Brush"/> that determines the color and texture of the drawn text.</param>
+        /// <param name="point"><see cref="PointF"/>structure that specifies the upper-left corner of the drawn text.</param>
+        /// <exception cref="ArgumentNullException">
+        ///  <paramref name="brush"/> is <see langword="null"/>. -or- <paramref name="font"/> is <see langword="null"/>.
+        /// </exception>
         public void DrawString(string? s, Font font, Brush brush, PointF point)
         {
             DrawString(s, font, brush, new RectangleF(point.X, point.Y, 0, 0), null);
         }
 
+#if NET8_0_OR_GREATER
+        /// <inheritdoc cref="DrawString(string?, Font, Brush, PointF)"/>
+        public void DrawString(ReadOnlySpan<char> s, Font font, Brush brush, PointF point)
+        {
+            DrawString(s, font, brush, new RectangleF(point.X, point.Y, 0, 0), null);
+        }
+#endif
+
+        /// <summary>
+        ///  Draws the specified text at the specified location with the specified <see cref="Brush"/> and
+        ///  <see cref="Font"/> objects using the formatting attributes of the specified <see cref="StringFormat"/>.
+        /// </summary>
+        /// <param name="s">The text to draw.</param>
+        /// <param name="font"><see cref="Font"/> that defines the text format.</param>
+        /// <param name="brush"><see cref="Brush"/> that determines the color and texture of the drawn text.</param>
+        /// <param name="x">The x-coordinate of the upper-left corner of the drawn text.</param>
+        /// <param name="y">The y-coordinate of the upper-left corner of the drawn text.</param>
+        /// <param name="format">
+        ///  <see cref="StringFormat"/> that specifies formatting attributes, such as line spacing and alignment,
+        ///  that are applied to the drawn text.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///  <paramref name="brush"/> is <see langword="null"/>. -or- <paramref name="font"/> is <see langword="null"/>.
+        /// </exception>
         public void DrawString(string? s, Font font, Brush brush, float x, float y, StringFormat? format)
         {
             DrawString(s, font, brush, new RectangleF(x, y, 0, 0), format);
         }
 
+#if NET8_0_OR_GREATER
+        /// <inheritdoc cref="DrawString(string?, Font, Brush, float, float, StringFormat?)"/>
+        public void DrawString(ReadOnlySpan<char> s, Font font, Brush brush, float x, float y, StringFormat? format)
+        {
+            DrawString(s, font, brush, new RectangleF(x, y, 0, 0), format);
+        }
+#endif
+
+        /// <summary>
+        ///  Draws the specified text at the specified location with the specified <see cref="Brush"/> and
+        ///  <see cref="Font"/> objects using the formatting attributes of the specified <see cref="StringFormat"/>.
+        /// </summary>
+        /// <param name="s">The text to draw.</param>
+        /// <param name="font"><see cref="Font"/> that defines the text format.</param>
+        /// <param name="brush"><see cref="Brush"/> that determines the color and texture of the drawn text.</param>
+        /// <param name="point"><see cref="PointF"/>structure that specifies the upper-left corner of the drawn text.</param>
+        /// <param name="format">
+        ///  <see cref="StringFormat"/> that specifies formatting attributes, such as line spacing and alignment,
+        ///  that are applied to the drawn text.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///  <paramref name="brush"/> is <see langword="null"/>. -or- <paramref name="font"/> is <see langword="null"/>.
+        /// </exception>
         public void DrawString(string? s, Font font, Brush brush, PointF point, StringFormat? format)
         {
             DrawString(s, font, brush, new RectangleF(point.X, point.Y, 0, 0), format);
         }
 
+#if NET8_0_OR_GREATER
+        /// <inheritdoc cref="DrawString(string?, Font, Brush, PointF, StringFormat?)"/>
+        public void DrawString(ReadOnlySpan<char> s, Font font, Brush brush, PointF point, StringFormat? format)
+        {
+            DrawString(s, font, brush, new RectangleF(point.X, point.Y, 0, 0), format);
+        }
+#endif
+
+        /// <summary>
+        ///  Draws the specified text in the specified rectangle with the specified <see cref="Brush"/> and
+        ///  <see cref="Font"/> objects.
+        /// </summary>
+        /// <param name="s">The text to draw.</param>
+        /// <param name="font"><see cref="Font"/> that defines the text format.</param>
+        /// <param name="brush"><see cref="Brush"/> that determines the color and texture of the drawn text.</param>
+        /// <param name="layoutRectangle"><see cref="RectangleF"/>structure that specifies the location of the drawn text.</param>
+        /// <exception cref="ArgumentNullException">
+        ///  <paramref name="brush"/> is <see langword="null"/>. -or- <paramref name="font"/> is <see langword="null"/>.
+        /// </exception>
+        /// <remarks>
+        ///  <para>
+        ///   The text represented by the <paramref name="s"/> parameter is drawn inside the rectangle represented by
+        ///   the <paramref name="layoutRectangle"/> parameter. If the text does not fit inside the rectangle, it is
+        ///   truncated at the nearest word. To further manipulate how the string is drawn inside the rectangle use the
+        ///   <see cref="DrawString(string?, Font, Brush, RectangleF, StringFormat?)"/> overload that takes
+        ///   a <see cref="StringFormat"/>.
+        ///  </para>
+        /// </remarks>
         public void DrawString(string? s, Font font, Brush brush, RectangleF layoutRectangle)
         {
             DrawString(s, font, brush, layoutRectangle, null);
         }
 
+#if NET8_0_OR_GREATER
+        /// <remarks>
+        ///  <para>
+        ///   The text represented by the <paramref name="s"/> parameter is drawn inside the rectangle represented by
+        ///   the <paramref name="layoutRectangle"/> parameter. If the text does not fit inside the rectangle, it is
+        ///   truncated at the nearest word. To further manipulate how the string is drawn inside the rectangle use the
+        ///   <see cref="DrawString(ReadOnlySpan{char}, Font, Brush, RectangleF, StringFormat?)"/> overload that takes
+        ///   a <see cref="StringFormat"/>.
+        ///  </para>
+        /// </remarks>
+        /// <inheritdoc cref="DrawString(string?, Font, Brush, RectangleF)"/>
+        public void DrawString(ReadOnlySpan<char> s, Font font, Brush brush, RectangleF layoutRectangle)
+        {
+            DrawString(s, font, brush, layoutRectangle, null);
+        }
+#endif
+
+        /// <summary>
+        ///  Draws the specified text in the specified rectangle with the specified <see cref="Brush"/> and
+        ///  <see cref="Font"/> objects using the formatting attributes of the specified <see cref="StringFormat"/>.
+        /// </summary>
+        /// <param name="s">The text to draw.</param>
+        /// <param name="font"><see cref="Font"/> that defines the text format.</param>
+        /// <param name="brush"><see cref="Brush"/> that determines the color and texture of the drawn text.</param>
+        /// <param name="layoutRectangle"><see cref="RectangleF"/>structure that specifies the location of the drawn text.</param>
+        /// <param name="format">
+        ///  <see cref="StringFormat"/> that specifies formatting attributes, such as line spacing and alignment,
+        ///  that are applied to the drawn text.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///  <paramref name="brush"/> is <see langword="null"/>. -or- <paramref name="font"/> is <see langword="null"/>.
+        /// </exception>
+        /// <remarks>
+        ///  <para>
+        ///   The text represented by the <paramref name="s"/> parameter is drawn inside the rectangle represented by
+        ///   the <paramref name="layoutRectangle"/> parameter. If the text does not fit inside the rectangle, it is
+        ///   truncated at the nearest word, unless otherwise specified with the <paramref name="format"/> parameter.
+        ///  </para>
+        /// </remarks>
         public void DrawString(string? s, Font font, Brush brush, RectangleF layoutRectangle, StringFormat? format)
         {
             ArgumentNullException.ThrowIfNull(brush);
@@ -1689,6 +1831,33 @@ namespace System.Drawing
                 new HandleRef(brush, brush.NativeBrush)));
         }
 
+#if NET8_0_OR_GREATER
+        /// <inheritdoc cref="DrawString(string?, Font, Brush, RectangleF, StringFormat?)"/>
+        public void DrawString(ReadOnlySpan<char> s, Font font, Brush brush, RectangleF layoutRectangle, StringFormat? format)
+        {
+            ArgumentNullException.ThrowIfNull(brush);
+
+            if (s.IsEmpty)
+            {
+                return;
+            }
+
+            ArgumentNullException.ThrowIfNull(font);
+
+            CheckErrorStatus(Gdip.GdipDrawString(
+                new HandleRef(this, NativeGraphics),
+                s,
+                s.Length,
+                new HandleRef(font, font.NativeFont),
+                ref layoutRectangle,
+                new HandleRef(format, format?.nativeFormat ?? IntPtr.Zero),
+                new HandleRef(brush, brush.NativeBrush)));
+        }
+#endif
+
+        /// <param name="charactersFitted">Number of characters in the text.</param>
+        /// <param name="linesFilled">Number of lines in the text.</param>
+        /// <inheritdoc cref="MeasureString(string?, Font, SizeF, StringFormat?)"/>
         public SizeF MeasureString(
             string? text,
             Font font,
@@ -1704,7 +1873,7 @@ namespace System.Drawing
                 return SizeF.Empty;
             }
 
-            if (font == null)
+            if (font is null)
                 throw new ArgumentNullException(nameof(font));
 
             RectangleF layout = new RectangleF(0, 0, layoutArea.Width, layoutArea.Height);
@@ -1724,11 +1893,51 @@ namespace System.Drawing
             return boundingBox.Size;
         }
 
+#if NET8_0_OR_GREATER
+        /// <inheritdoc cref="MeasureString(string?, Font, SizeF, StringFormat?, out int, out int)"/>
+        public SizeF MeasureString(
+            ReadOnlySpan<char> text,
+            Font font,
+            SizeF layoutArea,
+            StringFormat? stringFormat,
+            out int charactersFitted,
+            out int linesFilled)
+        {
+            if (text.IsEmpty)
+            {
+                charactersFitted = 0;
+                linesFilled = 0;
+                return SizeF.Empty;
+            }
+
+            if (font is null)
+                throw new ArgumentNullException(nameof(font));
+
+            RectangleF layout = new RectangleF(0, 0, layoutArea.Width, layoutArea.Height);
+            RectangleF boundingBox = default;
+
+            Gdip.CheckStatus(Gdip.GdipMeasureString(
+                new HandleRef(this, NativeGraphics),
+                text,
+                text.Length,
+                new HandleRef(font, font.NativeFont),
+                ref layout,
+                new HandleRef(stringFormat, stringFormat?.nativeFormat ?? IntPtr.Zero),
+                ref boundingBox,
+                out charactersFitted,
+                out linesFilled));
+
+            return boundingBox.Size;
+        }
+#endif
+
+        /// <param name="origin"><see cref="PointF"/> structure that represents the upper-left corner of the text.</param>
+        /// <inheritdoc cref="MeasureString(string?, Font, SizeF, StringFormat?)"/>
         public SizeF MeasureString(string? text, Font font, PointF origin, StringFormat? stringFormat)
         {
             if (string.IsNullOrEmpty(text))
                 return SizeF.Empty;
-            if (font == null)
+            if (font is null)
                 throw new ArgumentNullException(nameof(font));
 
             RectangleF layout = new RectangleF(origin.X, origin.Y, 0, 0);
@@ -1748,11 +1957,73 @@ namespace System.Drawing
             return boundingBox.Size;
         }
 
+#if NET8_0_OR_GREATER
+        /// <inheritdoc cref="MeasureString(string?, Font, PointF, StringFormat?)"/>
+        public SizeF MeasureString(ReadOnlySpan<char> text, Font font, PointF origin, StringFormat? stringFormat)
+        {
+            if (text.IsEmpty)
+                return SizeF.Empty;
+            if (font is null)
+                throw new ArgumentNullException(nameof(font));
+
+            RectangleF layout = new RectangleF(origin.X, origin.Y, 0, 0);
+            RectangleF boundingBox = default;
+
+            Gdip.CheckStatus(Gdip.GdipMeasureString(
+                new HandleRef(this, NativeGraphics),
+                text,
+                text.Length,
+                new HandleRef(font, font.NativeFont),
+                ref layout,
+                new HandleRef(stringFormat, stringFormat?.nativeFormat ?? IntPtr.Zero),
+                ref boundingBox,
+                out _,
+                out _));
+
+            return boundingBox.Size;
+        }
+#endif
+
+        /// <inheritdoc cref="MeasureString(string?, Font, SizeF, StringFormat?)"/>
         public SizeF MeasureString(string? text, Font font, SizeF layoutArea) => MeasureString(text, font, layoutArea, null);
 
+#if NET8_0_OR_GREATER
+        /// <inheritdoc cref="MeasureString(string?, Font, SizeF)"/>
+        public SizeF MeasureString(ReadOnlySpan<char> text, Font font, SizeF layoutArea) => MeasureString(text, font, layoutArea, null);
+#endif
+
+        /// <param name="stringFormat"><see cref="StringFormat"/> that represents formatting information, such as line spacing, for the text.</param>
+        /// <param name="layoutArea"><see cref="SizeF"/> structure that specifies the maximum layout area for the text.</param>
+        /// <inheritdoc cref="MeasureString(string?, Font, int, StringFormat?)"/>
         public SizeF MeasureString(string? text, Font font, SizeF layoutArea, StringFormat? stringFormat)
         {
             if (string.IsNullOrEmpty(text))
+                return SizeF.Empty;
+            if (font is null)
+                throw new ArgumentNullException(nameof(font));
+
+            RectangleF layout = new RectangleF(0, 0, layoutArea.Width, layoutArea.Height);
+            RectangleF boundingBox = default;
+
+            Gdip.CheckStatus(Gdip.GdipMeasureString(
+                new HandleRef(this, NativeGraphics),
+                text,
+                text.Length,
+                new HandleRef(font, font.NativeFont),
+                ref layout,
+                new HandleRef(stringFormat, stringFormat?.nativeFormat ?? IntPtr.Zero),
+                ref boundingBox,
+                out _,
+                out _));
+
+            return boundingBox.Size;
+        }
+
+#if NET8_0_OR_GREATER
+        /// <inheritdoc cref="MeasureString(string?, Font, SizeF, StringFormat?)"/>
+        public SizeF MeasureString(ReadOnlySpan<char> text, Font font, SizeF layoutArea, StringFormat? stringFormat)
+        {
+            if (text.IsEmpty)
                 return SizeF.Empty;
             if (font == null)
                 throw new ArgumentNullException(nameof(font));
@@ -1773,27 +2044,99 @@ namespace System.Drawing
 
             return boundingBox.Size;
         }
+#endif
 
+        /// <summary>
+        ///  Measures the specified text when drawn with the specified <see cref="Font"/>.
+        /// </summary>
+        /// <param name="text">Text to measure.</param>
+        /// <param name="font"><see cref="Font"/> that defines the text format.</param>
+        /// <returns>
+        ///  This method returns a <see cref="SizeF"/> structure that represents the size, in the units specified by the
+        ///  <see cref="PageUnit"/> property, of the text specified by the <paramref name="text"/> parameter as drawn
+        ///  with the <paramref name="font"/> parameter.
+        /// </returns>
+        /// <remarks>
+        ///  <para>
+        ///   The <see cref="MeasureString(string?, Font)"/> method is designed for use with individual strings and
+        ///   includes a small amount of extra space before and after the string to allow for overhanging glyphs. Also,
+        ///   the <see cref="DrawString(string?, Font, Brush, PointF)"/> method adjusts glyph points to optimize display
+        ///   quality and might display a string narrower than reported by <see cref="MeasureString(string?, Font)"/>.
+        ///   To obtain metrics suitable for adjacent strings in layout (for example, when implementing formatted text),
+        ///   use the <see cref="MeasureCharacterRanges(string?, Font, RectangleF, StringFormat?)"/> method or one of
+        ///   the <see cref="MeasureString(string?, Font, int, StringFormat?)"/> methods that takes a StringFormat, and
+        ///   pass <see cref="StringFormat.GenericTypographic"/>. Also, ensure the <see cref="TextRenderingHint"/> for
+        ///   the <see cref="Graphics"/> is <see cref="TextRenderingHint.AntiAlias"/>.
+        ///  </para>
+        /// </remarks>
+        /// <exception cref="ArgumentNullException"><paramref name="font"/> is null.</exception>
         public SizeF MeasureString(string? text, Font font)
         {
             return MeasureString(text, font, new SizeF(0, 0));
         }
 
+#if NET8_0_OR_GREATER
+        /// <inheritdoc cref="MeasureString(string?, Font)"/>
+        public SizeF MeasureString(ReadOnlySpan<char> text, Font font)
+        {
+            return MeasureString(text, font, new SizeF(0, 0));
+        }
+#endif
+
+        /// <param name="width">Maximum width of the string in pixels.</param>
+        /// <inheritdoc cref="MeasureString(string?, Font)"/>
         public SizeF MeasureString(string? text, Font font, int width)
         {
             return MeasureString(text, font, new SizeF(width, 999999));
         }
 
+#if NET8_0_OR_GREATER
+        /// <inheritdoc cref="MeasureString(string?, Font, int)"/>
+        public SizeF MeasureString(ReadOnlySpan<char> text, Font font, int width)
+        {
+            return MeasureString(text, font, new SizeF(width, 999999));
+        }
+#endif
+
+        /// <param name="format"><see cref="StringFormat"/> that represents formatting information, such as line spacing, for the text.</param>
+        /// <inheritdoc cref="MeasureString(string?, Font, int)"/>
         public SizeF MeasureString(string? text, Font font, int width, StringFormat? format)
         {
             return MeasureString(text, font, new SizeF(width, 999999), format);
         }
 
+#if NET8_0_OR_GREATER
+        /// <inheritdoc cref="MeasureString(string?, Font, int, StringFormat?)"/>
+        public SizeF MeasureString(ReadOnlySpan<char> text, Font font, int width, StringFormat? format)
+        {
+            return MeasureString(text, font, new SizeF(width, 999999), format);
+        }
+#endif
+
+        /// <summary>
+        ///  Gets an array of <see cref="Region"/> objects, each of which bounds a range of character positions within
+        ///  the specified text.
+        /// </summary>
+        /// <param name="text">Text to measure.</param>
+        /// <param name="font"><see cref="Font"/> that defines the text format.</param>
+        /// <param name="layoutRect"><see cref="RectangleF"/> structure that specifies the layout rectangle for the text.</param>
+        /// <param name="stringFormat"><see cref="StringFormat"/> that represents formatting information, such as line spacing, for the text.</param>
+        /// <returns>
+        ///  This method returns an array of <see cref="Region"/> objects, each of which bounds a range of character
+        ///  positions within the specified text.
+        /// </returns>
+        /// <remarks>
+        ///  <para>
+        ///   The regions returned by this method are resolution-dependent, so there might be a slight loss of accuracy
+        ///   if text is recorded in a metafile at one resolution and later played back at a different resolution.
+        ///  </para>
+        /// </remarks>
+        /// <exception cref="ArgumentNullException"><paramref name="font"/> is <see langword="null"/>.</exception>
         public Region[] MeasureCharacterRanges(string? text, Font font, RectangleF layoutRect, StringFormat? stringFormat)
         {
             if (string.IsNullOrEmpty(text))
                 return Array.Empty<Region>();
-            if (font == null)
+            if (font is null)
                 throw new ArgumentNullException(nameof(font));
 
             Gdip.CheckStatus(Gdip.GdipGetStringFormatMeasurableCharacterRangeCount(
@@ -1821,6 +2164,43 @@ namespace System.Drawing
 
             return regions;
         }
+
+#if NET8_0_OR_GREATER
+        /// <inheritdoc cref="MeasureCharacterRanges(string?, Font, RectangleF, StringFormat?)"/>
+        public Region[] MeasureCharacterRanges(ReadOnlySpan<char> text, Font font, RectangleF layoutRect, StringFormat? stringFormat)
+        {
+            if (text.IsEmpty)
+                return Array.Empty<Region>();
+            if (font is null)
+                throw new ArgumentNullException(nameof(font));
+
+            Gdip.CheckStatus(Gdip.GdipGetStringFormatMeasurableCharacterRangeCount(
+                new HandleRef(stringFormat, stringFormat?.nativeFormat ?? IntPtr.Zero),
+                out int count));
+
+            IntPtr[] gpRegions = new IntPtr[count];
+            Region[] regions = new Region[count];
+
+            for (int f = 0; f < count; f++)
+            {
+                regions[f] = new Region();
+                gpRegions[f] = regions[f].NativeRegion;
+            }
+
+            Gdip.CheckStatus(Gdip.GdipMeasureCharacterRanges(
+                new HandleRef(this, NativeGraphics),
+                text,
+                text.Length,
+                new HandleRef(font, font.NativeFont),
+                ref layoutRect,
+                new HandleRef(stringFormat, stringFormat?.nativeFormat ?? IntPtr.Zero),
+                count,
+                gpRegions));
+
+            return regions;
+        }
+#endif
+
 
         /// <summary>
         /// Draws the specified image at the specified location.

--- a/src/System.Drawing.Common/tests/mono/System.Drawing/GraphicsTests.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing/GraphicsTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 //
 // Graphics class testing unit
@@ -1719,10 +1719,15 @@ namespace MonoTests.System.Drawing
                     Assert.True(size.IsEmpty);
                     size = g.MeasureString(string.Empty, font);
                     Assert.True(size.IsEmpty);
+                    g.MeasureString(string.Empty.AsSpan(), font);
+                    Assert.True(size.IsEmpty);
+
                     // null font
                     size = g.MeasureString(null, null);
                     Assert.True(size.IsEmpty);
                     size = g.MeasureString(string.Empty, null);
+                    Assert.True(size.IsEmpty);
+                    g.MeasureString(string.Empty.AsSpan(), null);
                     Assert.True(size.IsEmpty);
                 }
             }
@@ -1735,6 +1740,7 @@ namespace MonoTests.System.Drawing
             using (Graphics g = Graphics.FromImage(bitmap))
             {
                 Assert.Throws<ArgumentNullException>(() => g.MeasureString("a", null));
+                Assert.Throws<ArgumentNullException>(() => g.MeasureString("a".AsSpan(), null));
             }
         }
 
@@ -1747,38 +1753,50 @@ namespace MonoTests.System.Drawing
                 SizeF size = g.MeasureString("a", font, SizeF.Empty);
                 Assert.False(size.IsEmpty);
 
+                size = g.MeasureString("a".AsSpan(), font, SizeF.Empty);
+                Assert.False(size.IsEmpty);
+
                 size = g.MeasureString(string.Empty, font, SizeF.Empty);
+                Assert.True(size.IsEmpty);
+
+                size = g.MeasureString(string.Empty.AsSpan(), font, SizeF.Empty);
                 Assert.True(size.IsEmpty);
             }
         }
 
-        private void MeasureString_StringFontInt(string s)
+        private void MeasureString_StringFontInt(string s, bool useSpan)
         {
             using (Bitmap bitmap = new Bitmap(20, 20))
             using (Graphics g = Graphics.FromImage(bitmap))
             {
-                SizeF size0 = g.MeasureString(s, font, 0);
-                SizeF sizeN = g.MeasureString(s, font, int.MinValue);
-                SizeF sizeP = g.MeasureString(s, font, int.MaxValue);
+                SizeF size0 = useSpan ? g.MeasureString(s.AsSpan(), font, 0) : g.MeasureString(s, font, 0);
+                SizeF sizeN = useSpan ? g.MeasureString(s.AsSpan(), font, int.MinValue) : g.MeasureString(s, font, int.MinValue);
+                SizeF sizeP = useSpan ? g.MeasureString(s.AsSpan(), font, int.MaxValue) : g.MeasureString(s, font, int.MaxValue);
                 Assert.Equal(size0, sizeN);
                 Assert.Equal(size0, sizeP);
             }
         }
 
-        [Fact]
-        public void MeasureString_StringFontInt_ShortString()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void MeasureString_StringFontInt_ShortString(bool useSpan)
         {
-            MeasureString_StringFontInt("a");
+            MeasureString_StringFontInt("a", useSpan);
         }
 
-        [Fact]
-        public void MeasureString_StringFontInt_LongString()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void MeasureString_StringFontInt_LongString(bool useSpan)
         {
-            MeasureString_StringFontInt("A very long string...");
+            MeasureString_StringFontInt("A very long string...", useSpan);
         }
 
-        [Fact]
-        public void MeasureString_StringFormat_Alignment()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void MeasureString_StringFormat_Alignment(bool useSpan)
         {
             string text = "Hello Mono::";
 
@@ -1787,13 +1805,19 @@ namespace MonoTests.System.Drawing
             using (Graphics g = Graphics.FromImage(bitmap))
             {
                 string_format.Alignment = StringAlignment.Near;
-                SizeF near = g.MeasureString(text, font, int.MaxValue, string_format);
+                SizeF near = useSpan
+                    ? g.MeasureString(text.AsSpan(), font, int.MaxValue, string_format)
+                    : g.MeasureString(text, font, int.MaxValue, string_format);
 
                 string_format.Alignment = StringAlignment.Center;
-                SizeF center = g.MeasureString(text, font, int.MaxValue, string_format);
+                SizeF center = useSpan
+                    ? g.MeasureString(text.AsSpan(), font, int.MaxValue, string_format)
+                    : g.MeasureString(text, font, int.MaxValue, string_format);
 
                 string_format.Alignment = StringAlignment.Far;
-                SizeF far = g.MeasureString(text, font, int.MaxValue, string_format);
+                SizeF far = useSpan
+                    ? g.MeasureString(text.AsSpan(), font, int.MaxValue, string_format)
+                    : g.MeasureString(text, font, int.MaxValue, string_format);
 
                 Assert.Equal((double)near.Width, center.Width, 1);
                 Assert.Equal((double)near.Height, center.Height, 1);
@@ -1803,8 +1827,10 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [Fact]
-        public void MeasureString_StringFormat_Alignment_DirectionVertical()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void MeasureString_StringFormat_Alignment_DirectionVertical(bool useSpan)
         {
             string text = "Hello Mono::";
             using (StringFormat string_format = new StringFormat())
@@ -1814,13 +1840,19 @@ namespace MonoTests.System.Drawing
                 string_format.FormatFlags = StringFormatFlags.DirectionVertical;
 
                 string_format.Alignment = StringAlignment.Near;
-                SizeF near = g.MeasureString(text, font, int.MaxValue, string_format);
+                SizeF near = useSpan
+                    ? g.MeasureString(text.AsSpan(), font, int.MaxValue, string_format)
+                    : g.MeasureString(text, font, int.MaxValue, string_format);
 
                 string_format.Alignment = StringAlignment.Center;
-                SizeF center = g.MeasureString(text, font, int.MaxValue, string_format);
+                SizeF center = useSpan
+                    ? g.MeasureString(text.AsSpan(), font, int.MaxValue, string_format)
+                    : g.MeasureString(text, font, int.MaxValue, string_format);
 
                 string_format.Alignment = StringAlignment.Far;
-                SizeF far = g.MeasureString(text, font, int.MaxValue, string_format);
+                SizeF far = useSpan
+                    ? g.MeasureString(text.AsSpan(), font, int.MaxValue, string_format)
+                    : g.MeasureString(text, font, int.MaxValue, string_format);
 
                 Assert.Equal((double)near.Width, center.Width, 0);
                 Assert.Equal((double)near.Height, center.Height, 0);
@@ -1830,8 +1862,10 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [Fact]
-        public void MeasureString_StringFormat_LineAlignment()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void MeasureString_StringFormat_LineAlignment(bool useSpan)
         {
             string text = "Hello Mono::";
             using (StringFormat string_format = new StringFormat())
@@ -1839,13 +1873,19 @@ namespace MonoTests.System.Drawing
             using (Graphics g = Graphics.FromImage(bitmap))
             {
                 string_format.LineAlignment = StringAlignment.Near;
-                SizeF near = g.MeasureString(text, font, int.MaxValue, string_format);
+                SizeF near = useSpan
+                    ? g.MeasureString(text.AsSpan(), font, int.MaxValue, string_format)
+                    : g.MeasureString(text, font, int.MaxValue, string_format);
 
                 string_format.LineAlignment = StringAlignment.Center;
-                SizeF center = g.MeasureString(text, font, int.MaxValue, string_format);
+                SizeF center = useSpan
+                    ? g.MeasureString(text.AsSpan(), font, int.MaxValue, string_format)
+                    : g.MeasureString(text, font, int.MaxValue, string_format);
 
                 string_format.LineAlignment = StringAlignment.Far;
-                SizeF far = g.MeasureString(text, font, int.MaxValue, string_format);
+                SizeF far = useSpan
+                    ? g.MeasureString(text.AsSpan(), font, int.MaxValue, string_format)
+                    : g.MeasureString(text, font, int.MaxValue, string_format);
 
                 Assert.Equal((double)near.Width, center.Width, 1);
                 Assert.Equal((double)near.Height, center.Height, 1);
@@ -1855,8 +1895,10 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [Fact]
-        public void MeasureString_StringFormat_LineAlignment_DirectionVertical()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void MeasureString_StringFormat_LineAlignment_DirectionVertical(bool useSpan)
         {
             string text = "Hello Mono::";
             using (StringFormat string_format = new StringFormat())
@@ -1866,13 +1908,19 @@ namespace MonoTests.System.Drawing
                 string_format.FormatFlags = StringFormatFlags.DirectionVertical;
 
                 string_format.LineAlignment = StringAlignment.Near;
-                SizeF near = g.MeasureString(text, font, int.MaxValue, string_format);
+                SizeF near = useSpan
+                    ? g.MeasureString(text.AsSpan(), font, int.MaxValue, string_format)
+                    : g.MeasureString(text, font, int.MaxValue, string_format);
 
                 string_format.LineAlignment = StringAlignment.Center;
-                SizeF center = g.MeasureString(text, font, int.MaxValue, string_format);
+                SizeF center = useSpan
+                    ? g.MeasureString(text.AsSpan(), font, int.MaxValue, string_format)
+                    : g.MeasureString(text, font, int.MaxValue, string_format);
 
                 string_format.LineAlignment = StringAlignment.Far;
-                SizeF far = g.MeasureString(text, font, int.MaxValue, string_format);
+                SizeF far = useSpan
+                    ? g.MeasureString(text.AsSpan(), font, int.MaxValue, string_format)
+                    : g.MeasureString(text, font, int.MaxValue, string_format);
 
                 Assert.Equal((double)near.Width, center.Width, 1);
                 Assert.Equal((double)near.Height, center.Height, 1);
@@ -1882,17 +1930,21 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [Fact]
-        public void MeasureString_CharactersFitted()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void MeasureString_CharactersFitted(bool useSpan)
         {
             using (Bitmap bitmap = new Bitmap(20, 20))
             using (Graphics g = Graphics.FromImage(bitmap))
             {
                 string s = "aaa aa aaaa a aaa";
-                SizeF size = g.MeasureString(s, font);
+                SizeF size = useSpan ? g.MeasureString(s.AsSpan(), font) : g.MeasureString(s, font);
 
                 int chars, lines;
-                SizeF size2 = g.MeasureString(s, font, new SizeF(80, size.Height), null, out chars, out lines);
+                SizeF size2 = useSpan
+                    ? g.MeasureString(s.AsSpan(), font, new SizeF(80, size.Height), null, out chars, out lines)
+                    : g.MeasureString(s, font, new SizeF(80, size.Height), null, out chars, out lines);
 
                 // in pixels
                 Assert.True(size2.Width < size.Width);
@@ -1904,46 +1956,48 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [Fact]
-        public void MeasureString_Whitespace()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void MeasureString_Whitespace(bool useSpan)
         {
             using (Bitmap bitmap = new Bitmap(20, 20))
             using (Graphics g = Graphics.FromImage(bitmap))
             {
                 string s = string.Empty;
-                SizeF size = g.MeasureString(s, font);
+                SizeF size = useSpan ? g.MeasureString(s.AsSpan(), font) : g.MeasureString(s, font);
                 Assert.Equal(0, size.Height);
                 Assert.Equal(0, size.Width);
 
                 s += " ";
-                SizeF expected = g.MeasureString(s, font);
+                SizeF expected = useSpan ? g.MeasureString(s.AsSpan(), font) : g.MeasureString(s, font);
                 for (int i = 1; i < 10; i++)
                 {
                     s += " ";
-                    size = g.MeasureString(s, font);
+                    size = useSpan ? g.MeasureString(s.AsSpan(), font) : g.MeasureString(s, font);
                     Assert.Equal((double)expected.Height, size.Height, 1);
                     Assert.Equal((double)expected.Width, size.Width, 1);
                 }
 
                 s = "a";
-                expected = g.MeasureString(s, font);
+                expected = useSpan ? g.MeasureString(s.AsSpan(), font) : g.MeasureString(s, font);
                 s = " " + s;
-                size = g.MeasureString(s, font);
+                size = useSpan ? g.MeasureString(s.AsSpan(), font) : g.MeasureString(s, font);
                 float space_width = size.Width - expected.Width;
                 for (int i = 1; i < 10; i++)
                 {
-                    size = g.MeasureString(s, font);
+                    size = useSpan ? g.MeasureString(s.AsSpan(), font) : g.MeasureString(s, font);
                     Assert.Equal((double)expected.Height, size.Height, 1);
                     Assert.Equal((double)expected.Width + i * space_width, size.Width, 1);
                     s = " " + s;
                 }
 
                 s = "a";
-                expected = g.MeasureString(s, font);
+                expected = useSpan ? g.MeasureString(s.AsSpan(), font) : g.MeasureString(s, font);
                 for (int i = 1; i < 10; i++)
                 {
                     s = s + " ";
-                    size = g.MeasureString(s, font);
+                    size = useSpan ? g.MeasureString(s.AsSpan(), font) : g.MeasureString(s, font);
                     Assert.Equal((double)expected.Height, size.Height, 1);
                     Assert.Equal((double)expected.Width, size.Width, 1);
                 }
@@ -1958,12 +2012,19 @@ namespace MonoTests.System.Drawing
             {
                 Region[] regions = g.MeasureCharacterRanges(null, font, new RectangleF(), null);
                 Assert.Equal(0, regions.Length);
+
                 regions = g.MeasureCharacterRanges(string.Empty, font, new RectangleF(), null);
                 Assert.Equal(0, regions.Length);
+                regions = g.MeasureCharacterRanges(string.Empty.AsSpan(), font, new RectangleF(), null);
+                Assert.Equal(0, regions.Length);
+
                 // null font is ok with null or empty string
                 regions = g.MeasureCharacterRanges(null, null, new RectangleF(), null);
                 Assert.Equal(0, regions.Length);
+
                 regions = g.MeasureCharacterRanges(string.Empty, null, new RectangleF(), null);
+                Assert.Equal(0, regions.Length);
+                regions = g.MeasureCharacterRanges(string.Empty.AsSpan(), null, new RectangleF(), null);
                 Assert.Equal(0, regions.Length);
             }
         }
@@ -1977,6 +2038,9 @@ namespace MonoTests.System.Drawing
                 // string format without character ranges
                 Region[] regions = g.MeasureCharacterRanges("Mono", font, new RectangleF(), new StringFormat());
                 Assert.Equal(0, regions.Length);
+
+                g.MeasureCharacterRanges("Mono".AsSpan(), font, new RectangleF(), new StringFormat());
+                Assert.Equal(0, regions.Length);
             }
         }
 
@@ -1987,6 +2051,7 @@ namespace MonoTests.System.Drawing
             using (Graphics g = Graphics.FromImage(bitmap))
             {
                 Assert.Throws<ArgumentNullException>(() => g.MeasureCharacterRanges("a", null, new RectangleF(), null));
+                Assert.Throws<ArgumentNullException>(() => g.MeasureCharacterRanges("a".AsSpan(), null, new RectangleF(), null));
             }
         }
 
@@ -2011,10 +2076,15 @@ namespace MonoTests.System.Drawing
 
                 Assert.Equal(2, regions.Length);
                 Assert.Equal(regions[0].GetBounds(g).Height, regions[1].GetBounds(g).Height);
+
+                regions = g.MeasureCharacterRanges(text.AsSpan(), font, layout_rect, string_format);
+
+                Assert.Equal(2, regions.Length);
+                Assert.Equal(regions[0].GetBounds(g).Height, regions[1].GetBounds(g).Height);
             }
         }
 
-        private void MeasureCharacterRanges(string text, int first, int length)
+        private void MeasureCharacterRanges(string text, int first, int length, bool useSpan)
         {
             CharacterRange[] ranges = new CharacterRange[1];
             ranges[0] = new CharacterRange(first, length);
@@ -2026,24 +2096,37 @@ namespace MonoTests.System.Drawing
                 string_format.FormatFlags = StringFormatFlags.NoClip;
                 string_format.SetMeasurableCharacterRanges(ranges);
 
-                SizeF size = g.MeasureString(text, font, new Point(0, 0), string_format);
+                SizeF size = useSpan
+                    ? g.MeasureString(text.AsSpan(), font, new Point(0, 0), string_format)
+                    : g.MeasureString(text, font, new Point(0, 0), string_format);
                 RectangleF layout_rect = new RectangleF(0.0f, 0.0f, size.Width, size.Height);
-                g.MeasureCharacterRanges(text, font, layout_rect, string_format);
+                if (useSpan)
+                {
+                    g.MeasureCharacterRanges(text.AsSpan(), font, layout_rect, string_format);
+                }
+                else
+                {
+                    g.MeasureCharacterRanges(text, font, layout_rect, string_format);
+                }
             }
         }
 
-        [Fact]
-        public void MeasureCharacterRanges_FirstTooFar()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void MeasureCharacterRanges_FirstTooFar(bool useSpan)
         {
             string text = "this\nis a test";
-            Assert.Throws<ArgumentException>(() => MeasureCharacterRanges(text, text.Length, 1));
+            Assert.Throws<ArgumentException>(() => MeasureCharacterRanges(text, text.Length, 1, useSpan));
         }
 
-        [Fact]
-        public void MeasureCharacterRanges_LengthTooLong()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void MeasureCharacterRanges_LengthTooLong(bool useSpan)
         {
             string text = "this\nis a test";
-            Assert.Throws<ArgumentException>(() => MeasureCharacterRanges(text, 0, text.Length + 1));
+            Assert.Throws<ArgumentException>(() => MeasureCharacterRanges(text, 0, text.Length + 1, useSpan));
         }
 
         [Fact]
@@ -2073,10 +2156,18 @@ namespace MonoTests.System.Drawing
                 RectangleF bounds_show = regions[0].GetBounds(g);
                 Assert.True(bounds_show.Width < bounds_none.Width);
 
+                regions = g.MeasureCharacterRanges(text.AsSpan(), font, layout_rect, string_format);
+                bounds_show = regions[0].GetBounds(g);
+                Assert.True(bounds_show.Width < bounds_none.Width);
+
                 // here & is part of the measure (range) but invisible
                 string_format.HotkeyPrefix = HotkeyPrefix.Hide;
                 regions = g.MeasureCharacterRanges(text, font, layout_rect, string_format);
                 RectangleF bounds_hide = regions[0].GetBounds(g);
+                Assert.Equal((double)bounds_hide.Width, bounds_show.Width);
+
+                g.MeasureCharacterRanges(text.AsSpan(), font, layout_rect, string_format);
+                bounds_hide = regions[0].GetBounds(g);
                 Assert.Equal((double)bounds_hide.Width, bounds_show.Width);
             }
         }
@@ -2088,6 +2179,7 @@ namespace MonoTests.System.Drawing
             using (Graphics g = Graphics.FromImage(bitmap))
             {
                 Assert.Throws<ArgumentException>(() => g.MeasureCharacterRanges("Mono", font, new RectangleF(), null));
+                Assert.Throws<ArgumentException>(() => g.MeasureCharacterRanges("Mono".AsSpan(), font, new RectangleF(), null));
             }
         }
 
@@ -2097,7 +2189,7 @@ namespace MonoTests.System.Drawing
                     new CharacterRange (2, 1)
                 };
 
-        Region[] Measure_Helper(Graphics gfx, RectangleF rect)
+        Region[] Measure_Helper(Graphics gfx, RectangleF rect, bool useSpan)
         {
             using (StringFormat format = StringFormat.GenericTypographic)
             {
@@ -2105,20 +2197,24 @@ namespace MonoTests.System.Drawing
 
                 using (Font font = new Font(FontFamily.GenericSerif, 11.0f))
                 {
-                    return gfx.MeasureCharacterRanges("abc", font, rect, format);
+                    return useSpan
+                        ? gfx.MeasureCharacterRanges("abc".AsSpan(), font, rect, format)
+                        : gfx.MeasureCharacterRanges("abc", font, rect, format);
                 }
             }
         }
 
-        [Fact]
-        public void Measure()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Measure(bool useSpan)
         {
             using (Graphics gfx = Graphics.FromImage(new Bitmap(1, 1)))
             {
-                Region[] zero = Measure_Helper(gfx, new RectangleF(0, 0, 0, 0));
+                Region[] zero = Measure_Helper(gfx, new RectangleF(0, 0, 0, 0), useSpan);
                 Assert.Equal(3, zero.Length);
 
-                Region[] small = Measure_Helper(gfx, new RectangleF(0, 0, 100, 100));
+                Region[] small = Measure_Helper(gfx, new RectangleF(0, 0, 100, 100), useSpan);
                 Assert.Equal(3, small.Length);
                 for (int i = 0; i < 3; i++)
                 {
@@ -2130,7 +2226,7 @@ namespace MonoTests.System.Drawing
                     Assert.Equal((double)sb.Height, zb.Height);
                 }
 
-                Region[] max = Measure_Helper(gfx, new RectangleF(0, 0, float.MaxValue, float.MaxValue));
+                Region[] max = Measure_Helper(gfx, new RectangleF(0, 0, float.MaxValue, float.MaxValue), useSpan);
                 Assert.Equal(3, max.Length);
                 for (int i = 0; i < 3; i++)
                 {
@@ -2144,12 +2240,14 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        [Fact]
-        public void MeasureLimits()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void MeasureLimits(bool useSpan)
         {
             using (Graphics gfx = Graphics.FromImage(new Bitmap(1, 1)))
             {
-                Region[] min = Measure_Helper(gfx, new RectangleF(0, 0, float.MinValue, float.MinValue));
+                Region[] min = Measure_Helper(gfx, new RectangleF(0, 0, float.MinValue, float.MinValue), useSpan);
                 Assert.Equal(3, min.Length);
                 for (int i = 0; i < 3; i++)
                 {
@@ -2160,7 +2258,7 @@ namespace MonoTests.System.Drawing
                     Assert.Equal(8388608.0f, mb.Height);
                 }
 
-                Region[] neg = Measure_Helper(gfx, new RectangleF(0, 0, -20, -20));
+                Region[] neg = Measure_Helper(gfx, new RectangleF(0, 0, -20, -20), useSpan);
                 Assert.Equal(3, neg.Length);
                 for (int i = 0; i < 3; i++)
                 {
@@ -2188,6 +2286,7 @@ namespace MonoTests.System.Drawing
                 fmt.FormatFlags = StringFormatFlags.NoWrap;
                 fmt.Trimming = StringTrimming.EllipsisWord;
                 g.DrawString("Test String", font, Brushes.Black, rect, fmt);
+                g.DrawString("Test String".AsSpan(), font, Brushes.Black, rect, fmt);
             }
         }
 
@@ -2205,6 +2304,7 @@ namespace MonoTests.System.Drawing
                 fmt.LineAlignment = StringAlignment.Center;
                 fmt.Trimming = StringTrimming.EllipsisWord;
                 g.DrawString("Test String", font, Brushes.Black, rect, fmt);
+                g.DrawString("Test String".AsSpan(), font, Brushes.Black, rect, fmt);
             }
         }
 
@@ -2218,6 +2318,10 @@ namespace MonoTests.System.Drawing
             {
                 format.Alignment = StringAlignment.Center;
                 SizeF sz = g.MeasureString(text, font, 80, format);
+                Assert.True(sz.Width <= 80);
+                Assert.True(sz.Height > font.Height * 2);
+
+                sz = g.MeasureString(text.AsSpan(), font, 80, format);
                 Assert.True(sz.Width <= 80);
                 Assert.True(sz.Height > font.Height * 2);
             }

--- a/src/System.Drawing.Common/tests/mono/System.Imaging/MetafileTest.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Imaging/MetafileTest.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 //
 // Metafile class unit tests
@@ -406,6 +406,9 @@ namespace MonoTests.System.Drawing.Imaging
 
                 RectangleF rect = new RectangleF(0, 0, size.Width, size.Height);
                 Region[] region = g.MeasureCharacterRanges(text, test_font, rect, sf);
+                Assert.Equal(2, region.Length);
+
+                region = g.MeasureCharacterRanges(text.AsSpan(), test_font, rect, sf);
                 Assert.Equal(2, region.Length);
                 mf.Dispose();
             }


### PR DESCRIPTION
Adds `ReadOnlySpan<char>` overloads to `Graphics.DrawString`, `MeasureCharacterRanges`, and `MeasureString`.

Cleaned up docs for these methods as well and called span/string overloads in existing tests.

Fixes: #8844

cc: @ericstj, @ViktorHofer, @carlossanlop 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8877)