### PR TITLE
Use CodeAnalysis.test.globalconfig only for overrides

### DIFF
--- a/eng/CodeAnalysis.test.globalconfig
+++ b/eng/CodeAnalysis.test.globalconfig
@@ -1,271 +1,26 @@
 is_global = true
 
-# AD0001: Analyzer threw an exception
-dotnet_diagnostic.AD0001.severity = suggestion
-
-# CA1000: Do not declare static members on generic types
-dotnet_diagnostic.CA1000.severity = none
-
-# CA1001: Types that own disposable fields should be disposable
-dotnet_diagnostic.CA1001.severity = none
-
-# CA1002: Do not expose generic lists
-dotnet_diagnostic.CA1002.severity = none
-
-# CA1003: Use generic event handler instances
-dotnet_diagnostic.CA1003.severity = none
-
-# CA1005: Avoid excessive parameters on generic types
-dotnet_diagnostic.CA1005.severity = none
-
-# CA1008: Enums should have zero value
-dotnet_diagnostic.CA1008.severity = none
-
-# CA1010: Generic interface should also be implemented
-dotnet_diagnostic.CA1010.severity = none
-
-# CA1012: Abstract types should not have public constructors
-dotnet_diagnostic.CA1012.severity = none
-
-# CA1014: Mark assemblies with CLSCompliant
-dotnet_diagnostic.CA1014.severity = none
-
-# CA1016: Mark assemblies with assembly version
-dotnet_diagnostic.CA1016.severity = none
-
-# CA1017: Mark assemblies with ComVisible
-dotnet_diagnostic.CA1017.severity = none
-
-# CA1018: Mark attributes with AttributeUsageAttribute
-dotnet_diagnostic.CA1018.severity = warning
-
-# CA1019: Define accessors for attribute arguments
-dotnet_diagnostic.CA1019.severity = none
-
-# CA1021: Avoid out parameters
-dotnet_diagnostic.CA1021.severity = none
-
-# CA1024: Use properties where appropriate
-dotnet_diagnostic.CA1024.severity = none
-
-# CA1027: Mark enums with FlagsAttribute
-dotnet_diagnostic.CA1027.severity = none
-
-# CA1028: Enum Storage should be Int32
-dotnet_diagnostic.CA1028.severity = none
-
-# CA1030: Use events where appropriate
-dotnet_diagnostic.CA1030.severity = none
-
-# CA1031: Do not catch general exception types
-dotnet_diagnostic.CA1031.severity = none
-
-# CA1032: Implement standard exception constructors
-dotnet_diagnostic.CA1032.severity = none
-
-# CA1033: Interface methods should be callable by child types
-dotnet_diagnostic.CA1033.severity = none
-
-# CA1034: Nested types should not be visible
-dotnet_diagnostic.CA1034.severity = none
-
-# CA1036: Override methods on comparable types
-dotnet_diagnostic.CA1036.severity = none
-
-# CA1040: Avoid empty interfaces
-dotnet_diagnostic.CA1040.severity = none
-
-# CA1041: Provide ObsoleteAttribute message
-dotnet_diagnostic.CA1041.severity = none
-
-# CA1043: Use Integral Or String Argument For Indexers
-dotnet_diagnostic.CA1043.severity = none
-
-# CA1044: Properties should not be write only
-dotnet_diagnostic.CA1044.severity = none
-
-# CA1045: Do not pass types by reference
-dotnet_diagnostic.CA1045.severity = none
-
-# CA1046: Do not overload equality operator on reference types
-dotnet_diagnostic.CA1046.severity = none
-
-# CA1047: Do not declare protected member in sealed type
-dotnet_diagnostic.CA1047.severity = warning
-
-# CA1050: Declare types in namespaces
-dotnet_diagnostic.CA1050.severity = warning
-
-# CA1051: Do not declare visible instance fields
-dotnet_diagnostic.CA1051.severity = none
+# This file takes priority over CodeAnalysis.src.globalconfig
+global_level = 1
 
 # CA1052: Static holder types should be Static or NotInheritable
 dotnet_diagnostic.CA1052.severity = none # TODO: warning
-
-# CA1054: URI-like parameters should not be strings
-dotnet_diagnostic.CA1054.severity = none
-
-# CA1055: URI-like return values should not be strings
-dotnet_diagnostic.CA1055.severity = none
-
-# CA1056: URI-like properties should not be strings
-dotnet_diagnostic.CA1056.severity = none
-
-# CA1058: Types should not extend certain base types
-dotnet_diagnostic.CA1058.severity = none
-
-# CA1060: Move pinvokes to native methods class
-dotnet_diagnostic.CA1060.severity = none
-
-# CA1061: Do not hide base class methods
-dotnet_diagnostic.CA1061.severity = none
-
-# CA1062: Validate arguments of public methods
-dotnet_diagnostic.CA1062.severity = none
-
-# CA1063: Implement IDisposable Correctly
-dotnet_diagnostic.CA1063.severity = none
-
-# CA1064: Exceptions should be public
-dotnet_diagnostic.CA1064.severity = none
-
-# CA1065: Do not raise exceptions in unexpected locations
-dotnet_diagnostic.CA1065.severity = none
-
-# CA1066: Implement IEquatable when overriding Object.Equals
-dotnet_diagnostic.CA1066.severity = warning
-
-# CA1067: Override Object.Equals(object) when implementing IEquatable<T>
-dotnet_diagnostic.CA1067.severity = warning
-
-# CA1068: CancellationToken parameters must come last
-dotnet_diagnostic.CA1068.severity = none
-
-# CA1069: Enums values should not be duplicated
-dotnet_diagnostic.CA1069.severity = none
-
-# CA1070: Do not declare event fields as virtual
-dotnet_diagnostic.CA1070.severity = suggestion
-
-# CA1200: Avoid using cref tags with a prefix
-dotnet_diagnostic.CA1200.severity = suggestion
-
-# CA1303: Do not pass literals as localized parameters
-dotnet_diagnostic.CA1303.severity = none
-
-# CA1304: Specify CultureInfo
-dotnet_diagnostic.CA1304.severity = none
-
-# CA1305: Specify IFormatProvider
-dotnet_diagnostic.CA1305.severity = none
-
-# CA1307: Specify StringComparison for clarity
-dotnet_diagnostic.CA1307.severity = none
-
-# CA1308: Normalize strings to uppercase
-dotnet_diagnostic.CA1308.severity = none
-
-# CA1309: Use ordinal string comparison
-dotnet_diagnostic.CA1309.severity = none
-
-# CA1310: Specify StringComparison for correctness
-dotnet_diagnostic.CA1310.severity = suggestion
+dotnet_code_quality.CA1052.api_surface = unset
 
 # CA1311: Specify a culture or use an invariant version
 dotnet_diagnostic.CA1311.severity = none
 
-# CA1401: P/Invokes should not be visible
-dotnet_diagnostic.CA1401.severity = warning
-
 # CA1416: Validate platform compatibility
 dotnet_diagnostic.CA1416.severity = none # TODO: warning
 
-# CA1417: Do not use 'OutAttribute' on string parameters for P/Invokes
-dotnet_diagnostic.CA1417.severity = warning
-
-# CA1418: Use valid platform string
-dotnet_diagnostic.CA1418.severity = warning
-
-# CA1419: Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle'
-dotnet_diagnostic.CA1419.severity = warning
-
-# CA1420: Property, type, or attribute requires runtime marshalling
-dotnet_diagnostic.CA1420.severity = warning
-
-# CA1421: This method uses runtime marshalling even when the 'DisableRuntimeMarshallingAttribute' is applied
-dotnet_diagnostic.CA1421.severity = suggestion
-
-# CA1501: Avoid excessive inheritance
-dotnet_diagnostic.CA1501.severity = none
-
-# CA1502: Avoid excessive complexity
-dotnet_diagnostic.CA1502.severity = none
-
-# CA1505: Avoid unmaintainable code
-dotnet_diagnostic.CA1505.severity = none
-
-# CA1506: Avoid excessive class coupling
-dotnet_diagnostic.CA1506.severity = none
-
 # CA1507: Use nameof to express symbol names
 dotnet_diagnostic.CA1507.severity = none
