### PR TITLE
Enable nullability in CodeDomSerializerBase

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/ComponentModel/Design/Serialization/DesignerSerializationManagerHelper.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/ComponentModel/Design/Serialization/DesignerSerializationManagerHelper.cs
@@ -6,7 +6,8 @@ namespace System.ComponentModel.Design.Serialization
 {
     internal static class DesignerSerializationManagerHelper
     {
-        public static bool TryGetContext<T>(this IDesignerSerializationManager manager,
+        public static bool TryGetContext<T>(
+            this IDesignerSerializationManager manager,
             [NotNullWhen(true)] out T? context) where T : class
         {
             context = manager.GetContext<T>();

--- a/src/System.Windows.Forms.Primitives/src/System/ComponentModel/Design/Serialization/DesignerSerializationManagerHelper.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/ComponentModel/Design/Serialization/DesignerSerializationManagerHelper.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.ComponentModel.Design.Serialization
+{
+    internal static class DesignerSerializationManagerHelper
+    {
+        public static bool TryGetContext<T>(this IDesignerSerializationManager manager,
+            [NotNullWhen(true)] out T? context) where T : class
+        {
+            context = manager.GetContext<T>();
+            return context is not null;
+        }
+
+        public static T? GetContext<T>(this IDesignerSerializationManager manager) where T : class
+        {
+            return manager.Context[typeof(T)] as T;
+        }
+
+        public static T? GetSerializer<T>(this IDesignerSerializationManager manager, Type? objectType) where T : class
+        {
+            return manager.GetSerializer(objectType, typeof(T)) as T;
+        }
+
+        public static bool TryGetSerializer<T>(this IDesignerSerializationManager manager, Type? objectType, [NotNullWhen(true)] out T? serializer) where T : class
+        {
+            serializer = manager.GetSerializer(objectType, typeof(T)) as T;
+            return serializer is not null;
+        }
+    }
+}


### PR DESCRIPTION
This PR is pretty big, apologies for that. It enables nullability in CodeDomSerializerBase to get one foot in the door to annotate more serializers down the road,
One issue I had doing this is the lack of annoations in System.CodeDom (see https://github.com/dotnet/runtime/issues/41720, https://github.com/dotnet/runtime/issues/78036)

Contributes to #8342


## Proposed changes

- Enable nullability in CodeDomSerializerBase
- Refactor CodeDomSerializerBase and fix an apparent bug
- Introduce new helper functions to simplify more parts of the code

Each change is its own commit.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9099)