### PR TITLE
Update to the latest CSWin32

### DIFF
--- a/Winforms.sln
+++ b/Winforms.sln
@@ -96,6 +96,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Directory.Build.targets = Directory.Build.targets
 		global.json = global.json
 		NuGet.Config = NuGet.Config
+		start-vs.cmd = start-vs.cmd
 		eng\Versions.props = eng\Versions.props
 	EndProjectSection
 EndProject

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -45,7 +45,7 @@
       Microsoft.NET.Sdk.IL.targets requires definition of MicrosoftNETCoreILAsmVersion
     -->
     <MicrosoftNETCoreILAsmVersion>$(MicrosoftNETCoreILAsmPackageVersion)</MicrosoftNETCoreILAsmVersion>
-    <MicrosoftWindowsCsWin32PackageVersion>0.2.176-beta</MicrosoftWindowsCsWin32PackageVersion>
+    <MicrosoftWindowsCsWin32PackageVersion>0.3.5-beta</MicrosoftWindowsCsWin32PackageVersion>
   </PropertyGroup>
   <!-- Docs / Intellisense -->
   <PropertyGroup>

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/MultilineStringEditor.OleCallback.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/MultilineStringEditor.OleCallback.cs
@@ -37,7 +37,7 @@ public sealed partial class MultilineStringEditor
             }
 
             using ComScope<ILockBytes> pLockBytes = new(null);
-            HRESULT hr = PInvoke.CreateILockBytesOnHGlobal(0, fDeleteOnRelease: true, pLockBytes);
+            HRESULT hr = PInvoke.CreateILockBytesOnHGlobal(default, fDeleteOnRelease: true, pLockBytes);
             if (hr.Failed)
             {
                 return hr;
@@ -114,7 +114,7 @@ public sealed partial class MultilineStringEditor
             return HRESULT.S_OK;
         }
 
