### PR TITLE
Enable nullability in DataGridViewComboBoxEditingControl

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -142,9 +142,9 @@
 ~override System.Windows.Forms.DataGridViewComboBoxColumn.CellTemplate.set -> void
 ~override System.Windows.Forms.DataGridViewComboBoxColumn.Clone() -> object
 ~override System.Windows.Forms.DataGridViewComboBoxColumn.ToString() -> string
-~override System.Windows.Forms.DataGridViewComboBoxEditingControl.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject
-~override System.Windows.Forms.DataGridViewComboBoxEditingControl.OnHandleCreated(System.EventArgs e) -> void
-~override System.Windows.Forms.DataGridViewComboBoxEditingControl.OnSelectedIndexChanged(System.EventArgs e) -> void
+override System.Windows.Forms.DataGridViewComboBoxEditingControl.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject!
+override System.Windows.Forms.DataGridViewComboBoxEditingControl.OnHandleCreated(System.EventArgs! e) -> void
+override System.Windows.Forms.DataGridViewComboBoxEditingControl.OnSelectedIndexChanged(System.EventArgs! e) -> void
 ~override System.Windows.Forms.DataGridViewHeaderCell.Clone() -> object
 ~override System.Windows.Forms.DataGridViewHeaderCell.FormattedValueType.get -> System.Type
 ~override System.Windows.Forms.DataGridViewHeaderCell.GetInheritedContextMenuStrip(int rowIndex) -> System.Windows.Forms.ContextMenuStrip
@@ -935,13 +935,13 @@
 ~virtual System.Windows.Forms.DataGridViewComboBoxCell.ObjectCollection.this[int index].set -> void
 ~virtual System.Windows.Forms.DataGridViewComboBoxCell.ValueMember.get -> string
 ~virtual System.Windows.Forms.DataGridViewComboBoxCell.ValueMember.set -> void
-~virtual System.Windows.Forms.DataGridViewComboBoxEditingControl.ApplyCellStyleToEditingControl(System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle) -> void
-~virtual System.Windows.Forms.DataGridViewComboBoxEditingControl.EditingControlDataGridView.get -> System.Windows.Forms.DataGridView
-~virtual System.Windows.Forms.DataGridViewComboBoxEditingControl.EditingControlDataGridView.set -> void
-~virtual System.Windows.Forms.DataGridViewComboBoxEditingControl.EditingControlFormattedValue.get -> object
-~virtual System.Windows.Forms.DataGridViewComboBoxEditingControl.EditingControlFormattedValue.set -> void
-~virtual System.Windows.Forms.DataGridViewComboBoxEditingControl.EditingPanelCursor.get -> System.Windows.Forms.Cursor
-~virtual System.Windows.Forms.DataGridViewComboBoxEditingControl.GetEditingControlFormattedValue(System.Windows.Forms.DataGridViewDataErrorContexts context) -> object
+virtual System.Windows.Forms.DataGridViewComboBoxEditingControl.ApplyCellStyleToEditingControl(System.Windows.Forms.DataGridViewCellStyle! dataGridViewCellStyle) -> void
+virtual System.Windows.Forms.DataGridViewComboBoxEditingControl.EditingControlDataGridView.get -> System.Windows.Forms.DataGridView?
+virtual System.Windows.Forms.DataGridViewComboBoxEditingControl.EditingControlDataGridView.set -> void
+virtual System.Windows.Forms.DataGridViewComboBoxEditingControl.EditingControlFormattedValue.get -> object!
+virtual System.Windows.Forms.DataGridViewComboBoxEditingControl.EditingControlFormattedValue.set -> void
+virtual System.Windows.Forms.DataGridViewComboBoxEditingControl.EditingPanelCursor.get -> System.Windows.Forms.Cursor!
+virtual System.Windows.Forms.DataGridViewComboBoxEditingControl.GetEditingControlFormattedValue(System.Windows.Forms.DataGridViewDataErrorContexts context) -> object!
 ~virtual System.Windows.Forms.DataGridViewRow.AdjustRowHeaderBorderStyle(System.Windows.Forms.DataGridViewAdvancedBorderStyle dataGridViewAdvancedBorderStyleInput, System.Windows.Forms.DataGridViewAdvancedBorderStyle dataGridViewAdvancedBorderStylePlaceholder, bool singleVerticalBorderAdded, bool singleHorizontalBorderAdded, bool isFirstDisplayedRow, bool isLastVisibleRow) -> System.Windows.Forms.DataGridViewAdvancedBorderStyle
 ~virtual System.Windows.Forms.DataGridViewRow.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject
 ~virtual System.Windows.Forms.DataGridViewRow.CreateCellsInstance() -> System.Windows.Forms.DataGridViewCellCollection

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxEditingControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxEditingControl.cs
@@ -18,10 +18,8 @@ public partial class DataGridViewComboBoxEditingControl : ComboBox, IDataGridVie
         TabStop = false;
     }
 
