### PR TITLE
Fix branch name while disabling UI tests

### DIFF
--- a/eng/pipelines/build.yml
+++ b/eng/pipelines/build.yml
@@ -118,7 +118,7 @@ jobs:
       env:
         XUNIT_LOGS: $(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)
       displayName: Run Integration Tests
-      condition: and(eq(variables['System.TeamProject'], 'public'), ne('${{ parameters.targetArchitecture }}', 'arm64'), ne(contains(variables['Build.SourceBranch'], 'release'), 'true'))
+      condition: and(eq(variables['System.TeamProject'], 'public'), ne('${{ parameters.targetArchitecture }}', 'arm64'), contains(variables['System.PullRequest.TargetBranch'], 'main'))
       retryCountOnTaskFailure: 3
 
     # Create Nuget package, sign, and publish


### PR DESCRIPTION
This is fixing an error in reading branch name in the PR https://github.com/dotnet/winforms/pull/9284

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9287)