### PR TITLE
Enable nullability in ToolStripItemCollection

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -960,20 +960,20 @@ System.Windows.Forms.ToolStrip.SetItemLocation(System.Windows.Forms.ToolStripIte
 System.Windows.Forms.ToolStripControlHost.Control.get -> System.Windows.Forms.Control!
 System.Windows.Forms.ToolStripControlHost.ToolStripControlHost(System.Windows.Forms.Control! c) -> void
 System.Windows.Forms.ToolStripControlHost.ToolStripControlHost(System.Windows.Forms.Control! c, string! name) -> void
-~System.Windows.Forms.ToolStripItemCollection.Add(string text) -> System.Windows.Forms.ToolStripItem
-~System.Windows.Forms.ToolStripItemCollection.Add(string text, System.Drawing.Image image) -> System.Windows.Forms.ToolStripItem
-~System.Windows.Forms.ToolStripItemCollection.Add(string text, System.Drawing.Image image, System.EventHandler onClick) -> System.Windows.Forms.ToolStripItem
-~System.Windows.Forms.ToolStripItemCollection.Add(System.Drawing.Image image) -> System.Windows.Forms.ToolStripItem
-~System.Windows.Forms.ToolStripItemCollection.Add(System.Windows.Forms.ToolStripItem value) -> int
-~System.Windows.Forms.ToolStripItemCollection.AddRange(System.Windows.Forms.ToolStripItem[] toolStripItems) -> void
-~System.Windows.Forms.ToolStripItemCollection.AddRange(System.Windows.Forms.ToolStripItemCollection toolStripItems) -> void
-~System.Windows.Forms.ToolStripItemCollection.Contains(System.Windows.Forms.ToolStripItem value) -> bool
-~System.Windows.Forms.ToolStripItemCollection.CopyTo(System.Windows.Forms.ToolStripItem[] array, int index) -> void
-~System.Windows.Forms.ToolStripItemCollection.Find(string key, bool searchAllChildren) -> System.Windows.Forms.ToolStripItem[]
-~System.Windows.Forms.ToolStripItemCollection.IndexOf(System.Windows.Forms.ToolStripItem value) -> int
-~System.Windows.Forms.ToolStripItemCollection.Insert(int index, System.Windows.Forms.ToolStripItem value) -> void
-~System.Windows.Forms.ToolStripItemCollection.Remove(System.Windows.Forms.ToolStripItem value) -> void
-~System.Windows.Forms.ToolStripItemCollection.ToolStripItemCollection(System.Windows.Forms.ToolStrip owner, System.Windows.Forms.ToolStripItem[] value) -> void
+System.Windows.Forms.ToolStripItemCollection.Add(string? text) -> System.Windows.Forms.ToolStripItem!
+System.Windows.Forms.ToolStripItemCollection.Add(string? text, System.Drawing.Image? image) -> System.Windows.Forms.ToolStripItem!
+System.Windows.Forms.ToolStripItemCollection.Add(string? text, System.Drawing.Image? image, System.EventHandler? onClick) -> System.Windows.Forms.ToolStripItem!
+System.Windows.Forms.ToolStripItemCollection.Add(System.Drawing.Image? image) -> System.Windows.Forms.ToolStripItem!
+System.Windows.Forms.ToolStripItemCollection.Add(System.Windows.Forms.ToolStripItem! value) -> int
+System.Windows.Forms.ToolStripItemCollection.AddRange(System.Windows.Forms.ToolStripItem![]! toolStripItems) -> void
+System.Windows.Forms.ToolStripItemCollection.AddRange(System.Windows.Forms.ToolStripItemCollection! toolStripItems) -> void
+System.Windows.Forms.ToolStripItemCollection.Contains(System.Windows.Forms.ToolStripItem! value) -> bool
+System.Windows.Forms.ToolStripItemCollection.CopyTo(System.Windows.Forms.ToolStripItem![]! array, int index) -> void
+System.Windows.Forms.ToolStripItemCollection.Find(string! key, bool searchAllChildren) -> System.Windows.Forms.ToolStripItem![]!
+System.Windows.Forms.ToolStripItemCollection.IndexOf(System.Windows.Forms.ToolStripItem! value) -> int
+System.Windows.Forms.ToolStripItemCollection.Insert(int index, System.Windows.Forms.ToolStripItem! value) -> void
+System.Windows.Forms.ToolStripItemCollection.Remove(System.Windows.Forms.ToolStripItem! value) -> void
+System.Windows.Forms.ToolStripItemCollection.ToolStripItemCollection(System.Windows.Forms.ToolStrip! owner, System.Windows.Forms.ToolStripItem![]! value) -> void
 System.Windows.Forms.ToolStripPanel.ToolStripPanelRowCollection.Add(System.Windows.Forms.ToolStripPanelRow! value) -> int
 System.Windows.Forms.ToolStripPanel.ToolStripPanelRowCollection.AddRange(System.Windows.Forms.ToolStripPanel.ToolStripPanelRowCollection! value) -> void
 System.Windows.Forms.ToolStripPanel.ToolStripPanelRowCollection.AddRange(System.Windows.Forms.ToolStripPanelRow![]! value) -> void
@@ -1428,11 +1428,11 @@ virtual System.Windows.Forms.ToolStripControlHost.OnSubscribeControlEvents(Syste
 virtual System.Windows.Forms.ToolStripControlHost.OnUnsubscribeControlEvents(System.Windows.Forms.Control? control) -> void
 virtual System.Windows.Forms.ToolStripControlHost.OnValidated(System.EventArgs! e) -> void
 virtual System.Windows.Forms.ToolStripControlHost.OnValidating(System.ComponentModel.CancelEventArgs! e) -> void
-~virtual System.Windows.Forms.ToolStripItemCollection.ContainsKey(string key) -> bool
-~virtual System.Windows.Forms.ToolStripItemCollection.IndexOfKey(string key) -> int
-~virtual System.Windows.Forms.ToolStripItemCollection.RemoveByKey(string key) -> void
-~virtual System.Windows.Forms.ToolStripItemCollection.this[int index].get -> System.Windows.Forms.ToolStripItem
-~virtual System.Windows.Forms.ToolStripItemCollection.this[string key].get -> System.Windows.Forms.ToolStripItem
+virtual System.Windows.Forms.ToolStripItemCollection.ContainsKey(string? key) -> bool
+virtual System.Windows.Forms.ToolStripItemCollection.IndexOfKey(string? key) -> int
+virtual System.Windows.Forms.ToolStripItemCollection.RemoveByKey(string? key) -> void
+virtual System.Windows.Forms.ToolStripItemCollection.this[int index].get -> System.Windows.Forms.ToolStripItem!
+virtual System.Windows.Forms.ToolStripItemCollection.this[string? key].get -> System.Windows.Forms.ToolStripItem?
 virtual System.Windows.Forms.ToolStripPanel.ToolStripPanelRowCollection.this[int index].get -> System.Windows.Forms.ToolStripPanelRow!
 virtual System.Windows.Forms.ToolStripPanelRow.OnControlAdded(System.Windows.Forms.Control! control, int index) -> void
 virtual System.Windows.Forms.ToolStripPanelRow.OnControlRemoved(System.Windows.Forms.Control! control, int index) -> void

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
@@ -3274,11 +3274,11 @@ public abstract partial class ToolStripItem : BindableComponent,
         }
     }
 
