### PR TITLE
Reduced nesting levels by inverting a few top-level `if`s

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,6 +34,7 @@ pr:
       - internal/release/*
       - internal/experimental/*
       - feature/win32
+      - Net9.0-Test
   paths:
     include:
       - '*'

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -7,174 +7,174 @@ Note: if the Uri is a new place, you will need to add a subscription from that p
 -->
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="VS.Redist.Common.NetCore.SharedFramework.x64.8.0" Version="8.0.0-preview.7.23367.16">
+    <Dependency Name="VS.Redist.Common.NetCore.SharedFramework.x64.8.0" Version="8.0.0-rc.1.23371.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4f933e1f77e211a73a44a3e3a1e5fb079d498ab7</Sha>
+      <Sha>03acd23bc8c209282c0a2e9664de81e962999da4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.Platforms" Version="8.0.0-preview.7.23367.16">
+    <Dependency Name="Microsoft.NETCore.Platforms" Version="8.0.0-rc.1.23371.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4f933e1f77e211a73a44a3e3a1e5fb079d498ab7</Sha>
+      <Sha>03acd23bc8c209282c0a2e9664de81e962999da4</Sha>
     </Dependency>
-    <Dependency Name="System.Resources.Extensions" Version="8.0.0-preview.7.23367.16">
+    <Dependency Name="System.Resources.Extensions" Version="8.0.0-rc.1.23371.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4f933e1f77e211a73a44a3e3a1e5fb079d498ab7</Sha>
+      <Sha>03acd23bc8c209282c0a2e9664de81e962999da4</Sha>
     </Dependency>
-    <Dependency Name="System.Windows.Extensions" Version="8.0.0-preview.7.23367.16">
+    <Dependency Name="System.Windows.Extensions" Version="8.0.0-rc.1.23371.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4f933e1f77e211a73a44a3e3a1e5fb079d498ab7</Sha>
+      <Sha>03acd23bc8c209282c0a2e9664de81e962999da4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.IL" Version="8.0.0-preview.7.23367.16">
+    <Dependency Name="Microsoft.NET.Sdk.IL" Version="8.0.0-rc.1.23371.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4f933e1f77e211a73a44a3e3a1e5fb079d498ab7</Sha>
+      <Sha>03acd23bc8c209282c0a2e9664de81e962999da4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.ILAsm" Version="8.0.0-preview.7.23367.16">
+    <Dependency Name="Microsoft.NETCore.ILAsm" Version="8.0.0-rc.1.23371.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4f933e1f77e211a73a44a3e3a1e5fb079d498ab7</Sha>
+      <Sha>03acd23bc8c209282c0a2e9664de81e962999da4</Sha>
     </Dependency>
-    <Dependency Name="runtime.win-x64.Microsoft.NETCore.ILAsm" Version="8.0.0-preview.7.23367.16">
+    <Dependency Name="runtime.win-x64.Microsoft.NETCore.ILAsm" Version="8.0.0-rc.1.23371.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4f933e1f77e211a73a44a3e3a1e5fb079d498ab7</Sha>
+      <Sha>03acd23bc8c209282c0a2e9664de81e962999da4</Sha>
     </Dependency>
-    <Dependency Name="runtime.win-x86.Microsoft.NETCore.ILAsm" Version="8.0.0-preview.7.23367.16">
+    <Dependency Name="runtime.win-x86.Microsoft.NETCore.ILAsm" Version="8.0.0-rc.1.23371.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4f933e1f77e211a73a44a3e3a1e5fb079d498ab7</Sha>
+      <Sha>03acd23bc8c209282c0a2e9664de81e962999da4</Sha>
     </Dependency>
-    <Dependency Name="System.Reflection.MetadataLoadContext" Version="8.0.0-preview.7.23367.16">
+    <Dependency Name="System.Reflection.MetadataLoadContext" Version="8.0.0-rc.1.23371.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4f933e1f77e211a73a44a3e3a1e5fb079d498ab7</Sha>
+      <Sha>03acd23bc8c209282c0a2e9664de81e962999da4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.ILDAsm" Version="8.0.0-preview.7.23367.16">
+    <Dependency Name="Microsoft.NETCore.ILDAsm" Version="8.0.0-rc.1.23371.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4f933e1f77e211a73a44a3e3a1e5fb079d498ab7</Sha>
+      <Sha>03acd23bc8c209282c0a2e9664de81e962999da4</Sha>
     </Dependency>
-    <Dependency Name="System.Text.Encodings.Web" Version="8.0.0-preview.7.23367.16">
+    <Dependency Name="System.Text.Encodings.Web" Version="8.0.0-rc.1.23371.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4f933e1f77e211a73a44a3e3a1e5fb079d498ab7</Sha>
+      <Sha>03acd23bc8c209282c0a2e9664de81e962999da4</Sha>
     </Dependency>
-    <Dependency Name="System.Text.Json" Version="8.0.0-preview.7.23367.16">
+    <Dependency Name="System.Text.Json" Version="8.0.0-rc.1.23371.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4f933e1f77e211a73a44a3e3a1e5fb079d498ab7</Sha>
+      <Sha>03acd23bc8c209282c0a2e9664de81e962999da4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="8.0.0-preview.7.23367.16">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="8.0.0-rc.1.23371.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4f933e1f77e211a73a44a3e3a1e5fb079d498ab7</Sha>
+      <Sha>03acd23bc8c209282c0a2e9664de81e962999da4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="8.0.0-preview.7.23367.16">
+    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="8.0.0-rc.1.23371.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4f933e1f77e211a73a44a3e3a1e5fb079d498ab7</Sha>
+      <Sha>03acd23bc8c209282c0a2e9664de81e962999da4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Internal.Runtime.WindowsDesktop.Transport" Version="8.0.0-preview.7.23367.16">
+    <Dependency Name="Microsoft.Internal.Runtime.WindowsDesktop.Transport" Version="8.0.0-rc.1.23371.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4f933e1f77e211a73a44a3e3a1e5fb079d498ab7</Sha>
+      <Sha>03acd23bc8c209282c0a2e9664de81e962999da4</Sha>
     </Dependency>
     <!-- These dependencies are required by windowsdesktop for coherency. -->
-    <Dependency Name="Microsoft.Win32.Registry.AccessControl" Version="8.0.0-preview.7.23367.16">
+    <Dependency Name="Microsoft.Win32.Registry.AccessControl" Version="8.0.0-rc.1.23371.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4f933e1f77e211a73a44a3e3a1e5fb079d498ab7</Sha>
+      <Sha>03acd23bc8c209282c0a2e9664de81e962999da4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Win32.SystemEvents" Version="8.0.0-preview.7.23367.16">
+    <Dependency Name="Microsoft.Win32.SystemEvents" Version="8.0.0-rc.1.23371.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4f933e1f77e211a73a44a3e3a1e5fb079d498ab7</Sha>
+      <Sha>03acd23bc8c209282c0a2e9664de81e962999da4</Sha>
     </Dependency>
-    <Dependency Name="System.CodeDom" Version="8.0.0-preview.7.23367.16">
+    <Dependency Name="System.CodeDom" Version="8.0.0-rc.1.23371.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4f933e1f77e211a73a44a3e3a1e5fb079d498ab7</Sha>
+      <Sha>03acd23bc8c209282c0a2e9664de81e962999da4</Sha>
     </Dependency>
-    <Dependency Name="System.ComponentModel.Composition" Version="8.0.0-preview.7.23367.16">
+    <Dependency Name="System.ComponentModel.Composition" Version="8.0.0-rc.1.23371.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4f933e1f77e211a73a44a3e3a1e5fb079d498ab7</Sha>
+      <Sha>03acd23bc8c209282c0a2e9664de81e962999da4</Sha>
     </Dependency>
-    <Dependency Name="System.Configuration.ConfigurationManager" Version="8.0.0-preview.7.23367.16">
+    <Dependency Name="System.Configuration.ConfigurationManager" Version="8.0.0-rc.1.23371.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4f933e1f77e211a73a44a3e3a1e5fb079d498ab7</Sha>
+      <Sha>03acd23bc8c209282c0a2e9664de81e962999da4</Sha>
     </Dependency>
-    <Dependency Name="System.Data.Odbc" Version="8.0.0-preview.7.23367.16">
+    <Dependency Name="System.Data.Odbc" Version="8.0.0-rc.1.23371.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4f933e1f77e211a73a44a3e3a1e5fb079d498ab7</Sha>
+      <Sha>03acd23bc8c209282c0a2e9664de81e962999da4</Sha>
     </Dependency>
-    <Dependency Name="System.Data.OleDb" Version="8.0.0-preview.7.23367.16">
+    <Dependency Name="System.Data.OleDb" Version="8.0.0-rc.1.23371.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4f933e1f77e211a73a44a3e3a1e5fb079d498ab7</Sha>
+      <Sha>03acd23bc8c209282c0a2e9664de81e962999da4</Sha>
     </Dependency>
-    <Dependency Name="System.Diagnostics.EventLog" Version="8.0.0-preview.7.23367.16">
+    <Dependency Name="System.Diagnostics.EventLog" Version="8.0.0-rc.1.23371.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4f933e1f77e211a73a44a3e3a1e5fb079d498ab7</Sha>
+      <Sha>03acd23bc8c209282c0a2e9664de81e962999da4</Sha>
     </Dependency>
-    <Dependency Name="System.Diagnostics.PerformanceCounter" Version="8.0.0-preview.7.23367.16">
+    <Dependency Name="System.Diagnostics.PerformanceCounter" Version="8.0.0-rc.1.23371.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4f933e1f77e211a73a44a3e3a1e5fb079d498ab7</Sha>
+      <Sha>03acd23bc8c209282c0a2e9664de81e962999da4</Sha>
     </Dependency>
-    <Dependency Name="System.DirectoryServices.AccountManagement" Version="8.0.0-preview.7.23367.16">
+    <Dependency Name="System.DirectoryServices.AccountManagement" Version="8.0.0-rc.1.23371.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4f933e1f77e211a73a44a3e3a1e5fb079d498ab7</Sha>
+      <Sha>03acd23bc8c209282c0a2e9664de81e962999da4</Sha>
     </Dependency>
-    <Dependency Name="System.DirectoryServices.Protocols" Version="8.0.0-preview.7.23367.16">
+    <Dependency Name="System.DirectoryServices.Protocols" Version="8.0.0-rc.1.23371.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4f933e1f77e211a73a44a3e3a1e5fb079d498ab7</Sha>
+      <Sha>03acd23bc8c209282c0a2e9664de81e962999da4</Sha>
     </Dependency>
-    <Dependency Name="System.DirectoryServices" Version="8.0.0-preview.7.23367.16">
+    <Dependency Name="System.DirectoryServices" Version="8.0.0-rc.1.23371.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4f933e1f77e211a73a44a3e3a1e5fb079d498ab7</Sha>
+      <Sha>03acd23bc8c209282c0a2e9664de81e962999da4</Sha>
     </Dependency>
-    <Dependency Name="System.IO.Packaging" Version="8.0.0-preview.7.23367.16">
+    <Dependency Name="System.IO.Packaging" Version="8.0.0-rc.1.23371.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4f933e1f77e211a73a44a3e3a1e5fb079d498ab7</Sha>
+      <Sha>03acd23bc8c209282c0a2e9664de81e962999da4</Sha>
     </Dependency>
-    <Dependency Name="System.IO.Ports" Version="8.0.0-preview.7.23367.16">
+    <Dependency Name="System.IO.Ports" Version="8.0.0-rc.1.23371.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4f933e1f77e211a73a44a3e3a1e5fb079d498ab7</Sha>
+      <Sha>03acd23bc8c209282c0a2e9664de81e962999da4</Sha>
     </Dependency>
-    <Dependency Name="System.Management" Version="8.0.0-preview.7.23367.16">
+    <Dependency Name="System.Management" Version="8.0.0-rc.1.23371.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4f933e1f77e211a73a44a3e3a1e5fb079d498ab7</Sha>
+      <Sha>03acd23bc8c209282c0a2e9664de81e962999da4</Sha>
     </Dependency>
-    <Dependency Name="System.Reflection.Context" Version="8.0.0-preview.7.23367.16">
+    <Dependency Name="System.Reflection.Context" Version="8.0.0-rc.1.23371.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4f933e1f77e211a73a44a3e3a1e5fb079d498ab7</Sha>
+      <Sha>03acd23bc8c209282c0a2e9664de81e962999da4</Sha>
     </Dependency>
-    <Dependency Name="System.Runtime.Caching" Version="8.0.0-preview.7.23367.16">
+    <Dependency Name="System.Runtime.Caching" Version="8.0.0-rc.1.23371.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4f933e1f77e211a73a44a3e3a1e5fb079d498ab7</Sha>
+      <Sha>03acd23bc8c209282c0a2e9664de81e962999da4</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Pkcs" Version="8.0.0-preview.7.23367.16">
+    <Dependency Name="System.Security.Cryptography.Pkcs" Version="8.0.0-rc.1.23371.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4f933e1f77e211a73a44a3e3a1e5fb079d498ab7</Sha>
+      <Sha>03acd23bc8c209282c0a2e9664de81e962999da4</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.ProtectedData" Version="8.0.0-preview.7.23367.16">
+    <Dependency Name="System.Security.Cryptography.ProtectedData" Version="8.0.0-rc.1.23371.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4f933e1f77e211a73a44a3e3a1e5fb079d498ab7</Sha>
+      <Sha>03acd23bc8c209282c0a2e9664de81e962999da4</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Xml" Version="8.0.0-preview.7.23367.16">
+    <Dependency Name="System.Security.Cryptography.Xml" Version="8.0.0-rc.1.23371.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4f933e1f77e211a73a44a3e3a1e5fb079d498ab7</Sha>
+      <Sha>03acd23bc8c209282c0a2e9664de81e962999da4</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Permissions" Version="8.0.0-preview.7.23367.16">
+    <Dependency Name="System.Security.Permissions" Version="8.0.0-rc.1.23371.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4f933e1f77e211a73a44a3e3a1e5fb079d498ab7</Sha>
+      <Sha>03acd23bc8c209282c0a2e9664de81e962999da4</Sha>
     </Dependency>
-    <Dependency Name="System.ServiceModel.Syndication" Version="8.0.0-preview.7.23367.16">
+    <Dependency Name="System.ServiceModel.Syndication" Version="8.0.0-rc.1.23371.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4f933e1f77e211a73a44a3e3a1e5fb079d498ab7</Sha>
+      <Sha>03acd23bc8c209282c0a2e9664de81e962999da4</Sha>
     </Dependency>
-    <Dependency Name="System.ServiceProcess.ServiceController" Version="8.0.0-preview.7.23367.16">
+    <Dependency Name="System.ServiceProcess.ServiceController" Version="8.0.0-rc.1.23371.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4f933e1f77e211a73a44a3e3a1e5fb079d498ab7</Sha>
+      <Sha>03acd23bc8c209282c0a2e9664de81e962999da4</Sha>
     </Dependency>
-    <Dependency Name="System.Speech" Version="8.0.0-preview.7.23367.16">
+    <Dependency Name="System.Speech" Version="8.0.0-rc.1.23371.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4f933e1f77e211a73a44a3e3a1e5fb079d498ab7</Sha>
+      <Sha>03acd23bc8c209282c0a2e9664de81e962999da4</Sha>
     </Dependency>
-    <Dependency Name="System.Text.Encoding.CodePages" Version="8.0.0-preview.7.23367.16">
+    <Dependency Name="System.Text.Encoding.CodePages" Version="8.0.0-rc.1.23371.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4f933e1f77e211a73a44a3e3a1e5fb079d498ab7</Sha>
+      <Sha>03acd23bc8c209282c0a2e9664de81e962999da4</Sha>
     </Dependency>
-    <Dependency Name="System.Threading.AccessControl" Version="8.0.0-preview.7.23367.16">
+    <Dependency Name="System.Threading.AccessControl" Version="8.0.0-rc.1.23371.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4f933e1f77e211a73a44a3e3a1e5fb079d498ab7</Sha>
+      <Sha>03acd23bc8c209282c0a2e9664de81e962999da4</Sha>
     </Dependency>
-    <Dependency Name="System.ComponentModel.Composition.Registration" Version="8.0.0-preview.7.23367.16">
+    <Dependency Name="System.ComponentModel.Composition.Registration" Version="8.0.0-rc.1.23371.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4f933e1f77e211a73a44a3e3a1e5fb079d498ab7</Sha>
+      <Sha>03acd23bc8c209282c0a2e9664de81e962999da4</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -179,29 +179,29 @@ Note: if the Uri is a new place, you will need to add a subscription from that p
   </ProductDependencies>
   <ToolsetDependencies>
     <!-- Arcade -->
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.23364.2">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.23370.6">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>60ea5b2eca5af06fc63b250f8669d2c70179b18c</Sha>
+      <Sha>a2d7c72df5b2e36b0f69bbe12ad4d7c52793c745</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.GenFacades" Version="8.0.0-beta.23364.2">
+    <Dependency Name="Microsoft.DotNet.GenFacades" Version="8.0.0-beta.23370.6">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>60ea5b2eca5af06fc63b250f8669d2c70179b18c</Sha>
+      <Sha>a2d7c72df5b2e36b0f69bbe12ad4d7c52793c745</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.CMake.Sdk" Version="8.0.0-beta.23364.2">
+    <Dependency Name="Microsoft.DotNet.CMake.Sdk" Version="8.0.0-beta.23370.6">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>60ea5b2eca5af06fc63b250f8669d2c70179b18c</Sha>
+      <Sha>a2d7c72df5b2e36b0f69bbe12ad4d7c52793c745</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="8.0.0-beta.23364.2">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="8.0.0-beta.23370.6">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>60ea5b2eca5af06fc63b250f8669d2c70179b18c</Sha>
+      <Sha>a2d7c72df5b2e36b0f69bbe12ad4d7c52793c745</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="8.0.0-beta.23364.2">
+    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="8.0.0-beta.23370.6">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>60ea5b2eca5af06fc63b250f8669d2c70179b18c</Sha>
+      <Sha>a2d7c72df5b2e36b0f69bbe12ad4d7c52793c745</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="8.0.0-beta.23364.2">
+    <Dependency Name="Microsoft.DotNet.XUnitExtensions" Version="8.0.0-beta.23370.6">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>60ea5b2eca5af06fc63b250f8669d2c70179b18c</Sha>
+      <Sha>a2d7c72df5b2e36b0f69bbe12ad4d7c52793c745</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -13,34 +13,34 @@
   </PropertyGroup>
   <!-- Below have corresponding entries in Versions.Details.XML because they are updated via Maestro -->
   <PropertyGroup>
-    <VSRedistCommonNetCoreSharedFrameworkx6480PackageVersion>8.0.0-preview.7.23367.16</VSRedistCommonNetCoreSharedFrameworkx6480PackageVersion>
-    <SystemDiagnosticsEventLogPackageVersion>8.0.0-preview.7.23367.16</SystemDiagnosticsEventLogPackageVersion>
-    <SystemDirectoryServicesPackageVersion>8.0.0-preview.7.23367.16</SystemDirectoryServicesPackageVersion>
-    <SystemReflectionMetadataLoadContextPackageVersion>8.0.0-preview.7.23367.16</SystemReflectionMetadataLoadContextPackageVersion>
-    <SystemSecurityCryptographyXmlPackageVersion>8.0.0-preview.7.23367.16</SystemSecurityCryptographyXmlPackageVersion>
-    <SystemIOPackagingPackageVersion>8.0.0-preview.7.23367.16</SystemIOPackagingPackageVersion>
+    <VSRedistCommonNetCoreSharedFrameworkx6480PackageVersion>8.0.0-rc.1.23371.1</VSRedistCommonNetCoreSharedFrameworkx6480PackageVersion>
+    <SystemDiagnosticsEventLogPackageVersion>8.0.0-rc.1.23371.1</SystemDiagnosticsEventLogPackageVersion>
+    <SystemDirectoryServicesPackageVersion>8.0.0-rc.1.23371.1</SystemDirectoryServicesPackageVersion>
+    <SystemReflectionMetadataLoadContextPackageVersion>8.0.0-rc.1.23371.1</SystemReflectionMetadataLoadContextPackageVersion>
+    <SystemSecurityCryptographyXmlPackageVersion>8.0.0-rc.1.23371.1</SystemSecurityCryptographyXmlPackageVersion>
+    <SystemIOPackagingPackageVersion>8.0.0-rc.1.23371.1</SystemIOPackagingPackageVersion>
     <MicrosoftNETCoreRuntimeCoreCLRPackageVersion>5.0.0-preview.7.20320.5</MicrosoftNETCoreRuntimeCoreCLRPackageVersion>
-    <MicrosoftNETCoreILDAsmPackageVersion>8.0.0-preview.7.23367.16</MicrosoftNETCoreILDAsmPackageVersion>
-    <SystemDiagnosticsPerformanceCounterPackageVersion>8.0.0-preview.7.23367.16</SystemDiagnosticsPerformanceCounterPackageVersion>
+    <MicrosoftNETCoreILDAsmPackageVersion>8.0.0-rc.1.23371.1</MicrosoftNETCoreILDAsmPackageVersion>
+    <SystemDiagnosticsPerformanceCounterPackageVersion>8.0.0-rc.1.23371.1</SystemDiagnosticsPerformanceCounterPackageVersion>
     <SystemRuntimeCompilerServicesUnsafePackageVersion>6.0.0</SystemRuntimeCompilerServicesUnsafePackageVersion>
-    <SystemSecurityCryptographyPkcsPackageVersion>8.0.0-preview.7.23367.16</SystemSecurityCryptographyPkcsPackageVersion>
-    <SystemSecurityCryptographyProtectedDataPackageVersion>8.0.0-preview.7.23367.16</SystemSecurityCryptographyProtectedDataPackageVersion>
-    <SystemTextEncodingsWebPackageVersion>8.0.0-preview.7.23367.16</SystemTextEncodingsWebPackageVersion>
-    <SystemTextJsonPackageVersion>8.0.0-preview.7.23367.16</SystemTextJsonPackageVersion>
-    <SystemThreadingAccessControlPackageVersion>8.0.0-preview.7.23367.16</SystemThreadingAccessControlPackageVersion>
-    <MicrosoftWin32RegistryAccessControlPackageVersion>8.0.0-preview.7.23367.16</MicrosoftWin32RegistryAccessControlPackageVersion>
-    <MicrosoftNETCoreAppRefPackageVersion>8.0.0-preview.7.23367.16</MicrosoftNETCoreAppRefPackageVersion>
-    <MicrosoftNETCoreAppRuntimewinx64PackageVersion>8.0.0-preview.7.23367.16</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
-    <MicrosoftNETCorePlatformsPackageVersion>8.0.0-preview.7.23367.16</MicrosoftNETCorePlatformsPackageVersion>
-    <MicrosoftWin32SystemEventsPackageVersion>8.0.0-preview.7.23367.16</MicrosoftWin32SystemEventsPackageVersion>
-    <SystemCodeDomPackageVersion>8.0.0-preview.7.23367.16</SystemCodeDomPackageVersion>
-    <SystemConfigurationConfigurationManagerPackageVersion>8.0.0-preview.7.23367.16</SystemConfigurationConfigurationManagerPackageVersion>
-    <SystemResourcesExtensionsPackageVersion>8.0.0-preview.7.23367.16</SystemResourcesExtensionsPackageVersion>
-    <SystemSecurityPermissionsPackageVersion>8.0.0-preview.7.23367.16</SystemSecurityPermissionsPackageVersion>
-    <SystemWindowsExtensionsPackageVersion>8.0.0-preview.7.23367.16</SystemWindowsExtensionsPackageVersion>
-    <MicrosoftNETCoreILAsmPackageVersion>8.0.0-preview.7.23367.16</MicrosoftNETCoreILAsmPackageVersion>
-    <runtimewinx64MicrosoftNETCoreILAsmPackageVersion>8.0.0-preview.7.23367.16</runtimewinx64MicrosoftNETCoreILAsmPackageVersion>
-    <runtimewinx86MicrosoftNETCoreILAsmPackageVersion>8.0.0-preview.7.23367.16</runtimewinx86MicrosoftNETCoreILAsmPackageVersion>
+    <SystemSecurityCryptographyPkcsPackageVersion>8.0.0-rc.1.23371.1</SystemSecurityCryptographyPkcsPackageVersion>
+    <SystemSecurityCryptographyProtectedDataPackageVersion>8.0.0-rc.1.23371.1</SystemSecurityCryptographyProtectedDataPackageVersion>
+    <SystemTextEncodingsWebPackageVersion>8.0.0-rc.1.23371.1</SystemTextEncodingsWebPackageVersion>
+    <SystemTextJsonPackageVersion>8.0.0-rc.1.23371.1</SystemTextJsonPackageVersion>
+    <SystemThreadingAccessControlPackageVersion>8.0.0-rc.1.23371.1</SystemThreadingAccessControlPackageVersion>
+    <MicrosoftWin32RegistryAccessControlPackageVersion>8.0.0-rc.1.23371.1</MicrosoftWin32RegistryAccessControlPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>8.0.0-rc.1.23371.1</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppRuntimewinx64PackageVersion>8.0.0-rc.1.23371.1</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
+    <MicrosoftNETCorePlatformsPackageVersion>8.0.0-rc.1.23371.1</MicrosoftNETCorePlatformsPackageVersion>
+    <MicrosoftWin32SystemEventsPackageVersion>8.0.0-rc.1.23371.1</MicrosoftWin32SystemEventsPackageVersion>
+    <SystemCodeDomPackageVersion>8.0.0-rc.1.23371.1</SystemCodeDomPackageVersion>
+    <SystemConfigurationConfigurationManagerPackageVersion>8.0.0-rc.1.23371.1</SystemConfigurationConfigurationManagerPackageVersion>
+    <SystemResourcesExtensionsPackageVersion>8.0.0-rc.1.23371.1</SystemResourcesExtensionsPackageVersion>
+    <SystemSecurityPermissionsPackageVersion>8.0.0-rc.1.23371.1</SystemSecurityPermissionsPackageVersion>
+    <SystemWindowsExtensionsPackageVersion>8.0.0-rc.1.23371.1</SystemWindowsExtensionsPackageVersion>
+    <MicrosoftNETCoreILAsmPackageVersion>8.0.0-rc.1.23371.1</MicrosoftNETCoreILAsmPackageVersion>
+    <runtimewinx64MicrosoftNETCoreILAsmPackageVersion>8.0.0-rc.1.23371.1</runtimewinx64MicrosoftNETCoreILAsmPackageVersion>
+    <runtimewinx86MicrosoftNETCoreILAsmPackageVersion>8.0.0-rc.1.23371.1</runtimewinx86MicrosoftNETCoreILAsmPackageVersion>
     <!-- 
       Microsoft.NET.Sdk.IL.targets requires definition of MicrosoftNETCoreILAsmVersion
     -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -53,9 +53,9 @@
   </PropertyGroup>
   <!-- Arcade -->
   <PropertyGroup>
-    <MicrosoftDotNetGenFacadesPackageVersion>8.0.0-beta.23364.2</MicrosoftDotNetGenFacadesPackageVersion>
-    <MicrosoftDotNetRemoteExecutorVersion>8.0.0-beta.23364.2</MicrosoftDotNetRemoteExecutorVersion>
-    <MicrosoftDotNetXUnitExtensionsPackageVersion>8.0.0-beta.23364.2</MicrosoftDotNetXUnitExtensionsPackageVersion>
+    <MicrosoftDotNetGenFacadesPackageVersion>8.0.0-beta.23370.6</MicrosoftDotNetGenFacadesPackageVersion>
+    <MicrosoftDotNetRemoteExecutorVersion>8.0.0-beta.23370.6</MicrosoftDotNetRemoteExecutorVersion>
+    <MicrosoftDotNetXUnitExtensionsPackageVersion>8.0.0-beta.23370.6</MicrosoftDotNetXUnitExtensionsPackageVersion>
     <MicrosoftNETTestSdkVersion>17.4.0-preview-20220707-01</MicrosoftNETTestSdkVersion>
   </PropertyGroup>
   <!-- Below have no corresponding entries in Versions.Details.XML because they are not updated via Maestro -->

--- a/eng/common/sdl/configure-sdl-tool.ps1
+++ b/eng/common/sdl/configure-sdl-tool.ps1
@@ -93,7 +93,9 @@ try {
       }
       'binskim' {
         if ($targetDirectory) {
-          $tool.Args += "`"Target < $TargetDirectory\**`""
+          # Binskim crashes due to specific PDBs. GitHub issue: https://github.com/microsoft/binskim/issues/924.
+          # We are excluding all `_.pdb` files from the scan.
+          $tool.Args += "`"Target < $TargetDirectory\**;-:file|$TargetDirectory\**\_.pdb`""
         }
         $tool.Args += $BinskimAdditionalRunConfigParams
       }

--- a/global.json
+++ b/global.json
@@ -14,9 +14,9 @@
     "version": "8.0.100-preview.6.23330.14"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.23364.2",
-    "Microsoft.DotNet.CMake.Sdk": "8.0.0-beta.23364.2",
-    "Microsoft.DotNet.Helix.Sdk": "8.0.0-beta.23364.2",
+    "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.23370.6",
+    "Microsoft.DotNet.CMake.Sdk": "8.0.0-beta.23370.6",
+    "Microsoft.DotNet.Helix.Sdk": "8.0.0-beta.23370.6",
     "FIX-85B6-MERGE-9C38-CONFLICT": "1.0.0",
     "Microsoft.NET.Sdk.IL": "8.0.0-rc.1.23371.1"
   },

--- a/global.json
+++ b/global.json
@@ -18,7 +18,7 @@
     "Microsoft.DotNet.CMake.Sdk": "8.0.0-beta.23364.2",
     "Microsoft.DotNet.Helix.Sdk": "8.0.0-beta.23364.2",
     "FIX-85B6-MERGE-9C38-CONFLICT": "1.0.0",
-    "Microsoft.NET.Sdk.IL": "8.0.0-preview.7.23367.16"
+    "Microsoft.NET.Sdk.IL": "8.0.0-rc.1.23371.1"
   },
   "native-tools": {
     "cmake": "latest"

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -368,29 +368,33 @@ public partial class Form : ContainerControl
         }
         set
         {
-            if (value != (_formState[FormStateAllowTransparency] != 0))
+            if (value == (_formState[FormStateAllowTransparency] != 0))
             {
-                _formState[FormStateAllowTransparency] = (value ? 1 : 0);
-
-                _formState[FormStateLayered] = _formState[FormStateAllowTransparency];
-
-                UpdateStyles();
-
-                if (!value)
-                {
-                    if (Properties.ContainsObject(PropOpacity))
-                    {
-                        Properties.SetObject(PropOpacity, 1.0f);
-                    }
-
-                    if (Properties.ContainsObject(PropTransparencyKey))
-                    {
-                        Properties.SetObject(PropTransparencyKey, Color.Empty);
-                    }
-
-                    UpdateLayered();
-                }
+                return;
             }
+
+            _formState[FormStateAllowTransparency] = (value ? 1 : 0);
+
+            _formState[FormStateLayered] = _formState[FormStateAllowTransparency];
+
+            UpdateStyles();
+
+            if (value)
+            {
+                return;
+            }
+
+            if (Properties.ContainsObject(PropOpacity))
+            {
+                Properties.SetObject(PropOpacity, 1.0f);
+            }
+
+            if (Properties.ContainsObject(PropTransparencyKey))
+            {
+                Properties.SetObject(PropTransparencyKey, Color.Empty);
+            }
+
+            UpdateLayered();
         }
     }
 
@@ -553,24 +557,28 @@ public partial class Form : ContainerControl
         {
             SourceGenerated.EnumValidator.Validate(value);
 
-            if (GetAutoSizeMode() != value)
+            if (GetAutoSizeMode() == value)
             {
-                SetAutoSizeMode(value);
-                Control toLayout = DesignMode || ParentInternal is null ? this : ParentInternal;
-
-                if (toLayout is not null)
-                {
-                    // DefaultLayout does not keep anchor information until it needs to.  When
-                    // AutoSize became a common property, we could no longer blindly call into
-                    // DefaultLayout, so now we do a special InitLayout just for DefaultLayout.
-                    if (toLayout.LayoutEngine == DefaultLayout.Instance)
-                    {
-                        toLayout.LayoutEngine.InitLayout(this, BoundsSpecified.Size);
-                    }
-
-                    LayoutTransaction.DoLayout(toLayout, this, PropertyNames.AutoSize);
-                }
+                return;
             }
+
+            SetAutoSizeMode(value);
+            Control toLayout = DesignMode || ParentInternal is null ? this : ParentInternal;
+
+            if (toLayout is null)
+            {
+                return;
+            }
+
+            // DefaultLayout does not keep anchor information until it needs to.  When
+            // AutoSize became a common property, we could no longer blindly call into
+            // DefaultLayout, so now we do a special InitLayout just for DefaultLayout.
+            if (toLayout.LayoutEngine == DefaultLayout.Instance)
+            {
+                toLayout.LayoutEngine.InitLayout(this, BoundsSpecified.Size);
+            }
+
+            LayoutTransaction.DoLayout(toLayout, this, PropertyNames.AutoSize);
         }
     }
 
@@ -1054,27 +1062,29 @@ public partial class Form : ContainerControl
         }
         set
         {
-            if (_icon != value)
+            if (_icon == value)
             {
-                // If the user is setting the default back in, treat this
-                // as a reset.
-                if (value == defaultIcon)
-                {
-                    value = null;
-                }
-
-                // If null is passed, reset the icon.
-                _formState[FormStateIconSet] = value is null ? 0 : 1;
-                _icon = value;
-
-                if (_smallIcon is not null)
-                {
-                    _smallIcon.Dispose();
-                    _smallIcon = null;
-                }
-
-                UpdateWindowIcon(true);
+                return;
             }
+
+            // If the user is setting the default back in, treat this
+            // as a reset.
+            if (value == defaultIcon)
+            {
+                value = null;
+            }
+
+            // If null is passed, reset the icon.
+            _formState[FormStateIconSet] = value is null ? 0 : 1;
+            _icon = value;
+
+            if (_smallIcon is not null)
+            {
+                _smallIcon.Dispose();
+                _smallIcon = null;
+            }
+
+            UpdateWindowIcon(true);
         }
     }
 
@@ -1231,11 +1241,13 @@ public partial class Form : ContainerControl
         }
         set
         {
-            if (!value.Equals(MaximizedBounds))
+            if (value.Equals(MaximizedBounds))
             {
-                Properties.SetRectangle(PropMaximizedBounds, value);
-                OnMaximizedBoundsChanged(EventArgs.Empty);
+                return;
             }
+
+            Properties.SetRectangle(PropMaximizedBounds, value);
+            OnMaximizedBoundsChanged(EventArgs.Empty);
         }
     }
 
@@ -1271,15 +1283,17 @@ public partial class Form : ContainerControl
         }
         set
         {
-            if (!value.Equals(MaximumSize))
+            if (value.Equals(MaximumSize))
             {
-                if (value.Width < 0 || value.Height < 0)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(MaximumSize));
-                }
-
-                UpdateMaximumSize(value);
+                return;
             }
+
+            if (value.Width < 0 || value.Height < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(MaximumSize));
+            }
+
+            UpdateMaximumSize(value);
         }
     }
 
@@ -1388,19 +1402,21 @@ public partial class Form : ContainerControl
         }
         set
         {
-            if (!value.Equals(MinimumSize))
+            if (value.Equals(MinimumSize))
             {
-                if (value.Width < 0 || value.Height < 0)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(MinimumSize));
-                }
-
-                Rectangle bounds = Bounds;
-                bounds.Size = value;
-                value = WindowsFormsUtils.ConstrainToScreenWorkingAreaBounds(bounds).Size;
-
-                UpdateMinimumSize(value);
+                return;
             }
+
+            if (value.Width < 0 || value.Height < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(MinimumSize));
+            }
+
+            Rectangle bounds = Bounds;
+            bounds.Size = value;
+            value = WindowsFormsUtils.ConstrainToScreenWorkingAreaBounds(bounds).Size;
+
+            UpdateMinimumSize(value);
         }
     }
 
@@ -1871,13 +1887,15 @@ public partial class Form : ContainerControl
 
         set
         {
-            if (value != _rightToLeftLayout)
+            if (value == _rightToLeftLayout)
             {
-                _rightToLeftLayout = value;
-                using (new LayoutTransaction(this, this, PropertyNames.RightToLeftLayout))
-                {
-                    OnRightToLeftLayoutChanged(EventArgs.Empty);
-                }
+                return;
+            }
+
+            _rightToLeftLayout = value;
+            using (new LayoutTransaction(this, this, PropertyNames.RightToLeftLayout))
+            {
+                OnRightToLeftLayoutChanged(EventArgs.Empty);
             }
         }
     }
@@ -2018,16 +2036,18 @@ public partial class Form : ContainerControl
         }
         set
         {
-            if (SizeGripStyle != value)
+            if (SizeGripStyle == value)
             {
-                //do some bounds checking here
-                //
-                //valid values are 0x0 to 0x2
-                SourceGenerated.EnumValidator.Validate(value);
-
-                _formState[FormStateSizeGripStyle] = (int)value;
-                UpdateRenderSizeGrip();
+                return;
             }
+
+            //do some bounds checking here
+            //
+            //valid values are 0x0 to 0x2
+            SourceGenerated.EnumValidator.Validate(value);
+
+            _formState[FormStateSizeGripStyle] = (int)value;
+            UpdateRenderSizeGrip();
         }
     }
 
@@ -2193,26 +2213,29 @@ public partial class Form : ContainerControl
         set
         {
             Properties.SetObject(PropTransparencyKey, value);
-            if (!IsMdiContainer)
+
+            if (IsMdiContainer)
             {
-                bool oldLayered = (_formState[FormStateLayered] == 1);
-                if (value != Color.Empty)
-                {
-                    AllowTransparency = true;
-                    _formState[FormStateLayered] = 1;
-                }
-                else
-                {
-                    _formState[FormStateLayered] = (OpacityAsByte < 255) ? 1 : 0;
-                }
-
-                if (oldLayered != (_formState[FormStateLayered] != 0))
-                {
-                    UpdateStyles();
-                }
-
-                UpdateLayered();
+                return;
             }
+
+            bool oldLayered = (_formState[FormStateLayered] == 1);
+            if (value != Color.Empty)
+            {
+                AllowTransparency = true;
+                _formState[FormStateLayered] = 1;
+            }
+            else
+            {
+                _formState[FormStateLayered] = (OpacityAsByte < 255) ? 1 : 0;
+            }
+
+            if (oldLayered != (_formState[FormStateLayered] != 0))
+            {
+                UpdateStyles();
+            }
+
+            UpdateLayered();
         }
     }
 
@@ -4672,14 +4695,17 @@ public partial class Form : ContainerControl
                 FormClosingEventArgs fce = new FormClosingEventArgs(CloseReason.FormOwnerClosing, false);
                 for (int i = ownedFormsCount - 1; i >= 0; i--)
                 {
-                    if (ownedForms[i] is not null && !Application.OpenForms.Contains(ownedForms[i]))
+                    if (ownedForms[i] is null || Application.OpenForms.Contains(ownedForms[i]))
                     {
-                        ownedForms[i].OnFormClosing(fce);
-                        if (fce.Cancel)
-                        {
-                            e.Cancel = true;
-                            break;
-                        }
+                        continue;
+                    }
+
+                    ownedForms[i].OnFormClosing(fce);
+
+                    if (fce.Cancel)
+                    {
+                        e.Cancel = true;
+                        break;
                     }
                 }
             }
@@ -4769,28 +4795,32 @@ public partial class Form : ContainerControl
         Form?[]? ownedForms = (Form?[]?)Properties.GetObject(PropOwnedForms);
         int ownedFormsCount = Properties.GetInteger(PropOwnedFormsCount);
 
-        if (ownedForms is not null)
+        if (ownedForms is null)
         {
-            for (int i = 0; i < ownedFormsCount; i++)
+            return;
+        }
+
+        for (int i = 0; i < ownedFormsCount; i++)
+        {
+            if (!ownedForm.Equals(ownedForms[i]))
             {
-                if (ownedForm.Equals(ownedForms[i]))
-                {
-                    // clear out the reference.
-                    ownedForms[i] = null;
-
-                    // compact the array.
-                    if (i + 1 < ownedFormsCount)
-                    {
-                        Array.Copy(ownedForms, i + 1, ownedForms, i, ownedFormsCount - i - 1);
-                        ownedForms[ownedFormsCount - 1] = null;
-                    }
-
-                    ownedFormsCount--;
-                }
+                continue;
             }
 
-            Properties.SetInteger(PropOwnedFormsCount, ownedFormsCount);
+            // clear out the reference.
+            ownedForms[i] = null;
+
+            // compact the array.
+            if (i + 1 < ownedFormsCount)
+            {
+                Array.Copy(ownedForms, i + 1, ownedForms, i, ownedFormsCount - i - 1);
+                ownedForms[ownedFormsCount - 1] = null;
+            }
+
+            ownedFormsCount--;
         }
+
+        Properties.SetInteger(PropOwnedFormsCount, ownedFormsCount);
     }
 
     /// <summary>
@@ -5625,30 +5655,32 @@ public partial class Form : ContainerControl
     /// </summary>
     private void UpdateLayered()
     {
-        if ((_formState[FormStateLayered] != 0) && IsHandleCreated && TopLevel)
+        if (_formState[FormStateLayered] == 0 || !IsHandleCreated || !TopLevel)
         {
-            BOOL result;
+            return;
+        }
 
-            Color transparencyKey = TransparencyKey;
+        BOOL result;
 
-            if (transparencyKey.IsEmpty)
-            {
-                result = PInvoke.SetLayeredWindowAttributes(this, (COLORREF)0, OpacityAsByte, LAYERED_WINDOW_ATTRIBUTES_FLAGS.LWA_ALPHA);
-            }
-            else if (OpacityAsByte == 255)
-            {
-                // Windows doesn't do so well setting colorkey and alpha, so avoid it if we can
-                result = PInvoke.SetLayeredWindowAttributes(this, (COLORREF)transparencyKey, 0, LAYERED_WINDOW_ATTRIBUTES_FLAGS.LWA_COLORKEY);
-            }
-            else
-            {
-                result = PInvoke.SetLayeredWindowAttributes(this, (COLORREF)transparencyKey, OpacityAsByte, LAYERED_WINDOW_ATTRIBUTES_FLAGS.LWA_ALPHA | LAYERED_WINDOW_ATTRIBUTES_FLAGS.LWA_COLORKEY);
-            }
+        Color transparencyKey = TransparencyKey;
 
-            if (!result)
-            {
-                throw new Win32Exception();
-            }
+        if (transparencyKey.IsEmpty)
+        {
+            result = PInvoke.SetLayeredWindowAttributes(this, (COLORREF)0, OpacityAsByte, LAYERED_WINDOW_ATTRIBUTES_FLAGS.LWA_ALPHA);
+        }
+        else if (OpacityAsByte == 255)
+        {
+            // Windows doesn't do so well setting colorkey and alpha, so avoid it if we can
+            result = PInvoke.SetLayeredWindowAttributes(this, (COLORREF)transparencyKey, 0, LAYERED_WINDOW_ATTRIBUTES_FLAGS.LWA_COLORKEY);
+        }
+        else
+        {
+            result = PInvoke.SetLayeredWindowAttributes(this, (COLORREF)transparencyKey, OpacityAsByte, LAYERED_WINDOW_ATTRIBUTES_FLAGS.LWA_ALPHA | LAYERED_WINDOW_ATTRIBUTES_FLAGS.LWA_COLORKEY);
+        }
+
+        if (!result)
+        {
+            throw new Win32Exception();
         }
     }
 
@@ -5863,25 +5895,27 @@ public partial class Form : ContainerControl
 
     internal void UpdateMdiWindowListStrip()
     {
-        if (IsMdiContainer)
+        if (!IsMdiContainer)
         {
-            if (MdiWindowListStrip is not null && MdiWindowListStrip.MergedMenu is not null)
-            {
-                ToolStripManager.RevertMergeInternal(MdiWindowListStrip.MergedMenu, MdiWindowListStrip, /*revertMdiStuff*/true);
-            }
+            return;
+        }
 