-        public HRESULT QueryAcceptData(Com.IDataObject* lpdataobj, ushort* lpcfFormat, RECO_FLAGS reco, BOOL fReally, nint hMetaPict)
+        public HRESULT QueryAcceptData(Com.IDataObject* lpdataobj, ushort* lpcfFormat, RECO_FLAGS reco, BOOL fReally, HGLOBAL hMetaPict)
         {
             Debug.WriteLineIf(RichTextDebug.TraceVerbose, $"IRichTextBoxOleCallback::QueryAcceptData(reco={reco})");
             if (reco == RECO_FLAGS.RECO_PASTE)

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FolderNameEditor.FolderBrowser.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FolderNameEditor.FolderBrowser.cs
@@ -58,7 +58,7 @@ public partial class FolderNameEditor
             HWND hWndOwner = owner is not null ? (HWND)owner.Handle : PInvoke.GetActiveWindow();
 
             // Get the IDL for the specific start location.
-            PInvoke.SHGetSpecialFolderLocation(hWndOwner, (int)StartLocation, out ITEMIDLIST* listHandle);
+            PInvoke.SHGetSpecialFolderLocation((int)StartLocation, out ITEMIDLIST* listHandle);
             if (listHandle is null)
             {
                 return DialogResult.Cancel;

--- a/src/System.Windows.Forms.Primitives/src/Interop/Ole32/Interop.GPStream.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Ole32/Interop.GPStream.cs
@@ -49,7 +49,7 @@ internal static partial class Interop
                 return HRESULT.S_OK;
             }
 
-            HRESULT IStream.Interface.Commit(Windows.Win32.System.Com.STGC grfCommitFlags)
+            HRESULT IStream.Interface.Commit(uint grfCommitFlags)
             {
                 _dataStream.Flush();
 
@@ -180,7 +180,7 @@ internal static partial class Interop
                 return HRESULT.S_OK;
             }
 
-            HRESULT IStream.Interface.Stat(STATSTG* pstatstg, Windows.Win32.System.Com.STATFLAG grfStatFlag)
+            HRESULT IStream.Interface.Stat(STATSTG* pstatstg, uint grfStatFlag)
             {
                 if (pstatstg is null)
                 {
@@ -200,7 +200,7 @@ internal static partial class Interop
                         : STGM.STGM_READ
                 };
 
-                if (grfStatFlag == STATFLAG.STATFLAG_DEFAULT)
+                if ((STATFLAG)grfStatFlag == STATFLAG.STATFLAG_DEFAULT)
                 {
                     // Caller wants a name
                     pstatstg->pwcsName = (char*)Marshal.StringToCoTaskMemUni(_dataStream is FileStream fs ? fs.Name : _dataStream.ToString());
@@ -210,7 +210,7 @@ internal static partial class Interop
             }
 
             /// Returns HRESULT.STG_E_INVALIDFUNCTION as a documented way to say we don't support locking
-            HRESULT IStream.Interface.LockRegion(ulong libOffset, ulong cb, LOCKTYPE dwLockType) => HRESULT.STG_E_INVALIDFUNCTION;
+            HRESULT IStream.Interface.LockRegion(ulong libOffset, ulong cb, uint dwLockType) => HRESULT.STG_E_INVALIDFUNCTION;
 
             // We never report ourselves as Transacted, so we can just ignore this.
             HRESULT IStream.Interface.Revert() => HRESULT.S_OK;

--- a/src/System.Windows.Forms.Primitives/src/Interop/OleAut32/Interop.VARIANTVector.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/OleAut32/Interop.VARIANTVector.cs
@@ -4,7 +4,7 @@
 
 using System.Runtime.InteropServices;
 
-namespace Windows.Win32.System.Com;
+namespace Windows.Win32.System.Variant;
 
 internal unsafe ref struct VARIANTVector
 {

--- a/src/System.Windows.Forms.Primitives/src/Microsoft/VisualStudio/Shell/IProvidePropertyBuilder.cs
+++ b/src/System.Windows.Forms.Primitives/src/Microsoft/VisualStudio/Shell/IProvidePropertyBuilder.cs
@@ -5,6 +5,7 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Windows.Win32.System.Com;
+using Windows.Win32.System.Variant;
 
 namespace Microsoft.VisualStudio.Shell;
 

--- a/src/System.Windows.Forms.Primitives/src/Microsoft/VisualStudio/Shell/IVSMDPerPropertyBrowsing.cs
+++ b/src/System.Windows.Forms.Primitives/src/Microsoft/VisualStudio/Shell/IVSMDPerPropertyBrowsing.cs
@@ -5,6 +5,7 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Windows.Win32.System.Com;
+using Windows.Win32.System.Variant;
 
 namespace Microsoft.VisualStudio.Shell;
 

--- a/src/System.Windows.Forms.Primitives/src/NativeMethods.txt
+++ b/src/System.Windows.Forms.Primitives/src/NativeMethods.txt
@@ -5,8 +5,10 @@ AdjustWindowRectEx
 AdjustWindowRectExForDpi
 AreDpiAwarenessContextsEqual
 AUTOCOMPLETEOPTIONS
+ADVF
 BeginPaint
 BFFM_*
+BI_COMPRESSION
 BIF_*
 BitBlt
 BITMAP
@@ -297,7 +299,6 @@ ICM_MODE
 ICON_*
 IDC_*
 IDI_*
-IDispatch
 IDispatchEx
 IConnectionPoint
 IConnectionPointContainer
@@ -395,7 +396,6 @@ IsWindowEnabled
 IsWindowUnicode
 IsWindowVisible
 IsZoomed
-IUnknown
 IVBFormat
 IVBGetControl
 IViewObject
@@ -440,7 +440,6 @@ LVSIL_*
 LVTILEVIEWINFO_FLAGS
 LVTILEVIEWINFO_MASK
 MapVirtualKey
-MAPVK_*
 MapWindowPoints
 MEMBERID_NIL
 MessageBeep
@@ -478,9 +477,11 @@ OLE_E_ADVISENOTSUPPORTED
 OLE_E_INVALIDRECT
 OLE_E_NOCONNECTION
 OLE_E_PROMPTSAVECANCELLED
+OLECLOSE
 OLECMDEXECOPT
 OLECMDF
 OLECMDID
+OLECONTF
 OleCreateFontIndirect
 OleCreatePictureIndirect
 OleCreatePropertyFrame
@@ -520,6 +521,7 @@ RevokeDragDrop
 REGDB_E_CLASSNOTREG
 RoundRect
 RPC_E_CHANGED_MODE
+SAFEARRAY
 SafeArrayGetRecordInfo
 S_FALSE
 S_OK
@@ -590,6 +592,7 @@ ShowWindow
 SHParseDisplayName
 SIATTRIBFLAGS
 SIGDN
+STATFLAG
 STATUS_PENDING
 STATUS_SUCCESS
 STATUSCLASSNAME
@@ -599,7 +602,9 @@ STG_E_INVALIDFLAG
 STG_E_INVALIDFUNCTION
 STG_E_INVALIDPOINTER
 StgCreateDocfileOnILockBytes
+STGMEDIUM
 StgOpenStorageOnILockBytes
+STGC
 STGTY
 StretchDIBits
 SystemParametersInfo
@@ -635,12 +640,15 @@ TYPEATTR
 TYPEDESC
 TYPEKIND
 UpdateWindow
+USERCLASSTYPE
 USEROBJECTFLAGS
 ValidateRect
 VARDESC
+VARENUM
 VARFLAGS
 VarFormat
 VARIANT
+VARIANT_*
 VARKIND
 VIEW_E_DRAW
 VIRTUAL_KEY
@@ -662,3 +670,4 @@ WindowFromDC
 WindowFromPoint
 WINDOWPOS
 WSF_VISIBLE
+XFORMCOORDS

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/Foundation/BSTR.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/Foundation/BSTR.cs
@@ -9,6 +9,8 @@ namespace Windows.Win32.Foundation;
 
 internal readonly unsafe partial struct BSTR : IDisposable
 {
+    // Use Marshal here to allocate/free as that is cross-plat which can come into play with our ComNativeDescriptor.
+
     public BSTR(string value) : this((char*)Marshal.StringToBSTR(value))
     {
     }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/Graphics/Gdi/HDC.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/Graphics/Gdi/HDC.cs
@@ -10,8 +10,4 @@ internal readonly partial struct HDC : IHandle<HDC>
     object? IHandle<HDC>.Wrapper => null;
 
     public bool IsNull => Value == 0;
-
-    //public static implicit operator HDC(CreatedHDC hdc) => new(hdc.Value);
-    //public static implicit operator CreatedHDC(HDC hdc) => new(hdc.Value);
-    //public static implicit operator HDC(HdcMetdataEnhFileHandle hdc) => new(hdc.Value);
 }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/Graphics/Gdi/HDC.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/Graphics/Gdi/HDC.cs
@@ -9,7 +9,9 @@ internal readonly partial struct HDC : IHandle<HDC>
     HDC IHandle<HDC>.Handle => this;
     object? IHandle<HDC>.Wrapper => null;
 
-    public static implicit operator HDC(CreatedHDC hdc) => new(hdc.Value);
-    public static implicit operator CreatedHDC(HDC hdc) => new(hdc.Value);
-    public static implicit operator HDC(HdcMetdataEnhFileHandle hdc) => new(hdc.Value);
+    public bool IsNull => Value == 0;
+
+    //public static implicit operator HDC(CreatedHDC hdc) => new(hdc.Value);
+    //public static implicit operator CreatedHDC(HDC hdc) => new(hdc.Value);
+    //public static implicit operator HDC(HdcMetdataEnhFileHandle hdc) => new(hdc.Value);
 }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/Graphics/Gdi/HGDIOBJ.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/Graphics/Gdi/HGDIOBJ.cs
@@ -6,13 +6,7 @@ namespace Windows.Win32.Graphics.Gdi;
 
 internal readonly partial struct HGDIOBJ
 {
-    public static implicit operator HGDIOBJ(HFONT value) => (HGDIOBJ)value.Value;
     public static implicit operator HGDIOBJ(HDC value) => (HGDIOBJ)value.Value;
-    public static implicit operator HGDIOBJ(HPEN value) => (HGDIOBJ)value.Value;
-    public static implicit operator HGDIOBJ(HBRUSH value) => (HGDIOBJ)value.Value;
-    public static implicit operator HGDIOBJ(HBITMAP value) => (HGDIOBJ)value.Value;
-    public static implicit operator HGDIOBJ(HRGN value) => (HGDIOBJ)value.Value;
-    public static implicit operator HGDIOBJ(HPALETTE value) => (HGDIOBJ)value.Value;
 
     public static explicit operator HFONT(HGDIOBJ value) => (HFONT)value.Value;
     public static explicit operator HBRUSH(HGDIOBJ value) => (HBRUSH)value.Value;

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.EnableScrollBar.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.EnableScrollBar.cs
@@ -9,7 +9,7 @@ internal static partial class PInvoke
     public static BOOL EnableScrollBar<T>(T hWnd, SCROLLBAR_CONSTANTS wSBflags, ENABLE_SCROLL_BAR_ARROWS wArrows)
         where T : IHandle<HWND>
     {
-        BOOL result = EnableScrollBar(hWnd.Handle, wSBflags, wArrows);
+        BOOL result = EnableScrollBar(hWnd.Handle, (uint)wSBflags, wArrows);
         GC.KeepAlive(hWnd.Wrapper);
         return result;
     }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.LoadLibrary.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.LoadLibrary.cs
@@ -22,7 +22,7 @@ internal static partial class PInvoke
             if (Path.IsPathFullyQualified(customPath))
             {
                 // OS will validate the path for us
-                HINSTANCE result = LoadLibraryEx(customPath, HANDLE.Null, 0);
+                HINSTANCE result = LoadLibraryEx(customPath, 0);
                 if (!result.IsNull)
                 {
                     return result;
@@ -49,7 +49,7 @@ internal static partial class PInvoke
 
         // LOAD_LIBRARY_SEARCH_SYSTEM32 was introduced in KB2533623. Check for its presence
         // to preserve compat with Windows 7 SP1 without this patch.
-        HINSTANCE result = LoadLibraryEx(libraryName, HANDLE.Null, LOAD_LIBRARY_FLAGS.LOAD_LIBRARY_SEARCH_SYSTEM32);
+        HINSTANCE result = LoadLibraryEx(libraryName, LOAD_LIBRARY_FLAGS.LOAD_LIBRARY_SEARCH_SYSTEM32);
         if (!result.IsNull)
         {
             return result;
@@ -61,6 +61,6 @@ internal static partial class PInvoke
             return HINSTANCE.Null;
         }
 
-        return LoadLibraryEx(libraryName, HANDLE.Null, 0);
+        return LoadLibraryEx(libraryName, 0);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Com/IDispatch.Interface.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Com/IDispatch.Interface.cs
@@ -4,6 +4,7 @@
 
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Windows.Win32.System.Variant;
 using ComWrappers = Interop.WinFormsComWrappers;
 
 namespace Windows.Win32.System.Com;

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Com/IDispatch.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Com/IDispatch.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Windows.Win32.System.Variant;
+
 namespace Windows.Win32.System.Com;
 
 internal unsafe partial struct IDispatch

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Com/SAFEARRAY.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Com/SAFEARRAY.cs
@@ -3,8 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.CompilerServices;
+using Windows.Win32.System.Variant;
 using static Windows.Win32.System.Com.ADVANCED_FEATURE_FLAGS;
-using static Windows.Win32.System.Com.VARENUM;
+using static Windows.Win32.System.Variant.VARENUM;
 
 namespace Windows.Win32.System.Com;
 

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Com/STGMEDIUM.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Com/STGMEDIUM.cs
@@ -10,7 +10,7 @@ namespace Windows.Win32.System.Com;
 internal unsafe partial struct STGMEDIUM
 {
     [UnscopedRef]
-    public ref nint hGlobal => ref Anonymous.hGlobal;
+    public ref HGLOBAL hGlobal => ref u.hGlobal;
 
     public static explicit operator STGMEDIUM(ComType.STGMEDIUM comTypeStg)
     {
@@ -20,9 +20,9 @@ internal unsafe partial struct STGMEDIUM
         {
             pUnkForRelease = pUnkForRelease,
             tymed = (TYMED)comTypeStg.tymed,
-            Anonymous = new()
+            u = new()
             {
-                hGlobal = comTypeStg.unionmember
+                hGlobal = (HGLOBAL)comTypeStg.unionmember
             }
         };
     }
@@ -33,6 +33,6 @@ internal unsafe partial struct STGMEDIUM
             ? null
             : Marshal.GetObjectForIUnknown((nint)stg.pUnkForRelease),
         tymed = (ComType.TYMED)stg.tymed,
-        unionmember = stg.Anonymous.hGlobal
+        unionmember = stg.u.hGlobal
     };
 }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Com/StandardDispatch.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Com/StandardDispatch.cs
@@ -4,6 +4,7 @@
 
 using System.Reflection;
 using Windows.Win32.System.Ole;
+using Windows.Win32.System.Variant;
 
 namespace Windows.Win32.System.Com;
 

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Com/StructuredStorage/PropertyBagExtensions.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Com/StructuredStorage/PropertyBagExtensions.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Windows.Win32.System.Variant;
+
 namespace Windows.Win32.System.Com.StructuredStorage;
 
 internal static class PropertyBagExtensions

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Ole/ClassPropertyDispatchAdapter.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Ole/ClassPropertyDispatchAdapter.cs
@@ -5,6 +5,7 @@
 using System.Reflection;
 using System.Runtime.InteropServices;
 using Windows.Win32.System.Com;
+using Windows.Win32.System.Variant;
 using InteropMarshal = System.Runtime.InteropServices.Marshal;
 
 namespace Windows.Win32.System.Ole;

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Ole/IPictureDisp.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Ole/IPictureDisp.cs
@@ -5,6 +5,7 @@
 using System.Drawing;
 using System.Runtime.InteropServices;
 using Windows.Win32.System.Com;
+using Windows.Win32.System.Variant;
 
 namespace Windows.Win32.System.Ole;
 

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Windows/Win32/System/Com/ComClassFactory.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Windows/Win32/System/Com/ComClassFactory.cs
@@ -25,7 +25,7 @@ internal unsafe class ComClassFactory : IDisposable
     {
         _filePath = filePath;
         ClassId = classId;
-        _instance = PInvoke.LoadLibraryEx(filePath, HANDLE.Null, default);
+        _instance = PInvoke.LoadLibraryEx(filePath, default);
         if (_instance.IsNull)
         {
             throw new Win32Exception();

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/Interop/Ole32/IPictureTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/Interop/Ole32/IPictureTests.cs
@@ -6,6 +6,7 @@ using System.Drawing;
 using System.Windows.Forms.Primitives.Tests.Interop.Mocks;
 using Windows.Win32.System.Com;
 using Windows.Win32.System.Ole;
+using Windows.Win32.System.Variant;
 
 namespace System.Windows.Forms.Primitives.Tests.Interop.Ole32;
 
@@ -19,8 +20,7 @@ public unsafe class IPictureTests
 
         using var picture = IPicture.CreateFromIcon(Icon.FromHandle(arrow.Handle), copy: true);
         Assert.False(picture.IsNull);
-        short type = picture.Value->Type;
-        Assert.Equal((short)PICTYPE.PICTYPE_ICON, type);
+        Assert.Equal(PICTYPE.PICTYPE_ICON, picture.Value->Type);
 
         int height = picture.Value->Height;
         Assert.Equal(arrow.Size.Height, GdiHelper.HimetricToPixelY(height));
@@ -36,8 +36,7 @@ public unsafe class IPictureTests
         using Bitmap bitmap = icon.ToBitmap();
         using var picture = IPicture.CreateFromImage(bitmap);
         Assert.False(picture.IsNull);
-        short type = picture.Value->Type;
-        Assert.Equal((short)PICTYPE.PICTYPE_BITMAP, type);
+        Assert.Equal(PICTYPE.PICTYPE_BITMAP, picture.Value->Type);
 
         int height = picture.Value->Height;
         Assert.Equal(bitmap.Size.Height, GdiHelper.HimetricToPixelY(height));

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/Interop/Oleaut32/ITypeInfoTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/Interop/Oleaut32/ITypeInfoTests.cs
@@ -6,6 +6,7 @@ using System.Drawing;
 using System.Runtime.InteropServices;
 using Windows.Win32.System.Com;
 using Windows.Win32.System.Ole;
+using Windows.Win32.System.Variant;
 
 namespace System.Windows.Forms.Primitives.Tests.Interop.Oleaut32;
 
@@ -190,9 +191,9 @@ public class ITypeInfoTests
         using ComScope<ITypeInfo> typeInfo = new(null);
         ((IDispatch*)iPictureDisp.Value)->GetTypeInfo(0, PInvoke.GetThreadLocale(), typeInfo);
 
-        int implTypeFlags = -1;
+        IMPLTYPEFLAGS implTypeFlags = (IMPLTYPEFLAGS)(-1);
         typeInfo.Value->GetImplTypeFlags(0, &implTypeFlags);
-        Assert.NotEqual((int)IMPLTYPEFLAGS.IMPLTYPEFLAG_FDEFAULT, implTypeFlags);
+        Assert.NotEqual(IMPLTYPEFLAGS.IMPLTYPEFLAG_FDEFAULT, implTypeFlags);
     }
 
     [StaFact]

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/Interop/Oleaut32/SAFEARRAYTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/Interop/Oleaut32/SAFEARRAYTests.cs
@@ -7,8 +7,9 @@
 using System.Runtime.InteropServices;
 using Windows.Win32.System.Com;
 using Windows.Win32.System.Ole;
+using Windows.Win32.System.Variant;
 using static Windows.Win32.System.Com.ADVANCED_FEATURE_FLAGS;
-using static Windows.Win32.System.Com.VARENUM;
+using static Windows.Win32.System.Variant.VARENUM;
 
 namespace System.Windows.Forms.Tests.Interop.SafeArrayTests;
 
@@ -150,9 +151,9 @@ public unsafe class SAFEARRAYTests
 
         public HRESULT GetFieldNoCopy(void* pvData, PCWSTR szFieldName, VARIANT* pvarField, void** ppvDataCArray) => throw new NotImplementedException();
 
-        public HRESULT PutField(INVOKEKIND wFlags, void* pvData, PCWSTR szFieldName, VARIANT* pvarField) => throw new NotImplementedException();
+        public HRESULT PutField(uint wFlags, void* pvData, PCWSTR szFieldName, VARIANT* pvarField) => throw new NotImplementedException();
 
-        public HRESULT PutFieldNoCopy(INVOKEKIND wFlags, void* pvData, PCWSTR szFieldName, VARIANT* pvarField) => throw new NotImplementedException();
+        public HRESULT PutFieldNoCopy(uint wFlags, void* pvData, PCWSTR szFieldName, VARIANT* pvarField) => throw new NotImplementedException();
 
         public HRESULT GetFieldNames(uint* pcNames, BSTR* rgBstrNames) => throw new NotImplementedException();
 

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/Interop/Oleaut32/VARIANTTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/Interop/Oleaut32/VARIANTTests.cs
@@ -7,8 +7,9 @@
 using System.Runtime.InteropServices;
 using Windows.Win32.System.Com;
 using Windows.Win32.System.Ole;
+using Windows.Win32.System.Variant;
 using static Windows.Win32.System.Com.ADVANCED_FEATURE_FLAGS;
-using static Windows.Win32.System.Com.VARENUM;
+using static Windows.Win32.System.Variant.VARENUM;
 using static Interop;
 
 namespace System.Windows.Forms.Tests.Interop.Oleaut32;
@@ -5644,7 +5645,7 @@ public unsafe class VARIANTTests
         VARIANT copy = variant;
         IntPtr pv = (IntPtr)(&copy);
         Assert.Throws<ArgumentException>(() => Marshal.GetObjectForNativeVariant(pv));
-        Assert.Throws<DivideByZeroException>(() => variant.ToObject());
+        Assert.Throws<ArgumentException>(() => variant.ToObject());
     }
 
     public static IEnumerable<object[]> RECORDARRAY_InvalidGuid_TestData()
@@ -5702,9 +5703,9 @@ public unsafe class VARIANTTests
 
         public HRESULT GetFieldNoCopy(void* pvData, PCWSTR szFieldName, VARIANT* pvarField, void** ppvDataCArray) => throw new NotImplementedException();
 
-        public HRESULT PutField(INVOKEKIND wFlags, void* pvData, PCWSTR szFieldName, VARIANT* pvarField) => throw new NotImplementedException();
+        public HRESULT PutField(uint wFlags, void* pvData, PCWSTR szFieldName, VARIANT* pvarField) => throw new NotImplementedException();
 
-        public HRESULT PutFieldNoCopy(INVOKEKIND wFlags, void* pvData, PCWSTR szFieldName, VARIANT* pvarField) => throw new NotImplementedException();
+        public HRESULT PutFieldNoCopy(uint wFlags, void* pvData, PCWSTR szFieldName, VARIANT* pvarField) => throw new NotImplementedException();
 
         public HRESULT GetFieldNames(uint* pcNames, BSTR* rgBstrNames) => throw new NotImplementedException();
 

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/Windows/Win32/GlobalInterfaceTableTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/Windows/Win32/GlobalInterfaceTableTests.cs
@@ -37,59 +37,16 @@ public unsafe class GlobalInterfaceTableTests
 
     internal class MyStream : IStream.Interface, IManagedWrapper<IStream, ISequentialStream>
     {
-        public unsafe HRESULT Read(void* pv, uint cb, [Optional] uint* pcbRead)
-        {
-            throw new NotImplementedException();
-        }
-
-        public unsafe HRESULT Write(void* pv, uint cb, [Optional] uint* pcbWritten)
-        {
-            throw new NotImplementedException();
-        }
-
-        public unsafe HRESULT Seek(long dlibMove, SeekOrigin dwOrigin, [Optional] ulong* plibNewPosition)
-        {
-            throw new NotImplementedException();
-        }
-
-        public HRESULT SetSize(ulong libNewSize)
-        {
-            throw new NotImplementedException();
-        }
-
-        public unsafe HRESULT CopyTo(IStream* pstm, ulong cb, [Optional] ulong* pcbRead, [Optional] ulong* pcbWritten)
-        {
-            throw new NotImplementedException();
-        }
-
-        public HRESULT Commit(STGC grfCommitFlags)
-        {
-            throw new NotImplementedException();
-        }
-
-        public HRESULT Revert()
-        {
-            throw new NotImplementedException();
-        }
-
-        public HRESULT LockRegion(ulong libOffset, ulong cb, LOCKTYPE dwLockType)
-        {
-            throw new NotImplementedException();
-        }
-
-        public HRESULT UnlockRegion(ulong libOffset, ulong cb, uint dwLockType)
-        {
-            throw new NotImplementedException();
-        }
-
-        public unsafe HRESULT Stat(STATSTG* pstatstg, STATFLAG grfStatFlag)
-        {
-            throw new NotImplementedException();
-        }
-
-        public unsafe HRESULT Clone(IStream** ppstm)
-        {
-            throw new NotImplementedException();
-        }
+        public unsafe HRESULT Read(void* pv, uint cb, [Optional] uint* pcbRead) => throw new NotImplementedException();
+        public unsafe HRESULT Write(void* pv, uint cb, [Optional] uint* pcbWritten) => throw new NotImplementedException();
+        public unsafe HRESULT Seek(long dlibMove, SeekOrigin dwOrigin, [Optional] ulong* plibNewPosition) => throw new NotImplementedException();
+        public HRESULT SetSize(ulong libNewSize) => throw new NotImplementedException();
+        public unsafe HRESULT CopyTo(IStream* pstm, ulong cb, [Optional] ulong* pcbRead, [Optional] ulong* pcbWritten) => throw new NotImplementedException();
+        public HRESULT Commit(uint grfCommitFlags) => throw new NotImplementedException();
+        public HRESULT Revert() => throw new NotImplementedException();
+        public HRESULT LockRegion(ulong libOffset, ulong cb, uint dwLockType) => throw new NotImplementedException();
+        public HRESULT UnlockRegion(ulong libOffset, ulong cb, uint dwLockType) => throw new NotImplementedException();
+        public unsafe HRESULT Stat(STATSTG* pstatstg, uint grfStatFlag) => throw new NotImplementedException();
+        public unsafe HRESULT Clone(IStream** ppstm) => throw new NotImplementedException();
     }
 }

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/Windows/Win32/System/Com/IDispatchTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/Windows/Win32/System/Com/IDispatchTests.cs
@@ -5,6 +5,7 @@
 using System.Drawing;
 using Windows.Win32.System.Com;
 using Windows.Win32.System.Ole;
+using Windows.Win32.System.Variant;
 
 namespace System.Windows.Forms.Primitives.Tests.Windows.Win32.System.Com;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.EnumVariantObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.EnumVariantObject.cs
@@ -5,6 +5,7 @@
 using System.ComponentModel;
 using Windows.Win32.System.Com;
 using Windows.Win32.System.Ole;
+using Windows.Win32.System.Variant;
 
 namespace System.Windows.Forms;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
@@ -10,10 +10,11 @@ using System.Runtime.InteropServices;
 using System.Windows.Forms.Automation;
 using Accessibility;
 using Windows.Win32.System.Ole;
+using Windows.Win32.System.Com;
+using Windows.Win32.System.Variant;
+using UIA = Windows.Win32.UI.Accessibility;
 using ComIServiceProvider = Windows.Win32.System.Com.IServiceProvider;
 using static Interop;
-using Windows.Win32.System.Com;
-using UIA = Windows.Win32.UI.Accessibility;
 
 namespace System.Windows.Forms;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObjectExtensions.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObjectExtensions.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Drawing;
-using Windows.Win32.System.Com;
+using Windows.Win32.System.Variant;
 using Windows.Win32.UI.Accessibility;
 
 namespace System.Windows.Forms;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxContainer.ExtenderProxy.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxContainer.ExtenderProxy.cs
@@ -4,6 +4,7 @@
 
 using Windows.Win32.System.Com;
 using Windows.Win32.System.Ole;
+using Windows.Win32.System.Variant;
 
 namespace System.Windows.Forms;
 
@@ -49,7 +50,7 @@ public abstract partial class AxHost
             }
 
             HRESULT IVBGetControl.Interface.EnumControls(
-                OLECONTF dwOleContF,
+                uint dwOleContF,
                 ENUM_CONTROLS_WHICH_FLAGS dwWhich,
                 IEnumUnknown** ppenum)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxContainer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxContainer.cs
@@ -6,6 +6,7 @@ using System.ComponentModel;
 using System.ComponentModel.Design;
 using Windows.Win32.System.Com;
 using Windows.Win32.System.Ole;
+using Windows.Win32.System.Variant;
 
 namespace System.Windows.Forms;
 
@@ -167,7 +168,7 @@ public abstract partial class AxHost
             }
         }
 
