### PR TITLE
Complete binary format object round-tripping

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/Collections/Generic/ListConverter.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Collections/Generic/ListConverter.cs
@@ -13,24 +13,24 @@ namespace System.Collections.Generic;
 ///   through the list this class should usually be avoided.
 ///  </para>
 /// </remarks>
-internal class ListConverter<TIn, TOut> : IReadOnlyList<TOut>
+internal class ListConverter<TIn> : IReadOnlyList<object>
 {
-    private readonly IReadOnlyList<TIn> _values;
-    private readonly Func<TIn, TOut> _converter;
+    private readonly IList _values;
+    private readonly Func<TIn, object> _converter;
 
-    public ListConverter(IReadOnlyList<TIn> values, Func<TIn, TOut> conveter)
+    public ListConverter(IList values, Func<TIn, object> converter)
     {
         _values = values;
-        _converter = conveter;
+        _converter = converter;
     }
 
-    public TOut this[int index] => _converter(_values[index]);
+    public object this[int index] => _converter((TIn)_values[index]!);
 
     public int Count => _values.Count;
 
     // Saving a little bit of code by not writing an enumerator. It isn't huge, so this can be
     // added if needed.
 
-    IEnumerator<TOut> IEnumerable<TOut>.GetEnumerator() => throw new NotImplementedException();
+    IEnumerator<object> IEnumerable<object>.GetEnumerator() => throw new NotImplementedException();
     IEnumerator IEnumerable.GetEnumerator() => throw new NotImplementedException();
 }

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/BinaryFormatWriter.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/BinaryFormatWriter.cs
@@ -196,10 +196,10 @@ internal static class BinaryFormatWriter
             switch (primitive)
             {
                 case nint nativeInt:
-                    WritePrimitive(stream, nativeInt);
+                    WriteNativeInt(stream, nativeInt);
                     return;
                 case nuint nativeUint:
-                    WritePrimitive(stream, nativeUint);
+                    WriteNativeUInt(stream, nativeUint);
                     return;
             }
 

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/BinaryFormattedObjectExtensions.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/BinaryFormattedObjectExtensions.cs
@@ -319,6 +319,51 @@ internal static class BinaryFormattedObjectExtensions
     }
 
     /// <summary>
+    ///  Tries to get this object as an <see cref="Array"/> of primitive types.
+    /// </summary>
+    public static bool TryGetPrimitiveArray(this BinaryFormattedObject format, [NotNullWhen(true)] out object? value)
+    {
+        value = null;
+        if (format.RecordCount != 3)
+        {
+            return false;
+        }
+
+        if (format[1] is ArraySingleString stringArray)
+        {
+            value = format.GetStringValues(stringArray, stringArray.Length).ToArray();
+            return true;
+        }
+
+        if (format[1] is not ArraySinglePrimitive primitiveArray)
+        {
+            return false;
+        }
+
+        value = primitiveArray.PrimitiveType switch
+        {
+            PrimitiveType.Boolean => primitiveArray.ArrayObjects.Cast<bool>().ToArray(),
+            PrimitiveType.Byte => primitiveArray.ArrayObjects.Cast<byte>().ToArray(),
+            PrimitiveType.Char => primitiveArray.ArrayObjects.Cast<char>().ToArray(),
+            PrimitiveType.Decimal => primitiveArray.ArrayObjects.Cast<decimal>().ToArray(),
+            PrimitiveType.Double => primitiveArray.ArrayObjects.Cast<double>().ToArray(),
+            PrimitiveType.Int16 => primitiveArray.ArrayObjects.Cast<short>().ToArray(),
+            PrimitiveType.Int32 => primitiveArray.ArrayObjects.Cast<int>().ToArray(),
+            PrimitiveType.Int64 => primitiveArray.ArrayObjects.Cast<long>().ToArray(),
+            PrimitiveType.SByte => primitiveArray.ArrayObjects.Cast<sbyte>().ToArray(),
+            PrimitiveType.Single => primitiveArray.ArrayObjects.Cast<float>().ToArray(),
+            PrimitiveType.TimeSpan => primitiveArray.ArrayObjects.Cast<TimeSpan>().ToArray(),
+            PrimitiveType.DateTime => primitiveArray.ArrayObjects.Cast<DateTime>().ToArray(),
+            PrimitiveType.UInt16 => primitiveArray.ArrayObjects.Cast<ushort>().ToArray(),
+            PrimitiveType.UInt32 => primitiveArray.ArrayObjects.Cast<uint>().ToArray(),
+            PrimitiveType.UInt64 => primitiveArray.ArrayObjects.Cast<ulong>().ToArray(),
+            _ => null
+        };
+
+        return value is not null;
+    }
+
+    /// <summary>
     ///  Trys to get this object as a binary formatted <see cref="Hashtable"/> of <see cref="PrimitiveType"/> keys and values.
     /// </summary>
     public static bool TryGetPrimitiveHashtable(this BinaryFormattedObject format, [NotNullWhen(true)] out Hashtable? hashtable)
