### PR TITLE
Remove unnecessary nullable preprocessor directive in ImageListStreamer

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ImageListStreamer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ImageListStreamer.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System.Runtime.Serialization;
 using static Interop;
 


### PR DESCRIPTION
## Proposed changes

- Remove unnecessary nullable preprocessor directive in ImageListStreamer.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9339)