-        internal IEnumUnknown.Interface EnumControls(Control control, OLECONTF dwOleContF, ENUM_CONTROLS_WHICH_FLAGS dwWhich)
+        internal IEnumUnknown.Interface EnumControls(Control control, uint dwOleContF, ENUM_CONTROLS_WHICH_FLAGS dwWhich)
         {
             GetComponents();
             _lockCount++;
@@ -234,13 +235,13 @@ public abstract partial class AxHost
                     case ENUM_CONTROLS_WHICH_FLAGS.GC_WCH_CONTAINER:
                         results = new();
                         additionalControl = null;
-                        MaybeAdd(results, control, selected, dwOleContF, allowContainingControls: false);
+                        MaybeAdd(results, control, selected, (OLECONTF)dwOleContF, allowContainingControls: false);
 
                         while (control is not null)
                         {
                             if (FindContainerForControl(control) is { } container)
                             {
-                                MaybeAdd(results, container._parent, selected, dwOleContF, allowContainingControls: true);
+                                MaybeAdd(results, container._parent, selected, (OLECONTF)dwOleContF, allowContainingControls: true);
                                 control = container._parent;
                             }
                             else
@@ -266,14 +267,14 @@ public abstract partial class AxHost
 
                     if (additionalControl is not null)
                     {
-                        MaybeAdd(results, additionalControl, selected, dwOleContF, allowContainingControls: false);
+                        MaybeAdd(results, additionalControl, selected, (OLECONTF)dwOleContF, allowContainingControls: false);
                     }
 
                     if (controls is not null)
                     {
                         for (int i = first; i < last; i++)
                         {
-                            MaybeAdd(results, controls[i], selected, dwOleContF, allowContainingControls: false);
+                            MaybeAdd(results, controls[i], selected, (OLECONTF)dwOleContF, allowContainingControls: false);
                         }
                     }
                 }
@@ -586,7 +587,7 @@ public abstract partial class AxHost
             return HRESULT.E_NOTIMPL;
         }
 
