### PR TITLE
Set foreground

### DIFF
--- a/eng/pipelines/build.yml
+++ b/eng/pipelines/build.yml
@@ -118,8 +118,7 @@ jobs:
       env:
         XUNIT_LOGS: $(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)
       displayName: Run Integration Tests
-      # UI tests are blocked from execution until we find solution for https://github.com/dotnet/winforms/issues/9318.
-      condition: and(eq(variables['System.TeamProject'], 'public'), ne('${{ parameters.targetArchitecture }}', 'arm64'), contains(variables['System.PullRequest.TargetBranch'], 'main'), false)
+      condition: eq(variables['System.TeamProject'], 'public')
       retryCountOnTaskFailure: 3
 
     # Create Nuget package, sign, and publish

--- a/src/System.Windows.Forms.Primitives/src/NativeMethods.txt
+++ b/src/System.Windows.Forms.Primitives/src/NativeMethods.txt
@@ -3,6 +3,7 @@ ActivateActCtx
 ActivateKeyboardLayout
 AdjustWindowRectEx
 AdjustWindowRectExForDpi
+AllocConsole
 AreDpiAwarenessContextsEqual
 ARW_*
 AUTOCOMPLETEOPTIONS
@@ -174,6 +175,7 @@ FillRect
 FindWindow
 FONTDESC
 FormatMessage
+FreeConsole
 FUNCDESC
 FUNCFLAGS
 FUNCKIND
@@ -199,6 +201,7 @@ GetClipboardFormatName
 GetClipBox
 GetClipCursor
 GetClipRgn
+GetConsoleWindow
 GetCurrentActCtx
 GetCurrentObject
 GetCurrentProcess
@@ -228,6 +231,7 @@ GetKeyState
 GetKeyboardState
 GetKeyboardLayout
 GetKeyboardLayoutList
+GetLastActivePopup
 GetLocaleInfoEx
 GetMapMode
 GetMenu
@@ -667,6 +671,7 @@ STGC
 STGTY
 STILL_ACTIVE
 StretchDIBits
+SwitchToThisWindow
 SYSBUTTONSTATES
 SystemParametersInfo
 SystemParametersInfoForDpi

--- a/src/System.Windows.Forms.Primitives/src/NativeMethods.txt
+++ b/src/System.Windows.Forms.Primitives/src/NativeMethods.txt
@@ -504,6 +504,7 @@ MOUSEHOOKSTRUCT
 MoveToEx
 MSFTEDIT_CLASS
 MsgWaitForMultipleObjectsEx
+MSLLHOOKSTRUCT
 MultiByteToWideChar
 NIN_*
 NFR_*

--- a/src/System.Windows.Forms.Primitives/src/NativeMethods.txt
+++ b/src/System.Windows.Forms.Primitives/src/NativeMethods.txt
@@ -3,7 +3,6 @@ ActivateActCtx
 ActivateKeyboardLayout
 AdjustWindowRectEx
 AdjustWindowRectExForDpi
-AllocConsole
 AreDpiAwarenessContextsEqual
 ARW_*
 AUTOCOMPLETEOPTIONS
@@ -175,7 +174,6 @@ FillRect
 FindWindow
 FONTDESC
 FormatMessage
-FreeConsole
 FUNCDESC
 FUNCFLAGS
 FUNCKIND
@@ -201,7 +199,6 @@ GetClipboardFormatName
 GetClipBox
 GetClipCursor
 GetClipRgn
-GetConsoleWindow
 GetCurrentActCtx
 GetCurrentObject
 GetCurrentProcess

--- a/src/System.Windows.Forms.Primitives/src/NativeMethods.txt
+++ b/src/System.Windows.Forms.Primitives/src/NativeMethods.txt
@@ -71,7 +71,6 @@ CreateStdAccessibleObject
 CreateStdDispatch
 CreateWindowEx
 CW_USEDEFAULT
-CWPSTRUCT
 DATETIMEPICK_CLASS
 DeactivateActCtx
 DefFrameProc

