### PR TITLE
Fix issue 9438: when setting GripStyle = hidden, the next focus position is not correct.

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
@@ -2191,7 +2191,7 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
         // backward direction entering the toolstrip, it means that the first
         // toolstrip item should be selected irrespectively TAB or SHIFT+TAB
         // is pressed.
-        start ??= GetStartItem(forward);
+        start ??= forward ? DisplayedItems[DisplayedItems.Count - 1] : DisplayedItems[0];
 
         int current = DisplayedItems.IndexOf(start);
         if (current == -1)
@@ -2233,8 +2233,6 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
 
         return null;
     }
-
-    private ToolStripItem GetStartItem(bool forward) => forward ? DisplayedItems[DisplayedItems.Count - 1] : DisplayedItems[0];
 
     /// <remarks>
     ///  Helper function for GetNextItem - do not directly call this.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
@@ -2245,7 +2245,7 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
         {
             // For the drop-down up-directed loop should be preserved.
             // So if the current item is topmost, then the bottom item should be selected on up-key press.
-            return DisplayedItems[DisplayedItems.Count > 1 ? 1 : 0];
+            return (DisplayedItems.Count > 1 && DisplayedItems[0].CanKeyboardSelect) ? DisplayedItems[0] : DisplayedItems[DisplayedItems.Count > 1 ? 1 : 0];
         }
 
         return DisplayedItems[0];

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
@@ -2191,7 +2191,7 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
         // backward direction entering the toolstrip, it means that the first
         // toolstrip item should be selected irrespectively TAB or SHIFT+TAB
         // is pressed.
-        start ??= GetStartItem(forward, dropDown is not null);
+        start ??= GetStartItem(forward);
 
         int current = DisplayedItems.IndexOf(start);
         if (current == -1)
@@ -2234,22 +2234,7 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
         return null;
     }
 
-    private ToolStripItem GetStartItem(bool forward, bool isDropDown)
-    {
-        if (forward)
-        {
-            return DisplayedItems[DisplayedItems.Count - 1];
-        }
-
-        if (!isDropDown)
-        {
-            // For the drop-down up-directed loop should be preserved.
-            // So if the current item is topmost, then the bottom item should be selected on up-key press.
-            return (DisplayedItems.Count > 1 && DisplayedItems[0].CanKeyboardSelect) ? DisplayedItems[0] : DisplayedItems[DisplayedItems.Count > 1 ? 1 : 0];
-        }
-
-        return DisplayedItems[0];
-    }
+    private ToolStripItem GetStartItem(bool forward) => forward ? DisplayedItems[DisplayedItems.Count - 1] : DisplayedItems[0];
 
     /// <remarks>
     ///  Helper function for GetNextItem - do not directly call this.
@@ -2394,7 +2379,7 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
         return prefSize + newPadding.Size;
     }
 
-#region GetPreferredSizeHelpers
+    #region GetPreferredSizeHelpers
 
     //
     // These are here so they can be shared between splitstack layout and StatusStrip
@@ -2529,7 +2514,7 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
     {
         return item.AutoSize ? item.GetPreferredSize(Size.Empty) : item.Size;
     }
-#endregion
+    #endregion
 
     internal ToolStripItem? GetSelectedItem()
     {
@@ -4918,7 +4903,7 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
 
     protected override ControlCollection CreateControlsInstance()
     {
-        return new ReadOnlyControlCollection(this,  isReadOnly: !DesignMode);
+        return new ReadOnlyControlCollection(this, isReadOnly: !DesignMode);
     }
 
     internal void OnItemAddedInternal(ToolStripItem item)

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripTests.cs
@@ -7249,7 +7249,7 @@ public partial class ToolStripTests
     {
         // Regression test for https://github.com/dotnet/winforms/issues/9181,https://github.com/dotnet/winforms/issues/9438
         // and it verifies that setting TabStop=true,
-        // When typing Right arrow keyboard, the next focus position is first item on the left,
+        // When typing Right arrow keyboard, the next focus position is first item on the left.
         // When typing Left arrow keyboard, the next focus position is first item on the Right.
 
         using ToolStrip toolStrip = new() { LayoutStyle = toolStripLayoutStyle, TabStop = tabStop, GripStyle = gripStyle };

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripTests.cs
@@ -7234,14 +7234,25 @@ public partial class ToolStripTests
         }
     }
 
