### PR TITLE
Create BinaryFormatter replacement for known types

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -74,6 +74,7 @@
     <!-- This is needed for Verify.Xunit to pull correct version of System.Speech -->
     <MicrosoftWindowsCompatibilityVersion>7.0.0</MicrosoftWindowsCompatibilityVersion>
     <MoqPackageVersion>4.10.0</MoqPackageVersion>
+    <FluentAssertionsVersion>6.11.0</FluentAssertionsVersion>
     <SystemComponentModelTypeConverterTestDataVersion>8.0.0-beta.23107.1</SystemComponentModelTypeConverterTestDataVersion>
     <SystemDrawingCommonTestDataVersion>8.0.0-beta.23107.1</SystemDrawingCommonTestDataVersion>
     <SystemWindowsExtensionsTestDataVersion>8.0.0-beta.23107.1</SystemWindowsExtensionsTestDataVersion>

--- a/src/System.Windows.Forms.Primitives/src/System/Collections/Generic/ListConverter.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Collections/Generic/ListConverter.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Collections.Generic;
+
+/// <summary>
+///  Helper class for converting values.
+/// </summary>
+/// <remarks>
+///  <para>
+///   It is intended to save the allocation of a temporary list when converting values. If there are multiple passes
+///   through the list this class should usually be avoided.
+///  </para>
+/// </remarks>
+internal class ListConverter<TIn, TOut> : IReadOnlyList<TOut>
+{
+    private readonly IReadOnlyList<TIn> _values;
+    private readonly Func<TIn, TOut> _converter;
+
+    public ListConverter(IReadOnlyList<TIn> values, Func<TIn, TOut> conveter)
+    {
+        _values = values;
+        _converter = conveter;
+    }
+
+    public TOut this[int index] => _converter(_values[index]);
+
+    public int Count => _values.Count;
+
+    // Saving a little bit of code by not writing an enumerator. It isn't huge, so this can be
+    // added if needed.
+
+    IEnumerator<TOut> IEnumerable<TOut>.GetEnumerator() => throw new NotImplementedException();
+    IEnumerator IEnumerable.GetEnumerator() => throw new NotImplementedException();
+}

--- a/src/System.Windows.Forms.Primitives/src/System/IO/BinaryReaderExtensions.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/IO/BinaryReaderExtensions.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.Serialization;
-using System.Text;
+using System.Windows.Forms.BinaryFormat;
 
 namespace System.IO;
 
@@ -14,63 +14,7 @@ internal static class BinaryReaderExtensions
     /// </summary>
     /// <exception cref="SerializationException">The data was invalid.</exception>
     public static unsafe DateTime ReadDateTime(this BinaryReader reader)
-    {
-        // Copied from System.Runtime.Serialization.Formatters.Binary.BinaryParser
-
-        long data = reader.ReadInt64();
-
-        // Use DateTime's public constructor to validate the input, but we
-        // can't return that result as it strips off the kind. To address
-        // that, store the value directly into a DateTime via an unsafe cast.
-        // See BinaryFormatterWriter.WriteDateTime for details.
-
-        try
-        {
-            const long TicksMask = 0x3FFFFFFFFFFFFFFF;
-            _ = new DateTime(data & TicksMask);
-        }
-        catch (ArgumentException ex)
-        {
-            // Bad data
-            throw new SerializationException(ex.Message, ex);
-        }
-
-        return *(DateTime*)&data;
-    }
-
-    /// <summary>
-    ///  Reads a UTF-8 string from the given <paramref name="reader"/> prefixed with a 7 bit encoded length.
-    /// </summary>
-    public static string ReadLengthPrefixedString(this BinaryReader reader)
-        => reader.ReadUtf8String(reader.Read7BitEncodedInt());
-
-    /// <summary>
-    ///  Reads a UTF-8 string of byte length <paramref name="lengthInBytes"/> from the given <paramref name="reader"/>.
-    /// </summary>
-    /// <exception cref="ArgumentOutOfRangeException"><paramref name="lengthInBytes"/> is negative.</exception>
-    private static unsafe string ReadUtf8String(this BinaryReader reader, int lengthInBytes)
-    {
-        if (lengthInBytes == 0)
-        {
-            return string.Empty;
-        }
-
-        if (lengthInBytes < 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(lengthInBytes));
-        }
-
-        if (reader.Remaining() < lengthInBytes)
-        {
-            throw new EndOfStreamException();
-        }
-
-        using BufferScope<byte> buffer = new(stackalloc byte[256], lengthInBytes);
-        Span<byte> bytes = buffer[..lengthInBytes];
-        return reader.Read(bytes) != lengthInBytes
-            ? throw new EndOfStreamException()
-            : Encoding.UTF8.GetString(bytes);
-    }
+        => BinaryFormatReader.CreateDateTimeFromData(reader.ReadInt64());
 
     /// <summary>
     ///  Returns the remaining amount of bytes in the given <paramref name="reader"/>.

