### PR TITLE
Use Width and Height properties where applicable

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/MultilineStringEditor.MultilineStringEditorUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/MultilineStringEditor.MultilineStringEditorUI.cs
@@ -186,7 +186,7 @@ namespace System.ComponentModel.Design
 
                     RECT rect = default(RECT);
                     User32.DrawTextW(hdc, Text, Text.Length, ref rect, User32.DT.CALCRECT);
-                    return new Size(rect.right - rect.left + CaretPadding, rect.bottom - rect.top);
+                    return new Size(rect.Width + CaretPadding, rect.Height);
                 }
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.MetafileDCWrapper.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.MetafileDCWrapper.cs
@@ -186,8 +186,8 @@ namespace System.Windows.Forms
                             {
                                 xDest = rect.left;
                                 yDest = rect.top;
-                                cxDest = rect.right - rect.left;
-                                cyDest = rect.bottom - rect.top;
+                                cxDest = rect.Width;
+                                cyDest = rect.Height;
                             }
                             else
                             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -424,8 +424,8 @@ namespace System.Windows.Forms
                 CreateParams cp = CreateParams;
 
                 AdjustWindowRectExForControlDpi(ref rect, (WINDOW_STYLE)cp.Style, false, (WINDOW_EX_STYLE)cp.ExStyle);
-                _clientWidth = _width - (rect.right - rect.left);
-                _clientHeight = _height - (rect.bottom - rect.top);
+                _clientWidth = _width - rect.Width;
+                _clientHeight = _height - rect.Height;
             }
 
             // Set up for async operations on this thread.
@@ -11452,8 +11452,8 @@ namespace System.Windows.Forms
             CreateParams cp = CreateParams;
 
             AdjustWindowRectExForControlDpi(ref rect, (WINDOW_STYLE)cp.Style, false, (WINDOW_EX_STYLE)cp.ExStyle);
-            int clientWidth = width - (rect.right - rect.left);
-            int clientHeight = height - (rect.bottom - rect.top);
+            int clientWidth = width - rect.Width;
+            int clientHeight = height - rect.Height;
             UpdateBounds(x, y, width, height, clientWidth, clientHeight);
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Design/ComponentEditorForm.PageSelector.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Design/ComponentEditorForm.PageSelector.cs
@@ -262,7 +262,7 @@ namespace System.Windows.Forms.Design
                     COLORREF oldTextColor = PInvoke.SetTextColor(dc, (COLORREF)(uint)ColorTranslator.ToWin32(SystemColors.ControlLightLight));
                     COLORREF oldBackColor = PInvoke.SetBkColor(dc, (COLORREF)(uint)ColorTranslator.ToWin32(SystemColors.Control));
 
-                    PInvoke.PatBlt(dc, rc.left, rc.top, rc.right - rc.left, rc.bottom - rc.top, ROP_CODE.PATCOPY);
+                    PInvoke.PatBlt(dc, rc.left, rc.top, rc.Width, rc.Height, ROP_CODE.PATCOPY);
                     PInvoke.SetTextColor(dc, oldTextColor);
                     PInvoke.SetBkColor(dc, oldBackColor);
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.CalendarButtonAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.CalendarButtonAccessibleObject.cs
@@ -57,8 +57,8 @@ namespace System.Windows.Forms
                 }
 
                 RECT rectangle = Bounds;
-                int x = rectangle.left + ((rectangle.right - rectangle.left) / 2);
-                int y = rectangle.top + ((rectangle.bottom - rectangle.top) / 2);
+                int x = rectangle.left + (rectangle.Width / 2);
+                int y = rectangle.top + (rectangle.Height / 2);
 
                 RaiseMouseClick(x, y);
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
@@ -1351,8 +1351,8 @@ namespace System.Windows.Forms
                         bottom = (rect.bottom > screen.WorkingArea.Bottom) ? screen.WorkingArea.Bottom : rect.bottom
                     };
 
-                    p.X = visibleRect.left + (visibleRect.right - visibleRect.left) / 2;
-                    p.Y = visibleRect.top + (visibleRect.bottom - visibleRect.top) / 2;
+                    p.X = visibleRect.left + visibleRect.Width / 2;
+                    p.Y = visibleRect.top + visibleRect.Height / 2;
                     associatedControl.PointToClient(p);
                     SetTrackPosition(p.X, p.Y);
                     SetTool(window, text, TipInfo.Type.SemiAbsolute, p);


### PR DESCRIPTION
This is a simplification of some code using a computed property instead of calculating the value in-line.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8974)