### PR TITLE
IDE to report unused usings as errors. 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -91,7 +91,7 @@ dotnet_style_allow_statement_immediately_after_block_experimental = true:silent
 
 # .NET diagnostic
 dotnet_diagnostic.RS0041.severity = none
-dotnet_diagnostic.IDE0005.severity = warning
+dotnet_diagnostic.IDE0005.severity = error
 
 # New line preferences
 csharp_new_line_before_open_brace = all


### PR DESCRIPTION
CLI has warnings as errors enabled for most of the projects, thus the CLI build is less affected.

Before
![image](https://github.com/dotnet/winforms/assets/15823268/67b87d8e-c394-47c3-a996-9de2c1ad9a48)

After
![image](https://github.com/dotnet/winforms/assets/15823268/a07ffe4a-be67-4d87-8ec6-f7219fb70383)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9604)