### PR TITLE
Update control owning field of TreeView to using weak reference

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.TreeViewAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.TreeViewAccessibleObject.cs
@@ -94,7 +94,7 @@ public partial class TreeView
 
                 if (!this.TryGetOwnerAs(out TreeView? owningTreeView))
                 {
-                    return state;
+                    return AccessibleStates.None;
                 }
 
                 if (owningTreeView.Focused)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.TreeViewAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.TreeViewAccessibleObject.cs
@@ -13,32 +13,28 @@ public partial class TreeView
 {
     internal class TreeViewAccessibleObject : ControlAccessibleObject
     {
-        private readonly TreeView _owningTreeView;
-
-        public TreeViewAccessibleObject(TreeView owningTreeView) : base(owningTreeView)
-        {
-            _owningTreeView = owningTreeView;
-        }
+        public TreeViewAccessibleObject(TreeView owningTreeView) : base(owningTreeView) { }
 
         internal override IRawElementProviderFragment? ElementProviderFromPoint(double x, double y)
             => HitTest((int)x, (int)y) ?? base.ElementProviderFromPoint(x, y);
 
-        internal override UiaCore.IRawElementProviderFragmentRoot FragmentRoot => this;
+        internal override IRawElementProviderFragmentRoot FragmentRoot => this;
 
-        internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
+        internal override IRawElementProviderFragment? FragmentNavigate(NavigateDirection direction)
             => direction switch
             {
-                UiaCore.NavigateDirection.FirstChild => GetChild(0),
-                UiaCore.NavigateDirection.LastChild => GetChild(GetChildCount() - 1),
+                NavigateDirection.FirstChild => GetChild(0),
+                NavigateDirection.LastChild => GetChild(GetChildCount() - 1),
                 _ => base.FragmentNavigate(direction),
             };
 
         public override AccessibleObject? GetChild(int index)
-            => index >= 0 && index < GetChildCount()
-                ? _owningTreeView.Nodes[index].AccessibilityObject
+            => index >= 0 && index < GetChildCount() && this.TryGetOwnerAs(out TreeView? owningTreeView)
+                ? owningTreeView.Nodes[index].AccessibilityObject
                 : null;
 
-        public override int GetChildCount() => _owningTreeView.Nodes.Count;
+        public override int GetChildCount() =>
+            this.TryGetOwnerAs(out TreeView? owningTreeView) ? owningTreeView.Nodes.Count : base.GetChildCount();
 
         internal override int GetChildIndex(AccessibleObject? child)
             => child is TreeNodeAccessibleObject node ? node.Index : -1;
@@ -47,42 +43,48 @@ public partial class TreeView
             => propertyID switch
             {
                 UIA.ControlTypePropertyId => UIA.TreeControlTypeId,
-                UIA.HasKeyboardFocusPropertyId => _owningTreeView.Enabled && _owningTreeView.Nodes.Count == 0,
-                UIA.IsEnabledPropertyId => _owningTreeView.Enabled,
+                UIA.HasKeyboardFocusPropertyId => this.TryGetOwnerAs(out TreeView? owningTreeView)
+                    && owningTreeView.Enabled && owningTreeView.Nodes.Count == 0,
+                UIA.IsEnabledPropertyId => this.TryGetOwnerAs(out TreeView? owningTreeView) && owningTreeView.Enabled,
                 UIA.IsKeyboardFocusablePropertyId => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,
                 _ => base.GetPropertyValue(propertyID)
             };
 
         public override AccessibleObject? HitTest(int x, int y)
         {
-            if (!_owningTreeView.IsHandleCreated)
+            if (!this.TryGetOwnerAs(out TreeView? owningTreeView) || !owningTreeView.IsHandleCreated)
             {
                 return null;
             }
 
-            Point p = _owningTreeView.PointToClient(new Point(x, y));
-            TreeNode node = _owningTreeView.GetNodeAt(p);
+            Point p = owningTreeView.PointToClient(new Point(x, y));
+            TreeNode node = owningTreeView.GetNodeAt(p);
 
             if (node is not null)
             {
                 return node.AccessibilityObject;
             }
 
-            if (Bounds.Contains(x, y))
-            {
-                return this;
-            }
-
-            return null;
+            return Bounds.Contains(x, y) ? this : null;
         }
 
         internal override int[] RuntimeId
-            => new int[]
+        {
+            get
             {
-                RuntimeIDFirstItem,
-                PARAM.ToInt(_owningTreeView.InternalHandle),
-                _owningTreeView.GetHashCode()
-            };
+                if (this.TryGetOwnerAs(out TreeView? owningTreeView))
+                {
+                    return new int[]
+                    {
+                        RuntimeIDFirstItem,
+                        PARAM.ToInt(owningTreeView.InternalHandle),
+                        owningTreeView.GetHashCode()
+                    };
+                }
+
+                return base.RuntimeId;
+            }
+        }
 
         public override AccessibleStates State
         {
@@ -90,12 +92,17 @@ public partial class TreeView
             {
                 AccessibleStates state = AccessibleStates.Focusable;
 
-                if (_owningTreeView.Focused)
+                if (!this.TryGetOwnerAs(out TreeView? owningTreeView))
+                {
+                    return state;
+                }
+
+                if (owningTreeView.Focused)
                 {
                     state |= AccessibleStates.Focused;
                 }
 
-                if (!_owningTreeView.Enabled)
+                if (!owningTreeView.Enabled)
                 {
                     state |= AccessibleStates.Unavailable;
                 }
@@ -104,26 +111,28 @@ public partial class TreeView
             }
         }
 
-        internal override bool IsPatternSupported(UiaCore.UIA patternId)
+        internal override bool IsPatternSupported(UIA patternId)
             => patternId switch
             {
-                UiaCore.UIA.LegacyIAccessiblePatternId => true,
-                UiaCore.UIA.SelectionPatternId => true,
+                UIA.LegacyIAccessiblePatternId => true,
+                UIA.SelectionPatternId => true,
                 _ => base.IsPatternSupported(patternId),
             };
 
         #region Selection Pattern
 
-        internal override bool IsSelectionRequired => _owningTreeView.Nodes.Count != 0;
+        internal override bool IsSelectionRequired => this.TryGetOwnerAs(out TreeView? owningTreeView) &&
+            owningTreeView.Nodes.Count != 0;
 
-        internal override UiaCore.IRawElementProviderSimple[]? GetSelection()
+        internal override IRawElementProviderSimple[]? GetSelection()
         {
-            if (_owningTreeView.IsHandleCreated && GetSelected() is UiaCore.IRawElementProviderSimple selected)
+            if (this.TryGetOwnerAs(out TreeView? owningTreeView) &&
+                owningTreeView.IsHandleCreated && GetSelected() is IRawElementProviderSimple selected)
             {
                 return new[] { selected };
             }
 
-            return Array.Empty<UiaCore.IRawElementProviderSimple>();
+            return Array.Empty<IRawElementProviderSimple>();
         }
 
         #endregion

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ControlAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ControlAccessibleObjectTests.cs
@@ -1220,7 +1220,7 @@ public class Control_ControlAccessibleObjectTests
         var typesToIgnore = new[]
         {
            typeof(HScrollBar), typeof(ListView), typeof(MonthCalendar),
-           typeof(PropertyGrid), typeof(TabPage), typeof(TreeView), typeof(VScrollBar)
+           typeof(PropertyGrid), typeof(TabPage), typeof(VScrollBar)
         };
 
         return ReflectionHelper.GetPublicNotAbstractClasses<Control>()


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Related to #9224 


## Proposed changes

- Update the control owning field of TreeView to using weak references
- Enable the GC collect test for the TreeView control in unit test cases


<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- The strong reference used by the original Owner property can cause a memory leak

## Regression? 

-  No


<!-- end TELL-MODE -->



## Test methodology <!-- How did you ensure quality? -->

- Unit tests
 

## Test environment(s) <!-- Remove any that don't apply -->

- dotnet 8.0.0-preview.7.23358.3


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9458)