### PR TITLE
Rework of empty finalizers fix in DataGridView

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewBand.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewBand.cs
@@ -35,7 +35,7 @@ namespace System.Windows.Forms
         }
 
         // NOTE: currently this finalizer is unneeded (empty). See https://github.com/dotnet/winforms/issues/6858.
-        // All classes that are not need to be finalized contains in DataGridViewElement.s_typesWithEmptyFinalizer collection. Consider to modify it if needed.
+        // All classes that are not need to be finalized must be checked in DataGridViewElement() constructor. Consider to modify it if needed.
         ~DataGridViewBand() => Dispose(false);
 
         internal int CachedThickness { get; set; }
@@ -827,7 +827,8 @@ namespace System.Windows.Forms
                 }
             }
 
-            // If you are adding releasing unmanaged resources code here (disposing == false), you need to remove this class type (and all of its subclasses) from DataGridViewElement.s_typesWithEmptyFinalizer!
+            // If you are adding releasing unmanaged resources code here (disposing == false), you need to remove this class type
+            // (and all of its subclasses) from check in DataGridViewElement() constructor and DataGridViewElement_Subclasses_SuppressFinalizeCall test!
             // Also consider to modify ~DataGridViewBand() description.
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
@@ -85,7 +85,7 @@ namespace System.Windows.Forms
         }
 
         // NOTE: currently this finalizer is unneeded (empty). See https://github.com/dotnet/winforms/issues/6858.
-        // All classes that are not need to be finalized contains in DataGridViewElement.s_typesWithEmptyFinalizer collection. Consider to modify it if needed.
+        // All classes that are not need to be finalized must be checked in DataGridViewElement() constructor. Consider to modify it if needed.
         ~DataGridViewCell()
         {
             Dispose(false);
@@ -1297,7 +1297,8 @@ namespace System.Windows.Forms
                 }
             }
 
-            // If you are adding releasing unmanaged resources code here (disposing == false), you need to remove this class type (and all of its subclasses) from DataGridViewElement.s_typesWithEmptyFinalizer!
+            // If you are adding releasing unmanaged resources code here (disposing == false), you need to remove this class type
+            // (and all of its subclasses) from check in DataGridViewElement() constructor and DataGridViewElement_Subclasses_SuppressFinalizeCall test!
             // Also consider to modify ~DataGridViewCell() description.
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumn.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumn.cs
@@ -932,7 +932,8 @@ namespace System.Windows.Forms
                     }
                 }
 
-                // If you are adding releasing unmanaged resources code here (disposing == false), you need to remove this class type (and all of its subclasses) from DataGridViewElement.s_typesWithEmptyFinalizer!
+                // If you are adding releasing unmanaged resources code here (disposing == false), you need to remove this class type
+                // (and all of its subclasses) from check in DataGridViewElement() constructor and DataGridViewElement_Subclasses_SuppressFinalizeCall test!
                 // Also consider to modify ~DataGridViewBand() description.
             }
             finally

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewElement.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewElement.cs
@@ -11,34 +11,6 @@ namespace System.Windows.Forms
     /// </summary>
     public class DataGridViewElement
     {
-        /// <summary>
-        /// These are subclasses of the <see cref="DataGridViewElement"/> for which we don't need to call the finalizer, because it's empty.
-        /// See https://github.com/dotnet/winforms/issues/6858.
-        /// </summary>
-        private static readonly HashSet<Type> s_typesWithEmptyFinalizer = new()
-        {
-            typeof(DataGridViewBand),
-            typeof(DataGridViewColumn),
-            typeof(DataGridViewButtonColumn),
-            typeof(DataGridViewCheckBoxColumn),
-            typeof(DataGridViewComboBoxColumn),
-            typeof(DataGridViewImageColumn),
-            typeof(DataGridViewLinkColumn),
-            typeof(DataGridViewTextBoxColumn),
-            typeof(DataGridViewRow),
-            typeof(DataGridViewCell),
-            typeof(DataGridViewButtonCell),
-            typeof(DataGridViewCheckBoxCell),
-            typeof(DataGridViewComboBoxCell),
-            typeof(DataGridViewHeaderCell),
-            typeof(DataGridViewColumnHeaderCell),
-            typeof(DataGridViewTopLeftHeaderCell),
-            typeof(DataGridViewRowHeaderCell),
-            typeof(DataGridViewImageCell),
-            typeof(DataGridViewLinkCell),
-            typeof(DataGridViewTextBoxCell)
-        };
-
         private DataGridView? _dataGridView;
 
         /// <summary>
@@ -46,8 +18,21 @@ namespace System.Windows.Forms
         /// </summary>
         public DataGridViewElement()
         {
-            if (s_typesWithEmptyFinalizer.Contains(GetType()))
+            // These are subclasses of the DataGridViewElement for which we don't need to call the finalizer, because it's empty.
+            // See https://github.com/dotnet/winforms/issues/6858.
+            if (GetType() == typeof(DataGridViewBand) || GetType() == typeof(DataGridViewColumn) ||
+                GetType() == typeof(DataGridViewButtonColumn) || GetType() == typeof(DataGridViewCheckBoxColumn) ||
+                GetType() == typeof(DataGridViewComboBoxColumn) || GetType() == typeof(DataGridViewImageColumn) ||
+                GetType() == typeof(DataGridViewLinkColumn) || GetType() == typeof(DataGridViewTextBoxColumn) ||
+                GetType() == typeof(DataGridViewRow) || GetType() == typeof(DataGridViewCell) ||
+                GetType() == typeof(DataGridViewButtonCell) || GetType() == typeof(DataGridViewCheckBoxCell) ||
+                GetType() == typeof(DataGridViewComboBoxCell) || GetType() == typeof(DataGridViewHeaderCell) ||
+                GetType() == typeof(DataGridViewColumnHeaderCell) || GetType() == typeof(DataGridViewTopLeftHeaderCell) ||
+                GetType() == typeof(DataGridViewRowHeaderCell) || GetType() == typeof(DataGridViewImageCell) ||
+                GetType() == typeof(DataGridViewLinkCell) || GetType() == typeof(DataGridViewTextBoxCell))
+            {
                 GC.SuppressFinalize(this);
+            }
 
             State = DataGridViewElementStates.Visible;
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewHeaderCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewHeaderCell.cs
@@ -63,7 +63,8 @@ namespace System.Windows.Forms
                 FlipXPThemesBitmap.Dispose();
             }
 
-            // If you are adding releasing unmanaged resources code here (disposing == false), you need to remove this class type (and all of its subclasses) from DataGridViewElement.s_typesWithEmptyFinalizer!
+            // If you are adding releasing unmanaged resources code here (disposing == false), you need to remove this class type
+            // (and all of its subclasses) from check in DataGridViewElement() constructor and DataGridViewElement_Subclasses_SuppressFinalizeCall test!
             // Also consider to modify ~DataGridViewCell() description.
 
             base.Dispose(disposing);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewElementTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewElementTests.cs
@@ -32,6 +32,16 @@ namespace System.Windows.Forms.Tests
             yield return new object[] { new DataGridViewCellEventArgs(1, 2) };
         }
 
