### PR TITLE
Fix Narrator cannot announce the progress of the VScrollbar/HScrollba…

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ScrollBar.ScrollBarAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ScrollBar.ScrollBarAccessibleObject.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Drawing;
-
 using static Interop;
 
 namespace System.Windows.Forms;
@@ -174,7 +173,6 @@ public partial class ScrollBar
             }
 
             _owningScrollBar.Value = (int)newValue;
-            base.SetValue(newValue);
         }
 
         internal override bool IsPatternSupported(UiaCore.UIA patternId)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ScrollBar.ScrollBarAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ScrollBar.ScrollBarAccessibleObject.cs
@@ -141,13 +141,30 @@ public partial class ScrollBar
                     _owningScrollBar.AccessibleRole == AccessibleRole.Default
                     => UiaCore.UIA.ScrollBarControlTypeId,
                 UiaCore.UIA.HasKeyboardFocusPropertyId => _owningScrollBar.Focused,
-                UiaCore.UIA.RangeValueValuePropertyId => true,
+                UiaCore.UIA.RangeValueValuePropertyId => RangeValue,
+                UiaCore.UIA.RangeValueIsReadOnlyPropertyId => true,
+                UiaCore.UIA.RangeValueLargeChangePropertyId => LargeChange,
+                UiaCore.UIA.RangeValueSmallChangePropertyId => SmallChange,
+                UiaCore.UIA.RangeValueMaximumPropertyId => Maximum,
+                UiaCore.UIA.RangeValueMinimumPropertyId =>Minimum,
+                UiaCore.UIA.IsValuePatternAvailablePropertyId => true,
+                UiaCore.UIA.IsRangeValuePatternAvailablePropertyId => true,
                 _ => base.GetPropertyValue(propertyID)
             };
 
         internal override bool IsIAccessibleExSupported() => true;
 
-        internal override double RangeValue => this.TryGetOwnerAs(out ScrollBar? owner) ? owner.Value : 0;
+        internal override double RangeValue => _owningScrollBar.Value;
+
+        internal override double LargeChange => double.NaN;
+
+        internal override double SmallChange => double.NaN;
+
+        internal override double Maximum => _owningScrollBar.Maximum;
+
+        internal override double Minimum => _owningScrollBar.Minimum;
+
+        internal override bool IsReadOnly => true;
 
         internal override bool IsPatternSupported(UiaCore.UIA patternId)
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ScrollBar.ScrollBarAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ScrollBar.ScrollBarAccessibleObject.cs
@@ -156,9 +156,9 @@ public partial class ScrollBar
 
         internal override double RangeValue => _owningScrollBar.Value;
 
-        internal override double LargeChange => double.NaN;
+        internal override double LargeChange => _owningScrollBar.LargeChange;
 
-        internal override double SmallChange => double.NaN;
+        internal override double SmallChange => _owningScrollBar.SmallChange;
 
         internal override double Maximum => _owningScrollBar.Maximum;
 
@@ -167,18 +167,11 @@ public partial class ScrollBar
         internal override bool IsReadOnly => true;
 
         internal override bool IsPatternSupported(UiaCore.UIA patternId)
-        {
-            if (patternId == UiaCore.UIA.ValuePatternId)
+            => patternId switch
             {
-                return true;
-            }
-
-            if (patternId == UiaCore.UIA.RangeValuePatternId)
-            {
-                return true;
-            }
-
-            return base.IsPatternSupported(patternId);
-        }
+                UiaCore.UIA.ValuePatternId => true,
+                UiaCore.UIA.RangeValuePatternId => true,
+                _ => base.IsPatternSupported(patternId)
+            };
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ScrollBar.ScrollBarAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ScrollBar.ScrollBarAccessibleObject.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Drawing;
+
 using static Interop;
 
 namespace System.Windows.Forms;
@@ -142,13 +143,12 @@ public partial class ScrollBar
                     => UiaCore.UIA.ScrollBarControlTypeId,
                 UiaCore.UIA.HasKeyboardFocusPropertyId => _owningScrollBar.Focused,
                 UiaCore.UIA.RangeValueValuePropertyId => RangeValue,
-                UiaCore.UIA.RangeValueIsReadOnlyPropertyId => true,
+                UiaCore.UIA.RangeValueIsReadOnlyPropertyId => IsReadOnly,
                 UiaCore.UIA.RangeValueLargeChangePropertyId => LargeChange,
                 UiaCore.UIA.RangeValueSmallChangePropertyId => SmallChange,
                 UiaCore.UIA.RangeValueMaximumPropertyId => Maximum,