@@ -406,6 +451,7 @@ internal static class BinaryFormattedObjectExtensions
         [NotNullWhen(true)] out object? value)
         => format.TryGetPrimitiveType(out value)
             || format.TryGetPrimitiveList(out value)
+            || format.TryGetPrimitiveArray(out value)
             || format.TryGetPrimitiveArrayList(out value)
             || format.TryGetPrimitiveHashtable(out value)
             || format.TryGetRectangleF(out value)

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/BinaryLibrary.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/BinaryLibrary.cs
@@ -16,8 +16,14 @@ namespace System.Windows.Forms.BinaryFormat;
 /// </remarks>
 internal sealed class BinaryLibrary : IRecord<BinaryLibrary>
 {
-    public Id LibraryId;
-    public string LibraryName = string.Empty;
+    public Id LibraryId { get; }
+    public string LibraryName { get; }
+
+    public BinaryLibrary(Id libraryId, string libraryName)
+    {
+        LibraryId = libraryId;
+        LibraryName = libraryName;
+    }
 
     public static RecordType RecordType => RecordType.BinaryLibrary;
 
@@ -25,11 +31,9 @@ internal sealed class BinaryLibrary : IRecord<BinaryLibrary>
         BinaryReader reader,
         RecordMap recordMap)
     {
-        BinaryLibrary record = new()
-        {
-            LibraryId = reader.ReadInt32(),
-            LibraryName = reader.ReadString()
-        };
+        BinaryLibrary record = new(
+            reader.ReadInt32(),
+            reader.ReadString());
 
         recordMap[record.LibraryId] = record;
         return record;

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/ClassWithMembersAndTypes.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/ClassWithMembersAndTypes.cs
@@ -21,8 +21,8 @@ internal sealed class ClassWithMembersAndTypes : ClassRecord, IRecord<ClassWithM
 
     public ClassWithMembersAndTypes(
         ClassInfo classInfo,
-        MemberTypeInfo memberTypeInfo,
         Id libraryId,
+        MemberTypeInfo memberTypeInfo,
         IReadOnlyList<object> memberValues)
         : base(classInfo, memberValues)
     {
@@ -32,10 +32,10 @@ internal sealed class ClassWithMembersAndTypes : ClassRecord, IRecord<ClassWithM
 
     public ClassWithMembersAndTypes(
         ClassInfo classInfo,
-        MemberTypeInfo memberTypeInfo,
         Id libraryId,
+        MemberTypeInfo memberTypeInfo,
         params object[] memberValues)
-        : this(classInfo, memberTypeInfo, libraryId, (IReadOnlyList<object>)memberValues)
+        : this(classInfo, libraryId, memberTypeInfo, (IReadOnlyList<object>)memberValues)
     {
     }
 
@@ -50,8 +50,8 @@ internal sealed class ClassWithMembersAndTypes : ClassRecord, IRecord<ClassWithM
 
         ClassWithMembersAndTypes record = new(
             classInfo,
-            memberTypeInfo,
             reader.ReadInt32(),
+            memberTypeInfo,
             ReadValuesFromMemberTypeInfo(reader, recordMap, memberTypeInfo));
 
         // Index this record by the id of the embedded ClassInfo's object id.

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/MemberPrimitiveTyped.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/MemberPrimitiveTyped.cs
@@ -28,7 +28,7 @@ internal sealed class MemberPrimitiveTyped : Record, IRecord<MemberPrimitiveType
     /// <exception cref="ArgumentException"><paramref name="value"/> is not primitive.</exception>
     internal MemberPrimitiveTyped(object value)
     {
-        PrimitiveType primitiveType = GetPrimitiveType(value.GetType());
+        PrimitiveType primitiveType = TypeInfo.GetPrimitiveType(value.GetType());
         if (primitiveType == default)
         {
             throw new ArgumentException($"{nameof(value)} is not primitive.");

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/Record.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/Record.cs
@@ -13,34 +13,6 @@ namespace System.Windows.Forms.BinaryFormat;
 internal abstract class Record : IRecord
 {
     /// <summary>
-    ///  Returns the <see cref="PrimitiveType"/> for the given <paramref name="type"/>.
-    /// </summary>
-    /// <param name="type"></param>
-    /// <returns><see cref="PrimitiveType"/> or <see langword="default"/> if not a <see cref="PrimitiveType"/>.</returns>
-    internal static PrimitiveType GetPrimitiveType(Type type) => Type.GetTypeCode(type) switch
-    {
-        TypeCode.Boolean => PrimitiveType.Boolean,
-        TypeCode.Char => PrimitiveType.Char,
-        TypeCode.SByte => PrimitiveType.SByte,
-        TypeCode.Byte => PrimitiveType.Byte,
-        TypeCode.Int16 => PrimitiveType.Int16,
-        TypeCode.UInt16 => PrimitiveType.UInt16,
-        TypeCode.Int32 => PrimitiveType.Int32,
-        TypeCode.UInt32 => PrimitiveType.UInt32,
-        TypeCode.Int64 => PrimitiveType.Int64,
-        TypeCode.UInt64 => PrimitiveType.UInt64,
-        TypeCode.Single => PrimitiveType.Single,
-        TypeCode.Double => PrimitiveType.Double,
-        TypeCode.Decimal => PrimitiveType.Decimal,
-        TypeCode.DateTime => PrimitiveType.DateTime,
-        TypeCode.String => PrimitiveType.String,
-        // TypeCode.Empty => 0,
-        // TypeCode.Object => 0,
-        // TypeCode.DBNull => 0,
-        _ => type == typeof(TimeSpan) ? PrimitiveType.TimeSpan : default,
-    };
-
-    /// <summary>
     ///  Reads a primitive of <paramref name="primitiveType"/> from the given <paramref name="reader"/>.
     /// </summary>
     private protected static object ReadPrimitiveType(BinaryReader reader, PrimitiveType primitiveType) => primitiveType switch

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/Support/ListConverter.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/Support/ListConverter.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+
+namespace System.Windows.Forms.BinaryFormat;
+
+internal static class ListConverter
+{
+    public static ListConverter<object?> GetPrimitiveConverter(
+        IList values,
+        StringRecordsCollection strings) => new(
+            values,
+            (object? value) => value switch
+            {
+                null => ObjectNull.Instance,
+                string stringValue => strings.GetStringRecord(stringValue),
+                _ => new MemberPrimitiveTyped(value)
+            });
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/Support/StringRecordsCollection.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/Support/StringRecordsCollection.cs
@@ -13,12 +13,20 @@ internal class StringRecordsCollection
     private readonly Dictionary<string, int> _strings = new();
     private readonly Dictionary<int, MemberReference> _memberReferences = new();
 
+    public int CurrentId { get; set; }
+
+    public StringRecordsCollection(int currentId) => CurrentId = currentId;
+
     /// <summary>
     ///  Returns the appropriate record for the given string.
     /// </summary>
-    /// <param name="nextId">The id to use if needed, will be incremented if used.</param>
-    public IRecord GetStringRecord(string value, ref int nextId)
+    public IRecord GetStringRecord(string? value)
     {
+        if (value is null)
+        {
+            return ObjectNull.Instance;
+        }
+
         if (_strings.TryGetValue(value, out int id))
         {
             // The record with the data has already been retrieved, only a reference is needed now
@@ -32,9 +40,9 @@ internal class StringRecordsCollection
             return reference;
         }
 
-        _strings[value] = nextId;
-        IRecord record = new BinaryObjectString(nextId, value);
-        nextId++;
+        _strings[value] = CurrentId;
+        IRecord record = new BinaryObjectString(CurrentId, value);
+        CurrentId++;
         return record;
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/Support/TypeInfo.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/Support/TypeInfo.cs
@@ -1,0 +1,86 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms.BinaryFormat;
+
+internal static class TypeInfo
+{
+    public const string BooleanType = "System.Boolean";
+    public const string CharType = "System.Char";
+    public const string StringType = "System.String";
+    public const string SByteType = "System.SByte";
+    public const string ByteType = "System.Byte";
+    public const string Int16Type = "System.Int16";
+    public const string UInt16Type = "System.UInt16";
+    public const string Int32Type = "System.Int32";
+    public const string UInt32Type = "System.UInt32";
+    public const string Int64Type = "System.Int64";
+    public const string DecimalType = "System.Decimal";
+    public const string UInt64Type = "System.UInt64";
+    public const string SingleType = "System.Single";
+    public const string DoubleType = "System.Double";
+    public const string TimeSpanType = "System.TimeSpan";
+    public const string DateTimeType = "System.DateTime";
+    public const string IntPtrType = "System.IntPtr";
+    public const string UIntPtrType = "System.UIntPtr";
+
+    public const string MscorlibAssemblyName
+        = "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089";
+    public const string SystemDrawingAssemblyName
+        = "System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a";
+
+    /// <summary>
+    ///  Returns the <see cref="PrimitiveType"/> for the given <paramref name="typeName"/>.
+    /// </summary>
+    /// <param name="typeName"></param>
+    /// <returns></returns>
+    internal static PrimitiveType GetPrimitiveType(ReadOnlySpan<char> typeName) => typeName switch
+    {
+        BooleanType => PrimitiveType.Boolean,
+        CharType => PrimitiveType.Char,
+        SByteType => PrimitiveType.SByte,
+        ByteType => PrimitiveType.Byte,
+        Int16Type => PrimitiveType.Int16,
+        UInt16Type => PrimitiveType.UInt16,
+        Int32Type => PrimitiveType.Int32,
+        UInt32Type => PrimitiveType.UInt32,
+        Int64Type => PrimitiveType.Int64,
+        UInt64Type => PrimitiveType.UInt64,
+        SingleType => PrimitiveType.Single,
+        DoubleType => PrimitiveType.Double,
+        DecimalType => PrimitiveType.Decimal,
+        DateTimeType => PrimitiveType.DateTime,
+        StringType => PrimitiveType.String,
+        TimeSpanType => PrimitiveType.TimeSpan,
+        _ => default,
+    };
+
+    /// <summary>
+    ///  Returns the <see cref="PrimitiveType"/> for the given <paramref name="type"/>.
+    /// </summary>
+    /// <param name="type"></param>
+    /// <returns><see cref="PrimitiveType"/> or <see langword="default"/> if not a <see cref="PrimitiveType"/>.</returns>
+    internal static PrimitiveType GetPrimitiveType(Type type) => Type.GetTypeCode(type) switch
+    {
+        TypeCode.Boolean => PrimitiveType.Boolean,
+        TypeCode.Char => PrimitiveType.Char,
+        TypeCode.SByte => PrimitiveType.SByte,
+        TypeCode.Byte => PrimitiveType.Byte,
+        TypeCode.Int16 => PrimitiveType.Int16,
+        TypeCode.UInt16 => PrimitiveType.UInt16,
+        TypeCode.Int32 => PrimitiveType.Int32,
+        TypeCode.UInt32 => PrimitiveType.UInt32,
+        TypeCode.Int64 => PrimitiveType.Int64,
+        TypeCode.UInt64 => PrimitiveType.UInt64,
+        TypeCode.Single => PrimitiveType.Single,
+        TypeCode.Double => PrimitiveType.Double,
+        TypeCode.Decimal => PrimitiveType.Decimal,
+        TypeCode.DateTime => PrimitiveType.DateTime,
+        TypeCode.String => PrimitiveType.String,
+        //TypeCode.Empty => 0,
+        //TypeCode.Object => 0,
+        //TypeCode.DBNull => 0,
+        _ => type == typeof(TimeSpan) ? PrimitiveType.TimeSpan : default,
+    };
+}

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/ArrayTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/ArrayTests.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections;
+
 namespace System.Windows.Forms.BinaryFormat.Tests;
 
 public class ArrayTests
@@ -40,5 +42,40 @@ public class ArrayTests
         { new MemoryStream(new byte[] { 0x00, 0x00, 0x00 }), typeof(EndOfStreamException) },
         // Negative numbers
         { new MemoryStream(new byte[] { 0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF }), typeof(ArgumentOutOfRangeException) }
+    };
+
+    [Theory]
+    [MemberData(nameof(StringArray_Parse_Data))]
+    public void StringArray_Parse(string?[] strings)
+    {
+        BinaryFormattedObject format = strings.SerializeAndParse();
+        format.RecordCount.Should().BeGreaterThanOrEqualTo(3);
+        ArraySingleString array = (ArraySingleString)format[1];
+        format.GetStringValues(array, strings.Length).Should().BeEquivalentTo(strings);
+    }
+
+    public static TheoryData<string?[]> StringArray_Parse_Data => new()
+    {
+        new string?[] { "one", "two" },
+        new string?[] { "yes", "no", null },
+        new string?[] { "same", "same", "same" }
+    };
+
+    [Theory]
+    [MemberData(nameof(PrimitiveArray_Parse_Data))]
+    public void PrimitiveArray_Parse(Array array)
+    {
+        BinaryFormattedObject format = array.SerializeAndParse();
+        format.RecordCount.Should().BeGreaterThanOrEqualTo(3);
+        ArraySinglePrimitive arrayRecord = (ArraySinglePrimitive)format[1];
+        ((IEnumerable)arrayRecord.ArrayObjects).Should().BeEquivalentTo((IEnumerable)array);
+    }
+
+    public static TheoryData<Array> PrimitiveArray_Parse_Data => new()
+    {
+        new int[] { 1, 2, 3 },
+        new int[] { 1, 2, 1 },
+        new float[] { 1.0f, float.NaN, float.PositiveInfinity },
+        new DateTime[] { DateTime.MaxValue }
     };
 }

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/ArrayTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/ArrayTests.cs
@@ -78,4 +78,6 @@ public class ArrayTests
         new float[] { 1.0f, float.NaN, float.PositiveInfinity },
         new DateTime[] { DateTime.MaxValue }
     };
+
+    public static IEnumerable<object[]> Array_TestData => StringArray_Parse_Data.Concat(PrimitiveArray_Parse_Data);
 }

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/BinaryFormatWriterTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/BinaryFormatWriterTests.cs
@@ -96,5 +96,6 @@ public class BinaryFormatWriterTests
             ListTests.PrimitiveLists_TestData).Concat(
             ListTests.ArrayLists_TestData).Concat(
             PrimitiveTypeTests.Primitive_Data).Concat(
-            SystemDrawingTests.SystemDrawing_TestData);
+            SystemDrawingTests.SystemDrawing_TestData).Concat(
+            ArrayTests.Array_TestData);
 }

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/BinaryFormatWriterTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/BinaryFormatWriterTests.cs
@@ -36,7 +36,7 @@ public class BinaryFormatWriterTests
         BinaryFormatWriter.TryWriteFrameworkObject(stream, value).Should().BeTrue();
         stream.Position = 0;
 