--- a/src/System.Windows.Forms.Primitives/src/NativeMethods.txt
+++ b/src/System.Windows.Forms.Primitives/src/NativeMethods.txt
@@ -71,6 +71,7 @@ CreateStdAccessibleObject
 CreateStdDispatch
 CreateWindowEx
 CW_USEDEFAULT
+CWPSTRUCT
 DATETIMEPICK_CLASS
 DeactivateActCtx
 DefFrameProc

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/MessageId.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/MessageId.cs
@@ -238,6 +238,8 @@ internal readonly struct MessageId
             PInvoke.WM_USER => "WM_USER",
             PInvoke.WM_CTLCOLOR => "WM_CTLCOLOR",
 
+            PInvoke.WM_DWMNCRENDERINGCHANGED => nameof(PInvoke.WM_DWMNCRENDERINGCHANGED),
+
             // RichEdit messages
             PInvoke.EM_GETLIMITTEXT => "EM_GETLIMITTEXT",
             PInvoke.EM_POSFROMCHAR => "EM_POSFROMCHAR",

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/MessageId.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/MessageId.cs
@@ -321,6 +321,9 @@ internal readonly struct MessageId
             // Extended Edit style specific messages
             PInvoke.EM_SETEDITSTYLE => "EM_SETEDITSTYLE",
             PInvoke.EM_GETEDITSTYLE => "EM_GETEDITSTYLE",
+
+            >= 0xC000 => GetRegisteredWindowMessageName(_id),
+
             _ => null,
         };
 
@@ -332,5 +335,20 @@ internal readonly struct MessageId
         }
 
         return text;
+
+        static unsafe string? GetRegisteredWindowMessageName(uint id)
+        {
+            const int Capacity = 256;
+            var name = stackalloc char[Capacity];
+
+            // RegisterWindowMessage shares IDs with RegisterClipboardFormat
+            var numberOfCharacters = PInvoke.GetClipboardFormatName(id, name, Capacity);
+            if (numberOfCharacters == 0)
+            {
+                return null;
+            }
+
+            return new string(name, 0, numberOfCharacters);
+        }
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/MessageId.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/MessageId.cs
@@ -324,6 +324,7 @@ internal readonly struct MessageId
             PInvoke.EM_SETEDITSTYLE => "EM_SETEDITSTYLE",
             PInvoke.EM_GETEDITSTYLE => "EM_GETEDITSTYLE",
 
