### PR TITLE
Implement task dialog hyperlink proposal

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -1,0 +1,7 @@
+System.Windows.Forms.TaskDialogLinkClickedEventArgs
+System.Windows.Forms.TaskDialogLinkClickedEventArgs.LinkHref.get -> string!
+System.Windows.Forms.TaskDialogLinkClickedEventArgs.TaskDialogLinkClickedEventArgs(string! linkHref) -> void
+System.Windows.Forms.TaskDialogPage.EnableLinks.get -> bool
+System.Windows.Forms.TaskDialogPage.EnableLinks.set -> void
+System.Windows.Forms.TaskDialogPage.LinkClicked -> System.EventHandler<System.Windows.Forms.TaskDialogLinkClickedEventArgs!>?
+System.Windows.Forms.TaskDialogPage.OnLinkClicked(System.Windows.Forms.TaskDialogLinkClickedEventArgs! e) -> void

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialog.cs
@@ -271,7 +271,8 @@ public partial class TaskDialog : IWin32Window
         (((GCHandle)lpRefData).Target as TaskDialog)!.HandleTaskDialogCallback(
             hwnd,
             msg,
-            wParam);
+            wParam,
+            lParam);
 
     private static bool IsTaskDialogButtonCommitting(TaskDialogButton? button)
     {
@@ -785,7 +786,8 @@ public partial class TaskDialog : IWin32Window
     private HRESULT HandleTaskDialogCallback(
         HWND hWnd,
         TASKDIALOG_NOTIFICATIONS notification,
-        IntPtr wParam)
+        IntPtr wParam,
+        IntPtr lParam)
     {
         Debug.Assert(_boundPage is not null);
 
@@ -1038,6 +1040,12 @@ public partial class TaskDialog : IWin32Window
 
                 case TASKDIALOG_NOTIFICATIONS.TDN_HELP:
                     _boundPage.OnHelpRequest(EventArgs.Empty);
+                    break;
+
+                case TASKDIALOG_NOTIFICATIONS.TDN_HYPERLINK_CLICKED:
+                    string? linkHref = Marshal.PtrToStringUni(lParam);
+                    Debug.Assert(linkHref is not null);
+                    _boundPage.OnLinkClicked(new TaskDialogLinkClickedEventArgs(linkHref));
                     break;
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogLinkClickedEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogLinkClickedEventArgs.cs
@@ -1,0 +1,25 @@
+﻿namespace System.Windows.Forms;
+
+/// <summary>
+/// Provides data for the <see cref="TaskDialogPage.LinkClicked"/> event.
+/// </summary>
+public class TaskDialogLinkClickedEventArgs : EventArgs
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TaskDialogLinkClickedEventArgs"/> class.
+    /// </summary>
+    public TaskDialogLinkClickedEventArgs(string linkHref)
+    {
+        LinkHref = linkHref;
+    }
+
+    /// <summary>
+    /// Gets the value of the <c>href</c> attribute of the link that the user clicked.
+    /// </summary>
+    /// <remarks>
+    /// Note: In order to avoid possible security vulnerabilities when showing content
+    /// from unsafe sources in a task dialog, you should always verify the value of this
+    /// property before actually opening the link.
+    /// </remarks>
+    public string LinkHref { get; }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogPage.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogPage.cs
@@ -513,6 +513,50 @@ public class TaskDialogPage
     }
 
     /// <summary>