-    [WinFormsFact]
-    public void ToolStrip_GetNextItem_ItemsBackwardExpected()
+    [WinFormsTheory]
+    [InlineData(ToolStripLayoutStyle.Flow, true, ToolStripGripStyle.Visible)]
+    [InlineData(ToolStripLayoutStyle.HorizontalStackWithOverflow, true, ToolStripGripStyle.Visible)]
+    [InlineData(ToolStripLayoutStyle.StackWithOverflow, true, ToolStripGripStyle.Visible)]
+    [InlineData(ToolStripLayoutStyle.Table, true, ToolStripGripStyle.Visible)]
+    [InlineData(ToolStripLayoutStyle.VerticalStackWithOverflow, true, ToolStripGripStyle.Visible)]
+    [InlineData(ToolStripLayoutStyle.Flow, true, ToolStripGripStyle.Hidden)]
+    [InlineData(ToolStripLayoutStyle.HorizontalStackWithOverflow, true, ToolStripGripStyle.Hidden)]
+    [InlineData(ToolStripLayoutStyle.StackWithOverflow, true, ToolStripGripStyle.Hidden)]
+    [InlineData(ToolStripLayoutStyle.Table, true, ToolStripGripStyle.Hidden)]
+    [InlineData(ToolStripLayoutStyle.VerticalStackWithOverflow, true, ToolStripGripStyle.Hidden)]
+    public void ToolStrip_GetNextItem_ItemsBackwardExpected(ToolStripLayoutStyle toolStripLayoutStyle, bool tabStop, ToolStripGripStyle gripStyle)
     {
-        // Regression test for https://github.com/dotnet/winforms/issues/9181, and it verifies that setting TabStop=true,
+        // Regression test for https://github.com/dotnet/winforms/issues/9181,https://github.com/dotnet/winforms/issues/9438
+        // and it verifies that setting TabStop=true,
         // When typing Right arrow keyboard, the next focus position is first item on the left,
         // When typing Left arrow keyboard, the next focus position is first item on the Right.
 
-        using ToolStrip toolStrip = new() { TabStop = true, Width = 300 };
+        using ToolStrip toolStrip = new() { LayoutStyle = toolStripLayoutStyle, TabStop = tabStop, GripStyle = gripStyle };
         using ToolStripMenuItem toolStripMenuItem1 = new();
         using ToolStripMenuItem toolStripMenuItem2 = new();
         using ToolStripMenuItem toolStripMenuItem3 = new();


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #9438 

When the GripStyle = Visible, the ToolStrip control can correctly find out the first item of can be selected by Keyboard.
but when we set the GripStyle = hidden, the ToolStrip control will find out the second item of can be selected by Keyboard, not the first. It may be caused this issue.

## Proposed changes

- Modify the method of finding the starting item - GetStartItem(bool forward, bool isDropDown).
- Refine test cases to cover more scenarios.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Whatever the value of GripStyle is, when typing Left/Right arrow keyboard, ToolStrip  can find the correct starting item.

## Regression? 

- Yes

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
Setting GripStyle = hidden, when selecting on a ToolStripButton using mouse or typing "enter" keyboard and then typing "right or left" keyboard, the next focus position is first item on the left, regardless of whether the right or left key is typed.
![image](https://github.com/dotnet/winforms/assets/133954995/d66e9427-0e7f-4cde-aed9-22b01ad840a2)

### After
The behavior is the same as when GripStyle = Visible, when typing Right keyboard, the next focus position is first item on the left, and if typing Left keyboard, the next focus position is first item on the Right.
![ToolStrip1](https://github.com/dotnet/winforms/assets/133954995/f3ead1f7-cbcc-49cf-826d-9d38be69d32e)

<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- Manual

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

- 8.0.0-preview.7.23323.5

<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9439)