### PR TITLE
Handle BinaryFormatter being disabled with the Clipboard

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/BinaryObjectString.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/BinaryObjectString.cs
@@ -49,4 +49,5 @@ internal sealed class BinaryObjectString : IRecord<BinaryObjectString>
             || (obj is BinaryObjectString bos && bos.ObjectId == ObjectId && bos.Value == Value);
 
     public override int GetHashCode() => HashCode.Combine(ObjectId, Value);
+    public override string ToString() => Value;
 }

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/Support/TypeInfo.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/Support/TypeInfo.cs
@@ -25,6 +25,11 @@ internal static class TypeInfo
     public const string IntPtrType = "System.IntPtr";
     public const string UIntPtrType = "System.UIntPtr";
 
+    public const string HashtableType = "System.Collections.Hashtable";
+    public const string IDictionaryType = "System.Collections.IDictionary";
+    public const string ExceptionType = "System.Exception";
+    public const string NotSupportedExceptionType = "System.NotSupportedException";
+
     public const string MscorlibAssemblyName
         = "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089";
     public const string SystemDrawingAssemblyName
@@ -33,8 +38,6 @@ internal static class TypeInfo
     /// <summary>
     ///  Returns the <see cref="PrimitiveType"/> for the given <paramref name="typeName"/>.
     /// </summary>