+    /// <para>
+    ///   Gets or sets a value that specifies whether the task dialog should
+    ///   interpret strings in the form <c>&lt;a href="target"&gt;link Text&lt;/a&gt;</c>
+    ///   as hyperlink when specified in the <see cref="Text"/>,
+    ///   <see cref="TaskDialogExpander.Text"/>,
+    ///   or <see cref="TaskDialogFootnote.Text"/> properties.
+    ///   When the user clicks on such a link, the <see cref="LinkClicked"/>
+    ///   event is raised, containing the value of the <c>target</c> attribute.
+    /// </para>
+    /// </summary>
+    /// <value>
+    ///   <see langword="true"/> to enable links; otherwise, <see langword="false"/>.
+    ///   The default value is <see langword="false"/>.
+    /// </value>
+    /// <remarks>
+    /// <para>
+    ///   The Task Dialog will not actually execute any links.
+    ///   Link execution must be handled in the <see cref="LinkClicked"/> event.
+    /// </para>
+    /// <para>
+    ///   Note: Enabling this setting causes the <c>"&amp;"</c> character to be
+    ///   interpreted as a prefix for an access key character (mnemonic) if at least
+    ///   one link is used. To show a literal <c>"&amp;"</c> character, it must be escaped
+    ///   as <c>"&amp;&amp;"</c>.
+    /// </para>
+    /// <para>
+    ///   When you enable this setting and you want to display text
+    ///   without interpreting links, you must replace the strings <c>"&lt;a"</c>
+    ///   and <c>"&lt;A"</c> with something like <c>"&lt;\u200Ba"</c>.
+    /// </para>
+    /// </remarks>
+    public bool EnableLinks { get; set; }
+
+    /// <summary>
+    ///   Occurs when the user has clicked on a link.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    ///   This event will only be raised if <see cref="EnableLinks"/> is set to <see langword="true"/>.
+    /// </para>
+    /// </remarks>
+    public event EventHandler<TaskDialogLinkClickedEventArgs>? LinkClicked;
+
+    /// <summary>
     ///   Gets the <see cref="TaskDialog"/> instance which this page
     ///   is currently bound to.
     /// </summary>
@@ -861,6 +905,11 @@ public class TaskDialogPage
         if (_boundCustomButtons.Any(e => e.IsCreated && e is TaskDialogCommandLinkButton))
             flags |= TASKDIALOG_FLAGS.TDF_USE_COMMAND_LINKS;
 
+        if (EnableLinks)
+        {
+            flags |= TASKDIALOG_FLAGS.TDF_ENABLE_HYPERLINKS;
+        }
+
         if (_checkBox is not null)
         {
             flags |= _checkBox.Bind(this);
@@ -980,6 +1029,12 @@ public class TaskDialogPage
     /// </summary>
     /// <param name="e">An <see cref="EventArgs"/> that contains the event data.</param>
     protected internal void OnHelpRequest(EventArgs e) => HelpRequest?.Invoke(this, e);
+
+    /// <summary>
+    ///   Raises the <see cref="LinkClicked"/> event.
+    /// </summary>
+    /// <param name="e">A <see cref="TaskDialogLinkClickedEventArgs"/> that contains the event data.</param>
+    protected internal void OnLinkClicked(TaskDialogLinkClickedEventArgs e) => LinkClicked?.Invoke(this, e);
 
     private bool GetFlag(TASKDIALOG_FLAGS flag) => (_flags & flag) == flag;
 

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TaskDialogSamples.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TaskDialogSamples.cs
@@ -38,6 +38,7 @@ public class TaskDialogSamples : Form
         AddButtonForAction("Multi-Page Dialog (modeless)", ShowMultiPageTaskDialog);
         AddButtonForAction("Elevation Required", ShowElevatedProcessTaskDialog);
         AddButtonForAction("Events Demo", ShowEventsDemoTaskDialog);
+        AddButtonForAction("Hyperlinks Demo", ShowHyperlinksDemoTaskDialog);
     }
 
     private void ShowSimpleTaskDialog()
@@ -527,5 +528,24 @@ public class TaskDialogSamples : Form
 
         var dialogResult = TaskDialog.ShowDialog(page1);
         Console.WriteLine($"---> Dialog Result: {dialogResult}");
+    }
+
+    private void ShowHyperlinksDemoTaskDialog()
+    {
+        var page = new TaskDialogPage
+        {
+            Caption = Text,
+            Text = """<a href="Href 1">Link with accelerator &1</a> Text with literal '&&' <a href="Href 2">Link with accelerator &2</a>""",
+            Footnote = new() { Text = """<a href="Href 3">Link with literal '&&'</a> Text with &accelerator""" },
+            Expander = new() { Text = """<a href="Href 4">Link 4</a>""" },
+            EnableLinks = true,
+        };
+
+        page.LinkClicked += (_, e) =>
+        {
+            page.Heading = "Clicked: " + e.LinkHref;
+        };
+
+        TaskDialog.ShowDialog(page);
     }
 }


