### PR TITLE
fix System.ArgumentOutOfRangeException: Value of '-22' is not valid for 'LargeChange'#9596

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewControl.cs
@@ -889,8 +889,8 @@ public partial class PrintPreviewControl : Control
 
         (bool horizontal, bool vertical) IsScrollNeeded(Size displaySize)
         {
-            bool horizontal = _virtualSize.Width > displaySize.Width;
-            bool vertical = _virtualSize.Height > displaySize.Height;
+            bool horizontal = _virtualSize.Width > displaySize.Width && displaySize.Width > _vScrollBar.Width;
+            bool vertical = _virtualSize.Height > displaySize.Height && displaySize.Height > _hScrollBar.Height;
 
             if (!horizontal && vertical)
             {


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #9596
## Issue description
When  PrintPreviewControl is created and the handle is created, then change the size of the PrintPreviewControl to a very little size ,for example (0,0) , an exception will be thrown.

## Proposed changes

- 
- Add parameter check before throwing Exception
- 

<!-- We are in TELL-MODE the following section must be completed -->




## Test methodology <!-- How did you ensure quality? -->

- 
- Manually 
- 



 

## Test environment(s) <!-- Remove any that don't apply -->

8.0.0-rc.1.23379.8


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9616)