-
-# CA1508: Avoid dead conditional code
-dotnet_diagnostic.CA1508.severity = none
-
-# CA1509: Invalid entry in code metrics rule specification file
-dotnet_diagnostic.CA1509.severity = none
-
-# CA1700: Do not name enum values 'Reserved'
-dotnet_diagnostic.CA1700.severity = none
-
-# CA1707: Identifiers should not contain underscores
-dotnet_diagnostic.CA1707.severity = none
-
-# CA1708: Identifiers should differ by more than case
-dotnet_diagnostic.CA1708.severity = none
-
-# CA1710: Identifiers should have correct suffix
-dotnet_diagnostic.CA1710.severity = none
-
-# CA1711: Identifiers should not have incorrect suffix
-dotnet_diagnostic.CA1711.severity = none
-
-# CA1712: Do not prefix enum values with type name
-dotnet_diagnostic.CA1712.severity = none
-
-# CA1713: Events should not have 'Before' or 'After' prefix
-dotnet_diagnostic.CA1713.severity = none
-
-# CA1715: Identifiers should have correct prefix
-dotnet_diagnostic.CA1715.severity = none
-
-# CA1716: Identifiers should not match keywords
-dotnet_diagnostic.CA1716.severity = none
-
-# CA1720: Identifier contains type name
-dotnet_diagnostic.CA1720.severity = none
-
-# CA1721: Property names should not match get methods
-dotnet_diagnostic.CA1721.severity = none
-
-# CA1724: Type names should not match namespaces
-dotnet_diagnostic.CA1724.severity = none
-
-# CA1725: Parameter names should match base declaration
-dotnet_diagnostic.CA1725.severity = suggestion
 
 # CA1727: Use PascalCase for named placeholders
 dotnet_diagnostic.CA1727.severity = suggestion
 
 # CA1802: Use literals where appropriate
-dotnet_diagnostic.CA1802.severity = warning
-
-# CA1805: Do not initialize unnecessarily
-dotnet_diagnostic.CA1805.severity = warning
-
-# CA1806: Do not ignore method results
-dotnet_diagnostic.CA1806.severity = none
+dotnet_code_quality.CA1802.api_surface = unset
 
 # CA1810: Initialize reference type static fields inline
 dotnet_diagnostic.CA1810.severity = none # TODO: warning
@@ -273,116 +28,9 @@ dotnet_diagnostic.CA1810.severity = none # TODO: warning
 # CA1812: Avoid uninstantiated internal classes
 dotnet_diagnostic.CA1812.severity = none
 
-# CA1813: Avoid unsealed attributes
-dotnet_diagnostic.CA1813.severity = none
-
-# CA1814: Prefer jagged arrays over multidimensional
-dotnet_diagnostic.CA1814.severity = none
-
-# CA1815: Override equals and operator equals on value types
-dotnet_diagnostic.CA1815.severity = none
-
-# CA1816: Dispose methods should call SuppressFinalize
-dotnet_diagnostic.CA1816.severity = none
-
-# CA1819: Properties should not return arrays
-dotnet_diagnostic.CA1819.severity = none
-
-# CA1820: Test for empty strings using string length
-dotnet_diagnostic.CA1820.severity = none
-
-# CA1821: Remove empty Finalizers
-dotnet_diagnostic.CA1821.severity = none # TODO: warning
-
 # CA1822: Mark members as static
 dotnet_diagnostic.CA1822.severity = none # TODO: warning
-
-# CA1823: Avoid unused private fields
-dotnet_diagnostic.CA1823.severity = warning
-
-# CA1824: Mark assemblies with NeutralResourcesLanguageAttribute
-dotnet_diagnostic.CA1824.severity = warning
-
-# CA1825: Avoid zero-length array allocations.
-dotnet_diagnostic.CA1825.severity = warning
-
-# CA1826: Do not use Enumerable methods on indexable collections
-dotnet_diagnostic.CA1826.severity = warning
-
-# CA1827: Do not use Count() or LongCount() when Any() can be used
-dotnet_diagnostic.CA1827.severity = warning
-
-# CA1828: Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used
-dotnet_diagnostic.CA1828.severity = warning
-
-# CA1829: Use Length/Count property instead of Count() when available
-dotnet_diagnostic.CA1829.severity = warning
-
-# CA1830: Prefer strongly-typed Append and Insert method overloads on StringBuilder
-dotnet_diagnostic.CA1830.severity = warning
-
-# CA1831: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
-dotnet_diagnostic.CA1831.severity = warning
-
-# CA1832: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
-dotnet_diagnostic.CA1832.severity = warning
-
-# CA1833: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
-dotnet_diagnostic.CA1833.severity = warning
-
-# CA1834: Consider using 'StringBuilder.Append(char)' when applicable
-dotnet_diagnostic.CA1834.severity = warning
-
-# CA1835: Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
-dotnet_diagnostic.CA1835.severity = warning
-
-# CA1836: Prefer IsEmpty over Count
-dotnet_diagnostic.CA1836.severity = warning
-
-# CA1837: Use 'Environment.ProcessId'
-dotnet_diagnostic.CA1837.severity = warning
-
-# CA1838: Avoid 'StringBuilder' parameters for P/Invokes
-dotnet_diagnostic.CA1838.severity = warning
-
-# CA1839: Use 'Environment.ProcessPath'
-dotnet_diagnostic.CA1839.severity = warning
-
-# CA1840: Use 'Environment.CurrentManagedThreadId'
-dotnet_diagnostic.CA1840.severity = warning
-
-# CA1841: Prefer Dictionary.Contains methods
-dotnet_diagnostic.CA1841.severity = warning
-
-# CA1842: Do not use 'WhenAll' with a single task
-dotnet_diagnostic.CA1842.severity = warning
-
-# CA1843: Do not use 'WaitAll' with a single task
-dotnet_diagnostic.CA1843.severity = warning
-
-# CA1844: Provide memory-based overrides of async methods when subclassing 'Stream'
-dotnet_diagnostic.CA1844.severity = warning
-
-# CA1845: Use span-based 'string.Concat'
-dotnet_diagnostic.CA1845.severity = warning
-
-# CA1846: Prefer 'AsSpan' over 'Substring'
-dotnet_diagnostic.CA1846.severity = warning
-
-# CA1847: Use char literal for a single character lookup
-dotnet_diagnostic.CA1847.severity = warning
-
-# CA1848: Use the LoggerMessage delegates
-dotnet_diagnostic.CA1848.severity = none
-
-# CA1849: Call async methods when in an async method
-dotnet_diagnostic.CA1849.severity = suggestion
-
-# CA1850: Prefer static 'HashData' method over 'ComputeHash'
-dotnet_diagnostic.CA1850.severity = warning
-
-# CA1851: Possible multiple enumerations of 'IEnumerable' collection
-dotnet_diagnostic.CA1851.severity = suggestion
+dotnet_code_quality.CA1822.api_surface = unset
 
 # CA1852: Seal internal types
 dotnet_diagnostic.CA1852.severity = none
@@ -393,473 +41,20 @@ dotnet_diagnostic.CA1853.severity = none
 # CA1854: Prefer the 'IDictionary.TryGetValue(TKey, out TValue)' method
 dotnet_diagnostic.CA1854.severity = none
 
-# CA2000: Dispose objects before losing scope
-dotnet_diagnostic.CA2000.severity = none
-
-# CA2002: Do not lock on objects with weak identity
-dotnet_diagnostic.CA2002.severity = none
-
 # CA2007: Consider calling ConfigureAwait on the awaited task
 dotnet_diagnostic.CA2007.severity = none # TODO: warning
-
-# CA2008: Do not create tasks without passing a TaskScheduler
-dotnet_diagnostic.CA2008.severity = warning
-
-# CA2009: Do not call ToImmutableCollection on an ImmutableCollection value
-dotnet_diagnostic.CA2009.severity = warning
-
-# CA2011: Avoid infinite recursion
-dotnet_diagnostic.CA2011.severity = warning
-
-# CA2012: Use ValueTasks correctly
-dotnet_diagnostic.CA2012.severity = warning
-
-# CA2013: Do not use ReferenceEquals with value types
-dotnet_diagnostic.CA2013.severity = warning
 
 # CA2014: Do not use stackalloc in loops.
 dotnet_diagnostic.CA2014.severity = none # TODO: warning
 