+            0x0060 => "WM_DISPATCHNOTIFY",
             >= 0xC000 => GetRegisteredWindowMessageName(_id),
 
             _ => null,

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/DataGridViewTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/DataGridViewTests.cs
@@ -61,7 +61,11 @@ public class DataGridViewTests : ControlTestBase
             // Wait 1 second to make sure that the toolTip appeared, it has some delay (500 ms by default).
             await InputSimulator.SendAsync(
                 form,
-                inputSimulator => inputSimulator.Mouse.MoveMouseTo(targetPoint.X, targetPoint.Y).Sleep(TimeSpan.FromMilliseconds(1000)));
+                async inputSimulator =>
+                {
+                    inputSimulator.Mouse.MoveMouseTo(targetPoint.X, targetPoint.Y);
+                    await Task.Delay(TimeSpan.FromMilliseconds(1000));
+                });
 
             // DataGridViewToolTip is private so use the reflection
             object toolTip = dataGridView.TestAccessor().Dynamic._toolTipControl;

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Infra/ControlTestBase.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Infra/ControlTestBase.cs
@@ -234,6 +234,13 @@ public abstract class ControlTestBase : IAsyncLifetime, IDisposable
     {
         await _joinableTaskCollection.JoinTillEmptyAsync();
 
+        // Write messages to test output in local testing
+        var isCI = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("BUILD_ARTIFACTSTAGINGDIRECTORY"));
+        if (!isCI)
+        {
+            TestOutputHelper.WriteLine(string.Join(Environment.NewLine, s_messages));
+        }
+
         // Verify keyboard and mouse state at the end of the test
         VerifyKeyStates(isStartOfTest: false, TestOutputHelper);
 

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Infra/ControlTestBase.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Infra/ControlTestBase.cs
@@ -169,6 +169,11 @@ public abstract class ControlTestBase : IAsyncLifetime, IDisposable
         {
             s_messages.Clear();
 
+            using (var currentProcess = Process.GetCurrentProcess())
+            {
+                s_messages.Add($"CURRENT Process={PInvoke.GetCurrentProcessId()} ({currentProcess.ProcessName}) Thread={PInvoke.GetCurrentThreadId()}");
+            }
+
             var isCI = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("BUILD_ARTIFACTSTAGINGDIRECTORY"));
             if (isCI)
             {

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Infra/ControlTestBase.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Infra/ControlTestBase.cs
@@ -67,6 +67,11 @@ public abstract class ControlTestBase : IAsyncLifetime, IDisposable
 
     protected SendInput InputSimulator => new(WaitForIdleAsync);
 
+    public static void AddLogMessage(string message)
+    {
+        s_messages.Add(message);
+    }
+
     [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
     private static unsafe LRESULT GlobalMouseCallback(int nCode, WPARAM wparam, LPARAM lparam)
     {
@@ -463,6 +468,7 @@ public abstract class ControlTestBase : IAsyncLifetime, IDisposable
             await WaitForIdleAsync();
             try
             {
+                s_messages.Add("Invoking test driver...");
                 await testDriverAsync(dialog!, control!);
             }
             catch (Exception ex) when (DataCollectionService.LogAndPropagate(ex))
@@ -502,6 +508,7 @@ public abstract class ControlTestBase : IAsyncLifetime, IDisposable
             await WaitForIdleAsync();
             try
             {
+                s_messages.Add("Invoking test driver...");
                 await testDriverAsync(dialog!);
             }
             catch (Exception ex) when (DataCollectionService.LogAndPropagate(ex))

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Infra/ControlTestBase.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Infra/ControlTestBase.cs
@@ -186,6 +186,9 @@ public abstract class ControlTestBase : IAsyncLifetime, IDisposable
             var isCI = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("BUILD_ARTIFACTSTAGINGDIRECTORY"));
             if (isCI)
             {
+                // Require process elevation in CI to establish and maintain focus
+                Assert.True(PlatformDetection.IsWindowsAndElevated);
+
                 // Attempt to hook all process in CI
                 s_wndProcHook = PInvoke.SetWindowsHookEx(
                     WINDOWS_HOOK_ID.WH_GETMESSAGE,

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Infra/ControlTestBase.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Infra/ControlTestBase.cs
@@ -187,14 +187,19 @@ public abstract class ControlTestBase : IAsyncLifetime, IDisposable
             (int)Math.Ceiling((65535.0 / (primaryMonitor.Height - 1)) * point.Y));
     }
 
-    protected async Task MoveMouseAsync(Form window, Point point, bool assertCorrectLocation = true)
+    protected Task MoveMouseAsync(Form? window, Point point, bool assertCorrectLocation = true)
     {
-        TestOutputHelper.WriteLine($"Moving mouse to ({point.X}, {point.Y}).");
+        return MoveMouseAsync(TestOutputHelper, InputSimulator, window, point, assertCorrectLocation);
+    }
+
+    protected internal static async Task MoveMouseAsync(ITestOutputHelper? testOutputHelper, SendInput sendInput, Form? window, Point point, bool assertCorrectLocation = true)
+    {
+        testOutputHelper?.WriteLine($"Moving mouse to ({point.X}, {point.Y}).");
         Size primaryMonitor = SystemInformation.PrimaryMonitorSize;
         var virtualPoint = ToVirtualPoint(point);
-        TestOutputHelper.WriteLine($"Screen resolution of ({primaryMonitor.Width}, {primaryMonitor.Height}) translates mouse to ({virtualPoint.X}, {virtualPoint.Y}).");
+        testOutputHelper?.WriteLine($"Screen resolution of ({primaryMonitor.Width}, {primaryMonitor.Height}) translates mouse to ({virtualPoint.X}, {virtualPoint.Y}).");
 
-        await InputSimulator.SendAsync(window, inputSimulator => inputSimulator.Mouse.MoveMouseTo(virtualPoint.X, virtualPoint.Y));
+        await sendInput.SendAsync(window, inputSimulator => inputSimulator.Mouse.MoveMouseTo(virtualPoint.X, virtualPoint.Y));
 
         // ⚠ The call to GetCursorPos is required for correct behavior.
         if (!PInvoke.GetCursorPos(out Point actualPoint))

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Infra/ControlTestBase.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Infra/ControlTestBase.cs
@@ -234,18 +234,6 @@ public abstract class ControlTestBase : IAsyncLifetime, IDisposable
     {
         await _joinableTaskCollection.JoinTillEmptyAsync();
 
-        if (!s_wndProcHook.IsNull)
-        {
-            PInvoke.UnhookWindowsHookEx(s_wndProcHook);
-            s_wndProcHook = HHOOK.Null;
-        }
-
-        if (!s_wndProcHook2.IsNull)
-        {
-            PInvoke.UnhookWindowsHookEx(s_wndProcHook2);
-            s_wndProcHook2 = HHOOK.Null;
-        }
-
         // Verify keyboard and mouse state at the end of the test
         VerifyKeyStates(isStartOfTest: false, TestOutputHelper);
 
@@ -266,6 +254,20 @@ public abstract class ControlTestBase : IAsyncLifetime, IDisposable
 
     public virtual void Dispose()
     {
+        // Unregister hooks in Dispose instead of DisposeAsync, since DisposeAsync might not run in the face of
+        // certain test failures.
+        if (!s_wndProcHook.IsNull)
+        {
+            PInvoke.UnhookWindowsHookEx(s_wndProcHook);
+            s_wndProcHook = HHOOK.Null;
+        }
+
+        if (!s_wndProcHook2.IsNull)
+        {
+            PInvoke.UnhookWindowsHookEx(s_wndProcHook2);
+            s_wndProcHook2 = HHOOK.Null;
+        }
+
         Assert.True(PInvoke.SystemParametersInfo(SYSTEM_PARAMETERS_INFO_ACTION.SPI_SETCLIENTAREAANIMATION, ref _clientAreaAnimation));
         DataCollectionService.CurrentTest = null;
     }

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Infra/ControlTestBase.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Infra/ControlTestBase.cs
@@ -77,20 +77,24 @@ public abstract class ControlTestBase : IAsyncLifetime, IDisposable
     {
         if (nCode == PInvoke.HC_ACTION)
         {
-            MOUSEHOOKSTRUCT mouse = *(MOUSEHOOKSTRUCT*)lparam;
-            var threadId = PInvoke.GetWindowThreadProcessId(mouse.hwnd, out var processId);
-            string processName;
-            try
-            {
-                using var process = Process.GetProcessById((int)processId);
-                processName = process.ProcessName;
-            }
-            catch (Exception ex)
-            {
-                processName = $"{ex.GetType().Name}?";
-            }
+            MSLLHOOKSTRUCT mouse = *(MSLLHOOKSTRUCT*)lparam;
 
-            s_messages.Add($"WH_MOUSE: Process={processId} ({processName}) Thread={threadId} msg={(MessageId)(uint)wparam} pt={mouse.pt}");
+            string threadId = "?";
+            string processId = "?";
+            string processName = "?";
+            //var threadId = PInvoke.GetWindowThreadProcessId(mouse.hwnd, out var processId);
+            //string processName;
+            //try
+            //{
+            //    using var process = Process.GetProcessById((int)processId);
+            //    processName = process.ProcessName;
+            //}
+            //catch (Exception ex)
+            //{
+            //    processName = $"{ex.GetType().Name}?";
+            //}
+
+            s_messages.Add($"WH_MOUSE_LL: Process={processId} ({processName}) Thread={threadId} msg={(MessageId)(uint)wparam} pt={mouse.pt}");
         }
 
         return PInvoke.CallNextHookEx(s_wndProcHook2, nCode, wparam, lparam);
@@ -192,7 +196,7 @@ public abstract class ControlTestBase : IAsyncLifetime, IDisposable
                 if (s_wndProcHook.IsNull)
                 {
                     s_wndProcHook2 = PInvoke.SetWindowsHookEx(
-                        WINDOWS_HOOK_ID.WH_MOUSE,
+                        WINDOWS_HOOK_ID.WH_MOUSE_LL,
                         &GlobalMouseCallback,
                         PInvoke.GetModuleHandle((PCWSTR)null),
                         0);

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Infra/ControlTestBase.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Infra/ControlTestBase.cs
@@ -406,6 +406,8 @@ public abstract class ControlTestBase : IAsyncLifetime, IDisposable
                 var control = new T();
                 form.Controls.Add(control);
 
+                AddLogMessage($"{control.GetType().Name}: HWND=0x{(long)control.HWND:x}");
+
                 return (form, control);
             },
             testDriverAsync);
@@ -434,6 +436,8 @@ public abstract class ControlTestBase : IAsyncLifetime, IDisposable
 
                 form.Controls.Add(control);
 
+                AddLogMessage($"{control.GetType().Name}: HWND=0x{(long)control.HWND:x}");
+
                 return (form, control);
             },
             testDriverAsync);
@@ -458,6 +462,9 @@ public abstract class ControlTestBase : IAsyncLifetime, IDisposable
                 tableLayout.Controls.Add(control1, 0, 0);
                 tableLayout.Controls.Add(control2, 1, 0);
                 form.Controls.Add(tableLayout);
+
+                AddLogMessage($"{control1.GetType().Name} 1: HWND=0x{(long)control1.HWND:x}");
+                AddLogMessage($"{control2.GetType().Name} 2: HWND=0x{(long)control2.HWND:x}");
 
                 return (form, (control1, control2));
             },

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Infra/SendInput.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Infra/SendInput.cs
@@ -69,7 +69,18 @@ public class SendInput
         });
     }
 
