### PR TITLE
Enable nullability in DataGridViewButtonCell

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -42,26 +42,26 @@
 ~override System.Windows.Forms.DataGridView.OnVisibleChanged(System.EventArgs e) -> void
 ~override System.Windows.Forms.DataGridView.Text.get -> string
 ~override System.Windows.Forms.DataGridView.Text.set -> void
-~override System.Windows.Forms.DataGridViewButtonCell.Clone() -> object
-~override System.Windows.Forms.DataGridViewButtonCell.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject
-~override System.Windows.Forms.DataGridViewButtonCell.EditType.get -> System.Type
-~override System.Windows.Forms.DataGridViewButtonCell.FormattedValueType.get -> System.Type
-~override System.Windows.Forms.DataGridViewButtonCell.GetContentBounds(System.Drawing.Graphics graphics, System.Windows.Forms.DataGridViewCellStyle cellStyle, int rowIndex) -> System.Drawing.Rectangle
-~override System.Windows.Forms.DataGridViewButtonCell.GetErrorIconBounds(System.Drawing.Graphics graphics, System.Windows.Forms.DataGridViewCellStyle cellStyle, int rowIndex) -> System.Drawing.Rectangle
-~override System.Windows.Forms.DataGridViewButtonCell.GetPreferredSize(System.Drawing.Graphics graphics, System.Windows.Forms.DataGridViewCellStyle cellStyle, int rowIndex, System.Drawing.Size constraintSize) -> System.Drawing.Size
-~override System.Windows.Forms.DataGridViewButtonCell.GetValue(int rowIndex) -> object
-~override System.Windows.Forms.DataGridViewButtonCell.KeyDownUnsharesRow(System.Windows.Forms.KeyEventArgs e, int rowIndex) -> bool
-~override System.Windows.Forms.DataGridViewButtonCell.KeyUpUnsharesRow(System.Windows.Forms.KeyEventArgs e, int rowIndex) -> bool
-~override System.Windows.Forms.DataGridViewButtonCell.MouseDownUnsharesRow(System.Windows.Forms.DataGridViewCellMouseEventArgs e) -> bool
-~override System.Windows.Forms.DataGridViewButtonCell.MouseUpUnsharesRow(System.Windows.Forms.DataGridViewCellMouseEventArgs e) -> bool
-~override System.Windows.Forms.DataGridViewButtonCell.OnKeyDown(System.Windows.Forms.KeyEventArgs e, int rowIndex) -> void
-~override System.Windows.Forms.DataGridViewButtonCell.OnKeyUp(System.Windows.Forms.KeyEventArgs e, int rowIndex) -> void
-~override System.Windows.Forms.DataGridViewButtonCell.OnMouseDown(System.Windows.Forms.DataGridViewCellMouseEventArgs e) -> void
-~override System.Windows.Forms.DataGridViewButtonCell.OnMouseMove(System.Windows.Forms.DataGridViewCellMouseEventArgs e) -> void
-~override System.Windows.Forms.DataGridViewButtonCell.OnMouseUp(System.Windows.Forms.DataGridViewCellMouseEventArgs e) -> void
-~override System.Windows.Forms.DataGridViewButtonCell.Paint(System.Drawing.Graphics graphics, System.Drawing.Rectangle clipBounds, System.Drawing.Rectangle cellBounds, int rowIndex, System.Windows.Forms.DataGridViewElementStates elementState, object value, object formattedValue, string errorText, System.Windows.Forms.DataGridViewCellStyle cellStyle, System.Windows.Forms.DataGridViewAdvancedBorderStyle advancedBorderStyle, System.Windows.Forms.DataGridViewPaintParts paintParts) -> void
-~override System.Windows.Forms.DataGridViewButtonCell.ToString() -> string
-~override System.Windows.Forms.DataGridViewButtonCell.ValueType.get -> System.Type
+override System.Windows.Forms.DataGridViewButtonCell.Clone() -> object!
+override System.Windows.Forms.DataGridViewButtonCell.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject!
+override System.Windows.Forms.DataGridViewButtonCell.EditType.get -> System.Type?
+override System.Windows.Forms.DataGridViewButtonCell.FormattedValueType.get -> System.Type!
+override System.Windows.Forms.DataGridViewButtonCell.GetContentBounds(System.Drawing.Graphics! graphics, System.Windows.Forms.DataGridViewCellStyle! cellStyle, int rowIndex) -> System.Drawing.Rectangle
+override System.Windows.Forms.DataGridViewButtonCell.GetErrorIconBounds(System.Drawing.Graphics! graphics, System.Windows.Forms.DataGridViewCellStyle! cellStyle, int rowIndex) -> System.Drawing.Rectangle
+override System.Windows.Forms.DataGridViewButtonCell.GetPreferredSize(System.Drawing.Graphics! graphics, System.Windows.Forms.DataGridViewCellStyle! cellStyle, int rowIndex, System.Drawing.Size constraintSize) -> System.Drawing.Size
+override System.Windows.Forms.DataGridViewButtonCell.GetValue(int rowIndex) -> object?
+override System.Windows.Forms.DataGridViewButtonCell.KeyDownUnsharesRow(System.Windows.Forms.KeyEventArgs! e, int rowIndex) -> bool
+override System.Windows.Forms.DataGridViewButtonCell.KeyUpUnsharesRow(System.Windows.Forms.KeyEventArgs! e, int rowIndex) -> bool
+override System.Windows.Forms.DataGridViewButtonCell.MouseDownUnsharesRow(System.Windows.Forms.DataGridViewCellMouseEventArgs! e) -> bool
+override System.Windows.Forms.DataGridViewButtonCell.MouseUpUnsharesRow(System.Windows.Forms.DataGridViewCellMouseEventArgs! e) -> bool
+override System.Windows.Forms.DataGridViewButtonCell.OnKeyDown(System.Windows.Forms.KeyEventArgs! e, int rowIndex) -> void
+override System.Windows.Forms.DataGridViewButtonCell.OnKeyUp(System.Windows.Forms.KeyEventArgs! e, int rowIndex) -> void
+override System.Windows.Forms.DataGridViewButtonCell.OnMouseDown(System.Windows.Forms.DataGridViewCellMouseEventArgs! e) -> void
+override System.Windows.Forms.DataGridViewButtonCell.OnMouseMove(System.Windows.Forms.DataGridViewCellMouseEventArgs! e) -> void
+override System.Windows.Forms.DataGridViewButtonCell.OnMouseUp(System.Windows.Forms.DataGridViewCellMouseEventArgs! e) -> void
+override System.Windows.Forms.DataGridViewButtonCell.Paint(System.Drawing.Graphics! graphics, System.Drawing.Rectangle clipBounds, System.Drawing.Rectangle cellBounds, int rowIndex, System.Windows.Forms.DataGridViewElementStates elementState, object? value, object? formattedValue, string? errorText, System.Windows.Forms.DataGridViewCellStyle! cellStyle, System.Windows.Forms.DataGridViewAdvancedBorderStyle! advancedBorderStyle, System.Windows.Forms.DataGridViewPaintParts paintParts) -> void
+override System.Windows.Forms.DataGridViewButtonCell.ToString() -> string!
+override System.Windows.Forms.DataGridViewButtonCell.ValueType.get -> System.Type!
 ~override System.Windows.Forms.DataGridViewButtonColumn.CellTemplate.get -> System.Windows.Forms.DataGridViewCell
 ~override System.Windows.Forms.DataGridViewButtonColumn.CellTemplate.set -> void
 ~override System.Windows.Forms.DataGridViewButtonColumn.Clone() -> object

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewButtonCell.DataGridViewButtonCellRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewButtonCell.DataGridViewButtonCellRenderer.cs
@@ -17,7 +17,7 @@ public partial class DataGridViewButtonCell
         {
             get
             {
-                s_visualStyleRenderer ??= new VisualStyleRenderer(ButtonElement);
+                s_visualStyleRenderer ??= new VisualStyleRenderer(s_buttonElement);
 
                 return s_visualStyleRenderer;
             }
@@ -25,7 +25,7 @@ public partial class DataGridViewButtonCell
 
         public static void DrawButton(Graphics g, Rectangle bounds, int buttonState)
         {
-            DataGridViewButtonRenderer.SetParameters(ButtonElement.ClassName, ButtonElement.Part, buttonState);
+            DataGridViewButtonRenderer.SetParameters(s_buttonElement.ClassName, s_buttonElement.Part, buttonState);
             DataGridViewButtonRenderer.DrawBackground(g, bounds, Rectangle.Truncate(g.ClipBounds));
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewButtonCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewButtonCell.cs
@@ -184,10 +184,7 @@ public partial class DataGridViewButtonCell : DataGridViewCell
         return dataGridViewCell;
     }
 
-    protected override AccessibleObject CreateAccessibilityInstance()
-    {
-        return new DataGridViewButtonCellAccessibleObject(this);
-    }
+    protected override AccessibleObject CreateAccessibilityInstance() => new DataGridViewButtonCellAccessibleObject(this);
 
     protected override Rectangle GetContentBounds(Graphics graphics, DataGridViewCellStyle cellStyle, int rowIndex)
     {
@@ -468,35 +465,23 @@ public partial class DataGridViewButtonCell : DataGridViewCell
         return base.GetValue(rowIndex);
     }
 
-    protected override bool KeyDownUnsharesRow(KeyEventArgs e, int rowIndex)
-    {
-        return e.KeyCode == Keys.Space && !e.Alt && !e.Control && !e.Shift;
-    }
+    protected override bool KeyDownUnsharesRow(KeyEventArgs e, int rowIndex) =>
+        e.KeyCode == Keys.Space && !e.Alt && !e.Control && !e.Shift;
 
-    protected override bool KeyUpUnsharesRow(KeyEventArgs e, int rowIndex)
-    {
-        return e.KeyCode == Keys.Space;
-    }
+    protected override bool KeyUpUnsharesRow(KeyEventArgs e, int rowIndex) =>
+        e.KeyCode == Keys.Space;
 
-    protected override bool MouseDownUnsharesRow(DataGridViewCellMouseEventArgs e)
-    {
-        return e.Button == MouseButtons.Left;
-    }
+    protected override bool MouseDownUnsharesRow(DataGridViewCellMouseEventArgs e) =>
+        e.Button == MouseButtons.Left;
 
-    protected override bool MouseEnterUnsharesRow(int rowIndex)
-    {
-        return ColumnIndex == DataGridView!.MouseDownCellAddress.X && rowIndex == DataGridView.MouseDownCellAddress.Y;
-    }
+    protected override bool MouseEnterUnsharesRow(int rowIndex) =>
+        ColumnIndex == DataGridView!.MouseDownCellAddress.X && rowIndex == DataGridView.MouseDownCellAddress.Y;
 
-    protected override bool MouseLeaveUnsharesRow(int rowIndex)
-    {
-        return (ButtonState & ButtonState.Pushed) != 0;
-    }
+    protected override bool MouseLeaveUnsharesRow(int rowIndex) =>
+        (ButtonState & ButtonState.Pushed) != 0;
 
-    protected override bool MouseUpUnsharesRow(DataGridViewCellMouseEventArgs e)
-    {
-        return e.Button == MouseButtons.Left;
-    }
+    protected override bool MouseUpUnsharesRow(DataGridViewCellMouseEventArgs e) =>
+        e.Button == MouseButtons.Left;
 
     protected override void OnKeyDown(KeyEventArgs e, int rowIndex)
     {
@@ -1051,10 +1036,8 @@ public partial class DataGridViewButtonCell : DataGridViewCell
         return resultBounds;
     }
 
-    public override string ToString()
-    {
-        return $"DataGridViewButtonCell {{ ColumnIndex={ColumnIndex}, RowIndex={RowIndex} }}";
-    }
+    public override string ToString() =>
+        $"DataGridViewButtonCell {{ ColumnIndex={ColumnIndex}, RowIndex={RowIndex} }}";
 
     private void UpdateButtonState(ButtonState newButtonState, int rowIndex)
     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewButtonCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewButtonCell.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 using System.Drawing;
 using System.Windows.Forms.ButtonInternal;
@@ -63,7 +61,7 @@ public partial class DataGridViewButtonCell : DataGridViewCell
     }
 
     [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.Interfaces)]
