### PR TITLE
Make task dialog sample menu window readable on high-DPI settings

### DIFF
--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TaskDialogSamples.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TaskDialogSamples.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.ComponentModel;
-using System.Drawing;
 using Timer = System.Windows.Forms.Timer;
 
 namespace WinformsControlsTest;
@@ -14,21 +13,33 @@ public class TaskDialogSamples : Form
     {
         this.Text = "Task Dialog Demos";
 
-        int currentButtonCount = 0;
+        AutoSize = true;
+        AutoSizeMode = AutoSizeMode.GrowAndShrink;
+        MinimizeBox = false;
+        MaximizeBox = false;
+
+        var flowLayout = new FlowLayoutPanel
+        {
+            Dock = DockStyle.Fill,
+            FlowDirection = FlowDirection.TopDown,
+            AutoSize = true,
+            AutoSizeMode = AutoSizeMode.GrowAndShrink,
+            Parent = this,
+        };
+
         void AddButtonForAction(string name, Action action)
         {
-            int nextButton = ++currentButtonCount;
-
-            var button = new Button()
+            var button = new Button
             {
                 Text = name,
-                Size = new Size(180, 23),
-                Location = new Point(nextButton / 20 * 200 + 20, nextButton % 20 * 30)
+                AutoSize = true,
+                AutoSizeMode = AutoSizeMode.GrowAndShrink,
+                Anchor = AnchorStyles.Left | AnchorStyles.Right,
             };
 
             button.Click += (s, e) => action();
 
-            Controls.Add(button);
+            flowLayout.Controls.Add(button);
         }
 
         AddButtonForAction("Confirmation Dialog (3x)", ShowSimpleTaskDialog);


### PR DESCRIPTION
## Proposed changes

Replace manual coordinate calculation with autosizing with FlowLayoutPanel so that the contributor samples window is readable on systems with high-DPI settings.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Makes no difference to customers, only contributors to the repository.

## Regression? 

- Not that I know of

## Risk

- None, does not affect shipping code

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/8040367/235369107-c582da14-ac0b-4676-a69b-7383bdefd91c.png)

### After

![image](https://user-images.githubusercontent.com/8040367/235369117-2b5c32bd-f3dc-45ee-b07e-22c9cd45e835.png)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9057)