### PR TITLE
DateTimePicker has incorrect AccessKey and KeyboardShortcut accessibility properties when Text contains '&' character

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.DateTimePickerAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.DateTimePickerAccessibleObject.cs
@@ -32,7 +32,7 @@ public partial class DateTimePicker
                     }
                 }
 
-                // WIn32 DTP does not interpret ampersand in its Text as an escape character for a mnemonic.
+                // Win32 DTP does not interpret ampersand in its Text as an escape character for a mnemonic.
                 return null;
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.DateTimePickerAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.DateTimePickerAccessibleObject.cs
@@ -32,6 +32,7 @@ public partial class DateTimePicker
                     }
                 }
 
+                // WIn32 DTP does not interpret ampersand in its Text as an escape character for a mnemonic.
                 return null;
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.DateTimePickerAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.DateTimePickerAccessibleObject.cs
@@ -32,18 +32,7 @@ public partial class DateTimePicker
                     }
                 }
 
-                string? baseShortcut = base.KeyboardShortcut;
-
-                if (baseShortcut is null || baseShortcut.Length == 0)
-                {
-                    char ownerTextMnemonic = WindowsFormsUtils.GetMnemonic(this.GetOwnerText(), convertToUpperCase: false);
-                    if (ownerTextMnemonic != '\0')
-                    {
-                        return $"Alt+{ownerTextMnemonic}";
-                    }
-                }
-
-                return baseShortcut;
+                return null;
             }
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DateTimePicker.DateTimePickerAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DateTimePicker.DateTimePickerAccessibleObjectTests.cs
@@ -342,4 +342,39 @@ public class DateTimePicker_DateTimePickerAccessibleObjectTests
         Assert.Equal((UiaCore.ExpandCollapseState)expected, accessibleObject.ExpandCollapseState);
         Assert.True(dateTimePicker.IsHandleCreated);
     }
+
+    // Unit Test for https://github.com/dotnet/winforms/issues/9281.
+    [WinFormsFact]
+    public void DateTimePickerAccessibleObject_KeyboardShortcut_ReturnsExpected()
+    {
+        using Form form = new Form();
+        using DateTimePicker dateTimePicker1 = new();
+        using Label label1 = new ();
+        using DateTimePicker dateTimePicker2 = new();
+
+        dateTimePicker1.CustomFormat = "'Date&Time' hh:mm dd/MM";
+        dateTimePicker1.Format = DateTimePickerFormat.Custom;
+        dateTimePicker1.Name = "dateTimePicker1";
+        dateTimePicker1.TabIndex = 0;
+
+        label1.AutoSize = true;
+        label1.Name = "label1";
+        label1.TabIndex = 1;
+        label1.Text = "&Date";
+
+        dateTimePicker2.Name = "dateTimePicker2";
+        dateTimePicker2.TabIndex = 2;
+
+        form.Controls.Add(dateTimePicker2);
+        form.Controls.Add(label1);
+        form.Controls.Add(dateTimePicker1);
+
+        string keyboardShortcut = dateTimePicker1.AccessibilityObject.KeyboardShortcut;
+
+        Assert.Null(keyboardShortcut);
+
+        keyboardShortcut = dateTimePicker2.AccessibilityObject.KeyboardShortcut;
+
+        Assert.Equal("Alt+d", keyboardShortcut);
+    }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DateTimePicker.DateTimePickerAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DateTimePicker.DateTimePickerAccessibleObjectTests.cs
@@ -354,15 +354,11 @@ public class DateTimePicker_DateTimePickerAccessibleObjectTests
 
         dateTimePicker1.CustomFormat = "'Date&Time' hh:mm dd/MM";
         dateTimePicker1.Format = DateTimePickerFormat.Custom;
-        dateTimePicker1.Name = "dateTimePicker1";
         dateTimePicker1.TabIndex = 0;
 
-        label1.AutoSize = true;
-        label1.Name = "label1";
-        label1.TabIndex = 1;
         label1.Text = "&Date";
+        label1.TabIndex = 1;
 
-        dateTimePicker2.Name = "dateTimePicker2";
         dateTimePicker2.TabIndex = 2;
 
         form.Controls.Add(dateTimePicker2);


### PR DESCRIPTION

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #9281 

## Proposed changes

- 
- fix DateTimePicker's KeyboardShortcut property
- add unit tests
- 

<!-- We are in TELL-MODE the following section must be completed -->


## Regression? 

- No





## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/dotnet/winforms/assets/135201996/bc8b74df-ff5b-46f9-b650-23a4a2c588e6)

### After

![image](https://github.com/dotnet/winforms/assets/135201996/c86d73cb-070d-41f7-98ed-d4a2d4ea4531)


## Test methodology <!-- How did you ensure quality? -->

- 
- Manually and Unit Test 
- 

 

## Test environment(s) <!-- Remove any that don't apply -->

8.0.0-preview.7.23330.6


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9414)