-    public override Type EditType
+    public override Type? EditType
     {
         get
         {
@@ -177,7 +175,7 @@ public partial class DataGridViewButtonCell : DataGridViewCell
         }
         else
         {
-            dataGridViewCell = (DataGridViewButtonCell)System.Activator.CreateInstance(thisType);
+            dataGridViewCell = (DataGridViewButtonCell)Activator.CreateInstance(thisType)!;
         }
 
         base.CloneInternal(dataGridViewCell);
@@ -206,7 +204,8 @@ public partial class DataGridViewButtonCell : DataGridViewCell
             out DataGridViewElementStates cellState,
             out Rectangle cellBounds);
 
-        Rectangle contentBounds = PaintPrivate(graphics,
+        Rectangle contentBounds = PaintPrivate(
+            graphics,
             cellBounds,
             cellBounds,
             rowIndex,
@@ -221,27 +220,28 @@ public partial class DataGridViewButtonCell : DataGridViewCell
             paint: false);
 
 #if DEBUG
-        object value = GetValue(rowIndex);
-        Rectangle contentBoundsDebug = PaintPrivate(graphics,
+        object? value = GetValue(rowIndex);
+        Rectangle contentBoundsDebug = PaintPrivate(
+            graphics,
             cellBounds,
             cellBounds,
             rowIndex,
             cellState,
-            GetFormattedValue(value, rowIndex, ref cellStyle, null, null, DataGridViewDataErrorContexts.Formatting),
+            GetFormattedValue(value, rowIndex, ref cellStyle, valueTypeConverter: null, formattedValueTypeConverter: null, DataGridViewDataErrorContexts.Formatting),
             GetErrorText(rowIndex),
             cellStyle,
             dgvabsEffective,
             DataGridViewPaintParts.ContentForeground,
-            true  /*computeContentBounds*/,
-            false /*computeErrorIconBounds*/,
-            false /*paint*/);
+            computeContentBounds: true,
+            computeErrorIconBounds: false,
+            paint: false);
         Debug.Assert(contentBoundsDebug.Equals(contentBounds));
 #endif
 
         return contentBounds;
     }
 
