### PR TITLE
Remove unused controlToPushAside variable

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanelRow.HorizontalRowManager.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanelRow.HorizontalRowManager.cs
@@ -443,7 +443,6 @@ public partial class ToolStripPanelRow
                             }
                         }
 
-                        Control controlToPushAside = Row.ControlsInternal[index];
                         // Plop the new control in the midst of the row in question.
                         if (index < Row.ControlsInternal.Count)
                         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanelRow.VerticalRowManager.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanelRow.VerticalRowManager.cs
@@ -452,7 +452,6 @@ public partial class ToolStripPanelRow
                             }
                         }
 
-                        Control controlToPushAside = Row.ControlsInternal[index];
                         // Plop the new control in the midst of the row in question.
                         if (index < Row.ControlsInternal.Count)
                         {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripPanelRow.ToolStripPanelRowControlCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripPanelRow.ToolStripPanelRowControlCollectionTests.cs
@@ -1,0 +1,42 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Drawing;
+
+namespace System.Windows.Forms.Tests;
+
+public class ToolStripPanelRowControlCollectionTests
+{
+    [WinFormsFact]
+    public void GetControl_ShouldNotThrowIndexOutOfRangeException()
+    {
+        // https://github.com/dotnet/winforms/issues/9126
+        using Form form = new();
+        using ToolStripContainer toolStripContainer = new();
+        using ToolStrip toolStrip1 = new();
+        using ToolStrip toolStrip2 = new();
+
+        toolStripContainer.TopToolStripPanel.SuspendLayout();
+        toolStripContainer.SuspendLayout();
+        form.SuspendLayout();
+
+        toolStripContainer.TopToolStripPanel.Controls.Add(toolStrip1);
+        toolStripContainer.TopToolStripPanel.Controls.Add(toolStrip2);
+
+        toolStrip1.Location = new Point(3, 0);
+        toolStrip2.Location = new Point(148, 0);
+
+        form.Controls.Add(toolStripContainer);
+        toolStripContainer.TopToolStripPanel.ResumeLayout(false);
+        toolStripContainer.TopToolStripPanel.PerformLayout();
+        toolStripContainer.ResumeLayout(false);
+        toolStripContainer.PerformLayout();
+        form.ResumeLayout(false);
+
+        var exception = Record.Exception(() => form.Show());
+
+        Assert.Null(exception);
+    }
+}
+


### PR DESCRIPTION
## Proposed changes

- Add test from https://github.com/dotnet/winforms/issues/9126
- Remove unused controlToPushAside variable

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9131)