### PR TITLE
Fix CheckBox indeterminate state announcement in screen readers

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/CheckBox.CheckBoxAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CheckBox.CheckBoxAccessibleObject.cs
@@ -33,8 +33,13 @@ public partial class CheckBox
             };
 
         internal override UiaCore.ToggleState ToggleState
-            => this.TryGetOwnerAs(out CheckBox? owner) && owner.Checked
-                ? UiaCore.ToggleState.On
+            => this.TryGetOwnerAs(out CheckBox? owner)
+                ? owner.CheckState switch
+                {
+                    CheckState.Checked => UiaCore.ToggleState.On,
+                    CheckState.Unchecked => UiaCore.ToggleState.Off,
+                    _ => UiaCore.ToggleState.Indeterminate,
+                }
                 : UiaCore.ToggleState.Off;
 
         internal override bool IsPatternSupported(UiaCore.UIA patternId)
@@ -79,7 +84,19 @@ public partial class CheckBox
         {
             if (this.TryGetOwnerAs(out CheckBox? owner))
             {
-                owner.Checked = !owner.Checked;
+                if (owner.ThreeState)
+                {
+                    owner.CheckState = owner.CheckState switch
+                    {
+                        CheckState.Unchecked => CheckState.Checked,
+                        CheckState.Checked => CheckState.Indeterminate,
+                        _ => CheckState.Unchecked
+                    };
+                }
+                else
+                {
+                    owner.Checked = !owner.Checked;
+                }
             }
         }
     }

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MultipleControls.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MultipleControls.Designer.cs
@@ -44,6 +44,7 @@ partial class MultipleControls
         this.comboBox1 = new System.Windows.Forms.ComboBox();
         this.tabPage2 = new System.Windows.Forms.TabPage();
         this.checkBox1 = new System.Windows.Forms.CheckBox();
+        this.checkBox2 = new System.Windows.Forms.CheckBox();
         this.radioButton2 = new System.Windows.Forms.RadioButton();
         this.radioButton1 = new System.Windows.Forms.RadioButton();
         this.groupBox1 = new System.Windows.Forms.GroupBox();
@@ -156,6 +157,7 @@ partial class MultipleControls
         // tabPage2
         // 
         this.tabPage2.Controls.Add(this.checkBox1);
+        this.tabPage2.Controls.Add(this.checkBox2);
         this.tabPage2.Location = new System.Drawing.Point(4, 24);
         this.tabPage2.Name = "tabPage2";
         this.tabPage2.Size = new System.Drawing.Size(225, 87);
@@ -173,6 +175,17 @@ partial class MultipleControls
         this.checkBox1.TabIndex = 0;
         this.checkBox1.Text = "checkBox1";
         this.checkBox1.UseVisualStyleBackColor = true;
+        // 
+        // checkBox2
+        // 
+        this.checkBox2.AutoSize = true;
+        this.checkBox2.Location = new System.Drawing.Point(8, 50);
+        this.checkBox2.Name = "checkBox2";
+        this.checkBox2.Size = new System.Drawing.Size(153, 19);
+        this.checkBox2.TabIndex = 0;
+        this.checkBox2.Text = "Three state CheckBox";
+        this.checkBox2.ThreeState = true;
+        this.checkBox2.UseVisualStyleBackColor = true;
         // 
         // radioButton2
         // 
@@ -325,6 +338,7 @@ partial class MultipleControls
     private System.Windows.Forms.ComboBox comboBox1;
     private System.Windows.Forms.TabPage tabPage2;
     private System.Windows.Forms.CheckBox checkBox1;
+    private System.Windows.Forms.CheckBox checkBox2;
     private System.Windows.Forms.RadioButton radioButton2;
     private System.Windows.Forms.RadioButton radioButton1;
     private System.Windows.Forms.GroupBox groupBox1;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CheckBox.CheckBoxAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CheckBox.CheckBoxAccessibleObjectTests.cs
@@ -242,7 +242,6 @@ public class CheckBox_CheckBoxAccessibleObjectTests
     public void CheckBoxAccessibleObject_Toggle_Invoke_ThreeState_Success()
     {
         using var checkBox = new CheckBox() { ThreeState = true };
-        Assert.False(checkBox.IsHandleCreated);
         var checkBoxAccessibleObject = new CheckBox.CheckBoxAccessibleObject(checkBox);
         Assert.Equal(CheckState.Unchecked, checkBox.CheckState);
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CheckBox.CheckBoxAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CheckBox.CheckBoxAccessibleObjectTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Data;
 using static Interop.UiaCore;
 
 namespace System.Windows.Forms.Tests;
@@ -115,7 +114,7 @@ public class CheckBox_CheckBoxAccessibleObjectTests
         Assert.Equal(createControl, checkBox.IsHandleCreated);
     }
 
-    private static IEnumerable<object[]> CheckBoxAccessibleObject_DoDefaultAction_Success_Data()
+    public static IEnumerable<object[]> CheckBoxAccessibleObject_DoDefaultAction_Success_Data()
     {
         yield return new object[] { true, false, CheckState.Checked, (int)ToggleState.Off };
         yield return new object[] { true, false, CheckState.Indeterminate, (int)ToggleState.Off };


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #9157


## Proposed changes

- Update TogglePattern ToggleState property implementation in `CheckBoxAccessibleObject`.
- Trigger StateChange accessible event when CheckBox is switched to Indeterminate state.
- Add unit tests to verify CheckBoxAccessibleObject.ToggleState property value and CheckBoxAccessibleObject.Toggle method behavior;
- Add three-state check box to WinformsControlsTest app.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Screen readers announce CheckBox state correctly.

## Regression? 

- Yes, the issue cannot repro in .Net Core 3.1, and repro in .Net 5, 6, 7 versions

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
Narrator announces Indeterminate state as Checked:
![Narrator announces Indeterminate as Checked](https://github.com/dotnet/winforms/assets/113603457/87f0d6dd-6d8c-433e-b571-436e3103b6df)

Narrator does not announce switching from Checked to Indeterminate state:

https://github.com/dotnet/winforms/assets/113603457/48630969-36ff-430a-8f80-d00d2e5c4d3e

ToogleState value is On for Indeterminate checkbox: 
![ToggleState is On](https://github.com/dotnet/winforms/assets/113603457/bee6b4c6-59e9-41d3-879f-277f206c908e)

### After

![Narrator announces Indeterminate](https://github.com/dotnet/winforms/assets/113603457/a011852c-6b76-486d-98e6-31a1e6c3681c)

https://github.com/dotnet/winforms/assets/113603457/1c04e0cb-c369-46c0-84e9-2ad8ebf3e979

![ToggleState is Indeterminate](https://github.com/dotnet/winforms/assets/113603457/1f9ca36c-51dc-444a-b278-989f2f0a619e)



## Test environment(s) <!-- Remove any that don't apply -->

- .NET  8.0.100-preview.4.23260.5
- Inspect 7.2.0.0


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9242)