-    private protected override string GetDefaultToolTipText()
+    private protected override string? GetDefaultToolTipText()
     {
         if (string.IsNullOrEmpty(Value?.ToString()?.Trim(' ')) || Value is DBNull)
         {
@@ -264,44 +264,54 @@ public partial class DataGridViewButtonCell : DataGridViewCell
             return Rectangle.Empty;
         }
 
-        ComputeBorderStyleCellStateAndCellBounds(rowIndex, out DataGridViewAdvancedBorderStyle dgvabsEffective, out DataGridViewElementStates cellState, out Rectangle cellBounds);
+        ComputeBorderStyleCellStateAndCellBounds(
+            rowIndex,
+            out DataGridViewAdvancedBorderStyle dgvabsEffective,
+            out DataGridViewElementStates cellState,
+            out Rectangle cellBounds);
 
-        Rectangle errorIconBounds = PaintPrivate(graphics,
+        Rectangle errorIconBounds = PaintPrivate(
+            graphics,
             cellBounds,
             cellBounds,
             rowIndex,
             cellState,
-            null /*formattedValue*/,            // errorIconBounds is independent of formattedValue
+            formattedValue: null, // errorIconBounds is independent of formattedValue
             GetErrorText(rowIndex),
             cellStyle,
             dgvabsEffective,
             DataGridViewPaintParts.ContentForeground,
-            false /*computeContentBounds*/,
-            true  /*computeErrorIconBounds*/,
-            false /*paint*/);
+            computeContentBounds: false,
+            computeErrorIconBounds: true,
+            paint: false);
 
 #if DEBUG
-        object value = GetValue(rowIndex);
-        Rectangle errorIconBoundsDebug = PaintPrivate(graphics,
+        object? value = GetValue(rowIndex);
+        Rectangle errorIconBoundsDebug = PaintPrivate(
+            graphics,
             cellBounds,
             cellBounds,
             rowIndex,
             cellState,
-            GetFormattedValue(value, rowIndex, ref cellStyle, null, null, DataGridViewDataErrorContexts.Formatting),
+            GetFormattedValue(value, rowIndex, ref cellStyle, valueTypeConverter: null, formattedValueTypeConverter: null, DataGridViewDataErrorContexts.Formatting),
             GetErrorText(rowIndex),
             cellStyle,
             dgvabsEffective,
             DataGridViewPaintParts.ContentForeground,
-            false /*computeContentBounds*/,
-            true  /*computeErrorIconBounds*/,
-            false /*paint*/);
+            computeContentBounds: false,
+            computeErrorIconBounds: true,
+            paint: false);
         Debug.Assert(errorIconBoundsDebug.Equals(errorIconBounds));
 #endif
 
         return errorIconBounds;
     }
 
