### PR TITLE
Fix GDI handle leak in GridEntry.

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.cs
@@ -1648,14 +1648,14 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                     int planes = Gdi32.GetDeviceCaps(compatibleDC, Gdi32.DeviceCapability.PLANES);
                     int bitsPixel = Gdi32.GetDeviceCaps(compatibleDC, Gdi32.DeviceCapability.BITSPIXEL);
-                    Gdi32.HBITMAP compatibleBitmap = Gdi32.CreateBitmap(rectangle.Width, rectangle.Height, (uint)planes, (uint)bitsPixel, lpvBits: null);
+                    using var compatibleBitmap = new Gdi32.CreateBitmapScope(rectangle.Width, rectangle.Height, (uint)planes, (uint)bitsPixel, lpvBits: null);
                     using var targetBitmapSelection = new Gdi32.SelectObjectScope(compatibleDC, compatibleBitmap);
 
                     using var brush = new Gdi32.CreateBrushScope(backgroundColor);
                     compatibleDC.HDC.FillRectangle(new Rectangle(0, 0, rectangle.Width, rectangle.Height), brush);
                     explorerTreeRenderer.DrawBackground(compatibleDC, new Rectangle(0, 0, rectangle.Width, rectangle.Height), handle);
 
-                    using Bitmap bitmap = Image.FromHbitmap(compatibleBitmap.Handle);
+                    using Bitmap bitmap = Image.FromHbitmap((nint)compatibleBitmap);
                     ControlPaint.InvertForeColorIfNeeded(bitmap, backgroundColor);
                     graphics.DrawImage(bitmap, rectangle, 0, 0, bitmap.Width, bitmap.Height, GraphicsUnit.Pixel);
                 }


### PR DESCRIPTION
Fixes #9028

This is a regression in .NET 7.0. Resizing a `PropertyGrid` control will continue to leak GDI handles until they are exhausted, eventually crashing the application.

There is no workaround as this is a native handle leak.

Validated repro manually.