-            MenuStrip sourceMenuStrip = ToolStripManager.GetMainMenuStrip(this);
-            if (sourceMenuStrip is not null && sourceMenuStrip.MdiWindowListItem is not null)
-            {
-                MdiWindowListStrip ??= new MdiWindowListStrip();
+        if (MdiWindowListStrip is not null && MdiWindowListStrip.MergedMenu is not null)
+        {
+            ToolStripManager.RevertMergeInternal(MdiWindowListStrip.MergedMenu, MdiWindowListStrip, /*revertMdiStuff*/true);
+        }
 
-                int nSubItems = sourceMenuStrip.MdiWindowListItem.DropDownItems.Count;
-                bool shouldIncludeSeparator = (nSubItems > 0 &&
-                    !(sourceMenuStrip.MdiWindowListItem.DropDownItems[nSubItems - 1] is ToolStripSeparator));
-                MdiWindowListStrip.PopulateItems(this, sourceMenuStrip.MdiWindowListItem, shouldIncludeSeparator);
-                ToolStripManager.Merge(MdiWindowListStrip, sourceMenuStrip);
-                MdiWindowListStrip.MergedMenu = sourceMenuStrip;
-            }
+        MenuStrip sourceMenuStrip = ToolStripManager.GetMainMenuStrip(this);
+        if (sourceMenuStrip is not null && sourceMenuStrip.MdiWindowListItem is not null)
+        {
+            MdiWindowListStrip ??= new MdiWindowListStrip();
+
+            int nSubItems = sourceMenuStrip.MdiWindowListItem.DropDownItems.Count;
+            bool shouldIncludeSeparator = (nSubItems > 0 &&
+                !(sourceMenuStrip.MdiWindowListItem.DropDownItems[nSubItems - 1] is ToolStripSeparator));
+            MdiWindowListStrip.PopulateItems(this, sourceMenuStrip.MdiWindowListItem, shouldIncludeSeparator);
+            ToolStripManager.Merge(MdiWindowListStrip, sourceMenuStrip);
+            MdiWindowListStrip.MergedMenu = sourceMenuStrip;
         }
     }
 
