### PR TITLE
Change Font cache in AxHost to ConditionalWeakTable

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/RefCountedCache.CacheEntry.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/RefCountedCache.CacheEntry.cs
@@ -39,8 +39,10 @@ namespace System.Windows.Forms
             ///  Removes a reference to this entry.
             /// </summary>
             /// <remarks>
-            ///  This will dispose of the entry when the ref count reaches zero- if the entry isn't actually
-            ///  cached <see cref="_cached"/>.
+            ///  <para>
+            ///   This will dispose of the entry when the ref count reaches zero- if the entry isn't actually
+            ///   cached <see cref="_cached"/>.
+            ///  </para>
             /// </remarks>
             public virtual void RemoveRef()
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.cs
@@ -12,6 +12,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
 using System.Globalization;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Microsoft.VisualStudio.Shell;
 using Windows.Win32.System.Com;
@@ -73,7 +74,7 @@ namespace System.Windows.Forms
         private static readonly Guid s_maskEdit_Clsid = new("{c932ba85-4374-101b-a56c-00aa003668dc}");
 
         // Static state for perf optimization
-        private static Dictionary<Font, FONTDESC> s_fontTable;
+        private static ConditionalWeakTable<Font, object> s_fontTable;
 
         // BitVector32 masks for various internal state flags.
         private static readonly int s_ocxStateSet = BitVector32.CreateMask();
@@ -3853,11 +3854,11 @@ namespace System.Windows.Forms
         {
             if (s_fontTable is null)
             {
-                s_fontTable = new Dictionary<Font, FONTDESC>();
+                s_fontTable = new();
             }
-            else if (s_fontTable.TryGetValue(font, out FONTDESC cachedFDesc))
+            else if (s_fontTable.TryGetValue(font, out object cachedFDesc))
             {
-                return cachedFDesc;
+                return (FONTDESC)cachedFDesc;
             }
 
             LOGFONTW logfont = LOGFONTW.FromFont(font);
@@ -3872,7 +3873,7 @@ namespace System.Windows.Forms
                 fStrikethrough = font.Strikeout
             };
 
-            s_fontTable[font] = fdesc;
+            s_fontTable.Add(font, fdesc);
             return fdesc;
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Internal/Gdi/FontCache.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Internal/Gdi/FontCache.cs
@@ -10,12 +10,15 @@ namespace System.Windows.Forms
     ///  Thread safe cache of <see cref="HFONT"/> objects created from <see cref="Font"/> objects.
     /// </summary>
     /// <remarks>
-    ///  This adds a slight managed memory overhead to creating the <see cref="HFONT"/>, but saves 56 bytes and
-    ///  98%+ of the time on each cache request that hits (taking less than 1 us as opposed to 50-100+ us).
-    ///
-    ///  This cache is optimized for retrieval speed and limiting the number of unused GDI handles we're caching while
-    ///  hopefully handling the majority of application use cases. There is a limit of 65K GDI handles system wide and
-    ///  10K (default) per process.
+    ///  <para>
+    ///   This adds a slight managed memory overhead to creating the <see cref="HFONT"/>, but saves 56 bytes and
+    ///   98%+ of the time on each cache request that hits (taking less than 1 us as opposed to 50-100+ us).
+    ///  </para>
+    ///  <para>
+    ///   This cache is optimized for retrieval speed and limiting the number of unused GDI handles we're caching while
+    ///   hopefully handling the majority of application use cases. There is a limit of 65K GDI handles system wide and
+    ///   10K (default) per process.
+    ///  </para>
     /// </remarks>
     internal sealed partial class FontCache : RefCountedCache<HFONT, FontCache.Data, (Font Font, FONT_QUALITY Quality)>
     {


### PR DESCRIPTION
Fonts were getting permanently rooted (leaking) here.

Did some minor comment cleanup in Cache classes.
