### PR TITLE
Added ToggleStatePropertyChanged UIA event for ToolStripButton.

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripButton.ToolStripButtonAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripButton.ToolStripButtonAccessibleObject.cs
@@ -76,8 +76,21 @@ public partial class ToolStripButton
             }
         }
 
-        internal override UiaCore.ToggleState ToggleState =>
-            _ownerItem.CheckState switch
+        internal override UiaCore.ToggleState ToggleState
+            => CheckedStateToToggleState(_ownerItem.CheckState);
+
+        internal void OnCheckStateChanged(CheckState oldValue, CheckState newValue)
+        {
+            RaiseAutomationPropertyChangedEvent(
+                UiaCore.UIA.ToggleToggleStatePropertyId,
+                CheckedStateToToggleState(oldValue),
+                CheckedStateToToggleState(newValue));
+
+            RaiseAutomationEvent(UiaCore.UIA.AutomationPropertyChangedEventId);
+        }
+
+        private static UiaCore.ToggleState CheckedStateToToggleState(CheckState checkState)
+            => checkState switch
             {
                 CheckState.Checked => UiaCore.ToggleState.On,
                 CheckState.Unchecked => UiaCore.ToggleState.Off,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripButton.ToolStripButtonAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripButton.ToolStripButtonAccessibleObject.cs
@@ -77,19 +77,17 @@ public partial class ToolStripButton
         }
 
         internal override UiaCore.ToggleState ToggleState
-            => CheckedStateToToggleState(_ownerItem.CheckState);
+            => CheckStateToToggleState(_ownerItem.CheckState);
 
         internal void OnCheckStateChanged(CheckState oldValue, CheckState newValue)
         {
             RaiseAutomationPropertyChangedEvent(
                 UiaCore.UIA.ToggleToggleStatePropertyId,
-                CheckedStateToToggleState(oldValue),
-                CheckedStateToToggleState(newValue));
-
-            RaiseAutomationEvent(UiaCore.UIA.AutomationPropertyChangedEventId);
+                CheckStateToToggleState(oldValue),
+                CheckStateToToggleState(newValue));
         }
 
-        private static UiaCore.ToggleState CheckedStateToToggleState(CheckState checkState)
+        private static UiaCore.ToggleState CheckStateToToggleState(CheckState checkState)
             => checkState switch
             {
                 CheckState.Checked => UiaCore.ToggleState.On,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripButton.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripButton.cs
@@ -12,6 +12,7 @@ namespace System.Windows.Forms;
 public partial class ToolStripButton : ToolStripItem
 {
     private CheckState _checkState = CheckState.Unchecked;
+    private CheckState _prevCheckState = CheckState.Unchecked;
     private const int StandardButtonWidth = 23;
     private int _standardButtonWidth = StandardButtonWidth;
 
@@ -102,6 +103,7 @@ public partial class ToolStripButton : ToolStripItem
 
             if (value != _checkState)
             {
+                _prevCheckState = _checkState;
                 _checkState = value;
                 Invalidate();
                 OnCheckedChanged(EventArgs.Empty);
@@ -184,6 +186,13 @@ public partial class ToolStripButton : ToolStripItem
     protected virtual void OnCheckStateChanged(EventArgs e)
     {
         AccessibilityNotifyClients(AccessibleEvents.StateChange);
+
+        if (IsAccessibilityObjectCreated &&
+            AccessibilityObject is ToolStripButtonAccessibleObject accessibilityObject)
+        {
+            accessibilityObject.OnCheckStateChanged(_prevCheckState, _checkState);
+        }
+
         ((EventHandler?)Events[s_checkStateChangedEvent])?.Invoke(this, e);
     }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #9137


## Proposed changes

- Fire ToggleStatePropertyChanged UIA event when ToolStripButton's `CheckState` changes.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Screen readers announce checked state change of ToolStripButton

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

https://github.com/dotnet/winforms/assets/113603457/525781bb-2a75-4fe2-8fe8-ab863141f90c

Narrator output:
> ToolStripTests window, toolStrip1 tool bar, Checkable button (unchecked) check box unchecked,

Notice that nothing is announced when button is checked or unchecked.

### After


<!-- TODO -->

https://github.com/dotnet/winforms/assets/113603457/c986f680-aecb-4754-9de5-50f9b2f4e2c2
Narrator output:
> ToolStripTests window, toolStrip1 tool bar, Checkable button (unchecked) check box unchecked,
> checked
> unchecked
> checked
> unchecked

## Test environment(s) <!-- Remove any that don't apply -->

- ,NET  8.0.0-preview.4.23259.5


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9142)