### PR TITLE
Change `ContainerSelectorGlyph` to use Icon internally

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/ContainerSelectorGlyph.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/ContainerSelectorGlyph.cs
@@ -14,7 +14,7 @@ namespace System.Windows.Forms.Design.Behavior;
 internal sealed class ContainerSelectorGlyph : Glyph
 {
     private readonly Rectangle _glyphBounds;
-    private Icon? _glyph;
+    private readonly Icon _glyph;
     private readonly ContainerSelectorBehavior? _relatedBehavior;
 
     /// <summary>
@@ -25,6 +25,7 @@ internal sealed class ContainerSelectorGlyph : Glyph
     {
         _relatedBehavior = behavior;
         _glyphBounds = new Rectangle(containerBounds.X + glyphOffset, containerBounds.Y - (int)(glyphSize * .5), glyphSize, glyphSize);
+        _glyph = new Icon(typeof(ContainerSelectorGlyph), "MoverGlyph");
     }
 
     /// <summary>
@@ -40,17 +41,8 @@ internal sealed class ContainerSelectorGlyph : Glyph
     public override Cursor? GetHitTest(Point p)
         => _glyphBounds.Contains(p) || _relatedBehavior?.OkToMove == true ? Cursors.SizeAll : null;
 
-    private Icon MoveGlyph
-    {
-        get
-        {
-            _glyph ??= new Icon(typeof(ContainerSelectorGlyph), "MoverGlyph");
-            return _glyph;
-        }
-    }
-
     /// <summary>
     ///  Very simple paint logic.
     /// </summary>
-    public override void Paint(PaintEventArgs pe) => pe.Graphics.DrawIcon(MoveGlyph, _glyphBounds);
+    public override void Paint(PaintEventArgs pe) => pe.Graphics.DrawIcon(_glyph, _glyphBounds);
 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/ContainerSelectorGlyph.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/ContainerSelectorGlyph.cs
@@ -13,7 +13,7 @@ namespace System.Windows.Forms.Design.Behavior;
 internal sealed class ContainerSelectorGlyph : Glyph
 {
     private Rectangle _glyphBounds;
-    private Bitmap? _glyph;
+    private Icon? _glyph;
     private readonly ContainerSelectorBehavior? _relatedBehavior;
 
     /// <summary>
@@ -44,20 +44,14 @@ internal sealed class ContainerSelectorGlyph : Glyph
     /// </summary>
     public override Cursor? GetHitTest(Point p)
     {
-        if (_glyphBounds.Contains(p) || _relatedBehavior?.OkToMove == true)
-        {
-            return Cursors.SizeAll;
-        }
-
-        return null;
+        return _glyphBounds.Contains(p) || _relatedBehavior?.OkToMove == true ? Cursors.SizeAll : null;
     }
 
-    private Bitmap MoveGlyph
+    private Icon MoveGlyph
     {
         get
         {
-            _glyph ??= new Bitmap(typeof(ContainerSelectorGlyph), "MoverGlyph");
-
+            _glyph ??= new Icon(typeof(ContainerSelectorGlyph), "MoverGlyph");
             return _glyph;
         }
     }
@@ -67,6 +61,6 @@ internal sealed class ContainerSelectorGlyph : Glyph
     /// </summary>
     public override void Paint(PaintEventArgs pe)
     {
-        pe.Graphics.DrawImage(MoveGlyph, _glyphBounds);
+        pe.Graphics.DrawIcon(MoveGlyph, _glyphBounds);
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/ContainerSelectorGlyph.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/ContainerSelectorGlyph.cs
@@ -49,7 +49,6 @@ internal sealed class ContainerSelectorGlyph : Glyph
         if (_glyph is null)
         {
             _glyph = new Icon(typeof(ContainerSelectorGlyph), "MoverGlyph").ToBitmap();
-            _glyph.MakeTransparent();
         }
 
         // Draw the transparent Bitmap

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/ContainerSelectorGlyph.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/ContainerSelectorGlyph.cs
@@ -14,7 +14,7 @@ namespace System.Windows.Forms.Design.Behavior;
 internal sealed class ContainerSelectorGlyph : Glyph
 {
     private readonly Rectangle _glyphBounds;
-    private Icon? _glyph;
+    private Bitmap? _glyph;
     private readonly ContainerSelectorBehavior? _relatedBehavior;
 
     /// <summary>
@@ -44,5 +44,15 @@ internal sealed class ContainerSelectorGlyph : Glyph
     ///  Very simple paint logic.
     /// </summary>
     public override void Paint(PaintEventArgs pe)
-        => pe.Graphics.DrawIcon(_glyph ??= new Icon(typeof(ContainerSelectorGlyph), "MoverGlyph"), _glyphBounds);
+    {
+        // Initialize the glyph
+        if (_glyph is null)
+        {
+            _glyph = new Icon(typeof(ContainerSelectorGlyph), "MoverGlyph").ToBitmap();
+            _glyph.MakeTransparent();
+        }
+
+        // Draw the transparent Bitmap
+        pe.Graphics.DrawImage(_glyph, _glyphBounds);
+    }
 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/ContainerSelectorGlyph.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/ContainerSelectorGlyph.cs
@@ -7,12 +7,13 @@ using System.Drawing;
 namespace System.Windows.Forms.Design.Behavior;
 
 /// <summary>
-///  This is the glyph used to drag container controls around the designer. This glyph (and associated behavior) is created by the ParentControlDesigner.
+///  This is the glyph used to drag container controls around the designer.
+///  This glyph (and associated behavior) is created by the ParentControlDesigner.
 /// </summary>
 [DebuggerDisplay("{GetType().Name}:: Component: {_component}, Cursor: {_hitTestCursor}")]
 internal sealed class ContainerSelectorGlyph : Glyph
 {
-    private Rectangle _glyphBounds;
+    private readonly Rectangle _glyphBounds;
     private Icon? _glyph;
     private readonly ContainerSelectorBehavior? _relatedBehavior;
 
@@ -29,23 +30,15 @@ internal sealed class ContainerSelectorGlyph : Glyph
     /// <summary>
     ///  The bounds of this Glyph.
     /// </summary>
-    public override Rectangle Bounds
-    {
-        get => _glyphBounds;
-    }
+    public override Rectangle Bounds => _glyphBounds;
 
-    public Behavior? RelatedBehavior
-    {
-        get => _relatedBehavior;
-    }
+    public Behavior? RelatedBehavior => _relatedBehavior;
 
     /// <summary>
     ///  Simple hit test rule: if the point is contained within the bounds - then it is a positive hit test.
     /// </summary>
     public override Cursor? GetHitTest(Point p)
-    {
-        return _glyphBounds.Contains(p) || _relatedBehavior?.OkToMove == true ? Cursors.SizeAll : null;
-    }
+        => _glyphBounds.Contains(p) || _relatedBehavior?.OkToMove == true ? Cursors.SizeAll : null;
 
     private Icon MoveGlyph
     {
@@ -59,8 +52,5 @@ internal sealed class ContainerSelectorGlyph : Glyph
     /// <summary>
     ///  Very simple paint logic.
     /// </summary>
-    public override void Paint(PaintEventArgs pe)
-    {
-        pe.Graphics.DrawIcon(MoveGlyph, _glyphBounds);
-    }
+    public override void Paint(PaintEventArgs pe) => pe.Graphics.DrawIcon(MoveGlyph, _glyphBounds);
 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/ContainerSelectorGlyph.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/ContainerSelectorGlyph.cs
@@ -14,7 +14,7 @@ namespace System.Windows.Forms.Design.Behavior;
 internal sealed class ContainerSelectorGlyph : Glyph
 {
     private readonly Rectangle _glyphBounds;
-    private readonly Icon _glyph;
+    private Icon? _glyph;
     private readonly ContainerSelectorBehavior? _relatedBehavior;
 
     /// <summary>
@@ -25,7 +25,6 @@ internal sealed class ContainerSelectorGlyph : Glyph
     {
         _relatedBehavior = behavior;
         _glyphBounds = new Rectangle(containerBounds.X + glyphOffset, containerBounds.Y - (int)(glyphSize * .5), glyphSize, glyphSize);
-        _glyph = new Icon(typeof(ContainerSelectorGlyph), "MoverGlyph");
     }
 
     /// <summary>
@@ -44,5 +43,6 @@ internal sealed class ContainerSelectorGlyph : Glyph
     /// <summary>
     ///  Very simple paint logic.
     /// </summary>
-    public override void Paint(PaintEventArgs pe) => pe.Graphics.DrawIcon(_glyph, _glyphBounds);
+    public override void Paint(PaintEventArgs pe)
+        => pe.Graphics.DrawIcon(_glyph ??= new Icon(typeof(ContainerSelectorGlyph), "MoverGlyph"), _glyphBounds);
 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/ContainerSelectorGlyph.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/ContainerSelectorGlyph.cs
@@ -46,10 +46,7 @@ internal sealed class ContainerSelectorGlyph : Glyph
     public override void Paint(PaintEventArgs pe)
     {
         // Initialize the glyph
-        if (_glyph is null)
-        {
-            _glyph = new Icon(typeof(ContainerSelectorGlyph), "MoverGlyph").ToBitmap();
-        }
+        _glyph ??= new Icon(typeof(ContainerSelectorGlyph), "MoverGlyph").ToBitmap();
 
         // Draw the transparent Bitmap
         pe.Graphics.DrawImage(_glyph, _glyphBounds);


### PR DESCRIPTION
Fixes #9421
Caused by #8358

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9432)