### PR TITLE
Fix items property for multiple checked list boxes shouldn't be displayed in properties window #5337

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.cs
@@ -163,6 +163,7 @@ public partial class CheckedListBox : ListBox
     [Localizable(true)]
     [SRDescription(nameof(SR.ListBoxItemsDescr))]
     [Editor($"System.Windows.Forms.Design.ListControlStringCollectionEditor, {AssemblyRef.SystemDesign}", typeof(UITypeEditor))]
+    [MergableProperty(false)]
     public new ObjectCollection Items
     {
         get


### PR DESCRIPTION
resubmit this [9524](https://github.com/dotnet/winforms/pull/9524) PR

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9570)