### PR TITLE
Dev/dreddy/anchor cherrypick

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/AnchorEditor.AnchorUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/AnchorEditor.AnchorUI.cs
@@ -72,11 +72,12 @@ public sealed partial class AnchorEditor
             return baseVar;
         }
 
-        internal virtual void InitializeComponent()
-        {
-            int XBORDER = SystemInformation.Border3DSize.Width;
-            int YBORDER = SystemInformation.Border3DSize.Height;
-            SetBounds(0, 0, 90, 90);
+            internal virtual void InitializeComponent()
+            {
+                int XBORDER = SystemInformation.Border3DSize.Width;
+                int YBORDER = SystemInformation.Border3DSize.Height;
+                SuspendLayout();
+                SetBounds(0, 0, 90, 90);
 
             AccessibleName = SR.AnchorEditorAccName;
 
@@ -122,16 +123,18 @@ public sealed partial class AnchorEditor
                 container
             });
 
-            container.Controls.Clear();
-            container.Controls.AddRange(new Control[]
-            {
-                control,
-                top,
-                left,
-                bottom,
-                right
-            });
-        }
+                container.Controls.Clear();
+                container.Controls.AddRange(new Control[]
+                {
+                    control,
+                    top,
+                    left,
+                    bottom,
+                    right
+                });
+
+                ResumeLayout(false);
+            }
 
         protected override void OnGotFocus(EventArgs e)
         {

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/AnchorEditor.AnchorUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/AnchorEditor.AnchorUI.cs
@@ -72,12 +72,12 @@ public sealed partial class AnchorEditor
             return baseVar;
         }
 
-            internal virtual void InitializeComponent()
-            {
-                int XBORDER = SystemInformation.Border3DSize.Width;
-                int YBORDER = SystemInformation.Border3DSize.Height;
-                SuspendLayout();
-                SetBounds(0, 0, 90, 90);
+        internal virtual void InitializeComponent()
+        {
+            int XBORDER = SystemInformation.Border3DSize.Width;
+            int YBORDER = SystemInformation.Border3DSize.Height;
+            SuspendLayout();
+            SetBounds(0, 0, 90, 90);
 
             AccessibleName = SR.AnchorEditorAccName;
 
@@ -123,18 +123,17 @@ public sealed partial class AnchorEditor
                 container
             });
 
-                container.Controls.Clear();
-                container.Controls.AddRange(new Control[]
-                {
+            container.Controls.Clear();
+            container.Controls.AddRange(new Control[]
+            {
                     control,
                     top,
                     left,
                     bottom,
                     right
-                });
-
-                ResumeLayout(false);
-            }
+            });
+            ResumeLayout(false);
+        }
 
         protected override void OnGotFocus(EventArgs e)
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
@@ -47,7 +47,7 @@ public class ContainerControl : ScrollableControl, IContainerControl
     /// </summary>
     private bool _isScaledByDpiChangedEvent;
 
-        private BitVector32 _state;
+    private BitVector32 _state;
 
     /// <summary>
     ///  True if we need to perform scaling when layout resumes
@@ -1430,21 +1430,21 @@ public class ContainerControl : ScrollableControl, IContainerControl
         }
     }
 