-        HRESULT IOleContainer.Interface.EnumObjects(OLECONTF grfFlags, IEnumUnknown** ppenum)
+        HRESULT IOleContainer.Interface.EnumObjects(uint grfFlags, IEnumUnknown** ppenum)
         {
             if (ppenum is null)
             {
@@ -595,7 +596,7 @@ public abstract partial class AxHost
 
             s_axHTraceSwitch.TraceVerbose("in EnumObjects");
 
-            if (grfFlags.HasFlag(OLECONTF.OLECONTF_EMBEDDINGS))
+            if (((OLECONTF)grfFlags).HasFlag(OLECONTF.OLECONTF_EMBEDDINGS))
             {
                 Debug.Assert(_parent is not null);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxPerPropertyBrowsingEnum.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxPerPropertyBrowsingEnum.cs
@@ -3,8 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Windows.Forms.ComponentModel.Com2Interop;
-using Windows.Win32.System.Com;
 using Windows.Win32.System.Ole;
+using Windows.Win32.System.Variant;
 
 namespace System.Windows.Forms;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.OleInterfaces.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.OleInterfaces.cs
@@ -8,6 +8,7 @@ using System.Drawing;
 using System.Runtime.InteropServices;
 using Windows.Win32.System.Com;
 using Windows.Win32.System.Ole;
+using Windows.Win32.System.Variant;
 
 namespace System.Windows.Forms;
 
@@ -88,7 +89,7 @@ public abstract partial class AxHost
         // IVBGetControl methods:
 
         HRESULT IVBGetControl.Interface.EnumControls(
-            OLECONTF dwOleContF,
+            uint dwOleContF,
             ENUM_CONTROLS_WHICH_FLAGS dwWhich,
             IEnumUnknown** ppenum)
         {
@@ -170,7 +171,7 @@ public abstract partial class AxHost
             return HRESULT.S_OK;
         }
 
-        HRESULT IOleControlSite.Interface.TransformCoords(POINTL* pPtlHimetric, PointF* pPtfContainer, XFORMCOORDS dwFlags)
+        HRESULT IOleControlSite.Interface.TransformCoords(POINTL* pPtlHimetric, PointF* pPtfContainer, uint dwFlags)
         {
             if (pPtlHimetric is null || pPtfContainer is null)
             {
@@ -183,14 +184,15 @@ public abstract partial class AxHost
                 return hr;
             }
 
-            if (dwFlags.HasFlag(XFORMCOORDS.XFORMCOORDS_HIMETRICTOCONTAINER))
+            XFORMCOORDS coordinates = (XFORMCOORDS)dwFlags;
+            if (coordinates.HasFlag(XFORMCOORDS.XFORMCOORDS_HIMETRICTOCONTAINER))
             {
-                if (dwFlags.HasFlag(XFORMCOORDS.XFORMCOORDS_SIZE))
+                if (coordinates.HasFlag(XFORMCOORDS.XFORMCOORDS_SIZE))
                 {
                     pPtfContainer->X = HM2Pix(pPtlHimetric->x, s_logPixelsX);
                     pPtfContainer->Y = HM2Pix(pPtlHimetric->y, s_logPixelsY);
                 }
-                else if (dwFlags.HasFlag(XFORMCOORDS.XFORMCOORDS_POSITION))
+                else if (coordinates.HasFlag(XFORMCOORDS.XFORMCOORDS_POSITION))
                 {
                     pPtfContainer->X = HM2Pix(pPtlHimetric->x, s_logPixelsX);
                     pPtfContainer->Y = HM2Pix(pPtlHimetric->y, s_logPixelsY);
@@ -201,14 +203,14 @@ public abstract partial class AxHost
                     return HRESULT.E_INVALIDARG;
                 }
             }
-            else if (dwFlags.HasFlag(XFORMCOORDS.XFORMCOORDS_CONTAINERTOHIMETRIC))
+            else if (coordinates.HasFlag(XFORMCOORDS.XFORMCOORDS_CONTAINERTOHIMETRIC))
             {
-                if (dwFlags.HasFlag(XFORMCOORDS.XFORMCOORDS_SIZE))
+                if (coordinates.HasFlag(XFORMCOORDS.XFORMCOORDS_SIZE))
                 {
                     pPtlHimetric->x = Pix2HM((int)pPtfContainer->X, s_logPixelsX);
                     pPtlHimetric->y = Pix2HM((int)pPtfContainer->Y, s_logPixelsY);
                 }
-                else if (dwFlags.HasFlag(XFORMCOORDS.XFORMCOORDS_POSITION))
+                else if (coordinates.HasFlag(XFORMCOORDS.XFORMCOORDS_POSITION))
                 {
                     pPtlHimetric->x = Pix2HM((int)pPtfContainer->X, s_logPixelsX);
                     pPtlHimetric->y = Pix2HM((int)pPtfContainer->Y, s_logPixelsY);
@@ -270,7 +272,7 @@ public abstract partial class AxHost
             return HRESULT.E_NOTIMPL;
         }
 
-        unsafe HRESULT IOleClientSite.Interface.GetMoniker(OLEGETMONIKER dwAssign, OLEWHICHMK dwWhichMoniker, IMoniker** ppmk)
+        unsafe HRESULT IOleClientSite.Interface.GetMoniker(uint dwAssign, uint dwWhichMoniker, IMoniker** ppmk)
         {
             if (ppmk is null)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.PropertyBagStream.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.PropertyBagStream.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Windows.Forms.BinaryFormat;
 using Windows.Win32.System.Com;
+using Windows.Win32.System.Variant;
 using Windows.Win32.System.Com.StructuredStorage;
 
 namespace System.Windows.Forms;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.State.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.State.cs
@@ -133,7 +133,7 @@ public abstract partial class AxHost
         private unsafe void CreateStorage()
         {
             Debug.Assert(_storage is null, "but we already have a storage!");
-            nint hglobal = 0;
+            HGLOBAL hglobal = default;
             if (_buffer is not null)
             {
                 hglobal = PInvoke.GlobalAlloc(GMEM_MOVEABLE, (uint)_length);
@@ -263,10 +263,11 @@ public abstract partial class AxHost
                 _buffer = null;
                 _memoryStream = null;
                 using var lockBytes = _lockBytes.GetInterface();
-                lockBytes.Value->Stat(out STATSTG stat, STATFLAG.STATFLAG_NONAME);
+                lockBytes.Value->Stat(out STATSTG stat, (uint)STATFLAG.STATFLAG_NONAME);
                 _length = (int)stat.cbSize;
                 _buffer = new byte[_length];
-                PInvoke.GetHGlobalFromILockBytes(lockBytes, out nint hglobal).ThrowOnFailure();
+                HGLOBAL hglobal;
+                PInvoke.GetHGlobalFromILockBytes(lockBytes, &hglobal).ThrowOnFailure();
                 void* pointer = PInvoke.GlobalLock(hglobal);
 
                 if (pointer is not null)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.VBFormat.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.VBFormat.cs
@@ -4,6 +4,7 @@
 
 using Windows.Win32.System.Com;
 using Windows.Win32.System.Ole;
+using Windows.Win32.System.Variant;
 
 namespace System.Windows.Forms;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.cs
@@ -1125,7 +1125,7 @@ public abstract unsafe partial class AxHost : Control, ISupportInitialize, ICust
         ((IOleControlSite.Interface)_oleSite).TransformCoords(
             (POINTL*)&phm,
             &pcont,
-            XFORMCOORDS.XFORMCOORDS_SIZE | XFORMCOORDS.XFORMCOORDS_HIMETRICTOCONTAINER);
+            (uint)(XFORMCOORDS.XFORMCOORDS_SIZE | XFORMCOORDS.XFORMCOORDS_HIMETRICTOCONTAINER));
 
         sz.Width = (int)pcont.X;
         sz.Height = (int)pcont.Y;
@@ -1138,7 +1138,7 @@ public abstract unsafe partial class AxHost : Control, ISupportInitialize, ICust
         ((IOleControlSite.Interface)_oleSite).TransformCoords(
             (POINTL*)&phm,
             &pcont,
-            XFORMCOORDS.XFORMCOORDS_SIZE | XFORMCOORDS.XFORMCOORDS_CONTAINERTOHIMETRIC);
+            (uint)(XFORMCOORDS.XFORMCOORDS_SIZE | XFORMCOORDS.XFORMCOORDS_CONTAINERTOHIMETRIC));
 
         sz.Width = phm.X;
         sz.Height = phm.Y;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildListUiaProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildListUiaProvider.cs
@@ -4,7 +4,7 @@
 
 using System.Drawing;
 using System.Runtime.InteropServices;
-using Windows.Win32.System.Com;
+using Windows.Win32.System.Variant;
 using static System.Windows.Forms.ComboBox.ObjectCollection;
 using static Interop;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2ColorConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2ColorConverter.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Drawing;
-using Windows.Win32.System.Com;
+using Windows.Win32.System.Variant;
 
 namespace System.Windows.Forms.ComponentModel.Com2Interop;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2DataTypeToManagedDataTypeConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2DataTypeToManagedDataTypeConverter.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Windows.Win32.System.Com;
 using Windows.Win32.System.Ole;
+using Windows.Win32.System.Variant;
 
 namespace System.Windows.Forms.ComponentModel.Com2Interop;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2FontConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2FontConverter.cs
@@ -5,6 +5,7 @@
 using System.Drawing;
 using Windows.Win32.System.Com;
 using Windows.Win32.System.Ole;
+using Windows.Win32.System.Variant;
 
 namespace System.Windows.Forms.ComponentModel.Com2Interop;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2IManagedPerPropertyBrowsingHandler.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2IManagedPerPropertyBrowsingHandler.cs
@@ -4,7 +4,7 @@
 
 using System.Reflection;
 using System.Runtime.InteropServices;
-using Windows.Win32.System.Com;
+using Windows.Win32.System.Variant;
 using Microsoft.VisualStudio.Shell;
 
 namespace System.Windows.Forms.ComponentModel.Com2Interop;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PictureConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PictureConverter.cs
@@ -5,6 +5,7 @@
 using System.Drawing;
 using Windows.Win32.System.Com;
 using Windows.Win32.System.Ole;
+using Windows.Win32.System.Variant;
 
 namespace System.Windows.Forms.ComponentModel.Com2Interop;
 
@@ -57,8 +58,7 @@ internal sealed unsafe class Com2PictureConverter : Com2DataTypeToManagedDataTyp
             // GDI handles are sign extended 32 bit values.
             // We need to first cast to int so sign extension happens correctly.
             nint extendedHandle = (int)handle.Value;
-            short type = picture.Value->Type;
-            switch ((PICTYPE)type)
+            switch (picture.Value->Type)
             {
                 case PICTYPE.PICTYPE_ICON:
                     _pictureType = typeof(Icon);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyBuilderUITypeEditor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyBuilderUITypeEditor.cs
@@ -6,7 +6,7 @@ using System.ComponentModel;
 using System.Drawing.Design;
 using System.Windows.Forms.Design;
 using Microsoft.VisualStudio.Shell;
-using Windows.Win32.System.Com;
+using Windows.Win32.System.Variant;
 
 namespace System.Windows.Forms.ComponentModel.Com2Interop;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyDescriptor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyDescriptor.cs
@@ -9,6 +9,7 @@ using System.Runtime.InteropServices;
 using Windows.Win32.System.Com;
 using Windows.Win32.System.Diagnostics.Debug;
 using Windows.Win32.System.Ole;
+using Windows.Win32.System.Variant;
 using static Interop;
 
 namespace System.Windows.Forms.ComponentModel.Com2Interop;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyPageUITypeConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyPageUITypeConverter.cs
@@ -85,9 +85,7 @@ internal sealed unsafe class Com2PropertyPageUITypeEditor : Com2ExtendedUITypeEd
                     (IUnknown**)pObjAddrs,
                     1,
                     pageGuid,
-                    PInvoke.GetThreadLocale(),
-                    0,
-                    null);
+                    PInvoke.GetThreadLocale());
             }
         }
         finally

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2TypeInfoProcessor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2TypeInfoProcessor.cs
@@ -9,8 +9,9 @@ using System.Reflection.Emit;
 using System.Runtime.InteropServices;
 using Windows.Win32.System.Com;
 using Windows.Win32.System.Ole;
+using Windows.Win32.System.Variant;
 using static Windows.Win32.System.Com.TYPEKIND;
-using static Windows.Win32.System.Com.VARENUM;
+using static Windows.Win32.System.Variant.VARENUM;
 using static Windows.Win32.System.Com.VARFLAGS;
 
 namespace System.Windows.Forms.ComponentModel.Com2Interop;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/Com2IPerPropertyBrowsingHandler.Com2IPerPropertyBrowsingEnum.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/Com2IPerPropertyBrowsingHandler.Com2IPerPropertyBrowsingEnum.cs
@@ -3,8 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Globalization;
-using Windows.Win32.System.Com;
 using Windows.Win32.System.Ole;
+using Windows.Win32.System.Variant;
 
 namespace System.Windows.Forms.ComponentModel.Com2Interop;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/ComNativeDescriptor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/ComNativeDescriptor.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.ComponentModel;
 using Microsoft.VisualStudio.Shell;
 using Windows.Win32.System.Com;
+using Windows.Win32.System.Variant;
 
 namespace System.Windows.Forms.ComponentModel.Com2Interop;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.PropertyBagStream.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.PropertyBagStream.cs
@@ -5,6 +5,7 @@
 using System.Collections;
 using Windows.Win32.System.Com;
 using Windows.Win32.System.Com.StructuredStorage;
+using Windows.Win32.System.Variant;
 using System.Windows.Forms.BinaryFormat;
 
 namespace System.Windows.Forms;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
@@ -15,6 +15,7 @@ using System.Windows.Forms.BinaryFormat;
 using Windows.Win32.System.Com;
 using Windows.Win32.System.Com.StructuredStorage;
 using Windows.Win32.System.Ole;
+using Windows.Win32.System.Variant;
 using Windows.Win32.UI.Input.KeyboardAndMouse;
 using static Interop;
 
@@ -1051,7 +1052,6 @@ public partial class Control
             using ComScope<IStream> stream = new(null);
             HRESULT hr = stg->OpenStream(
                 GetStreamName(),
-                null,
                 STGM.STGM_READ | STGM.STGM_SHARE_EXCLUSIVE,
                 0,
                 stream);
@@ -1062,7 +1062,6 @@ public partial class Control
                 // as the stream name in v1. Lets see if a stream by that name exists.
                 hr = stg->OpenStream(
                     GetType().FullName!,
-                    null,
                     STGM.STGM_READ | STGM.STGM_SHARE_EXCLUSIVE,
                     0,
                     stream);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.MetafileDCWrapper.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.MetafileDCWrapper.cs
@@ -131,7 +131,7 @@ public partial class Control
                         biHeight = bmp.bmHeight,
                         biPlanes = 1,
                         biBitCount = bmp.bmBitsPixel,
-                        biCompression = BI_COMPRESSION.BI_RGB
+                        biCompression = (uint)BI_COMPRESSION.BI_RGB
                     };
 
                     // Include the palette for 256 color bitmaps

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ControlPaint.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ControlPaint.cs
@@ -181,7 +181,7 @@ public static partial class ControlPaint
                 biHeight = bitmap.Height,
                 biPlanes = 1,
                 biBitCount = 16,
-                biCompression = BI_COMPRESSION.BI_RGB
+                biCompression = (uint)BI_COMPRESSION.BI_RGB
             };
 
             Span<RGBQUAD> colors = new(bi + sizeof(BITMAPINFOHEADER), (int)entryCount);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control_ActiveXControlInterfaces.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control_ActiveXControlInterfaces.cs
@@ -201,20 +201,20 @@ public unsafe partial class Control :
         return HRESULT.S_OK;
     }
 
