### PR TITLE
Issue/8295 - Added additional unit tests to System.Resources.ResXResourceReader

### DIFF
--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Resources/Tools/StronglyTypedResourceBuilderTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Resources/Tools/StronglyTypedResourceBuilderTests.cs
@@ -9,6 +9,8 @@ using System.ComponentModel;
 using System.Drawing;
 using System.Reflection;
 using System.Text;
+using System.Windows.Forms;
+using System.Windows.Forms.TestUtilities;
 using AxWMPLib;
 using Microsoft.CSharp;
 
@@ -21,25 +23,6 @@ public partial class StronglyTypedResourceBuilderTests
     private static readonly CodeDomProvider s_cSharpProvider = new CSharpCodeProvider();
     private const string TypeAssembly = "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089";
     private const string TxtFileEncoding = "Windows-1252";
-
-    private static string CreateResx(string data = null) =>
-        $"""
-        <root>
-            <resheader name="resmimetype">
-                <value>text/microsoft-resx</value>
-            </resheader>
-            <resheader name="version">
-                <value>2.0</value>
-            </resheader>
-            <resheader name="reader">
-                <value>System.Resources.ResXResourceReader</value>
-            </resheader>
-            <resheader name="writer">
-                <value>System.Resources.ResXResourceWriter</value>
-            </resheader>
-            {data ?? string.Empty}
-        </root>
-        """;
 
     [Fact]
     public void StronglyTypedResourceBuilder_Create_NullBaseName_ThrowsArgumentNull()
@@ -66,7 +49,7 @@ public partial class StronglyTypedResourceBuilderTests
                 internalClass: false,
                 out _));
 
-        using var temp = TempFile.Create(CreateResx());
+        using var temp = TempFile.Create(ResxHelper.CreateResx());
         Assert.Throws<ArgumentNullException>(
             "baseName",
             () => StronglyTypedResourceBuilder.Create(
@@ -114,7 +97,7 @@ public partial class StronglyTypedResourceBuilderTests
                 internalClass: false,
                 out _));
 
