### PR TITLE
Hook BinaryFormatter replacement in Resx / Clipboard

### DIFF
--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/HashTableTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/HashTableTests.cs
@@ -156,12 +156,6 @@ public class HashtableTests
         },
         new Hashtable()
         {
-            { "This", "That" },
-            { "TheOther", "This" },
-            { "That", "This" }
-        },
-        new Hashtable()
-        {
             { "Yowza", null },
             { "Youza", null },
             { "Meeza", null }

--- a/src/System.Windows.Forms/src/System/Resources/ResXSerializationBinder.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResXSerializationBinder.cs
@@ -81,7 +81,7 @@ internal class ResXSerializationBinder : SerializationBinder
 
     public override void BindToName(Type serializedType, out string? assemblyName, out string? typeName)
     {
-        // Normally we don't change the type name when changing the target framework, only the assembly name.
+        // Normally, we don't change the type name when changing the target framework, only the assembly name.
         // Setting the out values to null indicates that we want default handling.
 
         if (_typeNameConverter is not null)

--- a/src/System.Windows.Forms/src/System/Resources/ResXSerializationBinder.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResXSerializationBinder.cs
@@ -70,19 +70,20 @@ internal class ResXSerializationBinder : SerializationBinder
     // Get the multitarget-aware string representation for the give type.
     public override void BindToName(Type serializedType, out string? assemblyName, out string? typeName)
     {
-        // Normally we don't change typeName when changing the target framework,
-        // only assembly version or assembly name might change, thus we are setting
+        // Normally we don't change the type name when changing the target framework, only assembly version or assembly name might change, thus we are setting
         // typeName only if it changed with the framework version.
         // If binder passes in a null, BinaryFormatter will use the original value or
         // for un-serializable types will redirect to another type.
+        //
         // For example:
         //
-        // Encoding = Encoding.GetEncoding("shift_jis");
-        // public Encoding Encoding { get; set; }
-        // property type (Encoding) is abstract, but the value is instantiated to a specific class,
-        // and should be serialized as a specific class in order to be able to instantiate the result.
+        //   Encoding = Encoding.GetEncoding("shift_jis");
+        //   public Encoding Encoding { get; set; }
         //
-        // another example are singleton objects like DBNull.Value which are serialized by System.UnitySerializationHolder
+        // Property type (Encoding) is abstract, but the value is instantiated to a specific class, and should be
+        // serialized as a specific class in order to be able to instantiate the result.
+        //
+        // Another example are singleton objects like DBNull.Value which are serialized by System.UnitySerializationHolder.
         typeName = null;
         if (_typeNameConverter is not null)
         {
@@ -93,7 +94,7 @@ internal class ResXSerializationBinder : SerializationBinder
                 if (pos > 0 && pos < assemblyQualifiedTypeName.Length - 1)
                 {
                     assemblyName = assemblyQualifiedTypeName[(pos + 1)..].TrimStart();
-                    string newTypeName = assemblyQualifiedTypeName.Substring(0, pos);
+                    string newTypeName = assemblyQualifiedTypeName[..pos];
                     if (!string.Equals(newTypeName, serializedType.FullName, StringComparison.InvariantCulture))
                     {
                         typeName = newTypeName;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
@@ -1036,7 +1036,7 @@ public partial class Control
             // worked off of the current value. If the current value was null checking it for ISerializable would always
             // fail. This means properties would never load into a reference type property if it's current value was null.
             //
-            // While we could always just check the property type for serializable this would break derived class scenario
+            // While we could always just check the property type for serializable this would break derived class scenarios
             // where it adds ISerializable but the property type doesn't have it. In this scenario it would still not work
             // if the value is null on load. Not enabling that scenario for now as it would require more refactoring.
             return property.PropertyType.IsAssignableTo(typeof(ISerializable))

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
@@ -1196,7 +1196,7 @@ public partial class Control
                     object? deserialized = null;
                     try
                     {
-                        BinaryFormattedObject format = new(stream);
+                        BinaryFormattedObject format = new(stream, leaveOpen: true);
                         success = format.TryGetFrameworkObject(out deserialized);
                     }
                     catch (Exception ex) when (!ex.IsCriticalException())

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataFormats.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataFormats.cs
@@ -16,134 +16,134 @@ namespace System.Windows.Forms;
 /// </summary>
 public static partial class DataFormats
 {
+    internal const string TextConstant = "Text";
+    internal const string UnicodeTextConstant = "UnicodeText";
+    internal const string DibConstant = "DeviceIndependentBitmap";
+    internal const string BitmapConstant = "Bitmap";
+    internal const string EmfConstant = "EnhancedMetafile";
+    internal const string WmfConstant = "MetaFilePict";
+    internal const string SymbolicLinkConstant = "SymbolicLink";
+    internal const string DifConstant = "DataInterchangeFormat";
+    internal const string TiffConstant = "TaggedImageFileFormat";
+    internal const string OemTextConstant = "OEMText";
+    internal const string PaletteConstant = "Palette";
+    internal const string PenDataConstant = "PenData";
+    internal const string RiffConstant = "RiffAudio";
+    internal const string WaveAudioConstant = "WaveAudio";
+    internal const string FileDropConstant = "FileDrop";
+    internal const string LocaleConstant = "Locale";
+    internal const string HtmlConstant = "HTML Format";
+    internal const string RtfConstant = "Rich Text Format";
+    internal const string CsvConstant = "Csv";
+    internal const string StringConstant = "System.String";
+    internal const string SerializableConstant = "WindowsForms10PersistentObject";
+
     /// <summary>
-    ///  Specifies the standard ANSI text format. This <see langword="static"/>
-    ///  field is read-only.
+    ///  Specifies the standard ANSI text format.
     /// </summary>
-    public static readonly string Text = "Text";
+    public static readonly string Text = TextConstant;
 
     /// <summary>
     ///  Specifies the standard Windows Unicode text format.
-    ///  This <see langword="static"/> field is read-only.
     /// </summary>
-    public static readonly string UnicodeText = "UnicodeText";
+    public static readonly string UnicodeText = UnicodeTextConstant;
 
     /// <summary>
     ///  Specifies the Windows Device Independent Bitmap (DIB) format.
-    ///  This <see langword="static"/> field is read-only.
     /// </summary>
-    public static readonly string Dib = "DeviceIndependentBitmap";
+    public static readonly string Dib = DibConstant;
 
     /// <summary>
     ///  Specifies a Windows bitmap format.
-    ///  This <see langword="static"/> field is read-only. </summary>
-    public static readonly string Bitmap = "Bitmap";
+    /// </summary>
+    public static readonly string Bitmap = BitmapConstant;
 
     /// <summary>
     ///  Specifies the Windows enhanced metafile format.
-    ///  This <see langword="static"/> field is read-only.
     /// </summary>
-    public static readonly string EnhancedMetafile = "EnhancedMetafile";
+    public static readonly string EnhancedMetafile = EmfConstant;
 
     /// <summary>
     ///  Specifies the Windows metafile format, which WinForms does not directly use.
-    ///  This <see langword="static"/> field is read-only.
     /// </summary>
-    public static readonly string MetafilePict = "MetaFilePict";
+    public static readonly string MetafilePict = WmfConstant;
 
     /// <summary>
     ///  Specifies the Windows symbolic link format, which WinForms does not directly use.
-    ///  This <see langword="static"/> field is read-only.
     /// </summary>
-    public static readonly string SymbolicLink = "SymbolicLink";
+    public static readonly string SymbolicLink = SymbolicLinkConstant;
 
     /// <summary>
     ///  Specifies the Windows data interchange format, which WinForms does not directly use.
-    ///  This <see langword="static"/> field is read-only.
     /// </summary>
-    public static readonly string Dif = "DataInterchangeFormat";
+    public static readonly string Dif = DifConstant;
 
     /// <summary>
     ///  Specifies the Tagged Image File Format (TIFF), which WinForms does not directly use.
-    ///  This <see langword="static"/> field is read-only.
     /// </summary>
-    public static readonly string Tiff = "TaggedImageFileFormat";
+    public static readonly string Tiff = TiffConstant;
 
     /// <summary>
     ///  Specifies the standard Windows original equipment manufacturer (OEM) text format.
-    ///  This <see langword="static"/> field is read-only.
     /// </summary>
-    public static readonly string OemText = "OEMText";
+    public static readonly string OemText = OemTextConstant;
 
     /// <summary>
     ///  Specifies the Windows palette format.
-    ///  This <see langword="static"/> field is read-only.
     /// </summary>
-    public static readonly string Palette = "Palette";
+    public static readonly string Palette = PaletteConstant;
 
     /// <summary>
     ///  Specifies the Windows pen data format, which consists of pen strokes for handwriting
-    ///  software; Win Formsdoes not use this format.
-    ///  This <see langword="static"/> field is read-only.
+    ///  software; WinForms does not use this format.
     /// </summary>
-    public static readonly string PenData = "PenData";
+    public static readonly string PenData = PenDataConstant;
 
     /// <summary>
-    ///  Specifies the Resource Interchange File Format (RIFF) audio format, which WinForms
-    ///  does not directly use.
-    ///  This <see langword="static"/> field is read-only.
+    ///  Specifies the Resource Interchange File Format (RIFF) audio format, which WinForms does not directly use.
     /// </summary>
-    public static readonly string Riff = "RiffAudio";
+    public static readonly string Riff = RiffConstant;
 
     /// <summary>
-    ///  Specifies the wave audio format, which Win Forms does not
-    ///  directly use. This <see langword="static"/> field is read-only.
+    ///  Specifies the wave audio format, which Win Forms does not directly use.
     /// </summary>
-    public static readonly string WaveAudio = "WaveAudio";
+    public static readonly string WaveAudio = WaveAudioConstant;
 
     /// <summary>
     ///  Specifies the Windows file drop format, which WinForms does not directly use.
-    ///  This <see langword="static"/> field is read-only.
     /// </summary>
-    public static readonly string FileDrop = "FileDrop";
+    public static readonly string FileDrop = FileDropConstant;
 
     /// <summary>
     ///  Specifies the Windows culture format, which WinForms does not directly use.
-    ///  This <see langword="static"/> field is read-only.
     /// </summary>
-    public static readonly string Locale = "Locale";
+    public static readonly string Locale = LocaleConstant;
 
     /// <summary>
     ///  Specifies text consisting of HTML data.
-    ///  This <see langword="static"/> field is read-only.
     /// </summary>
-    public static readonly string Html = "HTML Format";
+    public static readonly string Html = HtmlConstant;
 
     /// <summary>
     ///  Specifies text consisting of Rich Text Format (RTF) data.
-    ///  This <see langword="static"/> field is read-only.
     /// </summary>
-    public static readonly string Rtf = "Rich Text Format";
+    public static readonly string Rtf = RtfConstant;
 
     /// <summary>
     ///  Specifies a comma-separated value (CSV) format, which is a common interchange format
     ///  used by spreadsheets. This format is not used directly by WinForms.
-    ///  This <see langword="static"/> field is read-only.
     /// </summary>
-    public static readonly string CommaSeparatedValue = "Csv";
+    public static readonly string CommaSeparatedValue = CsvConstant;
 
     /// <summary>
-    ///  Specifies the Win Forms string class format, which WinForms uses to store string
-    ///  objects.
-    ///  This <see langword="static"/> field is read-only.
+    ///  Specifies the WinForms string class format, which WinForms uses to store string objects.
     /// </summary>
-    public static readonly string StringFormat = typeof(string).FullName!;
+    public static readonly string StringFormat = StringConstant;
 
     /// <summary>
     ///  Specifies a format that encapsulates any type of WinForms object.
-    ///  This <see langword="static"/> field is read-only.
     /// </summary>
-    public static readonly string Serializable = Application.WindowsFormsVersion + "PersistentObject";
+    public static readonly string Serializable = SerializableConstant;
 
     private static Format[]? s_formatList;
     private static int s_formatCount;
@@ -151,8 +151,7 @@ public static partial class DataFormats
     private static readonly object s_internalSyncObject = new object();
 
     /// <summary>
-    ///  Gets a <see cref="Format"/> with the Windows
-    ///  Clipboard numeric ID and name for the specified format.
+    ///  Gets a <see cref="Format"/> with the Windows Clipboard numeric ID and name for the specified format.
     /// </summary>
     public static Format GetFormat(string format)
     {
@@ -197,8 +196,7 @@ public static partial class DataFormats
     }
 
     /// <summary>
-    ///  Gets a <see cref="Format"/> with the Windows
-    ///  Clipboard numeric ID and name for the specified ID.
+    ///  Gets a <see cref="Format"/> with the Windows Clipboard numeric ID and name for the specified ID.
     /// </summary>
     public static Format GetFormat(int id)
     {
@@ -261,27 +259,30 @@ public static partial class DataFormats
         {
             s_formatList = new Format[]
             {
-                //         Text name        Win32 format ID
-                new Format(UnicodeText,       (int)User32.CF.UNICODETEXT),
-                new Format(Text,              (int)User32.CF.TEXT),
-                new Format(Bitmap,            (int)User32.CF.BITMAP),
-                new Format(MetafilePict,      (int)User32.CF.METAFILEPICT),
-                new Format(EnhancedMetafile,  (int)User32.CF.ENHMETAFILE),
-                new Format(Dif,               (int)User32.CF.DIF),
-                new Format(Tiff,              (int)User32.CF.TIFF),
-                new Format(OemText,           (int)User32.CF.OEMTEXT),
-                new Format(Dib,               (int)User32.CF.DIB),
-                new Format(Palette,           (int)User32.CF.PALETTE),
-                new Format(PenData,           (int)User32.CF.PENDATA),
-                new Format(Riff,              (int)User32.CF.RIFF),
-                new Format(WaveAudio,         (int)User32.CF.WAVE),
-                new Format(SymbolicLink,      (int)User32.CF.SYLK),
-                new Format(FileDrop,          (int)User32.CF.HDROP),
-                new Format(Locale,            (int)User32.CF.LOCALE)
+                //         Text name                  Win32 format ID
+                new Format(UnicodeTextConstant,       (int)User32.CF.UNICODETEXT),
+                new Format(TextConstant,              (int)User32.CF.TEXT),
+                new Format(BitmapConstant,            (int)User32.CF.BITMAP),
+                new Format(WmfConstant,               (int)User32.CF.METAFILEPICT),
+                new Format(EmfConstant,               (int)User32.CF.ENHMETAFILE),
+                new Format(DifConstant,               (int)User32.CF.DIF),
+                new Format(TiffConstant,              (int)User32.CF.TIFF),
+                new Format(OemTextConstant,           (int)User32.CF.OEMTEXT),
+                new Format(DibConstant,               (int)User32.CF.DIB),
+                new Format(PaletteConstant,           (int)User32.CF.PALETTE),
+                new Format(PenDataConstant,           (int)User32.CF.PENDATA),
+                new Format(RiffConstant,              (int)User32.CF.RIFF),
+                new Format(WaveAudioConstant,         (int)User32.CF.WAVE),
+                new Format(SymbolicLinkConstant,      (int)User32.CF.SYLK),
+                new Format(FileDropConstant,          (int)User32.CF.HDROP),
+                new Format(LocaleConstant,            (int)User32.CF.LOCALE)
             };
 
             s_formatCount = s_formatList.Length;
         }
-        else s_formatList ??= Array.Empty<Format>();
+        else
+        {
+            s_formatList ??= Array.Empty<Format>();
+        }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.BitmapBinder.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.BitmapBinder.cs
@@ -55,7 +55,7 @@ public partial class DataObject
             assemblyName = null;
             typeName = null;
 
-            // Bitmap and string types are safe type to serialize/deserialize.
+            // Bitmap and string types are safe types to serialize/deserialize.
             if (!serializedType.Equals(typeof(string)) && !serializedType.Equals(typeof(Bitmap)))
             {
                 throw new SerializationException(string.Format(SR.UnexpectedTypeForClipboardFormat, serializedType.FullName));

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.BitmapBinder.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.BitmapBinder.cs
@@ -27,7 +27,7 @@ public partial class DataObject
         public override Type? BindToType(string assemblyName, string typeName)
         {
             // Only safe to deserialize types are bypassing this callback. Strings and arrays of primitive types in
-            // particular. We are explicitly allowing System.Drawing.Bitmap type to bind using the default binder.
+            // particular. We are explicitly allowing the System.Drawing.Bitmap type to bind using the default binder.
 
             if (AllowedTypeName.Equals(typeName, StringComparison.Ordinal))
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.BitmapBinder.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.BitmapBinder.cs
@@ -11,66 +11,52 @@ namespace System.Windows.Forms;
 public partial class DataObject
 {
     /// <summary>
-    ///  Binder that restricts DataObject content deserialization to Bitmap type and
-    ///  serialization to strings and Bitmaps.
+    ///  Binder that restricts deserialization to Bitmap type and serialization to strings and Bitmaps.
     ///  Deserialization of known safe types(strings and arrays of primitives) does not invoke the binder.
     /// </summary>
     private class BitmapBinder : SerializationBinder
     {
-        // Bitmap type lives in different assemblies in the .NET Framework and in .NET Core.
-        // However we allow desktop content to be deserialization in Core and Core content
-        // deserialized on desktop. To support this round trip,
-        // Bitmap type identity is unified to the desktop type during serialization
-        // and we use the desktop type name when filtering as well.
+        // Bitmap type lives in different assemblies in the .NET Framework and in .NET Core. To support serialization
+        // between both runtimes the .NET Framework identities are used.
         private const string AllowedTypeName = "System.Drawing.Bitmap";
         private const string AllowedAssemblyName = "System.Drawing";
-        // PublicKeyToken=b03f5f7f11d50a3a
+
+        // .NET Framework PublicKeyToken=b03f5f7f11d50a3a
         private static ReadOnlySpan<byte> AllowedToken => new byte[] { 0xB0, 0x3F, 0x5F, 0x7F, 0x11, 0xD5, 0x0A, 0x3A };
 
-        /// <summary>
-        ///  Only safe to deserialize types are bypassing this callback, Strings
-        ///  and arrays of primitive types in particular. We are explicitly allowing
-        ///  System.Drawing.Bitmap type to bind using the default binder.
-        /// </summary>
-        /// <param name="assemblyName"></param>
-        /// <param name="typeName"></param>
-        /// <returns>null - continue with the default binder.</returns>
         public override Type? BindToType(string assemblyName, string typeName)
         {
-            if (string.CompareOrdinal(typeName, AllowedTypeName) == 0)
+            // Only safe to deserialize types are bypassing this callback. Strings and arrays of primitive types in
+            // particular. We are explicitly allowing System.Drawing.Bitmap type to bind using the default binder.
+
+            if (AllowedTypeName.Equals(typeName, StringComparison.Ordinal))
             {
-                AssemblyName? nameToBind = null;
                 try
                 {
-                    nameToBind = new AssemblyName(assemblyName);
+                    AssemblyName nameToBind = new(assemblyName);
+                    if (AllowedAssemblyName.Equals(nameToBind.Name, StringComparison.Ordinal)
+                        && AllowedToken.SequenceEqual(nameToBind.GetPublicKeyToken()))
+                    {
+                        // Continue with the default binder.
+                        return null;
+                    }
                 }
-                catch
+                catch (Exception ex) when (ex is ArgumentException or FileLoadException)
                 {
-                }
-
-                if (nameToBind is not null
-                    && string.Equals(nameToBind.Name, AllowedAssemblyName, StringComparison.Ordinal)
-                    && nameToBind.GetPublicKeyToken().AsSpan().SequenceEqual(AllowedToken))
-                {
-                    return null;
                 }
             }
 
             throw new RestrictedTypeDeserializationException(SR.UnexpectedClipboardType);
         }
 
-        /// <summary>
-        ///  Bitmap and string types are safe type to serialize/deserialize.
-        /// </summary>
-        /// <param name="serializedType"></param>
-        /// <param name="assemblyName"></param>
-        /// <param name="typeName"></param>
         public override void BindToName(Type serializedType, out string? assemblyName, out string? typeName)
         {
-            // null strings will follow the default codepath in BinaryFormatter
+            // Null values will follow the default codepath in BinaryFormatter.
             assemblyName = null;
             typeName = null;
-            if (serializedType is not null && !serializedType.Equals(typeof(string)) && !serializedType.Equals(typeof(Bitmap)))
+
+            // Bitmap and string types are safe type to serialize/deserialize.
+            if (!serializedType.Equals(typeof(string)) && !serializedType.Equals(typeof(Bitmap)))
             {
                 throw new SerializationException(string.Format(SR.UnexpectedTypeForClipboardFormat, serializedType.FullName));
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.OleConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.OleConverter.cs
@@ -319,7 +319,6 @@ public partial class DataObject
                 // object.  We identify a serialized object by writing the
                 // bytes for the guid serializedObjectID at the front
                 // of the stream.  Check for that here.
-                //
                 if (size > s_serializedObjectID.Length)
                 {
                     isSerializedObject = true;
@@ -333,7 +332,6 @@ public partial class DataObject
                     }
 
                     // Advance the byte pointer.
-                    //
                     if (isSerializedObject)
                     {
                         index = s_serializedObjectID.Length;
@@ -353,18 +351,12 @@ public partial class DataObject
         }
 
         /// <summary>
-        ///  Creates a new instance of the Object that has been persisted into the
-        ///  handle.
+        ///  Creates a new instance of the Object that has been persisted into the handle.
         /// </summary>
         private static object ReadObjectFromHandle(IntPtr handle, bool restrictDeserialization)
         {
             Stream stream = ReadByteStreamFromHandle(handle, out bool isSerializedObject);
-            if (isSerializedObject)
-            {
-                return ReadObjectFromHandleDeserializer(stream, restrictDeserialization);
-            }
-
-            return stream;
+            return isSerializedObject ? ReadObjectFromHandleDeserializer(stream, restrictDeserialization) : stream;
         }
 
         private static object ReadObjectFromHandleDeserializer(Stream stream, bool restrictDeserialization)
@@ -372,36 +364,31 @@ public partial class DataObject
             long startPosition = stream.Position;
             try
             {
-                BinaryFormattedObject format = new(stream, leaveOpen: true);
-                if (format.TryGetPrimitiveType(out object? value))
+                if (new BinaryFormattedObject(stream, leaveOpen: true).TryGetFrameworkObject(out object? value))
                 {
                     return value;
                 }
             }
             catch (Exception ex) when (!ex.IsCriticalException())
             {
-                // Couldn't parse for some reason, let the BinaryFormatter handle it.
+                // Couldn't parse for some reason, let the BinaryFormatter try to handle it.
             }
-
-#pragma warning disable SYSLIB0011 // Type or member is obsolete
 
             stream.Position = startPosition;
-            BinaryFormatter formatter = new BinaryFormatter();
-            if (restrictDeserialization)
-            {
-                formatter.Binder = new BitmapBinder();
-            }
 
+#pragma warning disable SYSLIB0011 // Type or member is obsolete
 #pragma warning disable SYSLIB0050 // Type or member is obsolete
-            formatter.AssemblyFormat = FormatterAssemblyStyle.Simple;
-#pragma warning restore SYSLIB0050 // Type or member is obsolete
-            return formatter.Deserialize(stream);
-#pragma warning restore SYSLIB0011 // Type or member is obsolete
+            return new BinaryFormatter()
+            {
+                Binder = restrictDeserialization ? new BitmapBinder() : null,
+                AssemblyFormat = FormatterAssemblyStyle.Simple
+            }.Deserialize(stream);
+#pragma warning restore SYSLIB0050
+#pragma warning restore SYSLIB0011
         }
 
         /// <summary>
-        ///  Parses the HDROP format and returns a list of strings using
-        ///  the DragQueryFile function.
+        ///  Parses the HDROP format and returns a list of strings using the DragQueryFile function.
         /// </summary>
         private static unsafe string[]? ReadFileListFromHandle(HDROP hdrop)
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.OleConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.OleConverter.cs
@@ -351,7 +351,7 @@ public partial class DataObject
         }
 
         /// <summary>
-        ///  Creates a new instance of the Object that has been persisted into the handle.
+        ///  Creates a new instance of the object that has been persisted into the handle.
         /// </summary>
         private static object ReadObjectFromHandle(IntPtr handle, bool restrictDeserialization)
         {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Resources/ResxDataNodeTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Resources/ResxDataNodeTests.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
+using System.Collections;
 using System.ComponentModel;
 using System.Drawing;
 
@@ -31,7 +34,7 @@ public class ResxDataNodeTests
         ResXDataNode dataNode = new(dataNodeInfo, basePath: null);
 
         var bitmapBytes = dataNode.GetValue(typeResolver: null);
-        Bitmap result = Assert.IsType<Bitmap>(converter.ConvertFrom(bitmapBytes));
+        Bitmap result = Assert.IsType<Bitmap>(converter.ConvertFrom(bitmapBytes!));
         Assert.Equal(bitmap.Size, result.Size);
     }
 
@@ -46,7 +49,7 @@ public class ResxDataNodeTests
         ResXDataNode dataNode = new(dataNodeInfo, basePath: null);
 
         var bitmapBytes = dataNode.GetValue(typeResolver: null);
-        var result = Assert.IsType<Bitmap>(converter.ConvertFrom(bitmapBytes));
+        var result = Assert.IsType<Bitmap>(converter.ConvertFrom(bitmapBytes!));
         Assert.Equal(bitmap.Size, result.Size);
     }
 
@@ -71,4 +74,69 @@ public class ResxDataNodeTests
         var valueString = dataNode.GetValue(typeResolver: null);
         Assert.Equal("test", valueString);
     }
+
+    [Theory]
+    [MemberData(nameof(RoundTrip_BinaryFormatted_TestData))]
+    public void ResxDataNode_RoundTrip_BinaryFormatted(object? value)
+    {
+        using var formatterScope = new BinaryFormatterScope(enable: false);
+        ResXDataNode dataNode = new("Test", value);
+        DataNodeInfo nodeInfo = dataNode.GetDataNodeInfo();
+
+        ResXDataNode deserializedDataNode = new(nodeInfo, basePath: null);
+        Assert.Equal(value, deserializedDataNode.GetValue(typeResolver: null));
+    }
+
+    public static TheoryData<object?> RoundTrip_BinaryFormatted_TestData => new()
+    {
+        new RectangleF(10.0f, 20.0f, 30.0f, 40.0f),
+        new PointF(1.0f, 2.0f),
+        new List<string> { "Jack", "Queen", "King" },
+        new List<int> { 4, 3, 2, 1 },
+        new Hashtable(),
+        new Hashtable()
+        {
+            { "This", "That" }
+        },
+        new Hashtable()
+        {
+            { "Meaning", 42 }
+        },
+        new Hashtable()
+        {
+            { 42, 42 }
+        },
+        new Hashtable()
+        {
+            { 42, 42 },
+            { 43, 42 }
+        },
+        new Hashtable()
+        {
+            { "Hastings", new DateTime(1066, 10, 14) }
+        },
+        new Hashtable()
+        {
+            { "Decimal", decimal.MaxValue }
+        },
+        new Hashtable()
+        {
+            { "This", "That" },
+            { "TheOther", "This" },
+            { "That", "This" }
+        },
+        new Hashtable()
+        {
+            { "Yowza", null },
+            { "Youza", "Anakin" },
+            { "Meeza", "Binks" }
+        },
+        new Hashtable()
+        {
+            { decimal.MinValue, decimal.MaxValue },
+            { float.MinValue, float.MaxValue },
+            { DateTime.MinValue, DateTime.MaxValue },
+            { TimeSpan.MinValue, TimeSpan.MaxValue }
+        },
+    };
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ActiveXImplTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ActiveXImplTests.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+
+using System.Collections;
 using System.Drawing;
 using System.Runtime.Serialization;
 using Windows.Win32.System.Com;
@@ -14,7 +17,7 @@ public unsafe class Control_ActiveXImplTests
     [WinFormsFact]
     public void ActiveXImpl_SaveLoad_RoundTrip_FormatterDisabled()
     {
-        using var formatterScope = new BinaryFormatterScope(enable: false);
+        using BinaryFormatterScope formatterScope = new(enable: false);
         using Control control = new();
         control.BackColor = Color.Bisque;
         IPersistStreamInit.Interface persistStream = control;
@@ -34,7 +37,7 @@ public unsafe class Control_ActiveXImplTests
     [WinFormsFact]
     public void ActiveXImpl_SaveLoad_BinaryFormatterProperty_FormatterEnabled()
     {
-        using var formatterScope = new BinaryFormatterScope(enable: true);
+        using BinaryFormatterScope formatterScope = new(enable: true);
         using MyControl control = new();
 
         // We need to have a type that doesn't have a TypeConverter that implements ISerializable to hit the
@@ -58,7 +61,7 @@ public unsafe class Control_ActiveXImplTests
     [WinFormsFact]
     public void ActiveXImpl_SaveLoad_BinaryFormatterProperty_FormatterDisabled()
     {
-        using var formatterScope = new BinaryFormatterScope(enable: false);
+        using BinaryFormatterScope formatterScope = new(enable: false);
         using MyControl control = new();
 
         // We need to have a type that doesn't have a TypeConverter that implements ISerializable to hit the
@@ -73,15 +76,44 @@ public unsafe class Control_ActiveXImplTests
         Assert.Throws<NotSupportedException>(() => persistStream.Save(istreamPointer, fClearDirty: BOOL.FALSE));
     }
 
+    [WinFormsFact]
+    public void ActiveXImpl_SaveLoad_BinaryFormatterProperty_FormatterDisabledSupported()
+    {
+        using BinaryFormatterScope formatterScope = new(enable: false);
+        using BinaryFormatterPropertiesControl control = new();
+
+        // We need to have a type that doesn't have a TypeConverter that implements ISerializable to hit the
+        // BinaryFormatter code path.
+        control.Table = new Hashtable() { { "Whas", "sup" } };
+
+        IPersistStreamInit.Interface persistStream = control;
+
+        using MemoryStream memoryStream = new();
+        using var istream = ComHelpers.GetComScope<IStream>(new GPStream(memoryStream));
+        HRESULT hr = persistStream.Save(istream.Value, fClearDirty: BOOL.FALSE);
+        Assert.True(hr.Succeeded);
+        control.Table = default;
+
+        istream.Value->Seek(0, SeekOrigin.Begin);
+        hr = persistStream.Load(istream.Value);
+        Assert.True(hr.Succeeded);
+        Assert.Equal("sup", control.Table!["Whas"]);
+    }
+
     private class MyControl : Control
     {
         public SerializableStruct SerializableValue { get; set; }
     }
 
+    private class BinaryFormatterPropertiesControl : Control
+    {
+        public Hashtable? Table { get; set; }
+    }
+
     [Serializable]
     public struct SerializableStruct : ISerializable
     {
-        public string Value { get; set; }
+        public string? Value { get; set; }
 
         public void GetObjectData(SerializationInfo info, StreamingContext context)
         {
@@ -90,7 +122,7 @@ public unsafe class Control_ActiveXImplTests
 
         private SerializableStruct(SerializationInfo serializationInfo, StreamingContext streamingContext)
         {
-            Value = (string)serializationInfo.GetValue(nameof(Value), typeof(string));
+            Value = (string?)serializationInfo.GetValue(nameof(Value), typeof(string));
         }
     }
 }


### PR DESCRIPTION
This uses the BinaryFormat support classes to handle common framework types before falling back to the BinaryFormatter.

There is some cleanup in the Resx code and simplification in DataObject by adding internal constant strings for known DataFormats.

Also move MultitargetUtil to the normal CriticalException handler.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9178)