-                UiaCore.UIA.RangeValueMinimumPropertyId =>Minimum,
-                UiaCore.UIA.IsValuePatternAvailablePropertyId => true,
-                UiaCore.UIA.IsRangeValuePatternAvailablePropertyId => true,
+                UiaCore.UIA.RangeValueMinimumPropertyId => Minimum,
+                UiaCore.UIA.IsRangeValuePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.RangeValuePatternId),
                 _ => base.GetPropertyValue(propertyID)
             };
 
@@ -164,7 +164,18 @@ public partial class ScrollBar
 
         internal override double Minimum => _owningScrollBar.Minimum;
 
-        internal override bool IsReadOnly => true;
+        internal override bool IsReadOnly => false;
+
+        internal override void SetValue(double newValue)
+        {
+            if (!_owningScrollBar.IsHandleCreated)
+            {
+                return;
+            }
+
+            _owningScrollBar.Value = (int)newValue;
+            base.SetValue(newValue);
+        }
 
         internal override bool IsPatternSupported(UiaCore.UIA patternId)
             => patternId switch

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ScrollBar.ScrollBarAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ScrollBar.ScrollBarAccessibleObject.cs
@@ -141,14 +141,22 @@ public partial class ScrollBar
                     _owningScrollBar.AccessibleRole == AccessibleRole.Default
                     => UiaCore.UIA.ScrollBarControlTypeId,
                 UiaCore.UIA.HasKeyboardFocusPropertyId => _owningScrollBar.Focused,
+                UiaCore.UIA.RangeValueValuePropertyId => true,
                 _ => base.GetPropertyValue(propertyID)
             };
 
         internal override bool IsIAccessibleExSupported() => true;
 
+        internal override double RangeValue => this.TryGetOwnerAs(out ScrollBar? owner) ? owner.Value : 0;
+
         internal override bool IsPatternSupported(UiaCore.UIA patternId)
         {
             if (patternId == UiaCore.UIA.ValuePatternId)
+            {
+                return true;
+            }
+
+            if (patternId == UiaCore.UIA.RangeValuePatternId)
             {
                 return true;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ScrollBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ScrollBar.cs
@@ -371,7 +371,7 @@ public abstract partial class ScrollBar : Control
                 OnValueChanged(EventArgs.Empty);
                 if (IsAccessibilityObjectCreated)
                 {
-                    AccessibilityObject.RaiseAutomationPropertyChangedEvent(UiaCore.UIA.RangeValueValuePropertyId, oldValue, _value);
+                    AccessibilityObject.RaiseAutomationPropertyChangedEvent(UiaCore.UIA.RangeValueValuePropertyId, (double)oldValue, (double)_value);
                 }
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ScrollBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ScrollBar.cs
@@ -365,9 +365,14 @@ public abstract partial class ScrollBar : Control
                     throw new ArgumentOutOfRangeException(nameof(value), string.Format(SR.InvalidBoundArgument, nameof(Value), value, $"'{nameof(Minimum)}'", $"'{nameof(Maximum)}'"));
                 }
 
+                int oldValue = _value;
                 _value = value;
                 UpdateScrollInfo();
                 OnValueChanged(EventArgs.Empty);
+                if (IsAccessibilityObjectCreated)
+                {
+                    AccessibilityObject.RaiseAutomationPropertyChangedEvent(UiaCore.UIA.RangeValueValuePropertyId, oldValue, _value);
+                }
             }
         }
     }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ScrollBar.ScrollBarAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ScrollBar.ScrollBarAccessibleObjectTests.cs
@@ -51,6 +51,11 @@ public class ScrollBar_ScrollBarAccessibleObjectTests
     [InlineData((int)UIA.IsKeyboardFocusablePropertyId, true)]
     [InlineData((int)UIA.IsValuePatternAvailablePropertyId, true)]
     [InlineData((int)UIA.AutomationIdPropertyId, "AutomId")]
