### PR TITLE
Use the cell center in MonthCalendarTests

### DIFF
--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/MonthCalendarTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/MonthCalendarTests.cs
@@ -180,7 +180,8 @@ namespace System.Windows.Forms.UITests
         private Point GetCellPositionByDate(MonthCalendar calendar, DateTime dateTime)
         {
             MonthCalendarAccessibleObject accessibleObject = (MonthCalendarAccessibleObject)calendar.AccessibilityObject;
-            return accessibleObject.TestAccessor().Dynamic.GetCellByDate(dateTime.Date).Bounds.Location;
+            CalendarCellAccessibleObject cell = accessibleObject.TestAccessor().Dynamic.GetCellByDate(dateTime.Date);
+            return cell.Bounds.Location + (cell.Bounds.Size / 2);
         }
 
         private async Task ClickOnDateAsync(Form form, MonthCalendar calendar, DateTime date)


### PR DESCRIPTION
Matches other click operations in both production code and tests.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8973)