### PR TITLE
Add UIA Toggle pattern to ToolStripButton

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridToolStripButton.PropertyGridToolStripButtonAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridToolStripButton.PropertyGridToolStripButtonAccessibleObject.cs
@@ -26,6 +26,7 @@ namespace System.Windows.Forms
                 => patternId switch
                 {
                     UiaCore.UIA.SelectionItemPatternId => _owningPropertyGridToolStripButton._selectItemEnabled,
+                    UiaCore.UIA.TogglePatternId => false,
                     _ => base.IsPatternSupported(patternId)
                 };
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripButton.ToolStripButtonAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripButton.ToolStripButtonAccessibleObject.cs
@@ -32,6 +32,13 @@ namespace System.Windows.Forms
                     _ => base.GetPropertyValue(propertyID)
                 };
 
+            internal override bool IsPatternSupported(UiaCore.UIA patternId) =>
+                patternId switch
+                {
+                    UiaCore.UIA.TogglePatternId => _ownerItem.CheckOnClick || _ownerItem.Checked,
+                    _ => base.IsPatternSupported(patternId)
+                };
+
             public override AccessibleRole Role
             {
                 get
@@ -64,6 +71,26 @@ namespace System.Windows.Forms
                     return base.State;
                 }
             }
+
+            #region Toggle Pattern
+
+            internal override void Toggle()
+            {
+                if (_ownerItem.CheckOnClick)
+                {
+                    _ownerItem.Checked = !_ownerItem.Checked;
+                }
+            }
+
+            internal override UiaCore.ToggleState ToggleState =>
+                _ownerItem.CheckState switch
+                {
+                    CheckState.Checked => UiaCore.ToggleState.On,
+                    CheckState.Unchecked => UiaCore.ToggleState.Off,
+                    _ => UiaCore.ToggleState.Indeterminate
+                };
+
+            #endregion
         }
     }
 }

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ToolStripTests.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ToolStripTests.Designer.cs
@@ -70,6 +70,7 @@ namespace WinformsControlsTest
             this.toolStrip1.Size = new System.Drawing.Size(481, 22);
             this.toolStrip1.TabIndex = 0;
             this.toolStrip1.Text = "toolStrip1";
+            this.toolStrip1.TabStop = true;
             // 
             // toolStrip2
             // 
@@ -86,6 +87,7 @@ namespace WinformsControlsTest
             this.toolStrip2.Size = new System.Drawing.Size(481, 22);
             this.toolStrip2.TabIndex = 1;
             this.toolStrip2.Text = "toolStrip2";
+            this.toolStrip2.TabStop = true;
             // 
             // toolStrip2_Button1
             //
@@ -183,6 +185,7 @@ namespace WinformsControlsTest
             this.statusStrip1.Size = new System.Drawing.Size(481, 22);
             this.statusStrip1.TabIndex = 1;
             this.statusStrip1.Text = "statusStrip1";
+            this.statusStrip1.TabStop = true;
             // 
             // label1
             // 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridToolStripButton.PropertyGridToolStripButtonAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridToolStripButton.PropertyGridToolStripButtonAccessibleObjectTests.cs
@@ -173,5 +173,20 @@ namespace System.Windows.Forms.Tests
             Assert.False(alphaButton.Checked);
             Assert.Equal(PropertySort.CategorizedAlphabetical, propertyGrid.PropertySort);
         }
+
+        [WinFormsFact]
+        public void PropertyGridToolStripButtonAccessibleObject_IsTogglePatternSupported_ReturnsExpected()
+        {
+            using PropertyGrid propertyGrid = new PropertyGrid();
+            ToolStripButton[] toolStripButtons = propertyGrid.TestAccessor().Dynamic._viewSortButtons;
+            ToolStripButton propertyPagesButton = propertyGrid.TestAccessor().Dynamic._viewPropertyPagesButton;
+            AccessibleObject categoryButtonAccessibleObject = toolStripButtons[0].AccessibilityObject;
+            AccessibleObject alphaButtonAccessibleObject = toolStripButtons[1].AccessibilityObject;
+            AccessibleObject propertyPagesButtonAccessibleObject = propertyPagesButton.AccessibilityObject;
+
+            Assert.False(categoryButtonAccessibleObject.IsPatternSupported(UIA.TogglePatternId));
+            Assert.False(alphaButtonAccessibleObject.IsPatternSupported(UIA.TogglePatternId));
+            Assert.False(propertyPagesButtonAccessibleObject.IsPatternSupported(UIA.TogglePatternId));
+        }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripButton.ToolStripButtonAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripButton.ToolStripButtonAccessibleObjectTests.cs
@@ -82,5 +82,66 @@ namespace System.Windows.Forms.Tests
 
             Assert.Equal(expected, actual);
         }
