### PR TITLE
Fix ToolStripButton errors in Accessibility Insights

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripButton.ToolStripButtonAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripButton.ToolStripButtonAccessibleObject.cs
@@ -70,7 +70,7 @@ public partial class ToolStripButton
 
         internal override void Toggle()
         {
-            if (_ownerItem.CheckOnClick)
+            if (IsPatternSupported(UiaCore.UIA.TogglePatternId))
             {
                 _ownerItem.Checked = !_ownerItem.Checked;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripButton.ToolStripButtonAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripButton.ToolStripButtonAccessibleObject.cs
@@ -20,18 +20,6 @@ public partial class ToolStripButton
             _ownerItem = ownerItem;
         }
 
-        internal override object? GetPropertyValue(UiaCore.UIA propertyID) =>
-            propertyID switch
-            {
-                // If we don't set a default role for the accessible object
-                // it will be retrieved from Windows.
-                // And we don't have a 100% guarantee it will be correct, hence set it ourselves.
-                UiaCore.UIA.ControlTypePropertyId when
-                    _ownerItem.CheckOnClick
-                    => UiaCore.UIA.ButtonControlTypeId,
-                _ => base.GetPropertyValue(propertyID)
-            };
-
         internal override bool IsPatternSupported(UiaCore.UIA patternId) =>
             patternId switch
             {
@@ -43,7 +31,13 @@ public partial class ToolStripButton
         {
             get
             {
-                if (_ownerItem.CheckOnClick)
+                AccessibleRole role = _ownerItem.AccessibleRole;
+                if (role != AccessibleRole.Default)
+                {
+                    return role;
+                }
+
+                if (_ownerItem.CheckOnClick || _ownerItem.Checked)
                 {
                     return AccessibleRole.CheckButton;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripButton.ToolStripButtonAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripButton.ToolStripButtonAccessibleObject.cs
@@ -23,7 +23,7 @@ public partial class ToolStripButton
         internal override bool IsPatternSupported(UiaCore.UIA patternId) =>
             patternId switch
             {
-                UiaCore.UIA.TogglePatternId => _ownerItem.CheckOnClick || _ownerItem.Checked,
+                UiaCore.UIA.TogglePatternId => Role == AccessibleRole.CheckButton,
                 _ => base.IsPatternSupported(patternId)
             };
 

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ToolStripTests.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ToolStripTests.Designer.cs
@@ -47,6 +47,7 @@ partial class ToolStripTests
         this.toolStrip2_Button3 = new System.Windows.Forms.ToolStripButton();
         this.toolStrip2_Button4 = new System.Windows.Forms.ToolStripButton();
         this.toolStrip2_Button5 = new System.Windows.Forms.ToolStripButton();
+        this.toolStrip2_Button6 = new System.Windows.Forms.ToolStripButton();
         this.toolStrip2_SplitButton1 = new System.Windows.Forms.ToolStripSplitButton();
         this.toolStrip2_DropDownButton1 = new System.Windows.Forms.ToolStripDropDownButton();
         this.toolStrip2_DropDownButton1_ChildButton1 = new System.Windows.Forms.ToolStripMenuItem();
@@ -80,6 +81,7 @@ partial class ToolStripTests
         this.toolStrip2_Button3,
         this.toolStrip2_Button4,
         this.toolStrip2_Button5,
+        this.toolStrip2_Button6,
         this.toolStrip2_SplitButton1,
         this.toolStrip2_DropDownButton1,});
         this.toolStrip2.Location = new System.Drawing.Point(0, 22);
@@ -129,6 +131,13 @@ partial class ToolStripTests
         this.toolStrip2_Button5.Name = "toolStrip2_Button5";
         this.toolStrip2_Button5.Size = new System.Drawing.Size(114, 22);
         this.toolStrip2_Button5.Text = "toolStrip2_Button5";
+        // 
+        // toolStrip2_Button6
+        //
+        this.toolStrip2_Button6.AccessibleRole = AccessibleRole.CheckButton;
+        this.toolStrip2_Button6.Name = "toolStrip2_Button6";
+        this.toolStrip2_Button6.Size = new System.Drawing.Size(114, 22);
+        this.toolStrip2_Button6.Text = "CheckButton role";
         // 
         // toolStrip2_SplitButton1_ChildButton1
         // 
@@ -271,6 +280,7 @@ partial class ToolStripTests
     private System.Windows.Forms.ToolStripButton toolStrip2_Button3;
     private System.Windows.Forms.ToolStripButton toolStrip2_Button4;
     private System.Windows.Forms.ToolStripButton toolStrip2_Button5;
+    private System.Windows.Forms.ToolStripButton toolStrip2_Button6;
     private System.Windows.Forms.ToolStripSplitButton toolStrip2_SplitButton1;
     private System.Windows.Forms.ToolStripDropDownButton toolStrip2_DropDownButton1;
     private System.Windows.Forms.ToolStripMenuItem toolStrip2_DropDownButton1_ChildButton1;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripButton.ToolStripButtonAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripButton.ToolStripButtonAccessibleObjectTests.cs
@@ -142,6 +142,19 @@ public class ToolStripButton_ToolStripButtonAccessibleObjectTests
         Assert.Equal(expected, actual);
     }
 
+    [WinFormsFact]
+    public void ToolStripButtonAccessibleObject_IsTogglePatternSupported_ReturnsTrue_IfAccessibleRoleIsCheckButton()
+    {
+        using ToolStripButton toolStripButton = new()
+        {
+            AccessibleRole = AccessibleRole.CheckButton
+        };
+
+        object actual = toolStripButton.AccessibilityObject.IsPatternSupported(UiaCore.UIA.TogglePatternId);
+
+        Assert.Equal(true, actual);
+    }
+
     [WinFormsTheory]
     [InlineData(CheckState.Checked, (int)UiaCore.ToggleState.On)]
     [InlineData(CheckState.Unchecked, (int)UiaCore.ToggleState.Off)]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripButton.ToolStripButtonAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripButton.ToolStripButtonAccessibleObjectTests.cs
@@ -12,8 +12,8 @@ public class ToolStripButton_ToolStripButtonAccessibleObjectTests
     [WinFormsFact]
     public void ToolStripButtonAccessibleObject_Ctor_Default()
     {
-        using ToolStripButton toolStripButton = new ToolStripButton();
-        ToolStripButtonAccessibleObject accessibleObject = new ToolStripButtonAccessibleObject(toolStripButton);
+        using ToolStripButton toolStripButton = new();
+        ToolStripButtonAccessibleObject accessibleObject = new(toolStripButton);
 
         Assert.Equal(toolStripButton, accessibleObject.Owner);
     }
@@ -21,7 +21,7 @@ public class ToolStripButton_ToolStripButtonAccessibleObjectTests
     [WinFormsFact]
     public void ToolStripButtonAccessibleObject_ControlType_IsButton_IfAccessibleRoleIsDefault()
     {
-        using ToolStripButton toolStripButton = new ToolStripButton();
+        using ToolStripButton toolStripButton = new();
         // AccessibleRole is not set = Default
 
         object actual = toolStripButton.AccessibilityObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId);
@@ -32,12 +32,38 @@ public class ToolStripButton_ToolStripButtonAccessibleObjectTests
     [WinFormsFact]
     public void ToolStripButtonAccessibleObject_Role_IsPushButton_ByDefault()
     {
-        using ToolStripButton toolStripButton = new ToolStripButton();
+        using ToolStripButton toolStripButton = new();
         // AccessibleRole is not set = Default
 
         AccessibleRole actual = toolStripButton.AccessibilityObject.Role;
 
         Assert.Equal(AccessibleRole.PushButton, actual);
+    }
+
+    [WinFormsFact]
+    public void ToolStripButtonAccessibleObject_Role_IsCheckButton_IfCheckOnClick()
+    {
+        using ToolStripButton toolStripButton = new()
+        {
+            CheckOnClick = true
+        };
+
+        AccessibleRole actual = toolStripButton.AccessibilityObject.Role;
+
+        Assert.Equal(AccessibleRole.CheckButton, actual);
+    }
+
+    [WinFormsFact]
+    public void ToolStripButtonAccessibleObject_Role_IsCheckButton_IfChecked()
+    {
+        using ToolStripButton toolStripButton = new()
+        {
+            Checked = true
+        };
+
+        AccessibleRole actual = toolStripButton.AccessibilityObject.Role;
+
+        Assert.Equal(AccessibleRole.CheckButton, actual);
     }
 
     public static IEnumerable<object[]> ToolStripButtonAccessibleObject_GetPropertyValue_ControlType_IsExpected_ForCustomRole_TestData()
@@ -59,7 +85,7 @@ public class ToolStripButton_ToolStripButtonAccessibleObjectTests
     [MemberData(nameof(ToolStripButtonAccessibleObject_GetPropertyValue_ControlType_IsExpected_ForCustomRole_TestData))]
     public void ToolStripButtonAccessibleObject_GetPropertyValue_ControlType_IsExpected_ForCustomRole(AccessibleRole role)
     {
-        using ToolStripButton toolStripButton = new ToolStripButton();
+        using ToolStripButton toolStripButton = new();
         toolStripButton.AccessibleRole = role;
 
         object actual = toolStripButton.AccessibilityObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId);
@@ -68,16 +94,30 @@ public class ToolStripButton_ToolStripButtonAccessibleObjectTests
         Assert.Equal(expected, actual);
     }
 
-    [WinFormsTheory]
-    [MemberData(nameof(ToolStripButtonAccessibleObject_GetPropertyValue_ControlType_IsExpected_ForCustomRole_TestData))]
-    public void ToolStripButtonAccessibleObject_GetPropertyValue_ControlType_IsButton_ForCustomRole_IfCheckOnClick(AccessibleRole role)
+    [WinFormsFact]
+    public void ToolStripButtonAccessibleObject_GetPropertyValue_ControlType_IsCheckBox_IfCheckOnClick()
     {
-        using ToolStripButton toolStripButton = new ToolStripButton();
-        toolStripButton.CheckOnClick = true;
-        toolStripButton.AccessibleRole = role;
+        using ToolStripButton toolStripButton = new()
+        {
+            CheckOnClick = true
+        };
 
         object actual = toolStripButton.AccessibilityObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId);
-        UiaCore.UIA expected = UiaCore.UIA.ButtonControlTypeId;
+        UiaCore.UIA expected = UiaCore.UIA.CheckBoxControlTypeId;
+
+        Assert.Equal(expected, actual);
+    }
+
+    [WinFormsFact]
+    public void ToolStripButtonAccessibleObject_GetPropertyValue_ControlType_IsCheckBox_IfChecked()
+    {
+        using ToolStripButton toolStripButton = new()
+        {
+            Checked = true
+        };
+
+        object actual = toolStripButton.AccessibilityObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId);
+        UiaCore.UIA expected = UiaCore.UIA.CheckBoxControlTypeId;
 
         Assert.Equal(expected, actual);
     }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripButton.ToolStripButtonAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripButton.ToolStripButtonAccessibleObjectTests.cs
