### PR TITLE
Fix loc for the keyboard buttons.

### DIFF
--- a/src/System.Windows.Forms/src/Resources/SR.resx
+++ b/src/System.Windows.Forms/src/Resources/SR.resx
@@ -6160,7 +6160,8 @@ Stack trace where the illegal operation occurred was:
 	<comment>{Locked=!fr-FR,!de-DE,!es-ES; "Home"}</comment>
   </data>
   <data name="toStringInsert" xml:space="preserve">
-    <value>Ins</value>
+    <value>Insert</value>
+	<comment>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES,!zh-Hant; "Insert"}</comment>
   </data>
   <data name="toStringNone" xml:space="preserve">
     <value>(none)</value>

--- a/src/System.Windows.Forms/src/Resources/SR.resx
+++ b/src/System.Windows.Forms/src/Resources/SR.resx
@@ -6131,27 +6131,33 @@ Stack trace where the illegal operation occurred was:
   </data>
   <data name="toStringAlt" xml:space="preserve">
     <value>Alt</value>
+	<comment>{Locked="Alt"}</comment>
   </data>
   <data name="toStringBack" xml:space="preserve">
     <value>Back</value>
   </data>
   <data name="toStringControl" xml:space="preserve">
     <value>Ctrl</value>
+	<comment>{Locked=!de-DE; "Ctrl"}</comment>
   </data>
   <data name="toStringDefault" xml:space="preserve">
     <value>(default)</value>
   </data>
   <data name="toStringDelete" xml:space="preserve">
     <value>Del</value>
+	<comment>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "Del"}</comment>
   </data>
   <data name="toStringEnd" xml:space="preserve">
     <value>End</value>
+	<comment>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "End"}</comment>
   </data>
   <data name="toStringEnter" xml:space="preserve">
     <value>Enter</value>
+	<comment>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "Enter"}</comment>
   </data>
   <data name="toStringHome" xml:space="preserve">
     <value>Home</value>
+	<comment>{Locked=!fr-FR,!de-DE,!es-ES; "Home"}</comment>
   </data>
   <data name="toStringInsert" xml:space="preserve">
     <value>Ins</value>
@@ -6161,12 +6167,15 @@ Stack trace where the illegal operation occurred was:
   </data>
   <data name="toStringPageDown" xml:space="preserve">
     <value>PgDn</value>
+	<comment>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "PgDn"}</comment>
   </data>
   <data name="toStringPageUp" xml:space="preserve">
     <value>PgUp</value>
+	<comment>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "PgUp"}</comment>
   </data>
   <data name="toStringShift" xml:space="preserve">
     <value>Shift</value>
+	<comment>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "Shift"}</comment>
   </data>
   <data name="TrackBarAutoSizeDescr" xml:space="preserve">
     <value>Indicates whether the control will resize itself automatically based on a computation of the default scroll bar dimensions.</value>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
@@ -11405,9 +11405,9 @@ Trasování zásobníku, kde došlo k neplatné operaci:
         <note>{Locked=!fr-FR,!de-DE,!es-ES; "Home"}</note>
       </trans-unit>
       <trans-unit id="toStringInsert">
-        <source>Ins</source>
-        <target state="translated">Vložit</target>
-        <note />
+        <source>Insert</source>
+        <target state="needs-review-translation">Vložit</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES,!zh-Hant; "Insert"}</note>
       </trans-unit>
       <trans-unit id="toStringNone">
         <source>(none)</source>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
@@ -11366,8 +11366,8 @@ Trasování zásobníku, kde došlo k neplatné operaci:
       </trans-unit>
       <trans-unit id="toStringAlt">
         <source>Alt</source>
-        <target state="translated">Alt</target>
-        <note />
+        <target state="needs-review-translation">Alt</target>
+        <note>{Locked="Alt"}</note>
       </trans-unit>
       <trans-unit id="toStringBack">
         <source>Back</source>
@@ -11376,8 +11376,8 @@ Trasování zásobníku, kde došlo k neplatné operaci:
       </trans-unit>
       <trans-unit id="toStringControl">
         <source>Ctrl</source>
-        <target state="translated">Ctrl</target>
-        <note />
+        <target state="needs-review-translation">Ctrl</target>
+        <note>{Locked=!de-DE; "Ctrl"}</note>
       </trans-unit>
       <trans-unit id="toStringDefault">
         <source>(default)</source>
@@ -11386,23 +11386,23 @@ Trasování zásobníku, kde došlo k neplatné operaci:
       </trans-unit>
       <trans-unit id="toStringDelete">
         <source>Del</source>
-        <target state="translated">Odstranit</target>
-        <note />
+        <target state="needs-review-translation">Odstranit</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "Del"}</note>
       </trans-unit>
       <trans-unit id="toStringEnd">
         <source>End</source>
-        <target state="translated">End</target>
-        <note />
+        <target state="needs-review-translation">End</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "End"}</note>
       </trans-unit>
       <trans-unit id="toStringEnter">
         <source>Enter</source>
-        <target state="translated">Enter</target>
-        <note />
+        <target state="needs-review-translation">Enter</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "Enter"}</note>
       </trans-unit>
       <trans-unit id="toStringHome">
         <source>Home</source>
-        <target state="translated">Domů</target>
-        <note />
+        <target state="needs-review-translation">Domů</target>
+        <note>{Locked=!fr-FR,!de-DE,!es-ES; "Home"}</note>
       </trans-unit>
       <trans-unit id="toStringInsert">
         <source>Ins</source>
@@ -11416,18 +11416,18 @@ Trasování zásobníku, kde došlo k neplatné operaci:
       </trans-unit>
       <trans-unit id="toStringPageDown">
         <source>PgDn</source>
-        <target state="translated">Page Down</target>
-        <note />
+        <target state="needs-review-translation">Page Down</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "PgDn"}</note>
       </trans-unit>
       <trans-unit id="toStringPageUp">
         <source>PgUp</source>
-        <target state="translated">Page Up</target>
-        <note />
+        <target state="needs-review-translation">Page Up</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "PgUp"}</note>
       </trans-unit>
       <trans-unit id="toStringShift">
         <source>Shift</source>
