### PR TITLE
Add PrintDialogDesigner.cs

### DIFF
--- a/src/System.Design/src/System.Design.Forwards.cs
+++ b/src/System.Design/src/System.Design.Forwards.cs
@@ -46,6 +46,7 @@ using System.Runtime.CompilerServices;
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.MonthCalendarDesigner))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.PanelDesigner))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.PictureBoxDesigner))]
+[assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.PrintDialogDesigner))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.RadioButtonDesigner))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.RichTextBoxDesigner))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.SplitContainerDesigner))]

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/PrintDialogDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/PrintDialogDesigner.cs
@@ -1,4 +1,8 @@
-﻿using System.Collections;
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
 using System.ComponentModel.Design;
 
 namespace System.Windows.Forms.Design;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/PrintDialogDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/PrintDialogDesigner.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections;
+using System.ComponentModel.Design;
+
+namespace System.Windows.Forms.Design;
+
+internal class PrintDialogDesigner : ComponentDesigner
+{
+    /// <summary>
+    ///  This method is called when a component is first initialized, typically after being first added
+    ///  to a design surface.  The defaultValues property contains a name/value dictionary of default
+    ///  values that should be applied to properties.  This dictionary may be null if no default values
+    ///  are specified.  You may perform any initialization of this component that you like, and you
+    ///  may even ignore the defaultValues dictionary altogether if you wish.
+    ///  The default implementation of this method does nothing.
+    /// </summary>
+    public override void InitializeNewComponent(IDictionary defaultValues)
+    {
+        PrintDialog? pd = Component as PrintDialog;
+        if (pd is not null)
+        {
+            pd.UseEXDialog = true;
+        }
+    }
+}

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/PrintDialogDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/PrintDialogDesigner.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -19,10 +19,9 @@ internal class PrintDialogDesigner : ComponentDesigner
     /// </summary>
     public override void InitializeNewComponent(IDictionary defaultValues)
     {
-        PrintDialog? pd = Component as PrintDialog;
-        if (pd is not null)
+        if (Component is PrintDialog dialog)
         {
-            pd.UseEXDialog = true;
+            dialog.UseEXDialog = true;
         }
     }
 }

--- a/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/MainForm.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/MainForm.cs
@@ -217,6 +217,7 @@ public partial class MainForm : Form
 
                         Timer tm11 = surface.CreateComponent<Timer>();
                         FontDialog fd1 = surface.CreateComponent<FontDialog>();
+                        PrintDialog pd1 = surface.CreateComponent<PrintDialog>();
 
                         surface.CreateControl<MonthCalendar>(new Size(230, 170), new Point(10,110));
                     }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Design/DesignerAttributeTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Design/DesignerAttributeTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -33,7 +33,6 @@ public class DesignerAttributeTests
         "System.Windows.Forms.Design.FlowLayoutPanelDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
         "System.Windows.Forms.Design.FolderBrowserDialogDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
         "System.Windows.Forms.Design.NotifyIconDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
-        "System.Windows.Forms.Design.PrintDialogDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
         "System.Windows.Forms.Design.PropertyGridDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
         "System.Windows.Forms.Design.SaveFileDialogDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
         "System.Windows.Forms.Design.StatusBarDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Related to #4908 


## Proposed changes

- Port MonthCalendarDesigner to runtime

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- PrintDialogDesigner can be designed in runtime


## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

The default value of the property "UseEXDialog" is false
![image](https://github.com/dotnet/winforms/assets/132890443/182ecfe1-30fa-47f1-90a0-38d643d6f2b7)


### After

The default value of the property "UseEXDialog" is true
![image](https://github.com/dotnet/winforms/assets/132890443/db063665-a4c8-481f-9b67-39c362e6e657)


## Test methodology <!-- How did you ensure quality? -->

- Manually (added PrintDialogDesigner to DemoConsole test app)

## Test environment(s) <!-- Remove any that don't apply -->

- .Net 8.0.100-rc.1.23375.11
- Windows 10 Enterprise 22H2

<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9595)