### PR TITLE
Update control owning field of TabPage to using weak reference

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ControlAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ControlAccessibleObjectTests.cs
@@ -1220,7 +1220,7 @@ public class Control_ControlAccessibleObjectTests
         var typesToIgnore = new[]
         {
            typeof(HScrollBar), typeof(ListView), typeof(MonthCalendar),
-           typeof(PropertyGrid), typeof(TabPage), typeof(TreeView), typeof(VScrollBar)
+           typeof(PropertyGrid), typeof(TreeView), typeof(VScrollBar)
         };
 
         return ReflectionHelper.GetPublicNotAbstractClasses<Control>()


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Related to #9224 


## Proposed changes

- Update the control owning field of TabPage to using weak references
- Enable the GC collect test for the TabPage control in unit test cases


<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- The strong reference used by the original Owner property can cause a memory leak

## Regression? 

-  No


<!-- end TELL-MODE -->



## Test methodology <!-- How did you ensure quality? -->

- Unit tests
 

## Test environment(s) <!-- Remove any that don't apply -->

- dotnet 8.0.0-preview.7.23358.3


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9453)