### PR DESCRIPTION
Closes #1199

## Proposed changes

- Exposes the Windows Task Dialog API in regard to enabling hyperlinks to be shown (TDF_ENABLE_HYPERLINKS) and hyperlink clicks to be reacted to (TDN_HYPERLINK_CLICKED). This is conceptually 1:1 with the underlying Windows API and does not contain code that interprets or executes the contents of hrefs.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Customers who show task dialogs containing links are unable to move to the new Windows Forms API, away from handwritten implementations or community libraries for TaskDialog which have fewer capabilities in other regards than the Windows Forms API.

## Regression? 

- No

## Risk

- Minimal; this feature is opt-in, and behavior without opting in remains the same as without this feature being implemented.

<!-- end TELL-MODE -->


## Screenshots

![TaskDialog demo](https://user-images.githubusercontent.com/8040367/235365622-39c01ce6-d31f-492b-956b-daebd2369f3d.gif)

## Test methodology

- A new Task Dialog demo is added along with the existing ones, putting all aspects of this feature through their paces. The screenshot for this is above.
- I was not able to identify any existing unit tests for functionality that could be extended to cover hyperlinks.

## Accessibility testing

[Please advise: is this relevant for lighting up the hyperlink feature of the Windows Task Dialog? The winforms codebase has no control over the accessibility of this built-in Windows idiom.]

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

```
.NET SDK:
 Version:   8.0.100-preview.3.23178.7
 Commit:    e300b0e1e6

Runtime Environment:
 OS Name:     Windows
 OS Version:  10.0.22621
 OS Platform: Windows
 RID:         win10-x64
 Base Path:   C:\Program Files\dotnet\sdk\8.0.100-preview.3.23178.7\

.NET workloads installed:
There are no installed workloads to display.

Host:
  Version:      8.0.0-preview.4.23221.1
  Architecture: x64
  Commit:       ab2b80d06d

.NET SDKs installed:
  7.0.203 [C:\Program Files\dotnet\sdk]
  8.0.100-preview.3.23178.7 [C:\Program Files\dotnet\sdk]

.NET runtimes installed:
  Microsoft.AspNetCore.App 6.0.16 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]
  Microsoft.AspNetCore.App 7.0.5 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]
  Microsoft.AspNetCore.App 8.0.0-preview.3.23177.8 [C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App]
  Microsoft.NETCore.App 3.1.32 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  Microsoft.NETCore.App 5.0.17 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  Microsoft.NETCore.App 6.0.12 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  Microsoft.NETCore.App 6.0.16 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  Microsoft.NETCore.App 7.0.5 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  Microsoft.NETCore.App 8.0.0-preview.3.23174.8 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  Microsoft.NETCore.App 8.0.0-preview.4.23221.1 [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  Microsoft.WindowsDesktop.App 3.1.32 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
  Microsoft.WindowsDesktop.App 5.0.17 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
  Microsoft.WindowsDesktop.App 6.0.6 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
  Microsoft.WindowsDesktop.App 6.0.8 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
  Microsoft.WindowsDesktop.App 6.0.9 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
  Microsoft.WindowsDesktop.App 6.0.16 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
  Microsoft.WindowsDesktop.App 7.0.5 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]
  Microsoft.WindowsDesktop.App 8.0.0-preview.3.23178.1 [C:\Program Files\dotnet\shared\Microsoft.WindowsDesktop.App]

Other architectures found:
  x86   [C:\Program Files (x86)\dotnet]
    registered at [HKLM\SOFTWARE\dotnet\Setup\InstalledVersions\x86\InstallLocation]

Environment variables:
  Not set

global.json file:
  C:\Users\Joseph\Source\Repos\winforms\global.json
```

I tested and created the screenshot on a machine using 200% DPI.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9056)