### PR TITLE
More clipboard cleanup

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.ComDataObjectAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.ComDataObjectAdapter.cs
@@ -23,11 +23,11 @@ public partial class DataObject
     /// <summary>
     ///  Maps <see cref="IComDataObject"/> to <see cref="IDataObject"/> for reading data only.
     /// </summary>
-    private sealed class OleConverter : IDataObject
+    private sealed class ComDataObjectAdapter : IDataObject
     {
         private readonly IComDataObject _innerData;
 
-        public OleConverter(IComDataObject data)
+        public ComDataObjectAdapter(IComDataObject data)
         {
             Debug.Assert(data is not null);
             CompModSwitches.DataObject.TraceVerbose("OleConverter: Constructed OleConverter");


### PR DESCRIPTION
- Renames OleConverter to ComDataObjectAdapter
- Adds summaries to Clipboard public methods
- Removes redundancy in Clipboard methods
- Remove unnecessary asserts in DataObject
- Other minor simplifications