-    internal async Task SendAsync(Form? window, Action<InputSimulator> actions)
+    internal Task SendAsync(Form? window, Action<InputSimulator> actions)
+    {
+        return SendAsync(
+            window,
+            inputSimulator =>
+            {
+                actions(inputSimulator);
+                return Task.CompletedTask;
+            });
+    }
+
+    internal async Task SendAsync(Form? window, Func<InputSimulator, Task> actions)
     {
         if (actions is null)
         {
@@ -91,7 +102,7 @@ public class SendInput
             PInvoke.SetFocus(window);
         }
 
-        await Task.Run(() => actions(new InputSimulator()));
+        await actions(new InputSimulator());
 
         await _waitForIdleAsync();
     }

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Infra/SendInput.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Infra/SendInput.cs
@@ -82,6 +82,12 @@ public class SendInput
             throw new InvalidOperationException("Failed to set the foreground window.");
         }
 
+        // Ensure the window is 'Active' as it may not have been achieved by 'SetForegroundWindow'
+        PInvoke.SetActiveWindow(window);
+
+        // Give the window the keyboard focus as it may not have been achieved by 'SetActiveWindow'
+        PInvoke.SetFocus(window);
+
         await Task.Run(() => actions(new InputSimulator()));
 
         await _waitForIdleAsync();

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Infra/SendInput.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Infra/SendInput.cs
@@ -142,6 +142,8 @@ public class SendInput
 
     private async Task<bool> TrySetForegroundWindowViaMouseAsync(Form form, HWND activeWindow)
     {
+        ControlTestBase.AddLogMessage("Attempting to set foreground window with the mouse...");
+
         // If that fails, try setting focus by clicking the title bar of the form
         var rect = form.DisplayRectangle;
         var positionOnTitleBar = new Point(GetMiddle(rect.Right, rect.Left), rect.Top + 5);

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Infra/SendInput.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Infra/SendInput.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Drawing;
-using System.Runtime.InteropServices;
 using System.Windows.Forms.UITests.Input;
 using Windows.Win32.UI.Input.KeyboardAndMouse;
 using Windows.Win32.UI.WindowsAndMessaging;
@@ -127,9 +126,6 @@ public class SendInput
         if (form is not null && await TrySetForegroundWindowViaMouseAsync(form, activeWindow))
             return true;
 
-        if (TrySetForegroundWindowViaConsole(activeWindow))
-            return true;
-
         return false;
     }
 
