### PR TITLE
Update the test data used for test case ControlAccessibleObject_DoesNotRootControls_AllPublicControl

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ControlAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ControlAccessibleObjectTests.cs
@@ -1219,9 +1219,8 @@ public class Control_ControlAccessibleObjectTests
     {
         var typesToIgnore = new[]
         {
-           typeof(DataGridViewComboBoxEditingControl), typeof(DataGridViewTextBoxEditingControl),
-           typeof(FlowLayoutPanel), typeof(HScrollBar), typeof(LinkLabel), typeof(ListBox),typeof(ListView), typeof(MonthCalendar),
-           typeof(PropertyGrid), typeof(TableLayoutPanel), typeof(TabPage), typeof(ToolStripContentPanel), typeof(TreeView), typeof(VScrollBar)
+           typeof(HScrollBar), typeof(ListView), typeof(MonthCalendar),
+           typeof(PropertyGrid), typeof(TabPage), typeof(TreeView), typeof(VScrollBar)
         };
 
         return ReflectionHelper.GetPublicNotAbstractClasses<Control>()


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Related to https://github.com/dotnet/winforms/issues/9224


## Proposed changes

- Update the test data used for test case.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Test case ControlAccessibleObject_DoesNotRootControls_AllPublicControl can run normally through.

## Regression? 

- No

## Test methodology <!-- How did you ensure quality? -->

- Unit tests

## Test environment(s) <!-- Remove any that don't apply -->

- 8.0.100-preview.7.23324.2


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9440)