### PR TITLE
Remove non-generic IHandle

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.EditorPropertyLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.EditorPropertyLine.cs
@@ -482,7 +482,7 @@ internal sealed partial class DesignerActionPanel
             }
         }
 
-        internal class FlyoutDialog : Form, IHandle
+        internal class FlyoutDialog : Form
         {
             private readonly Control _hostedControl;
             private readonly Control _parentControl;

--- a/src/System.Windows.Forms.Primitives/src/Interop/IHandle.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/IHandle.cs
@@ -6,29 +6,6 @@ using System.Runtime.InteropServices;
 
 /// <summary>
 ///  Used to abstract access to classes that contain a potentially owned handle.
-///  NOTE: This ultimately should be replaced by <see cref="IHandle{THandle}"/>.
-/// </summary>
-/// <remarks>
-///  <para>
-///   The key benefit of this is that we can keep the owning class from being
-///   collected during interop calls. <see cref="HandleRef"/> wraps arbitrary
-///   owners with target handles. Having this interface allows implicit use
-///   of the classes (such as System.Windows.Forms.Control) that
-///   meet this common pattern in interop and encourages correct alignment
-///   with the proper owner.
-///  </para>
-///  <para>
-///   Note that keeping objects alive is necessary ONLY when the object has
-///   a finalizer that will explicitly close the handle.
-///  </para>
-/// </remarks>
-internal interface IHandle
-{
-    public IntPtr Handle { get; }
-}
-
-/// <summary>
-///  Used to abstract access to classes that contain a potentially owned handle.
 /// </summary>
 /// <remarks>
 ///  <para>

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/MessageDecoder.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/MessageDecoder.cs
@@ -11,24 +11,24 @@ namespace System.Windows.Forms;
 internal static class MessageDecoder
 {
     public static string ToString(Message message) => ToString(
-        message.HWnd,
+        message.HWND,
         message.MsgInternal,
         message.WParamInternal,
         message.LParamInternal,
         message.ResultInternal);
 
-    private static string ToString(IntPtr hWnd, MessageId msg, WPARAM wparam, LPARAM lparam, LRESULT result)
+    private static string ToString(HWND hwnd, MessageId messageId, WPARAM wparam, LPARAM lparam, LRESULT result)
     {
         static string Parenthesize(string? input) => input is null ? string.Empty : $" ({input})";
 
-        string id = Parenthesize(msg.MessageIdToString());
+        string id = Parenthesize(messageId.MessageIdToString());
 
         string lDescription = string.Empty;
-        if (msg == PInvoke.WM_PARENTNOTIFY)
+        if (messageId == PInvoke.WM_PARENTNOTIFY)
         {
             lDescription = Parenthesize(((MessageId)(uint)wparam.LOWORD).MessageIdToString());
         }
 
-        return $@"msg=0x{(uint)msg:x}{id} hwnd=0x{(long)hWnd:x} wparam=0x{(nint)wparam:x} lparam=0x{(nint)lparam:x}{lDescription} result=0x{(nint)result:x}";
+        return $@"msg=0x{(uint)messageId:x}{id} hwnd=0x{(long)hwnd:x} wparam=0x{(nint)wparam:x} lparam=0x{(nint)lparam:x}{lDescription} result=0x{(nint)result:x}";
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -46,7 +46,6 @@ public unsafe partial class Control :
     IArrangedElement,
     IBindableComponent,
     IKeyboardToolTip,
-    IHandle,
     IHandle<HWND>
 {
 #if DEBUG

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.cs
@@ -23,7 +23,7 @@ namespace System.Windows.Forms;
 [DesignerSerializer($"System.Windows.Forms.Design.ImageListCodeDomSerializer, {AssemblyRef.SystemDesign}",
     $"System.ComponentModel.Design.Serialization.CodeDomSerializer, {AssemblyRef.SystemDesign}")]
 [SRDescription(nameof(SR.DescriptionImageList))]
-public sealed partial class ImageList : Component, IHandle, IHandle<HIMAGELIST>
+public sealed partial class ImageList : Component, IHandle<HIMAGELIST>
 {
     private static readonly Color s_fakeTransparencyColor = Color.FromArgb(0x0d, 0x0b, 0x0c);
     private static readonly Size s_defaultImageSize = new Size(16, 16);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NativeWindow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NativeWindow.cs
@@ -13,7 +13,7 @@ namespace System.Windows.Forms;
 ///  Provides a low-level encapsulation of a window handle and a window procedure. The class automatically
 ///  manages window class creation and registration.
 /// </summary>
-public unsafe partial class NativeWindow : MarshalByRefObject, IWin32Window, IHandle, IHandle<HWND>
+public unsafe partial class NativeWindow : MarshalByRefObject, IWin32Window, IHandle<HWND>
 {
 #if DEBUG
     private static readonly BooleanSwitch AlwaysUseNormalWndProc

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Timer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Timer.cs
@@ -174,7 +174,7 @@ public class Timer : Component
 
     public override string ToString() => $"{base.ToString()}, Interval: {Interval}";
 
-    private class TimerNativeWindow : NativeWindow, IHandle
+    private class TimerNativeWindow : NativeWindow
     {
         // The timer that owns the window
         private readonly Timer _owner;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
@@ -18,7 +18,7 @@ namespace System.Windows.Forms;
 [DefaultEvent(nameof(Popup))]
 [ToolboxItemFilter("System.Windows.Forms")]
 [SRDescription(nameof(SR.DescriptionToolTip))]
-public partial class ToolTip : Component, IExtenderProvider, IHandle, IHandle<HWND>
+public partial class ToolTip : Component, IExtenderProvider, IHandle<HWND>
 {
     // The actual delay values are based on the user-set double click time.
     // These values are initialized using the default double-click time value.
@@ -263,8 +263,6 @@ public partial class ToolTip : Component, IExtenderProvider, IHandle, IHandle<HW
             }
         }
     }
-
-    IntPtr IHandle.Handle => Handle;
 
     HWND IHandle<HWND>.Handle => HWND;
 


### PR DESCRIPTION
IHandle<T> is the better way to do things and now that we have removed all of the dependencies I'm removing the non generic version.

Also includes a small tweak to parameter names in MessageDecoder.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9336)