+
+        [WinFormsTheory]
+        [InlineData(true, CheckState.Checked, true)]
+        [InlineData(true, CheckState.Unchecked, true)]
+        [InlineData(true, CheckState.Indeterminate, true)]
+        [InlineData(false, CheckState.Checked, true)]
+        [InlineData(false, CheckState.Unchecked, false)]
+        [InlineData(false, CheckState.Indeterminate, true)]
+        public void ToolStripButtonAccessibleObject_IsTogglePatternSupported_ReturnsExpected(bool checkOnClick, CheckState checkState, bool expected)
+        {
+            using ToolStripButton toolStripButton = new()
+            {
+                CheckOnClick = checkOnClick,
+                CheckState = checkState
+            };
+
+            object actual = toolStripButton.AccessibilityObject.IsPatternSupported(UiaCore.UIA.TogglePatternId);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [WinFormsTheory]
+        [InlineData(CheckState.Checked, (int)UiaCore.ToggleState.On)]
+        [InlineData(CheckState.Unchecked, (int)UiaCore.ToggleState.Off)]
+        [InlineData(CheckState.Indeterminate, (int)UiaCore.ToggleState.Indeterminate)]
+        public void ToolStripButtonAccessibleObject_ToggleState_ReturnsExpected(CheckState checkState, int expectedToggleState)
+        {
+            using ToolStripButton toolStripButton = new()
+            {
+                CheckState = checkState
+            };
+
+            object actual = toolStripButton.AccessibilityObject.ToggleState;
+
+            Assert.Equal((UiaCore.ToggleState)expectedToggleState, actual);
+        }
+
+        [WinFormsFact]
+        public void ToolStripButtonAccessibleObject_Toggle_Invoke()
+        {
+            using ToolStripButton toolStripButton = new()
+            {
+                CheckOnClick = true
+            };
+
+            int clickCounter = 0;
+
+            toolStripButton.Click += (s, e) => { clickCounter++; };
+
+            Assert.Equal(UiaCore.ToggleState.Off, toolStripButton.AccessibilityObject.ToggleState);
+
+            toolStripButton.AccessibilityObject.Toggle();
+
+            Assert.Equal(UiaCore.ToggleState.On, toolStripButton.AccessibilityObject.ToggleState);
+
+            toolStripButton.AccessibilityObject.Toggle();
+
+            Assert.Equal(UiaCore.ToggleState.Off, toolStripButton.AccessibilityObject.ToggleState);
+
+            Assert.Equal(0, clickCounter);
+        }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripMenuItem.ToolStripMenuItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripMenuItem.ToolStripMenuItemAccessibleObjectTests.cs
@@ -156,7 +156,7 @@ namespace System.Windows.Forms.Tests
         [InlineData(false, CheckState.Checked, true)]
         [InlineData(false, CheckState.Unchecked, false)]
         [InlineData(false, CheckState.Indeterminate, true)]
-        public void ToolStripMenuItemAccessibleObject_IsTogglePatternSupported_ReturnExpected(bool checkOnClick, CheckState checkState, bool expected)
+        public void ToolStripMenuItemAccessibleObject_IsTogglePatternSupported_ReturnsExpected(bool checkOnClick, CheckState checkState, bool expected)
         {
             using ToolStripMenuItem toolStripMenuItem = new()
             {


### PR DESCRIPTION
Fixes #8961


## Proposed changes

* Added Toggle pattern support for ToolStripButton
* Disabled pattern support for PropertyGridToolStripButton (e.g. "Categorized", "Alphabetical" buttons on a PropertyGrid) because they may have `Checked = true`, but will not behave like a toggle button in that case. Instead they behave like radio buttons and screen readers already announce their selected state
* Added unit tests
* Added `TabStop = true` for tool strips on a test form to make them selectable via keyboard for easier testing. The form already contained ToolStripButton-s with different checked states so there was no need to add it.

## Customer Impact

- Screen readers will announce toggle state of a checkable `ToolStripButton`

## Regression? 

- No

## Risk

- Minimal


## Test methodology <!-- How did you ensure quality? -->

- Unit tests
- Manual testing

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->

### Before

Screen reader announcements for a ToolStrip with following buttons:
* toolStripButton1 with `CheckState = CheckState.Checked` 
* toolStripButton2 with `CheckState = CheckState.Unchecked` and `CheckOnClick = true`
* toolStripButton3 with `CheckState = CheckState.Indeterminate`

Narrator:

> toolStripButton1, button, 
> toolStripButton2, button, 
> toolStripButton3, button, 

NVDA:

> toolStripButton1  button
> toolStripButton2  button
> toolStripButton3  button

JAWS:

> toolStripButton1 Button
> To activate press spacebar.
> toolStripButton2 Button
> To activate press spacebar.
> toolStripButton3 Button
> To activate press spacebar.

Toggle state is not announced anywhere.

### After

Narrator:

> toolStripButton1, button, on,
> toolStripButton2, button, off,
> toolStripButton3, button, indeterminate,

NVDA:

> toolStripButton1  toggle button  pressed
> toolStripButton2  toggle button  not pressed
> toolStripButton3  toggle button  half pressed

JAWS:

> toolStripButton1 Button checked
> To activate press spacebar.
> toolStripButton2 Button not checked 
> To activate press spacebar.
> toolStripButton3 Button not checked partially checked 
> To activate press spacebar.

All screen readers announce toggle state.

 

## Test environment(s) <!-- Remove any that don't apply -->

- .NET 8.0.100-preview.4.23202.1
- Windows 11


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8978)