### PR TITLE
Fixed PrintPreviewControl accessibility bounds calculation

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/PrintPreviewControl.PrintPreviewControlAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PrintPreviewControl.PrintPreviewControlAccessibleObject.cs
@@ -27,9 +27,9 @@ public partial class PrintPreviewControl
                 _ => base.GetPropertyValue(propertyID)
             };
 
-        public override Rectangle Bounds
-            => _owningPrintPreviewControl.IsHandleCreated && _owningPrintPreviewControl.Parent is not null
-                ? _owningPrintPreviewControl.Parent.RectangleToScreen(_owningPrintPreviewControl.Bounds)
+        internal override Rectangle BoundingRectangle
+            => _owningPrintPreviewControl.IsHandleCreated
+                ? _owningPrintPreviewControl.GetToolNativeScreenRectangle()
                 : Rectangle.Empty;
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PrintPreviewControl.PrintPreviewControlAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PrintPreviewControl.PrintPreviewControlAccessibleObjectTests.cs
@@ -66,7 +66,36 @@ public class PrintPreviewControl_PrintPreviewControlAccessibleObjectTests
     }
 
     [WinFormsFact]
-    public void PrintPreviewControlAccessibleObject_Bounds_NoParent_ReturnsExpected()
+    public void PrintPreviewControlAccessibleObject_BoundingRectangle_NoHandle_ReturnsExpected()
+    {
+        using PrintPreviewControl control = new();
+
+        AccessibleObject accessibleObject = new PrintPreviewControl.PrintPreviewControlAccessibleObject(control);
+
+        Assert.Equal(Rectangle.Empty, accessibleObject.BoundingRectangle);
+        Assert.False(control.IsHandleCreated);
+    }
+
+    [WinFormsFact]
+    public void PrintPreviewControlAccessibleObject_BoundingRectangle_ReturnsExpected()
+    {
+        using PrintPreviewControl control = new();
+
+        using Panel panel = new();
+        panel.Controls.Add(control);
+        panel.CreateControl();
+
+        Rectangle controlBounds = panel.RectangleToScreen(control.Bounds);
+
+        AccessibleObject accessibleObject = new PrintPreviewControl.PrintPreviewControlAccessibleObject(control);
+        Rectangle accessibleObjectBoundingRectangle = accessibleObject.BoundingRectangle;
+
+        Assert.Equal(controlBounds, accessibleObjectBoundingRectangle);
+        Assert.True(control.IsHandleCreated);
+    }
+
+    [WinFormsFact]
+    public void PrintPreviewControlAccessibleObject_Bounds_NoHandle_ReturnsExpected()
     {
         using PrintPreviewControl control = new();
 
@@ -80,19 +109,13 @@ public class PrintPreviewControl_PrintPreviewControlAccessibleObjectTests
     public void PrintPreviewControlAccessibleObject_Bounds_ReturnsExpected()
     {
         using PrintPreviewControl control = new();
+        control.CreateControl();
 
-        using Panel panel = new();
-        panel.Controls.Add(control);
-        panel.CreateControl();
-
-        Point controlScreenLocation = panel.PointToScreen(control.Location);
-        Size controlBoundsSize = control.Bounds.Size;
+        Rectangle controlClientRectangle = control.RectangleToScreen(control.ClientRectangle);
 
         AccessibleObject accessibleObject = new PrintPreviewControl.PrintPreviewControlAccessibleObject(control);
-        Rectangle accessibleObjectBounds = accessibleObject.Bounds;
 
-        Assert.Equal(controlScreenLocation, accessibleObjectBounds.Location);
-        Assert.Equal(controlBoundsSize, accessibleObjectBounds.Size);
+        Assert.Equal(controlClientRectangle, accessibleObject.Bounds);
         Assert.True(control.IsHandleCreated);
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #9175

PR #9136 has changed calculation of `AccessibilityObject.Bounds` property of `PrintPreviewControl` to include non-client area of the control. That fixed bounds of UIA object but broke MSAA object.

This PR modifies calculations to make bounds correct in both MSAA and UIA modes.

## Proposed changes

- Override PrintPreviewControlAccessibleObject's `BoundingRectangle` instead of `Bounds`.
- Fix unit tests for `PrintPreviewControlAccessibleObject.Bounds` property.
- Add unit tests for `PrintPreviewControlAccessibleObject.BoundingRectangle` property.


<!-- We are in TELL-MODE the following section must be completed -->

## Regression? 

- Yes

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Before PR #9136 MSAA client  and non-client bounds were correct, but UIA bounds were too small.

MSAA non-client bounds:
![before_9136_msaa_window](https://github.com/dotnet/winforms/assets/113603457/803603f7-3595-4ec7-aa86-4d11851999b1)

MSAA client bounds:
![before_9136_msaa_client](https://github.com/dotnet/winforms/assets/113603457/ce91fd8e-45c5-4242-9597-4f189bbfc768)

UIA bounds:
![before_9136_uia](https://github.com/dotnet/winforms/assets/113603457/dbc4d5b0-99e2-4bee-a5d9-389a12f077ed)

PR #9136 fixed UIA bounds, but broke MSAA client bounds, which now include non-client areas.

MSAA non-client bounds:
![after_9136_msaa_window](https://github.com/dotnet/winforms/assets/113603457/5eda7204-fcd7-4bd7-b213-7074edb28ea1)

MSAA client bounds:
![after_9136_msaa_client](https://github.com/dotnet/winforms/assets/113603457/359fad68-414f-4ab7-aff2-1605f0b4f6e3)

UIA bounds:
![after_9136_uia](https://github.com/dotnet/winforms/assets/113603457/b62eb617-00a5-4e53-b297-2c49693c76f6)

### After

All bounds are correct:

MSAA non-client bounds:
![fixed_msaa_window](https://github.com/dotnet/winforms/assets/113603457/26aa12ca-efa9-4bfc-a321-9eea1f3d0458)

MSAA client bounds:
![fixed_msaa_client](https://github.com/dotnet/winforms/assets/113603457/1e2300be-791c-4643-82dc-57f03721f61d)

UIA bounds:
![fixed_uia](https://github.com/dotnet/winforms/assets/113603457/134eb86f-489e-4b0a-a534-124951ededd8)



## Test environment(s) <!-- Remove any that don't apply -->

- .NET 8.0.0-preview.4.23259.5
-  Accessibility Insights 1.1.2213.1

<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9187)