### PR TITLE
Fix Application.Exit issues

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/FormCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FormCollection.cs
@@ -12,6 +12,10 @@ namespace System.Windows.Forms;
 public class FormCollection : ReadOnlyCollectionBase
 {
     internal static object CollectionSyncRoot = new();
+    /// <summary>
+    /// Changes when a new form is added.
+    /// </summary>
+    internal int AddVersion { get; private set; }
 
     /// <summary>
     ///  Gets a form specified by name, if present, else returns null. If there are multiple
@@ -65,6 +69,7 @@ public class FormCollection : ReadOnlyCollectionBase
         lock (CollectionSyncRoot)
         {
             InnerList.Add(form);
+            AddVersion++;
         }
     }
 
@@ -83,13 +88,24 @@ public class FormCollection : ReadOnlyCollectionBase
     }
 
     /// <summary>
-    ///  Used internally to add a Form to the FormCollection
+    ///  Used internally to remove a Form from the FormCollection
     /// </summary>
     internal void Remove(Form form)
     {
         lock (CollectionSyncRoot)
         {
             InnerList.Remove(form);
+        }
+    }
+
+    /// <summary>
+    ///  Used internally to remove a Form from the FormCollection
+    /// </summary>
+    internal void RemoveAt(int index)
+    {
+        lock (CollectionSyncRoot)
+        {
+            InnerList.RemoveAt(index);
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ApplicationTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ApplicationTests.cs
@@ -260,6 +260,280 @@ public class ApplicationTests
         Assert.Throws<InvalidEnumArgumentException>("highDpiMode", () => Application.SetHighDpiMode(value));
     }
 
+    /// <summary>
+    /// Test <see cref="Application.Exit()"/> fire Closing events in correct order for MDI windows.
+    /// </summary>
+    /// <param name="mainMDIFormCountParam">Count of MdiContainers. If == 1 then main form is MdiContainer.</param>
+    /// <param name="childFormCountParam">Count of MDI child.</param>
+    [WinFormsTheory]
+    [InlineData(1, 0)]
+    [InlineData(1, 1)]
+    [InlineData(1, 3)]
+    [InlineData(2, 0)]
+    [InlineData(2, 1)]
+    [InlineData(2, 3)]
+    [InlineData(3, 0)]
+    [InlineData(3, 1)]
+    [InlineData(3, 3)]
+    public void Application_Exit_MDIFormClosing_Order(int mainMDIFormCountParam, int childFormCountParam)
+    {
+        Assert.True(mainMDIFormCountParam > 0);
+        Assert.True(childFormCountParam > -1);
+        Assert.True(mainMDIFormCountParam < 10);  // to not flood
+        Assert.True(childFormCountParam < 10); // to not flood
+
+        RemoteExecutor.Invoke((mainMDIFormCountString, childFormCountString) =>
+        {
+            int mainMDIFormCount = int.Parse(mainMDIFormCountString);
+            int childFormCount = int.Parse(childFormCountString);
+
+            Application.EnableVisualStyles();
+            using Form mainForm = new Form();
+            Assert.Equal(0, Application.OpenForms.Count);
+            Dictionary<object, int> formClosingProcessed = new(mainMDIFormCount);
+            Dictionary<object, int> formClosedProcessed = new(mainMDIFormCount);
+            bool exitCalled = false;
+
+            if (mainMDIFormCount == 1) // main form is MdiContainer 
+            {
+                AddMDI(mainForm);
+            }
+            else
+            {
+                mainForm.Show();
+                for (int i = 0; i < mainMDIFormCount; i++)
+                {
+                    AddMDI(new Form());
+                }
+            }
+
+            try
+            {
+                Application.Exit();
+            }
+            finally
+            {
+                exitCalled = true;
+            }
+
+            Assert.Equal(mainMDIFormCount + mainMDIFormCount * childFormCount, formClosingProcessed.Values.Sum());
+            Assert.Equal(mainMDIFormCount + mainMDIFormCount * childFormCount, formClosedProcessed.Values.Sum());
+
+            void AddMDI(Form mdiParent)
+            {
+                formClosingProcessed[mdiParent] = 0;
+                formClosedProcessed[mdiParent] = 0;
+                mdiParent.IsMdiContainer = true;
+                mdiParent.FormClosing += (object sender, FormClosingEventArgs e) =>
+                {
+                    if (exitCalled)
+                        return;
+
+                    Assert.Equal(childFormCount, formClosingProcessed[sender]++);
+                };
+
+                mdiParent.FormClosed += (object sender, FormClosedEventArgs e) =>
+                {
+                    if (exitCalled)
+                        return;
+
+                    Assert.Equal(childFormCount, formClosedProcessed[sender]++);
+                };
+
+                mdiParent.Show();
+                for (int i = 0; i < childFormCount; i++)
+                {
+                    var child = new Form
+                    {
+                        MdiParent = mdiParent
+                    };
+
+                    child.FormClosing += (object sender, FormClosingEventArgs e) =>
+                    {
+                        if (exitCalled)
+                            return;
+
+                        formClosingProcessed[(sender as Form).MdiParent]++;
+                    };
+
+                    child.FormClosed += (object sender, FormClosedEventArgs e) =>
+                    {
+                        if (exitCalled)
+                            return;
+
+                        formClosedProcessed[(sender as Form).MdiParent]++;
+                    };
+
+                    child.Show();
+                }
+            }
+        }, mainMDIFormCountParam.ToString(), childFormCountParam.ToString()).Dispose();
+    }
+
+    /// <summary>
+    /// Test <see cref="Application.Exit()"/> fire Closing events in which we close existing and open new forms.
+    /// </summary>
+    /// <param name="childFormCountParam">Count of child forms.</param>
+    /// <param name="removedFormCountParam">Count of forms that we will remove during last form <see cref="Form.OnFormClosing(FormClosingEventArgs)"/>.</param>
+    /// <param name="addFormCountParam">Count of forms that we will add during last form <see cref="Form.OnFormClosing(FormClosingEventArgs)"/>.</param>
+    /// <param name="cancelParam">If set to <see langword="true" /> we will cancel application exit process.</param>
+    [WinFormsTheory]
+    [InlineData(0, 0, 0, false)]
+    [InlineData(0, 0, 1, false)]
+    [InlineData(1, 1, 0, false)]
+    [InlineData(1, 1, 1, false)]
+    [InlineData(1, 1, 2, false)]
+    [InlineData(2, 0, 0, false)]
+    [InlineData(2, 0, 1, false)]
+    [InlineData(2, 1, 1, false)]
+    [InlineData(2, 2, 2, false)]
+    [InlineData(2, 1, 4, false)]
+    [InlineData(5, 4, 3, false)]
+    [InlineData(5, 4, 5, false)]
+    [InlineData(5, 5, 5, false)]
+    [InlineData(0, 0, 0, true)]
+    [InlineData(0, 0, 1, true)]
+    [InlineData(1, 1, 0, true)]
+    [InlineData(1, 1, 1, true)]
+    [InlineData(1, 1, 2, true)]
+    [InlineData(2, 0, 0, true)]
+    [InlineData(2, 0, 1, true)]
+    [InlineData(2, 1, 1, true)]
+    [InlineData(2, 2, 2, true)]
+    [InlineData(2, 1, 4, true)]
+    [InlineData(5, 4, 3, true)]
+    [InlineData(5, 4, 5, true)]
+    [InlineData(5, 5, 5, true)]
+    public void Application_Exit_OpenForms_Show_Close(int childFormCountParam, int removedFormCountParam, int addFormCountParam, bool cancelParam)
+    {
+        Assert.True(childFormCountParam > -1);
+        Assert.True(removedFormCountParam > -1);
+        Assert.True(addFormCountParam > -1);
+        Assert.True(childFormCountParam < 10); // to not flood
+        Assert.True(addFormCountParam < 10);  // to not flood
+        Assert.True(removedFormCountParam <= childFormCountParam);
+        Assert.True(childFormCountParam > 0 || removedFormCountParam == 0);
+
+        RemoteExecutor.Invoke((childFormCountString, removedFormCountString, addFormCountString, cancelString) =>
+        {
+            int childFormCount = int.Parse(childFormCountString);
+            int removedFormCount = int.Parse(removedFormCountString);
+            int addFormCount = int.Parse(addFormCountString);
+            bool cancel = bool.Parse(cancelString);
+
+            Application.EnableVisualStyles();
+            using Form mainForm = new Form();
+            Assert.Equal(0, Application.OpenForms.Count);
+            int formClosingProcessed = 0;
+            Form lastChild = null;
+            bool exitCalled = false;
+            bool lastChildProcessed = false;
+
+            mainForm.FormClosing += (object sender, FormClosingEventArgs e) =>
+            {
+                if (exitCalled)
+                    return;
+
+                Assert.Equal(childFormCount + (childFormCount > 0 ? addFormCount : 0), formClosingProcessed);
+                formClosingProcessed++;
+                if (childFormCount == 0) // no child forms
+                {
+                    for (int j = 0; j < addFormCount; j++)
+                    {
+                        AddForm();
+                    }
+
+                    if (cancel)
+                    {
+                        e.Cancel = cancel;
+                        formClosingProcessed--; // not count on e.Cancel == true
+                    }
+                }
+            };
+
+            mainForm.Show();
+            for (int i = 0; i < childFormCount; i++)
+            {
+                Form other = new Form() { Text = "Child" };
+                other.Show(mainForm);
+                if (i == childFormCount - 1)
+                    lastChild = other;
+
+                other.FormClosing += (object sender, FormClosingEventArgs e) =>
+                {
+                    if (exitCalled)
+                        return;
+
+                    formClosingProcessed++;
+                    if (sender == lastChild)
+                    {
+                        if (!lastChildProcessed)
+                        {
+                            lastChildProcessed = true;
+                            if (removedFormCount > 0)
+                            {
+                                Random rnd = new Random();
+                                for (int j = 0; j < removedFormCount; j++)
+                                {
+                                    Application.OpenForms[rnd.Next(1, Application.OpenForms.Count - 1)].Close();
+                                }
+                            }
+
+                            for (int j = 0; j < addFormCount; j++)
+                            {
+                                AddForm();
+                            }
+
+                            if (cancel)
+                            {
+                                e.Cancel = cancel;
+                                formClosingProcessed--; // not count on e.Cancel == true
+                            }
+                        }
+                        else if (!cancel)
+                        {
+                            formClosingProcessed--; // need to compensate 2-d call on last child form
+                        }
+                    }
+                };
+            }
+
+            try
+            {
+                Application.Exit();
+            }
+            finally
+            {
+                exitCalled = true;
+            }
+
+            if (!cancel)
+            {
+                Assert.Equal(0, Application.OpenForms.Count);
+                Assert.Equal(1 + childFormCount + addFormCount, formClosingProcessed);
+            }
+            else
+            {
+                Assert.Equal(1 + childFormCount + addFormCount - removedFormCount, Application.OpenForms.Count);
+                Assert.Equal(removedFormCount, formClosingProcessed);
+            }
+
+            void AddForm()
+            {
+                Form add = new Form() { Text = "Add" };
+                add.FormClosing += (object sender, FormClosingEventArgs e) =>
+                {
+                    if (exitCalled)
+                        return;
+
+                    formClosingProcessed++;
+                };
+
+                add.Show(mainForm);
+            }
+        }, childFormCountParam.ToString(), removedFormCountParam.ToString(), addFormCountParam.ToString(), cancelParam.ToString()).Dispose();
+    }
+
     private static void AreFontEqual(Font expected, Font actual)
     {
         Assert.Equal(expected.Name, actual.Name);


### PR DESCRIPTION
Fixes #3606


## Proposed changes

- Replace `foreach` in `OpenForms` iteration.
- Iterate in backward direction.

## Customer Impact
- Users now can close existing and open new forms in `FormClosing` after `Application.Exit` or`Application.Restart` call.
- MDI users now safely can use `Application.Exit` and `Application.Restart`.

## Regression? 

- No

## Risk

- Minimal

## Test methodology

- New ~integration~ unit tests added.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9085)