### PR TITLE
Fixed IAccessible.get_accRole method for non-client AccessibleObject.…

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
@@ -1569,7 +1569,7 @@ public unsafe partial class AccessibleObject :
         int count = SystemIAccessible.TryGetChildCount();
 
         // Unclear why this returns null for no children.
-        return (count == 0 || childID is not int id) ? null : SystemIAccessible.TryGetRole(id);
+        return count == 0 ? null : SystemIAccessible.TryGetRole(ChildIdToVARIANT(childID));
     }
 
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
@@ -1569,7 +1569,7 @@ public unsafe partial class AccessibleObject :
         int count = SystemIAccessible.TryGetChildCount();
 
         // Unclear why this returns null for no children.
-        return count == 0 ? null : count;
+        return (count == 0 || childID is not int id) ? null : SystemIAccessible.TryGetRole(id);
     }
 
     /// <summary>

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjectTests.cs
@@ -2048,15 +2048,13 @@ public partial class AccessibleObjectTests
     [WinFormsFact]
     public void AccessibleObject_IAccessibleget_accRole_InvokeDefaultSelfNotAClientObject_ReturnsExpected()
     {
-        int childID = (int)PInvoke.CHILDID_SELF;
-
         using Control control = new();
         control.CreateControl();
 
         AccessibleObject accessibleObject = control.TestAccessor().Dynamic.NcAccessibilityObject;
 
         IAccessible iAccessible = accessibleObject;
-        Assert.Equal(AccessibleRole.Window, iAccessible.get_accRole(childID));
+        Assert.Equal(AccessibleRole.Window, iAccessible.get_accRole((int)PInvoke.CHILDID_SELF));
         Assert.True(control.IsHandleCreated);
     }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjectTests.cs
@@ -2053,9 +2053,7 @@ public partial class AccessibleObjectTests
         using Control control = new();
         control.CreateControl();
 
-        var accessibleObject = new SubAccessibleObject();
-        accessibleObject.UseStdAccessibleObjects(control.Handle, childID);
-        accessibleObject.AccessibleObjectId = User32.OBJID.WINDOW; 
+        AccessibleObject accessibleObject = control.TestAccessor().Dynamic.NcAccessibilityObject;
 
         IAccessible iAccessible = accessibleObject;
         Assert.Equal(AccessibleRole.Window, iAccessible.get_accRole(childID));

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjectTests.cs
@@ -2045,6 +2045,23 @@ public partial class AccessibleObjectTests
         mockAccessibleObject.Verify(a => a.Role, Times.Once());
     }
 
+    [WinFormsFact]
+    public void AccessibleObject_IAccessibleget_accRole_InvokeDefaultSelfNotAClientObject_ReturnsExpected()
+    {
+        int childID = (int)PInvoke.CHILDID_SELF;
+
+        using Control control = new Control();
+        control.CreateControl();
+
+        var accessibleObject = new SubAccessibleObject();
+        accessibleObject.UseStdAccessibleObjects(control.Handle, childID);
+        accessibleObject.AccessibleObjectId = User32.OBJID.WINDOW; 
+
+        IAccessible iAccessible = accessibleObject;
+        Assert.Equal(AccessibleRole.Window, iAccessible.get_accRole(childID));
+        Assert.True(control.IsHandleCreated);
+    }
+
     [WinFormsTheory]
     [InlineData(AccessibleRole.None, 2, 1, 0)]
     [InlineData(AccessibleRole.Default, 2, 1, 0)]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjectTests.cs
@@ -2050,7 +2050,7 @@ public partial class AccessibleObjectTests
     {
         int childID = (int)PInvoke.CHILDID_SELF;
 
-        using Control control = new Control();
+        using Control control = new();
         control.CreateControl();
 
         var accessibleObject = new SubAccessibleObject();


### PR DESCRIPTION
Fixes #9096

## Proposed changes

- Fixed `AccessibleObject.get_accRole(object childID)` for the case of non-client objects
- Added a unit test for that case

<!-- We are in TELL-MODE the following section must be completed -->

## Regression? 

- Yes

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
![before](https://github.com/dotnet/winforms/assets/113603457/739a667a-fdc6-4c21-9a43-405bb1d24284)


### After
![after](https://github.com/dotnet/winforms/assets/113603457/5b44aecb-ca27-4b2a-bb59-1a4a8b2cbdee)


## Test environment(s) <!-- Remove any that don't apply -->

- .NET 8.0.0-alpha.1.23057.5
- Inspect Object 7.2

<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9122)