@@ -5923,56 +5957,58 @@ public partial class Form : ContainerControl
     /// </summary>
     private unsafe void UpdateWindowIcon(bool redrawFrame)
     {
-        if (IsHandleCreated)
+        if (!IsHandleCreated)
         {
-            Icon? icon;
+            return;
+        }
 
-            // Preserve Win32 behavior by keeping the icon we set NULL if
-            // the user hasn't specified an icon and we are a dialog frame.
-            if ((FormBorderStyle == FormBorderStyle.FixedDialog && _formState[FormStateIconSet] == 0) || !ShowIcon)
-            {
-                icon = null;
-            }
-            else
-            {
-                icon = Icon;
-            }
+        Icon? icon;
 
-            if (icon is not null)
+        // Preserve Win32 behavior by keeping the icon we set NULL if
+        // the user hasn't specified an icon and we are a dialog frame.
+        if ((FormBorderStyle == FormBorderStyle.FixedDialog && _formState[FormStateIconSet] == 0) || !ShowIcon)
+        {
+            icon = null;
+        }
+        else
+        {
+            icon = Icon;
+        }
+
+        if (icon is not null)
+        {
+            if (_smallIcon is null)
             {
-                if (_smallIcon is null)
+                try
                 {
-                    try
-                    {
-                        _smallIcon = new Icon(icon, SystemInformation.SmallIconSize);
-                    }
-                    catch
-                    {
-                    }
+                    _smallIcon = new Icon(icon, SystemInformation.SmallIconSize);
                 }
-
-                if (_smallIcon is not null)
+                catch
                 {
-                    PInvoke.SendMessage(this, PInvoke.WM_SETICON, (WPARAM)PInvoke.ICON_SMALL, (LPARAM)_smallIcon.Handle);
                 }
-
-                PInvoke.SendMessage(this, PInvoke.WM_SETICON, (WPARAM)PInvoke.ICON_BIG, (LPARAM)icon.Handle);
-            }
-            else
-            {
-                PInvoke.SendMessage(this, PInvoke.WM_SETICON, (WPARAM)PInvoke.ICON_SMALL);
-                PInvoke.SendMessage(this, PInvoke.WM_SETICON, (WPARAM)PInvoke.ICON_BIG);
             }
 
-            if (WindowState == FormWindowState.Maximized && MdiParent?.MdiControlStrip is not null)
+            if (_smallIcon is not null)
             {
-                MdiParent.MdiControlStrip.updateIcon();
+                PInvoke.SendMessage(this, PInvoke.WM_SETICON, (WPARAM)PInvoke.ICON_SMALL, (LPARAM)_smallIcon.Handle);
             }
 
-            if (redrawFrame)
-            {
-                PInvoke.RedrawWindow(this, lprcUpdate: null, HRGN.Null, REDRAW_WINDOW_FLAGS.RDW_INVALIDATE | REDRAW_WINDOW_FLAGS.RDW_FRAME);
-            }
+            PInvoke.SendMessage(this, PInvoke.WM_SETICON, (WPARAM)PInvoke.ICON_BIG, (LPARAM)icon.Handle);
+        }
+        else
+        {
+            PInvoke.SendMessage(this, PInvoke.WM_SETICON, (WPARAM)PInvoke.ICON_SMALL);
+            PInvoke.SendMessage(this, PInvoke.WM_SETICON, (WPARAM)PInvoke.ICON_BIG);
+        }
+
+        if (WindowState == FormWindowState.Maximized && MdiParent?.MdiControlStrip is not null)
+        {
+            MdiParent.MdiControlStrip.updateIcon();
+        }
+
+        if (redrawFrame)
+        {
+            PInvoke.RedrawWindow(this, lprcUpdate: null, HRGN.Null, REDRAW_WINDOW_FLAGS.RDW_INVALIDATE | REDRAW_WINDOW_FLAGS.RDW_FRAME);
         }
     }
 


### PR DESCRIPTION
In #9540 I was asked to rebase my changes on `Net9.0-Test`, so I closed that pull request and opened this one.

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

The logic of certain `if` blocks has been inverted. Namely:
- Some setters and some methods have `if` blocks that span more than a screen full of text, which makes it hard to see where the block ends. By inverting the logic, the `if` block becomes an `if` guard that is just one more element in the sequence of instructions.
- Also, some `if` blocks in certain setters could be better described and understood as guards, which is not very clear if the block spans all or at least most of the body of the setter. 

## Customer Impact

- No direct customer impact. The code is functionally identical

## Regression? 

- No

## Risk

- Low. Only safe, localized refactorings have been applied, aided by Visual Studio


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9540)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9548)