-        internal void ScaleContainerForDpi(int deviceDpiNew, int deviceDpiOld, Rectangle suggestedRectangle)
+    internal void ScaleContainerForDpi(int deviceDpiNew, int deviceDpiOld, Rectangle suggestedRectangle)
+    {
+        CommonProperties.xClearAllPreferredSizeCaches(this);
+        SuspendAllLayout(this);
+        try
         {
-            CommonProperties.xClearAllPreferredSizeCaches(this);
-            SuspendAllLayout(this);
-            try
+            if (LocalAppContextSwitches.ScaleTopLevelFormMinMaxSizeForDpi)
             {
-                if (LocalAppContextSwitches.ScaleTopLevelFormMinMaxSizeForDpi)
-                {
-                    // AutoscaleFactor is not updated until after the OnFontChanged event is raised. Hence, computing
-                    // factor based on the change in bounds of the Form, which aligns with AutoscaleFactor for both
-                    // AutoscaleMode is Font and/or Dpi. Especially after adding support for non-linear Form size in PMv2.
-                    float xScaleFactor = (float)suggestedRectangle.Width / Width;
-                    float yScaleFactor = (float)suggestedRectangle.Height / Height;
-                    ScaleMinMaxSize(xScaleFactor, yScaleFactor, updateContainerSize: false);
-                }
+                // AutoscaleFactor is not updated until after the OnFontChanged event is raised. Hence, computing
+                // factor based on the change in bounds of the Form, which aligns with AutoscaleFactor for both
+                // AutoscaleMode is Font and/or Dpi. Especially after adding support for non-linear Form size in PMv2.
+                float xScaleFactor = (float)suggestedRectangle.Width / Width;
+                float yScaleFactor = (float)suggestedRectangle.Height / Height;
+                ScaleMinMaxSize(xScaleFactor, yScaleFactor, updateContainerSize: false);
+            }
 
             // If this container is a top-level window, we would receive WM_DPICHANGED message that
             // has SuggestedRectangle for the control. We are forced to use this in such cases to
@@ -1470,27 +1470,27 @@ public class ContainerControl : ScrollableControl, IContainerControl
             // this control further by the 'OnFontChanged' event.
             _isScaledByDpiChangedEvent = true;
 
-                Font fontForDpi = GetScaledFont(Font, deviceDpiNew, deviceDpiOld);
-                ScaledControlFont = fontForDpi;
-                if (IsFontSet())
-                {
-                    SetScaledFont(fontForDpi);
-                }
-                else
-                {
-                    using (new LayoutTransaction(ParentInternal, this, PropertyNames.Font))
-                    {
-                        OnFontChanged(EventArgs.Empty);
-                    }
-                }
-            }
-            finally
+            Font fontForDpi = GetScaledFont(Font, deviceDpiNew, deviceDpiOld);
+            ScaledControlFont = fontForDpi;
+            if (IsFontSet())
             {
-                // We want to perform layout for dpi-changed high Dpi improvements - setting the second parameter to 'true'
-                ResumeAllLayout(this, true);
-                _isScaledByDpiChangedEvent = false;
+                SetScaledFont(fontForDpi);
+            }
+            else
+            {
+                using (new LayoutTransaction(ParentInternal, this, PropertyNames.Font))
+                {
+                    OnFontChanged(EventArgs.Empty);
+                }
             }
         }
+        finally
+        {
+            // We want to perform layout for dpi-changed high Dpi improvements - setting the second parameter to 'true'
+            ResumeAllLayout(this, true);
+            _isScaledByDpiChangedEvent = false;
+        }
+    }
 
     protected override void Select(bool directed, bool forward)
     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -331,7 +331,10 @@ public unsafe partial class Control :
     // Contains a collection of calculated fonts for various Dpi values of the control in the PerMonV2 mode.
     private Dictionary<int, Font>? _dpiFonts;
 
+        // Flag to signify whether any child controls necessitate the calculation of AnchorsInfo, particularly in cases involving nested containers.
         internal bool _childControlsNeedAnchorLayout;
+
+        // Inform whether the AnchorsInfo needs to be reevaluated, especially when the control's bounds have been altered explicitly.
         internal bool _forceAnchorCalculations;
 
         internal byte LayoutSuspendCount { get; private set; }
@@ -10637,15 +10640,23 @@ public unsafe partial class Control :
         }
     }
 