-# CA2015: Do not define finalizers for types derived from MemoryManager<T>
-dotnet_diagnostic.CA2015.severity = warning
-
-# CA2016: Forward the 'CancellationToken' parameter to methods
-dotnet_diagnostic.CA2016.severity = warning
-
-# CA2017: Parameter count mismatch
-dotnet_diagnostic.CA2017.severity = warning
-
-# CA2018: 'Buffer.BlockCopy' expects the number of bytes to be copied for the 'count' argument
-dotnet_diagnostic.CA2018.severity = warning
-
-# CA2019: Improper 'ThreadStatic' field initialization
-dotnet_diagnostic.CA2019.severity = warning
-
-# CA2100: Review SQL queries for security vulnerabilities
-dotnet_diagnostic.CA2100.severity = none
-
-# CA2101: Specify marshaling for P/Invoke string arguments
-dotnet_diagnostic.CA2101.severity = none
-
-# CA2109: Review visible event handlers
-dotnet_diagnostic.CA2109.severity = none
-
-# CA2119: Seal methods that satisfy private interfaces
-dotnet_diagnostic.CA2119.severity = none
-
-# CA2153: Do Not Catch Corrupted State Exceptions
-dotnet_diagnostic.CA2153.severity = none
-
-# CA2200: Rethrow to preserve stack details
-dotnet_diagnostic.CA2200.severity = warning
-
-# CA2201: Do not raise reserved exception types
-dotnet_diagnostic.CA2201.severity = none
-
-# CA2207: Initialize value type static fields inline
-dotnet_diagnostic.CA2207.severity = warning
-
 # CA2208: Instantiate argument exceptions correctly
-dotnet_diagnostic.CA2208.severity = none # TODO: warning
-
-# CA2211: Non-constant fields should not be visible
-dotnet_diagnostic.CA2211.severity = none
-
-# CA2213: Disposable fields should be disposed
-dotnet_diagnostic.CA2213.severity = none
-
-# CA2214: Do not call overridable methods in constructors
-dotnet_diagnostic.CA2214.severity = none
-
-# CA2215: Dispose methods should call base class dispose
-dotnet_diagnostic.CA2215.severity = none
-
-# CA2216: Disposable types should declare finalizer
-dotnet_diagnostic.CA2216.severity = none
-
-# CA2217: Do not mark enums with FlagsAttribute
-dotnet_diagnostic.CA2217.severity = none
-
-# CA2218: Override GetHashCode on overriding Equals
-dotnet_diagnostic.CA2218.severity = none
-
-# CA2219: Do not raise exceptions in finally clauses
-dotnet_diagnostic.CA2219.severity = none
-
-# CA2224: Override Equals on overloading operator equals
-dotnet_diagnostic.CA2224.severity = none
-
-# CA2225: Operator overloads have named alternates
-dotnet_diagnostic.CA2225.severity = none
-
-# CA2226: Operators should have symmetrical overloads
-dotnet_diagnostic.CA2226.severity = none
-
-# CA2227: Collection properties should be read only
-dotnet_diagnostic.CA2227.severity = none
-
-# CA2229: Implement serialization constructors
-dotnet_diagnostic.CA2229.severity = warning
-
-# CA2231: Overload operator equals on overriding value type Equals
-dotnet_diagnostic.CA2231.severity = none
-
-# CA2234: Pass system uri objects instead of strings
-dotnet_diagnostic.CA2234.severity = none
-
-# CA2235: Mark all non-serializable fields
-dotnet_diagnostic.CA2235.severity = none
-
-# CA2237: Mark ISerializable types with serializable
-dotnet_diagnostic.CA2237.severity = none
-
-# CA2241: Provide correct arguments to formatting methods
-dotnet_diagnostic.CA2241.severity = warning
-
-# CA2242: Test for NaN correctly
-dotnet_diagnostic.CA2242.severity = warning
-
-# CA2243: Attribute string literals should parse correctly
-dotnet_diagnostic.CA2243.severity = warning
-
-# CA2244: Do not duplicate indexed element initializations
-dotnet_diagnostic.CA2244.severity = warning
+dotnet_code_quality.CA2208.api_surface = unset
 
 # CA2245: Do not assign a property to itself
 dotnet_diagnostic.CA2245.severity = warning
 
-# CA2246: Assigning symbol and its member in the same statement
-dotnet_diagnostic.CA2246.severity = warning
-
-# CA2247: Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum
-dotnet_diagnostic.CA2247.severity = warning
-
-# CA2248: Provide correct 'enum' argument to 'Enum.HasFlag'
-dotnet_diagnostic.CA2248.severity = warning
-
-# CA2249: Consider using 'string.Contains' instead of 'string.IndexOf'
-dotnet_diagnostic.CA2249.severity = warning
-
-# CA2250: Use 'ThrowIfCancellationRequested'
-dotnet_diagnostic.CA2250.severity = warning
-
-# CA2251: Use 'string.Equals'
-dotnet_diagnostic.CA2251.severity = warning
-
-# CA2252: This API requires opting into preview features
-dotnet_diagnostic.CA2252.severity = error
-
 # CA2253: Named placeholders should not be numeric values
 dotnet_diagnostic.CA2253.severity = none