-        using BinaryFormatterScope formaterScope = new BinaryFormatterScope(enable: true);
+        using BinaryFormatterScope formaterScope = new(enable: true);
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
         BinaryFormatter formatter = new();
 #pragma warning restore SYSLIB0011 // Type or member is obsolete

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/BinaryFormatWriterTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/BinaryFormatWriterTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections;
 using System.Runtime.Serialization.Formatters.Binary;
 
 namespace System.Windows.Forms.BinaryFormat.Tests;
@@ -13,12 +14,12 @@ public class BinaryFormatWriterTests
     [InlineData("")]
     [InlineData("\0")]
     [InlineData("Embedded\0 Null.")]
-    public void WriteString(string testString)
+    public void BinaryFormatWriter_WriteString(string testString)
     {
         using MemoryStream stream = new();
         BinaryFormatWriter.WriteString(stream, testString);
-
         stream.Position = 0;
+
         using var formatterScope = new BinaryFormatterScope(enable: true);
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
         BinaryFormatter formatter = new();
@@ -26,4 +27,74 @@ public class BinaryFormatWriterTests
         object deserialized = formatter.Deserialize(stream);
         deserialized.Should().Be(testString);
     }
+
+    [Theory]
+    [MemberData(nameof(TryWriteObject_SupportedObjects_TestData))]
+    public void TryWriteObject_SupportedObjects_BinaryFormatterRead(object value)
+    {
+        using MemoryStream stream = new();
+        BinaryFormatWriter.TryWriteFrameworkObject(stream, value).Should().BeTrue();
+        stream.Position = 0;
+
+        using BinaryFormatterScope formaterScope = new BinaryFormatterScope(enable: true);
+#pragma warning disable SYSLIB0011 // Type or member is obsolete
+        BinaryFormatter formatter = new();
+#pragma warning restore SYSLIB0011 // Type or member is obsolete
+        object deserialized = formatter.Deserialize(stream);
+
+        if (value is Hashtable hashtable)
+        {
+            Hashtable deserializedHashtable = (Hashtable)deserialized;
+            deserializedHashtable.Count.Should().Be(hashtable.Count);
+            foreach (var key in hashtable.Keys)
+            {
+                deserializedHashtable[key].Should().Be(hashtable[key]);
+            }
+        }
+        else if (value is IEnumerable enumerable)
+        {
+            ((IEnumerable)deserialized).Should().BeEquivalentTo(enumerable);
+        }
+        else
+        {
+            deserialized.Should().Be(value);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(TryWriteObject_SupportedObjects_TestData))]
+    public void TryWriteObject_SupportedObjects_RoundTrip(object value)
+    {
+        using MemoryStream stream = new();
+        BinaryFormatWriter.TryWriteFrameworkObject(stream, value).Should().BeTrue();
+        stream.Position = 0;
+
+        BinaryFormattedObject format = new(stream);
+        format.TryGetFrameworkObject(out object? deserialized).Should().BeTrue();
+
+        if (value is Hashtable hashtable)
+        {
+            Hashtable deserializedHashtable = (Hashtable)deserialized!;
+            deserializedHashtable.Count.Should().Be(hashtable.Count);
+            foreach (var key in hashtable.Keys)
+            {
+                deserializedHashtable[key].Should().Be(hashtable[key]);
+            }
+        }
+        else if (value is IEnumerable enumerable)
+        {
+            ((IEnumerable)deserialized!).Should().BeEquivalentTo(enumerable);
+        }
+        else
+        {
+            deserialized.Should().Be(value);
+        }
+    }
+
+    public static IEnumerable<object[]?> TryWriteObject_SupportedObjects_TestData =>
+        HashTableTests.Hashtables_TestData.Concat(
+            ListTests.PrimitiveLists_TestData).Concat(
+            ListTests.ArrayLists_TestData).Concat(
+            PrimitiveTypeTests.Primitive_Data).Concat(
+            SystemDrawingTests.SystemDrawing_TestData);
 }

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/NullTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/NullTests.cs
@@ -11,7 +11,7 @@ public class NullTests
     {
         // We read a byte on the way in so there is nothing to check.
 
-        ObjectNull.ObjectNullMultiple256 objectNull = new(1000);
+        NullRecord.ObjectNullMultiple256 objectNull = new(1000);
 
         using BinaryWriter writer = new(new MemoryStream());
         Action action = () => objectNull.Write(writer);
@@ -21,11 +21,11 @@ public class NullTests
     [Fact]
     public void ObjectNullMultiple256_WritesCorrectly()
     {
-        ObjectNull.ObjectNullMultiple256 objectNull = new(0xCA);
+        NullRecord.ObjectNullMultiple256 objectNull = new(0xCA);
 
         byte[] buffer = new byte[2];
         using BinaryWriter writer = new(new MemoryStream(buffer));
         objectNull.Write(writer);
-        buffer.Should().BeEquivalentTo(new byte[] { (byte)ObjectNull.ObjectNullMultiple256.RecordType, 0xCA });
+        buffer.Should().BeEquivalentTo(new byte[] { (byte)NullRecord.ObjectNullMultiple256.RecordType, 0xCA });
     }
 }

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/PrimitiveTypeTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/PrimitiveTypeTests.cs
@@ -2,15 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.Serialization.Formatters.Binary;
 using System.Text;
 
 namespace System.Windows.Forms.BinaryFormat.Tests;
 