@@ -195,4 +195,17 @@ public class ToolStripButton_ToolStripButtonAccessibleObjectTests
 
         Assert.Equal(0, clickCounter);
     }
+
+    [WinFormsFact]
+    public void ToolStripButtonAccessibleObject_Toggle_DoesNotChangeChecked_IfTogglePatternNotSupported()
+    {
+        using ToolStripButton toolStripButton = new();
+
+        Assert.False(toolStripButton.AccessibilityObject.IsPatternSupported(UiaCore.UIA.TogglePatternId));
+        Assert.False(toolStripButton.Checked);
+
+        toolStripButton.AccessibilityObject.Toggle();
+
+        Assert.False(toolStripButton.Checked);
+    }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripButtonTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripButtonTests.cs
@@ -1038,28 +1038,11 @@ public partial class ToolStripButtonTests
         Assert.NotSame(accessibleObject, item.AccessibilityObject);
     }
 
-    [WinFormsFact]
-    public void ToolStripButton_CreateAccessibilityInstance_InvokeCheckOnClickWithCustomRole_ReturnsExpected()
-    {
-        using var item = new SubToolStripButton
-        {
-            CheckOnClick = true,
-            AccessibleRole = AccessibleRole.HelpBalloon
-        };
-        ToolStripItem.ToolStripItemAccessibleObject accessibleObject = Assert.IsAssignableFrom<ToolStripItem.ToolStripItemAccessibleObject>(item.CreateAccessibilityInstance());
-        Assert.Equal(AccessibleRole.CheckButton, accessibleObject.Role);
-        Assert.Equal(AccessibleStates.Focusable, accessibleObject.State);
-        Assert.NotSame(accessibleObject, item.CreateAccessibilityInstance());
-        Assert.NotSame(accessibleObject, item.AccessibilityObject);
-    }
-
     [WinFormsTheory]
     [InlineData(true, CheckState.Checked, AccessibleStates.Focusable | AccessibleStates.Checked)]
     [InlineData(true, CheckState.Indeterminate, AccessibleStates.Focusable | AccessibleStates.Checked)]
