### PR TITLE
Fix error dialog on editing AutoCompleteCustomSource in PropertyGrid

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/AutoCompleteStringCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AutoCompleteStringCollection.cs
@@ -168,7 +168,7 @@ namespace System.Windows.Forms
 
         void IList.Remove(object value) => Remove((string)value);
 
-        void ICollection.CopyTo(Array array, int index) => data.CopyTo((string[])array, index);
+        void ICollection.CopyTo(Array array, int index) => ((ICollection)data).CopyTo(array, index);
 
         public IEnumerator GetEnumerator() => data.GetEnumerator();
     }


### PR DESCRIPTION
Fixes #9008

Regression was introduced in https://github.com/dotnet/winforms/pull/8142 (from .NET 8). Replacing cast to be similar to other `CopyTo` overrides, for example:
https://github.com/dotnet/winforms/blob/024a9ab98d4bea535ce9fe6c473326bcd00464b7/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellCollection.cs#L48
https://github.com/dotnet/winforms/blob/024a9ab98d4bea535ce9fe6c473326bcd00464b7/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutStyleCollection.cs#L130

## Proposed changes

- Replace invalid cast to string[] with cast to ICollection

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- AutoCompleteCustomSource property can be edited

## Regression? 

- Yes

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/26474449/233242927-0d02986d-4873-4f39-ba96-69a295c20c40.png)

### After

![autocomplete-fix](https://user-images.githubusercontent.com/102954094/233406119-c2cb8bcb-33f1-4137-9603-4184d440fad8.gif)


## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- .NET 8.0.100-preview.4.23218.21


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9012)