### PR TITLE
Simplify code using RECT/Rectangle conversions

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
@@ -1824,7 +1824,7 @@ public partial class Control
             }
 #endif
 
-            Rectangle posRect = Rectangle.FromLTRB(lprcPosRect->left, lprcPosRect->top, lprcPosRect->right, lprcPosRect->bottom);
+            Rectangle posRect = *lprcPosRect;
 
             Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, $"Set control bounds: {posRect}");
 
@@ -1841,10 +1841,7 @@ public partial class Control
             Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, $"Old Control Bounds: {_control.Bounds}");
             if (_activeXState[s_adjustingRect])
             {
-                _adjustRect->left = posRect.X;
-                _adjustRect->top = posRect.Y;
-                _adjustRect->right = posRect.Right;
-                _adjustRect->bottom = posRect.Bottom;
+                *_adjustRect = posRect;
             }
             else
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -11895,7 +11895,7 @@ namespace System.Windows.Forms
                     }
 
                     PInvoke.GetClientRect(this, out RECT rc);
-                    using PaintEventArgs pevent = new PaintEventArgs(dc, Rectangle.FromLTRB(rc.left, rc.top, rc.right, rc.bottom));
+                    using PaintEventArgs pevent = new PaintEventArgs(dc, rc);
                     PaintWithErrorHandling(pevent, PaintLayerBackground);
                 }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DpiChangedEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DpiChangedEventArgs.cs
@@ -21,8 +21,7 @@ namespace System.Windows.Forms
             DeviceDpiOld = old;
             DeviceDpiNew = (short)m.WParamInternal.LOWORD;
             Debug.Assert((short)m.WParamInternal.HIWORD == DeviceDpiNew, "Non-square pixels!");
-            RECT suggestedRect = *(RECT*)(nint)m.LParamInternal;
-            SuggestedRectangle = Rectangle.FromLTRB(suggestedRect.left, suggestedRect.top, suggestedRect.right, suggestedRect.bottom);
+            SuggestedRectangle = *(RECT*)(nint)m.LParamInternal;
         }
 
         public int DeviceDpiOld { get; }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.cs
@@ -655,7 +655,7 @@ namespace System.Windows.Forms
                     {
                         tmpBitmap = Bitmap.FromHbitmap((IntPtr)imageInfo.hbmImage);
 
-                        bmpData = tmpBitmap.LockBits(new Rectangle(imageInfo.rcImage.left, imageInfo.rcImage.top, imageInfo.rcImage.right - imageInfo.rcImage.left, imageInfo.rcImage.bottom - imageInfo.rcImage.top), ImageLockMode.ReadOnly, tmpBitmap.PixelFormat);
+                        bmpData = tmpBitmap.LockBits(imageInfo.rcImage, ImageLockMode.ReadOnly, tmpBitmap.PixelFormat);
 
                         int offset = bmpData.Stride * _imageSize.Height * index;
                         // we need do the following if the image has alpha because otherwise the image is fully transparent even though it has data

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
@@ -1489,7 +1489,7 @@ namespace System.Windows.Forms
                 return Rectangle.Empty;
             }
 
-            return Rectangle.FromLTRB(rect.left, rect.top, rect.right, rect.bottom);
+            return rect;
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -3683,7 +3683,7 @@ namespace System.Windows.Forms
                     string.Format(SR.InvalidArgument, nameof(index), index));
             }
 
-            return Rectangle.FromLTRB(itemrect.left, itemrect.top, itemrect.right, itemrect.bottom);
+            return itemrect;
         }
 
         /// <summary>
@@ -3712,7 +3712,7 @@ namespace System.Windows.Forms
                 return Rectangle.Empty;
             }
 
-            return Rectangle.FromLTRB(itemrect.left, itemrect.top, itemrect.right, itemrect.bottom);
+            return itemrect;
         }
 
         /// <summary>
@@ -3763,9 +3763,7 @@ namespace System.Windows.Forms
                 throw new ArgumentOutOfRangeException(nameof(itemIndex), itemIndex, string.Format(SR.InvalidArgument, nameof(itemIndex), itemIndex));
             }
 
-            Rectangle result = Rectangle.FromLTRB(itemrect.left, itemrect.top, itemrect.right, itemrect.bottom);
-
-            return result;
+            return itemrect;
         }
 
         private void GroupImageListChangedHandle(object? sender, EventArgs e)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewInsertionMark.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewInsertionMark.cs
@@ -59,7 +59,7 @@ namespace System.Windows.Forms
             {
                 var rect = default(RECT);
                 PInvoke.SendMessage(_listView, (User32.WM)PInvoke.LVM_GETINSERTMARKRECT, (WPARAM)0, ref rect);
-                return Rectangle.FromLTRB(rect.left, rect.top, rect.right, rect.bottom);
+                return rect;
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewLabelEditUiaTextProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewLabelEditUiaTextProvider.cs
@@ -264,7 +264,7 @@ namespace System.Windows.Forms
         {
             RECT r = rect;
             PInvoke.MapWindowPoints((HWND)_owningChildEdit.Handle, HWND.Null, ref r);
-            return Rectangle.FromLTRB(r.left, r.top, r.right, r.bottom);
+            return r;
         }
 
         public override void SetSelection(int start, int end)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
@@ -1135,7 +1135,7 @@ namespace System.Windows.Forms
             }
 
             PInvoke.SendMessage(this, (User32.WM)PInvoke.TCM_GETITEMRECT, (WPARAM)index, ref rect);
-            return Rectangle.FromLTRB(rect.left, rect.top, rect.right, rect.bottom);
+            return rect;
         }
 
         protected string GetToolTipText(object item)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeNode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeNode.cs
@@ -241,7 +241,7 @@ namespace System.Windows.Forms
                     return Rectangle.Empty;
                 }
 
-                return Rectangle.FromLTRB(rc.left, rc.top, rc.right, rc.bottom);
+                return rc;
             }
         }
 
@@ -270,7 +270,7 @@ namespace System.Windows.Forms
                     return Rectangle.Empty;
                 }
 
-                return Rectangle.FromLTRB(rc.left, rc.top, rc.right, rc.bottom);
+                return rc;
             }
         }
 

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/MonthCalendarTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/MonthCalendarTests.cs
@@ -172,8 +172,7 @@ namespace System.Windows.Forms.UITests
                 };
 
                 Assert.NotEqual(default, PInvoke.SendMessage(control, (User32.WM)PInvoke.MCM_GETCALENDARGRIDINFO, default, ref result));
-                var rect = Rectangle.FromLTRB(result.rc.left, result.rc.top, result.rc.right, result.rc.bottom);
-                return rect;
+                return result.rc;
             }
         }
 


### PR DESCRIPTION
An implicit conversion `RECT` &lrarr; `Rectangle` already existed in code. This change simplifies code manually converting between these types to instead rely on this operator.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8975)