-        <target state="translated">Shift</target>
-        <note />
+        <target state="needs-review-translation">Shift</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "Shift"}</note>
       </trans-unit>
       <trans-unit id="valueChangedEventDescr">
         <source>Occurs when the value of the control changes.</source>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
@@ -11366,8 +11366,8 @@ Stapelüberwachung, in der der unzulässige Vorgang auftrat:
       </trans-unit>
       <trans-unit id="toStringAlt">
         <source>Alt</source>
-        <target state="translated">Alt</target>
-        <note />
+        <target state="needs-review-translation">Alt</target>
+        <note>{Locked="Alt"}</note>
       </trans-unit>
       <trans-unit id="toStringBack">
         <source>Back</source>
@@ -11376,8 +11376,8 @@ Stapelüberwachung, in der der unzulässige Vorgang auftrat:
       </trans-unit>
       <trans-unit id="toStringControl">
         <source>Ctrl</source>
-        <target state="translated">Strg</target>
-        <note />
+        <target state="needs-review-translation">Strg</target>
+        <note>{Locked=!de-DE; "Ctrl"}</note>
       </trans-unit>
       <trans-unit id="toStringDefault">
         <source>(default)</source>
@@ -11386,23 +11386,23 @@ Stapelüberwachung, in der der unzulässige Vorgang auftrat:
       </trans-unit>
       <trans-unit id="toStringDelete">
         <source>Del</source>
-        <target state="translated">Entf</target>
-        <note />
+        <target state="needs-review-translation">Entf</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "Del"}</note>
       </trans-unit>
       <trans-unit id="toStringEnd">
         <source>End</source>
-        <target state="translated">Beenden</target>
-        <note />
+        <target state="needs-review-translation">Beenden</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "End"}</note>
       </trans-unit>
       <trans-unit id="toStringEnter">
         <source>Enter</source>
-        <target state="translated">EINGABE</target>
-        <note />
+        <target state="needs-review-translation">EINGABE</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "Enter"}</note>
       </trans-unit>
       <trans-unit id="toStringHome">
         <source>Home</source>
-        <target state="translated">Startseite</target>
-        <note />
+        <target state="needs-review-translation">Startseite</target>
+        <note>{Locked=!fr-FR,!de-DE,!es-ES; "Home"}</note>
       </trans-unit>
       <trans-unit id="toStringInsert">
         <source>Ins</source>
@@ -11416,18 +11416,18 @@ Stapelüberwachung, in der der unzulässige Vorgang auftrat:
       </trans-unit>
       <trans-unit id="toStringPageDown">
         <source>PgDn</source>
-        <target state="translated">Bild ab</target>
-        <note />
+        <target state="needs-review-translation">Bild ab</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "PgDn"}</note>
       </trans-unit>
       <trans-unit id="toStringPageUp">
         <source>PgUp</source>
-        <target state="translated">Bild auf</target>
-        <note />
+        <target state="needs-review-translation">Bild auf</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "PgUp"}</note>
       </trans-unit>
       <trans-unit id="toStringShift">
         <source>Shift</source>
-        <target state="translated">Umschalttaste</target>
-        <note />
+        <target state="needs-review-translation">Umschalttaste</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "Shift"}</note>
       </trans-unit>
       <trans-unit id="valueChangedEventDescr">
         <source>Occurs when the value of the control changes.</source>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
@@ -11405,9 +11405,9 @@ Stapelüberwachung, in der der unzulässige Vorgang auftrat:
         <note>{Locked=!fr-FR,!de-DE,!es-ES; "Home"}</note>
       </trans-unit>
       <trans-unit id="toStringInsert">
-        <source>Ins</source>
-        <target state="translated">Einfg</target>
-        <note />
+        <source>Insert</source>
+        <target state="needs-review-translation">Einfg</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES,!zh-Hant; "Insert"}</note>
       </trans-unit>
       <trans-unit id="toStringNone">
         <source>(none)</source>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
@@ -11366,8 +11366,8 @@ El seguimiento de la pila donde tuvo lugar la operación no válida fue:
       </trans-unit>
       <trans-unit id="toStringAlt">
         <source>Alt</source>
-        <target state="translated">Alt</target>
-        <note />
+        <target state="needs-review-translation">Alt</target>
+        <note>{Locked="Alt"}</note>
       </trans-unit>
       <trans-unit id="toStringBack">
         <source>Back</source>
@@ -11376,8 +11376,8 @@ El seguimiento de la pila donde tuvo lugar la operación no válida fue:
       </trans-unit>
       <trans-unit id="toStringControl">
         <source>Ctrl</source>
-        <target state="translated">Ctrl</target>
-        <note />
+        <target state="needs-review-translation">Ctrl</target>
+        <note>{Locked=!de-DE; "Ctrl"}</note>
       </trans-unit>
       <trans-unit id="toStringDefault">
         <source>(default)</source>
@@ -11386,23 +11386,23 @@ El seguimiento de la pila donde tuvo lugar la operación no válida fue:
       </trans-unit>
       <trans-unit id="toStringDelete">
         <source>Del</source>
-        <target state="translated">Suprimir</target>
-        <note />
+        <target state="needs-review-translation">Suprimir</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "Del"}</note>
       </trans-unit>
       <trans-unit id="toStringEnd">
         <source>End</source>
-        <target state="translated">Fin</target>
-        <note />
+        <target state="needs-review-translation">Fin</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "End"}</note>
       </trans-unit>
       <trans-unit id="toStringEnter">
         <source>Enter</source>
-        <target state="translated">Entrar</target>
-        <note />
+        <target state="needs-review-translation">Entrar</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "Enter"}</note>
       </trans-unit>
       <trans-unit id="toStringHome">
         <source>Home</source>
-        <target state="translated">Inicio</target>
-        <note />
+        <target state="needs-review-translation">Inicio</target>
+        <note>{Locked=!fr-FR,!de-DE,!es-ES; "Home"}</note>
       </trans-unit>
       <trans-unit id="toStringInsert">
         <source>Ins</source>
@@ -11416,18 +11416,18 @@ El seguimiento de la pila donde tuvo lugar la operación no válida fue:
       </trans-unit>
       <trans-unit id="toStringPageDown">
         <source>PgDn</source>