-
-# CA2254: Template should be a static expression
-dotnet_diagnostic.CA2254.severity = none
-
-# CA2255: The 'ModuleInitializer' attribute should not be used in libraries
-dotnet_diagnostic.CA2255.severity = warning
-
-# CA2256: All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface
-dotnet_diagnostic.CA2256.severity = warning
-
-# CA2257: Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static'
-dotnet_diagnostic.CA2257.severity = warning
-
-# CA2258: Providing a 'DynamicInterfaceCastableImplementation' interface in Visual Basic is unsupported
-dotnet_diagnostic.CA2258.severity = warning
-
-# CA2259: 'ThreadStatic' only affects static fields
-dotnet_diagnostic.CA2259.severity = warning
-
-# CA2300: Do not use insecure deserializer BinaryFormatter
-dotnet_diagnostic.CA2300.severity = none
-
-# CA2301: Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder
-dotnet_diagnostic.CA2301.severity = none
-
-# CA2302: Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize
-dotnet_diagnostic.CA2302.severity = none
-
-# CA2305: Do not use insecure deserializer LosFormatter
-dotnet_diagnostic.CA2305.severity = none
-
-# CA2310: Do not use insecure deserializer NetDataContractSerializer
-dotnet_diagnostic.CA2310.severity = none
-
-# CA2311: Do not deserialize without first setting NetDataContractSerializer.Binder
-dotnet_diagnostic.CA2311.severity = none
-
-# CA2312: Ensure NetDataContractSerializer.Binder is set before deserializing
-dotnet_diagnostic.CA2312.severity = none
-
-# CA2315: Do not use insecure deserializer ObjectStateFormatter
-dotnet_diagnostic.CA2315.severity = none
-
-# CA2321: Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver
-dotnet_diagnostic.CA2321.severity = none
-
-# CA2322: Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing
-dotnet_diagnostic.CA2322.severity = none
-
-# CA2326: Do not use TypeNameHandling values other than None
-dotnet_diagnostic.CA2326.severity = none
-
-# CA2327: Do not use insecure JsonSerializerSettings
-dotnet_diagnostic.CA2327.severity = none
-
-# CA2328: Ensure that JsonSerializerSettings are secure
-dotnet_diagnostic.CA2328.severity = none
-
-# CA2329: Do not deserialize with JsonSerializer using an insecure configuration
-dotnet_diagnostic.CA2329.severity = none
-
-# CA2330: Ensure that JsonSerializer has a secure configuration when deserializing
-dotnet_diagnostic.CA2330.severity = none
-
-# CA2350: Do not use DataTable.ReadXml() with untrusted data
-dotnet_diagnostic.CA2350.severity = none
-
-# CA2351: Do not use DataSet.ReadXml() with untrusted data
-dotnet_diagnostic.CA2351.severity = none
-
-# CA2352: Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
-dotnet_diagnostic.CA2352.severity = none
-
-# CA2353: Unsafe DataSet or DataTable in serializable type
-dotnet_diagnostic.CA2353.severity = none
-
-# CA2354: Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
-dotnet_diagnostic.CA2354.severity = none
-
-# CA2355: Unsafe DataSet or DataTable type found in deserializable object graph
-dotnet_diagnostic.CA2355.severity = none
-
-# CA2356: Unsafe DataSet or DataTable type in web deserializable object graph
-dotnet_diagnostic.CA2356.severity = none
-
-# CA2361: Ensure auto-generated class containing DataSet.ReadXml() is not used with untrusted data
-dotnet_diagnostic.CA2361.severity = none
-
-# CA2362: Unsafe DataSet or DataTable in auto-generated serializable type can be vulnerable to remote code execution attacks
-dotnet_diagnostic.CA2362.severity = none
-
-# CA3001: Review code for SQL injection vulnerabilities
-dotnet_diagnostic.CA3001.severity = none
-
-# CA3002: Review code for XSS vulnerabilities
-dotnet_diagnostic.CA3002.severity = none
-
-# CA3003: Review code for file path injection vulnerabilities
-dotnet_diagnostic.CA3003.severity = none
-
-# CA3004: Review code for information disclosure vulnerabilities
-dotnet_diagnostic.CA3004.severity = none
-
-# CA3005: Review code for LDAP injection vulnerabilities
-dotnet_diagnostic.CA3005.severity = none
-
-# CA3006: Review code for process command injection vulnerabilities
-dotnet_diagnostic.CA3006.severity = none
-
-# CA3007: Review code for open redirect vulnerabilities
-dotnet_diagnostic.CA3007.severity = none
-
-# CA3008: Review code for XPath injection vulnerabilities
-dotnet_diagnostic.CA3008.severity = none
-
-# CA3009: Review code for XML injection vulnerabilities
-dotnet_diagnostic.CA3009.severity = none
-
-# CA3010: Review code for XAML injection vulnerabilities
-dotnet_diagnostic.CA3010.severity = none
-
-# CA3011: Review code for DLL injection vulnerabilities
-dotnet_diagnostic.CA3011.severity = none
-
-# CA3012: Review code for regex injection vulnerabilities
-dotnet_diagnostic.CA3012.severity = none
-
-# CA3061: Do Not Add Schema By URL
-dotnet_diagnostic.CA3061.severity = warning
-
-# CA3075: Insecure DTD processing in XML
-dotnet_diagnostic.CA3075.severity = warning
-
-# CA3076: Insecure XSLT script processing.
-dotnet_diagnostic.CA3076.severity = warning
-
-# CA3077: Insecure Processing in API Design, XmlDocument and XmlTextReader
-dotnet_diagnostic.CA3077.severity = warning
-
-# CA3147: Mark Verb Handlers With Validate Antiforgery Token
-dotnet_diagnostic.CA3147.severity = warning
-
-# CA5350: Do Not Use Weak Cryptographic Algorithms
-dotnet_diagnostic.CA5350.severity = warning
-
-# CA5351: Do Not Use Broken Cryptographic Algorithms
-dotnet_diagnostic.CA5351.severity = warning
-
-# CA5358: Review cipher mode usage with cryptography experts
-dotnet_diagnostic.CA5358.severity = none
-
-# CA5359: Do Not Disable Certificate Validation
-dotnet_diagnostic.CA5359.severity = warning
-
-# CA5360: Do Not Call Dangerous Methods In Deserialization
-dotnet_diagnostic.CA5360.severity = warning
-
-# CA5361: Do Not Disable SChannel Use of Strong Crypto
-dotnet_diagnostic.CA5361.severity = warning
-
-# CA5362: Potential reference cycle in deserialized object graph
-dotnet_diagnostic.CA5362.severity = none
-
-# CA5363: Do Not Disable Request Validation
-dotnet_diagnostic.CA5363.severity = warning
-
-# CA5364: Do Not Use Deprecated Security Protocols
-dotnet_diagnostic.CA5364.severity = warning
-
-# CA5365: Do Not Disable HTTP Header Checking
-dotnet_diagnostic.CA5365.severity = warning
-
-# CA5366: Use XmlReader for 'DataSet.ReadXml()'
-dotnet_diagnostic.CA5366.severity = none
-
-# CA5367: Do Not Serialize Types With Pointer Fields
-dotnet_diagnostic.CA5367.severity = none
-
-# CA5368: Set ViewStateUserKey For Classes Derived From Page
-dotnet_diagnostic.CA5368.severity = warning
-
-# CA5369: Use XmlReader for 'XmlSerializer.Deserialize()'
-dotnet_diagnostic.CA5369.severity = none
-
-# CA5370: Use XmlReader for XmlValidatingReader constructor
-dotnet_diagnostic.CA5370.severity = warning
-
-# CA5371: Use XmlReader for 'XmlSchema.Read()'
-dotnet_diagnostic.CA5371.severity = none
-
-# CA5372: Use XmlReader for XPathDocument constructor
-dotnet_diagnostic.CA5372.severity = none
-
-# CA5373: Do not use obsolete key derivation function
-dotnet_diagnostic.CA5373.severity = warning
-
-# CA5374: Do Not Use XslTransform
-dotnet_diagnostic.CA5374.severity = warning
-
-# CA5375: Do Not Use Account Shared Access Signature
-dotnet_diagnostic.CA5375.severity = none
-
-# CA5376: Use SharedAccessProtocol HttpsOnly
-dotnet_diagnostic.CA5376.severity = warning
-
-# CA5377: Use Container Level Access Policy
-dotnet_diagnostic.CA5377.severity = warning
-
-# CA5378: Do not disable ServicePointManagerSecurityProtocols
-dotnet_diagnostic.CA5378.severity = warning
-
-# CA5379: Ensure Key Derivation Function algorithm is sufficiently strong
-dotnet_diagnostic.CA5379.severity = warning
-
-# CA5380: Do Not Add Certificates To Root Store
-dotnet_diagnostic.CA5380.severity = warning
-
-# CA5381: Ensure Certificates Are Not Added To Root Store
-dotnet_diagnostic.CA5381.severity = warning
-
-# CA5382: Use Secure Cookies In ASP.Net Core
-dotnet_diagnostic.CA5382.severity = none
-
-# CA5383: Ensure Use Secure Cookies In ASP.NET Core
-dotnet_diagnostic.CA5383.severity = none
-
-# CA5384: Do Not Use Digital Signature Algorithm (DSA)
-dotnet_diagnostic.CA5384.severity = warning
-
-# CA5385: Use Rivest-Shamir-Adleman (RSA) Algorithm With Sufficient Key Size
-dotnet_diagnostic.CA5385.severity = warning
-
-# CA5386: Avoid hardcoding SecurityProtocolType value
-dotnet_diagnostic.CA5386.severity = none
-
-# CA5387: Do Not Use Weak Key Derivation Function With Insufficient Iteration Count
-dotnet_diagnostic.CA5387.severity = none
-
-# CA5388: Ensure Sufficient Iteration Count When Using Weak Key Derivation Function
-dotnet_diagnostic.CA5388.severity = none
-
-# CA5389: Do Not Add Archive Item's Path To The Target File System Path
-dotnet_diagnostic.CA5389.severity = none
-
-# CA5390: Do not hard-code encryption key
-dotnet_diagnostic.CA5390.severity = none
-
-# CA5391: Use antiforgery tokens in ASP.NET Core MVC controllers
-dotnet_diagnostic.CA5391.severity = none
-
-# CA5392: Use DefaultDllImportSearchPaths attribute for P/Invokes
-dotnet_diagnostic.CA5392.severity = none
-
-# CA5393: Do not use unsafe DllImportSearchPath value
-dotnet_diagnostic.CA5393.severity = none
-
-# CA5394: Do not use insecure randomness
-dotnet_diagnostic.CA5394.severity = none
-
-# CA5395: Miss HttpVerb attribute for action methods
-dotnet_diagnostic.CA5395.severity = none
-
-# CA5396: Set HttpOnly to true for HttpCookie
-dotnet_diagnostic.CA5396.severity = none
-
-# CA5397: Do not use deprecated SslProtocols values
-dotnet_diagnostic.CA5397.severity = none
-
-# CA5398: Avoid hardcoded SslProtocols values
-dotnet_diagnostic.CA5398.severity = none
-
-# CA5399: HttpClients should enable certificate revocation list checks
-dotnet_diagnostic.CA5399.severity = none
-
-# CA5400: Ensure HttpClient certificate revocation list check is not disabled
-dotnet_diagnostic.CA5400.severity = none
-
-# CA5401: Do not use CreateEncryptor with non-default IV
-dotnet_diagnostic.CA5401.severity = none
-
-# CA5402: Use CreateEncryptor with the default IV
-dotnet_diagnostic.CA5402.severity = none
-
-# CA5403: Do not hard-code certificate
-dotnet_diagnostic.CA5403.severity = none
-
-# CA5404: Do not disable token validation checks
-dotnet_diagnostic.CA5404.severity = none
-
-# CA5405: Do not always skip token validation in delegates
-dotnet_diagnostic.CA5405.severity = none
-
-# IL3000: Avoid using accessing Assembly file path when publishing as a single-file
-dotnet_diagnostic.IL3000.severity = none # TODO: warning
-
-# IL3001: Avoid using accessing Assembly file path when publishing as a single-file
-dotnet_diagnostic.IL3001.severity = warning
-
-# IL3002: Using member with RequiresAssemblyFilesAttribute can break functionality when embedded in a single-file app
-dotnet_diagnostic.IL3002.severity = warning
-
-# Public members should not use oblivious types
-dotnet_diagnostic.RS0041.severity = none
-
-# SA0001: XML comments
-dotnet_diagnostic.SA0001.severity = none
-
-# Invalid settings file
-dotnet_diagnostic.SA0002.severity = none
 
 # SA1000: Spacing around keywords
 dotnet_diagnostic.SA1000.severity = none
