### PR TITLE
Prevent checkable ToolStripButton from losing focus on check/uncheck

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+override System.Windows.Forms.ToolStripButton.ProcessDialogKey(System.Windows.Forms.Keys keyData) -> bool

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripButton.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripButton.cs
@@ -233,4 +233,19 @@ public partial class ToolStripButton : ToolStripItem
 
         base.OnClick(e);
     }
+
+    protected internal override bool ProcessDialogKey(Keys keyData)
+    {
+        // If this button is top-level checkable button and Space key is pressed,
+        // then handle it as a click, but do not unselect the button or switch focus
+        // as base implementation of this method does,
+        // to allow user to toggle this button again (imitate checkbox behavior)
+        if (keyData == Keys.Space && SupportsSpaceKey && CheckOnClick && Enabled && !IsOnDropDown)
+        {
+            FireEvent(ToolStripItemEventType.Click);
+            return true;
+        }
+
+        return base.ProcessDialogKey(keyData);
+    }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #9199

## Proposed changes

- Do **not** unselect checkable ToolStripButton (with CheckOnClick=true) on click

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

ToolStripButton can handle consecutive Space key pressings:
- Screen readers announce checked state change every time.
- Click event is triggered every time.

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Narrator announces only the first Space key press:

https://github.com/dotnet/winforms/assets/113603457/839fbfd7-643d-4f32-9cc3-1e7c96c19476


### After

Narrator announces every Space key press:

https://github.com/dotnet/winforms/assets/113603457/e93e3c51-da1c-4897-9b57-4d641ff767ed


## Test methodology <!-- How did you ensure quality? -->

- Manual


## Test environment(s) <!-- Remove any that don't apply -->

- .NET 8.0.100-preview.4.23260.5


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9328)