-        <target state="translated">Avanzar página</target>
-        <note />
+        <target state="needs-review-translation">Avanzar página</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "PgDn"}</note>
       </trans-unit>
       <trans-unit id="toStringPageUp">
         <source>PgUp</source>
-        <target state="translated">Retroceder página</target>
-        <note />
+        <target state="needs-review-translation">Retroceder página</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "PgUp"}</note>
       </trans-unit>
       <trans-unit id="toStringShift">
         <source>Shift</source>
-        <target state="translated">Mayúsculas</target>
-        <note />
+        <target state="needs-review-translation">Mayúsculas</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "Shift"}</note>
       </trans-unit>
       <trans-unit id="valueChangedEventDescr">
         <source>Occurs when the value of the control changes.</source>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
@@ -11405,9 +11405,9 @@ El seguimiento de la pila donde tuvo lugar la operación no válida fue:
         <note>{Locked=!fr-FR,!de-DE,!es-ES; "Home"}</note>
       </trans-unit>
       <trans-unit id="toStringInsert">
-        <source>Ins</source>
-        <target state="translated">Insertar</target>
-        <note />
+        <source>Insert</source>
+        <target state="needs-review-translation">Insertar</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES,!zh-Hant; "Insert"}</note>
       </trans-unit>
       <trans-unit id="toStringNone">
         <source>(none)</source>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
@@ -11405,9 +11405,9 @@ Cette opération non conforme s'est produite sur la trace de la pile :
         <note>{Locked=!fr-FR,!de-DE,!es-ES; "Home"}</note>
       </trans-unit>
       <trans-unit id="toStringInsert">
-        <source>Ins</source>
-        <target state="translated">Insertion</target>
-        <note />
+        <source>Insert</source>
+        <target state="needs-review-translation">Insertion</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES,!zh-Hant; "Insert"}</note>
       </trans-unit>
       <trans-unit id="toStringNone">
         <source>(none)</source>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
@@ -11366,8 +11366,8 @@ Cette opération non conforme s'est produite sur la trace de la pile :
       </trans-unit>
       <trans-unit id="toStringAlt">
         <source>Alt</source>
-        <target state="translated">Alt</target>
-        <note />
+        <target state="needs-review-translation">Alt</target>
+        <note>{Locked="Alt"}</note>
       </trans-unit>
       <trans-unit id="toStringBack">
         <source>Back</source>
@@ -11376,8 +11376,8 @@ Cette opération non conforme s'est produite sur la trace de la pile :
       </trans-unit>
       <trans-unit id="toStringControl">
         <source>Ctrl</source>
-        <target state="translated">Ctrl</target>
-        <note />
+        <target state="needs-review-translation">Ctrl</target>
+        <note>{Locked=!de-DE; "Ctrl"}</note>
       </trans-unit>
       <trans-unit id="toStringDefault">
         <source>(default)</source>
@@ -11386,23 +11386,23 @@ Cette opération non conforme s'est produite sur la trace de la pile :
       </trans-unit>
       <trans-unit id="toStringDelete">
         <source>Del</source>
-        <target state="translated">Supprimer</target>
-        <note />
+        <target state="needs-review-translation">Supprimer</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "Del"}</note>
       </trans-unit>
       <trans-unit id="toStringEnd">
         <source>End</source>
-        <target state="translated">Fin</target>
-        <note />
+        <target state="needs-review-translation">Fin</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "End"}</note>
       </trans-unit>
       <trans-unit id="toStringEnter">
         <source>Enter</source>
-        <target state="translated">Entrée</target>
-        <note />
+        <target state="needs-review-translation">Entrée</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "Enter"}</note>
       </trans-unit>
       <trans-unit id="toStringHome">
         <source>Home</source>
-        <target state="translated">Début</target>
-        <note />
+        <target state="needs-review-translation">Début</target>
+        <note>{Locked=!fr-FR,!de-DE,!es-ES; "Home"}</note>
       </trans-unit>
       <trans-unit id="toStringInsert">
         <source>Ins</source>
@@ -11416,18 +11416,18 @@ Cette opération non conforme s'est produite sur la trace de la pile :
       </trans-unit>
       <trans-unit id="toStringPageDown">
         <source>PgDn</source>
-        <target state="translated">Page suivante</target>
-        <note />
+        <target state="needs-review-translation">Page suivante</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "PgDn"}</note>
       </trans-unit>
       <trans-unit id="toStringPageUp">
         <source>PgUp</source>
-        <target state="translated">Page précédente</target>
-        <note />
+        <target state="needs-review-translation">Page précédente</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "PgUp"}</note>
       </trans-unit>
       <trans-unit id="toStringShift">
         <source>Shift</source>
-        <target state="translated">Majuscule</target>
-        <note />
+        <target state="needs-review-translation">Majuscule</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "Shift"}</note>
       </trans-unit>
       <trans-unit id="valueChangedEventDescr">
         <source>Occurs when the value of the control changes.</source>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
@@ -11405,9 +11405,9 @@ Traccia dello stack da cui si è verificata l'operazione non valida:
         <note>{Locked=!fr-FR,!de-DE,!es-ES; "Home"}</note>
       </trans-unit>
       <trans-unit id="toStringInsert">
-        <source>Ins</source>
-        <target state="translated">INS</target>
-        <note />
+        <source>Insert</source>
+        <target state="needs-review-translation">INS</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES,!zh-Hant; "Insert"}</note>
       </trans-unit>
       <trans-unit id="toStringNone">
         <source>(none)</source>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
@@ -11366,8 +11366,8 @@ Traccia dello stack da cui si è verificata l'operazione non valida:
       </trans-unit>
       <trans-unit id="toStringAlt">
         <source>Alt</source>
-        <target state="translated">ALT</target>
-        <note />
+        <target state="needs-review-translation">ALT</target>
+        <note>{Locked="Alt"}</note>
       </trans-unit>
       <trans-unit id="toStringBack">
         <source>Back</source>
@@ -11376,8 +11376,8 @@ Traccia dello stack da cui si è verificata l'operazione non valida:
       </trans-unit>
       <trans-unit id="toStringControl">
         <source>Ctrl</source>
