### PR TITLE
Fix UIA tree structure for ToolStrip overflow menu

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripOverflow.ToolStripOverflowAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripOverflow.ToolStripOverflowAccessibleObject.cs
@@ -30,5 +30,13 @@ public partial class ToolStripOverflow
                     => owner.OwnerItem?.AccessibilityObject,
                 _ => base.FragmentNavigate(direction),
             };
+
+        internal override object? GetPropertyValue(UIA propertyID)
+            => propertyID switch
+            {
+                UIA.IsControlElementPropertyId => true,
+                UIA.IsContentElementPropertyId => false,
+                _ => base.GetPropertyValue(propertyID)
+            };
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #9384


## Proposed changes

- Fix values of IsControlElementProperty and IsContentElementProperty properties in `ToolStripOverflowAccessibleObject` to support UI tree structure as described in 
[UI Automation Support for the MenuItem Control Type](https://learn.microsoft.com/en-us/dotnet/framework/ui-automation/ui-automation-support-for-the-menuitem-control-type#required-ui-automation-tree-structure)


<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Correct UIA tree structure

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Menu is visible in content view:

![before](https://github.com/dotnet/winforms/assets/113603457/115d635a-d0ec-4990-b9c0-9858c2a88f50)


### After

Menu is hidden in **content** view:

![after - content view](https://github.com/dotnet/winforms/assets/113603457/8bb004cc-5a0b-42c9-a17f-e368ec9cc6b4)

Menu is still visible in **control** view: 

![after - control view](https://github.com/dotnet/winforms/assets/113603457/c9773006-6d98-4ec6-8cdf-11fb2f7d9b39)



## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- .NET 8.0.0-preview.4.23259.5
- Accessibility Insights 1.1.2360.01

<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9385)