### PR TITLE
Ensure the native dialogs are released

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.Vista.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.Vista.cs
@@ -4,7 +4,6 @@
 
 using System.ComponentModel;
 using System.Diagnostics;
-using System.Runtime.InteropServices;
 using Windows.Win32.UI.Controls.Dialogs;
 using static Windows.Win32.UI.Controls.Dialogs.OPEN_FILENAME_FLAGS;
 using static Windows.Win32.UI.Shell.FILEOPENDIALOGOPTIONS;
@@ -21,37 +20,32 @@ namespace System.Windows.Forms
                 && SettingsSupportVistaDialog
                 && SystemInformation.BootMode == BootMode.Normal;
 
-        private protected abstract unsafe IFileDialog* CreateVistaDialog();
+        private protected abstract unsafe ComScope<IFileDialog> CreateVistaDialog();
 
         private unsafe bool TryRunDialogVista(HWND hWndOwner, out bool returnValue)
         {
-            IFileDialog* dialog;
-            try
+            using ComScope<IFileDialog> dialog = CreateVistaDialog();
+
+            if (dialog.IsNull)
             {
                 // Creating the Vista dialog can fail on Windows Server Core, even if the
                 // Server Core App Compatibility FOD is installed.
-                dialog = CreateVistaDialog();
-            }
-            catch (COMException)
-            {
                 returnValue = false;
                 return false;
             }
 
             OnBeforeVistaDialog(dialog);
-            IFileDialogEvents* events = ComHelpers.GetComPointer<IFileDialogEvents>(new VistaDialogEvents(this));
+            using var events = ComHelpers.GetComScope<IFileDialogEvents>(new VistaDialogEvents(this));
 
-            dialog->Advise(events, out uint eventCookie);
+            dialog.Value->Advise(events, out uint eventCookie);
             try
             {
-                returnValue = dialog->Show(hWndOwner) == HRESULT.S_OK;
+                returnValue = dialog.Value->Show(hWndOwner) == HRESULT.S_OK;
                 return true;
             }
             finally
             {
-                dialog->Unadvise(eventCookie);
-                uint count = events->Release();
-                Debug.Assert(count == 0);
+                dialog.Value->Unadvise(eventCookie);
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.Vista.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.Vista.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.ComponentModel;
-using System.Diagnostics;
 using Windows.Win32.UI.Controls.Dialogs;
 using static Windows.Win32.UI.Controls.Dialogs.OPEN_FILENAME_FLAGS;
 using static Windows.Win32.UI.Shell.FILEOPENDIALOGOPTIONS;
@@ -105,7 +104,7 @@ namespace System.Windows.Forms
                 | OFN_ENABLESIZING  // These shouldn't be set in options (only set in the flags for the legacy dialog)
                 | OFN_EXPLORER;     // These shouldn't be set in options (only set in the flags for the legacy dialog)
 
-            Debug.Assert((UnexpectedOptions & _fileNameFlags) == 0, "Unexpected FileDialog options");
+            System.Diagnostics.Debug.Assert((UnexpectedOptions & _fileNameFlags) == 0, "Unexpected FileDialog options");
 #endif
 
             FILEOPENDIALOGOPTIONS result = (FILEOPENDIALOGOPTIONS)_fileNameFlags & BlittableOptions;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OpenFileDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OpenFileDialog.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.ComponentModel;
+using System.Diagnostics;
 using Windows.Win32.System.Com;
 using Windows.Win32.UI.Controls.Dialogs;
 using static Windows.Win32.UI.Controls.Dialogs.OPEN_FILENAME_FLAGS;
@@ -164,15 +165,16 @@ namespace System.Windows.Forms
             return files;
         }
 
-        private protected override unsafe IFileDialog* CreateVistaDialog()
+        private protected override unsafe ComScope<IFileDialog> CreateVistaDialog()
         {
-            PInvoke.CoCreateInstance(
+            HRESULT hr = PInvoke.CoCreateInstance(
                 in CLSID.FileOpenDialog,
                 pUnkOuter: null,
                 CLSCTX.CLSCTX_INPROC_SERVER | CLSCTX.CLSCTX_LOCAL_SERVER | CLSCTX.CLSCTX_REMOTE_SERVER,
-                out IFileDialog* fileDialog).ThrowOnFailure();
+                out IFileDialog* fileDialog);
 
-            return fileDialog;
+            Debug.Assert(hr.Succeeded);
+            return new(fileDialog);
         }
 
         [Browsable(false)]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SaveFileDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SaveFileDialog.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.ComponentModel;
+using System.Diagnostics;
 using Windows.Win32.System.Com;
 using Windows.Win32.UI.Controls.Dialogs;
 using static Windows.Win32.UI.Controls.Dialogs.OPEN_FILENAME_FLAGS;
@@ -162,15 +163,16 @@ namespace System.Windows.Forms
             return item.IsNull ? Array.Empty<string>() : new string[] { GetFilePathFromShellItem(item) };
         }
 
-        private protected override unsafe IFileDialog* CreateVistaDialog()
+        private protected override unsafe ComScope<IFileDialog> CreateVistaDialog()
         {
-            PInvoke.CoCreateInstance(
+            HRESULT hr = PInvoke.CoCreateInstance(
                 in CLSID.FileSaveDialog,
                 pUnkOuter: null,
                 CLSCTX.CLSCTX_INPROC_SERVER | CLSCTX.CLSCTX_LOCAL_SERVER | CLSCTX.CLSCTX_REMOTE_SERVER,
                 out IFileDialog* fileDialog);
 
-            return fileDialog;
+            Debug.Assert(hr.Succeeded);
+            return new(fileDialog);
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FileDialogTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FileDialogTests.cs
@@ -811,7 +811,7 @@ namespace System.Windows.Forms.Tests
                 return RunFileDialogAction(*ofn);
             }
 
-            private protected override IFileDialog* CreateVistaDialog() => null;
+            private protected override ComScope<IFileDialog> CreateVistaDialog() => default;
 
             private protected override string[] ProcessVistaFiles(IFileDialog* dialog) => null;
 


### PR DESCRIPTION
We weren't releasing the native dialog classes we create. Use scopes and don't throw/catch, just return if we're unable to create the dialog.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9017)