-        <target state="translated">CTRL</target>
-        <note />
+        <target state="needs-review-translation">CTRL</target>
+        <note>{Locked=!de-DE; "Ctrl"}</note>
       </trans-unit>
       <trans-unit id="toStringDefault">
         <source>(default)</source>
@@ -11386,23 +11386,23 @@ Traccia dello stack da cui si è verificata l'operazione non valida:
       </trans-unit>
       <trans-unit id="toStringDelete">
         <source>Del</source>
-        <target state="translated">CANC</target>
-        <note />
+        <target state="needs-review-translation">CANC</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "Del"}</note>
       </trans-unit>
       <trans-unit id="toStringEnd">
         <source>End</source>
-        <target state="translated">FINE</target>
-        <note />
+        <target state="needs-review-translation">FINE</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "End"}</note>
       </trans-unit>
       <trans-unit id="toStringEnter">
         <source>Enter</source>
-        <target state="translated">INVIO</target>
-        <note />
+        <target state="needs-review-translation">INVIO</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "Enter"}</note>
       </trans-unit>
       <trans-unit id="toStringHome">
         <source>Home</source>
-        <target state="translated">Home</target>
-        <note />
+        <target state="needs-review-translation">Home</target>
+        <note>{Locked=!fr-FR,!de-DE,!es-ES; "Home"}</note>
       </trans-unit>
       <trans-unit id="toStringInsert">
         <source>Ins</source>
@@ -11416,18 +11416,18 @@ Traccia dello stack da cui si è verificata l'operazione non valida:
       </trans-unit>
       <trans-unit id="toStringPageDown">
         <source>PgDn</source>
-        <target state="translated">PGGIÙ</target>
-        <note />
+        <target state="needs-review-translation">PGGIÙ</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "PgDn"}</note>
       </trans-unit>
       <trans-unit id="toStringPageUp">
         <source>PgUp</source>
-        <target state="translated">PGSU</target>
-        <note />
+        <target state="needs-review-translation">PGSU</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "PgUp"}</note>
       </trans-unit>
       <trans-unit id="toStringShift">
         <source>Shift</source>
-        <target state="translated">MAIUSC</target>
-        <note />
+        <target state="needs-review-translation">MAIUSC</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "Shift"}</note>
       </trans-unit>
       <trans-unit id="valueChangedEventDescr">
         <source>Occurs when the value of the control changes.</source>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
@@ -11405,9 +11405,9 @@ Stack trace where the illegal operation occurred was:
         <note>{Locked=!fr-FR,!de-DE,!es-ES; "Home"}</note>
       </trans-unit>
       <trans-unit id="toStringInsert">
-        <source>Ins</source>
-        <target state="translated">Insert</target>
-        <note />
+        <source>Insert</source>
+        <target state="needs-review-translation">Insert</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES,!zh-Hant; "Insert"}</note>
       </trans-unit>
       <trans-unit id="toStringNone">
         <source>(none)</source>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
@@ -11366,8 +11366,8 @@ Stack trace where the illegal operation occurred was:
       </trans-unit>
       <trans-unit id="toStringAlt">
         <source>Alt</source>
-        <target state="translated">Alt</target>
-        <note />
+        <target state="needs-review-translation">Alt</target>
+        <note>{Locked="Alt"}</note>
       </trans-unit>
       <trans-unit id="toStringBack">
         <source>Back</source>
@@ -11376,8 +11376,8 @@ Stack trace where the illegal operation occurred was:
       </trans-unit>
       <trans-unit id="toStringControl">
         <source>Ctrl</source>
-        <target state="translated">Ctrl</target>
-        <note />
+        <target state="needs-review-translation">Ctrl</target>
+        <note>{Locked=!de-DE; "Ctrl"}</note>
       </trans-unit>
       <trans-unit id="toStringDefault">
         <source>(default)</source>
@@ -11386,23 +11386,23 @@ Stack trace where the illegal operation occurred was:
       </trans-unit>
       <trans-unit id="toStringDelete">
         <source>Del</source>
-        <target state="translated">Delete</target>
-        <note />
+        <target state="needs-review-translation">Delete</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "Del"}</note>
       </trans-unit>
       <trans-unit id="toStringEnd">
         <source>End</source>
-        <target state="translated">終了</target>
-        <note />
+        <target state="needs-review-translation">終了</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "End"}</note>
       </trans-unit>
       <trans-unit id="toStringEnter">
         <source>Enter</source>
-        <target state="translated">入力</target>
-        <note />
+        <target state="needs-review-translation">入力</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "Enter"}</note>
       </trans-unit>
       <trans-unit id="toStringHome">
         <source>Home</source>
-        <target state="translated">ホーム</target>
-        <note />
+        <target state="needs-review-translation">ホーム</target>
+        <note>{Locked=!fr-FR,!de-DE,!es-ES; "Home"}</note>
       </trans-unit>
       <trans-unit id="toStringInsert">
         <source>Ins</source>
@@ -11416,18 +11416,18 @@ Stack trace where the illegal operation occurred was:
       </trans-unit>
       <trans-unit id="toStringPageDown">
         <source>PgDn</source>
-        <target state="translated">PageDown</target>
-        <note />
+        <target state="needs-review-translation">PageDown</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "PgDn"}</note>
       </trans-unit>
       <trans-unit id="toStringPageUp">
         <source>PgUp</source>
-        <target state="translated">PageUp</target>
-        <note />
+        <target state="needs-review-translation">PageUp</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "PgUp"}</note>
       </trans-unit>
       <trans-unit id="toStringShift">
         <source>Shift</source>
-        <target state="translated">Shift</target>
-        <note />
+        <target state="needs-review-translation">Shift</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "Shift"}</note>
       </trans-unit>
       <trans-unit id="valueChangedEventDescr">
         <source>Occurs when the value of the control changes.</source>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
@@ -11405,9 +11405,9 @@ Stack trace where the illegal operation occurred was:
         <note>{Locked=!fr-FR,!de-DE,!es-ES; "Home"}</note>
       </trans-unit>
       <trans-unit id="toStringInsert">
