### PR TITLE
Fix ComBox rendering issues

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -3741,11 +3741,11 @@ public partial class ComboBox : ListControl
         DRAWITEMSTRUCT* dis = (DRAWITEMSTRUCT*)(nint)m.LParamInternal;
 
         using var e = new DrawItemEventArgs(
-            dis->hDC.CreateGraphics(),
+            dis->hDC,
             Font,
             dis->rcItem,
-            (int)dis->itemID,
-            (DrawItemState)(int)dis->itemState,
+            dis->itemID,
+            dis->itemState,
             ForeColor,
             BackColor);
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Related to # https://github.com/dotnet/winforms/pull/9475#issuecomment-1632935429


## Proposed changes

- Use compatible constructor for creating DrawItemEventArgs in ComBox

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- No rendering issues on ComBox scroll

## Regression? 

- Yes 

## Risk

- Low

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->

### After

<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- Manual

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

- 8.0.0-preview.7.23323.5
- Windows 11 22H2


<!-- Mention language, UI scaling, or anything else that might be relevant -->
