### PR TITLE
Add checked ToolStripMenuItems to WinformsControlsTest app

### DIFF
--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MenuStripAndCheckedListBox.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MenuStripAndCheckedListBox.Designer.cs
@@ -37,7 +37,6 @@ namespace WinformsControlsTest
             this.newToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.openToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
-            this.checkUnCheckToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.memoryCardFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.navigationToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.newToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
@@ -51,6 +50,13 @@ namespace WinformsControlsTest
             this.editToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.viewToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.insertToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.checkStateSamplesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.uncheckedToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.uncheckedCheckOnClickToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.checkedToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.checkedCheckOnClickToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.indeterminateToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.indeterminateCheckOnClickToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.currentDpiLabel = new System.Windows.Forms.Label();
             this.menuStrip1.SuspendLayout();
             this.SuspendLayout();
@@ -63,7 +69,8 @@ namespace WinformsControlsTest
             this.fileToolStripMenuItem,
             this.editToolStripMenuItem,
             this.viewToolStripMenuItem,
-            this.insertToolStripMenuItem});
+            this.insertToolStripMenuItem,
+            this.checkStateSamplesToolStripMenuItem});
             this.menuStrip1.Location = new System.Drawing.Point(0, 0);
             this.menuStrip1.Name = "menuStrip1";
             this.menuStrip1.Padding = new System.Windows.Forms.Padding(12, 4, 0, 4);
@@ -77,7 +84,6 @@ namespace WinformsControlsTest
             this.newToolStripMenuItem,
             this.openToolStripMenuItem1,
             this.toolStripSeparator1,
-            this.checkUnCheckToolStripMenuItem,
             this.memoryCardFileToolStripMenuItem,
             this.toolStripSeparator2,
             this.exitToolStripMenuItem});
@@ -104,16 +110,6 @@ namespace WinformsControlsTest
             //
             this.toolStripSeparator1.Name = "toolStripSeparator1";
             this.toolStripSeparator1.Size = new System.Drawing.Size(398, 6);
-            //
-            // checkUnCheckToolStripMenuItem
-            //
-            this.checkUnCheckToolStripMenuItem.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-            this.checkUnCheckToolStripMenuItem.Checked = true;
-            this.checkUnCheckToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.checkUnCheckToolStripMenuItem.Name = "checkUnCheckToolStripMenuItem";
-            this.checkUnCheckToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.C)));
-            this.checkUnCheckToolStripMenuItem.Size = new System.Drawing.Size(401, 44);
-            this.checkUnCheckToolStripMenuItem.Text = "Check/UnCheck";
             //
             // memoryCardFileToolStripMenuItem
             //
@@ -205,6 +201,73 @@ namespace WinformsControlsTest
             this.insertToolStripMenuItem.Size = new System.Drawing.Size(94, 38);
             this.insertToolStripMenuItem.Text = "Insert";
             //
