### PR TITLE
Clean up OleConverter code

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/NativeMethods.txt
+++ b/src/System.Windows.Forms.Primitives/src/NativeMethods.txt
@@ -26,6 +26,7 @@ CloseDesktop
 CloseEnhMetaFile
 CloseHandle
 CloseThemeData
+CLIPBRD_E_BAD_DATA
 CLR_*
 CLSCTX
 cmb4

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.OleConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.OleConverter.cs
@@ -7,7 +7,6 @@ using System.ComponentModel;
 using System.Drawing;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
-using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Text;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.cs
@@ -76,7 +76,8 @@ public unsafe partial class DataObject :
             takeOwnership: true,
             out ComTypes.IDataObject? comTypesData);
 
-        Debug.Assert(success);
+        Debug.Assert(success && comTypesData is not null);
+
         return new(comTypesData!);
     }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ClipboardTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ClipboardTests.cs
@@ -471,4 +471,28 @@ public class ClipboardTests
         Assert.Throws<ThreadStateException>(() => Clipboard.SetText("text"));
         Assert.Throws<ThreadStateException>(() => Clipboard.SetText("text", TextDataFormat.Text));
     }
+
+    [WinFormsFact]
+    public void ClipBoard_SetData_CustomFormat_Color()
+    {
+        using BinaryFormatterScope scope = new(enable: true);
+        string format = nameof(ClipBoard_SetData_CustomFormat_Color);
+        Clipboard.SetData(format, Color.Black);
+        Assert.True(Clipboard.ContainsData(format));
+        Assert.Equal(Color.Black, Clipboard.GetData(format));
+    }
+
+    [WinFormsFact]
+    public void ClipBoard_SetData_CustomFormat_Color_BinaryFormatterDisabled_Throws()
+    {
+        using BinaryFormatterScope scope = new(enable: false);
+        string format = nameof(ClipBoard_SetData_CustomFormat_Color);
+
+        // This will "succeed", but fail under the covers. Windows doesn't return any errors when setting data.
+        Clipboard.SetData(format, Color.Black);
+        Assert.True(Clipboard.ContainsData(format));
+
+        // The data is invalid, which surfaces as CLIPBRD_E_BAD_DATA which we swallow and return null for.
+        Assert.Null(Clipboard.GetData(format));
+    }
 }


### PR DESCRIPTION
The OleConverter class had significant readability issues. This brings it closer to standard and cuts over 100 lines of code. Getting the code into better shape is important with BinaryFormatter changes and the need to move this to ComWrappers moving forward.

Recommend reviewing split.

Notable bits:

- The class is never derived, and is now sealed
- Members that do nothing now clearly do nothing (write methods)
- Moved some single call methods inline callees

The name isn't great so I'm going to follow up with a change to ComDataObjectAdapter for increased clarity.

Also add a few tests related to #9180.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9195)