### PR TITLE
Enable nullability in ToolStripPanelRowCollection and remove some unnecessary DEBUG pre-processor checks

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomDesignerLoader.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomDesignerLoader.cs
@@ -9,8 +9,6 @@ using System.CodeDom.Compiler;
 using System.Collections;
 using System.Collections.Specialized;
 using System.Globalization;
-#if DEBUG
-#endif
 using System.Reflection;
 using System.Text;
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewRowCollectionCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewRowCollectionCodeDomSerializer.cs
@@ -7,8 +7,6 @@
 using System.CodeDom;
 using System.Collections;
 using System.ComponentModel.Design.Serialization;
-#if DEBUG
-#endif
 
 namespace System.Windows.Forms.Design;
 

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Message.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Message.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if DEBUG
-#endif
 using System.Runtime.InteropServices;
 using static Interop;
 

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SelectionScope.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SelectionScope.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if DEBUG
-#endif
-
 namespace Windows.Win32;
 
 internal static partial class PInvoke

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SetBkModeScope.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SetBkModeScope.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if DEBUG
-#endif
-
 namespace Windows.Win32;
 
 internal static partial class PInvoke

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SetMapModeScope.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SetMapModeScope.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if DEBUG
-#endif
-
 namespace Windows.Win32;
 
 internal static partial class PInvoke

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SetRop2Scope.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SetRop2Scope.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if DEBUG
-#endif
-
 namespace Windows.Win32;
 
 internal static partial class PInvoke

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SetTextAlignmentScope.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SetTextAlignmentScope.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if DEBUG
-#endif
-
 namespace Windows.Win32;
 
 internal static partial class PInvoke

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SetTextColorScope.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SetTextColorScope.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if DEBUG
-#endif
-
 namespace Windows.Win32;
 
 internal static partial class PInvoke

