### PR TITLE
Fix Narrator cannot announce the indeterminate state of CheckedListBo…

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.CheckedListBoxItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.CheckedListBoxItemAccessibleObject.cs
@@ -26,7 +26,7 @@ public partial class CheckedListBox
                     return string.Empty;
                 }
 
-                 return IsItemChecked ?  SR.AccessibleActionUncheck : SR.AccessibleActionCheck;
+                return IsItemChecked ? SR.AccessibleActionUncheck : SR.AccessibleActionCheck;
             }
         }
 
@@ -48,6 +48,8 @@ public partial class CheckedListBox
             };
 
         private bool IsItemChecked => _owningCheckedListBox.GetItemChecked(CurrentIndex);
+
+        private CheckState _checkstate => _owningCheckedListBox.GetItemCheckState(CurrentIndex);
 
         internal override bool IsPatternSupported(UiaCore.UIA patternId)
             => patternId switch
@@ -108,8 +110,10 @@ public partial class CheckedListBox
         internal override void Toggle() => DoDefaultAction();
 
         internal override UiaCore.ToggleState ToggleState
-            => IsItemChecked ? UiaCore.ToggleState.On : UiaCore.ToggleState.Off;
+            => (_checkstate == CheckState.Unchecked)
+                ? UiaCore.ToggleState.Off : (_checkstate != CheckState.Checked)
+                ? UiaCore.ToggleState.Indeterminate : UiaCore.ToggleState.On;
 
-        public override string Value => IsItemChecked.ToString();
+        public override string Value => _checkstate.ToString();
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.CheckedListBoxItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.CheckedListBoxItemAccessibleObject.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using static System.Windows.Forms.AxHost;
 using static Interop;
 
 namespace System.Windows.Forms;
@@ -48,8 +49,6 @@ public partial class CheckedListBox
             };
 
         private bool IsItemChecked => _owningCheckedListBox.GetItemChecked(CurrentIndex);
-
-        private CheckState _checkstate => _owningCheckedListBox.GetItemCheckState(CurrentIndex);
 
         internal override bool IsPatternSupported(UiaCore.UIA patternId)
             => patternId switch
@@ -110,9 +109,25 @@ public partial class CheckedListBox
         internal override void Toggle() => DoDefaultAction();
 
         internal override UiaCore.ToggleState ToggleState
-            => (_checkstate == CheckState.Unchecked)
-                ? UiaCore.ToggleState.Off : (_checkstate != CheckState.Checked)
-                ? UiaCore.ToggleState.Indeterminate : UiaCore.ToggleState.On;
+        {
+            get
+            {
+                UiaCore.ToggleState toggleState= UiaCore.ToggleState.Off;
+                switch (_owningCheckedListBox.GetItemCheckState(CurrentIndex))
+                {
+                    case CheckState.Checked:
+                        toggleState = UiaCore.ToggleState.On;
+                        break;
+                    case CheckState.Indeterminate:
+                        toggleState = UiaCore.ToggleState.Indeterminate;
+                        break;
+                    case CheckState.Unchecked:
+                        break;
+                }
+
+                return toggleState;
+            }
+        }
 
         public override string Value => IsItemChecked.ToString();
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.CheckedListBoxItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.CheckedListBoxItemAccessibleObject.cs
@@ -120,8 +120,6 @@ public partial class CheckedListBox
                     case CheckState.Indeterminate:
                         toggleState = UiaCore.ToggleState.Indeterminate;
                         break;
-                    case CheckState.Unchecked:
-                        break;
                 }
 
                 return toggleState;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.CheckedListBoxItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.CheckedListBoxItemAccessibleObject.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using static System.Windows.Forms.AxHost;
 using static Interop;
 
 namespace System.Windows.Forms;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.CheckedListBoxItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.CheckedListBoxItemAccessibleObject.cs
@@ -114,6 +114,6 @@ public partial class CheckedListBox
                 ? UiaCore.ToggleState.Off : (_checkstate != CheckState.Checked)
                 ? UiaCore.ToggleState.Indeterminate : UiaCore.ToggleState.On;
 
