### PR TITLE
Fix caching of DpiAwarenessContext for Mixed mode DPI hosting scenarios.

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/NativeWindow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NativeWindow.cs
@@ -69,12 +69,13 @@ namespace System.Windows.Forms
         public NativeWindow()
         {
             _weakThisPtr = new WeakReference(this);
+            DpiAwarenessContext = PInvoke.GetThreadDpiAwarenessContextInternal();
         }
 
         /// <summary>
         /// Cache window DpiContext awareness information that helps to create handle with right context at the later time.
         /// </summary>
-        internal DPI_AWARENESS_CONTEXT DpiAwarenessContext { get; } = PInvoke.GetThreadDpiAwarenessContextInternal();
+        internal DPI_AWARENESS_CONTEXT DpiAwarenessContext { get; }
 
         /// <summary>
         ///  Override's the base object's finalize method.


### PR DESCRIPTION
The `DpiAwarenessContext `is utilized to establish the desired `DpiAwarenessContext ` for a control from the moment it is initialized and is then applied when creating the control's handle. However, the current implementation of the  `DpiAwarenessContext `property evaluates the DpiContext based on the thread's current DPI awareness context. This may not accurately reflect the DPI awareness context that was initially desired for the control, particularly in scenarios where the application is running with mixed-mode DPI hosting and threads DPI awareness context is altered programmatically throughout the application.

Added unit test.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8917)