-    /// <summary>
-    ///  Sets the bounds of the control.
-    /// </summary>
-    public void SetBounds(int x, int y, int width, int height)
-    {
-        if (_x != x || _y != y || _width != width ||
-            _height != height)
+        /// <summary>
+        ///  Sets the bounds of the control.
+        /// </summary>
+        public void SetBounds(int x, int y, int width, int height)
         {
-            SetBoundsCore(x, y, width, height, BoundsSpecified.All);
+            if (_x != x || _y != y || _width != width ||
+                _height != height)
+            {
+                _forceAnchorCalculations = true;
+                try
+                {
+                    SetBoundsCore(x, y, width, height, BoundsSpecified.All);
+                }
+                finally
+                {
+                    _forceAnchorCalculations = false;
+                }
 
                 // WM_WINDOWPOSCHANGED will trickle down to an OnResize() which will
                 // have refreshed the interior layout.  We only need to layout the parent.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -331,13 +331,13 @@ public unsafe partial class Control :
     // Contains a collection of calculated fonts for various Dpi values of the control in the PerMonV2 mode.
     private Dictionary<int, Font>? _dpiFonts;
 
-        // Flag to signify whether any child controls necessitate the calculation of AnchorsInfo, particularly in cases involving nested containers.
-        internal bool _childControlsNeedAnchorLayout;
+    // Flag to signify whether any child controls necessitate the calculation of AnchorsInfo, particularly in cases involving nested containers.
+    internal bool _childControlsNeedAnchorLayout;
 
-        // Inform whether the AnchorsInfo needs to be reevaluated, especially when the control's bounds have been altered explicitly.
-        internal bool _forceAnchorCalculations;
+    // Inform whether the AnchorsInfo needs to be reevaluated, especially when the control's bounds have been altered explicitly.
+    internal bool _forceAnchorCalculations;
 
-        internal byte LayoutSuspendCount { get; private set; }
+    internal byte LayoutSuspendCount { get; private set; }
 
 #if DEBUG
     internal void AssertLayoutSuspendCount(int value)
@@ -4560,34 +4560,34 @@ public unsafe partial class Control :
                 OnRightToLeftChanged(EventArgs.Empty);
             }
 
-                if (!Properties.ContainsObjectThatIsNotNull(s_bindingManagerProperty) && Created)
-                {
-                    // We do not want to call our parent's BindingContext property here.
-                    // We have no idea if us or any of our children are using data binding,
-                    // and invoking the property would just create the binding manager, which
-                    // we don't need.  We just blindly notify that the binding manager has
-                    // changed, and if anyone cares, they will do the comparison at that time.
-                    OnBindingContextChanged(EventArgs.Empty);
-                }
-            }
-            else
+            if (!Properties.ContainsObjectThatIsNotNull(s_bindingManagerProperty) && Created)
             {
-                _parent = value;
-                OnParentChanged(EventArgs.Empty);
-            }
-
-            SetState(States.CheckedHost, false);
-
-            _forceAnchorCalculations = LocalAppContextSwitches.AnchorLayoutV2; // Parent has changed. AnchorsInfo should be recalculated.
-            try
-            {
-                ParentInternal?.LayoutEngine.InitLayout(this, BoundsSpecified.All);
-            }
-            finally
-            {
-                _forceAnchorCalculations = false;
+                // We do not want to call our parent's BindingContext property here.
+                // We have no idea if us or any of our children are using data binding,
+                // and invoking the property would just create the binding manager, which
+                // we don't need.  We just blindly notify that the binding manager has
+                // changed, and if anyone cares, they will do the comparison at that time.
+                OnBindingContextChanged(EventArgs.Empty);
             }
         }
+        else
+        {
+            _parent = value;
+            OnParentChanged(EventArgs.Empty);
+        }
+
+        SetState(States.CheckedHost, false);
+
+        _forceAnchorCalculations = LocalAppContextSwitches.AnchorLayoutV2; // Parent has changed. AnchorsInfo should be recalculated.
+        try
+        {
+            ParentInternal?.LayoutEngine.InitLayout(this, BoundsSpecified.All);
+        }
+        finally
+        {
+            _forceAnchorCalculations = false;
+        }
+    }
 
     [SRCategory(nameof(SR.CatPropertyChanged))]
     [SRDescription(nameof(SR.ControlOnParentChangedDescr))]
@@ -10636,34 +10636,34 @@ public unsafe partial class Control :
         }
     }
 
-        /// <summary>
-        ///  Sets the bounds of the control.
-        /// </summary>
-        public void SetBounds(int x, int y, int width, int height)
+    /// <summary>
+    ///  Sets the bounds of the control.
+    /// </summary>
+    public void SetBounds(int x, int y, int width, int height)
+    {
+        if (_x != x || _y != y || _width != width ||
+            _height != height)
         {
-            if (_x != x || _y != y || _width != width ||
-                _height != height)
+            _forceAnchorCalculations = LocalAppContextSwitches.AnchorLayoutV2;
+            try
             {
-                _forceAnchorCalculations = LocalAppContextSwitches.AnchorLayoutV2;
-                try
-                {
-                    SetBoundsCore(x, y, width, height, BoundsSpecified.All);
-                }
-                finally
-                {
-                    _forceAnchorCalculations = false;
-                }
+                SetBoundsCore(x, y, width, height, BoundsSpecified.All);
+            }
+            finally
+            {
+                _forceAnchorCalculations = false;
+            }
 
-                // WM_WINDOWPOSCHANGED will trickle down to an OnResize() which will
-                // have refreshed the interior layout.  We only need to layout the parent.
-                LayoutTransaction.DoLayout(ParentInternal, this, PropertyNames.Bounds);
-            }
-            else
-            {
-                // Still need to init scaling.
-                InitScaling(BoundsSpecified.All);
-            }
+            // WM_WINDOWPOSCHANGED will trickle down to an OnResize() which will
+            // have refreshed the interior layout.  We only need to layout the parent.
+            LayoutTransaction.DoLayout(ParentInternal, this, PropertyNames.Bounds);
         }
+        else
+        {
+            // Still need to init scaling.
+            InitScaling(BoundsSpecified.All);
+        }
+    }
 
     /// <summary>
     ///  Sets the bounds of the control.