+    [InlineData((double)UIA.RangeValueMaximumPropertyId, (double)100)]
+    [InlineData((double)UIA.RangeValueMinimumPropertyId, (double)0)]
+    [InlineData((double)UIA.RangeValueValuePropertyId, (double)0)]
+    [InlineData((double)UIA.RangeValueLargeChangePropertyId, (double)10)]
+    [InlineData((double)UIA.RangeValueSmallChangePropertyId, (double)1)]
     public void ScrollBarAccessibleObject_GetPropertyValue_Invoke_ReturnsExpected(int propertyID, object expected)
     {
         using var scrollBar = new SubScrollBar
@@ -139,11 +144,13 @@ public class ScrollBar_ScrollBarAccessibleObjectTests
     [InlineData(false, ((int)UIA.IsTextPatternAvailablePropertyId))]
     [InlineData(false, ((int)UIA.IsTogglePatternAvailablePropertyId))]
     [InlineData(true, ((int)UIA.IsValuePatternAvailablePropertyId))]
+    [InlineData(true, ((int)UIA.RangeValueIsReadOnlyPropertyId))]
+    [InlineData(true, ((int)UIA.IsRangeValuePatternAvailablePropertyId))]
     public void ScrollBarAccessibleObject_GetPropertyValue_Pattern_ReturnsExpected(bool expected, int propertyId)
     {
         using SubScrollBar scrollBar = new() { Enabled = true };
         ScrollBar.ScrollBarAccessibleObject accessibleObject = (ScrollBar.ScrollBarAccessibleObject)scrollBar.AccessibilityObject;
-
+        var a= accessibleObject.GetPropertyValue((UiaCore.UIA)propertyId);
         Assert.Equal(expected, accessibleObject.GetPropertyValue((UiaCore.UIA)propertyId) ?? false);
         Assert.False(scrollBar.IsHandleCreated);
     }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ScrollBar.ScrollBarAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ScrollBar.ScrollBarAccessibleObjectTests.cs
@@ -170,6 +170,7 @@ public class ScrollBar_ScrollBarAccessibleObjectTests
         object actual = accessibleObject.GetPropertyValue(UiaCore.UIA.RangeValueValuePropertyId);
 
         Assert.Equal(expected, actual);
+        Assert.Equal(expected, (double)scrollBar.Value);
         Assert.True(scrollBar.IsHandleCreated);
     }
 
@@ -182,15 +183,7 @@ public class ScrollBar_ScrollBarAccessibleObjectTests
         scrollBar.CreateControl();
         AccessibleObject accessibleObject = scrollBar.AccessibilityObject;
 
-        try
-        {
-            accessibleObject.SetValue(newValue);
-        }
-        catch (Exception ex)
-        {
-            Assert.Equal(ex.Message, $"Value of '{newValue}' is not valid for 'Value'. 'Value' should be between 'Minimum' and 'Maximum'. (Parameter 'value')");
-        }
-
+        Assert.Throws<ArgumentOutOfRangeException>("value", () => accessibleObject.SetValue(newValue));
         Assert.True(scrollBar.IsHandleCreated);
     }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ScrollBar.ScrollBarAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ScrollBar.ScrollBarAccessibleObjectTests.cs
@@ -155,6 +155,45 @@ public class ScrollBar_ScrollBarAccessibleObjectTests
         Assert.False(scrollBar.IsHandleCreated);
     }
 
