### PR TITLE
Add AutoScaleMode for ThreadExceptionDialog

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ThreadExceptionDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ThreadExceptionDialog.cs
@@ -332,6 +332,9 @@ public class ThreadExceptionDialog : Form
         _details.SetBounds(_scaledButtonDetailsLeftPadding, buttonTop + _scaledButtonTopPadding, width - _scaledDetailsWidthPadding, _scaledDetailsHeight);
         _details.Visible = _detailsVisible;
         Controls.Add(_details);
+
+        AutoScaleMode = AutoScaleMode.Dpi;
+
         if (DpiHelper.IsScalingRequirementMet)
         {
             DpiChanged += ThreadExceptionDialog_DpiChanged;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #9251 


## Proposed changes

- Add AutoScaleMode.Dpi for ThreadExceptionDialog

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- ThreadExceptionDialog doesn't scaled well when DPI is differ

## Regression? 

-  No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![BeforeScaled](https://github.com/dotnet/winforms/assets/132890443/efaafa69-ce05-49df-9a25-503f23aca134)


### After

![ScaledExceptionDialog](https://github.com/dotnet/winforms/assets/132890443/e258a594-8bc2-4e02-bd55-71d6b6ca3036)



## Test methodology <!-- How did you ensure quality? -->

- Manually 

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
 

## Test environment(s) <!-- Remove any that don't apply -->

- .net 8.0.100-preview.7.23328.8


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9399)