### PR TITLE
Fixed PrintPreviewControlAccessibleObject.Bounds

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/PrintPreviewControl.PrintPreviewControlAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PrintPreviewControl.PrintPreviewControlAccessibleObject.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Drawing;
 using static Interop;
 
 namespace System.Windows.Forms;
@@ -25,5 +26,10 @@ public partial class PrintPreviewControl
                 UiaCore.UIA.IsKeyboardFocusablePropertyId => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,
                 _ => base.GetPropertyValue(propertyID)
             };
+
+        public override Rectangle Bounds
+            => _owningPrintPreviewControl.IsHandleCreated && _owningPrintPreviewControl.Parent is not null
+                        ? _owningPrintPreviewControl.Parent.RectangleToScreen(_owningPrintPreviewControl.Bounds)
+                        : Rectangle.Empty;
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PrintPreviewControl.PrintPreviewControlAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PrintPreviewControl.PrintPreviewControlAccessibleObject.cs
@@ -29,7 +29,7 @@ public partial class PrintPreviewControl
 
         public override Rectangle Bounds
             => _owningPrintPreviewControl.IsHandleCreated && _owningPrintPreviewControl.Parent is not null
-                        ? _owningPrintPreviewControl.Parent.RectangleToScreen(_owningPrintPreviewControl.Bounds)
-                        : Rectangle.Empty;
+                ? _owningPrintPreviewControl.Parent.RectangleToScreen(_owningPrintPreviewControl.Bounds)
+                : Rectangle.Empty;
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #8892


## Proposed changes

- Override `AccessibleObject.Bounds` property for `PrintPreviewControlAccessibleObject`

<!-- We are in TELL-MODE the following section must be completed -->

## Regression? 

- No

## Risk

- Mininmal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
![Before](https://github.com/dotnet/winforms/assets/113603457/90c8a790-22be-4672-bb52-4acf99b1a9aa)

### After

![After](https://github.com/dotnet/winforms/assets/113603457/e40bc0f6-abc3-4fce-8578-72db03b6b1df)



## Test environment(s) <!-- Remove any that don't apply -->

- NET 8.0.0-preview.4.23259.5
- Accessibility Insights 1.1.2213.1

<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9136)