+    [WinFormsTheory]
+    [InlineData(100, 100d)]
+    [InlineData(1, 1d)]
+    [InlineData(0, 0d)]
+    [InlineData(50d, 50d)]
+    public void ScrollBarAccessibleObject_SetValue_Invoke_ReturnsExpected(int newValue, object expected)
+    {
+        using var scrollBar = new SubScrollBar();
+        scrollBar.CreateControl();
+        AccessibleObject accessibleObject = scrollBar.AccessibilityObject;
+
+        accessibleObject.SetValue(newValue);
+        object actual = accessibleObject.GetPropertyValue(UiaCore.UIA.RangeValueValuePropertyId);
+
+        Assert.Equal(expected, actual);
+        Assert.True(scrollBar.IsHandleCreated);
+    }
+
+    [WinFormsTheory]
+    [InlineData(101)]
+    [InlineData(-1)]
+    public void ScrollBarAccessibleObject_SetValue_OutOfRangeValue_ThrowExceptionExpected(int newValue)
+    {
+        using var scrollBar = new SubScrollBar();
+        scrollBar.CreateControl();
+        AccessibleObject accessibleObject = scrollBar.AccessibilityObject;
+
+        try
+        {
+            accessibleObject.SetValue(newValue);
+        }
+        catch (Exception ex)
+        {
+            Assert.Equal(ex.Message, $"Value of '{newValue}' is not valid for 'Value'. 'Value' should be between 'Minimum' and 'Maximum'. (Parameter 'value')");
+        }
+
+        Assert.True(scrollBar.IsHandleCreated);
+    }
+
     private class SubScrollBar : ScrollBar
     {
         public SubScrollBar() : base()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ScrollBar.ScrollBarAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ScrollBar.ScrollBarAccessibleObjectTests.cs
@@ -51,11 +51,12 @@ public class ScrollBar_ScrollBarAccessibleObjectTests
     [InlineData((int)UIA.IsKeyboardFocusablePropertyId, true)]
     [InlineData((int)UIA.IsValuePatternAvailablePropertyId, true)]
     [InlineData((int)UIA.AutomationIdPropertyId, "AutomId")]
-    [InlineData((double)UIA.RangeValueMaximumPropertyId, (double)100)]
-    [InlineData((double)UIA.RangeValueMinimumPropertyId, (double)0)]
-    [InlineData((double)UIA.RangeValueValuePropertyId, (double)0)]
-    [InlineData((double)UIA.RangeValueLargeChangePropertyId, (double)10)]
-    [InlineData((double)UIA.RangeValueSmallChangePropertyId, (double)1)]
+    [InlineData((int)UIA.RangeValueMaximumPropertyId, 100d)]
+    [InlineData((int)UIA.RangeValueMinimumPropertyId, 0d)]
+    [InlineData((int)UIA.RangeValueValuePropertyId, 0d)]
+    [InlineData((int)UIA.RangeValueLargeChangePropertyId, 10d)]
+    [InlineData((int)UIA.RangeValueSmallChangePropertyId, 1d)]
+    [InlineData((int)UIA.RangeValueIsReadOnlyPropertyId, false)]
     public void ScrollBarAccessibleObject_GetPropertyValue_Invoke_ReturnsExpected(int propertyID, object expected)
     {
         using var scrollBar = new SubScrollBar
@@ -144,13 +145,12 @@ public class ScrollBar_ScrollBarAccessibleObjectTests
     [InlineData(false, ((int)UIA.IsTextPatternAvailablePropertyId))]
     [InlineData(false, ((int)UIA.IsTogglePatternAvailablePropertyId))]
     [InlineData(true, ((int)UIA.IsValuePatternAvailablePropertyId))]
-    [InlineData(true, ((int)UIA.RangeValueIsReadOnlyPropertyId))]
     [InlineData(true, ((int)UIA.IsRangeValuePatternAvailablePropertyId))]
     public void ScrollBarAccessibleObject_GetPropertyValue_Pattern_ReturnsExpected(bool expected, int propertyId)
     {
         using SubScrollBar scrollBar = new() { Enabled = true };
         ScrollBar.ScrollBarAccessibleObject accessibleObject = (ScrollBar.ScrollBarAccessibleObject)scrollBar.AccessibilityObject;
-        
+
         Assert.Equal(expected, accessibleObject.GetPropertyValue((UiaCore.UIA)propertyId) ?? false);
         Assert.False(scrollBar.IsHandleCreated);
     }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ScrollBar.ScrollBarAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ScrollBar.ScrollBarAccessibleObjectTests.cs
@@ -150,7 +150,7 @@ public class ScrollBar_ScrollBarAccessibleObjectTests
     {
         using SubScrollBar scrollBar = new() { Enabled = true };
         ScrollBar.ScrollBarAccessibleObject accessibleObject = (ScrollBar.ScrollBarAccessibleObject)scrollBar.AccessibilityObject;
-        var a= accessibleObject.GetPropertyValue((UiaCore.UIA)propertyId);
+        
         Assert.Equal(expected, accessibleObject.GetPropertyValue((UiaCore.UIA)propertyId) ?? false);
         Assert.False(scrollBar.IsHandleCreated);
     }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #9158 
RangeValue property determines whether Scroll Bar value  should be read out by screen reader as the Scroll Bar Range Value changed.

## Proposed changes

- Implement RangeValue pattern in ScrollBarAccessibleObject.
- Raising RangeValueValuePropertyId property-changed event when scroll bar value is changed.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Narrator cannot announce the progress of the VScrollbar/HScrollbar when updating it.

## Regression? 

- No

## Risk

-Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
RangeValue Patten is not displayed in the Insights properties panel.
![image](https://github.com/dotnet/winforms/assets/133954995/8d678ada-9fe1-4dd2-b5a8-a7bce7451827)
![image](https://user-images.githubusercontent.com/26474449/239871005-915e9726-23d9-4bba-a659-f735a552467e.gif)

### After
RangeValue Patten is displayed in the Insights properties panel.
![image](https://github.com/dotnet/winforms/assets/133954995/186bed2b-0277-48d1-85ee-0e37d0bf30ec)
![ScrollBar](https://github.com/dotnet/winforms/assets/133954995/bb9ee7db-4a95-4078-b344-5c91e0e017c8)
Narrator Buddy output as range value is changed into the Scroll Bar:

1,
2,
3,
4,
5,
6,
7,

<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- Manual testing
- Unit tests
- CTI

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

- Using Narrator and AI

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

- dotnet 8.0.0-preview.6.23280.5
- Windows 11


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9217)