### PR TITLE
Designer action panel line refactoring

### DIFF
--- a/src/System.Windows.Forms.Design/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms.Design/src/PublicAPI.Shipped.txt
@@ -159,12 +159,12 @@ System.ComponentModel.Design.DesignerActionService.GetComponentActions(System.Co
 System.ComponentModel.Design.DesignerActionService.Remove(System.ComponentModel.Design.DesignerActionList! actionList) -> void
 System.ComponentModel.Design.DesignerActionService.Remove(System.ComponentModel.IComponent! comp) -> void
 System.ComponentModel.Design.DesignerActionService.Remove(System.ComponentModel.IComponent! comp, System.ComponentModel.Design.DesignerActionList! actionList) -> void
-~System.ComponentModel.Design.DesignerActionUIService.HideUI(System.ComponentModel.IComponent component) -> void
-~System.ComponentModel.Design.DesignerActionUIService.Refresh(System.ComponentModel.IComponent component) -> void
-~System.ComponentModel.Design.DesignerActionUIService.ShouldAutoShow(System.ComponentModel.IComponent component) -> bool
-~System.ComponentModel.Design.DesignerActionUIService.ShowUI(System.ComponentModel.IComponent component) -> void
-~System.ComponentModel.Design.DesignerActionUIStateChangeEventArgs.DesignerActionUIStateChangeEventArgs(object relatedObject, System.ComponentModel.Design.DesignerActionUIStateChangeType changeType) -> void
-~System.ComponentModel.Design.DesignerActionUIStateChangeEventArgs.RelatedObject.get -> object
+System.ComponentModel.Design.DesignerActionUIService.HideUI(System.ComponentModel.IComponent? component) -> void
+System.ComponentModel.Design.DesignerActionUIService.Refresh(System.ComponentModel.IComponent? component) -> void
+System.ComponentModel.Design.DesignerActionUIService.ShouldAutoShow(System.ComponentModel.IComponent! component) -> bool
+System.ComponentModel.Design.DesignerActionUIService.ShowUI(System.ComponentModel.IComponent? component) -> void
+System.ComponentModel.Design.DesignerActionUIStateChangeEventArgs.DesignerActionUIStateChangeEventArgs(object? relatedObject, System.ComponentModel.Design.DesignerActionUIStateChangeType changeType) -> void
+System.ComponentModel.Design.DesignerActionUIStateChangeEventArgs.RelatedObject.get -> object?
 System.ComponentModel.Design.EventBindingService.EventBindingService(System.IServiceProvider! provider) -> void
 System.ComponentModel.Design.EventBindingService.GetService(System.Type! serviceType) -> object?
 ~System.ComponentModel.Design.MenuCommandService.FindCommand(System.ComponentModel.Design.CommandID commandID) -> System.ComponentModel.Design.MenuCommand
@@ -594,7 +594,7 @@ System.ComponentModel.Design.DesignerActionService.Dispose() -> void
 System.ComponentModel.Design.DesignerActionTextItem
 System.ComponentModel.Design.DesignerActionTextItem.DesignerActionTextItem(string? displayName, string? category) -> void
 System.ComponentModel.Design.DesignerActionUIService
-System.ComponentModel.Design.DesignerActionUIService.DesignerActionUIStateChange -> System.ComponentModel.Design.DesignerActionUIStateChangeEventHandler
+System.ComponentModel.Design.DesignerActionUIService.DesignerActionUIStateChange -> System.ComponentModel.Design.DesignerActionUIStateChangeEventHandler?
 System.ComponentModel.Design.DesignerActionUIService.Dispose() -> void
 System.ComponentModel.Design.DesignerActionUIStateChangeEventArgs
 System.ComponentModel.Design.DesignerActionUIStateChangeEventArgs.ChangeType.get -> System.ComponentModel.Design.DesignerActionUIStateChangeType

--- a/src/System.Windows.Forms.Design/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms.Design/src/PublicAPI.Shipped.txt
@@ -151,14 +151,14 @@ static System.Windows.Forms.Design.MaskDescriptor.IsValidMaskDescriptor(System.W
 ~System.ComponentModel.Design.DesignerActionMethodItem.DesignerActionMethodItem(System.ComponentModel.Design.DesignerActionList actionList, string memberName, string displayName, string category, string description, bool includeAsDesignerVerb) -> void
 ~System.ComponentModel.Design.DesignerActionMethodItem.RelatedComponent.get -> System.ComponentModel.IComponent
 ~System.ComponentModel.Design.DesignerActionMethodItem.RelatedComponent.set -> void
-~System.ComponentModel.Design.DesignerActionService.Add(System.ComponentModel.IComponent comp, System.ComponentModel.Design.DesignerActionList actionList) -> void
-~System.ComponentModel.Design.DesignerActionService.Add(System.ComponentModel.IComponent comp, System.ComponentModel.Design.DesignerActionListCollection designerActionListCollection) -> void
-~System.ComponentModel.Design.DesignerActionService.Contains(System.ComponentModel.IComponent comp) -> bool
-~System.ComponentModel.Design.DesignerActionService.DesignerActionService(System.IServiceProvider serviceProvider) -> void
-~System.ComponentModel.Design.DesignerActionService.GetComponentActions(System.ComponentModel.IComponent component) -> System.ComponentModel.Design.DesignerActionListCollection
-~System.ComponentModel.Design.DesignerActionService.Remove(System.ComponentModel.Design.DesignerActionList actionList) -> void
-~System.ComponentModel.Design.DesignerActionService.Remove(System.ComponentModel.IComponent comp) -> void
-~System.ComponentModel.Design.DesignerActionService.Remove(System.ComponentModel.IComponent comp, System.ComponentModel.Design.DesignerActionList actionList) -> void
+System.ComponentModel.Design.DesignerActionService.Add(System.ComponentModel.IComponent! comp, System.ComponentModel.Design.DesignerActionList! actionList) -> void
+System.ComponentModel.Design.DesignerActionService.Add(System.ComponentModel.IComponent! comp, System.ComponentModel.Design.DesignerActionListCollection! designerActionListCollection) -> void
+System.ComponentModel.Design.DesignerActionService.Contains(System.ComponentModel.IComponent! comp) -> bool
+System.ComponentModel.Design.DesignerActionService.DesignerActionService(System.IServiceProvider? serviceProvider) -> void
+System.ComponentModel.Design.DesignerActionService.GetComponentActions(System.ComponentModel.IComponent! component) -> System.ComponentModel.Design.DesignerActionListCollection!
+System.ComponentModel.Design.DesignerActionService.Remove(System.ComponentModel.Design.DesignerActionList! actionList) -> void
+System.ComponentModel.Design.DesignerActionService.Remove(System.ComponentModel.IComponent! comp) -> void
+System.ComponentModel.Design.DesignerActionService.Remove(System.ComponentModel.IComponent! comp, System.ComponentModel.Design.DesignerActionList! actionList) -> void
 ~System.ComponentModel.Design.DesignerActionUIService.HideUI(System.ComponentModel.IComponent component) -> void
 ~System.ComponentModel.Design.DesignerActionUIService.Refresh(System.ComponentModel.IComponent component) -> void
 ~System.ComponentModel.Design.DesignerActionUIService.ShouldAutoShow(System.ComponentModel.IComponent component) -> bool
@@ -324,9 +324,9 @@ System.ComponentModel.Design.Serialization.BasicDesignerLoader.SetBaseComponentC
 ~virtual System.ComponentModel.Design.ComponentDesigner.PreFilterProperties(System.Collections.IDictionary properties) -> void
 ~virtual System.ComponentModel.Design.ComponentDesigner.Verbs.get -> System.ComponentModel.Design.DesignerVerbCollection
 ~virtual System.ComponentModel.Design.DesignerActionMethodItem.MemberName.get -> string
-~virtual System.ComponentModel.Design.DesignerActionService.GetComponentActions(System.ComponentModel.IComponent component, System.Windows.Forms.Design.ComponentActionsType type) -> System.ComponentModel.Design.DesignerActionListCollection
-~virtual System.ComponentModel.Design.DesignerActionService.GetComponentDesignerActions(System.ComponentModel.IComponent component, System.ComponentModel.Design.DesignerActionListCollection actionLists) -> void
-~virtual System.ComponentModel.Design.DesignerActionService.GetComponentServiceActions(System.ComponentModel.IComponent component, System.ComponentModel.Design.DesignerActionListCollection actionLists) -> void
+virtual System.ComponentModel.Design.DesignerActionService.GetComponentActions(System.ComponentModel.IComponent! component, System.Windows.Forms.Design.ComponentActionsType type) -> System.ComponentModel.Design.DesignerActionListCollection!
+virtual System.ComponentModel.Design.DesignerActionService.GetComponentDesignerActions(System.ComponentModel.IComponent! component, System.ComponentModel.Design.DesignerActionListCollection! actionLists) -> void
+virtual System.ComponentModel.Design.DesignerActionService.GetComponentServiceActions(System.ComponentModel.IComponent! component, System.ComponentModel.Design.DesignerActionListCollection! actionLists) -> void
 virtual System.ComponentModel.Design.EventBindingService.FreeMethod(System.ComponentModel.IComponent! component, System.ComponentModel.EventDescriptor! e, string! methodName) -> void
 virtual System.ComponentModel.Design.EventBindingService.UseMethod(System.ComponentModel.IComponent! component, System.ComponentModel.EventDescriptor! e, string! methodName) -> void
 virtual System.ComponentModel.Design.EventBindingService.ValidateMethodName(string! methodName) -> void
@@ -589,7 +589,7 @@ System.ComponentModel.Design.DesignerActionPropertyItem.RelatedComponent.get -> 
 System.ComponentModel.Design.DesignerActionPropertyItem.RelatedComponent.set -> void
 System.ComponentModel.Design.DesignerActionService
 System.ComponentModel.Design.DesignerActionService.Clear() -> void
-System.ComponentModel.Design.DesignerActionService.DesignerActionListsChanged -> System.ComponentModel.Design.DesignerActionListsChangedEventHandler
+System.ComponentModel.Design.DesignerActionService.DesignerActionListsChanged -> System.ComponentModel.Design.DesignerActionListsChangedEventHandler?
 System.ComponentModel.Design.DesignerActionService.Dispose() -> void
 System.ComponentModel.Design.DesignerActionTextItem
 System.ComponentModel.Design.DesignerActionTextItem.DesignerActionTextItem(string? displayName, string? category) -> void

--- a/src/System.Windows.Forms.Design/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms.Design/src/PublicAPI.Shipped.txt
@@ -908,7 +908,7 @@ System.Windows.Forms.Design.Behavior.BehaviorService.Invalidate() -> void
 System.Windows.Forms.Design.Behavior.BehaviorService.Invalidate(System.Drawing.Rectangle rect) -> void
 System.Windows.Forms.Design.Behavior.BehaviorService.Invalidate(System.Drawing.Region! r) -> void
 System.Windows.Forms.Design.Behavior.BehaviorService.MapAdornerWindowPoint(nint handle, System.Drawing.Point pt) -> System.Drawing.Point
-System.Windows.Forms.Design.Behavior.BehaviorService.PopBehavior(System.Windows.Forms.Design.Behavior.Behavior! behavior) -> System.Windows.Forms.Design.Behavior.Behavior?
+System.Windows.Forms.Design.Behavior.BehaviorService.PopBehavior(System.Windows.Forms.Design.Behavior.Behavior! behavior) -> System.Windows.Forms.Design.Behavior.Behavior!
 System.Windows.Forms.Design.Behavior.BehaviorService.PushBehavior(System.Windows.Forms.Design.Behavior.Behavior! behavior) -> void
 System.Windows.Forms.Design.Behavior.BehaviorService.PushCaptureBehavior(System.Windows.Forms.Design.Behavior.Behavior! behavior) -> void
 System.Windows.Forms.Design.Behavior.BehaviorService.ScreenToAdornerWindow(System.Drawing.Point p) -> System.Drawing.Point

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.CheckBoxPropertyLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.CheckBoxPropertyLine.cs
@@ -10,14 +10,10 @@ internal sealed partial class DesignerActionPanel
 {
     private sealed class CheckBoxPropertyLine : PropertyLine
     {
-        private CheckBox? _checkBox;
+        private readonly CheckBox _checkBox;
 
-        public CheckBoxPropertyLine(IServiceProvider serviceProvider, DesignerActionPanel actionPanel)
+        private CheckBoxPropertyLine(IServiceProvider serviceProvider, DesignerActionPanel actionPanel)
             : base(serviceProvider, actionPanel)
-        {
-        }
-
-        protected override void AddControls(List<Control> controls)
         {
             _checkBox = new CheckBox
             {
@@ -29,14 +25,14 @@ internal sealed partial class DesignerActionPanel
             };
             _checkBox.CheckedChanged += new EventHandler(OnCheckBoxCheckedChanged);
 
-            controls.Add(_checkBox);
+            AddedControls.Add(_checkBox);
         }
 
-        public sealed override void Focus() => _checkBox!.Focus();
+        public override void Focus() => _checkBox.Focus();
 
         public override Size LayoutControls(int top, int width, bool measureOnly)
         {
-            Size checkBoxPreferredSize = _checkBox!.GetPreferredSize(new Size(int.MaxValue, int.MaxValue));
+            Size checkBoxPreferredSize = _checkBox.GetPreferredSize(new Size(int.MaxValue, int.MaxValue));
             if (!measureOnly)
             {
                 _checkBox.Location = new Point(LineLeftMargin, top + LineVerticalPadding / 2);
@@ -48,12 +44,12 @@ internal sealed partial class DesignerActionPanel
 
         private void OnCheckBoxCheckedChanged(object? sender, EventArgs e)
         {
-            SetValue(_checkBox!.Checked);
+            SetValue(_checkBox.Checked);
         }
 
         protected override void OnPropertyTaskItemUpdated(ToolTip toolTip, ref int currentTabIndex)
         {
-            _checkBox!.Text = StripAmpersands(PropertyItem!.DisplayName);
+            _checkBox.Text = StripAmpersands(PropertyItem!.DisplayName);
             _checkBox.AccessibleDescription = PropertyItem.Description;
             _checkBox.TabIndex = currentTabIndex++;
 
@@ -62,7 +58,17 @@ internal sealed partial class DesignerActionPanel
 
         protected override void OnValueChanged()
         {
-            _checkBox!.Checked = (bool)Value!;
+            _checkBox.Checked = (bool)Value!;
+        }
+
+        public sealed class Info(DesignerActionList list, DesignerActionItem item) : LineInfo(list, item)
+        {
+            public override Line CreateLine(IServiceProvider serviceProvider, DesignerActionPanel actionPanel)
+            {
+                return new CheckBoxPropertyLine(serviceProvider, actionPanel);
+            }
+
+            public override Type LineType => typeof(CheckBoxPropertyLine);
         }
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.CheckBoxPropertyLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.CheckBoxPropertyLine.cs
@@ -61,7 +61,7 @@ internal sealed partial class DesignerActionPanel
             _checkBox.Checked = (bool)Value!;
         }
 
-        public sealed class Info(DesignerActionList list, DesignerActionItem item) : LineInfo(list, item)
+        public sealed class Info(DesignerActionList list, DesignerActionPropertyItem item) : PropertyLineInfo(list, item)
         {
             public override Line CreateLine(IServiceProvider serviceProvider, DesignerActionPanel actionPanel)
             {

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.CheckBoxPropertyLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.CheckBoxPropertyLine.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.Drawing;
 using System.Windows.Forms;
 
@@ -12,7 +10,7 @@ internal sealed partial class DesignerActionPanel
 {
     private sealed class CheckBoxPropertyLine : PropertyLine
     {
-        private CheckBox _checkBox;
+        private CheckBox? _checkBox;
 
         public CheckBoxPropertyLine(IServiceProvider serviceProvider, DesignerActionPanel actionPanel)
             : base(serviceProvider, actionPanel)
@@ -34,11 +32,11 @@ internal sealed partial class DesignerActionPanel
             controls.Add(_checkBox);
         }
 
-        public sealed override void Focus() => _checkBox.Focus();
+        public sealed override void Focus() => _checkBox!.Focus();
 
         public override Size LayoutControls(int top, int width, bool measureOnly)
         {
-            Size checkBoxPreferredSize = _checkBox.GetPreferredSize(new Size(int.MaxValue, int.MaxValue));
+            Size checkBoxPreferredSize = _checkBox!.GetPreferredSize(new Size(int.MaxValue, int.MaxValue));
             if (!measureOnly)
             {
                 _checkBox.Location = new Point(LineLeftMargin, top + LineVerticalPadding / 2);
@@ -48,14 +46,14 @@ internal sealed partial class DesignerActionPanel
             return checkBoxPreferredSize + new Size(LineLeftMargin + LineRightMargin, LineVerticalPadding);
         }
 
-        private void OnCheckBoxCheckedChanged(object sender, EventArgs e)
+        private void OnCheckBoxCheckedChanged(object? sender, EventArgs e)
         {
-            SetValue(_checkBox.Checked);
+            SetValue(_checkBox!.Checked);
         }
 
         protected override void OnPropertyTaskItemUpdated(ToolTip toolTip, ref int currentTabIndex)
         {
-            _checkBox.Text = StripAmpersands(PropertyItem.DisplayName);
+            _checkBox!.Text = StripAmpersands(PropertyItem!.DisplayName);
             _checkBox.AccessibleDescription = PropertyItem.Description;
             _checkBox.TabIndex = currentTabIndex++;
 
@@ -64,7 +62,7 @@ internal sealed partial class DesignerActionPanel
 
         protected override void OnValueChanged()
         {
-            _checkBox.Checked = (bool)Value;
+            _checkBox!.Checked = (bool)Value!;
         }
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.DesignerActionPanelHeaderItem.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.DesignerActionPanelHeaderItem.cs
@@ -7,16 +7,11 @@ internal sealed partial class DesignerActionPanel
 {
     private sealed class DesignerActionPanelHeaderItem : DesignerActionItem
     {
-        private readonly string _subtitle;
-
-        public DesignerActionPanelHeaderItem(string title, string subtitle) : base(title, null, null)
+        public DesignerActionPanelHeaderItem(string title, string? subtitle) : base(title, null, null)
         {
-            _subtitle = subtitle;
+            Subtitle = subtitle;
         }
 
-        public string Subtitle
-        {
-            get => _subtitle;
-        }
+        public string? Subtitle { get; }
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.EditorPropertyLine.EditorButton.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.EditorPropertyLine.EditorButton.cs
@@ -17,7 +17,6 @@ internal sealed partial class DesignerActionPanel
         {
             private bool _mouseOver;
             private bool _mouseDown;
-            private bool _ellipsis;
 
             protected override void OnMouseDown(MouseEventArgs e)
             {
@@ -51,16 +50,12 @@ internal sealed partial class DesignerActionPanel
                 }
             }
 
-            public bool Ellipsis
-            {
-                get => _ellipsis;
-                set => _ellipsis = value;
-            }
+            public bool Ellipsis { get; set; }
 
             protected override void OnPaint(PaintEventArgs e)
             {
                 Graphics g = e.Graphics;
-                if (_ellipsis)
+                if (Ellipsis)
                 {
                     PushButtonState buttonState = PushButtonState.Normal;
                     if (_mouseDown)
@@ -161,7 +156,7 @@ internal sealed partial class DesignerActionPanel
                             }
                             finally
                             {
-                                icon?.Dispose();
+                                icon.Dispose();
                             }
                         }
                         catch

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.EditorPropertyLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.EditorPropertyLine.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.Drawing;
 using System.Drawing.Design;
 using System.Globalization;
@@ -15,11 +13,11 @@ internal sealed partial class DesignerActionPanel
 {
     private sealed partial class EditorPropertyLine : TextBoxPropertyLine, IWindowsFormsEditorService, IServiceProvider
     {
-        private EditorButton _button;
-        private UITypeEditor _editor;
+        private EditorButton? _button;
+        private UITypeEditor? _editor;
         private bool _hasSwatch;
-        private Image _swatch;
-        private FlyoutDialog _dropDownHolder;
+        private Image? _swatch;
+        private FlyoutDialog? _dropDownHolder;
         private bool _ignoreNextSelectChange;
         private bool _ignoreDropDownValue;
 
@@ -34,7 +32,7 @@ internal sealed partial class DesignerActionPanel
             {
                 try
                 {
-                    object newValue = _editor.EditValue(TypeDescriptorContext, this, Value);
+                    object? newValue = _editor.EditValue(TypeDescriptorContext, this, Value);
                     SetValue(newValue);
                 }
                 catch (Exception ex)
@@ -53,12 +51,12 @@ internal sealed partial class DesignerActionPanel
                 listBox.SelectedIndexChanged += new EventHandler(OnListBoxSelectedIndexChanged);
                 listBox.KeyDown += new KeyEventHandler(OnListBoxKeyDown);
 
-                TypeConverter.StandardValuesCollection standardValues = GetStandardValues();
+                TypeConverter.StandardValuesCollection? standardValues = GetStandardValues();
                 if (standardValues is not null)
                 {
                     foreach (object o in standardValues)
                     {
-                        string newItem = PropertyDescriptor.Converter.ConvertToString(TypeDescriptorContext, CultureInfo.CurrentCulture, o);
+                        string newItem = PropertyDescriptor.Converter.ConvertToString(TypeDescriptorContext, CultureInfo.CurrentCulture, o)!;
                         listBox.Items.Add(newItem);
 
                         if ((o is not null) && o.Equals(Value))
@@ -180,27 +178,27 @@ internal sealed partial class DesignerActionPanel
             if (!measureOnly)
             {
                 int buttonHeight = EditRegionSize.Height - EditorLineButtonPadding * 2 - 1;
-                _button.Location = new Point(EditRegionLocation.X + EditRegionSize.Width - buttonHeight - EditorLineButtonPadding, EditRegionLocation.Y + EditorLineButtonPadding + 1);
+                _button!.Location = new Point(EditRegionLocation.X + EditRegionSize.Width - buttonHeight - EditorLineButtonPadding, EditRegionLocation.Y + EditorLineButtonPadding + 1);
                 _button.Size = new Size(buttonHeight, buttonHeight);
             }
 
             return size;
         }
 
-        private void OnButtonClick(object sender, EventArgs e)
+        private void OnButtonClick(object? sender, EventArgs e)
         {
             ActivateDropDown();
         }
 
-        private void OnButtonGotFocus(object sender, EventArgs e)
+        private void OnButtonGotFocus(object? sender, EventArgs e)
         {
-            if (!_button.Ellipsis)
+            if (!_button!.Ellipsis)
             {
                 Focus();
             }
         }
 
-        private void OnListBoxKeyDown(object sender, KeyEventArgs e)
+        private void OnListBoxKeyDown(object? sender, KeyEventArgs e)
         {
             // Always respect the enter key and F4
             if (e.KeyData == Keys.Enter)
@@ -216,7 +214,7 @@ internal sealed partial class DesignerActionPanel
             }
         }
 
-        private void OnListBoxSelectedIndexChanged(object sender, EventArgs e)
+        private void OnListBoxSelectedIndexChanged(object? sender, EventArgs e)
         {
             // If we're ignoring this selected index change, do nothing
             if (_ignoreNextSelectChange)
@@ -231,27 +229,27 @@ internal sealed partial class DesignerActionPanel
 
         protected override void OnPropertyTaskItemUpdated(ToolTip toolTip, ref int currentTabIndex)
         {
-            _editor = (UITypeEditor)PropertyDescriptor.GetEditor(typeof(UITypeEditor));
+            _editor = PropertyDescriptor.GetEditor<UITypeEditor>();
 
             base.OnPropertyTaskItemUpdated(toolTip, ref currentTabIndex);
 
             if (_editor is not null)
             {
-                _button.Ellipsis = (_editor.GetEditStyle(TypeDescriptorContext) == UITypeEditorEditStyle.Modal);
+                _button!.Ellipsis = (_editor.GetEditStyle(TypeDescriptorContext) == UITypeEditorEditStyle.Modal);
                 _hasSwatch = _editor.GetPaintValueSupported(TypeDescriptorContext);
             }
             else
             {
-                _button.Ellipsis = false;
+                _button!.Ellipsis = false;
             }
 
             if (_button.Ellipsis)
             {
-                EditControl.AccessibleRole = (IsReadOnly() ? AccessibleRole.StaticText : AccessibleRole.Text);
+                EditControl!.AccessibleRole = (IsReadOnly() ? AccessibleRole.StaticText : AccessibleRole.Text);
             }
             else
             {
-                EditControl.AccessibleRole = (IsReadOnly() ? AccessibleRole.DropList : AccessibleRole.ComboBox);
+                EditControl!.AccessibleRole = (IsReadOnly() ? AccessibleRole.DropList : AccessibleRole.ComboBox);
             }
 
             _button.TabStop = _button.Ellipsis;
@@ -262,13 +260,13 @@ internal sealed partial class DesignerActionPanel
             _button.AccessibleName = EditControl.AccessibleName;
         }
 
-        protected override void OnReadOnlyTextBoxLabelClick(object sender, MouseEventArgs e)
+        protected override void OnReadOnlyTextBoxLabelClick(object? sender, MouseEventArgs e)
         {
             base.OnReadOnlyTextBoxLabelClick(sender, e);
 
             if (e.Button == MouseButtons.Left)
             {
-                if (ActionPanel.DropDownActive)
+                if (ActionPanel._dropDownActive)
                 {
                     _ignoreDropDownValue = true;
                     CloseDropDown();
@@ -305,7 +303,7 @@ internal sealed partial class DesignerActionPanel
                     Rectangle rect = new Rectangle(1, 1, width - 2, height - 2);
                     using (Graphics swatchGraphics = Graphics.FromImage(_swatch))
                     {
-                        _editor.PaintValue(Value, swatchGraphics, rect);
+                        _editor!.PaintValue(Value, swatchGraphics, rect);
                         swatchGraphics.DrawRectangle(SystemPens.ControlDark, new Rectangle(0, 0, width - 1, height - 1));
                     }
                 }
@@ -320,11 +318,11 @@ internal sealed partial class DesignerActionPanel
             // VS is going to eat the F4 in PreProcessMessage, preventing it from ever
             // getting to an OnKeyDown on this control. Doing it here also allow to not
             // hook up to multiple events for each button.
-            if (!_button.Focused && !_button.Ellipsis)
+            if (!_button!.Focused && !_button.Ellipsis)
             {
-                if ((keyData == (Keys.Alt | Keys.Down)) || (keyData == (Keys.Alt | Keys.Up)) || (keyData == Keys.F4))
+                if (keyData is (Keys.Alt | Keys.Down) or (Keys.Alt | Keys.Up) or Keys.F4)
                 {
-                    if (!ActionPanel.DropDownActive)
+                    if (!ActionPanel._dropDownActive)
                     {
                         ActivateDropDown();
                     }
@@ -403,11 +401,11 @@ internal sealed partial class DesignerActionPanel
             ActionPanel.SetDropDownActive(true);
             try
             {
-                _dropDownHolder.ShowDropDown(_button);
+                _dropDownHolder.ShowDropDown(_button!);
             }
             finally
             {
-                _button.ResetMouseStates();
+                _button!.ResetMouseStates();
                 ActionPanel.SetDropDownActive(false);
                 ActionPanel.InMethodInvoke = false;
             }
@@ -419,14 +417,14 @@ internal sealed partial class DesignerActionPanel
             CloseDropDown();
         }
 
-        void IWindowsFormsEditorService.DropDownControl(Control control)
+        void IWindowsFormsEditorService.DropDownControl(Control? control)
         {
-            ShowDropDown(control, ActionPanel.BorderColor);
+            ShowDropDown(control!, ActionPanel.BorderColor);
         }
 
         DialogResult IWindowsFormsEditorService.ShowDialog(Form dialog)
         {
-            IUIService uiService = (IUIService)ServiceProvider.GetService(typeof(IUIService));
+            IUIService? uiService = ServiceProvider.GetService<IUIService>();
             if (uiService is not null)
             {
                 return uiService.ShowDialog(dialog);
@@ -437,7 +435,7 @@ internal sealed partial class DesignerActionPanel
         #endregion
 
         #region IServiceProvider implementation
-        object IServiceProvider.GetService(Type serviceType)
+        object? IServiceProvider.GetService(Type serviceType)
         {
             // Inject this class as the IWindowsFormsEditorService
             // so drop-down custom editors can work

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.EditorPropertyLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.EditorPropertyLine.cs
@@ -417,9 +417,9 @@ internal sealed partial class DesignerActionPanel
             CloseDropDown();
         }
 
-        void IWindowsFormsEditorService.DropDownControl(Control? control)
+        void IWindowsFormsEditorService.DropDownControl(Control control)
         {
-            ShowDropDown(control!, ActionPanel.BorderColor);
+            ShowDropDown(control, ActionPanel.BorderColor);
         }
 
         DialogResult IWindowsFormsEditorService.ShowDialog(Form dialog)

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.EditorPropertyLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.EditorPropertyLine.cs
@@ -473,7 +473,7 @@ internal sealed partial class DesignerActionPanel
             }
         }
 
-        public new sealed class Info(DesignerActionList list, DesignerActionItem item) : LineInfo(list, item)
+        public new sealed class Info(DesignerActionList list, DesignerActionPropertyItem item) : PropertyLineInfo(list, item)
         {
             public override Line CreateLine(IServiceProvider serviceProvider, DesignerActionPanel actionPanel)
             {

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.HeaderLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.HeaderLine.cs
@@ -15,8 +15,9 @@ internal sealed partial class DesignerActionPanel
 
         protected override Font GetFont() => new(ActionPanel.Font, FontStyle.Bold);
 
-        public new sealed class Info(DesignerActionList list, DesignerActionItem item) : LineInfo(list, item)
+        public new sealed class Info(DesignerActionList list, DesignerActionTextItem item) : StandardLineInfo(list)
         {
+            public override DesignerActionTextItem Item { get; } = item;
             public override Line CreateLine(IServiceProvider serviceProvider, DesignerActionPanel actionPanel)
             {
                 return new HeaderLine(serviceProvider, actionPanel);

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.HeaderLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.HeaderLine.cs
@@ -9,10 +9,20 @@ internal sealed partial class DesignerActionPanel
 {
     private sealed class HeaderLine : TextLine
     {
-        public HeaderLine(IServiceProvider serviceProvider, DesignerActionPanel actionPanel) : base(serviceProvider, actionPanel)
+        private HeaderLine(IServiceProvider serviceProvider, DesignerActionPanel actionPanel) : base(serviceProvider, actionPanel)
         {
         }
 
         protected override Font GetFont() => new(ActionPanel.Font, FontStyle.Bold);
+
+        public new sealed class Info(DesignerActionList list, DesignerActionItem item) : LineInfo(list, item)
+        {
+            public override Line CreateLine(IServiceProvider serviceProvider, DesignerActionPanel actionPanel)
+            {
+                return new HeaderLine(serviceProvider, actionPanel);
+            }
+
+            public override Type LineType => typeof(HeaderLine);
+        }
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.Line.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.Line.cs
@@ -10,9 +10,9 @@ internal sealed partial class DesignerActionPanel
 {
     private abstract class Line
     {
-        private List<Control>? _addedControls;
+        protected readonly List<Control> AddedControls = new();
 
-        public Line(IServiceProvider serviceProvider, DesignerActionPanel actionPanel)
+        protected Line(IServiceProvider serviceProvider, DesignerActionPanel actionPanel)
         {
             ServiceProvider = serviceProvider;
             ActionPanel = actionPanel.OrThrowIfNull();
@@ -27,19 +27,15 @@ internal sealed partial class DesignerActionPanel
 
         protected IServiceProvider ServiceProvider { get; }
 
-        protected abstract void AddControls(List<Control> controls);
-
         internal List<Control> GetControls()
         {
-            _addedControls = new List<Control>();
-            AddControls(_addedControls);
             // Tag all the controls with the Line so we know who owns it
-            foreach (Control c in _addedControls)
+            foreach (Control c in AddedControls)
             {
                 c.Tag = this;
             }
 
-            return _addedControls;
+            return AddedControls;
         }
 
         public abstract void Focus();
@@ -54,9 +50,8 @@ internal sealed partial class DesignerActionPanel
 
         internal void RemoveControls(ControlCollection controls)
         {
-            for (int i = 0; i < _addedControls!.Count; i++)
+            foreach (Control c in AddedControls)
             {
-                Control c = _addedControls[i];
                 c.Tag = null;
                 controls.Remove(c);
             }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.Line.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.Line.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.Drawing;
 using System.Windows.Forms;
 
@@ -12,30 +10,22 @@ internal sealed partial class DesignerActionPanel
 {
     private abstract class Line
     {
-        private readonly DesignerActionPanel _actionPanel;
-        private List<Control> _addedControls;
-        private readonly IServiceProvider _serviceProvider;
+        private List<Control>? _addedControls;
 
         public Line(IServiceProvider serviceProvider, DesignerActionPanel actionPanel)
         {
-            _serviceProvider = serviceProvider;
-            _actionPanel = actionPanel.OrThrowIfNull();
+            ServiceProvider = serviceProvider;
+            ActionPanel = actionPanel.OrThrowIfNull();
         }
 
-        protected DesignerActionPanel ActionPanel
-        {
-            get => _actionPanel;
-        }
+        protected DesignerActionPanel ActionPanel { get; }
 
         public abstract string FocusId
         {
             get;
         }
 
-        protected IServiceProvider ServiceProvider
-        {
-            get => _serviceProvider;
-        }
+        protected IServiceProvider ServiceProvider { get; }
 
         protected abstract void AddControls(List<Control> controls);
 
@@ -64,7 +54,7 @@ internal sealed partial class DesignerActionPanel
 
         internal void RemoveControls(ControlCollection controls)
         {
-            for (int i = 0; i < _addedControls.Count; i++)
+            for (int i = 0; i < _addedControls!.Count; i++)
             {
                 Control c = _addedControls[i];
                 c.Tag = null;
@@ -72,6 +62,6 @@ internal sealed partial class DesignerActionPanel
             }
         }
 
-        internal abstract void UpdateActionItem(DesignerActionList actionList, DesignerActionItem actionItem, ToolTip toolTip, ref int currentTabIndex);
+        internal abstract void UpdateActionItem(DesignerActionList? actionList, DesignerActionItem? actionItem, ToolTip toolTip, ref int currentTabIndex);
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.Line.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.Line.cs
@@ -57,6 +57,6 @@ internal sealed partial class DesignerActionPanel
             }
         }
 
-        internal abstract void UpdateActionItem(DesignerActionList? actionList, DesignerActionItem? actionItem, ToolTip toolTip, ref int currentTabIndex);
+        internal abstract void UpdateActionItem(LineInfo lineInfo, ToolTip toolTip, ref int currentTabIndex);
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.LineInfo.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.LineInfo.cs
@@ -7,16 +7,15 @@ internal sealed partial class DesignerActionPanel
 {
     private abstract class LineInfo
     {
-        public readonly DesignerActionItem? Item;
-        public readonly DesignerActionList? List;
-
-        protected LineInfo(DesignerActionList? list, DesignerActionItem? item)
-        {
-            Item = item;
-            List = list;
-        }
+        public abstract DesignerActionItem? Item { get; }
 
         public abstract Line CreateLine(IServiceProvider serviceProvider, DesignerActionPanel actionPanel);
         public abstract Type LineType { get; }
+    }
+
+    private abstract class StandardLineInfo(DesignerActionList list) : LineInfo
+    {
+        public abstract override DesignerActionItem Item { get; }
+        public DesignerActionList List { get; } = list;
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.LineInfo.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.LineInfo.cs
@@ -7,11 +7,11 @@ internal sealed partial class DesignerActionPanel
 {
     private class LineInfo
     {
-        public Line Line;
-        public DesignerActionItem Item;
-        public DesignerActionList List;
+        public readonly Line Line;
+        public readonly DesignerActionItem? Item;
+        public readonly DesignerActionList? List;
 
-        public LineInfo(DesignerActionList list, DesignerActionItem item, Line line)
+        public LineInfo(DesignerActionList? list, DesignerActionItem? item, Line line)
         {
             Debug.Assert(line is not null);
             Line = line;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.LineInfo.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.LineInfo.cs
@@ -5,18 +5,18 @@ namespace System.ComponentModel.Design;
 
 internal sealed partial class DesignerActionPanel
 {
-    private class LineInfo
+    private abstract class LineInfo
     {
-        public readonly Line Line;
         public readonly DesignerActionItem? Item;
         public readonly DesignerActionList? List;
 
-        public LineInfo(DesignerActionList? list, DesignerActionItem? item, Line line)
+        protected LineInfo(DesignerActionList? list, DesignerActionItem? item)
         {
-            Debug.Assert(line is not null);
-            Line = line;
             Item = item;
             List = list;
         }
+
+        public abstract Line CreateLine(IServiceProvider serviceProvider, DesignerActionPanel actionPanel);
+        public abstract Type LineType { get; }
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.MethodLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.MethodLine.cs
@@ -78,10 +78,11 @@ internal sealed partial class DesignerActionPanel
             }
         }
 
-        internal override void UpdateActionItem(DesignerActionList? actionList, DesignerActionItem? actionItem, ToolTip toolTip, ref int currentTabIndex)
+        internal override void UpdateActionItem(LineInfo lineInfo, ToolTip toolTip, ref int currentTabIndex)
         {
-            _actionList = actionList!;
-            _methodItem = (DesignerActionMethodItem)actionItem!;
+            Info info = (Info)lineInfo;
+            _actionList = info.List;
+            _methodItem = info.Item;
             toolTip.SetToolTip(_linkLabel, _methodItem.Description);
             _linkLabel.Text = StripAmpersands(_methodItem.DisplayName);
             _linkLabel.AccessibleDescription = _methodItem.Description;
@@ -107,8 +108,9 @@ internal sealed partial class DesignerActionPanel
             }
         }
 
-        public sealed class Info(DesignerActionList list, DesignerActionItem item) : LineInfo(list, item)
+        public sealed class Info(DesignerActionList list, DesignerActionMethodItem item) : StandardLineInfo(list)
         {
+            public override DesignerActionMethodItem Item { get; } = item;
             public override Line CreateLine(IServiceProvider serviceProvider, DesignerActionPanel actionPanel)
             {
                 return new MethodLine(serviceProvider, actionPanel);

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.MethodLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.MethodLine.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.Drawing;
 using System.Reflection;
 using System.Windows.Forms;
@@ -13,16 +11,16 @@ internal sealed partial class DesignerActionPanel
 {
     private sealed class MethodLine : Line
     {
-        private DesignerActionList _actionList;
-        private DesignerActionMethodItem _methodItem;
-        private MethodItemLinkLabel _linkLabel;
+        private DesignerActionList? _actionList;
+        private DesignerActionMethodItem? _methodItem;
+        private MethodItemLinkLabel? _linkLabel;
         public MethodLine(IServiceProvider serviceProvider, DesignerActionPanel actionPanel) : base(serviceProvider, actionPanel)
         {
         }
 
-        public sealed override string FocusId
+        public override string FocusId
         {
-            get => $"METHOD:{_actionList.GetType().FullName}.{_methodItem.MemberName}";
+            get => $"METHOD:{_actionList!.GetType().FullName}.{_methodItem!.MemberName}";
         }
 
         protected override void AddControls(List<Control> controls)
@@ -42,14 +40,14 @@ internal sealed partial class DesignerActionPanel
             controls.Add(_linkLabel);
         }
 
-        public sealed override void Focus()
+        public override void Focus()
         {
-            _linkLabel.Focus();
+            _linkLabel!.Focus();
         }
 
         public override Size LayoutControls(int top, int width, bool measureOnly)
         {
-            Size linkLabelSize = _linkLabel.GetPreferredSize(new Size(int.MaxValue, int.MaxValue));
+            Size linkLabelSize = _linkLabel!.GetPreferredSize(new Size(int.MaxValue, int.MaxValue));
             if (!measureOnly)
             {
                 _linkLabel.Location = new Point(LineLeftMargin, top + LineVerticalPadding / 2);
@@ -59,19 +57,19 @@ internal sealed partial class DesignerActionPanel
             return linkLabelSize + new Size(LineLeftMargin + LineRightMargin, LineVerticalPadding);
         }
 
-        private void OnLinkLabelLinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+        private void OnLinkLabelLinkClicked(object? sender, LinkLabelLinkClickedEventArgs e)
         {
             Debug.Assert(!ActionPanel.InMethodInvoke, "Nested method invocation");
             ActionPanel.InMethodInvoke = true;
             try
             {
-                _methodItem.Invoke();
+                _methodItem!.Invoke();
             }
             catch (Exception ex)
             {
                 if (ex is TargetInvocationException)
                 {
-                    ex = ex.InnerException;
+                    ex = ex.InnerException!;
                 }
 
                 //NOTE: We had code to rethrow if this was one of [NullReferenceException, StackOverflowException, OutOfMemoryException,
@@ -79,7 +77,7 @@ internal sealed partial class DesignerActionPanel
                 //NullRef and OutOfMemory really shouldn't be caught.  Out of these, OOM is the most correct one to call, but OOM is
                 //thrown by GDI+ for pretty much any problem, so isn't reliable as an actual indicator that you're out of memory.  If
                 //you really are out of memory, it's very likely you'll get another OOM shortly.
-                ActionPanel.ShowError(string.Format(SR.DesignerActionPanel_ErrorInvokingAction, _methodItem.DisplayName, Environment.NewLine + ex.Message));
+                ActionPanel.ShowError(string.Format(SR.DesignerActionPanel_ErrorInvokingAction, _methodItem!.DisplayName, Environment.NewLine + ex.Message));
             }
             finally
             {
@@ -87,13 +85,13 @@ internal sealed partial class DesignerActionPanel
             }
         }
 
-        internal override void UpdateActionItem(DesignerActionList actionList, DesignerActionItem actionItem, ToolTip toolTip, ref int currentTabIndex)
+        internal override void UpdateActionItem(DesignerActionList? actionList, DesignerActionItem? actionItem, ToolTip toolTip, ref int currentTabIndex)
         {
             _actionList = actionList;
-            _methodItem = (DesignerActionMethodItem)actionItem;
-            toolTip.SetToolTip(_linkLabel, _methodItem.Description);
-            _linkLabel.Text = StripAmpersands(_methodItem.DisplayName);
-            _linkLabel.AccessibleDescription = actionItem.Description;
+            _methodItem = (DesignerActionMethodItem?)actionItem;
+            toolTip.SetToolTip(_linkLabel!, _methodItem!.Description);
+            _linkLabel!.Text = StripAmpersands(_methodItem.DisplayName);
+            _linkLabel.AccessibleDescription = actionItem!.Description;
             _linkLabel.TabIndex = currentTabIndex++;
         }
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.PanelHeaderLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.PanelHeaderLine.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.Drawing;
 using System.Windows.Forms;
 
@@ -12,10 +10,9 @@ internal sealed partial class DesignerActionPanel
 {
     private sealed class PanelHeaderLine : Line
     {
-        private DesignerActionList _actionList;
-        private DesignerActionPanelHeaderItem _panelHeaderItem;
-        private Label _titleLabel;
-        private Label _subtitleLabel;
+        private DesignerActionPanelHeaderItem? _panelHeaderItem;
+        private Label? _titleLabel;
+        private Label? _subtitleLabel;
         private bool _formActive;
 
         public PanelHeaderLine(IServiceProvider serviceProvider, DesignerActionPanel actionPanel)
@@ -62,11 +59,11 @@ internal sealed partial class DesignerActionPanel
 
         public override Size LayoutControls(int top, int width, bool measureOnly)
         {
-            Size titleSize = _titleLabel.GetPreferredSize(new Size(int.MaxValue, int.MaxValue));
+            Size titleSize = _titleLabel!.GetPreferredSize(new Size(int.MaxValue, int.MaxValue));
             Size subtitleSize = Size.Empty;
-            if (!string.IsNullOrEmpty(_panelHeaderItem.Subtitle))
+            if (!string.IsNullOrEmpty(_panelHeaderItem!.Subtitle))
             {
-                subtitleSize = _subtitleLabel.GetPreferredSize(new Size(int.MaxValue, int.MaxValue));
+                subtitleSize = _subtitleLabel!.GetPreferredSize(new Size(int.MaxValue, int.MaxValue));
             }
 
             if (!measureOnly)
@@ -74,7 +71,7 @@ internal sealed partial class DesignerActionPanel
                 _titleLabel.Location = new Point(LineLeftMargin, top + PanelHeaderVerticalPadding);
                 _titleLabel.Size = titleSize;
 
-                _subtitleLabel.Location = new Point(LineLeftMargin, top + PanelHeaderVerticalPadding * 2 + titleSize.Height);
+                _subtitleLabel!.Location = new Point(LineLeftMargin, top + PanelHeaderVerticalPadding * 2 + titleSize.Height);
                 _subtitleLabel.Size = subtitleSize;
             }
 
@@ -83,7 +80,7 @@ internal sealed partial class DesignerActionPanel
             return new Size(newWidth + 2, newHeight + 1);
         }
 
-        private void OnFormActivated(object sender, EventArgs e)
+        private void OnFormActivated(object? sender, EventArgs e)
         {
             // TODO: Figure out better rect
             _formActive = true;
@@ -91,14 +88,14 @@ internal sealed partial class DesignerActionPanel
             //ActionPanel.Invalidate(new Rectangle(EditRegionLocation, EditRegionSize), false);
         }
 
-        private void OnFormDeactivate(object sender, EventArgs e)
+        private void OnFormDeactivate(object? sender, EventArgs e)
         {
             // TODO: Figure out better rect
             _formActive = false;
             ActionPanel.Invalidate();
         }
 
-        private void OnParentControlFontChanged(object sender, EventArgs e)
+        private void OnParentControlFontChanged(object? sender, EventArgs e)
         {
             if (_titleLabel is not null && _subtitleLabel is not null)
             {
@@ -109,7 +106,7 @@ internal sealed partial class DesignerActionPanel
 
         public override void PaintLine(Graphics g, int lineWidth, int lineHeight)
         {
-            Color backColor = (_formActive || ActionPanel.DropDownActive) ? ActionPanel.TitleBarColor : ActionPanel.TitleBarUnselectedColor;
+            Color backColor = (_formActive || ActionPanel._dropDownActive) ? ActionPanel.TitleBarColor : ActionPanel.TitleBarUnselectedColor;
             using (SolidBrush b = new SolidBrush(backColor))
             {
                 g.FillRectangle(b, 1, 1, lineWidth - 2, lineHeight - 1);
@@ -122,14 +119,13 @@ internal sealed partial class DesignerActionPanel
             }
         }
 
-        internal override void UpdateActionItem(DesignerActionList actionList, DesignerActionItem actionItem, ToolTip toolTip, ref int currentTabIndex)
+        internal override void UpdateActionItem(DesignerActionList? actionList, DesignerActionItem? actionItem, ToolTip toolTip, ref int currentTabIndex)
         {
-            _actionList = actionList;
-            _panelHeaderItem = (DesignerActionPanelHeaderItem)actionItem;
+            _panelHeaderItem = (DesignerActionPanelHeaderItem)actionItem!;
 
-            _titleLabel.Text = _panelHeaderItem.DisplayName;
+            _titleLabel!.Text = _panelHeaderItem.DisplayName;
             _titleLabel.TabIndex = currentTabIndex++;
-            _subtitleLabel.Text = _panelHeaderItem.Subtitle;
+            _subtitleLabel!.Text = _panelHeaderItem.Subtitle;
             _subtitleLabel.TabIndex = currentTabIndex++;
             _subtitleLabel.Visible = (_subtitleLabel.Text.Length != 0);
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.PanelHeaderLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.PanelHeaderLine.cs
@@ -110,9 +110,10 @@ internal sealed partial class DesignerActionPanel
             }
         }
 
-        internal override void UpdateActionItem(DesignerActionList? actionList, DesignerActionItem? actionItem, ToolTip toolTip, ref int currentTabIndex)
+        internal override void UpdateActionItem(LineInfo lineInfo, ToolTip toolTip, ref int currentTabIndex)
         {
-            _panelHeaderItem = (DesignerActionPanelHeaderItem)actionItem!;
+            Info info = (Info)lineInfo;
+            _panelHeaderItem = info.Item;
 
             _titleLabel.Text = _panelHeaderItem.DisplayName;
             _titleLabel.TabIndex = currentTabIndex++;
@@ -124,8 +125,9 @@ internal sealed partial class DesignerActionPanel
             OnParentControlFontChanged(null, EventArgs.Empty);
         }
 
-        public sealed class Info(DesignerActionItem item) : LineInfo(null, item)
+        public sealed class Info(DesignerActionPanelHeaderItem item) : LineInfo
         {
+            public override DesignerActionPanelHeaderItem Item { get; } = item;
             public override Line CreateLine(IServiceProvider serviceProvider, DesignerActionPanel actionPanel)
             {
                 return new PanelHeaderLine(serviceProvider, actionPanel);

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.PropertyLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.PropertyLine.cs
@@ -20,28 +20,13 @@ internal sealed partial class DesignerActionPanel
         {
         }
 
-        public sealed override string FocusId
-        {
-            get => $"PROPERTY:{_actionList!.GetType().FullName}.{PropertyItem!.MemberName}";
-        }
+        public sealed override string FocusId => $"PROPERTY:{_actionList!.GetType().FullName}.{PropertyItem!.MemberName}";
 
-        protected PropertyDescriptor PropertyDescriptor
-        {
-            get
-            {
-                return _propDesc ??= TypeDescriptor.GetProperties(_actionList!)[PropertyItem!.MemberName]!;
-            }
-        }
+        protected PropertyDescriptor PropertyDescriptor => _propDesc ??= TypeDescriptor.GetProperties(_actionList!)[PropertyItem!.MemberName]!;
 
         protected DesignerActionPropertyItem? PropertyItem { get; private set; }
 
-        protected ITypeDescriptorContext TypeDescriptorContext
-        {
-            get
-            {
-                return _typeDescriptorContext ??= new TypeDescriptorContext(ServiceProvider, PropertyDescriptor, _actionList!);
-            }
-        }
+        protected ITypeDescriptorContext TypeDescriptorContext => _typeDescriptorContext ??= new TypeDescriptorContext(ServiceProvider, PropertyDescriptor, _actionList!);
 
         protected object? Value { get; private set; }
 
@@ -105,13 +90,14 @@ internal sealed partial class DesignerActionPanel
             }
         }
 
-        internal sealed override void UpdateActionItem(DesignerActionList? actionList, DesignerActionItem? actionItem, ToolTip toolTip, ref int currentTabIndex)
+        internal sealed override void UpdateActionItem(LineInfo lineInfo, ToolTip toolTip, ref int currentTabIndex)
         {
-            _actionList = actionList;
-            PropertyItem = (DesignerActionPropertyItem?)actionItem;
+            PropertyLineInfo info = (PropertyLineInfo)lineInfo;
+            _actionList = info.List;
+            PropertyItem = info.Item;
             _propDesc = null;
             _typeDescriptorContext = null;
-            Value = PropertyDescriptor.GetValue(actionList);
+            Value = PropertyDescriptor.GetValue(info.List);
             OnPropertyTaskItemUpdated(toolTip, ref currentTabIndex);
             _pushingValue = true;
             try
@@ -122,6 +108,11 @@ internal sealed partial class DesignerActionPanel
             {
                 _pushingValue = false;
             }
+        }
+
+        public abstract class PropertyLineInfo(DesignerActionList list, DesignerActionPropertyItem item) : StandardLineInfo(list)
+        {
+            public override DesignerActionPropertyItem Item { get; } = item;
         }
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.PropertyLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.PropertyLine.cs
@@ -16,7 +16,7 @@ internal sealed partial class DesignerActionPanel
         private PropertyDescriptor? _propDesc;
         private ITypeDescriptorContext? _typeDescriptorContext;
 
-        public PropertyLine(IServiceProvider serviceProvider, DesignerActionPanel actionPanel) : base(serviceProvider, actionPanel)
+        protected PropertyLine(IServiceProvider serviceProvider, DesignerActionPanel actionPanel) : base(serviceProvider, actionPanel)
         {
         }
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.SeparatorLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.SeparatorLine.cs
@@ -43,7 +43,7 @@ internal sealed partial class DesignerActionPanel
             }
         }
 
-        internal override void UpdateActionItem(DesignerActionList actionList, DesignerActionItem actionItem, ToolTip toolTip, ref int currentTabIndex)
+        internal override void UpdateActionItem(DesignerActionList? actionList, DesignerActionItem? actionItem, ToolTip toolTip, ref int currentTabIndex)
         {
         }
     }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.SeparatorLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.SeparatorLine.cs
@@ -10,16 +10,14 @@ internal sealed partial class DesignerActionPanel
 {
     private sealed class SeparatorLine : Line
     {
-        private readonly bool _isSubSeparator;
-
         private SeparatorLine(IServiceProvider serviceProvider, DesignerActionPanel actionPanel, bool isSubSeparator) : base(serviceProvider, actionPanel)
         {
-            _isSubSeparator = isSubSeparator;
+            IsSubSeparator = isSubSeparator;
         }
 
         public override string FocusId => string.Empty;
 
-        public bool IsSubSeparator => _isSubSeparator;
+        public bool IsSubSeparator { get; }
 
         public sealed override void Focus() => Debug.Fail("Should never try to focus a SeparatorLine");
 
@@ -33,14 +31,14 @@ internal sealed partial class DesignerActionPanel
             }
         }
 
-        internal override void UpdateActionItem(DesignerActionList? actionList, DesignerActionItem? actionItem, ToolTip toolTip, ref int currentTabIndex)
+        internal override void UpdateActionItem(LineInfo lineInfo, ToolTip toolTip, ref int currentTabIndex)
         {
         }
 
-        public sealed class Info(bool isSubSeparator = false) : LineInfo(null, null)
+        public sealed class Info(bool isSubSeparator = false) : LineInfo
         {
             private readonly bool _isSubSeparator = isSubSeparator;
-
+            public override DesignerActionItem? Item => null;
             public override Line CreateLine(IServiceProvider serviceProvider, DesignerActionPanel actionPanel)
             {
                 return new SeparatorLine(serviceProvider, actionPanel, _isSubSeparator);

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.SeparatorLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.SeparatorLine.cs
@@ -11,25 +11,15 @@ internal sealed partial class DesignerActionPanel
     private sealed class SeparatorLine : Line
     {
         private readonly bool _isSubSeparator;
-        public SeparatorLine(IServiceProvider serviceProvider, DesignerActionPanel actionPanel) : this(serviceProvider, actionPanel, false)
-        {
-        }
 
-        public SeparatorLine(IServiceProvider serviceProvider, DesignerActionPanel actionPanel, bool isSubSeparator) : base(serviceProvider, actionPanel)
+        private SeparatorLine(IServiceProvider serviceProvider, DesignerActionPanel actionPanel, bool isSubSeparator) : base(serviceProvider, actionPanel)
         {
             _isSubSeparator = isSubSeparator;
         }
 
-        public sealed override string FocusId
-        {
-            get => string.Empty;
-        }
+        public override string FocusId => string.Empty;
 
         public bool IsSubSeparator => _isSubSeparator;
-
-        protected override void AddControls(List<Control> controls)
-        {
-        }
 
         public sealed override void Focus() => Debug.Fail("Should never try to focus a SeparatorLine");
 
@@ -45,6 +35,18 @@ internal sealed partial class DesignerActionPanel
 
         internal override void UpdateActionItem(DesignerActionList? actionList, DesignerActionItem? actionItem, ToolTip toolTip, ref int currentTabIndex)
         {
+        }
+
+        public sealed class Info(bool isSubSeparator = false) : LineInfo(null, null)
+        {
+            private readonly bool _isSubSeparator = isSubSeparator;
+
+            public override Line CreateLine(IServiceProvider serviceProvider, DesignerActionPanel actionPanel)
+            {
+                return new SeparatorLine(serviceProvider, actionPanel, _isSubSeparator);
+            }
+
+            public override Type LineType => typeof(SeparatorLine);
         }
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.TextBoxPropertyLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.TextBoxPropertyLine.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.Drawing;
 using System.Windows.Forms;
 
@@ -12,14 +10,12 @@ internal sealed partial class DesignerActionPanel
 {
     private class TextBoxPropertyLine : PropertyLine
     {
-        private TextBox _textBox;
-        private EditorLabel _readOnlyTextBoxLabel;
-        private Control _editControl;
-        private Label _label;
+        private TextBox? _textBox;
+        private EditorLabel? _readOnlyTextBoxLabel;
+        private Label? _label;
         private int _editXPos;
         private bool _textBoxDirty;
         private Point _editRegionLocation;
-        private Point _editRegionRelativeLocation;
         private Size _editRegionSize;
 
         public TextBoxPropertyLine(IServiceProvider serviceProvider, DesignerActionPanel actionPanel)
@@ -27,20 +23,14 @@ internal sealed partial class DesignerActionPanel
         {
         }
 
-        protected Control EditControl
-        {
-            get => _editControl;
-        }
+        protected Control? EditControl { get; private set; }
 
         protected Point EditRegionLocation
         {
             get => _editRegionLocation;
         }
 
-        protected Point EditRegionRelativeLocation
-        {
-            get => _editRegionRelativeLocation;
-        }
+        protected Point EditRegionRelativeLocation { get; private set; }
 
         protected Size EditRegionSize
         {
@@ -88,12 +78,12 @@ internal sealed partial class DesignerActionPanel
 
         public sealed override void Focus()
         {
-            _editControl.Focus();
+            EditControl!.Focus();
         }
 
         internal int GetEditRegionXPos()
         {
-            if (string.IsNullOrEmpty(_label.Text))
+            if (string.IsNullOrEmpty(_label!.Text))
             {
                 return LineLeftMargin;
             }
@@ -108,7 +98,7 @@ internal sealed partial class DesignerActionPanel
         public override Size LayoutControls(int top, int width, bool measureOnly)
         {
             // Figure out our minimum width, Compare to proposed width, If we are smaller, widen the textbox to fit the line based on the bonus
-            int textBoxPreferredHeight = _textBox.GetPreferredSize(new Size(int.MaxValue, int.MaxValue)).Height;
+            int textBoxPreferredHeight = _textBox!.GetPreferredSize(new Size(int.MaxValue, int.MaxValue)).Height;
             textBoxPreferredHeight += TextBoxHeightFixup;
             int height = textBoxPreferredHeight + LineVerticalPadding + TextBoxLineInnerPadding * 2 + 2; // 2 == border size
 
@@ -120,21 +110,21 @@ internal sealed partial class DesignerActionPanel
             if (!measureOnly)
             {
                 _editRegionLocation = new Point(editRegionXPos, top + TextBoxTopPadding);
-                _editRegionRelativeLocation = new Point(editRegionXPos, TextBoxTopPadding);
+                EditRegionRelativeLocation = new Point(editRegionXPos, TextBoxTopPadding);
                 _editRegionSize = new Size(EditInputWidth + textBoxWidthBonus, textBoxPreferredHeight + TextBoxLineInnerPadding * 2);
 
-                _label.Location = new Point(LineLeftMargin, top);
+                _label!.Location = new Point(LineLeftMargin, top);
                 int labelPreferredWidth = _label.GetPreferredSize(new Size(int.MaxValue, int.MaxValue)).Width;
                 _label.Size = new Size(labelPreferredWidth, height);
                 int specialPadding = 0;
-                if (_editControl is TextBox)
+                if (EditControl is TextBox)
                 {
                     specialPadding = 2;
                 }
 
-                _editControl.Location = new Point(_editRegionLocation.X + GetTextBoxLeftPadding(textBoxPreferredHeight) + 1 + specialPadding, _editRegionLocation.Y + TextBoxLineInnerPadding + 1);
-                _editControl.Width = _editRegionSize.Width - GetTextBoxRightPadding(textBoxPreferredHeight) - GetTextBoxLeftPadding(textBoxPreferredHeight) - specialPadding;
-                _editControl.Height = _editRegionSize.Height - TextBoxLineInnerPadding * 2 - 1;
+                EditControl!.Location = new Point(_editRegionLocation.X + GetTextBoxLeftPadding(textBoxPreferredHeight) + 1 + specialPadding, _editRegionLocation.Y + TextBoxLineInnerPadding + 1);
+                EditControl.Width = _editRegionSize.Width - GetTextBoxRightPadding(textBoxPreferredHeight) - GetTextBoxLeftPadding(textBoxPreferredHeight) - specialPadding;
+                EditControl.Height = _editRegionSize.Height - TextBoxLineInnerPadding * 2 - 1;
             }
 
             return new Size(width, height);
@@ -144,35 +134,35 @@ internal sealed partial class DesignerActionPanel
 
         protected override void OnPropertyTaskItemUpdated(ToolTip toolTip, ref int currentTabIndex)
         {
-            _label.Text = StripAmpersands(PropertyItem.DisplayName);
+            _label!.Text = StripAmpersands(PropertyItem!.DisplayName);
             _label.TabIndex = currentTabIndex++;
             toolTip.SetToolTip(_label, PropertyItem.Description);
             _textBoxDirty = false;
 
             if (IsReadOnly())
             {
-                _readOnlyTextBoxLabel.Visible = true;
-                _textBox.Visible = false;
+                _readOnlyTextBoxLabel!.Visible = true;
+                _textBox!.Visible = false;
                 // REVIEW: Setting Visible to false doesn't seem to work, so position far away
                 _textBox.Location = new Point(int.MaxValue, int.MaxValue);
-                _editControl = _readOnlyTextBoxLabel;
+                EditControl = _readOnlyTextBoxLabel;
             }
             else
             {
-                _readOnlyTextBoxLabel.Visible = false;
+                _readOnlyTextBoxLabel!.Visible = false;
                 // REVIEW: Setting Visible to false doesn't seem to work, so position far away
                 _readOnlyTextBoxLabel.Location = new Point(int.MaxValue, int.MaxValue);
-                _textBox.Visible = true;
-                _editControl = _textBox;
+                _textBox!.Visible = true;
+                EditControl = _textBox;
             }
 
-            _editControl.AccessibleDescription = PropertyItem.Description;
-            _editControl.AccessibleName = StripAmpersands(PropertyItem.DisplayName);
-            _editControl.TabIndex = currentTabIndex++;
-            _editControl.BringToFront();
+            EditControl.AccessibleDescription = PropertyItem.Description;
+            EditControl.AccessibleName = StripAmpersands(PropertyItem.DisplayName);
+            EditControl.TabIndex = currentTabIndex++;
+            EditControl.BringToFront();
         }
 
-        protected virtual void OnReadOnlyTextBoxLabelClick(object sender, MouseEventArgs e)
+        protected virtual void OnReadOnlyTextBoxLabelClick(object? sender, MouseEventArgs e)
         {
             if (e.Button == MouseButtons.Left)
             {
@@ -180,19 +170,19 @@ internal sealed partial class DesignerActionPanel
             }
         }
 
-        private void OnReadOnlyTextBoxLabelEnter(object sender, EventArgs e)
+        private void OnReadOnlyTextBoxLabelEnter(object? sender, EventArgs e)
         {
-            _readOnlyTextBoxLabel.ForeColor = SystemColors.HighlightText;
+            _readOnlyTextBoxLabel!.ForeColor = SystemColors.HighlightText;
             _readOnlyTextBoxLabel.BackColor = SystemColors.Highlight;
         }
 
-        private void OnReadOnlyTextBoxLabelLeave(object sender, EventArgs e)
+        private void OnReadOnlyTextBoxLabelLeave(object? sender, EventArgs e)
         {
-            _readOnlyTextBoxLabel.ForeColor = SystemColors.WindowText;
+            _readOnlyTextBoxLabel!.ForeColor = SystemColors.WindowText;
             _readOnlyTextBoxLabel.BackColor = SystemColors.Window;
         }
 
-        protected TypeConverter.StandardValuesCollection GetStandardValues()
+        protected TypeConverter.StandardValuesCollection? GetStandardValues()
         {
             TypeConverter converter = PropertyDescriptor.Converter;
             if (converter is not null &&
@@ -210,7 +200,7 @@ internal sealed partial class DesignerActionPanel
             {
                 e.Handled = true;
                 // Try to find the existing value and then pick the one after it
-                TypeConverter.StandardValuesCollection standardValues = GetStandardValues();
+                TypeConverter.StandardValuesCollection? standardValues = GetStandardValues();
                 if (standardValues is not null)
                 {
                     for (int i = 0; i < standardValues.Count; i++)
@@ -240,7 +230,7 @@ internal sealed partial class DesignerActionPanel
             {
                 e.Handled = true;
                 // Try to find the existing value and then pick the one before it
-                TypeConverter.StandardValuesCollection standardValues = GetStandardValues();
+                TypeConverter.StandardValuesCollection? standardValues = GetStandardValues();
                 if (standardValues is not null)
                 {
                     for (int i = 0; i < standardValues.Count; i++)
@@ -267,15 +257,15 @@ internal sealed partial class DesignerActionPanel
             }
         }
 
-        private void OnReadOnlyTextBoxLabelKeyDown(object sender, KeyEventArgs e)
+        private void OnReadOnlyTextBoxLabelKeyDown(object? sender, KeyEventArgs e)
         {
             // Delegate the rest of the processing to a common helper
             OnEditControlKeyDown(e);
         }
 
-        private void OnTextBoxKeyDown(object sender, KeyEventArgs e)
+        private void OnTextBoxKeyDown(object? sender, KeyEventArgs e)
         {
-            if (ActionPanel.DropDownActive)
+            if (ActionPanel._dropDownActive)
             {
                 return;
             }
@@ -291,9 +281,9 @@ internal sealed partial class DesignerActionPanel
             OnEditControlKeyDown(e);
         }
 
-        private void OnTextBoxLostFocus(object sender, EventArgs e)
+        private void OnTextBoxLostFocus(object? sender, EventArgs e)
         {
-            if (ActionPanel.DropDownActive)
+            if (ActionPanel._dropDownActive)
             {
                 return;
             }
@@ -301,9 +291,9 @@ internal sealed partial class DesignerActionPanel
             UpdateValue();
         }
 
-        private void OnTextBoxTextChanged(object sender, EventArgs e) => _textBoxDirty = true;
+        private void OnTextBoxTextChanged(object? sender, EventArgs e) => _textBoxDirty = true;
 
-        protected override void OnValueChanged() => _editControl.Text = PropertyDescriptor.Converter.ConvertToString(TypeDescriptorContext, Value);
+        protected override void OnValueChanged() => EditControl!.Text = PropertyDescriptor.Converter.ConvertToString(TypeDescriptorContext, Value);
 
         public override void PaintLine(Graphics g, int lineWidth, int lineHeight)
         {
@@ -315,7 +305,7 @@ internal sealed partial class DesignerActionPanel
         internal void SetEditRegionXPos(int xPos)
         {
             // Ignore the x-position if we have no text. This allows the textbox to span the entire width of the panel.
-            if (!string.IsNullOrEmpty(_label.Text))
+            if (!string.IsNullOrEmpty(_label!.Text))
             {
                 _editXPos = xPos;
             }
@@ -329,7 +319,7 @@ internal sealed partial class DesignerActionPanel
         {
             if (_textBoxDirty)
             {
-                SetValue(_editControl.Text);
+                SetValue(EditControl!.Text);
                 _textBoxDirty = false;
             }
         }
@@ -358,8 +348,7 @@ internal sealed partial class DesignerActionPanel
 
             protected override bool IsInputKey(Keys keyData)
             {
-                if (keyData == Keys.Down ||
-                    keyData == Keys.Up)
+                if (keyData is Keys.Down or Keys.Up)
                 {
                     return true;
                 }
@@ -374,10 +363,7 @@ internal sealed partial class DesignerActionPanel
                 {
                 }
 
-                public override string Value
-                {
-                    get => Owner.Text;
-                }
+                public override string Value => Owner!.Text;
             }
         }
     }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.TextBoxPropertyLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.TextBoxPropertyLine.cs
@@ -353,7 +353,7 @@ internal sealed partial class DesignerActionPanel
             }
         }
 
-        public sealed class Info(DesignerActionList list, DesignerActionItem item) : LineInfo(list, item)
+        public sealed class Info(DesignerActionList list, DesignerActionPropertyItem item) : PropertyLineInfo(list, item)
         {
             public override Line CreateLine(IServiceProvider serviceProvider, DesignerActionPanel actionPanel)
             {

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.TextBoxPropertyLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.TextBoxPropertyLine.cs
@@ -116,11 +116,7 @@ internal sealed partial class DesignerActionPanel
                 _label!.Location = new Point(LineLeftMargin, top);
                 int labelPreferredWidth = _label.GetPreferredSize(new Size(int.MaxValue, int.MaxValue)).Width;
                 _label.Size = new Size(labelPreferredWidth, height);
-                int specialPadding = 0;
-                if (EditControl is TextBox)
-                {
-                    specialPadding = 2;
-                }
+                int specialPadding = EditControl is TextBox ? 2 : 0;
 
                 EditControl!.Location = new Point(_editRegionLocation.X + GetTextBoxLeftPadding(textBoxPreferredHeight) + 1 + specialPadding, _editRegionLocation.Y + TextBoxLineInnerPadding + 1);
                 EditControl.Width = _editRegionSize.Width - GetTextBoxRightPadding(textBoxPreferredHeight) - GetTextBoxLeftPadding(textBoxPreferredHeight) - specialPadding;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.TextLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.TextLine.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.Drawing;
 using System.Windows.Forms;
 
@@ -12,8 +10,8 @@ internal sealed partial class DesignerActionPanel
 {
     private class TextLine : Line
     {
-        private Label _label;
-        private DesignerActionTextItem _textItem;
+        private Label? _label;
+        private DesignerActionTextItem? _textItem;
 
         public TextLine(IServiceProvider serviceProvider, DesignerActionPanel actionPanel)
             : base(serviceProvider, actionPanel)
@@ -45,7 +43,7 @@ internal sealed partial class DesignerActionPanel
 
         public override Size LayoutControls(int top, int width, bool measureOnly)
         {
-            Size labelSize = _label.GetPreferredSize(new Size(int.MaxValue, int.MaxValue));
+            Size labelSize = _label!.GetPreferredSize(new Size(int.MaxValue, int.MaxValue));
             if (!measureOnly)
             {
                 _label.Location = new Point(LineLeftMargin, top + LineVerticalPadding / 2);
@@ -55,7 +53,7 @@ internal sealed partial class DesignerActionPanel
             return labelSize + new Size(LineLeftMargin + LineRightMargin, LineVerticalPadding);
         }
 
-        private void OnParentControlFontChanged(object sender, EventArgs e)
+        private void OnParentControlFontChanged(object? sender, EventArgs e)
         {
             if (_label is not null && _label.Font is not null)
             {
@@ -68,10 +66,10 @@ internal sealed partial class DesignerActionPanel
             return ActionPanel.Font;
         }
 
-        internal override void UpdateActionItem(DesignerActionList actionList, DesignerActionItem actionItem, ToolTip toolTip, ref int currentTabIndex)
+        internal override void UpdateActionItem(DesignerActionList? actionList, DesignerActionItem? actionItem, ToolTip toolTip, ref int currentTabIndex)
         {
-            _textItem = (DesignerActionTextItem)actionItem;
-            _label.Text = StripAmpersands(_textItem.DisplayName);
+            _textItem = (DesignerActionTextItem)actionItem!;
+            _label!.Text = StripAmpersands(_textItem.DisplayName);
             _label.Font = GetFont();
             _label.TabIndex = currentTabIndex++;
             toolTip.SetToolTip(_label, _textItem.Description);

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.TextLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.TextLine.cs
@@ -10,31 +10,24 @@ internal sealed partial class DesignerActionPanel
 {
     private class TextLine : Line
     {
-        private Label? _label;
+        private readonly Label _label;
         private DesignerActionTextItem? _textItem;
 
-        public TextLine(IServiceProvider serviceProvider, DesignerActionPanel actionPanel)
+        protected TextLine(IServiceProvider serviceProvider, DesignerActionPanel actionPanel)
             : base(serviceProvider, actionPanel)
         {
             actionPanel.FontChanged += new EventHandler(OnParentControlFontChanged);
-        }
-
-        public sealed override string FocusId
-        {
-            get => string.Empty;
-        }
-
-        protected override void AddControls(List<Control> controls)
-        {
             _label = new Label
             {
                 BackColor = Color.Transparent,
                 ForeColor = ActionPanel.LabelForeColor,
                 TextAlign = ContentAlignment.MiddleLeft,
-                UseMnemonic = false
+                UseMnemonic = false,
             };
-            controls.Add(_label);
+            AddedControls.Add(_label);
         }
+
+        public sealed override string FocusId => string.Empty;
 
         public sealed override void Focus()
         {
@@ -43,7 +36,7 @@ internal sealed partial class DesignerActionPanel
 
         public override Size LayoutControls(int top, int width, bool measureOnly)
         {
-            Size labelSize = _label!.GetPreferredSize(new Size(int.MaxValue, int.MaxValue));
+            Size labelSize = _label.GetPreferredSize(new Size(int.MaxValue, int.MaxValue));
             if (!measureOnly)
             {
                 _label.Location = new Point(LineLeftMargin, top + LineVerticalPadding / 2);
@@ -55,7 +48,7 @@ internal sealed partial class DesignerActionPanel
 
         private void OnParentControlFontChanged(object? sender, EventArgs e)
         {
-            if (_label is not null && _label.Font is not null)
+            if (_label.Font is not null)
             {
                 _label.Font = GetFont();
             }
@@ -69,10 +62,20 @@ internal sealed partial class DesignerActionPanel
         internal override void UpdateActionItem(DesignerActionList? actionList, DesignerActionItem? actionItem, ToolTip toolTip, ref int currentTabIndex)
         {
             _textItem = (DesignerActionTextItem)actionItem!;
-            _label!.Text = StripAmpersands(_textItem.DisplayName);
+            _label.Text = StripAmpersands(_textItem.DisplayName);
             _label.Font = GetFont();
             _label.TabIndex = currentTabIndex++;
             toolTip.SetToolTip(_label, _textItem.Description);
+        }
+
+        public sealed class Info(DesignerActionList list, DesignerActionItem item) : LineInfo(list, item)
+        {
+            public override Line CreateLine(IServiceProvider serviceProvider, DesignerActionPanel actionPanel)
+            {
+                return new TextLine(serviceProvider, actionPanel);
+            }
+
+            public override Type LineType => typeof(TextLine);
         }
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.TextLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.TextLine.cs
@@ -59,17 +59,19 @@ internal sealed partial class DesignerActionPanel
             return ActionPanel.Font;
         }
 
-        internal override void UpdateActionItem(DesignerActionList? actionList, DesignerActionItem? actionItem, ToolTip toolTip, ref int currentTabIndex)
+        internal override void UpdateActionItem(LineInfo lineInfo, ToolTip toolTip, ref int currentTabIndex)
         {
-            _textItem = (DesignerActionTextItem)actionItem!;
+            Info info = (Info)lineInfo;
+            _textItem = info.Item;
             _label.Text = StripAmpersands(_textItem.DisplayName);
             _label.Font = GetFont();
             _label.TabIndex = currentTabIndex++;
             toolTip.SetToolTip(_label, _textItem.Description);
         }
 
-        public sealed class Info(DesignerActionList list, DesignerActionItem item) : LineInfo(list, item)
+        public sealed class Info(DesignerActionList list, DesignerActionTextItem item) : StandardLineInfo(list)
         {
+            public override DesignerActionTextItem Item { get; } = item;
             public override Line CreateLine(IServiceProvider serviceProvider, DesignerActionPanel actionPanel)
             {
                 return new TextLine(serviceProvider, actionPanel);

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.TypeDescriptorContext.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.TypeDescriptorContext.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 namespace System.ComponentModel.Design;
 
 internal sealed partial class DesignerActionPanel
@@ -10,31 +8,29 @@ internal sealed partial class DesignerActionPanel
     internal sealed class TypeDescriptorContext : ITypeDescriptorContext
     {
         private readonly IServiceProvider _serviceProvider;
-        private readonly PropertyDescriptor _propertyDescriptor;
-        private readonly object _instance;
 
         public TypeDescriptorContext(IServiceProvider serviceProvider, PropertyDescriptor propertyDescriptor, object instance)
         {
             _serviceProvider = serviceProvider;
-            _propertyDescriptor = propertyDescriptor;
-            _instance = instance;
+            PropertyDescriptor = propertyDescriptor;
+            Instance = instance;
         }
 
-        private IComponentChangeService ComponentChangeService => _serviceProvider.GetService<IComponentChangeService>();
+        private IComponentChangeService? ComponentChangeService => _serviceProvider.GetService<IComponentChangeService>();
 
-        public IContainer Container => _serviceProvider.GetService<IContainer>();
+        public IContainer? Container => _serviceProvider.GetService<IContainer>();
 
-        public object Instance => _instance;
+        public object Instance { get; }
 
-        public PropertyDescriptor PropertyDescriptor => _propertyDescriptor;
+        public PropertyDescriptor PropertyDescriptor { get; }
 
-        public object GetService(Type serviceType) => _serviceProvider.GetService(serviceType);
+        public object? GetService(Type serviceType) => _serviceProvider.GetService(serviceType);
 
         public bool OnComponentChanging()
         {
             try
             {
-                ComponentChangeService?.OnComponentChanging(_instance, _propertyDescriptor);
+                ComponentChangeService?.OnComponentChanging(Instance, PropertyDescriptor);
                 return true;
             }
             catch (CheckoutException ce) when (ce == CheckoutException.Canceled)
@@ -43,6 +39,6 @@ internal sealed partial class DesignerActionPanel
             }
         }
 
-        public void OnComponentChanged() => ComponentChangeService?.OnComponentChanged(_instance, _propertyDescriptor);
+        public void OnComponentChanged() => ComponentChangeService?.OnComponentChanged(Instance, PropertyDescriptor);
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.Collections;
 using System.Collections.Specialized;
 using System.Drawing;
@@ -38,25 +36,13 @@ internal sealed partial class DesignerActionPanel : ContainerControl
     private const int PanelHeaderHorizontalPadding = 5; // Horizontal padding within the header of the panel
 
     private const int TextBoxHeightFixup = 2; // Countereffects the fix for VSWhidbey 359726 - we relied on the broken behavior before
-    private CommandID[] _filteredCommandIDs;
+    private CommandID[]? _filteredCommandIDs;
     private readonly ToolTip _toolTip;
     private readonly List<Line> _lines;
     private readonly List<int> _lineYPositions;
     private readonly List<int> _lineHeights;
 
-    private readonly Color _gradientLightColor = SystemColors.Control;
-    private readonly Color _gradientDarkColor = SystemColors.Control;
-    private readonly Color _titleBarColor = SystemColors.ActiveCaption;
-    private readonly Color _titleBarUnselectedColor = SystemColors.InactiveCaption;
-    private readonly Color _titleBarTextColor = SystemColors.ActiveCaptionText;
-    private readonly Color _separatorColor = SystemColors.ControlDark;
-    private readonly Color _borderColor = SystemColors.ActiveBorder;
-    private readonly Color _linkColor = SystemColors.HotTrack;
-    private readonly Color _activeLinkColor = SystemColors.HotTrack;
-    private readonly Color _labelForeColor = SystemColors.ControlText;
-
     private readonly IServiceProvider _serviceProvider;
-    private bool _inMethodInvoke;
     private bool _updatingTasks;
     private bool _dropDownActive;
 
@@ -74,194 +60,131 @@ internal sealed partial class DesignerActionPanel : ContainerControl
         _lineYPositions = new List<int>();
         _toolTip = new ToolTip();
         // Try to get the font from the IUIService, otherwise, use the default
-        IUIService uiService = (IUIService)ServiceProvider.GetService(typeof(IUIService));
+        IUIService? uiService = _serviceProvider.GetService<IUIService>();
         if (uiService is not null)
         {
-            Font = (Font)uiService.Styles["DialogFont"];
-            if (uiService.Styles["VsColorPanelGradientDark"] is Color)
+            Font = (Font)uiService.Styles["DialogFont"]!;
+            if (uiService.Styles["VsColorPanelGradientDark"] is Color vsColorPanelGradientDarkColor)
             {
-                _gradientDarkColor = (Color)uiService.Styles["VsColorPanelGradientDark"];
+                GradientDarkColor = vsColorPanelGradientDarkColor;
             }
 
-            if (uiService.Styles["VsColorPanelGradientLight"] is Color)
+            if (uiService.Styles["VsColorPanelGradientLight"] is Color vsColorPanelGradientLight)
             {
-                _gradientLightColor = (Color)uiService.Styles["VsColorPanelGradientLight"];
+                GradientLightColor = vsColorPanelGradientLight;
             }
 
-            if (uiService.Styles["VsColorPanelHyperLink"] is Color)
+            if (uiService.Styles["VsColorPanelHyperLink"] is Color vsColorPanelHyperLink)
             {
-                _linkColor = (Color)uiService.Styles["VsColorPanelHyperLink"];
+                LinkColor = vsColorPanelHyperLink;
             }
 
-            if (uiService.Styles["VsColorPanelHyperLinkPressed"] is Color)
+            if (uiService.Styles["VsColorPanelHyperLinkPressed"] is Color vsColorPanelHyperLinkPressed)
             {
-                _activeLinkColor = (Color)uiService.Styles["VsColorPanelHyperLinkPressed"];
+                ActiveLinkColor = vsColorPanelHyperLinkPressed;
             }
 
-            if (uiService.Styles["VsColorPanelTitleBar"] is Color)
+            if (uiService.Styles["VsColorPanelTitleBar"] is Color vsColorPanelTitleBar)
             {
-                _titleBarColor = (Color)uiService.Styles["VsColorPanelTitleBar"];
+                TitleBarColor = vsColorPanelTitleBar;
             }
 
-            if (uiService.Styles["VsColorPanelTitleBarUnselected"] is Color)
+            if (uiService.Styles["VsColorPanelTitleBarUnselected"] is Color vsColorPanelTitleBarUnselected)
             {
-                _titleBarUnselectedColor = (Color)uiService.Styles["VsColorPanelTitleBarUnselected"];
+                TitleBarUnselectedColor = vsColorPanelTitleBarUnselected;
             }
 
-            if (uiService.Styles["VsColorPanelTitleBarText"] is Color)
+            if (uiService.Styles["VsColorPanelTitleBarText"] is Color vsColorPanelTitleBarText)
             {
-                _titleBarTextColor = (Color)uiService.Styles["VsColorPanelTitleBarText"];
+                TitleBarTextColor = vsColorPanelTitleBarText;
             }
 
-            if (uiService.Styles["VsColorPanelBorder"] is Color)
+            if (uiService.Styles["VsColorPanelBorder"] is Color vsColorPanelBorder)
             {
-                _borderColor = (Color)uiService.Styles["VsColorPanelBorder"];
+                BorderColor = vsColorPanelBorder;
             }
 
-            if (uiService.Styles["VsColorPanelSeparator"] is Color)
+            if (uiService.Styles["VsColorPanelSeparator"] is Color vsColorPanelSeparator)
             {
-                _separatorColor = (Color)uiService.Styles["VsColorPanelSeparator"];
+                SeparatorColor = vsColorPanelSeparator;
             }
 
-            if (uiService.Styles["VsColorPanelText"] is Color)
+            if (uiService.Styles["VsColorPanelText"] is Color vsColorPanelText)
             {
-                _labelForeColor = (Color)uiService.Styles["VsColorPanelText"];
+                LabelForeColor = vsColorPanelText;
             }
         }
 
         MinimumSize = new Size(150, 0);
     }
 
-    public Color ActiveLinkColor
-    {
-        get => _activeLinkColor;
-    }
+    public Color ActiveLinkColor { get; } = SystemColors.HotTrack;
 
-    public Color BorderColor
-    {
-        get => _borderColor;
-    }
-
-    private bool DropDownActive
-    {
-        get => _dropDownActive;
-    }
+    public Color BorderColor { get; } = SystemColors.ActiveBorder;
 
     /// <summary>
     ///  Returns the list of commands that should be filtered by the form that hosts this panel. This is done so that these specific commands will not get passed on to VS, and can instead be handled by the panel itself.
     /// </summary>
-    public CommandID[] FilteredCommandIDs
-    {
-        get
+    public CommandID[] FilteredCommandIDs =>
+        _filteredCommandIDs ??= new CommandID[]
         {
-            _filteredCommandIDs ??= new CommandID[]
-                {
-                    StandardCommands.Copy,
-                    StandardCommands.Cut,
-                    StandardCommands.Delete,
-                    StandardCommands.F1Help,
-                    StandardCommands.Paste,
-                    StandardCommands.Redo,
-                    StandardCommands.SelectAll,
-                    StandardCommands.Undo,
-                    MenuCommands.KeyCancel,
-                    MenuCommands.KeyReverseCancel,
-                    MenuCommands.KeyDefaultAction,
-                    MenuCommands.KeyEnd,
-                    MenuCommands.KeyHome,
-                    MenuCommands.KeyMoveDown,
-                    MenuCommands.KeyMoveLeft,
-                    MenuCommands.KeyMoveRight,
-                    MenuCommands.KeyMoveUp,
-                    MenuCommands.KeyNudgeDown,
-                    MenuCommands.KeyNudgeHeightDecrease,
-                    MenuCommands.KeyNudgeHeightIncrease,
-                    MenuCommands.KeyNudgeLeft,
-                    MenuCommands.KeyNudgeRight,
-                    MenuCommands.KeyNudgeUp,
-                    MenuCommands.KeyNudgeWidthDecrease,
-                    MenuCommands.KeyNudgeWidthIncrease,
-                    MenuCommands.KeySizeHeightDecrease,
-                    MenuCommands.KeySizeHeightIncrease,
-                    MenuCommands.KeySizeWidthDecrease,
-                    MenuCommands.KeySizeWidthIncrease,
-                    MenuCommands.KeySelectNext,
-                    MenuCommands.KeySelectPrevious,
-                    MenuCommands.KeyShiftEnd,
-                    MenuCommands.KeyShiftHome,
-                };
-
-            return _filteredCommandIDs;
-        }
-    }
+            StandardCommands.Copy,
+            StandardCommands.Cut,
+            StandardCommands.Delete,
+            StandardCommands.F1Help,
+            StandardCommands.Paste,
+            StandardCommands.Redo,
+            StandardCommands.SelectAll,
+            StandardCommands.Undo,
+            MenuCommands.KeyCancel,
+            MenuCommands.KeyReverseCancel,
+            MenuCommands.KeyDefaultAction,
+            MenuCommands.KeyEnd,
+            MenuCommands.KeyHome,
+            MenuCommands.KeyMoveDown,
+            MenuCommands.KeyMoveLeft,
+            MenuCommands.KeyMoveRight,
+            MenuCommands.KeyMoveUp,
+            MenuCommands.KeyNudgeDown,
+            MenuCommands.KeyNudgeHeightDecrease,
+            MenuCommands.KeyNudgeHeightIncrease,
+            MenuCommands.KeyNudgeLeft,
+            MenuCommands.KeyNudgeRight,
+            MenuCommands.KeyNudgeUp,
+            MenuCommands.KeyNudgeWidthDecrease,
+            MenuCommands.KeyNudgeWidthIncrease,
+            MenuCommands.KeySizeHeightDecrease,
+            MenuCommands.KeySizeHeightIncrease,
+            MenuCommands.KeySizeWidthDecrease,
+            MenuCommands.KeySizeWidthIncrease,
+            MenuCommands.KeySelectNext,
+            MenuCommands.KeySelectPrevious,
+            MenuCommands.KeyShiftEnd,
+            MenuCommands.KeyShiftHome,
+        };
 
     /// <summary>
     ///  Gets the Line that currently has input focus.
     /// </summary>
-    private Line FocusedLine
-    {
-        get
-        {
-            Control activeControl = ActiveControl;
-            if (activeControl is not null)
-            {
-                return activeControl.Tag as Line;
-            }
+    private Line? FocusedLine => ActiveControl?.Tag as Line;
 
-            return null;
-        }
-    }
+    public Color GradientDarkColor { get; } = SystemColors.Control;
 
-    public Color GradientDarkColor
-    {
-        get => _gradientDarkColor;
-    }
+    public Color GradientLightColor { get; } = SystemColors.Control;
 
-    public Color GradientLightColor
-    {
-        get => _gradientLightColor;
-    }
+    public bool InMethodInvoke { get; internal set; }
 
-    public bool InMethodInvoke
-    {
-        get => _inMethodInvoke;
-        internal set => _inMethodInvoke = value;
-    }
+    public Color LinkColor { get; } = SystemColors.HotTrack;
 
-    public Color LinkColor
-    {
-        get => _linkColor;
-    }
+    public Color SeparatorColor { get; } = SystemColors.ControlDark;
 
-    public Color SeparatorColor
-    {
-        get => _separatorColor;
-    }
+    public Color TitleBarColor { get; } = SystemColors.ActiveCaption;
 
-    private IServiceProvider ServiceProvider
-    {
-        get => _serviceProvider;
-    }
+    public Color TitleBarTextColor { get; } = SystemColors.ActiveCaptionText;
 
-    public Color TitleBarColor
-    {
-        get => _titleBarColor;
-    }
+    public Color TitleBarUnselectedColor { get; } = SystemColors.InactiveCaption;
 
-    public Color TitleBarTextColor
-    {
-        get => _titleBarTextColor;
-    }
-
-    public Color TitleBarUnselectedColor
-    {
-        get => _titleBarUnselectedColor;
-    }
-
-    public Color LabelForeColor
-    {
-        get => _labelForeColor;
-    }
+    public Color LabelForeColor { get; } = SystemColors.ControlText;
 
     /// <summary>
     ///  Helper event so that Lines can be notified of this event.
@@ -283,21 +206,21 @@ internal sealed partial class DesignerActionPanel : ContainerControl
 
     private static void AddToCategories(LineInfo lineInfo, ListDictionary categories)
     {
-        string categoryName = lineInfo.Item.Category;
+        string? categoryName = lineInfo.Item!.Category;
         categoryName ??= string.Empty;
 
-        ListDictionary category = (ListDictionary)categories[categoryName];
+        ListDictionary? category = (ListDictionary?)categories[categoryName];
         if (category is null)
         {
             category = new ListDictionary();
             categories.Add(categoryName, category);
         }
 
-        List<LineInfo> categoryList = (List<LineInfo>)category[lineInfo.List];
+        List<LineInfo>? categoryList = (List<LineInfo>?)category[lineInfo.List!];
         if (categoryList is null)
         {
             categoryList = new List<LineInfo>();
-            category.Add(lineInfo.List, categoryList);
+            category.Add(lineInfo.List!, categoryList);
         }
 
         categoryList.Add(lineInfo);
@@ -323,7 +246,7 @@ internal sealed partial class DesignerActionPanel : ContainerControl
             }
         }
 
-        bool fBelowAnchor = (fRightOfAnchor ? true : false);
+        bool fBelowAnchor = fRightOfAnchor;
         bool fAlignToScreenTop = false;
         if (fBelowAnchor)
         {
@@ -482,7 +405,7 @@ internal sealed partial class DesignerActionPanel : ContainerControl
             return true;
         }
 
-        return (pd.ComponentType.GetProperty(pd.Name).GetSetMethod() is null);
+        return (pd.ComponentType.GetProperty(pd.Name)!.GetSetMethod() is null);
     }
 
     protected override void OnFontChanged(EventArgs e)
@@ -494,10 +417,10 @@ internal sealed partial class DesignerActionPanel : ContainerControl
 
     private void OnFormActivated(object sender, EventArgs e)
     {
-        ((EventHandler)Events[s_eventFormActivated])?.Invoke(sender, e);
+        ((EventHandler?)Events[s_eventFormActivated])?.Invoke(sender, e);
     }
 
-    private void OnFormClosing(object sender, CancelEventArgs e)
+    private void OnFormClosing(object? sender, CancelEventArgs e)
     {
         if (!e.Cancel && TopLevelControl is not null)
         {
@@ -512,7 +435,7 @@ internal sealed partial class DesignerActionPanel : ContainerControl
 
     private void OnFormDeactivate(object sender, EventArgs e)
     {
-        ((EventHandler)Events[s_eventFormDeactivate])?.Invoke(sender, e);
+        ((EventHandler?)Events[s_eventFormDeactivate])?.Invoke(sender, e);
     }
 
     protected override void OnHandleCreated(EventArgs e)
@@ -602,7 +525,7 @@ internal sealed partial class DesignerActionPanel : ContainerControl
     protected override bool ProcessDialogKey(Keys keyData)
     {
         // TODO: RightToLeft management for left/right arrow keys (from old DesignerActionPanel)
-        Line focusedLine = FocusedLine;
+        Line? focusedLine = FocusedLine;
         if (focusedLine is not null)
         {
             if (focusedLine.ProcessDialogKey(keyData))
@@ -620,7 +543,7 @@ internal sealed partial class DesignerActionPanel : ContainerControl
         return (SelectNextControl(ActiveControl, forward, true, true, true));
     }
 
-    private void ProcessLists(DesignerActionListCollection lists, ListDictionary categories)
+    private void ProcessLists(DesignerActionListCollection? lists, ListDictionary categories)
     {
         if (lists is null)
         {
@@ -641,7 +564,7 @@ internal sealed partial class DesignerActionPanel : ContainerControl
                             continue;
                         }
 
-                        LineInfo lineInfo = ProcessTaskItem(list, item);
+                        LineInfo? lineInfo = ProcessTaskItem(list, item);
                         if (lineInfo is null)
                         {
                             continue;
@@ -649,7 +572,7 @@ internal sealed partial class DesignerActionPanel : ContainerControl
 
                         AddToCategories(lineInfo, categories);
                         // Process lists from related component
-                        IComponent relatedComponent = null;
+                        IComponent? relatedComponent = null;
                         if (item is DesignerActionPropertyItem propItem)
                         {
                             relatedComponent = propItem.RelatedComponent;
@@ -664,7 +587,7 @@ internal sealed partial class DesignerActionPanel : ContainerControl
 
                         if (relatedComponent is not null)
                         {
-                            IEnumerable<LineInfo> relatedLineInfos = ProcessRelatedTaskItems(relatedComponent);
+                            IEnumerable<LineInfo>? relatedLineInfos = ProcessRelatedTaskItems(relatedComponent);
                             if (relatedLineInfos is not null)
                             {
                                 foreach (LineInfo relatedLineInfo in relatedLineInfos)
@@ -683,8 +606,8 @@ internal sealed partial class DesignerActionPanel : ContainerControl
     {
         // Add the related tasks
         Debug.Assert(relatedComponent is not null);
-        DesignerActionListCollection relatedLists = null;
-        DesignerActionService actionService = (DesignerActionService)ServiceProvider.GetService(typeof(DesignerActionService));
+        DesignerActionListCollection? relatedLists = null;
+        DesignerActionService? actionService = _serviceProvider.GetService<DesignerActionService>();
         if (actionService is not null)
         {
             relatedLists = actionService.GetComponentActions(relatedComponent);
@@ -692,16 +615,13 @@ internal sealed partial class DesignerActionPanel : ContainerControl
         else
         {
             // Try to use the component's service provider if it exists so that we end up getting the right IDesignerHost.
-            IServiceProvider serviceProvider = relatedComponent.Site;
-            serviceProvider ??= ServiceProvider;
+            IServiceProvider? serviceProvider = relatedComponent.Site;
+            serviceProvider ??= _serviceProvider;
 
-            IDesignerHost host = (IDesignerHost)serviceProvider.GetService(typeof(IDesignerHost));
-            if (host is not null)
+            IDesignerHost? host = serviceProvider.GetService<IDesignerHost>();
+            if (host?.GetDesigner(relatedComponent) is ComponentDesigner componentDesigner)
             {
-                if (host.GetDesigner(relatedComponent) is ComponentDesigner componentDesigner)
-                {
-                    relatedLists = componentDesigner.ActionLists;
-                }
+                relatedLists = componentDesigner.ActionLists;
             }
         }
 
@@ -722,7 +642,7 @@ internal sealed partial class DesignerActionPanel : ContainerControl
                             {
                                 if (relatedItem.AllowAssociate)
                                 {
-                                    LineInfo lineInfo = ProcessTaskItem(relatedList, relatedItem);
+                                    LineInfo? lineInfo = ProcessTaskItem(relatedList, relatedItem);
                                     if (lineInfo is not null)
                                     {
                                         lineInfos.Add(lineInfo);
@@ -738,7 +658,7 @@ internal sealed partial class DesignerActionPanel : ContainerControl
         return lineInfos;
     }
 
-    private LineInfo ProcessTaskItem(DesignerActionList list, DesignerActionItem item)
+    private LineInfo? ProcessTaskItem(DesignerActionList list, DesignerActionItem item)
     {
         Line newLine;
         if (item is DesignerActionMethodItem)
@@ -747,40 +667,36 @@ internal sealed partial class DesignerActionPanel : ContainerControl
         }
         else if (item is DesignerActionPropertyItem pti)
         {
-            PropertyDescriptor pd = TypeDescriptor.GetProperties(list)[pti.MemberName];
+            PropertyDescriptor? pd = TypeDescriptor.GetProperties(list)[pti.MemberName];
             if (pd is null)
             {
                 throw new InvalidOperationException(string.Format(SR.DesignerActionPanel_CouldNotFindProperty, pti.MemberName, list.GetType().FullName));
             }
 
             TypeDescriptorContext context = new TypeDescriptorContext(_serviceProvider, pd, list);
-            UITypeEditor editor = (UITypeEditor)pd.GetEditor(typeof(UITypeEditor));
             bool standardValuesSupported = pd.Converter.GetStandardValuesSupported(context);
-            if (editor is null)
+            if (pd.TryGetEditor(out UITypeEditor? _))
             {
-                if (pd.PropertyType == typeof(bool))
-                {
-                    if (IsReadOnlyProperty(pd))
-                    {
-                        newLine = new TextBoxPropertyLine(_serviceProvider, this);
-                    }
-                    else
-                    {
-                        newLine = new CheckBoxPropertyLine(_serviceProvider, this);
-                    }
-                }
-                else if (standardValuesSupported)
-                {
-                    newLine = new EditorPropertyLine(_serviceProvider, this);
-                }
-                else
+                newLine = new EditorPropertyLine(_serviceProvider, this);
+            }
+            else if (pd.PropertyType == typeof(bool))
+            {
+                if (IsReadOnlyProperty(pd))
                 {
                     newLine = new TextBoxPropertyLine(_serviceProvider, this);
                 }
+                else
+                {
+                    newLine = new CheckBoxPropertyLine(_serviceProvider, this);
+                }
+            }
+            else if (standardValuesSupported)
+            {
+                newLine = new EditorPropertyLine(_serviceProvider, this);
             }
             else
             {
-                newLine = new EditorPropertyLine(_serviceProvider, this);
+                newLine = new TextBoxPropertyLine(_serviceProvider, this);
             }
         }
         else if (item is DesignerActionTextItem)
@@ -810,7 +726,7 @@ internal sealed partial class DesignerActionPanel : ContainerControl
 
     private void ShowError(string errorMessage)
     {
-        IUIService uiService = (IUIService)ServiceProvider.GetService(typeof(IUIService));
+        IUIService? uiService = _serviceProvider.GetService<IUIService>();
         if (uiService is not null)
         {
             uiService.ShowError(errorMessage);
@@ -833,7 +749,7 @@ internal sealed partial class DesignerActionPanel : ContainerControl
     ///  - Convert "&amp;x" to "x"
     ///  - An ampersand by itself at the end of a string is displayed as-is
     /// </summary>
-    private static string StripAmpersands(string s)
+    private static string StripAmpersands(string? s)
     {
         if (string.IsNullOrEmpty(s))
         {
@@ -883,7 +799,7 @@ internal sealed partial class DesignerActionPanel : ContainerControl
         }
     }
 
-    public void UpdateTasks(DesignerActionListCollection actionLists, DesignerActionListCollection serviceActionLists, string title, string subtitle)
+    public void UpdateTasks(DesignerActionListCollection actionLists, DesignerActionListCollection serviceActionLists, string title, string? subtitle)
     {
         _updatingTasks = true;
         SuspendLayout();
@@ -894,7 +810,7 @@ internal sealed partial class DesignerActionPanel : ContainerControl
 
             // Store the focus state
             string focusId = string.Empty;
-            Line focusedLine = FocusedLine;
+            Line? focusedLine = FocusedLine;
             if (focusedLine is not null)
             {
                 focusId = focusedLine.FocusId;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionService.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.Windows.Forms.Design;
 
 namespace System.ComponentModel.Design;
@@ -13,9 +11,9 @@ namespace System.ComponentModel.Design;
 public class DesignerActionService : IDisposable
 {
     private readonly Dictionary<IComponent, DesignerActionListCollection> _designerActionLists; // this is how we store 'em.  Syntax: key = object, value = DesignerActionListCollection
-    private DesignerActionListsChangedEventHandler _designerActionListsChanged;
-    private readonly IServiceProvider _serviceProvider; // standard service provider
-    private readonly ISelectionService _selSvc; // selection service
+    private DesignerActionListsChangedEventHandler? _designerActionListsChanged;
+    private readonly IServiceProvider? _serviceProvider; // standard service provider
+    private readonly ISelectionService? _selSvc; // selection service
     private readonly HashSet<IComponent> _componentToVerbsEventHookedUp; //Hashset of components which have events hooked up.
     // Guard against ReEntrant Code. The Infragistics TabControlDesigner, Sets the Commands Status when the Verbs property is accessed. This property is used in the OnVerbStatusChanged code here and hence causes recursion leading to Stack Overflow Exception.
     private bool _reEntrantCode;
@@ -23,22 +21,20 @@ public class DesignerActionService : IDisposable
     /// <summary>
     ///  Standard constructor. A Service Provider is necessary for monitoring selection and component changes.
     /// </summary>
-    public DesignerActionService(IServiceProvider serviceProvider)
+    public DesignerActionService(IServiceProvider? serviceProvider)
     {
         if (serviceProvider is not null)
         {
             _serviceProvider = serviceProvider;
-            if (serviceProvider.GetService(typeof(IDesignerHost)) is IDesignerHost host)
-            {
-                host.AddService(typeof(DesignerActionService), this);
-            }
+            IDesignerHost? host = serviceProvider.GetService<IDesignerHost>();
+            host?.AddService(typeof(DesignerActionService), this);
 
             if (serviceProvider.GetService(typeof(IComponentChangeService)) is IComponentChangeService cs)
             {
                 cs.ComponentRemoved += new ComponentEventHandler(OnComponentRemoved);
             }
 
-            _selSvc = serviceProvider.GetService(typeof(ISelectionService)) as ISelectionService;
+            _selSvc = serviceProvider.GetService<ISelectionService>();
         }
 
         _designerActionLists = new();
@@ -48,7 +44,7 @@ public class DesignerActionService : IDisposable
     /// <summary>
     ///  This event is thrown whenever a DesignerActionList is removed or added for any object.
     /// </summary>
-    public event DesignerActionListsChangedEventHandler DesignerActionListsChanged
+    public event DesignerActionListsChangedEventHandler? DesignerActionListsChanged
     {
         add => _designerActionListsChanged += value;
         remove => _designerActionListsChanged -= value;
@@ -62,7 +58,7 @@ public class DesignerActionService : IDisposable
         ArgumentNullException.ThrowIfNull(comp);
         ArgumentNullException.ThrowIfNull(designerActionListCollection);
 
-        if (_designerActionLists.TryGetValue(comp, out DesignerActionListCollection dhlc))
+        if (_designerActionLists.TryGetValue(comp, out DesignerActionListCollection? dhlc))
         {
             dhlc.AddRange(designerActionListCollection);
         }
@@ -100,7 +96,7 @@ public class DesignerActionService : IDisposable
         _designerActionLists.Clear();
 
         // Fire our DesignerActionsChanged event for each comp we just removed.
-        foreach (Component comp in compsRemoved)
+        foreach (IComponent comp in compsRemoved)
         {
             OnDesignerActionListsChanged(new(comp, DesignerActionListsChangedType.ActionListsRemoved, GetComponentActions(comp)));
         }
@@ -127,10 +123,8 @@ public class DesignerActionService : IDisposable
     {
         if (disposing && _serviceProvider is not null)
         {
-            if (_serviceProvider.GetService(typeof(IDesignerHost)) is IDesignerHost host)
-            {
-                host.RemoveService(typeof(DesignerActionService));
-            }
+            IDesignerHost? host = _serviceProvider.GetService<IDesignerHost>();
+            host?.RemoveService(typeof(DesignerActionService));
 
             if (_serviceProvider.GetService(typeof(IComponentChangeService)) is IComponentChangeService cs)
             {
@@ -171,68 +165,66 @@ public class DesignerActionService : IDisposable
         ArgumentNullException.ThrowIfNull(component);
         ArgumentNullException.ThrowIfNull(actionLists);
 
-        if (component.Site is IServiceContainer sc)
+        IServiceContainer? sc = component.Site as IServiceContainer;
+        if (sc.TryGetService(out DesignerCommandSet? dcs))
         {
-            if (sc.GetService(typeof(DesignerCommandSet)) is DesignerCommandSet dcs)
+            DesignerActionListCollection? pullCollection = dcs.ActionLists;
+            if (pullCollection is not null)
             {
-                DesignerActionListCollection pullCollection = dcs.ActionLists;
-                if (pullCollection is not null)
-                {
-                    actionLists.AddRange(pullCollection);
-                }
+                actionLists.AddRange(pullCollection);
+            }
 
-                // if we don't find any, add the verbs for this component there...
-                if (actionLists.Count == 0)
+            // if we don't find any, add the verbs for this component there...
+            if (actionLists.Count == 0)
+            {
+                DesignerVerbCollection? verbs = dcs.Verbs;
+                if (verbs is not null && verbs.Count != 0)
                 {
-                    DesignerVerbCollection verbs = dcs.Verbs;
-                    if (verbs is not null && verbs.Count != 0)
+                    List<DesignerVerb> verbsArray = new();
+                    bool hookupEvents = _componentToVerbsEventHookedUp.Add(component);
+
+                    foreach (DesignerVerb verb in verbs)
                     {
-                        List<DesignerVerb> verbsArray = new();
-                        bool hookupEvents = _componentToVerbsEventHookedUp.Add(component);
-
-                        foreach (DesignerVerb verb in verbs)
+                        if (verb is null)
                         {
-                            if (verb is null)
-                            {
-                                continue;
-                            }
-
-                            if (hookupEvents)
-                            {
-                                verb.CommandChanged += new EventHandler(OnVerbStatusChanged);
-                            }
-
-                            if (verb.Enabled && verb.Visible)
-                            {
-                                verbsArray.Add(verb);
-                            }
+                            continue;
                         }
 
-                        if (verbsArray.Count != 0)
+                        if (hookupEvents)
                         {
-                            actionLists.Add(new DesignerActionVerbList(verbsArray.ToArray()));
+                            verb.CommandChanged += new EventHandler(OnVerbStatusChanged);
+                        }
+
+                        if (verb.Enabled && verb.Visible)
+                        {
+                            verbsArray.Add(verb);
                         }
                     }
-                }
 
-                // remove all the ones that are empty... ie GetSortedActionList returns nothing. we might waste some time doing this twice but don't have much of a choice here... the panel is not yet displayed and we want to know if a non empty panel is present...
-                // NOTE: We do this AFTER the verb check that way to disable auto verb upgrading you can just return an empty actionlist collection
-                if (pullCollection is not null)
-                {
-                    foreach (DesignerActionList actionList in pullCollection)
+                    if (verbsArray.Count != 0)
                     {
-                        DesignerActionItemCollection collection = actionList?.GetSortedActionItems();
-                        if (collection is null || collection.Count == 0)
-                        {
-                            actionLists.Remove(actionList);
-                        }
+                        actionLists.Add(new DesignerActionVerbList(verbsArray.ToArray()));
+                    }
+                }
+            }
+
+            // remove all the ones that are empty... ie GetSortedActionList returns nothing. we might waste some time doing this twice but don't have much of a choice here... the panel is not yet displayed and we want to know if a non empty panel is present...
+            // NOTE: We do this AFTER the verb check that way to disable auto verb upgrading you can just return an empty actionlist collection
+            if (pullCollection is not null)
+            {
+                foreach (DesignerActionList actionList in pullCollection)
+                {
+                    DesignerActionItemCollection? collection = actionList?.GetSortedActionItems();
+                    if (collection is null || collection.Count == 0)
+                    {
+                        actionLists.Remove(actionList);
                     }
                 }
             }
         }
     }
 
-    private void OnVerbStatusChanged(object sender, EventArgs args)
+    private void OnVerbStatusChanged(object? sender, EventArgs args)
     {
         if (!_reEntrantCode)
         {
@@ -243,12 +235,12 @@ public class DesignerActionService : IDisposable
                 {
                     if (comp.Site is IServiceContainer sc)
                     {
-                        DesignerCommandSet dcs = (DesignerCommandSet)sc.GetService(typeof(DesignerCommandSet));
-                        foreach (DesignerVerb verb in dcs.Verbs)
+                        DesignerCommandSet dcs = (DesignerCommandSet)sc.GetService(typeof(DesignerCommandSet))!;
+                        foreach (DesignerVerb verb in dcs.Verbs!)
                         {
                             if (verb == sender)
                             {
-                                DesignerActionUIService dapUISvc = (DesignerActionUIService)sc.GetService(typeof(DesignerActionUIService));
+                                DesignerActionUIService? dapUISvc = sc.GetService<DesignerActionUIService>();
                                 dapUISvc?.Refresh(comp); // we need to refresh, a verb on the current panel has changed its state
                             }
                         }
@@ -267,13 +259,13 @@ public class DesignerActionService : IDisposable
         ArgumentNullException.ThrowIfNull(component);
         ArgumentNullException.ThrowIfNull(actionLists);
 
-        if (_designerActionLists.TryGetValue(component, out DesignerActionListCollection pushCollection))
+        if (_designerActionLists.TryGetValue(component, out DesignerActionListCollection? pushCollection))
         {
             actionLists.AddRange(pushCollection);
             // remove all the ones that are empty... ie GetSortedActionList returns nothing. we might waste some time doing this twice but don't have much of a choice here... the panel is not yet displayed and we want to know if a non empty panel is present...
             foreach (DesignerActionList actionList in pushCollection)
             {
-                DesignerActionItemCollection collection = actionList?.GetSortedActionItems();
+                DesignerActionItemCollection? collection = actionList?.GetSortedActionItems();
                 if (collection is null || collection.Count == 0)
                 {
                     actionLists.Remove(actionList);
@@ -285,9 +277,9 @@ public class DesignerActionService : IDisposable
     /// <summary>
     ///  We hook the OnComponentRemoved event so we can clean up  all associated actions.
     /// </summary>
-    private void OnComponentRemoved(object source, ComponentEventArgs ce)
+    private void OnComponentRemoved(object? source, ComponentEventArgs ce)
     {
-        Remove(ce.Component);
+        Remove(ce.Component!);
     }
 
     /// <summary>
@@ -321,7 +313,7 @@ public class DesignerActionService : IDisposable
         //find the associated component
         foreach (IComponent comp in _designerActionLists.Keys)
         {
-            if (_designerActionLists.TryGetValue(comp, out DesignerActionListCollection dacl) && dacl.Contains(actionList))
+            if (_designerActionLists.TryGetValue(comp, out DesignerActionListCollection? dacl) && dacl.Contains(actionList))
             {
                 Remove(comp, actionList);
                 break;
@@ -337,7 +329,7 @@ public class DesignerActionService : IDisposable
         ArgumentNullException.ThrowIfNull(comp);
         ArgumentNullException.ThrowIfNull(actionList);
 
-        if (!_designerActionLists.TryGetValue(comp, out DesignerActionListCollection actionLists) || !actionLists.Contains(actionList))
+        if (!_designerActionLists.TryGetValue(comp, out DesignerActionListCollection? actionLists) || !actionLists.Contains(actionList))
         {
             return;
         }
@@ -363,20 +355,18 @@ public class DesignerActionService : IDisposable
         }
     }
 
-    internal event DesignerActionUIStateChangeEventHandler DesignerActionUIStateChange
+    internal event DesignerActionUIStateChangeEventHandler? DesignerActionUIStateChange
     {
         add
         {
-            DesignerActionUIService dapUISvc = (DesignerActionUIService)_serviceProvider.GetService(typeof(DesignerActionUIService));
-            if (dapUISvc is not null)
+            if (_serviceProvider.TryGetService(out DesignerActionUIService? dapUISvc))
             {
                 dapUISvc.DesignerActionUIStateChange += value;
             }
         }
         remove
         {
-            DesignerActionUIService dapUISvc = (DesignerActionUIService)_serviceProvider.GetService(typeof(DesignerActionUIService));
-            if (dapUISvc is not null)
+            if (_serviceProvider.TryGetService(out DesignerActionUIService? dapUISvc))
             {
                 dapUISvc.DesignerActionUIStateChange -= value;
             }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionUI.cs
@@ -606,7 +606,7 @@ internal partial class DesignerActionUI : IDisposable
                 Point glyphCoord = GetGlyphLocationScreenCoord(_lastPanelComponent, currentGlyph);
                 if ((new Rectangle(glyphCoord, new Size(currentGlyph.Bounds.Width, currentGlyph.Bounds.Height))).Contains(point))
                 {
-                    DesignerActionBehavior behavior = (DesignerActionBehavior)currentGlyph.Behavior;
+                    DesignerActionBehavior behavior = (DesignerActionBehavior)currentGlyph.Behavior!;
                     behavior.IgnoreNextMouseUp = true;
                 }
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionUI.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.Drawing;
 using System.Windows.Forms;
 using System.Windows.Forms.Design;
@@ -31,20 +29,18 @@ internal partial class DesignerActionUI : IDisposable
     private DesignerActionService _designerActionService; //this is how all designeractions will be managed
     private DesignerActionUIService _designerActionUIService; //this is how all designeractions UI elements will be managed
     private BehaviorService _behaviorService; //this is how all of our UI is implemented (glyphs, behaviors, etc...)
-    private readonly IMenuCommandService _menuCommandService;
-    private DesignerActionKeyboardBehavior _dapkb;   //out keyboard behavior
+    private DesignerActionKeyboardBehavior? _dapkb;   //out keyboard behavior
     private readonly Dictionary<object, DesignerActionGlyph> _componentToGlyph; //used for quick reference between components and our glyphs
     private Control _marshalingControl; //used to invoke events on our main gui thread
-    private IComponent _lastPanelComponent;
+    private IComponent? _lastPanelComponent;
 
-    private readonly IUIService _uiService;
-    private readonly IWin32Window _mainParentWindow;
-    internal DesignerActionToolStripDropDown designerActionHost;
+    private readonly IWin32Window? _mainParentWindow;
+    internal DesignerActionToolStripDropDown? designerActionHost;
 
-    private readonly MenuCommand _cmdShowDesignerActions; //used to respond to the Alt+Shift+F10 command
+    private readonly MenuCommand? _cmdShowDesignerActions; //used to respond to the Alt+Shift+F10 command
     private bool _inTransaction;
-    private IComponent _relatedComponentTransaction;
-    private DesignerActionGlyph _relatedGlyphTransaction;
+    private IComponent? _relatedComponentTransaction;
+    private DesignerActionGlyph? _relatedGlyphTransaction;
     private readonly bool _disposeActionService;
     private readonly bool _disposeActionUIService;
     private bool _cancelClose;
@@ -53,7 +49,7 @@ internal partial class DesignerActionUI : IDisposable
 #if DEBUG
     internal static readonly TraceSwitch DropDownVisibilityDebug = new("DropDownVisibilityDebug", "Debug ToolStrip Selection code");
 #else
-    internal static readonly TraceSwitch DropDownVisibilityDebug;
+    internal static readonly TraceSwitch? DropDownVisibilityDebug;
 #endif
     /// <summary>
     ///  Constructor that takes a service provider.  This is needed to establish references to the BehaviorService and SelectionService, as well as spin-up the DesignerActionService.
@@ -62,9 +58,9 @@ internal partial class DesignerActionUI : IDisposable
     {
         _serviceProvider = serviceProvider;
         _designerActionAdorner = containerAdorner;
-        _behaviorService = (BehaviorService)serviceProvider.GetService(typeof(BehaviorService));
-        _menuCommandService = (IMenuCommandService)serviceProvider.GetService(typeof(IMenuCommandService));
-        _selSvc = (ISelectionService)serviceProvider.GetService(typeof(ISelectionService));
+        _behaviorService = serviceProvider.GetService<BehaviorService>()!;
+        IMenuCommandService? menuCommandService = serviceProvider.GetService<IMenuCommandService>();
+        _selSvc = serviceProvider.GetService<ISelectionService>()!;
         if (_behaviorService is null || _selSvc is null)
         {
             Debug.Fail("Either BehaviorService or ISelectionService is null, cannot continue.");
@@ -72,16 +68,22 @@ internal partial class DesignerActionUI : IDisposable
         }
 
         //query for our DesignerActionService
-        _designerActionService = (DesignerActionService)serviceProvider.GetService(typeof(DesignerActionService));
-        if (_designerActionService is null)
+        if (serviceProvider.GetService<DesignerActionService>() is { } designerActionService)
+        {
+            _designerActionService = designerActionService;
+        }
+        else
         {
             //start the service
             _designerActionService = new DesignerActionService(serviceProvider);
             _disposeActionService = true;
         }
 
-        _designerActionUIService = (DesignerActionUIService)serviceProvider.GetService(typeof(DesignerActionUIService));
-        if (_designerActionUIService is null)
+        if (serviceProvider.GetService<DesignerActionUIService>() is { } designerActionUIService)
+        {
+            _designerActionUIService = designerActionUIService;
+        }
+        else
         {
             _designerActionUIService = new DesignerActionUIService(serviceProvider);
             _disposeActionUIService = true;
@@ -91,22 +93,22 @@ internal partial class DesignerActionUI : IDisposable
         _designerActionService.DesignerActionListsChanged += new DesignerActionListsChangedEventHandler(OnDesignerActionsChanged);
         _lastPanelComponent = null;
 
-        IComponentChangeService cs = (IComponentChangeService)serviceProvider.GetService(typeof(IComponentChangeService));
+        IComponentChangeService? cs = serviceProvider.GetService<IComponentChangeService>();
         if (cs is not null)
         {
             cs.ComponentChanged += new ComponentChangedEventHandler(OnComponentChanged);
         }
 
-        if (_menuCommandService is not null)
+        if (menuCommandService is not null)
         {
             _cmdShowDesignerActions = new MenuCommand(new EventHandler(OnKeyShowDesignerActions), MenuCommands.KeyInvokeSmartTag);
-            _menuCommandService.AddCommand(_cmdShowDesignerActions);
+            menuCommandService.AddCommand(_cmdShowDesignerActions);
         }
 
-        _uiService = (IUIService)serviceProvider.GetService(typeof(IUIService));
-        if (_uiService is not null)
+        IUIService? uiService = serviceProvider.GetService<IUIService>();
+        if (uiService is not null)
         {
-            _mainParentWindow = _uiService.GetDialogOwnerWindow();
+            _mainParentWindow = uiService.GetDialogOwnerWindow();
         }
 
         _componentToGlyph = new();
@@ -123,12 +125,12 @@ internal partial class DesignerActionUI : IDisposable
         if (_marshalingControl is not null)
         {
             _marshalingControl.Dispose();
-            _marshalingControl = null;
+            _marshalingControl = null!;
         }
 
         if (_serviceProvider is not null)
         {
-            IComponentChangeService cs = (IComponentChangeService)_serviceProvider.GetService(typeof(IComponentChangeService));
+            IComponentChangeService? cs = _serviceProvider.GetService<IComponentChangeService>();
             if (cs is not null)
             {
                 cs.ComponentChanged -= new ComponentChangedEventHandler(OnComponentChanged);
@@ -136,14 +138,14 @@ internal partial class DesignerActionUI : IDisposable
 
             if (_cmdShowDesignerActions is not null)
             {
-                IMenuCommandService mcs = (IMenuCommandService)_serviceProvider.GetService(typeof(IMenuCommandService));
+                IMenuCommandService? mcs = _serviceProvider.GetService<IMenuCommandService>();
                 mcs?.RemoveCommand(_cmdShowDesignerActions);
             }
         }
 
-        _serviceProvider = null;
-        _behaviorService = null;
-        _selSvc = null;
+        _serviceProvider = null!;
+        _behaviorService = null!;
+        _selSvc = null!;
         if (_designerActionService is not null)
         {
             _designerActionService.DesignerActionListsChanged -= new DesignerActionListsChangedEventHandler(OnDesignerActionsChanged);
@@ -153,7 +155,7 @@ internal partial class DesignerActionUI : IDisposable
             }
         }
 
-        _designerActionService = null;
+        _designerActionService = null!;
 
         if (_designerActionUIService is not null)
         {
@@ -164,19 +166,19 @@ internal partial class DesignerActionUI : IDisposable
             }
         }
 
-        _designerActionUIService = null;
-        _designerActionAdorner = null;
+        _designerActionUIService = null!;
+        _designerActionAdorner = null!;
     }
 
-    public DesignerActionGlyph GetDesignerActionGlyph(IComponent comp)
+    public DesignerActionGlyph? GetDesignerActionGlyph(IComponent comp)
     {
         return GetDesignerActionGlyph(comp, null);
     }
 
-    internal DesignerActionGlyph GetDesignerActionGlyph(IComponent comp, DesignerActionListCollection dalColl)
+    internal DesignerActionGlyph? GetDesignerActionGlyph(IComponent comp, DesignerActionListCollection? dalColl)
     {
         // check this component origin, this class or is it readonly because inherited...
-        InheritanceAttribute attribute = (InheritanceAttribute)TypeDescriptor.GetAttributes(comp)[typeof(InheritanceAttribute)];
+        InheritanceAttribute? attribute = (InheritanceAttribute?)TypeDescriptor.GetAttributes(comp)[typeof(InheritanceAttribute)];
         if (attribute == InheritanceAttribute.InheritedReadOnly)
         { // only do it if we can change the control...
             return null;
@@ -187,8 +189,7 @@ internal partial class DesignerActionUI : IDisposable
 
         if (dalColl is not null && dalColl.Count > 0)
         {
-            DesignerActionGlyph dag = null;
-            if (!_componentToGlyph.ContainsKey(comp))
+            if (!_componentToGlyph.TryGetValue(comp, out DesignerActionGlyph? dag))
             {
                 DesignerActionBehavior dab = new DesignerActionBehavior(_serviceProvider, comp, dalColl, this);
 
@@ -211,23 +212,17 @@ internal partial class DesignerActionUI : IDisposable
                 //if the related comp is a control, then this shortcut will be off its bounds
                 dag ??= new DesignerActionGlyph(dab, _designerActionAdorner);
 
-                if (dag is not null)
-                {
-                    //store off this relationship
-                    _componentToGlyph[comp] = dag;
-                }
+                //store off this relationship
+                _componentToGlyph[comp] = dag;
             }
             else
             {
-                if (_componentToGlyph.TryGetValue(comp, out dag))
+                if (dag.Behavior is DesignerActionBehavior behavior)
                 {
-                    if (dag.Behavior is DesignerActionBehavior behavior)
-                    {
-                        behavior.ActionLists = dalColl;
-                    }
-
-                    dag.Invalidate(); // need to invalidate here too, someone could have called refresh too soon, causing the glyph to get created in the wrong place
+                    behavior.ActionLists = dalColl;
                 }
+
+                dag.Invalidate(); // need to invalidate here too, someone could have called refresh too soon, causing the glyph to get created in the wrong place
             }
 
             return dag;
@@ -243,7 +238,7 @@ internal partial class DesignerActionUI : IDisposable
     /// <summary>
     ///  We monitor this event so we can update smart tag locations when  controls move.
     /// </summary>
-    private void OnComponentChanged(object source, ComponentChangedEventArgs ce)
+    private void OnComponentChanged(object? source, ComponentChangedEventArgs ce)
     {
         //validate event args
         if (ce.Component is null || ce.Member is null || !IsDesignerActionPanelVisible)
@@ -258,7 +253,7 @@ internal partial class DesignerActionUI : IDisposable
         }
 
         //if something changed on a component we have actions associated with then invalidate all (repaint & reposition)
-        if (_componentToGlyph.TryGetValue(ce.Component, out DesignerActionGlyph glyph))
+        if (_componentToGlyph.TryGetValue(ce.Component, out DesignerActionGlyph? glyph))
         {
             glyph.Invalidate();
 
@@ -277,7 +272,7 @@ internal partial class DesignerActionUI : IDisposable
         }
     }
 
-    private void RecreatePanel(IComponent comp)
+    private void RecreatePanel(IComponent? comp)
     {
         if (_inTransaction || comp != _selSvc.PrimarySelection)
         { // we only ever need to do that when the comp is the primary selection
@@ -302,16 +297,16 @@ internal partial class DesignerActionUI : IDisposable
             }
         }
 
-        RecreateInternal(comp);
+        RecreateInternal(comp!);
     }
 
-    private void DesignerTransactionClosed(object sender, DesignerTransactionCloseEventArgs e)
+    private void DesignerTransactionClosed(object? sender, DesignerTransactionCloseEventArgs e)
     {
         if (e.LastTransaction && _relatedComponentTransaction is not null)
         {
             // surprise surprise we can get multiple even with e.LastTransaction set to true, even though we unhook here this is because the list on which we enumerate (the event handler list) is copied before it's enumerated on which means that if the undo engine for example creates and commit a transaction during the OnCancel of another  completed transaction we will get this twice. So we have to check also for relatedComponentTransaction is not null
             _inTransaction = false;
-            IDesignerHost host = _serviceProvider.GetService(typeof(IDesignerHost)) as IDesignerHost;
+            IDesignerHost host = _serviceProvider.GetService<IDesignerHost>()!;
             host.TransactionClosed -= new DesignerTransactionCloseEventHandler(DesignerTransactionClosed);
             RecreateInternal(_relatedComponentTransaction);
             _relatedComponentTransaction = null;
@@ -320,7 +315,7 @@ internal partial class DesignerActionUI : IDisposable
 
     private void RecreateInternal(IComponent comp)
     {
-        DesignerActionGlyph glyph = GetDesignerActionGlyph(comp);
+        DesignerActionGlyph? glyph = GetDesignerActionGlyph(comp);
         if (glyph is not null)
         {
             VerifyGlyphIsInAdorner(glyph);
@@ -335,21 +330,18 @@ internal partial class DesignerActionUI : IDisposable
         // we don't want to do anything if the panel is not visible
         if (!IsDesignerActionPanelVisible)
         {
-            Debug.WriteLineIf(DropDownVisibilityDebug.TraceVerbose, "[DesignerActionUI.RecreatePanel] panel is not visible, bail");
+            DropDownVisibilityDebug.TraceVerbose("[DesignerActionUI.RecreatePanel] panel is not visible, bail");
             return;
         }
 
         //recreate a designeraction panel
-        if (glyphWithPanelToRegen is not null)
+        if (glyphWithPanelToRegen.Behavior is DesignerActionBehavior behaviorWithPanelToRegen)
         {
-            if (glyphWithPanelToRegen.Behavior is DesignerActionBehavior behaviorWithPanelToRegen)
-            {
-                Debug.Assert(behaviorWithPanelToRegen.RelatedComponent is not null, "could not find related component for this refresh");
-                DesignerActionPanel dap = designerActionHost.CurrentPanel; // WE DO NOT RECREATE THE WHOLE THING / WE UPDATE THE TASKS - should flicker less
-                dap.UpdateTasks(behaviorWithPanelToRegen.ActionLists, new DesignerActionListCollection(), string.Format(SR.DesignerActionPanel_DefaultPanelTitle,
-                    behaviorWithPanelToRegen.RelatedComponent.GetType().Name), null);
-                designerActionHost.UpdateContainerSize();
-            }
+            Debug.Assert(behaviorWithPanelToRegen.RelatedComponent is not null, "could not find related component for this refresh");
+            DesignerActionPanel dap = designerActionHost.CurrentPanel; // WE DO NOT RECREATE THE WHOLE THING / WE UPDATE THE TASKS - should flicker less
+            dap.UpdateTasks(behaviorWithPanelToRegen.ActionLists, new DesignerActionListCollection(), string.Format(SR.DesignerActionPanel_DefaultPanelTitle,
+                behaviorWithPanelToRegen.RelatedComponent.GetType().Name), null);
+            designerActionHost.UpdateContainerSize();
         }
     }
 
@@ -357,7 +349,7 @@ internal partial class DesignerActionUI : IDisposable
     {
         if (glyph.IsInComponentTray)
         {
-            ComponentTray compTray = _serviceProvider.GetService(typeof(ComponentTray)) as ComponentTray;
+            ComponentTray compTray = _serviceProvider.GetService<ComponentTray>()!;
             if (compTray.SelectionGlyphs is not null && !compTray.SelectionGlyphs.Contains(glyph))
             {
                 compTray.SelectionGlyphs.Insert(0, glyph);
@@ -365,7 +357,7 @@ internal partial class DesignerActionUI : IDisposable
         }
         else
         {
-            if (_designerActionAdorner is not null && _designerActionAdorner.Glyphs is not null && !_designerActionAdorner.Glyphs.Contains(glyph))
+            if (_designerActionAdorner?.Glyphs is not null && !_designerActionAdorner.Glyphs.Contains(glyph))
             {
                 _designerActionAdorner.Glyphs.Insert(0, glyph);
             }
@@ -388,11 +380,11 @@ internal partial class DesignerActionUI : IDisposable
 
     private void OnDesignerActionUIStateChange(object sender, DesignerActionUIStateChangeEventArgs e)
     {
-        IComponent comp = e.RelatedObject as IComponent;
+        IComponent? comp = e.RelatedObject as IComponent;
         Debug.Assert(comp is not null || e.ChangeType == DesignerActionUIStateChangeType.Hide, "related object is not an IComponent, something is wrong here...");
         if (comp is not null)
         {
-            DesignerActionGlyph relatedGlyph = GetDesignerActionGlyph(comp);
+            DesignerActionGlyph? relatedGlyph = GetDesignerActionGlyph(comp);
             if (relatedGlyph is not null)
             {
                 if (e.ChangeType == DesignerActionUIStateChangeType.Show)
@@ -412,7 +404,7 @@ internal partial class DesignerActionUI : IDisposable
                 else if (e.ChangeType == DesignerActionUIStateChangeType.Refresh)
                 {
                     relatedGlyph.Invalidate();
-                    RecreatePanel((IComponent)e.RelatedObject);
+                    RecreatePanel((IComponent?)e.RelatedObject);
                 }
             }
         }
@@ -430,7 +422,7 @@ internal partial class DesignerActionUI : IDisposable
     /// </summary>
     private void OnInvokedDesignerActionChanged(object sender, DesignerActionListsChangedEventArgs e)
     {
-        DesignerActionGlyph g = null;
+        DesignerActionGlyph? g = null;
         if (e.ChangeType == DesignerActionListsChangedType.ActionListsAdded)
         {
             if (e.RelatedObject is not IComponent relatedComponent)
@@ -439,7 +431,7 @@ internal partial class DesignerActionUI : IDisposable
                 return;
             }
 
-            IComponent primSel = _selSvc.PrimarySelection as IComponent;
+            IComponent? primSel = _selSvc.PrimarySelection as IComponent;
             if (primSel == e.RelatedObject)
             {
                 g = GetDesignerActionGlyph(relatedComponent, e.ActionLists);
@@ -454,7 +446,7 @@ internal partial class DesignerActionUI : IDisposable
             }
         }
 
-        if (e.ChangeType == DesignerActionListsChangedType.ActionListsRemoved && e.ActionLists.Count == 0)
+        if (e.ChangeType == DesignerActionListsChangedType.ActionListsRemoved && e.ActionLists!.Count == 0)
         {
             //only remove our glyph if there are no more DesignerActions associated with it.
             RemoveActionGlyph(e.RelatedObject);
@@ -469,7 +461,7 @@ internal partial class DesignerActionUI : IDisposable
     /// <summary>
     ///  Called when our KeyShowDesignerActions menu command is fired  (a.k.a. Alt+Shift+F10) - we will find the primary selection, see if it has designer actions, and if so - show the menu.
     /// </summary>
-    private void OnKeyShowDesignerActions(object sender, EventArgs e)
+    private void OnKeyShowDesignerActions(object? sender, EventArgs e)
     {
         ShowDesignerActionPanelForPrimarySelection();
     }
@@ -483,28 +475,25 @@ internal partial class DesignerActionUI : IDisposable
             return false;
         }
 
-        object primarySelection = _selSvc.PrimarySelection;
+        object? primarySelection = _selSvc.PrimarySelection;
         //verify that we have obtained a valid component with designer actions
-        if (primarySelection is null || !_componentToGlyph.TryGetValue(primarySelection, out DesignerActionGlyph glyph))
+        if (primarySelection is null || !_componentToGlyph.TryGetValue(primarySelection, out DesignerActionGlyph? glyph))
         {
             return false;
         }
 
-        if (glyph is not null && glyph.Behavior is DesignerActionBehavior)
+        if (glyph.Behavior is DesignerActionBehavior behavior)
+        // show the menu
         {
-            // show the menu
-            if (glyph.Behavior is DesignerActionBehavior behavior)
+            if (!IsDesignerActionPanelVisible)
             {
-                if (!IsDesignerActionPanelVisible)
-                {
-                    behavior.ShowUI(glyph);
-                    return true;
-                }
-                else
-                {
-                    behavior.HideUI();
-                    return false;
-                }
+                behavior.ShowUI(glyph);
+                return true;
+            }
+            else
+            {
+                behavior.HideUI();
+                return false;
             }
         }
 
@@ -514,7 +503,7 @@ internal partial class DesignerActionUI : IDisposable
     /// <summary>
     ///  When all the DesignerActions have been removed for a particular object, we remove any UI (glyphs) that we may have been managing.
     /// </summary>
-    internal void RemoveActionGlyph(object relatedObject)
+    internal void RemoveActionGlyph(object? relatedObject)
     {
         if (relatedObject is null)
         {
@@ -526,16 +515,13 @@ internal partial class DesignerActionUI : IDisposable
             HideDesignerActionPanel();
         }
 
-        if (!_componentToGlyph.TryGetValue(relatedObject, out DesignerActionGlyph glyph))
+        if (!_componentToGlyph.TryGetValue(relatedObject, out DesignerActionGlyph? glyph))
         {
             return;
         }
 
         // Check ComponentTray first
-        if (_serviceProvider.GetService(typeof(ComponentTray)) is ComponentTray compTray && compTray.SelectionGlyphs is not null)
-        {
-            compTray.SelectionGlyphs.Remove(glyph);
-        }
+        _serviceProvider.GetService<ComponentTray>()?.SelectionGlyphs?.Remove(glyph);
 
         _designerActionAdorner.Glyphs.Remove(glyph);
         _componentToGlyph.Remove(relatedObject);
@@ -548,12 +534,11 @@ internal partial class DesignerActionUI : IDisposable
         }
     }
 
-    private void InvalidateGlyphOnLastTransaction(object sender, DesignerTransactionCloseEventArgs e)
+    private void InvalidateGlyphOnLastTransaction(object? sender, DesignerTransactionCloseEventArgs e)
     {
         if (e.LastTransaction)
         {
-            IDesignerHost host = (_serviceProvider is not null) ? _serviceProvider.GetService(typeof(IDesignerHost)) as IDesignerHost : null;
-            if (host is not null)
+            if (_serviceProvider.TryGetService(out IDesignerHost? host))
             {
                 host.TransactionClosed -= new DesignerTransactionCloseEventHandler(InvalidateGlyphOnLastTransaction);
             }
@@ -572,40 +557,41 @@ internal partial class DesignerActionUI : IDisposable
         }
     }
 
+    [MemberNotNullWhen(true, nameof(designerActionHost))]
     internal bool IsDesignerActionPanelVisible
     {
         get => (designerActionHost is not null && designerActionHost.Visible);
     }
 
-    internal IComponent LastPanelComponent
+    internal IComponent? LastPanelComponent
     {
         get => (IsDesignerActionPanelVisible ? _lastPanelComponent : null);
     }
 
-    private void ToolStripDropDown_Closing(object sender, ToolStripDropDownClosingEventArgs e)
+    private void ToolStripDropDown_Closing(object? sender, ToolStripDropDownClosingEventArgs e)
     {
         if (_cancelClose || e.Cancel)
         {
             e.Cancel = true;
-            Debug.WriteLineIf(DropDownVisibilityDebug.TraceVerbose, "[DesignerActionUI.toolStripDropDown_Closing] cancelClose true, bail");
+            DropDownVisibilityDebug.TraceVerbose("[DesignerActionUI.toolStripDropDown_Closing] cancelClose true, bail");
             return;
         }
 
         if (e.CloseReason == ToolStripDropDownCloseReason.ItemClicked)
         {
             e.Cancel = true;
-            Debug.WriteLineIf(DropDownVisibilityDebug.TraceVerbose, $"[DesignerActionUI.toolStripDropDown_Closing] ItemClicked: e.Cancel set to: {e.Cancel}");
+            DropDownVisibilityDebug.TraceVerbose($"[DesignerActionUI.toolStripDropDown_Closing] ItemClicked: e.Cancel set to: {e.Cancel}");
         }
 
         if (e.CloseReason == ToolStripDropDownCloseReason.Keyboard)
         {
             e.Cancel = false;
-            Debug.WriteLineIf(DropDownVisibilityDebug.TraceVerbose, $"[DesignerActionUI.toolStripDropDown_Closing] Keyboard: e.Cancel set to: {e.Cancel}");
+            DropDownVisibilityDebug.TraceVerbose($"[DesignerActionUI.toolStripDropDown_Closing] Keyboard: e.Cancel set to: {e.Cancel}");
         }
 
         if (e.Cancel == false)
         { // we WILL disappear
-            Debug.WriteLineIf(DropDownVisibilityDebug.TraceVerbose, "[DesignerActionUI.toolStripDropDown_Closing] Closing...");
+            DropDownVisibilityDebug.TraceVerbose("[DesignerActionUI.toolStripDropDown_Closing] Closing...");
             Debug.Assert(_lastPanelComponent is not null, "last panel component should not be null here... " +
                 "(except if you're currently debugging VS where deactivation messages in the middle of the pump can mess up everything...)");
             if (_lastPanelComponent is null)
@@ -615,12 +601,12 @@ internal partial class DesignerActionUI : IDisposable
 
             // if we're actually closing get the coordinate of the last message, the one causing us to close, is it within the glyph coordinate. if it is that mean that someone just clicked back from the panel, on VS, but ON THE GLYPH, that means that he actually wants to close it. The activation change is going to do that for us but we should NOT reopen right away because he clicked on the glyph... this code is here to prevent this...
             Point point = DesignerUtils.LastCursorPoint;
-            if (_componentToGlyph.TryGetValue(_lastPanelComponent, out DesignerActionGlyph currentGlyph))
+            if (_componentToGlyph.TryGetValue(_lastPanelComponent, out DesignerActionGlyph? currentGlyph))
             {
                 Point glyphCoord = GetGlyphLocationScreenCoord(_lastPanelComponent, currentGlyph);
                 if ((new Rectangle(glyphCoord, new Size(currentGlyph.Bounds.Width, currentGlyph.Bounds.Height))).Contains(point))
                 {
-                    DesignerActionBehavior behavior = currentGlyph.Behavior as DesignerActionBehavior;
+                    DesignerActionBehavior behavior = (DesignerActionBehavior)currentGlyph.Behavior;
                     behavior.IgnoreNextMouseUp = true;
                 }
 
@@ -630,12 +616,12 @@ internal partial class DesignerActionUI : IDisposable
             _lastPanelComponent = null;
             // panel is going away, pop the behavior that's on the stack...
             Debug.Assert(_dapkb is not null, "why is dapkb null?");
-            Behavior popBehavior = _behaviorService.PopBehavior(_dapkb);
+            Behavior popBehavior = _behaviorService.PopBehavior(_dapkb!);
             Debug.Assert(popBehavior is DesignerActionKeyboardBehavior, "behavior returned is of the wrong kind?");
         }
     }
 
-    internal Point UpdateDAPLocation(IComponent component, DesignerActionGlyph glyph)
+    internal Point UpdateDAPLocation(IComponent? component, DesignerActionGlyph? glyph)
     {
         component ??= _lastPanelComponent;
 
@@ -674,14 +660,14 @@ internal partial class DesignerActionUI : IDisposable
         }
 
         //ISSUE: we can't have this special cased here - we should find a more generic approach to solving this problem
-        else if (relatedComponent is ToolStripItem)
+        else if (relatedComponent is ToolStripItem item)
         {
-            if (relatedComponent is ToolStripItem item && item.Owner is not null)
+            if (item.Owner is not null)
             {
                 glyphLocationScreenCoord = _behaviorService.AdornerWindowPointToScreen(glyph.Bounds.Location);
             }
         }
-        else if (relatedComponent is IComponent)
+        else
         {
             if (_serviceProvider.GetService(typeof(ComponentTray)) is ComponentTray compTray)
             {
@@ -723,7 +709,7 @@ internal partial class DesignerActionUI : IDisposable
             if (_mainParentWindow is not null && _mainParentWindow.Handle != IntPtr.Zero)
             {
                 Debug.WriteLineIf(s_designerActionPanelTraceSwitch.TraceVerbose, "Assigning owner to mainParentWindow");
-                Debug.WriteLineIf(DropDownVisibilityDebug.TraceVerbose, "Assigning owner to mainParentWindow");
+                DropDownVisibilityDebug.TraceVerbose("Assigning owner to mainParentWindow");
                 PInvoke.SetWindowLong(
                     designerActionHost,
                     WINDOW_LONG_PTR_INDEX.GWL_HWNDPARENT,
@@ -744,7 +730,7 @@ internal partial class DesignerActionUI : IDisposable
         }
     }
 
-    private void OnShowComplete(object sender, EventArgs e)
+    private void OnShowComplete(object? sender, EventArgs e)
     {
         _cancelClose = false;
         // force the panel to be the active window - for some reason someone else could have forced VS to become active for real while we were ignoring close. This might be bad cause we'd be in a bad state.

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionUIService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionUIService.cs
@@ -1,17 +1,15 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.Windows.Forms.Design.Behavior;
 
 namespace System.ComponentModel.Design;
 
 public sealed class DesignerActionUIService : IDisposable
 {
-    private DesignerActionUIStateChangeEventHandler _designerActionUIStateChangedEventHandler;
-    private readonly IServiceProvider _serviceProvider; //standard service provider
-    private readonly DesignerActionService _designerActionService;
+    private DesignerActionUIStateChangeEventHandler? _designerActionUIStateChangedEventHandler;
+    private readonly IServiceProvider? _serviceProvider; //standard service provider
+    private readonly DesignerActionService? _designerActionService;
 
     internal DesignerActionUIService(IServiceProvider serviceProvider)
     {
@@ -19,9 +17,9 @@ public sealed class DesignerActionUIService : IDisposable
         if (serviceProvider is not null)
         {
             _serviceProvider = serviceProvider;
-            IDesignerHost host = (IDesignerHost)serviceProvider.GetService(typeof(IDesignerHost));
+            IDesignerHost host = serviceProvider.GetService<IDesignerHost>()!;
             host.AddService(typeof(DesignerActionUIService), this);
-            _designerActionService = serviceProvider.GetService(typeof(DesignerActionService)) as DesignerActionService;
+            _designerActionService = serviceProvider.GetService<DesignerActionService>();
             Debug.Assert(_designerActionService is not null, "we should have created and registered the DAService first");
         }
     }
@@ -33,7 +31,7 @@ public sealed class DesignerActionUIService : IDisposable
     {
         if (_serviceProvider is not null)
         {
-            IDesignerHost host = (IDesignerHost)_serviceProvider.GetService(typeof(IDesignerHost));
+            IDesignerHost? host = _serviceProvider.GetService<IDesignerHost>();
             host?.RemoveService(typeof(DesignerActionUIService));
         }
     }
@@ -41,18 +39,18 @@ public sealed class DesignerActionUIService : IDisposable
     /// <summary>
     ///  This event is thrown whenever a request is made to show/hide the UI.
     /// </summary>
-    public event DesignerActionUIStateChangeEventHandler DesignerActionUIStateChange
+    public event DesignerActionUIStateChangeEventHandler? DesignerActionUIStateChange
     {
         add => _designerActionUIStateChangedEventHandler += value;
         remove => _designerActionUIStateChangedEventHandler -= value;
     }
 
-    public void HideUI(IComponent component)
+    public void HideUI(IComponent? component)
     {
         OnDesignerActionUIStateChange(new DesignerActionUIStateChangeEventArgs(component, DesignerActionUIStateChangeType.Hide));
     }
 
-    public void ShowUI(IComponent component)
+    public void ShowUI(IComponent? component)
     {
         OnDesignerActionUIStateChange(new DesignerActionUIStateChangeEventArgs(component, DesignerActionUIStateChangeType.Show));
     }
@@ -60,7 +58,7 @@ public sealed class DesignerActionUIService : IDisposable
     /// <summary>
     ///  Refreshes the <see cref="DesignerActionGlyph">designer action glyph</see> as well as <see cref="DesignerActionPanel">designer action panels</see>.
     /// </summary>
-    public void Refresh(IComponent component)
+    public void Refresh(IComponent? component)
     {
         OnDesignerActionUIStateChange(new DesignerActionUIStateChangeEventArgs(component, DesignerActionUIStateChangeType.Refresh));
     }
@@ -76,29 +74,23 @@ public sealed class DesignerActionUIService : IDisposable
     public bool ShouldAutoShow(IComponent component)
     {
         // Check the designer options...
-        if (_serviceProvider is not null)
+        if (_serviceProvider.TryGetService(out DesignerOptionService? opts))
         {
-            if (_serviceProvider.GetService(typeof(DesignerOptionService)) is DesignerOptionService opts)
+            PropertyDescriptor? p = opts.Options.Properties["ObjectBoundSmartTagAutoShow"];
+            if (p is not null && p.TryGetValue(null, out bool isObjectBoundSmartTagAutoShow) && !isObjectBoundSmartTagAutoShow)
             {
-                PropertyDescriptor p = opts.Options.Properties["ObjectBoundSmartTagAutoShow"];
-                if (p is not null && p.PropertyType == typeof(bool) && !(bool)p.GetValue(null))
-                {
-                    return false;
-                }
+                return false;
             }
         }
 
-        if (_designerActionService is not null)
+        DesignerActionListCollection? coll = _designerActionService?.GetComponentActions(component);
+        if (coll is not null && coll.Count > 0)
         {
-            DesignerActionListCollection coll = _designerActionService.GetComponentActions(component);
-            if (coll is not null && coll.Count > 0)
+            for (int i = 0; i < coll.Count; i++)
             {
-                for (int i = 0; i < coll.Count; i++)
+                if (coll[i]!.AutoShow)
                 {
-                    if (coll[i].AutoShow)
-                    {
-                        return true;
-                    }
+                    return true;
                 }
             }
         }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionUIStateChangeEventArgs.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionUIStateChangeEventArgs.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 namespace System.ComponentModel.Design;
 
 /// <summary>
@@ -13,7 +11,7 @@ public class DesignerActionUIStateChangeEventArgs : EventArgs
     /// <summary>
     ///  Constructor that requires the object in question, the type of change and the remaining actionlists left for the object on the related object.
     /// </summary>
-    public DesignerActionUIStateChangeEventArgs(object relatedObject, DesignerActionUIStateChangeType changeType)
+    public DesignerActionUIStateChangeEventArgs(object? relatedObject, DesignerActionUIStateChangeType changeType)
     {
         RelatedObject = relatedObject;
         ChangeType = changeType;
@@ -22,7 +20,7 @@ public class DesignerActionUIStateChangeEventArgs : EventArgs
     /// <summary>
     ///  The object this change is related to.
     /// </summary>
-    public object RelatedObject { get; }
+    public object? RelatedObject { get; }
 
     /// <summary>
     ///  The type of changed that caused the related event to be thrown.

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.cs
@@ -389,7 +389,7 @@ public sealed partial class BehaviorService : IDisposable
     /// <summary>
     ///  Removes the behavior from the behavior stack
     /// </summary>
-    public Behavior? PopBehavior(Behavior behavior)
+    public Behavior PopBehavior(Behavior behavior)
     {
         if (_behaviorStack.Count == 0)
         {
@@ -399,7 +399,7 @@ public sealed partial class BehaviorService : IDisposable
         int index = _behaviorStack.IndexOf(behavior);
         if (index == -1)
         {
-            Debug.Assert(false, $"Could not find the behavior to pop - did it already get popped off? {behavior}");
+            Debug.Fail($"Could not find the behavior to pop - did it already get popped off? {behavior}");
             return null;
         }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DesignerActionBehavior.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DesignerActionBehavior.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.ComponentModel;
 using System.ComponentModel.Design;
 using System.Drawing;
@@ -14,9 +12,6 @@ namespace System.Windows.Forms.Design.Behavior;
 /// </summary>
 internal sealed class DesignerActionBehavior : Behavior
 {
-    private readonly IComponent _relatedComponent; //The component we are bound to
-    private readonly DesignerActionUI _parentUI; //ptr to the parenting UI, used for showing menus and setting selection
-    private DesignerActionListCollection _actionLists; //all the shortcuts!
     private readonly IServiceProvider _serviceProvider; // we need to cache the service provider here to be able to create the panel with the proper arguments
     private bool _ignoreNextMouseUp;
 
@@ -25,36 +20,26 @@ internal sealed class DesignerActionBehavior : Behavior
     /// </summary>
     internal DesignerActionBehavior(IServiceProvider serviceProvider, IComponent relatedComponent, DesignerActionListCollection actionLists, DesignerActionUI parentUI)
     {
-        _actionLists = actionLists;
+        ActionLists = actionLists;
         _serviceProvider = serviceProvider;
-        _relatedComponent = relatedComponent;
-        _parentUI = parentUI;
+        RelatedComponent = relatedComponent;
+        ParentUI = parentUI;
     }
 
     /// <summary>
     ///  Returns the collection of DesignerActionLists this Behavior is managing. These will be dynamically updated (some can be removed, new ones can be added, etc...).
     /// </summary>
-    internal DesignerActionListCollection ActionLists
-    {
-        get => _actionLists;
-        set => _actionLists = value;
-    }
+    internal DesignerActionListCollection ActionLists { get; set; }
 
     /// <summary>
     ///  Returns the parenting UI (a DesignerActionUI)
     /// </summary>
-    internal DesignerActionUI ParentUI
-    {
-        get => _parentUI;
-    }
+    internal DesignerActionUI ParentUI { get; }
 
     /// <summary>
     ///  Returns the Component that this glyph is attached to.
     /// </summary>
-    internal IComponent RelatedComponent
-    {
-        get => _relatedComponent;
-    }
+    internal IComponent RelatedComponent { get; }
 
     /// <summary>
     ///  Hides the designer action panel UI.
@@ -79,7 +64,7 @@ internal sealed class DesignerActionBehavior : Behavior
     /// </summary>
     internal void ShowUI(Glyph g)
     {
-        if (!(g is DesignerActionGlyph glyph))
+        if (g is not DesignerActionGlyph glyph)
         {
             Debug.Fail("Why are we trying to 'showui' on a glyph that's not a DesignerActionGlyph?");
             return;
@@ -97,13 +82,13 @@ internal sealed class DesignerActionBehavior : Behavior
         }
     }
 
-    public override bool OnMouseDoubleClick(Glyph g, MouseButtons button, Point mouseLoc)
+    public override bool OnMouseDoubleClick(Glyph? g, MouseButtons button, Point mouseLoc)
     {
         _ignoreNextMouseUp = true;
         return true;
     }
 
-    public override bool OnMouseDown(Glyph g, MouseButtons button, Point mouseLoc)
+    public override bool OnMouseDown(Glyph? g, MouseButtons button, Point mouseLoc)
     { // we take the msg
         return (!ParentUI.IsDesignerActionPanelVisible);
     }
@@ -111,7 +96,7 @@ internal sealed class DesignerActionBehavior : Behavior
     /// <summary>
     ///  In response to a MouseUp, we will either 1) select the Glyph and control if not selected, or 2) Build up our context menu representing our DesignerActions and show it.
     /// </summary>
-    public override bool OnMouseUp(Glyph g, MouseButtons button)
+    public override bool OnMouseUp(Glyph? g, MouseButtons button)
     {
         if (button != MouseButtons.Left || ParentUI is null)
         {
@@ -125,23 +110,19 @@ internal sealed class DesignerActionBehavior : Behavior
         }
         else if (!_ignoreNextMouseUp)
         {
-            if (_serviceProvider is not null)
+            if (_serviceProvider.TryGetService(out ISelectionService? selectionService))
             {
-                ISelectionService selectionService = (ISelectionService)_serviceProvider.GetService(typeof(ISelectionService));
-                if (selectionService is not null)
+                if (selectionService.PrimarySelection != RelatedComponent)
                 {
-                    if (selectionService.PrimarySelection != RelatedComponent)
+                    List<IComponent> componentList = new List<IComponent>
                     {
-                        List<IComponent> componentList = new List<IComponent>
-                        {
-                            RelatedComponent
-                        };
-                        selectionService.SetSelectedComponents(componentList, SelectionTypes.Primary);
-                    }
+                        RelatedComponent
+                    };
+                    selectionService.SetSelectedComponents(componentList, SelectionTypes.Primary);
                 }
             }
 
-            ShowUI(g);
+            ShowUI(g!);
         }
         else
         {

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DesignerActionGlyph.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DesignerActionGlyph.cs
@@ -221,7 +221,7 @@ internal sealed class DesignerActionGlyph : Glyph
                 return;
             }
 
-            IComponent panelComponent = behavior.ParentUI.LastPanelComponent;
+            IComponent? panelComponent = behavior.ParentUI.LastPanelComponent;
             IComponent relatedComponent = behavior.RelatedComponent;
             if (panelComponent is not null && panelComponent == relatedComponent)
             {

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/SelectionManager.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/SelectionManager.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.ComponentModel;
 using System.ComponentModel.Design;
 using System.Drawing;
@@ -14,20 +12,17 @@ namespace System.Windows.Forms.Design.Behavior;
 /// </summary>
 internal sealed class SelectionManager : IDisposable
 {
-    private Adorner _selectionAdorner;                  //used to provide all selection glyphs
-    private Adorner _bodyAdorner;                       //used to track all body glyphs for each control
     private BehaviorService _behaviorService;           //ptr back to our BehaviorService
     private IServiceProvider _serviceProvider;          //standard service provider
     private readonly Dictionary<IComponent, ControlDesigner> _componentToDesigner;    //used for quick look up of designers related to components
     private readonly Control _rootComponent;            //root component being designed
     private ISelectionService _selSvc;                  //we cache the selection service for perf.
     private IDesignerHost _designerHost;                //we cache the designerhost for perf.
-    private bool _needRefresh;                          // do we need to refresh?
-    private Rectangle[] _prevSelectionBounds;           //used to only repaint the changing part of the selection
-    private object _prevPrimarySelection;               //used to check if the primary selection changed
-    private Rectangle[] _curSelectionBounds;
+    private Rectangle[]? _prevSelectionBounds;           //used to only repaint the changing part of the selection
+    private object? _prevPrimarySelection;               //used to check if the primary selection changed
+    private Rectangle[]? _curSelectionBounds;
     private int _curCompIndex;
-    private DesignerActionUI _designerActionUI;         // the "container" for all things related to the designer action (smarttags) UI
+    private DesignerActionUI? _designerActionUI;         // the "container" for all things related to the designer action (smarttags) UI
     private bool _selectionChanging;                    //we don't want the OnSelectionChanged to be recursively called.
 
     /// <summary>
@@ -40,8 +35,8 @@ internal sealed class SelectionManager : IDisposable
         _behaviorService = behaviorService;
         _serviceProvider = serviceProvider;
 
-        _selSvc = (ISelectionService)serviceProvider.GetService(typeof(ISelectionService));
-        _designerHost = (IDesignerHost)serviceProvider.GetService(typeof(IDesignerHost));
+        _selSvc = serviceProvider.GetService<ISelectionService>()!;
+        _designerHost = serviceProvider.GetService<IDesignerHost>()!;
 
         if (_designerHost is null || _selSvc is null)
         {
@@ -59,15 +54,15 @@ internal sealed class SelectionManager : IDisposable
 
         //create and add both of our adorners,
         //one for selection, one for bodies
-        _selectionAdorner = new Adorner();
-        _bodyAdorner = new Adorner();
-        behaviorService.Adorners.Add(_bodyAdorner);
-        behaviorService.Adorners.Add(_selectionAdorner); // adding this will cause the adorner to get setup with a ptr
+        SelectionGlyphAdorner = new Adorner();
+        BodyGlyphAdorner = new Adorner();
+        behaviorService.Adorners.Add(BodyGlyphAdorner);
+        behaviorService.Adorners.Add(SelectionGlyphAdorner); // adding this will cause the adorner to get setup with a ptr
                                                          // to the beh.svc.
 
         _componentToDesigner = new();
 
-        IComponentChangeService cs = (IComponentChangeService)serviceProvider.GetService(typeof(IComponentChangeService));
+        IComponentChangeService? cs = serviceProvider.GetService<IComponentChangeService>();
         if (cs is not null)
         {
             cs.ComponentAdded += new ComponentEventHandler(OnComponentAdded);
@@ -80,10 +75,10 @@ internal sealed class SelectionManager : IDisposable
         // designeraction UI
         if (_designerHost.GetService(typeof(DesignerOptionService)) is DesignerOptionService options)
         {
-            PropertyDescriptor p = options.Options.Properties["UseSmartTags"];
-            if (p is not null && p.PropertyType == typeof(bool) && (bool)p.GetValue(null))
+            PropertyDescriptor? p = options.Options.Properties["UseSmartTags"];
+            if (p is not null && p.TryGetValue(null, out bool useSmartTags) && useSmartTags)
             {
-                _designerActionUI = new DesignerActionUI(serviceProvider, _selectionAdorner);
+                _designerActionUI = new DesignerActionUI(serviceProvider, SelectionGlyphAdorner);
                 behaviorService.DesignerActionUI = _designerActionUI;
             }
         }
@@ -92,10 +87,7 @@ internal sealed class SelectionManager : IDisposable
     /// <summary>
     ///  Returns the Adorner that contains all the BodyGlyphs for the current selection state.
     /// </summary>
-    internal Adorner BodyGlyphAdorner
-    {
-        get => _bodyAdorner;
-    }
+    internal Adorner BodyGlyphAdorner { get; private set; }
 
     /// <summary>
     ///  There are certain cases like Adding Item to ToolStrips through InSitu Editor, where there is
@@ -105,25 +97,18 @@ internal sealed class SelectionManager : IDisposable
     ///  Since this property is checked in the TransactionClosed, the SelectionManager won't REFRESH and hence
     ///  just eat up the refresh thus avoiding unnecessary flicker.
     /// </summary>
-    internal bool NeedRefresh
-    {
-        get => _needRefresh;
-        set => _needRefresh = value;
-    }
+    internal bool NeedRefresh { get; set; }
 
     /// <summary>
     ///  Returns the Adorner that contains all the BodyGlyphs for the current selection state.
     /// </summary>
-    internal Adorner SelectionGlyphAdorner
-    {
-        get => _selectionAdorner;
-    }
+    internal Adorner SelectionGlyphAdorner { get; private set; }
 
     /// <summary>
     ///  This method fist calls the recursive AddControlGlyphs() method. When finished, we add the final glyph(s)
     ///  to the root comp.
     /// </summary>
-    private void AddAllControlGlyphs(Control parent, List<IComponent> selComps, object primarySelection)
+    private void AddAllControlGlyphs(Control parent, List<IComponent> selComps, object? primarySelection)
     {
         foreach (Control control in parent.Controls)
         {
@@ -151,16 +136,15 @@ internal sealed class SelectionManager : IDisposable
     /// </summary>
     private void AddControlGlyphs(Control control, GlyphSelectionType selType)
     {
-        if (_componentToDesigner.TryGetValue(control, out ControlDesigner controlDesigner) && controlDesigner is not null)
+        if (_componentToDesigner.TryGetValue(control, out ControlDesigner? controlDesigner))
         {
             ControlBodyGlyph bodyGlyph = controlDesigner.GetControlGlyphInternal(selType);
             if (bodyGlyph is not null)
             {
-                _bodyAdorner.Glyphs.Add(bodyGlyph);
-                if (selType == GlyphSelectionType.SelectedPrimary ||
-                    selType == GlyphSelectionType.Selected)
+                BodyGlyphAdorner.Glyphs.Add(bodyGlyph);
+                if (selType is GlyphSelectionType.SelectedPrimary or GlyphSelectionType.Selected)
                 {
-                    if (_curSelectionBounds[_curCompIndex] == Rectangle.Empty)
+                    if (_curSelectionBounds![_curCompIndex] == Rectangle.Empty)
                     {
                         _curSelectionBounds[_curCompIndex] = bodyGlyph.Bounds;
                     }
@@ -174,19 +158,18 @@ internal sealed class SelectionManager : IDisposable
             GlyphCollection glyphs = controlDesigner.GetGlyphs(selType);
             if (glyphs is not null)
             {
-                _selectionAdorner.Glyphs.AddRange(glyphs);
-                if (selType == GlyphSelectionType.SelectedPrimary ||
-                    selType == GlyphSelectionType.Selected)
+                SelectionGlyphAdorner.Glyphs.AddRange(glyphs);
+                if (selType is GlyphSelectionType.SelectedPrimary or GlyphSelectionType.Selected)
                 {
                     foreach (Glyph glyph in glyphs)
                     {
-                        _curSelectionBounds[_curCompIndex] = Rectangle.Union(_curSelectionBounds[_curCompIndex], glyph.Bounds);
+                        _curSelectionBounds![_curCompIndex] = Rectangle.Union(_curSelectionBounds[_curCompIndex], glyph.Bounds);
                     }
                 }
             }
         }
 
-        if (selType == GlyphSelectionType.SelectedPrimary || selType == GlyphSelectionType.Selected)
+        if (selType is GlyphSelectionType.SelectedPrimary or GlyphSelectionType.Selected)
         {
             _curCompIndex++;
         }
@@ -201,12 +184,12 @@ internal sealed class SelectionManager : IDisposable
         if (_designerHost is not null)
         {
             _designerHost.TransactionClosed -= new DesignerTransactionCloseEventHandler(OnTransactionClosed);
-            _designerHost = null;
+            _designerHost = null!;
         }
 
         if (_serviceProvider is not null)
         {
-            IComponentChangeService cs = (IComponentChangeService)_serviceProvider.GetService(typeof(IComponentChangeService));
+            IComponentChangeService? cs = _serviceProvider.GetService<IComponentChangeService>();
             if (cs is not null)
             {
                 cs.ComponentAdded -= new ComponentEventHandler(OnComponentAdded);
@@ -217,37 +200,37 @@ internal sealed class SelectionManager : IDisposable
             if (_selSvc is not null)
             {
                 _selSvc.SelectionChanged -= new EventHandler(OnSelectionChanged);
-                _selSvc = null;
+                _selSvc = null!;
             }
 
-            _serviceProvider = null;
+            _serviceProvider = null!;
         }
 
         if (_behaviorService is not null)
         {
-            _behaviorService.Adorners.Remove(_bodyAdorner);
-            _behaviorService.Adorners.Remove(_selectionAdorner);
+            _behaviorService.Adorners.Remove(BodyGlyphAdorner);
+            _behaviorService.Adorners.Remove(SelectionGlyphAdorner);
             _behaviorService.BeginDrag -= new BehaviorDragDropEventHandler(OnBeginDrag);
             _behaviorService.Synchronize -= new EventHandler(OnSynchronize);
-            _behaviorService = null;
+            _behaviorService = null!;
         }
 
-        if (_selectionAdorner is not null)
+        if (SelectionGlyphAdorner is not null)
         {
-            _selectionAdorner.Glyphs.Clear();
-            _selectionAdorner = null;
+            SelectionGlyphAdorner.Glyphs.Clear();
+            SelectionGlyphAdorner = null!;
         }
 
-        if (_bodyAdorner is not null)
+        if (BodyGlyphAdorner is not null)
         {
-            _bodyAdorner.Glyphs.Clear();
-            _bodyAdorner = null;
+            BodyGlyphAdorner.Glyphs.Clear();
+            BodyGlyphAdorner = null!;
         }
 
         if (_designerActionUI is not null)
         {
             _designerActionUI.Dispose();
-            _designerActionUI = null;
+            _designerActionUI = null!;
         }
     }
 
@@ -263,10 +246,10 @@ internal sealed class SelectionManager : IDisposable
     /// <summary>
     ///  When a component is added, we get the designer and add it to our hashtable for quick lookup.
     /// </summary>
-    private void OnComponentAdded(object source, ComponentEventArgs ce)
+    private void OnComponentAdded(object? source, ComponentEventArgs ce)
     {
-        IComponent component = ce.Component;
-        IDesigner designer = _designerHost.GetDesigner(component);
+        IComponent component = ce.Component!;
+        IDesigner? designer = _designerHost.GetDesigner(component);
         if (designer is ControlDesigner controlDesigner)
         {
             _componentToDesigner.Add(component, controlDesigner);
@@ -276,11 +259,11 @@ internal sealed class SelectionManager : IDisposable
     /// <summary>
     ///  Before a drag, remove all glyphs that are involved in the drag operation and any that don't allow drops.
     /// </summary>
-    private void OnBeginDrag(object source, BehaviorDragDropEventArgs e)
+    private void OnBeginDrag(object? source, BehaviorDragDropEventArgs e)
     {
         List<IComponent> dragComps = e.DragComponents.Cast<IComponent>().ToList();
         List<Glyph> glyphsToRemove = new();
-        foreach (ControlBodyGlyph g in _bodyAdorner.Glyphs)
+        foreach (ControlBodyGlyph g in BodyGlyphAdorner.Glyphs)
         {
             if (g.RelatedComponent is Control control && (dragComps.Contains(g.RelatedComponent) || !control.AllowDrop))
             {
@@ -290,7 +273,7 @@ internal sealed class SelectionManager : IDisposable
 
         foreach (Glyph g in glyphsToRemove)
         {
-            _bodyAdorner.Glyphs.Remove(g);
+            BodyGlyphAdorner.Glyphs.Remove(g);
         }
     }
 
@@ -303,9 +286,9 @@ internal sealed class SelectionManager : IDisposable
     /// <summary>
     ///  When a component is changed - we need to refresh the selection.
     /// </summary>
-    private void OnComponentChanged(object source, ComponentChangedEventArgs ce)
+    private void OnComponentChanged(object? source, ComponentChangedEventArgs ce)
     {
-        if (_selSvc.GetComponentSelected(ce.Component))
+        if (_selSvc.GetComponentSelected(ce.Component!))
         {
             if (!_designerHost.InTransaction)
             {
@@ -321,9 +304,9 @@ internal sealed class SelectionManager : IDisposable
     /// <summary>
     ///  When a component is removed - we remove the key and value from our hashtable.
     /// </summary>
-    private void OnComponentRemoved(object source, ComponentEventArgs ce)
+    private void OnComponentRemoved(object? source, ComponentEventArgs ce)
     {
-            _componentToDesigner.Remove(ce.Component);
+        _componentToDesigner.Remove(ce.Component!);
 
         //remove the associated designeractionpanel
         _designerActionUI?.RemoveActionGlyph(ce.Component);
@@ -332,12 +315,12 @@ internal sealed class SelectionManager : IDisposable
     /// <summary>
     ///  Computes the region representing the difference between the old selection and the new selection.
     /// </summary>
-    private Region DetermineRegionToRefresh(object primarySelection)
+    private Region DetermineRegionToRefresh(object? primarySelection)
     {
         Region toRefresh = new Region(Rectangle.Empty);
         Rectangle[] larger;
         Rectangle[] smaller;
-        if (_curSelectionBounds.Length >= _prevSelectionBounds.Length)
+        if (_curSelectionBounds!.Length >= _prevSelectionBounds!.Length)
         {
             larger = _curSelectionBounds;
             smaller = _prevSelectionBounds;
@@ -360,10 +343,9 @@ internal sealed class SelectionManager : IDisposable
         // determine which rects in the larger array need to be
         // included in the region to invalidate by intersecting
         // with rects in the smaller array.
-        for (int l = 0; l < larger.Length; l++)
+        foreach (Rectangle large in larger)
         {
             bool largeIntersected = false;
-            Rectangle large = larger[l];
             for (int s = 0; s < smaller.Length; s++)
             {
                 if (large.IntersectsWith(smaller[s]))
@@ -413,7 +395,7 @@ internal sealed class SelectionManager : IDisposable
     /// <summary>
     ///  Event handler for the behaviorService's Synchronize event
     /// </summary>
-    private void OnSynchronize(object sender, EventArgs e)
+    private void OnSynchronize(object? sender, EventArgs e)
     {
         Refresh();
     }
@@ -421,7 +403,7 @@ internal sealed class SelectionManager : IDisposable
     /// <summary>
     ///  On every selectionchange, we remove all glyphs, get the newly selected components, and re-add all glyphs back to the Adorner.
     /// </summary>
-    private void OnSelectionChanged(object sender, EventArgs e)
+    private void OnSelectionChanged(object? sender, EventArgs? e)
     {
         // Note: selectionChanging would guard against a re-entrant code...
         // Since we don't want to be in messed up state when adding new Glyphs.
@@ -429,11 +411,11 @@ internal sealed class SelectionManager : IDisposable
         {
             _selectionChanging = true;
 
-            _selectionAdorner.Glyphs.Clear();
-            _bodyAdorner.Glyphs.Clear();
+            SelectionGlyphAdorner.Glyphs.Clear();
+            BodyGlyphAdorner.Glyphs.Clear();
 
             List<IComponent> selComps = _selSvc.GetSelectedComponents().Cast<IComponent>().ToList();
-            object primarySelection = _selSvc.PrimarySelection;
+            object? primarySelection = _selSvc.PrimarySelection;
 
             //add all control glyphs to all controls on rootComp
             _curCompIndex = 0;
@@ -446,7 +428,7 @@ internal sealed class SelectionManager : IDisposable
                 using Graphics g = _behaviorService.AdornerWindowGraphics;
                 if (!toUpdate.IsEmpty(g))
                 {
-                    _selectionAdorner.Invalidate(toUpdate);
+                    SelectionGlyphAdorner.Invalidate(toUpdate);
                 }
             }
             else
@@ -463,20 +445,19 @@ internal sealed class SelectionManager : IDisposable
 
                     if (toUpdate != Rectangle.Empty)
                     {
-                        _selectionAdorner.Invalidate(toUpdate);
+                        SelectionGlyphAdorner.Invalidate(toUpdate);
                     }
                 }
                 else
                 {
-                    _selectionAdorner.Invalidate();
+                    SelectionGlyphAdorner.Invalidate();
                 }
             }
 
             _prevPrimarySelection = primarySelection;
             if (_curSelectionBounds.Length > 0)
             {
-                _prevSelectionBounds = new Rectangle[_curSelectionBounds.Length];
-                Array.Copy(_curSelectionBounds, _prevSelectionBounds, _curSelectionBounds.Length);
+                _prevSelectionBounds = _curSelectionBounds.AsSpan().ToArray();
             }
             else
             {
@@ -490,7 +471,7 @@ internal sealed class SelectionManager : IDisposable
     /// <summary>
     ///  When a transaction that involves one of our components closes,  refresh to reflect any changes.
     /// </summary>
-    private void OnTransactionClosed(object sender, DesignerTransactionCloseEventArgs e)
+    private void OnTransactionClosed(object? sender, DesignerTransactionCloseEventArgs e)
     {
         if (e.LastTransaction && NeedRefresh)
         {

--- a/src/System.Windows.Forms.Primitives/src/System/ComponentModel/MemberDescriptorExtensions.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/ComponentModel/MemberDescriptorExtensions.cs
@@ -40,4 +40,12 @@ internal static class MemberDescriptorExtensions
 
         return null;
     }
+
+    public static T? GetEditor<T>(this PropertyDescriptor descriptor) => (T?)descriptor.GetEditor(typeof(T));
+
+    public static bool TryGetEditor<T>(this PropertyDescriptor descriptor, [NotNullWhen(true)] out T? value)
+    {
+        value = (T?)descriptor.GetEditor(typeof(T));
+        return value is not null;
+    }
 }

--- a/src/System.Windows.Forms.Primitives/src/System/Diagnostics/TraceSwitchExtensions.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Diagnostics/TraceSwitchExtensions.cs
@@ -5,7 +5,7 @@ using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Text;
 
-namespace System.Windows.Forms;
+namespace System.Diagnostics;
 
 internal static class TraceSwitchExtensions
 {

--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -6398,7 +6398,7 @@ System.Windows.Forms.Design.IUIService.ShowToolWindow(System.Guid toolWindow) ->
 System.Windows.Forms.Design.IUIService.Styles.get -> System.Collections.IDictionary!
 System.Windows.Forms.Design.IWindowsFormsEditorService
 System.Windows.Forms.Design.IWindowsFormsEditorService.CloseDropDown() -> void
-System.Windows.Forms.Design.IWindowsFormsEditorService.DropDownControl(System.Windows.Forms.Control? control) -> void
+System.Windows.Forms.Design.IWindowsFormsEditorService.DropDownControl(System.Windows.Forms.Control! control) -> void
 System.Windows.Forms.Design.IWindowsFormsEditorService.ShowDialog(System.Windows.Forms.Form! dialog) -> System.Windows.Forms.DialogResult
 System.Windows.Forms.Design.PropertyTab
 System.Windows.Forms.Design.PropertyTab.~PropertyTab() -> void

--- a/src/System.Windows.Forms/src/System.Windows.Forms.csproj
+++ b/src/System.Windows.Forms/src/System.Windows.Forms.csproj
@@ -43,7 +43,6 @@
     <Compile Include="..\..\Common\src\IComparerHelpers.cs" Link="Common\IComparerHelpers.cs" />
     <Compile Include="..\..\Common\src\Obsoletions.cs" Link="Common\Obsoletions.cs" />
     <Compile Include="..\..\Common\src\RTLAwareMessageBox.cs" Link="Common\RTLAwareMessageBox.cs" />
-    <Compile Include="..\..\Common\src\TraceSwitchExtensions.cs" Link="Common\TraceSwitchExtensions.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/System.Windows.Forms/src/System/Resources/ResXResourceWriter.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResXResourceWriter.cs
@@ -3,7 +3,6 @@
 
 using System.Reflection;
 using System.Text;
-using System.Windows.Forms;
 using System.Xml;
 
 namespace System.Resources;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Design/IWindowsFormsEditorService.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Design/IWindowsFormsEditorService.cs
@@ -50,7 +50,7 @@ public interface IWindowsFormsEditorService
     ///   no other stored reference to the control.
     ///  </para>
     /// </remarks>
-    void DropDownControl(Control? control);
+    void DropDownControl(Control control);
 
     /// <summary>
     ///  Shows the specified <see cref="Form"/> as a dialog and returns its result. You should always use this


### PR DESCRIPTION
Depends on #9367. Only the last commit is not in the quoted PR and should be reviewed here.

As dicussed [here](https://github.com/dotnet/winforms/pull/9367#discussion_r1251266055), we're attempting a refactoring to limit the use of the `!` operator when annotating `DesignerActionPanel.Line` objects.

The idea is to stop creating `Line` objects early without initialising them and start creating then only when we are actually going to use them. To do so we change the `LineInfo` type to be a factory type.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9422)