### PR TITLE
Defer StackTrace rendering

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/DisposalTracking.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/DisposalTracking.cs
@@ -41,13 +41,13 @@ internal static class DisposalTracking
     /// </remarks>
     internal abstract class Tracker
     {
-        private readonly string _originatingStack;
+        private readonly StackTrace? _originatingStack;
         private readonly bool _throwIfFinalized;
 
         public Tracker(bool throwIfFinalized = true)
         {
             _throwIfFinalized = throwIfFinalized;
-            _originatingStack = _throwIfFinalized ? new StackTrace().ToString() : string.Empty;
+            _originatingStack = _throwIfFinalized ? new StackTrace() : null;
         }
 
         ~Tracker()


### PR DESCRIPTION
Fixes #9304

Originally marked as draft because this is a real bug that needs to be investigated. If someone has the ability to update CI to collect a heap dump when one of these crashes occurs, it would be significantly preferred to just hiding it with a workaround like this.

Now marked ready for review due to the performance impact. Local testing showed this as a significant contributor to allocations and execution time for integration tests, where deferring the `ToString()` call resolved more than 50% of the overhead.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9357)