### PR TITLE
Restore the cursor position at the end of each integration test

### DIFF
--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Infra/ControlTestBase.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Infra/ControlTestBase.cs
@@ -23,6 +23,8 @@ namespace System.Windows.Forms.UITests
         private DenyExecutionSynchronizationContext? _denyExecutionSynchronizationContext;
         private JoinableTaskCollection _joinableTaskCollection = null!;
 
+        private Point? _mousePosition;
+
         static ControlTestBase()
         {
             DataCollectionService.InstallFirstChanceExceptionHandler();
@@ -61,6 +63,9 @@ namespace System.Windows.Forms.UITests
             // Verify keyboard and mouse state at the start of the test
             VerifyKeyStates(isStartOfTest: true, TestOutputHelper);
 
+            // Record the mouse position so it can be restored at the end of the test
+            _mousePosition = Cursor.Position;
+
             if (Thread.CurrentThread.GetApartmentState() == ApartmentState.STA)
             {
                 JoinableTaskContext = new JoinableTaskContext();
@@ -82,6 +87,12 @@ namespace System.Windows.Forms.UITests
 
             // Verify keyboard and mouse state at the end of the test
             VerifyKeyStates(isStartOfTest: false, TestOutputHelper);
+
+            // Restore the mouse position
+            if (_mousePosition is { } mousePosition)
+            {
+                Cursor.Position = mousePosition;
+            }
 
             JoinableTaskContext = null!;
             JoinableTaskFactory = null!;

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/RichTextBoxTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/RichTextBoxTests.cs
@@ -35,8 +35,6 @@ namespace System.Windows.Forms.UITests
 \pard\sa200\sl276\slmult1\f0\fs22\lang9  for more information.\par
 }";
 
-                BOOL setOldCursorPos = PInvoke.GetPhysicalCursorPos(out Point previousPosition);
-
                 LinkClickedEventArgs? result = null;
                 LinkClickedEventHandler handler = (sender, e) => result = e;
                 richTextBox.LinkClicked += handler;
@@ -51,22 +49,10 @@ namespace System.Windows.Forms.UITests
                     await InputSimulator.SendAsync(
                         form,
                         inputSimulator => inputSimulator.Mouse.LeftButtonClick());
-                    if (setOldCursorPos)
-                    {
-                        await MoveMouseAsync(form, previousPosition);
-                    }
                 }
                 finally
                 {
                     richTextBox.LinkClicked -= handler;
-
-                    if (setOldCursorPos)
-                    {
-                        // Move cursor to the old position.
-                        await InputSimulator.SendAsync(
-                            form,
-                            inputSimulator => inputSimulator.Mouse.MoveMouseTo(previousPosition.X, previousPosition.Y));
-                    }
                 }
 
                 Assert.NotNull(result);
@@ -106,8 +92,6 @@ This is hidden text preceeding a \v #link3#\v0 custom link.\par
                 MakeLink(richTextBox, "#link2#custom link");
                 MakeLink(richTextBox, "#link3#custom link");
 
-                BOOL setOldCursorPos = PInvoke.GetPhysicalCursorPos(out Point previousPosition);
-
                 LinkClickedEventArgs? result = null;
                 LinkClickedEventHandler handler = (sender, e) => result = e;
                 richTextBox.LinkClicked += handler;
@@ -122,22 +106,10 @@ This is hidden text preceeding a \v #link3#\v0 custom link.\par
                     await InputSimulator.SendAsync(
                         form,
                         inputSimulator => inputSimulator.Mouse.LeftButtonClick());
-                    if (setOldCursorPos)
-                    {
-                        await MoveMouseAsync(form, previousPosition);
-                    }
                 }
                 finally
                 {
                     richTextBox.LinkClicked -= handler;
-
-                    if (setOldCursorPos)
-                    {
-                        // Move cursor to the old position.
-                        await InputSimulator.SendAsync(
-                            form,
-                            inputSimulator => inputSimulator.Mouse.MoveMouseTo(previousPosition.X, previousPosition.Y));
-                    }
                 }
 
                 Assert.NotNull(result);
@@ -177,8 +149,6 @@ This is hidden text preceeding a \v #link3#\v0 custom link.\par
                 MakeLink(richTextBox, "custom link#link2#");
                 MakeLink(richTextBox, "custom link#link3#");
 
-                BOOL setOldCursorPos = PInvoke.GetPhysicalCursorPos(out Point previousPosition);
-
                 LinkClickedEventArgs? result = null;
                 LinkClickedEventHandler handler = (sender, e) => result = e;
                 richTextBox.LinkClicked += handler;
@@ -193,22 +163,10 @@ This is hidden text preceeding a \v #link3#\v0 custom link.\par
                     await InputSimulator.SendAsync(
                         form,
                         inputSimulator => inputSimulator.Mouse.LeftButtonClick());
-                    if (setOldCursorPos)
-                    {
-                        await MoveMouseAsync(form, previousPosition);
-                    }
                 }
                 finally
                 {
                     richTextBox.LinkClicked -= handler;
-
-                    if (setOldCursorPos)
-                    {
-                        // Move cursor to the old position.
-                        await InputSimulator.SendAsync(
-                            form,
-                            inputSimulator => inputSimulator.Mouse.MoveMouseTo(previousPosition.X, previousPosition.Y));
-                    }
                 }
 
                 Assert.NotNull(result);


### PR DESCRIPTION
Many of the integration tests move the mouse as part of the test implementation. This change updates the base control helper to record the mouse position at the start of the test and restore it at the end.

I verified locally that this implementation works even when the mouse is initially on a different monitor in multi-monitor configurations.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8960)