@@ -867,77 +62,14 @@ dotnet_diagnostic.SA1000.severity = none
 # SA1001: Commas should not be preceded by whitespace
 dotnet_diagnostic.SA1001.severity = none
 
-# SA1002: Semicolons should not be preceded by a space
-dotnet_diagnostic.SA1002.severity = none
-
-# SA1003: Operator should not appear at the end of a line
-dotnet_diagnostic.SA1003.severity = none
-
-# SA1004: Documentation line should begin with a space
-dotnet_diagnostic.SA1004.severity = none
-
-# SA1005: Single line comment should begin with a space
-dotnet_diagnostic.SA1005.severity = none
-
-# SA1006: Preprocessor keywords should not be preceded by space
-dotnet_diagnostic.SA1006.severity = none
-
-# SA1007: Operator keyword should be followed by space
-dotnet_diagnostic.SA1007.severity = none
-
-# SA1008: Opening parenthesis should not be preceded by a space
-dotnet_diagnostic.SA1008.severity = none
-
-# SA1009: Closing parenthesis should not be followed by a space
-dotnet_diagnostic.SA1009.severity = none
-
-# SA1010: Opening square brackets should not be preceded by a space
-dotnet_diagnostic.SA1010.severity = none
-
-# SA1011: Closing square bracket should be followed by a space
-dotnet_diagnostic.SA1011.severity = none
-
-# SA1012: Opening brace should be followed by a space
-dotnet_diagnostic.SA1012.severity = none
-
-# SA1013: Closing brace should be preceded by a space
-dotnet_diagnostic.SA1013.severity = none
-
 # SA1014: Opening generic brackets should not be preceded by a space
 dotnet_diagnostic.SA1014.severity = none
-
-# SA1015: Closing generic bracket should not be followed by a space
-dotnet_diagnostic.SA1015.severity = none
-
-# SA1016: Opening attribute brackets should be spaced correctly
-dotnet_diagnostic.SA1016.severity = none
-
-# SA1017: Closing attribute brackets should be spaced correctly
-dotnet_diagnostic.SA1017.severity = none
 
 # SA1018: Nullable type symbol should not be preceded by a space
 dotnet_diagnostic.SA1018.severity = none
 
-# SA1019: Member access symbols should be spaced correctly
-dotnet_diagnostic.SA1019.severity = none
-
 # SA1020: Increment symbol should not be preceded by a space
 dotnet_diagnostic.SA1020.severity = none
-
-# SA1021: Negative sign should be preceded by a space
-dotnet_diagnostic.SA1021.severity = none
-
-# SA1022: Positive signs should be spaced correctly
-dotnet_diagnostic.SA1022.severity = none
-
-# SA1023: Dereference symbol '*' should not be preceded by a space."
-dotnet_diagnostic.SA1023.severity = none
-
-# SA1024: Colon should be followed by a space
-dotnet_diagnostic.SA1024.severity = none
-
-# SA1025: Code should not contain multiple whitespace characters in a row
-dotnet_diagnostic.SA1025.severity = none
 
 # SA1026: Keyword followed by span or blank line
 dotnet_diagnostic.SA1026.severity = none
@@ -948,122 +80,26 @@ dotnet_diagnostic.SA1027.severity = none
 # SA1028: Code should not contain trailing whitespace
 dotnet_diagnostic.SA1028.severity = none
 
-# SA1100: Do not prefix calls with base unless local implementation exists
-dotnet_diagnostic.SA1100.severity = none
-
-# SA1101: Prefix local calls with this
-dotnet_diagnostic.SA1101.severity = none
-
 # SA1102: Query clause should follow previous clause
 dotnet_diagnostic.SA1102.severity = none
 
 # SA1103: Query clauses should be on separate lines or all on one line
 dotnet_diagnostic.SA1103.severity = none
 
-# SA1104: Query clause should begin on new line when previous clause spans multiple lines
-dotnet_diagnostic.SA1104.severity = none
-
-# SA1105: Query clauses spanning multiple lines should begin on own line
-dotnet_diagnostic.SA1105.severity = none
-
-# SA1106: Code should not contain empty statements
-dotnet_diagnostic.SA1106.severity = none
-
-# SA1107: Code should not contain multiple statements on one line
-dotnet_diagnostic.SA1107.severity = none
-
-# SA1108: Block statements should not contain embedded comments
-dotnet_diagnostic.SA1108.severity = none
-
-# SA1109: Block statements should not contain embedded regions
-dotnet_diagnostic.SA1109.severity = none
-
-# SA1110: Opening parenthesis or bracket should be on declaration line
-dotnet_diagnostic.SA1110.severity = none
-
-# SA1111: Closing parenthesis should be on line of last parameter
-dotnet_diagnostic.SA1111.severity = none
-
-# SA1112: Closing parenthesis should be on line of opening parenthesis
-dotnet_diagnostic.SA1112.severity = none
-
 # SA1113: Comma should be on the same line as previous parameter
 dotnet_diagnostic.SA1113.severity = none
-
-# SA1114: Parameter list should follow declaration
-dotnet_diagnostic.SA1114.severity = none
 
 # SA1115: Parameter should begin on the line after the previous parameter
 dotnet_diagnostic.SA1115.severity = none
 
-# SA1116: Split parameters should start on line after declaration
-dotnet_diagnostic.SA1116.severity = none
-
-# SA1117: Parameters should be on same line or separate lines
-dotnet_diagnostic.SA1117.severity = none
-
-# SA1118: Parameter should not span multiple lines
-dotnet_diagnostic.SA1118.severity = none
-
-# SA1119: Statement should not use unnecessary parenthesis
-dotnet_diagnostic.SA1119.severity = none
-
-# SA1120: Comments should contain text
-dotnet_diagnostic.SA1120.severity = none
-
 # SA1121: Use built-in type alias
 dotnet_diagnostic.SA1121.severity = none
-
-# SA1122: Use string.Empty for empty strings
-dotnet_diagnostic.SA1122.severity = none
-
-# SA1123: Region should not be located within a code element
-dotnet_diagnostic.SA1123.severity = none
-
-# SA1124: Do not use regions
-dotnet_diagnostic.SA1124.severity = none
-
-# SA1125: Use shorthand for nullable types
-dotnet_diagnostic.SA1125.severity = none
-
-# SA1126: Prefix calls correctly
-dotnet_diagnostic.SA1126.severity = none
-
-# SA1127: Generic type constraints should be on their own line
-dotnet_diagnostic.SA1127.severity = none
-
-# SA1128: Put constructor initializers on their own line
-dotnet_diagnostic.SA1128.severity = none
 
 # SA1129: Do not use default value type constructor
 dotnet_diagnostic.SA1129.severity = none
 
-# SA1130: Use lambda syntax
-dotnet_diagnostic.SA1130.severity = none
-
 # SA1131: Constant values should appear on the right-hand side of comparisons
 dotnet_diagnostic.SA1131.severity = suggestion
-
-# SA1132: Do not combine fields
-dotnet_diagnostic.SA1132.severity = none
-
-# SA1133: Do not combine attributes
-dotnet_diagnostic.SA1133.severity = none
-
-# SA1134: Each attribute should be placed on its own line of code
-dotnet_diagnostic.SA1134.severity = none
-
-# SA1135: Using directive should be qualified
-dotnet_diagnostic.SA1135.severity = none
-
-# SA1136: Enum values should be on separate lines
-dotnet_diagnostic.SA1136.severity = none
-
-# SA1137: Elements should have the same indentation
-dotnet_diagnostic.SA1137.severity = none
-
-# SA1139: Use literal suffix notation instead of casting
-dotnet_diagnostic.SA1139.severity = none
 
 # SA1141: Use tuple syntax
 dotnet_diagnostic.SA1141.severity = none
