### PR TITLE
Utilize StockIcons in a couple interfaces

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
@@ -2300,7 +2300,7 @@ public partial class ControlDesigner : ComponentDesigner
                 e.Graphics.DrawRectangle(pen, borderRectangle);
             }
 
-            Icon err = SystemIcons.Error;
+            using Icon err = SystemIcons.GetStockIcon(StockIconId.Error);
             e.Graphics.FillRectangle(Brushes.White, imageRect);
             e.Graphics.DrawIcon(err, imageRect.X, imageRect.Y);
             textRect.X++;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ThreadExceptionDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ThreadExceptionDialog.cs
@@ -256,14 +256,9 @@ public class ThreadExceptionDialog : Form
         _pictureBox.Location = new Point(_scaledPictureWidth / 8, _scaledPictureHeight / 8);
         _pictureBox.Size = new Size(_scaledPictureWidth * 3 / 4, _scaledPictureHeight * 3 / 4);
         _pictureBox.SizeMode = PictureBoxSizeMode.StretchImage;
-        if (t is Security.SecurityException)
-        {
-            _pictureBox.Image = SystemIcons.Information.ToBitmap();
-        }
-        else
-        {
-            _pictureBox.Image = SystemIcons.Error.ToBitmap();
-        }
+        StockIconId stockIconId = (t is Security.SecurityException) ? StockIconId.Info : StockIconId.Error;
+        using Icon icon = SystemIcons.GetStockIcon(stockIconId, _scaledPictureWidth);
+        _pictureBox.Image = icon.ToBitmap();
 
         Controls.Add(_pictureBox);
         _message.SetBounds(_scaledPictureWidth,


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

- Use the new `SystemIcons.GetStockIcon()` method to display up-to-date icons from the OS

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Negligible
- Customers will no longer think these User Interface elements look like they're from Windows Vista/7

## Regression? 

- No

## Risk

-

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->
Exception Dialog (this screenshot was taken at 200% scaling)
![exBefore](https://github.com/dotnet/winforms/assets/11582193/005544c6-46be-4c78-9baf-199c082f04ab)

Paint exception in Winforms Designer
![designerBefore](https://github.com/dotnet/winforms/assets/11582193/f22dbec7-7b73-498e-8a44-03870485e957)


### After

<!-- TODO -->
Exception Dialog (this screenshot was taken at 200% scaling)
![exAfter](https://github.com/dotnet/winforms/assets/11582193/3cfe8188-5ae0-42ef-bb91-da2f30752096)

Paint exception in Winforms Designer
(I didn't know how to get the Winforms Designer to use the DLL I built, so testing was simulated by copying code from `ControlDesigner.cs`  into a test control. Which is why it doesn't show the same call stack in this screenshot)
![designerAfter](https://github.com/dotnet/winforms/assets/11582193/3adea580-b0a6-4894-933e-ebc025a059a5)


## Test methodology <!-- How did you ensure quality? -->

- Manual
- tested the Exception Dialog at 100% and 200% scaling
- tested at 100% in the Winforms Designer

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

- <!-- use `dotnet --info` -->


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9492)