-        public override string Value => _checkstate.ToString();
+        public override string Value => IsItemChecked.ToString();
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.cs
@@ -454,10 +454,9 @@ public partial class CheckedListBox : ListBox
         if (!_killnextselect && (index == _lastSelected || CheckOnClick))
         {
             CheckState currentValue = CheckedItems.GetCheckedState(index);
-            CheckState newValue =
-                currentValue != CheckState.Unchecked
-                ? currentValue != CheckState.Checked ? CheckState.Indeterminate : CheckState.Checked
-                : CheckState.Unchecked;
+            CheckState newValue = (currentValue != CheckState.Unchecked)
+                                  ? CheckState.Unchecked
+                                  : CheckState.Checked;
 
             ItemCheckEventArgs itemCheckEvent = new ItemCheckEventArgs(index, newValue, currentValue);
             OnItemCheck(itemCheckEvent);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.cs
@@ -454,9 +454,10 @@ public partial class CheckedListBox : ListBox
         if (!_killnextselect && (index == _lastSelected || CheckOnClick))
         {
             CheckState currentValue = CheckedItems.GetCheckedState(index);
-            CheckState newValue = (currentValue != CheckState.Unchecked)
+            CheckState newValue = (currentValue == CheckState.Unchecked)
                                   ? CheckState.Unchecked
-                                  : CheckState.Checked;
+                                  : (currentValue != CheckState.Checked)
+                                  ? CheckState.Indeterminate : CheckState.Checked;
 
             ItemCheckEventArgs itemCheckEvent = new ItemCheckEventArgs(index, newValue, currentValue);
             OnItemCheck(itemCheckEvent);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.cs
@@ -455,9 +455,9 @@ public partial class CheckedListBox : ListBox
         {
             CheckState currentValue = CheckedItems.GetCheckedState(index);
             CheckState newValue =
-                currentValue == CheckState.Unchecked
-                ? CheckState.Unchecked
-                : currentValue != CheckState.Checked ? CheckState.Indeterminate : CheckState.Checked;
+                currentValue != CheckState.Unchecked
+                ? currentValue != CheckState.Checked ? CheckState.Indeterminate : CheckState.Checked
+                : CheckState.Unchecked;
 
             ItemCheckEventArgs itemCheckEvent = new ItemCheckEventArgs(index, newValue, currentValue);
             OnItemCheck(itemCheckEvent);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.cs
@@ -454,10 +454,10 @@ public partial class CheckedListBox : ListBox
         if (!_killnextselect && (index == _lastSelected || CheckOnClick))
         {
             CheckState currentValue = CheckedItems.GetCheckedState(index);
-            CheckState newValue = (currentValue == CheckState.Unchecked)
-                                  ? CheckState.Unchecked
-                                  : (currentValue != CheckState.Checked)
-                                  ? CheckState.Indeterminate : CheckState.Checked;
+            CheckState newValue =
+                currentValue == CheckState.Unchecked
+                ? CheckState.Unchecked
+                : currentValue != CheckState.Checked ? CheckState.Indeterminate : CheckState.Checked;
 
             ItemCheckEventArgs itemCheckEvent = new ItemCheckEventArgs(index, newValue, currentValue);
             OnItemCheck(itemCheckEvent);

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MultipleControls.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MultipleControls.Designer.cs
@@ -234,6 +234,8 @@ partial class MultipleControls
         this.checkedListBox1.Name = "checkedListBox1";
         this.checkedListBox1.Size = new System.Drawing.Size(140, 112);
         this.checkedListBox1.TabIndex = 10;
+        this.checkedListBox1.SetItemCheckState(0, CheckState.Checked);
+        this.checkedListBox1.SetItemCheckState(1, CheckState.Indeterminate);
         // 
         // numericUpDown1
         // 
@@ -290,6 +292,8 @@ partial class MultipleControls
         this.checkedListBox2.Name = "checkedListBox2";
         this.checkedListBox2.Size = new System.Drawing.Size(140, 58);
         this.checkedListBox2.TabIndex = 13;
+        this.checkedListBox2.SetItemCheckState(0, CheckState.Checked);
+        this.checkedListBox2.SetItemCheckState(1, CheckState.Indeterminate);
         // 
         // MultipleControls
         // 

--- a/src/System.Windows.Forms/tests/UnitTests/CheckedListBoxItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/CheckedListBoxItemAccessibleObjectTests.cs
@@ -4,7 +4,6 @@
 
 using static System.Windows.Forms.CheckedListBox;
 using static Interop;
-using static Interop.UiaCore;
 
 namespace System.Windows.Forms.Tests.AccessibleObjects;
 
@@ -254,17 +253,17 @@ public class CheckedListBoxItemAccessibleObjectTests
     }
 
     [WinFormsTheory]
-    [InlineData(true, CheckState.Checked, (int)ToggleState.On)]
-    [InlineData(false, CheckState.Unchecked, (int)ToggleState.Off)]
-    [InlineData(true, CheckState.Indeterminate, (int)ToggleState.Indeterminate)]
+    [InlineData(true, CheckState.Checked, (int)UiaCore.ToggleState.On)]
+    [InlineData(false, CheckState.Unchecked, (int)UiaCore.ToggleState.Off)]
+    [InlineData(true, CheckState.Indeterminate, (int)UiaCore.ToggleState.Indeterminate)]
     public void CheckedListBoxItemAccessibleObject_ToggleState_ReturnsExpected(bool checkValue, CheckState checkState, int toggleState)
     {
-        using CheckedListBox checkedListBox = new ();
+        using CheckedListBox checkedListBox = new();
         checkedListBox.Items.Add("A");
         checkedListBox.SetItemCheckState(0, checkState);
 
         Assert.Equal((UiaCore.ToggleState)toggleState, checkedListBox.AccessibilityObject.GetChild(0).ToggleState);
-        Assert.Equal(checkValue.ToString(), checkedListBox.AccessibilityObject.GetChild(0).GetPropertyValue(UIA.ValueValuePropertyId));
+        Assert.Equal(checkValue.ToString(), checkedListBox.AccessibilityObject.GetChild(0).GetPropertyValue(UiaCore.UIA.ValueValuePropertyId));
         Assert.False(checkedListBox.IsHandleCreated);
     }
 

--- a/src/System.Windows.Forms/tests/UnitTests/CheckedListBoxItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/CheckedListBoxItemAccessibleObjectTests.cs
@@ -4,6 +4,7 @@
 
 using static System.Windows.Forms.CheckedListBox;
 using static Interop;
+using static Interop.UiaCore;
 
 namespace System.Windows.Forms.Tests.AccessibleObjects;
 
@@ -253,15 +254,17 @@ public class CheckedListBoxItemAccessibleObjectTests
     }
 
     [WinFormsTheory]
-    [InlineData(true, (int)UiaCore.ToggleState.On)]
-    [InlineData(false, (int)UiaCore.ToggleState.Off)]
-    public void CheckedListBoxItemAccessibleObject_ToggleState_ReturnsExpected(bool isChecked, int expected)
+    [InlineData(true, CheckState.Checked, (int)ToggleState.On)]
+    [InlineData(false, CheckState.Unchecked, (int)ToggleState.Off)]
+    [InlineData(true, CheckState.Indeterminate, (int)ToggleState.Indeterminate)]
+    public void CheckedListBoxItemAccessibleObject_ToggleState_ReturnsExpected(bool checkValue, CheckState checkState, int toggleState)
     {
-        using CheckedListBox checkedListBox = new();
+        using CheckedListBox checkedListBox = new ();
         checkedListBox.Items.Add("A");
-        checkedListBox.SetItemChecked(0, isChecked);
+        checkedListBox.SetItemCheckState(0, checkState);
 
-        Assert.Equal((UiaCore.ToggleState)expected, checkedListBox.AccessibilityObject.GetChild(0).ToggleState);
+        Assert.Equal((UiaCore.ToggleState)toggleState, checkedListBox.AccessibilityObject.GetChild(0).ToggleState);
+        Assert.Equal(checkValue.ToString(), checkedListBox.AccessibilityObject.GetChild(0).GetPropertyValue(UIA.ValueValuePropertyId));
         Assert.False(checkedListBox.IsHandleCreated);
     }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #9243 


## Proposed changes

- The issue is reproduced because the indeterminate state is not converted corretly in accessibility in the .NET Core.
- Add validation of indeterminate state during state transition.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Screen readers announce CheckBox state correctly.

## Regression? 

- Yes 

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
Indeterminate state is not converted corretly in accessibility
![image](https://github.com/dotnet/winforms/assets/133954995/f3bae377-7e44-4c25-93ba-1541a779e654)
![image](https://github.com/dotnet/winforms/assets/133954995/0f9d6e52-105a-444f-8ac0-490dd1616231)

<!-- TODO -->

### After
![屏幕截图 2023-06-13 000320](https://github.com/dotnet/winforms/assets/133954995/ac441df5-66be-4dcd-8883-488e3105e996)
![无标题1](https://github.com/dotnet/winforms/assets/133954995/9390825e-afe9-4730-8fd9-b03c74312730)

<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- Manual

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

- .Net 8.0.100-preview.6.23281.18


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9276)