### PR TITLE
Enable nullability in HitTestInfo

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -55,8 +55,8 @@ override System.Windows.Forms.ComboBox.ToString() -> string!
 ~override System.Windows.Forms.DataGridView.Font.get -> System.Drawing.Font
 ~override System.Windows.Forms.DataGridView.Font.set -> void
 ~override System.Windows.Forms.DataGridView.GetAccessibilityObjectById(int objectId) -> System.Windows.Forms.AccessibleObject
-~override System.Windows.Forms.DataGridView.HitTestInfo.Equals(object value) -> bool
-~override System.Windows.Forms.DataGridView.HitTestInfo.ToString() -> string
+override System.Windows.Forms.DataGridView.HitTestInfo.Equals(object? value) -> bool
+override System.Windows.Forms.DataGridView.HitTestInfo.ToString() -> string!
 ~override System.Windows.Forms.DataGridView.OnBindingContextChanged(System.EventArgs e) -> void
 ~override System.Windows.Forms.DataGridView.OnCursorChanged(System.EventArgs e) -> void
 ~override System.Windows.Forms.DataGridView.OnDoubleClick(System.EventArgs e) -> void
@@ -366,7 +366,7 @@ override System.Windows.Forms.ComboBox.ToString() -> string!
 ~override System.Windows.Forms.WebBrowserBase.Site.set -> void
 ~override System.Windows.Forms.WebBrowserBase.Text.get -> string
 ~override System.Windows.Forms.WebBrowserBase.Text.set -> void
-~static readonly System.Windows.Forms.DataGridView.HitTestInfo.Nowhere -> System.Windows.Forms.DataGridView.HitTestInfo
+static readonly System.Windows.Forms.DataGridView.HitTestInfo.Nowhere -> System.Windows.Forms.DataGridView.HitTestInfo!
 ~static System.Windows.Forms.AxHost.GetFontFromIFont(object font) -> System.Drawing.Font
 ~static System.Windows.Forms.AxHost.GetFontFromIFontDisp(object font) -> System.Drawing.Font
 ~static System.Windows.Forms.AxHost.GetIFontDispFromFont(System.Drawing.Font font) -> object

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.HitTestInfo.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.HitTestInfo.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms;
 
 public partial class DataGridView
@@ -29,7 +27,6 @@ public partial class DataGridView
         {
             _type = DataGridViewHitTestType.None;
             _typeInternal = DataGridViewHitTestTypeInternal.None;
-            //this.edge = DataGridViewHitTestTypeCloseEdge.None;
             _row = _col = -1;
             _rowStart = _colStart = -1;
             _adjacentRow = _adjacentCol = -1;
@@ -95,7 +92,7 @@ public partial class DataGridView
         /// <summary>
         ///  Indicates whether two objects are identical.
         /// </summary>
-        public override bool Equals(object value)
+        public override bool Equals(object? value)
         {
             if (value is HitTestInfo hti)
             {


### PR DESCRIPTION
## Proposed changes

- Enable nullability in HitTestInfo.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9404)