### PR TITLE
Add dependencies required by windowsdesktop

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -71,6 +71,7 @@ Note: if the Uri is a new place, you will need to add a subscription from that p
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
     </Dependency>
+
     <!-- These dependencies are required by windowsdesktop for coherency. -->
     <Dependency Name="Microsoft.Win32.Registry.AccessControl" Version="8.0.0-preview.4.23177.1">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -15,10 +15,6 @@ Note: if the Uri is a new place, you will need to add a subscription from that p
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Windows.Compatibility" Version="8.0.0-preview.4.23177.1">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
-    </Dependency>
     <Dependency Name="System.Resources.Extensions" Version="8.0.0-preview.4.23177.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -15,27 +15,11 @@ Note: if the Uri is a new place, you will need to add a subscription from that p
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Win32.SystemEvents" Version="8.0.0-preview.4.23177.1">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
-    </Dependency>
     <Dependency Name="Microsoft.Windows.Compatibility" Version="8.0.0-preview.4.23177.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
     </Dependency>
-    <Dependency Name="System.CodeDom" Version="8.0.0-preview.4.23177.1">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
-    </Dependency>
-    <Dependency Name="System.Configuration.ConfigurationManager" Version="8.0.0-preview.4.23177.1">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
-    </Dependency>
     <Dependency Name="System.Resources.Extensions" Version="8.0.0-preview.4.23177.1">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
-    </Dependency>
-    <Dependency Name="System.Security.Permissions" Version="8.0.0-preview.4.23177.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
     </Dependency>
@@ -59,39 +43,11 @@ Note: if the Uri is a new place, you will need to add a subscription from that p
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
     </Dependency>
-    <Dependency Name="System.Diagnostics.EventLog" Version="8.0.0-preview.4.23177.1">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
-    </Dependency>
-    <Dependency Name="System.DirectoryServices" Version="8.0.0-preview.4.23177.1">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
-    </Dependency>
     <Dependency Name="System.Reflection.MetadataLoadContext" Version="8.0.0-preview.4.23177.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Xml" Version="8.0.0-preview.4.23177.1">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
-    </Dependency>
-    <Dependency Name="System.IO.Packaging" Version="8.0.0-preview.4.23177.1">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
-    </Dependency>
     <Dependency Name="Microsoft.NETCore.ILDAsm" Version="8.0.0-preview.4.23177.1">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
-    </Dependency>
-    <Dependency Name="System.Diagnostics.PerformanceCounter" Version="8.0.0-preview.4.23177.1">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
-    </Dependency>
-    <Dependency Name="System.Security.Cryptography.Pkcs" Version="8.0.0-preview.4.23177.1">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
-    </Dependency>
-    <Dependency Name="System.Security.Cryptography.ProtectedData" Version="8.0.0-preview.4.23177.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
     </Dependency>
@@ -100,14 +56,6 @@ Note: if the Uri is a new place, you will need to add a subscription from that p
       <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
     </Dependency>
     <Dependency Name="System.Text.Json" Version="8.0.0-preview.4.23177.1">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
-    </Dependency>
-    <Dependency Name="System.Threading.AccessControl" Version="8.0.0-preview.4.23177.1">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.Win32.Registry.AccessControl" Version="8.0.0-preview.4.23177.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
     </Dependency>
@@ -120,6 +68,115 @@ Note: if the Uri is a new place, you will need to add a subscription from that p
       <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Internal.Runtime.WindowsDesktop.Transport" Version="8.0.0-preview.4.23177.1">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
