### PR TITLE
Handle a few skipped test failures in System.Drawing

### DIFF
--- a/src/System.Drawing.Common/src/Interop/Windows/User32/Interop.GetDC.cs
+++ b/src/System.Drawing.Common/src/Interop/Windows/User32/Interop.GetDC.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -10,16 +10,16 @@ internal static partial class Interop
     {
 #if NET7_0_OR_GREATER
         [LibraryImport(Libraries.User32)]
-        public static partial IntPtr GetDC(
+        public static partial nint GetDC(
 #else
         [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern IntPtr GetDC(
+        public static extern nint GetDC(
 #endif
-            IntPtr hWnd);
+            nint hWnd);
 
-        public static IntPtr GetDC(HandleRef hWnd)
+        public static nint GetDC(HandleRef hWnd)
         {
-            IntPtr dc = GetDC(hWnd.Handle);
+            nint dc = GetDC(hWnd.Handle);
             GC.KeepAlive(hWnd.Wrapper);
             return dc;
         }

--- a/src/System.Drawing.Common/src/System/Drawing/Font.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Font.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel;
@@ -202,9 +202,12 @@ namespace System.Drawing
         public float GetHeight(Graphics graphics)
         {
             ArgumentNullException.ThrowIfNull(graphics);
+            if (graphics.NativeGraphics == IntPtr.Zero)
+            {
+                throw new ArgumentException(nameof(graphics));
+            }
 
-            float height;
-            int status = Gdip.GdipGetFontHeight(new HandleRef(this, NativeFont), new HandleRef(graphics, graphics.NativeGraphics), out height);
+            int status = Gdip.GdipGetFontHeight(new HandleRef(this, NativeFont), new HandleRef(graphics, graphics.NativeGraphics), out float height);
             Gdip.CheckStatus(status);
 
             return height;

--- a/src/System.Drawing.Common/src/System/Drawing/Graphics.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Graphics.cs
@@ -3096,10 +3096,11 @@ namespace System.Drawing
             int destWidth = blockRegionSize.Width;
             int destHeight = blockRegionSize.Height;
 
-            IntPtr screenDC = Interop.User32.GetDC(IntPtr.Zero);
+            nint screenDC = Interop.User32.GetDC(0);
+            nint targetDC = 0;
             try
             {
-                IntPtr targetDC = GetHdc();
+                targetDC = GetHdc();
                 int result = Interop.Gdi32.BitBlt(
                     targetDC,
                     destinationX,
@@ -3111,7 +3112,6 @@ namespace System.Drawing
                     sourceY,
                     (Interop.Gdi32.RasterOp)copyPixelOperation);
 
-                //a zero result indicates a win32 exception has been thrown
                 if (result == 0)
                 {
                     throw new Win32Exception();
@@ -3120,7 +3120,10 @@ namespace System.Drawing
             finally
             {
                 Interop.User32.ReleaseDC(IntPtr.Zero, screenDC);
-                ReleaseHdc();
+                if (targetDC != 0)
+                {
+                    ReleaseHdc();
+                }
             }
         }
 

--- a/src/System.Drawing.Common/tests/BitmapTests.cs
+++ b/src/System.Drawing.Common/tests/BitmapTests.cs
@@ -969,7 +969,7 @@ namespace System.Drawing.Tests
             using var bitmap = new Bitmap(1, 1, PixelFormat.Format16bppGrayScale);
             AssertExtensions.Throws<ArgumentException>(null, () => bitmap.MakeTransparent());
 
-            if (PlatformDetection.IsWindows10Version1803OrGreater)
+            if (PlatformDetection.IsWindows11OrHigher)
             {
                 bitmap.MakeTransparent(Color.Red);
             }

--- a/src/System.Drawing.Common/tests/BitmapTests.cs
+++ b/src/System.Drawing.Common/tests/BitmapTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 //
 // (C) 2004 Ximian, Inc.  http://www.ximian.com
@@ -963,14 +963,18 @@ namespace System.Drawing.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => bitmap.MakeTransparent(Color.Red));
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/22629", TargetFrameworkMonikers.NetFramework)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/26247", TestPlatforms.Windows)]
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void MakeTransparent_GrayscalePixelFormat_ThrowsArgumentException()
         {
-            using (var bitmap = new Bitmap(1, 1, PixelFormat.Format16bppGrayScale))
+            using var bitmap = new Bitmap(1, 1, PixelFormat.Format16bppGrayScale);
+            AssertExtensions.Throws<ArgumentException>(null, () => bitmap.MakeTransparent());
+
+            if (PlatformDetection.IsWindows10Version1803OrGreater)
             {
-                AssertExtensions.Throws<ArgumentException>(null, () => bitmap.MakeTransparent());
+                bitmap.MakeTransparent(Color.Red);
+            }
+            else
+            {
                 Assert.Throws<ExternalException>(() => bitmap.MakeTransparent(Color.Red));
             }
         }

--- a/src/System.Drawing.Common/tests/BrushTests.cs
+++ b/src/System.Drawing.Common/tests/BrushTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Xunit;
@@ -12,29 +12,31 @@ namespace System.Drawing.Tests
         {
             using (var brush = new SubBrush())
             {
-                brush.PublicSetNativeBrush((IntPtr)10);
+                brush.PublicSetNativeBrush(10);
                 brush.PublicSetNativeBrush(IntPtr.Zero);
 
-                brush.PublicSetNativeBrush((IntPtr)10);
+                brush.PublicSetNativeBrush(10);
                 brush.PublicSetNativeBrush(IntPtr.Zero);
             }
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/30157")]
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void Dispose_NoSuchEntryPoint_SilentyCatchesException()
         {
             var brush = new SubBrush();
-            brush.PublicSetNativeBrush((IntPtr)10);
-
-            // No EntryPointNotFoundException will be thrown.
+            brush.PublicSetNativeBrush(10);
             brush.Dispose();
         }
 
         private class SubBrush : Brush
         {
             public override object Clone() => this;
-            public void PublicSetNativeBrush(IntPtr brush) => SetNativeBrush(brush);
+            public void PublicSetNativeBrush(nint brush) => SetNativeBrush(brush);
+
+            protected override void Dispose(bool disposing)
+            {
+                // The pointers we're creating here are invalid and dangerous to dereference.
+            }
         }
     }
 }

--- a/src/System.Drawing.Common/tests/FontTests.cs
+++ b/src/System.Drawing.Common/tests/FontTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
@@ -577,8 +577,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ConditionalFact(Helpers.IsDrawingSupported)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/2060")] // causes an AccessViolation in GDI+
+        [Fact]
         public void GetHeight_DisposedGraphics_ThrowsArgumentException()
         {
             using (FontFamily family = FontFamily.GenericMonospace)

--- a/src/System.Drawing.Common/tests/GraphicsTests.cs
+++ b/src/System.Drawing.Common/tests/GraphicsTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
@@ -13,7 +13,7 @@ namespace System.Drawing.Tests
     public partial class GraphicsTests
     {
         public static bool IsWindows7OrWindowsArm64 => PlatformDetection.IsWindows7 || (PlatformDetection.IsWindows && PlatformDetection.IsArm64Process);
-        
+
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void GetHdc_FromHdc_Roundtrips()
         {
@@ -1742,7 +1742,7 @@ namespace System.Drawing.Tests
         public static IEnumerable<object[]> CopyFromScreen_TestData()
         {
             yield return new object[] { 0, 0, 0, 0, new Size(0, 0) };
-            yield return new object[] { -1, -1, 0, 0, new Size(1, 1) };
+            yield return new object[] { int.MinValue, int.MinValue, 0, 0, new Size(1, 1) };
             yield return new object[] { int.MaxValue, int.MaxValue, 0, 0, new Size(1, 1) };
             yield return new object[] { int.MaxValue, int.MaxValue, 0, 0, new Size(1, 1) };
             yield return new object[] { 0, 0, -1, -1, new Size(1, 1) };
@@ -1750,8 +1750,7 @@ namespace System.Drawing.Tests
             yield return new object[] { 0, 0, 0, 0, new Size(-1, -1) };
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/23375")]
-        [ConditionalTheory(Helpers.IsDrawingSupported)]
+        [Theory]
         [MemberData(nameof(CopyFromScreen_TestData))]
         public void CopyFromScreen_OutOfRange_DoesNotAffectGraphics(int sourceX, int sourceY, int destinationX, int destinationY, Size size)
         {
@@ -1767,8 +1766,7 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/23375")]
-        [ConditionalTheory(Helpers.IsDrawingSupported)]
+        [Theory]
         [InlineData(0, 0, 0, 0, 10, 10)]
         [InlineData(0, 0, 0, 0, int.MaxValue, int.MaxValue)]
         [InlineData(1, 1, 2, 2, 3, 3)]
@@ -1881,25 +1879,23 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/23375")]
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void CopyFromScreen_Busy_ThrowsInvalidOperationException()
         {
-            using (var image = new Bitmap(10, 10))
-            using (Graphics graphics = Graphics.FromImage(image))
+            using Bitmap image = new(10, 10);
+            using Graphics graphics = Graphics.FromImage(image);
+
+            nint hdc = graphics.GetHdc();
+            try
             {
-                graphics.GetHdc();
-                try
-                {
-                    Assert.Throws<InvalidOperationException>(() => graphics.CopyFromScreen(0, 0, 0, 0, Size.Empty));
-                    Assert.Throws<InvalidOperationException>(() => graphics.CopyFromScreen(0, 0, 0, 0, Size.Empty, CopyPixelOperation.DestinationInvert));
-                    Assert.Throws<InvalidOperationException>(() => graphics.CopyFromScreen(Point.Empty, Point.Empty, Size.Empty));
-                    Assert.Throws<InvalidOperationException>(() => graphics.CopyFromScreen(Point.Empty, Point.Empty, Size.Empty, CopyPixelOperation.DestinationInvert));
-                }
-                finally
-                {
-                    graphics.ReleaseHdc();
-                }
+                Assert.Throws<InvalidOperationException>(() => graphics.CopyFromScreen(0, 0, 0, 0, Size.Empty));
+                Assert.Throws<InvalidOperationException>(() => graphics.CopyFromScreen(0, 0, 0, 0, Size.Empty, CopyPixelOperation.DestinationInvert));
+                Assert.Throws<InvalidOperationException>(() => graphics.CopyFromScreen(Point.Empty, Point.Empty, Size.Empty));
+                Assert.Throws<InvalidOperationException>(() => graphics.CopyFromScreen(Point.Empty, Point.Empty, Size.Empty, CopyPixelOperation.DestinationInvert));
+            }
+            finally
+            {
+                graphics.ReleaseHdc();
             }
         }
 

--- a/src/System.Drawing.Common/tests/Imaging/ImageAttributesTests.cs
+++ b/src/System.Drawing.Common/tests/Imaging/ImageAttributesTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 //
 // Copyright (C) 2005-2006 Novell, Inc (http://www.novell.com)
@@ -863,37 +863,33 @@ namespace System.Drawing.Imaging.Tests
             }
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/22784")]
-        [ConditionalFact(Helpers.IsDrawingSupported)]
+        [Fact]
         public void SetColorKey_Success()
         {
-            using (var bitmap = new Bitmap(_rectangle.Width, _rectangle.Height))
-            using (var graphics = Graphics.FromImage(bitmap))
-            using (var imageAttr = new ImageAttributes())
-            {
-                imageAttr.SetColorKey(Color.FromArgb(50, 50, 50), Color.FromArgb(150, 150, 150));
+            using var bitmap = new Bitmap(_rectangle.Width, _rectangle.Height);
+            using var graphics = Graphics.FromImage(bitmap);
+            using var imageAttr = new ImageAttributes();
 
-                bitmap.SetPixel(0, 0, Color.FromArgb(255, 100, 100, 100));
-                graphics.DrawImage(bitmap, _rectangle, _rectangle.X, _rectangle.Y, _rectangle.Width, _rectangle.Height, GraphicsUnit.Pixel, imageAttr);
-                Assert.Equal(Color.FromArgb(0, 0, 0, 0), bitmap.GetPixel(0, 0));
-            }
+            imageAttr.SetColorKey(Color.FromArgb(50, 50, 50), Color.FromArgb(150, 150, 150));
+
+            bitmap.SetPixel(0, 0, Color.FromArgb(255, 100, 100, 100));
+            graphics.DrawImage(bitmap, _rectangle, _rectangle.X, _rectangle.Y, _rectangle.Width, _rectangle.Height, GraphicsUnit.Pixel, imageAttr);
+            Assert.Equal(Color.FromArgb(255, 100, 100, 100), bitmap.GetPixel(0, 0));
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/22784")]
-        [ConditionalTheory(Helpers.IsDrawingSupported)]
+        [Theory]
         [MemberData(nameof(ColorAdjustType_TestData))]
         public void SetColorKey_Type_Success(ColorAdjustType type)
         {
-            using (var bitmap = new Bitmap(_rectangle.Width, _rectangle.Height))
-            using (var graphics = Graphics.FromImage(bitmap))
-            using (var imageAttr = new ImageAttributes())
-            {
-                imageAttr.SetColorKey(Color.FromArgb(50, 50, 50), Color.FromArgb(150, 150, 150), type);
+            using var bitmap = new Bitmap(_rectangle.Width, _rectangle.Height);
+            using var graphics = Graphics.FromImage(bitmap);
+            using var imageAttr = new ImageAttributes();
 
-                bitmap.SetPixel(0, 0, Color.FromArgb(255, 100, 100, 100));
-                graphics.DrawImage(bitmap, _rectangle, _rectangle.X, _rectangle.Y, _rectangle.Width, _rectangle.Height, GraphicsUnit.Pixel, imageAttr);
-                Assert.Equal(Color.FromArgb(0, 0, 0, 0), bitmap.GetPixel(0, 0));
-            }
+            imageAttr.SetColorKey(Color.FromArgb(50, 50, 50), Color.FromArgb(150, 150, 150), type);
+
+            bitmap.SetPixel(0, 0, Color.FromArgb(255, 100, 100, 100));
+            graphics.DrawImage(bitmap, _rectangle, _rectangle.X, _rectangle.Y, _rectangle.Width, _rectangle.Height, GraphicsUnit.Pixel, imageAttr);
+            Assert.Equal(Color.FromArgb(255, 100, 100, 100), bitmap.GetPixel(0, 0));
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]

--- a/src/System.Drawing.Common/tests/Imaging/ImageFormatTests.cs
+++ b/src/System.Drawing.Common/tests/Imaging/ImageFormatTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
@@ -103,13 +103,12 @@ namespace System.Drawing.Imaging.Tests
             Assert.Equal(expected, imageFormat.ToString());
         }
 
-        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Bug fix not in NETFX, https://github.com/dotnet/runtime/issues/20332")]
-        [ConditionalTheory(Helpers.IsDrawingSupported)]
+        [Theory]
         [MemberData(nameof(ImageFromFileToStringTestData))]
         public void Image_RawFormat_ToString(string path, string expected)
         {
             var img = Image.FromFile(path);
-            Assert.Same(expected, img.RawFormat.ToString());
+            Assert.Equal(expected, img.RawFormat.ToString());
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]

--- a/src/System.Drawing.Common/tests/PenTests.cs
+++ b/src/System.Drawing.Common/tests/PenTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
@@ -43,8 +43,10 @@ namespace System.Drawing.Tests
             if (Environment.OSVersion.Platform != PlatformID.Win32NT || CultureInfo.InstalledUICulture.TwoLetterISOLanguageName == "en")
             {
                 yield return new object[] { new SolidBrush(Color.Red), 0, PenType.SolidColor };
-                yield return new object[] { new SolidBrush(Color.Red), -1, PenType.SolidColor };
-                yield return new object[] { new SolidBrush(Color.Red), float.NegativeInfinity, PenType.SolidColor };
+
+                // GDI+ No longer allows negative pen width values (Windows PR6441324)
+                // yield return new object[] { new SolidBrush(Color.Red), -1, PenType.SolidColor };
+                // yield return new object[] { new SolidBrush(Color.Red), float.NegativeInfinity, PenType.SolidColor };
             }
 
             yield return new object[] { new SolidBrush(Color.Red), float.PositiveInfinity, PenType.SolidColor };
@@ -52,8 +54,7 @@ namespace System.Drawing.Tests
             yield return new object[] { new SolidBrush(Color.Red), float.MaxValue, PenType.SolidColor };
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/60731", TestPlatforms.Windows)]
-        [ConditionalTheory(Helpers.IsDrawingSupported)]
+        [Theory]
         [MemberData(nameof(Ctor_Brush_Width_TestData))]
         public void Ctor_Brush_Width<T>(T brush, float width, PenType expectedPenType) where T : Brush
         {
@@ -103,12 +104,12 @@ namespace System.Drawing.Tests
             }
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/60731", TestPlatforms.Windows)]
-        [ConditionalTheory(Helpers.IsDrawingSupported)]
-        [InlineData(-1)]
+        [Theory]
+        // GDI+ No longer allows negative pen width values (Windows PR6441324)
+        // [InlineData(-1)]
+        // [InlineData(float.NegativeInfinity)]
         [InlineData(0)]
         [InlineData(1)]
-        [InlineData(float.NegativeInfinity)]
         [InlineData(float.PositiveInfinity)]
         [InlineData(float.NaN)]
         public void Ctor_Color_Width(float width)

--- a/src/System.Drawing.Common/tests/System.Drawing.Common.Tests.csproj
+++ b/src/System.Drawing.Common/tests/System.Drawing.Common.Tests.csproj
@@ -6,6 +6,7 @@
     <!-- Code warnings that weren't enabled in dotnet/runtime but are raised in winforms.
          TODO: Clean the code up and remove the NoWarns. -->
     <NoWarn>$(NoWarn);CA1825;CA5351;CA1850</NoWarn>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
 
   <ItemGroup>
@@ -121,6 +122,10 @@
     <EmbeddedResource Include="$(PkgSystem_Drawing_Common_TestData)\contentFiles\any\any\bitmaps\256x256_one_entry_32bit.ico">
       <LogicalName>System.Drawing.Tests.Icon_toolboxBitmapAttributeTest</LogicalName>
     </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="runtimeconfig.template.json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/System.Drawing.Common/tests/runtimeconfig.template.json
+++ b/src/System.Drawing.Common/tests/runtimeconfig.template.json
@@ -1,0 +1,6 @@
+{
+  "configProperties": {
+    "TestSwitch.LocalAppContext.DisableCaching": "true",
+    "System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization": "false"
+  }
+}

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/PlatformDetection.Windows.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/PlatformDetection.Windows.cs
@@ -49,6 +49,8 @@ namespace System
             GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildNumber() >= 16299;
         public static bool IsWindows10Version1803OrGreater =>
             GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildNumber() >= 17134;
+        public static bool IsWindows11OrHigher =>
+            GetWindowsVersion() == 10 && GetWindowsMinorVersion() == 0 && GetWindowsBuildNumber() >= 22000;
 
         // Windows OneCoreUAP SKU doesn't have httpapi.dll
         public static bool IsNotOneCoreUAP =>


### PR DESCRIPTION
`[KnownIssue]` doesn't actually skip tests in the Test Explorer. This change fixes the tests that were "skipped" and actually failing.

- GDI+ no longer accepts negative pen widths
- Some tests were ported from Mono and skipped as they validated Mono's behavior, not GDI+
- Graphics.CopyFromScreen would call ReleaseHDC even if GetHDC was not called.
- CopyFromScreen assumed -1, -1 was an invalid screen coordinate. Not true for multimonitor.
- SetNativeBrush tests should not be disposing the invalid handle- random badness will occur.
- Prevent using a Graphics object with a null pointer in Font.GetHeight (to avoid AV).

I've also disabled the BinaryFormatter by default for these tests.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8935)