### PR TITLE
Draw the cursor on screenshots

### DIFF
--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Infra/ScreenshotService.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Infra/ScreenshotService.cs
@@ -72,6 +72,12 @@ namespace System.Windows.Forms.UITests
                     blockRegionSize: bitmap.Size,
                     copyPixelOperation: CopyPixelOperation.SourceCopy);
 
+                if (Cursor.Current is { } cursor)
+                {
+                    var bounds = new Rectangle(Cursor.Position - (Size)cursor.HotSpot, cursor.Size);
+                    cursor.Draw(graphics, bounds);
+                }
+
                 return bitmap;
             }
         }


### PR DESCRIPTION
I was really surprised that all the resources on this topic online use `Graphics.CopyFromScreen`, but seem to complicate the cursor drawing.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8953)