### PR TITLE
Remove `RequiresPreviewFeatures` attributes from Command Binding APIs

### DIFF
--- a/src/System.Windows.Forms/src/System.Windows.Forms.csproj
+++ b/src/System.Windows.Forms/src/System.Windows.Forms.csproj
@@ -4,8 +4,6 @@
     <AssemblyName>System.Windows.Forms</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLSCompliant>true</CLSCompliant>
-    <EnablePreviewFeatures>True</EnablePreviewFeatures>
-    <GenerateRequiresPreviewFeaturesAttribute>False</GenerateRequiresPreviewFeaturesAttribute>
     <Nullable>enable</Nullable>
 
     <NoWarn>$(NoWarn);618</NoWarn>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/BindableComponent.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/BindableComponent.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel;
-using System.Runtime.Versioning;
 
 namespace System.Windows.Forms;
 
@@ -10,7 +9,6 @@ namespace System.Windows.Forms;
 /// Base class for components which provide properties which can be
 /// data bound with the WinForms Designer.
 /// </summary>
-[RequiresPreviewFeatures]
 public abstract class BindableComponent : Component, IBindableComponent
 {
     internal static readonly object s_bindingContextChangedEvent = new();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ButtonBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ButtonBase.cs
@@ -879,11 +879,6 @@ public abstract partial class ButtonBase : Control, ICommandBindingTargetProvide
     protected override void OnClick(EventArgs e)
     {
         base.OnClick(e);
-
-        // We won't let the preview feature warnings bubble further up beyond this point.
-#pragma warning disable CA2252 // Suppress 'Opt in to preview features' (https://aka.ms/dotnet-warnings/preview-features)
-        OnRequestCommandExecute(e);
-#pragma warning restore CA2252
     }
 
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ButtonBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ButtonBase.cs
@@ -4,7 +4,6 @@
 using System.ComponentModel;
 using System.Drawing;
 using System.Drawing.Design;
-using System.Runtime.Versioning;
 using System.Windows.Forms.ButtonInternal;
 using System.Windows.Forms.Layout;
 using static Interop;
@@ -174,7 +173,6 @@ public abstract partial class ButtonBase : Control, ICommandBindingTargetProvide
     ///  Gets or sets the <see cref="System.Windows.Input.ICommand"/> whose <see cref="System.Windows.Input.ICommand.Execute(object?)"/>
     ///  method will be called when the <see cref="Control.Click"/> event gets invoked.
     /// </summary>
-    [RequiresPreviewFeatures]
     [Bindable(true)]
     [Browsable(false)]
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
@@ -190,7 +188,6 @@ public abstract partial class ButtonBase : Control, ICommandBindingTargetProvide
     ///  Occurs when the <see cref="System.Windows.Input.ICommand.CanExecute(object?)"/> status of the
     ///  <see cref="System.Windows.Input.ICommand"/> which is assigned to the <see cref="Command"/> property has changed.
     /// </summary>
-    [RequiresPreviewFeatures]
     [SRCategory(nameof(SR.CatData))]
     [EditorBrowsable(EditorBrowsableState.Advanced)]
     [SRDescription(nameof(SR.CommandCanExecuteChangedEventDescr))]
@@ -203,7 +200,6 @@ public abstract partial class ButtonBase : Control, ICommandBindingTargetProvide
     /// <summary>
     ///  Occurs when the assigned <see cref="System.Windows.Input.ICommand"/> of the <see cref="Command"/> property has changed.
     /// </summary>
-    [RequiresPreviewFeatures]
     [SRCategory(nameof(SR.CatData))]
     [EditorBrowsable(EditorBrowsableState.Advanced)]
     [SRDescription(nameof(SR.CommandChangedEventDescr))]
@@ -224,12 +220,10 @@ public abstract partial class ButtonBase : Control, ICommandBindingTargetProvide
     [SRDescription(nameof(SR.CommandComponentCommandParameterDescr))]
     public object? CommandParameter
     {
-        [RequiresPreviewFeatures]
         get => _commandParameter;
 
         // We need to opt into preview features on the getter and the setter rather than on top of the property,
         // because we calling a preview feature from the setter.
-        [RequiresPreviewFeatures]
         set
         {
             if (!Equals(_commandParameter, value))
@@ -243,7 +237,6 @@ public abstract partial class ButtonBase : Control, ICommandBindingTargetProvide
     /// <summary>
     ///  Occurs when the value of the <see cref="CommandParameter"/> property has changed.
     /// </summary>
-    [RequiresPreviewFeatures]
     [SRCategory(nameof(SR.CatData))]
     [EditorBrowsable(EditorBrowsableState.Advanced)]
     [SRDescription(nameof(SR.CommandParameterChangedEventDescr))]
@@ -1122,7 +1115,6 @@ public abstract partial class ButtonBase : Control, ICommandBindingTargetProvide
     ///  Raises the <see cref="ButtonBase.CommandChanged"/> event.
     /// </summary>
     /// <param name="e">An empty <see cref="EventArgs"/> instance.</param>
-    [RequiresPreviewFeatures]
     [EditorBrowsable(EditorBrowsableState.Advanced)]
     protected virtual void OnCommandChanged(EventArgs e)
         => RaiseEvent(s_commandChangedEvent, e);
@@ -1131,7 +1123,6 @@ public abstract partial class ButtonBase : Control, ICommandBindingTargetProvide
     ///  Raises the <see cref="ButtonBase.CommandCanExecuteChanged"/> event.
     /// </summary>
     /// <param name="e">An empty <see cref="EventArgs"/> instance.</param>
-    [RequiresPreviewFeatures]
     [EditorBrowsable(EditorBrowsableState.Advanced)]
     protected virtual void OnCommandCanExecuteChanged(EventArgs e)
         => ((EventHandler?)Events[s_commandCanExecuteChangedEvent])?.Invoke(this, e);
@@ -1140,7 +1131,6 @@ public abstract partial class ButtonBase : Control, ICommandBindingTargetProvide
     ///  Raises the <see cref="ButtonBase.CommandParameterChanged"/> event.
     /// </summary>
     /// <param name="e">An empty <see cref="EventArgs"/> instance.</param>
-    [RequiresPreviewFeatures]
     [EditorBrowsable(EditorBrowsableState.Advanced)]
     protected virtual void OnCommandParameterChanged(EventArgs e) => RaiseEvent(s_commandParameterChangedEvent, e);
 
@@ -1148,17 +1138,14 @@ public abstract partial class ButtonBase : Control, ICommandBindingTargetProvide
     ///  Called in the context of <see cref="OnClick(EventArgs)"/> to invoke <see cref="System.Windows.Input.ICommand.Execute(object?)"/> if the context allows.
     /// </summary>
     /// <param name="e">An empty <see cref="EventArgs"/> instance.</param>
-    [RequiresPreviewFeatures]
     protected virtual void OnRequestCommandExecute(EventArgs e)
         => ICommandBindingTargetProvider.RequestCommandExecute(this);
 
     // Called by the CommandProviderManager's command handling logic.
-    [RequiresPreviewFeatures]
     void ICommandBindingTargetProvider.RaiseCommandChanged(EventArgs e)
         => OnCommandChanged(e);
 
     // Called by the CommandProviderManager's command handling logic.
-    [RequiresPreviewFeatures]
     void ICommandBindingTargetProvider.RaiseCommandCanExecuteChanged(EventArgs e)
         => OnCommandCanExecuteChanged(e);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ButtonBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ButtonBase.cs
@@ -222,8 +222,6 @@ public abstract partial class ButtonBase : Control, ICommandBindingTargetProvide
     {
         get => _commandParameter;
 
-        // We need to opt into preview features on the getter and the setter rather than on top of the property,
-        // because we calling a preview feature from the setter.
         set
         {
             if (!Equals(_commandParameter, value))

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ButtonBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ButtonBase.cs
@@ -879,6 +879,7 @@ public abstract partial class ButtonBase : Control, ICommandBindingTargetProvide
     protected override void OnClick(EventArgs e)
     {
         base.OnClick(e);
+        OnRequestCommandExecute(e);
     }
 
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripComboBox.cs
@@ -397,7 +397,6 @@ public partial class ToolStripComboBox : ToolStripControlHost
         OnTextUpdate(e);
     }
 
-#pragma warning disable CA2252 // Suppress 'Opt in to preview features' (https://aka.ms/dotnet-warnings/preview-features)
     protected virtual void OnDropDown(EventArgs e)
     {
         if (ParentInternal is not null)
@@ -441,7 +440,6 @@ public partial class ToolStripComboBox : ToolStripControlHost
     {
         RaiseEvent(s_eventTextUpdate, e);
     }
-#pragma warning restore CA2252
 
     protected override void OnSubscribeControlEvents(Control? control)
     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripControlHost.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripControlHost.cs
@@ -521,7 +521,6 @@ public partial class ToolStripControlHost : ToolStripItem
         RaiseMouseEvent(s_mouseDownEvent, e);
     }
 
-#pragma warning disable CA2252 // Suppress 'Opt in to preview features' (https://aka.ms/dotnet-warnings/preview-features)
     private void HandleMouseEnter(object? sender, EventArgs e)
     {
         OnMouseEnter(e);
@@ -539,7 +538,6 @@ public partial class ToolStripControlHost : ToolStripItem
         OnMouseHover(e);
         RaiseEvent(s_mouseHoverEvent, e);
     }
-#pragma warning restore CA2252
 
     private void HandleMouseMove(object? sender, MouseEventArgs e)
     {
@@ -617,7 +615,6 @@ public partial class ToolStripControlHost : ToolStripItem
         ControlInternal.AccessibleRole = AccessibleRole;
     }
 
-#pragma warning disable CA2252 // Suppress 'Opt in to preview features' (https://aka.ms/dotnet-warnings/preview-features)
     protected virtual void OnEnter(EventArgs e) => RaiseEvent(s_enterEvent, e);
 
     /// <summary>
@@ -631,7 +628,6 @@ public partial class ToolStripControlHost : ToolStripItem
     ///  called when the control has lost focus
     /// </summary>
     protected virtual void OnLostFocus(EventArgs e) => RaiseEvent(s_lostFocusEvent, e);
-#pragma warning restore CA2252
 
     protected virtual void OnKeyDown(KeyEventArgs e) => RaiseKeyEvent(s_keyDownEvent, e);
 
@@ -795,9 +791,7 @@ public partial class ToolStripControlHost : ToolStripItem
 
     protected virtual void OnValidating(CancelEventArgs e) => RaiseCancelEvent(s_validatingEvent, e);
 
-#pragma warning disable CA2252 // Suppress 'Opt in to preview features' (https://aka.ms/dotnet-warnings/preview-features)
     protected virtual void OnValidated(EventArgs e) => RaiseEvent(s_validatedEvent, e);
-#pragma warning restore CA2252
 
     private static ReadOnlyControlCollection? GetControlCollection(ToolStrip? toolStrip)
         => (ReadOnlyControlCollection?)toolStrip?.Controls;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
@@ -13,7 +13,6 @@ using IComDataObject = System.Runtime.InteropServices.ComTypes.IDataObject;
 
 namespace System.Windows.Forms;
 
-#pragma warning disable CA2252 // Suppress 'Opt in to preview features' (https://aka.ms/dotnet-warnings/preview-features)
 [DesignTimeVisible(false)]
 [Designer($"System.Windows.Forms.Design.ToolStripItemDesigner, {AssemblyRef.SystemDesign}")]
 [DefaultEvent(nameof(Click))]
@@ -3728,5 +3727,3 @@ public abstract partial class ToolStripItem : BindableComponent,
         return local is not null;
     }
 }
-#pragma warning restore CA2252
-

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
@@ -472,7 +472,6 @@ public abstract partial class ToolStripItem : BindableComponent,
     {
         get => _commandParameter;
 
-        // We need to opt into previre features here, because we calling a preview feature from the setter.
         set
         {
             if (!Equals(_commandParameter, value))
@@ -2693,8 +2692,6 @@ public abstract partial class ToolStripItem : BindableComponent,
     protected virtual void OnClick(EventArgs e)
     {
         RaiseEvent(s_clickEvent, e);
-
-        // We won't let the preview feature warnings bubble further up beyond this point.
         OnRequestCommandExecute(e);
     }
 
@@ -2762,7 +2759,8 @@ public abstract partial class ToolStripItem : BindableComponent,
     protected virtual void OnCommandParameterChanged(EventArgs e) => RaiseEvent(s_commandParameterChangedEvent, e);
 
     /// <summary>
-    ///  Called in the context of <see cref="OnClick(EventArgs)"/> to invoke <see cref="System.Windows.Input.ICommand.Execute(object?)"/> if the context allows.
+    ///  Called in the context of <see cref="OnClick(EventArgs)"/> to invoke
+    ///  <see cref="System.Windows.Input.ICommand.Execute(object?)"/> if the context allows.
     /// </summary>
     /// <param name="e">An empty <see cref="EventArgs"/> instance.</param>
     protected virtual void OnRequestCommandExecute(EventArgs e)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
@@ -6,7 +6,6 @@ using System.ComponentModel;
 using System.Drawing;
 using System.Drawing.Design;
 using System.Drawing.Imaging;
-using System.Runtime.Versioning;
 using System.Windows.Forms.Layout;
 using Windows.Win32.System.Ole;
 using static Interop;
@@ -425,7 +424,6 @@ public abstract partial class ToolStripItem : BindableComponent,
     ///  Gets or sets the <see cref="System.Windows.Input.ICommand"/> whose <see cref="System.Windows.Input.ICommand.Execute(object?)"/>
     ///  method will be called when the ToolStripItem's <see cref="Click"/> event gets invoked.
     /// </summary>
-    [RequiresPreviewFeatures]
     [Bindable(true)]
     [Browsable(false)]
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
@@ -441,7 +439,6 @@ public abstract partial class ToolStripItem : BindableComponent,
     ///  Occurs when the <see cref="System.Windows.Input.ICommand.CanExecute(object?)"/> status of the
     ///  <see cref="System.Windows.Input.ICommand"/> which is assigned to the <see cref="Command"/> property has changed.
     /// </summary>
-    [RequiresPreviewFeatures]
     [SRCategory(nameof(SR.CatData))]
     [EditorBrowsable(EditorBrowsableState.Advanced)]
     [SRDescription(nameof(SR.CommandCanExecuteChangedEventDescr))]
@@ -454,7 +451,6 @@ public abstract partial class ToolStripItem : BindableComponent,
     /// <summary>
     ///  Occurs when the assigned <see cref="System.Windows.Input.ICommand"/> of the <see cref="Command"/> property has changed.
     /// </summary>
-    [RequiresPreviewFeatures]
     [SRCategory(nameof(SR.CatData))]
     [EditorBrowsable(EditorBrowsableState.Advanced)]
     [SRDescription(nameof(SR.CommandChangedEventDescr))]
@@ -475,11 +471,9 @@ public abstract partial class ToolStripItem : BindableComponent,
     [SRDescription(nameof(SR.CommandComponentCommandParameterDescr))]
     public object? CommandParameter
     {
-        [RequiresPreviewFeatures]
         get => _commandParameter;
 
         // We need to opt into previre features here, because we calling a preview feature from the setter.
-        [RequiresPreviewFeatures]
         set
         {
             if (!Equals(_commandParameter, value))
@@ -493,7 +487,6 @@ public abstract partial class ToolStripItem : BindableComponent,
     /// <summary>
     ///  Occurs when the value of the <see cref="CommandParameter"/> property has changed.
     /// </summary>
-    [RequiresPreviewFeatures]
     [SRCategory(nameof(SR.CatData))]
     [EditorBrowsable(EditorBrowsableState.Advanced)]
     [SRDescription(nameof(SR.CommandParameterChangedEventDescr))]
@@ -2750,7 +2743,6 @@ public abstract partial class ToolStripItem : BindableComponent,
     ///  Raises the <see cref="ToolStripItem.CommandChanged"/> event.
     /// </summary>
     /// <param name="e">An empty <see cref="EventArgs"/> instance.</param>
-    [RequiresPreviewFeatures]
     [EditorBrowsable(EditorBrowsableState.Advanced)]
     protected virtual void OnCommandChanged(EventArgs e)
         => RaiseEvent(s_commandChangedEvent, e);
@@ -2759,7 +2751,6 @@ public abstract partial class ToolStripItem : BindableComponent,
     ///  Raises the <see cref="ToolStripItem.CommandCanExecuteChanged"/> event.
     /// </summary>
     /// <param name="e">An empty <see cref="EventArgs"/> instance.</param>
-    [RequiresPreviewFeatures]
     [EditorBrowsable(EditorBrowsableState.Advanced)]
     protected virtual void OnCommandCanExecuteChanged(EventArgs e)
         => ((EventHandler?)Events[s_commandCanExecuteChangedEvent])?.Invoke(this, e);
@@ -2768,7 +2759,6 @@ public abstract partial class ToolStripItem : BindableComponent,
     ///  Raises the <see cref="ToolStripItem.CommandParameterChanged"/> event.
     /// </summary>
     /// <param name="e">An empty <see cref="EventArgs"/> instance.</param>
-    [RequiresPreviewFeatures]
     [EditorBrowsable(EditorBrowsableState.Advanced)]
     protected virtual void OnCommandParameterChanged(EventArgs e) => RaiseEvent(s_commandParameterChangedEvent, e);
 
@@ -2776,17 +2766,14 @@ public abstract partial class ToolStripItem : BindableComponent,
     ///  Called in the context of <see cref="OnClick(EventArgs)"/> to invoke <see cref="System.Windows.Input.ICommand.Execute(object?)"/> if the context allows.
     /// </summary>
     /// <param name="e">An empty <see cref="EventArgs"/> instance.</param>
-    [RequiresPreviewFeatures]
     protected virtual void OnRequestCommandExecute(EventArgs e)
         => ICommandBindingTargetProvider.RequestCommandExecute(this);
 
     // Called by the CommandProviderManager's command handling logic.
-    [RequiresPreviewFeatures]
     void ICommandBindingTargetProvider.RaiseCommandChanged(EventArgs e)
         => OnCommandChanged(e);
 
     // Called by the CommandProviderManager's command handling logic.
-    [RequiresPreviewFeatures]
     void ICommandBindingTargetProvider.RaiseCommandCanExecuteChanged(EventArgs e)
         => OnCommandCanExecuteChanged(e);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripProgressBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripProgressBar.cs
@@ -256,9 +256,7 @@ public partial class ToolStripProgressBar : ToolStripControlHost
 
     protected virtual void OnRightToLeftLayoutChanged(EventArgs e)
     {
-#pragma warning disable CA2252 // Suppress 'Opt in to preview features' (https://aka.ms/dotnet-warnings/preview-features)
         RaiseEvent(EventRightToLeftLayoutChanged, e);
-#pragma warning restore CA2252
     }
 
     protected override void OnSubscribeControlEvents(Control? control)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSeparator.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSeparator.cs
@@ -300,9 +300,7 @@ public partial class ToolStripSeparator : ToolStripItem
     protected override void OnFontChanged(EventArgs e)
     {
         // Perf: don't call base, we don't care if the font changes
-#pragma warning disable CA2252 // Suppress 'Opt in to preview features' (https://aka.ms/dotnet-warnings/preview-features)
         RaiseEvent(s_fontChangedEvent, e);
-#pragma warning restore CA2252
     }
 
     [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripTextBox.cs
@@ -154,7 +154,6 @@ public partial class ToolStripTextBox : ToolStripControlHost
         OnReadOnlyChanged(e);
     }
 
-#pragma warning disable CA2252 // Suppress 'Opt in to preview features' (https://aka.ms/dotnet-warnings/preview-features)
     private void HandleTextBoxTextAlignChanged(object? sender, EventArgs e)
     {
         RaiseEvent(s_eventTextBoxTextAlignChanged, e);
@@ -189,7 +188,6 @@ public partial class ToolStripTextBox : ToolStripControlHost
     {
         RaiseEvent(s_eventReadOnlyChanged, e);
     }
-#pragma warning restore CA2252
 
     protected override void OnSubscribeControlEvents(Control? control)
     {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ButtonBaseTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ButtonBaseTests.cs
@@ -762,7 +762,6 @@ public class ButtonBaseTests
     }
 
     [WinFormsFact]
-    [RequiresPreviewFeatures]
     public void ButtonBase_BasicCommandBinding()
     {
         const string CommandParameter = nameof(CommandParameter);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ButtonBaseTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ButtonBaseTests.cs
@@ -4,7 +4,6 @@
 using System.ComponentModel;
 using System.ComponentModel.Design;
 using System.Drawing;
-using System.Runtime.Versioning;
 using System.Windows.Forms.DataBinding.TestUtilities;
 using System.Windows.Forms.TestUtilities;
 using Moq;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripButtonTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripButtonTests.cs
@@ -566,7 +566,6 @@ public partial class ToolStripButtonTests
     }
 
     [WinFormsFact]
-    [RequiresPreviewFeatures]
     public void ToolStripButton_BasicCommandBinding()
     {
         const string CommandParameter = nameof(CommandParameter);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripButtonTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripButtonTests.cs
@@ -3,7 +3,6 @@
 
 using System.ComponentModel;
 using System.Drawing;
-using System.Runtime.Versioning;
 using System.Windows.Forms.DataBinding.TestUtilities;
 using System.Windows.Forms.TestUtilities;
 using Size = System.Drawing.Size;


### PR DESCRIPTION
We introduce Command Binding APIs under Preview in .NET 7 and aimed to remove this in the .NET 8 timeframe, when it did not cause any breaking changes. 

https://github.com/dotnet/winforms/pull/7143

We got some feedback, but mainly asking to invest further into data biding, like simplifying Converters or allow automatic marshalling from other threads to the UI thread when updating controls from the data sources. We want to address that in the .NET 9 release.

We found some issues in the Designer though, but they were due to the fact that the Out-Of-Proc Designer couldn't handle preview-assemblies per se and had nothing to do with the new APIs themselves. In so far, having those new APIs attributed with `RequiresPreviewFeatures` helped us to make the Designer more robust and able to deal with binding to properties in the runtime, which are attributed to be under preview.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9589)