### PR TITLE
Scale ContextMenuStrip for high DPI devices

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ContextMenuStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ContextMenuStrip.cs
@@ -120,9 +120,11 @@ public class ContextMenuStrip : ToolStripDropDownMenu
         base.SetVisibleCore(visible);
 
         // There are two problems we're facing when trying to scale ContextMenuStrip:
-        //    1. When the "visible" property is set to false, the control window doesn't receive the "DPI_CHANGED" message.
+        //    1. ContextMenuStrip is a top level window and thus only receive "WM_DPICHANGED" message but not WM_DPICHANGED_BEFOREPARENT/WM_DPICHANGED_AFTERPARENT.
+        //       Unfortunately, we do not handle scaling of controls in "WM_DPICHANGED" message. In WinForms, "WM_DPICHANGED" message is intended for Top-level Forms/ContainerControls.
         //       As a result, the ContextMenuStrip window doesn't scale itself when moved from one monitor to another on the "PerMonitorV2" process.
-        //    2. If a window is invisible(with "visible" set to false), the "GetDpiForWindow()" API returns the DPI of the primary monitor.
+        //    2. When ContextMenuStrip changes to invisible(with "visible" set to false), owner of the window is changed to a ParkingWindow that may possibly parked on primary monitor.
+        //       The "GetDpiForWindow()" API on ContextMenuStrip thus returns the DPI of the primary monitor.
         // Because of this inconsistency, we intentionally recreate the handle that triggers scaling according to the new DPI, after setting the "visible" property.
         if (visible
             && IsHandleCreated

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ContextMenuStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ContextMenuStrip.cs
@@ -118,5 +118,18 @@ public class ContextMenuStrip : ToolStripDropDownMenu
         }
 
         base.SetVisibleCore(visible);
+
+        // There are two problems we're facing when trying to scale ContextMenuStrip:
+        //    1. When the "visible" property is set to false, the control window doesn't receive the "DPI_CHANGED" message.
+        //       As a result, the ContextMenuStrip window doesn't scale itself when moved from one monitor to another on the "PerMonitorV2" process.
+        //    2. If a window is invisible(with "visible" set to false), the "GetDpiForWindow()" API returns the DPI of the primary monitor.
+        // Because of this inconsistency, we intentionally recreate the handle that triggers scaling according to the new DPI, after setting the "visible" property.
+        if (visible
+            && IsHandleCreated
+            && DpiHelper.IsPerMonitorV2Awareness
+            && DeviceDpi != (int)PInvoke.GetDpiForWindow(this))
+        {
+            RecreateHandle();
+        }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownItem.cs
@@ -749,7 +749,7 @@ public abstract class ToolStripDropDownItem : ToolStripItem
 
         // Traversing the tree of DropDownMenuItems non-recursively to set new
         // Font (where necessary because not inherited from parent), DeviceDpi and reset the scaling.
-        var itemsStack = new Collections.Generic.Stack<ToolStripDropDownItem>();
+        var itemsStack = new Stack<ToolStripDropDownItem>();
 
         itemsStack.Push(this);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripMenuItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripMenuItem.cs
