### PR TITLE
Bring API proposal template in line with .NET runtime

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -6,31 +6,72 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to put the proposal forward!
-
-        Please read https://github.com/dotnet/winforms/blob/main/docs/issue-guide.md#feature-and-api-suggestions and understand the API Review process before proceeding further.
+        We welcome API proposals! We have a process to evaluate the value and shape of new API. There is an overview of our process [here](https://github.com/dotnet/runtime/blob/main/docs/project/api-review-process.md). This template will help us gather the information we need to start the review process.
   - type: textarea
-    id: problem
+    id: background
     attributes:
-      label: Is your feature request related to a problem? Please describe
-      description: A clear and concise description of what the problem is. E.g., _I'm always frustrated when..._.
+      label: Background and motivation
+      description: Please describe the purpose and value of the new API here.
+      placeholder: Purpose
     validations:
       required: true
   - type: textarea
-    id: proposal
+    id: api-proposal
     attributes:
-      label: Describe the solution you'd like and alternatives you've considered
+      label: API Proposal
       description: |
-        A clear and concise description of what you want to happen. This includes:
-        - Description of what API need to be added or changed.
-        - Code that shows the surface area of the API.
-        - Code that shows real world scenarios, and how they would otherwise be handled.
-        - Details showing the usage/consumption of the proposed new API, and alternatives (e.g., not having this API).
-        - Any other context or screenshots about the feature request here.
+        Please provide the specific public API signature diff that you are proposing.
 
-        :exclamation: Read https://github.com/dotnet/winforms/blob/main/docs/issue-guide.md for more details, and check out the already [approved API proposals](https://github.com/dotnet/winforms/issues?q=label%3Aapi-approved).
+        You may find the [Framework Design Guidelines](https://github.com/dotnet/runtime/blob/main/docs/coding-guidelines/framework-design-guidelines-digest.md) helpful.
+      placeholder: API declaration (no method bodies)
+      value: |
+        ```csharp
+        namespace System.Collections.Generic;
+
+        public class MyFancyCollection<T> : IEnumerable<T>
+        {
+            public void Fancy(T item);
+        }
+        ```
     validations:
       required: true
+  - type: textarea
+    id: api-usage
+    attributes:
+      label: API Usage
+      description: |
+        Please provide code examples that highlight how the proposed API additions are meant to be consumed. This will help suggest whether the API has the right shape to be functional, performant and usable.
+      placeholder: API usage
+      value: |
+        ```csharp
+        // Fancy the value
+        var c = new MyFancyCollection<int>();
+        c.Fancy(42);
+
+        // Getting the values out
+        foreach (var v in c)
+            Console.WriteLine(v);
+        ```
+    validations:
+      required: true
+  - type: textarea
+    id: alternative-designs
+    attributes:
+      label: Alternative Designs
+      description: |
+        Please provide alternative designs. This might not be APIs; for example instead of providing new APIs an option might be to change the behavior of an existing API.
+      placeholder: Alternative designs
+    validations:
+      required: false
+  - type: textarea
+    id: risks
+    attributes:
+      label: Risks
+      description: |
+        Please mention any risks that to your knowledge the API proposal might entail, such as breaking changes, performance regressions, etc.
+      placeholder: Risks
+    validations:
+      required: false
   - type: textarea
     id: steps
     attributes:


### PR DESCRIPTION
For easier interaction with the review process, copying most of the .NET Runtime issue template for new API.
