### PR TITLE
Enable nullability in several UITypeEditors

### DIFF
--- a/src/System.Windows.Forms.Design/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms.Design/src/PublicAPI.Shipped.txt
@@ -24,8 +24,8 @@ override System.ComponentModel.Design.BinaryEditor.GetEditStyle(System.Component
 ~override System.ComponentModel.Design.ByteViewer.OnPaint(System.Windows.Forms.PaintEventArgs e) -> void
 ~override System.ComponentModel.Design.CollectionEditor.EditValue(System.ComponentModel.ITypeDescriptorContext context, System.IServiceProvider provider, object value) -> object
 ~override System.ComponentModel.Design.CollectionEditor.GetEditStyle(System.ComponentModel.ITypeDescriptorContext context) -> System.Drawing.Design.UITypeEditorEditStyle
-~override System.ComponentModel.Design.DateTimeEditor.EditValue(System.ComponentModel.ITypeDescriptorContext context, System.IServiceProvider provider, object value) -> object
-~override System.ComponentModel.Design.DateTimeEditor.GetEditStyle(System.ComponentModel.ITypeDescriptorContext context) -> System.Drawing.Design.UITypeEditorEditStyle
+override System.ComponentModel.Design.DateTimeEditor.EditValue(System.ComponentModel.ITypeDescriptorContext? context, System.IServiceProvider! provider, object? value) -> object?
+override System.ComponentModel.Design.DateTimeEditor.GetEditStyle(System.ComponentModel.ITypeDescriptorContext? context) -> System.Drawing.Design.UITypeEditorEditStyle
 override System.ComponentModel.Design.Serialization.BasicDesignerLoader.BeginLoad(System.ComponentModel.Design.Serialization.IDesignerLoaderHost! host) -> void
 ~override System.ComponentModel.Design.Serialization.CodeDomComponentSerializationService.CreateStore() -> System.ComponentModel.Design.Serialization.SerializationStore
 ~override System.ComponentModel.Design.Serialization.CodeDomComponentSerializationService.Deserialize(System.ComponentModel.Design.Serialization.SerializationStore store) -> System.Collections.ICollection

--- a/src/System.Windows.Forms.Design/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms.Design/src/PublicAPI.Shipped.txt
@@ -82,8 +82,8 @@ override System.Windows.Forms.Design.MaskDescriptor.ToString() -> string!
 ~override System.Windows.Forms.Design.ParentControlDesigner.OnPaintAdornments(System.Windows.Forms.PaintEventArgs pe) -> void
 ~override System.Windows.Forms.Design.ParentControlDesigner.PreFilterProperties(System.Collections.IDictionary properties) -> void
 ~override System.Windows.Forms.Design.ParentControlDesigner.SnapLines.get -> System.Collections.IList
-~override System.Windows.Forms.Design.ShortcutKeysEditor.EditValue(System.ComponentModel.ITypeDescriptorContext context, System.IServiceProvider provider, object value) -> object
-~override System.Windows.Forms.Design.ShortcutKeysEditor.GetEditStyle(System.ComponentModel.ITypeDescriptorContext context) -> System.Drawing.Design.UITypeEditorEditStyle
+override System.Windows.Forms.Design.ShortcutKeysEditor.EditValue(System.ComponentModel.ITypeDescriptorContext? context, System.IServiceProvider! provider, object? value) -> object?
+override System.Windows.Forms.Design.ShortcutKeysEditor.GetEditStyle(System.ComponentModel.ITypeDescriptorContext? context) -> System.Drawing.Design.UITypeEditorEditStyle
 ~override System.Windows.Forms.Design.WindowsFormsDesignerOptionService.PopulateOptionCollection(System.ComponentModel.Design.DesignerOptionService.DesignerOptionCollection options) -> void
 ~static readonly System.Windows.Forms.Design.MenuCommands.ComponentTrayMenu -> System.ComponentModel.Design.CommandID
 ~static readonly System.Windows.Forms.Design.MenuCommands.ContainerMenu -> System.ComponentModel.Design.CommandID

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DateTimeEditor.DateTimeUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DateTimeEditor.DateTimeUI.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.Windows.Forms;
 using System.Windows.Forms.Design;
 
@@ -16,7 +14,7 @@ public partial class DateTimeEditor
     private class DateTimeUI : Control
     {
         private readonly MonthCalendar _monthCalendar = new DateTimeMonthCalendar();
-        private IWindowsFormsEditorService _editorService;
+        private IWindowsFormsEditorService? _editorService;
 
         public DateTimeUI()
         {
@@ -25,7 +23,7 @@ public partial class DateTimeEditor
             _monthCalendar.Resize += MonthCalResize;
         }
 
-        public object Value { get; private set; }
+        public object? Value { get; private set; }
 
         public void End()
         {
@@ -33,7 +31,7 @@ public partial class DateTimeEditor
             Value = null;
         }
 
-        private void MonthCalKeyDown(object sender, KeyEventArgs e)
+        private void MonthCalKeyDown(object? sender, KeyEventArgs e)
         {
             switch (e.KeyCode)
             {
@@ -58,15 +56,15 @@ public partial class DateTimeEditor
             Controls.Add(_monthCalendar);
         }
 
-        private void MonthCalResize(object sender, EventArgs e)
+        private void MonthCalResize(object? sender, EventArgs e)
         {
             Size = _monthCalendar.Size;
         }
 
-        private void OnDateSelected(object sender, DateRangeEventArgs e)
+        private void OnDateSelected(object? sender, DateRangeEventArgs? e)
         {
             Value = _monthCalendar.SelectionStart;
-            _editorService.CloseDropDown();
+            _editorService!.CloseDropDown();
         }
 
         protected override void OnGotFocus(EventArgs e)
@@ -75,7 +73,7 @@ public partial class DateTimeEditor
             _monthCalendar.Focus();
         }
 
-        public void Start(IWindowsFormsEditorService editorService, object value)
+        public void Start(IWindowsFormsEditorService editorService, object? value)
         {
             _editorService = editorService;
             Value = value;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DateTimeEditor.DateTimeUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DateTimeEditor.DateTimeUI.cs
@@ -14,21 +14,31 @@ public partial class DateTimeEditor
     private class DateTimeUI : Control
     {
         private readonly MonthCalendar _monthCalendar = new DateTimeMonthCalendar();
-        private IWindowsFormsEditorService? _editorService;
+        private IWindowsFormsEditorService _editorService;
 
-        public DateTimeUI()
+        public DateTimeUI(IWindowsFormsEditorService editorService, object? value)
         {
             InitializeComponent();
             Size = _monthCalendar.SingleMonthSize;
             _monthCalendar.Resize += MonthCalResize;
+            _editorService = editorService;
+            Value = value;
+
+            if (value is not null)
+            {
+                DateTime dateTime = (DateTime)value;
+                _monthCalendar.SetDate(dateTime.Equals(DateTime.MinValue) ? DateTime.Today : dateTime);
+            }
         }
 
         public object? Value { get; private set; }
 
-        public void End()
+        protected override void Dispose(bool disposing)
         {
-            _editorService = null;
+            _editorService = null!;
             Value = null;
+
+            base.Dispose(disposing);
         }
 
         private void MonthCalKeyDown(object? sender, KeyEventArgs e)
@@ -71,18 +81,6 @@ public partial class DateTimeEditor
         {
             base.OnGotFocus(e);
             _monthCalendar.Focus();
-        }
-
-        public void Start(IWindowsFormsEditorService editorService, object? value)
-        {
-            _editorService = editorService;
-            Value = value;
-
-            if (value is not null)
-            {
-                DateTime dateTime = (DateTime)value;
-                _monthCalendar.SetDate((dateTime.Equals(DateTime.MinValue)) ? DateTime.Today : dateTime);
-            }
         }
 
         private class DateTimeMonthCalendar : MonthCalendar

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DateTimeEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DateTimeEditor.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.Drawing.Design;
 using System.Windows.Forms.Design;
 
@@ -14,9 +12,9 @@ namespace System.ComponentModel.Design;
 /// </summary>
 public partial class DateTimeEditor : UITypeEditor
 {
-    public override object EditValue(ITypeDescriptorContext context, IServiceProvider provider, object value)
+    public override object? EditValue(ITypeDescriptorContext? context, IServiceProvider provider, object? value)
     {
-        if (!provider.TryGetService(out IWindowsFormsEditorService editorService))
+        if (!provider.TryGetService(out IWindowsFormsEditorService? editorService))
         {
             return value;
         }
@@ -33,5 +31,5 @@ public partial class DateTimeEditor : UITypeEditor
     }
 
     /// <inheritdoc />
-    public override UITypeEditorEditStyle GetEditStyle(ITypeDescriptorContext context) => UITypeEditorEditStyle.DropDown;
+    public override UITypeEditorEditStyle GetEditStyle(ITypeDescriptorContext? context) => UITypeEditorEditStyle.DropDown;
 }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DateTimeEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DateTimeEditor.cs
@@ -19,12 +19,10 @@ public partial class DateTimeEditor : UITypeEditor
             return value;
         }
 
-        using (DateTimeUI dateTimeUI = new DateTimeUI())
+        using (DateTimeUI dateTimeUI = new DateTimeUI(editorService, value))
         {
-            dateTimeUI.Start(editorService, value);
             editorService.DropDownControl(dateTimeUI);
             value = dateTimeUI.Value;
-            dateTimeUI.End();
         }
 
         return value;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskedTextBoxTextEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskedTextBoxTextEditor.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.ComponentModel;
 using System.Drawing.Design;
 
@@ -10,15 +8,14 @@ namespace System.Windows.Forms.Design;
 
 internal class MaskedTextBoxTextEditor : UITypeEditor
 {
-    public override object EditValue(ITypeDescriptorContext context, IServiceProvider provider, object value)
+    public override object? EditValue(ITypeDescriptorContext? context, IServiceProvider provider, object? value)
     {
-        if (context?.Instance is null | !provider.TryGetService(out IWindowsFormsEditorService editorService))
+        if (context?.Instance is null || !provider.TryGetService(out IWindowsFormsEditorService? editorService))
         {
             return value;
         }
 
-        var maskedTextBox = context.Instance as MaskedTextBox;
-        if (maskedTextBox is null)
+        if (context.Instance is not MaskedTextBox maskedTextBox)
         {
             maskedTextBox = new();
             maskedTextBox.Text = value as string;
@@ -35,7 +32,7 @@ internal class MaskedTextBoxTextEditor : UITypeEditor
         return value;
     }
 
-    public override UITypeEditorEditStyle GetEditStyle(ITypeDescriptorContext context)
+    public override UITypeEditorEditStyle GetEditStyle(ITypeDescriptorContext? context)
     {
         if (context?.Instance is not null)
         {
@@ -45,7 +42,7 @@ internal class MaskedTextBoxTextEditor : UITypeEditor
         return base.GetEditStyle(context);
     }
 
-    public override bool GetPaintValueSupported(ITypeDescriptorContext context)
+    public override bool GetPaintValueSupported(ITypeDescriptorContext? context)
     {
         if (context?.Instance is not null)
         {

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ShortcutKeysEditor.ShortcutKeysUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ShortcutKeysEditor.ShortcutKeysUI.cs
@@ -318,7 +318,7 @@ public partial class ShortcutKeysEditor
         /// <summary>
         ///  Triggered whenever the user drops down the editor.
         /// </summary>
-        public void Start(object value)
+        public void Start(object? value)
         {
             Debug.Assert(!_updateCurrentValue);
             _originalValue = _currentValue = value;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ShortcutKeysEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ShortcutKeysEditor.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.ComponentModel;
 using System.Drawing;
 using System.Drawing.Design;
@@ -15,14 +13,14 @@ namespace System.Windows.Forms.Design;
 [CLSCompliant(false)]
 public partial class ShortcutKeysEditor : UITypeEditor
 {
-    private ShortcutKeysUI _shortcutKeysUI;
+    private ShortcutKeysUI? _shortcutKeysUI;
 
     /// <summary>
     ///  Edits the given object value using the editor style provided by ShortcutKeysEditor.GetEditStyle.
     /// </summary>
-    public override object EditValue(ITypeDescriptorContext context, IServiceProvider provider, object value)
+    public override object? EditValue(ITypeDescriptorContext? context, IServiceProvider provider, object? value)
     {
-        if (!provider.TryGetService(out IWindowsFormsEditorService editorService))
+        if (!provider.TryGetService(out IWindowsFormsEditorService? editorService))
         {
             return value;
         }
@@ -45,5 +43,5 @@ public partial class ShortcutKeysEditor : UITypeEditor
     }
 
     /// <inheritdoc />
-    public override UITypeEditorEditStyle GetEditStyle(ITypeDescriptorContext context) => UITypeEditorEditStyle.DropDown;
+    public override UITypeEditorEditStyle GetEditStyle(ITypeDescriptorContext? context) => UITypeEditorEditStyle.DropDown;
 }


### PR DESCRIPTION
Those should be straightforward.

## Proposed changes

- Enable nullability in `ShortcutKeysEditor`
- Enable nullability in `DateTimeEditor`
- Enable nullability in `MaskedTextBoxTextEditor`

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9611)