-        <source>Ins</source>
-        <target state="translated">Insert</target>
-        <note />
+        <source>Insert</source>
+        <target state="needs-review-translation">Insert</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES,!zh-Hant; "Insert"}</note>
       </trans-unit>
       <trans-unit id="toStringNone">
         <source>(none)</source>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
@@ -11366,8 +11366,8 @@ Stack trace where the illegal operation occurred was:
       </trans-unit>
       <trans-unit id="toStringAlt">
         <source>Alt</source>
-        <target state="translated">Alt</target>
-        <note />
+        <target state="needs-review-translation">Alt</target>
+        <note>{Locked="Alt"}</note>
       </trans-unit>
       <trans-unit id="toStringBack">
         <source>Back</source>
@@ -11376,8 +11376,8 @@ Stack trace where the illegal operation occurred was:
       </trans-unit>
       <trans-unit id="toStringControl">
         <source>Ctrl</source>
-        <target state="translated">Ctrl</target>
-        <note />
+        <target state="needs-review-translation">Ctrl</target>
+        <note>{Locked=!de-DE; "Ctrl"}</note>
       </trans-unit>
       <trans-unit id="toStringDefault">
         <source>(default)</source>
@@ -11386,23 +11386,23 @@ Stack trace where the illegal operation occurred was:
       </trans-unit>
       <trans-unit id="toStringDelete">
         <source>Del</source>
-        <target state="translated">Delete</target>
-        <note />
+        <target state="needs-review-translation">Delete</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "Del"}</note>
       </trans-unit>
       <trans-unit id="toStringEnd">
         <source>End</source>
-        <target state="translated">End</target>
-        <note />
+        <target state="needs-review-translation">End</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "End"}</note>
       </trans-unit>
       <trans-unit id="toStringEnter">
         <source>Enter</source>
-        <target state="translated">Enter</target>
-        <note />
+        <target state="needs-review-translation">Enter</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "Enter"}</note>
       </trans-unit>
       <trans-unit id="toStringHome">
         <source>Home</source>
-        <target state="translated">홈</target>
-        <note />
+        <target state="needs-review-translation">홈</target>
+        <note>{Locked=!fr-FR,!de-DE,!es-ES; "Home"}</note>
       </trans-unit>
       <trans-unit id="toStringInsert">
         <source>Ins</source>
@@ -11416,18 +11416,18 @@ Stack trace where the illegal operation occurred was:
       </trans-unit>
       <trans-unit id="toStringPageDown">
         <source>PgDn</source>
-        <target state="translated">Page Down</target>
-        <note />
+        <target state="needs-review-translation">Page Down</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "PgDn"}</note>
       </trans-unit>
       <trans-unit id="toStringPageUp">
         <source>PgUp</source>
-        <target state="translated">Page Up</target>
-        <note />
+        <target state="needs-review-translation">Page Up</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "PgUp"}</note>
       </trans-unit>
       <trans-unit id="toStringShift">
         <source>Shift</source>
-        <target state="translated">Shift</target>
-        <note />
+        <target state="needs-review-translation">Shift</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "Shift"}</note>
       </trans-unit>
       <trans-unit id="valueChangedEventDescr">
         <source>Occurs when the value of the control changes.</source>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
@@ -11405,9 +11405,9 @@ Stos śledzenia, w którym wystąpiła zabroniona operacja:
         <note>{Locked=!fr-FR,!de-DE,!es-ES; "Home"}</note>
       </trans-unit>
       <trans-unit id="toStringInsert">
-        <source>Ins</source>
-        <target state="translated">Insert</target>
-        <note />
+        <source>Insert</source>
+        <target state="needs-review-translation">Insert</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES,!zh-Hant; "Insert"}</note>
       </trans-unit>
       <trans-unit id="toStringNone">
         <source>(none)</source>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
@@ -11366,8 +11366,8 @@ Stos śledzenia, w którym wystąpiła zabroniona operacja:
       </trans-unit>
       <trans-unit id="toStringAlt">
         <source>Alt</source>
-        <target state="translated">Alt</target>
-        <note />
+        <target state="needs-review-translation">Alt</target>
+        <note>{Locked="Alt"}</note>
       </trans-unit>
       <trans-unit id="toStringBack">
         <source>Back</source>
@@ -11376,8 +11376,8 @@ Stos śledzenia, w którym wystąpiła zabroniona operacja:
       </trans-unit>
       <trans-unit id="toStringControl">
         <source>Ctrl</source>
-        <target state="translated">Ctrl</target>
-        <note />
+        <target state="needs-review-translation">Ctrl</target>
+        <note>{Locked=!de-DE; "Ctrl"}</note>
       </trans-unit>
       <trans-unit id="toStringDefault">
         <source>(default)</source>
@@ -11386,23 +11386,23 @@ Stos śledzenia, w którym wystąpiła zabroniona operacja:
       </trans-unit>
       <trans-unit id="toStringDelete">
         <source>Del</source>
-        <target state="translated">Delete</target>
-        <note />
+        <target state="needs-review-translation">Delete</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "Del"}</note>
       </trans-unit>
       <trans-unit id="toStringEnd">
         <source>End</source>
-        <target state="translated">End</target>
-        <note />
+        <target state="needs-review-translation">End</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "End"}</note>
       </trans-unit>
       <trans-unit id="toStringEnter">
         <source>Enter</source>
-        <target state="translated">Enter</target>
-        <note />
+        <target state="needs-review-translation">Enter</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "Enter"}</note>
       </trans-unit>
       <trans-unit id="toStringHome">
         <source>Home</source>
-        <target state="translated">Strona główna</target>
-        <note />
+        <target state="needs-review-translation">Strona główna</target>
+        <note>{Locked=!fr-FR,!de-DE,!es-ES; "Home"}</note>
       </trans-unit>
       <trans-unit id="toStringInsert">
         <source>Ins</source>
@@ -11416,18 +11416,18 @@ Stos śledzenia, w którym wystąpiła zabroniona operacja:
       </trans-unit>
       <trans-unit id="toStringPageDown">
         <source>PgDn</source>