-    protected override Size GetPreferredSize(Graphics graphics, DataGridViewCellStyle cellStyle, int rowIndex, Size constraintSize)
+    protected override Size GetPreferredSize(
+        Graphics graphics,
+        DataGridViewCellStyle cellStyle,
+        int rowIndex,
+        Size constraintSize)
     {
         if (DataGridView is null)
         {
@@ -316,7 +326,7 @@ public partial class DataGridViewButtonCell : DataGridViewCell
         int borderAndPaddingHeights = borderWidthsRect.Top + borderWidthsRect.Height + cellStyle.Padding.Vertical;
         DataGridViewFreeDimension freeDimension = DataGridViewCell.GetFreeDimensionFromConstraint(constraintSize);
         int marginWidths, marginHeights;
-        string formattedString = GetFormattedValue(rowIndex, ref cellStyle, DataGridViewDataErrorContexts.Formatting | DataGridViewDataErrorContexts.PreferredSize) as string;
+        string? formattedString = GetFormattedValue(rowIndex, ref cellStyle, DataGridViewDataErrorContexts.Formatting | DataGridViewDataErrorContexts.PreferredSize) as string;
         if (string.IsNullOrEmpty(formattedString))
         {
             formattedString = " ";
@@ -349,8 +359,7 @@ public partial class DataGridViewButtonCell : DataGridViewCell
                                 graphics,
                                 formattedString,
                                 cellStyle.Font,
-                                constraintSize.Height - borderAndPaddingHeights - marginHeights - 2
-                                    * DATAGRIDVIEWBUTTONCELL_verticalTextMargin,
+                                constraintSize.Height - borderAndPaddingHeights - marginHeights - 2 * DATAGRIDVIEWBUTTONCELL_verticalTextMargin,
                                 flags),
                             0);
                     }
@@ -445,15 +454,15 @@ public partial class DataGridViewButtonCell : DataGridViewCell
         return rectThemeMargins;
     }
 