--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -974,16 +974,16 @@ System.Windows.Forms.ToolStripControlHost.ToolStripControlHost(System.Windows.Fo
 ~System.Windows.Forms.ToolStripItemCollection.Insert(int index, System.Windows.Forms.ToolStripItem value) -> void
 ~System.Windows.Forms.ToolStripItemCollection.Remove(System.Windows.Forms.ToolStripItem value) -> void
 ~System.Windows.Forms.ToolStripItemCollection.ToolStripItemCollection(System.Windows.Forms.ToolStrip owner, System.Windows.Forms.ToolStripItem[] value) -> void
-~System.Windows.Forms.ToolStripPanel.ToolStripPanelRowCollection.Add(System.Windows.Forms.ToolStripPanelRow value) -> int
-~System.Windows.Forms.ToolStripPanel.ToolStripPanelRowCollection.AddRange(System.Windows.Forms.ToolStripPanel.ToolStripPanelRowCollection value) -> void
-~System.Windows.Forms.ToolStripPanel.ToolStripPanelRowCollection.AddRange(System.Windows.Forms.ToolStripPanelRow[] value) -> void
-~System.Windows.Forms.ToolStripPanel.ToolStripPanelRowCollection.Contains(System.Windows.Forms.ToolStripPanelRow value) -> bool
-~System.Windows.Forms.ToolStripPanel.ToolStripPanelRowCollection.CopyTo(System.Windows.Forms.ToolStripPanelRow[] array, int index) -> void
-~System.Windows.Forms.ToolStripPanel.ToolStripPanelRowCollection.IndexOf(System.Windows.Forms.ToolStripPanelRow value) -> int
-~System.Windows.Forms.ToolStripPanel.ToolStripPanelRowCollection.Insert(int index, System.Windows.Forms.ToolStripPanelRow value) -> void
-~System.Windows.Forms.ToolStripPanel.ToolStripPanelRowCollection.Remove(System.Windows.Forms.ToolStripPanelRow value) -> void
-~System.Windows.Forms.ToolStripPanel.ToolStripPanelRowCollection.ToolStripPanelRowCollection(System.Windows.Forms.ToolStripPanel owner) -> void
-~System.Windows.Forms.ToolStripPanel.ToolStripPanelRowCollection.ToolStripPanelRowCollection(System.Windows.Forms.ToolStripPanel owner, System.Windows.Forms.ToolStripPanelRow[] value) -> void
+System.Windows.Forms.ToolStripPanel.ToolStripPanelRowCollection.Add(System.Windows.Forms.ToolStripPanelRow! value) -> int
+System.Windows.Forms.ToolStripPanel.ToolStripPanelRowCollection.AddRange(System.Windows.Forms.ToolStripPanel.ToolStripPanelRowCollection! value) -> void
+System.Windows.Forms.ToolStripPanel.ToolStripPanelRowCollection.AddRange(System.Windows.Forms.ToolStripPanelRow![]! value) -> void
+System.Windows.Forms.ToolStripPanel.ToolStripPanelRowCollection.Contains(System.Windows.Forms.ToolStripPanelRow! value) -> bool
+System.Windows.Forms.ToolStripPanel.ToolStripPanelRowCollection.CopyTo(System.Windows.Forms.ToolStripPanelRow![]! array, int index) -> void
+System.Windows.Forms.ToolStripPanel.ToolStripPanelRowCollection.IndexOf(System.Windows.Forms.ToolStripPanelRow! value) -> int
+System.Windows.Forms.ToolStripPanel.ToolStripPanelRowCollection.Insert(int index, System.Windows.Forms.ToolStripPanelRow! value) -> void
+System.Windows.Forms.ToolStripPanel.ToolStripPanelRowCollection.Remove(System.Windows.Forms.ToolStripPanelRow! value) -> void
+System.Windows.Forms.ToolStripPanel.ToolStripPanelRowCollection.ToolStripPanelRowCollection(System.Windows.Forms.ToolStripPanel! owner) -> void
+System.Windows.Forms.ToolStripPanel.ToolStripPanelRowCollection.ToolStripPanelRowCollection(System.Windows.Forms.ToolStripPanel! owner, System.Windows.Forms.ToolStripPanelRow![]! value) -> void
 System.Windows.Forms.ToolStripPanelRow.CanMove(System.Windows.Forms.ToolStrip! toolStripToDrag) -> bool
 System.Windows.Forms.ToolStripPanelRow.Controls.get -> System.Windows.Forms.Control![]!
 System.Windows.Forms.ToolStripPanelRow.LayoutEngine.get -> System.Windows.Forms.Layout.LayoutEngine!
@@ -1433,7 +1433,7 @@ virtual System.Windows.Forms.ToolStripControlHost.OnValidating(System.ComponentM
 ~virtual System.Windows.Forms.ToolStripItemCollection.RemoveByKey(string key) -> void
 ~virtual System.Windows.Forms.ToolStripItemCollection.this[int index].get -> System.Windows.Forms.ToolStripItem
 ~virtual System.Windows.Forms.ToolStripItemCollection.this[string key].get -> System.Windows.Forms.ToolStripItem
-~virtual System.Windows.Forms.ToolStripPanel.ToolStripPanelRowCollection.this[int index].get -> System.Windows.Forms.ToolStripPanelRow
+virtual System.Windows.Forms.ToolStripPanel.ToolStripPanelRowCollection.this[int index].get -> System.Windows.Forms.ToolStripPanelRow!
 virtual System.Windows.Forms.ToolStripPanelRow.OnControlAdded(System.Windows.Forms.Control! control, int index) -> void
 virtual System.Windows.Forms.ToolStripPanelRow.OnControlRemoved(System.Windows.Forms.Control! control, int index) -> void
 virtual System.Windows.Forms.ToolStripPanelRow.OnLayout(System.Windows.Forms.LayoutEventArgs! e) -> void

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/CommonProperties.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/CommonProperties.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if DEBUG
-#endif
 using System.Collections.Specialized;
 #if DEBUG
 using System.ComponentModel;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MDIWindowDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MDIWindowDialog.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if DEBUG
-#endif
-
 namespace System.Windows.Forms;
 
 internal sealed partial class MdiWindowDialog : Form

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextRenderer.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#if DEBUG
-#endif
 using System.Drawing;
 using System.Drawing.Text;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanel.ToolStripPanelRowCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanel.ToolStripPanelRowCollection.cs
@@ -2,12 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections;
 using System.ComponentModel;
-#if DEBUG
-#endif
 using System.Windows.Forms.Layout;
 
 namespace System.Windows.Forms;
@@ -115,15 +111,15 @@ public partial class ToolStripPanel
 
         void IList.Clear() { Clear(); }
         bool IList.IsFixedSize { get { return ((IList)InnerList).IsFixedSize; } }
-        bool IList.Contains(object value) { return InnerList.Contains(value); }
+        bool IList.Contains(object? value) { return InnerList.Contains(value); }
         bool IList.IsReadOnly { get { return ((IList)InnerList).IsReadOnly; } }
         void IList.RemoveAt(int index) { RemoveAt(index); }
-        void IList.Remove(object value) { Remove(value as ToolStripPanelRow); }
-        int IList.Add(object value) { return Add(value as ToolStripPanelRow); }
-        int IList.IndexOf(object value) { return IndexOf(value as ToolStripPanelRow); }
-        void IList.Insert(int index, object value) { Insert(index, value as ToolStripPanelRow); }
+        void IList.Remove(object? value) { Remove((ToolStripPanelRow)value!); }
+        int IList.Add(object? value) { return Add((ToolStripPanelRow)value!); }
+        int IList.IndexOf(object? value) { return IndexOf((ToolStripPanelRow)value!); }
+        void IList.Insert(int index, object? value) { Insert(index, (ToolStripPanelRow)value!); }
 
-        object IList.this[int index]
+        object? IList.this[int index]
         {
             get { return InnerList[index]; }
             set { throw new NotSupportedException(SR.ToolStripCollectionMustInsertAndRemove); /* InnerList[index] = value; */ }
@@ -153,7 +149,7 @@ public partial class ToolStripPanel
         /// <summary>
         ///  Do proper cleanup of ownership, etc.
         /// </summary>
-        private static void OnAfterRemove(ToolStripPanelRow row)
+        private static void OnAfterRemove(ToolStripPanelRow? row)
         {
 #if DEBUG
             if (s_toolStripPanelMissingRowDebug.TraceVerbose)
@@ -177,7 +173,7 @@ public partial class ToolStripPanel
 
         public void RemoveAt(int index)
         {
-            ToolStripPanelRow item = null;
+            ToolStripPanelRow? item = null;
             if (index < Count && index >= 0)
             {
                 item = (ToolStripPanelRow)(InnerList[index]);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanel.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanel.cs
@@ -499,7 +499,7 @@ public partial class ToolStripPanel : ContainerControl, IArrangedElement
     {
         if (e.AffectedComponent != ParentInternal && e.AffectedComponent as Control is not null)
         {
-            if (e.AffectedComponent is ISupportToolStripPanel draggedControl && RowsInternal.Contains(draggedControl.ToolStripPanelRow))
+            if (e.AffectedComponent is ISupportToolStripPanel draggedControl && RowsInternal.Contains(draggedControl.ToolStripPanelRow!))
             {
                 // there's a problem in the base onlayout... if toolstrip needs more space it talks to us
                 // not the row that needs layout.
@@ -1183,7 +1183,7 @@ public partial class ToolStripPanel : ContainerControl, IArrangedElement
 
                     static object GetRow(ISupportToolStripPanel draggedToolStrip, ToolStripPanelRowCollection rows)
                     {
-                        int rowIndex = rows.IndexOf(draggedToolStrip.ToolStripPanelRow);
+                        int rowIndex = rows.IndexOf(draggedToolStrip.ToolStripPanelRow!);
                         return rowIndex == -1
                             ? "unknown"
                             : rowIndex;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanelRow.VerticalRowManager.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanelRow.VerticalRowManager.cs
@@ -3,8 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections;
-#if DEBUG
-#endif
 using System.Drawing;
 using System.Windows.Forms.Layout;
 


### PR DESCRIPTION
## Proposed changes

- Enable nullability in ToolStripPanelRowCollection.
- Remove some unnecessary DEBUG pre-processor checks.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9077)