### PR TITLE
Fix issue #7721 by inverting the color of the Browse button

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/DropDownButton.DropDownButtonAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/DropDownButton.DropDownButtonAdapter.cs
@@ -87,12 +87,11 @@ internal sealed partial class DropDownButton : Button
 
         internal override void DrawImageCore(Graphics graphics, Image image, Rectangle imageBounds, Point imageStart, LayoutData layout)
         {
-            if (SystemInformation.HighContrast && image is Bitmap bitmap)
+            bool isHighContrastHighlighted = !Control.MouseIsDown && IsHighContrastHighlighted();
+            Color backgroundColor = isHighContrastHighlighted ? SystemColors.Highlight : Control.BackColor;
+            if (ControlPaint.IsDark(backgroundColor) && image is Bitmap bitmap)
             {
-                Image invertedImage = (Control.MouseIsOver && SystemColors.WindowText.GetBrightness() <= 0.5) ||
-                                 (!Control.MouseIsOver && ControlPaint.IsDark(SystemColors.Window))
-                    ? ControlPaint.CreateBitmapWithInvertedForeColor(bitmap, Control.BackColor)
-                    : image;
+                using Image invertedImage = ControlPaint.CreateBitmapWithInvertedForeColor(bitmap, Control.BackColor);
                 graphics.DrawImage(invertedImage, imageBounds, 0, 0, image.Width, image.Height, GraphicsUnit.Pixel, new ImageAttributes());
             }
             else

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/DropDownButton.DropDownButtonAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/DropDownButton.DropDownButtonAdapter.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Drawing;
+using System.Drawing.Imaging;
 using System.Windows.Forms.ButtonInternal;
 
 namespace System.Windows.Forms.PropertyGridInternal;
@@ -86,12 +87,18 @@ internal sealed partial class DropDownButton : Button
 
         internal override void DrawImageCore(Graphics graphics, Image image, Rectangle imageBounds, Point imageStart, LayoutData layout)
         {
-            ControlPaint.DrawImageReplaceColor(
-                graphics,
-                image,
-                imageBounds,
-                Color.Black,
-                IsHighContrastHighlighted() && !Control.MouseIsDown ? SystemColors.HighlightText : Control.ForeColor);
+            if (SystemInformation.HighContrast && image is Bitmap bitmap)
+            {
+                Image invertedImage = (Control.MouseIsOver && SystemColors.WindowText.GetBrightness() <= 0.5) ||
+                                 (!Control.MouseIsOver && ControlPaint.IsDark(SystemColors.Window))
+                    ? ControlPaint.CreateBitmapWithInvertedForeColor(bitmap, Control.BackColor)
+                    : image;
+                graphics.DrawImage(invertedImage, imageBounds, 0, 0, image.Width, image.Height, GraphicsUnit.Pixel, new ImageAttributes());
+            }
+            else
+            {
+                graphics.DrawImage(image, imageBounds, 0, 0, image.Width, image.Height, GraphicsUnit.Pixel, new ImageAttributes());
+            }
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/DropDownButton.DropDownButtonAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/DropDownButton.DropDownButtonAdapter.cs
@@ -89,7 +89,7 @@ internal sealed partial class DropDownButton : Button
         {
             if (SystemInformation.HighContrast && image is Bitmap bitmap)
             {
-                Image invertedImage = (Control.MouseIsOver && SystemColors.WindowText.GetBrightness() > 0.5) ||
+                Image invertedImage = (Control.MouseIsOver && SystemColors.WindowText.GetBrightness() <= 0.5) ||
                                  (!Control.MouseIsOver && ControlPaint.IsDark(SystemColors.Window))
                     ? ControlPaint.CreateBitmapWithInvertedForeColor(bitmap, Control.BackColor)
                     : image;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/DropDownButton.DropDownButtonAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/DropDownButton.DropDownButtonAdapter.cs
@@ -89,7 +89,7 @@ internal sealed partial class DropDownButton : Button
         {
             if (SystemInformation.HighContrast && image is Bitmap bitmap)
             {
-                Image invertedImage = (Control.MouseIsOver && SystemColors.WindowText.GetBrightness() <= 0.5) ||
+                Image invertedImage = (Control.MouseIsOver && SystemColors.WindowText.GetBrightness() > 0.5) ||
                                  (!Control.MouseIsOver && ControlPaint.IsDark(SystemColors.Window))
                     ? ControlPaint.CreateBitmapWithInvertedForeColor(bitmap, Control.BackColor)
                     : image;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -247,19 +247,12 @@ internal sealed partial class PropertyGridView :
             {
                 OwnerGrid.CheckInCreate();
 
-                Bitmap bmp = CreateResizedBitmap("dotdotdot", DotDotDotIconWidth, DotDotDotIconHeight);
-
-                if (ControlPaint.IsDark(BackColor))
-                {
-                    bmp = ControlPaint.CreateBitmapWithInvertedForeColor(bmp, BackColor);
-                }
-
                 _dialogButton = new DropDownButton
                 {
                     BackColor = SystemColors.Control,
                     ForeColor = SystemColors.ControlText,
                     TabIndex = 3,
-                    Image = bmp
+                    Image = CreateResizedBitmap("dotdotdot", DotDotDotIconWidth, DotDotDotIconHeight)
                 };
 
                 _dialogButton.Click += OnButtonClick;
@@ -5332,17 +5325,7 @@ internal sealed partial class PropertyGridView :
                     DialogButton.Size = DropDownButton.Size;
                     if (isScalingRequirementMet)
                     {
-                        Bitmap bmp = CreateResizedBitmap("dotdotdot", DotDotDotIconWidth, DotDotDotIconHeight);
-
-                        if (ControlPaint.IsDark(BackColor))
-                        {
-                            Bitmap invertedBitmap = ControlPaint.CreateBitmapWithInvertedForeColor(bmp, BackColor);
-                            _dialogButton.Image = invertedBitmap;
-                        }
-                        else
-                        {
-                            _dialogButton.Image = bmp;
-                        }
+                        _dialogButton.Image = CreateResizedBitmap("dotdotdot", DotDotDotIconWidth, DotDotDotIconHeight);
                     }
                 }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -247,14 +247,19 @@ internal sealed partial class PropertyGridView :
             {
                 OwnerGrid.CheckInCreate();
 
-                Bitmap bitmap = CreateResizedBitmap("dotdotdot", DotDotDotIconWidth, DotDotDotIconHeight);
+                Bitmap bmp = CreateResizedBitmap("dotdotdot", DotDotDotIconWidth, DotDotDotIconHeight);
+
+                if (ControlPaint.IsDark(BackColor))
+                {
+                    bmp = ControlPaint.CreateBitmapWithInvertedForeColor(bmp, BackColor);
+                }
 
                 _dialogButton = new DropDownButton
                 {
                     BackColor = SystemColors.Control,
                     ForeColor = SystemColors.ControlText,
                     TabIndex = 3,
-                    Image = ControlPaint.IsDark(BackColor) ? ControlPaint.CreateBitmapWithInvertedForeColor(bitmap, BackColor) : bitmap
+                    Image = bmp
                 };
 
                 _dialogButton.Click += OnButtonClick;
@@ -5327,8 +5332,17 @@ internal sealed partial class PropertyGridView :
                     DialogButton.Size = DropDownButton.Size;
                     if (isScalingRequirementMet)
                     {
-                        Bitmap bitmap = CreateResizedBitmap("dotdotdot", DotDotDotIconWidth, DotDotDotIconHeight);
-                        _dialogButton.Image = ControlPaint.IsDark(BackColor) ? ControlPaint.CreateBitmapWithInvertedForeColor(bitmap, BackColor) : bitmap;
+                        Bitmap bmp = CreateResizedBitmap("dotdotdot", DotDotDotIconWidth, DotDotDotIconHeight);
+
+                        if (ControlPaint.IsDark(BackColor))
+                        {
+                            Bitmap invertedBitmap = ControlPaint.CreateBitmapWithInvertedForeColor(bmp, BackColor);
+                            _dialogButton.Image = invertedBitmap;
+                        }
+                        else
+                        {
+                            _dialogButton.Image = bmp;
+                        }
                     }
                 }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -247,12 +247,19 @@ internal sealed partial class PropertyGridView :
             {
                 OwnerGrid.CheckInCreate();
 
+                Bitmap bmp = CreateResizedBitmap("dotdotdot", DotDotDotIconWidth, DotDotDotIconHeight);
+
+                if (ControlPaint.IsDark(BackColor))
+                {
+                    bmp = ControlPaint.CreateBitmapWithInvertedForeColor(bmp, BackColor);
+                }
+
                 _dialogButton = new DropDownButton
                 {
                     BackColor = SystemColors.Control,
                     ForeColor = SystemColors.ControlText,
                     TabIndex = 3,
-                    Image = CreateResizedBitmap("dotdotdot", DotDotDotIconWidth, DotDotDotIconHeight)
+                    Image = bmp
                 };
 
                 _dialogButton.Click += OnButtonClick;
@@ -5325,7 +5332,17 @@ internal sealed partial class PropertyGridView :
                     DialogButton.Size = DropDownButton.Size;
                     if (isScalingRequirementMet)
                     {
-                        _dialogButton.Image = CreateResizedBitmap("dotdotdot", DotDotDotIconWidth, DotDotDotIconHeight);
+                        Bitmap bmp = CreateResizedBitmap("dotdotdot", DotDotDotIconWidth, DotDotDotIconHeight);
+
+                        if (ControlPaint.IsDark(BackColor))
+                        {
+                            Bitmap invertedBitmap = ControlPaint.CreateBitmapWithInvertedForeColor(bmp, BackColor);
+                            _dialogButton.Image = invertedBitmap;
+                        }
+                        else
+                        {
+                            _dialogButton.Image = bmp;
+                        }
                     }
                 }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -247,19 +247,14 @@ internal sealed partial class PropertyGridView :
             {
                 OwnerGrid.CheckInCreate();
 
-                Bitmap bmp = CreateResizedBitmap("dotdotdot", DotDotDotIconWidth, DotDotDotIconHeight);
-
-                if (ControlPaint.IsDark(BackColor))
-                {
-                    bmp = ControlPaint.CreateBitmapWithInvertedForeColor(bmp, BackColor);
-                }
+                Bitmap bitmap = CreateResizedBitmap("dotdotdot", DotDotDotIconWidth, DotDotDotIconHeight);
 
                 _dialogButton = new DropDownButton
                 {
                     BackColor = SystemColors.Control,
                     ForeColor = SystemColors.ControlText,
                     TabIndex = 3,
-                    Image = bmp
+                    Image = ControlPaint.IsDark(BackColor) ? ControlPaint.CreateBitmapWithInvertedForeColor(bitmap, BackColor) : bitmap
                 };
 
                 _dialogButton.Click += OnButtonClick;
@@ -5332,17 +5327,8 @@ internal sealed partial class PropertyGridView :
                     DialogButton.Size = DropDownButton.Size;
                     if (isScalingRequirementMet)
                     {
-                        Bitmap bmp = CreateResizedBitmap("dotdotdot", DotDotDotIconWidth, DotDotDotIconHeight);
-
-                        if (ControlPaint.IsDark(BackColor))
-                        {
-                            Bitmap invertedBitmap = ControlPaint.CreateBitmapWithInvertedForeColor(bmp, BackColor);
-                            _dialogButton.Image = invertedBitmap;
-                        }
-                        else
-                        {
-                            _dialogButton.Image = bmp;
-                        }
+                        Bitmap bitmap = CreateResizedBitmap("dotdotdot", DotDotDotIconWidth, DotDotDotIconHeight);
+                        _dialogButton.Image = ControlPaint.IsDark(BackColor) ? ControlPaint.CreateBitmapWithInvertedForeColor(bitmap, BackColor) : bitmap;
                     }
                 }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #7721 


## Proposed changes

- Add HighContrast judgment when drawing dropdown button in file DropDownButton.DropDownButtonAdapter.cs
- Under the HC black theme, call the method "CreateBitmapWithInvertedForeColor" to invert the icon color
- When the button gets the focus, judge whether to revert the image color 

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- The icon of "Browse..." in PropertyGrid control is unclear when non-selecting it

## Regression? 

- No

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/dotnet/winforms/assets/132890443/0ffedbc6-4397-436c-b9ae-7a744170494a)


### After

![image](https://github.com/dotnet/winforms/assets/132890443/a5051f93-3aa6-4a1d-ab24-d70db6249cd2)

## Test methodology <!-- How did you ensure quality? -->


## Test environment(s) <!-- Remove any that don't apply -->

- DotNet 8.0.100-preview.6.23307.24

<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9250)