### PR TITLE
Fix nullability of ArgumentValidation class

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/ArgumentValidation.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/ArgumentValidation.cs
@@ -2,19 +2,20 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 namespace System.Windows.Forms
 {
     internal static class ArgumentValidation
     {
-        internal static T OrThrowIfNull<T>(this T? argument, [CallerArgumentExpression("argument")] string? paramName = null)
+        internal static T OrThrowIfNull<T>([NotNull] this T? argument, [CallerArgumentExpression(nameof(argument))] string? paramName = null)
         {
             ArgumentNullException.ThrowIfNull(argument, paramName);
             return argument;
         }
 
-        internal static T OrThrowIfNullWithMessage<T>(this T? argument, string message, [CallerArgumentExpression("argument")] string? paramName = null)
+        internal static T OrThrowIfNullWithMessage<T>([NotNull] this T? argument, string message, [CallerArgumentExpression(nameof(argument))] string? paramName = null)
         {
             if (argument is null)
             {
@@ -24,7 +25,7 @@ namespace System.Windows.Forms
             return argument!;
         }
 
-        internal static IntPtr OrThrowIfZero(this IntPtr argument, [CallerArgumentExpression("argument")] string? paramName = null)
+        internal static IntPtr OrThrowIfZero(this IntPtr argument, [CallerArgumentExpression(nameof(argument))] string? paramName = null)
         {
             if (argument == IntPtr.Zero)
             {
@@ -34,13 +35,13 @@ namespace System.Windows.Forms
             return argument;
         }
 
-        internal static string OrThrowIfNullOrEmpty(this string? argument, [CallerArgumentExpression("argument")] string? paramName = null)
+        internal static string OrThrowIfNullOrEmpty([NotNull] this string? argument, [CallerArgumentExpression(nameof(argument))] string? paramName = null)
         {
             ThrowIfNullOrEmpty(argument, paramName);
             return argument!;
         }
 
-        internal static void ThrowIfNullOrEmpty(this string? argument, [CallerArgumentExpression("argument")] string? paramName = null)
+        internal static void ThrowIfNullOrEmpty([NotNull] this string? argument, [CallerArgumentExpression(nameof(argument))] string? paramName = null)
         {
             if (string.IsNullOrEmpty(argument))
             {
@@ -48,7 +49,7 @@ namespace System.Windows.Forms
             }
         }
 
-        internal static void ThrowIfNullOrEmptyWithMessage(this string? argument, string message, [CallerArgumentExpression("argument")] string? paramName = null)
+        internal static void ThrowIfNullOrEmptyWithMessage([NotNull] this string? argument, string message, [CallerArgumentExpression(nameof(argument))] string? paramName = null)
         {
             if (string.IsNullOrEmpty(argument))
             {
@@ -56,7 +57,7 @@ namespace System.Windows.Forms
             }
         }
 
-        internal static void ThrowIfNull(HDC argument, [CallerArgumentExpression("argument")] string? paramName = null)
+        internal static void ThrowIfNull(HDC argument, [CallerArgumentExpression(nameof(argument))] string? paramName = null)
         {
             if (argument.IsNull)
             {

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/ArgumentValidation.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/ArgumentValidation.cs
@@ -22,7 +22,7 @@ namespace System.Windows.Forms
                 throw new ArgumentNullException(paramName, message);
             }
 
-            return argument!;
+            return argument;
         }
 
         internal static IntPtr OrThrowIfZero(this IntPtr argument, [CallerArgumentExpression(nameof(argument))] string? paramName = null)
@@ -38,7 +38,7 @@ namespace System.Windows.Forms
         internal static string OrThrowIfNullOrEmpty([NotNull] this string? argument, [CallerArgumentExpression(nameof(argument))] string? paramName = null)
         {
             ThrowIfNullOrEmpty(argument, paramName);
-            return argument!;
+            return argument;
         }
 
         internal static void ThrowIfNullOrEmpty([NotNull] this string? argument, [CallerArgumentExpression(nameof(argument))] string? paramName = null)


### PR DESCRIPTION
## Proposed changes

The null-checking extension methods defined in ArgumentValidation are lacking an annotation stating that the first argument is checked for null. This PR adds it back.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8925)