@@ -204,19 +204,14 @@ public partial class ToolStripMenuItem : ToolStripDropDownItem
     {
         if (DpiHelper.IsScalingRequirementMet)
         {
-            ScaleDpiConstants();
+            _scaledDefaultPadding = DpiHelper.LogicalToDeviceUnits(s_defaultPadding);
+            _scaledDefaultDropDownPadding = DpiHelper.LogicalToDeviceUnits(s_defaultDropDownPadding);
+            _scaledCheckMarkBitmapSize = DpiHelper.LogicalToDeviceUnits(s_checkMarkBitmapSize);
         }
 
         Overflow = ToolStripItemOverflow.Never;
         MouseDownAndUpMustBeInSameItem = false;
         SupportsDisabledHotTracking = true;
-    }
-
-    private void ScaleDpiConstants(int newDpi = 0)
-    {
-        _scaledDefaultPadding = DpiHelper.LogicalToDeviceUnits(s_defaultPadding, newDpi);
-        _scaledDefaultDropDownPadding = DpiHelper.LogicalToDeviceUnits(s_defaultDropDownPadding, newDpi);
-        _scaledCheckMarkBitmapSize = DpiHelper.LogicalToDeviceUnits(s_checkMarkBitmapSize, newDpi);
     }
 
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripMenuItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripMenuItem.cs
@@ -204,14 +204,19 @@ public partial class ToolStripMenuItem : ToolStripDropDownItem
     {
         if (DpiHelper.IsScalingRequirementMet)
         {
-            _scaledDefaultPadding = DpiHelper.LogicalToDeviceUnits(s_defaultPadding);
-            _scaledDefaultDropDownPadding = DpiHelper.LogicalToDeviceUnits(s_defaultDropDownPadding);
-            _scaledCheckMarkBitmapSize = DpiHelper.LogicalToDeviceUnits(s_checkMarkBitmapSize);
+            ScaleDpiConstants();
         }
 
         Overflow = ToolStripItemOverflow.Never;
         MouseDownAndUpMustBeInSameItem = false;
         SupportsDisabledHotTracking = true;
+    }
+
+    private void ScaleDpiConstants(int newDpi = 0)
+    {
+        _scaledDefaultPadding = DpiHelper.LogicalToDeviceUnits(s_defaultPadding, newDpi);
+        _scaledDefaultDropDownPadding = DpiHelper.LogicalToDeviceUnits(s_defaultDropDownPadding, newDpi);
+        _scaledCheckMarkBitmapSize = DpiHelper.LogicalToDeviceUnits(s_checkMarkBitmapSize, newDpi);
     }
 
     /// <summary>
@@ -320,7 +325,7 @@ public partial class ToolStripMenuItem : ToolStripDropDownItem
                         {
                             if (DpiHelper.IsScalingRequired)
                             {
-                                DpiHelper.ScaleBitmapLogicalToDevice(ref indeterminateCheckedBmp);
+                                DpiHelper.ScaleBitmapLogicalToDevice(ref indeterminateCheckedBmp, DeviceDpi);
                             }
 
                             t_indeterminateCheckedImage = indeterminateCheckedBmp;
@@ -345,7 +350,7 @@ public partial class ToolStripMenuItem : ToolStripDropDownItem
                         {
                             if (DpiHelper.IsScalingRequired)
                             {
-                                DpiHelper.ScaleBitmapLogicalToDevice(ref checkedBmp);
+                                DpiHelper.ScaleBitmapLogicalToDevice(ref checkedBmp, DeviceDpi);
                             }
 
                             t_checkedImage = checkedBmp;
@@ -675,6 +680,10 @@ public partial class ToolStripMenuItem : ToolStripDropDownItem
             _scaledDefaultPadding = DpiHelper.LogicalToDeviceUnits(s_defaultPadding, value);
             _scaledDefaultDropDownPadding = DpiHelper.LogicalToDeviceUnits(s_defaultDropDownPadding, value);
             _scaledCheckMarkBitmapSize = DpiHelper.LogicalToDeviceUnits(s_checkMarkBitmapSize, value);
+            t_indeterminateCheckedImage?.Dispose();
+            t_indeterminateCheckedImage = null;
+            t_checkedImage?.Dispose();
+            t_checkedImage = null;
         }
     }
 


### PR DESCRIPTION
Fixes #9044

There are two problems we're facing when trying to scale `ContextMenuStrip`:

1. `ContextMenuStrip `is a top level window and thus only receive "WM_DPICHANGED" message but not WM_DPICHANGED_BEFOREPARENT/WM_DPICHANGED_AFTERPARENT.  Unfortunately, we do not handle scaling of controls in "WM_DPICHANGED" message. In WinForms, "WM_DPICHANGED" message is intended for Top-level Forms/ContainerControls.              As a result, the `ContextMenuStrip `window doesn't scale itself when moved from one monitor to another on the "PerMonitorV2" process.

2. When `ContextMenuStrip `changes to invisible (with "visible" set to false), owner of the window is changed to a `ParkingWindow `that may possibly be parked on primary monitor. The `GetDpiForWindow()` API on `ContextMenuStrip` thus returns the DPI of the primary monitor.

Because of this inconsistency, we intentionally recreate the handle that triggers scaling according to the new DPI, after setting the "visible" property.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9063)