-    [InlineData(true, CheckState.Unchecked, AccessibleStates.Focusable)]
     [InlineData(false, CheckState.Checked, AccessibleStates.None)]
     [InlineData(false, CheckState.Indeterminate, AccessibleStates.None)]
-    [InlineData(false, CheckState.Unchecked, AccessibleStates.None)]
     public void ToolStripButton_CreateAccessibilityInstance_InvokeChecked_ReturnsExpected(bool enabled, CheckState checkState, AccessibleStates expectedState)
     {
         using var item = new SubToolStripButton
@@ -1068,7 +1051,7 @@ public partial class ToolStripButtonTests
             CheckState = checkState
         };
         ToolStripItem.ToolStripItemAccessibleObject accessibleObject = Assert.IsAssignableFrom<ToolStripItem.ToolStripItemAccessibleObject>(item.CreateAccessibilityInstance());
-        Assert.Equal(AccessibleRole.PushButton, accessibleObject.Role);
+        Assert.Equal(AccessibleRole.CheckButton, accessibleObject.Role);
         Assert.Equal(expectedState, accessibleObject.State);
         Assert.NotSame(accessibleObject, item.CreateAccessibilityInstance());
         Assert.NotSame(accessibleObject, item.AccessibilityObject);


### PR DESCRIPTION
Fixes #9108

