### PR TITLE
Include stack trace from log method

### DIFF
--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Infra/DataCollectionService.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Infra/DataCollectionService.cs
@@ -5,6 +5,7 @@
 using System.Collections.Immutable;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
+using System.Text;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
@@ -164,7 +165,12 @@ internal static class DataCollectionService
 
             Directory.CreateDirectory(logDir);
 
-            File.WriteAllText(CreateLogFileName(logDir, timestamp, testName, errorId, logId: string.Empty, "log"), ex.ToString());
+            var exceptionDetails = new StringBuilder();
+            exceptionDetails.AppendLine(ex.ToString());
+            exceptionDetails.AppendLine("---------------------------------");
+            exceptionDetails.AppendLine("Stack Trace at Log Time:");
+            exceptionDetails.AppendLine(new StackTrace(true).ToString());
+            File.WriteAllText(CreateLogFileName(logDir, timestamp, testName, errorId, logId: string.Empty, "log"), exceptionDetails.ToString());
             foreach (var (callback, logId, extension) in _customInProcessLoggers)
             {
                 callback(CreateLogFileName(logDir, timestamp, testName, errorId, logId, extension));


### PR DESCRIPTION
Sometimes the first chance exception stack is incomplete, so the additional stack collected at the point where it's written to the log can help narrow down code locations.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9356)