### PR TITLE
InputLanguage: Use RegLoadMUIString instead of SHLoadIndirectString API

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/NativeMethods.txt
+++ b/src/System.Windows.Forms.Primitives/src/NativeMethods.txt
@@ -505,6 +505,7 @@ RegisterClass
 RegisterClipboardFormat
 RegisterDragDrop
 RegisterWindowMessage
+RegLoadMUIString
 ReleaseCapture
 ReleaseStgMedium
 RestoreDC
@@ -578,7 +579,6 @@ SHGetSpecialFolderLocation
 ShowCaret
 ShowCursor
 SHGetSpecialFolderLocation
-SHLoadIndirectString
 ShowWindow
 SHParseDisplayName
 SIATTRIBFLAGS

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/Pinvoke.RegLoadMUIString.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/Pinvoke.RegLoadMUIString.cs
@@ -1,0 +1,47 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+using Microsoft.Win32;
+
+namespace Windows.Win32;
+
+internal static partial class PInvoke
+{
+    /// <inheritdoc cref="RegLoadMUIString(System.Registry.HKEY, string, PWSTR, uint, uint*, uint, string)"/>
+    [SkipLocalsInit]
+    public static unsafe bool RegLoadMUIString(RegistryKey key, string keyName, out string localizedValue)
+    {
+        using BufferScope<char> buffer = new(stackalloc char[128]);
+
+        while (true)
+        {
+            fixed (char* pszOutBuf = buffer)
+            {
+                uint bytes = 0;
+                var errorCode = RegLoadMUIString(
+                    (System.Registry.HKEY)key.Handle.DangerousGetHandle(),
+                    keyName,
+                    pszOutBuf,
+                    (uint)(buffer.Length * sizeof(char)),
+                    &bytes,
+                    0,
+                    null);
+
+                // The buffer is too small. Try again with a larger buffer.
+                if (errorCode == WIN32_ERROR.ERROR_MORE_DATA)
+                {
+                    buffer.EnsureCapacity((int)(bytes / sizeof(char)));
+                    continue;
+                }
+
+                localizedValue = errorCode == WIN32_ERROR.ERROR_SUCCESS
+                    ? buffer[..Math.Max((int)(bytes / sizeof(char)) - 1, 0)].ToString()
+                    : string.Empty;
+
+                return errorCode == WIN32_ERROR.ERROR_SUCCESS;
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RegistryKeyExtensions.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RegistryKeyExtensions.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Win32;
+
+namespace System.Windows.Forms;
+
+internal static class RegistryKeyExtensions
+{
+    public static string? GetMUIString(this RegistryKey? key, string keyName, string fallbackKeyName)
+    {
+        return key is not null
+            ? PInvoke.RegLoadMUIString(key, keyName, out var localizedValue)
+                ? localizedValue
+                : key.GetValue(fallbackKeyName) is string value
+                    ? value
+                    : null
+            : null;
+    }
+}


### PR DESCRIPTION
I have extracted part of #8573 into separate PR until decision is made on some aspects of that PR.

## Proposed changes

- Use `RegLoadMUIString` instead of the `SHLoadIndirectString` API as recommended at https://learn.microsoft.com/windows/win32/intl/locating-redirected-strings#load-a-language-neutral-registry-value
- Move InputLanguage `GetKeyboardLayoutNameForHKL` method implementation to the internal `LayoutId` property (to ease debugging)
- Added proper testing of InputLanguage.LayoutName
- Added InputLanguage_Culture_ThrowsArgumentException and InputLanguage_LayoutName_UnknownExpected tests
- Use `PARAM.ToInt` instead of casts in `GetHashCode` implementation

## Customer Impact

- Shouldn't have any visible customer impact

## Regression? 

- No

## Risk

- Little


## Test methodology <!-- How did you ensure quality? -->

Auto test:
- InputLanguage_InputLanguageLayoutId_Expected (updated)
- InputLanguage_Culture_ThrowsArgumentException (new)
- InputLanguage_LayoutName_UnknownExpected  (new)

Manually:
- Install "Canadian Multilingual Standard"  keyboard layout in Windows.
- Add breakpoint in `InputLanguage_InstalledInputLanguages_Get_ReturnsExpected` test and run it under debugger.
- Check that its `LayoutId` is `00011009` under debugger.
- Check that its `LayoutName` is "Canadian Multilingual Standard".

![image](https://user-images.githubusercontent.com/1285934/228928513-2272ba30-e23d-4de4-a61d-d9d99194ea6d.png)

![image](https://user-images.githubusercontent.com/1285934/228929329-fd9ab7a4-90a9-4a51-abc7-5d56d14f0144.png)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8921)