### PR TITLE
Add ReleaseUiaProvider for LinkLabel

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.Link.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.Link.cs
@@ -44,6 +44,8 @@ public partial class LinkLabel
         internal LinkAccessibleObject? AccessibleObject
             => _accessibleObject ??= Owner is not null ? new(this, Owner) : null;
 
+        internal bool IsAccessibilityObjectCreated => _accessibleObject is not null;
+
         /// <summary>
         ///  Description for accessibility
         /// </summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.cs
@@ -423,6 +423,22 @@ public partial class LinkLabel : Label, IButtonControl
 
     protected override AccessibleObject CreateAccessibilityInstance() => new LinkLabelAccessibleObject(this);
 
+    internal override void ReleaseUiaProvider(HWND handle)
+    {
+        base.ReleaseUiaProvider(handle);
+
+        if (_linkCollection is not null)
+        {
+            foreach (Link link in _linkCollection)
+            {
+                if (link.IsAccessibilityObjectCreated)
+                {
+                    UiaCore.UiaDisconnectProvider(link.AccessibleObject);
+                }
+            }
+        }
+    }
+
     protected override void CreateHandle()
     {
         base.CreateHandle();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.cs
@@ -424,7 +424,7 @@ public partial class LinkLabel : Label, IButtonControl
     protected override AccessibleObject CreateAccessibilityInstance() => new LinkLabelAccessibleObject(this);
 
     internal override void ReleaseUiaProvider(HWND handle)
-    {       
+    {
         base.ReleaseUiaProvider(handle);
 
         if (OsVersion.IsWindows8OrGreater())

--- a/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.cs
@@ -425,13 +425,16 @@ public partial class LinkLabel : Label, IButtonControl
 
     internal override void ReleaseUiaProvider(HWND handle)
     {
-        base.ReleaseUiaProvider(handle);
-
-        foreach (Link link in _links)
+        if (OsVersion.IsWindows8OrGreater())
         {
-            if (link.IsAccessibilityObjectCreated)
+            base.ReleaseUiaProvider(handle);
+
+            foreach (Link link in _links)
             {
-                UiaCore.UiaDisconnectProvider(link.AccessibleObject);
+                if (link.IsAccessibilityObjectCreated)
+                {
+                    UiaCore.UiaDisconnectProvider(link.AccessibleObject);
+                }
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.cs
@@ -424,11 +424,11 @@ public partial class LinkLabel : Label, IButtonControl
     protected override AccessibleObject CreateAccessibilityInstance() => new LinkLabelAccessibleObject(this);
 
     internal override void ReleaseUiaProvider(HWND handle)
-    {
+    {       
+        base.ReleaseUiaProvider(handle);
+
         if (OsVersion.IsWindows8OrGreater())
         {
-            base.ReleaseUiaProvider(handle);
-
             foreach (Link link in _links)
             {
                 if (link.IsAccessibilityObjectCreated)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.cs
@@ -427,14 +427,11 @@ public partial class LinkLabel : Label, IButtonControl
     {
         base.ReleaseUiaProvider(handle);
 
-        if (_linkCollection is not null)
+        foreach (Link link in _links)
         {
-            foreach (Link link in _linkCollection)
+            if (link.IsAccessibilityObjectCreated)
             {
-                if (link.IsAccessibilityObjectCreated)
-                {
-                    UiaCore.UiaDisconnectProvider(link.AccessibleObject);
-                }
+                UiaCore.UiaDisconnectProvider(link.AccessibleObject);
             }
         }
     }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/LinkLabel.LinkLabelAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/LinkLabel.LinkLabelAccessibleObjectTests.cs
@@ -176,4 +176,18 @@ public class LinkLabel_LinkLabelAccessibleObjectTests
         Assert.Equal(linkLabel.Links[^1].AccessibleObject, accessibleObject.FragmentNavigate(NavigateDirection.LastChild));
         Assert.False(linkLabel.IsHandleCreated);
     }
+
+    [WinFormsFact]
+    public void LinkLabel_Releases_UiaProvider()
+    {
+        using LinkLabel linkLabel = new();
+        AccessibleObject accessibleObject = linkLabel.AccessibilityObject;
+
+        Assert.True(linkLabel.IsAccessibilityObjectCreated);
+
+        linkLabel.ReleaseUiaProvider(linkLabel.HWND);
+
+        Assert.False(linkLabel.IsAccessibilityObjectCreated);
+        Assert.True(linkLabel.IsHandleCreated);
+    }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #9327 


## Proposed changes

- Override function ReleaseUiaProvider to LinkLabel.cs
- Add unit test for the function ReleaseUiaProvider 

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- LinkLabel accessible object memory leak

## Regression? 

-  No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/dotnet/winforms/assets/132890443/ba985043-3333-428f-a53a-87ba53922804)


### After

![image](https://github.com/dotnet/winforms/assets/132890443/14f46c5b-24d0-427e-ae70-ed09b8db0c1f)



## Test methodology <!-- How did you ensure quality? -->

- Manually (via WinDbg)

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

- Using AI, Inspect, Narrator
 

## Test environment(s) <!-- Remove any that don't apply -->

- .net 8.0.100-preview.7.23325.3

<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9370)