-        <target state="translated">Page Down</target>
-        <note />
+        <target state="needs-review-translation">Page Down</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "PgDn"}</note>
       </trans-unit>
       <trans-unit id="toStringPageUp">
         <source>PgUp</source>
-        <target state="translated">Page Up</target>
-        <note />
+        <target state="needs-review-translation">Page Up</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "PgUp"}</note>
       </trans-unit>
       <trans-unit id="toStringShift">
         <source>Shift</source>
-        <target state="translated">Shift</target>
-        <note />
+        <target state="needs-review-translation">Shift</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "Shift"}</note>
       </trans-unit>
       <trans-unit id="valueChangedEventDescr">
         <source>Occurs when the value of the control changes.</source>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
@@ -11366,8 +11366,8 @@ Rastreamento de pilha em que a operação ilegal ocorreu:
       </trans-unit>
       <trans-unit id="toStringAlt">
         <source>Alt</source>
-        <target state="translated">Alt</target>
-        <note />
+        <target state="needs-review-translation">Alt</target>
+        <note>{Locked="Alt"}</note>
       </trans-unit>
       <trans-unit id="toStringBack">
         <source>Back</source>
@@ -11376,8 +11376,8 @@ Rastreamento de pilha em que a operação ilegal ocorreu:
       </trans-unit>
       <trans-unit id="toStringControl">
         <source>Ctrl</source>
-        <target state="translated">Ctrl</target>
-        <note />
+        <target state="needs-review-translation">Ctrl</target>
+        <note>{Locked=!de-DE; "Ctrl"}</note>
       </trans-unit>
       <trans-unit id="toStringDefault">
         <source>(default)</source>
@@ -11386,23 +11386,23 @@ Rastreamento de pilha em que a operação ilegal ocorreu:
       </trans-unit>
       <trans-unit id="toStringDelete">
         <source>Del</source>
-        <target state="translated">Delete</target>
-        <note />
+        <target state="needs-review-translation">Delete</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "Del"}</note>
       </trans-unit>
       <trans-unit id="toStringEnd">
         <source>End</source>
-        <target state="translated">End</target>
-        <note />
+        <target state="needs-review-translation">End</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "End"}</note>
       </trans-unit>
       <trans-unit id="toStringEnter">
         <source>Enter</source>
-        <target state="translated">Enter</target>
-        <note />
+        <target state="needs-review-translation">Enter</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "Enter"}</note>
       </trans-unit>
       <trans-unit id="toStringHome">
         <source>Home</source>
-        <target state="translated">Início</target>
-        <note />
+        <target state="needs-review-translation">Início</target>
+        <note>{Locked=!fr-FR,!de-DE,!es-ES; "Home"}</note>
       </trans-unit>
       <trans-unit id="toStringInsert">
         <source>Ins</source>
@@ -11416,18 +11416,18 @@ Rastreamento de pilha em que a operação ilegal ocorreu:
       </trans-unit>
       <trans-unit id="toStringPageDown">
         <source>PgDn</source>
-        <target state="translated">Page Down</target>
-        <note />
+        <target state="needs-review-translation">Page Down</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "PgDn"}</note>
       </trans-unit>
       <trans-unit id="toStringPageUp">
         <source>PgUp</source>
-        <target state="translated">Page Up</target>
-        <note />
+        <target state="needs-review-translation">Page Up</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "PgUp"}</note>
       </trans-unit>
       <trans-unit id="toStringShift">
         <source>Shift</source>
-        <target state="translated">Shift</target>
-        <note />
+        <target state="needs-review-translation">Shift</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "Shift"}</note>
       </trans-unit>
       <trans-unit id="valueChangedEventDescr">
         <source>Occurs when the value of the control changes.</source>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
@@ -11405,9 +11405,9 @@ Rastreamento de pilha em que a operação ilegal ocorreu:
         <note>{Locked=!fr-FR,!de-DE,!es-ES; "Home"}</note>
       </trans-unit>
       <trans-unit id="toStringInsert">
-        <source>Ins</source>
-        <target state="translated">Insert</target>
-        <note />
+        <source>Insert</source>
+        <target state="needs-review-translation">Insert</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES,!zh-Hant; "Insert"}</note>
       </trans-unit>
       <trans-unit id="toStringNone">
         <source>(none)</source>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
@@ -11406,9 +11406,9 @@ Stack trace where the illegal operation occurred was:
         <note>{Locked=!fr-FR,!de-DE,!es-ES; "Home"}</note>
       </trans-unit>
       <trans-unit id="toStringInsert">
-        <source>Ins</source>
-        <target state="translated">INSERT</target>
-        <note />
+        <source>Insert</source>
+        <target state="needs-review-translation">INSERT</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES,!zh-Hant; "Insert"}</note>
       </trans-unit>
       <trans-unit id="toStringNone">
         <source>(none)</source>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
@@ -11367,8 +11367,8 @@ Stack trace where the illegal operation occurred was:
       </trans-unit>
       <trans-unit id="toStringAlt">
         <source>Alt</source>
-        <target state="translated">Alt</target>
-        <note />
+        <target state="needs-review-translation">Alt</target>
+        <note>{Locked="Alt"}</note>
       </trans-unit>
       <trans-unit id="toStringBack">
         <source>Back</source>
@@ -11377,8 +11377,8 @@ Stack trace where the illegal operation occurred was:
       </trans-unit>
       <trans-unit id="toStringControl">
         <source>Ctrl</source>
-        <target state="translated">Ctrl</target>
-        <note />
+        <target state="needs-review-translation">Ctrl</target>
+        <note>{Locked=!de-DE; "Ctrl"}</note>
       </trans-unit>
       <trans-unit id="toStringDefault">
         <source>(default)</source>
@@ -11387,23 +11387,23 @@ Stack trace where the illegal operation occurred was:
       </trans-unit>
       <trans-unit id="toStringDelete">
         <source>Del</source>
-        <target state="translated">DELETE</target>
-        <note />
+        <target state="needs-review-translation">DELETE</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "Del"}</note>
       </trans-unit>
       <trans-unit id="toStringEnd">
         <source>End</source>
-        <target state="translated">Конец</target>
-        <note />
+        <target state="needs-review-translation">Конец</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "End"}</note>
       </trans-unit>
       <trans-unit id="toStringEnter">
         <source>Enter</source>