-    protected override object GetValue(int rowIndex)
+    protected override object? GetValue(int rowIndex)
     {
         if (UseColumnTextForButtonValue &&
             DataGridView is not null &&
             DataGridView.NewRowIndex != rowIndex &&
             OwningColumn is not null &&
-            OwningColumn is DataGridViewButtonColumn)
+            OwningColumn is DataGridViewButtonColumn dataGridViewButtonColumn)
         {
-            return ((DataGridViewButtonColumn)OwningColumn).Text;
+            return dataGridViewButtonColumn.Text;
         }
 
         return base.GetValue(rowIndex);
@@ -476,7 +485,7 @@ public partial class DataGridViewButtonCell : DataGridViewCell
 
     protected override bool MouseEnterUnsharesRow(int rowIndex)
     {
-        return ColumnIndex == DataGridView.MouseDownCellAddress.X && rowIndex == DataGridView.MouseDownCellAddress.Y;
+        return ColumnIndex == DataGridView!.MouseDownCellAddress.X && rowIndex == DataGridView.MouseDownCellAddress.Y;
     }
 
     protected override bool MouseLeaveUnsharesRow(int rowIndex)
@@ -631,21 +640,23 @@ public partial class DataGridViewButtonCell : DataGridViewCell
         }
     }
 
