### PR TITLE
Move away from BinaryFormatter for ActiveX purposes

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/OleAut32/Interop.VARIANT.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/OleAut32/Interop.VARIANT.cs
@@ -938,7 +938,7 @@ internal unsafe partial struct VARIANT : IDisposable
     private static T ThrowInvalidCast<T>() => throw new InvalidCastException();
 
     /// <summary>
-    ///  Converts the given object to <see cref="VARIANT"/>. WARNING: Only handles <see cref="string"/>.
+    ///  Converts the given object to <see cref="VARIANT"/>.
     /// </summary>
     public static VARIANT FromObject(object? value)
     {

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/BinaryFormatReader.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/BinaryFormatReader.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 
@@ -13,109 +12,6 @@ namespace System.Windows.Forms.BinaryFormat;
 /// </summary>
 internal static class BinaryFormatReader
 {
-    /// <summary>
-    ///  Reads a binary formatted string.
-    /// </summary>
-    /// <exception cref="SerializationException">Data isn't a valid string.</exception>
-    public static string ReadString(Stream stream)
-    {
-        BinaryFormattedObject format = new(stream, leaveOpen: true);
-        if (format.RecordCount < 3 || format[1] is not BinaryObjectString value)
-        {
-            throw new SerializationException();
-        }
-
-        return value.Value;
-    }
-
-    /// <summary>
-    ///  Reads a binary formatted primitive list.
-    /// </summary>
-    /// <exception cref="NotSupportedException"><typeparamref name="T"/> was not primitive.</exception>
-    /// <exception cref="SerializationException">Data isn't a valid <see cref="List{T}"/>.</exception>
-    public static List<T> ReadPrimitiveList<T>(Stream stream)
-        where T : unmanaged
-    {
-        if (!typeof(T).IsPrimitive)
-        {
-            throw new NotSupportedException($"{nameof(T)} is not primitive.");
-        }
-
-        BinaryFormattedObject format = new(stream, leaveOpen: true);
-        if (format.RecordCount < 4
-            || format[1] is not SystemClassWithMembersAndTypes classInfo
-            || !classInfo.Name.StartsWith($"System.Collections.Generic.List`1[[{typeof(T).FullName}")
-            || format[2] is not ArraySinglePrimitive array
-            || array.PrimitiveType != Record.GetPrimitiveType(typeof(T)))
-        {
-            throw new SerializationException();
-        }
-
-        int count;
-        try
-        {
-            count = (int)classInfo["_size"];
-        }
-        catch (Exception ex)
-        {
-            throw ex.ConvertToSerializationException();
-        }
-
-        List<T> list = new(count);
-        list.AddRange(array.Take(count).Cast<T>());
-        return list;
-    }
-
-    /// <summary>
-    ///  Reads a binary formatted <see cref="Hashtable"/>. Only accepts <see langword="string"/> keys
-    ///  and <see langword="string"/>? values.
-    /// </summary>
-    /// <exception cref="SerializationException">
-    ///  Data isn't a valid <see langword="string"/> - <see langword="string"/>? <see cref="Hashtable"/>.
-    /// </exception>
-    public static Hashtable ReadHashtableOfStrings(Stream stream)
-    {
-        BinaryFormattedObject format = new(stream, leaveOpen: true);
-        if (format.RecordCount < 5
-            || format[1] is not SystemClassWithMembersAndTypes classInfo
-            || classInfo.Name != "System.Collections.Hashtable"
-            || format[2] is not ArraySingleObject keys
-            || format[3] is not ArraySingleObject values
-            || keys.Length != values.Length)
-        {
-            throw new SerializationException();
-        }
-
-        Hashtable hashtable = new(keys.Length);
-        for (int i = 0; i < keys.Length; i++)
-        {
-            string key = keys[i] switch
-            {
-                BinaryObjectString keyString => keyString.Value,
-                MemberReference reference => format[reference.IdRef] switch
-                {
-                    BinaryObjectString refString => refString.Value,
-                    _ => throw new SerializationException()
-                },
-                _ => throw new SerializationException()
-            };
-
-            hashtable[key] = values[i] switch
-            {
-                BinaryObjectString valueString => valueString.Value,
-                ObjectNull => null,
-                MemberReference reference => format[reference.IdRef] switch
-                {
-                    BinaryObjectString refString => refString.Value,
-                    _ => throw new SerializationException()
-                },
-                _ => throw new SerializationException(),
-            };
-        }
-
-        return hashtable;
-    }
-
     /// <summary>
     ///  Creates a <see cref="DateTime"/> object from raw data with validation.
     /// </summary>

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/BinaryFormattedObject.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/BinaryFormattedObject.cs
@@ -22,22 +22,6 @@ namespace System.Windows.Forms.BinaryFormat;
 /// </remarks>
 internal sealed class BinaryFormattedObject
 {
-    private static readonly string[] s_systemPrimitiveTypeNames = new string[]
-    {
-        typeof(int).FullName!,
-        typeof(long).FullName!,
-        typeof(bool).FullName!,
-        typeof(char).FullName!,
-        typeof(float).FullName!,
-        typeof(double).FullName!,
-        typeof(sbyte).FullName!,
-        typeof(byte).FullName!,
-        typeof(short).FullName!,
-        typeof(ushort).FullName!,
-        typeof(uint).FullName!,
-        typeof(ulong).FullName!,
-    };
-
     // Don't reserve space in collections based on read lengths for more than this size to defend against corrupted lengths.
 #if DEBUG
     internal const int MaxNewCollectionSize = 1024 * 10;
@@ -94,92 +78,4 @@ internal sealed class BinaryFormattedObject
     ///  can be referenced by other records.
     /// </summary>
     public IRecord this[Id id] => _recordMap[id];
-
-    /// <summary>
-    ///  Trys to get this object as a primitive type or string.
-    /// </summary>
-    /// <returns><see langword="true"/> if this represented a primitive type or string.</returns>
-    public bool TryGetPrimitiveType([NotNullWhen(true)] out object? value)
-    {
-        try
-        {
-            return TryGetPrimitiveTypeInternal(out value);
-        }
-        catch (Exception ex) when (!ClientUtils.IsCriticalException(ex))
-        {
-            value = default;
-            return false;
-        }
-    }
-
-    private bool TryGetPrimitiveTypeInternal([NotNullWhen(true)] out object? value)
-    {
-        value = null;
-        if (RecordCount != 3)
-        {
-            return false;
-        }
-
-        if (_records[1] is BinaryObjectString binaryString)
-        {
-            value = binaryString.Value;
-            return true;
-        }
-
-        if (_records[1] is not SystemClassWithMembersAndTypes systemClass)
-        {
-            return false;
-        }
-
-        // Basic primitive types
-        if (s_systemPrimitiveTypeNames.Contains(systemClass.Name)
-            && systemClass.MemberTypeInfo[0].Type == BinaryType.Primitive)
-        {
-            value = systemClass.MemberValues[0];
-            return true;
-        }
-
-        // Handle decimal, nint, nuint, TimeSpan, DateTime
-
-        if (systemClass.Name == typeof(TimeSpan).FullName)
-        {
-            value = new TimeSpan((long)systemClass.MemberValues[0]);
-            return true;
-        }
-
-        if (systemClass.Name == typeof(DateTime).FullName)
-        {
-            value = BinaryFormatReader.CreateDateTimeFromData((long)systemClass["dateData"]);
-            return true;
-        }
-
-        if (systemClass.Name == typeof(nint).FullName)
-        {
-            // Rehydrating still throws even though casting doesn't any more
-            value = checked((nint)(long)systemClass.MemberValues[0]);
-            return true;
-        }
-
-        if (systemClass.Name == typeof(nuint).FullName)
-        {
-            value = checked((nuint)(ulong)systemClass.MemberValues[0]);
-            return true;
-        }
-
-        if (systemClass.Name == typeof(decimal).FullName)
-        {
-            Span<int> bits = stackalloc int[4]
-            {
-                (int)systemClass["lo"],
-                (int)systemClass["mid"],
-                (int)systemClass["hi"],
-                (int)systemClass["flags"]
-            };
-
-            value = new decimal(bits);
-            return true;
-        }
-
-        return false;
-    }
 }

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/BinaryFormattedObjectExtensions.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/BinaryFormattedObjectExtensions.cs
@@ -1,0 +1,218 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Runtime.CompilerServices;
+using System.Runtime.Serialization;
+
+namespace System.Windows.Forms.BinaryFormat;
+
+internal static class BinaryFormattedObjectExtensions
+{
+    private static readonly string[] s_systemPrimitiveTypeNames = new string[]
+    {
+        typeof(int).FullName!,
+        typeof(long).FullName!,
+        typeof(bool).FullName!,
+        typeof(char).FullName!,
+        typeof(float).FullName!,
+        typeof(double).FullName!,
+        typeof(sbyte).FullName!,
+        typeof(byte).FullName!,
+        typeof(short).FullName!,
+        typeof(ushort).FullName!,
+        typeof(uint).FullName!,
+        typeof(ulong).FullName!,
+    };
+
+    /// <summary>
+    ///  Trys to get this object as a primitive type or string.
+    /// </summary>
+    public static bool TryGetString(this BinaryFormattedObject format, [NotNullWhen(true)] out string? value)
+    {
+        if (format.RecordCount < 3 || format[1] is not BinaryObjectString binaryString)
+        {
+            value = null;
+            return false;
+        }
+
+        value = binaryString.Value;
+        return false;
+    }
+
+    /// <summary>
+    ///  Trys to get this object as a primitive type or string.
+    /// </summary>
+    /// <returns><see langword="true"/> if this represented a primitive type or string.</returns>
+    public static bool TryGetPrimitiveType(this BinaryFormattedObject format, [NotNullWhen(true)] out object? value)
+    {
+        value = null;
+        if (format.RecordCount < 3)
+        {
+            return false;
+        }
+
+        if (format[1] is BinaryObjectString binaryString)
+        {
+            value = binaryString.Value;
+            return true;
+        }
+
+        if (format[1] is not SystemClassWithMembersAndTypes systemClass)
+        {
+            return false;
+        }
+
+        if (s_systemPrimitiveTypeNames.Contains(systemClass.Name)
+            && systemClass.MemberTypeInfo[0].Type == BinaryType.Primitive)
+        {
+            value = systemClass.MemberValues[0];
+            return true;
+        }
+
+        if (systemClass.Name == typeof(TimeSpan).FullName)
+        {
+            value = new TimeSpan((long)systemClass.MemberValues[0]);
+            return true;
+        }
+
+        if (systemClass.Name == typeof(DateTime).FullName)
+        {
+            ulong ulongValue = (ulong)systemClass["dateData"];
+            value = Unsafe.As<ulong, DateTime>(ref ulongValue);
+            return true;
+        }
+
+        if (systemClass.Name == typeof(nint).FullName)
+        {
+            // Rehydrating still throws even though casting doesn't any more
+            value = checked((nint)(long)systemClass.MemberValues[0]);
+            return true;
+        }
+
+        if (systemClass.Name == typeof(nuint).FullName)
+        {
+            value = checked((nuint)(ulong)systemClass.MemberValues[0]);
+            return true;
+        }
+
+        // Handle decimal, nint, nuint, TimeSpan, DateTime
+        if (systemClass.Name == typeof(decimal).FullName)
+        {
+            Span<int> bits = stackalloc int[4]
+            {
+                (int)systemClass["lo"],
+                (int)systemClass["mid"],
+                (int)systemClass["hi"],
+                (int)systemClass["flags"]
+            };
+
+            value = new decimal(bits);
+            return true;
+        }
+
+        return false;
+    }
+
+    public static bool TryGetPrimitiveList<T>(this BinaryFormattedObject format, [NotNullWhen(true)] out object? list)
+        where T : unmanaged
+    {
+        bool success = format.TryGetPrimitiveList(out List<T>? tList);
+        list = tList;
+        return success;
+    }
+
+    /// <summary>
+    ///  Reads a binary formatted primitive list.
+    /// </summary>
+    /// <exception cref="NotSupportedException"><typeparamref name="T"/> was not primitive.</exception>
+    /// <exception cref="SerializationException">Data isn't a valid <see cref="List{T}"/>.</exception>
+    public static bool TryGetPrimitiveList<T>(this BinaryFormattedObject format, [NotNullWhen(true)] out List<T>? list)
+        where T : unmanaged
+    {
+        if (!typeof(T).IsPrimitive)
+        {
+            throw new NotSupportedException($"{nameof(T)} is not primitive.");
+        }
+
+        list = null;
+
+        if (format.RecordCount != 4
+            || format[1] is not SystemClassWithMembersAndTypes classInfo
+            || !classInfo.Name.StartsWith($"System.Collections.Generic.List`1[[{typeof(T).FullName}", StringComparison.Ordinal)
+            || format[2] is not ArraySinglePrimitive array
+            || array.PrimitiveType != Record.GetPrimitiveType(typeof(T)))
+        {
+            return false;
+        }
+
+        int count;
+        try
+        {
+            count = (int)classInfo["_size"];
+        }
+        catch (Exception ex)
+        {
+            throw ex.ConvertToSerializationException();
+        }
+
+        List<T> newList = new(count);
+        newList.AddRange(array.Take(count).Cast<T>());
+        list = newList;
+        return true;
+    }
+
+    /// <summary>
+    ///  Gets a binary formatted <see cref="Hashtable"/>. Only accepts <see langword="string"/> keys
+    ///  and <see langword="string"/>, <see langword="null"/>, or primitive values.
+    /// </summary>
+    /// <exception cref="SerializationException">
+    ///  Data isn't a valid primitive only <see cref="Hashtable"/>.
+    /// </exception>
+    public static bool TryGetPrimitiveHashtable(this BinaryFormattedObject format, [NotNullWhen(true)] out Hashtable? hashtable)
+    {
+        hashtable = null;
+
+        if (format.RecordCount < 5
+            || format[1] is not SystemClassWithMembersAndTypes classInfo
+            || classInfo.Name != "System.Collections.Hashtable"
+            || format[2] is not ArraySingleObject keys
+            || format[3] is not ArraySingleObject values
+            || keys.Length != values.Length)
+        {
+            return false;
+        }
+
+        hashtable = new(keys.Length);
+        for (int i = 0; i < keys.Length; i++)
+        {
+            object key = keys[i] switch
+            {
+                BinaryObjectString keyString => keyString.Value,
+                MemberReference reference => format[reference.IdRef] switch
+                {
+                    BinaryObjectString refString => refString.Value,
+                    _ => throw new SerializationException()
+                },
+                MemberPrimitiveTyped primitive => primitive.Value,
+                _ => throw new SerializationException(),
+            };
+
+            hashtable[key] = values[i] switch
+            {
+                BinaryObjectString valueString => valueString.Value,
+                ObjectNull => null,
+                MemberReference reference => format[reference.IdRef] switch
+                {
+                    BinaryObjectString refString => refString.Value,
+                    _ => throw new SerializationException()
+                },
+                MemberPrimitiveTyped primitive => primitive.Value,
+                _ => throw new SerializationException(),
+            };
+        }
+
+        return true;
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/ClassRecord.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/ClassRecord.cs
@@ -70,8 +70,6 @@ internal abstract class ClassRecord : Record
                     memberValues.Add(ReadPrimitiveType(reader, (PrimitiveType)info!));
                     break;
                 case BinaryType.String:
-                    memberValues.Add(reader.ReadString());
-                    break;
                 case BinaryType.Object:
                 case BinaryType.StringArray:
                 case BinaryType.PrimitiveArray:
@@ -99,8 +97,6 @@ internal abstract class ClassRecord : Record
                     WritePrimitiveType(writer, (PrimitiveType)info!, memberValues[i]);
                     break;
                 case BinaryType.String:
-                    writer.Write((string)memberValues[i]);
-                    break;
                 case BinaryType.Object:
                 case BinaryType.StringArray:
                 case BinaryType.PrimitiveArray:

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/MemberPrimitiveTyped.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/MemberPrimitiveTyped.cs
@@ -25,6 +25,19 @@ internal sealed class MemberPrimitiveTyped : Record, IRecord<MemberPrimitiveType
         Value = value;
     }
 
+    /// <exception cref="ArgumentException"><paramref name="value"/> is not primitive.</exception>
+    internal MemberPrimitiveTyped(object value)
+    {
+        PrimitiveType primitiveType = GetPrimitiveType(value.GetType());
+        if (primitiveType == default)
+        {
+            throw new ArgumentException($"{nameof(value)} is not primitive.");
+        }
+
+        PrimitiveType = primitiveType;
+        Value = value;
+    }
+
     public static RecordType RecordType => RecordType.MemberPrimitiveTyped;
 
     static MemberPrimitiveTyped IBinaryFormatParseable<MemberPrimitiveTyped>.Parse(
@@ -40,6 +53,7 @@ internal sealed class MemberPrimitiveTyped : Record, IRecord<MemberPrimitiveType
     public override void Write(BinaryWriter writer)
     {
         writer.Write((byte)RecordType);
+        writer.Write((byte)PrimitiveType);
         WritePrimitiveType(writer, PrimitiveType, Value);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/MemberTypeInfo.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/MemberTypeInfo.cs
@@ -17,7 +17,6 @@ namespace System.Windows.Forms.BinaryFormat;
 ///   </see>
 ///  </para>
 /// </remarks>
-
 internal readonly struct MemberTypeInfo : IBinaryWriteable, IEnumerable<(BinaryType Type, object? Info)>
 {
     private readonly IList<(BinaryType Type, object? Info)> _info;

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/Record.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/Record.cs
@@ -61,7 +61,7 @@ internal abstract class Record : IRecord
         PrimitiveType.DateTime => reader.ReadDateTime(),
         PrimitiveType.TimeSpan => new TimeSpan(reader.ReadInt64()),
         // String is handled with a record, never on it's own
-        _ => throw new SerializationException(),
+        _ => throw new SerializationException($"Failure trying to read primitve '{primitiveType}'"),
     };
 
     /// <summary>
@@ -181,7 +181,7 @@ internal abstract class Record : IRecord
             RecordType.ArraySingleString => ReadSpecificRecord<ArraySingleString>(recordMap),
             RecordType.MethodCall => throw new NotSupportedException(),
             RecordType.MethodReturn => throw new NotSupportedException(),
-            _ => throw new SerializationException(),
+            _ => throw new SerializationException("Unexpected record type."),
         };
 
         unsafe TRecord ReadSpecificRecord<TRecord>(RecordMap recordMap) where TRecord : class, IRecord<TRecord>

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Com/CY.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Com/CY.cs
@@ -4,8 +4,15 @@
 
 namespace Windows.Win32.System.Com;
 
-internal partial struct CY
+internal partial struct CY : IEquatable<CY>
 {
+    public readonly bool Equals(CY other) => int64 == other.int64;
+    public override readonly bool Equals(object? obj) => obj is CY cy && Equals(cy);
+    public override readonly int GetHashCode() => int64.GetHashCode();
+
+    public static bool operator ==(CY left, CY right) => left.Equals(right);
+    public static bool operator !=(CY left, CY right) => !left.Equals(right);
+
     // https://learn.microsoft.com/openspecs/windows_protocols/ms-oaut/5a2b34c4-d109-438e-9ec8-84816d8de40d
 
     public static explicit operator decimal(CY value) => decimal.FromOACurrency(value.int64);

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Com/StructuredStorage/PropertyBagExtensions.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Com/StructuredStorage/PropertyBagExtensions.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Windows.Win32.System.Com.StructuredStorage;
+
+internal static class PropertyBagExtensions
+{
+    /// <inheritdoc cref="IPropertyBag.Interface.Read(PCWSTR, VARIANT*, IErrorLog*)"/>
+    internal static unsafe HRESULT Read(this IPropertyBag.Interface @this, string pszPropName, VARIANT* pVar, IErrorLog* pErrorLog)
+    {
+        fixed (char* c = pszPropName)
+        {
+            return @this.Read(c, pVar, pErrorLog);
+        }
+    }
+
+    /// <inheritdoc cref="IPropertyBag.Interface.Write(PCWSTR, VARIANT*)"/>
+    internal static unsafe HRESULT Write(this IPropertyBag.Interface @this, string pszPropName, VARIANT* pVar)
+    {
+        fixed (char* c = pszPropName)
+        {
+            return @this.Write(c, pVar);
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/ListTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/ListTests.cs
@@ -92,20 +92,23 @@ public class ListTests
     [MemberData(nameof(PrimitiveLists_TestData))]
     public void List_Primitive_Read(IList list)
     {
-        Stream stream = list.Serialize();
-        IList result = list switch
+        BinaryFormattedObject format = list.SerializeAndParse();
+
+        object? deserialized;
+        bool success = list switch
         {
-            List<int> => BinaryFormatReader.ReadPrimitiveList<int>(stream),
-            List<float> => BinaryFormatReader.ReadPrimitiveList<float>(stream),
-            List<byte> => BinaryFormatReader.ReadPrimitiveList<byte>(stream),
-            List<char> => BinaryFormatReader.ReadPrimitiveList<char>(stream),
+            List<int> => format.TryGetPrimitiveList<int>(out deserialized),
+            List<float> => format.TryGetPrimitiveList<float>(out deserialized),
+            List<byte> => format.TryGetPrimitiveList<byte>(out deserialized),
+            List<char> => format.TryGetPrimitiveList<char>(out deserialized),
             _ => throw new InvalidOperationException(),
         };
 
-        result.Should().BeEquivalentTo(list);
+        success.Should().BeTrue();
+        deserialized.Should().BeEquivalentTo(list);
     }
 
-    public static TheoryData<IList> PrimitiveLists_TestData = new()
+    public static TheoryData<IList> PrimitiveLists_TestData => new()
     {
         new List<int>(),
         new List<float>() { 3.14f },

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.PropertyBagStream.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.PropertyBagStream.cs
@@ -4,6 +4,7 @@
 
 using System.Collections;
 using System.Runtime.Serialization.Formatters.Binary;
+using System.Windows.Forms.BinaryFormat;
 using Windows.Win32.System.Com;
 using Windows.Win32.System.Com.StructuredStorage;
 
@@ -13,20 +14,42 @@ public abstract unsafe partial class AxHost
 {
     internal class PropertyBagStream : IPropertyBag.Interface
     {
-        private Hashtable _bag = new();
+        private readonly Hashtable _bag;
 
-        internal void Read(Stream stream)
+        internal PropertyBagStream() => _bag = new();
+
+        internal PropertyBagStream(Stream stream)
         {
+            long position = stream.Position;
             try
             {
+                BinaryFormattedObject format = new(stream, leaveOpen: true);
+                if (format.TryGetPrimitiveHashtable(out _bag!))
+                {
+                    return;
+                }
+            }
+            catch (Exception ex) when (!ClientUtils.IsCriticalException(ex))
+            {
+                // Don't usually expect to fall into this case as we should usually not have anything
+                // in the stream other than primitive VARIANTs, which are handled. If there are arrays or
+                // interface pointers we'd hit this.
+                Debug.WriteLine($"PropertyBagStream: {nameof(BinaryFormattedObject)} failed with {ex.Message}");
+            }
+
+            try
+            {
+                stream.Position = position;
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
                 _bag = (Hashtable)new BinaryFormatter().Deserialize(stream);
-#pragma warning restore SYSLIB0011 // Type or member is obsolete
             }
-            catch
+            catch (Exception inner) when (!ClientUtils.IsCriticalException(inner))
             {
-                // Error reading.  Just init an empty hashtable.
-                _bag = new Hashtable();
+                Debug.Fail($"PropertyBagStream: {nameof(BinaryFormatter)} failed with {inner.Message}");
+#pragma warning restore SYSLIB0011
+
+                // Error reading. Just init an empty hashtable.
+                _bag = new();
             }
         }
 
@@ -74,11 +97,23 @@ public abstract unsafe partial class AxHost
             return HRESULT.S_OK;
         }
 
-        internal void Write(Stream stream)
+        internal void Save(Stream stream)
         {
+            long position = stream.Position;
+
+            try
+            {
+                BinaryFormatWriter.WritePrimitiveHashtable(stream, _bag);
+            }
+            catch (Exception ex) when (!ClientUtils.IsCriticalException(ex))
+            {
+                Debug.WriteLine($"PropertyBagStream.Save: {nameof(BinaryFormattedObject)} failed with {ex.Message}");
+
+                stream.Position = position;
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
-            new BinaryFormatter().Serialize(stream, _bag);
-#pragma warning restore SYSLIB0011 // Type or member is obsolete
+                new BinaryFormatter().Serialize(stream, _bag);
+#pragma warning restore SYSLIB0011
+            }
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.State.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.State.cs
@@ -112,9 +112,8 @@ public abstract partial class AxHost
                         byte[]? data = enumerator.Value as byte[];
                         if (data is not null)
                         {
-                            _propertyBag = new PropertyBagStream();
                             using MemoryStream memoryStream = new(data);
-                            _propertyBag.Read(memoryStream);
+                            _propertyBag = new PropertyBagStream(memoryStream);
                         }
                     }
                     catch (Exception e)
@@ -344,7 +343,7 @@ public abstract partial class AxHost
                 try
                 {
                     using MemoryStream propertyBagBinaryStream = new();
-                    _propertyBag.Write(propertyBagBinaryStream);
+                    _propertyBag.Save(propertyBagBinaryStream);
                     info.AddValue(PropertyBagSerializationName, propertyBagBinaryStream.ToArray());
                 }
                 catch (Exception e)

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ActiveXImplTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ActiveXImplTests.cs
@@ -12,9 +12,9 @@ namespace System.Windows.Forms.Tests;
 public unsafe class Control_ActiveXImplTests
 {
     [WinFormsFact]
-    public void ActiveXImpl_SaveLoad_RoundTrip_FormatterEnabled()
+    public void ActiveXImpl_SaveLoad_RoundTrip_FormatterDisabled()
     {
-        using var formatterScope = new BinaryFormatterScope(enable: true);
+        using var formatterScope = new BinaryFormatterScope(enable: false);
         using Control control = new();
         control.BackColor = Color.Bisque;
         IPersistStreamInit.Interface persistStream = control;
@@ -29,26 +29,6 @@ public unsafe class Control_ActiveXImplTests
         hr = persistStream.Load(istream.Value);
         Assert.True(hr.Succeeded);
         Assert.Equal(Color.Bisque, control.BackColor);
-    }
-
-    [WinFormsFact]
-    public void ActiveXImpl_SaveLoad_RoundTrip_FormatterDisabled()
-    {
-        using var formatterScope = new BinaryFormatterScope(enable: false);
-        using Control control = new();
-        control.BackColor = Color.Bisque;
-        IPersistStreamInit.Interface persistStream = control;
-
-        using MemoryStream memoryStream = new();
-        using var istream = ComHelpers.GetComScope<IStream>(new GPStream(memoryStream));
-        var istreamPointer = istream.Value;
-
-        // Even though there are no properties that need BinaryFormatter in this case, it is ultimately saving
-        // AxHost.PropertyBagStream, which itself uses BinaryFormatter to save its Hashtable. There is never
-        // anything put in this Hashtable other than string/string pairs, so we *could* convert it to NOT use the
-        // BinaryFormatter for the bag itself. There would have to be a config switch most likely and a compat
-        // piece to look at the incoming stream to see if it is a BinaryFormatted stream.
-        Assert.Throws<NotSupportedException>(() => persistStream.Save(istreamPointer, fClearDirty: BOOL.FALSE));
     }
 
     [WinFormsFact]


### PR DESCRIPTION
The PropertyBags now serialize without it where possible. This allows a standard Control to completely serialize without the BinaryFormatter enabled.

For the AxHost case, I've left the BinaryFormatter as a fall-back.

I've also extended the Hashtable serialization to handle all primitive types. Note the two line change to make this happen. :)

This change also moves the "Reader" methods to "BinaryFormattedObjectExtensions". Due to our layering and the need to check multiple states I realized that we need to have all of the reading of objects directly using an existing BinaryFormattedObject instance.

Fixes a few bugs and adds more tests. Some random cleanup related to VARIANT (as I was exploring the scope of things).


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9104)