### PR TITLE
Fixed TreeView custom sorting failure when TreeNode has child nodes

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeNode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeNode.cs
@@ -1260,7 +1260,7 @@ public partial class TreeNode : MarshalByRefObject, ICloneable, ISerializable
             }
             else
             {
-                childNodes.Sort((x, y) => parentTreeView.TreeViewNodeSorter.Compare(x.Text, y.Text));
+                childNodes.Sort(parentTreeView.TreeViewNodeSorter.Compare);
             }
 
             for (int i = 0; i < childNodes.Count; i++)

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
@@ -7089,6 +7089,32 @@ public class TreeViewTests
         Assert.Equal(0, treeView.Nodes.Count);
     }
 
+    [WinFormsFact]
+    public void TreeView_TreeViewNodeSorter_ComparesTreeNodes()
+    {
+        using TreeView treeView = new();
+
+        treeView.Nodes.Add("Root 1");
+        treeView.Nodes[0].Nodes.Add("Child 1");
+        treeView.Nodes[0].Nodes.Add("Child 2");
+
+        treeView.Nodes.Add("Root 2");
+        treeView.Nodes[1].Nodes.Add("Child 3");
+        treeView.Nodes[1].Nodes.Add("Child 4");
+
+        IComparer treeSorter = Comparer<object>.Create(
+            (object x, object y) =>
+            {
+                Assert.True(x is TreeNode);
+                Assert.True(y is TreeNode);
+
+                return 0;
+            });
+
+        // Setting TreeViewNodeSorter invokes sorting automatically
+        treeView.TreeViewNodeSorter = treeSorter;
+    }
+
     private class SubTreeView : TreeView
     {
         public new bool CanEnableIme => base.CanEnableIme;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #9394


### Changes

- Fix using of `TreeViewNodeSorter.Compare` method: compare tree nodes, not nodes' `Text` values.
- Add a unit test to ensure TreeNodes are compared while sorting TreeView.



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9395)