### PR TITLE
Port MonthCalendarDesigner to runtime

### DIFF
--- a/src/System.Design/src/System.Design.Forwards.cs
+++ b/src/System.Design/src/System.Design.Forwards.cs
@@ -42,6 +42,7 @@ using System.Runtime.CompilerServices;
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.ListBoxDesigner))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.ListViewDesigner))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.MaskedTextBoxDesigner))]
+[assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.MonthCalendarDesigner))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.PanelDesigner))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.PictureBoxDesigner))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.RadioButtonDesigner))]

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MonthCalendarDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MonthCalendarDesigner.cs
@@ -18,13 +18,12 @@ namespace System.Windows.Forms.Design
             {
                 SelectionRules rules = base.SelectionRules;
 
-                if (Control.Parent is null || (Control.Parent is not null && !Control.Parent.IsMirrored))
+                if (Control.Parent is null || !Control.Parent.IsMirrored)
                 {
                     rules &= ~(SelectionRules.TopSizeable | SelectionRules.LeftSizeable);
                 }
                 else
                 {
-                    Debug.Assert(Control.Parent is not null && Control.Parent.IsMirrored);
                     rules &= ~(SelectionRules.TopSizeable | SelectionRules.RightSizeable);
                 }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MonthCalendarDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MonthCalendarDesigner.cs
@@ -1,34 +1,33 @@
-namespace System.Windows.Forms.Design
+namespace System.Windows.Forms.Design;
+
+internal class MonthCalendarDesigner : ControlDesigner
 {
-    internal class MonthCalendarDesigner : ControlDesigner
+    public MonthCalendarDesigner()
     {
-        public MonthCalendarDesigner()
-        {
-            AutoResizeHandles = true;
-        }
+        AutoResizeHandles = true;
+    }
 
-        /// <summary>
-        /// Retrieves a set of rules concerning the movement capabilities of a component.
-        /// This should be one or more flags from the SelectionRules class.  If no designer
-        /// provides rules for a component, the component will not get any UI services.
-        /// </summary>
-        public override SelectionRules SelectionRules
+    /// <summary>
+    /// Retrieves a set of rules concerning the movement capabilities of a component.
+    /// This should be one or more flags from the SelectionRules class.  If no designer
+    /// provides rules for a component, the component will not get any UI services.
+    /// </summary>
+    public override SelectionRules SelectionRules
+    {
+        get
         {
-            get
+            SelectionRules rules = base.SelectionRules;
+
+            if (Control.Parent is null || !Control.Parent.IsMirrored)
             {
-                SelectionRules rules = base.SelectionRules;
-
-                if (Control.Parent is null || !Control.Parent.IsMirrored)
-                {
-                    rules &= ~(SelectionRules.TopSizeable | SelectionRules.LeftSizeable);
-                }
-                else
-                {
-                    rules &= ~(SelectionRules.TopSizeable | SelectionRules.RightSizeable);
-                }
-
-                return rules;
+                rules &= ~(SelectionRules.TopSizeable | SelectionRules.LeftSizeable);
             }
+            else
+            {
+                rules &= ~(SelectionRules.TopSizeable | SelectionRules.RightSizeable);
+            }
+
+            return rules;
         }
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MonthCalendarDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MonthCalendarDesigner.cs
@@ -1,0 +1,40 @@
+﻿// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Drawing;
+using System.Windows.Forms.Design.Behavior;
+
+namespace System.Windows.Forms.Design;
+
+internal class MonthCalendarDesigner : ControlDesigner
+{
+    public MonthCalendarDesigner()
+    {
+        AutoResizeHandles = true;
+    }
+
+    /// <summary>
+    /// Retrieves a set of rules concerning the movement capabilities of a component.
+    /// This should be one or more flags from the SelectionRules class.  If no designer
+    /// provides rules for a component, the component will not get any UI services.
+    /// </summary>
+    public override SelectionRules SelectionRules
+    {
+        get
+        {
+            SelectionRules rules = base.SelectionRules;
+
+            if (Control.Parent is null || (Control.Parent is not null && !Control.Parent.IsMirrored))
+            {
+                rules &= ~(SelectionRules.TopSizeable | SelectionRules.LeftSizeable);
+            }
+            else
+            {
+                Debug.Assert(Control.Parent is not null && Control.Parent.IsMirrored);
+                rules &= ~(SelectionRules.TopSizeable | SelectionRules.RightSizeable);
+            }
+
+            return rules;
+        }
+    }
+}

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MonthCalendarDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MonthCalendarDesigner.cs
@@ -1,40 +1,35 @@
-﻿// See the LICENSE file in the project root for more information.
-
-using System.Collections;
-using System.Drawing;
-using System.Windows.Forms.Design.Behavior;
-
-namespace System.Windows.Forms.Design;
-
-internal class MonthCalendarDesigner : ControlDesigner
+namespace System.Windows.Forms.Design
 {
-    public MonthCalendarDesigner()
+    internal class MonthCalendarDesigner : ControlDesigner
     {
-        AutoResizeHandles = true;
-    }
-
-    /// <summary>
-    /// Retrieves a set of rules concerning the movement capabilities of a component.
-    /// This should be one or more flags from the SelectionRules class.  If no designer
-    /// provides rules for a component, the component will not get any UI services.
-    /// </summary>
-    public override SelectionRules SelectionRules
-    {
-        get
+        public MonthCalendarDesigner()
         {
-            SelectionRules rules = base.SelectionRules;
+            AutoResizeHandles = true;
+        }
 
-            if (Control.Parent is null || (Control.Parent is not null && !Control.Parent.IsMirrored))
+        /// <summary>
+        /// Retrieves a set of rules concerning the movement capabilities of a component.
+        /// This should be one or more flags from the SelectionRules class.  If no designer
+        /// provides rules for a component, the component will not get any UI services.
+        /// </summary>
+        public override SelectionRules SelectionRules
+        {
+            get
             {
-                rules &= ~(SelectionRules.TopSizeable | SelectionRules.LeftSizeable);
-            }
-            else
-            {
-                Debug.Assert(Control.Parent is not null && Control.Parent.IsMirrored);
-                rules &= ~(SelectionRules.TopSizeable | SelectionRules.RightSizeable);
-            }
+                SelectionRules rules = base.SelectionRules;
 
-            return rules;
+                if (Control.Parent is null || (Control.Parent is not null && !Control.Parent.IsMirrored))
+                {
+                    rules &= ~(SelectionRules.TopSizeable | SelectionRules.LeftSizeable);
+                }
+                else
+                {
+                    Debug.Assert(Control.Parent is not null && Control.Parent.IsMirrored);
+                    rules &= ~(SelectionRules.TopSizeable | SelectionRules.RightSizeable);
+                }
+
+                return rules;
+            }
         }
     }
 }

--- a/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/MainForm.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/MainForm.cs
@@ -203,13 +203,13 @@ public partial class MainForm : Form
                     break;
                 case 4:
                     {
-                        rootComponent = surface.CreateRootComponent<Form>(new Size(320, 200));
+                        rootComponent = surface.CreateRootComponent<Form>(new Size(800, 600));
                         rootComponent.BackColor = Color.Orange;
                         rootComponent.Text = "Root Component hosted by the DesignSurface N.4";       //- step.1
                                                                                                      //- step.3
                                                                                                      //- create some Controls at DesignTime
                         Button b1 = surface.CreateControl<Button>(new Size(200, 40), new Point(10, 10));
-                        Button b2 = surface.CreateControl<Button>(new Size(200, 40), new Point(100, 100));
+                        Button b2 = surface.CreateControl<Button>(new Size(200, 40), new Point(10, 60));
                         b1.Text = "I'm the first Button";
                         b2.Text = "I'm the second Button";
                         b1.BackColor = Color.Gold;
@@ -217,6 +217,8 @@ public partial class MainForm : Form
 
                         Timer tm11 = surface.CreateComponent<Timer>();
                         FontDialog fd1 = surface.CreateComponent<FontDialog>();
+
+                        surface.CreateControl<MonthCalendar>(new Size(230, 170), new Point(10,110));
                     }
 
                     break;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Design/DesignerAttributeTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Design/DesignerAttributeTests.cs
@@ -33,7 +33,6 @@ public class DesignerAttributeTests
         "System.Windows.Forms.Design.FlowLayoutPanelDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
         "System.Windows.Forms.Design.FolderBrowserDialogDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
         "System.Windows.Forms.Design.ImageListDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
-        "System.Windows.Forms.Design.MonthCalendarDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
         "System.Windows.Forms.Design.NotifyIconDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
         "System.Windows.Forms.Design.PrintDialogDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
         "System.Windows.Forms.Design.PropertyGridDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Related to #4908 


## Proposed changes

- Port MonthCalendarDesigner to runtime

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- MonthCalendarDesigner can be designed in runtime

## Regression? 

-  No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/dotnet/winforms/assets/132890443/2170cdd9-6f02-49b8-b03f-b043be4b6ed9)

### After
![MonthCalendar](https://github.com/dotnet/winforms/assets/132890443/fa0b302c-aea4-46c5-974c-baf0b042148f)


## Test methodology <!-- How did you ensure quality? -->

- Manually (added MonthCalendarDesigner to DemoConsole test app)

## Test environment(s) <!-- Remove any that don't apply -->

- .Net 8.0.100-preview.7.23364.1
- Windows 10 Enterprise 22H2


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9536)