+        public static IEnumerable<object[]> DataGridViewElement_Subclasses_SuppressFinalizeCall_TestData()
+        {
+            foreach (var type in typeof(DataGridViewElement).Assembly.GetTypes().Where(type =>
+                type == typeof(DataGridViewBand) || type == typeof(DataGridViewCell) ||
+                type.IsSubclassOf(typeof(DataGridViewBand)) || type.IsSubclassOf(typeof(DataGridViewCell))))
+            {
+                yield return new object[] { type };
+            }
+        }
+
         [WinFormsTheory]
         [MemberData(nameof(DataGridViewCellEventArgs_TestData))]
         public void DataGridViewElement_RaiseCellClick_Invoke_Nop(DataGridViewCellEventArgs eventArgs)
@@ -351,18 +361,22 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(1, callCount);
         }
 
-        [WinFormsFact]
-        public void DataGridViewElement_Subclasses_SuppressFinalizeCall()
+        [WinFormsTheory]
+        [MemberData(nameof(DataGridViewElement_Subclasses_SuppressFinalizeCall_TestData))]
+        public void DataGridViewElement_Subclasses_SuppressFinalizeCall(Type type)
         {
-            TestAccessor<DataGridViewElement> testAccessor = new(null);
-            var typesWithEmptyFinalizer = testAccessor.Dynamic.s_typesWithEmptyFinalizer as HashSet<Type>;
-
-            foreach (var type in typeof(DataGridViewElement).Assembly.GetTypes().Where(type => type == typeof(DataGridViewBand) || type == typeof(DataGridViewCell) ||
-                type.IsSubclassOf(typeof(DataGridViewBand)) || type.IsSubclassOf(typeof(DataGridViewCell))))
-            {
-                Assert.True(typesWithEmptyFinalizer.Contains(type), $"Type {type} is not present in the DataGridViewElement.s_typesWithEmptyFinalizer collection. " +
-                    $"Consider adding it or add exclusion to this test (if a new class really needs a finalizer).");
-            }
+            Assert.True(type == typeof(DataGridViewBand) || type == typeof(DataGridViewColumn) ||
+                type == typeof(DataGridViewButtonColumn) || type == typeof(DataGridViewCheckBoxColumn) ||
+                type == typeof(DataGridViewComboBoxColumn) || type == typeof(DataGridViewImageColumn) ||
+                type == typeof(DataGridViewLinkColumn) || type == typeof(DataGridViewTextBoxColumn) ||
+                type == typeof(DataGridViewRow) || type == typeof(DataGridViewCell) || type == typeof(DataGridViewButtonCell) ||
+                type == typeof(DataGridViewCheckBoxCell) || type == typeof(DataGridViewComboBoxCell) ||
+                type == typeof(DataGridViewHeaderCell) || type == typeof(DataGridViewColumnHeaderCell) ||
+                type == typeof(DataGridViewTopLeftHeaderCell) || type == typeof(DataGridViewRowHeaderCell) ||
+                type == typeof(DataGridViewImageCell) || type == typeof(DataGridViewLinkCell) || type == typeof(DataGridViewTextBoxCell),
+                $"Type {type} is not one of known {nameof(DataGridViewElement)} subclauses with empty finalizers. " +
+                $"Consider adding it here and to the {nameof(DataGridViewElement)}() constructor. " +
+                $"Or add exclusion to this test (if a new class really needs a finalizer).");
         }
 
         private class SubDataGridViewCell : DataGridViewCell


### PR DESCRIPTION
Rework of empty finalizers fix in DataGridView due to [this discussion](https://github.com/dotnet/winforms/pull/7431#issuecomment-1423140820).

Also added a benchmark for clarity.
- `HashSetB` - previous variant where types were in `HashSet`.
- `GetTypeB` - new variant with `if (GetType() == typeof(DataGridViewBand) || GetType() == typeof(DataGridViewColumn) ...`
- `GetTypeVarB` - `var t = GetType(); if (t == typeof(D1) || t == typeof(D2) ...`
- `HelperMB` - helper method `NeedSuppressFinalize(Type t)` with `return t == typeof(E1) || t == typeof(E2) ...`
![bench](https://user-images.githubusercontent.com/17767561/229299467-711119e8-c0b8-455b-aa8d-cf5ef6bbf3db.png)
[Bench.zip](https://github.com/dotnet/winforms/files/11129968/Bench.zip)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8930)