### PR TITLE
Add test for VerifyResourceName of StronglyTypedResourceBuilder

### DIFF
--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Resources/Tools/StronglyTypedResourceBuilderTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Resources/Tools/StronglyTypedResourceBuilderTests.cs
@@ -558,6 +558,46 @@ public partial class StronglyTypedResourceBuilderTests
         ValidateResultAudio(CompileAndGetPropertyInfo(reader.GetEnumerator(), compileUnit, "Audio1"));
     }
 
+    [Fact]
+    public static void StronglyTypedResourceBuilder_VerifyResourceName_ValidName()
+    {
+        var key = "MyResource";
+        string result = StronglyTypedResourceBuilder.VerifyResourceName(key, s_cSharpProvider);
+        Assert.Equal(key, result);
+    }
+
+    [Fact]
+    public static void StronglyTypedResourceBuilder_VerifyResourceName_InvalidName()
+    {
+        var key = "Invalid Resource?";
+        string result = StronglyTypedResourceBuilder.VerifyResourceName(key, s_cSharpProvider);
+        Assert.Equal("Invalid_Resource_", result);
+    }
+
+    [Fact]
+    public static void StronglyTypedResourceBuilder_VerifyResourceName_NameWithSpaces()
+    {
+        var key = "Resource Name";
+        string result = StronglyTypedResourceBuilder.VerifyResourceName(key, s_cSharpProvider);
+        Assert.Equal("Resource_Name", result);
+    }
+
+    [Fact]
+    public static void StronglyTypedResourceBuilder_VerifyResourceName_NameStartWithNumber()
+    {
+        var key = "1.name";
+        string result = StronglyTypedResourceBuilder.VerifyResourceName(key, s_cSharpProvider);
+        Assert.Equal("_1_name", result);
+    }
+
+    [Theory]
+    [MemberData(nameof(ResourceName_TestData))]
+    public static void StronglyTypedResourceBuilder_VerifyResourceName_NameWithSpecialCharacters(string resourceName, string expectedResult)
+    {
+        string result = StronglyTypedResourceBuilder.VerifyResourceName(resourceName, s_cSharpProvider);
+        Assert.Equal(expectedResult, result);
+    }
+
     [WinFormsFact]
     public static void StronglyTypedResourceBuilder_Create_AxHost_FromMemory_SerializeWith_StateConverter()
     {
@@ -664,5 +704,13 @@ public partial class StronglyTypedResourceBuilderTests
         }
 
         Assert.Equal("HELLO", Encoding.UTF8.GetString(contents));
+    }
+
+    public static IEnumerable<object[]> ResourceName_TestData()
+    {
+        yield return new object[] { "Image#Jpeg", "Image_Jpeg" };
+        yield return new object[] { "Generate &method", "Generate__method" };
+        yield return new object[] { "'%s' in this scope", "__s__in_this_scope" };
+        yield return new object[] { "{ ... }", "_______" };
     }
 }

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Resources/Tools/StronglyTypedResourceBuilderTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Resources/Tools/StronglyTypedResourceBuilderTests.cs
@@ -561,7 +561,7 @@ public partial class StronglyTypedResourceBuilderTests
     [Fact]
     public static void StronglyTypedResourceBuilder_VerifyResourceName_ValidName()
     {
-        var key = "MyResource";
+        string key = "MyResource";
         string result = StronglyTypedResourceBuilder.VerifyResourceName(key, s_cSharpProvider);
         Assert.Equal(key, result);
     }
@@ -569,7 +569,7 @@ public partial class StronglyTypedResourceBuilderTests
     [Fact]
     public static void StronglyTypedResourceBuilder_VerifyResourceName_InvalidName()
     {
-        var key = "Invalid Resource?";
+        string key = "Invalid Resource?";
         string result = StronglyTypedResourceBuilder.VerifyResourceName(key, s_cSharpProvider);
         Assert.Equal("Invalid_Resource_", result);
     }
@@ -577,7 +577,7 @@ public partial class StronglyTypedResourceBuilderTests
     [Fact]
     public static void StronglyTypedResourceBuilder_VerifyResourceName_NameWithSpaces()
     {
-        var key = "Resource Name";
+        string key = "Resource Name";
         string result = StronglyTypedResourceBuilder.VerifyResourceName(key, s_cSharpProvider);
         Assert.Equal("Resource_Name", result);
     }
@@ -585,7 +585,7 @@ public partial class StronglyTypedResourceBuilderTests
     [Fact]
     public static void StronglyTypedResourceBuilder_VerifyResourceName_NameStartWithNumber()
     {
-        var key = "1.name";
+        string key = "1.name";
         string result = StronglyTypedResourceBuilder.VerifyResourceName(key, s_cSharpProvider);
         Assert.Equal("_1_name", result);
     }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #8295 


## Proposed changes

- Add test cases for function "VerifyResourceName" of the class "StronglyTypedResourceBuilder"

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- None

## Regression? 

-  No

## Risk

- Low
- PR only has unit tests

<!-- end TELL-MODE -->


## Test methodology <!-- How did you ensure quality? -->

- Unit Tests


## Test environment(s) <!-- Remove any that don't apply -->

- .net 8.0.100-preview.7.23357.8


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9471)