-        <target state="translated">ВВОД</target>
-        <note />
+        <target state="needs-review-translation">ВВОД</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "Enter"}</note>
       </trans-unit>
       <trans-unit id="toStringHome">
         <source>Home</source>
-        <target state="translated">Главная</target>
-        <note />
+        <target state="needs-review-translation">Главная</target>
+        <note>{Locked=!fr-FR,!de-DE,!es-ES; "Home"}</note>
       </trans-unit>
       <trans-unit id="toStringInsert">
         <source>Ins</source>
@@ -11417,18 +11417,18 @@ Stack trace where the illegal operation occurred was:
       </trans-unit>
       <trans-unit id="toStringPageDown">
         <source>PgDn</source>
-        <target state="translated">PAGE DOWN</target>
-        <note />
+        <target state="needs-review-translation">PAGE DOWN</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "PgDn"}</note>
       </trans-unit>
       <trans-unit id="toStringPageUp">
         <source>PgUp</source>
-        <target state="translated">PAGE UP</target>
-        <note />
+        <target state="needs-review-translation">PAGE UP</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "PgUp"}</note>
       </trans-unit>
       <trans-unit id="toStringShift">
         <source>Shift</source>
-        <target state="translated">SHIFT</target>
-        <note />
+        <target state="needs-review-translation">SHIFT</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "Shift"}</note>
       </trans-unit>
       <trans-unit id="valueChangedEventDescr">
         <source>Occurs when the value of the control changes.</source>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
@@ -11366,8 +11366,8 @@ Geçersiz işlemin gerçekleştiği yığın izi:
       </trans-unit>
       <trans-unit id="toStringAlt">
         <source>Alt</source>
-        <target state="translated">Alt</target>
-        <note />
+        <target state="needs-review-translation">Alt</target>
+        <note>{Locked="Alt"}</note>
       </trans-unit>
       <trans-unit id="toStringBack">
         <source>Back</source>
@@ -11376,8 +11376,8 @@ Geçersiz işlemin gerçekleştiği yığın izi:
       </trans-unit>
       <trans-unit id="toStringControl">
         <source>Ctrl</source>
-        <target state="translated">Ctrl</target>
-        <note />
+        <target state="needs-review-translation">Ctrl</target>
+        <note>{Locked=!de-DE; "Ctrl"}</note>
       </trans-unit>
       <trans-unit id="toStringDefault">
         <source>(default)</source>
@@ -11386,23 +11386,23 @@ Geçersiz işlemin gerçekleştiği yığın izi:
       </trans-unit>
       <trans-unit id="toStringDelete">
         <source>Del</source>
-        <target state="translated">Delete</target>
-        <note />
+        <target state="needs-review-translation">Delete</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "Del"}</note>
       </trans-unit>
       <trans-unit id="toStringEnd">
         <source>End</source>
-        <target state="translated">End</target>
-        <note />
+        <target state="needs-review-translation">End</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "End"}</note>
       </trans-unit>
       <trans-unit id="toStringEnter">
         <source>Enter</source>
-        <target state="translated">Enter</target>
-        <note />
+        <target state="needs-review-translation">Enter</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "Enter"}</note>
       </trans-unit>
       <trans-unit id="toStringHome">
         <source>Home</source>
-        <target state="translated">Giriş</target>
-        <note />
+        <target state="needs-review-translation">Giriş</target>
+        <note>{Locked=!fr-FR,!de-DE,!es-ES; "Home"}</note>
       </trans-unit>
       <trans-unit id="toStringInsert">
         <source>Ins</source>
@@ -11416,18 +11416,18 @@ Geçersiz işlemin gerçekleştiği yığın izi:
       </trans-unit>
       <trans-unit id="toStringPageDown">
         <source>PgDn</source>
-        <target state="translated">Page Down</target>
-        <note />
+        <target state="needs-review-translation">Page Down</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "PgDn"}</note>
       </trans-unit>
       <trans-unit id="toStringPageUp">
         <source>PgUp</source>
-        <target state="translated">Page Up</target>
-        <note />
+        <target state="needs-review-translation">Page Up</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "PgUp"}</note>
       </trans-unit>
       <trans-unit id="toStringShift">
         <source>Shift</source>
-        <target state="translated">Shift</target>
-        <note />
+        <target state="needs-review-translation">Shift</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "Shift"}</note>
       </trans-unit>
       <trans-unit id="valueChangedEventDescr">
         <source>Occurs when the value of the control changes.</source>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
@@ -11405,9 +11405,9 @@ Geçersiz işlemin gerçekleştiği yığın izi:
         <note>{Locked=!fr-FR,!de-DE,!es-ES; "Home"}</note>
       </trans-unit>
       <trans-unit id="toStringInsert">
-        <source>Ins</source>
-        <target state="translated">Insert</target>
-        <note />
+        <source>Insert</source>
+        <target state="needs-review-translation">Insert</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES,!zh-Hant; "Insert"}</note>
       </trans-unit>
       <trans-unit id="toStringNone">
         <source>(none)</source>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
@@ -11405,9 +11405,9 @@ Stack trace where the illegal operation occurred was:
         <note>{Locked=!fr-FR,!de-DE,!es-ES; "Home"}</note>
       </trans-unit>
       <trans-unit id="toStringInsert">
-        <source>Ins</source>
-        <target state="translated">Insert</target>
-        <note />
+        <source>Insert</source>
+        <target state="needs-review-translation">Insert</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES,!zh-Hant; "Insert"}</note>
       </trans-unit>
       <trans-unit id="toStringNone">
         <source>(none)</source>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
@@ -11366,8 +11366,8 @@ Stack trace where the illegal operation occurred was:
       </trans-unit>
       <trans-unit id="toStringAlt">
         <source>Alt</source>
-        <target state="translated">Alt</target>
-        <note />
+        <target state="needs-review-translation">Alt</target>
+        <note>{Locked="Alt"}</note>
       </trans-unit>
       <trans-unit id="toStringBack">
         <source>Back</source>
