### PR TITLE
Update control owning field of ListView to using weak reference

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewAccessibleObject.cs
@@ -382,7 +382,7 @@ public partial class ListView
         {
             if (!this.TryGetOwnerAs(out ListView? owningListView))
             {
-                return base.IsPatternSupported(patternId);
+                return false;
             }
 
             if (patternId == UiaCore.UIA.SelectionPatternId ||

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewAccessibleObject.cs
@@ -11,21 +11,19 @@ public partial class ListView
 {
     internal class ListViewAccessibleObject : ControlAccessibleObject
     {
-        private readonly ListView _owningListView;
         private static readonly int[] s_enumViewValues = (int[])Enum.GetValues(typeof(View));
 
         internal ListViewAccessibleObject(ListView owningListView) : base(owningListView)
         {
-            _owningListView = owningListView;
         }
 
         internal override Rectangle BoundingRectangle
         {
             get
             {
-                if (_owningListView.IsHandleCreated)
+                if (this.TryGetOwnerAs(out ListView? owningListView) && owningListView.IsHandleCreated)
                 {
-                    PInvoke.GetWindowRect(_owningListView, out var rect);
+                    PInvoke.GetWindowRect(owningListView, out var rect);
                     return rect;
                 }
 
@@ -34,21 +32,21 @@ public partial class ListView
         }
 
         internal override bool CanSelectMultiple
-            => _owningListView.IsHandleCreated;
+            => this.TryGetOwnerAs(out ListView? owningListView) && owningListView.IsHandleCreated;
 
         internal override int ColumnCount
-            => _owningListView.Columns.Count;
+            => this.TryGetOwnerAs(out ListView? owningListView) ? owningListView.Columns.Count : base.ColumnCount;
 
         internal bool OwnerHasDefaultGroup
         {
             get
             {
-                if (!_owningListView.GroupsDisplayed)
+                if (!this.TryGetOwnerAs(out ListView? owningListView) || !owningListView.GroupsDisplayed)
                 {
                     return false;
                 }
 
-                foreach (ListViewItem? item in _owningListView.Items)
+                foreach (ListViewItem? item in owningListView.Items)
                 {
                     // If there are groups in the ListView, then the items which do not belong
                     // to any of the group and have null as the item.Group value, so these items
@@ -65,7 +63,7 @@ public partial class ListView
         }
 
         internal override int RowCount
-            => _owningListView.Items.Count;
+            => this.TryGetOwnerAs(out ListView? owningListView) ? owningListView.Items.Count : base.RowCount;
 
         internal override UiaCore.RowOrColumnMajor RowOrColumnMajor
             => UiaCore.RowOrColumnMajor.RowMajor;
@@ -79,7 +77,7 @@ public partial class ListView
 
         internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
         {
-            if (!_owningListView.IsHandleCreated)
+            if (!this.TryGetOwnerAs(out ListView? owningListView) || !owningListView.IsHandleCreated)
             {
                 return null;
             }
@@ -94,34 +92,34 @@ public partial class ListView
 
         public override AccessibleObject? GetChild(int index)
         {
-            if (!_owningListView.IsHandleCreated || index < 0)
+            if (!this.TryGetOwnerAs(out ListView? owningListView) || !owningListView.IsHandleCreated || index < 0)
             {
                 return null;
             }
 
-            if (_owningListView._labelEdit is {} labelEdit && index == GetChildCount() - 1)
+            if (owningListView._labelEdit is {} labelEdit && index == GetChildCount() - 1)
             {
                 return labelEdit.AccessibilityObject;
             }
 
-            if (_owningListView.GroupsDisplayed)
+            if (owningListView.GroupsDisplayed)
             {
                 IReadOnlyList<ListViewGroup> visibleGroups = GetVisibleGroups();
                 return index < visibleGroups.Count ? visibleGroups[index].AccessibilityObject : null;
             }
 
-            return index < _owningListView.Items.Count ? _owningListView.Items[index].AccessibilityObject : null;
+            return index < owningListView.Items.Count ? owningListView.Items[index].AccessibilityObject : null;
         }
 
         public override int GetChildCount()
         {
-            if (!_owningListView.IsHandleCreated)
+            if (!this.TryGetOwnerAs(out ListView? owningListView) || !owningListView.IsHandleCreated)
             {
                 return InvalidIndex;
             }
 
-            int count = _owningListView.GroupsDisplayed ? GetVisibleGroups().Count : _owningListView.Items.Count;
-            if (_owningListView._labelEdit is not null)
+            int count = owningListView.GroupsDisplayed ? GetVisibleGroups().Count : owningListView.Items.Count;
+            if (owningListView._labelEdit is not null)
             {
                 count++;
             }
@@ -131,7 +129,7 @@ public partial class ListView
 
         private int GetItemIndex(AccessibleObject? child)
         {
-            if (child is null)
+            if (!this.TryGetOwnerAs(out ListView? owningListView) || child is null)
             {
                 return InvalidIndex;
             }
@@ -139,7 +137,7 @@ public partial class ListView
             if (child is ListViewItem.ListViewItemBaseAccessibleObject itemAccessibleObject)
             {
                 int index = itemAccessibleObject.CurrentIndex;
-                return index < _owningListView.Items.Count ? index : InvalidIndex;
+                return index < owningListView.Items.Count ? index : InvalidIndex;
             }
 
             return InvalidIndex;
@@ -165,24 +163,43 @@ public partial class ListView
         }
 
         internal override int GetChildIndex(AccessibleObject? child)
-            => _owningListView._labelEdit is {} labelEdit && child == labelEdit.AccessibilityObject
-                ? GetChildCount() - 1
-                : _owningListView.GroupsDisplayed ? GetGroupIndex(child) : GetItemIndex(child);
+        {
+            if (!this.TryGetOwnerAs(out ListView? owningListView))
+            {
+                return base.GetChildIndex(child);
+            }
+
+            return owningListView._labelEdit is { } labelEdit && child == labelEdit.AccessibilityObject
+                     ? GetChildCount() - 1
+                     : owningListView.GroupsDisplayed ? GetGroupIndex(child) : GetItemIndex(child);
+        }
 
         private string GetItemStatus()
-            => _owningListView.Sorting switch
+        {
+            if (!this.TryGetOwnerAs(out ListView? owningListView))
+            {
+                return string.Empty;
+            }
+
+            return owningListView.Sorting switch
             {
                 SortOrder.Ascending => SR.SortedAscendingAccessibleStatus,
                 SortOrder.Descending => SR.SortedDescendingAccessibleStatus,
                 _ => SR.NotSortedAccessibleStatus
             };
+        }
 
         internal override UiaCore.IRawElementProviderSimple[]? GetColumnHeaders()
         {
-            UiaCore.IRawElementProviderSimple[] columnHeaders = new UiaCore.IRawElementProviderSimple[_owningListView.Columns.Count];
+            if (!this.TryGetOwnerAs(out ListView? owningListView))
+            {
+                return base.GetColumnHeaders();
+            }
+
+            UiaCore.IRawElementProviderSimple[] columnHeaders = new UiaCore.IRawElementProviderSimple[owningListView.Columns.Count];
             for (int i = 0; i < columnHeaders.Length; i++)
             {
-                columnHeaders[i] = _owningListView.Columns[i].AccessibilityObject;
+                columnHeaders[i] = owningListView.Columns[i].AccessibilityObject;
             }
 
             return columnHeaders;
@@ -190,16 +207,16 @@ public partial class ListView
 
         internal override UiaCore.IRawElementProviderFragment? GetFocus()
         {
-            if (!_owningListView.IsHandleCreated)
+            if (!this.TryGetOwnerAs(out ListView? owningListView) || !owningListView.IsHandleCreated)
             {
                 return null;
             }
 
-            return _owningListView.FocusedItem?.AccessibilityObject ?? _owningListView.FocusedGroup?.AccessibilityObject;
+            return owningListView.FocusedItem?.AccessibilityObject ?? owningListView.FocusedGroup?.AccessibilityObject;
         }
 
         internal override int GetMultiViewProviderCurrentView()
-            => (int)_owningListView.View;
+            => this.TryGetOwnerAs(out ListView? owningListView) ? (int)owningListView.View : base.GetMultiViewProviderCurrentView();
 
         internal override int[] GetMultiViewProviderSupportedViews()
             => new int[] { (int)View.Details };
@@ -219,18 +236,23 @@ public partial class ListView
 
         private AccessibleObject? GetLastChild()
         {
-            if (_owningListView._labelEdit is {} labelEdit)
+            if (!this.TryGetOwnerAs(out ListView? owningListView))
+            {
+                return null;
+            }
+
+            if (owningListView._labelEdit is {} labelEdit)
             {
                 return labelEdit.AccessibilityObject;
             }
 
-            if (_owningListView.GroupsDisplayed)
+            if (owningListView.GroupsDisplayed)
             {
                 IReadOnlyList<ListViewGroup> visibleGroups = GetVisibleGroups();
                 return visibleGroups.Count == 0 ? null : visibleGroups[visibleGroups.Count - 1].AccessibilityObject;
             }
 
-            return _owningListView.Items.Count == 0 ? null : _owningListView.Items[_owningListView.Items.Count - 1].AccessibilityObject;
+            return owningListView.Items.Count == 0 ? null : owningListView.Items[owningListView.Items.Count - 1].AccessibilityObject;
         }
 
         internal override object? GetPropertyValue(UiaCore.UIA propertyID)
@@ -240,7 +262,7 @@ public partial class ListView
                 // it will be retrieved from Windows.
                 // And we don't have a 100% guarantee it will be correct, hence set it ourselves.
                 UiaCore.UIA.ControlTypePropertyId when
-                    _owningListView.AccessibleRole == AccessibleRole.Default
+                    this.GetOwnerAccessibleRole() == AccessibleRole.Default
                     => UiaCore.UIA.ListControlTypeId,
                 UiaCore.UIA.HasKeyboardFocusPropertyId => false,
                 UiaCore.UIA.IsKeyboardFocusablePropertyId => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,
@@ -253,15 +275,15 @@ public partial class ListView
 
         internal override UiaCore.IRawElementProviderSimple[] GetSelection()
         {
-            if (!_owningListView.IsHandleCreated)
+            if (!this.TryGetOwnerAs(out ListView? owningListView) || !owningListView.IsHandleCreated)
             {
                 return Array.Empty<UiaCore.IRawElementProviderSimple>();
             }
 
-            UiaCore.IRawElementProviderSimple[] selectedItemProviders = new UiaCore.IRawElementProviderSimple[_owningListView.SelectedIndices.Count];
+            UiaCore.IRawElementProviderSimple[] selectedItemProviders = new UiaCore.IRawElementProviderSimple[owningListView.SelectedIndices.Count];
             for (int i = 0; i < selectedItemProviders.Length; i++)
             {
-                selectedItemProviders[i] = _owningListView.Items[_owningListView.SelectedIndices[i]].AccessibilityObject;
+                selectedItemProviders[i] = owningListView.Items[owningListView.SelectedIndices[i]].AccessibilityObject;
             }
 
             return selectedItemProviders;
@@ -270,12 +292,18 @@ public partial class ListView
         internal IReadOnlyList<ListViewGroup> GetVisibleGroups()
         {
             List<ListViewGroup> list = new();
-            if (OwnerHasDefaultGroup)
+
+            if (!this.TryGetOwnerAs(out ListView? owningListView))
             {
-                list.Add(_owningListView.DefaultGroup);
+                return list;
             }
 
-            foreach (ListViewGroup listViewGroup in _owningListView.Groups)
+            if (OwnerHasDefaultGroup)
+            {
+                list.Add(owningListView.DefaultGroup);
+            }
+
+            foreach (ListViewGroup listViewGroup in owningListView.Groups)
             {
                 if (listViewGroup.AccessibilityObject is ListViewGroup.ListViewGroupAccessibleObject listViewGroupAccessibleObject
                     && listViewGroupAccessibleObject.GetVisibleItems().Count > 0)
@@ -289,15 +317,15 @@ public partial class ListView
 
         public override AccessibleObject? HitTest(int x, int y)
         {
-            if (!_owningListView.IsHandleCreated)
+            if (!this.TryGetOwnerAs(out ListView? owningListView) || !owningListView.IsHandleCreated)
             {
                 return null;
             }
 
             Point hitTestPoint = new(x, y);
-            Point point = _owningListView.PointToClient(hitTestPoint);
-            ListViewHitTestInfo hitTestInfo = _owningListView.HitTest(point.X, point.Y);
-            if (hitTestInfo.Item is null && _owningListView.GroupsDisplayed)
+            Point point = owningListView.PointToClient(hitTestPoint);
+            ListViewHitTestInfo hitTestInfo = owningListView.HitTest(point.X, point.Y);
+            if (hitTestInfo.Item is null && owningListView.GroupsDisplayed)
             {
                 IReadOnlyList<ListViewGroup> visibleGroups = GetVisibleGroups();
                 for (int i = 0; i < visibleGroups.Count; i++)
@@ -317,7 +345,7 @@ public partial class ListView
 
                 if (hitTestInfo.SubItem is not null)
                 {
-                    return _owningListView.View switch
+                    return owningListView.View switch
                     {
                         View.Details => ((ListViewItem.ListViewItemDetailsAccessibleObject)itemAccessibleObject)
                             .GetChild(hitTestInfo.SubItem.Index, point),
@@ -331,7 +359,7 @@ public partial class ListView
 
                 if (itemAccessibleObject is ListViewItem.ListViewItemDetailsAccessibleObject itemDetailsAccessibleObject)
                 {
-                    for (int i = 1; i < _owningListView.Columns.Count; i++)
+                    for (int i = 1; i < owningListView.Columns.Count; i++)
                     {
                         if (itemDetailsAccessibleObject.GetSubItemBounds(i).Contains(point))
                         {
@@ -352,10 +380,15 @@ public partial class ListView
 
         internal override bool IsPatternSupported(UiaCore.UIA patternId)
         {
+            if (!this.TryGetOwnerAs(out ListView? owningListView))
+            {
+                return base.IsPatternSupported(patternId);
+            }
+
             if (patternId == UiaCore.UIA.SelectionPatternId ||
                 patternId == UiaCore.UIA.MultipleViewPatternId ||
-                (patternId == UiaCore.UIA.GridPatternId && _owningListView.View == View.Details) ||
-                (patternId == UiaCore.UIA.TablePatternId && _owningListView.View == View.Details))
+                (patternId == UiaCore.UIA.GridPatternId && owningListView.View == View.Details) ||
+                (patternId == UiaCore.UIA.TablePatternId && owningListView.View == View.Details))
             {
                 return true;
             }
@@ -365,11 +398,16 @@ public partial class ListView
 
         internal override void SetMultiViewProviderCurrentView(int viewId)
         {
+            if (!this.TryGetOwnerAs(out ListView? owningListView))
+            {
+                return;
+            }
+
             foreach (var view in s_enumViewValues)
             {
                 if (view == viewId)
                 {
-                    _owningListView.View = (View)view;
+                    owningListView.View = (View)view;
                 }
             }
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ControlAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ControlAccessibleObjectTests.cs
@@ -1219,7 +1219,7 @@ public class Control_ControlAccessibleObjectTests
     {
         var typesToIgnore = new[]
         {
-           typeof(HScrollBar), typeof(ListView), typeof(MonthCalendar),
+           typeof(HScrollBar),  typeof(MonthCalendar),
            typeof(PropertyGrid), typeof(TabPage), typeof(TreeView), typeof(VScrollBar)
         };
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Related to #9224 


## Proposed changes

- Update the control owning field of ListView  to using weak references
- Enable the GC collect test for the ListView  control in unit test cases


<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- The strong reference used by the original Owner property can cause a memory leak

## Regression? 

-  No


<!-- end TELL-MODE -->



## Test methodology <!-- How did you ensure quality? -->

- Unit tests
 

## Test environment(s) <!-- Remove any that don't apply -->

- dotnet 8.0.0-preview.7.23358.3


<!-- Mention language, UI scaling, or anything else that might be relevant -->
