### PR TITLE
Fix stack overflow in BehaviorServiceAdornerCollectionEnumerator

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorServiceAdornerCollectionEnumerator.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorServiceAdornerCollectionEnumerator.cs
@@ -12,7 +12,7 @@ public class BehaviorServiceAdornerCollectionEnumerator : object, IEnumerator
 
     public BehaviorServiceAdornerCollectionEnumerator(BehaviorServiceAdornerCollection mappings)
     {
-        baseEnumerator = mappings.GetEnumerator();
+        baseEnumerator = ((IEnumerable)mappings).GetEnumerator();
     }
 
 #nullable disable // explicitly leaving Current as "oblivious" to avoid spurious warnings in foreach over non-generic enumerables

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorServiceAdornerCollectionEnumerator.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorServiceAdornerCollectionEnumerator.cs
@@ -8,36 +8,36 @@ namespace System.Windows.Forms.Design.Behavior;
 
 public class BehaviorServiceAdornerCollectionEnumerator : object, IEnumerator
 {
-    private readonly IEnumerator baseEnumerator;
+    private readonly IEnumerator _baseEnumerator;
 
     public BehaviorServiceAdornerCollectionEnumerator(BehaviorServiceAdornerCollection mappings)
     {
-        baseEnumerator = ((IEnumerable)mappings).GetEnumerator();
+        _baseEnumerator = ((IEnumerable)mappings).GetEnumerator();
     }
 
 #nullable disable // explicitly leaving Current as "oblivious" to avoid spurious warnings in foreach over non-generic enumerables
-    public Adorner Current => (Adorner)baseEnumerator.Current;
+    public Adorner Current => (Adorner)_baseEnumerator.Current;
 
-    object IEnumerator.Current => baseEnumerator.Current;
+    object IEnumerator.Current => _baseEnumerator.Current;
 #nullable restore
 
     public bool MoveNext()
     {
-        return baseEnumerator.MoveNext();
+        return _baseEnumerator.MoveNext();
     }
 
     bool IEnumerator.MoveNext()
     {
-        return baseEnumerator.MoveNext();
+        return _baseEnumerator.MoveNext();
     }
 
     public void Reset()
     {
-        baseEnumerator.Reset();
+        _baseEnumerator.Reset();
     }
 
     void IEnumerator.Reset()
     {
-        baseEnumerator.Reset();
+        _baseEnumerator.Reset();
     }
 }


### PR DESCRIPTION
Fixes #9410 - The parameter must be cast first before calling `GetEnumerator`.
Repeated frames:
```
System.Windows.Forms.Design.dll!System.Windows.Forms.Design.Behavior.BehaviorServiceAdornerCollectionEnumerator.BehaviorServiceAdornerCollectionEnumerator(System.Windows.Forms.Design.Behavior.BehaviorServiceAdornerCollection mappings) Line 13	C#
 	System.Windows.Forms.Design.dll!System.Windows.Forms.Design.Behavior.BehaviorServiceAdornerCollection.GetEnumerator() Line 217	C#
System.Windows.Forms.Design.dll!System.Windows.Forms.Design.Behavior.BehaviorServiceAdornerCollectionEnumerator.BehaviorServiceAdornerCollectionEnumerator(System.Windows.Forms.Design.Behavior.BehaviorServiceAdornerCollection mappings) Line 15	C#
 	[The 2 frame(s) above this were repeated 9584 times]	
```

Caused by #9341

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9411)