-    HRESULT IOleObject.Interface.Close(OLECLOSE dwSaveOption)
+    HRESULT IOleObject.Interface.Close(uint dwSaveOption)
     {
         Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, $"AxSource:Close. Save option: {dwSaveOption}");
-        ActiveXInstance.Close(dwSaveOption);
+        ActiveXInstance.Close((OLECLOSE)dwSaveOption);
         return HRESULT.S_OK;
     }
 
-    unsafe HRESULT IOleObject.Interface.SetMoniker(OLEWHICHMK dwWhichMoniker, IMoniker* pmk)
+    unsafe HRESULT IOleObject.Interface.SetMoniker(uint dwWhichMoniker, IMoniker* pmk)
     {
         Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "AxSource:SetMoniker");
         return HRESULT.E_NOTIMPL;
     }
 
-    HRESULT IOleObject.Interface.GetMoniker(OLEGETMONIKER dwAssign, OLEWHICHMK dwWhichMoniker, IMoniker** ppmk)
+    HRESULT IOleObject.Interface.GetMoniker(uint dwAssign, uint dwWhichMoniker, IMoniker** ppmk)
     {
         if (ppmk is null)
         {
@@ -317,7 +317,7 @@ public unsafe partial class Control :
         return HRESULT.S_OK;
     }
 
-    HRESULT IOleObject.Interface.GetUserType(USERCLASSTYPE dwFormOfType, PWSTR* pszUserType)
+    HRESULT IOleObject.Interface.GetUserType(uint dwFormOfType, PWSTR* pszUserType)
     {
         if (pszUserType is null)
         {
@@ -326,7 +326,7 @@ public unsafe partial class Control :
 
         Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "AxSource:GetUserType");
         *pszUserType = (char*)Marshal.StringToCoTaskMemUni(
-            dwFormOfType == USERCLASSTYPE.USERCLASSTYPE_FULL ? GetType().FullName : GetType().Name);
+            (USERCLASSTYPE)dwFormOfType == USERCLASSTYPE.USERCLASSTYPE_FULL ? GetType().FullName : GetType().Name);
 
         return HRESULT.S_OK;
     }
@@ -696,10 +696,10 @@ public unsafe partial class Control :
         return HRESULT.E_NOTIMPL;
     }
 
-    HRESULT IViewObject.Interface.SetAdvise(DVASPECT aspects, ADVF advf, IAdviseSink* pAdvSink)
+    HRESULT IViewObject.Interface.SetAdvise(DVASPECT aspects, uint advf, IAdviseSink* pAdvSink)
     {
         Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "AxSource:SetAdvise");
-        return ActiveXInstance.SetAdvise(aspects, advf, pAdvSink);
+        return ActiveXInstance.SetAdvise(aspects, (ADVF)advf, pAdvSink);
     }
 
     HRESULT IViewObject.Interface.GetAdvise(uint* pAspects, uint* pAdvf, IAdviseSink** ppAdvSink)
@@ -746,7 +746,7 @@ public unsafe partial class Control :
     HRESULT IViewObject2.Interface.Unfreeze(uint dwFreeze)
         => ((IViewObject.Interface)this).Unfreeze(dwFreeze);
 
-    HRESULT IViewObject2.Interface.SetAdvise(DVASPECT aspects, ADVF advf, IAdviseSink* pAdvSink)
+    HRESULT IViewObject2.Interface.SetAdvise(DVASPECT aspects, uint advf, IAdviseSink* pAdvSink)
         => ((IViewObject.Interface)this).SetAdvise(aspects, advf, pAdvSink);
 
     HRESULT IViewObject2.Interface.GetAdvise(uint* pAspects, uint* pAdvf, IAdviseSink** ppAdvSink)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Cursor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Cursor.cs
@@ -413,7 +413,7 @@ public sealed class Cursor : IDisposable, ISerializable, IHandle<HICON>, IHandle
             using var pStream = ComHelpers.GetComScope<IStream>(stream);
             persist.Value->Load(pStream);
 
-            if (picture.Value->Type == (short)PICTYPE.PICTYPE_ICON)
+            if (picture.Value->Type == PICTYPE.PICTYPE_ICON)
             {
                 HICON cursorHandle = (HICON)picture.Value->Handle;
                 Size picSize = GetIconSize(cursorHandle);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataStreamFromComStream.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataStreamFromComStream.cs
@@ -145,7 +145,7 @@ internal unsafe class DataStreamFromComStream : Stream
     {
         if (disposing && _comStream is not null)
         {
-            _comStream->Commit(STGC.STGC_DEFAULT);
+            _comStream->Commit((uint)STGC.STGC_DEFAULT);
         }
 
         _comStream = null;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DragDropHelper.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DragDropHelper.cs
@@ -171,12 +171,12 @@ internal static class DragDropHelper
 
             medium = default;
             dataObject.GetData(ref formatEtc, out medium);
-            void* basePtr = PInvoke.GlobalLock(medium.unionmember);
+            void* basePtr = PInvoke.GlobalLock((HGLOBAL)medium.unionmember);
             return (basePtr is not null) && (*(BOOL*)basePtr == true);
         }
         finally
         {
-            PInvoke.GlobalUnlock(medium.unionmember);
+            PInvoke.GlobalUnlock((HGLOBAL)medium.unionmember);
             Ole32.ReleaseStgMedium(ref medium);
         }
     }
@@ -196,12 +196,12 @@ internal static class DragDropHelper
         {
             try
             {
-                void* basePtr = PInvoke.GlobalLock(dragDropFormat.Medium.unionmember);
+                void* basePtr = PInvoke.GlobalLock((HGLOBAL)dragDropFormat.Medium.unionmember);
                 return (basePtr is not null) && (*(BOOL*)basePtr == true);
             }
             finally
             {
-                PInvoke.GlobalUnlock(dragDropFormat.Medium.unionmember);
+                PInvoke.GlobalUnlock((HGLOBAL)dragDropFormat.Medium.unionmember);
             }
         }
         else
@@ -280,16 +280,16 @@ internal static class DragDropHelper
             throw new Win32Exception(Marshal.GetLastSystemError(), SR.ExternalException);
         }
 
-        void* basePtr = PInvoke.GlobalLock(medium.unionmember);
+        void* basePtr = PInvoke.GlobalLock((HGLOBAL)medium.unionmember);
         if (basePtr is null)
         {
-            PInvoke.GlobalFree(medium.unionmember);
+            PInvoke.GlobalFree((HGLOBAL)medium.unionmember);
             medium.unionmember = IntPtr.Zero;
             throw new Win32Exception(Marshal.GetLastSystemError(), SR.ExternalException);
         }
 
         *(BOOL*)basePtr = value;
-        PInvoke.GlobalUnlock(medium.unionmember);
+        PInvoke.GlobalUnlock((HGLOBAL)medium.unionmember);
         dataObject.SetData(ref formatEtc, ref medium, release: true);
     }
 
@@ -438,10 +438,10 @@ internal static class DragDropHelper
             throw new Win32Exception(Marshal.GetLastSystemError(), SR.ExternalException);
         }
 
-        void* basePtr = PInvoke.GlobalLock(medium.unionmember);
+        void* basePtr = PInvoke.GlobalLock((HGLOBAL)medium.unionmember);
         if (basePtr is null)
         {
-            PInvoke.GlobalFree(medium.unionmember);
+            PInvoke.GlobalFree((HGLOBAL)medium.unionmember);
             medium.unionmember = IntPtr.Zero;
             throw new Win32Exception(Marshal.GetLastSystemError(), SR.ExternalException);
         }
