### PR TITLE
Automatically retry integration tests on failure

### DIFF
--- a/eng/pipelines/build.yml
+++ b/eng/pipelines/build.yml
@@ -111,6 +111,7 @@ jobs:
       env:
         XUNIT_LOGS: $(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)
       displayName: Run Integration Tests
+      retryCountOnTaskFailure: 1
 
     # Create Nuget package, sign, and publish
     - script: eng\cibuild.cmd


### PR DESCRIPTION
Re-runs just the integration test step up to one more time if a test failure occurs. Helps prevent flakiness in the system from impacting CI runs, but doesn't have any impact on developer scenarios.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8981)