### PR TITLE
add possibility to change BorderStyle to GroupBox

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/GroupBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/GroupBox.cs
@@ -24,6 +24,11 @@ public partial class GroupBox : Control
     private FlatStyle _flatStyle = FlatStyle.Standard;
 
     /// <summary>
+    ///  The current border for this edit control.
+    /// </summary>
+    private BorderStyle _borderStyle = BorderStyle.Fixed3D;
+
+    /// <summary>
     ///  Initializes a new instance of the <see cref="GroupBox"/> class.
     /// </summary>
     public GroupBox() : base()
@@ -102,6 +107,37 @@ public partial class GroupBox : Control
                     }
 
                     LayoutTransaction.DoLayout(ParentInternal, this, PropertyNames.AutoSize);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    ///  Gets or sets the border type
+    ///  of the text box control.
+    /// </summary>
+    [SRCategory(nameof(SR.CatAppearance))]
+    [DefaultValue(BorderStyle.Fixed3D)]
+    [DispId(PInvoke.DISPID_BORDERSTYLE)]
+    [SRDescription(nameof(SR.TextBoxBorderDescr))]
+    public BorderStyle BorderStyle
+    {
+        get => _borderStyle;
+        set
+        {
+            if (_borderStyle != value)
+            {
+                SourceGenerated.EnumValidator.Validate(value);
+
+                _borderStyle = value;
+                UpdateStyles();
+                RecreateHandle();
+
+                // PreferredSize depends on BorderStyle : thru CreateParams.ExStyle in User32!AdjustRectEx.
+                // So when the BorderStyle changes let the parent of this control know about it.
+                using (LayoutTransaction.CreateTransactionIf(AutoSize, ParentInternal, this, PropertyNames.BorderStyle))
+                {
+                    OnBorderStyleChanged(EventArgs.Empty);
                 }
             }
         }
@@ -455,6 +491,11 @@ public partial class GroupBox : Control
 
         // Max text bounding box passed to drawing methods to support RTL.
         Rectangle textRectangle = ClientRectangle;
+        if (borderStyle == BorderStyle.None)
+        {
+            textRectangle.BorderWidth = 0;
+        }
+
         textRectangle.X += TextOffset;
         textRectangle.Width -= 2 * TextOffset;
 


### PR DESCRIPTION
Issue #9343 : https://github.com/dotnet/winforms/issues/9343

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #


## Proposed changes

- possibility to change BorderStyle to GroupBox


<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- to change GroupBox style


## Regression? 

- No

## Risk

- No

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->

### After

<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->



## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

- <!-- use `dotnet --info` -->


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9369)