### PR TITLE
Do not run tests on internal CI

### DIFF
--- a/eng/pipelines/build.yml
+++ b/eng/pipelines/build.yml
@@ -99,8 +99,8 @@ jobs:
         /p:TestRunnerAdditionalArguments='-notrait Category=IgnoreForCI -notrait Category=failing'
         /bl:$(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)\Test-${{ parameters.targetArchitecture }}.binlog
         /m:1
-      displayName: Run Unit Tests
-      condition: and(eq(variables['System.TeamProject'], 'public'), ne(variables['_Platform'], 'arm64'))
+      displayName: Run Unit Tests - Test
+      condition: and(eq(variables['System.TeamProject'], 'public'), false)
 
     # Run Integration Tests
     # Tests are run with /m:1 to avoid parallelism across different assemblies which can lead to
@@ -117,7 +117,7 @@ jobs:
         /m:1
       env:
         XUNIT_LOGS: $(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)
-      displayName: Run Integration Tests
+      displayName: Run Integration Tests - Test
       condition: and(eq(variables['System.TeamProject'], 'public'), ne(variables['_Platform'], 'arm64'))
       retryCountOnTaskFailure: 1
 

--- a/eng/pipelines/build.yml
+++ b/eng/pipelines/build.yml
@@ -100,7 +100,7 @@ jobs:
         /bl:$(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)\Test-${{ parameters.targetArchitecture }}.binlog
         /m:1
       displayName: Run Unit Tests
-      condition: and(eq(variables['System.TeamProject'], 'public'), ne(${{ parameters.targetArchitecture }}, 'arm64'))
+      condition: and(eq(variables['System.TeamProject'], 'public'), ne('${{ parameters.targetArchitecture }}', 'arm64'))
 
     # Run Integration Tests
     # Tests are run with /m:1 to avoid parallelism across different assemblies which can lead to
@@ -118,7 +118,7 @@ jobs:
       env:
         XUNIT_LOGS: $(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)
       displayName: Run Integration Tests
-      condition: and(eq(variables['System.TeamProject'], 'public'), ne(${{ parameters.targetArchitecture }}, 'arm64'))
+      condition: and(eq(variables['System.TeamProject'], 'public'), ne('${{ parameters.targetArchitecture }}', 'arm64'))
       retryCountOnTaskFailure: 1
 
     # Create Nuget package, sign, and publish

--- a/eng/pipelines/build.yml
+++ b/eng/pipelines/build.yml
@@ -99,8 +99,8 @@ jobs:
         /p:TestRunnerAdditionalArguments='-notrait Category=IgnoreForCI -notrait Category=failing'
         /bl:$(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)\Test-${{ parameters.targetArchitecture }}.binlog
         /m:1
-      displayName: Run Unit Tests - Test
-      condition: and(eq(variables['System.TeamProject'], 'public'), ne(parameters.targetArchitecture, 'arm64'))
+      displayName: Run Unit Tests
+      condition: and(eq(variables['System.TeamProject'], 'public'), ne(${{ parameters.targetArchitecture }}, 'arm64'))
 
     # Run Integration Tests
     # Tests are run with /m:1 to avoid parallelism across different assemblies which can lead to
@@ -117,8 +117,8 @@ jobs:
         /m:1
       env:
         XUNIT_LOGS: $(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)
-      displayName: Run Integration Tests - Test
-      condition: and(eq(variables['System.TeamProject'], 'public'), ne(parameters.targetArchitecture, 'arm64'))
+      displayName: Run Integration Tests
+      condition: and(eq(variables['System.TeamProject'], 'public'), ne(${{ parameters.targetArchitecture }}, 'arm64'))
       retryCountOnTaskFailure: 1
 
     # Create Nuget package, sign, and publish

--- a/eng/pipelines/build.yml
+++ b/eng/pipelines/build.yml
@@ -100,6 +100,7 @@ jobs:
         /bl:$(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)\Test-${{ parameters.targetArchitecture }}.binlog
         /m:1
       displayName: Run Unit Tests
+      condition: and(eq(variables['System.TeamProject'], 'public'), ne(variables['_Platform'], 'arm64'))
 
     # Run Integration Tests
     # Tests are run with /m:1 to avoid parallelism across different assemblies which can lead to
@@ -117,6 +118,7 @@ jobs:
       env:
         XUNIT_LOGS: $(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)
       displayName: Run Integration Tests
+      condition: and(eq(variables['System.TeamProject'], 'public'), ne(variables['_Platform'], 'arm64'))
       retryCountOnTaskFailure: 1
 
     # Create Nuget package, sign, and publish

--- a/eng/pipelines/build.yml
+++ b/eng/pipelines/build.yml
@@ -100,7 +100,7 @@ jobs:
         /bl:$(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)\Test-${{ parameters.targetArchitecture }}.binlog
         /m:1
       displayName: Run Unit Tests - Test
-      condition: and(eq(variables['System.TeamProject'], 'public'), false)
+      condition: and(eq(variables['System.TeamProject'], 'public'), ne(parameters.targetArchitecture, 'arm64'))
 
     # Run Integration Tests
     # Tests are run with /m:1 to avoid parallelism across different assemblies which can lead to
@@ -118,7 +118,7 @@ jobs:
       env:
         XUNIT_LOGS: $(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)
       displayName: Run Integration Tests - Test
-      condition: and(eq(variables['System.TeamProject'], 'public'), ne(variables['_Platform'], 'arm64'))
+      condition: and(eq(variables['System.TeamProject'], 'public'), ne(parameters.targetArchitecture, 'arm64'))
       retryCountOnTaskFailure: 1
 
     # Create Nuget package, sign, and publish


### PR DESCRIPTION
Do not run tests (Unit and integration) on internal CI.

We run tests against PRs and i do not see a reason why we need to repeat them against internal CI. Few repos already opted out running tests on internal CI. (ex: WPF, SDK and installer).

I am also blocking our ARM64 tests until we get specific pool for ARM64 or move to Helix. They currently are simply using X64.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9064)