### PR TITLE
Null out FontFamily field on Font when disposing

### DIFF
--- a/src/System.Drawing.Common/src/System/Drawing/Font.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Font.cs
@@ -182,7 +182,10 @@ namespace System.Drawing
             //
             // https://github.com/dotnet/winforms/issues/8823
 
-            _fontFamily = null;
+            if (!LocalAppContextSwitches.DoNotNullOutFontFamilyOnDispose)
+            {
+                _fontFamily = null;
+            }
 
             if (_nativeFont == 0)
             {
@@ -249,7 +252,7 @@ namespace System.Drawing
                 return false;
             }
 
-            if (font._nativeFont == 0 || _nativeFont == 0)
+            if (!LocalAppContextSwitches.DoNotConsiderDisposedStateInFontEquals && (font._nativeFont == 0 || _nativeFont == 0))
             {
                 // Disposed objects can't be compared outside of reference equality
                 return false;

--- a/src/System.Drawing.Common/src/System/Drawing/Font.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Font.cs
@@ -249,10 +249,15 @@ namespace System.Drawing
                 return false;
             }
 
-            // Note: If this and/or the passed-in font are disposed, this method can still return true since we check for cached properties
-            // here.
-            // We need to call properties on the passed-in object since it could be a proxy in a remoting scenario and proxies don't
-            // have access to private/internal fields.
+            if (font._nativeFont == 0 || _nativeFont == 0)
+            {
+                // Disposed objects can't be compared outside of reference equality
+                return false;
+            }
+
+            // This historically checked properties as it was trying to compare equality for proxies in remoting
+            // scenarios. Remoting isn't supported on Core, but we're retaining this for compatibility, with the
+            // exception of bailing out on disposed objects above (which was not checked for in the past).
             return font.FontFamily.Equals(FontFamily) &&
                 font.GdiVerticalFont == GdiVerticalFont &&
                 font.GdiCharSet == GdiCharSet &&
@@ -476,10 +481,10 @@ namespace System.Drawing
         /// <summary>
         /// Constructor to initialize fields from an existing native GDI+ object reference. Used by ToLogFont.
         /// </summary>
-        private Font(IntPtr nativeFont, byte gdiCharSet, bool gdiVerticalFont)
+        private Font(nint nativeFont, byte gdiCharSet, bool gdiVerticalFont)
         {
-            Debug.Assert(_nativeFont == IntPtr.Zero, "GDI+ native font already initialized, this will generate a handle leak");
-            Debug.Assert(nativeFont != IntPtr.Zero, "nativeFont is null");
+            Debug.Assert(_nativeFont == 0, "GDI+ native font already initialized, this will generate a handle leak");
+            Debug.Assert(nativeFont != 0, "nativeFont is null");
 
             _nativeFont = nativeFont;
 

--- a/src/System.Drawing.Common/src/System/Drawing/LocalAppContextSwitches.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/LocalAppContextSwitches.cs
@@ -32,6 +32,6 @@ internal static partial class LocalAppContextSwitches
     public static bool DoNotConsiderDisposedStateInFontEquals
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => GetCachedSwitchValue(@"Switch.System.Drawing.DoNotNullOutFontFamilyOnDispose", ref s_fontConsiderDisposedState);
+        get => GetCachedSwitchValue(@"Switch.System.Drawing.DoNotConsiderDisposedStateInFontEquals", ref s_fontConsiderDisposedState);
     }
 }

--- a/src/System.Drawing.Common/src/System/Drawing/LocalAppContextSwitches.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/LocalAppContextSwitches.cs
@@ -1,30 +1,37 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.CompilerServices;
 