@@ -1071,134 +107,20 @@ dotnet_diagnostic.SA1141.severity = none
 # SA1142: Refer to tuple elements by name
 dotnet_diagnostic.SA1142.severity = none
 
-# SA1200: Using directive should appear within a namespace declaration
-dotnet_diagnostic.SA1200.severity = none
-
-# SA1201: Elements should appear in the correct order
-dotnet_diagnostic.SA1201.severity = none
-
-# SA1202: Elements should be ordered by access
-dotnet_diagnostic.SA1202.severity = none
-
-# SA1203: Constants should appear before fields
-dotnet_diagnostic.SA1203.severity = none
-
-# SA1204: Static elements should appear before instance elements
-dotnet_diagnostic.SA1204.severity = none
-
 # SA1205: Partial elements should declare an access modifier
 dotnet_diagnostic.SA1205.severity = none
 
 # SA1206: Keyword ordering
 dotnet_diagnostic.SA1206.severity = none
 
-# SA1207: Protected should come before internal
-dotnet_diagnostic.SA1207.severity = none
-
-# SA1208: Using directive ordering
-dotnet_diagnostic.SA1208.severity = none
-
-# SA1209: Using alias directives should be placed after all using namespace directives
-dotnet_diagnostic.SA1209.severity = none
-
-# SA1210: Using directives should be ordered alphabetically by the namespaces
-dotnet_diagnostic.SA1210.severity = none
-
-# SA1211: Using alias directive ordering
-dotnet_diagnostic.SA1211.severity = none
-
 # SA1212: A get accessor appears after a set accessor within a property or indexer
 dotnet_diagnostic.SA1212.severity = none
-
-# SA1213: Event accessors should follow order
-dotnet_diagnostic.SA1213.severity = none
-
-# SA1214: Readonly fields should appear before non-readonly fields
-dotnet_diagnostic.SA1214.severity = none
-
-# SA1216: Using static directives should be placed at the correct location
-dotnet_diagnostic.SA1216.severity = none
-
-# SA1217: Using static directives should be ordered alphabetically
-dotnet_diagnostic.SA1217.severity = none
-
-# SA1300: Element should begin with an uppercase letter
-dotnet_diagnostic.SA1300.severity = none
-
-# SA1301: Element should begin with lower-case letter
-dotnet_diagnostic.SA1301.severity = none
 
 # SA1302: Interface names should begin with I
 dotnet_diagnostic.SA1302.severity = none
 
-# SA1303: Const field names should begin with upper-case letter
-dotnet_diagnostic.SA1303.severity = none
-
-# SA1304: Non-private readonly fields should begin with upper-case letter
-dotnet_diagnostic.SA1304.severity = none
-
-# SA1305: Field names should not use Hungarian notation
-dotnet_diagnostic.SA1305.severity = none
-
-# SA1306: Field should begin with lower-case letter
-dotnet_diagnostic.SA1306.severity = none
-
-# SA1307: Field should begin with upper-case letter
-dotnet_diagnostic.SA1307.severity = none
-
-# SA1308: Field should not begin with the prefix 's_'
-dotnet_diagnostic.SA1308.severity = none
-
-# SA1309: Field names should not begin with underscore
-dotnet_diagnostic.SA1309.severity = none
-
-# SA1310: Field should not contain an underscore
-dotnet_diagnostic.SA1310.severity = none
-
-# SA1311: Static readonly fields should begin with upper-case letter
-dotnet_diagnostic.SA1311.severity = none
-
-# SA1312: Variable should begin with lower-case letter
-dotnet_diagnostic.SA1312.severity = none
-
-# SA1313: Parameter should begin with lower-case letter
-dotnet_diagnostic.SA1313.severity = none
-
-# SA1314: Type parameter names should begin with T
-dotnet_diagnostic.SA1314.severity = none
-
-# SA1316: Tuple element names should use correct casing
-dotnet_diagnostic.SA1316.severity = none
-
 # SA1400: Member should declare an access modifier
 dotnet_diagnostic.SA1400.severity = none
-
-# SA1401: Fields should be private
-dotnet_diagnostic.SA1401.severity = none
-
-# SA1402: File may only contain a single type
-dotnet_diagnostic.SA1402.severity = none
-
-# SA1403: File may only contain a single namespace
-dotnet_diagnostic.SA1403.severity = none
-
-# SA1404: Code analysis suppression should have justification
-dotnet_diagnostic.SA1404.severity = none
-
-# SA1405: Debug.Assert should provide message text
-dotnet_diagnostic.SA1405.severity = none
-
-# SA1406: Debug.Fail should provide message text
-dotnet_diagnostic.SA1406.severity = none
-
-# SA1407: Arithmetic expressions should declare precedence
-dotnet_diagnostic.SA1407.severity = none
-
-# SA1408: Conditional expressions should declare precedence
-dotnet_diagnostic.SA1408.severity = warning
-
-# SA1409: Remove unnecessary code
-dotnet_diagnostic.SA1409.severity = none
 
 # SA1410: Remove delegate parens when possible
 dotnet_diagnostic.SA1410.severity = none
@@ -1206,242 +128,8 @@ dotnet_diagnostic.SA1410.severity = none
 # SA1411: Attribute constructor shouldn't use unnecessary parenthesis
 dotnet_diagnostic.SA1411.severity = none
 
-# SA1412: Store files as UTF-8 with byte order mark
-dotnet_diagnostic.SA1412.severity = none
-
-# SA1413: Use trailing comma in multi-line initializers
-dotnet_diagnostic.SA1413.severity = none
-
-# SA1414: Tuple types in signatures should have element names
-dotnet_diagnostic.SA1414.severity = none
-
-# SA1500: Braces for multi-line statements should not share line
-dotnet_diagnostic.SA1500.severity = error
-
-# SA1501: Statement should not be on a single line
-dotnet_diagnostic.SA1501.severity = none
-
-# SA1502: Element should not be on a single line
-dotnet_diagnostic.SA1502.severity = none
-
-# SA1503: Braces should not be omitted
-dotnet_diagnostic.SA1503.severity = none
-
-# SA1504: All accessors should be single-line or multi-line
-dotnet_diagnostic.SA1504.severity = none
-
-# SA1505: An opening brace should not be followed by a blank line
-dotnet_diagnostic.SA1505.severity = warning
-
-# SA1506: Element documentation headers should not be followed by blank line
-dotnet_diagnostic.SA1506.severity = none
-
-# SA1507: Code should not contain multiple blank lines in a row
-dotnet_diagnostic.SA1507.severity = warning
-
-# SA1508: A closing brace should not be preceded by a blank line
-dotnet_diagnostic.SA1508.severity = warning
-
-# SA1509: Opening braces should not be preceded by blank line
-dotnet_diagnostic.SA1509.severity = warning
-
-# SA1510: 'else' statement should not be preceded by a blank line
-dotnet_diagnostic.SA1510.severity = none
-
-# SA1511: While-do footer should not be preceded by blank line
-dotnet_diagnostic.SA1511.severity = none
-
-# SA1512: Single-line comments should not be followed by blank line
-dotnet_diagnostic.SA1512.severity = none
-
-# SA1513: Closing brace should be followed by blank line
-dotnet_diagnostic.SA1513.severity = error
-
-# SA1514: Element documentation header should be preceded by blank line
-dotnet_diagnostic.SA1514.severity = none
-
-# SA1515: Single-line comment should be preceded by blank line
-dotnet_diagnostic.SA1515.severity = none
-
-# SA1516: Elements should be separated by blank line
-dotnet_diagnostic.SA1516.severity = none
-
-# SA1517: Code should not contain blank lines at start of file
-dotnet_diagnostic.SA1517.severity = warning
-
 # SA1518: Code should not contain blank lines at the end of the file
 dotnet_diagnostic.SA1518.severity = none
