### PR TITLE
Fixed extra ListViewItemImageAccessibleObject for ListViewItem without any Image

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemBaseAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemBaseAccessibleObject.cs
@@ -53,7 +53,8 @@ public partial class ListViewItem
         internal override UiaCore.IRawElementProviderFragmentRoot FragmentRoot
             => _owningListView.AccessibilityObject;
 
-        protected bool HasImage => _owningItem.ImageIndex != ImageList.Indexer.DefaultIndex;
+        internal bool HasImage => _owningItem.ImageList is not null && _owningItem.ImageList.Images.Count > 0
+            && _owningItem.ImageIndex != ImageList.Indexer.DefaultIndex;
 
         internal override bool IsItemSelected
             => (State & AccessibleStates.Selected) != 0;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemAccessibleObjectTests.cs
@@ -1618,6 +1618,7 @@ public class ListViewItem_ListViewItemAccessibleObjectTests
             View = View.Details,
             SmallImageList = imageCollection
         };
+
         listView.Columns.Add(new ColumnHeader());
         var listViewItem = new ListViewItem("Item 1", imageIndex: hasImage ? 0 : -1);
         listView.Items.Add(listViewItem);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemDetailsAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemDetailsAccessibleObjectTests.cs
@@ -127,4 +127,32 @@ public class ListViewItem_ListViewItemDetailsAccessibleObjectTests
         Assert.Empty(item.AccessibilityObject.TestAccessor().Dynamic._listViewSubItemAccessibleObjects);
         Assert.False(control.IsHandleCreated);
     }
+
+    [WinFormsTheory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ListViewItemDetailsAccessibleObject_HasImage_ReturnsExpected(bool addImages)
+    {
+        using ListView listView = new()
+        {
+            View = View.Details
+        };
+
+        listView.Columns.Add(new ColumnHeader());
+
+        using ImageList imageList = new();
+        imageList.Images.Add(Form.DefaultIcon);
+
+        if (addImages)
+        {
+            listView.SmallImageList = imageList;
+        }
+
+        ListViewItem listViewItem = new ListViewItem("1", 0);
+        listView.Items.Add(listViewItem);
+
+        var accessibleObject = (ListViewItemDetailsAccessibleObject)listView.Items[0].AccessibilityObject;
+        Assert.Equal(addImages, accessibleObject.HasImage);
+        Assert.False(listView.IsHandleCreated);
+    }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemWithImageAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemWithImageAccessibleObjectTests.cs
@@ -35,7 +35,8 @@ public class ListViewItem_ListViewItemWithImageAccessibleObjectTests
         using ListView control = new()
         {
             View = view,
-            SmallImageList = imageCollection
+            SmallImageList = imageCollection,
+            LargeImageList = imageCollection
         };
         control.Items.Add(listViewItem);
 
@@ -74,7 +75,8 @@ public class ListViewItem_ListViewItemWithImageAccessibleObjectTests
         using ListView control = new()
         {
             View = view,
-            SmallImageList = imageCollection
+            SmallImageList = imageCollection,
+            LargeImageList = imageCollection
         };
         control.Items.Add(listViewItem);
 
@@ -110,7 +112,8 @@ public class ListViewItem_ListViewItemWithImageAccessibleObjectTests
         using ListView control = new()
         {
             View = view,
-            SmallImageList = imageCollection
+            SmallImageList = imageCollection,
+            LargeImageList = imageCollection
         };
         control.Items.Add(listViewItem);
         control.CreateControl();


### PR DESCRIPTION
Fixes #9125 (this is a regression from ##7672)


## Proposed changes

- changed `HasImage` property check in `ListViewItemBaseAccessibleObject` class.
- Added new regressive unit test `ListViewItemDetailsAccessibleObject_HasImage_ReturnsExpected` (it covers `HasImage` property which is responsible for creation of `ListViewItemImageAccessibleObject` accessible object).
- Fixed faulty unit tests affected by this regression

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- User can see correct information about ListViewItem without image via accessibility tools

## Regression? 

- Yes

## Risk

- Minimal

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/26474449/238509023-b108df72-6629-44d8-be3f-200264c1fb4a.png)
![image](https://user-images.githubusercontent.com/26474449/238509063-302ced9e-6bc9-4fc6-899c-f7fe7d40910b.png)

### After

![image](https://github.com/dotnet/winforms/assets/102961955/7b587b32-bfff-45d3-b323-788a7422b0a1)
![image](https://github.com/dotnet/winforms/assets/102961955/e1f51a1a-b48e-46a6-ad6e-17ce9ed7904e)

## Test methodology <!-- How did you ensure quality? -->

- Manual
- Unit tests

## Test environment(s) <!-- Remove any that don't apply -->

- dotnet 8.0.100-preview.3.23178.7

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9204)