### PR TITLE
Enable nullability in HtmlElementEventArgs

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -717,9 +717,9 @@ System.Windows.Forms.HtmlElementCollection.GetElementsByName(string! name) -> Sy
 System.Windows.Forms.HtmlElementCollection.GetEnumerator() -> System.Collections.IEnumerator!
 System.Windows.Forms.HtmlElementCollection.this[int index].get -> System.Windows.Forms.HtmlElement?
 System.Windows.Forms.HtmlElementCollection.this[string! elementId].get -> System.Windows.Forms.HtmlElement?
-~System.Windows.Forms.HtmlElementEventArgs.EventType.get -> string
-~System.Windows.Forms.HtmlElementEventArgs.FromElement.get -> System.Windows.Forms.HtmlElement
-~System.Windows.Forms.HtmlElementEventArgs.ToElement.get -> System.Windows.Forms.HtmlElement
+System.Windows.Forms.HtmlElementEventArgs.EventType.get -> string!
+System.Windows.Forms.HtmlElementEventArgs.FromElement.get -> System.Windows.Forms.HtmlElement?
+System.Windows.Forms.HtmlElementEventArgs.ToElement.get -> System.Windows.Forms.HtmlElement?
 ~System.Windows.Forms.HtmlWindow.Alert(string message) -> void
 ~System.Windows.Forms.HtmlWindow.AttachEventHandler(string eventName, System.EventHandler eventHandler) -> void
 ~System.Windows.Forms.HtmlWindow.Confirm(string message) -> bool

--- a/src/System.Windows.Forms/src/System/Windows/Forms/HtmlElementEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/HtmlElementEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 using System.Drawing;
 using static Interop.Mshtml;
@@ -104,7 +102,7 @@ public sealed class HtmlElementEventArgs : EventArgs
 
     [Browsable(false)]
     [EditorBrowsable(EditorBrowsableState.Advanced)]
-    public HtmlElement FromElement
+    public HtmlElement? FromElement
     {
         get
         {
@@ -115,7 +113,7 @@ public sealed class HtmlElementEventArgs : EventArgs
 
     [Browsable(false)]
     [EditorBrowsable(EditorBrowsableState.Advanced)]
-    public HtmlElement ToElement
+    public HtmlElement? ToElement
     {
         get
         {


### PR DESCRIPTION
## Proposed changes

- Enable nullability in HtmlElementEventArgs.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9417)