### PR TITLE
suppress CodeQL warning in one test

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataObject_BitmapBinderTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataObject_BitmapBinderTests.cs
@@ -54,7 +54,8 @@ public class DataObject_BitmapBinderTests
                 Binder = s_serializationBinder
             };
 
-            object deserialized = formatter.Deserialize(stream);
+            // cs/dangerous-binary-deserialization
+            object deserialized = formatter.Deserialize(stream); // CodeQL [SM03722] : Safe use because input stream is controlled contains strings and Bitmap which is instantiated by a binder. 
             Assert.NotNull(deserialized);
 
             if (value is not Bitmap)


### PR DESCRIPTION
This is an experiment to see if this is the right kind of a suppression. THe next CodeQL run will validate it.
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1845201

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9431)