## Proposed changes

* Changed ControlType for checkable/checked `ToolStripButton` from `Button` to `CheckBox` to allow having both Toggle and Invoke patterns. We cannot remove Invoke pattern for compatibility reasons, and Toggle pattern is needed to announce checked state. This is done by removing hardcoded `Button` type.
* Extend condition on which accessible object will get `CheckButton` role to include buttons with only `Checked = true` (without `CheckOnClick = true`), so that screen readers can also announce it as "checked";
* Allow setting custom role even if button is checkable/checked. For instance, this enables setting `RadioButton` role for `PropertyGridToolStripButton`, which can have `Checked = true` but shouldn't have `CheckBox` type because it doesn't behave like one.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- No errors in Accessibility Insights for ToolStripButton
- Screen readers announce checked/checkable ToolStripButton as "check box" instead of "button". 

## Regression? 

- Yes

## Risk

- Low. Change in screen reader announcement from "button" to "check box" may be somewhat confusing for users.

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![A screenshot of Accessibility Insights app showing test pass with 5 errors for a form with different ToolStripButtons](https://github.com/dotnet/winforms/assets/102954094/809cc911-5a21-4366-b402-a0cda41a3fd2)

### After

![A screenshot of Accessibility Insights app showing test pass without errors for a form with different ToolStripButtons](https://github.com/dotnet/winforms/assets/102954094/22fe9bd8-2056-40af-9382-9409ee8340b2)
![A screenshot of Accessibility Insights app showing that both Invoke and Toggle patterns are supported](https://github.com/dotnet/winforms/assets/102954094/5ca21aab-358c-43c3-8d6b-f583a778d956)


## Test methodology <!-- How did you ensure quality? -->

- Unit tests
- Manual

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

Narrator announcements for ToolStripButtons from StripControls form in Accessibility Core test app:

#### Before

> New, button, Alt+ n, 
> Unchecked_CheckOnClick(F), button, 
> Unchecked_CheckOnClick(T), button, off, 
> Checked_CheckOnClick(T), button, on, 
> Checked_CheckOnClick(F), button, on, 
> Indeterminate_CheckOnClick(T), button, indeterminate, 
> Indeterminate_CheckOnClick(F), button, indeterminate, 

#### After

> New, button, Alt+ n, 
> Unchecked_CheckOnClick(F), button, 
> Unchecked_CheckOnClick(T) check box unchecked, 
> Checked_CheckOnClick(T) check box checked, 
> Checked_CheckOnClick(F) check box checked, 
> Indeterminate_CheckOnClick(T) check box indeterminate, 
> Indeterminate_CheckOnClick(F) check box indeterminate, 

 Tooltip announcements are removed for brevity. Similar result in JAWS and NVDA.

## Test environment(s) <!-- Remove any that don't apply -->

- .NET 8.0.0-preview.5.23260.3
- Win 11


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9115)