### PR TITLE
Extend test for pr#9164

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ControlAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ControlAccessibleObjectTests.cs
@@ -1588,6 +1588,25 @@ public class Control_ControlAccessibleObjectTests
         }
     }
 
+    [WinFormsTheory]
+    [MemberData(nameof(ControlAccessibleObject_TestData))]
+    public void ControlAccessibleObject_DoesNotRootControls_AllPublicControl(Type type)
+    {
+        Control.ControlAccessibleObject accessibleObject = CreateAndDisposeControl(type);
+        GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, blocking: true);
+        Assert.False(accessibleObject.TryGetOwnerAs(out Control _));
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static Control.ControlAccessibleObject CreateAndDisposeControl(Type type)
+        {
+            using Control control = ReflectionHelper.InvokePublicConstructor<Control>(type);
+            var accessibleObject = (Control.ControlAccessibleObject)control.AccessibilityObject;
+            Assert.NotNull(accessibleObject);
+            Assert.True(accessibleObject.TryGetOwnerAs(out Control _));
+            return accessibleObject;
+        }
+    }
+
     // ContextMenuStrip, From, ToolStripDropDown, ToolStripDropDownMenu
     // are Top level controls that can't be added to a ToolStrip.
     // A TabPage can be added to a TabControl only (see TabPage.AssignParent method).

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ControlAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ControlAccessibleObjectTests.cs
@@ -1212,6 +1212,22 @@ public class Control_ControlAccessibleObjectTests
         return ReflectionHelper.GetPublicNotAbstractClasses<Control>().Select(type => new object[] { type });
     }
 
+    // The weak reference is still not referenced by the accessible object of the control below, thus preventing GC collect.
+    // After all _owningLabel field were removed, this method will be deprecated.
+    public static IEnumerable<object[]> ControlAccessibleObject_UsingWeakReference_TestData()
+    {
+        var typesToIgnore = new[]
+        {
+           typeof(Label), typeof(CheckedListBox), typeof(ComboBox), typeof(DataGridView), typeof(DataGridViewComboBoxEditingControl), typeof(DataGridViewTextBoxEditingControl),
+           typeof(FlowLayoutPanel), typeof(HScrollBar), typeof(LinkLabel), typeof(ListBox),typeof(ListView), typeof(MaskedTextBox), typeof(MonthCalendar), typeof(Panel),
+           typeof(PropertyGrid), typeof(TableLayoutPanel), typeof(TabPage), typeof(TextBox), typeof(ToolStripContentPanel), typeof(TreeView), typeof(VScrollBar)
+        };
+
+        return ReflectionHelper.GetPublicNotAbstractClasses<Control>()
+           .Where(t => !typesToIgnore.Contains(t))
+           .Select(type => new object[] { type });
+    }
+
     [WinFormsTheory]
     [MemberData(nameof(ControlAccessibleObject_TestData))]
     public void ControlAccessibleObject_Custom_Role_ReturnsExpected(Type type)
@@ -1589,7 +1605,7 @@ public class Control_ControlAccessibleObjectTests
     }
 
     [WinFormsTheory]
-    [MemberData(nameof(ControlAccessibleObject_TestData))]
+    [MemberData(nameof(ControlAccessibleObject_UsingWeakReference_TestData))]
     public void ControlAccessibleObject_DoesNotRootControls_AllPublicControl(Type type)
     {
         Control.ControlAccessibleObject accessibleObject = CreateAndDisposeControl(type);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ControlAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ControlAccessibleObjectTests.cs
@@ -1600,6 +1600,7 @@ public class Control_ControlAccessibleObjectTests
             var accessibleObject = (Control.ControlAccessibleObject)control.AccessibilityObject;
             Assert.NotNull(accessibleObject);
             Assert.True(accessibleObject.TryGetOwnerAs(out Control _));
+
             return accessibleObject;
         }
     }
@@ -1619,6 +1620,7 @@ public class Control_ControlAccessibleObjectTests
             var accessibleObject = (Control.ControlAccessibleObject)control.AccessibilityObject;
             Assert.NotNull(accessibleObject);
             Assert.True(accessibleObject.TryGetOwnerAs(out Control _));
+
             return accessibleObject;
         }
     }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ControlAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ControlAccessibleObjectTests.cs
@@ -1213,7 +1213,8 @@ public class Control_ControlAccessibleObjectTests
     }
 
     // The weak reference is still not referenced by the accessible object of the control below, thus preventing GC collect.
-    // After all _owningLabel field were removed, this method will be deprecated.
+    // After all field referencing owning control are removed, this method will be deprecated.
+    // See: https://github.com/dotnet/winforms/issues/9224.
     public static IEnumerable<object[]> ControlAccessibleObject_UsingWeakReference_TestData()
     {
         var typesToIgnore = new[]


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Extend test for Fixes #9164 


## Proposed changes

- Add test "ControlAccessibleObject_DoesNotRootControls_AllPublicControl" to cover all Accessible objects that use weak referenced public controls to be successfully collected

<!-- We are in TELL-MODE the following section must be completed -->

## Regression?
- No

## Risk

- Minimal

<!-- end TELL-MODE -->

## Test methodology <!-- How did you ensure quality? -->

- Unit tests
 

## Test environment(s) <!-- Remove any that don't apply -->

- dotnet 8.0.100-preview.6.23304.3


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9215)