+    </Dependency>
+    <!-- These dependencies are required by windowsdesktop for coherency. -->
+    <Dependency Name="Microsoft.Win32.Registry.AccessControl" Version="8.0.0-preview.4.23177.1">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Win32.SystemEvents" Version="8.0.0-preview.4.23177.1">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
+    </Dependency>
+    <Dependency Name="System.CodeDom" Version="8.0.0-preview.4.23177.1">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
+    </Dependency>
+    <Dependency Name="System.ComponentModel.Composition" Version="8.0.0-preview.4.23177.1">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
+    </Dependency>
+    <Dependency Name="System.Configuration.ConfigurationManager" Version="8.0.0-preview.4.23177.1">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
+    </Dependency>
+    <Dependency Name="System.Data.Odbc" Version="8.0.0-preview.4.23177.1">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
+    </Dependency>
+    <Dependency Name="System.Data.OleDb" Version="8.0.0-preview.4.23177.1">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
+    </Dependency>
+    <Dependency Name="System.Diagnostics.EventLog" Version="8.0.0-preview.4.23177.1">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
+    </Dependency>
+    <Dependency Name="System.Diagnostics.PerformanceCounter" Version="8.0.0-preview.4.23177.1">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
+    </Dependency>
+    <Dependency Name="System.DirectoryServices.AccountManagement" Version="8.0.0-preview.4.23177.1">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
+    </Dependency>
+    <Dependency Name="System.DirectoryServices.Protocols" Version="8.0.0-preview.4.23177.1">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
+    </Dependency>
+    <Dependency Name="System.DirectoryServices" Version="8.0.0-preview.4.23177.1">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
+    </Dependency>
+    <Dependency Name="System.IO.Packaging" Version="8.0.0-preview.4.23177.1">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
+    </Dependency>
+    <Dependency Name="System.IO.Ports" Version="8.0.0-preview.4.23177.1">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
+    </Dependency>
+    <Dependency Name="System.Management" Version="8.0.0-preview.4.23177.1">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
+    </Dependency>
+    <Dependency Name="System.Reflection.Context" Version="8.0.0-preview.4.23177.1">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
+    </Dependency>
+    <Dependency Name="System.Runtime.Caching" Version="8.0.0-preview.4.23177.1">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
+    </Dependency>
+    <Dependency Name="System.Security.Cryptography.Pkcs" Version="8.0.0-preview.4.23177.1">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
+    </Dependency>
+    <Dependency Name="System.Security.Cryptography.ProtectedData" Version="8.0.0-preview.4.23177.1">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
+    </Dependency>
+    <Dependency Name="System.Security.Cryptography.Xml" Version="8.0.0-preview.4.23177.1">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
+    </Dependency>
+    <Dependency Name="System.Security.Permissions" Version="8.0.0-preview.4.23177.1">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
+    </Dependency>
+    <Dependency Name="System.ServiceModel.Syndication" Version="8.0.0-preview.4.23177.1">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
+    </Dependency>
+    <Dependency Name="System.ServiceProcess.ServiceController" Version="8.0.0-preview.4.23177.1">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
+    </Dependency>
+    <Dependency Name="System.Speech" Version="8.0.0-preview.4.23177.1">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
+    </Dependency>
+    <Dependency Name="System.Text.Encoding.CodePages" Version="8.0.0-preview.4.23177.1">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
+    </Dependency>
+    <Dependency Name="System.Threading.AccessControl" Version="8.0.0-preview.4.23177.1">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
+    </Dependency>
+    <Dependency Name="System.ComponentModel.Composition.Registration" Version="8.0.0-preview.4.23177.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>beb708f6fe999cbbe5542846c9985ce596569097</Sha>
     </Dependency>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -73,7 +73,7 @@
     <InputSimulatorPlusVersion>1.0.7</InputSimulatorPlusVersion>
     <MicrosoftVisualStudioThreadingVersion>17.0.15-alpha</MicrosoftVisualStudioThreadingVersion>
     <!-- This is needed for Verify.Xunit to pull correct version of System.Speech -->
-    <MicrosoftWindowsCompatibilityVersion>8.0.0-preview.4.23177.1</MicrosoftWindowsCompatibilityVersion>
+    <MicrosoftWindowsCompatibilityVersion>7.0.0</MicrosoftWindowsCompatibilityVersion>
     <MoqPackageVersion>4.10.0</MoqPackageVersion>
     <SystemComponentModelTypeConverterTestDataVersion>8.0.0-beta.23107.1</SystemComponentModelTypeConverterTestDataVersion>
     <SystemDrawingCommonTestDataVersion>8.0.0-beta.23107.1</SystemDrawingCommonTestDataVersion>


### PR DESCRIPTION
Contributes to https://github.com/dotnet/windowsdesktop/pull/3516
Unblocks https://github.com/dotnet/wpf/pull/7681

Microsoft.Windows.Compatibility is being migrated from runtime to windowsdesktop and depends on packages from dotnet/runtime. As there's already a subscription from `runtime -> winforms`, a new one can't be added directly between `runtime -> windowsdesktop` as that would cause coherency issues. Instead, we need to flow the dependencies through winforms and wpf.

The `git diff` is confusing. I just added the new dependencies at the end of the product dependencies section and removed the ones that already existed from above so that all the ones that are required by windowsdesktop are grouped together.

Note that I also removed the `Microsoft.Windows.Compatiblity` dependency as that package is now produced in a higher layer (not runtime but windowsdesktop) so winforms can't depend on a live version of it. The package is only required for a test library so it felt safe to remove the live dependency and downgrade to last stable version.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8909)