### PR TITLE
Update/Scale Font on each DPICHNAGED message

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
@@ -1452,21 +1452,7 @@ public class ContainerControl : ScrollableControl, IContainerControl
             // WM_DPICHANGED event. Failing to apply SuggestedRectangle will result in a circular WM_DPICHANGED
             // events on the control.
 
-            // Note: SuggestedRectangle supplied  by WM_DPICHANGED event is Dpi (not Font) scaled. if top-level window is
-            // Font scaled, we might see deviations in the expected bounds and may result in adding Scrollbars (horizontal/vertical)
-            if (IsHandleCreated)
-            {
-                PInvoke.SetWindowPos(
-                    this,
-                    HWND.HWND_TOP,
-                    suggestedRectangle.X,
-                    suggestedRectangle.Y,
-                    suggestedRectangle.Width,
-                    suggestedRectangle.Height,
-                    SET_WINDOW_POS_FLAGS.SWP_NOZORDER | SET_WINDOW_POS_FLAGS.SWP_NOACTIVATE);
-            }
-
-            // Bounds are already scaled for the top-level window. We would need to skip scaling of
+            // Bounds are being scaled for the top-level window via SuggestedRectangle. We would need to skip scaling of
             // this control further by the 'OnFontChanged' event.
             _isScaledByDpiChangedEvent = true;
 
@@ -1482,6 +1468,18 @@ public class ContainerControl : ScrollableControl, IContainerControl
                 {
                     OnFontChanged(EventArgs.Empty);
                 }
+            }
+
+            if (IsHandleCreated)
+            {
+                PInvoke.SetWindowPos(
+                    this,
+                    HWND.HWND_TOP,
+                    suggestedRectangle.X,
+                    suggestedRectangle.Y,
+                    suggestedRectangle.Width,
+                    suggestedRectangle.Height,
+                    SET_WINDOW_POS_FLAGS.SWP_NOZORDER | SET_WINDOW_POS_FLAGS.SWP_NOACTIVATE);
             }
         }
         finally

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -2122,9 +2122,13 @@ public unsafe partial class Control :
     internal Font GetScaledFont(Font font, int newDpi, int oldDpi)
     {
         Debug.Assert(PInvoke.AreDpiAwarenessContextsEqualInternal(DpiAwarenessContext, DPI_AWARENESS_CONTEXT.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2),
-            $"Fonts need to be cached only for PermonitorV2 mode applications : {DpiHelper.IsPerMonitorV2Awareness} : {DpiAwarenessContext}");
+            $"Fonts need to be cached only for PerMonitorV2 mode applications : {DpiHelper.IsPerMonitorV2Awareness} : {DpiAwarenessContext}");
 
-        _dpiFonts ??= new Dictionary<int, Font>();
+        _dpiFonts ??= new Dictionary<int, Font>
+        {
+            { oldDpi, font.WithSize(font.Size) }
+        };
+
         if (_dpiFonts.TryGetValue(newDpi, out Font? scaledFont))
         {
             return scaledFont!;
@@ -5123,6 +5127,7 @@ public unsafe partial class Control :
                     Properties.SetObject(s_controlsCollectionProperty, null);
                 }
 
+                ClearDpiFonts();
                 base.Dispose(disposing);
             }
             finally


### PR DESCRIPTION
fixes #8946 
fixes #9004

By default, control handles are created with the DPI (dots per inch) of the primary monitor. If we assign an owner or parent to a control that is not on the primary monitor and has a different DPI than the primary monitor, it may trigger a DPICHANGED event. This situation leads to issues linked above.

When the DPICHANGED event occurs, we adjust the font and scale the control according to the new DPI. However, if the child control is a top-level window and explicitly or by default placed on the primary monitor, it generates another DPICHANGED message within the first one, causing the scaling process to repeat. This behavior is expected. The problem arises from the current order in which we attempt to scale the font and the control itself. We encounter the second DPICHANGED message before scaling the font, resulting in incorrect font information.

This pull request addresses the issue by fixing the order of operations and also disposing of fonts that are no longer needed.

Created a new issue to further investigate DefaultFont and DPI combination in WInForms. https://github.com/dotnet/winforms/issues/9111

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9112)