### PR TITLE
Update control owning field of Label and Panel to using weak references

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Label.LabelAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Label.LabelAccessibleObject.cs
@@ -8,26 +8,10 @@ public partial class Label
 {
     internal class LabelAccessibleObject : ControlAccessibleObject
     {
-        private readonly Label _owningLabel;
-
         public LabelAccessibleObject(Label owner) : base(owner)
         {
-            _owningLabel = owner;
         }
 
-        public override AccessibleRole Role
-        {
-            get
-            {
-                AccessibleRole role = _owningLabel.AccessibleRole;
-
-                if (role != AccessibleRole.Default)
-                {
-                    return role;
-                }
-
-                return AccessibleRole.StaticText;
-            }
-        }
+        public override AccessibleRole Role => this.GetOwnerAccessibleRole(AccessibleRole.StaticText);
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Panel.PanelAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Panel.PanelAccessibleObject.cs
@@ -10,28 +10,25 @@ public partial class Panel
 {
     internal class PanelAccessibleObject : ControlAccessibleObject
     {
-        private readonly Panel _owningPanel;
-
         public PanelAccessibleObject(Panel owner) : base(owner)
         {
-            _owningPanel = owner;
         }
 
         internal override UiaCore.IRawElementProviderFragmentRoot FragmentRoot => this;
 
         public override AccessibleObject? GetChild(int index)
         {
-            if (!_owningPanel.IsHandleCreated || index < 0 || index >= _owningPanel.Controls.Count)
+            if (!this.TryGetOwnerAs(out Panel? owner) || !owner.IsHandleCreated || index < 0 || index >= owner.Controls.Count)
             {
                 return null;
             }
 
-            return _owningPanel.Controls[index].AccessibilityObject;
+            return owner.Controls[index].AccessibilityObject;
         }
 
         public override int GetChildCount()
-            => _owningPanel.IsHandleCreated
-                ? _owningPanel.Controls.Count
+            => this.TryGetOwnerAs(out Panel? owner) && owner.IsHandleCreated
+                ? owner.Controls.Count
                 : -1;
 
         internal override object? GetPropertyValue(UiaCore.UIA propertyID)

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ControlAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ControlAccessibleObjectTests.cs
@@ -1219,8 +1219,8 @@ public class Control_ControlAccessibleObjectTests
     {
         var typesToIgnore = new[]
         {
-           typeof(Label), typeof(CheckedListBox), typeof(ComboBox), typeof(DataGridView), typeof(DataGridViewComboBoxEditingControl), typeof(DataGridViewTextBoxEditingControl),
-           typeof(FlowLayoutPanel), typeof(HScrollBar), typeof(LinkLabel), typeof(ListBox),typeof(ListView), typeof(MaskedTextBox), typeof(MonthCalendar), typeof(Panel),
+           typeof(CheckedListBox), typeof(ComboBox), typeof(DataGridView), typeof(DataGridViewComboBoxEditingControl), typeof(DataGridViewTextBoxEditingControl),
+           typeof(FlowLayoutPanel), typeof(HScrollBar), typeof(LinkLabel), typeof(ListBox),typeof(ListView), typeof(MaskedTextBox), typeof(MonthCalendar),
            typeof(PropertyGrid), typeof(TableLayoutPanel), typeof(TabPage), typeof(TextBox), typeof(ToolStripContentPanel), typeof(TreeView), typeof(VScrollBar)
         };
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Related to #9224 


## Proposed changes

- Update the control owning field of Label and Panel to using weak references
- Enable the GC collect test for the Label and Panel control in unit test cases

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- The strong reference used by the original Owner property can cause a memory leak

## Regression? 

- No

<!-- end TELL-MODE -->


## Test methodology <!-- How did you ensure quality? -->

- Unit tests

## Test environment(s) <!-- Remove any that don't apply -->

- dotnet 8.0.100-preview.6.23307.24

<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9246)