### PR TITLE
Fix null reference in PermonV2 mode.

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripRenderer.cs
@@ -634,7 +634,7 @@ namespace System.Windows.Forms
                 Point[] arrow = null;
 
                 // We need the Elvis operator here, since at design time at this point Item can be null.
-                if (e.Item?.DeviceDpi != previousDeviceDpi && DpiHelper.IsPerMonitorV2Awareness)
+                if (e.Item is not null && e.Item.DeviceDpi != previousDeviceDpi && DpiHelper.IsPerMonitorV2Awareness)
                 {
                     previousDeviceDpi = e.Item.DeviceDpi;
                     ScaleArrowOffsetsIfNeeded(e.Item.DeviceDpi);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripRenderer.cs
@@ -633,7 +633,7 @@ namespace System.Windows.Forms
 
                 Point[] arrow = null;
 
-                // We need the Elvis operator here, since at design time at this point Item can be null.
+                // At design time, Item can be null.
                 if (e.Item is not null && e.Item.DeviceDpi != previousDeviceDpi && DpiHelper.IsPerMonitorV2Awareness)
                 {
                     previousDeviceDpi = e.Item.DeviceDpi;


### PR DESCRIPTION
Null check should be explicit to avoid further access of the Item object. It is not uncovered until we enabled PermonV2 mode for the designer.

Fixes #[5125](https://github.com/microsoft/winforms-designer/issues/5125)
Fixes #[5124](https://github.com/microsoft/winforms-designer/issues/5124)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9018)