### PR TITLE
Add AppContext switch scope functionality

### DIFF
--- a/src/Common/tests/TestUtilities/AppContextSwitchNames.cs
+++ b/src/Common/tests/TestUtilities/AppContextSwitchNames.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.Serialization.Formatters.Binary;
+
+namespace System;
+
+public static class AppContextSwitchNames
+{
+    /// <summary>
+    ///  The switch that controls whether or not the <see cref="BinaryFormatter"/> is enabled.
+    /// </summary>
+    public static string EnableUnsafeBinaryFormatterSerialization { get; }
+        = "System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization";
+
+    /// <summary>
+    ///  Switch that controls <see cref="AppContext"/> switch caching.
+    /// </summary>
+    public static string LocalAppContext_DisableCaching { get; }
+        = "TestSwitch.LocalAppContext.DisableCaching";
+}

--- a/src/Common/tests/TestUtilities/AppContextSwitchScope.cs
+++ b/src/Common/tests/TestUtilities/AppContextSwitchScope.cs
@@ -1,0 +1,49 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System;
+
+/// <summary>
+///  Scope for temporarily setting an <see cref="AppContext"/> switch. Use in a <see langword="using"/> statement.
+/// </summary>
+/// <remarks>
+///  <para>
+///   It is recommended to create wrappers for this struct for both simplicity and to allow adding synchronization.
+///   See <see cref="BinaryFormatterScope"/> for an example of doing this.
+///  </para>
+/// </remarks>
+public readonly ref struct AppContextSwitchScope
+{
+    private readonly string _switchName;
+    private readonly bool _originalState;
+
+    public AppContextSwitchScope(string switchName, bool enable)
+    {
+        if (!AppContext.TryGetSwitch(AppContextSwitchNames.LocalAppContext_DisableCaching, out bool isEnabled)
+            || !isEnabled)
+        {
+            // It doesn't make sense to try messing with AppContext switches if they are going to be cached.
+            throw new InvalidOperationException("LocalAppContext switch caching is not disabled.");
+        }
+
+        AppContext.TryGetSwitch(switchName, out _originalState);
+
+        AppContext.SetSwitch(switchName, enable);
+        if (!AppContext.TryGetSwitch(switchName, out isEnabled) || isEnabled != enable)
+        {
+            throw new InvalidOperationException($"Could not set {switchName} to {enable}.");
+        }
+
+        _switchName = switchName;
+    }
+
+    public void Dispose()
+    {
+        AppContext.SetSwitch(_switchName, _originalState);
+        if (!AppContext.TryGetSwitch(_switchName, out bool isEnabled) || isEnabled != _originalState)
+        {
+            throw new InvalidOperationException($"Could not reset {_switchName} to {_originalState}.");
+        }
+    }
+}

--- a/src/Common/tests/TestUtilities/BinaryFormatterScope.cs
+++ b/src/Common/tests/TestUtilities/BinaryFormatterScope.cs
@@ -1,0 +1,60 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.Serialization.Formatters.Binary;
+
+namespace System;
+
+/// <summary>
+///  Scope for enabling / disabling the <see cref="BinaryFormatter"/>. Use in a <see langword="using"/> statement.
+/// </summary>
+public readonly ref struct BinaryFormatterScope
+{
+    private readonly AppContextSwitchScope _switchScope;
+
+    public BinaryFormatterScope(bool enable)
+    {
+        // Prevent multiple BinaryFormatterScopes from running simultaneously. Using Monitor to allow recursion on
+        // the same thread.
+        Monitor.Enter(typeof(BinaryFormatterScope));
+        _switchScope = new AppContextSwitchScope(AppContextSwitchNames.EnableUnsafeBinaryFormatterSerialization, enable);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            _switchScope.Dispose();
+        }
+        finally
+        {
+            Monitor.Exit(typeof(BinaryFormatterScope));
+        }
+    }
+
+    static BinaryFormatterScope()
+    {
+        // Need to explicitly set the switch to whatever the default is as its default value is in transition.
+
+        BinaryFormatter formatter = new();
+        try
+        {
+#pragma warning disable SYSLIB0011 // Type or member is obsolete
+            formatter.Serialize(null!, null!);
+#pragma warning restore SYSLIB0011
+        }
+        catch (NotSupportedException)
+        {
+            AppContext.SetSwitch(AppContextSwitchNames.EnableUnsafeBinaryFormatterSerialization, false);
+            return;
+        }
+        catch (ArgumentNullException)
+        {
+            AppContext.SetSwitch(AppContextSwitchNames.EnableUnsafeBinaryFormatterSerialization, true);
+            return;
+        }
+
+        throw new InvalidOperationException();
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
@@ -1567,7 +1567,7 @@ public partial class Control
 
                 Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, $"Saving property {currentProperty.Name}");
 