@@ -450,7 +450,7 @@ internal static class DragDropHelper
         pDropDescription->type = (DROPIMAGETYPE)dropImageType;
         pDropDescription->szMessage = message;
         pDropDescription->szInsert = messageReplacementToken;
-        PInvoke.GlobalUnlock(medium.unionmember);
+        PInvoke.GlobalUnlock((HGLOBAL)medium.unionmember);
 
         // Set the InShellDragLoop flag to true to facilitate loading and retrieving arbitrary private formats. The
         // drag-and-drop helper object calls IDataObject::SetData to load private formats--used for cross-process support--into

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FolderBrowserDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FolderBrowserDialog.cs
@@ -389,10 +389,10 @@ public sealed class FolderBrowserDialog : CommonDialog
 
     private unsafe bool RunDialogOld(HWND hWndOwner)
     {
-        PInvoke.SHGetSpecialFolderLocation(hWndOwner, (int)_rootFolder, out ITEMIDLIST* listHandle);
+        PInvoke.SHGetSpecialFolderLocation((int)_rootFolder, out ITEMIDLIST* listHandle);
         if (listHandle is null)
         {
-            PInvoke.SHGetSpecialFolderLocation(hWndOwner, (int)Environment.SpecialFolder.Desktop, out listHandle);
+            PInvoke.SHGetSpecialFolderLocation((int)Environment.SpecialFolder.Desktop, out listHandle);
             if (listHandle is null)
             {
                 throw new InvalidOperationException(SR.FolderBrowserDialogNoRootFolder);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/HtmlDocument.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/HtmlDocument.cs
@@ -8,6 +8,7 @@ using System.ComponentModel;
 using System.Drawing;
 using System.Globalization;
 using Windows.Win32.System.Com;
+using Windows.Win32.System.Variant;
 using static Interop;
 using static Interop.Mshtml;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/HtmlElement.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/HtmlElement.cs
@@ -7,6 +7,7 @@
 using System.Drawing;
 using System.Runtime.InteropServices;
 using Windows.Win32.System.Com;
+using Windows.Win32.System.Variant;
 using static Interop;
 using static Interop.Mshtml;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PageSetupDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PageSetupDialog.cs
@@ -354,8 +354,8 @@ public sealed class PageSetupDialog : CommonDialog
         }
         finally
         {
-            PInvoke.GlobalFree(data.hDevMode);
-            PInvoke.GlobalFree(data.hDevNames);
+            PInvoke.GlobalFree((HGLOBAL)data.hDevMode);
+            PInvoke.GlobalFree((HGLOBAL)data.hDevNames);
             GC.KeepAlive(hookProc);
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintDialog.cs
@@ -425,8 +425,8 @@ public sealed class PrintDialog : CommonDialog
         finally
         {
             GC.KeepAlive(wndproc);
-            PInvoke.GlobalFree(data.hDevMode);
-            PInvoke.GlobalFree(data.hDevNames);
+            PInvoke.GlobalFree((HGLOBAL)data.hDevMode);
+            PInvoke.GlobalFree((HGLOBAL)data.hDevNames);
         }
     }
 
@@ -536,17 +536,17 @@ public sealed class PrintDialog : CommonDialog
         {
             if (data.hDevMode != IntPtr.Zero)
             {
-                PInvoke.GlobalFree(data.hDevMode);
+                PInvoke.GlobalFree((HGLOBAL)data.hDevMode);
             }
 
             if (data.hDevNames != IntPtr.Zero)
             {
-                PInvoke.GlobalFree(data.hDevNames);
+                PInvoke.GlobalFree((HGLOBAL)data.hDevNames);
             }
 
             if (data.pageRanges != IntPtr.Zero)
             {
-                PInvoke.GlobalFree(data.pageRanges);
+                PInvoke.GlobalFree((HGLOBAL)data.pageRanges);
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.OleCallback.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.OleCallback.cs
@@ -45,7 +45,7 @@ public partial class RichTextBox
             }
 
             using ComScope<ILockBytes> pLockBytes = new(null);
-            HRESULT hr = PInvoke.CreateILockBytesOnHGlobal(0, fDeleteOnRelease: true, pLockBytes);
+            HRESULT hr = PInvoke.CreateILockBytesOnHGlobal(default, fDeleteOnRelease: true, pLockBytes);
             if (hr.Failed)
             {
                 return hr;
@@ -89,7 +89,7 @@ public partial class RichTextBox
             return HRESULT.S_OK;
         }
 
-        public HRESULT QueryAcceptData(Com.IDataObject* lpdataobj, ushort* lpcfFormat, RECO_FLAGS reco, BOOL fReally, nint hMetaPict)
+        public HRESULT QueryAcceptData(Com.IDataObject* lpdataobj, ushort* lpcfFormat, RECO_FLAGS reco, BOOL fReally, HGLOBAL hMetaPict)
         {
             RichTextDbg.TraceVerbose($"IRichEditOleCallback::QueryAcceptData(reco={reco})");
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserBase.cs
@@ -1187,7 +1187,7 @@ public unsafe partial class WebBrowserBase : Control
         ((IOleControlSite.Interface)ActiveXSite).TransformCoords(
             (POINTL*)&phm,
             &pcont,
-            XFORMCOORDS.XFORMCOORDS_SIZE | XFORMCOORDS.XFORMCOORDS_HIMETRICTOCONTAINER);
+            (uint)(XFORMCOORDS.XFORMCOORDS_SIZE | XFORMCOORDS.XFORMCOORDS_HIMETRICTOCONTAINER));
         sz.Width = (int)pcont.X;
         sz.Height = (int)pcont.Y;
     }
@@ -1199,7 +1199,7 @@ public unsafe partial class WebBrowserBase : Control
         ((IOleControlSite.Interface)ActiveXSite).TransformCoords(
             (POINTL*)&phm,
             &pcont,
-            XFORMCOORDS.XFORMCOORDS_SIZE | XFORMCOORDS.XFORMCOORDS_CONTAINERTOHIMETRIC);
+            (uint)(XFORMCOORDS.XFORMCOORDS_SIZE | XFORMCOORDS.XFORMCOORDS_CONTAINERTOHIMETRIC));
         sz.Width = phm.X;
         sz.Height = phm.Y;
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserContainer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserContainer.cs
@@ -41,14 +41,14 @@ internal unsafe class WebBrowserContainer : IOleContainer.Interface, IOleInPlace
         return HRESULT.E_NOTIMPL;
     }
 