-    protected override AccessibleObject CreateAccessibilityInstance()
-    {
-        return new DataGridViewComboBoxEditingControlAccessibleObject(this);
-    }
+    protected override AccessibleObject CreateAccessibilityInstance() =>
+        new DataGridViewComboBoxEditingControlAccessibleObject(this);
 
     // IDataGridViewEditingControl interface implementation
 
@@ -39,10 +37,7 @@ public partial class DataGridViewComboBoxEditingControl : ComboBox, IDataGridVie
 
     public virtual object EditingControlFormattedValue
     {
-        get
-        {
-            return GetEditingControlFormattedValue(DataGridViewDataErrorContexts.Formatting);
-        }
+        get => GetEditingControlFormattedValue(DataGridViewDataErrorContexts.Formatting);
         set
         {
             if (value is string valueStr)
@@ -58,43 +53,19 @@ public partial class DataGridViewComboBoxEditingControl : ComboBox, IDataGridVie
 
     public virtual int EditingControlRowIndex
     {
-        get
-        {
-            return _rowIndex;
-        }
-        set
-        {
-            _rowIndex = value;
-        }
+        get => _rowIndex;
+        set => _rowIndex = value;
     }
 
     public virtual bool EditingControlValueChanged
     {
-        get
-        {
-            return _valueChanged;
-        }
-        set
-        {
-            _valueChanged = value;
-        }
+        get => _valueChanged;
+        set => _valueChanged = value;
     }
 
-    public virtual Cursor EditingPanelCursor
-    {
-        get
-        {
-            return Cursors.Default;
-        }
-    }
+    public virtual Cursor EditingPanelCursor => Cursors.Default;
 
-    public virtual bool RepositionEditingControlOnValueChange
-    {
-        get
-        {
-            return false;
-        }
-    }
+    public virtual bool RepositionEditingControlOnValueChange => false;
 
     public virtual void ApplyCellStyleToEditingControl(DataGridViewCellStyle dataGridViewCellStyle)
     {
@@ -128,10 +99,7 @@ public partial class DataGridViewComboBoxEditingControl : ComboBox, IDataGridVie
         return !dataGridViewWantsInputKey;
     }
 
-    public virtual object GetEditingControlFormattedValue(DataGridViewDataErrorContexts context)
-    {
-        return Text;
-    }
+    public virtual object GetEditingControlFormattedValue(DataGridViewDataErrorContexts context) => Text;
 
     public virtual void PrepareEditingControlForEdit(bool selectAll)
     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxEditingControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxEditingControl.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Drawing;
 using System.Globalization;
 
@@ -11,7 +9,7 @@ namespace System.Windows.Forms;
 
 public partial class DataGridViewComboBoxEditingControl : ComboBox, IDataGridViewEditingControl
 {
-    private DataGridView _dataGridView;
+    private DataGridView? _dataGridView;
     private bool _valueChanged;
     private int _rowIndex;
 
@@ -27,7 +25,7 @@ public partial class DataGridViewComboBoxEditingControl : ComboBox, IDataGridVie
 
     // IDataGridViewEditingControl interface implementation
 
-    public virtual DataGridView EditingControlDataGridView
+    public virtual DataGridView? EditingControlDataGridView
     {
         get
         {
@@ -106,7 +104,7 @@ public partial class DataGridViewComboBoxEditingControl : ComboBox, IDataGridVie
             // Our ComboBox does not support transparent back colors
             Color opaqueBackColor = Color.FromArgb(255, dataGridViewCellStyle.BackColor);
             BackColor = opaqueBackColor;
-            _dataGridView.EditingPanel.BackColor = opaqueBackColor;
+            _dataGridView!.EditingPanel.BackColor = opaqueBackColor;
         }
         else
         {
@@ -146,7 +144,7 @@ public partial class DataGridViewComboBoxEditingControl : ComboBox, IDataGridVie
     private void NotifyDataGridViewOfValueChange()
     {
         _valueChanged = true;
-        _dataGridView.NotifyCurrentCellDirty(true);
+        _dataGridView!.NotifyCurrentCellDirty(true);
     }
 
     protected override void OnSelectedIndexChanged(EventArgs e)
@@ -171,7 +169,7 @@ public partial class DataGridViewComboBoxEditingControl : ComboBox, IDataGridVie
 
     internal override void ReleaseUiaProvider(HWND handle)
     {
-        if (TryGetAccessibilityObject(out AccessibleObject accessibleObject))
+        if (TryGetAccessibilityObject(out AccessibleObject? accessibleObject))
         {
             ((DataGridViewComboBoxEditingControlAccessibleObject)accessibleObject).ClearParent();
         }


### PR DESCRIPTION
## Proposed changes

- Enable nullability in DataGridViewComboBoxEditingControl.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9522)