-public class PrimitiveTypes
+public class PrimitiveTypeTests
 {
     [Theory]
     [MemberData(nameof(RoundTrip_Data))]
-    public void RoundTripPrimitiveTypes(byte type, object value)
+    public void WriteReadPrimitiveValue_RoundTrip(byte type, object value)
     {
         MemoryStream stream = new();
         using (BinaryWriter writer = new(stream, Encoding.UTF8, leaveOpen: true))
@@ -77,6 +78,69 @@ public class PrimitiveTypes
         { (byte)PrimitiveType.TimeSpan, TimeSpan.MaxValue },
         { (byte)PrimitiveType.DateTime, DateTime.MinValue },
         { (byte)PrimitiveType.DateTime, DateTime.MaxValue },
+    };
+
+    [Theory]
+    [MemberData(nameof(Primitive_Data))]
+    public void PrimitiveTypeMemberName(object value)
+    {
+        BinaryFormattedObject format = value.SerializeAndParse();
+        SystemClassWithMembersAndTypes systemClass = (SystemClassWithMembersAndTypes)format[1];
+        systemClass.MemberNames[0].Should().Be("m_value");
+        systemClass.MemberValues.Count.Should().Be(1);
+    }
+
+    [Theory]
+    [MemberData(nameof(Primitive_Data))]
+    [MemberData(nameof(Primitive_ExtendedData))]
+    public void BinaryFormatWriter_WritePrimitive(object value)
+    {
+        MemoryStream stream = new();
+        BinaryFormatWriter.WritePrimitive(stream, value);
+        stream.Position = 0;
+
+        using BinaryFormatterScope formatterScope = new(enable: true);
+#pragma warning disable SYSLIB0011 // Type or member is obsolete
+        BinaryFormatter formatter = new();
+#pragma warning restore SYSLIB0011 // Type or member is obsolete
+        object deserialized = formatter.Deserialize(stream);
+        deserialized.Should().Be(value);
+    }
+
+    [Theory]
+    [MemberData(nameof(Primitive_Data))]
+    [MemberData(nameof(Primitive_ExtendedData))]
+    public void BinaryFormattedObject_ReadPrimitive(object value)
+    {
+        BinaryFormattedObject formattedObject = value.SerializeAndParse();
+        formattedObject.TryGetPrimitiveType(out object? deserialized).Should().BeTrue();
+        deserialized.Should().Be(value);
+    }
+
+    public static TheoryData<object> Primitive_Data => new()
+    {
+        int.MaxValue,
+        uint.MaxValue,
+        long.MaxValue,
+        ulong.MaxValue,
+        short.MaxValue,
+        ushort.MaxValue,
+        byte.MaxValue,
+        sbyte.MaxValue,
+        true,
+        float.MaxValue,
+        double.MaxValue,
+        char.MaxValue
+    };
+
+    public static TheoryData<object> Primitive_ExtendedData => new()
+    {
+        TimeSpan.MaxValue,
+        DateTime.MaxValue,
+        decimal.MaxValue,
+        (nint)1918,
+        (nuint)2020,
+        "Roundabout"
     };
 
     internal class TestRecord : Record

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/StringRecordsCollectionTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/StringRecordsCollectionTests.cs
@@ -9,20 +9,19 @@ public class StringRecordsCollectionTests
     [Fact]
     public void BasicFunctionality()
     {
-        StringRecordsCollection collection = new();
-        int id = 1;
-        IRecord record = collection.GetStringRecord("Foo", ref id);
-        id.Should().Be(2);
+        StringRecordsCollection collection = new(currentId: 1);
+        IRecord record = collection.GetStringRecord("Foo");
+        collection.CurrentId.Should().Be(2);
         record.Should().BeOfType<BinaryObjectString>();
         ((BinaryObjectString)record).ObjectId.Should().Be(1);
 
-        record = collection.GetStringRecord("Foo", ref id);
-        id.Should().Be(2);
+        record = collection.GetStringRecord("Foo");
+        collection.CurrentId.Should().Be(2);
         record.Should().BeOfType<MemberReference>();
         ((MemberReference)record).IdRef.Should().Be(1);
 
-        record = collection.GetStringRecord("Bar", ref id);
-        id.Should().Be(3);
+        record = collection.GetStringRecord("Bar");
+        collection.CurrentId.Should().Be(3);
         record.Should().BeOfType<BinaryObjectString>();
         ((BinaryObjectString)record).ObjectId.Should().Be(2);
     }

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/SystemDrawingTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/SystemDrawingTests.cs
@@ -1,0 +1,60 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Drawing;
+
+namespace System.Windows.Forms.BinaryFormat.Tests;
+
+public class SystemDrawingTests
+{
+    [Fact]
+    public void PointF_Parse()
+    {
+        BinaryFormattedObject format = new PointF().SerializeAndParse();
+
+        BinaryLibrary binaryLibrary = (BinaryLibrary)format[1];
+        binaryLibrary.LibraryId.Should().Be(2);
+        binaryLibrary.LibraryName.ToString().Should().Be("System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
+
+        ClassWithMembersAndTypes classInfo = (ClassWithMembersAndTypes)format[2];
+        classInfo.ObjectId.Should().Be(1);
+        classInfo.Name.Should().Be("System.Drawing.PointF");
+        classInfo.MemberNames.Should().BeEquivalentTo(new string[] { "x", "y" });
+        classInfo.MemberValues.Should().BeEquivalentTo(new object[] { 0.0f, 0.0f });
+        classInfo.MemberTypeInfo.Should().BeEquivalentTo(new[]
+        {
+            (BinaryType.Primitive, PrimitiveType.Single),
+            (BinaryType.Primitive, PrimitiveType.Single)
+        });
+    }
+
+    [Fact]
+    public void RectangleF_Parse()
+    {
+        BinaryFormattedObject format = new RectangleF().SerializeAndParse();
+
+        BinaryLibrary binaryLibrary = (BinaryLibrary)format[1];
+        binaryLibrary.LibraryId.Should().Be(2);
+        binaryLibrary.LibraryName.ToString().Should().Be("System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
+
+        ClassWithMembersAndTypes classInfo = (ClassWithMembersAndTypes)format[2];
+        classInfo.ObjectId.Should().Be(1);
+        classInfo.Name.Should().Be("System.Drawing.RectangleF");
+        classInfo.MemberNames.Should().BeEquivalentTo(new string[] { "x", "y", "width", "height" });
+        classInfo.MemberValues.Should().BeEquivalentTo(new object[] { 0.0f, 0.0f, 0.0f, 0.0f });
+        classInfo.MemberTypeInfo.Should().BeEquivalentTo(new[]
+        {
+            (BinaryType.Primitive, PrimitiveType.Single),
+            (BinaryType.Primitive, PrimitiveType.Single),
+            (BinaryType.Primitive, PrimitiveType.Single),
+            (BinaryType.Primitive, PrimitiveType.Single)
+        });
+    }
+
+    public static TheoryData<object> SystemDrawing_TestData => new()
+    {
+        new PointF(),
+        new RectangleF()
+    };
+}


### PR DESCRIPTION
Now have saving/reading from object for supported types. This will allow plugging in more generically for property and resource serialization.

- Adds support for Array, ArrayList, and PointF/RectangleF.
- Tweaks ListConverter<T> to support more usages
- Create primitive ListConverter<T> helper in ListConverter static class.
- Have StringRecordsCollection maintain id to allow ListConverter helper above.
- Move type info into TypeInfo class.

Next step is hooking into IPropertyBag Control serialization and ResxDataNode.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9144)