### PR TITLE
Fix `System.Drawing.Common` `SRDescriptionAttribute`

### DIFF
--- a/src/System.Drawing.Common/src/SRDescriptionAttribute.cs
+++ b/src/System.Drawing.Common/src/SRDescriptionAttribute.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel;
@@ -17,7 +17,7 @@ internal sealed class SRDescriptionAttribute : DescriptionAttribute
             if (!_replaced)
             {
                 _replaced = true;
-                DescriptionValue = SR.Format(base.Description);
+                base.DescriptionValue = SR.GetResourceString(base.Description);
             }
             return base.Description;
         }


### PR DESCRIPTION
Fixes #3822

Only used in `PrintDocument`.
![image](https://github.com/dotnet/winforms/assets/2433737/7b81fe30-cc98-4335-ac1c-e93c4eb4b022)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9506)