### PR TITLE
Add SplitContainer to the integration test in DemoConsle

### DIFF
--- a/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/MainForm.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/MainForm.cs
@@ -130,6 +130,19 @@ public partial class MainForm : Form
                         rb1.Parent = pnl;
                         rb2.Parent = pnl;
 
+                        Label l1 = surface.CreateControl<Label>(new Size(100, 25), new Point(12, 12));
+                        Label l2 = surface.CreateControl<Label>(new Size(120, 25), new Point(12, 12));
+                        l1.Text = "I'm the first Label";
+                        l2.Text = "I'm the second Label";
+                        l1.BackColor = Color.Coral;
+                        l2.BackColor = Color.LightGreen;
+
+                        SplitContainer sct = surface.CreateControl<SplitContainer>(new Size(400, 100), new Point(0, 0));
+                        sct.Dock = DockStyle.Bottom;
+                        sct.BackColor = Color.White;
+                        l1.Parent = sct.Panel1;
+                        l2.Parent = sct.Panel2;
+
                         PictureBox pb1 = surface.CreateControl<PictureBox>(new Size(64, 64), new Point(24, 166));
                         pb1.Image = new Icon("painter.ico").ToBitmap();
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #9359 


## Proposed changes

- Add SplitContainer to the Integration test inDemoConsle

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- SplitContainer can be tested in the Integration test project.

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/dotnet/winforms/assets/133954995/324bc553-7db3-4fc6-8cff-f2b85f90e88f)

### After

![image](https://github.com/dotnet/winforms/assets/133954995/68473035-a028-45eb-8a68-4f20459fca0f)


## Test methodology <!-- How did you ensure quality? -->

-  Manually (added SplitContainer to DemoConsole test app)

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

- 8.0.100-preview.7.23324.2
- Windows 10.0.22621


<!-- Mention language, UI scaling, or anything else that might be relevant -->