@@ -147,40 +143,6 @@ public class SendInput
         return PInvoke.SetForegroundWindow(activeWindow);
 
         static int GetMiddle(int a, int b) => a + ((b - a) / 2);
-    }
-
-    private static bool TrySetForegroundWindowViaConsole(HWND activeWindow)
-    {
-        bool allocatedConsole = PInvoke.AllocConsole();
-        int? allocationError = !allocatedConsole ? Marshal.GetHRForLastWin32Error() : null;
-
-        try
-        {
-            var consoleWindow = PInvoke.GetConsoleWindow();
-            if (consoleWindow == IntPtr.Zero)
-            {
-                if (allocationError is { } hr)
-                {
-                    Marshal.ThrowExceptionForHR(hr);
-                }
-
-                throw new InvalidOperationException("Failed to obtain the console window.");
-            }
-
-            if (!PInvoke.SetWindowPos(consoleWindow, hWndInsertAfter: (HWND)0, 0, 0, 0, 0, SET_WINDOW_POS_FLAGS.SWP_NOZORDER))
-            {
-                Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
-            }
-        }
-        finally
-        {
-            if (allocatedConsole && !PInvoke.FreeConsole())
-            {
-                Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
-            }
-        }
-
-        return PInvoke.SetForegroundWindow(activeWindow);
     }
 
     private static void SetForegroundWindow(Form window)

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Input/KeyboardSimulator.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Input/KeyboardSimulator.cs
@@ -112,10 +112,4 @@ internal class KeyboardSimulator
         PInvoke.SendInput(inputs, Marshal.SizeOf<INPUT>());
         return this;
     }