-    protected override void Paint(Graphics graphics,
+    protected override void Paint(
+        Graphics graphics,
         Rectangle clipBounds,
         Rectangle cellBounds,
         int rowIndex,
         DataGridViewElementStates elementState,
-        object value,
-        object formattedValue,
-        string errorText,
+        object? value,
+        object? formattedValue,
+        string? errorText,
         DataGridViewCellStyle cellStyle,
         DataGridViewAdvancedBorderStyle advancedBorderStyle,
         DataGridViewPaintParts paintParts)
     {
         ArgumentNullException.ThrowIfNull(cellStyle);
 
-        PaintPrivate(graphics,
+        PaintPrivate(
+            graphics,
             clipBounds,
             cellBounds,
             rowIndex,
@@ -655,9 +666,9 @@ public partial class DataGridViewButtonCell : DataGridViewCell
             cellStyle,
             advancedBorderStyle,
             paintParts,
-            false /*computeContentBounds*/,
-            false /*computeErrorIconBounds*/,
-            true  /*paint*/);
+            computeContentBounds: false,
+            computeErrorIconBounds: false,
+            paint: true);
     }
 
     // PaintPrivate is used in three places that need to duplicate the paint code:
@@ -668,13 +679,14 @@ public partial class DataGridViewButtonCell : DataGridViewCell
     // if computeContentBounds is true then PaintPrivate returns the contentBounds
     // else if computeErrorIconBounds is true then PaintPrivate returns the errorIconBounds
     // else it returns Rectangle.Empty;
-    private Rectangle PaintPrivate(Graphics g,
+    private Rectangle PaintPrivate(
+        Graphics g,
         Rectangle clipBounds,
         Rectangle cellBounds,
         int rowIndex,
         DataGridViewElementStates elementState,
-        object formattedValue,
-        string errorText,
+        object? formattedValue,
+        string? errorText,
         DataGridViewCellStyle cellStyle,
         DataGridViewAdvancedBorderStyle advancedBorderStyle,
         DataGridViewPaintParts paintParts,
@@ -690,12 +702,12 @@ public partial class DataGridViewButtonCell : DataGridViewCell
         Debug.Assert(!computeErrorIconBounds || !paint || !computeContentBounds);
         Debug.Assert(cellStyle is not null);
 
-        Point ptCurrentCell = DataGridView.CurrentCellAddress;
+        Point ptCurrentCell = DataGridView!.CurrentCellAddress;
         bool cellSelected = (elementState & DataGridViewElementStates.Selected) != 0;
         bool cellCurrent = (ptCurrentCell.X == ColumnIndex && ptCurrentCell.Y == rowIndex);
 
         Rectangle resultBounds;
-        string formattedString = formattedValue as string;
+        string? formattedString = formattedValue as string;
 
         Color backBrushColor = PaintSelectionBackground(paintParts) && cellSelected
             ? cellStyle.SelectionBackColor
@@ -1049,7 +1061,7 @@ public partial class DataGridViewButtonCell : DataGridViewCell
         if (ButtonState != newButtonState)
         {
             ButtonState = newButtonState;
-            DataGridView.InvalidateCell(ColumnIndex, rowIndex);
+            DataGridView!.InvalidateCell(ColumnIndex, rowIndex);
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewButtonCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewButtonCell.cs
@@ -107,14 +107,9 @@ public partial class DataGridViewButtonCell : DataGridViewCell
         }
     }
 
-    public override Type FormattedValueType
-    {
-        get
-        {
-            // we return string for the formatted type
-            return s_defaultFormattedValueType;
-        }
-    }
+    public override Type FormattedValueType =>
+            // We return string for the formatted type.
+            s_defaultFormattedValueType;
 
     [DefaultValue(false)]
     public bool UseColumnTextForButtonValue

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewButtonCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewButtonCell.cs
@@ -456,7 +456,6 @@ public partial class DataGridViewButtonCell : DataGridViewCell
         if (UseColumnTextForButtonValue &&
             DataGridView is not null &&
             DataGridView.NewRowIndex != rowIndex &&
-            OwningColumn is not null &&
             OwningColumn is DataGridViewButtonColumn dataGridViewButtonColumn)
         {
             return dataGridViewButtonColumn.Text;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewButtonCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewButtonCell.cs
@@ -15,22 +15,22 @@ namespace System.Windows.Forms;
 [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 public partial class DataGridViewButtonCell : DataGridViewCell
 {
-    private static readonly int PropButtonCellFlatStyle = PropertyStore.CreateKey();
-    private static readonly int PropButtonCellState = PropertyStore.CreateKey();
-    private static readonly int PropButtonCellUseColumnTextForButtonValue = PropertyStore.CreateKey();
-    private static readonly VisualStyleElement ButtonElement = VisualStyleElement.Button.PushButton.Normal;
+    private static readonly int s_propButtonCellFlatStyle = PropertyStore.CreateKey();
+    private static readonly int s_propButtonCellState = PropertyStore.CreateKey();
+    private static readonly int s_propButtonCellUseColumnTextForButtonValue = PropertyStore.CreateKey();
+    private static readonly VisualStyleElement s_buttonElement = VisualStyleElement.Button.PushButton.Normal;
 
     private const byte DATAGRIDVIEWBUTTONCELL_themeMargin = 100; // Used to calculate the margins required for theming rendering
     private const byte DATAGRIDVIEWBUTTONCELL_horizontalTextMargin = 2;
     private const byte DATAGRIDVIEWBUTTONCELL_verticalTextMargin = 1;
     private const byte DATAGRIDVIEWBUTTONCELL_textPadding = 5;
 
-    private static Rectangle rectThemeMargins = new(-1, -1, 0, 0);
-    private static bool mouseInContentBounds;
+    private static Rectangle s_rectThemeMargins = new(-1, -1, 0, 0);
+    private static bool s_mouseInContentBounds;
 
-    private static readonly Type defaultFormattedValueType = typeof(string);
-    private static readonly Type defaultValueType = typeof(object);
-    private static readonly Type cellType = typeof(DataGridViewButtonCell);
+    private static readonly Type s_defaultFormattedValueType = typeof(string);
+    private static readonly Type s_defaultValueType = typeof(object);
+    private static readonly Type s_cellType = typeof(DataGridViewButtonCell);
 
     public DataGridViewButtonCell()
     {
@@ -40,7 +40,7 @@ public partial class DataGridViewButtonCell : DataGridViewCell
     {
         get
         {
-            int buttonState = Properties.GetInteger(PropButtonCellState, out bool found);
+            int buttonState = Properties.GetInteger(s_propButtonCellState, out bool found);
             if (found)
             {
                 return (ButtonState)buttonState;
@@ -55,7 +55,7 @@ public partial class DataGridViewButtonCell : DataGridViewCell
             Debug.Assert((value & ~(ButtonState.Normal | ButtonState.Pushed | ButtonState.Checked)) == 0);
             if (ButtonState != value)
             {
-                Properties.SetInteger(PropButtonCellState, (int)value);
+                Properties.SetInteger(s_propButtonCellState, (int)value);
             }
         }
     }
@@ -75,7 +75,7 @@ public partial class DataGridViewButtonCell : DataGridViewCell
     {
         get
         {
-            int flatStyle = Properties.GetInteger(PropButtonCellFlatStyle, out bool found);
+            int flatStyle = Properties.GetInteger(s_propButtonCellFlatStyle, out bool found);
             if (found)
             {
                 return (FlatStyle)flatStyle;
@@ -89,7 +89,7 @@ public partial class DataGridViewButtonCell : DataGridViewCell
             SourceGenerated.EnumValidator.Validate(value);
             if (value != FlatStyle)
             {
-                Properties.SetInteger(PropButtonCellFlatStyle, (int)value);
+                Properties.SetInteger(s_propButtonCellFlatStyle, (int)value);
                 OnCommonChange();
             }
         }
@@ -102,7 +102,7 @@ public partial class DataGridViewButtonCell : DataGridViewCell
             Debug.Assert(value >= FlatStyle.Flat && value <= FlatStyle.System);
             if (value != FlatStyle)
             {
-                Properties.SetInteger(PropButtonCellFlatStyle, (int)value);
+                Properties.SetInteger(s_propButtonCellFlatStyle, (int)value);
             }
         }
     }
@@ -112,7 +112,7 @@ public partial class DataGridViewButtonCell : DataGridViewCell
         get
         {
             // we return string for the formatted type
-            return defaultFormattedValueType;
+            return s_defaultFormattedValueType;
         }
     }
 
@@ -121,7 +121,7 @@ public partial class DataGridViewButtonCell : DataGridViewCell
     {
         get
         {
-            int useColumnTextForButtonValue = Properties.GetInteger(PropButtonCellUseColumnTextForButtonValue, out bool found);
+            int useColumnTextForButtonValue = Properties.GetInteger(s_propButtonCellUseColumnTextForButtonValue, out bool found);
             if (found)
             {
                 return useColumnTextForButtonValue == 0 ? false : true;
@@ -133,7 +133,7 @@ public partial class DataGridViewButtonCell : DataGridViewCell
         {
             if (value != UseColumnTextForButtonValue)
             {
-                Properties.SetInteger(PropButtonCellUseColumnTextForButtonValue, value ? 1 : 0);
+                Properties.SetInteger(s_propButtonCellUseColumnTextForButtonValue, value ? 1 : 0);
                 OnCommonChange();
             }
         }
@@ -145,7 +145,7 @@ public partial class DataGridViewButtonCell : DataGridViewCell
         {
             if (value != UseColumnTextForButtonValue)
             {
-                Properties.SetInteger(PropButtonCellUseColumnTextForButtonValue, value ? 1 : 0);
+                Properties.SetInteger(s_propButtonCellUseColumnTextForButtonValue, value ? 1 : 0);
             }
         }
     }
@@ -160,7 +160,7 @@ public partial class DataGridViewButtonCell : DataGridViewCell
                 return valueType;
             }
 
-            return defaultValueType;
+            return s_defaultValueType;
         }
     }
 
@@ -169,7 +169,7 @@ public partial class DataGridViewButtonCell : DataGridViewCell
         DataGridViewButtonCell dataGridViewCell;
         Type thisType = GetType();
 
-        if (thisType == cellType) //performance improvement
+        if (thisType == s_cellType) //performance improvement
         {
             dataGridViewCell = new DataGridViewButtonCell();
         }
@@ -441,17 +441,17 @@ public partial class DataGridViewButtonCell : DataGridViewCell
 
     private static Rectangle GetThemeMargins(Graphics g)
     {
-        if (rectThemeMargins.X == -1)
+        if (s_rectThemeMargins.X == -1)
         {
             Rectangle rectCell = new Rectangle(0, 0, DATAGRIDVIEWBUTTONCELL_themeMargin, DATAGRIDVIEWBUTTONCELL_themeMargin);
             Rectangle rectContent = DataGridViewButtonCellRenderer.DataGridViewButtonRenderer.GetBackgroundContentRectangle(g, rectCell);
-            rectThemeMargins.X = rectContent.X;
-            rectThemeMargins.Y = rectContent.Y;
-            rectThemeMargins.Width = DATAGRIDVIEWBUTTONCELL_themeMargin - rectContent.Right;
-            rectThemeMargins.Height = DATAGRIDVIEWBUTTONCELL_themeMargin - rectContent.Bottom;
+            s_rectThemeMargins.X = rectContent.X;
+            s_rectThemeMargins.Y = rectContent.Y;
+            s_rectThemeMargins.Width = DATAGRIDVIEWBUTTONCELL_themeMargin - rectContent.Right;
+            s_rectThemeMargins.Height = DATAGRIDVIEWBUTTONCELL_themeMargin - rectContent.Bottom;
         }
 
-        return rectThemeMargins;
+        return s_rectThemeMargins;
     }
 
     protected override object? GetValue(int rowIndex)
@@ -558,7 +558,7 @@ public partial class DataGridViewButtonCell : DataGridViewCell
             return;
         }
 
-        if (e.Button == MouseButtons.Left && mouseInContentBounds)
+        if (e.Button == MouseButtons.Left && s_mouseInContentBounds)
         {
             Debug.Assert(DataGridView.CellMouseDownInContentBounds);
             UpdateButtonState(ButtonState | ButtonState.Pushed, e.RowIndex);
@@ -572,9 +572,9 @@ public partial class DataGridViewButtonCell : DataGridViewCell
             return;
         }
 
-        if (mouseInContentBounds)
+        if (s_mouseInContentBounds)
         {
-            mouseInContentBounds = false;
+            s_mouseInContentBounds = false;
             if (ColumnIndex >= 0 &&
                 rowIndex >= 0 &&
                 (DataGridView.ApplyVisualStylesToInnerCells || FlatStyle == FlatStyle.Flat || FlatStyle == FlatStyle.Popup))
@@ -598,9 +598,9 @@ public partial class DataGridViewButtonCell : DataGridViewCell
             return;
         }
 
-        bool oldMouseInContentBounds = mouseInContentBounds;
-        mouseInContentBounds = GetContentBounds(e.RowIndex).Contains(e.X, e.Y);
-        if (oldMouseInContentBounds != mouseInContentBounds)
+        bool oldMouseInContentBounds = s_mouseInContentBounds;
+        s_mouseInContentBounds = GetContentBounds(e.RowIndex).Contains(e.X, e.Y);
+        if (oldMouseInContentBounds != s_mouseInContentBounds)
         {
             if (DataGridView.ApplyVisualStylesToInnerCells || FlatStyle == FlatStyle.Flat || FlatStyle == FlatStyle.Popup)
             {
@@ -612,12 +612,12 @@ public partial class DataGridViewButtonCell : DataGridViewCell
                 Control.MouseButtons == MouseButtons.Left)
             {
                 if ((ButtonState & ButtonState.Pushed) == 0 &&
-                    mouseInContentBounds &&
+                    s_mouseInContentBounds &&
                     DataGridView.CellMouseDownInContentBounds)
                 {
                     UpdateButtonState(ButtonState | ButtonState.Pushed, e.RowIndex);
                 }
-                else if ((ButtonState & ButtonState.Pushed) != 0 && !mouseInContentBounds)
+                else if ((ButtonState & ButtonState.Pushed) != 0 && !s_mouseInContentBounds)
                 {
                     UpdateButtonState(ButtonState & ~ButtonState.Pushed, e.RowIndex);
                 }
@@ -770,7 +770,7 @@ public partial class DataGridViewButtonCell : DataGridViewCell
                                 pbState = PushButtonState.Pressed;
                             }
                             else if (DataGridView.MouseEnteredCellAddress.Y == rowIndex &&
-                                DataGridView.MouseEnteredCellAddress.X == ColumnIndex && mouseInContentBounds)
+                                DataGridView.MouseEnteredCellAddress.X == ColumnIndex && s_mouseInContentBounds)
                             {
                                 pbState = PushButtonState.Hot;
                             }
@@ -826,7 +826,7 @@ public partial class DataGridViewButtonCell : DataGridViewCell
                                 hdc.FillRectangle(valBounds, hbrush);
                             }
                             else if (DataGridView.MouseEnteredCellAddress.Y == rowIndex &&
-                                DataGridView.MouseEnteredCellAddress.X == ColumnIndex && mouseInContentBounds)
+                                DataGridView.MouseEnteredCellAddress.X == ColumnIndex && s_mouseInContentBounds)
                             {
                                 using DeviceContextHdcScope hdc = new(g);
                                 using PInvoke.CreateBrushScope hbrush = new(SystemColors.ControlDark);
@@ -864,7 +864,7 @@ public partial class DataGridViewButtonCell : DataGridViewCell
                         }
                         else if (DataGridView.MouseEnteredCellAddress.Y == rowIndex &&
                                     DataGridView.MouseEnteredCellAddress.X == ColumnIndex &&
-                                    mouseInContentBounds)
+                                    s_mouseInContentBounds)
                         {
                             // paint over
                             ButtonBaseAdapter.ColorData colors = ButtonBaseAdapter.PaintPopupRender(

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxCell.cs
@@ -488,13 +488,7 @@ public partial class DataGridViewComboBoxCell : DataGridViewCell
         }
     }
 
-    public override Type FormattedValueType
-    {
-        get
-        {
-            return s_defaultFormattedValueType;
-        }
-    }
+    public override Type FormattedValueType => s_defaultFormattedValueType;
 
     internal bool HasItems => Properties.ContainsObjectThatIsNotNull(s_propComboBoxCellItems);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewHeaderCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewHeaderCell.cs
@@ -112,13 +112,7 @@ public partial class DataGridViewHeaderCell : DataGridViewCell
         }
     }
 
