### PR TITLE
Refactor `LayoutEventArgs` to use a `WeakReference` for the `AffectedComponent` property with a backing field

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/LayoutEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/LayoutEventArgs.cs
@@ -8,9 +8,11 @@ namespace System.Windows.Forms;
 
 public sealed class LayoutEventArgs : EventArgs
 {
+    private readonly WeakReference<IComponent>? _affectedComponent;
+
     public LayoutEventArgs(IComponent? affectedComponent, string? affectedProperty)
     {
-        AffectedComponent = affectedComponent;
+        _affectedComponent = affectedComponent is not null ? new(affectedComponent) : null;
         AffectedProperty = affectedProperty;
     }
 
@@ -19,7 +21,15 @@ public sealed class LayoutEventArgs : EventArgs
     {
     }
 
-    public IComponent? AffectedComponent { get; }
+    public IComponent? AffectedComponent
+    {
+        get
+        {
+            IComponent? target = null;
+            _affectedComponent?.TryGetTarget(out target);
+            return target;
+        }
+    }
 
     public Control? AffectedControl => AffectedComponent as Control;
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/LayoutEventArgsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/LayoutEventArgsTests.cs
@@ -55,7 +55,7 @@ public class LayoutEventArgsTests
         static LayoutEventArgs CreateAndDisposeControl()
         {
             // Setup TableLayoutPanel and Panel
-            TableLayoutPanel tableLayoutPanel = new()
+            using TableLayoutPanel tableLayoutPanel = new()
             {
                 ColumnCount = 2,
                 RowCount = 2,

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/LayoutEventArgsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/LayoutEventArgsTests.cs
@@ -71,8 +71,6 @@ public class LayoutEventArgsTests
             // Force layout update
             tableLayoutPanel.PerformLayout();
 
-            var fieldInfo = typeof(Control).GetField("_cachedLayoutEventArgs", BindingFlags.NonPublic | BindingFlags.Instance);
-
             // Suspend layout
             tableLayoutPanel.SuspendLayout();
             using (Panel panel = (Panel)tableLayoutPanel.Controls.Find("Panel", false).First())
@@ -81,7 +79,9 @@ public class LayoutEventArgsTests
                 panel.Dispose();
             }
 
-            LayoutEventArgs layoutEventArgs = (LayoutEventArgs)fieldInfo.GetValue(tableLayoutPanel);
+            // Check the cachedLayoutEventArgs
+            ITestAccessor tableLayoutPanelTestAccessor = tableLayoutPanel.TestAccessor();
+            LayoutEventArgs layoutEventArgs = (LayoutEventArgs)tableLayoutPanelTestAccessor.Dynamic._cachedLayoutEventArgs;
 
             tableLayoutPanel.ResumeLayout();
             return layoutEventArgs;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/LayoutEventArgsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/LayoutEventArgsTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.ComponentModel;
-using System.Reflection;
 using System.Runtime.CompilerServices;
 
 namespace System.Windows.Forms.Tests;


### PR DESCRIPTION
Attempting to fix #165

Which is a memory leak in `System.Windows.Forms.Control.CachedLayoutEventArgs`.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9393)