### PR TITLE
Fix items property for multiple checked list boxes shouldn't be displayed in properties window #5337

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.cs
@@ -163,6 +163,7 @@ public partial class CheckedListBox : ListBox
     [Localizable(true)]
     [SRDescription(nameof(SR.ListBoxItemsDescr))]
     [Editor($"System.Windows.Forms.Design.ListControlStringCollectionEditor, {AssemblyRef.SystemDesign}", typeof(UITypeEditor))]
+    [MergableProperty(false)]
     public new ObjectCollection Items
     {
         get


### PR DESCRIPTION
Fix items property for multiple checked list boxes shouldn't be displayed in properties window #5337

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes [5337](https://github.com/microsoft/winforms-designer/issues/5337)


## Proposed changes

- 
- add attribute MergableProperty(false)
- 

<!-- We are in TELL-MODE the following section must be completed -->



## Regression? 

-  No







 

## Test environment(s) <!-- Remove any that don't apply -->
8.0.0-preview.7.23364.11
 <!-- use `dotnet --info` -->


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9524)