-    internal void SetOwner(ToolStrip newOwner)
+    internal void SetOwner(ToolStrip? newOwner)
     {
         if (_owner != newOwner)
         {
-            Font f = this.Font;
+            Font f = Font;
 
             if (_owner is not null)
             {
@@ -3295,7 +3295,7 @@ public abstract partial class ToolStripItem : BindableComponent,
             // clear the parent if the owner is null.
             if (newOwner is null)
             {
-                this.ParentInternal = null;
+                ParentInternal = null;
             }
 
             if (!_state[s_stateDisposing] && !IsDisposed)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItemCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItemCollection.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections;
 using System.ComponentModel;
 using System.Drawing;
@@ -16,7 +14,7 @@ namespace System.Windows.Forms;
 [ListBindable(false)]
 public class ToolStripItemCollection : ArrangedElementCollection, IList
 {
-    private readonly ToolStrip _owner;
+    private readonly ToolStrip? _owner;
     private readonly bool _itemsCollection;
     private readonly bool _isReadOnly;
 
@@ -24,12 +22,12 @@ public class ToolStripItemCollection : ArrangedElementCollection, IList
     // references. Note this is not thread safe - but WinForms has to be run in a STA anyways.
     private int _lastAccessedIndex = -1;
 
-    internal ToolStripItemCollection(ToolStrip owner, bool itemsCollection)
+    internal ToolStripItemCollection(ToolStrip? owner, bool itemsCollection)
         : this(owner, itemsCollection, isReadOnly: false)
     {
     }
 
-    internal ToolStripItemCollection(ToolStrip owner, bool itemsCollection, bool isReadOnly)
+    internal ToolStripItemCollection(ToolStrip? owner, bool itemsCollection, bool isReadOnly)
     {
         _owner = owner;
         _itemsCollection = itemsCollection;
@@ -55,7 +53,7 @@ public class ToolStripItemCollection : ArrangedElementCollection, IList
     /// <summary>
     ///  Retrieves the child control with the specified key.
     /// </summary>
-    public virtual ToolStripItem this[string key]
+    public virtual ToolStripItem? this[string? key]
     {
         get
         {
@@ -78,24 +76,24 @@ public class ToolStripItemCollection : ArrangedElementCollection, IList
         }
     }
 
-    public ToolStripItem Add(string text)
+    public ToolStripItem Add(string? text)
     {
         return Add(text, null, null);
     }
 
-    public ToolStripItem Add(Image image)
+    public ToolStripItem Add(Image? image)
     {
         return Add(null, image, null);
     }
 
-    public ToolStripItem Add(string text, Image image)
+    public ToolStripItem Add(string? text, Image? image)
     {
         return Add(text, image, null);
     }
 
-    public ToolStripItem Add(string text, Image image, EventHandler onClick)
+    public ToolStripItem Add(string? text, Image? image, EventHandler? onClick)
     {
-        ToolStripItem item = _owner.CreateDefaultItem(text, image, onClick);
+        ToolStripItem item = _owner!.CreateDefaultItem(text, image, onClick);
         Add(item);
         return item;
     }
@@ -126,7 +124,7 @@ public class ToolStripItemCollection : ArrangedElementCollection, IList
 
         // ToolStripDropDown will look for PropertyNames.Items to determine if it needs
         // to resize itself.
-        using (new LayoutTransaction(_owner, _owner, PropertyNames.Items))
+        using (new LayoutTransaction(_owner, _owner!, PropertyNames.Items))
         {
             for (int i = 0; i < toolStripItems.Length; i++)
             {
@@ -146,7 +144,7 @@ public class ToolStripItemCollection : ArrangedElementCollection, IList
 
         // ToolStripDropDown will look for PropertyNames.Items to determine if it needs
         // to resize itself.
-        using (new LayoutTransaction(_owner, _owner, PropertyNames.Items))
+        using (new LayoutTransaction(_owner, _owner!, PropertyNames.Items))
         {
             for (int i = 0; i < toolStripItems.Count; i++)
             {
@@ -175,7 +173,7 @@ public class ToolStripItemCollection : ArrangedElementCollection, IList
             return;
         }
 
-        ToolStripOverflow overflow = null;
+        ToolStripOverflow? overflow = null;
 
         if (_owner is not null && !_owner.IsDisposingItems)
         {
@@ -205,7 +203,7 @@ public class ToolStripItemCollection : ArrangedElementCollection, IList
     /// <summary>
     ///  Returns true if the collection contains an item with the specified key, false otherwise.
     /// </summary>
-    public virtual bool ContainsKey(string key)
+    public virtual bool ContainsKey(string? key)
     {
         return IsValidIndex(IndexOfKey(key));
     }
@@ -292,14 +290,14 @@ public class ToolStripItemCollection : ArrangedElementCollection, IList
 
     void IList.Clear() { Clear(); }
     bool IList.IsFixedSize { get { return ((IList)InnerList).IsFixedSize; } }
-    bool IList.Contains(object value) { return InnerList.Contains(value); }
+    bool IList.Contains(object? value) { return InnerList.Contains(value); }
     void IList.RemoveAt(int index) { RemoveAt(index); }
-    void IList.Remove(object value) { Remove(value as ToolStripItem); }
-    int IList.Add(object value) { return Add(value as ToolStripItem); }
-    int IList.IndexOf(object value) { return IndexOf(value as ToolStripItem); }
-    void IList.Insert(int index, object value) { Insert(index, value as ToolStripItem); }
+    void IList.Remove(object? value) { Remove((value as ToolStripItem)!); }
+    int IList.Add(object? value) { return Add((value as ToolStripItem)!); }
+    int IList.IndexOf(object? value) { return IndexOf((value as ToolStripItem)!); }
+    void IList.Insert(int index, object? value) { Insert(index, (value as ToolStripItem)!); }
 
-    object IList.this[int index]
+    object? IList.this[int index]
     {
         get { return InnerList[index]; }
         set { throw new NotSupportedException(SR.ToolStripCollectionMustInsertAndRemove); /* InnerList[index] = value; */ }
@@ -335,7 +333,7 @@ public class ToolStripItemCollection : ArrangedElementCollection, IList
     /// <summary>
     ///  The zero-based index of the first occurrence of value within the entire CollectionBase, if found; otherwise, -1.
     /// </summary>
-    public virtual int IndexOfKey(string key)
+    public virtual int IndexOfKey(string? key)
     {
         // Step 0 - Arg validation
         if ((key is null) || (key.Length == 0))
@@ -378,11 +376,11 @@ public class ToolStripItemCollection : ArrangedElementCollection, IList
     /// <summary>
     ///  Do proper cleanup of ownership, etc.
     /// </summary>
-    private void OnAfterRemove(ToolStripItem item)
+    private void OnAfterRemove(ToolStripItem? item)
     {
         if (_itemsCollection)
         {
-            ToolStrip parent = null;
+            ToolStrip? parent = null;
             if (item is not null)
             {
                 parent = item.ParentInternal;
@@ -391,7 +389,7 @@ public class ToolStripItemCollection : ArrangedElementCollection, IList
 
             if (_owner is not null)
             {
-                _owner.OnItemRemovedInternal(item);
+                _owner.OnItemRemovedInternal(item!);
 
                 if (!_owner.IsDisposingItems)
                 {
@@ -403,7 +401,7 @@ public class ToolStripItemCollection : ArrangedElementCollection, IList
                     // is really being removed from the master collection.
                     if (parent is not null && parent != _owner)
                     {
-                        parent.OnItemVisibleChanged(e, /*performLayout*/false);
+                        parent.OnItemVisibleChanged(e, performLayout: false);
                     }
                 }
             }
@@ -432,7 +430,7 @@ public class ToolStripItemCollection : ArrangedElementCollection, IList
             throw new NotSupportedException(SR.ToolStripItemCollectionIsReadOnly);
         }
 
-        ToolStripItem item = null;
+        ToolStripItem? item = null;
         if (index < Count && index >= 0)
         {
             item = (ToolStripItem)(InnerList[index]);
@@ -445,7 +443,7 @@ public class ToolStripItemCollection : ArrangedElementCollection, IList
     /// <summary>
     ///  Removes the child item with the specified key.
     /// </summary>
-    public virtual void RemoveByKey(string key)
+    public virtual void RemoveByKey(string? key)
     {
         if (IsReadOnly)
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItemCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItemCollection.cs
@@ -376,20 +376,17 @@ public class ToolStripItemCollection : ArrangedElementCollection, IList
     /// <summary>
     ///  Do proper cleanup of ownership, etc.
     /// </summary>
-    private void OnAfterRemove(ToolStripItem? item)
+    private void OnAfterRemove(ToolStripItem item)
     {
         if (_itemsCollection)
         {
             ToolStrip? parent = null;
-            if (item is not null)
-            {
-                parent = item.ParentInternal;
-                item.SetOwner(null);
-            }
+            parent = item.ParentInternal;
+            item.SetOwner(null);
 
             if (_owner is not null)
             {
-                _owner.OnItemRemovedInternal(item!);
+                _owner.OnItemRemovedInternal(item);
 
                 if (!_owner.IsDisposingItems)
                 {
@@ -434,6 +431,10 @@ public class ToolStripItemCollection : ArrangedElementCollection, IList
         if (index < Count && index >= 0)
         {
             item = (ToolStripItem)(InnerList[index]);
+        }
+        else
+        {
+            throw new IndexOutOfRangeException();
         }
 
         InnerList.RemoveAt(index);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItemCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItemCollection.cs
@@ -292,10 +292,10 @@ public class ToolStripItemCollection : ArrangedElementCollection, IList
     bool IList.IsFixedSize { get { return ((IList)InnerList).IsFixedSize; } }
     bool IList.Contains(object? value) { return InnerList.Contains(value); }
     void IList.RemoveAt(int index) { RemoveAt(index); }
-    void IList.Remove(object? value) { Remove((value as ToolStripItem)!); }
-    int IList.Add(object? value) { return Add((value as ToolStripItem)!); }
-    int IList.IndexOf(object? value) { return IndexOf((value as ToolStripItem)!); }
-    void IList.Insert(int index, object? value) { Insert(index, (value as ToolStripItem)!); }
+    void IList.Remove(object? value) { Remove((ToolStripItem)value!); }
+    int IList.Add(object? value) { return Add((ToolStripItem)value!); }
+    int IList.IndexOf(object? value) { return IndexOf((ToolStripItem)value!); }
+    void IList.Insert(int index, object? value) { Insert(index, (ToolStripItem)value!); }
 
     object? IList.this[int index]
     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSettingsManager.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSettingsManager.cs
@@ -194,7 +194,7 @@ internal partial class ToolStripSettingsManager
                         string key = match.Value;
                         if (!string.IsNullOrEmpty(key) && itemLocationHash.TryGetValue(key, out ToolStrip? value))
                         {
-                            toolStrip.Items.Insert(i, value.Items[key]);
+                            toolStrip.Items.Insert(i, value.Items[key]!);
                         }
                     }
                 }


### PR DESCRIPTION
## Proposed changes

- Enable nullability in ToolStripItemCollection.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9072)