### PR TITLE
BindingNavigatorDesigner

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/BindingNavigatorDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/BindingNavigatorDesigner.cs
@@ -4,12 +4,6 @@
 
 #nullable disable
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace System.Windows.Forms.Design
 {
     /// <summary>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/BindingNavigatorDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/BindingNavigatorDesigner.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms.Design
 {
     /// <summary>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/BindingNavigatorDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/BindingNavigatorDesigner.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace System.Windows.Forms.Design
+{
+    /// <summary>
+    ///  Designer for the BindingNavigator class.
+    /// </summary>
+    internal class BindingNavigatorDesigner : ToolStripDesigner
+    {
+    }
+}


### PR DESCRIPTION
Fixes #8208

This should fix the BindingNavigator not been shown in the Toolbox.

Seems like the class didn't exist. See https://github.com/dotnet/winforms/blob/b3a0efc78e82ab0deba0d25d6f196f996e13bab5/src/System.Windows.Forms/src/System/Windows/Forms/BindingNavigator.cs#L13

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9009)