-                object? value = null;
+                string? value = null;
 
                 if (IsResourceProperty(currentProperty))
                 {
@@ -1606,11 +1606,13 @@ public partial class Control
                     value = Convert.ToBase64String(data);
                 }
 
-                VARIANT variant = default;
-                Marshal.GetNativeVariantForObject(value, (nint)(void*)&variant);
-                fixed (char* pszPropName = props[i].Name)
+                if (value is not null)
                 {
-                    propertyBag->Write(pszPropName, &variant);
+                    using VARIANT variant = (VARIANT)(new BSTR(value));
+                    fixed (char* pszPropName = props[i].Name)
+                    {
+                        propertyBag->Write(pszPropName, &variant);
+                    }
                 }
             }
 

--- a/src/System.Windows.Forms/tests/UnitTests/SerializableTypesTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/SerializableTypesTests.cs
@@ -18,6 +18,7 @@ namespace System.Windows.Forms.Tests.Serialization
         [Fact]
         public void AxHostState_RoundTripAndExchangeWithNet()
         {
+            using var formatterScope = new BinaryFormatterScope(enable: true);
             string payload = "abc";
             string licenseKey = "licenseKey";
             string netBlob;
@@ -70,13 +71,14 @@ namespace System.Windows.Forms.Tests.Serialization
         [Fact]
         public void ImageListStreamer_RoundTripAndExchangeWithNet()
         {
+            using var formatterScope = new BinaryFormatterScope(enable: true);
             string netBlob;
 
             using (var imageList = new ImageList()
-            {
-                ImageSize = new Size(16, 16),
-                TransparentColor = Color.White
-            })
+                {
+                    ImageSize = new Size(16, 16),
+                    TransparentColor = Color.White
+                })
             {
                 imageList.Images.Add(new Bitmap(16, 16));
                 netBlob = BinarySerialization.ToBase64String(imageList.ImageStream);
@@ -104,6 +106,7 @@ namespace System.Windows.Forms.Tests.Serialization
         [Fact]
         public void LinkArea_RoundTripAndExchangeWithNet()
         {
+            using var formatterScope = new BinaryFormatterScope(enable: true);
             var linkArea = new LinkArea(5, 7);
             var netBlob = BinarySerialization.ToBase64String(linkArea);
 
@@ -123,11 +126,13 @@ namespace System.Windows.Forms.Tests.Serialization
         [Fact]
         public void ListViewGroup_RoundTripAndExchangeWithNet()
         {
+            using var formatterScope = new BinaryFormatterScope(enable: true);
             var listViewGroup = new ListViewGroup("Header", HorizontalAlignment.Center)
             {
                 Tag = "Tag",
                 Name = "GroupName",
             };
+
             listViewGroup.Items.Add(new ListViewItem("Item"));
 
             var netBlob = BinarySerialization.ToBase64String(listViewGroup);
@@ -154,6 +159,7 @@ namespace System.Windows.Forms.Tests.Serialization
         [Fact]
         public void ListViewItem_RoundTripAndExchangeWithNet()
         {
+            using var formatterScope = new BinaryFormatterScope(enable: true);
             string netBlob;
 
             using (var font = new Font(FontFamily.GenericSansSerif, 9f))
@@ -200,6 +206,7 @@ namespace System.Windows.Forms.Tests.Serialization
         [Fact]
         public void ListViewSubItemAndSubItemStyle_RoundTripAndExchangeWithNet()
         {
+            using var formatterScope = new BinaryFormatterScope(enable: true);
             string netBlob;
 
             using (var font = new Font(FontFamily.GenericSansSerif, 9f))
@@ -241,6 +248,7 @@ namespace System.Windows.Forms.Tests.Serialization
         [Fact]
         public void Padding_RoundTripAndExchangeWithNet()
         {
+            using var formatterScope = new BinaryFormatterScope(enable: true);
             var padding = new Padding(1, 2, 3, 4);
             var netBlob = BinarySerialization.ToBase64String(padding);
 
@@ -260,6 +268,8 @@ namespace System.Windows.Forms.Tests.Serialization
         [Fact]
         public void TableLayoutSettings_RoundTripAndExchangeWithNet()
         {
+            using var formatterScope = new BinaryFormatterScope(enable: true);
+
             string netBlob;
 
             using (var tableLayoutPanel = new TableLayoutPanel
@@ -335,6 +345,7 @@ namespace System.Windows.Forms.Tests.Serialization
         [Fact]
         public void TreeNodeAndPropertyBag_RoundTripAndExchangeWithNet()
         {
+            using var formatterScope = new BinaryFormatterScope(enable: true);
             var children = new TreeNode[] { new TreeNode("node2"), new TreeNode("node3") };
             TreeNode treeNodeIn = new TreeNode("node1", 1, 2, children)
             {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ClipboardTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ClipboardTests.cs
@@ -220,6 +220,7 @@ namespace System.Windows.Forms.Tests
         [InlineData("format", 1)]
         public void Clipboard_SetData_Invoke_GetReturnsExpected(string format, object data)
         {
+            using var formatterScope = new BinaryFormatterScope(enable: data is int);
             Clipboard.SetData(format, data);
             Assert.Equal(data, Clipboard.GetData(format));
             Assert.True(Clipboard.ContainsData(format));
@@ -251,6 +252,7 @@ namespace System.Windows.Forms.Tests
         [InlineData("data")]
         public void Clipboard_SetDataObject_InvokeObjectNotIComDataObject_GetReturnsExpected(object data)
         {
+            using var formatterScope = new BinaryFormatterScope(enable: data is int);
             Clipboard.SetDataObject(data);
             Assert.Equal(data, Clipboard.GetDataObject().GetData(data.GetType()));
             Assert.True(Clipboard.ContainsData(data.GetType().FullName));
@@ -261,6 +263,7 @@ namespace System.Windows.Forms.Tests
         [InlineData("data")]
         public void Clipboard_SetDataObject_InvokeObjectIComDataObject_GetReturnsExpected(object data)
         {
+            using var formatterScope = new BinaryFormatterScope(enable: data is int);
             var dataObject = new DataObject(data);
             Clipboard.SetDataObject(dataObject);
             Assert.Equal(data, Clipboard.GetDataObject().GetData(data.GetType()));
@@ -274,6 +277,7 @@ namespace System.Windows.Forms.Tests
         [InlineData("data", false)]
         public void Clipboard_SetDataObject_InvokeObjectBoolNotIComDataObject_GetReturnsExpected(object data, bool copy)
         {
+            using var formatterScope = new BinaryFormatterScope(enable: data is int);
             Clipboard.SetDataObject(data, copy);
             Assert.Equal(data, Clipboard.GetDataObject().GetData(data.GetType()));
             Assert.True(Clipboard.ContainsData(data.GetType().FullName));
@@ -286,6 +290,7 @@ namespace System.Windows.Forms.Tests
         [InlineData("data", false, 1, 2)]
         public void Clipboard_SetDataObject_InvokeObjectBoolIComDataObject_GetReturnsExpected(object data, bool copy, int retryTimes, int retryDelay)
         {
+            using var formatterScope = new BinaryFormatterScope(enable: data is int);
             var dataObject = new DataObject(data);
             Clipboard.SetDataObject(dataObject, copy, retryTimes, retryDelay);
             Assert.Equal(data, Clipboard.GetDataObject().GetData(data.GetType()));
@@ -299,6 +304,7 @@ namespace System.Windows.Forms.Tests
         [InlineData("data", false, 1, 2)]
         public void Clipboard_SetDataObject_InvokeObjectBoolIntIntNotIComDataObject_GetReturnsExpected(object data, bool copy, int retryTimes, int retryDelay)
         {
+            using var formatterScope = new BinaryFormatterScope(enable: data is int);
             Clipboard.SetDataObject(data, copy, retryTimes, retryDelay);
             Assert.Equal(data, Clipboard.GetDataObject().GetData(data.GetType()));
             Assert.True(Clipboard.ContainsData(data.GetType().FullName));
@@ -446,6 +452,7 @@ namespace System.Windows.Forms.Tests
         [EnumData<TextDataFormat>]
         public void Clipboard_SetText_InvokeStringTextDataFormat_GetReturnsExpected(TextDataFormat format)
         {
+            using var formatterScope = new BinaryFormatterScope(enable: format == TextDataFormat.CommaSeparatedValue);
             Clipboard.SetText("text", format);
             Assert.Equal("text", Clipboard.GetText(format));
             Assert.True(Clipboard.ContainsText(format));

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ImageList.NativeImageListTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ImageList.NativeImageListTests.cs
@@ -12,6 +12,7 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void NativeImageList_Dispose_releases_native_handle()
         {
+            using var formatterScope = new BinaryFormatterScope(enable: true);
             using ImageListStreamer result = BinarySerialization.EnsureDeserialize<ImageListStreamer>(ClassicImageListStreamer);
 
             NativeImageList nativeImageList = result.GetNativeImageList();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ImageListStreamerTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ImageListStreamerTests.cs
@@ -12,6 +12,8 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void ImageListStreamer_BinaryFormatter_Stream_BinaryFormatter_round_trip_equality()
         {
+            using var formatterScope = new BinaryFormatterScope(enable: true);
+
             // Create an ImageListStreamer via BinaryFormatter
             using ImageListStreamer streamerFromBf = BinarySerialization.EnsureDeserialize<ImageListStreamer>(ClassicBfImageListStreamer);
             using NativeImageList nativeImageListBf = streamerFromBf.GetNativeImageList();
@@ -42,6 +44,8 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void ImageListStreamer_Stream_BinaryFormatter_compatible()
         {
+            using var formatterScope = new BinaryFormatterScope(enable: true);
+
             // Create a new ImageListStreamer from the stream
             byte[] bytes = Convert.FromBase64String(DevMsImageListStreamer);
             using MemoryStream ms = new(bytes);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ImageListTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ImageListTests.cs
@@ -440,6 +440,7 @@ namespace System.Windows.Forms.Tests
 
         private static T RoundtripSerialize<T>(T source)
         {
+            using var formatterScope = new BinaryFormatterScope(enable: true);
             using var stream = new MemoryStream();
             var formatter = new BinaryFormatter();
 #pragma warning disable SYSLIB0011 // Type or member is obsolete

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Layout/TableLayoutSettingsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Layout/TableLayoutSettingsTests.cs
@@ -1770,6 +1770,7 @@ namespace System.Windows.Forms.Layout.Tests
         [WinFormsFact]
         public void TableLayoutSettings_Serialize_Deserialize_Success()
         {
+            using var formatterScope = new BinaryFormatterScope(enable: true);
             using var control = new TableLayoutPanel();
             TableLayoutSettings settings = control.LayoutSettings;
             var columnStyle = new ColumnStyle(SizeType.Percent, 1);
@@ -1809,6 +1810,7 @@ namespace System.Windows.Forms.Layout.Tests
         [InlineData(typeof(EmptyStringConverter))]
         public void TableLayoutSettings_Serialize_InvalidStringConverter_DeserializeThrowsSerializationException(Type type)
         {
+            using var formatterScope = new BinaryFormatterScope(enable: true);
             using var control = new TableLayoutPanel();
             TableLayoutSettings settings = control.LayoutSettings;
             TypeDescriptor.AddAttributes(settings, new Attribute[] { new TypeConverterAttribute(type) });
@@ -1829,6 +1831,7 @@ namespace System.Windows.Forms.Layout.Tests
         [InlineData(typeof(NonTableLayoutSettingsConverter))]
         public void TableLayoutSettings_Deserialize_InvalidConverterResult_Success(Type type)
         {
+            using var formatterScope = new BinaryFormatterScope(enable: true);
             using var control = new TableLayoutPanel();
             TableLayoutSettings settings = control.LayoutSettings;
             TypeDescriptor.AddAttributes(settings, new Attribute[] { new TypeConverterAttribute(type) });

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroupTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroupTests.cs
@@ -1335,21 +1335,20 @@ namespace System.Windows.Forms.Tests
         [MemberData(nameof(Serialize_Deserialize_TestData))]
         public void ListViewGroup_Serialize_Deserialize_Success(ListViewGroup group)
         {
-            using (var stream = new MemoryStream())
-            {
-                var formatter = new BinaryFormatter();
+            using var formatterScope = new BinaryFormatterScope(enable: true);
+            using var stream = new MemoryStream();
+            var formatter = new BinaryFormatter();
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
-                formatter.Serialize(stream, group);
-                stream.Seek(0, SeekOrigin.Begin);
+            formatter.Serialize(stream, group);
+            stream.Seek(0, SeekOrigin.Begin);
 
-                ListViewGroup result = Assert.IsType<ListViewGroup>(formatter.Deserialize(stream));
+            ListViewGroup result = Assert.IsType<ListViewGroup>(formatter.Deserialize(stream));
 #pragma warning restore SYSLIB0011 // Type or member is obsolete
-                Assert.Equal(group.Header, result.Header);
-                Assert.Equal(group.HeaderAlignment, result.HeaderAlignment);
-                Assert.Equal(group.Items.Cast<ListViewItem>().Select(i => i.Text), result.Items.Cast<ListViewItem>().Select(i => i.Text));
-                Assert.Equal(group.Name, result.Name);
-                Assert.Equal(group.Tag, result.Tag);
-            }
+            Assert.Equal(group.Header, result.Header);
+            Assert.Equal(group.HeaderAlignment, result.HeaderAlignment);
+            Assert.Equal(group.Items.Cast<ListViewItem>().Select(i => i.Text), result.Items.Cast<ListViewItem>().Select(i => i.Text));
+            Assert.Equal(group.Name, result.Name);
+            Assert.Equal(group.Tag, result.Tag);
         }
 
         [WinFormsTheory]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewSubItemTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewSubItemTests.cs
@@ -579,22 +579,21 @@ namespace System.Windows.Forms.Tests
         [MemberData(nameof(Serialize_Deserialize_TestData))]
         public void ListViewSubItem_Serialize_Deserialize_Success(ListViewItem.ListViewSubItem subItem)
         {
-            using (var stream = new MemoryStream())
-            {
-                var formatter = new BinaryFormatter();
+            using var formatterScope = new BinaryFormatterScope(enable: true);
+            using var stream = new MemoryStream();
+            var formatter = new BinaryFormatter();
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
-                formatter.Serialize(stream, subItem);
-                stream.Seek(0, SeekOrigin.Begin);
+            formatter.Serialize(stream, subItem);
+            stream.Seek(0, SeekOrigin.Begin);
 
-                ListViewItem.ListViewSubItem result = Assert.IsType<ListViewItem.ListViewSubItem>(formatter.Deserialize(stream));
+            ListViewItem.ListViewSubItem result = Assert.IsType<ListViewItem.ListViewSubItem>(formatter.Deserialize(stream));
 #pragma warning restore SYSLIB0011 // Type or member is obsolete
-                Assert.Equal(subItem.BackColor, result.BackColor);
-                Assert.Equal(subItem.Font, result.Font);
-                Assert.Equal(subItem.ForeColor, result.ForeColor);
-                Assert.Empty(result.Name);
-                Assert.Null(result.Tag);
-                Assert.Equal(subItem.Text, result.Text);
-            }
+            Assert.Equal(subItem.BackColor, result.BackColor);
+            Assert.Equal(subItem.Font, result.Font);
+            Assert.Equal(subItem.ForeColor, result.ForeColor);
+            Assert.Empty(result.Name);
+            Assert.Null(result.Tag);
+            Assert.Equal(subItem.Text, result.Text);
         }
 
         [WinFormsTheory]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/OwnerDrawPropertyBagTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/OwnerDrawPropertyBagTests.cs
@@ -106,6 +106,7 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void OwnerDrawPropertyBag_Serialize_Deserialize_Success()
         {
+            using var formatterScope = new BinaryFormatterScope(enable: true);
             using var treeView = new SubTreeView();
             OwnerDrawPropertyBag original = treeView.GetItemRenderStyles(null, 0);
             original.BackColor = Color.Blue;

--- a/src/System.Windows.Forms/tests/UnitTests/runtimeconfig.template.json
+++ b/src/System.Windows.Forms/tests/UnitTests/runtimeconfig.template.json
@@ -1,0 +1,5 @@
+{
+  "configProperties": {
+    "TestSwitch.LocalAppContext.DisableCaching" : "true"
+  }
+}


### PR DESCRIPTION
Adds the `BinaryFormatterScope` ref struct for explicitly setting `BinaryFormatter` enabled state.

Ran through System.Windows.Forms.Tests with the `BinaryFormatter` explicitly disabled to identify tests that were dependent and add the context to said tests.

The intent is to follow this change with additional changes to do the same for the other test assemblies. I'll be using what I find here to open additional issues or add additional context to existing ones. For example, it wasn't clear that CSV text uses the `BinaryFormatter` for the clipboard until I ran through this set of tests.

After all assemblies are scoped I'll be then looking to close test gaps.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8907)