-
-# SA1519: Braces should not be omitted from multi-line child statement
-dotnet_diagnostic.SA1519.severity = none
-
-# SA1520: Use braces consistently
-dotnet_diagnostic.SA1520.severity = none
-
-# SA1600: Elements should be documented
-dotnet_diagnostic.SA1600.severity = none
-
-# SA1601: Partial elements should be documented
-dotnet_diagnostic.SA1601.severity = none
-
-# SA1602: Enumeration items should be documented
-dotnet_diagnostic.SA1602.severity = none
-
-# SA1603: Documentation should contain valid XML
-dotnet_diagnostic.SA1603.severity = none
-
-# SA1604: Element documentation should have summary
-dotnet_diagnostic.SA1604.severity = none
-
-# SA1605: Partial element documentation should have summary
-dotnet_diagnostic.SA1605.severity = none
-
-# SA1606: Element documentation should have summary text
-dotnet_diagnostic.SA1606.severity = none
-
-# SA1607: Partial element documentation should have summary text
-dotnet_diagnostic.SA1607.severity = none
-
-# SA1608: Element documentation should not have default summary
-dotnet_diagnostic.SA1608.severity = none
-
-# SA1609: Property documentation should have value
-dotnet_diagnostic.SA1609.severity = none
-
-# SA1610: Property documentation should have value text
-dotnet_diagnostic.SA1610.severity = none
-
-# SA1611: The documentation for parameter 'message' is missing
-dotnet_diagnostic.SA1611.severity = none
-
-# SA1612: The parameter documentation is at incorrect position
-dotnet_diagnostic.SA1612.severity = none
-
-# SA1613: Element parameter documentation should declare parameter name
-dotnet_diagnostic.SA1613.severity = none
-
-# SA1614: Element parameter documentation should have text
-dotnet_diagnostic.SA1614.severity = none
-
-# SA1615: Element return value should be documented
-dotnet_diagnostic.SA1615.severity = none
-
-# SA1616: Element return value documentation should have text
-dotnet_diagnostic.SA1616.severity = none
-
-# SA1617: Void return value should not be documented
-dotnet_diagnostic.SA1617.severity = none
-
-# SA1618: The documentation for type parameter is missing
-dotnet_diagnostic.SA1618.severity = none
-
-# SA1619: The documentation for type parameter is missing
-dotnet_diagnostic.SA1619.severity = none
-
-# SA1620: Generic type parameter documentation should match type parameters
-dotnet_diagnostic.SA1620.severity = none
-
-# SA1621: Generic type parameter documentation should declare parameter name
-dotnet_diagnostic.SA1621.severity = none
-
-# SA1622: Generic type parameter documentation should have text
-dotnet_diagnostic.SA1622.severity = none
-
-# SA1623: Property documentation text
-dotnet_diagnostic.SA1623.severity = none
-
-# SA1624: Because the property only contains a visible get accessor, the documentation summary text should begin with 'Gets'
-dotnet_diagnostic.SA1624.severity = none
-
-# SA1625: Element documentation should not be copied and pasted
-dotnet_diagnostic.SA1625.severity = none
-
-# SA1626: Single-line comments should not use documentation style slashes
-dotnet_diagnostic.SA1626.severity = none
-
-# SA1627: The documentation text within the \'exception\' tag should not be empty
-dotnet_diagnostic.SA1627.severity = none
-
-# SA1628: Documentation text should begin with a capital letter
-dotnet_diagnostic.SA1628.severity = none
-
-# SA1629: Documentation text should end with a period
-dotnet_diagnostic.SA1629.severity = none
-
-# SA1630: Documentation text should contain whitespace
-dotnet_diagnostic.SA1630.severity = none
-
-# SA1631: Documentation should meet character percentage
-dotnet_diagnostic.SA1631.severity = none
-
-# SA1632: Documentation text should meet minimum character length
-dotnet_diagnostic.SA1632.severity = none
-
-# SA1633: File should have header
-dotnet_diagnostic.SA1633.severity = none
-
-# SA1634: File header should show copyright
-dotnet_diagnostic.SA1634.severity = none
-
-# SA1635: File header should have copyright text
-dotnet_diagnostic.SA1635.severity = none
-
-# SA1636: File header copyright text should match
-dotnet_diagnostic.SA1636.severity = none
-
-# SA1637: File header should contain file name
-dotnet_diagnostic.SA1637.severity = none
-
-# SA1638: File header file name documentation should match file name
-dotnet_diagnostic.SA1638.severity = none
-
-# SA1639: File header should have summary
-dotnet_diagnostic.SA1639.severity = none
-
-# SA1640: File header should have valid company text
-dotnet_diagnostic.SA1640.severity = none
-
-# SA1641: File header company name text should match
-dotnet_diagnostic.SA1641.severity = none
-
-# SA1642: Constructor summary documentation should begin with standard text
-dotnet_diagnostic.SA1642.severity = none
-
-# SA1643: Destructor summary documentation should begin with standard text
-dotnet_diagnostic.SA1643.severity = none
-
-# SA1644: Documentation headers should not contain blank lines
-dotnet_diagnostic.SA1644.severity = none
-
-# SA1645: Included documentation file does not exist
-dotnet_diagnostic.SA1645.severity = none
-
-# SA1646: Included documentation XPath does not exist
-dotnet_diagnostic.SA1646.severity = none
-
-# SA1647: Include node does not contain valid file and path
-dotnet_diagnostic.SA1647.severity = none
-
-# SA1648: Inheritdoc should be used with inheriting class
-dotnet_diagnostic.SA1648.severity = none
-
-# SA1649: File name should match first type name
-dotnet_diagnostic.SA1649.severity = none
-
-# SA1650: Element documentation should be spelled correctly
-dotnet_diagnostic.SA1650.severity = none
-
-# SA1651: Do not use placeholder elements
-dotnet_diagnostic.SA1651.severity = none
-
-# SX1101: Do not prefix local calls with 'this.'
-dotnet_diagnostic.SX1101.severity = none
-
-# SX1309: Field names should begin with underscore
-dotnet_diagnostic.SX1309.severity = none
-
-# SX1309S: Static field names should begin with underscore
-dotnet_diagnostic.SX1309S.severity = none
 
 # IDE0001: Simplify name
 dotnet_diagnostic.IDE0001.severity = silent
@@ -1458,23 +146,8 @@ dotnet_diagnostic.IDE0004.severity = silent
 # IDE0005: Using directive is unnecessary.
 dotnet_diagnostic.IDE0005.severity = silent
 
-# IDE0007: Use implicit type
-dotnet_diagnostic.IDE0007.severity = silent
-
 # IDE0008: Use explicit type
 dotnet_diagnostic.IDE0008.severity = silent
-
-# IDE0009: Add this or Me qualification
-dotnet_diagnostic.IDE0009.severity = silent
-
-# IDE0010: Add missing cases
-dotnet_diagnostic.IDE0010.severity = silent
-
-# IDE0011: Add braces
-dotnet_diagnostic.IDE0011.severity = silent
-
-# IDE0016: Use 'throw' expression
-dotnet_diagnostic.IDE0016.severity = silent
 
 # IDE0017: Simplify object initialization
 dotnet_diagnostic.IDE0017.severity = silent
@@ -1488,27 +161,6 @@ dotnet_diagnostic.IDE0019.severity = silent
 # IDE0020: Use pattern matching to avoid is check followed by a cast (with variable)
 dotnet_diagnostic.IDE0020.severity = silent
 
-# IDE0021: Use expression body for constructors
-dotnet_diagnostic.IDE0021.severity = silent
-
-# IDE0022: Use expression body for methods
-dotnet_diagnostic.IDE0022.severity = silent
-
-# IDE0023: Use expression body for operators
-dotnet_diagnostic.IDE0023.severity = silent
-
-# IDE0024: Use expression body for operators
-dotnet_diagnostic.IDE0024.severity = silent
-
-# IDE0025: Use expression body for properties
-dotnet_diagnostic.IDE0025.severity = silent
-
-# IDE0026: Use expression body for indexers
-dotnet_diagnostic.IDE0026.severity = silent
-
-# IDE0027: Use expression body for accessors
-dotnet_diagnostic.IDE0027.severity = silent
-
 # IDE0028: Simplify collection initialization
 dotnet_diagnostic.IDE0028.severity = silent
 
@@ -1520,9 +172,6 @@ dotnet_diagnostic.IDE0030.severity = silent
 
 # IDE0031: Use null propagation
 dotnet_diagnostic.IDE0031.severity = silent