@@ -10690,18 +10690,18 @@ public unsafe partial class Control :
             height = _height;
         }
 
-            if (_x != x || _y != y || _width != width ||
-                _height != height)
+        if (_x != x || _y != y || _width != width ||
+            _height != height)
+        {
+            _forceAnchorCalculations = LocalAppContextSwitches.AnchorLayoutV2;
+            try
             {
-                _forceAnchorCalculations = LocalAppContextSwitches.AnchorLayoutV2;
-                try
-                {
-                    SetBoundsCore(x, y, width, height, specified);
-                }
-                finally
-                {
-                    _forceAnchorCalculations = false;
-                }
+                SetBoundsCore(x, y, width, height, specified);
+            }
+            finally
+            {
+                _forceAnchorCalculations = false;
+            }
 
             // WM_WINDOWPOSCHANGED will trickle down to an OnResize() which will
             // have refreshed the interior layout or the resized control.  We only need to layout

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -10644,7 +10644,7 @@ public unsafe partial class Control :
             if (_x != x || _y != y || _width != width ||
                 _height != height)
             {
-                _forceAnchorCalculations = true;
+                _forceAnchorCalculations = LocalAppContextSwitches.AnchorLayoutV2;
                 try
                 {
                     SetBoundsCore(x, y, width, height, BoundsSpecified.All);
@@ -10693,7 +10693,7 @@ public unsafe partial class Control :
             if (_x != x || _y != y || _width != width ||
                 _height != height)
             {
-                _forceAnchorCalculations = true;
+                _forceAnchorCalculations = LocalAppContextSwitches.AnchorLayoutV2;
                 try
                 {
                     SetBoundsCore(x, y, width, height, specified);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -4576,21 +4576,17 @@ public unsafe partial class Control :
                 OnParentChanged(EventArgs.Empty);
             }
 
-            if (LocalAppContextSwitches.AnchorLayoutV2)
-            {
-                _forceAnchorCalculations = true;
-                try
-                {
-                    DefaultLayout.UpdateAnchorInfoV2(this);
-                }
-                finally
-                {
-                    _forceAnchorCalculations = false;
-                }
-            }
-
             SetState(States.CheckedHost, false);
-            ParentInternal?.LayoutEngine.InitLayout(this, BoundsSpecified.All);
+
+            _forceAnchorCalculations = LocalAppContextSwitches.AnchorLayoutV2; // Parent has changed. AnchorsInfo should be recalculated.
+            try
+            {
+                ParentInternal?.LayoutEngine.InitLayout(this, BoundsSpecified.All);
+            }
+            finally
+            {
+                _forceAnchorCalculations = false;
+            }
         }
 
     [SRCategory(nameof(SR.CatPropertyChanged))]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DefaultLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DefaultLayout.cs
@@ -391,10 +391,10 @@ internal partial class DefaultLayout : LayoutEngine
                 continue;
             }
 
-            Debug.Assert(GetAnchorInfo(element) is not null, "AnchorInfo should be initialized before LayoutAnchorControls().");
-            SetCachedBounds(element, GetAnchorDestination(element, displayRectangle, measureOnly: false));
+                Debug.Assert(GetAnchorInfo(element) is not null, "AnchorInfo should be initialized before LayoutAnchorControls().");
+                SetCachedBounds(element, GetAnchorDestination(element, displayRectangle, measureOnly: false));
+            }
         }
-    }
 
     private static Size LayoutDockedControls(IArrangedElement container, bool measureOnly)
     {
@@ -877,6 +877,8 @@ internal partial class DefaultLayout : LayoutEngine
         }
 
             AnchorInfo anchorInfo = GetAnchorInfo(control);
+
+            // AnchorsInfo is not computed yet. Check if control is ready for AnchorInfo calculation at this time.
             if (anchorInfo is null)
             {
                 // Design time scenarios suspend layout while deserializing the designer. This is an extra suspension
@@ -886,6 +888,7 @@ internal partial class DefaultLayout : LayoutEngine
                 if ((ancestorInDesignMode && parent.LayoutSuspendCount > 1)
                     || (!ancestorInDesignMode && parent.LayoutSuspendCount != 0))
                 {
+                    // Mark parent to indicate that one of its child control requires AnchorsInfo to be calculated.
                     parent._childControlsNeedAnchorLayout = true;
                     return;
                 }
@@ -904,8 +907,9 @@ internal partial class DefaultLayout : LayoutEngine
                 SetAnchorInfo(control, anchorInfo);
             }
 
