### PR TITLE
Handle WM_DPICHANGED_BEFOREPARENT message for the Form in design scenarios

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DpiChangedEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DpiChangedEventArgs.cs
@@ -23,11 +23,17 @@ public sealed class DpiChangedEventArgs : CancelEventArgs
         SuggestedRectangle = *(RECT*)(nint)m.LParamInternal;
     }
 
+    internal DpiChangedEventArgs(int oldDpi, int newDpi)
+    {
+        DeviceDpiOld = oldDpi;
+        DeviceDpiNew = newDpi;
+    }
+
     public int DeviceDpiOld { get; }
 
     public int DeviceDpiNew { get; }
 
-    public Rectangle SuggestedRectangle { get; }
+    public Rectangle SuggestedRectangle { get; internal set; }
 
     public override string ToString() => $"was: {DeviceDpiOld}, now: {DeviceDpiNew}";
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -4339,6 +4339,19 @@ public partial class Form : ContainerControl
         remove => Events.RemoveHandler(EVENT_DPI_CHANGED, value);
     }
 
+    internal void FormDpiChangedBeforeParent(int oldDpi, int newDpi)
+    {
+        DpiChangedEventArgs e = new DpiChangedEventArgs(oldDpi, newDpi);
+        Size desiredSize = Size.Empty;
+        if (!OnGetDpiScaledSize(e.DeviceDpiOld, e.DeviceDpiNew, ref desiredSize) || desiredSize.IsEmpty)
+        {
+            Debug.Assert(false, $"Form's size could not be calculated for the DPI: {newDpi}");
+        }
+
+        e.SuggestedRectangle = new Rectangle(Location, desiredSize);
+        OnDpiChanged(e);
+    }
+
     /// <summary>
     ///  Handles the WM_DPICHANGED message
     /// </summary>
@@ -4363,7 +4376,7 @@ public partial class Form : ContainerControl
         Font fontForDpi = GetScaledFont(Font, deviceDpiNew, deviceDpiOld);
 
         // If AutoScaleMode=AutoScaleMode.Dpi then we continue with the linear size we get from Windows for the top-level window.
-        if (AutoScaleMode == AutoScaleMode.Dpi)
+        if (AutoScaleMode == AutoScaleMode.Dpi && !DesignMode)
         {
             return false;
         }


### PR DESCRIPTION
During runtime scenarios in a WinForms application, the main Form is considered a top-level window. Consequently, it will only receive the WM_DPICHANGED message in PermonitorV2 applications. On the other hand, child controls within the Form will receive both WM_DPICHANGED_BEFOREPARENT and WM_DPICHANGED_AFTERPARENT messages.

However, in WinForms designer scenarios, the Form behaves differently. It functions as a child window hosted within Visual Studio. As a result, during design-time, the Form will receive WM_DPICHANGED_BEFOREPARENT and WM_DPICHANGED_AFTERPARENT messages instead of WM_DPICHANGED, just like any other child controls would.

This is applicable only to the WinForms designer scenarios.

Fixes #https://github.com/microsoft/winforms-designer/issues/5192

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9116)