-
-# IDE0032: Use auto property
-dotnet_diagnostic.IDE0032.severity = silent
 
 # IDE0033: Use explicitly provided tuple name
 dotnet_diagnostic.IDE0033.severity = silent
@@ -1536,9 +185,6 @@ dotnet_diagnostic.IDE0035.severity = silent
 # IDE0036: Order modifiers
 dotnet_diagnostic.IDE0036.severity = silent
 
-# IDE0037: Use inferred member name
-dotnet_diagnostic.IDE0037.severity = silent
-
 # IDE0038: Use pattern matching to avoid is check followed by a cast (without variable)
 dotnet_diagnostic.IDE0038.severity = silent
 
@@ -1550,9 +196,6 @@ dotnet_diagnostic.IDE0040.severity = silent
 
 # IDE0041: Use 'is null' check
 dotnet_diagnostic.IDE0041.severity = silent
-
-# IDE0042: Deconstruct variable declaration
-dotnet_diagnostic.IDE0042.severity = silent
 
 # IDE0043: Invalid format string
 dotnet_diagnostic.IDE0043.severity = silent
@@ -1566,12 +209,6 @@ dotnet_diagnostic.IDE0045.severity = silent
 # IDE0046: Use conditional expression for return
 dotnet_diagnostic.IDE0046.severity = silent
 
-# IDE0047: Remove unnecessary parentheses
-dotnet_diagnostic.IDE0047.severity = silent
-
-# IDE0048: Add parentheses for clarity
-dotnet_diagnostic.IDE0048.severity = silent
-
 # IDE0049: Use language keywords instead of framework type names for type references
 dotnet_diagnostic.IDE0049.severity = silent
 
@@ -1580,9 +217,6 @@ dotnet_diagnostic.IDE0051.severity = silent
 
 # IDE0052: Remove unread private members
 dotnet_diagnostic.IDE0052.severity = silent
-
-# IDE0053: Use expression body for lambdas
-dotnet_diagnostic.IDE0053.severity = silent
 
 # IDE0054: Use compound assignment
 dotnet_diagnostic.IDE0054.severity = silent
@@ -1596,26 +230,14 @@ dotnet_diagnostic.IDE0056.severity = silent
 # IDE0057: Use range operator
 dotnet_diagnostic.IDE0057.severity = silent
 
-# IDE0058: Expression value is never used
-dotnet_diagnostic.IDE0058.severity = silent
-
 # IDE0059: Unnecessary assignment of a value
 dotnet_diagnostic.IDE0059.severity = silent
 
 # IDE0060: Remove unused parameter
-dotnet_diagnostic.IDE0060.severity = silent
-
-# IDE0061: Use expression body for local functions
-dotnet_diagnostic.IDE0061.severity = silent
+dotnet_code_quality_unused_parameters = unset
 
 # IDE0062: Make local function 'static'
 dotnet_diagnostic.IDE0062.severity = silent
-
-# IDE0063: Use simple 'using' statement
-dotnet_diagnostic.IDE0063.severity = silent
-
-# IDE0064: Make readonly fields writable
-dotnet_diagnostic.IDE0064.severity = silent
 
 # IDE0065: Misplaced using directive
 dotnet_diagnostic.IDE0065.severity = silent
@@ -1629,23 +251,14 @@ dotnet_diagnostic.IDE0070.severity = silent
 # IDE0071: Simplify interpolation
 dotnet_diagnostic.IDE0071.severity = silent
 
-# IDE0072: Add missing cases
-dotnet_diagnostic.IDE0072.severity = silent
-
 # IDE0073: The file header is missing or not located at the top of the file
 dotnet_diagnostic.IDE0073.severity = silent
 
 # IDE0074: Use compound assignment
 dotnet_diagnostic.IDE0074.severity = silent
 
-# IDE0075: Simplify conditional expression
-dotnet_diagnostic.IDE0075.severity = silent
-
 # IDE0076: Invalid global 'SuppressMessageAttribute'
 dotnet_diagnostic.IDE0076.severity = silent
-
-# IDE0077: Avoid legacy format target in 'SuppressMessageAttribute'
-dotnet_diagnostic.IDE0077.severity = silent
 
 # IDE0078: Use pattern matching
 dotnet_diagnostic.IDE0078.severity = silent
@@ -1662,14 +275,8 @@ dotnet_diagnostic.IDE0081.severity = silent
 # IDE0082: 'typeof' can be converted  to 'nameof'
 dotnet_diagnostic.IDE0082.severity = silent
 
-# IDE0083: Use pattern matching
-dotnet_diagnostic.IDE0083.severity = silent
-
 # IDE0084: Use pattern matching (IsNot operator)
 dotnet_diagnostic.IDE0084.severity = silent
-
-# IDE0090: Use 'new(...)'
-dotnet_diagnostic.IDE0090.severity = silent
 
 # IDE0100: Remove redundant equality
 dotnet_diagnostic.IDE0100.severity = silent
@@ -1680,20 +287,8 @@ dotnet_diagnostic.IDE0110.severity = silent
 # IDE0120: Simplify LINQ expression
 dotnet_diagnostic.IDE0120.severity = silent
 
-# IDE0130: Namespace does not match folder structure
-dotnet_diagnostic.IDE0130.severity = silent
-
 # IDE0140: Simplify object creation
 dotnet_diagnostic.IDE0140.severity = silent
-
-# IDE0150: Prefer 'null' check over type check
-dotnet_diagnostic.IDE0150.severity = silent
-
-# IDE0160: Convert to block scoped namespace
-dotnet_diagnostic.IDE0160.severity = silent
-
-# IDE0161: Convert to file-scoped namespace
-dotnet_diagnostic.IDE0161.severity = silent
 
 # IDE0170: Simplify property pattern
 dotnet_diagnostic.IDE0170.severity = silent
@@ -1704,38 +299,11 @@ dotnet_diagnostic.IDE0180.severity = silent
 # IDE0200: Remove unnecessary lambda expression
 dotnet_diagnostic.IDE0200.severity = silent
 
-# IDE0210: Use top-level statements
-dotnet_diagnostic.IDE0210.severity = silent
-
-# IDE0211: Use program main
-dotnet_diagnostic.IDE0211.severity = silent
-
-# IDE0220: foreach cast
-dotnet_diagnostic.IDE0220.severity = silent
-
 # IDE0230: Use UTF8 string literal
 dotnet_diagnostic.IDE0230.severity = silent
 
 # IDE1005: Delegate invocation can be simplified.
 dotnet_diagnostic.IDE1005.severity = silent
-
-# IDE1006: Naming Styles
-dotnet_diagnostic.IDE1006.severity = silent
-
-# IDE2000: C#
-dotnet_diagnostic.IDE2000.severity = silent
-
-# IDE2001: Embedded statements must be on their own line
-dotnet_diagnostic.IDE2001.severity = silent
-
-# IDE2002: Consecutive braces must not have blank line between them
-dotnet_diagnostic.IDE2002.severity = silent
-
-# IDE2003: C#
-dotnet_diagnostic.IDE2003.severity = silent
-
-# IDE2004: Blank line not allowed after constructor initializer colon
-dotnet_diagnostic.IDE2004.severity = silent
 
 # xUnit1000: Test classes must be public
 dotnet_diagnostic.xUnit1000.severity = warning
@@ -1883,9 +451,3 @@ dotnet_diagnostic.xUnit3000.severity = warning
 
 # xUnit3001: Classes that implement Xunit.Abstractions.IXunitSerializable must have a public parameterless constructor
 dotnet_diagnostic.xUnit3001.severity = warning
-
-# CSIsNull001 to catch uses of == null
-dotnet_diagnostic.CSIsNull001.severity = warning
-
-# CSIsNull002 to catch uses of != null
-dotnet_diagnostic.CSIsNull002.severity = warning

--- a/eng/CodeStyle.targets
+++ b/eng/CodeStyle.targets
@@ -6,7 +6,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsShipping)' == 'false'">
-    <EditorConfigFiles Remove="$(MSBuildThisFileDirectory)CodeAnalysis.src.globalconfig" />
+    <!-- Include CodeAnalysis.test.globalconfig to override (relax) some rules from the primary configuration. -->
     <EditorConfigFiles Include="$(MSBuildThisFileDirectory)CodeAnalysis.test.globalconfig" />
   </ItemGroup>
 


### PR DESCRIPTION
All duplicate items have been removed, leaving only the unique configuration for tests. The specific configuration behavior is not changed.