+            // Reset parent flag as we now ready to iterate over all children requiring AnchorInfo calculation.
             parent._childControlsNeedAnchorLayout = false;
-            control._forceAnchorCalculations = false;
+
             Rectangle displayRectangle = control.Parent.DisplayRectangle;
             Rectangle elementBounds = GetCachedBounds(control);
             int x = elementBounds.X;
@@ -1142,38 +1146,6 @@ internal partial class DefaultLayout : LayoutEngine
                 UpdateAnchorInfo(element);
             }
         }
-
-        /*
-        private static void UpdateAnchors(IArrangedElement element)
-        {
-            if (UseAnchorLayoutV2(element))
-            {
-                if (ElementOrItsChildrenNeedAnchorLayout((Control)element, out bool childElementAnchored))
-                {
-                    UpdateAnchorsIteratively((Control)element);
-                }
-            }
-            else if (CommonProperties.GetNeedsAnchorLayout(element))
-            {
-                UpdateAnchorInfo(element);
-            }
-
-            static void UpdateAnchorsIteratively(Control control)
-            {
-                if (CommonProperties.GetNeedsAnchorLayout(control))
-                {
-                    UpdateAnchorInfoV2(control);
-                }
-
-                var childControls = control.Controls;
-                for (int i = 0; i < childControls.Count; i++)
-                {
-                    UpdateAnchorsIteratively(childControls[i]);
-                }
-
-                return;
-            }
-        }*/
 
     internal override Size GetPreferredSize(IArrangedElement container, Size proposedBounds)
     {

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/AnchorLayoutTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/AnchorLayoutTests.cs
@@ -171,7 +171,37 @@ public class AnchorLayoutTests : ControlTestBase
                 Assert.Null(anchorInfo);
 
                 form.Controls.Add(container);
+                Assert.Null(anchorInfo);
+
+                container.ResumeLayout(false);
+                form.ResumeLayout(false);
                 anchorInfo = DefaultLayout.GetAnchorInfo(button);
+                Assert.NotNull(anchorInfo);
+            }
+            finally
+            {
+                // Reset switch.
+                SetAnchorLayoutV2Switch(previousSwitchValue);
+                Dispose(form, button);
+            }
+        }
+
+        [WinFormsFact]
+        public void ParentChanged_AnchorsUpdated()
+        {
+            int previousSwitchValue = SetAncorLayoutV2();
+            (Form form, Button button) = GetFormWithAnchoredButton(anchorAllDirection);
+            try
+            {
+                using var container = new ContainerControl();
+                container.Dock = DockStyle.Fill;
+                container.SuspendLayout();
+                container.Controls.Add(button);
+
+                DefaultLayout.AnchorInfo anchorInfo = DefaultLayout.GetAnchorInfo(button);
+                Assert.Null(anchorInfo);
+
+                form.Controls.Add(container);
                 Assert.Null(anchorInfo);
 
                 container.ResumeLayout(false);
@@ -179,6 +209,13 @@ public class AnchorLayoutTests : ControlTestBase
 
                 anchorInfo = DefaultLayout.GetAnchorInfo(button);
                 Assert.NotNull(anchorInfo);
+
+                container.Controls.Remove(button);
+                Assert.NotNull(anchorInfo);
+
+                var previousDisplayRect = anchorInfo.DisplayRectangle;
+                form.Controls.Add(button);
+                Assert.NotEqual(previousDisplayRect, anchorInfo.DisplayRectangle);
             }
             finally
             {

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/AnchorLayoutTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/AnchorLayoutTests.cs
@@ -28,7 +28,7 @@ public class AnchorLayoutTests : ControlTestBase
     [InlineData(AnchorStyles.Top | AnchorStyles.Bottom, 120, 30, 20, 330)]
     [InlineData(AnchorStyles.Left | AnchorStyles.Right, 20, 180, 220, 30)]
     [InlineData(AnchorStyles.Bottom | AnchorStyles.Right | AnchorStyles.Top | AnchorStyles.Left, 20, 30, 220, 330)]
-    public void Control_ResizeAnchoredControls_ParentHanldeCreated_NewAnchorsApplied(AnchorStyles anchors, int expectedX, int expectedY, int expectedWidth, int expectedHeight)
+    public void Control_ResizeAnchoredControls_ParentHandleCreated_NewAnchorsApplied(AnchorStyles anchors, int expectedX, int expectedY, int expectedWidth, int expectedHeight)
     {
         LaunchFormAndVerify(anchors, expectedX, expectedY, expectedWidth, expectedHeight);
     }
@@ -43,9 +43,9 @@ public class AnchorLayoutTests : ControlTestBase
     [InlineData(AnchorStyles.Top | AnchorStyles.Bottom, 120, 30, 20, 330)]
     [InlineData(AnchorStyles.Left | AnchorStyles.Right, 20, 180, 220, 30)]
     [InlineData(AnchorStyles.Bottom | AnchorStyles.Right | AnchorStyles.Top | AnchorStyles.Left, 20, 30, 220, 330)]
-    public void Control_AnchorLayoutV2_ResizeAnchoredControls_ParentHanldeCreated_NewAnchorsApplied(AnchorStyles anchors, int expectedX, int expectedY, int expectedWidth, int expectedHeight)
+    public void Control_AnchorLayoutV2_ResizeAnchoredControls_ParentHandleCreated_NewAnchorsApplied(AnchorStyles anchors, int expectedX, int expectedY, int expectedWidth, int expectedHeight)
     {
-        int previousLayoutSwtch = SetAncorLayoutV2();
+        int previousLayoutSwitch = SetAnchorLayoutV2();
 
         try
         {
@@ -54,14 +54,14 @@ public class AnchorLayoutTests : ControlTestBase
         finally
         {
             // Reset switch.
-            SetAnchorLayoutV2Switch(previousLayoutSwtch);
+            SetAnchorLayoutV2Switch(previousLayoutSwitch);
         }
     }
 
     [WinFormsFact]
     public void Control_NotParented_AnchorsNotComputed()
     {
-        int previousSwitchValue = SetAncorLayoutV2();
+        int previousSwitchValue = SetAnchorLayoutV2();
         (Form form, Button button) = GetFormWithAnchoredButton(anchorAllDirection);
 
         try
@@ -87,7 +87,7 @@ public class AnchorLayoutTests : ControlTestBase
     [WinFormsFact]
     public void Control_SuspendedLayout_AnchorsNotComputed()
     {
-        int previousSwitchValue = SetAncorLayoutV2();
+        int previousSwitchValue = SetAnchorLayoutV2();
         (Form form, Button button) = GetFormWithAnchoredButton(anchorAllDirection);
 
         try
@@ -110,7 +110,7 @@ public class AnchorLayoutTests : ControlTestBase
     [WinFormsFact]
     public void Control_ResumedLayout_AnchorsComputed()
     {
-        int previousSwitchValue = SetAncorLayoutV2();
+        int previousSwitchValue = SetAnchorLayoutV2();
         (Form form, Button button) = GetFormWithAnchoredButton(anchorAllDirection);
 
         try
@@ -137,7 +137,7 @@ public class AnchorLayoutTests : ControlTestBase
     [WinFormsFact]
     public void ConfigSwitch_Disabled_SuspendedLayout_AnchorsComputed()
     {
-        int previousSwitchValue = SetAncorLayoutV1();
+        int previousSwitchValue = SetAnchorLayoutV1();
         (Form form, Button button) = GetFormWithAnchoredButton(anchorAllDirection);
 
         try
@@ -155,122 +155,122 @@ public class AnchorLayoutTests : ControlTestBase
         }
     }
 
-        [WinFormsFact]
-        public void NestedContainer_AnchorsComputed()
+    [WinFormsFact]
+    public void NestedContainer_AnchorsComputed()
+    {
+        int previousSwitchValue = SetAnchorLayoutV2();
+        (Form form, Button button) = GetFormWithAnchoredButton(anchorAllDirection);
+        try
         {
-            int previousSwitchValue = SetAncorLayoutV2();
-            (Form form, Button button) = GetFormWithAnchoredButton(anchorAllDirection);
-            try
-            {
-                using var container = new ContainerControl();
-                container.Dock = DockStyle.Fill;
-                container.SuspendLayout();
-                container.Controls.Add(button);
+            using var container = new ContainerControl();
+            container.Dock = DockStyle.Fill;
+            container.SuspendLayout();
+            container.Controls.Add(button);
 
-                DefaultLayout.AnchorInfo anchorInfo = DefaultLayout.GetAnchorInfo(button);
-                Assert.Null(anchorInfo);
+            DefaultLayout.AnchorInfo anchorInfo = DefaultLayout.GetAnchorInfo(button);
+            Assert.Null(anchorInfo);
 
-                form.Controls.Add(container);
-                Assert.Null(anchorInfo);
+            form.Controls.Add(container);
+            Assert.Null(anchorInfo);
 
-                container.ResumeLayout(false);
-                form.ResumeLayout(false);
-                anchorInfo = DefaultLayout.GetAnchorInfo(button);
-                Assert.NotNull(anchorInfo);
-            }
-            finally
-            {
-                // Reset switch.
-                SetAnchorLayoutV2Switch(previousSwitchValue);
-                Dispose(form, button);
-            }
+            container.ResumeLayout(false);
+            form.ResumeLayout(false);
+            anchorInfo = DefaultLayout.GetAnchorInfo(button);
+            Assert.NotNull(anchorInfo);
         }
-
-        [WinFormsFact]
-        public void ParentChanged_AnchorsUpdated()
+        finally
         {
-            int previousSwitchValue = SetAncorLayoutV2();
-            (Form form, Button button) = GetFormWithAnchoredButton(anchorAllDirection);
-            try
-            {
-                using var container = new ContainerControl();
-                container.Dock = DockStyle.Fill;
-                container.SuspendLayout();
-                container.Controls.Add(button);
-
-                DefaultLayout.AnchorInfo anchorInfo = DefaultLayout.GetAnchorInfo(button);
-                Assert.Null(anchorInfo);
-
-                form.Controls.Add(container);
-                Assert.Null(anchorInfo);
-
-                container.ResumeLayout(false);
-                form.ResumeLayout(false);
-
-                anchorInfo = DefaultLayout.GetAnchorInfo(button);
-                Assert.NotNull(anchorInfo);
-
-                container.Controls.Remove(button);
-                Assert.NotNull(anchorInfo);
-
-                var previousDisplayRect = anchorInfo.DisplayRectangle;
-                form.Controls.Add(button);
-                Assert.NotEqual(previousDisplayRect, anchorInfo.DisplayRectangle);
-            }
-            finally
-            {
-                // Reset switch.
-                SetAnchorLayoutV2Switch(previousSwitchValue);
-                Dispose(form, button);
-            }
+            // Reset switch.
+            SetAnchorLayoutV2Switch(previousSwitchValue);
+            Dispose(form, button);
         }
+    }
 
-        [WinFormsFact]
-        public void SetBoundsOnAcnhoredControl_BoundsChanged()
+    [WinFormsFact]
+    public void ParentChanged_AnchorsUpdated()
+    {
+        int previousSwitchValue = SetAnchorLayoutV2();
+        (Form form, Button button) = GetFormWithAnchoredButton(anchorAllDirection);
+        try
         {
-            int previousSwitchValue = SetAncorLayoutV2();
-            (Form form, Button button) = GetFormWithAnchoredButton(anchorAllDirection);
-            try
-            {
-                form.Controls.Add(button);
+            using var container = new ContainerControl();
+            container.Dock = DockStyle.Fill;
+            container.SuspendLayout();
+            container.Controls.Add(button);
 
-                DefaultLayout.AnchorInfo anchorInfo = DefaultLayout.GetAnchorInfo(button);
-                Assert.Null(anchorInfo);
+            DefaultLayout.AnchorInfo anchorInfo = DefaultLayout.GetAnchorInfo(button);
+            Assert.Null(anchorInfo);
 
-                form.ResumeLayout(false);
+            form.Controls.Add(container);
+            Assert.Null(anchorInfo);
 
-                anchorInfo = DefaultLayout.GetAnchorInfo(button);
-                Assert.NotNull(anchorInfo);
+            container.ResumeLayout(false);
+            form.ResumeLayout(false);
 
-                var bounds = button.Bounds;
-                button.SetBounds(bounds.X + 5, bounds.Y + 5, bounds.Width + 10, bounds.Height + 10, BoundsSpecified.None);
-                Assert.Equal(bounds, button.Bounds); // Bounds Specified is None.
+            anchorInfo = DefaultLayout.GetAnchorInfo(button);
+            Assert.NotNull(anchorInfo);
 
-                button.SetBounds(bounds.X + 5, bounds.Y + 5, bounds.Width + 10, bounds.Height + 10, BoundsSpecified.All);
-                Assert.NotEqual(bounds, button.Bounds); // Bounds Specified is None.
+            container.Controls.Remove(button);
+            Assert.NotNull(anchorInfo);
 
-                bounds = button.Bounds;
-                button.SetBounds(bounds.X + 5, bounds.Y + 5, bounds.Width + 10, bounds.Height + 10);
-                Assert.NotEqual(bounds, button.Bounds);
-            }
-            finally
-            {
-                // Reset switch.
-                SetAnchorLayoutV2Switch(previousSwitchValue);
-                Dispose(form, button);
-            }
+            var previousDisplayRect = anchorInfo.DisplayRectangle;
+            form.Controls.Add(button);
+            Assert.NotEqual(previousDisplayRect, anchorInfo.DisplayRectangle);
         }
-
-        private static void LaunchFormAndVerify(AnchorStyles anchors, int expectedX, int expectedY, int expectedWidth, int expectedHeight)
+        finally
         {
-            (Form form, Button button) = GetFormWithAnchoredButton(anchors);
-            Rectangle newButtonBounds = button.Bounds;
-            try
-            {
-                form.ResumeLayout(true);
-                form.Controls.Add(button);
-                form.Shown += OnFormShown;
-                form.ShowDialog();
+            // Reset switch.
+            SetAnchorLayoutV2Switch(previousSwitchValue);
+            Dispose(form, button);
+        }
+    }
+
+    [WinFormsFact]
+    public void SetBoundsOnAnchoredControl_BoundsChanged()
+    {
+        int previousSwitchValue = SetAnchorLayoutV2();
+        (Form form, Button button) = GetFormWithAnchoredButton(anchorAllDirection);
+        try
+        {
+            form.Controls.Add(button);
+
+            DefaultLayout.AnchorInfo anchorInfo = DefaultLayout.GetAnchorInfo(button);
+            Assert.Null(anchorInfo);
+
+            form.ResumeLayout(false);
+
+            anchorInfo = DefaultLayout.GetAnchorInfo(button);
+            Assert.NotNull(anchorInfo);
+
+            var bounds = button.Bounds;
+            button.SetBounds(bounds.X + 5, bounds.Y + 5, bounds.Width + 10, bounds.Height + 10, BoundsSpecified.None);
+            Assert.Equal(bounds, button.Bounds); // Bounds Specified is None.
+
+            button.SetBounds(bounds.X + 5, bounds.Y + 5, bounds.Width + 10, bounds.Height + 10, BoundsSpecified.All);
+            Assert.NotEqual(bounds, button.Bounds); // Bounds Specified is None.
+
+            bounds = button.Bounds;
+            button.SetBounds(bounds.X + 5, bounds.Y + 5, bounds.Width + 10, bounds.Height + 10);
+            Assert.NotEqual(bounds, button.Bounds);
+        }
+        finally
+        {
+            // Reset switch.
+            SetAnchorLayoutV2Switch(previousSwitchValue);
+            Dispose(form, button);
+        }
+    }
+
+    private static void LaunchFormAndVerify(AnchorStyles anchors, int expectedX, int expectedY, int expectedWidth, int expectedHeight)
+    {
+        (Form form, Button button) = GetFormWithAnchoredButton(anchors);
+        Rectangle newButtonBounds = button.Bounds;
+        try
+        {
+            form.ResumeLayout(true);
+            form.Controls.Add(button);
+            form.Shown += OnFormShown;
+            form.ShowDialog();
 
             Assert.Equal(expectedX, newButtonBounds.X);
             Assert.Equal(expectedY, newButtonBounds.Y);
@@ -316,7 +316,7 @@ public class AnchorLayoutTests : ControlTestBase
 
     private static int SetAnchorLayoutV2Switch(int value)
     {
-        // TargetFramework on the testhost.exe is NetCoreApp2.1. AppContext.TargetFrameworkName return this value
+        // TargetFramework on the test host.exe is NetCoreApp2.1. AppContext.TargetFrameworkName return this value
         // while running unit tests. To avoid using this invalid target framework for unit tests, we are
         // explicitly setting and unsetting the switch.
         // Switch value has 3 states: 0 - unknown, 1 - true, -1 - false
@@ -327,9 +327,9 @@ public class AnchorLayoutTests : ControlTestBase
         return previousSwitchValue;
     }
 
-    private static int SetAncorLayoutV2() => SetAnchorLayoutV2Switch(value: 1);
+    private static int SetAnchorLayoutV2() => SetAnchorLayoutV2Switch(value: 1);
 
-    private static int SetAncorLayoutV1() => SetAnchorLayoutV2Switch(value: -1);
+    private static int SetAnchorLayoutV1() => SetAnchorLayoutV2Switch(value: -1);
 
     private static void Dispose(Form form, Button button)
     {


### PR DESCRIPTION
- Controls anchored within the nested containers are never getting chance to compute `AnchorInfo `in V2 layout and thus seeing issues mentioned in #8933. 
- Explicit bounds change on the control either by setting Properties like `Size`, `Location` or by calling public APIs `SetBounds` should recompute `AnchorsInfo` for the control. We documented this but missed in the validation. Issue #8494.
- Added unit tests covering these scenarios.

Fixes #8933 
Fixes #8494 

Anchor UI needs VS servicing to pick these changes.

replacing #9006. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9006)