-    /// <param name="typeName"></param>
-    /// <returns></returns>
     internal static PrimitiveType GetPrimitiveType(ReadOnlySpan<char> typeName) => typeName switch
     {
         BooleanType => PrimitiveType.Boolean,
@@ -59,7 +62,6 @@ internal static class TypeInfo
     /// <summary>
     ///  Returns the <see cref="PrimitiveType"/> for the given <paramref name="type"/>.
     /// </summary>
-    /// <param name="type"></param>
     /// <returns><see cref="PrimitiveType"/> or <see langword="default"/> if not a <see cref="PrimitiveType"/>.</returns>
     internal static PrimitiveType GetPrimitiveType(Type type) => Type.GetTypeCode(type) switch
     {
@@ -78,9 +80,9 @@ internal static class TypeInfo
         TypeCode.Decimal => PrimitiveType.Decimal,
         TypeCode.DateTime => PrimitiveType.DateTime,
         TypeCode.String => PrimitiveType.String,
-        //TypeCode.Empty => 0,
-        //TypeCode.Object => 0,
-        //TypeCode.DBNull => 0,
+        // TypeCode.Empty => 0,
+        // TypeCode.Object => 0,
+        // TypeCode.DBNull => 0,
         _ => type == typeof(TimeSpan) ? PrimitiveType.TimeSpan : default,
     };
 }

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/ExceptionTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/ExceptionTests.cs
@@ -1,0 +1,66 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+
+namespace System.Windows.Forms.BinaryFormat.Tests;
+
+public class ExceptionTests
+{
+    [Fact]
+    public void NotSupportedException_Parse()
+    {
+        BinaryFormattedObject format = new NotSupportedException().SerializeAndParse();
+        format.RecordCount.Should().Be(3);
+        var systemClass = (SystemClassWithMembersAndTypes)format[1];
+        systemClass.Name.Should().Be(typeof(NotSupportedException).FullName);
+        systemClass.MemberNames.Should().BeEquivalentTo(new string[]
+        {
+            "ClassName",
+            "Message",
+            "Data",
+            "InnerException",
+            "HelpURL",
+            "StackTraceString",
+            "RemoteStackTraceString",
+            "RemoteStackIndex",
+            "ExceptionMethod",
+            "HResult",
+            "Source",
+            "WatsonBuckets"
+        });
+
+        systemClass.MemberTypeInfo.Should().BeEquivalentTo(new (BinaryType, object?)[]
+        {
+            (BinaryType.String, null),
+            (BinaryType.String, null),
+            (BinaryType.SystemClass, typeof(IDictionary).FullName),
+            (BinaryType.SystemClass, typeof(Exception).FullName),
+            (BinaryType.String, null),
+            (BinaryType.String, null),
+            (BinaryType.String, null),
+            (BinaryType.Primitive, PrimitiveType.Int32),
+            (BinaryType.String, null),
+            (BinaryType.Primitive, PrimitiveType.Int32),
+            (BinaryType.String, null),
+            (BinaryType.PrimitiveArray, PrimitiveType.Byte)
+        });
+
+        systemClass.MemberValues.Should().BeEquivalentTo(new object[]
+        {
+            new BinaryObjectString(2, "System.NotSupportedException"),
+            new BinaryObjectString(3, "Specified method is not supported."),
+            ObjectNull.Instance,
+            ObjectNull.Instance,
+            ObjectNull.Instance,
+            ObjectNull.Instance,
+            ObjectNull.Instance,
+            0,
+            ObjectNull.Instance,
+            unchecked((int)0x80131515),
+            ObjectNull.Instance,
+            ObjectNull.Instance
+        });
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.BitmapBinder.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.BitmapBinder.cs
@@ -12,9 +12,15 @@ public partial class DataObject
 {
     /// <summary>
     ///  Binder that restricts deserialization to Bitmap type and serialization to strings and Bitmaps.
-    ///  Deserialization of known safe types(strings and arrays of primitives) does not invoke the binder.
+    ///  Deserialization of known safe types (strings and arrays of primitives) does not invoke the binder.
     /// </summary>
-    private class BitmapBinder : SerializationBinder
+    /// <remarks>
+    ///  <para>
+    ///   This gets skipped when our <see cref="BinaryFormat.BinaryFormattedObject"/> code handles its known types.
+    ///   While there are more types allowed (such as <see cref="List{String}"/>, they are all safe.
+    ///  </para>
+    /// </remarks>
+    private sealed class BitmapBinder : SerializationBinder
     {
         // Bitmap type lives in different assemblies in the .NET Framework and in .NET Core. To support serialization
         // between both runtimes the .NET Framework identities are used.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.ComDataObjectAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.ComDataObjectAdapter.cs
@@ -217,7 +217,6 @@ public partial class DataObject
 
             static object? TryGetBitmapData(IComDataObject dataObject, string format)
             {
-                // Currently this only supports Bitmap.
                 if (format != DataFormats.BitmapConstant)
                 {
                     return null;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.cs
@@ -472,7 +472,18 @@ public unsafe partial class DataObject :
 
         if (formatetc.tymed.HasFlag(TYMED.TYMED_HGLOBAL))
         {
-            SaveDataToHGLOBAL(data!, format, ref medium).ThrowOnFailure();
+            try
+            {
+                SaveDataToHGLOBAL(data!, format, ref medium).ThrowOnFailure();
+            }
+            catch (NotSupportedException ex)
+            {
+                // BinaryFormatter is disabled. As all errors get swallowed by Windows, put the exception on the
+                // clipboard so consumers can get some indication as to what is wrong. (We handle the binary formatting
+                // of this exception, so it will always work.)
+                SaveDataToHGLOBAL(ex, format, ref medium).ThrowOnFailure();
+            }
+
             return;
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataObject_BitmapBinderTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataObject_BitmapBinderTests.cs
@@ -1,0 +1,116 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Drawing;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters.Binary;
+
+namespace System.Windows.Forms.Tests;
+
+public class DataObject_BitmapBinderTests
+{
+    private static readonly SerializationBinder s_serializationBinder
+        = (SerializationBinder)Activator.CreateInstance(typeof(DataObject).Assembly.GetType("System.Windows.Forms.DataObject+BitmapBinder"));
+
+    [WinFormsTheory]
+    [MemberData(nameof(AllowedSerializationTypes))]
+    public void BitmapBinder_BindToName_AllowedSerializationTypes(object value)
+    {
+        using BinaryFormatterScope formatterScope = new(enable: true);
+        using (value as IDisposable)
+        {
+            using MemoryStream stream = new();
+#pragma warning disable SYSLIB0011 // Type or member is obsolete
+            BinaryFormatter formatter = new()
+            {
+                Binder = s_serializationBinder
+            };
+#pragma warning restore
+
+            formatter.Serialize(stream, value);
+            Assert.True(stream.Length > 0);
+        }
+    }
+
+    [WinFormsTheory]
+    [MemberData(nameof(AllowedSerializationTypes))]
+    public void BitmapBinder_BindToType_AllowedSerializationTypes(object value)
+    {
+        using BinaryFormatterScope formatterScope = new(enable: true);
+        using (value as IDisposable)
+        {
+            using MemoryStream stream = new();
+#pragma warning disable SYSLIB0011 // Type or member is obsolete
+            BinaryFormatter formatter = new();
+#pragma warning restore
+            formatter.Serialize(stream, value);
+            Assert.True(stream.Length > 0);
+            stream.Position = 0;
+
+            formatter = new()
+            {
+                Binder = s_serializationBinder
+            };
+
+            object deserialized = formatter.Deserialize(stream);
+            Assert.NotNull(deserialized);
+
+            if (value is not Bitmap)
+            {
+                Assert.Equal(value, deserialized);
+            }
+        }
+    }
+
+    public static TheoryData<object> AllowedSerializationTypes => new()
+    {
+        "Information At your Fingertips",
+        new string[] { "Hello" },
+        new Bitmap(5, 5)
+    };
+
+    [WinFormsTheory]
+    [MemberData(nameof(DisallowedSerializationTypes))]
+    public void BitmapBinder_BindToName_DisallowedSerializationTypes(object value)
+    {
+        using BinaryFormatterScope formatterScope = new(enable: true);
+        using MemoryStream stream = new();
+#pragma warning disable SYSLIB0011 // Type or member is obsolete
+        BinaryFormatter formatter = new()
+        {
+            Binder = s_serializationBinder
+        };
+#pragma warning restore SYSLIB0011
+
+        Assert.Throws<SerializationException>(() => formatter.Serialize(stream, value));
+    }
+
+    [WinFormsTheory]
+    [MemberData(nameof(DisallowedSerializationTypes))]
+    public void BitmapBinder_BindToType_DisallowedSerializationTypes(object value)
+    {
+        using BinaryFormatterScope formatterScope = new(enable: true);
+        using MemoryStream stream = new();
+#pragma warning disable SYSLIB0011 // Type or member is obsolete
+        BinaryFormatter formatter = new();
+#pragma warning restore SYSLIB0011
+        formatter.Serialize(stream, value);
+        Assert.True(stream.Length > 0);
+        stream.Position = 0;
+
+        formatter = new()
+        {
+            Binder = s_serializationBinder
+        };
+
+        Assert.Throws<SerializationException>(() => formatter.Deserialize(stream));
+    }
+
+    public static TheoryData<object> DisallowedSerializationTypes => new()
+    {
+        new List<string>() { "Hello" },
+        new Hashtable() { { "Silver", "Hammer" } }
+    };
+}


### PR DESCRIPTION
Windows swallows all errors when getting data for the clipboard. This was resulting in seeming success, but a return of a null when trying to get the data out (as the data would be invalid and we would swallow that error on data retrieval).

There aren't great answers to this. To give some indication of the source of the failure I've implemented binary format support for NotSupportedException and put that on the clipboard if we need the BinaryFormatter.  Getting the value will give this object, with the message that the BinaryFormatter is disabled.

While we could check on settting the data it would involve deserializing to see that it is what is on the clipboard. I don't want to take that performance hit for every (normally working) usage of the clipboard.

cc @GrabYourPitchforks 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9206)