-    public override Type FormattedValueType
-    {
-        get
-        {
-            return s_defaultFormattedValueType;
-        }
-    }
+    public override Type FormattedValueType => s_defaultFormattedValueType;
 
     [Browsable(false)]
     public override bool Frozen

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewLinkCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewLinkCell.cs
@@ -112,13 +112,7 @@ public partial class DataGridViewLinkCell : DataGridViewCell
         }
     }
 
-    public override Type FormattedValueType
-    {
-        get
-        {
-            return s_defaultFormattedValueType;
-        }
-    }
+    public override Type FormattedValueType => s_defaultFormattedValueType;
 
     [DefaultValue(LinkBehavior.SystemDefault)]
     public LinkBehavior LinkBehavior

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewLinkCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewLinkCell.cs
@@ -733,10 +733,9 @@ public partial class DataGridViewLinkCell : DataGridViewCell
         if (UseColumnTextForLinkValue &&
             DataGridView is not null &&
             DataGridView.NewRowIndex != rowIndex &&
-            OwningColumn is not null &&
-            OwningColumn is DataGridViewLinkColumn)
+            OwningColumn is DataGridViewLinkColumn dataGridViewLinkColumn)
         {
-            return ((DataGridViewLinkColumn)OwningColumn).Text;
+            return dataGridViewLinkColumn.Text;
         }
 
         return base.GetValue(rowIndex);


### PR DESCRIPTION
## Proposed changes

- Enable nullability in DataGridViewButtonCell.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9542)