-namespace System
-{
-    internal static partial class LocalAppContextSwitches
-    {
-        private static int s_dontSupportPngFramesInIcons;
-        public static bool DontSupportPngFramesInIcons
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get
-            {
-                return GetCachedSwitchValue(@"Switch.System.Drawing.DontSupportPngFramesInIcons", ref s_dontSupportPngFramesInIcons);
-            }
-        }
+namespace System;
 
-        private static int s_optimizePrintPreview;
-        public static bool OptimizePrintPreview
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get
-            {
-                return GetCachedSwitchValue(@"Switch.System.Drawing.Printing.OptimizePrintPreview", ref s_optimizePrintPreview);
-            }
-        }
+internal static partial class LocalAppContextSwitches
+{
+    private static int s_dontSupportPngFramesInIcons;
+    public static bool DontSupportPngFramesInIcons
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => GetCachedSwitchValue(@"Switch.System.Drawing.DontSupportPngFramesInIcons", ref s_dontSupportPngFramesInIcons);
+    }
+
+    private static int s_optimizePrintPreview;
+    public static bool OptimizePrintPreview
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => GetCachedSwitchValue(@"Switch.System.Drawing.Printing.OptimizePrintPreview", ref s_optimizePrintPreview);
+    }
+
+    private static int s_nullOutFontFamily;
+    public static bool DoNotNullOutFontFamilyOnDispose
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => GetCachedSwitchValue(@"Switch.System.Drawing.DoNotNullOutFontFamilyOnDispose", ref s_nullOutFontFamily);
+    }
+
+    private static int s_fontConsiderDisposedState;
+    public static bool DoNotConsiderDisposedStateInFontEquals
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => GetCachedSwitchValue(@"Switch.System.Drawing.DoNotNullOutFontFamilyOnDispose", ref s_fontConsiderDisposedState);
     }
 }

--- a/src/System.Drawing.Common/tests/FontTests.cs
+++ b/src/System.Drawing.Common/tests/FontTests.cs
@@ -341,18 +341,14 @@ namespace System.Drawing.Tests
         }
 
         [Fact]
-        public void Ctor_DisposedFont_Success()
+        public void Ctor_DisposedFont_ThrowsObjectDisposed()
         {
             using (FontFamily family = FontFamily.GenericSerif)
             {
                 var font = new Font(family, 10);
                 font.Dispose();
 
-                using (var copy = new Font(font, FontStyle.Italic))
-                {
-                    Assert.Equal(FontStyle.Italic, copy.Style);
-                    Assert.Equal(family.Name, copy.Name);
-                }
+                Assert.Throws<ObjectDisposedException>(() => new Font(font, FontStyle.Italic));
             }
         }
 

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/RefCountedCache.CacheEntry.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/RefCountedCache.CacheEntry.cs
@@ -39,8 +39,10 @@ namespace System.Windows.Forms
             ///  Removes a reference to this entry.
             /// </summary>
             /// <remarks>
-            ///  This will dispose of the entry when the ref count reaches zero- if the entry isn't actually
-            ///  cached <see cref="_cached"/>.
+            ///  <para>
+            ///   This will dispose of the entry when the ref count reaches zero- if the entry isn't actually
+            ///   cached <see cref="_cached"/>.
+            ///  </para>
             /// </remarks>
             public virtual void RemoveRef()
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.cs
@@ -12,6 +12,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
 using System.Globalization;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Microsoft.VisualStudio.Shell;
 using Windows.Win32.System.Com;
@@ -73,7 +74,7 @@ namespace System.Windows.Forms
         private static readonly Guid s_maskEdit_Clsid = new("{c932ba85-4374-101b-a56c-00aa003668dc}");
 
         // Static state for perf optimization
-        private static Dictionary<Font, FONTDESC> s_fontTable;
+        private static ConditionalWeakTable<Font, object> s_fontTable;
 
         // BitVector32 masks for various internal state flags.
         private static readonly int s_ocxStateSet = BitVector32.CreateMask();
@@ -3853,11 +3854,11 @@ namespace System.Windows.Forms
         {
             if (s_fontTable is null)
             {
-                s_fontTable = new Dictionary<Font, FONTDESC>();
+                s_fontTable = new();
             }
-            else if (s_fontTable.TryGetValue(font, out FONTDESC cachedFDesc))
+            else if (s_fontTable.TryGetValue(font, out object cachedFDesc))
             {
-                return cachedFDesc;
+                return (FONTDESC)cachedFDesc;
             }
 
             LOGFONTW logfont = LOGFONTW.FromFont(font);
@@ -3872,7 +3873,7 @@ namespace System.Windows.Forms
                 fStrikethrough = font.Strikeout
             };
 
