### PR TITLE
Use the `ApplicationIcon` as the `Form.DefaultIcon`

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/NativeMethods.txt
+++ b/src/System.Windows.Forms.Primitives/src/NativeMethods.txt
@@ -143,6 +143,7 @@ EndPaint
 EnumDisplaySettings
 EnumEnhMetaFile
 EVENTMSG
+ExtractIconEx
 ExtTextOut
 FDAP
 fdex*

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.ExtractIconEx.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.ExtractIconEx.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Drawing;
+
+namespace Windows.Win32
+{
+    internal static partial class PInvoke
+    {
+        internal static unsafe Icon? ExtractIconEx(string? lpszFile)
+        {
+            if (string.IsNullOrWhiteSpace(lpszFile))
+            {
+                return null;
+            }
+
+            HICON iconSmall = default;
+            uint readIconCount = 0;
+            fixed (char* lpszFileLocal = lpszFile)
+            {
+                readIconCount = ExtractIconEx(lpszFile: lpszFileLocal, nIconIndex: 0, phiconSmall: &iconSmall, nIcons: 1);
+            }
+
+            return readIconCount > 0 && !iconSmall.IsNull ? (Icon)Icon.FromHandle(iconSmall).Clone() : null;
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -897,7 +897,9 @@ namespace System.Windows.Forms
                     {
                         // Once we grab the lock, we re-check the value to avoid a
                         // race condition.
-                        defaultIcon ??= new Icon(typeof(Form), "wfc");
+                        defaultIcon ??=
+                            PInvoke.ExtractIconEx(Process.GetCurrentProcess().MainModule?.FileName)
+                            ?? new Icon(typeof(Form), "wfc");
                     }
                 }
 


### PR DESCRIPTION
Test implementation based on discussion.

Related: #8905 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8918)