-
-    internal KeyboardSimulator Sleep(TimeSpan time)
-    {
-        Thread.Sleep(time);
-        return this;
-    }
 }

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Input/MouseSimulator.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Input/MouseSimulator.cs
@@ -168,10 +168,4 @@ internal class MouseSimulator
         PInvoke.SendInput(inputs, Marshal.SizeOf<INPUT>());
         return this;
     }
-
-    internal MouseSimulator Sleep(TimeSpan time)
-    {
-        Thread.Sleep(time);
-        return this;
-    }
 }

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/ListViewTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/ListViewTests.cs
@@ -52,7 +52,6 @@ public class ListViewTests : ControlTestBase
 
             listView.Groups.Add(group);
             listView.Items.AddRange(new[] { item1, item2, item3 });
-            listView.Focus();
 
             bool collapsedStateChangedFired = false;
             listView.GroupCollapsedStateChanged += (sender, e) => collapsedStateChangedFired = true;

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/MonthCalendarTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/MonthCalendarTests.cs
@@ -193,10 +193,12 @@ public class MonthCalendarTests : ControlTestBase
         await MoveMouseAsync(form, GetCellPositionByDate(calendar, date));
         await InputSimulator.SendAsync(
             form,
-            inputSimulator => inputSimulator.Mouse
-                                            .LeftButtonClick()
-                                            .Sleep(TimeSpan.FromMilliseconds(500))
-                                            .LeftButtonClick());
+            async inputSimulator =>
+            {
+                inputSimulator.Mouse.LeftButtonClick();
+                await Task.Delay(TimeSpan.FromMilliseconds(500));
+                inputSimulator.Mouse.LeftButtonClick();
+            });
     }
 
     private async Task RunClickTestAsync(Func<Form, MonthCalendar, Task> runTest)


### PR DESCRIPTION
Ensure a test window has focus before calling `SendInput`. If the window does not have focus, the test will first try to set focus using the [`SwitchToThisWindow`](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-switchtothiswindow), [`SetActiveWindow`](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setactivewindow), and [`SetFocus`](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setfocus) APIs, and if that fails it will attempt to click the visible title bar with the mouse. If the test fails to establish focus, it will fail.

In an earlier commit in this PR, the code would attempt to use the console to set focus (a practice that works very well for Visual Studio integration testing). However, this strategy failed in the `AllocConsole` method for unknown reasons when applied to winforms testing.

Merge commit is recommended to preserve history.