### PR TITLE
Fix PrintPreviewControl persisting print failure.

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewControl.cs
@@ -472,6 +472,7 @@ public partial class PrintPreviewControl : Control
     public void InvalidatePreview()
     {
         pageInfo = null;
+        exceptionPrinting = false;
         InvalidateLayout();
     }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #9474


## Proposed changes

- Reset `exceptionPrinting` flag when `Document` property is set.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- User is able to preview different documents without re-creating `PrintPreviewControl`.

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

After clicking "Print with error" button other buttons have no effect, `PrintPreviewControl` always shows error message:

https://github.com/dotnet/winforms/assets/113603457/60106600-1d2b-42f6-ab1e-b43c0ff2f427


### After

"Print successfully" and "Reset" buttons work as expected:

https://github.com/dotnet/winforms/assets/113603457/2257e70a-f1f8-4e92-9f09-bcfe9e4adce0



## Test methodology <!-- How did you ensure quality? -->

- Manual


## Test environment(s) <!-- Remove any that don't apply -->

- .NET 8.0.100-preview.4.23260.5


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9476)