-        using var temp = TempFile.Create(CreateResx());
+        using var temp = TempFile.Create(ResxHelper.CreateResx());
         Assert.Throws<ArgumentNullException>(
             "codeProvider",
             () => StronglyTypedResourceBuilder.Create(
@@ -208,7 +191,7 @@ public partial class StronglyTypedResourceBuilderTests
     [Fact]
     public static void StronglyTypedResourceBuilder_Create_EmptyResx()
     {
-        using var temp = TempFile.Create(CreateResx());
+        using var temp = TempFile.Create(ResxHelper.CreateResx());
         var compileUnit = StronglyTypedResourceBuilder.Create(
             resxFile: temp.Path,
             baseName: "Resources",
@@ -230,7 +213,7 @@ public partial class StronglyTypedResourceBuilderTests
             </data>
             """;
 
-        using var temp = TempFile.Create(CreateResx(data));
+        using var temp = TempFile.Create(ResxHelper.CreateResx(data));
         var compileUnit = StronglyTypedResourceBuilder.Create(
             resxFile: temp.Path,
             baseName: "Resources",
@@ -321,7 +304,7 @@ public partial class StronglyTypedResourceBuilderTests
             </data>
             """;
 
-        using var temp = TempFile.Create(CreateResx(data));
+        using var temp = TempFile.Create(ResxHelper.CreateResx(data));
 
         var compileUnit = StronglyTypedResourceBuilder.Create(
             resxFile: temp.Path,
@@ -402,7 +385,7 @@ public partial class StronglyTypedResourceBuilderTests
             </data>
             """;
 
-        using var temp = TempFile.Create(CreateResx(data));
+        using var temp = TempFile.Create(ResxHelper.CreateResx(data));
 
         var compileUnit = StronglyTypedResourceBuilder.Create(
             resxFile: temp.Path,
@@ -482,7 +465,7 @@ public partial class StronglyTypedResourceBuilderTests
             </data>
             """;
 
-        using var temp = TempFile.Create(CreateResx(data));
+        using var temp = TempFile.Create(ResxHelper.CreateResx(data));
         Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
 
         var compileUnit = StronglyTypedResourceBuilder.Create(
@@ -536,7 +519,7 @@ public partial class StronglyTypedResourceBuilderTests
             </data>
             """;
 
-        using var temp = TempFile.Create(CreateResx(data));
+        using var temp = TempFile.Create(ResxHelper.CreateResx(data));
 
         var compileUnit = StronglyTypedResourceBuilder.Create(
             resxFile: temp.Path,

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Resources/Tools/StronglyTypedResourceBuilderTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Resources/Tools/StronglyTypedResourceBuilderTests.cs
@@ -9,7 +9,6 @@ using System.ComponentModel;
 using System.Drawing;
 using System.Reflection;
 using System.Text;
-using System.Windows.Forms;
 using System.Windows.Forms.TestUtilities;
 using AxWMPLib;
 using Microsoft.CSharp;

--- a/src/System.Windows.Forms/src/System/Resources/ResXResourceReader.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResXResourceReader.cs
@@ -155,33 +155,33 @@ public partial class ResXResourceReader : IResourceReader
         }
     }
 
-    /// <summary>
-    ///  ResXFileRef's TypeConverter automatically unwraps it, creates the referenced
-    ///  object and returns it. This property gives the user control over whether this unwrapping should
-    ///  happen, or a ResXFileRef object should be returned. Default is true for backward compat and common case
-    ///  scenario.
-    /// </summary>
-    public bool UseResXDataNodes
-    {
-        get => _useResXDataNodes;
-        set
+        /// <summary>
+        ///  ResXFileRef's TypeConverter automatically unwraps it, creates the referenced
+        ///  object and returns it. This property gives the user control over whether this unwrapping should
+        ///  happen, or a ResXFileRef object should be returned. Default is true for backwards compatibility
+        ///  and common case scenarios.
+        /// </summary>
+        public bool UseResXDataNodes
         {
-            if (_isReaderDirty)
+            get => _useResXDataNodes;
+            set
             {
-                throw new InvalidOperationException(SR.InvalidResXBasePathOperation);
-            }
+                if (_isReaderDirty)
+                {
+                    throw new InvalidOperationException(SR.InvalidResXBasePathOperation);
+                }
 
             _useResXDataNodes = value;
         }
     }
 
-    /// <summary>
-    ///  Closes and files or streams being used by the reader.
-    /// </summary>
-    public void Close()
-    {
-        ((IDisposable)this).Dispose();
-    }
+        /// <summary>
+        ///  Closes any files or streams being used by the reader.
+        /// </summary>
+        public void Close()
+        {
+            ((IDisposable)this).Dispose();
+        }
 
     void IDisposable.Dispose()
     {

--- a/src/System.Windows.Forms/src/System/Resources/ResXResourceReader.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResXResourceReader.cs
@@ -155,33 +155,33 @@ public partial class ResXResourceReader : IResourceReader
         }
     }
 
-        /// <summary>
-        ///  ResXFileRef's TypeConverter automatically unwraps it, creates the referenced
-        ///  object and returns it. This property gives the user control over whether this unwrapping should
-        ///  happen, or a ResXFileRef object should be returned. Default is true for backwards compatibility
-        ///  and common case scenarios.
-        /// </summary>
-        public bool UseResXDataNodes
+    /// <summary>
+    ///  ResXFileRef's TypeConverter automatically unwraps it, creates the referenced
+    ///  object and returns it. This property gives the user control over whether this unwrapping should
+    ///  happen, or a ResXFileRef object should be returned. Default is true for backwards compatibility
+    ///  and common case scenarios.
+    /// </summary>
+    public bool UseResXDataNodes
+    {
+        get => _useResXDataNodes;
+        set
         {
-            get => _useResXDataNodes;
-            set
+            if (_isReaderDirty)
             {
-                if (_isReaderDirty)
-                {
-                    throw new InvalidOperationException(SR.InvalidResXBasePathOperation);
-                }
+                throw new InvalidOperationException(SR.InvalidResXBasePathOperation);
+            }
 
             _useResXDataNodes = value;
         }
     }
 
-        /// <summary>
-        ///  Closes any files or streams being used by the reader.
-        /// </summary>
-        public void Close()
-        {
-            ((IDisposable)this).Dispose();
-        }
+    /// <summary>
+    ///  Closes any files or streams being used by the reader.
+    /// </summary>
+    public void Close()
+    {
+        ((IDisposable)this).Dispose();
+    }
 
     void IDisposable.Dispose()
     {

--- a/src/System.Windows.Forms/tests/TestUtilities/ResxHelper.cs
+++ b/src/System.Windows.Forms/tests/TestUtilities/ResxHelper.cs
@@ -1,0 +1,23 @@
+﻿namespace System.Windows.Forms.TestUtilities;
+
+public static class ResxHelper
+{
+    public static string CreateResx(string data = null) =>
+    $"""
+    <root>
+        <resheader name="resmimetype">
+            <value>text/microsoft-resx</value>
+        </resheader>
+        <resheader name="version">
+            <value>2.0</value>
+        </resheader>
+        <resheader name="reader">
+            <value>System.Resources.ResXResourceReader</value>
+        </resheader>
+        <resheader name="writer">
+            <value>System.Resources.ResXResourceWriter</value>
+        </resheader>
+        {data ?? string.Empty}
+    </root>
+    """;
+}

--- a/src/System.Windows.Forms/tests/UnitTests/System/Resources/ResXResourceReaderTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Resources/ResXResourceReaderTests.cs
@@ -5,6 +5,7 @@
 using System.Collections;
 using System.Text;
 using System.Windows.Forms;
+using System.Windows.Forms.TestUtilities;
 using Xunit;
 
 namespace System.Resources.Tests;
@@ -52,30 +53,11 @@ public class ResXResourceReaderTests
         Assert.Throws<ArgumentException>(() => resxReader.GetEnumerator());
     }
 
-    private static string CreateResx(string data = null) =>
-    $"""
-        <root>
-            <resheader name="resmimetype">
-                <value>text/microsoft-resx</value>
-            </resheader>
-            <resheader name="version">
-                <value>2.0</value>
-            </resheader>
-            <resheader name="reader">
-                <value>System.Resources.ResXResourceReader</value>
-            </resheader>
-            <resheader name="writer">
-                <value>System.Resources.ResXResourceWriter</value>
-            </resheader>
-            {data ?? string.Empty}
-        </root>
-        """;
-
     [Fact]
     public void ResXResourceReader_Constructor_FileName()
     {
         // Create a temp file and write the resx to it.        
-        using TempFile tempFile = TempFile.Create(CreateResx());
+        using TempFile tempFile = TempFile.Create(ResxHelper.CreateResx());
         using ResXResourceReader resXReader = new(tempFile.Path);
         IDictionaryEnumerator enumerator = resXReader.GetEnumerator();
         Assert.NotNull(enumerator);
@@ -84,7 +66,7 @@ public class ResXResourceReaderTests
     [Fact]
     public void ResXResourceReader_Constructor_TextReader()
     {
-        using TextReader textReader = new StringReader(CreateResx());
+        using TextReader textReader = new StringReader(ResxHelper.CreateResx());
         using ResXResourceReader resXReader = new(textReader);
         IDictionaryEnumerator enumerator = resXReader.GetEnumerator();
         Assert.NotNull(enumerator);
@@ -93,7 +75,7 @@ public class ResXResourceReaderTests
     [Fact]
     public void ResXResourceReader_Constructor_Stream()
     {
-        byte[] resxBytes = Encoding.UTF8.GetBytes(CreateResx());
+        byte[] resxBytes = Encoding.UTF8.GetBytes(ResxHelper.CreateResx());
         using Stream resxStream = new MemoryStream(resxBytes);
         using ResXResourceReader resXReader = new ResXResourceReader(resxStream);
         IDictionaryEnumerator enumerator = resXReader.GetEnumerator();
@@ -103,7 +85,7 @@ public class ResXResourceReaderTests
     [Fact]
     public void ResXResourceReader_FromFileContents()
     {
-        using var resXReader = ResXResourceReader.FromFileContents(CreateResx());
+        using var resXReader = ResXResourceReader.FromFileContents(ResxHelper.CreateResx());
         IDictionaryEnumerator enumerator = resXReader.GetEnumerator();
         Assert.NotNull(enumerator);
     }
@@ -128,7 +110,7 @@ public class ResXResourceReaderTests
             """;
 
         // Act
-        using var resXReader = ResXResourceReader.FromFileContents(CreateResx(data));
+        using var resXReader = ResXResourceReader.FromFileContents(ResxHelper.CreateResx(data));
         IDictionary actualData = new Hashtable();
         IDictionaryEnumerator enumerator = resXReader.GetEnumerator();
 
@@ -156,7 +138,7 @@ public class ResXResourceReaderTests
             """;
 
         // Act
-        using var resXReader = ResXResourceReader.FromFileContents(CreateResx(data));
+        using var resXReader = ResXResourceReader.FromFileContents(ResxHelper.CreateResx(data));
         IDictionary actualData = new Hashtable();
         IDictionaryEnumerator enumerator = resXReader.GetEnumerator();
         while (enumerator.MoveNext())
@@ -183,7 +165,7 @@ public class ResXResourceReaderTests
             """;
 
         // Act
-        using ResXResourceReader resXReader = ResXResourceReader.FromFileContents(CreateResx(metadata));
+        using ResXResourceReader resXReader = ResXResourceReader.FromFileContents(ResxHelper.CreateResx(metadata));
         IDictionary actualMetadata = new Hashtable();
         IDictionaryEnumerator metadataEnumerator = resXReader.GetMetadataEnumerator();
         while (metadataEnumerator.MoveNext())

--- a/src/System.Windows.Forms/tests/UnitTests/System/Resources/ResXResourceReaderTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Resources/ResXResourceReaderTests.cs
@@ -83,7 +83,6 @@ public class ResXResourceReaderTests
             using ResXResourceReader resXReader = new(tempFileName);
             IDictionaryEnumerator enumerator = resXReader.GetEnumerator();
             Assert.NotNull(enumerator);
-
         }
         finally
         {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Resources/ResXResourceReaderTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Resources/ResXResourceReaderTests.cs
@@ -176,4 +176,48 @@ public class ResXResourceReaderTests
         // Assert
         Assert.Equal(expectedMetadata, actualMetadata);
     }
+
+    [Fact]
+    public void ResXResourceReader_GetEnumerator_UnknownType_ThowsException()
+    {
+        // Arrange
+        string unknownType = "System.XYZ";
+        string data = $"""
+            <data name="UnknownType" type="{unknownType}">
+              <value>UnknownValueType</value>
+            </data>
+            """;
+
+        // Act
+        using var resXReader = ResXResourceReader.FromFileContents(ResxHelper.CreateResx(data));
+
+        // Assert
+        ArgumentException exception = Assert.Throws<ArgumentException>(() => { IDictionaryEnumerator enumerator = resXReader.GetEnumerator(); });
+        Assert.Contains($"ResX file Type {unknownType} in the data", exception.Message);
+    }
+
+    [Fact]
+    public void ResXResourceReader_GetEnumerator_InvalidValue_ThowsException()
+    {
+        // Arrange
+        string keyName = "TestKey";
+        string testValue = "FortyTwo";
+
+        IDictionary expectedData = new Hashtable { { keyName, testValue } };
+        string data = $"""
+            <data name="{keyName}" type="System.Int32">
+              <value>{testValue}</value>
+            </data>
+            """;
+
+        // Act
+        using var resXReader = ResXResourceReader.FromFileContents(ResxHelper.CreateResx(data));
+
+        // Assert
+        ArgumentException exception = Assert.Throws<ArgumentException>(() =>
+        {
+            IDictionaryEnumerator enumerator = resXReader.GetEnumerator();
+        });
+        Assert.Contains($"ResX file {testValue} is not a valid value for Int32", exception.Message);
+    }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Resources/ResXResourceReaderTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Resources/ResXResourceReaderTests.cs
@@ -74,20 +74,11 @@ public class ResXResourceReaderTests
     [Fact]
     public void ResXResourceReader_Constructor_FileName()
     {
-        // Create a temp file and write the resx to it.
-        string tempFileName = Path.GetTempFileName();
-        File.WriteAllText(tempFileName, CreateResx());
-
-        try
-        {
-            using ResXResourceReader resXReader = new(tempFileName);
-            IDictionaryEnumerator enumerator = resXReader.GetEnumerator();
-            Assert.NotNull(enumerator);
-        }
-        finally
-        {
-            File.Delete(tempFileName);
-        }
+        // Create a temp file and write the resx to it.        
+        using TempFile tempFile = TempFile.Create(CreateResx());
+        using ResXResourceReader resXReader = new(tempFile.Path);
+        IDictionaryEnumerator enumerator = resXReader.GetEnumerator();
+        Assert.NotNull(enumerator);
     }
 
     [Fact]
@@ -143,7 +134,7 @@ public class ResXResourceReaderTests
 
         while (enumerator.MoveNext())
         {
-            actualData.Add(enumerator.Key, enumerator.Value);          
+            actualData.Add(enumerator.Key, enumerator.Value);
         }
 
         // Assert

--- a/src/System.Windows.Forms/tests/UnitTests/System/Resources/ResXResourceReaderTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Resources/ResXResourceReaderTests.cs
@@ -4,9 +4,7 @@
 
 using System.Collections;
 using System.Text;
-using System.Windows.Forms;
 using System.Windows.Forms.TestUtilities;
-using Xunit;
 
 namespace System.Resources.Tests;
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Resources/ResXResourceReaderTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Resources/ResXResourceReaderTests.cs
@@ -2,6 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections;
+using System.Text;
+using System.Windows.Forms;
+using Xunit;
+
 namespace System.Resources.Tests;
 
 public class ResXResourceReaderTests
@@ -45,5 +50,99 @@ public class ResXResourceReaderTests
 
         using ResXResourceReader resxReader = new(resxPath);
         Assert.Throws<ArgumentException>(() => resxReader.GetEnumerator());
+    }
+
+    private static string CreateResx(string data = null) =>
+    $"""
+        <root>
+            <resheader name="resmimetype">
+                <value>text/microsoft-resx</value>
+            </resheader>
+            <resheader name="version">
+                <value>2.0</value>
+            </resheader>
+            <resheader name="reader">
+                <value>System.Resources.ResXResourceReader</value>
+            </resheader>
+            <resheader name="writer">
+                <value>System.Resources.ResXResourceWriter</value>
+            </resheader>
+            {data ?? string.Empty}
+        </root>
+        """;
+
+    [Fact]
+    public void ResXResourceReader_Constructor_FileName()
+    {
+        // Create a temp file and write the resx to it.
+        string tempFileName = Path.GetTempFileName();
+        File.WriteAllText(tempFileName, CreateResx());
+
+        try
+        {
+            using ResXResourceReader resXReader = new(tempFileName);
+            IDictionaryEnumerator enumerator = resXReader.GetEnumerator();
+            Assert.NotNull(enumerator);
+        }
+        finally
+        {
+            File.Delete(tempFileName);
+        }
+    }
+
+    [Fact]
+    public void ResXResourceReader_Constructor_TextReader()
+    {
+        using TextReader textReader = new StringReader(CreateResx());
+        using ResXResourceReader resXReader = new(textReader);
+        IDictionaryEnumerator enumerator = resXReader.GetEnumerator();
+        Assert.NotNull(enumerator);
+    }
+
+    [Fact]
+    public void ResXResourceReader_Constructor_Stream()
+    {
+        byte[] resxBytes = Encoding.UTF8.GetBytes(CreateResx());
+        using Stream resxStream = new MemoryStream(resxBytes);
+        using ResXResourceReader resXReader = new ResXResourceReader(resxStream);
+        IDictionaryEnumerator enumerator = resXReader.GetEnumerator();
+        Assert.NotNull(enumerator);
+    }
+
+    [Fact]
+    public void ResXResourceReader_FromFileContents()
+    {
+        using var resXReader = ResXResourceReader.FromFileContents(CreateResx());
+        IDictionaryEnumerator enumerator = resXReader.GetEnumerator();
+        Assert.NotNull(enumerator);
+    }
+
+    [Fact]
+    public void ResXResourceReader_GetEnumerator()
+    {
+        const string data = """
+            <data name="TestName1" xml:space="preserve">
+              <value>TestValue1</value>
+            </data>
+            <data name="TestName2" xml:space="preserve">
+              <value>TestValue2</value>
+            </data>
+            """;
+
+        using var resXReader = ResXResourceReader.FromFileContents(CreateResx(data));
+        IDictionaryEnumerator enumerator = resXReader.GetEnumerator();
+
+        int itemCount = 0;
+
+        while (enumerator.MoveNext())
+        {
+            itemCount++;
+            string key = (string)enumerator.Key;
+            string value = (string)enumerator.Value;
+            Assert.True(!string.IsNullOrEmpty(key));
+            Assert.True(!string.IsNullOrEmpty(value));
+        }
+
+        Assert.Equal(2, itemCount);
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Resources/ResXResourceReaderTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Resources/ResXResourceReaderTests.cs
@@ -83,6 +83,7 @@ public class ResXResourceReaderTests
             using ResXResourceReader resXReader = new(tempFileName);
             IDictionaryEnumerator enumerator = resXReader.GetEnumerator();
             Assert.NotNull(enumerator);
+
         }
         finally
         {
@@ -118,31 +119,89 @@ public class ResXResourceReaderTests
     }
 
     [Fact]
-    public void ResXResourceReader_GetEnumerator()
+    public void ResXResourceReader_GetEnumerator_String()
     {
-        const string data = """
-            <data name="TestName1" xml:space="preserve">
-              <value>TestValue1</value>
+        // Arrange
+        string keyName1 = "TestString";
+        string keyName2 = "TestString2";
+        string testValue1 = "TestValue1";
+        string testValue2 = "TestValue2";
+
+        IDictionary expectedData = new Hashtable { { keyName1, testValue1 }, { keyName2, testValue2 } };
+        string data = $"""
+            <data name="{keyName1}" xml:space="preserve">
+              <value>{testValue1}</value>
             </data>
-            <data name="TestName2" xml:space="preserve">
-              <value>TestValue2</value>
+            <data name="{keyName2}" xml:space="preserve">
+              <value>{testValue2}</value>
             </data>
             """;
 
+        // Act
         using var resXReader = ResXResourceReader.FromFileContents(CreateResx(data));
+        IDictionary actualData = new Hashtable();
         IDictionaryEnumerator enumerator = resXReader.GetEnumerator();
-
-        int itemCount = 0;
 
         while (enumerator.MoveNext())
         {
-            itemCount++;
-            string key = (string)enumerator.Key;
-            string value = (string)enumerator.Value;
-            Assert.True(!string.IsNullOrEmpty(key));
-            Assert.True(!string.IsNullOrEmpty(value));
+            actualData.Add(enumerator.Key, enumerator.Value);          
         }
 
-        Assert.Equal(2, itemCount);
+        // Assert
+        Assert.Equal(expectedData, actualData);
+    }
+
+    [Fact]
+    public void ResXResourceReader_GetEnumerator_Int()
+    {
+        // Arrange
+        string keyName = "TestNumber";
+        int testValue = 42;
+
+        IDictionary expectedData = new Hashtable { { keyName, testValue } };
+        string data = $"""
+            <data name="{keyName}" type="System.Int32">
+              <value>{testValue}</value>
+            </data>
+            """;
+
+        // Act
+        using var resXReader = ResXResourceReader.FromFileContents(CreateResx(data));
+        IDictionary actualData = new Hashtable();
+        IDictionaryEnumerator enumerator = resXReader.GetEnumerator();
+        while (enumerator.MoveNext())
+        {
+            actualData.Add(enumerator.Key, enumerator.Value);
+        }
+
+        // Assert
+        Assert.Equal(expectedData, actualData);
+    }
+
+    [Fact]
+    public void GetMetadataEnumerator_ReturnsMetadataNodes()
+    {
+        // Arrange
+        string metadataName = "TestMetadata";
+        string sampleMetadataValue = "Sample metadata";
+
+        IDictionary expectedMetadata = new Hashtable { { metadataName, sampleMetadataValue } };
+        string metadata = $"""
+            <metadata name="{metadataName}" type="System.String">
+              <value>{sampleMetadataValue}</value>
+            </metadata>
+            """;
+
+        // Act
+        using ResXResourceReader resXReader = ResXResourceReader.FromFileContents(CreateResx(metadata));
+        IDictionary actualMetadata = new Hashtable();
+        IDictionaryEnumerator metadataEnumerator = resXReader.GetMetadataEnumerator();
+        while (metadataEnumerator.MoveNext())
+        {
+            actualMetadata.Add(metadataEnumerator.Key, metadataEnumerator.Value);
+        }
+
+        // Assert
+        Assert.Equal(expectedMetadata, actualMetadata);
     }
 }


### PR DESCRIPTION
Fixes #8295 

## Proposed changes
- Added additional unit tests for System.Resources.ResXResourceReader 
  - Constructors
  - GetEnumerator()
  - GetMetaDataEnumerator

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact
- None

## Regression? 

- No

## Risk

- Low
- PR only has unit tests


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8955)