### PR TITLE
Guard against re-entry in ActiveXImpl / AgileComPointer.

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/DisposeHelper.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/DisposeHelper.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+
+namespace System;
+
+internal static class DisposeHelper
+{
+    /// <summary>
+    ///  Sets <paramref name="disposable"/> to null before disposing it. Useful for guarding against field
+    ///  access when disposing the field.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void NullAndDispose<T>(ref T? disposable) where T : class, IDisposable
+    {
+        IDisposable? localDisposable = disposable;
+        disposable = null;
+        localDisposable?.Dispose();
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/Foundation/AgileComPointer.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/Foundation/AgileComPointer.cs
@@ -15,6 +15,11 @@ namespace Windows.Win32.Foundation;
 ///   safely finalized when needed. Finalization should be avoided whenever possible for performance and timely
 ///   resource release (that is, this class should be disposed).
 ///  </para>
+///  <para>
+///   Fields should be nulled out before calling <see cref="Dispose()"/>. Releasing the COM pointer during disposal
+///   can result in callbacks to containing classes. Rather than evaluate the risk of this for every class, always
+///   follow this pattern. <see cref="DisposeHelper.NullAndDispose"/> facilitates doing this safely.
+///  </para>
 /// </remarks>
 internal unsafe class AgileComPointer<TInterface> :
 #if DEBUG

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/Foundation/AgileComPointer.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/Foundation/AgileComPointer.cs
@@ -100,8 +100,11 @@ internal unsafe class AgileComPointer<TInterface> :
             return;
         }
 
-        HRESULT hr = GlobalInterfaceTable.RevokeInterface(_cookie);
+        // Clear the cookie before revoking the interface to guard against re-entry.
+        uint cookie = _cookie;
         _cookie = 0;
+
+        HRESULT hr = GlobalInterfaceTable.RevokeInterface(cookie);
 
         if (disposing)
         {

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Com/StandardDispatch.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Com/StandardDispatch.cs
@@ -277,8 +277,7 @@ internal abstract unsafe class StandardDispatch : IDispatch.Interface, IDispatch
     {
         if (disposing)
         {
-            _standardDispatch?.Dispose();
-            _standardDispatch = null;
+            DisposeHelper.NullAndDispose(ref _standardDispatch);
         }
     }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxContainer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxContainer.cs
@@ -682,6 +682,8 @@ public abstract partial class AxHost
                 && activeHost._iOleInPlaceActiveObjectExternal is { } existing
                 && existing.OriginalHandle != pActiveObject)
             {
+                // Release the field before disposing to avoid accessing it during disposal on callbacks.
+                activeHost._iOleInPlaceActiveObjectExternal = null;
                 existing.Dispose();
                 activeHost._iOleInPlaceActiveObjectExternal = new(pActiveObject, takeOwnership: true);
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.State.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.State.cs
@@ -351,10 +351,8 @@ public abstract partial class AxHost
         {
             if (disposing)
             {
-                _lockBytes?.Dispose();
-                _storage?.Dispose();
-                _lockBytes = null;
-                _storage = null;
+                DisposeHelper.NullAndDispose(ref _lockBytes);
+                DisposeHelper.NullAndDispose(ref _storage);
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
@@ -2261,8 +2261,12 @@ public partial class Control
             _inPlaceFrame = null;
             _inPlaceUiWindow?.Dispose();
             _inPlaceUiWindow = null;
-            _clientSite?.Dispose();
+
+            // Disposing the client site handle can get us called back with SetClientSite(null). We need to
+            // make sure that we clear the field before disposing it.
+            var clientSite = _clientSite;
             _clientSite = null;
+            clientSite?.Dispose();
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
@@ -865,11 +865,8 @@ public partial class Control
                 RECT posRect = default;
                 RECT clipRect = default;
 
-                _inPlaceUiWindow?.Dispose();
-                _inPlaceUiWindow = null;
-
-                _inPlaceFrame?.Dispose();
-                _inPlaceFrame = null;
+                DisposeHelper.NullAndDispose(ref _inPlaceUiWindow);
+                DisposeHelper.NullAndDispose(ref _inPlaceFrame);
 
                 IOleInPlaceFrame* pFrame;
                 IOleInPlaceUIWindow* pWindow;
@@ -1002,11 +999,8 @@ public partial class Control
             _control.Visible = false;
             HWNDParent = default;
 
-            _inPlaceUiWindow?.Dispose();
-            _inPlaceUiWindow = null;
-
-            _inPlaceFrame?.Dispose();
-            _inPlaceFrame = null;
+            DisposeHelper.NullAndDispose(ref _inPlaceUiWindow);
+            DisposeHelper.NullAndDispose(ref _inPlaceFrame);
 
             return HRESULT.S_OK;
         }
@@ -1702,7 +1696,7 @@ public partial class Control
         /// </summary>
         internal void SetClientSite(IOleClientSite* value)
         {
-            _clientSite?.Dispose();
+            DisposeHelper.NullAndDispose(ref _clientSite);
             _clientSite = value is null ? null : new(value, takeOwnership: true);
 
             _control.Site = _clientSite is not null
@@ -2257,16 +2251,13 @@ public partial class Control
 
         public void Dispose()
         {
-            _inPlaceFrame?.Dispose();
-            _inPlaceFrame = null;
-            _inPlaceUiWindow?.Dispose();
-            _inPlaceUiWindow = null;
-
             // Disposing the client site handle can get us called back with SetClientSite(null). We need to
-            // make sure that we clear the field before disposing it.
-            var clientSite = _clientSite;
-            _clientSite = null;
-            clientSite?.Dispose();
+            // make sure that we clear the field before disposing it. To avoid similar problems, we do the same
+            // pattern for every COM pointer.
+
+            DisposeHelper.NullAndDispose(ref _inPlaceFrame);
+            DisposeHelper.NullAndDispose(ref _inPlaceUiWindow);
+            DisposeHelper.NullAndDispose(ref _clientSite);
         }
     }
 }


### PR DESCRIPTION
Releasing a COM interface can lead to a call back. We need to clear fields before releasing so we don't attempt to release twice.

Fixes #9551 


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9588)