### PR TITLE
Add the logical judgment of scaledHeightPadding in the function Detai…

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ThreadExceptionDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ThreadExceptionDialog.cs
@@ -69,8 +69,7 @@ public class ThreadExceptionDialog : Form
     private Bitmap? _expandImage;
     private Bitmap? _collapseImage;
     private bool _detailsVisible;
-    private SizeF savedAutoScaleDimensions;
-    private int scaledHeightPadding = HEIGHTPADDING;
+    private SizeF _savedAutoScaleDimensions;
 
     /// <summary>
     ///  Initializes a new instance of the <see cref="ThreadExceptionDialog"/> class.
@@ -358,7 +357,7 @@ public class ThreadExceptionDialog : Form
 
         _detailsButton.Image = _detailsVisible ? _collapseImage : _expandImage;
 
-        savedAutoScaleDimensions = AutoScaleDimensions;
+        _savedAutoScaleDimensions = AutoScaleDimensions;
     }
 
     /// <summary>
@@ -386,10 +385,11 @@ public class ThreadExceptionDialog : Form
     /// </summary>
     private void DetailsClick(object? sender, EventArgs eventargs)
     {
-        if (savedAutoScaleDimensions.Height > 0)
+        int scaledHeightPadding = _scaledHeightPadding;
+        if (_savedAutoScaleDimensions.Height > 0)
         {
             SizeF currentAutoScaleDimensions = CurrentAutoScaleDimensions;
-            scaledHeightPadding = (int)(_scaledHeightPadding * (currentAutoScaleDimensions.Height / savedAutoScaleDimensions.Height));
+            scaledHeightPadding = (int)Math.Round((_scaledHeightPadding * (currentAutoScaleDimensions.Height / _savedAutoScaleDimensions.Height)));
         }
 
         int delta = _details.Height + scaledHeightPadding;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ThreadExceptionDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ThreadExceptionDialog.cs
@@ -48,7 +48,6 @@ public class ThreadExceptionDialog : Form
     private readonly int _scaledButtonTopPadding = BUTTONTOPPADDING;
     private readonly int _scaledButtonDetailsLeftPadding = BUTTONDETAILS_LEFTPADDING;
     private readonly int _scaledMessageTopPadding = MESSAGE_TOPPADDING;
-    private readonly int _scaledHeightPadding = HEIGHTPADDING;
     private readonly int _scaledButtonWidth = BUTTONWIDTH;
     private readonly int _scaledButtonHeight = BUTTONHEIGHT;
     private readonly int _scaledButtonAlignmentWidth = BUTTONALIGNMENTWIDTH;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ThreadExceptionDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ThreadExceptionDialog.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -69,7 +69,7 @@ public class ThreadExceptionDialog : Form
     private Bitmap? _expandImage;
     private Bitmap? _collapseImage;
     private bool _detailsVisible;
-    private SizeF _savedAutoScaleDimensions;
+    private int _scaledHeightPadding = HEIGHTPADDING;
 
     /// <summary>
     ///  Initializes a new instance of the <see cref="ThreadExceptionDialog"/> class.
@@ -357,7 +357,10 @@ public class ThreadExceptionDialog : Form
 
         _detailsButton.Image = _detailsVisible ? _collapseImage : _expandImage;
 
-        _savedAutoScaleDimensions = AutoScaleDimensions;
+        if (e.DeviceDpiNew != e.DeviceDpiOld)
+        {
+            _scaledHeightPadding = (int)Math.Round(HEIGHTPADDING * ((float)e.DeviceDpiNew / e.DeviceDpiOld));
+        }
     }
 
     /// <summary>
@@ -385,14 +388,7 @@ public class ThreadExceptionDialog : Form
     /// </summary>
     private void DetailsClick(object? sender, EventArgs eventargs)
     {
-        int scaledHeightPadding = _scaledHeightPadding;
-        if (_savedAutoScaleDimensions.Height > 0)
-        {
-            SizeF currentAutoScaleDimensions = CurrentAutoScaleDimensions;
-            scaledHeightPadding = (int)Math.Round((_scaledHeightPadding * (currentAutoScaleDimensions.Height / _savedAutoScaleDimensions.Height)));
-        }
-
-        int delta = _details.Height + scaledHeightPadding;
+        int delta = _details.Height + _scaledHeightPadding;
         if (_detailsVisible)
         {
             delta = -delta;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ThreadExceptionDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ThreadExceptionDialog.cs
@@ -69,6 +69,8 @@ public class ThreadExceptionDialog : Form
     private Bitmap? _expandImage;
     private Bitmap? _collapseImage;
     private bool _detailsVisible;
+    private SizeF savedAutoScaleDimensions;
+    private int scaledHeightPadding = HEIGHTPADDING;
 
     /// <summary>
     ///  Initializes a new instance of the <see cref="ThreadExceptionDialog"/> class.
@@ -355,6 +357,8 @@ public class ThreadExceptionDialog : Form
         ScaleBitmapLogicalToDevice(ref _collapseImage);
 
         _detailsButton.Image = _detailsVisible ? _collapseImage : _expandImage;
+
+        savedAutoScaleDimensions = AutoScaleDimensions;
     }
 
     /// <summary>
@@ -382,7 +386,13 @@ public class ThreadExceptionDialog : Form
     /// </summary>
     private void DetailsClick(object? sender, EventArgs eventargs)
     {
-        int delta = _details.Height + _scaledHeightPadding;
+        if (savedAutoScaleDimensions.Height > 0)
+        {
+            SizeF currentAutoScaleDimensions = CurrentAutoScaleDimensions;
+            scaledHeightPadding = (int)(_scaledHeightPadding * (currentAutoScaleDimensions.Height / savedAutoScaleDimensions.Height));
+        }
+
+        int delta = _details.Height + scaledHeightPadding;
         if (_detailsVisible)
         {
             delta = -delta;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #9449 


## Proposed changes

- Add the logical judgment of scaledHeightPadding in the function DetailsClick

- Expand the details in threadExpectionDialog at 300%DPI, the height of the expanded details bar is detailHeight (height is 454) + scaledHeightPadding (which is a fixed value of 8), move to 100% secondary screen and collapse the details, collapsed height is detailHeight (because auto scaling is added, detailHeight will automatically scale to 154) + scaledHeightPadding (this value is hard-coded, so it has not changed due to movement, so my fix idea is to adjust the height according to the scaling `scaledHeightPadding = (int)(_scaledHeightPadding * (currentAutoScaleDimensions. Height / savedAutoScaleDimensions. Height));`)

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

-  Buttons on ThreadExceptionDialog are truncated when DPI is differ

## Regression? 

-  No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
Buttons on ThreadExceptionDialog are truncated when expanding Details button in threadExpectionDialog on 300%DPI primary screen, then move to 100% secondary screen, and collapse Details button.
![BeforeScaledExceptionDialog](https://github.com/dotnet/winforms/assets/132890443/62d7f543-81b4-4055-a25f-a4972d5ba8c4)


### After
Buttons on ThreadExceptionDialog can be fully displayed when expanding Details button in threadExpectionDialog on 300%DPI primary screen, then move to 100% secondary screen, and collapse Details button.
![ScaledExceptionDialog](https://github.com/dotnet/winforms/assets/132890443/d234310d-5dd6-4d59-b972-93c3758dda2f)



## Test methodology <!-- How did you ensure quality? -->

- Manually


## Test environment(s) <!-- Remove any that don't apply -->

- .net 8.0.100-preview.7.23357.8


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9463)