-            s_fontTable[font] = fdesc;
+            s_fontTable.Add(font, fdesc);
             return fdesc;
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Internal/Gdi/FontCache.Data.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Internal/Gdi/FontCache.Data.cs
@@ -5,121 +5,120 @@
 using System.Diagnostics;
 using System.Drawing;
 
-namespace System.Windows.Forms
+namespace System.Windows.Forms;
+
+internal sealed partial class FontCache
 {
-    internal sealed partial class FontCache
+    internal struct Data : IDisposable
     {
-        internal struct Data : IDisposable
+        // Note: These defaults are according to the ones in GDI+ but those are not necessarily the same as the system
+        // default font.  The GetSystemDefaultHFont() method should be used if needed.
+        private const string DefaultFaceName = "Microsoft Sans Serif";
+        private const byte True = 1;
+        private const byte False = 0;
+
+        public WeakReference<Font> Font { get; }
+        public HFONT HFONT { get; private set; }
+        public FONT_QUALITY Quality { get; }
+
+        private int? _tmHeight;
+
+        public Data(Font font, FONT_QUALITY quality)
         {
-            // Note: These defaults are according to the ones in GDI+ but those are not necessarily the same as the system
-            // default font.  The GetSystemDefaultHFont() method should be used if needed.
-            private const string DefaultFaceName = "Microsoft Sans Serif";
-            private const byte True = 1;
-            private const byte False = 0;
+            Font = new WeakReference<Font>(font);
+            Quality = quality;
+            HFONT = FromFont(font, quality);
+            _tmHeight = null;
+        }
 
-            public WeakReference<Font> Font { get; }
-            public HFONT HFONT { get; private set; }
-            public FONT_QUALITY Quality { get; }
-
-            private int? _tmHeight;
-
-            public Data(Font font, FONT_QUALITY quality)
+        public unsafe int Height
+        {
+            get
             {
-                Font = new WeakReference<Font>(font);
-                Quality = quality;
-                HFONT = FromFont(font, quality);
-                _tmHeight = null;
+                if (!_tmHeight.HasValue)
+                {
+                    using var screenDC = GdiCache.GetScreenHdc();
+                    HDC hdc = screenDC.HDC;
+                    using PInvoke.SelectObjectScope fontSelection = new(hdc, HFONT);
+                    Debug.Assert(PInvoke.GetMapMode(hdc) == HDC_MAP_MODE.MM_TEXT);
+
+                    TEXTMETRICW tm = default;
+                    PInvoke.GetTextMetrics(hdc, &tm);
+                    _tmHeight = tm.tmHeight;
+                }
+
+                return _tmHeight.Value;
+            }
+        }
+
+        public void Dispose()
+        {
+            if (!HFONT.IsNull)
+            {
+                PInvoke.DeleteObject(HFONT);
             }
 
-            public unsafe int Height
+            HFONT = default;
+        }
+
+        /// <summary>
+        ///  Constructs a WindowsFont object from an existing System.Drawing.Font object (GDI+), based on the screen dc
+        ///  MapMode and resolution (normally: MM_TEXT and 96 dpi).
+        /// </summary>
+        private static unsafe HFONT FromFont(Font font, FONT_QUALITY quality = FONT_QUALITY.DEFAULT_QUALITY)
+        {
+            string familyName = font.FontFamily.Name;
+
+            // Strip vertical-font mark from the name if needed.
+            if (familyName is not null && familyName.Length > 1 && familyName[0] == '@')
             {
-                get
-                {
-                    if (!_tmHeight.HasValue)
-                    {
-                        using var screenDC = GdiCache.GetScreenHdc();
-                        HDC hdc = screenDC.HDC;
-                        using PInvoke.SelectObjectScope fontSelection = new(hdc, HFONT);
-                        Debug.Assert(PInvoke.GetMapMode(hdc) == HDC_MAP_MODE.MM_TEXT);
-
-                        TEXTMETRICW tm = default;
-                        PInvoke.GetTextMetrics(hdc, &tm);
-                        _tmHeight = tm.tmHeight;
-                    }
-
-                    return _tmHeight.Value;
-                }
+                familyName = familyName.Substring(1);
             }
 
-            public void Dispose()
-            {
-                if (!HFONT.IsNull)
-                {
-                    PInvoke.DeleteObject(HFONT);
-                }
+            // Now, creating it using the Font.SizeInPoints makes it GraphicsUnit-independent.
 
-                HFONT = default;
+            Debug.Assert(font.SizeInPoints > 0.0f, "size has a negative value.");
+
+            // Get the font height from the specified size. The size is in point units and height in logical units
+            // (pixels when using MM_TEXT) so we need to make the conversion using the number of pixels per logical
+            // inch along the screen height. (1 point = 1/72 inch.)
+            int pixelsY = (int)Math.Ceiling(DpiHelper.DeviceDpi * font.SizeInPoints / 72);
+
+            // The lfHeight represents the font cell height (line spacing) which includes the internal leading; we
+            // specify a negative size value (in pixels) for the height so the font mapper provides the closest match
+            // for the character height rather than the cell height.
+
+            LOGFONTW logFont = new()
+            {
+                lfHeight = -pixelsY,
+                lfCharSet = (FONT_CHARSET)font.GdiCharSet,
+                lfOutPrecision = FONT_OUTPUT_PRECISION.OUT_TT_PRECIS,
+                lfQuality = quality,
+                lfWeight = (int)((font.Style & FontStyle.Bold) == FontStyle.Bold ? FW.BOLD : FW.NORMAL),
+                lfItalic = (font.Style & FontStyle.Italic) == FontStyle.Italic ? True : False,
+                lfUnderline = (font.Style & FontStyle.Underline) == FontStyle.Underline ? True : False,
+                lfStrikeOut = (font.Style & FontStyle.Strikeout) == FontStyle.Strikeout ? True : False,
+                FaceName = familyName
+            };
+
+            if (logFont.FaceName.IsEmpty)
+            {
+                logFont.FaceName = DefaultFaceName;
             }
 
-            /// <summary>
-            ///  Constructs a WindowsFont object from an existing System.Drawing.Font object (GDI+), based on the screen dc
-            ///  MapMode and resolution (normally: MM_TEXT and 96 dpi).
-            /// </summary>
-            private static unsafe HFONT FromFont(Font font, FONT_QUALITY quality = FONT_QUALITY.DEFAULT_QUALITY)
+            HFONT hfont = PInvoke.CreateFontIndirect(&logFont);
+
+            if (hfont.IsNull)
             {
-                string familyName = font.FontFamily.Name;
+                // Get the default font if we couldn't get what we requested.
+                logFont.FaceName = DefaultFaceName;
+                logFont.lfOutPrecision = FONT_OUTPUT_PRECISION.OUT_TT_ONLY_PRECIS;
+                hfont = PInvoke.CreateFontIndirect(&logFont);
 
-                // Strip vertical-font mark from the name if needed.
-                if (familyName is not null && familyName.Length > 1 && familyName[0] == '@')
-                {
-                    familyName = familyName.Substring(1);
-                }
-
-                // Now, creating it using the Font.SizeInPoints makes it GraphicsUnit-independent.
-
-                Debug.Assert(font.SizeInPoints > 0.0f, "size has a negative value.");
-
-                // Get the font height from the specified size. The size is in point units and height in logical units
-                // (pixels when using MM_TEXT) so we need to make the conversion using the number of pixels per logical
-                // inch along the screen height. (1 point = 1/72 inch.)
-                int pixelsY = (int)Math.Ceiling(DpiHelper.DeviceDpi * font.SizeInPoints / 72);
-
-                // The lfHeight represents the font cell height (line spacing) which includes the internal leading; we
-                // specify a negative size value (in pixels) for the height so the font mapper provides the closest match
-                // for the character height rather than the cell height.
-
-                LOGFONTW logFont = new()
-                {
-                    lfHeight = -pixelsY,
-                    lfCharSet = (FONT_CHARSET)font.GdiCharSet,
-                    lfOutPrecision = FONT_OUTPUT_PRECISION.OUT_TT_PRECIS,
-                    lfQuality = quality,
-                    lfWeight = (int)((font.Style & FontStyle.Bold) == FontStyle.Bold ? FW.BOLD : FW.NORMAL),
-                    lfItalic = (font.Style & FontStyle.Italic) == FontStyle.Italic ? True : False,
-                    lfUnderline = (font.Style & FontStyle.Underline) == FontStyle.Underline ? True : False,
-                    lfStrikeOut = (font.Style & FontStyle.Strikeout) == FontStyle.Strikeout ? True : False,
-                    FaceName = familyName
-                };
-
-                if (logFont.FaceName.IsEmpty)
-                {
-                    logFont.FaceName = DefaultFaceName;
-                }
-
-                HFONT hfont = PInvoke.CreateFontIndirect(&logFont);
-
-                if (hfont.IsNull)
-                {
-                    // Get the default font if we couldn't get what we requested.
-                    logFont.FaceName = DefaultFaceName;
-                    logFont.lfOutPrecision = FONT_OUTPUT_PRECISION.OUT_TT_ONLY_PRECIS;
-                    hfont = PInvoke.CreateFontIndirect(&logFont);
-
-                    Debug.Assert(!hfont.IsNull);
-                }
-
-                return hfont;
+                Debug.Assert(!hfont.IsNull);
             }
+
+            return hfont;
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Internal/Gdi/FontCache.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Internal/Gdi/FontCache.cs
@@ -4,49 +4,51 @@
 
 using System.Drawing;
 
-namespace System.Windows.Forms
+namespace System.Windows.Forms;
+
+/// <summary>
+///  Thread safe cache of <see cref="HFONT"/> objects created from <see cref="Font"/> objects.
+/// </summary>
+/// <remarks>
+///  <para>
+///   This adds a slight managed memory overhead to creating the <see cref="HFONT"/>, but saves 56 bytes and
+///   98%+ of the time on each cache request that hits (taking less than 1 us as opposed to 50-100+ us).
+///  </para>
+///  <para>
+///   This cache is optimized for retrieval speed and limiting the number of unused GDI handles we're caching while
+///   hopefully handling the majority of application use cases. There is a limit of 65K GDI handles system wide and
+///   10K (default) per process.
+///  </para>
+/// </remarks>
+internal sealed partial class FontCache : RefCountedCache<HFONT, FontCache.Data, (Font Font, FONT_QUALITY Quality)>
 {
+    private readonly object _lock = new object();
+
     /// <summary>
-    ///  Thread safe cache of <see cref="HFONT"/> objects created from <see cref="Font"/> objects.
+    ///  Create a <see cref="FontCache"/> with the specified collection limits.
     /// </summary>
-    /// <remarks>
-    ///  This adds a slight managed memory overhead to creating the <see cref="HFONT"/>, but saves 56 bytes and
-    ///  98%+ of the time on each cache request that hits (taking less than 1 us as opposed to 50-100+ us).
-    ///
-    ///  This cache is optimized for retrieval speed and limiting the number of unused GDI handles we're caching while
-    ///  hopefully handling the majority of application use cases. There is a limit of 65K GDI handles system wide and
-    ///  10K (default) per process.
-    /// </remarks>
-    internal sealed partial class FontCache : RefCountedCache<HFONT, FontCache.Data, (Font Font, FONT_QUALITY Quality)>
+    public FontCache(int softLimit = 20, int hardLimit = 40) : base(softLimit, hardLimit) { }
+
+    /// <summary>
+    ///  Gets a ref-counting scope containing the <see cref="HFONT"/> that matches the specified
+    ///  <paramref name="font"/> and <paramref name="quality"/>. The scope MUST be disposed to release the ref
+    ///  count accurately. Use the result in a using statement to avoid leaking fonts.
+    /// </summary>
+    public Scope GetEntry(Font font, FONT_QUALITY quality = FONT_QUALITY.DEFAULT_QUALITY) => GetEntry((font, quality));
+
+    public override Scope GetEntry((Font Font, FONT_QUALITY Quality) key)
     {
-        private readonly object _lock = new object();
-
-        /// <summary>
-        ///  Create a <see cref="FontCache"/> with the specified collection limits.
-        /// </summary>
-        public FontCache(int softLimit = 20, int hardLimit = 40) : base(softLimit, hardLimit) { }
-
-        /// <summary>
-        ///  Gets a ref-counting scope containing the <see cref="HFONT"/> that matches the specified
-        ///  <paramref name="font"/> and <paramref name="quality"/>. The scope MUST be disposed to release the ref
-        ///  count accurately. Use the result in a using statement to avoid leaking fonts.
-        /// </summary>
-        public Scope GetEntry(Font font, FONT_QUALITY quality = FONT_QUALITY.DEFAULT_QUALITY) => GetEntry((font, quality));
-
-        public override Scope GetEntry((Font Font, FONT_QUALITY Quality) key)
+        lock (_lock)
         {
-            lock (_lock)
-            {
-                return base.GetEntry(key);
-            }
+            return base.GetEntry(key);
         }
-
-        protected override CacheEntry CreateEntry((Font Font, FONT_QUALITY Quality) key, bool cached)
-            => new FontCacheEntry(new Data(key.Font, key.Quality), cached);
-
-        protected override bool IsMatch((Font Font, FONT_QUALITY Quality) key, CacheEntry entry)
-            => entry.Data.Font.TryGetTarget(out Font? currentFont)
-                && key.Font == currentFont
-                && key.Quality == entry.Data.Quality;
     }
+
+    protected override CacheEntry CreateEntry((Font Font, FONT_QUALITY Quality) key, bool cached)
+        => new FontCacheEntry(new Data(key.Font, key.Quality), cached);
+
+    protected override bool IsMatch((Font Font, FONT_QUALITY Quality) key, CacheEntry entry)
+        => entry.Data.Font.TryGetTarget(out Font? currentFont)
+            && key.Font == currentFont
+            && key.Quality == entry.Data.Quality;
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTextBoxEditingControlTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTextBoxEditingControlTests.cs
@@ -548,8 +548,8 @@ namespace System.Windows.Forms.Tests
         {
             yield return new object[] { new DataGridViewCellStyle(), null, Color.FromArgb(0xFF, 0x00, 0x00, 0x00), SystemColors.WindowText, false, HorizontalAlignment.Left, false };
 
-            using var font = new Font("Arial", 8.25f);
-            var customStyle = new DataGridViewCellStyle
+            Font font = new("Arial", 8.25f);
+            DataGridViewCellStyle customStyle = new()
             {
                 Font = font,
                 BackColor = Color.Gray,
@@ -557,7 +557,7 @@ namespace System.Windows.Forms.Tests
             };
             yield return new object[] { customStyle, font, Color.Gray, Color.Green, false, HorizontalAlignment.Left, false };
 
-            var transparentStyle = new DataGridViewCellStyle
+            DataGridViewCellStyle transparentStyle = new()
             {
                 Font = font,
                 BackColor = Color.FromArgb(0x12, 0x34, 0x56, 0x78),

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTextBoxEditingControlTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTextBoxEditingControlTests.cs
@@ -757,21 +757,23 @@ namespace System.Windows.Forms.Tests
         {
             yield return new object[] { new DataGridViewCellStyle(), null, Color.FromArgb(0xFF, 0x00, 0x00, 0x00), Color.FromArgb(0xFF, 0x00, 0x00, 0x00), SystemColors.WindowText, false, HorizontalAlignment.Left, false };
 
-            using var font = new Font("Arial", 8.25f);
-            var customStyle = new DataGridViewCellStyle
+            Font font = new("Arial", 8.25f);
+            DataGridViewCellStyle customStyle = new()
             {
                 Font = font,
                 BackColor = Color.Gray,
                 ForeColor = Color.Green
             };
+
             yield return new object[] { customStyle, font, Color.Gray, SystemColors.Control, Color.Green, false, HorizontalAlignment.Left, false };
 
-            var transparentStyle = new DataGridViewCellStyle
+            DataGridViewCellStyle transparentStyle = new()
             {
                 Font = font,
                 BackColor = Color.FromArgb(0x12, 0x34, 0x56, 0x78),
                 ForeColor = Color.FromArgb(0x23, 0x45, 0x67, 0x80)
             };
+
             yield return new object[] { transparentStyle, font, Color.FromArgb(0xFF, 0x34, 0x56, 0x78), Color.FromArgb(0xFF, 0x34, 0x56, 0x78), Color.FromArgb(0x23, 0x45, 0x67, 0x80), false, HorizontalAlignment.Left, false };
 
             yield return new object[]


### PR DESCRIPTION
To avoid rooting the FontFamily if the Font itself is still rooted after disposal.

This introduces an ObjectDisposedException if you try to access fields that use the FontFamily after disposing.

Fixes #8823


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8986)