### PR TITLE
Add unit test for System.Windows.Forms.Design.ControlDesigner.#ctor

### DIFF
--- a/src/System.Windows.Forms.Design/tests/UnitTests/ControlDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/ControlDesignerTests.cs
@@ -11,12 +11,28 @@ public class ControlDesignerTests
     [WinFormsFact]
     public void ControlDesigner_Ctor_Default()
     {
-        using var designer = new ControlDesigner();
-        Assert.Null(designer.Control);
-        Assert.Null(designer.Component);
-        Assert.Equal(SelectionRules.Visible, designer.SelectionRules);
-        Assert.True(designer.ParticipatesWithSnapLines);
-        Assert.False(designer.AutoResizeHandles);
+        using TestControlDesigner controlDesigner = new TestControlDesigner();
+        Assert.False(controlDesigner.AutoResizeHandles);
+        Assert.Null(controlDesigner.Control);
+        Assert.True(controlDesigner.ControlSupportsSnaplines);
+        Assert.Null(controlDesigner.Component);
+        Assert.True(controlDesigner.ForceVisible);
+        Assert.Null(controlDesigner.GetParentComponentProperty());
+        Assert.False(controlDesigner.SerializePerformLayout);
+    }
+
+    [WinFormsFact]
+    public void ControlDesigner_PropertiesTest()
+    {
+        using TestControlDesigner controlDesigner = new TestControlDesigner();
+        using Button button = new Button();
+        controlDesigner.Initialize(button);
+        Assert.Empty(controlDesigner.AssociatedComponents);
+        Assert.False(controlDesigner.IsRootDesigner);
+        Assert.NotNull(controlDesigner.SnapLines);
+        Assert.Equal(8, controlDesigner.SnapLines.Count);
+        Assert.NotNull(controlDesigner.StandardBehavior);
+        Assert.Equal(Cursors.Default, controlDesigner.StandardBehavior.Cursor);
     }
 
     [Fact]

--- a/src/System.Windows.Forms.Design/tests/UnitTests/ControlDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/ControlDesignerTests.cs
@@ -168,4 +168,15 @@ public class ControlDesignerTests
         };
         designer.TestAccessor().Dynamic.WndProc(ref m);
     }
+
+    [WinFormsFact]
+    public void ControlDesigner_Ctor_Default()
+    {
+        using var designer = new ControlDesigner();
+        Assert.Null(designer.Control);
+        Assert.Null(designer.Component);
+        Assert.Equal(SelectionRules.Visible, designer.SelectionRules);
+        Assert.True(designer.ParticipatesWithSnapLines);
+        Assert.False(designer.AutoResizeHandles);
+    }
 }

--- a/src/System.Windows.Forms.Design/tests/UnitTests/ControlDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/ControlDesignerTests.cs
@@ -8,6 +8,17 @@ namespace System.Windows.Forms.Design.Tests;
 
 public class ControlDesignerTests
 {
+    [WinFormsFact]
+    public void ControlDesigner_Ctor_Default()
+    {
+        using var designer = new ControlDesigner();
+        Assert.Null(designer.Control);
+        Assert.Null(designer.Component);
+        Assert.Equal(SelectionRules.Visible, designer.SelectionRules);
+        Assert.True(designer.ParticipatesWithSnapLines);
+        Assert.False(designer.AutoResizeHandles);
+    }
+
     [Fact]
     public void AccessibleObjectField()
     {
@@ -167,16 +178,5 @@ public class ControlDesignerTests
             Msg = (int)PInvoke.WM_PAINT
         };
         designer.TestAccessor().Dynamic.WndProc(ref m);
-    }
-
-    [WinFormsFact]
-    public void ControlDesigner_Ctor_Default()
-    {
-        using var designer = new ControlDesigner();
-        Assert.Null(designer.Control);
-        Assert.Null(designer.Component);
-        Assert.Equal(SelectionRules.Visible, designer.SelectionRules);
-        Assert.True(designer.ParticipatesWithSnapLines);
-        Assert.False(designer.AutoResizeHandles);
     }
 }

--- a/src/System.Windows.Forms.Design/tests/UnitTests/TestControlDesigner.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/TestControlDesigner.cs
@@ -10,18 +10,6 @@ namespace System.Windows.Forms.Design.Tests;
 
 internal class TestControlDesigner : ControlDesigner
 {
-    internal new bool ControlSupportsSnaplines => base.ControlSupportsSnaplines;
-
-    internal new bool ForceVisible => base.ForceVisible;
-
-    internal new bool IsRootDesigner => base.IsRootDesigner;
-
-    internal new Behavior.Behavior MoveBehavior => base.MoveBehavior;
-
-    internal new bool SerializePerformLayout => base.SerializePerformLayout;
-
-    internal new Behavior.Behavior StandardBehavior => base.StandardBehavior;
-
     internal AccessibleObject GetAccessibleObjectField()
     {
         return accessibilityObj;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/TestControlDesigner.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/TestControlDesigner.cs
@@ -10,6 +10,18 @@ namespace System.Windows.Forms.Design.Tests;
 
 internal class TestControlDesigner : ControlDesigner
 {
+    internal new bool ControlSupportsSnaplines => base.ControlSupportsSnaplines;
+
+    internal new bool ForceVisible => base.ForceVisible;
+
+    internal new bool IsRootDesigner => base.IsRootDesigner;
+
+    internal new Behavior.Behavior MoveBehavior => base.MoveBehavior;
+
+    internal new bool SerializePerformLayout => base.SerializePerformLayout;
+
+    internal new Behavior.Behavior StandardBehavior => base.StandardBehavior;
+
     internal AccessibleObject GetAccessibleObjectField()
     {
         return accessibilityObj;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Related to https://github.com/dotnet/winforms/issues/721


## Proposed changes

- Add unit test for System.Windows.Forms.Design.ControlDesigner.#ctor
- The test cases for SelectionRules already exist, here is the link:  [SelectionRulesProperty ](https://github.com/SimonZhao888/v-weidzh-winforms/blob/4b56c489bbe0858806bee1a0365824b945c06949/src/System.Windows.Forms.Design/tests/UnitTests/ControlDesignerTests.cs#L55C21-L55C21)

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- The new test case can run normally through.

## Regression? 

- No

## Test methodology <!-- How did you ensure quality? -->

- Unit test

## Test environment(s) <!-- Remove any that don't apply -->

- 8.0.100-preview.7.23324.2



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9462)