### PR TITLE
Enable nullability in classes that inherit from DesignerActionList

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ContextMenuStripActionList.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ContextMenuStripActionList.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 using System.ComponentModel.Design;
 
@@ -14,15 +12,16 @@ internal class ContextMenuStripActionList : DesignerActionList
     private readonly ToolStripDropDown _toolStripDropDown;
     private bool _autoShow;
 
-    public ContextMenuStripActionList(ToolStripDropDownDesigner designer) : base(designer.Component)
+    public ContextMenuStripActionList(ToolStripDropDownDesigner designer)
+        : base(designer.Component)
     {
         _toolStripDropDown = (ToolStripDropDown)designer.Component;
     }
 
     //helper function to get the property on the actual Control
-    private object GetProperty(string propertyName)
+    private object? GetProperty(string propertyName)
     {
-        PropertyDescriptor getProperty = TypeDescriptor.GetProperties(_toolStripDropDown)[propertyName];
+        PropertyDescriptor? getProperty = TypeDescriptor.GetProperties(_toolStripDropDown)[propertyName];
         Debug.Assert(getProperty is not null, "Could not find given property in control.");
         if (getProperty is not null)
         {
@@ -35,7 +34,7 @@ internal class ContextMenuStripActionList : DesignerActionList
     //helper function to change the property on the actual Control
     private void ChangeProperty(string propertyName, object value)
     {
-        PropertyDescriptor changingProperty = TypeDescriptor.GetProperties(_toolStripDropDown)[propertyName];
+        PropertyDescriptor? changingProperty = TypeDescriptor.GetProperties(_toolStripDropDown)[propertyName];
         Debug.Assert(changingProperty is not null, "Could not find given property in control.");
         changingProperty?.SetValue(_toolStripDropDown, value);
     }
@@ -57,7 +56,7 @@ internal class ContextMenuStripActionList : DesignerActionList
 
     public bool ShowImageMargin
     {
-        get => (bool)GetProperty(nameof(ShowImageMargin));
+        get => (bool)GetProperty(nameof(ShowImageMargin))!;
         set
         {
             if (value != ShowImageMargin)
@@ -69,7 +68,7 @@ internal class ContextMenuStripActionList : DesignerActionList
 
     public bool ShowCheckMargin
     {
-        get => (bool)GetProperty(nameof(ShowCheckMargin));
+        get => (bool)GetProperty(nameof(ShowCheckMargin))!;
         set
         {
             if (value != ShowCheckMargin)
@@ -81,7 +80,7 @@ internal class ContextMenuStripActionList : DesignerActionList
 
     public ToolStripRenderMode RenderMode
     {
-        get => (ToolStripRenderMode)GetProperty(nameof(RenderMode));
+        get => (ToolStripRenderMode)GetProperty(nameof(RenderMode))!;
         set
         {
             if (value != RenderMode)

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.DockingActionList.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.DockingActionList.cs
@@ -21,7 +21,12 @@ public partial class ControlDesigner
 
         private string? GetActionName()
         {
-            PropertyDescriptor? dockProp = TypeDescriptor.GetProperties(Component!)["Dock"];
+            if (Component is null)
+            {
+                return null;
+            }
+
+            PropertyDescriptor? dockProp = TypeDescriptor.GetProperties(Component)["Dock"];
             if (dockProp is not null)
             {
                 DockStyle dockStyle = (DockStyle)dockProp.GetValue(Component)!;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.DockingActionList.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.DockingActionList.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 using System.ComponentModel.Design;
 
@@ -13,21 +11,20 @@ public partial class ControlDesigner
 {
     private class DockingActionList : DesignerActionList
     {
-        private readonly ControlDesigner _designer;
-        private readonly IDesignerHost _host;
+        private readonly IDesignerHost? _host;
 
-        public DockingActionList(ControlDesigner owner) : base(owner.Component)
+        public DockingActionList(ControlDesigner owner)
+            : base(owner.Component)
         {
-            _designer = owner;
             _host = GetService(typeof(IDesignerHost)) as IDesignerHost;
         }
 
-        private string GetActionName()
+        private string? GetActionName()
         {
-            PropertyDescriptor dockProp = TypeDescriptor.GetProperties(Component)["Dock"];
+            PropertyDescriptor? dockProp = TypeDescriptor.GetProperties(Component!)["Dock"];
             if (dockProp is not null)
             {
-                DockStyle dockStyle = (DockStyle)dockProp.GetValue(Component);
+                DockStyle dockStyle = (DockStyle)dockProp.GetValue(Component)!;
                 if (dockStyle == DockStyle.Fill)
                 {
                     return SR.DesignerShortcutUndockInParent;
@@ -44,24 +41,24 @@ public partial class ControlDesigner
         public override DesignerActionItemCollection GetSortedActionItems()
         {
             DesignerActionItemCollection items = new DesignerActionItemCollection();
-            string actionName = GetActionName();
+            string? actionName = GetActionName();
             if (actionName is not null)
             {
-                items.Add(new DesignerActionVerbItem(new DesignerVerb(GetActionName(), OnDockActionClick)));
+                items.Add(new DesignerActionVerbItem(new DesignerVerb(actionName, OnDockActionClick)));
             }
 
             return items;
         }
 
-        private void OnDockActionClick(object sender, EventArgs e)
+        private void OnDockActionClick(object? sender, EventArgs e)
         {
             if (sender is DesignerVerb designerVerb && _host is not null)
             {
                 using DesignerTransaction t = _host.CreateTransaction(designerVerb.Text);
 
                 // Set the dock prop to DockStyle.Fill
-                PropertyDescriptor dockProp = TypeDescriptor.GetProperties(Component)["Dock"];
-                DockStyle dockStyle = (DockStyle)dockProp.GetValue(Component);
+                PropertyDescriptor dockProp = TypeDescriptor.GetProperties(Component!)["Dock"]!;
+                DockStyle dockStyle = (DockStyle)dockProp.GetValue(Component)!;
                 dockProp.SetValue(Component, dockStyle == DockStyle.Fill ? DockStyle.None : DockStyle.Fill);
                 t.Commit();
             }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerActionVerbList.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerActionVerbList.cs
@@ -8,7 +8,8 @@ internal class DesignerActionVerbList : DesignerActionList
 {
     private readonly DesignerVerb[] _verbs;
 
-    public DesignerActionVerbList(DesignerVerb[] verbs) : base(null)
+    public DesignerActionVerbList(DesignerVerb[] verbs)
+        : base(null)
     {
         _verbs = verbs;
     }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ListControlUnboundActionList.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ListControlUnboundActionList.cs
@@ -10,7 +10,8 @@ internal class ListControlUnboundActionList : DesignerActionList
 {
     private readonly ComponentDesigner _designer;
 
-    public ListControlUnboundActionList(ComponentDesigner designer) : base(designer.Component)
+    public ListControlUnboundActionList(ComponentDesigner designer)
+        : base(designer.Component)
     {
         _designer = designer;
     }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ListViewActionList.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ListViewActionList.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel.Design;
 using System.ComponentModel;
 
@@ -12,7 +10,8 @@ namespace System.Windows.Forms.Design;
 internal class ListViewActionList : DesignerActionList
 {
     private readonly ComponentDesigner _designer;
-    public ListViewActionList(ComponentDesigner designer) : base(designer.Component)
+    public ListViewActionList(ComponentDesigner designer)
+        : base(designer.Component)
     {
         _designer = designer;
     }
@@ -36,35 +35,35 @@ internal class ListViewActionList : DesignerActionList
     {
         get
         {
-            return ((ListView)Component).View;
+            return ((ListView)Component!).View;
         }
         set
         {
-            TypeDescriptor.GetProperties(Component)["View"].SetValue(Component, value);
+            TypeDescriptor.GetProperties(Component!)["View"]!.SetValue(Component, value);
         }
     }
 
-    public ImageList LargeImageList
+    public ImageList? LargeImageList
     {
         get
         {
-            return ((ListView)Component).LargeImageList;
+            return ((ListView)Component!).LargeImageList;
         }
         set
         {
-            TypeDescriptor.GetProperties(Component)["LargeImageList"].SetValue(Component, value);
+            TypeDescriptor.GetProperties(Component!)["LargeImageList"]!.SetValue(Component, value);
         }
     }
 
-    public ImageList SmallImageList
+    public ImageList? SmallImageList
     {
         get
         {
-            return ((ListView)Component).SmallImageList;
+            return ((ListView)Component!).SmallImageList;
         }
         set
         {
-            TypeDescriptor.GetProperties(Component)["SmallImageList"].SetValue(Component, value);
+            TypeDescriptor.GetProperties(Component!)["SmallImageList"]!.SetValue(Component, value);
         }
     }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ListViewActionList.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ListViewActionList.cs
@@ -10,10 +10,13 @@ namespace System.Windows.Forms.Design;
 internal class ListViewActionList : DesignerActionList
 {
     private readonly ComponentDesigner _designer;
+    private readonly ListView _listView;
+
     public ListViewActionList(ComponentDesigner designer)
         : base(designer.Component)
     {
         _designer = designer;
+        _listView = (ListView)Component!;
     }
 
     public void InvokeItemsDialog()
@@ -35,11 +38,11 @@ internal class ListViewActionList : DesignerActionList
     {
         get
         {
-            return ((ListView)Component!).View;
+            return _listView.View;
         }
         set
         {
-            TypeDescriptor.GetProperties(Component!)["View"]!.SetValue(Component, value);
+            TypeDescriptor.GetProperties(_listView)["View"]!.SetValue(Component, value);
         }
     }
 
@@ -47,11 +50,11 @@ internal class ListViewActionList : DesignerActionList
     {
         get
         {
-            return ((ListView)Component!).LargeImageList;
+            return _listView.LargeImageList;
         }
         set
         {
-            TypeDescriptor.GetProperties(Component!)["LargeImageList"]!.SetValue(Component, value);
+            TypeDescriptor.GetProperties(_listView)["LargeImageList"]!.SetValue(Component, value);
         }
     }
 
@@ -59,11 +62,11 @@ internal class ListViewActionList : DesignerActionList
     {
         get
         {
-            return ((ListView)Component!).SmallImageList;
+            return _listView.SmallImageList;
         }
         set
         {
-            TypeDescriptor.GetProperties(Component!)["SmallImageList"]!.SetValue(Component, value);
+            TypeDescriptor.GetProperties(_listView)["SmallImageList"]!.SetValue(Component, value);
         }
     }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskedTextBoxDesignerActionList.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskedTextBoxDesignerActionList.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 using System.ComponentModel.Design;
 
@@ -16,16 +14,17 @@ namespace System.Windows.Forms.Design;
 internal class MaskedTextBoxDesignerActionList : DesignerActionList
 {
     private readonly MaskedTextBox _maskedTextBox;
-    private readonly ITypeDiscoveryService _discoverySvc;
-    private readonly IUIService _uiSvc;
-    private readonly IHelpService _helpService;
+    private readonly ITypeDiscoveryService? _discoverySvc;
+    private readonly IUIService? _uiSvc;
+    private readonly IHelpService? _helpService;
 
     /// <summary>
     /// Constructor receiving a MaskedTextBox control the action list applies to.  The ITypeDiscoveryService
     /// service provider is used to populate the canned mask list control in the MaskDesignerDialog dialog and
     /// the IUIService provider is used to display the MaskDesignerDialog within VS.
     /// </summary>
-    public MaskedTextBoxDesignerActionList(MaskedTextBoxDesigner designer) : base(designer.Component)
+    public MaskedTextBoxDesignerActionList(MaskedTextBoxDesigner designer)
+        : base(designer.Component)
     {
         _maskedTextBox = (MaskedTextBox)designer.Component;
         _discoverySvc = GetService(typeof(ITypeDiscoveryService)) as ITypeDiscoveryService;
@@ -50,7 +49,7 @@ internal class MaskedTextBoxDesignerActionList : DesignerActionList
             return;
         }
 
-        PropertyDescriptor maskProperty = TypeDescriptor.GetProperties(_maskedTextBox)["Mask"];
+        PropertyDescriptor? maskProperty = TypeDescriptor.GetProperties(_maskedTextBox)["Mask"];
         maskProperty?.SetValue(_maskedTextBox, mask);
     }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/PictureBoxActionList.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/PictureBoxActionList.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel.Design;
 using System.ComponentModel;
 
@@ -12,7 +10,8 @@ namespace System.Windows.Forms.Design;
 internal class PictureBoxActionList : DesignerActionList
 {
     private readonly PictureBoxDesigner _designer;
-    public PictureBoxActionList(PictureBoxDesigner designer) : base(designer.Component)
+    public PictureBoxActionList(PictureBoxDesigner designer)
+        : base(designer.Component)
     {
         _designer = designer;
     }
@@ -21,11 +20,11 @@ internal class PictureBoxActionList : DesignerActionList
     {
         get
         {
-            return ((PictureBox)Component).SizeMode;
+            return ((PictureBox)Component!).SizeMode;
         }
         set
         {
-            TypeDescriptor.GetProperties(Component)["SizeMode"].SetValue(Component, value);
+            TypeDescriptor.GetProperties(Component!)["SizeMode"]!.SetValue(Component, value);
         }
     }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/PictureBoxActionList.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/PictureBoxActionList.cs
@@ -10,21 +10,24 @@ namespace System.Windows.Forms.Design;
 internal class PictureBoxActionList : DesignerActionList
 {
     private readonly PictureBoxDesigner _designer;
+    private readonly PictureBox _pictureBox;
+
     public PictureBoxActionList(PictureBoxDesigner designer)
         : base(designer.Component)
     {
         _designer = designer;
+        _pictureBox = (PictureBox)designer.Component;
     }
 
     public PictureBoxSizeMode SizeMode
     {
         get
         {
-            return ((PictureBox)Component!).SizeMode;
+            return _pictureBox.SizeMode;
         }
         set
         {
-            TypeDescriptor.GetProperties(Component!)["SizeMode"]!.SetValue(Component, value);
+            TypeDescriptor.GetProperties(_pictureBox)["SizeMode"]!.SetValue(Component, value);
         }
     }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/RichTextBoxActionList.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/RichTextBoxActionList.cs
@@ -10,7 +10,8 @@ internal class RichTextBoxActionList : DesignerActionList
 {
     private readonly RichTextBoxDesigner _designer;
 
-    public RichTextBoxActionList(RichTextBoxDesigner designer) : base(designer.Component)
+    public RichTextBoxActionList(RichTextBoxDesigner designer)
+        : base(designer.Component)
     {
         _designer = designer;
     }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TextBoxActionList.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TextBoxActionList.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 using System.ComponentModel.Design;
 
@@ -11,7 +9,8 @@ namespace System.Windows.Forms.Design;
 
 internal class TextBoxActionList : DesignerActionList
 {
-    public TextBoxActionList(TextBoxDesigner designer) : base(designer.Component)
+    public TextBoxActionList(TextBoxDesigner designer)
+        : base(designer.Component)
     {
     }
 
@@ -19,11 +18,11 @@ internal class TextBoxActionList : DesignerActionList
     {
         get
         {
-            return ((TextBox)Component).Multiline;
+            return ((TextBox)Component!).Multiline;
         }
         set
         {
-            TypeDescriptor.GetProperties(Component)["Multiline"].SetValue(Component, value);
+            TypeDescriptor.GetProperties(Component!)["Multiline"]!.SetValue(Component, value);
         }
     }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TextBoxActionList.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TextBoxActionList.cs
@@ -9,20 +9,23 @@ namespace System.Windows.Forms.Design;
 
 internal class TextBoxActionList : DesignerActionList
 {
+    private readonly TextBox _textBox;
+
     public TextBoxActionList(TextBoxDesigner designer)
         : base(designer.Component)
     {
+        _textBox = (TextBox)designer.Component;
     }
 
     public bool Multiline
     {
         get
         {
-            return ((TextBox)Component!).Multiline;
+            return _textBox.Multiline;
         }
         set
         {
-            TypeDescriptor.GetProperties(Component!)["Multiline"]!.SetValue(Component, value);
+            TypeDescriptor.GetProperties(_textBox)["Multiline"]!.SetValue(Component, value);
         }
     }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripActionList.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripActionList.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 using System.ComponentModel.Design;
 
@@ -13,18 +11,17 @@ internal class ToolStripActionList : DesignerActionList
 {
     private readonly ToolStrip _toolStrip;
     private bool _autoShow;
-    private readonly ToolStripDesigner _designer;
 
     private readonly ChangeToolStripParentVerb _changeParentVerb;
-    private readonly StandardMenuStripVerb _standardItemsVerb;
+    private readonly StandardMenuStripVerb? _standardItemsVerb;
 
-    public ToolStripActionList(ToolStripDesigner designer) : base(designer.Component)
+    public ToolStripActionList(ToolStripDesigner designer)
+        : base(designer.Component)
     {
         _toolStrip = (ToolStrip)designer.Component;
-        _designer = designer;
 
         _changeParentVerb = new ChangeToolStripParentVerb(SR.ToolStripDesignerEmbedVerb, designer);
-        if (!(_toolStrip is StatusStrip))
+        if (_toolStrip is not StatusStrip)
         {
             _standardItemsVerb = new StandardMenuStripVerb(designer);
         }
@@ -38,8 +35,7 @@ internal class ToolStripActionList : DesignerActionList
         get
         {
             // Make sure the component is not being inherited -- we can't delete these!
-            InheritanceAttribute ia = (InheritanceAttribute)TypeDescriptor.GetAttributes(_toolStrip)[typeof(InheritanceAttribute)];
-            if (ia is null || ia.InheritanceLevel == InheritanceLevel.NotInherited)
+            if (!TypeDescriptorHelper.TryGetAttribute(_toolStrip, out InheritanceAttribute? ia) || ia.InheritanceLevel == InheritanceLevel.NotInherited)
             {
                 return true;
             }
@@ -53,8 +49,7 @@ internal class ToolStripActionList : DesignerActionList
         get
         {
             // Make sure the component is not being inherited -- we can't delete these!
-            InheritanceAttribute ia = (InheritanceAttribute)TypeDescriptor.GetAttributes(_toolStrip)[typeof(InheritanceAttribute)];
-            if (ia is null || ia.InheritanceLevel == InheritanceLevel.InheritedReadOnly)
+            if (!TypeDescriptorHelper.TryGetAttribute(_toolStrip, out InheritanceAttribute? ia) || ia.InheritanceLevel == InheritanceLevel.InheritedReadOnly)
             {
                 return true;
             }
@@ -64,9 +59,9 @@ internal class ToolStripActionList : DesignerActionList
     }
 
     //helper function to get the property on the actual Control
-    private object GetProperty(string propertyName)
+    private object? GetProperty(string propertyName)
     {
-        PropertyDescriptor getProperty = TypeDescriptor.GetProperties(_toolStrip)[propertyName];
+        PropertyDescriptor? getProperty = TypeDescriptor.GetProperties(_toolStrip)[propertyName];
         Debug.Assert(getProperty is not null, "Could not find given property in control.");
         if (getProperty is not null)
         {
@@ -79,7 +74,7 @@ internal class ToolStripActionList : DesignerActionList
     //helper function to change the property on the actual Control
     private void ChangeProperty(string propertyName, object value)
     {
-        PropertyDescriptor changingProperty = TypeDescriptor.GetProperties(_toolStrip)[propertyName];
+        PropertyDescriptor? changingProperty = TypeDescriptor.GetProperties(_toolStrip)[propertyName];
         Debug.Assert(changingProperty is not null, "Could not find given property in control.");
         changingProperty?.SetValue(_toolStrip, value);
     }
@@ -101,7 +96,7 @@ internal class ToolStripActionList : DesignerActionList
 
     public DockStyle Dock
     {
-        get => (DockStyle)GetProperty(nameof(Dock));
+        get => (DockStyle)GetProperty(nameof(Dock))!;
         set
         {
             if (value != Dock)
@@ -113,7 +108,7 @@ internal class ToolStripActionList : DesignerActionList
 
     public ToolStripRenderMode RenderMode
     {
-        get => (ToolStripRenderMode)GetProperty(nameof(RenderMode));
+        get => (ToolStripRenderMode)GetProperty(nameof(RenderMode))!;
         set
         {
             if (value != RenderMode)
@@ -125,7 +120,7 @@ internal class ToolStripActionList : DesignerActionList
 
     public ToolStripGripStyle GripStyle
     {
-        get => (ToolStripGripStyle)GetProperty(nameof(GripStyle));
+        get => (ToolStripGripStyle)GetProperty(nameof(GripStyle))!;
         set
         {
             if (value != GripStyle)
@@ -138,7 +133,7 @@ internal class ToolStripActionList : DesignerActionList
     private void InvokeEmbedVerb()
     {
         // Hide the Panel...
-        DesignerActionUIService actionUIService = (DesignerActionUIService)_toolStrip.Site.GetService(typeof(DesignerActionUIService));
+        DesignerActionUIService? actionUIService = (DesignerActionUIService?)_toolStrip.Site?.GetService(typeof(DesignerActionUIService));
         actionUIService?.HideUI(_toolStrip);
 
         _changeParentVerb.ChangeParent();
@@ -146,7 +141,7 @@ internal class ToolStripActionList : DesignerActionList
 
     private void InvokeInsertStandardItemsVerb()
     {
-        _standardItemsVerb.InsertItems();
+        _standardItemsVerb?.InsertItems();
     }
 
     /// <summary>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TreeViewActionList.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TreeViewActionList.cs
@@ -10,11 +10,13 @@ namespace System.Windows.Forms.Design;
 internal class TreeViewActionList : DesignerActionList
 {
     private readonly TreeViewDesigner _designer;
+    private readonly TreeView _treeView;
 
     public TreeViewActionList(TreeViewDesigner designer)
         : base(designer.Component)
     {
         _designer = designer;
+        _treeView = (TreeView)designer.Component;
     }
 
     public void InvokeNodesDialog()
@@ -26,11 +28,11 @@ internal class TreeViewActionList : DesignerActionList
     {
         get
         {
-            return ((TreeView)Component!).ImageList;
+            return _treeView.ImageList;
         }
         set
         {
-            TypeDescriptor.GetProperties(Component!)["ImageList"]!.SetValue(Component, value);
+            TypeDescriptor.GetProperties(_treeView)["ImageList"]!.SetValue(Component, value);
         }
     }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TreeViewActionList.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TreeViewActionList.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 using System.ComponentModel.Design;
 
@@ -12,7 +10,9 @@ namespace System.Windows.Forms.Design;
 internal class TreeViewActionList : DesignerActionList
 {
     private readonly TreeViewDesigner _designer;
-    public TreeViewActionList(TreeViewDesigner designer) : base(designer.Component)
+
+    public TreeViewActionList(TreeViewDesigner designer)
+        : base(designer.Component)
     {
         _designer = designer;
     }
@@ -26,11 +26,11 @@ internal class TreeViewActionList : DesignerActionList
     {
         get
         {
-            return ((TreeView)Component).ImageList;
+            return ((TreeView)Component!).ImageList;
         }
         set
         {
-            TypeDescriptor.GetProperties(Component)["ImageList"].SetValue(Component, value);
+            TypeDescriptor.GetProperties(Component!)["ImageList"]!.SetValue(Component, value);
         }
     }
 


### PR DESCRIPTION
## Proposed changes

- Enable nullability in classes that inherit from DesignerActionList.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9084)