### PR TITLE
Add BufferScope for handling buffer rentals for interop

### DIFF
--- a/src/Common/src/HandleRefMarshaller.cs
+++ b/src/Common/src/HandleRefMarshaller.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics.CodeAnalysis;
-
 namespace System.Runtime.InteropServices.Marshalling
 {
     [CustomMarshaller(typeof(HandleRef), MarshalMode.ManagedToUnmanagedIn, typeof(KeepAliveMarshaller))]

--- a/src/System.Drawing.Common/src/Interop/Windows/Gdi32/Interop.CombineRgn.cs
+++ b/src/System.Drawing.Common/src/Interop/Windows/Gdi32/Interop.CombineRgn.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Diagnostics;
 using System.Runtime.InteropServices;
 
 internal static partial class Interop

--- a/src/System.Drawing.Common/src/Interop/Windows/Gdi32/Interop.CreateFontIndirect.cs
+++ b/src/System.Drawing.Common/src/Interop/Windows/Gdi32/Interop.CreateFontIndirect.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Drawing.Interop;
 using System.Runtime.InteropServices;
 

--- a/src/System.Drawing.Common/src/Interop/Windows/Gdi32/Interop.DEVMODE.cs
+++ b/src/System.Drawing.Common/src/Interop/Windows/Gdi32/Interop.DEVMODE.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Runtime.InteropServices;
 #if NET7_0_OR_GREATER
 using System.Runtime.InteropServices.Marshalling;

--- a/src/System.Drawing.Common/src/Interop/Windows/Gdi32/Interop.GetClipRgn.cs
+++ b/src/System.Drawing.Common/src/Interop/Windows/Gdi32/Interop.GetClipRgn.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Diagnostics;
 using System.Runtime.InteropServices;
 
 internal static partial class Interop

--- a/src/System.Drawing.Common/src/Interop/Windows/Gdi32/Interop.GetDeviceCaps.cs
+++ b/src/System.Drawing.Common/src/Interop/Windows/Gdi32/Interop.GetDeviceCaps.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Diagnostics;
 using System.Runtime.InteropServices;
 
 internal static partial class Interop

--- a/src/System.Drawing.Common/src/Interop/Windows/Gdi32/Interop.IntersectClipRect.cs
+++ b/src/System.Drawing.Common/src/Interop/Windows/Gdi32/Interop.IntersectClipRect.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Runtime.InteropServices;
 #if NET7_0_OR_GREATER
 using System.Runtime.InteropServices.Marshalling;

--- a/src/System.Drawing.Common/src/Interop/Windows/Gdi32/Interop.RasterOp.cs
+++ b/src/System.Drawing.Common/src/Interop/Windows/Gdi32/Interop.RasterOp.cs
@@ -1,9 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Runtime.InteropServices;
-
 internal static partial class Interop
 {
     internal static partial class Gdi32

--- a/src/System.Drawing.Common/src/Interop/Windows/Shell32/Interop.SHDefExtractIcon.cs
+++ b/src/System.Drawing.Common/src/Interop/Windows/Shell32/Interop.SHDefExtractIcon.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Runtime.InteropServices;
 
 internal static partial class Interop

--- a/src/System.Drawing.Common/src/Interop/Windows/Shell32/Interop.SHGetStockIconInfo.cs
+++ b/src/System.Drawing.Common/src/Interop/Windows/Shell32/Interop.SHGetStockIconInfo.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Runtime.InteropServices;
 
 internal static partial class Interop

--- a/src/System.Drawing.Common/src/Interop/Windows/User32/Interop.DestroyIcon.cs
+++ b/src/System.Drawing.Common/src/Interop/Windows/User32/Interop.DestroyIcon.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Runtime.InteropServices;
 #if NET7_0_OR_GREATER
 using System.Runtime.InteropServices.Marshalling;

--- a/src/System.Drawing.Common/src/Interop/Windows/User32/Interop.DrawIconEx.cs
+++ b/src/System.Drawing.Common/src/Interop/Windows/User32/Interop.DrawIconEx.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Runtime.InteropServices;
 #if NET7_0_OR_GREATER
 using System.Runtime.InteropServices.Marshalling;

--- a/src/System.Drawing.Common/src/Interop/Windows/User32/Interop.GetDC.cs
+++ b/src/System.Drawing.Common/src/Interop/Windows/User32/Interop.GetDC.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Runtime.InteropServices;
 
 internal static partial class Interop

--- a/src/System.Drawing.Common/src/Interop/Windows/User32/Interop.GetSystemMetrics.cs
+++ b/src/System.Drawing.Common/src/Interop/Windows/User32/Interop.GetSystemMetrics.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Runtime.InteropServices;
 #if NET7_0_OR_GREATER
 using System.Runtime.InteropServices.Marshalling;

--- a/src/System.Drawing.Common/src/Interop/Windows/User32/Interop.NONCLIENTMETRICS.cs
+++ b/src/System.Drawing.Common/src/Interop/Windows/User32/Interop.NONCLIENTMETRICS.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Drawing;
 using System.Drawing.Interop;
 using System.Runtime.InteropServices;
 

--- a/src/System.Drawing.Common/src/Interop/Windows/User32/Interop.SystemParametersInfo.cs
+++ b/src/System.Drawing.Common/src/Interop/Windows/User32/Interop.SystemParametersInfo.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Runtime.InteropServices;
 
 internal static partial class Interop

--- a/src/System.Drawing.Common/src/System/Drawing/BufferedGraphicsManager.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/BufferedGraphicsManager.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Runtime.ConstrainedExecution;
-
 namespace System.Drawing
 {
     /// <summary>

--- a/src/System.Drawing.Common/src/System/Drawing/Drawing2D/PathGradientBrush.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Drawing2D/PathGradientBrush.cs
@@ -4,7 +4,6 @@
 using System.Runtime.InteropServices;
 using System.Diagnostics;
 using System.ComponentModel;
-using System.Drawing.Internal;
 using Gdip = System.Drawing.SafeNativeMethods.Gdip;
 
 namespace System.Drawing.Drawing2D

--- a/src/System.Drawing.Common/src/System/Drawing/Drawing2D/SafeCustomLineCapHandle.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Drawing2D/SafeCustomLineCapHandle.cs
@@ -4,7 +4,6 @@
 using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.InteropServices;
-using System.Security;
 using Gdip = System.Drawing.SafeNativeMethods.Gdip;
 
 namespace System.Drawing.Drawing2D

--- a/src/System.Drawing.Common/src/System/Drawing/FontConverter.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/FontConverter.cs
@@ -2,14 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.Design.Serialization;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Drawing.Text;
 using System.Globalization;
-using System.Reflection;
 using System.Text;
 
 namespace System.Drawing

--- a/src/System.Drawing.Common/src/System/Drawing/GdiplusNative.Common.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/GdiplusNative.Common.cs
@@ -1,10 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Drawing.Drawing2D;
-using System.Drawing.Imaging;
-using System.Drawing.Internal;
-using System.Drawing.Text;
 using System.Runtime.InteropServices;
 using static Interop;
 

--- a/src/System.Drawing.Common/src/System/Drawing/Graphics.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Graphics.cs
@@ -11,7 +11,6 @@ using System.Globalization;
 using System.Numerics;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
-using System.Diagnostics.CodeAnalysis;
 #if NET7_0_OR_GREATER
 using System.Runtime.InteropServices.Marshalling;
 #endif

--- a/src/System.Drawing.Common/src/System/Drawing/Image.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Image.cs
@@ -10,7 +10,6 @@ using System.Globalization;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
-using System.Diagnostics.CodeAnalysis;
 #if NET7_0_OR_GREATER
 using System.Runtime.InteropServices.Marshalling;
 #endif

--- a/src/System.Drawing.Common/src/System/Drawing/ImageConverter.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/ImageConverter.cs
@@ -8,8 +8,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Drawing.Imaging;
 using System.Globalization;
 using System.IO;
-using System.Runtime.InteropServices;
-using System.Text;
 
 namespace System.Drawing
 {

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/EncoderParameterNative.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/EncoderParameterNative.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
 namespace System.Drawing.Imaging;

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/EncoderParameters.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/EncoderParameters.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Gdip = System.Drawing.SafeNativeMethods.Gdip;
 

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/MetafileHeaderWmf.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/MetafileHeaderWmf.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 #if NET7_0_OR_GREATER

--- a/src/System.Drawing.Common/src/System/Drawing/Interop/LOGFONT.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Interop/LOGFONT.cs
@@ -1,13 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace System.Drawing.Interop;
 

--- a/src/System.Drawing.Common/src/System/Drawing/NativeMethods.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/NativeMethods.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
 namespace System.Drawing

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/Margins.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/Margins.cs
@@ -3,7 +3,6 @@
 
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using System.Runtime.Serialization;
 
 namespace System.Drawing.Printing

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/PrinterResolution.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/PrinterResolution.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel;
-using System.Globalization;
 
 namespace System.Drawing.Printing
 {

--- a/src/System.Drawing.Common/src/System/Drawing/PropertyItemInternal.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/PropertyItemInternal.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Runtime.InteropServices;
-
 namespace System.Drawing.Imaging
 {
     internal unsafe struct PropertyItemInternal

--- a/src/System.Drawing.Common/src/System/Drawing/Region.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Region.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using System.Drawing.Drawing2D;
-using System.Drawing.Internal;
 using System.Globalization;
 using System.Runtime.InteropServices;
 using Gdip = System.Drawing.SafeNativeMethods.Gdip;

--- a/src/System.Drawing.Common/src/System/Drawing/ScreenDC.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/ScreenDC.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Runtime.InteropServices;
 using static Interop;
 
 namespace System.Drawing

--- a/src/System.Drawing.Common/src/misc/DpiHelper.cs
+++ b/src/System.Drawing.Common/src/misc/DpiHelper.cs
@@ -1,11 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Configuration;
 using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
 using System.Drawing.Drawing2D;
-using System.Runtime.InteropServices;
 
 namespace System.Windows.Forms
 {

--- a/src/System.Drawing.Common/src/misc/GDI/WindowsGraphics.cs
+++ b/src/System.Drawing.Common/src/misc/GDI/WindowsGraphics.cs
@@ -5,7 +5,6 @@
 // GETTING, DISPOSING AND WORKING WITH A DC.
 
 using System.Diagnostics;
-using System.Drawing.Drawing2D;
 
 namespace System.Drawing.Internal
 {

--- a/src/System.Drawing.Common/tests/BitmapTests.cs
+++ b/src/System.Drawing.Common/tests/BitmapTests.cs
@@ -23,13 +23,8 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.Drawing.Imaging;
-using System.IO;
-using System.Linq;
 using System.Runtime.InteropServices;
-using Microsoft.DotNet.RemoteExecutor;
 using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
 

--- a/src/System.Drawing.Common/tests/BrushesTests.cs
+++ b/src/System.Drawing.Common/tests/BrushesTests.cs
@@ -1,9 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
-using System.Drawing.Drawing2D;
-using System.Reflection;
 using Xunit;
 
 namespace System.Drawing.Tests

--- a/src/System.Drawing.Common/tests/CharacterRangeTests.cs
+++ b/src/System.Drawing.Common/tests/CharacterRangeTests.cs
@@ -1,9 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Drawing.Text;
 using Xunit;
 
 namespace System.Drawing.Tests

--- a/src/System.Drawing.Common/tests/ColorTranslatorTests.cs
+++ b/src/System.Drawing.Common/tests/ColorTranslatorTests.cs
@@ -1,10 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
 using System.Globalization;
-using System.Reflection;
-using System.Threading;
 using Xunit;
 
 namespace System.Drawing.Tests

--- a/src/System.Drawing.Common/tests/Design/CategoryNameCollectionTests.cs
+++ b/src/System.Drawing.Common/tests/Design/CategoryNameCollectionTests.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Linq;
 using Xunit;
 
 namespace System.Drawing.Design.Tests

--- a/src/System.Drawing.Common/tests/Drawing2D/AdjustableArrowCapTests.cs
+++ b/src/System.Drawing.Common/tests/Drawing2D/AdjustableArrowCapTests.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
 using Xunit;
 
 namespace System.Drawing.Drawing2D.Tests

--- a/src/System.Drawing.Common/tests/Drawing2D/CustomLineCapTests.cs
+++ b/src/System.Drawing.Common/tests/Drawing2D/CustomLineCapTests.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
 using Xunit;
 
 namespace System.Drawing.Drawing2D.Tests

--- a/src/System.Drawing.Common/tests/Drawing2D/GraphicsPathIteratorTests.cs
+++ b/src/System.Drawing.Common/tests/Drawing2D/GraphicsPathIteratorTests.cs
@@ -23,7 +23,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-using System.Collections.Generic;
 using Xunit;
 
 namespace System.Drawing.Drawing2D.Tests

--- a/src/System.Drawing.Common/tests/Drawing2D/GraphicsPathTests.cs
+++ b/src/System.Drawing.Common/tests/Drawing2D/GraphicsPathTests.cs
@@ -23,9 +23,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-using System.Collections.Generic;
-using System.ComponentModel;
-using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
 
 namespace System.Drawing.Drawing2D.Tests

--- a/src/System.Drawing.Common/tests/Drawing2D/HatchBrushTests.cs
+++ b/src/System.Drawing.Common/tests/Drawing2D/HatchBrushTests.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
 using Xunit;
 
 namespace System.Drawing.Drawing2D.Tests

--- a/src/System.Drawing.Common/tests/Drawing2D/LinearGradientBrushTests.cs
+++ b/src/System.Drawing.Common/tests/Drawing2D/LinearGradientBrushTests.cs
@@ -1,10 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Runtime.InteropServices;
 using Xunit;
 
 namespace System.Drawing.Drawing2D.Tests

--- a/src/System.Drawing.Common/tests/Drawing2D/MatrixTests.cs
+++ b/src/System.Drawing.Common/tests/Drawing2D/MatrixTests.cs
@@ -23,10 +23,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-using System.Collections.Generic;
-using System.Linq;
 using System.XUnit;
-using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
 
 namespace System.Drawing.Drawing2D.Tests

--- a/src/System.Drawing.Common/tests/Drawing2D/PathGradientBrushTests.cs
+++ b/src/System.Drawing.Common/tests/Drawing2D/PathGradientBrushTests.cs
@@ -23,9 +23,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
 using Xunit;
 
 namespace System.Drawing.Drawing2D.Tests

--- a/src/System.Drawing.Common/tests/DrawingTest.cs
+++ b/src/System.Drawing.Common/tests/DrawingTest.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Drawing.Imaging;
-using System.IO;
-using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
 using Xunit;
 
 namespace System.Drawing.Tests

--- a/src/System.Drawing.Common/tests/FontFamilyTests.cs
+++ b/src/System.Drawing.Common/tests/FontFamilyTests.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
 using System.Drawing.Text;
 using Xunit;
 

--- a/src/System.Drawing.Common/tests/FontTests.cs
+++ b/src/System.Drawing.Common/tests/FontTests.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
 using System.Drawing.Text;
 using System.Runtime.InteropServices;
 using Xunit;

--- a/src/System.Drawing.Common/tests/GraphicsTests.cs
+++ b/src/System.Drawing.Common/tests/GraphicsTests.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;

--- a/src/System.Drawing.Common/tests/Helpers.cs
+++ b/src/System.Drawing.Common/tests/Helpers.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Drawing.Printing;
-using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
 using Xunit;

--- a/src/System.Drawing.Common/tests/IconTests.cs
+++ b/src/System.Drawing.Common/tests/IconTests.cs
@@ -22,12 +22,9 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing.Imaging;
-using System.IO;
 using System.Reflection;
-using System.Runtime.InteropServices;
 using Microsoft.DotNet.RemoteExecutor;
 using Xunit;
 

--- a/src/System.Drawing.Common/tests/ImageTests.cs
+++ b/src/System.Drawing.Common/tests/ImageTests.cs
@@ -1,11 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
 using System.Drawing.Imaging;
-using System.IO;
-using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.DotNet.XUnitExtensions;

--- a/src/System.Drawing.Common/tests/Imaging/BitmapDataTests.cs
+++ b/src/System.Drawing.Common/tests/Imaging/BitmapDataTests.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.ComponentModel;
 using Xunit;
 
 namespace System.Drawing.Imaging.Tests

--- a/src/System.Drawing.Common/tests/Imaging/ColorMatrixTests.cs
+++ b/src/System.Drawing.Common/tests/Imaging/ColorMatrixTests.cs
@@ -27,7 +27,6 @@
 //   Jordi Mas i Hernandez (jordi@ximian.com)
 //   Sebastien Pouliot  <sebastien@ximian.com>
 //
-using System.Collections.Generic;
 using Xunit;
 
 namespace System.Drawing.Imaging.Tests

--- a/src/System.Drawing.Common/tests/Imaging/EncoderParameterTests.cs
+++ b/src/System.Drawing.Common/tests/Imaging/EncoderParameterTests.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
-using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
 
 namespace System.Drawing.Imaging.Tests

--- a/src/System.Drawing.Common/tests/Imaging/EncoderParametersTests.cs
+++ b/src/System.Drawing.Common/tests/Imaging/EncoderParametersTests.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
 using Xunit;
 
 namespace System.Drawing.Imaging.Tests

--- a/src/System.Drawing.Common/tests/Imaging/EncoderTests.cs
+++ b/src/System.Drawing.Common/tests/Imaging/EncoderTests.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
 using Xunit;
 
 namespace System.Drawing.Imaging.Tests

--- a/src/System.Drawing.Common/tests/Imaging/FrameDimensionTests.cs
+++ b/src/System.Drawing.Common/tests/Imaging/FrameDimensionTests.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
 using Xunit;
 
 namespace System.Drawing.Imaging.Tests

--- a/src/System.Drawing.Common/tests/Imaging/ImageAttributesTests.cs
+++ b/src/System.Drawing.Common/tests/Imaging/ImageAttributesTests.cs
@@ -23,10 +23,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-using System.Collections.Generic;
 using System.Drawing.Drawing2D;
-using System.Drawing.Tests;
-using System.IO;
 using Xunit;
 
 namespace System.Drawing.Imaging.Tests

--- a/src/System.Drawing.Common/tests/Imaging/ImageCodecInfoTests.cs
+++ b/src/System.Drawing.Common/tests/Imaging/ImageCodecInfoTests.cs
@@ -28,7 +28,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 using System.Collections;
-using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using Xunit;
 

--- a/src/System.Drawing.Common/tests/Imaging/ImageFormatTests.cs
+++ b/src/System.Drawing.Common/tests/Imaging/ImageFormatTests.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
-using System.IO;
 using Xunit;
 
 namespace System.Drawing.Imaging.Tests

--- a/src/System.Drawing.Common/tests/Imaging/MetafileTests.cs
+++ b/src/System.Drawing.Common/tests/Imaging/MetafileTests.cs
@@ -23,8 +23,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-using System.Collections.Generic;
-using System.IO;
 using System.Runtime.InteropServices;
 using Xunit;
 

--- a/src/System.Drawing.Common/tests/Imaging/PropertyItemTests.cs
+++ b/src/System.Drawing.Common/tests/Imaging/PropertyItemTests.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
 using Xunit;
 
 namespace System.Drawing.Imaging.Tests

--- a/src/System.Drawing.Common/tests/PenTests.cs
+++ b/src/System.Drawing.Common/tests/PenTests.cs
@@ -1,11 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
-using System.ComponentModel;
 using System.Drawing.Drawing2D;
 using System.Globalization;
-using System.Runtime.InteropServices;
 using Xunit;
 
 namespace System.Drawing.Tests

--- a/src/System.Drawing.Common/tests/PensTests.cs
+++ b/src/System.Drawing.Common/tests/PensTests.cs
@@ -1,9 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
 using System.Drawing.Drawing2D;
-using System.Reflection;
 using Xunit;
 
 namespace System.Drawing.Tests

--- a/src/System.Drawing.Common/tests/Printing/MarginsTests.cs
+++ b/src/System.Drawing.Common/tests/Printing/MarginsTests.cs
@@ -25,7 +25,6 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-using System.Collections.Generic;
 using Xunit;
 
 namespace System.Drawing.Printing.Tests

--- a/src/System.Drawing.Common/tests/Printing/PaperSizeTests.cs
+++ b/src/System.Drawing.Common/tests/Printing/PaperSizeTests.cs
@@ -26,7 +26,6 @@
 //  Andy Hume <andyhume32@yahoo.co.uk>
 //
 
-using System.Collections.Generic;
 using Xunit;
 
 namespace System.Drawing.Printing.Tests

--- a/src/System.Drawing.Common/tests/Printing/PreviewPrintControllerTests.cs
+++ b/src/System.Drawing.Common/tests/Printing/PreviewPrintControllerTests.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
 using Xunit;
 
 namespace System.Drawing.Printing.Tests

--- a/src/System.Drawing.Common/tests/Printing/PrintControllerTests.cs
+++ b/src/System.Drawing.Common/tests/Printing/PrintControllerTests.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
 using Xunit;
 
 namespace System.Drawing.Printing.Tests

--- a/src/System.Drawing.Common/tests/Printing/PrintDocumentTests.cs
+++ b/src/System.Drawing.Common/tests/Printing/PrintDocumentTests.cs
@@ -23,7 +23,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-using System.IO;
 using Xunit;
 
 namespace System.Drawing.Printing.Tests

--- a/src/System.Drawing.Common/tests/Printing/PrinterResolutionTests.cs
+++ b/src/System.Drawing.Common/tests/Printing/PrinterResolutionTests.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
 using System.ComponentModel;
 using Xunit;
 

--- a/src/System.Drawing.Common/tests/Printing/PrinterSettingsTests.cs
+++ b/src/System.Drawing.Common/tests/Printing/PrinterSettingsTests.cs
@@ -25,11 +25,8 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-using System.Collections.Generic;
-using System.ComponentModel;
 using System.Drawing.Imaging;
 using System.Globalization;
-using System.Linq;
 using Xunit;
 
 namespace System.Drawing.Printing.Tests

--- a/src/System.Drawing.Common/tests/RegionTests.cs
+++ b/src/System.Drawing.Common/tests/RegionTests.cs
@@ -22,7 +22,6 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-using System.Collections.Generic;
 using System.Drawing.Drawing2D;
 using System.Runtime.InteropServices;
 using Xunit;

--- a/src/System.Drawing.Common/tests/SolidBrushTests.cs
+++ b/src/System.Drawing.Common/tests/SolidBrushTests.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
 using Xunit;
 
 namespace System.Drawing.Tests

--- a/src/System.Drawing.Common/tests/StringFormatTests.cs
+++ b/src/System.Drawing.Common/tests/StringFormatTests.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
-using System.ComponentModel;
 using System.Drawing.Text;
 using Xunit;
 

--- a/src/System.Drawing.Common/tests/System/Drawing/FontConverterTests.cs
+++ b/src/System.Drawing.Common/tests/System/Drawing/FontConverterTests.cs
@@ -5,8 +5,6 @@ using System.ComponentModel.Design.Serialization;
 using System.Drawing;
 using System.Drawing.Text;
 using System.Globalization;
-using System.Linq;
-using NuGet.Frameworks;
 using Xunit;
 using static System.Drawing.FontConverter;
 

--- a/src/System.Drawing.Common/tests/System/Drawing/IconConverterTests.cs
+++ b/src/System.Drawing.Common/tests/System/Drawing/IconConverterTests.cs
@@ -4,7 +4,6 @@
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.Globalization;
-using System.IO;
 using Xunit;
 
 namespace System.ComponentModel.TypeConverterTests

--- a/src/System.Drawing.Common/tests/System/Drawing/ImageAnimator.ManualTests.cs
+++ b/src/System.Drawing.Common/tests/System/Drawing/ImageAnimator.ManualTests.cs
@@ -1,11 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing.Imaging;
-using System.IO;
-using System.Threading;
 using Xunit;
 
 namespace System.Drawing.Tests

--- a/src/System.Drawing.Common/tests/System/Drawing/ImageAnimatorTests.cs
+++ b/src/System.Drawing.Common/tests/System/Drawing/ImageAnimatorTests.cs
@@ -1,12 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace System.Drawing.Tests

--- a/src/System.Drawing.Common/tests/System/Drawing/ImageConverterTests.cs
+++ b/src/System.Drawing.Common/tests/System/Drawing/ImageConverterTests.cs
@@ -4,7 +4,6 @@
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.Globalization;
-using System.IO;
 using Xunit;
 
 namespace System.ComponentModel.TypeConverterTests

--- a/src/System.Drawing.Common/tests/System/Drawing/Printing/MarginsConverterTests.cs
+++ b/src/System.Drawing.Common/tests/System/Drawing/Printing/MarginsConverterTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.Design.Serialization;
 using System.Globalization;

--- a/src/System.Drawing.Common/tests/SystemBrushesTests.cs
+++ b/src/System.Drawing.Common/tests/SystemBrushesTests.cs
@@ -1,9 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
-using System.Drawing.Drawing2D;
-using System.Reflection;
 using Xunit;
 
 namespace System.Drawing.Tests

--- a/src/System.Drawing.Common/tests/SystemFontsTests.cs
+++ b/src/System.Drawing.Common/tests/SystemFontsTests.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using Xunit;
 

--- a/src/System.Drawing.Common/tests/SystemIconsTests.cs
+++ b/src/System.Drawing.Common/tests/SystemIconsTests.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
 using Xunit;
 
 namespace System.Drawing.Tests

--- a/src/System.Drawing.Common/tests/SystemPensTest.cs
+++ b/src/System.Drawing.Common/tests/SystemPensTest.cs
@@ -1,9 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
 using System.Drawing.Drawing2D;
-using System.Reflection;
 using Xunit;
 
 namespace System.Drawing.Tests

--- a/src/System.Drawing.Common/tests/Text/PrivateFontCollectionTests.cs
+++ b/src/System.Drawing.Common/tests/Text/PrivateFontCollectionTests.cs
@@ -1,9 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
-using System.Drawing.Tests;
-using System.IO;
 using System.Runtime.InteropServices;
 using Xunit;
 

--- a/src/System.Drawing.Common/tests/TextureBrushTests.cs
+++ b/src/System.Drawing.Common/tests/TextureBrushTests.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
-using System.ComponentModel;
 using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
 using Xunit;

--- a/src/System.Drawing.Common/tests/ToolboxBitmapAttributeTests.cs
+++ b/src/System.Drawing.Common/tests/ToolboxBitmapAttributeTests.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
-using System.Diagnostics;
 using Xunit;
 
 #pragma warning disable CA1050 // Declare types in namespaces

--- a/src/System.Drawing.Common/tests/mono/System.Drawing.Imaging/BmpCodecTests.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing.Imaging/BmpCodecTests.cs
@@ -30,10 +30,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-using System;
 using System.Drawing;
 using System.Drawing.Imaging;
-using System.IO;
 using Xunit;
 
 namespace MonoTests.System.Drawing.Imaging

--- a/src/System.Drawing.Common/tests/mono/System.Drawing.Imaging/GifCodecTests.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing.Imaging/GifCodecTests.cs
@@ -29,10 +29,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-using System;
 using System.Drawing;
 using System.Drawing.Imaging;
-using System.IO;
 using Xunit;
 
 namespace MonoTests.System.Drawing.Imaging

--- a/src/System.Drawing.Common/tests/mono/System.Drawing.Imaging/IconCodecTests.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing.Imaging/IconCodecTests.cs
@@ -29,10 +29,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-using System;
 using System.Drawing;
 using System.Drawing.Imaging;
-using System.IO;
 using Xunit;
 
 namespace MonoTests.System.Drawing.Imaging

--- a/src/System.Drawing.Common/tests/mono/System.Drawing.Imaging/JpegCodecTests.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing.Imaging/JpegCodecTests.cs
@@ -30,11 +30,9 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-using System;
 using System.Drawing;
 using System.Drawing.Imaging;
 using Xunit;
-using System.IO;
 
 namespace MonoTests.System.Drawing.Imaging
 {

--- a/src/System.Drawing.Common/tests/mono/System.Drawing.Imaging/PngCodecTests.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing.Imaging/PngCodecTests.cs
@@ -29,10 +29,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-using System;
 using System.Drawing;
 using System.Drawing.Imaging;
-using System.IO;
 using Xunit;
 
 namespace MonoTests.System.Drawing.Imaging

--- a/src/System.Drawing.Common/tests/mono/System.Drawing.Imaging/TiffCodecTests.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing.Imaging/TiffCodecTests.cs
@@ -29,10 +29,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-using System;
 using System.Drawing;
 using System.Drawing.Imaging;
-using System.IO;
 using Xunit;
 
 namespace MonoTests.System.Drawing.Imaging

--- a/src/System.Drawing.Common/tests/mono/System.Drawing/BitmapTests.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing/BitmapTests.cs
@@ -31,13 +31,9 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-using System;
 using System.Drawing;
 using System.Drawing.Imaging;
-using System.IO;
 using System.Runtime.InteropServices;
-using System.Runtime.Serialization;
-using System.Runtime.Serialization.Formatters.Binary;
 using System.Security.Cryptography;
 using System.Text;
 using System.Xml.Serialization;

--- a/src/System.Drawing.Common/tests/mono/System.Drawing/GraphicsTests.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing/GraphicsTests.cs
@@ -29,7 +29,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-using System;
 using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;

--- a/src/System.Drawing.Common/tests/mono/System.Imaging/MetafileTest.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Imaging/MetafileTest.cs
@@ -28,12 +28,9 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-using System;
 using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
-using System.IO;
-using System.Runtime.InteropServices;
 using Xunit;
 
 namespace MonoTests.System.Drawing.Imaging

--- a/src/System.Windows.Forms.Primitives/src/Interop/Ole32/Interop.GPStream.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Ole32/Interop.GPStream.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Buffers;
 using System.Runtime.InteropServices;
 using Windows.Win32.System.Com;
 
@@ -66,7 +65,7 @@ internal static partial class Interop
                     return HRESULT.STG_E_INVALIDPOINTER;
                 }
 
-                byte[] buffer = ArrayPool<byte>.Shared.Rent(4096);
+                using BufferScope<byte> buffer = new(4096);
 
                 ulong remaining = cb;
                 ulong totalWritten = 0;
@@ -92,8 +91,6 @@ internal static partial class Interop
                         totalWritten += written;
                     }
                 }
-
-                ArrayPool<byte>.Shared.Return(buffer);
 
                 if (pcbRead is not null)
                     *pcbRead = totalRead;

--- a/src/System.Windows.Forms.Primitives/src/System/BufferScope.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/BufferScope.cs
@@ -11,6 +11,11 @@ namespace System;
 ///  Allows renting a buffer from <see cref="ArrayPool{T}"/> with a using statement. Can be used directly as if it
 ///  were a <see cref="Span{T}"/>.
 /// </summary>
+/// <remarks>
+///  <para>
+///   Buffers are not cleared and as such their inital contents will be random.
+///  </para>
+/// </remarks>
 internal ref struct BufferScope<T>
 {
     private T[]? _array;

--- a/src/System.Windows.Forms.Primitives/src/System/BufferScope.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/BufferScope.cs
@@ -1,0 +1,127 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers;
+using System.Runtime.InteropServices;
+
+namespace System;
+
+/// <summary>
+///  Allows renting a buffer from <see cref="ArrayPool{T}"/> with a using statement. Can be used directly as if it
+///  were a <see cref="Span{T}"/>.
+/// </summary>
+internal ref struct BufferScope<T>
+{
+    private T[]? _array;
+    private Span<T> _span;
+
+    public BufferScope(int minimumLength)
+    {
+        _array = ArrayPool<T>.Shared.Rent(minimumLength);
+        _span = _array;
+    }
+
+    /// <summary>
+    ///  Create the <see cref="BufferScope{T}"/> with an initial buffer. Useful for creating with an initial stack
+    ///  allocated buffer.
+    /// </summary>
+    public BufferScope(Span<T> initialBuffer)
+    {
+        _array = null;
+        _span = initialBuffer;
+    }
+
+    /// <summary>
+    ///  Create the <see cref="BufferScope{T}"/> with an initial buffer. Useful for creating with an initial stack
+    ///  allocated buffer.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <example>
+    ///    <para>Creating with a stack allocated buffer:</para>
+    ///    <code>using BufferScope&lt;char> buffer = new(stackalloc char[64]);</code>
+    ///   </example>
+    ///  </para>
+    ///  <para>
+    ///   Stack allocated buffers should be kept small to avoid overflowing the stack.
+    ///  </para>
+    /// </remarks>
+    /// <param name="minimumLength">
+    ///  The required minimum length. If the <paramref name="initialBuffer"/> is not large enough, this will rent from
+    ///  the shared <see cref="ArrayPool{T}"/>.
+    /// </param>
+    public BufferScope(Span<T> initialBuffer, int minimumLength)
+    {
+        if (initialBuffer.Length >= minimumLength)
+        {
+            _array = null;
+            _span = initialBuffer;
+        }
+        else
+        {
+            _array = ArrayPool<T>.Shared.Rent(minimumLength);
+            _span = _array;
+        }
+    }
+
+    /// <summary>
+    ///  Ensure that the buffer has enough space for <paramref name="capacity"/> number of elements.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   Consider if creating new <see cref="BufferScope{T}"/> instances is possible and cleaner than using
+    ///   this method.
+    ///  </para>
+    /// </remarks>
+    /// <param name="copy">True to copy the existing elements when new space is allocated.</param>
+    public unsafe void EnsureCapacity(int capacity, bool copy = false)
+    {
+        if (_span!.Length >= capacity)
+        {
+            return;
+        }
+
+        T[] newArray = ArrayPool<T>.Shared.Rent(capacity);
+        if (copy)
+        {
+            _span.CopyTo(newArray);
+        }
+
+        if (_array is not null)
+        {
+            ArrayPool<T>.Shared.Return(_array);
+        }
+
+        _array = newArray;
+        _span = _array;
+    }
+
+    public ref T this[int i] => ref _span[i];
+
+    public Span<T> this[Range range] => _span[range];
+
+    public readonly Span<T> Slice(int start, int length) => _span.Slice(start, length);
+
+    public readonly ref T GetPinnableReference() => ref MemoryMarshal.GetReference(_span);
+
+    public int Length => _span.Length;
+
+    public readonly Span<T> AsSpan() => _span;
+
+    public static implicit operator Span<T>(BufferScope<T> scope) => scope._span;
+
+    public static implicit operator ReadOnlySpan<T>(BufferScope<T> scope) => scope._span;
+
+    public void Dispose()
+    {
+        if (_array is not null)
+        {
+            ArrayPool<T>.Shared.Return(_array);
+        }
+
+        _array = default;
+    }
+
+    public override readonly string ToString() => _span.ToString();
+}

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/Foundation/BSTR.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/Foundation/BSTR.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace Windows.Win32.Foundation;
@@ -15,10 +16,7 @@ internal readonly unsafe partial struct BSTR : IDisposable
     public void Dispose()
     {
         Marshal.FreeBSTR((nint)Value);
-        fixed (char** c = &Value)
-        {
-            *c = null;
-        }
+        Unsafe.AsRef(this) = default;
     }
 
     /// <summary>

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/Graphics/Gdi/HRGN.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/Graphics/Gdi/HRGN.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Buffers;
-
 namespace Windows.Win32.Graphics.Gdi
 {
     internal readonly partial struct HRGN
@@ -16,7 +14,7 @@ namespace Windows.Win32.Graphics.Gdi
                 return Array.Empty<RECT>();
             }
 
-            byte[] buffer = ArrayPool<byte>.Shared.Rent((int)regionDataSize);
+            using BufferScope<byte> buffer = new((int)regionDataSize);
 
             fixed (byte* b = buffer)
             {
@@ -26,7 +24,6 @@ namespace Windows.Win32.Graphics.Gdi
                 }
 
                 RECT[] result = RGNDATAHEADER.GetRegionRects((RGNDATAHEADER*)b);
-                ArrayPool<byte>.Shared.Return(buffer);
                 return result;
             }
         }

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/BufferScopeTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/BufferScopeTests.cs
@@ -1,0 +1,69 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Tests;
+
+public unsafe class BufferScopeTests
+{
+    [Fact]
+    public void Construct_WithStackAlloc()
+    {
+        using BufferScope<char> buffer = new(stackalloc char[10]);
+        Assert.Equal(10, buffer.Length);
+        buffer[0] = 'Y';
+        Assert.Equal("Y", buffer[..1].ToString());
+    }
+
+    [Fact]
+    public void Construct_WithStackAlloc_GrowAndCopy()
+    {
+        using BufferScope<char> buffer = new(stackalloc char[10]);
+        Assert.Equal(10, buffer.Length);
+        buffer[0] = 'Y';
+        buffer.EnsureCapacity(64, copy: true);
+        Assert.True(buffer.Length >= 64);
+        Assert.Equal("Y", buffer[..1].ToString());
+    }
+
+    [Fact]
+    public void Construct_WithStackAlloc_Pin()
+    {
+        using BufferScope<char> buffer = new(stackalloc char[10]);
+        Assert.Equal(10, buffer.Length);
+        buffer[0] = 'Y';
+        fixed (char* c = buffer)
+        {
+            Assert.Equal('Y', *c);
+            *c = 'Z';
+        }
+
+        Assert.Equal("Z", buffer[..1].ToString());
+    }
+
+    [Fact]
+    public void Construct_GrowAndCopy()
+    {
+        using BufferScope<char> buffer = new(32);
+        Assert.True(buffer.Length >= 32);
+        buffer[0] = 'Y';
+        buffer.EnsureCapacity(64, copy: true);
+        Assert.True(buffer.Length >= 64);
+        Assert.Equal("Y", buffer[..1].ToString());
+    }
+
+    [Fact]
+    public void Construct_Pin()
+    {
+        using BufferScope<char> buffer = new(64);
+        Assert.True(buffer.Length >= 64);
+        buffer[0] = 'Y';
+        fixed (char* c = buffer)
+        {
+            Assert.Equal('Y', *c);
+            *c = 'Z';
+        }
+
+        Assert.Equal("Z", buffer[..1].ToString());
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ControlPaint.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ControlPaint.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Buffers;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ControlPaint.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ControlPaint.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Buffers;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
@@ -170,8 +169,8 @@ namespace System.Windows.Forms
             HPALETTE palette = PInvoke.CreateHalftonePalette(dc);
             PInvoke.GetObject(palette, out uint entryCount);
 
-            byte[] bitmapInfoBuffer = ArrayPool<byte>.Shared
-                .Rent(checked((int)(sizeof(BITMAPINFOHEADER) + (sizeof(RGBQUAD) * entryCount))));
+            using BufferScope<byte> bitmapInfoBuffer = new
+                (checked((int)(sizeof(BITMAPINFOHEADER) + (sizeof(RGBQUAD) * entryCount))));
 
             // Create a DIB based on the screen DC to write into with a halftone palette
             fixed (byte* bi = bitmapInfoBuffer)
@@ -217,8 +216,6 @@ namespace System.Windows.Forms
                 {
                     throw new Win32Exception();
                 }
-
-                ArrayPool<byte>.Shared.Return(bitmapInfoBuffer);
             }
 
             try
@@ -275,7 +272,7 @@ namespace System.Windows.Forms
                 monochromeStride++;
             }
 
-            byte[] bits = new byte[monochromeStride * height];
+            using BufferScope<byte> buffer = new(monochromeStride * height);
             BitmapData data = bitmap.LockBits(
                 new Rectangle(0, 0, width, height),
                 ImageLockMode.ReadOnly,
@@ -293,7 +290,7 @@ namespace System.Windows.Forms
                     {
                         // Pixel is transparent; set bit to 1
                         int index = monochromeStride * y + x / 8;
-                        bits[index] |= (byte)(0x80 >> (x % 8));
+                        buffer[index] |= (byte)(0x80 >> (x % 8));
                     }
                 }
             }
@@ -301,9 +298,9 @@ namespace System.Windows.Forms
             bitmap.UnlockBits(data);
 
             // Create 1bpp.
-            fixed (byte* pBits = bits)
+            fixed (byte* b = buffer)
             {
-                return (IntPtr)PInvoke.CreateBitmap(size.Width, size.Height, nPlanes: 1, nBitCount: 1, pBits);
+                return (IntPtr)PInvoke.CreateBitmap(size.Width, size.Height, nPlanes: 1, nBitCount: 1, b);
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.IconRegion.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.IconRegion.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Buffers;
 using System.Drawing;
 
 namespace System.Windows.Forms
@@ -52,7 +51,7 @@ namespace System.Windows.Forms
 
                     // If width is not multiple of 16, we need to allocate BitmapBitsAllocationSize for remaining bits.
                     int widthInBytes = 2 * ((size.Width + 15) / bitmapBitsAllocationSize); // its in bytes.
-                    byte[] bits = ArrayPool<byte>.Shared.Rent(widthInBytes * size.Height);
+                    using BufferScope<byte> bits = new(widthInBytes * size.Height);
                     fixed (void* pbits = bits)
                     {
                         PInvoke.GetBitmapBits(mask, bits.Length, pbits);
@@ -71,7 +70,6 @@ namespace System.Windows.Forms
                     }
 
                     _region.Intersect(new Rectangle(0, 0, size.Width, size.Height));
-                    ArrayPool<byte>.Shared.Return(bits);
 
                     return _region;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FolderBrowserDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FolderBrowserDialog.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Buffers;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Drawing.Design;
@@ -417,7 +416,7 @@ namespace System.Windows.Forms
             }
 
             delegate* unmanaged[Stdcall]<HWND, uint, LPARAM, LPARAM, int> callback = &FolderBrowserDialog_BrowseCallbackProc;
-            char[] displayName = ArrayPool<char>.Shared.Rent(PInvoke.MAX_PATH + 1);
+            using BufferScope<char> displayName = new(PInvoke.MAX_PATH + 1);
             var handle = GCHandle.Alloc(this);
             try
             {
@@ -456,7 +455,6 @@ namespace System.Windows.Forms
             finally
             {
                 handle.Free();
-                ArrayPool<char>.Shared.Return(displayName);
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Help.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Help.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Buffers;
 using System.Diagnostics;
 using System.Drawing;
 using System.Globalization;
@@ -148,15 +147,13 @@ namespace System.Windows.Forms
                 if (requiredStringSize > 0)
                 {
                     // It's able to make it a short path.
-                    char[] shortName = ArrayPool<char>.Shared.Rent((int)requiredStringSize);
+                    using BufferScope<char> shortName = new((int)requiredStringSize);
                     fixed (char* pShortName = shortName)
                     {
                         requiredStringSize = PInvoke.GetShortPathName(localPath, pShortName, requiredStringSize);
                         // If it can't make it a  short path, just leave the path we had.
-                        pathAndFileName = new string(pShortName, 0, (int)requiredStringSize);
+                        pathAndFileName = shortName[..(int)requiredStringSize].ToString();
                     }
-
-                    ArrayPool<char>.Shared.Return(shortName);
                 }
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.MonthCalendarAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.MonthCalendarAccessibleObject.cs
@@ -290,8 +290,7 @@ namespace System.Windows.Forms
                     return string.Empty;
                 }
 
-                const int nameLength = 20;
-                Span<char> name = stackalloc char[nameLength];
+                Span<char> name = stackalloc char[20];
 
                 fixed (char* pName = name)
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PageSetupDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PageSetupDialog.cs
@@ -293,12 +293,16 @@ namespace System.Windows.Forms
             // EnableMetric allows the users to choose between the AutoConversion or not.
             if (EnableMetric)
             {
-                //take the Units of Measurement while determining the PrinterUnits...
+                // Take the Units of Measurement while determining the Printer Units.
                 Span<char> buffer = stackalloc char[2];
                 int result;
                 fixed (char* pBuffer = buffer)
                 {
-                    result = PInvoke.GetLocaleInfoEx(PInvoke.LOCALE_NAME_SYSTEM_DEFAULT, PInvoke.LOCALE_IMEASURE, pBuffer, 2);
+                    result = PInvoke.GetLocaleInfoEx(
+                        PInvoke.LOCALE_NAME_SYSTEM_DEFAULT,
+                        PInvoke.LOCALE_IMEASURE,
+                        pBuffer,
+                        buffer.Length);
                 }
 
                 if (result > 0 && int.Parse(buffer, NumberStyles.Integer, CultureInfo.InvariantCulture) == 0)


### PR DESCRIPTION
`BufferScope` is a ref struct that handles rental and return from the `ArrayPool` as well as:

- Initial stack allocated buffers
- Reacquisition of buffers (with content copying if necessary)
- Span semantics (converters, range operators, etc.)

It significantly simplifies creating temporary buffers, particularly in cases where you need to make multiple calls (for the buffer not being large enough).

Also add `[SkipLocalsInit]` in a few places (so the stack allocated buffer doesn't get zeroed out).

Did a global removal of unused usings (most of the file changes are just this).

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8999)