@@ -11376,8 +11376,8 @@ Stack trace where the illegal operation occurred was:
       </trans-unit>
       <trans-unit id="toStringControl">
         <source>Ctrl</source>
-        <target state="translated">Ctrl</target>
-        <note />
+        <target state="needs-review-translation">Ctrl</target>
+        <note>{Locked=!de-DE; "Ctrl"}</note>
       </trans-unit>
       <trans-unit id="toStringDefault">
         <source>(default)</source>
@@ -11386,23 +11386,23 @@ Stack trace where the illegal operation occurred was:
       </trans-unit>
       <trans-unit id="toStringDelete">
         <source>Del</source>
-        <target state="translated">Delete</target>
-        <note />
+        <target state="needs-review-translation">Delete</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "Del"}</note>
       </trans-unit>
       <trans-unit id="toStringEnd">
         <source>End</source>
-        <target state="translated">End</target>
-        <note />
+        <target state="needs-review-translation">End</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "End"}</note>
       </trans-unit>
       <trans-unit id="toStringEnter">
         <source>Enter</source>
-        <target state="translated">Enter</target>
-        <note />
+        <target state="needs-review-translation">Enter</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "Enter"}</note>
       </trans-unit>
       <trans-unit id="toStringHome">
         <source>Home</source>
-        <target state="translated">主页</target>
-        <note />
+        <target state="needs-review-translation">主页</target>
+        <note>{Locked=!fr-FR,!de-DE,!es-ES; "Home"}</note>
       </trans-unit>
       <trans-unit id="toStringInsert">
         <source>Ins</source>
@@ -11416,18 +11416,18 @@ Stack trace where the illegal operation occurred was:
       </trans-unit>
       <trans-unit id="toStringPageDown">
         <source>PgDn</source>
-        <target state="translated">Page Down</target>
-        <note />
+        <target state="needs-review-translation">Page Down</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "PgDn"}</note>
       </trans-unit>
       <trans-unit id="toStringPageUp">
         <source>PgUp</source>
-        <target state="translated">Page Up</target>
-        <note />
+        <target state="needs-review-translation">Page Up</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "PgUp"}</note>
       </trans-unit>
       <trans-unit id="toStringShift">
         <source>Shift</source>
-        <target state="translated">Shift</target>
-        <note />
+        <target state="needs-review-translation">Shift</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "Shift"}</note>
       </trans-unit>
       <trans-unit id="valueChangedEventDescr">
         <source>Occurs when the value of the control changes.</source>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
@@ -11405,9 +11405,9 @@ Stack trace where the illegal operation occurred was:
         <note>{Locked=!fr-FR,!de-DE,!es-ES; "Home"}</note>
       </trans-unit>
       <trans-unit id="toStringInsert">
-        <source>Ins</source>
-        <target state="translated">Ins</target>
-        <note />
+        <source>Insert</source>
+        <target state="needs-review-translation">Ins</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES,!zh-Hant; "Insert"}</note>
       </trans-unit>
       <trans-unit id="toStringNone">
         <source>(none)</source>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
@@ -11366,8 +11366,8 @@ Stack trace where the illegal operation occurred was:
       </trans-unit>
       <trans-unit id="toStringAlt">
         <source>Alt</source>
-        <target state="translated">Alt</target>
-        <note />
+        <target state="needs-review-translation">Alt</target>
+        <note>{Locked="Alt"}</note>
       </trans-unit>
       <trans-unit id="toStringBack">
         <source>Back</source>
@@ -11376,8 +11376,8 @@ Stack trace where the illegal operation occurred was:
       </trans-unit>
       <trans-unit id="toStringControl">
         <source>Ctrl</source>
-        <target state="translated">Ctrl</target>
-        <note />
+        <target state="needs-review-translation">Ctrl</target>
+        <note>{Locked=!de-DE; "Ctrl"}</note>
       </trans-unit>
       <trans-unit id="toStringDefault">
         <source>(default)</source>
@@ -11386,23 +11386,23 @@ Stack trace where the illegal operation occurred was:
       </trans-unit>
       <trans-unit id="toStringDelete">
         <source>Del</source>
-        <target state="translated">Del</target>
-        <note />
+        <target state="needs-review-translation">Del</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "Del"}</note>
       </trans-unit>
       <trans-unit id="toStringEnd">
         <source>End</source>
-        <target state="translated">End</target>
-        <note />
+        <target state="needs-review-translation">End</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "End"}</note>
       </trans-unit>
       <trans-unit id="toStringEnter">
         <source>Enter</source>
-        <target state="translated">Enter</target>
-        <note />
+        <target state="needs-review-translation">Enter</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "Enter"}</note>
       </trans-unit>
       <trans-unit id="toStringHome">
         <source>Home</source>
-        <target state="translated">首頁</target>
-        <note />
+        <target state="needs-review-translation">首頁</target>
+        <note>{Locked=!fr-FR,!de-DE,!es-ES; "Home"}</note>
       </trans-unit>
       <trans-unit id="toStringInsert">
         <source>Ins</source>
@@ -11416,18 +11416,18 @@ Stack trace where the illegal operation occurred was:
       </trans-unit>
       <trans-unit id="toStringPageDown">
         <source>PgDn</source>
-        <target state="translated">PgDn</target>
-        <note />
+        <target state="needs-review-translation">PgDn</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "PgDn"}</note>
       </trans-unit>
       <trans-unit id="toStringPageUp">
         <source>PgUp</source>
-        <target state="translated">PgUp</target>
-        <note />
+        <target state="needs-review-translation">PgUp</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "PgUp"}</note>
       </trans-unit>
       <trans-unit id="toStringShift">
         <source>Shift</source>
-        <target state="translated">Shift</target>
-        <note />
+        <target state="needs-review-translation">Shift</target>
+        <note>{Locked=!fr-FR,!de-DE,!it-IT,!es-ES; "Shift"}</note>
       </trans-unit>
       <trans-unit id="valueChangedEventDescr">
         <source>Occurs when the value of the control changes.</source>


### PR DESCRIPTION
fixes #8440

Some of the keyboard button names should not be translated for all the languages.  Following internal document outlines which keys to be translated and which or not, based on Window's On screen keyboard, for .Net supported languages.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9556)