--- a/src/System.Windows.Forms.Primitives/src/System/IO/BinaryReaderExtensions.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/IO/BinaryReaderExtensions.cs
@@ -1,0 +1,83 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.Serialization;
+using System.Text;
+
+namespace System.IO;
+
+internal static class BinaryReaderExtensions
+{
+    /// <summary>
+    ///  Reads a binary formatted <see cref="DateTime"/> from the given <paramref name="reader"/>.
+    /// </summary>
+    /// <exception cref="SerializationException">The data was invalid.</exception>
+    public static unsafe DateTime ReadDateTime(this BinaryReader reader)
+    {
+        // Copied from System.Runtime.Serialization.Formatters.Binary.BinaryParser
+
+        long data = reader.ReadInt64();
+
+        // Use DateTime's public constructor to validate the input, but we
+        // can't return that result as it strips off the kind. To address
+        // that, store the value directly into a DateTime via an unsafe cast.
+        // See BinaryFormatterWriter.WriteDateTime for details.
+
+        try
+        {
+            const long TicksMask = 0x3FFFFFFFFFFFFFFF;
+            _ = new DateTime(data & TicksMask);
+        }
+        catch (ArgumentException ex)
+        {
+            // Bad data
+            throw new SerializationException(ex.Message, ex);
+        }
+
+        return *(DateTime*)&data;
+    }
+
+    /// <summary>
+    ///  Reads a UTF-8 string from the given <paramref name="reader"/> prefixed with a 7 bit encoded length.
+    /// </summary>
+    public static string ReadLengthPrefixedString(this BinaryReader reader)
+        => reader.ReadUtf8String(reader.Read7BitEncodedInt());
+
+    /// <summary>
+    ///  Reads a UTF-8 string of byte length <paramref name="lengthInBytes"/> from the given <paramref name="reader"/>.
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="lengthInBytes"/> is negative.</exception>
+    private static unsafe string ReadUtf8String(this BinaryReader reader, int lengthInBytes)
+    {
+        if (lengthInBytes == 0)
+        {
+            return string.Empty;
+        }
+
+        if (lengthInBytes < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(lengthInBytes));
+        }
+
+        if (reader.Remaining() < lengthInBytes)
+        {
+            throw new EndOfStreamException();
+        }
+
+        using BufferScope<byte> buffer = new(stackalloc byte[256], lengthInBytes);
+        Span<byte> bytes = buffer[..lengthInBytes];
+        return reader.Read(bytes) != lengthInBytes
+            ? throw new EndOfStreamException()
+            : Encoding.UTF8.GetString(bytes);
+    }
+
+    /// <summary>
+    ///  Returns the remaining amount of bytes in the given <paramref name="reader"/>.
+    /// </summary>
+    public static long Remaining(this BinaryReader reader)
+    {
+        Stream stream = reader.BaseStream;
+        return stream.Length - stream.Position;
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/IO/BinaryWriterExtensions.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/IO/BinaryWriterExtensions.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace System.IO;
+
+internal static class BinaryWriterExtensions
+{
+    /// <summary>
+    ///  Writes a UTF-8 string prefixed by a 7-bit encoded length. Does not include a trailing null.
+    /// </summary>
+    public static void WriteLengthPrefixedString(this BinaryWriter writer, string value)
+    {
+        Encoding encoding = Encoding.UTF8;
+        using BufferScope<byte> buffer = new(stackalloc byte[256], encoding.GetMaxByteCount(value.Length));
+        int length = encoding.GetBytes(value, buffer);
+        writer.Write7BitEncodedInt(length);
+        writer.Write(buffer[..length]);
+    }
+
+    /// <summary>
+    ///  Writes a <see cref="DateTime"/> object to the given <paramref name="writer"/>.
+    /// </summary>
+    public static void Write(this BinaryWriter writer, DateTime value)
+    {
+        // Copied from System.Runtime.Serialization.Formatters.Binary.BinaryFormatterWriter
+
+        // In .NET Framework, BinaryFormatter is able to access DateTime's ToBinaryRaw,
+        // which just returns the value of its sole Int64 dateData field.  Here, we don't
+        // have access to that member (which doesn't even exist anymore, since it was only for
+        // BinaryFormatter, which is now in a separate assembly).  To address that,
+        // we access the sole field directly via an unsafe cast.
+        long dateData = Unsafe.As<DateTime, long>(ref value);
+        writer.Write(dateData);
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/IO/BinaryWriterExtensions.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/IO/BinaryWriterExtensions.cs
@@ -3,24 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.CompilerServices;
-using System.Text;
 
 namespace System.IO;
 
 internal static class BinaryWriterExtensions
 {
-    /// <summary>
-    ///  Writes a UTF-8 string prefixed by a 7-bit encoded length. Does not include a trailing null.
-    /// </summary>
-    public static void WriteLengthPrefixedString(this BinaryWriter writer, string value)
-    {
-        Encoding encoding = Encoding.UTF8;
-        using BufferScope<byte> buffer = new(stackalloc byte[256], encoding.GetMaxByteCount(value.Length));
-        int length = encoding.GetBytes(value, buffer);
-        writer.Write7BitEncodedInt(length);
-        writer.Write(buffer[..length]);
-    }
-
     /// <summary>
     ///  Writes a <see cref="DateTime"/> object to the given <paramref name="writer"/>.
     /// </summary>

--- a/src/System.Windows.Forms.Primitives/src/System/IntrinsicExtensions.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/IntrinsicExtensions.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Numerics;
+
+namespace System;
+
+internal static class IntrinsicExtensions
+{
+    /// <summary>
+    ///  Throws if the given number is negative, otherwise returns it.
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="value"/> is negative.</exception>
+    public static T OrThrowIfNegative<T>(this T value)
+        where T : ISignedNumber<T>
+    {
+        if (T.IsNegative(value))
+        {
+            throw new ArgumentOutOfRangeException(nameof(value));
+        }
+
+        return value;
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/ArrayInfo.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/ArrayInfo.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms.BinaryFormat;
+
+/// <summary>
+///  Array information structure.
+/// </summary>
+/// <remarks>
+///  <para>
+///   <see href="https://learn.microsoft.com/openspecs/windows_protocols/ms-nrbf/8fac763f-e46d-43a1-b360-80eb83d2c5fb">
+///    [MS-NRBF] 2.4.2.1
+///   </see>
+///  </para>
+/// </remarks>
+internal readonly struct ArrayInfo : IBinaryWriteable
+{
+    public Id ObjectId { get; }
+    public Count Length { get; }
+
+    public ArrayInfo(Id objectId, Count length)
+    {
+        Length = length;
+        ObjectId = objectId;
+    }
+
+    public static ArrayInfo Parse(BinaryReader reader, out Count length)
+    {
+        ArrayInfo arrayInfo = new(reader.ReadInt32(), reader.ReadInt32());
+        length = arrayInfo.Length;
+        return arrayInfo;
+    }
+
+    public readonly void Write(BinaryWriter writer)
+    {
+        writer.Write(ObjectId);
+        writer.Write(Length);
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/ArrayRecord.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/ArrayRecord.cs
@@ -1,0 +1,60 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+
+namespace System.Windows.Forms.BinaryFormat;
+
+/// <summary>
+///  Base class for array records.
+/// </summary>
+/// <devdoc>
+///  <see href="https://learn.microsoft.com/openspecs/windows_protocols/ms-nrbf/f57d41e5-d3c0-4340-add8-fa4449a68d1c">
+///  [MS-NRBF] 2.4</see> describes how item records must follow the array record and how multiple null records
+///  can be coalesced into an <see cref="NullRecord.ObjectNullMultiple"/> or <see cref="NullRecord.ObjectNullMultiple256"/>
+///  record.
+/// </devdoc>
+internal abstract class ArrayRecord : Record, IEnumerable<object>
+{
+    public ArrayInfo ArrayInfo { get; }
+
+    /// <summary>
+    ///  The array items.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   Multi-null records are always expanded to individual <see cref="ObjectNull"/> entries when reading.
+    ///  </para>
+    /// </remarks>
+    public IReadOnlyList<object> ArrayObjects { get; }
+
+    /// <summary>
+    ///  Identifier for the array.
+    /// </summary>
+    public Id ObjectId => ArrayInfo.ObjectId;
+
+    /// <summary>
+    ///  Length of the array.
+    /// </summary>
+    public Count Length => ArrayInfo.Length;
+
+    /// <summary>
+    ///  Returns the item at the given index.
+    /// </summary>
+    public object this[int index] => ArrayObjects[index];
+
+    public ArrayRecord(ArrayInfo arrayInfo, IReadOnlyList<object> arrayObjects)
+    {
+        if (arrayInfo.Length != arrayObjects.Count)
+        {
+            throw new ArgumentException($"{nameof(arrayInfo)} doesn't match count of {nameof(arrayObjects)}");
+        }
+
+        ArrayInfo = arrayInfo;
+        ArrayObjects = arrayObjects;
+    }
+
+    IEnumerator<object> IEnumerable<object>.GetEnumerator() => ArrayObjects.GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator() => ArrayObjects.GetEnumerator();
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/ArraySingleObject.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/ArraySingleObject.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms.BinaryFormat;
+
+/// <summary>
+///  Single dimensional array of objects.
+/// </summary>
+/// <remarks>
+///  <para>
+///   <see href="https://learn.microsoft.com/openspecs/windows_protocols/ms-nrbf/aa509b5a-620a-4592-a5d8-7e9613e0a03e">
+///    [MS-NRBF] 2.3.1.2
+///   </see>
+///  </para>
+/// </remarks>
+internal sealed class ArraySingleObject : ArrayRecord, IRecord<ArraySingleObject>
+{
+    public static RecordType RecordType => RecordType.ArraySingleObject;
+
+    public ArraySingleObject(ArrayInfo arrayInfo, IReadOnlyList<object> arrayObjects)
+        : base(arrayInfo, arrayObjects)
+    { }
+
+    static ArraySingleObject IBinaryFormatParseable<ArraySingleObject>.Parse(
+        BinaryReader reader,
+        RecordMap recordMap)
+    {
+        ArraySingleObject record = new(
+            ArrayInfo.Parse(reader, out Count length),
+            ReadRecords(reader, recordMap, length));
+
+        recordMap[record.ObjectId] = record;
+        return record;
+    }
+
+    public override void Write(BinaryWriter writer)
+    {
+        writer.Write((byte)RecordType);
+        ArrayInfo.Write(writer);
+        WriteRecords(writer, ArrayObjects);
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/ArraySinglePrimitive.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/ArraySinglePrimitive.cs
@@ -1,0 +1,52 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms.BinaryFormat;
+
+/// <summary>
+///  Single dimensional array of a primitive type.
+/// </summary>
+/// <remarks>
+///  <para>
+///   <see href="https://learn.microsoft.com/openspecs/windows_protocols/ms-nrbf/3a50a305-5f32-48a1-a42a-c34054db310b">
+///    [MS-NRBF] 2.4.3.3
+///   </see>
+///  </para>
+/// </remarks>
+internal sealed class ArraySinglePrimitive : ArrayRecord, IRecord<ArraySinglePrimitive>
+{
+    public PrimitiveType PrimitiveType { get; }
+
+    public static RecordType RecordType => RecordType.ArraySinglePrimitive;
+
+    public ArraySinglePrimitive(ArrayInfo arrayInfo, PrimitiveType primitiveType, IReadOnlyList<object> arrayObjects)
+        : base(arrayInfo, arrayObjects)
+    {
+        PrimitiveType = primitiveType;
+    }
+
+    static ArraySinglePrimitive IBinaryFormatParseable<ArraySinglePrimitive>.Parse(
+        BinaryReader reader,
+        RecordMap recordMap)
+    {
+        ArrayInfo arrayInfo = ArrayInfo.Parse(reader, out Count length);
+        PrimitiveType primitiveType = (PrimitiveType)reader.ReadByte();
+
+        ArraySinglePrimitive record = new(
+            arrayInfo,
+            primitiveType,
+            ReadPrimitiveTypes(reader, primitiveType, length));
+
+        recordMap[record.ObjectId] = record;
+        return record;
+    }
+
+    public override void Write(BinaryWriter writer)
+    {
+        writer.Write((byte)RecordType);
+        ArrayInfo.Write(writer);
+        writer.Write((byte)PrimitiveType);
+        WritePrimitiveTypes(writer, PrimitiveType, ArrayObjects);
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/ArraySingleString.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/ArraySingleString.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms.BinaryFormat;
+
+/// <summary>
+///  Single dimensional array of strings.
+/// </summary>
+/// <remarks>
+///  <para>
+///   <see href="https://learn.microsoft.com/openspecs/windows_protocols/ms-nrbf/3d98fd60-d2b4-448a-ac0b-3cd8dea41f9d">
+///    [MS-NRBF] 2.4.3.4
+///   </see>
+///  </para>
+/// </remarks>
+internal sealed class ArraySingleString : ArrayRecord, IRecord<ArraySingleString>
+{
+    public static RecordType RecordType => RecordType.ArraySingleString;
+
+    public ArraySingleString(ArrayInfo arrayInfo, IReadOnlyList<object> arrayObjects)
+        : base(arrayInfo, arrayObjects)
+    { }
+
+    static ArraySingleString IBinaryFormatParseable<ArraySingleString>.Parse(
+        BinaryReader reader,
+        RecordMap recordMap)
+    {
+        ArraySingleString record = new(
+            ArrayInfo.Parse(reader, out Count length),
+            ReadRecords(reader, recordMap, length));
+
+        recordMap[record.ObjectId] = record;
+        return record;
+    }
+
+    public override void Write(BinaryWriter writer)
+    {
+        writer.Write((byte)RecordType);
+        ArrayInfo.Write(writer);
+        WriteRecords(writer, ArrayObjects);
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/BinaryFormatReader.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/BinaryFormatReader.cs
@@ -1,0 +1,117 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Runtime.Serialization;
+
+namespace System.Windows.Forms.BinaryFormat;
+
+/// <summary>
+///  Reader that reads specific types in binary format without using the BinaryFormatter.
+/// </summary>
+internal static class BinaryFormatReader
+{
+    /// <summary>
+    ///  Reads a binary formatted string.
+    /// </summary>
+    /// <exception cref="SerializationException">Data isn't a valid string.</exception>
+    public static string ReadString(Stream stream)
+    {
+        BinaryFormattedObject format = new(stream, leaveOpen: true);
+        if (format.RecordCount < 3 || format[1] is not BinaryObjectString value)
+        {
+            throw new SerializationException();
+        }
+
+        return value.Value;
+    }
+
+    /// <summary>
+    ///  Reads a binary formatted primitive list.
+    /// </summary>
+    /// <exception cref="NotSupportedException"><typeparamref name="T"/> was not primitive.</exception>
+    /// <exception cref="SerializationException">Data isn't a valid <see cref="List{T}"/>.</exception>
+    public static List<T> ReadPrimitiveList<T>(Stream stream)
+        where T : unmanaged
+    {
+        if (!typeof(T).IsPrimitive)
+        {
+            throw new NotSupportedException($"{nameof(T)} is not primitive.");
+        }
+
+        BinaryFormattedObject format = new(stream, leaveOpen: true);
+        if (format.RecordCount < 4
+            || format[1] is not SystemClassWithMembersAndTypes classInfo
+            || !classInfo.Name.StartsWith($"System.Collections.Generic.List`1[[{typeof(T).FullName}")
+            || format[2] is not ArraySinglePrimitive array
+            || array.PrimitiveType != Record.GetPrimitiveType(typeof(T)))
+        {
+            throw new SerializationException();
+        }
+
+        int count;
+        try
+        {
+            count = (int)classInfo["_size"];
+        }
+        catch (Exception ex)
+        {
+            throw ex.ConvertToSerializationException();
+        }
+
+        List<T> list = new(count);
+        list.AddRange(array.Take(count).Cast<T>());
+        return list;
+    }
+
+    /// <summary>
+    ///  Reads a binary formatted <see cref="Hashtable"/>. Only accepts <see langword="string"/> keys
+    ///  and <see langword="string"/>? values.
+    /// </summary>
+    /// <exception cref="SerializationException">
+    ///  Data isn't a valid <see langword="string"/> - <see langword="string"/>? <see cref="Hashtable"/>.
+    /// </exception>
+    public static Hashtable ReadHashtableOfStrings(Stream stream)
+    {
+        BinaryFormattedObject format = new(stream, leaveOpen: true);
+        if (format.RecordCount < 5
+            || format[1] is not SystemClassWithMembersAndTypes classInfo
+            || classInfo.Name != "System.Collections.Hashtable"
+            || format[2] is not ArraySingleObject keys
+            || format[3] is not ArraySingleObject values
+            || keys.Length != values.Length)
+        {
+            throw new SerializationException();
+        }
+
+        Hashtable hashtable = new(keys.Length);
+        for (int i = 0; i < keys.Length; i++)
+        {
+            string key = keys[i] switch
+            {
+                BinaryObjectString keyString => keyString.Value,
+                MemberReference reference => format[reference.IdRef] switch
+                {
+                    BinaryObjectString refString => refString.Value,
+                    _ => throw new SerializationException()
+                },
+                _ => throw new SerializationException()
+            };
+
+            hashtable[key] = values[i] switch
+            {
+                BinaryObjectString valueString => valueString.Value,
+                ObjectNull => null,
+                MemberReference reference => format[reference.IdRef] switch
+                {
+                    BinaryObjectString refString => refString.Value,
+                    _ => throw new SerializationException()
+                },
+                _ => throw new SerializationException(),
+            };
+        }
+
+        return hashtable;
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/BinaryFormatWriter.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/BinaryFormatWriter.cs
@@ -1,0 +1,425 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Runtime.CompilerServices;
+using System.Runtime.Serialization;
+using System.Text;
+
+namespace System.Windows.Forms.BinaryFormat;
+
+/// <summary>
+///  Writer that writes specific types in binary format without using the BinaryFormatter.
+/// </summary>
+internal static class BinaryFormatWriter
+{
+    private static readonly IReadOnlyList<string> s_hashtableMemberNames = new List<string>()
+    {
+        "LoadFactor", "Version", "Comparer", "HashCodeProvider", "HashSize", "Keys", "Values"
+    };
+
+    private static readonly IReadOnlyList<string> s_listMemberNames = new List<string>()
+    {
+        "_items", "_size", "_version"
+    };
+
+    private static readonly IReadOnlyList<string> s_decimalMemberNames = new List<string>()
+    {
+        "flags", "hi", "lo", "mid"
+    };
+
+    private static readonly IReadOnlyList<string> s_dateTimeMemberNames = new List<string>()
+    {
+        "ticks", "dateData"
+    };
+
+    private const string Mscorlib = "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089";
+
+    /// <summary>
+    ///  Writes a <see langword="string"/> in binary format.
+    /// </summary>
+    public static void WriteString(Stream stream, string value)
+    {
+        using BinaryWriter writer = new(stream, Encoding.UTF8, leaveOpen: true);
+        SerializationHeader.Default.Write(writer);
+        BinaryObjectString binaryString = new(1, value);
+        binaryString.Write(writer);
+        MessageEnd.Instance.Write(writer);
+    }
+
+    /// <summary>
+    ///  Writes a <see langword="decimal"/> in binary format.
+    /// </summary>
+    public static void WriteDecimal(Stream stream, decimal value)
+    {
+        Span<int> ints = stackalloc int[4];
+        decimal.TryGetBits(value, ints, out _);
+
+        using BinaryWriter writer = new(stream, Encoding.UTF8, leaveOpen: true);
+
+        SerializationHeader.Default.Write(writer);
+
+        new SystemClassWithMembersAndTypes(
+            new ClassInfo(1, typeof(decimal).FullName!, s_decimalMemberNames),
+            new MemberTypeInfo(new List<(BinaryType Type, object? Info)>
+            {
+                (BinaryType.Primitive, PrimitiveType.Int32),
+                (BinaryType.Primitive, PrimitiveType.Int32),
+                (BinaryType.Primitive, PrimitiveType.Int32),
+                (BinaryType.Primitive, PrimitiveType.Int32)
+            }),
+            new List<object>()
+            {
+                ints[3],
+                ints[2],
+                ints[0],
+                ints[1]
+            }).Write(writer);
+
+        MessageEnd.Instance.Write(writer);
+    }
+
+    /// <summary>
+    ///  Writes a <see cref="DateTime"/> in binary format.
+    /// </summary>
+    public static void WriteDateTime(Stream stream, DateTime value)
+    {
+        using BinaryWriter writer = new(stream, Encoding.UTF8, leaveOpen: true);
+
+        SerializationHeader.Default.Write(writer);
+
+        // We could use ISerializable here to get the data, but it is pretty
+        // heavy weight, and the internals of DateTime should never change.
+
+        new SystemClassWithMembersAndTypes(
+            new ClassInfo(1, typeof(DateTime).FullName!, s_dateTimeMemberNames),
+            new MemberTypeInfo(new List<(BinaryType Type, object? Info)>
+            {
+                (BinaryType.Primitive, PrimitiveType.Int64),
+                (BinaryType.Primitive, PrimitiveType.UInt64)
+            }),
+            new List<object>()
+            {
+                value.Ticks,
+                Unsafe.As<DateTime, ulong>(ref value)
+            }).Write(writer);
+
+        MessageEnd.Instance.Write(writer);
+    }
+
+    /// <summary>
+    ///  Writes a <see cref="TimeSpan"/> in binary format.
+    /// </summary>
+    public static void WriteTimeSpan(Stream stream, TimeSpan value)
+    {
+        using BinaryWriter writer = new(stream, Encoding.UTF8, leaveOpen: true);
+
+        SerializationHeader.Default.Write(writer);
+
+        new SystemClassWithMembersAndTypes(
+            new ClassInfo(1, typeof(TimeSpan).FullName!, new string[] { "_ticks" }),
+            new MemberTypeInfo(new List<(BinaryType Type, object? Info)>
+            {
+                (BinaryType.Primitive, PrimitiveType.Int64),
+            }),
+            new List<object>()
+            {
+                value.Ticks
+            }).Write(writer);
+
+        MessageEnd.Instance.Write(writer);
+    }
+
+    /// <summary>
+    ///  Writes a nint in binary format.
+    /// </summary>
+    public static void WriteNativeInt(Stream stream, nint value)
+    {
+        using BinaryWriter writer = new(stream, Encoding.UTF8, leaveOpen: true);
+
+        SerializationHeader.Default.Write(writer);
+
+        new SystemClassWithMembersAndTypes(
+            new ClassInfo(1, typeof(nint).FullName!, new string[] { "value" }),
+            new MemberTypeInfo(new List<(BinaryType Type, object? Info)>
+            {
+                (BinaryType.Primitive, PrimitiveType.Int64),
+            }),
+            new List<object>()
+            {
+                (long)value
+            }).Write(writer);
+
+        MessageEnd.Instance.Write(writer);
+    }
+
+    /// <summary>
+    ///  Writes a nuint in binary format.
+    /// </summary>
+    public static void WriteNativeUInt(Stream stream, nuint value)
+    {
+        using BinaryWriter writer = new(stream, Encoding.UTF8, leaveOpen: true);
+
+        SerializationHeader.Default.Write(writer);
+
+        new SystemClassWithMembersAndTypes(
+            new ClassInfo(1, typeof(nuint).FullName!, new string[] { "value" }),
+            new MemberTypeInfo(new List<(BinaryType Type, object? Info)>
+            {
+                (BinaryType.Primitive, PrimitiveType.UInt64),
+            }),
+            new List<object>()
+            {
+                (ulong)value
+            }).Write(writer);
+
+        MessageEnd.Instance.Write(writer);
+    }
+
+    /// <summary>
+    ///  Attempts to write a primitive value or string in binary format.
+    /// </summary>
+    /// <returns><see langword="true"/> if successful.</returns>
+    public static bool TryWritePrimitive(Stream stream, object primitive)
+    {
+        long originalPosition = stream.Position;
+        try
+        {
+            WritePrimitive(stream, primitive);
+            return true;
+        }
+        catch (Exception ex) when (!ClientUtils.IsCriticalException(ex))
+        {
+            stream.Position = originalPosition;
+            return false;
+        }
+    }
+
+    /// <summary>
+    ///  Writes a primitive value or string in binary format.
+    /// </summary>
+    public static void WritePrimitive(Stream stream, object primitive)
+    {
+        // These aren't considered primitive per the binary format, but are primitives in .NET.
+        if (primitive is nint nativeInt)
+        {
+            WriteNativeInt(stream, nativeInt);
+            return;
+        }
+
+        if (primitive is nuint nativeUint)
+        {
+            WriteNativeUInt(stream, nativeUint);
+            return;
+        }
+
+        if (primitive is string stringValue)
+        {
+            WriteString(stream, stringValue);
+            return;
+        }
+
+        Type type = primitive.GetType();
+
+        PrimitiveType primitiveType = Record.GetPrimitiveType(type);
+        if (primitiveType == default)
+        {
+            throw new NotSupportedException($"{nameof(primitive)} is not primitive.");
+        }
+
+        // These are handled differently from the rest of the primitive types when serialized on their own.
+        if (primitiveType == PrimitiveType.Decimal)
+        {
+            WriteDecimal(stream, (decimal)primitive);
+            return;
+        }
+        else if (primitiveType == PrimitiveType.DateTime)
+        {
+            WriteDateTime(stream, (DateTime)primitive);
+            return;
+        }
+        else if (primitiveType == PrimitiveType.TimeSpan)
+        {
+            WriteTimeSpan(stream, (TimeSpan)primitive);
+            return;
+        }
+
+        using BinaryWriter writer = new(stream, Encoding.UTF8, leaveOpen: true);
+
+        SerializationHeader.Default.Write(writer);
+
+        new SystemClassWithMembersAndTypes(
+            new ClassInfo(1, type.FullName!, new string[] { "m_value" }),
+            new MemberTypeInfo(new List<(BinaryType Type, object? Info)>
+            {
+                (BinaryType.Primitive, primitiveType),
+            }),
+            new List<object>()
+            {
+                primitive
+            }).Write(writer);
+
+        MessageEnd.Instance.Write(writer);
+    }
+
+    /// <summary>
+    ///  Writes a primitive list in binary format.
+    /// </summary>
+    public static void WritePrimitiveList<T>(Stream stream, IReadOnlyList<T> list)
+        where T : unmanaged
+    {
+        PrimitiveType primitiveType = Record.GetPrimitiveType(typeof(T));
+        if (primitiveType == default)
+        {
+            throw new NotSupportedException($"{nameof(T)} is not primitive.");
+        }
+
+        using BinaryWriter writer = new(stream, Encoding.UTF8, leaveOpen: true);
+
+        SerializationHeader.Default.Write(writer);
+
+        SystemClassWithMembersAndTypes systemClass = new(
+            new ClassInfo(1, $"System.Collections.Generic.List`1[[{typeof(T).FullName}, {Mscorlib}]]", s_listMemberNames),
+            new MemberTypeInfo(new List<(BinaryType Type, object? Info)>
+            {
+                (BinaryType.PrimitiveArray, primitiveType),
+                (BinaryType.Primitive, PrimitiveType.Int32),
+                (BinaryType.Primitive, PrimitiveType.Int32),
+            }),
+            new List<object>()
+            {
+                new MemberReference(2),
+                list.Count,
+                // _version doesn't matter
+                0
+            });
+
+        systemClass.Write(writer);
+
+        ArraySinglePrimitive array = new(
+            new(2, list.Count),
+            primitiveType,
+            new ListConverter<T, object>(list, (T value) => value));
+        array.Write(writer);
+
+        MessageEnd.Instance.Write(writer);
+    }
+
+    /// <summary>
+    ///  Writes a <see cref="Hashtable"/> of strings to the given stream in binary format.
+    /// </summary>
+    /// <exception cref="ArgumentException"><paramref name="hashtable"/> contained non-<see langword="string"/> values</exception>
+    public static void WriteHashtableOfStrings(Stream stream, Hashtable hashtable)
+    {
+        // Get the ISerializable data from the hashtable. This way we don't have to worry about
+        // getting the LoadFactor, Version, etc. wrong.
+#pragma warning disable SYSLIB0050 // Type or member is obsolete
+        SerializationInfo info = new(typeof(Hashtable), FormatterConverterStub.Instance);
+#pragma warning restore SYSLIB0050
+#pragma warning disable SYSLIB0051 // Type or member is obsolete
+        hashtable.GetObjectData(info, default);
+#pragma warning restore SYSLIB0051
+
+        // Build up the key and value data
+        object[] keys = info.GetValue<object[]>("Keys")!;
+        object?[] values = info.GetValue<object?[]>("Values")!;
+
+        using BinaryWriter writer = new(stream, Encoding.UTF8, leaveOpen: true);
+
+        SerializationHeader.Default.Write(writer);
+        SystemClassWithMembersAndTypes systemClass = new(
+            new ClassInfo(1, "System.Collections.Hashtable", s_hashtableMemberNames),
+            new MemberTypeInfo(new List<(BinaryType Type, object? Info)>
+            {
+                (BinaryType.Primitive, PrimitiveType.Single),
+                (BinaryType.Primitive, PrimitiveType.Int32),
+                (BinaryType.SystemClass, "System.Collections.IComparer"),
+                (BinaryType.SystemClass, "System.Collections.IHashCodeProvider"),
+                (BinaryType.Primitive, PrimitiveType.Int32),
+                (BinaryType.ObjectArray, null),
+                (BinaryType.ObjectArray, null)
+            }),
+            new List<object>()
+            {
+                info.GetValue<float>("LoadFactor"),
+                info.GetValue<int>("Version"),
+                // No need to persist the comparer and hashcode provider
+                ObjectNull.Instance,
+                ObjectNull.Instance,
+                info.GetValue<int>("HashSize"),
+                // MemberReference to Arrays here
+                new MemberReference(2),
+                new MemberReference(3)
+            });
+
+        systemClass.Write(writer);
+
+        // We've used 1, 2 and 3 for the class id and array ids
+        int currentId = 4;
+
+        // Using an array converter to save a temporary array allocation. By not doing this we come much closer
+        // to the memory usage of BinaryFormatter for large hashsets.
+
+        StringRecordsCollection strings = new();
+
+        ListConverter<object, object> keyConverter = new(
+            keys,
+            (object value) => value switch
+            {
+                string stringValue => strings.GetStringRecord(stringValue, ref currentId),
+                _ => throw new ArgumentException("Only strings are permitted")
+            });
+
+        ArraySingleObject array = new(new(2, keys.Length), keyConverter);
+        array.Write(writer);
+
+        ListConverter<object?, object> valueConverter = new(
+            values,
+            (object? value) => value switch
+            {
+                null => ObjectNull.Instance,
+                string stringValue => strings.GetStringRecord(stringValue, ref currentId),
+                _ => throw new ArgumentException("Only strings are permitted")
+            });
+
+        array = new(new(3, values.Length), valueConverter);
+        array.Write(writer);
+
+        MessageEnd.Instance.Write(writer);
+    }
+
+    public static PrimitiveType GetPrimitiveType(object @object)
+    {
+        if (@object is null)
+        {
+            return PrimitiveType.Null;
+        }
+
+        Type type = @object.GetType();
+        if (type == typeof(TimeSpan))
+        {
+            return PrimitiveType.TimeSpan;
+        }
+
+        return Type.GetTypeCode(type) switch
+        {
+            TypeCode.Boolean => PrimitiveType.Boolean,
+            TypeCode.Char => PrimitiveType.Char,
+            TypeCode.SByte => PrimitiveType.SByte,
+            TypeCode.Byte => PrimitiveType.Byte,
+            TypeCode.Int16 => PrimitiveType.Int16,
+            TypeCode.UInt16 => PrimitiveType.UInt16,
+            TypeCode.Int32 => PrimitiveType.Int32,
+            TypeCode.UInt32 => PrimitiveType.UInt32,
+            TypeCode.Int64 => PrimitiveType.Int64,
+            TypeCode.UInt64 => PrimitiveType.UInt64,
+            TypeCode.Single => PrimitiveType.Single,
+            TypeCode.Double => PrimitiveType.Double,
+            TypeCode.Decimal => PrimitiveType.Decimal,
+            TypeCode.DateTime => PrimitiveType.DateTime,
+            TypeCode.String => PrimitiveType.String,
+            _ => default,
+        };
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/BinaryFormattedObject.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/BinaryFormattedObject.cs
@@ -1,0 +1,185 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+using System.Runtime.Serialization;
+using System.Text;
+
+namespace System.Windows.Forms.BinaryFormat;
+
+/// <summary>
+///  Object model for the binary format put out by BinaryFormatter. It parses andcreates a model but does not
+///  instantiate any reference types outside of string.
+/// </summary>
+/// <remarks>
+///  <para>
+///   This is useful for explicitly controlling the rehydration of binary formatted data. BinaryFormatter is
+///   depreciated for security concerns (it has no way to constrain what it hydrates from an incoming stream).
+///  </para>
+///  <para>
+///   NOTE: Multidimensional and jagged arrays are not yet implemented.
+///  </para>
+/// </remarks>
+internal sealed class BinaryFormattedObject
+{
+    private static readonly string[] s_systemPrimitiveTypeNames = new string[]
+    {
+        typeof(int).FullName!,
+        typeof(long).FullName!,
+        typeof(bool).FullName!,
+        typeof(char).FullName!,
+        typeof(float).FullName!,
+        typeof(double).FullName!,
+        typeof(sbyte).FullName!,
+        typeof(byte).FullName!,
+        typeof(short).FullName!,
+        typeof(ushort).FullName!,
+        typeof(uint).FullName!,
+        typeof(ulong).FullName!,
+    };
+
+    // Don't reserve space in collections based on read lengths for more than this size to defend against corrupted lengths.
+#if DEBUG
+    internal const int MaxNewCollectionSize = 1024 * 10;
+#else
+    internal const int MaxNewCollectionSize = 10;
+#endif
+
+    private readonly List<IRecord> _records = new();
+    private readonly RecordMap _recordMap = new();
+
+    /// <summary>
+    ///  Creates <see cref="BinaryFormattedObject"/> by parsing <paramref name="stream"/>.
+    /// </summary>
+    /// <param name="leaveOpen"></param>
+    public BinaryFormattedObject(Stream stream, bool leaveOpen = false)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+        using BinaryReader reader = new(stream, Encoding.UTF8, leaveOpen: leaveOpen);
+
+        IRecord? currentRecord;
+        do
+        {
+            try
+            {
+                currentRecord = Record.ReadBinaryFormatRecord(reader, _recordMap);
+            }
+            catch (SerializationException)
+            {
+                throw;
+            }
+            catch (Exception ex) when (ex is ArgumentException or InvalidCastException or ArithmeticException or IOException)
+            {
+                // Make the exception easier to catch, but retain the original stack trace.
+                throw ex.ConvertToSerializationException();
+            }
+
+            _records.Add(currentRecord);
+        }
+        while (currentRecord is not MessageEnd);
+    }
+
+    /// <summary>
+    ///  Total count of top-level records.
+    /// </summary>
+    public int RecordCount => _records.Count;
+
+    /// <summary>
+    ///  Gets a record by it's index.
+    /// </summary>
+    public IRecord this[int index] => _records[index];
+
+    /// <summary>
+    ///  Gets a record by it's identfier. Not all records have identifiers, only ones that
+    ///  can be referenced by other records.
+    /// </summary>
+    public IRecord this[Id id] => _recordMap[id];
+
+    /// <summary>
+    ///  Trys to get this object as a primitive type or string.
+    /// </summary>
+    /// <returns><see langword="true"/> if this represented a primitive type or string.</returns>
+    public bool TryGetPrimitiveType([NotNullWhen(true)] out object? value)
+    {
+        try
+        {
+            return TryGetPrimitiveTypeInternal(out value);
+        }
+        catch (Exception ex) when (!ClientUtils.IsCriticalException(ex))
+        {
+            value = default;
+            return false;
+        }
+    }
+
+    private bool TryGetPrimitiveTypeInternal([NotNullWhen(true)] out object? value)
+    {
+        value = null;
+        if (RecordCount < 3)
+        {
+            return false;
+        }
+
+        if (_records[1] is BinaryObjectString binaryString)
+        {
+            value = binaryString.Value;
+            return true;
+        }
+
+        if (_records[1] is not SystemClassWithMembersAndTypes systemClass)
+        {
+            return false;
+        }
+
+        if (s_systemPrimitiveTypeNames.Contains(systemClass.Name)
+            && systemClass.MemberTypeInfo[0].Type == BinaryType.Primitive)
+        {
+            value = systemClass.MemberValues[0];
+            return true;
+        }
+
+        if (systemClass.Name == typeof(TimeSpan).FullName)
+        {
+            value = new TimeSpan((long)systemClass.MemberValues[0]);
+            return true;
+        }
+
+        if (systemClass.Name == typeof(DateTime).FullName)
+        {
+            ulong ulongValue = (ulong)systemClass["dateData"];
+            value = Unsafe.As<ulong, DateTime>(ref ulongValue);
+            return true;
+        }
+
+        if (systemClass.Name == typeof(nint).FullName)
+        {
+            // Rehydrating still throws even though casting doesn't any more
+            value = checked((nint)(long)systemClass.MemberValues[0]);
+            return true;
+        }
+
+        if (systemClass.Name == typeof(nuint).FullName)
+        {
+            value = checked((nuint)(ulong)systemClass.MemberValues[0]);
+            return true;
+        }
+
+        // Handle decimal, nint, nuint, TimeSpan, DateTime
+        if (systemClass.Name == typeof(decimal).FullName)
+        {
+            Span<int> bits = stackalloc int[4]
+            {
+                (int)systemClass["lo"],
+                (int)systemClass["mid"],
+                (int)systemClass["hi"],
+                (int)systemClass["flags"]
+            };
+
+            value = new decimal(bits);
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/BinaryFormattedObject.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/BinaryFormattedObject.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using System.Text;
 

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/BinaryLibrary.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/BinaryLibrary.cs
@@ -28,7 +28,7 @@ internal sealed class BinaryLibrary : IRecord<BinaryLibrary>
         BinaryLibrary record = new()
         {
             LibraryId = reader.ReadInt32(),
-            LibraryName = reader.ReadLengthPrefixedString()
+            LibraryName = reader.ReadString()
         };
 
         recordMap[record.LibraryId] = record;
@@ -39,6 +39,6 @@ internal sealed class BinaryLibrary : IRecord<BinaryLibrary>
     {
         writer.Write((byte)RecordType);
         writer.Write(LibraryId);
-        writer.WriteLengthPrefixedString(LibraryName);
+        writer.Write(LibraryName);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/BinaryLibrary.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/BinaryLibrary.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms.BinaryFormat;
+
+/// <summary>
+///  Library full name information.
+/// </summary>
+/// <remarks>
+///  <para>
+///   <see href="https://learn.microsoft.com/openspecs/windows_protocols/ms-nrbf/7fcf30e1-4ad4-4410-8f1a-901a4a1ea832">
+///    [MS-NRBF] 2.6.2
+///   </see>
+///  </para>
+/// </remarks>
+internal sealed class BinaryLibrary : IRecord<BinaryLibrary>
+{
+    public Id LibraryId;
+    public string LibraryName = string.Empty;
+
+    public static RecordType RecordType => RecordType.BinaryLibrary;
+
+    static BinaryLibrary IBinaryFormatParseable<BinaryLibrary>.Parse(
+        BinaryReader reader,
+        RecordMap recordMap)
+    {
+        BinaryLibrary record = new()
+        {
+            LibraryId = reader.ReadInt32(),
+            LibraryName = reader.ReadLengthPrefixedString()
+        };
+
+        recordMap[record.LibraryId] = record;
+        return record;
+    }
+
+    public void Write(BinaryWriter writer)
+    {
+        writer.Write((byte)RecordType);
+        writer.Write(LibraryId);
+        writer.WriteLengthPrefixedString(LibraryName);
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/BinaryObjectString.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/BinaryObjectString.cs
@@ -31,7 +31,7 @@ internal sealed class BinaryObjectString : IRecord<BinaryObjectString>
         BinaryReader reader,
         RecordMap recordMap)
     {
-        BinaryObjectString record = new(reader.ReadInt32(), reader.ReadLengthPrefixedString());
+        BinaryObjectString record = new(reader.ReadInt32(), reader.ReadString());
 
         recordMap[record.ObjectId] = record;
         return record;
@@ -41,7 +41,7 @@ internal sealed class BinaryObjectString : IRecord<BinaryObjectString>
     {
         writer.Write((byte)RecordType);
         writer.Write(ObjectId);
-        writer.WriteLengthPrefixedString(Value);
+        writer.Write(Value);
     }
 
     public override bool Equals(object? obj)

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/BinaryObjectString.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/BinaryObjectString.cs
@@ -1,0 +1,52 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms.BinaryFormat;
+
+/// <summary>
+///  String record.
+/// </summary>
+/// <remarks>
+///  <para>
+///   <see href="https://learn.microsoft.com/openspecs/windows_protocols/ms-nrbf/eb503ca5-e1f6-4271-a7ee-c4ca38d07996">
+///    [MS-NRBF] 2.5.7
+///   </see>
+///  </para>
+/// </remarks>
+internal sealed class BinaryObjectString : IRecord<BinaryObjectString>
+{
+    public Id ObjectId { get; }
+    public string Value { get; }
+
+    public static RecordType RecordType => RecordType.BinaryObjectString;
+
+    public BinaryObjectString(Id objectId, string value)
+    {
+        ObjectId = objectId;
+        Value = value;
+    }
+
+    static BinaryObjectString IBinaryFormatParseable<BinaryObjectString>.Parse(
+        BinaryReader reader,
+        RecordMap recordMap)
+    {
+        BinaryObjectString record = new(reader.ReadInt32(), reader.ReadLengthPrefixedString());
+
+        recordMap[record.ObjectId] = record;
+        return record;
+    }
+
+    public void Write(BinaryWriter writer)
+    {
+        writer.Write((byte)RecordType);
+        writer.Write(ObjectId);
+        writer.WriteLengthPrefixedString(Value);
+    }
+
+    public override bool Equals(object? obj)
+        => ReferenceEquals(this, obj)
+            || (obj is BinaryObjectString bos && bos.ObjectId == ObjectId && bos.Value == Value);
+
+    public override int GetHashCode() => HashCode.Combine(ObjectId, Value);
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/BinaryType.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/BinaryType.cs
@@ -1,0 +1,59 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms.BinaryFormat;
+
+/// <summary>
+///  Identifies the remoting type of a class member or array item.
+/// </summary>
+/// <remarks>
+///  <para>
+///   <see href="https://learn.microsoft.com/openspecs/windows_protocols/ms-nrbf/054e5c58-be21-4c86-b1c3-f6d3ce17ec72">
+///    [MS-NRBF] 2.1.2.2
+///   </see>
+///  </para>
+/// </remarks>
+internal enum BinaryType : byte
+{
+    /// <summary>
+    ///  Type is defined by <see cref="PrimitiveType"/> and it is not a string.
+    /// </summary>
+    Primitive,
+
+    /// <summary>
+    ///  Type is <see href="https://learn.microsoft.com/openspecs/windows_protocols/ms-nrbf/10b218f5-9b2b-4947-b4b7-07725a2c8127">
+    ///  length prefixed string</see>.
+    /// </summary>
+    String,
+
+    /// <summary>
+    ///  Type is System.Object.
+    /// </summary>
+    Object,
+
+    /// <summary>
+    ///  Type is a standard .NET object.
+    /// </summary>
+    SystemClass,
+
+    /// <summary>
+    ///  Type is an object.
+    /// </summary>
+    Class,
+
+    /// <summary>
+    ///  Type is a single-dimensional array of objects.
+    /// </summary>
+    ObjectArray,
+
+    /// <summary>
+    ///  Type is a single-dimensional array of strings.
+    /// </summary>
+    StringArray,
+
+    /// <summary>
+    ///  Types is a single-dimensional array of a primitive type.
+    /// </summary>
+    PrimitiveArray
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/ClassInfo.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/ClassInfo.cs
@@ -30,12 +30,12 @@ internal class ClassInfo : IBinaryWriteable
     public static ClassInfo Parse(BinaryReader reader, out Count memberCount)
     {
         Id objectId = reader.ReadInt32();
-        string name = reader.ReadLengthPrefixedString();
+        string name = reader.ReadString();
         memberCount = reader.ReadInt32();
         List<string> memberNames = new(Math.Min(BinaryFormattedObject.MaxNewCollectionSize, memberCount));
         for (int i = 0; i < memberCount; i++)
         {
-            memberNames.Add(reader.ReadLengthPrefixedString());
+            memberNames.Add(reader.ReadString());
         }
 
         return new(objectId, name, memberNames);
@@ -44,12 +44,12 @@ internal class ClassInfo : IBinaryWriteable
     public void Write(BinaryWriter writer)
     {
         writer.Write(ObjectId);
-        writer.WriteLengthPrefixedString(Name);
+        writer.Write(Name);
         writer.Write(MemberNames.Count);
 
         foreach (string name in MemberNames)
         {
-            writer.WriteLengthPrefixedString(name);
+            writer.Write(name);
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/ClassInfo.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/ClassInfo.cs
@@ -1,0 +1,55 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms.BinaryFormat;
+
+/// <summary>
+///  Class info.
+/// </summary>
+/// <remarks>
+///  <para>
+///   <see href="https://learn.microsoft.com/openspecs/windows_protocols/ms-nrbf/0a192be0-58a1-41d0-8a54-9c91db0ab7bf">
+///    [MS-NRBF] 2.3.1.1
+///   </see>
+///  </para>
+/// </remarks>
+internal class ClassInfo : IBinaryWriteable
+{
+    public Id ObjectId { get; }
+    public string Name { get; }
+    public IReadOnlyList<string> MemberNames { get; }
+
+    public ClassInfo(Id objectId, string name, IReadOnlyList<string> memberNames)
+    {
+        ObjectId = objectId;
+        Name = name;
+        MemberNames = memberNames;
+    }
+
+    public static ClassInfo Parse(BinaryReader reader, out Count memberCount)
+    {
+        Id objectId = reader.ReadInt32();
+        string name = reader.ReadLengthPrefixedString();
+        memberCount = reader.ReadInt32();
+        List<string> memberNames = new(Math.Min(BinaryFormattedObject.MaxNewCollectionSize, memberCount));
+        for (int i = 0; i < memberCount; i++)
+        {
+            memberNames.Add(reader.ReadLengthPrefixedString());
+        }
+
+        return new(objectId, name, memberNames);
+    }
+
+    public void Write(BinaryWriter writer)
+    {
+        writer.Write(ObjectId);
+        writer.WriteLengthPrefixedString(Name);
+        writer.Write(MemberNames.Count);
+
+        foreach (string name in MemberNames)
+        {
+            writer.WriteLengthPrefixedString(name);
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/ClassRecord.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/ClassRecord.cs
@@ -1,0 +1,117 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.Serialization;
+
+namespace System.Windows.Forms.BinaryFormat;
+
+/// <summary>
+///  Base class for class records.
+/// </summary>
+/// <remarks>
+///  <para>
+///   Includes the values for the class (which trail the record)
+///   <see href="https://learn.microsoft.com/openspecs/windows_protocols/ms-nrbf/c9bc3af3-5a0c-4b29-b517-1b493b51f7bb">
+///    [MS-NRBF] 2.3
+///   </see>.
+///  </para>
+/// </remarks>
+internal abstract class ClassRecord : Record
+{
+    internal ClassInfo ClassInfo { get; }
+    public IReadOnlyList<object> MemberValues { get; }
+
+    public string Name => ClassInfo.Name;
+    public virtual Id ObjectId => ClassInfo.ObjectId;
+    public IReadOnlyList<string> MemberNames => ClassInfo.MemberNames;
+
+    public object this[string memberName]
+    {
+        get
+        {
+            for (int i = 0; i < ClassInfo.MemberNames.Count; i++)
+            {
+                string current = ClassInfo.MemberNames[i];
+                if (current == memberName)
+                {
+                    return MemberValues[i];
+                }
+            }
+
+            throw new KeyNotFoundException();
+        }
+    }
+
+    private protected ClassRecord(ClassInfo classInfo, IReadOnlyList<object> memberValues)
+    {
+        ClassInfo = classInfo;
+        MemberValues = memberValues;
+    }
+
+    private protected static List<object> ReadDataFromClassInfo(BinaryReader reader, RecordMap recordMap, ClassInfo info)
+    {
+        // Not sure what gets us into this state yet.
+        return ReadRecords(reader, recordMap, info.MemberNames.Count);
+    }
+
+    private protected static IReadOnlyList<object> ReadDataFromMemberTypeInfo(
+        BinaryReader reader,
+        RecordMap recordMap,
+        MemberTypeInfo memberTypeInfo)
+    {
+        List<object> memberValues = new();
+        memberValues.EnsureCapacity(memberTypeInfo.Count);
+        foreach ((BinaryType type, object? info) in memberTypeInfo)
+        {
+            switch (type)
+            {
+                case BinaryType.Primitive:
+                    memberValues.Add(ReadPrimitiveType(reader, (PrimitiveType)info!));
+                    break;
+                case BinaryType.String:
+                    memberValues.Add(reader.ReadLengthPrefixedString());
+                    break;
+                case BinaryType.Object:
+                case BinaryType.StringArray:
+                case BinaryType.PrimitiveArray:
+                case BinaryType.Class:
+                case BinaryType.SystemClass:
+                case BinaryType.ObjectArray:
+                    memberValues.Add(ReadBinaryFormatRecord(reader, recordMap));
+                    break;
+                default:
+                    throw new SerializationException();
+            }
+        }
+
+        return memberValues;
+    }
+
+    private protected static void WriteDataFromMemberTypeInfo(BinaryWriter writer, MemberTypeInfo memberTypeInfo, IReadOnlyList<object> memberValues)
+    {
+        for (int i = 0; i < memberTypeInfo.Count; i++)
+        {
+            (BinaryType type, object? info) = memberTypeInfo[i];
+            switch (type)
+            {
+                case BinaryType.Primitive:
+                    WritePrimitiveType(writer, (PrimitiveType)info!, memberValues[i]);
+                    break;
+                case BinaryType.String:
+                    writer.WriteLengthPrefixedString((string)memberValues[i]);
+                    break;
+                case BinaryType.Object:
+                case BinaryType.StringArray:
+                case BinaryType.PrimitiveArray:
+                case BinaryType.Class:
+                case BinaryType.SystemClass:
+                case BinaryType.ObjectArray:
+                    ((IRecord)memberValues[i]).Write(writer);
+                    break;
+                default:
+                    throw new SerializationException();
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/ClassRecord.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/ClassRecord.cs
@@ -70,7 +70,7 @@ internal abstract class ClassRecord : Record
                     memberValues.Add(ReadPrimitiveType(reader, (PrimitiveType)info!));
                     break;
                 case BinaryType.String:
-                    memberValues.Add(reader.ReadLengthPrefixedString());
+                    memberValues.Add(reader.ReadString());
                     break;
                 case BinaryType.Object:
                 case BinaryType.StringArray:
@@ -99,7 +99,7 @@ internal abstract class ClassRecord : Record
                     WritePrimitiveType(writer, (PrimitiveType)info!, memberValues[i]);
                     break;
                 case BinaryType.String:
-                    writer.WriteLengthPrefixedString((string)memberValues[i]);
+                    writer.Write((string)memberValues[i]);
                     break;
                 case BinaryType.Object:
                 case BinaryType.StringArray:

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/ClassTypeInfo.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/ClassTypeInfo.cs
@@ -26,12 +26,12 @@ internal readonly struct ClassTypeInfo : IBinaryWriteable
     }
 
     public static ClassTypeInfo Parse(BinaryReader reader) => new(
-        reader.ReadLengthPrefixedString(),
+        reader.ReadString(),
         reader.ReadInt32());
 
     public void Write(BinaryWriter writer)
     {
-        writer.WriteLengthPrefixedString(TypeName);
+        writer.Write(TypeName);
         writer.Write(LibraryId);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/ClassTypeInfo.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/ClassTypeInfo.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms.BinaryFormat;
+
+/// <summary>
+///  Identifies a class by it's name and library id.
+/// </summary>
+/// <remarks>
+///  <para>
+///   <see href="https://learn.microsoft.com/openspecs/windows_protocols/ms-nrbf/844b24dd-9f82-426e-9b98-05334307a239">
+///    [MS-NRBF] 2.1.1.8
+///   </see>
+///  </para>
+/// </remarks>
+internal readonly struct ClassTypeInfo : IBinaryWriteable
+{
+    public readonly string TypeName;
+    public readonly Id LibraryId;
+
+    public ClassTypeInfo(string typeName, Id libraryId)
+    {
+        TypeName = typeName;
+        LibraryId = libraryId;
+    }
+
+    public static ClassTypeInfo Parse(BinaryReader reader) => new(
+        reader.ReadLengthPrefixedString(),
+        reader.ReadInt32());
+
+    public void Write(BinaryWriter writer)
+    {
+        writer.WriteLengthPrefixedString(TypeName);
+        writer.Write(LibraryId);
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/ClassWithId.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/ClassWithId.cs
@@ -1,0 +1,101 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.Serialization;
+
+namespace System.Windows.Forms.BinaryFormat;
+
+/// <summary>
+///  Class information that references another class record's metadata.
+/// </summary>
+/// <remarks>
+///  <para>
+///   <see href="https://learn.microsoft.com/openspecs/windows_protocols/ms-nrbf/2d168388-37f4-408a-b5e0-e48dbce73e26">
+///    [MS-NRBF] 2.3.2.5
+///   </see>
+///  </para>
+/// </remarks>
+internal sealed class ClassWithId : ClassRecord, IRecord<ClassWithId>
+{
+    private readonly ClassRecord _metadataClass;
+
+    public override Id ObjectId { get; }
+
+    /// <summary>
+    ///  The ObjectId of a prior <see cref="SystemClassWithMembers"/>, <see cref="SystemClassWithMembersAndTypes"/>,
+    ///  <see cref="ClassWithMembers"/>, or <see cref="ClassWithMembersAndTypes"/>.
+    /// </summary>
+    public Id MetadataId { get; }
+
+    public ClassWithId(Id id, ClassRecord metadataClass, IReadOnlyList<object> memberValues)
+        : base(metadataClass.ClassInfo, memberValues)
+    {
+        ObjectId = id;
+        MetadataId = metadataClass.ObjectId;
+        _metadataClass = metadataClass;
+    }
+
+    public static RecordType RecordType => RecordType.ClassWithId;
+
+    static ClassWithId IBinaryFormatParseable<ClassWithId>.Parse(
+        BinaryReader reader,
+        RecordMap recordMap)
+    {
+        Id objectId = reader.ReadInt32();
+        Id metadataId = reader.ReadInt32();
+
+        if (recordMap[metadataId] is not ClassRecord referencedRecord)
+        {
+            throw new SerializationException();
+        }
+
+        ClassWithId record = new(
+            objectId,
+            referencedRecord,
+            ReadDataFromRefId(reader, recordMap, referencedRecord));
+        recordMap[record.ObjectId] = record;
+
+        return record;
+
+        static IReadOnlyList<object> ReadDataFromRefId(BinaryReader reader, RecordMap recordMap, ClassRecord record) => record switch
+        {
+            ClassWithMembersAndTypes classWithMembersAndTypes
+                => ReadDataFromMemberTypeInfo(reader, recordMap, classWithMembersAndTypes.MemberTypeInfo),
+            SystemClassWithMembersAndTypes systemClassWithMembersAndTypes
+                => ReadDataFromMemberTypeInfo(reader, recordMap, systemClassWithMembersAndTypes.MemberTypeInfo),
+            ClassWithMembers classWithMembers
+                => ReadRecords(reader, recordMap, classWithMembers.MemberValues.Count),
+            SystemClassWithMembers systemClassWithMembers
+                => ReadRecords(reader, recordMap, systemClassWithMembers.MemberValues.Count),
+            _ => throw new SerializationException(),
+        };
+    }
+
+    public override void Write(BinaryWriter writer)
+    {
+        writer.Write((byte)RecordType);
+        writer.Write(ObjectId);
+        writer.Write(MetadataId);
+
+        switch (_metadataClass)
+        {
+            case ClassWithMembersAndTypes classWithMembersAndTypes:
+                WriteDataFromMemberTypeInfo(writer, classWithMembersAndTypes.MemberTypeInfo, MemberValues);
+                break;
+            case SystemClassWithMembersAndTypes systemClassWithMembersAndTypes:
+                WriteDataFromMemberTypeInfo(writer, systemClassWithMembersAndTypes.MemberTypeInfo, MemberValues);
+                break;
+            case ClassWithMembers or SystemClassWithMembers:
+                WriteRecords(writer, MemberValues);
+                break;
+            default:
+                throw new SerializationException();
+        }
+    }
+
+    // The following implicit conversion is to facilitate lookup of related records
+    // using the correct identifier.
+
+    public static implicit operator Id(ClassWithId value) => value.MetadataId;
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/ClassWithMembers.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/ClassWithMembers.cs
@@ -1,0 +1,50 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms.BinaryFormat;
+
+/// <summary>
+///  Class information with the source library.
+/// </summary>
+/// <remarks>
+///  <para>
+///   <see href="https://learn.microsoft.com/openspecs/windows_protocols/ms-nrbf/ebbdad88-91fe-48ae-a985-661f9cc7e0de">
+///    [MS-NRBF] 2.3.2.2
+///   </see>
+///  </para>
+/// </remarks>
+internal sealed class ClassWithMembers : ClassRecord, IRecord<ClassWithMembers>
+{
+    public Id LibraryId { get; }
+
+    public ClassWithMembers(ClassInfo classInfo, Id libraryId, IReadOnlyList<object> memberValues)
+        : base(classInfo, memberValues)
+    {
+        LibraryId = libraryId;
+    }
+
+    public static RecordType RecordType => RecordType.ClassWithMembers;
+
+    static ClassWithMembers IBinaryFormatParseable<ClassWithMembers>.Parse(
+        BinaryReader reader,
+        RecordMap recordMap)
+    {
+        ClassInfo classInfo = ClassInfo.Parse(reader, out _);
+        ClassWithMembers record = new(
+            classInfo,
+            reader.ReadInt32(),
+            ReadDataFromClassInfo(reader, recordMap, classInfo));
+
+        // Index this record by the id of the embedded ClassInfo's object id.
+        recordMap[classInfo.ObjectId] = record;
+        return record;
+    }
+
+    public override void Write(BinaryWriter writer)
+    {
+        writer.Write((byte)RecordType);
+        ClassInfo.Write(writer);
+        writer.Write(LibraryId);
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/ClassWithMembersAndTypes.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/ClassWithMembersAndTypes.cs
@@ -1,0 +1,61 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms.BinaryFormat;
+
+/// <summary>
+///  Class information with type info and the source library.
+/// </summary>
+/// <remarks>
+///  <para>
+///   <see href="https://learn.microsoft.com/openspecs/windows_protocols/ms-nrbf/847b0b6a-86af-4203-8ed0-f84345f845b9">
+///    [MS-NRBF] 2.3.2.1
+///   </see>
+///  </para>
+/// </remarks>
+internal sealed class ClassWithMembersAndTypes : ClassRecord, IRecord<ClassWithMembersAndTypes>
+{
+    public MemberTypeInfo MemberTypeInfo { get; }
+    public Id LibraryId { get; }
+
+    public ClassWithMembersAndTypes(
+        ClassInfo classInfo,
+        MemberTypeInfo memberTypeInfo,
+        Id libraryId,
+        IReadOnlyList<object> memberValues)
+        : base(classInfo, memberValues)
+    {
+        MemberTypeInfo = memberTypeInfo;
+        LibraryId = libraryId;
+    }
+
+    public static RecordType RecordType => RecordType.ClassWithMembersAndTypes;
+
+    static ClassWithMembersAndTypes IBinaryFormatParseable<ClassWithMembersAndTypes>.Parse(
+        BinaryReader reader,
+        RecordMap recordMap)
+    {
+        ClassInfo classInfo = ClassInfo.Parse(reader, out Count memberCount);
+        MemberTypeInfo memberTypeInfo = MemberTypeInfo.Parse(reader, memberCount);
+
+        ClassWithMembersAndTypes record = new(
+            classInfo,
+            memberTypeInfo,
+            reader.ReadInt32(),
+            ReadDataFromMemberTypeInfo(reader, recordMap, memberTypeInfo));
+
+        // Index this record by the id of the embedded ClassInfo's object id.
+        recordMap[record.ClassInfo.ObjectId] = record;
+        return record;
+    }
+
+    public override void Write(BinaryWriter writer)
+    {
+        writer.Write((byte)RecordType);
+        ClassInfo.Write(writer);
+        MemberTypeInfo.Write(writer);
+        writer.Write(LibraryId);
+        WriteDataFromMemberTypeInfo(writer, MemberTypeInfo, MemberValues);
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/IBinaryFormatParseable.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/IBinaryFormatParseable.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms.BinaryFormat;
+
+/// <summary>
+///  Specifies that the given record type can be created from a <see cref="BinaryReader"/>.
+/// </summary>
+internal interface IBinaryFormatParseable<T> where T : IRecord
+{
+    /// <summary>
+    ///  Creates the type utilizaing the given <see cref="BinaryReader"/>.
+    /// </summary>
+    /// <param name="recordMap">
+    ///  Record map for looking up referenced records. If this record has an id it will be added to the map.
+    /// </param>
+    static abstract T Parse(BinaryReader reader, RecordMap recordMap);
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/IBinaryWriteable.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/IBinaryWriteable.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms.BinaryFormat;
+
+/// <summary>
+///  Expresses that the object can be written with a <see cref="BinaryWriter"/>
+/// </summary>
+internal interface IBinaryWriteable
+{
+    /// <summary>
+    ///  Writes the current object to the given <paramref name="writer"/>.
+    /// </summary>
+    void Write(BinaryWriter writer);
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/IRecord.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/IRecord.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms.BinaryFormat;
+
+/// <summary>
+///  Non-generic record base interface.
+/// </summary>
+internal interface IRecord : IBinaryWriteable
+{
+    static virtual RecordType RecordType { get; }
+}
+
+/// <summary>
+///  Typed record interface.
+/// </summary>
+internal interface IRecord<T> : IRecord, IBinaryFormatParseable<T> where T : class, IRecord
+{
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/MemberPrimitiveTyped.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/MemberPrimitiveTyped.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms.BinaryFormat;
+
+/// <summary>
+///  Primitive value other than <see langword="string"/>.
+/// </summary>
+/// <remarks>
+///  <para>
+///   <see href="https://learn.microsoft.com/openspecs/windows_protocols/ms-nrbf/c0a190b2-762c-46b9-89f2-c7dabecfc084">
+///    [MS-NRBF] 2.5.1
+///   </see>
+///  </para>
+/// </remarks>
+internal sealed class MemberPrimitiveTyped : Record, IRecord<MemberPrimitiveTyped>
+{
+    public PrimitiveType PrimitiveType { get; }
+    public object Value { get; }
+
+    public MemberPrimitiveTyped(PrimitiveType primitiveType, object value)
+    {
+        PrimitiveType = primitiveType;
+        Value = value;
+    }
+
+    public static RecordType RecordType => RecordType.MemberPrimitiveTyped;
+
+    static MemberPrimitiveTyped IBinaryFormatParseable<MemberPrimitiveTyped>.Parse(
+        BinaryReader reader,
+        RecordMap recordMap)
+    {
+        PrimitiveType primitiveType = (PrimitiveType)reader.ReadByte();
+        return new(
+            primitiveType,
+            ReadPrimitiveType(reader, primitiveType));
+    }
+
+    public override void Write(BinaryWriter writer)
+    {
+        writer.Write((byte)RecordType);
+        WritePrimitiveType(writer, PrimitiveType, Value);
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/MemberReference.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/MemberReference.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms.BinaryFormat;
+
+/// <summary>
+///  The <see cref="MemberReference"/> record contains a reference to another record that contains the actual value.
+/// </summary>
+/// <remarks>
+///  <para>
+///   <see href="https://learn.microsoft.com/openspecs/windows_protocols/ms-nrbf/eef0aa32-ab03-4b6a-a506-bcdfc10583fd">
+///    [MS-NRBF] 2.5.3
+///   </see>
+///  </para>
+/// </remarks>
+internal sealed class MemberReference : IRecord<MemberReference>
+{
+    public Id IdRef { get; }
+
+    public MemberReference(Id idRef) => IdRef = idRef;
+
+    public static RecordType RecordType => RecordType.MemberReference;
+
+    static MemberReference IBinaryFormatParseable<MemberReference>.Parse(
+        BinaryReader reader,
+        RecordMap recordMap) => new(reader.ReadInt32());
+
+    public void Write(BinaryWriter writer)
+    {
+        writer.Write((byte)RecordType);
+        writer.Write(IdRef);
+    }
+
+    // The following implicit conversions are to facilitate lookup of related records
+    // using the correct identifier.
+
+    public static implicit operator Id(MemberReference value) => value.IdRef;
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/MemberTypeInfo.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/MemberTypeInfo.cs
@@ -1,0 +1,108 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Runtime.Serialization;
+
+namespace System.Windows.Forms.BinaryFormat;
+
+/// <summary>
+///  Member type info.
+/// </summary>
+/// <remarks>
+///  <para>
+///   <see href="https://learn.microsoft.com/openspecs/windows_protocols/ms-nrbf/aa509b5a-620a-4592-a5d8-7e9613e0a03e">
+///    [MS-NRBF] 2.3.1.2
+///   </see>
+///  </para>
+/// </remarks>
+
+internal readonly struct MemberTypeInfo : IBinaryWriteable, IEnumerable<(BinaryType Type, object? Info)>
+{
+    private readonly IList<(BinaryType Type, object? Info)> _info;
+
+    public MemberTypeInfo(IList<(BinaryType Type, object? Info)> info) => _info = info;
+
+    public readonly (BinaryType Type, object? Info) this[int index] => _info[index];
+    public readonly int Count => _info.Count;
+
+    public static MemberTypeInfo Parse(BinaryReader reader, Count expectedCount)
+    {
+        List<(BinaryType Type, object? Info)> info = new(expectedCount);
+
+        // Get all of the BinaryTypes
+        for (int i = 0; i < expectedCount; i++)
+        {
+            info.Add(((BinaryType)reader.ReadByte(), null));
+        }
+
+        // Check for more clarifying information
+
+        for (int i = 0; i < expectedCount; i++)
+        {
+            BinaryType type = info[i].Type;
+            switch (type)
+            {
+                case BinaryType.Primitive:
+                case BinaryType.PrimitiveArray:
+                    info[i] = (type, (PrimitiveType)reader.ReadByte());
+                    break;
+                case BinaryType.SystemClass:
+                    info[i] = (type, reader.ReadLengthPrefixedString());
+                    break;
+                case BinaryType.Class:
+                    info[i] = (type, ClassTypeInfo.Parse(reader));
+                    break;
+                case BinaryType.String:
+                case BinaryType.ObjectArray:
+                case BinaryType.StringArray:
+                case BinaryType.Object:
+                    // Other types have no additional data.
+                    break;
+                default:
+                    throw new SerializationException("Unexpected binary type.");
+            }
+        }
+
+        return new MemberTypeInfo(info);
+    }
+
+    public readonly void Write(BinaryWriter writer)
+    {
+        foreach ((BinaryType type, _) in this)
+        {
+            writer.Write((byte)type);
+        }
+
+        foreach ((BinaryType type, object? info) in this)
+        {
+            switch (type)
+            {
+                case BinaryType.Primitive:
+                case BinaryType.PrimitiveArray:
+                    writer.Write((byte)info!);
+                    break;
+                case BinaryType.SystemClass:
+                    writer.WriteLengthPrefixedString((string)info!);
+                    break;
+                case BinaryType.Class:
+                    ((ClassTypeInfo)info!).Write(writer);
+                    break;
+                case BinaryType.String:
+                case BinaryType.ObjectArray:
+                case BinaryType.StringArray:
+                case BinaryType.Object:
+                    // Other types have no additional data.
+                    break;
+                default:
+                    throw new SerializationException("Unexpected binary type.");
+            }
+        }
+    }
+
+    IEnumerator<(BinaryType Type, object? Info)> IEnumerable<(BinaryType Type, object? Info)>.GetEnumerator()
+        => _info.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => _info.GetEnumerator();
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/MemberTypeInfo.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/MemberTypeInfo.cs
@@ -49,7 +49,7 @@ internal readonly struct MemberTypeInfo : IBinaryWriteable, IEnumerable<(BinaryT
                     info[i] = (type, (PrimitiveType)reader.ReadByte());
                     break;
                 case BinaryType.SystemClass:
-                    info[i] = (type, reader.ReadLengthPrefixedString());
+                    info[i] = (type, reader.ReadString());
                     break;
                 case BinaryType.Class:
                     info[i] = (type, ClassTypeInfo.Parse(reader));
@@ -84,7 +84,7 @@ internal readonly struct MemberTypeInfo : IBinaryWriteable, IEnumerable<(BinaryT
                     writer.Write((byte)info!);
                     break;
                 case BinaryType.SystemClass:
-                    writer.WriteLengthPrefixedString((string)info!);
+                    writer.Write((string)info!);
                     break;
                 case BinaryType.Class:
                     ((ClassTypeInfo)info!).Write(writer);

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/MessageEnd.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/MessageEnd.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms.BinaryFormat;
+
+/// <summary>
+///  Record that marks the end of the binary format stream.
+/// </summary>
+internal sealed class MessageEnd : IRecord<MessageEnd>
+{
+    public static MessageEnd Instance { get; } = new();
+
+    private MessageEnd() { }
+
+    public static RecordType RecordType => RecordType.MessageEnd;
+
+    static MessageEnd IBinaryFormatParseable<MessageEnd>.Parse(
+        BinaryReader reader,
+        RecordMap recordMap) => Instance;
+
+    public void Write(BinaryWriter writer) => writer.Write((byte)RecordType);
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/NullRecord.ObjectNullMultiple.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/NullRecord.ObjectNullMultiple.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms.BinaryFormat;
+
+internal abstract partial class NullRecord
+{
+    /// <summary>
+    ///  Multiple null object record.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/openspecs/windows_protocols/ms-nrbf/f4abb5dd-aab7-4e0a-9d77-1d6c99f5779e">
+    ///    [MS-NRBF] 2.5.5
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    internal sealed class ObjectNullMultiple : NullRecord, IRecord<ObjectNullMultiple>
+    {
+        public static RecordType RecordType => RecordType.ObjectNullMultiple;
+
+        public ObjectNullMultiple(Count count) => NullCount = count;
+
+        static ObjectNullMultiple IBinaryFormatParseable<ObjectNullMultiple>.Parse(
+            BinaryReader reader,
+            RecordMap recordMap)
+            => new(reader.ReadInt32());
+
+        public void Write(BinaryWriter writer)
+        {
+            writer.Write((byte)RecordType);
+            writer.Write(NullCount);
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/NullRecord.ObjectNullMultiple256.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/NullRecord.ObjectNullMultiple256.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms.BinaryFormat;
+
+internal abstract partial class NullRecord
+{
+    /// <summary>
+    ///  Multiple null object record (less than 256).
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/openspecs/windows_protocols/ms-nrbf/f4abb5dd-aab7-4e0a-9d77-1d6c99f5779e">
+    ///    [MS-NRBF] 2.5.5
+    ///   </see>
+    ///  </para>
+    /// </remarks>
+    internal sealed class ObjectNullMultiple256 : NullRecord, IRecord<ObjectNullMultiple256>
+    {
+        public static RecordType RecordType => RecordType.ObjectNullMultiple256;
+
+        public ObjectNullMultiple256(Count count) => NullCount = count;
+
+        static ObjectNullMultiple256 IBinaryFormatParseable<ObjectNullMultiple256>.Parse(
+            BinaryReader reader,
+            RecordMap recordMap) => new(reader.ReadByte());
+
+        public void Write(BinaryWriter writer)
+        {
+            writer.Write((byte)RecordType);
+            writer.Write(checked((byte)NullCount));
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/NullRecord.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/NullRecord.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms.BinaryFormat;
+
+/// <summary>
+///  Base class for null records.
+/// </summary>
+internal abstract partial class NullRecord
+{
+    private Count _count;
+
+    public virtual Count NullCount
+    {
+        get => _count;
+        private protected set
+        {
+            if (value == 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value));
+            }
+
+            _count = value;
+        }
+    }
+
+    internal static void Write(BinaryWriter writer, int nullCount)
+    {
+        switch (nullCount)
+        {
+            case 1:
+                ObjectNull.Instance.Write(writer);
+                break;
+            case <= 255:
+                new ObjectNullMultiple256(nullCount).Write(writer);
+                break;
+            default:
+                new ObjectNullMultiple(nullCount).Write(writer);
+                break;
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/ObjectNull.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/ObjectNull.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms.BinaryFormat;
+
+/// <summary>
+///  Null object record.
+/// </summary>
+/// <remarks>
+///  <para>
+///   <see href="https://learn.microsoft.com/openspecs/windows_protocols/ms-nrbf/fe51522c-23d1-48dd-9913-c84894abc127">
+///    [MS-NRBF] 2.5.4
+///   </see>
+///  </para>
+/// </remarks>
+internal sealed class ObjectNull : NullRecord, IRecord<ObjectNull>
+{
+    public static ObjectNull Instance { get; } = new();
+
+    private ObjectNull() { }
+
+    public override Count NullCount => Count.One;
+
+    public static RecordType RecordType => RecordType.ObjectNull;
+
+    static ObjectNull IBinaryFormatParseable<ObjectNull>.Parse(
+        BinaryReader reader,
+        RecordMap recordMap) => Instance;
+
+    public void Write(BinaryWriter writer) => writer.Write((byte)RecordType);
+
+    public override bool Equals(object? obj) => obj is ObjectNull;
+
+    public override int GetHashCode() => Instance.GetHashCode();
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/PrimitiveType.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/PrimitiveType.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms.BinaryFormat;
+
+/// <summary>
+///  Primitive type.
+/// </summary>
+/// <remarks>
+///  <para>
+///   <see href="https://learn.microsoft.com/openspecs/windows_protocols/ms-nrbf/4e77849f-89e3-49db-8fb9-e77ee4bc7214">
+///    [MS-NRBF] 2.1.2.3
+///   </see>
+///  </para>
+/// </remarks>
+internal enum PrimitiveType : byte
+{
+    Boolean = 1,
+    Byte,
+    Char,
+    Decimal = 5,
+    Double,
+    Int16,
+    Int32,
+    Int64,
+    SByte,
+    Single,
+    TimeSpan,
+    DateTime,
+    UInt16,
+    UInt32,
+    UInt64,
+    Null,
+    String
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/Record.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/Record.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Globalization;
 using System.Runtime.Serialization;
 
 namespace System.Windows.Forms.BinaryFormat;
@@ -56,7 +57,7 @@ internal abstract class Record : IRecord
         PrimitiveType.UInt64 => reader.ReadUInt64(),
         PrimitiveType.Single => reader.ReadSingle(),
         PrimitiveType.Double => reader.ReadDouble(),
-        PrimitiveType.Decimal => reader.ReadDecimal(),
+        PrimitiveType.Decimal => decimal.Parse(reader.ReadString(), CultureInfo.InvariantCulture),
         PrimitiveType.DateTime => reader.ReadDateTime(),
         PrimitiveType.TimeSpan => new TimeSpan(reader.ReadInt64()),
         // String is handled with a record, never on it's own
@@ -94,7 +95,7 @@ internal abstract class Record : IRecord
                 writer.Write((char)value);
                 break;
             case PrimitiveType.Decimal:
-                writer.Write((decimal)value);
+                writer.Write(((decimal)value).ToString(CultureInfo.InvariantCulture));
                 break;
             case PrimitiveType.Double:
                 writer.Write((double)value);

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/Record.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/Record.cs
@@ -1,0 +1,264 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.Serialization;
+
+namespace System.Windows.Forms.BinaryFormat;
+
+/// <summary>
+///  Base record class.
+/// </summary>
+internal abstract class Record : IRecord
+{
+    /// <summary>
+    ///  Returns the <see cref="PrimitiveType"/> for the given <paramref name="type"/>.
+    /// </summary>
+    /// <param name="type"></param>
+    /// <returns><see cref="PrimitiveType"/> or <see langword="default"/> if not a <see cref="PrimitiveType"/>.</returns>
+    internal static PrimitiveType GetPrimitiveType(Type type) => Type.GetTypeCode(type) switch
+    {
+        TypeCode.Boolean => PrimitiveType.Boolean,
+        TypeCode.Char => PrimitiveType.Char,
+        TypeCode.SByte => PrimitiveType.SByte,
+        TypeCode.Byte => PrimitiveType.Byte,
+        TypeCode.Int16 => PrimitiveType.Int16,
+        TypeCode.UInt16 => PrimitiveType.UInt16,
+        TypeCode.Int32 => PrimitiveType.Int32,
+        TypeCode.UInt32 => PrimitiveType.UInt32,
+        TypeCode.Int64 => PrimitiveType.Int64,
+        TypeCode.UInt64 => PrimitiveType.UInt64,
+        TypeCode.Single => PrimitiveType.Single,
+        TypeCode.Double => PrimitiveType.Double,
+        TypeCode.Decimal => PrimitiveType.Decimal,
+        TypeCode.DateTime => PrimitiveType.DateTime,
+        TypeCode.String => PrimitiveType.String,
+        // TypeCode.Empty => 0,
+        // TypeCode.Object => 0,
+        // TypeCode.DBNull => 0,
+        _ => type == typeof(TimeSpan) ? PrimitiveType.TimeSpan : default,
+    };
+
+    /// <summary>
+    ///  Reads a primitive of <paramref name="primitiveType"/> from the given <paramref name="reader"/>.
+    /// </summary>
+    private protected static object ReadPrimitiveType(BinaryReader reader, PrimitiveType primitiveType) => primitiveType switch
+    {
+        PrimitiveType.Boolean => reader.ReadBoolean(),
+        PrimitiveType.Byte => reader.ReadByte(),
+        PrimitiveType.SByte => reader.ReadSByte(),
+        PrimitiveType.Char => reader.ReadChar(),
+        PrimitiveType.Int16 => reader.ReadInt16(),
+        PrimitiveType.UInt16 => reader.ReadUInt16(),
+        PrimitiveType.Int32 => reader.ReadInt32(),
+        PrimitiveType.UInt32 => reader.ReadUInt32(),
+        PrimitiveType.Int64 => reader.ReadInt64(),
+        PrimitiveType.UInt64 => reader.ReadUInt64(),
+        PrimitiveType.Single => reader.ReadSingle(),
+        PrimitiveType.Double => reader.ReadDouble(),
+        PrimitiveType.Decimal => reader.ReadDecimal(),
+        PrimitiveType.DateTime => reader.ReadDateTime(),
+        PrimitiveType.TimeSpan => new TimeSpan(reader.ReadInt64()),
+        // String is handled with a record, never on it's own
+        _ => throw new SerializationException(),
+    };
+
+    /// <summary>
+    ///  Reads <paramref name="count"/> primitives of <paramref name="primitiveType"/> from the given <paramref name="reader"/>.
+    /// </summary>
+    private protected static IReadOnlyList<object> ReadPrimitiveTypes(BinaryReader reader, PrimitiveType primitiveType, int count)
+    {
+        List<object> values = new(Math.Min(count, BinaryFormattedObject.MaxNewCollectionSize));
+        for (int i = 0; i < count; i++)
+        {
+            values.Add(ReadPrimitiveType(reader, primitiveType));
+        }
+
+        return values;
+    }
+
+    /// <summary>
+    ///  Writes <paramref name="value"/> as <paramref name="primitiveType"/> to the given <paramref name="writer"/>.
+    /// </summary>
+    private protected static unsafe void WritePrimitiveType(BinaryWriter writer, PrimitiveType primitiveType, object value)
+    {
+        switch (primitiveType)
+        {
+            case PrimitiveType.Boolean:
+                writer.Write((bool)value);
+                break;
+            case PrimitiveType.Byte:
+                writer.Write((byte)value);
+                break;
+            case PrimitiveType.Char:
+                writer.Write((char)value);
+                break;
+            case PrimitiveType.Decimal:
+                writer.Write((decimal)value);
+                break;
+            case PrimitiveType.Double:
+                writer.Write((double)value);
+                break;
+            case PrimitiveType.Int16:
+                writer.Write((short)value);
+                break;
+            case PrimitiveType.Int32:
+                writer.Write((int)value);
+                break;
+            case PrimitiveType.Int64:
+                writer.Write((long)value);
+                break;
+            case PrimitiveType.SByte:
+                writer.Write((sbyte)value);
+                break;
+            case PrimitiveType.Single:
+                writer.Write((float)value);
+                break;
+            case PrimitiveType.TimeSpan:
+                writer.Write(((TimeSpan)value).Ticks);
+                break;
+            case PrimitiveType.DateTime:
+                writer.Write((DateTime)value);
+                break;
+            case PrimitiveType.UInt16:
+                writer.Write((ushort)value);
+                break;
+            case PrimitiveType.UInt32:
+                writer.Write((uint)value);
+                break;
+            case PrimitiveType.UInt64:
+                writer.Write((ulong)value);
+                break;
+            // String is handled with a record, never on it's own
+            case PrimitiveType.Null:
+            case PrimitiveType.String:
+                throw new SerializationException();
+        }
+    }
+
+    /// <summary>
+    ///  Writes <paramref name="values"/> as <paramref name="primitiveType"/> to the given <paramref name="writer"/>.
+    /// </summary>
+    private protected static void WritePrimitiveTypes(BinaryWriter writer, PrimitiveType primitiveType, IReadOnlyList<object> values)
+    {
+        for (int i = 0; i < values.Count; i++)
+        {
+            WritePrimitiveType(writer, primitiveType, values[i]);
+        }
+    }
+
+    /// <summary>
+    ///  Reads the next record from the given <paramref name="reader"/>.
+    /// </summary>
+    /// <exception cref="NotImplementedException">Found a mulitdimensional array.</exception>
+    /// <exception cref="NotSupportedException">Found a remote method invocation record.</exception>
+    /// <exception cref="SerializationException">Unknown or corrupted data.</exception>
+    internal static IRecord ReadBinaryFormatRecord(BinaryReader reader, RecordMap recordMap)
+    {
+        RecordType recordType = (RecordType)reader.ReadByte();
+
+        return recordType switch
+        {
+            RecordType.SerializedStreamHeader => ReadSpecificRecord<SerializationHeader>(recordMap),
+            RecordType.ClassWithId => ReadSpecificRecord<ClassWithId>(recordMap),
+            RecordType.SystemClassWithMembers => ReadSpecificRecord<SystemClassWithMembers>(recordMap),
+            RecordType.ClassWithMembers => ReadSpecificRecord<ClassWithMembers>(recordMap),
+            RecordType.SystemClassWithMembersAndTypes => ReadSpecificRecord<SystemClassWithMembersAndTypes>(recordMap),
+            RecordType.ClassWithMembersAndTypes => ReadSpecificRecord<ClassWithMembersAndTypes>(recordMap),
+            RecordType.BinaryObjectString => ReadSpecificRecord<BinaryObjectString>(recordMap),
+            // The BinaryArray record is used for multidimensional arrays
+            RecordType.BinaryArray => throw new NotImplementedException(),
+            RecordType.MemberPrimitiveTyped => ReadSpecificRecord<MemberPrimitiveTyped>(recordMap),
+            RecordType.MemberReference => ReadSpecificRecord<MemberReference>(recordMap),
+            RecordType.ObjectNull => ReadSpecificRecord<ObjectNull>(recordMap),
+            RecordType.MessageEnd => ReadSpecificRecord<MessageEnd>(recordMap),
+            RecordType.BinaryLibrary => ReadSpecificRecord<BinaryLibrary>(recordMap),
+            RecordType.ObjectNullMultiple256 => ReadSpecificRecord<NullRecord.ObjectNullMultiple256>(recordMap),
+            RecordType.ObjectNullMultiple => ReadSpecificRecord<NullRecord.ObjectNullMultiple>(recordMap),
+            RecordType.ArraySinglePrimitive => ReadSpecificRecord<ArraySinglePrimitive>(recordMap),
+            RecordType.ArraySingleObject => ReadSpecificRecord<ArraySingleObject>(recordMap),
+            RecordType.ArraySingleString => ReadSpecificRecord<ArraySingleString>(recordMap),
+            RecordType.MethodCall => throw new NotSupportedException(),
+            RecordType.MethodReturn => throw new NotSupportedException(),
+            _ => throw new SerializationException(),
+        };
+
+        unsafe TRecord ReadSpecificRecord<TRecord>(RecordMap recordMap) where TRecord : class, IRecord<TRecord>
+        {
+            return TRecord.Parse(reader, recordMap);
+        }
+    }
+
+    /// <summary>
+    ///  Reads records, expanding null records into individual entries.
+    /// </summary>
+    private protected static List<object> ReadRecords(BinaryReader reader, RecordMap recordMap, Count count)
+    {
+        List<object> objects = new(Math.Min(count, BinaryFormattedObject.MaxNewCollectionSize));
+
+        for (int i = 0; i < count; i++)
+        {
+            var record = ReadBinaryFormatRecord(reader, recordMap);
+            if (record is not NullRecord nullRecord)
+            {
+                objects.Add(record);
+            }
+            else
+            {
+                i += nullRecord.NullCount - 1;
+                if (i >= count)
+                {
+                    throw new SerializationException();
+                }
+
+                for (int j = 0; j < nullRecord.NullCount; j++)
+                {
+                    objects.Add(ObjectNull.Instance);
+                }
+            }
+        }
+
+        return objects;
+    }
+
+    /// <summary>
+    ///  Writes records, coalescing null records into single entries.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    ///  <paramref name="objects"/> contained an object that isn't a record.
+    /// </exception>
+    private protected static void WriteRecords(BinaryWriter writer, IReadOnlyList<object> objects)
+    {
+        int nullCount = 0;
+
+        for (int i = 0; i < objects.Count; i++)
+        {
+            if (objects[i] is not IRecord record)
+            {
+                throw new ArgumentException(null, nameof(objects));
+            }
+
+            // Aggregate consecutive null records.
+            if (record is NullRecord)
+            {
+                nullCount++;
+                continue;
+            }
+
+            if (nullCount > 0)
+            {
+                NullRecord.Write(writer, nullCount);
+                nullCount = 0;
+            }
+
+            record.Write(writer);
+        }
+
+        if (nullCount > 0)
+        {
+            NullRecord.Write(writer, nullCount);
+        }
+    }
+
+    public abstract void Write(BinaryWriter writer);
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/RecordMap.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/RecordMap.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms.BinaryFormat;
+
+/// <summary>
+///  Map of records that ensures that IDs are only entered once.
+/// </summary>
+internal class RecordMap
+{
+    private readonly Dictionary<int, IRecord> _records = new();
+
+    public IRecord this[Id id]
+    {
+        get => _records[id];
+        set => _records.Add(id, value);
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/RecordType.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/RecordType.cs
@@ -1,0 +1,49 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms.BinaryFormat;
+
+/// <summary>
+///  Record type.
+/// </summary>
+/// <remarks>
+///  <para>
+///   <see href="https://learn.microsoft.com/openspecs/windows_protocols/ms-nrbf/954a0657-b901-4813-9398-4ec732fe8b32">
+///    [MS-NRBF] 2.1.2.1
+///   </see>
+///  </para>
+/// </remarks>
+internal enum RecordType : byte
+{
+    SerializedStreamHeader,
+    ClassWithId,
+    SystemClassWithMembers,
+    ClassWithMembers,
+    SystemClassWithMembersAndTypes,
+    ClassWithMembersAndTypes,
+    BinaryObjectString,
+    BinaryArray,
+    MemberPrimitiveTyped,
+    MemberReference,
+    ObjectNull,
+    MessageEnd,
+    BinaryLibrary,
+    ObjectNullMultiple256,
+    ObjectNullMultiple,
+    ArraySinglePrimitive,
+    ArraySingleObject,
+    ArraySingleString,
+
+    /// <summary>
+    ///  Used for remote method invocation. <see href="https://learn.microsoft.com/openspecs/windows_protocols/ms-nrbf/4c727b2f-2c30-468d-b12e-b56406f14862">
+    ///  [MS-NRBF] 2.2</see>
+    /// </summary>
+    MethodCall,
+
+    /// <summary>
+    ///  Used for remote method invocation. <see href="https://learn.microsoft.com/openspecs/windows_protocols/ms-nrbf/4c727b2f-2c30-468d-b12e-b56406f14862">
+    ///  [MS-NRBF] 2.2</see>
+    /// </summary>
+    MethodReturn
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/SerializationHeader.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/SerializationHeader.cs
@@ -1,0 +1,66 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms.BinaryFormat;
+
+/// <summary>
+///  Binary format header.
+/// </summary>
+/// <remarks>
+///  <para>
+///   <see href="https://learn.microsoft.com/openspecs/windows_protocols/ms-nrbf/a7e578d3-400a-4249-9424-7529d10d1b3c">
+///    [MS-NRBF] 2.6.1
+///   </see>
+///  </para>
+/// </remarks>
+internal sealed class SerializationHeader : IRecord<SerializationHeader>
+{
+    /// <summary>
+    ///  The id of the root object record.
+    /// </summary>
+    public Id RootId;
+
+    /// <summary>
+    ///  Ignored. BinaryFormatter puts out -1.
+    /// </summary>
+    public int HeaderId;
+
+    /// <summary>
+    ///  Must be 1.
+    /// </summary>
+    public Id MajorVersion;
+
+    /// <summary>
+    ///  Must be 0.
+    /// </summary>
+    public Id MinorVersion;
+
+    public static RecordType RecordType => RecordType.SerializedStreamHeader;
+
+    public static SerializationHeader Default => new()
+    {
+        MajorVersion = 1,
+        RootId = 1,
+        HeaderId = -1,
+    };
+
+    static SerializationHeader IBinaryFormatParseable<SerializationHeader>.Parse(
+        BinaryReader reader,
+        RecordMap recordMap) => new()
+    {
+        RootId = reader.ReadInt32(),
+        HeaderId = reader.ReadInt32(),
+        MajorVersion = reader.ReadInt32(),
+        MinorVersion = reader.ReadInt32(),
+    };
+
+    public void Write(BinaryWriter writer)
+    {
+        writer.Write((byte)RecordType);
+        writer.Write(RootId);
+        writer.Write(HeaderId);
+        writer.Write(MajorVersion);
+        writer.Write(MinorVersion);
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/Support/FormatterConverterStub.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/Support/FormatterConverterStub.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.Serialization;
+
+namespace System.Windows.Forms.BinaryFormat;
+
+/// <summary>
+///  <see cref="IFormatterConverter"/> that only returns default values.
+/// </summary>
+/// <remarks>
+///  <para>
+///   Allows creating a <see cref="SerializationInfo"/> when a <see cref="IFormatterConverter"/>
+///   isn't necessary.
+///  </para>
+/// </remarks>
+#pragma warning disable SYSLIB0050 // Type or member is obsolete (IFormatterConverter)
+internal sealed class FormatterConverterStub : IFormatterConverter
+{
+    private FormatterConverterStub() { }
+
+    public static IFormatterConverter Instance { get; } = new FormatterConverterStub();
+#pragma warning restore SYSLIB0050 // Type or member is obsolete
+
+    public object Convert(object value, Type type) => default!;
+    public object Convert(object value, TypeCode typeCode) => default!;
+    public bool ToBoolean(object value) => default;
+    public byte ToByte(object value) => default;
+    public char ToChar(object value) => default;
+    public DateTime ToDateTime(object value) => default;
+    public decimal ToDecimal(object value) => default;
+    public double ToDouble(object value) => default;
+    public short ToInt16(object value) => default;
+    public int ToInt32(object value) => default;
+    public long ToInt64(object value) => default;
+    public sbyte ToSByte(object value) => default;
+    public float ToSingle(object value) => default;
+    public string? ToString(object value) => default;
+    public ushort ToUInt16(object value) => default;
+    public uint ToUInt32(object value) => default;
+    public ulong ToUInt64(object value) => default;
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/Support/SerializationExtensions.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/Support/SerializationExtensions.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.ExceptionServices;
+using System.Runtime.Serialization;
+
+namespace System.Windows.Forms.BinaryFormat;
+
+internal static class SerializationExtensions
+{
+    /// <summary>
+    ///  Get a typed value. Hard casts.
+    /// </summary>
+    public static T? GetValue<T>(this SerializationInfo info, string name) => (T?)info.GetValue(name, typeof(T));
+
+    /// <summary>
+    ///  Converts the given exception to a <see cref="SerializationException"/> if needed, nesting the original exception
+    ///  and assigning the original stack trace.
+    /// </summary>
+    public static SerializationException ConvertToSerializationException(this Exception ex)
+        => ex is SerializationException serializationException
+            ? serializationException
+            : (SerializationException)ExceptionDispatchInfo.SetRemoteStackTrace(
+                new SerializationException(ex.Message, ex),
+                ex.StackTrace ?? string.Empty);
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/Support/StringRecordsCollection.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/Support/StringRecordsCollection.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms.BinaryFormat;
+
+/// <summary>
+///  Helper to create and track records for <see cref="BinaryObjectString"/> and <see cref="MemberReference"/>
+///  when duplicates are found.
+/// </summary>
+internal class StringRecordsCollection
+{
+    private readonly Dictionary<string, int> _strings = new();
+    private readonly Dictionary<int, MemberReference> _memberReferences = new();
+
+    /// <summary>
+    ///  Returns the appropriate record for the given string.
+    /// </summary>
+    /// <param name="nextId">The id to use if needed, will be incremented if used.</param>
+    public IRecord GetStringRecord(string value, ref int nextId)
+    {
+        if (_strings.TryGetValue(value, out int id))
+        {
+            // The record with the data has already been retrieved, only a reference is needed now
+            if (_memberReferences.TryGetValue(id, out MemberReference? memberReference))
+            {
+                return memberReference;
+            }
+
+            MemberReference reference = new(id);
+            _memberReferences.Add(id, reference);
+            return reference;
+        }
+
+        _strings[value] = nextId;
+        IRecord record = new BinaryObjectString(nextId, value);
+        nextId++;
+        return record;
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/SystemClassWithMembers.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/SystemClassWithMembers.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms.BinaryFormat;
+
+/// <summary>
+///  System class information.
+/// </summary>
+/// <remarks>
+///  <para>
+///   <see href="https://learn.microsoft.com/openspecs/windows_protocols/ms-nrbf/f5bd730f-d944-42ab-b6b3-013099559a4b">
+///    [MS-NRBF] 2.3.2.4
+///   </see>
+///  </para>
+/// </remarks>
+internal sealed class SystemClassWithMembers : ClassRecord, IRecord<SystemClassWithMembers>
+{
+    public SystemClassWithMembers(ClassInfo classInfo, IReadOnlyList<object> memberValues)
+        : base(classInfo, memberValues) { }
+
+    public static RecordType RecordType => RecordType.SystemClassWithMembers;
+
+    static SystemClassWithMembers IBinaryFormatParseable<SystemClassWithMembers>.Parse(
+        BinaryReader reader,
+        RecordMap recordMap)
+    {
+        ClassInfo classInfo = ClassInfo.Parse(reader, out _);
+        SystemClassWithMembers record = new(
+            classInfo,
+            ReadDataFromClassInfo(reader, recordMap, classInfo));
+
+        // Index this record by the id of the embedded ClassInfo's object id.
+        recordMap[record.ClassInfo.ObjectId] = record;
+        return record;
+    }
+
+    public override void Write(BinaryWriter writer)
+    {
+        writer.Write((byte)RecordType);
+        ClassInfo.Write(writer);
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/SystemClassWithMembersAndTypes.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/SystemClassWithMembersAndTypes.cs
@@ -1,0 +1,53 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms.BinaryFormat;
+
+/// <summary>
+///  System class information with type info.
+/// </summary>
+/// <remarks>
+///  <para>
+///   <see href="https://learn.microsoft.com/openspecs/windows_protocols/ms-nrbf/ecb47445-831f-4ef5-9c9b-afd4d06e3657">
+///    [MS-NRBF] 2.3.2.3
+///   </see>
+///  </para>
+/// </remarks>
+internal sealed class SystemClassWithMembersAndTypes : ClassRecord, IRecord<SystemClassWithMembersAndTypes>
+{
+    public MemberTypeInfo MemberTypeInfo { get; }
+
+    public SystemClassWithMembersAndTypes(ClassInfo classInfo, MemberTypeInfo memberTypeInfo, IReadOnlyList<object> memberValues)
+        : base(classInfo, memberValues)
+    {
+        MemberTypeInfo = memberTypeInfo;
+    }
+
+    public static RecordType RecordType => RecordType.SystemClassWithMembersAndTypes;
+
+    static SystemClassWithMembersAndTypes IBinaryFormatParseable<SystemClassWithMembersAndTypes>.Parse(
+        BinaryReader reader,
+        RecordMap recordMap)
+    {
+        ClassInfo classInfo = ClassInfo.Parse(reader, out Count memberCount);
+        MemberTypeInfo memberTypeInfo = MemberTypeInfo.Parse(reader, memberCount);
+
+        SystemClassWithMembersAndTypes record = new(
+            classInfo,
+            memberTypeInfo,
+            ReadDataFromMemberTypeInfo(reader, recordMap, memberTypeInfo));
+
+        // Index this record by the id of the embedded ClassInfo's object id.
+        recordMap[record.ClassInfo.ObjectId] = record;
+        return record;
+    }
+
+    public override void Write(BinaryWriter writer)
+    {
+        writer.Write((byte)RecordType);
+        ClassInfo.Write(writer);
+        MemberTypeInfo.Write(writer);
+        WriteDataFromMemberTypeInfo(writer, MemberTypeInfo, MemberValues);
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Count.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Count.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms;
+
+/// <summary>
+///  Positive <see langword="int"/> enforcing count of items.
+/// </summary>
+/// <devdoc>
+///  Idea here is that doing this makes it less likely we'll slip through cases where
+///  we don't check for negative numbers. And also not confuse counts with ids.
+/// </devdoc>
+internal readonly struct Count : IEquatable<Count>
+{
+    private readonly int _count;
+
+    private Count(int count) => _count = count.OrThrowIfNegative();
+
+    public static Count Zero { get; } = 0;
+    public static Count One { get; } = 1;
+
+    public static implicit operator int(Count value) => value._count;
+    public static implicit operator Count(int value) => new(value);
+
+    public override bool Equals([NotNullWhen(true)] object? obj)
+        => (obj is Count count && Equals(count)) || (obj is int value && value == _count);
+
+    public bool Equals(Count other) => _count == other._count;
+
+    public override readonly int GetHashCode() => _count.GetHashCode();
+    public override readonly string ToString() => _count.ToString();
+
+    public static bool operator ==(Count left, Count right) => left._count == right._count;
+    public static bool operator !=(Count left, Count right) => !(left == right);
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Id.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Id.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms;
+
+/// <summary>
+///  Positive <see langword="int"/> enforcing identifier.
+/// </summary>
+/// <devdoc>
+///  Idea here is that doing this makes it less likely we'll slip through cases where
+///  we don't check for negative numbers. And also not confuse counts with ids.
+/// </devdoc>
+internal readonly struct Id : IEquatable<Id>
+{
+    private readonly int _id;
+
+    private Id(int id) => _id = id.OrThrowIfNegative();
+
+    public static implicit operator int(Id value) => value._id;
+    public static implicit operator Id(int value) => new(value);
+
+    public override bool Equals([NotNullWhen(true)] object? obj)
+        => (obj is Id id && Equals(id)) || (obj is int value && value == _id);
+
+    public bool Equals(Id other) => _id == other._id;
+
+    public override readonly int GetHashCode() => _id.GetHashCode();
+    public override readonly string ToString() => _id.ToString();
+
+    public static bool operator ==(Id left, Id right) => left._id == right._id;
+
+    public static bool operator !=(Id left, Id right) => !(left == right);
+}

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/GlobalUsings.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/GlobalUsings.cs
@@ -7,3 +7,4 @@ global using Windows.Win32.Foundation;
 global using Windows.Win32.Graphics.Gdi;
 global using Windows.Win32.UI.WindowsAndMessaging;
 global using Xunit;
+global using FluentAssertions;

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System.Windows.Forms.Primitives.Tests.csproj
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System.Windows.Forms.Primitives.Tests.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
     <PackageReference Include="Moq" Version="$(MoqPackageVersion)" />
     <PackageReference Include="xunit.stafact" Version="$(XUnitStaFactPackageVersion)" />
     <PackageReference Include="coverlet.msbuild" Version="$(CoverletMSBuildPackageVersion)" />

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System.Windows.Forms.Primitives.Tests.csproj
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System.Windows.Forms.Primitives.Tests.csproj
@@ -5,6 +5,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>$(NoWarn);618</NoWarn>
     <Nullable>enable</Nullable>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/ArrayTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/ArrayTests.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms.BinaryFormat.Tests;
+
+public class ArrayTests
+{
+    [Theory]
+    [MemberData(nameof(ArrayInfo_ParseSuccessData))]
+    public void ArrayInfo_Parse_Success(MemoryStream stream, int expectedId, int expectedLength)
+    {
+        using BinaryReader reader = new(stream);
+        ArrayInfo info = ArrayInfo.Parse(reader, out Count length);
+        info.ObjectId.Should().Be(expectedId);
+        info.Length.Should().Be(expectedLength);
+        length.Should().Be(expectedLength);
+    }
+
+    public static TheoryData<Stream, int, int> ArrayInfo_ParseSuccessData => new()
+    {
+        { new MemoryStream(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }), 0, 0 },
+        { new MemoryStream(new byte[] { 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00 }), 1, 1 },
+        { new MemoryStream(new byte[] { 0x02, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00 }), 2, 1 },
+        { new MemoryStream(new byte[] { 0xFF, 0xFF, 0xFF, 0x7F, 0xFF, 0xFF, 0xFF, 0x7F }), int.MaxValue, int.MaxValue }
+    };
+
+    [Theory]
+    [MemberData(nameof(ArrayInfo_ParseNegativeData))]
+    public void ArrayInfo_Parse_Negative(MemoryStream stream, Type expectedException)
+    {
+        using BinaryReader reader = new(stream);
+        Assert.Throws(expectedException, () => ArrayInfo.Parse(reader, out Count length));
+    }
+
+    public static TheoryData<Stream, Type> ArrayInfo_ParseNegativeData => new()
+    {
+        // Not enough data
+        { new MemoryStream(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }), typeof(EndOfStreamException) },
+        { new MemoryStream(new byte[] { 0x00, 0x00, 0x00 }), typeof(EndOfStreamException) },
+        // Negative numbers
+        { new MemoryStream(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF }), typeof(ArgumentOutOfRangeException) },
+        { new MemoryStream(new byte[] { 0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF }), typeof(ArgumentOutOfRangeException) }
+    };
+}

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/BinaryFormatWriterTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/BinaryFormatWriterTests.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.Serialization.Formatters.Binary;
+
+namespace System.Windows.Forms.BinaryFormat.Tests;
+
+public class BinaryFormatWriterTests
+{
+    [Theory]
+    [InlineData("Hello World.")]
+    [InlineData("")]
+    [InlineData("\0")]
+    [InlineData("Embedded\0 Null.")]
+    public void WriteString(string testString)
+    {
+        using MemoryStream stream = new();
+        BinaryFormatWriter.WriteString(stream, testString);
+
+        stream.Position = 0;
+        using var formatterScope = new BinaryFormatterScope(enable: true);
+#pragma warning disable SYSLIB0011 // Type or member is obsolete
+        BinaryFormatter formatter = new();
+#pragma warning restore
+        object deserialized = formatter.Deserialize(stream);
+        deserialized.Should().Be(testString);
+    }
+}

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/BinaryFormattedObjectTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/BinaryFormattedObjectTests.cs
@@ -1,0 +1,414 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+
+namespace System.Windows.Forms.BinaryFormat.Tests;
+
+public class BinaryFormattedObjectTests
+{
+    [Fact]
+    public void ReadHeader()
+    {
+        BinaryFormattedObject format = "Hello World.".SerializeAndParse();
+        SerializationHeader header = (SerializationHeader)format[0];
+        header.MajorVersion.Should().Be(1);
+        header.MinorVersion.Should().Be(0);
+        header.RootId.Should().Be(1);
+        header.HeaderId.Should().Be(-1);
+    }
+
+    [Theory]
+    [InlineData("Hello there.")]
+    [InlineData("")]
+    [InlineData("Embedded\0 Null.")]
+    public void ReadBinaryObjectString(string testString)
+    {
+        BinaryFormattedObject format = testString.SerializeAndParse();
+        BinaryObjectString stringRecord = (BinaryObjectString)format[1];
+        stringRecord.ObjectId.Should().Be(1);
+        stringRecord.Value.Should().Be(testString);
+    }
+
+    [Fact]
+    public void ReadEmptyHashTable()
+    {
+        BinaryFormattedObject format = new Hashtable().SerializeAndParse();
+
+        SystemClassWithMembersAndTypes systemClass = (SystemClassWithMembersAndTypes)format[1];
+        systemClass.ObjectId.Should().Be(1);
+        systemClass.Name.Should().Be("System.Collections.Hashtable");
+        systemClass.MemberNames.Should().BeEquivalentTo(new[]
+        {
+            "LoadFactor",
+            "Version",
+            "Comparer",
+            "HashCodeProvider",
+            "HashSize",
+            "Keys",
+            "Values"
+        });
+
+        systemClass.MemberTypeInfo.Should().BeEquivalentTo(new (BinaryType Type, object? Info)[]
+        {
+            (BinaryType.Primitive, PrimitiveType.Single),
+            (BinaryType.Primitive, PrimitiveType.Int32),
+            (BinaryType.SystemClass, "System.Collections.IComparer"),
+            (BinaryType.SystemClass, "System.Collections.IHashCodeProvider"),
+            (BinaryType.Primitive, PrimitiveType.Int32),
+            (BinaryType.ObjectArray, null),
+            (BinaryType.ObjectArray, null)
+        });
+
+        systemClass.MemberValues.Should().BeEquivalentTo(new object?[]
+        {
+            0.72f,
+            0,
+            ObjectNull.Instance,
+            ObjectNull.Instance,
+            3,
+            new MemberReference(2),
+            new MemberReference(3)
+        });
+
+        ArraySingleObject array = (ArraySingleObject)format[2];
+        array.ArrayInfo.ObjectId.Should().Be(2);
+        array.ArrayInfo.Length.Should().Be(0);
+
+        array = (ArraySingleObject)format[3];
+        array.ArrayInfo.ObjectId.Should().Be(3);
+        array.ArrayInfo.Length.Should().Be(0);
+    }
+
+    [Fact]
+    public void ReadHashTableWithStringPair()
+    {
+        BinaryFormattedObject format = new Hashtable()
+        {
+            { "This", "That" }
+        }.SerializeAndParse();
+
+        SystemClassWithMembersAndTypes systemClass = (SystemClassWithMembersAndTypes)format[1];
+
+        systemClass.MemberTypeInfo.Should().BeEquivalentTo(new (BinaryType Type, object? Info)[]
+        {
+            (BinaryType.Primitive, PrimitiveType.Single),
+            (BinaryType.Primitive, PrimitiveType.Int32),
+            (BinaryType.SystemClass, "System.Collections.IComparer"),
+            (BinaryType.SystemClass, "System.Collections.IHashCodeProvider"),
+            (BinaryType.Primitive, PrimitiveType.Int32),
+            (BinaryType.ObjectArray, null),
+            (BinaryType.ObjectArray, null)
+        });
+
+        systemClass.MemberValues.Should().BeEquivalentTo(new object?[]
+        {
+            0.72f,
+            1,
+            ObjectNull.Instance,
+            ObjectNull.Instance,
+            3,
+            new MemberReference(2),
+            new MemberReference(3)
+        });
+
+        ArraySingleObject array = (ArraySingleObject)format[2];
+        array.ArrayInfo.ObjectId.Should().Be(2);
+        array.ArrayInfo.Length.Should().Be(1);
+        BinaryObjectString value = (BinaryObjectString)array.ArrayObjects[0];
+        value.ObjectId.Should().Be(4);
+        value.Value.Should().Be("This");
+
+        array = (ArraySingleObject)format[3];
+        array.ArrayInfo.ObjectId.Should().Be(3);
+        array.ArrayInfo.Length.Should().Be(1);
+        value = (BinaryObjectString)array.ArrayObjects[0];
+        value.ObjectId.Should().Be(5);
+        value.Value.Should().Be("That");
+    }
+
+    [Fact]
+    public void ReadHashTableWithRepeatedStrings()
+    {
+        BinaryFormattedObject format = new Hashtable()
+        {
+            { "This", "That" },
+            { "TheOther", "This" },
+            { "That", "This" }
+        }.SerializeAndParse();
+
+        // The collections themselves get ids first before the strings do.
+        // Everything in the second array is a string reference.
+        ArraySingleObject array = (ArraySingleObject)format[3];
+        array.ObjectId.Should().Be(3);
+        array[0].Should().BeOfType<MemberReference>();
+        array[1].Should().BeOfType<MemberReference>();
+        array[2].Should().BeOfType<MemberReference>();
+    }
+
+    [Fact]
+    public void ReadHashTableWithNullValues()
+    {
+        BinaryFormattedObject format = new Hashtable()
+        {
+            { "Yowza", null },
+            { "Youza", null },
+            { "Meeza", null }
+        }.SerializeAndParse();
+
+        SystemClassWithMembersAndTypes systemClass = (SystemClassWithMembersAndTypes)format[1];
+
+        systemClass.MemberValues.Should().BeEquivalentTo(new object?[]
+        {
+            0.72f,
+            4,
+            ObjectNull.Instance,
+            ObjectNull.Instance,
+            7,
+            new MemberReference(2),
+            new MemberReference(3)
+        });
+
+        ArrayRecord array = (ArrayRecord)format[(MemberReference)systemClass.MemberValues[5]];
+
+        array.ArrayInfo.ObjectId.Should().Be(2);
+        array.ArrayInfo.Length.Should().Be(3);
+        BinaryObjectString value = (BinaryObjectString)array.ArrayObjects[0];
+        value.ObjectId.Should().Be(4);
+        value.Value.Should().BeOneOf("Yowza", "Youza", "Meeza");
+
+        array = (ArrayRecord)format[(MemberReference)systemClass["Values"]]; ;
+        array.ArrayInfo.ObjectId.Should().Be(3);
+        array.ArrayInfo.Length.Should().Be(3);
+        array.ArrayObjects[0].Should().BeOfType<ObjectNull>();
+    }
+
+    [Fact]
+    public void ReadObject()
+    {
+        BinaryFormattedObject format = new object().SerializeAndParse();
+        format[1].Should().BeOfType<SystemClassWithMembersAndTypes>();
+    }
+
+    [Fact]
+    public void ReadStruct()
+    {
+        ValueTuple<int> tuple = new(355);
+        BinaryFormattedObject format = tuple.SerializeAndParse();
+        format[1].Should().BeOfType<SystemClassWithMembersAndTypes>();
+    }
+
+    [Fact]
+    public void ReadSimpleSerializableObject()
+    {
+        BinaryFormattedObject format = new SimpleSerializableObject().SerializeAndParse();
+
+        BinaryLibrary library = (BinaryLibrary)format[1];
+        library.LibraryName.Should().Be(typeof(BinaryFormattedObjectTests).Assembly.FullName);
+        library.LibraryId.Should().Be(2);
+
+        ClassWithMembersAndTypes @class = (ClassWithMembersAndTypes)format[2];
+        @class.ObjectId.Should().Be(1);
+        @class.Name.Should().Be(typeof(SimpleSerializableObject).FullName);
+        @class.MemberNames.Should().BeEmpty();
+        @class.LibraryId.Should().Be(2);
+        @class.MemberTypeInfo.Should().BeEmpty();
+
+        format[3].Should().BeOfType<MessageEnd>();
+    }
+
+    [Fact]
+    public void ReadNestedSerializableObject()
+    {
+        BinaryFormattedObject format = new NestedSerializableObject().SerializeAndParse();
+
+        BinaryLibrary library = (BinaryLibrary)format[1];
+        library.LibraryName.Should().Be(typeof(BinaryFormattedObjectTests).Assembly.FullName);
+        library.LibraryId.Should().Be(2);
+
+        ClassWithMembersAndTypes @class = (ClassWithMembersAndTypes)format[2];
+        @class.ObjectId.Should().Be(1);
+        @class.Name.Should().Be(typeof(NestedSerializableObject).FullName);
+        @class.MemberNames.Should().BeEquivalentTo(new[] { "_object", "_meaning" });
+        @class.LibraryId.Should().Be(2);
+        @class.MemberTypeInfo.Should().BeEquivalentTo(new (BinaryType Type, object? Info)[]
+        {
+            (BinaryType.Class, new ClassTypeInfo(typeof(SimpleSerializableObject).FullName!, 2)),
+            (BinaryType.Primitive, PrimitiveType.Int32)
+        });
+        @class.MemberValues.Should().BeEquivalentTo(new object?[]
+        {
+            new MemberReference(3),
+            42
+        });
+
+        @class = (ClassWithMembersAndTypes)format[3];
+        @class.ObjectId.Should().Be(3);
+        @class.Name.Should().Be(typeof(SimpleSerializableObject).FullName);
+        @class.MemberNames.Should().BeEmpty();
+        @class.LibraryId.Should().Be(2);
+        @class.MemberTypeInfo.Should().BeEmpty();
+
+        format[4].Should().BeOfType<MessageEnd>();
+    }
+
+    [Fact]
+    public void ReadTwoIntObject()
+    {
+        BinaryFormattedObject format = new TwoIntSerializableObject().SerializeAndParse();
+
+        BinaryLibrary library = (BinaryLibrary)format[1];
+        library.LibraryName.Should().Be(typeof(BinaryFormattedObjectTests).Assembly.FullName);
+        library.LibraryId.Should().Be(2);
+
+        ClassWithMembersAndTypes @class = (ClassWithMembersAndTypes)format[2];
+        @class.ObjectId.Should().Be(1);
+        @class.Name.Should().Be(typeof(TwoIntSerializableObject).FullName);
+        @class.MemberNames.Should().BeEquivalentTo(new[] { "_value", "_meaning" });
+        @class.LibraryId.Should().Be(2);
+        @class.MemberTypeInfo.Should().BeEquivalentTo(new (BinaryType Type, object? Info)[]
+        {
+            (BinaryType.Primitive, PrimitiveType.Int32),
+            (BinaryType.Primitive, PrimitiveType.Int32)
+        });
+
+        @class.MemberValues.Should().BeEquivalentTo(new object?[]
+        {
+            1970,
+            42
+        });
+
+        format[3].Should().BeOfType<MessageEnd>();
+    }
+
+    [Fact]
+    public void ReadRepeatedNestedObject()
+    {
+        BinaryFormattedObject format = new RepeatedNestedSerializableObject().SerializeAndParse();
+        ClassWithMembersAndTypes firstClass = (ClassWithMembersAndTypes)format[3];
+        ClassWithId classWithId = (ClassWithId)format[4];
+        classWithId.MetadataId.Should().Be(firstClass.ObjectId);
+        classWithId.MemberValues.Should().BeEquivalentTo(new object[] { 1970, 42 });
+    }
+
+    [Fact]
+    public void ReadPrimitiveArray()
+    {
+        BinaryFormattedObject format = new int[] { 10, 9, 8, 7 }.SerializeAndParse();
+
+        ArraySinglePrimitive array = (ArraySinglePrimitive)format[1];
+        array.ArrayInfo.Length.Should().Be(4);
+        array.PrimitiveType.Should().Be(PrimitiveType.Int32);
+        array.ArrayObjects.Should().BeEquivalentTo(new object[] { 10, 9, 8, 7 });
+    }
+
+    [Fact]
+    public void ReadStringArray()
+    {
+        BinaryFormattedObject format = new string[] { "Monday", "Tuesday", "Wednesday" }.SerializeAndParse();
+        ArraySingleString array = (ArraySingleString)format[1];
+        array.ArrayInfo.ObjectId.Should().Be(1);
+        array.ArrayInfo.Length.Should().Be(3);
+        BinaryObjectString value = (BinaryObjectString)array.ArrayObjects[0];
+    }
+
+    [Fact]
+    public void ReadStringArrayWithNulls()
+    {
+        BinaryFormattedObject format = new string?[] { "Monday", null, "Wednesday", null, null, null }.SerializeAndParse();
+        ArraySingleString array = (ArraySingleString)format[1];
+        array.ArrayInfo.ObjectId.Should().Be(1);
+        array.ArrayInfo.Length.Should().Be(6);
+        array.ArrayObjects.Should().BeEquivalentTo(new object?[]
+        {
+            new BinaryObjectString(2, "Monday"),
+            ObjectNull.Instance,
+            new BinaryObjectString(3, "Wednesday"),
+            ObjectNull.Instance,
+            ObjectNull.Instance,
+            ObjectNull.Instance
+        });
+        BinaryObjectString value = (BinaryObjectString)array.ArrayObjects[0];
+    }
+
+    [Fact]
+    public void ReadDuplicatedStringArray()
+    {
+        BinaryFormattedObject format = new string[] { "Monday", "Tuesday", "Monday" }.SerializeAndParse();
+        ArraySingleString array = (ArraySingleString)format[1];
+        array.ArrayInfo.ObjectId.Should().Be(1);
+        array.ArrayInfo.Length.Should().Be(3);
+        BinaryObjectString value = (BinaryObjectString)array.ArrayObjects[0];
+        MemberReference reference = (MemberReference)array.ArrayObjects[2];
+        reference.IdRef.Should().Be(value.ObjectId);
+    }
+
+    [Fact]
+    public void ReadObjectWithNullableObjects()
+    {
+        BinaryFormattedObject format = new ObjectWithNullableObjects().SerializeAndParse();
+        ClassWithMembersAndTypes classRecord = (ClassWithMembersAndTypes)format[2];
+        BinaryLibrary library = (BinaryLibrary)format[classRecord.LibraryId];
+    }
+
+    [Fact]
+    public void ReadNestedObjectWithNullableObjects()
+    {
+        BinaryFormattedObject format = new NestedObjectWithNullableObjects().SerializeAndParse();
+        ClassWithMembersAndTypes classRecord = (ClassWithMembersAndTypes)format[2];
+        BinaryLibrary library = (BinaryLibrary)format[classRecord.LibraryId];
+    }
+
+    [Serializable]
+    private class SimpleSerializableObject
+    {
+    }
+
+#pragma warning disable IDE0052 // Remove unread private members
+#pragma warning disable IDE0051 // Remove unused private members
+#pragma warning disable CS0414  // Field is assigned but its value is never used
+#pragma warning disable CS0649  // Field is never assigned to, and will always have its default value null
+#pragma warning disable CA1823 // Avoid unused private fields
+    [Serializable]
+    private class ObjectWithNullableObjects
+    {
+        public object? First;
+        public object? Second;
+        public object? Third;
+    }
+
+    [Serializable]
+    private class NestedObjectWithNullableObjects
+    {
+        public ObjectWithNullableObjects? First;
+        public ObjectWithNullableObjects? Second;
+        public ObjectWithNullableObjects? Third = new();
+    }
+
+    [Serializable]
+    private class NestedSerializableObject
+    {
+        private readonly SimpleSerializableObject _object = new();
+        private readonly int _meaning = 42;
+    }
+
+    [Serializable]
+    private class TwoIntSerializableObject
+    {
+        private readonly int _value = 1970;
+        private readonly int _meaning = 42;
+    }
+
+    [Serializable]
+    private class RepeatedNestedSerializableObject
+    {
+        private readonly TwoIntSerializableObject _first = new();
+        private readonly TwoIntSerializableObject _second = new();
+    }
+#pragma warning restore IDE0052 // Remove unread private members
+#pragma warning restore IDE0051 // Remove unused private members
+#pragma warning restore CS0414  // Field is assigned but its value is never used
+#pragma warning restore CS0649  // Field is never assigned to, and will always have its default value null
+#pragma warning restore CA1823 // Avoid unused private fields
+}

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/BinaryFormattedTypes.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/BinaryFormattedTypes.cs
@@ -1,0 +1,62 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.ComponentModel;
+using System.Drawing;
+using System.Runtime.Serialization;
+
+namespace System.Windows.Forms.BinaryFormat.Tests;
+
+public class BinaryFormattedTypes
+{
+    [Theory]
+    [MemberData(nameof(BinaryFormattedTypes_TestData))]
+    public void Types_UseBinaryFormatter(Type type)
+    {
+        bool iSerializable = type.IsAssignableTo(typeof(ISerializable));
+#pragma warning disable SYSLIB0050 // Type or member is obsolete
+        bool serializable = type.IsSerializable;
+#pragma warning restore SYSLIB0050
+
+        Assert.True(iSerializable || serializable, "Type should either implement ISerializable or be marked as [Serializable]");
+
+        var converter = TypeDescriptor.GetConverter(type);
+        Assert.False(
+            converter.CanConvertFrom(typeof(string)) && converter.CanConvertTo(typeof(string)),
+            "Type should not be convertable back and forth to string.");
+        Assert.False(
+            converter.CanConvertFrom(typeof(byte[])) && converter.CanConvertTo(typeof(byte[])),
+            "Type should not be convertable back and forth to byte[].");
+    }
+
+    public static TheoryData<Type> BinaryFormattedTypes_TestData => new()
+    {
+        typeof(Hashtable),
+        typeof(ArrayList),
+        typeof(PointF),
+        typeof(RectangleF),
+        typeof(List<string>),
+    };
+
+    [Theory]
+    [MemberData(nameof(NotBinaryFormattedTypes_TestData))]
+    public void Types_DoNotUseBinaryFormatter(Type type)
+    {
+        var converter = TypeDescriptor.GetConverter(type);
+        Assert.True(
+            (converter.CanConvertFrom(typeof(string)) && converter.CanConvertTo(typeof(string)))
+            || (converter.CanConvertFrom(typeof(byte[])) && converter.CanConvertTo(typeof(byte[]))),
+            "Type should be convertable back and forth to string or byte[].");
+    }
+
+    public static TheoryData<Type> NotBinaryFormattedTypes_TestData => new()
+    {
+        typeof(Point),
+        typeof(Size),
+        typeof(SizeF),
+        typeof(Rectangle),
+        typeof(Color)
+    };
+}

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/ClassInfoTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/ClassInfoTests.cs
@@ -1,0 +1,79 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms.BinaryFormat.Tests;
+
+public class ClassInfoTests
+{
+    private static readonly byte[] s_hashtableClassInfo = new byte[]
+    {
+        0x01, 0x00, 0x00, 0x00, 0x1c, 0x53, 0x79, 0x73, 0x74, 0x65, 0x6d, 0x2e, 0x43, 0x6f, 0x6c, 0x6c,
+        0x65, 0x63, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x48, 0x61, 0x73, 0x68, 0x74, 0x61, 0x62, 0x6c,
+        0x65, 0x07, 0x00, 0x00, 0x00, 0x0a, 0x4c, 0x6f, 0x61, 0x64, 0x46, 0x61, 0x63, 0x74, 0x6f, 0x72,
+        0x07, 0x56, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, 0x08, 0x43, 0x6f, 0x6d, 0x70, 0x61, 0x72, 0x65,
+        0x72, 0x10, 0x48, 0x61, 0x73, 0x68, 0x43, 0x6f, 0x64, 0x65, 0x50, 0x72, 0x6f, 0x76, 0x69, 0x64,
+        0x65, 0x72, 0x08, 0x48, 0x61, 0x73, 0x68, 0x53, 0x69, 0x7a, 0x65, 0x04, 0x4b, 0x65, 0x79, 0x73,
+        0x06, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x73
+    };
+
+    [Fact]
+    public void ClassInfo_ReadHashtable()
+    {
+        using BinaryReader reader = new(new MemoryStream(s_hashtableClassInfo));
+        ClassInfo info = ClassInfo.Parse(reader, out Count memberCount);
+
+        memberCount.Should().Be(7);
+        info.ObjectId.Should().Be(1);
+        info.Name.Should().Be("System.Collections.Hashtable");
+        info.MemberNames.Should().BeEquivalentTo(new[]
+        {
+            "LoadFactor",
+            "Version",
+            "Comparer",
+            "HashCodeProvider",
+            "HashSize",
+            "Keys",
+            "Values"
+        });
+    }
+
+    [Fact]
+    public void ClassInfo_Hashtable_RoundTrip()
+    {
+        using BinaryReader reader = new(new MemoryStream(s_hashtableClassInfo));
+        ClassInfo info = ClassInfo.Parse(reader, out Count memberCount);
+
+        MemoryStream stream = new();
+        BinaryWriter writer = new(stream);
+        info.Write(writer);
+        stream.Position = 0;
+
+        using BinaryReader reader2 = new(stream);
+        info = ClassInfo.Parse(reader2, out memberCount);
+
+        memberCount.Should().Be(7);
+        info.ObjectId.Should().Be(1);
+        info.Name.Should().Be("System.Collections.Hashtable");
+        info.MemberNames.Should().BeEquivalentTo(new[]
+        {
+            "LoadFactor",
+            "Version",
+            "Comparer",
+            "HashCodeProvider",
+            "HashSize",
+            "Keys",
+            "Values"
+        });
+    }
+
+    [Fact]
+    public void MemberTypeInfo_ReadHashtable_TooShort()
+    {
+        MemoryStream stream = new(s_hashtableClassInfo);
+        stream.SetLength(stream.Length - 1);
+        using BinaryReader reader = new(stream);
+        Action action = () => ClassInfo.Parse(reader, out _);
+        action.Should().Throw<EndOfStreamException>();
+    }
+}

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/CountTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/CountTests.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms.BinaryFormat.Tests;
+
+public class CountTests
+{
+    [Fact]
+    public void CountDoesNotAcceptNegativeValues()
+    {
+        Func<Count> func = () => (Count)(-1);
+        func.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void CountEqualsInt()
+    {
+        ((Count)4).Should().Be(4);
+    }
+
+    [Fact]
+    public void CountEqualsCount()
+    {
+        ((Count)4).Should().Be((Count)4);
+    }
+
+    [Fact]
+    public void CountToStringIsInt()
+    {
+        ((Count)5).ToString().Should().Be("5");
+    }
+}

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/HashTableTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/HashTableTests.cs
@@ -1,0 +1,176 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters.Binary;
+
+namespace System.Windows.Forms.BinaryFormat.Tests;
+
+public class HashTableTests
+{
+    [Fact]
+    public void HashTable_GetObjectData()
+    {
+        Hashtable hashtable = new()
+        {
+            { "This", "That" }
+        };
+
+        // The converter isn't used for this scenario and can be a no-op.
+#pragma warning disable SYSLIB0050 // Type or member is obsolete
+        SerializationInfo info = new(typeof(Hashtable), FormatterConverterStub.Instance);
+#pragma warning restore SYSLIB0050
+#pragma warning disable SYSLIB0051 // Type or member is obsolete
+        hashtable.GetObjectData(info, default);
+#pragma warning restore SYSLIB0051
+        info.MemberCount.Should().Be(7);
+
+        var enumerator = info.GetEnumerator();
+
+        enumerator.MoveNext().Should().BeTrue();
+        enumerator.Current.Name.Should().Be("LoadFactor");
+        enumerator.Current.Value.Should().Be(0.72f);
+
+        enumerator.MoveNext().Should().BeTrue();
+        enumerator.Current.Name.Should().Be("Version");
+        enumerator.Current.Value.Should().Be(1);
+
+        enumerator.MoveNext().Should().BeTrue();
+        enumerator.Current.Name.Should().Be("Comparer");
+        enumerator.Current.Value.Should().BeNull();
+
+        enumerator.MoveNext().Should().BeTrue();
+        enumerator.Current.Name.Should().Be("HashCodeProvider");
+        enumerator.Current.Value.Should().BeNull();
+
+        enumerator.MoveNext().Should().BeTrue();
+        enumerator.Current.Name.Should().Be("HashSize");
+        enumerator.Current.Value.Should().Be(3);
+
+        enumerator.MoveNext().Should().BeTrue();
+        enumerator.Current.Name.Should().Be("Keys");
+        enumerator.Current.Value.Should().BeEquivalentTo(new object[] { "This" });
+
+        enumerator.MoveNext().Should().BeTrue();
+        enumerator.Current.Name.Should().Be("Values");
+        enumerator.Current.Value.Should().BeEquivalentTo(new object[] { "That" });
+    }
+
+    [Theory]
+    [MemberData(nameof(Hashtables_TestData))]
+    public void WriteHashtables(Hashtable hashtable)
+    {
+        using MemoryStream stream = new();
+        BinaryFormatWriter.WriteHashtableOfStrings(stream, hashtable);
+        stream.Position = 0;
+
+        using var formatterScope = new BinaryFormatterScope(enable: true);
+#pragma warning disable SYSLIB0011 // Type or member is obsolete
+        BinaryFormatter formatter = new();
+        Hashtable deserialized = (Hashtable)formatter.Deserialize(stream);
+#pragma warning restore SYSLIB0011
+
+        deserialized.Count.Should().Be(hashtable.Count);
+        foreach (var key in hashtable.Keys)
+        {
+            deserialized[key].Should().Be(hashtable[key]);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(Hashtables_TestData))]
+    public void ReadHashtables(Hashtable hashtable)
+    {
+        Hashtable deserialized = BinaryFormatReader.ReadHashtableOfStrings(hashtable.Serialize());
+
+        deserialized.Count.Should().Be(hashtable.Count);
+        foreach (var key in hashtable.Keys)
+        {
+            deserialized[key].Should().Be(hashtable[key]);
+        }
+    }
+
+    public static TheoryData<Hashtable> Hashtables_TestData = new()
+    {
+        new Hashtable(),
+        new Hashtable()
+        {
+            { "This", "That" }
+        },
+        new Hashtable()
+        {
+            { "This", "That" },
+            { "TheOther", "This" },
+            { "That", "This" }
+        },
+        new Hashtable()
+        {
+            { "This", "That" },
+            { "TheOther", "This" },
+            { "That", "This" }
+        },
+        new Hashtable()
+        {
+            { "Yowza", null },
+            { "Youza", null },
+            { "Meeza", null }
+        },
+        new Hashtable()
+        {
+            { "Yowza", null },
+            { "Youza", "Binks" },
+            { "Meeza", null }
+        },
+        new Hashtable()
+        {
+            { "Yowza", "Binks" },
+            { "Youza", "Binks" },
+            { "Meeza", null }
+        },
+        // Stress the string interning
+        MakeRepeatedHashtable(50, "Ditto"),
+        MakeRepeatedHashtable(100, "..."),
+        // Cross over into ObjectNullMultiple
+        MakeRepeatedHashtable(255, null),
+        MakeRepeatedHashtable(256, null),
+        MakeRepeatedHashtable(257, null)
+    };
+
+    private static Hashtable MakeRepeatedHashtable(int countOfEntries, object? value)
+    {
+        Hashtable result = new(countOfEntries);
+        for (int i = 1; i <= countOfEntries; i++)
+        {
+            result.Add($"Entry{i}", value);
+        }
+
+        return result;
+    }
+
+#pragma warning disable SYSLIB0050 // Type or member is obsolete
+    private sealed class FormatterConverterStub : IFormatterConverter
+    {
+        public static IFormatterConverter Instance { get; } = new FormatterConverterStub();
+#pragma warning restore SYSLIB0050
+
+        public object Convert(object value, Type type) => throw new NotImplementedException();
+        public object Convert(object value, TypeCode typeCode) => throw new NotImplementedException();
+        public bool ToBoolean(object value) => throw new NotImplementedException();
+        public byte ToByte(object value) => throw new NotImplementedException();
+        public char ToChar(object value) => throw new NotImplementedException();
+        public DateTime ToDateTime(object value) => throw new NotImplementedException();
+        public decimal ToDecimal(object value) => throw new NotImplementedException();
+        public double ToDouble(object value) => throw new NotImplementedException();
+        public short ToInt16(object value) => throw new NotImplementedException();
+        public int ToInt32(object value) => throw new NotImplementedException();
+        public long ToInt64(object value) => throw new NotImplementedException();
+        public sbyte ToSByte(object value) => throw new NotImplementedException();
+        public float ToSingle(object value) => throw new NotImplementedException();
+        public string? ToString(object value) => throw new NotImplementedException();
+        public ushort ToUInt16(object value) => throw new NotImplementedException();
+        public uint ToUInt32(object value) => throw new NotImplementedException();
+        public ulong ToUInt64(object value) => throw new NotImplementedException();
+    }
+}

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/ListTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/ListTests.cs
@@ -1,0 +1,118 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Runtime.Serialization.Formatters.Binary;
+
+namespace System.Windows.Forms.BinaryFormat.Tests;
+
+public class ListTests
+{
+    [Fact]
+    public void List_Int_ParseEmpty()
+    {
+        BinaryFormattedObject format = new List<int>().SerializeAndParse();
+        SystemClassWithMembersAndTypes classInfo = (SystemClassWithMembersAndTypes)format[1];
+
+        // Note that T types are serialized as the mscorlib type.
+        classInfo.Name.Should().Be(
+            "System.Collections.Generic.List`1[[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]");
+
+        classInfo.ClassInfo.MemberNames.Should().BeEquivalentTo(new string[]
+        {
+            "_items",
+            // This is something that wouldn't be needed if List<T> implemented ISerializable. If we format
+            // we can save any extra unused array spots.
+            "_size",
+            // It is a bit silly that _version gets serialized, it's only use is as a check to see if
+            // the collection is modified while it is being enumerated.
+            "_version"
+        });
+        classInfo.MemberTypeInfo[0].Should().Be((BinaryType.PrimitiveArray, PrimitiveType.Int32));
+        classInfo.MemberTypeInfo[1].Should().Be((BinaryType.Primitive, PrimitiveType.Int32));
+        classInfo.MemberTypeInfo[2].Should().Be((BinaryType.Primitive, PrimitiveType.Int32));
+        classInfo["_items"].Should().BeOfType<MemberReference>();
+        classInfo["_size"].Should().Be(0);
+        classInfo["_version"].Should().Be(0);
+
+        ArraySinglePrimitive array = (ArraySinglePrimitive)format[2];
+        array.Length.Should().Be(0);
+    }
+
+    [Fact]
+    public void List_String_ParseEmpty()
+    {
+        BinaryFormattedObject format = new List<string>().SerializeAndParse();
+        SystemClassWithMembersAndTypes classInfo = (SystemClassWithMembersAndTypes)format[1];
+        classInfo.ClassInfo.Name.Should().StartWith("System.Collections.Generic.List`1[[System.String,");
+        classInfo.MemberTypeInfo[0].Should().Be((BinaryType.StringArray, null));
+        classInfo["_items"].Should().BeOfType<MemberReference>();
+
+        ArraySingleString array = (ArraySingleString)format[2];
+        array.Length.Should().Be(0);
+    }
+
+    [Theory]
+    [MemberData(nameof(PrimitiveLists_TestData))]
+    public void List_Primitive_Write(IList list)
+    {
+        using MemoryStream stream = new();
+
+        switch (list)
+        {
+            case List<int> intList:
+                BinaryFormatWriter.WritePrimitiveList(stream, intList);
+                break;
+            case List<float> floatList:
+                BinaryFormatWriter.WritePrimitiveList(stream, floatList);
+                break;
+            case List<byte> byteList:
+                BinaryFormatWriter.WritePrimitiveList(stream, byteList);
+                break;
+            case List<char> charList:
+                BinaryFormatWriter.WritePrimitiveList(stream, charList);
+                break;
+            default:
+                throw new InvalidOperationException();
+        }
+
+        stream.Position = 0;
+
+        using var formatterScope = new BinaryFormatterScope(enable: true);
+#pragma warning disable SYSLIB0011 // Type or member is obsolete
+        BinaryFormatter formatter = new();
+        IList deserialized = (IList)formatter.Deserialize(stream);
+#pragma warning restore SYSLIB0011
+
+        deserialized.Should().BeEquivalentTo(list);
+    }
+
+    [Theory]
+    [MemberData(nameof(PrimitiveLists_TestData))]
+    public void List_Primitive_Read(IList list)
+    {
+        Stream stream = list.Serialize();
+        IList result = list switch
+        {
+            List<int> => BinaryFormatReader.ReadPrimitiveList<int>(stream),
+            List<float> => BinaryFormatReader.ReadPrimitiveList<float>(stream),
+            List<byte> => BinaryFormatReader.ReadPrimitiveList<byte>(stream),
+            List<char> => BinaryFormatReader.ReadPrimitiveList<char>(stream),
+            _ => throw new InvalidOperationException(),
+        };
+
+        result.Should().BeEquivalentTo(list);
+    }
+
+    public static TheoryData<IList> PrimitiveLists_TestData = new()
+    {
+        new List<int>(),
+        new List<float>() { 3.14f },
+        new List<float>() { float.NaN, float.PositiveInfinity, float.NegativeInfinity, float.NegativeZero },
+        new List<int>() { 1, 3, 4, 5, 6, 7 },
+        new List<byte>() { 0xDE, 0xAD, 0xBE, 0xEF },
+        new List<char>() { 'a', 'b',  'c', 'd', 'e', 'f', 'g', 'h' },
+        new List<char>() { 'a', '\0',  'c' },
+    };
+}

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/MemberTypeInfoTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/MemberTypeInfoTests.cs
@@ -1,0 +1,70 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms.BinaryFormat.Tests;
+
+public class MemberTypeInfoTests
+{
+    private static readonly byte[] s_hashtableMemberInfo = new byte[]
+    {
+        0x00, 0x00, 0x03, 0x03, 0x00, 0x05, 0x05, 0x0b, 0x08, 0x1c, 0x53, 0x79, 0x73, 0x74, 0x65, 0x6d,
+        0x2e, 0x43, 0x6f, 0x6c, 0x6c, 0x65, 0x63, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x49, 0x43, 0x6f,
+        0x6d, 0x70, 0x61, 0x72, 0x65, 0x72, 0x24, 0x53, 0x79, 0x73, 0x74, 0x65, 0x6d, 0x2e, 0x43, 0x6f,
+        0x6c, 0x6c, 0x65, 0x63, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x49, 0x48, 0x61, 0x73, 0x68, 0x43,
+        0x6f, 0x64, 0x65, 0x50, 0x72, 0x6f, 0x76, 0x69, 0x64, 0x65, 0x72, 0x08
+    };
+
+    [Fact]
+    public void MemberTypeInfo_ReadHashtable()
+    {
+        using BinaryReader reader = new(new MemoryStream(s_hashtableMemberInfo));
+        MemberTypeInfo info = MemberTypeInfo.Parse(reader, 7);
+
+        info.Should().BeEquivalentTo(new (BinaryType Type, object? Info)[]
+        {
+            (BinaryType.Primitive, PrimitiveType.Single),
+            (BinaryType.Primitive, PrimitiveType.Int32),
+            (BinaryType.SystemClass, "System.Collections.IComparer"),
+            (BinaryType.SystemClass, "System.Collections.IHashCodeProvider"),
+            (BinaryType.Primitive, PrimitiveType.Int32),
+            (BinaryType.ObjectArray, null),
+            (BinaryType.ObjectArray, null)
+        });
+    }
+
+    [Fact]
+    public void MemberTypeInfo_HashtableRoundTrip()
+    {
+        using BinaryReader reader = new(new MemoryStream(s_hashtableMemberInfo));
+        MemberTypeInfo info = MemberTypeInfo.Parse(reader, 7);
+
+        MemoryStream stream = new();
+        BinaryWriter writer = new(stream);
+        info.Write(writer);
+        stream.Position = 0;
+
+        using BinaryReader reader2 = new(stream);
+        info = MemberTypeInfo.Parse(reader2, 7);
+        info.Should().BeEquivalentTo(new (BinaryType Type, object? Info)[]
+        {
+            (BinaryType.Primitive, PrimitiveType.Single),
+            (BinaryType.Primitive, PrimitiveType.Int32),
+            (BinaryType.SystemClass, "System.Collections.IComparer"),
+            (BinaryType.SystemClass, "System.Collections.IHashCodeProvider"),
+            (BinaryType.Primitive, PrimitiveType.Int32),
+            (BinaryType.ObjectArray, null),
+            (BinaryType.ObjectArray, null)
+        });
+    }
+
+    [Fact]
+    public void MemberTypeInfo_ReadHashtable_TooShort()
+    {
+        MemoryStream stream = new(s_hashtableMemberInfo);
+        stream.SetLength(stream.Length - 1);
+        using BinaryReader reader = new(stream);
+        Action action = () => MemberTypeInfo.Parse(reader, 7);
+        action.Should().Throw<EndOfStreamException>();
+    }
+}

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/NullTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/NullTests.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms.BinaryFormat.Tests;
+
+public class NullTests
+{
+    [Fact]
+    public void ObjectNullMultiple256_ThrowsOverflowOnWrite()
+    {
+        // We read a byte on the way in so there is nothing to check.
+
+        ObjectNull.ObjectNullMultiple256 objectNull = new(1000);
+
+        using BinaryWriter writer = new(new MemoryStream());
+        Action action = () => objectNull.Write(writer);
+        action.Should().Throw<OverflowException>();
+    }
+
+    [Fact]
+    public void ObjectNullMultiple256_WritesCorrectly()
+    {
+        ObjectNull.ObjectNullMultiple256 objectNull = new(0xCA);
+
+        byte[] buffer = new byte[2];
+        using BinaryWriter writer = new(new MemoryStream(buffer));
+        objectNull.Write(writer);
+        buffer.Should().BeEquivalentTo(new byte[] { (byte)ObjectNull.ObjectNullMultiple256.RecordType, 0xCA });
+    }
+}

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/PointFTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/PointFTests.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Drawing;
+
+namespace System.Windows.Forms.BinaryFormat.Tests;
+
+public class PointFTests
+{
+    [Fact]
+    public void PointF_Parse()
+    {
+        BinaryFormattedObject format = new PointF().SerializeAndParse();
+
+        BinaryLibrary binaryLibrary = (BinaryLibrary)format[1];
+        binaryLibrary.LibraryId.Should().Be(2);
+        binaryLibrary.LibraryName.Should().Be("System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
+
+        ClassWithMembersAndTypes classInfo = (ClassWithMembersAndTypes)format[2];
+        classInfo.ObjectId.Should().Be(1);
+        classInfo.Name.Should().Be("System.Drawing.PointF");
+        classInfo.MemberNames.Should().BeEquivalentTo(new string[] { "x", "y" });
+        classInfo.MemberValues.Should().BeEquivalentTo(new object[] { 0.0f, 0.0f });
+        classInfo.MemberTypeInfo.Should().BeEquivalentTo(new[]
+        {
+            (BinaryType.Primitive, PrimitiveType.Single),
+            (BinaryType.Primitive, PrimitiveType.Single)
+        });
+    }
+}

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/PrimitiveTypes.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/PrimitiveTypes.cs
@@ -1,0 +1,95 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text;
+
+namespace System.Windows.Forms.BinaryFormat.Tests;
+
+public class PrimitiveTypes
+{
+    [Theory]
+    [MemberData(nameof(RoundTrip_Data))]
+    public void RoundTripPrimitiveTypes(byte type, object value)
+    {
+        MemoryStream stream = new();
+        using (BinaryWriter writer = new(stream, Encoding.UTF8, leaveOpen: true))
+        {
+            TestRecord.WritePrimitiveValue(writer, (PrimitiveType)type, value);
+        }
+
+        stream.Position = 0;
+
+        using BinaryReader reader = new(stream);
+        object result = TestRecord.ReadPrimitiveValue(reader, (PrimitiveType)type);
+        result.Should().Be(value);
+    }
+
+    public static TheoryData<byte, object> RoundTrip_Data => new()
+    {
+        { (byte)PrimitiveType.Int64, 0L },
+        { (byte)PrimitiveType.Int64, -1L },
+        { (byte)PrimitiveType.Int64, 1L },
+        { (byte)PrimitiveType.Int64, long.MaxValue },
+        { (byte)PrimitiveType.Int64, long.MinValue },
+        { (byte)PrimitiveType.UInt64, ulong.MaxValue },
+        { (byte)PrimitiveType.UInt64, ulong.MinValue },
+        { (byte)PrimitiveType.Int32, 0 },
+        { (byte)PrimitiveType.Int32, -1 },
+        { (byte)PrimitiveType.Int32, 1 },
+        { (byte)PrimitiveType.Int32, int.MaxValue },
+        { (byte)PrimitiveType.Int32, int.MinValue },
+        { (byte)PrimitiveType.UInt32, uint.MaxValue },
+        { (byte)PrimitiveType.UInt32, uint.MinValue },
+        { (byte)PrimitiveType.Int16, (short)0 },
+        { (byte)PrimitiveType.Int16, (short)-1 },
+        { (byte)PrimitiveType.Int16, (short)1 },
+        { (byte)PrimitiveType.Int16, short.MaxValue },
+        { (byte)PrimitiveType.Int16, short.MinValue },
+        { (byte)PrimitiveType.UInt16, ushort.MaxValue },
+        { (byte)PrimitiveType.UInt16, ushort.MinValue },
+        { (byte)PrimitiveType.SByte, (sbyte)0 },
+        { (byte)PrimitiveType.SByte, (sbyte)-1 },
+        { (byte)PrimitiveType.SByte, (sbyte)1 },
+        { (byte)PrimitiveType.SByte, sbyte.MaxValue },
+        { (byte)PrimitiveType.SByte, sbyte.MinValue },
+        { (byte)PrimitiveType.Byte, byte.MinValue },
+        { (byte)PrimitiveType.Byte, byte.MaxValue },
+        { (byte)PrimitiveType.Boolean, true },
+        { (byte)PrimitiveType.Boolean, false },
+        { (byte)PrimitiveType.Single, 0.0f },
+        { (byte)PrimitiveType.Single, -1.0f },
+        { (byte)PrimitiveType.Single, 1.0f },
+        { (byte)PrimitiveType.Single, float.MaxValue },
+        { (byte)PrimitiveType.Single, float.MinValue },
+        { (byte)PrimitiveType.Single, float.NegativeZero },
+        { (byte)PrimitiveType.Single, float.NaN },
+        { (byte)PrimitiveType.Single, float.NegativeInfinity },
+        { (byte)PrimitiveType.Double, 0.0d },
+        { (byte)PrimitiveType.Double, -1.0d },
+        { (byte)PrimitiveType.Double, 1.0d },
+        { (byte)PrimitiveType.Double, double.MaxValue },
+        { (byte)PrimitiveType.Double, double.MinValue },
+        { (byte)PrimitiveType.Double, double.NegativeZero },
+        { (byte)PrimitiveType.Double, double.NaN },
+        { (byte)PrimitiveType.Double, double.NegativeInfinity },
+        { (byte)PrimitiveType.TimeSpan, TimeSpan.MinValue },
+        { (byte)PrimitiveType.TimeSpan, TimeSpan.MaxValue },
+        { (byte)PrimitiveType.DateTime, DateTime.MinValue },
+        { (byte)PrimitiveType.DateTime, DateTime.MaxValue },
+    };
+
+    internal class TestRecord : Record
+    {
+        public static void WritePrimitiveValue(BinaryWriter writer, PrimitiveType type, object value)
+            => WritePrimitiveType(writer, type, value);
+
+        public static object ReadPrimitiveValue(BinaryReader reader, PrimitiveType type)
+            => ReadPrimitiveType(reader, type);
+
+        public override void Write(BinaryWriter writer)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/RecordMapTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/RecordMapTests.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms.BinaryFormat.Tests;
+
+public class RecordMapTests
+{
+    private class Record : IRecord
+    {
+        void IBinaryWriteable.Write(BinaryWriter writer) { }
+    }
+
+    [Fact]
+    public void RecordMap_CannotAddSameIndexTwice()
+    {
+        RecordMap map = new();
+        Action action = () => map[1] = new Record();
+        action();
+        action.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void RecordMap_CannotAddNegativeIndex()
+    {
+        RecordMap map = new();
+        Action action = () => map[-1] = new Record();
+        action.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void RecordMap_GetMissingThrowsKeyNotFound()
+    {
+        RecordMap map = new();
+        Func<object> func = () => map[0];
+        func.Should().Throw<KeyNotFoundException>();
+    }
+}

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/StringRecordsCollectionTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/StringRecordsCollectionTests.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms.BinaryFormat.Tests;
+
+public class StringRecordsCollectionTests
+{
+    [Fact]
+    public void BasicFunctionality()
+    {
+        StringRecordsCollection collection = new();
+        int id = 1;
+        IRecord record = collection.GetStringRecord("Foo", ref id);
+        id.Should().Be(2);
+        record.Should().BeOfType<BinaryObjectString>();
+        ((BinaryObjectString)record).ObjectId.Should().Be(1);
+
+        record = collection.GetStringRecord("Foo", ref id);
+        id.Should().Be(2);
+        record.Should().BeOfType<MemberReference>();
+        ((MemberReference)record).IdRef.Should().Be(1);
+
+        record = collection.GetStringRecord("Bar", ref id);
+        id.Should().Be(3);
+        record.Should().BeOfType<BinaryObjectString>();
+        ((BinaryObjectString)record).ObjectId.Should().Be(2);
+    }
+}

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/TestExtensions.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/TestExtensions.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.Serialization.Formatters.Binary;
+
+namespace System.Windows.Forms.BinaryFormat.Tests;
+
+internal static class TestExtensions
+{
+    /// <summary>
+    ///  Serializes the object using the <see cref="BinaryFormatter"/> and reads it into a <see cref="BinaryFormattedObject"/>.
+    /// </summary>
+    public static BinaryFormattedObject SerializeAndParse(this object source) => new(source.Serialize());
+
+    /// <summary>
+    ///  Serializes the object using the <see cref="BinaryFormatter"/>.
+    /// </summary>
+    public static Stream Serialize(this object source)
+    {
+        MemoryStream stream = new();
+        using var formatterScope = new BinaryFormatterScope(enable: true);
+#pragma warning disable SYSLIB0011 // Type or member is obsolete
+        BinaryFormatter formatter = new();
+#pragma warning restore SYSLIB0011
+        formatter.Serialize(stream, source);
+        stream.Position = 0;
+        return stream;
+    }
+}

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/IdTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/IdTests.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms.Tests;
+
+public class IdTests
+{
+    [Fact]
+    public void IdDoesNotAcceptNegativeValues()
+    {
+        Func<Id> func = () => (Id)(-1);
+        func.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void IdEqualsInt()
+    {
+        ((Id)4).Should().Be(4);
+    }
+
+    [Fact]
+    public void IdEqualsId()
+    {
+        ((Id)4).Should().Be((Id)4);
+    }
+
+    [Fact]
+    public void IdToStringIsInt()
+    {
+        ((Id)5).ToString().Should().Be("5");
+    }
+}

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/runtimeconfig.template.json
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/runtimeconfig.template.json
@@ -1,0 +1,6 @@
+{
+  "configProperties": {
+    "TestSwitch.LocalAppContext.DisableCaching": "true",
+    "System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization": "false"
+  }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.OleConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.OleConverter.cs
@@ -370,10 +370,17 @@ public partial class DataObject
         private static object ReadObjectFromHandleDeserializer(Stream stream, bool restrictDeserialization)
         {
             long startPosition = stream.Position;
-            BinaryFormattedObject format = new(stream, leaveOpen: true);
-            if (format.TryGetPrimitiveType(out object? value))
+            try
             {
-                return value;
+                BinaryFormattedObject format = new(stream, leaveOpen: true);
+                if (format.TryGetPrimitiveType(out object? value))
+                {
+                    return value;
+                }
+            }
+            catch (Exception ex) when (!ClientUtils.IsCriticalException(ex))
+            {
+                // Couldn't parse for some reason, let the BinaryFormatter handle it.
             }
 
 #pragma warning disable SYSLIB0011 // Type or member is obsolete

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.OleConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.OleConverter.cs
@@ -11,6 +11,7 @@ using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Text;
+using System.Windows.Forms.BinaryFormat;
 using static Interop;
 using static Windows.Win32.System.Memory.GLOBAL_ALLOC_FLAGS;
 using Com = Windows.Win32.System.Com;
@@ -368,7 +369,16 @@ public partial class DataObject
 
         private static object ReadObjectFromHandleDeserializer(Stream stream, bool restrictDeserialization)
         {
+            long startPosition = stream.Position;
+            BinaryFormattedObject format = new(stream, leaveOpen: true);
+            if (format.TryGetPrimitiveType(out object? value))
+            {
+                return value;
+            }
+
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
+
+            stream.Position = startPosition;
             BinaryFormatter formatter = new BinaryFormatter();
             if (restrictDeserialization)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.cs
@@ -10,6 +10,7 @@ using System.Runtime.InteropServices.ComTypes;
 using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Text;
+using System.Windows.Forms.BinaryFormat;
 using static Interop;
 using Com = Windows.Win32.System.Com;
 using ComTypes = System.Runtime.InteropServices.ComTypes;
@@ -804,6 +805,11 @@ public unsafe partial class DataObject :
 
     private static void SaveObjectToHandleSerializer(Stream stream, object data, bool restrictSerialization)
     {
+        if (BinaryFormatWriter.TryWritePrimitive(stream, data))
+        {
+            return;
+        }
+
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
         BinaryFormatter formatter = new BinaryFormatter();
         if (restrictSerialization)

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ClipboardTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ClipboardTests.cs
@@ -219,7 +219,6 @@ public class ClipboardTests
     [InlineData("format", 1)]
     public void Clipboard_SetData_Invoke_GetReturnsExpected(string format, object data)
     {
-        using var formatterScope = new BinaryFormatterScope(enable: data is int);
         Clipboard.SetData(format, data);
         Assert.Equal(data, Clipboard.GetData(format));
         Assert.True(Clipboard.ContainsData(format));
@@ -251,7 +250,6 @@ public class ClipboardTests
     [InlineData("data")]
     public void Clipboard_SetDataObject_InvokeObjectNotIComDataObject_GetReturnsExpected(object data)
     {
-        using var formatterScope = new BinaryFormatterScope(enable: data is int);
         Clipboard.SetDataObject(data);
         Assert.Equal(data, Clipboard.GetDataObject().GetData(data.GetType()));
         Assert.True(Clipboard.ContainsData(data.GetType().FullName));
@@ -262,7 +260,6 @@ public class ClipboardTests
     [InlineData("data")]
     public void Clipboard_SetDataObject_InvokeObjectIComDataObject_GetReturnsExpected(object data)
     {
-        using var formatterScope = new BinaryFormatterScope(enable: data is int);
         var dataObject = new DataObject(data);
         Clipboard.SetDataObject(dataObject);
         Assert.Equal(data, Clipboard.GetDataObject().GetData(data.GetType()));
@@ -276,7 +273,6 @@ public class ClipboardTests
     [InlineData("data", false)]
     public void Clipboard_SetDataObject_InvokeObjectBoolNotIComDataObject_GetReturnsExpected(object data, bool copy)
     {
-        using var formatterScope = new BinaryFormatterScope(enable: data is int);
         Clipboard.SetDataObject(data, copy);
         Assert.Equal(data, Clipboard.GetDataObject().GetData(data.GetType()));
         Assert.True(Clipboard.ContainsData(data.GetType().FullName));
@@ -289,7 +285,6 @@ public class ClipboardTests
     [InlineData("data", false, 1, 2)]
     public void Clipboard_SetDataObject_InvokeObjectBoolIComDataObject_GetReturnsExpected(object data, bool copy, int retryTimes, int retryDelay)
     {
-        using var formatterScope = new BinaryFormatterScope(enable: data is int);
         var dataObject = new DataObject(data);
         Clipboard.SetDataObject(dataObject, copy, retryTimes, retryDelay);
         Assert.Equal(data, Clipboard.GetDataObject().GetData(data.GetType()));
@@ -303,7 +298,6 @@ public class ClipboardTests
     [InlineData("data", false, 1, 2)]
     public void Clipboard_SetDataObject_InvokeObjectBoolIntIntNotIComDataObject_GetReturnsExpected(object data, bool copy, int retryTimes, int retryDelay)
     {
-        using var formatterScope = new BinaryFormatterScope(enable: data is int);
         Clipboard.SetDataObject(data, copy, retryTimes, retryDelay);
         Assert.Equal(data, Clipboard.GetDataObject().GetData(data.GetType()));
         Assert.True(Clipboard.ContainsData(data.GetType().FullName));
@@ -451,7 +445,6 @@ public class ClipboardTests
     [EnumData<TextDataFormat>]
     public void Clipboard_SetText_InvokeStringTextDataFormat_GetReturnsExpected(TextDataFormat format)
     {
-        using var formatterScope = new BinaryFormatterScope(enable: format == TextDataFormat.CommaSeparatedValue);
         Clipboard.SetText("text", format);
         Assert.Equal("text", Clipboard.GetText(format));
         Assert.True(Clipboard.ContainsText(format));


### PR DESCRIPTION
In a number of cases we know what data we're serializing or deserializing and can avoid using the BinaryFormatter if we weren't concerned about compatibility.

I was considering using a different format on the wire and writing a parser to deal with legacy data. It finally occured to me that if I'm going to parse legacy data I might as well put the data out in the legacy format to maintain compatibility.

This creates a model for the NRBF format that can be used to look at data the BinaryFormatter puts out. The top level of the model is represented by the BinaryFormattedObject class.

The binary records that are part of the model all self serialize and deserialize, which allows manually constructing known models to export data that can be read by the BinaryFormatter. The records never hydrate any complex types other than strings, that must be done manually.

BinaryFormatReader and BinaryFormatWriter have helper methods for creating and reading a set of known types. I've handled primitive types and Hashtable and started on List<T> as well.

Clipboard will no longer use the BinaryFormatter for primitive types. Tests have been updated appropriately.

My next step is to change the ActiveX property bag serialization to use the Hashtable serialization that this change introduces.  I also have a few more tests to port from my prototype repo.

The idea is to then further reduce the need to fall back on the BinaryFormatter by providing support for other BinaryFormatted types in WinForms and other types that WinForms projects would commonly use as public property types. This includes things like PointF and RectangleF, primitive arrays, and other collections of primitive types (List<T> and ArrayList are the priorities there).

Note that performance isn't far off from using the BinaryFormatter. For serializing a really large Hashtable (around 10K records) we are about the same speed and use a slightly larger amount of memory. It's possible it could be significantly better if we use the enumerator to get the data instead of ISerializable- would have to spend some time to figure out the right values for the other private fields without using reflection.

BinaryFormattedObject does not yet support multidimensional or jagged arrays. This doesn't hit any of our scenarios, will implement when needed.

This change also consumes FluentAssertions in the Primitives test assembly. We've discussed using this as a team and will be looking at it in use here before committing to the rest of the test projects.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9088)