-    HRESULT IOleContainer.Interface.EnumObjects(OLECONTF grfFlags, IEnumUnknown** ppenum)
+    HRESULT IOleContainer.Interface.EnumObjects(uint grfFlags, IEnumUnknown** ppenum)
     {
         if (ppenum is null)
         {
             return HRESULT.E_POINTER;
         }
 
-        if (grfFlags.HasFlag(OLECONTF.OLECONTF_EMBEDDINGS))
+        if (((OLECONTF)grfFlags).HasFlag(OLECONTF.OLECONTF_EMBEDDINGS))
         {
             Debug.Assert(parent is not null);
             List<object> list = new();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserSiteBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserSiteBase.cs
@@ -84,21 +84,22 @@ public unsafe class WebBrowserSiteBase :
         return HRESULT.E_NOTIMPL;
     }
 
-    HRESULT IOleControlSite.Interface.TransformCoords(POINTL* pPtlHimetric, PointF* pPtfContainer, XFORMCOORDS dwFlags)
+    HRESULT IOleControlSite.Interface.TransformCoords(POINTL* pPtlHimetric, PointF* pPtfContainer, uint dwFlags)
     {
         if (pPtlHimetric is null || pPtfContainer is null)
         {
             return HRESULT.E_POINTER;
         }
 
-        if (dwFlags.HasFlag(XFORMCOORDS.XFORMCOORDS_HIMETRICTOCONTAINER))
+        XFORMCOORDS coordinates = (XFORMCOORDS)dwFlags;
+        if (coordinates.HasFlag(XFORMCOORDS.XFORMCOORDS_HIMETRICTOCONTAINER))
         {
-            if (dwFlags.HasFlag(XFORMCOORDS.XFORMCOORDS_SIZE))
+            if (coordinates.HasFlag(XFORMCOORDS.XFORMCOORDS_SIZE))
             {
                 pPtfContainer->X = WebBrowserHelper.HM2Pix(pPtlHimetric->x, WebBrowserHelper.LogPixelsX);
                 pPtfContainer->Y = WebBrowserHelper.HM2Pix(pPtlHimetric->y, WebBrowserHelper.LogPixelsY);
             }
-            else if (dwFlags.HasFlag(XFORMCOORDS.XFORMCOORDS_POSITION))
+            else if (coordinates.HasFlag(XFORMCOORDS.XFORMCOORDS_POSITION))
             {
                 pPtfContainer->X = WebBrowserHelper.HM2Pix(pPtlHimetric->x, WebBrowserHelper.LogPixelsX);
                 pPtfContainer->Y = WebBrowserHelper.HM2Pix(pPtlHimetric->y, WebBrowserHelper.LogPixelsY);
@@ -108,14 +109,14 @@ public unsafe class WebBrowserSiteBase :
                 return HRESULT.E_INVALIDARG;
             }
         }
-        else if (dwFlags.HasFlag(XFORMCOORDS.XFORMCOORDS_CONTAINERTOHIMETRIC))
+        else if (coordinates.HasFlag(XFORMCOORDS.XFORMCOORDS_CONTAINERTOHIMETRIC))
         {
-            if (dwFlags.HasFlag(XFORMCOORDS.XFORMCOORDS_SIZE))
+            if (coordinates.HasFlag(XFORMCOORDS.XFORMCOORDS_SIZE))
             {
                 pPtlHimetric->x = WebBrowserHelper.Pix2HM((int)pPtfContainer->X, WebBrowserHelper.LogPixelsX);
                 pPtlHimetric->y = WebBrowserHelper.Pix2HM((int)pPtfContainer->Y, WebBrowserHelper.LogPixelsY);
             }
-            else if (dwFlags.HasFlag(XFORMCOORDS.XFORMCOORDS_POSITION))
+            else if (coordinates.HasFlag(XFORMCOORDS.XFORMCOORDS_POSITION))
             {
                 pPtlHimetric->x = WebBrowserHelper.Pix2HM((int)pPtfContainer->X, WebBrowserHelper.LogPixelsX);
                 pPtlHimetric->y = WebBrowserHelper.Pix2HM((int)pPtfContainer->Y, WebBrowserHelper.LogPixelsY);
@@ -162,7 +163,7 @@ public unsafe class WebBrowserSiteBase :
     // IOleClientSite methods:
     HRESULT IOleClientSite.Interface.SaveObject() => HRESULT.E_NOTIMPL;
 
-    HRESULT IOleClientSite.Interface.GetMoniker(OLEGETMONIKER dwAssign, OLEWHICHMK dwWhichMoniker, IMoniker** ppmk)
+    HRESULT IOleClientSite.Interface.GetMoniker(uint dwAssign, uint dwWhichMoniker, IMoniker** ppmk)
     {
         if (ppmk is null)
         {

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Input/InputBuilder.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Input/InputBuilder.cs
@@ -18,7 +18,7 @@ internal static class InputBuilder
                 ki = new KEYBDINPUT
                 {
                     wVk = keyCode,
-                    wScan = (ushort)(PInvoke.MapVirtualKey((uint)keyCode, PInvoke.MAPVK_VK_TO_VSC) & 0xFFU),
+                    wScan = (ushort)(PInvoke.MapVirtualKey((uint)keyCode, MAP_VIRTUAL_KEY_TYPE.MAPVK_VK_TO_VSC) & 0xFFU),
                     dwFlags = IsExtendedKey(keyCode) ? KEYBD_EVENT_FLAGS.KEYEVENTF_EXTENDEDKEY : 0,
                     time = 0,
                     dwExtraInfo = 0,

--- a/src/System.Windows.Forms/tests/InteropTests/AccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/InteropTests/AccessibleObjectTests.cs
@@ -3,8 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.InteropServices;
-using Windows.Win32.System.Com;
 using Windows.Win32.System.Ole;
+using Windows.Win32.System.Variant;
 using static Interop.UiaCore;
 
 namespace System.Windows.Forms.InteropTests;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AxHost.PropertyBagStreamTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AxHost.PropertyBagStreamTests.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.InteropServices;
-using Windows.Win32.System.Com;
+using Windows.Win32.System.Variant;
 using Windows.Win32.System.Com.StructuredStorage;
 
 namespace System.Windows.Forms.Tests;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AxHostTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AxHostTests.cs
@@ -11,6 +11,7 @@ using System.Windows.Forms.TestUtilities;
 using Moq;
 using Windows.Win32.System.Com;
 using Windows.Win32.System.Ole;
+using Windows.Win32.System.Variant;
 using Point = System.Drawing.Point;
 using Size = System.Drawing.Size;
 
@@ -1574,14 +1575,14 @@ public class AxHostTests
         Assert.NotNull(iPicture);
 
         OLE_HANDLE handle = iPicture.Handle;
-        short type = iPicture.Type;
+        PICTYPE type = iPicture.Type;
         int width = iPicture.Width;
         int height = iPicture.Height;
         uint attributes = iPicture.Attributes;
 
         Assert.NotEqual(0u, handle);
         Assert.True(iPicture.get_hPal(out _).Failed);
-        Assert.Equal(3, type);
+        Assert.Equal(PICTYPE.PICTYPE_ICON, type);
         Assert.Equal(847, width);
         Assert.Equal(847, height);
         Assert.Throws<COMException>(() => iPicture.CurDC);
@@ -1660,7 +1661,7 @@ public class AxHostTests
 
         OLE_HANDLE handle = iPicture.Handle;
         iPicture.get_hPal(out OLE_HANDLE hPal).ThrowOnFailure();
-        short type = iPicture.Type;
+        PICTYPE type = iPicture.Type;
         int width = iPicture.Width;
         int height = iPicture.Height;
         uint attributes = iPicture.Attributes;
@@ -1668,10 +1669,10 @@ public class AxHostTests
 
         Assert.NotEqual(0u, handle);
         Assert.Equal(0u, hPal);
-        Assert.Equal(1, type);
+        Assert.Equal(PICTYPE.PICTYPE_BITMAP, type);
         Assert.Equal(265, width);
         Assert.Equal(291, height);
-        Assert.Equal(HDC.Null, curDc);
+        Assert.Equal(default, curDc);
         Assert.Equal(0u, attributes);
 
         var result = Assert.IsType<Bitmap>(SubAxHost.GetPictureFromIPicture(iPicture));
@@ -1688,14 +1689,14 @@ public class AxHostTests
         Assert.NotNull(iPicture);
 
         OLE_HANDLE handle = iPicture.Handle;
-        short type = iPicture.Type;
+        PICTYPE type = iPicture.Type;
         int width = iPicture.Width;
         int height = iPicture.Height;
         uint attributes = iPicture.Attributes;
 
         Assert.NotEqual(0u, handle);
         Assert.True(iPicture.get_hPal(out _).Failed);
-        Assert.Equal(4, type);
+        Assert.Equal(PICTYPE.PICTYPE_ENHMETAFILE, type);
         Assert.Equal(19972, width);
         Assert.Equal(28332, height);
         Assert.Throws<COMException>(() => iPicture.CurDC);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComponentModel/Com2Interop/COM2FontConverterTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComponentModel/Com2Interop/COM2FontConverterTests.cs
@@ -9,6 +9,7 @@ using System.Drawing;
 using System.Windows.Forms.ComponentModel.Com2Interop;
 using Windows.Win32.System.Com;
 using Windows.Win32.System.Ole;
+using Windows.Win32.System.Variant;
 
 namespace System.Windows.Forms.Tests.ComponentModel.Com2Interop;
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComponentModel/Com2Interop/COM2PictureConverterTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComponentModel/Com2Interop/COM2PictureConverterTests.cs
@@ -6,6 +6,7 @@ using System.Drawing;
 using System.Windows.Forms.ComponentModel.Com2Interop;
 using Windows.Win32.System.Com;
 using Windows.Win32.System.Ole;
+using Windows.Win32.System.Variant;
 
 namespace System.Windows.Forms.Tests.ComponentModel.Com2Interop;
 
@@ -40,7 +41,7 @@ public unsafe class COM2PictureConverterTests
 
         public override OLE_HANDLE Handle => new((uint)(int)_handle);
 
-        public override short Type => (short)_type;
+        public override PICTYPE Type => _type;
     }
 
     [Fact]
@@ -123,10 +124,9 @@ public unsafe class COM2PictureConverterTests
         using ComScope<IPicture> picture = ComScope<IPicture>.QueryFrom((IUnknown*)native);
 
         Assert.False(cancelSet);
-        short type = picture.Value->Type;
         int height = picture.Value->Height;
         int width = picture.Value->Width;
-        Assert.Equal((short)PICTYPE.PICTYPE_ICON, type);
+        Assert.Equal(PICTYPE.PICTYPE_ICON, picture.Value->Type);
         Assert.Equal(exclamationIcon.Height, GdiHelper.HimetricToPixelY(height));
         Assert.Equal(exclamationIcon.Width, GdiHelper.HimetricToPixelX(width));
 
@@ -144,10 +144,9 @@ public unsafe class COM2PictureConverterTests
         using ComScope<IPicture> picture = ComScope<IPicture>.QueryFrom((IUnknown*)native);
 
         Assert.False(cancelSet);
-        short type = picture.Value->Type;
         int height = picture.Value->Height;
         int width = picture.Value->Width;
-        Assert.Equal((short)PICTYPE.PICTYPE_BITMAP, type);
+        Assert.Equal(PICTYPE.PICTYPE_BITMAP, picture.Value->Type);
         Assert.Equal(bitmap.Height, GdiHelper.HimetricToPixelY(height));
         Assert.Equal(bitmap.Width, GdiHelper.HimetricToPixelX(width));
 
@@ -181,7 +180,7 @@ public unsafe class COM2PictureConverterTests
 
         public virtual HRESULT get_hPal(OLE_HANDLE* phPal) => HRESULT.S_OK;
 
-        public virtual short Type => default;
+        public virtual PICTYPE Type => default;
 
         public virtual int Width => default;
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComponentModel/Com2Interop/ComNativeDescriptorTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComponentModel/Com2Interop/ComNativeDescriptorTests.cs
@@ -9,6 +9,7 @@ using System.Runtime.InteropServices;
 using System.Windows.Forms.Tests.TestResources;
 using Windows.Win32.System.Com;
 using Windows.Win32.System.Ole;
+using Windows.Win32.System.Variant;
 using Windows.Win32.UI.Accessibility;
 using WMPLib;
 using static Interop;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataObjectTests.cs
@@ -2146,18 +2146,21 @@ public class DataObjectTests
         dataObject.SetText("text", textDataFormat);
         IComDataObject iComDataObject = dataObject;
 
-        var formatetc = new FORMATETC
+        FORMATETC formatetc = new()
         {
             tymed = TYMED.TYMED_HGLOBAL,
             cfFormat = cfFormat
         };
-        var stgMedium = new STGMEDIUM
+
+        STGMEDIUM stgMedium = new()
         {
             tymed = TYMED.TYMED_HGLOBAL
         };
-        nint handle = PInvoke.GlobalAlloc(
+
+        HGLOBAL handle = PInvoke.GlobalAlloc(
             GLOBAL_ALLOC_FLAGS.GMEM_MOVEABLE | GLOBAL_ALLOC_FLAGS.GMEM_ZEROINIT,
             1);
+
         try
         {
             stgMedium.unionmember = handle;
@@ -2186,18 +2189,21 @@ public class DataObjectTests
         dataObject.SetText("text", textDataFormat);
         IComDataObject iComDataObject = dataObject;
 
-        var formatetc = new FORMATETC
+        FORMATETC formatetc = new()
         {
             tymed = TYMED.TYMED_HGLOBAL,
             cfFormat = cfFormat
         };
-        var stgMedium = new STGMEDIUM
+
+        STGMEDIUM stgMedium = new()
         {
             tymed = TYMED.TYMED_HGLOBAL
         };
-        nint handle = PInvoke.GlobalAlloc(
+
+        HGLOBAL handle = PInvoke.GlobalAlloc(
             GLOBAL_ALLOC_FLAGS.GMEM_MOVEABLE | GLOBAL_ALLOC_FLAGS.GMEM_ZEROINIT,
             1);
+
         try
         {
             stgMedium.unionmember = handle;
@@ -2220,15 +2226,17 @@ public class DataObjectTests
         dataObject.SetText("text", textDataFormat);
         IComDataObject iComDataObject = dataObject;
 
-        var formatetc = new FORMATETC
+        FORMATETC formatetc = new()
         {
             tymed = TYMED.TYMED_HGLOBAL,
             cfFormat = cfFormat
         };
-        var stgMedium = new STGMEDIUM
+
+        STGMEDIUM stgMedium = new()
         {
             tymed = TYMED.TYMED_HGLOBAL
         };
+
         Assert.Throws<ArgumentException>(() => iComDataObject.GetDataHere(ref formatetc, ref stgMedium));
     }
 
@@ -2240,15 +2248,17 @@ public class DataObjectTests
         dataObject.SetText("text", textDataFormat);
         IComDataObject iComDataObject = dataObject;
 
-        var formatetc = new FORMATETC
+        FORMATETC formatetc = new()
         {
             tymed = TYMED.TYMED_HGLOBAL,
             cfFormat = cfFormat
         };
-        var stgMedium = new STGMEDIUM
+
+        STGMEDIUM stgMedium = new()
         {
             tymed = TYMED.TYMED_HGLOBAL
         };
+
         Assert.Throws<ArgumentException>(() => iComDataObject.GetDataHere(ref formatetc, ref stgMedium));
     }
 
@@ -2259,18 +2269,21 @@ public class DataObjectTests
         dataObject.SetFileDropList(new StringCollection { "Path1", "Path2" });
         IComDataObject iComDataObject = dataObject;
 
-        var formatetc = new FORMATETC
+        FORMATETC formatetc = new()
         {
             tymed = TYMED.TYMED_HGLOBAL,
             cfFormat = (short)CF.HDROP
         };
-        var stgMedium = new STGMEDIUM
+
+        STGMEDIUM stgMedium = new()
         {
             tymed = TYMED.TYMED_HGLOBAL
         };
-        nint handle = PInvoke.GlobalAlloc(
+
+        HGLOBAL handle = PInvoke.GlobalAlloc(
             GLOBAL_ALLOC_FLAGS.GMEM_MOVEABLE | GLOBAL_ALLOC_FLAGS.GMEM_ZEROINIT,
             1);
+
         try
         {
             stgMedium.unionmember = handle;
@@ -2297,18 +2310,21 @@ public class DataObjectTests
         dataObject.SetFileDropList(new StringCollection());
         IComDataObject iComDataObject = dataObject;
 
-        var formatetc = new FORMATETC
+        FORMATETC formatetc = new()
         {
             tymed = TYMED.TYMED_HGLOBAL,
             cfFormat = (short)CF.HDROP
         };
-        var stgMedium = new STGMEDIUM
+
+        STGMEDIUM stgMedium = new()
         {
             tymed = TYMED.TYMED_HGLOBAL
         };
-        nint handle = PInvoke.GlobalAlloc(
+
+        HGLOBAL handle = PInvoke.GlobalAlloc(
            GLOBAL_ALLOC_FLAGS.GMEM_MOVEABLE | GLOBAL_ALLOC_FLAGS.GMEM_ZEROINIT,
-            (uint)sizeof(DROPFILES));
+           (uint)sizeof(DROPFILES));
+
         try
         {
             stgMedium.unionmember = handle;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DragDropFormatTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DragDropFormatTests.cs
@@ -33,7 +33,7 @@ public class DragDropFormatTests
                 BOOL.Size)
         };
 
-        SaveInDragLoopToHandle(medium.unionmember, inDragLoop: true);
+        SaveInDragLoopToHandle((HGLOBAL)medium.unionmember, inDragLoop: true);
         yield return new object[] { formatEtc, medium };
 
         MemoryStream memoryStream = new();
@@ -67,7 +67,7 @@ public class DragDropFormatTests
         {
             dragDropFormat = new DragDropFormat(formatEtc.cfFormat, medium, copyData: false);
             dragDropFormat.Dispose();
-            int handleSize = (int)PInvoke.GlobalSize(dragDropFormat.Medium.unionmember);
+            int handleSize = (int)PInvoke.GlobalSize((HGLOBAL)dragDropFormat.Medium.unionmember);
             Assert.Equal(0, handleSize);
             Assert.Null(dragDropFormat.Medium.pUnkForRelease);
             Assert.Equal(TYMED.TYMED_NULL, dragDropFormat.Medium.tymed);
@@ -171,7 +171,7 @@ public class DragDropFormatTests
         }
     }
 
-    private static unsafe void SaveInDragLoopToHandle(IntPtr handle, bool inDragLoop)
+    private static unsafe void SaveInDragLoopToHandle(HGLOBAL handle, bool inDragLoop)
     {
         try
         {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DragDropHelperTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DragDropHelperTests.cs
@@ -101,12 +101,12 @@ public class DragDropHelperTests
         {
             DragDropHelper.SetDragImage(dataObject, dragImage, cursorOffset, useDefaultDragImage);
             DragDropFormat dragDropFormat = (DragDropFormat)dataObject.GetData(DragDropHelper.CF_DRAGIMAGEBITS);
-            void* basePtr = PInvoke.GlobalLock(dragDropFormat.Medium.unionmember);
+            void* basePtr = PInvoke.GlobalLock((HGLOBAL)dragDropFormat.Medium.unionmember);
             SHDRAGIMAGE* pDragImage = (SHDRAGIMAGE*)basePtr;
             bool isDragImageNull = BitOperations.LeadingZeroCount((uint)(nint)pDragImage->hbmpDragImage).Equals(32);
             Size dragImageSize = pDragImage->sizeDragImage;
             Point offset = pDragImage->ptOffset;
-            PInvoke.GlobalUnlock(dragDropFormat.Medium.unionmember);
+            PInvoke.GlobalUnlock((HGLOBAL)dragDropFormat.Medium.unionmember);
             Assert.Equal(dragImage is null, isDragImageNull);
             Assert.Equal(dragImage is null ? new Size(0, 0) : dragImage.Size, dragImageSize);
             Assert.Equal(cursorOffset, offset);
@@ -125,12 +125,12 @@ public class DragDropHelperTests
         {
             DragDropHelper.SetDragImage(dataObject, e);
             DragDropFormat dragDropFormat = (DragDropFormat)dataObject.GetData(DragDropHelper.CF_DRAGIMAGEBITS);
-            void* basePtr = PInvoke.GlobalLock(dragDropFormat.Medium.unionmember);
+            void* basePtr = PInvoke.GlobalLock((HGLOBAL)dragDropFormat.Medium.unionmember);
             SHDRAGIMAGE* pDragImage = (SHDRAGIMAGE*)basePtr;
             bool isDragImageNull = BitOperations.LeadingZeroCount((uint)(nint)pDragImage->hbmpDragImage).Equals(32);
             Size dragImageSize = pDragImage->sizeDragImage;
             Point offset = pDragImage->ptOffset;
-            PInvoke.GlobalUnlock(dragDropFormat.Medium.unionmember);
+            PInvoke.GlobalUnlock((HGLOBAL)dragDropFormat.Medium.unionmember);
             Assert.Equal(e.DragImage is null, isDragImageNull);
             Assert.Equal(e.DragImage is null ? new Size(0, 0) : e.DragImage.Size, dragImageSize);
             Assert.Equal(e.CursorOffset, offset);
@@ -172,12 +172,12 @@ public class DragDropHelperTests
             DragDropHelper.SetDropDescription(dataObject, dropImageType, message, messageReplacementToken);
             DragDropHelper.ClearDropDescription(dataObject);
             DragDropFormat dragDropFormat = (DragDropFormat)dataObject.GetData(DragDropHelper.CF_DROPDESCRIPTION);
-            void* basePtr = PInvoke.GlobalLock(dragDropFormat.Medium.unionmember);
+            void* basePtr = PInvoke.GlobalLock((HGLOBAL)dragDropFormat.Medium.unionmember);
             DROPDESCRIPTION* pDropDescription = (DROPDESCRIPTION*)basePtr;
             DROPIMAGETYPE type = pDropDescription->type;
             string szMessage = pDropDescription->szMessage.ToString();
             string szInsert = pDropDescription->szInsert.ToString();
-            PInvoke.GlobalUnlock(dragDropFormat.Medium.unionmember);
+            PInvoke.GlobalUnlock((HGLOBAL)dragDropFormat.Medium.unionmember);
             Assert.Equal(DROPIMAGETYPE.DROPIMAGE_INVALID, type);
             Assert.Equal(string.Empty, szMessage);
             Assert.Equal(string.Empty, szInsert);
@@ -239,7 +239,7 @@ public class DragDropHelperTests
         {
             if (dataObject.GetData(format) is DragDropFormat dragDropFormat)
             {
-                Assert.Equal(0, (int)PInvoke.GlobalSize(dragDropFormat.Medium.unionmember));
+                Assert.Equal(0, (int)PInvoke.GlobalSize((HGLOBAL)dragDropFormat.Medium.unionmember));
                 Assert.Null(dragDropFormat.Medium.pUnkForRelease);
                 Assert.Equal(TYMED.TYMED_NULL, dragDropFormat.Medium.tymed);
                 Assert.Equal(IntPtr.Zero, dragDropFormat.Medium.unionmember);
@@ -255,12 +255,12 @@ public class DragDropHelperTests
         {
             DragDropHelper.SetDropDescription(e);
             DragDropFormat dragDropFormat = (DragDropFormat)e.Data.GetData(DragDropHelper.CF_DROPDESCRIPTION);
-            void* basePtr = PInvoke.GlobalLock(dragDropFormat.Medium.unionmember);
+            void* basePtr = PInvoke.GlobalLock((HGLOBAL)dragDropFormat.Medium.unionmember);
             DROPDESCRIPTION* pDropDescription = (DROPDESCRIPTION*)basePtr;
             DROPIMAGETYPE type = pDropDescription->type;
             string szMessage = pDropDescription->szMessage.ToString();
             string szInsert = pDropDescription->szInsert.ToString();
-            PInvoke.GlobalUnlock(dragDropFormat.Medium.unionmember);
+            PInvoke.GlobalUnlock((HGLOBAL)dragDropFormat.Medium.unionmember);
             Assert.Equal((DROPIMAGETYPE)e.DropImageType, type);
             Assert.Equal(e.Message, szMessage);
             Assert.Equal(e.MessageReplacementToken, szInsert);
@@ -282,12 +282,12 @@ public class DragDropHelperTests
         {
             DragDropHelper.SetDropDescription(dataObject, dropImageType, message, messageReplacementToken);
             DragDropFormat dragDropFormat = (DragDropFormat)dataObject.GetData(DragDropHelper.CF_DROPDESCRIPTION);
-            void* basePtr = PInvoke.GlobalLock(dragDropFormat.Medium.unionmember);
+            void* basePtr = PInvoke.GlobalLock((HGLOBAL)dragDropFormat.Medium.unionmember);
             DROPDESCRIPTION* pDropDescription = (DROPDESCRIPTION*)basePtr;
             DROPIMAGETYPE type = pDropDescription->type;
             string szMessage = pDropDescription->szMessage.ToString();
             string szInsert = pDropDescription->szInsert.ToString();
-            PInvoke.GlobalUnlock(dragDropFormat.Medium.unionmember);
+            PInvoke.GlobalUnlock((HGLOBAL)dragDropFormat.Medium.unionmember);
             Assert.Equal((DROPIMAGETYPE)dropImageType, type);
             Assert.Equal(message, szMessage);
             Assert.Equal(messageReplacementToken, szInsert);
@@ -313,9 +313,9 @@ public class DragDropHelperTests
         {
             DragDropHelper.SetInDragLoop(dataObject, inDragLoop);
             DragDropFormat dragDropFormat = (DragDropFormat)dataObject.GetData(DragDropHelper.CF_INSHELLDRAGLOOP);
-            void* basePtr = PInvoke.GlobalLock(dragDropFormat.Medium.unionmember);
+            void* basePtr = PInvoke.GlobalLock((HGLOBAL)dragDropFormat.Medium.unionmember);
             bool inShellDragLoop = (basePtr is not null) && (*(BOOL*)basePtr == true);
-            PInvoke.GlobalUnlock(dragDropFormat.Medium.unionmember);
+            PInvoke.GlobalUnlock((HGLOBAL)dragDropFormat.Medium.unionmember);
             Assert.Equal(inDragLoop, inShellDragLoop);
         }
         finally


### PR DESCRIPTION
Take the latest drop of CSWin32.

There were a number of changes, but the key ones were:

- VARIANT moved to another namespace
- CsWin32 wrapper methods that take strings no longer have unusued/reserved parameters
- HGLOBAL is now used in signatures
- Some parameters moved from enums to uint

A few other things in this change:

- Added start-vs.cmd to the solution folder
- Pinned created Arrays in VARIANT to avoid a potential memory corruption
- Removed VARIANT IRecord related code that was ultimately going to throw


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9300)