+            // checkStateSamplesToolStripMenuItem
+            //
+            this.checkStateSamplesToolStripMenuItem.Name = "checkStateSamplesToolStripMenuItem";
+            this.checkStateSamplesToolStripMenuItem.Size = new System.Drawing.Size(200, 38);
+            this.checkStateSamplesToolStripMenuItem.Text = "CheckState samples";
+            this.checkStateSamplesToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.uncheckedToolStripMenuItem,
+            this.uncheckedCheckOnClickToolStripMenuItem,
+            this.checkedToolStripMenuItem,
+            this.checkedCheckOnClickToolStripMenuItem,
+            this.indeterminateToolStripMenuItem,
+            this.indeterminateCheckOnClickToolStripMenuItem});
+            // 
+            // uncheckedToolStripMenuItem
+            // 
+            this.uncheckedToolStripMenuItem.Name = "uncheckedToolStripMenuItem";
+            this.uncheckedToolStripMenuItem.Size = new System.Drawing.Size(401, 44);
+            this.uncheckedToolStripMenuItem.Text = "Unchecked CheckOnClick(F)";
+            this.uncheckedToolStripMenuItem.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            // 
+            // uncheckedCheckOnClickToolStripMenuItem
+            // 
+            this.uncheckedCheckOnClickToolStripMenuItem.CheckOnClick = true;
+            this.uncheckedCheckOnClickToolStripMenuItem.Name = "uncheckedCheckOnClickToolStripMenuItem";
+            this.uncheckedCheckOnClickToolStripMenuItem.Size = new System.Drawing.Size(401, 44);
+            this.uncheckedCheckOnClickToolStripMenuItem.Text = "Unchecked CheckOnClick(T)";
+            this.uncheckedCheckOnClickToolStripMenuItem.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.uncheckedCheckOnClickToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.C)));
+            // 
+            // checkedToolStripMenuItem
+            // 
+            this.checkedToolStripMenuItem.Checked = true;
+            this.checkedToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.checkedToolStripMenuItem.Name = "checkedToolStripMenuItem";
+            this.checkedToolStripMenuItem.Size = new System.Drawing.Size(401, 44);
+            this.checkedToolStripMenuItem.Text = "Checked CheckOnClick(F)";
+            this.checkedToolStripMenuItem.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            // 
+            // checkedCheckOnClickToolStripMenuItem
+            // 
+            this.checkedCheckOnClickToolStripMenuItem.Checked = true;
+            this.checkedCheckOnClickToolStripMenuItem.CheckOnClick = true;
+            this.checkedCheckOnClickToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.checkedCheckOnClickToolStripMenuItem.Name = "checkedCheckOnClickToolStripMenuItem";
+            this.checkedCheckOnClickToolStripMenuItem.Size = new System.Drawing.Size(401, 44);
+            this.checkedCheckOnClickToolStripMenuItem.Text = "Checked CheckOnClick(T)";
+            this.checkedCheckOnClickToolStripMenuItem.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            // 
+            // indeterminateToolStripMenuItem
+            // 
+            this.indeterminateToolStripMenuItem.Checked = true;
+            this.indeterminateToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Indeterminate;
+            this.indeterminateToolStripMenuItem.Name = "indeterminateToolStripMenuItem";
+            this.indeterminateToolStripMenuItem.Size = new System.Drawing.Size(401, 44);
+            this.indeterminateToolStripMenuItem.Text = "Indeterminate CheckOnClick(F)";
+            this.indeterminateToolStripMenuItem.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            // 
+            // indeterminateCheckOnClickToolStripMenuItem
+            // 
+            this.indeterminateCheckOnClickToolStripMenuItem.Checked = true;
+            this.indeterminateCheckOnClickToolStripMenuItem.CheckOnClick = true;
+            this.indeterminateCheckOnClickToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Indeterminate;
+            this.indeterminateCheckOnClickToolStripMenuItem.Name = "indeterminateCheckOnClickToolStripMenuItem";
+            this.indeterminateCheckOnClickToolStripMenuItem.Size = new System.Drawing.Size(401, 44);
+            this.indeterminateCheckOnClickToolStripMenuItem.Text = "Indeterminate CheckOnClick(T)";
+            this.indeterminateCheckOnClickToolStripMenuItem.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            //
             // currentDpiLabel
             //
             this.currentDpiLabel.AutoSize = true;
@@ -242,7 +305,6 @@ namespace WinformsControlsTest
         private System.Windows.Forms.ToolStripMenuItem newToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem openToolStripMenuItem1;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
-        private System.Windows.Forms.ToolStripMenuItem checkUnCheckToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem memoryCardFileToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem navigationToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem newToolStripMenuItem1;
@@ -256,6 +318,13 @@ namespace WinformsControlsTest
         private System.Windows.Forms.ToolStripMenuItem editToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem viewToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem insertToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem checkStateSamplesToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem uncheckedToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem uncheckedCheckOnClickToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem checkedToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem checkedCheckOnClickToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem indeterminateToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem indeterminateCheckOnClickToolStripMenuItem;
         private System.Windows.Forms.Label currentDpiLabel;
     }
 }


### PR DESCRIPTION
Part of #9005


## Proposed changes

- Add menu items to cover different checked combinations, replacing previous single checked item

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Easier to test CheckState values of ToolStripMenuItem from winforms repo

## Regression? 

- No

## Risk

- None

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/102954094/233435055-144c7fe2-7bbf-4ac4-bd5f-4b920fcbe101.png)
A single checked item, that cannot be unchecked

### After

![image](https://user-images.githubusercontent.com/102954094/233434492-30a989a9-70ea-4e79-9d8d-6f1b86ec60dc.png)
Multiple items covering all checked options

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->

As expected, Narrator announces checked state where needed:

> Unchecked CheckOnClick(F), menu item, <say-as interpret-as="spell">1</say-as> of <say-as interpret-as="spell">6</say-as>, 
> Unchecked CheckOnClick(T), menu item, unchecked, <say-as interpret-as="spell">2</say-as> of <say-as interpret-as="spell">6</say-as>, Ctrl+ C, 
> Checked CheckOnClick(F), menu item, checked, <say-as interpret-as="spell">3</say-as> of <say-as interpret-as="spell">6</say-as>, 
> Checked CheckOnClick(T), menu item, checked, <say-as interpret-as="spell">4</say-as> of <say-as interpret-as="spell">6</say-as>, 
> Indeterminate CheckOnClick(F), menu item, indeterminate, <say-as interpret-as="spell">5</say-as> of <say-as interpret-as="spell">6</say-as>, 
> Indeterminate CheckOnClick(T), menu item, indeterminate, <say-as interpret-as="spell">6</say-as> of <say-as interpret-as="spell">6</say-as>, 


## Test environment(s) <!-- Remove any that don't apply -->

- .NET 8.0.100-preview.4.23218.21
