### PR TITLE
Refactor `ControlCollection.AddRange` to use `params` keyword

### DIFF
--- a/src/System.Windows.Forms.Design/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms.Design/src/PublicAPI.Unshipped.txt
@@ -1,0 +1,3 @@
+System.ComponentModel.Design.DesignerActionListCollection.AddRange(params System.ComponentModel.Design.DesignerActionList?[]! value) -> void
+~System.Windows.Forms.Design.Behavior.BehaviorServiceAdornerCollection.AddRange(params System.Windows.Forms.Design.Behavior.Adorner[] value) -> void
+~System.Windows.Forms.Design.Behavior.GlyphCollection.AddRange(params System.Windows.Forms.Design.Behavior.Glyph[] value) -> void

--- a/src/System.Windows.Forms.Design/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms.Design/src/PublicAPI.Unshipped.txt
@@ -1,3 +1,6 @@
+*REMOVED*System.ComponentModel.Design.DesignerActionListCollection.AddRange(System.ComponentModel.Design.DesignerActionList?[]! value) -> void
+*REMOVED*~System.Windows.Forms.Design.Behavior.BehaviorServiceAdornerCollection.AddRange(System.Windows.Forms.Design.Behavior.Adorner[] value) -> void
+*REMOVED*~System.Windows.Forms.Design.Behavior.GlyphCollection.AddRange(System.Windows.Forms.Design.Behavior.Glyph[] value) -> void
 System.ComponentModel.Design.DesignerActionListCollection.AddRange(params System.ComponentModel.Design.DesignerActionList?[]! value) -> void
 ~System.Windows.Forms.Design.Behavior.BehaviorServiceAdornerCollection.AddRange(params System.Windows.Forms.Design.Behavior.Adorner[] value) -> void
 ~System.Windows.Forms.Design.Behavior.GlyphCollection.AddRange(params System.Windows.Forms.Design.Behavior.Glyph[] value) -> void

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionListCollection.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionListCollection.cs
@@ -25,7 +25,7 @@ public class DesignerActionListCollection : CollectionBase
 
     public int Add(DesignerActionList? value) => List.Add(value);
 
-    public void AddRange(DesignerActionList?[] value)
+    public void AddRange(params DesignerActionList?[] value)
     {
         ArgumentNullException.ThrowIfNull(value);
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/AdornerCollection.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/AdornerCollection.cs
@@ -96,7 +96,7 @@ public sealed class BehaviorServiceAdornerCollection : CollectionBase
     ///  None.
     /// </returns>
     /// <seealso cref="Add"/>
-    public void AddRange(Adorner[] value)
+    public void AddRange(params Adorner[] value)
     {
         for (int i = 0; (i < value.Length); i++)
         {

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/GlyphCollection.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/GlyphCollection.cs
@@ -57,7 +57,7 @@ public class GlyphCollection : CollectionBase
     /// <summary>
     ///  Copies the elements of an array to the end of the Behavior.GlyphCollection.
     /// </summary>
-    public void AddRange(Glyph[] value)
+    public void AddRange(params Glyph[] value)
     {
         for (int i = 0; i < value.Length; i += 1)
         {

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.DesignerControlCollection.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.DesignerControlCollection.cs
@@ -34,7 +34,7 @@ public partial class ControlDesigner
 
         public override void Add(Control c) => _realCollection.Add(c);
 
-        public override void AddRange(Control[] controls) => _realCollection.AddRange(controls);
+        public override void AddRange(params Control[] controls) => _realCollection.AddRange(controls);
 
         bool IList.Contains(object control) => ((IList)_realCollection).Contains(control);
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/CustomMenuItemCollection.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/CustomMenuItemCollection.cs
@@ -29,7 +29,7 @@ internal class CustomMenuItemCollection : CollectionBase
     /// <summary>
     ///  Add range of values to the collection
     /// </summary>
-    public void AddRange(ToolStripItem[] value)
+    public void AddRange(params ToolStripItem[] value)
     {
         for (int i = 0; (i < value.Length); i++)
         {

--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -4,3 +4,18 @@ override System.Windows.Forms.PrintPreviewControl.OnMouseDown(System.Windows.For
 override System.Windows.Forms.PrintPreviewControl.OnPaintBackground(System.Windows.Forms.PaintEventArgs! e) -> void
 *REMOVED*override System.Windows.Forms.PrintPreviewControl.CreateParams.get -> System.Windows.Forms.CreateParams!
 *REMOVED*System.Windows.Forms.PrintPreviewControl.TabStopChanged -> System.EventHandler?
+System.Windows.Forms.AutoCompleteStringCollection.AddRange(params string![]! value) -> void
+System.Windows.Forms.ComboBox.ObjectCollection.AddRange(params object![]! items) -> void
+System.Windows.Forms.ImageList.ImageCollection.AddRange(params System.Drawing.Image![]! images) -> void
+System.Windows.Forms.ListBox.IntegerCollection.AddRange(params int[]! items) -> void
+System.Windows.Forms.ListBox.ObjectCollection.AddRange(params object![]! items) -> void
+System.Windows.Forms.ListView.ListViewItemCollection.AddRange(params System.Windows.Forms.ListViewItem![]! items) -> void
+System.Windows.Forms.ListViewGroupCollection.AddRange(params System.Windows.Forms.ListViewGroup![]! groups) -> void
+System.Windows.Forms.ListViewItem.ListViewSubItemCollection.AddRange(params string![]! items) -> void
+System.Windows.Forms.ListViewItem.ListViewSubItemCollection.AddRange(params System.Windows.Forms.ListViewItem.ListViewSubItem![]! items) -> void
+System.Windows.Forms.TabControl.TabPageCollection.AddRange(params System.Windows.Forms.TabPage![]! pages) -> void
+System.Windows.Forms.ToolStripItemCollection.AddRange(params System.Windows.Forms.ToolStripItem![]! toolStripItems) -> void
+System.Windows.Forms.ToolStripPanel.ToolStripPanelRowCollection.AddRange(params System.Windows.Forms.ToolStripPanelRow![]! value) -> void
+virtual System.Windows.Forms.Control.ControlCollection.AddRange(params System.Windows.Forms.Control![]! controls) -> void
+virtual System.Windows.Forms.ListView.ColumnHeaderCollection.AddRange(params System.Windows.Forms.ColumnHeader![]! values) -> void
+~virtual System.Windows.Forms.TreeNodeCollection.AddRange(params System.Windows.Forms.TreeNode[] nodes) -> void

--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -4,6 +4,21 @@ override System.Windows.Forms.PrintPreviewControl.OnMouseDown(System.Windows.For
 override System.Windows.Forms.PrintPreviewControl.OnPaintBackground(System.Windows.Forms.PaintEventArgs! e) -> void
 *REMOVED*override System.Windows.Forms.PrintPreviewControl.CreateParams.get -> System.Windows.Forms.CreateParams!
 *REMOVED*System.Windows.Forms.PrintPreviewControl.TabStopChanged -> System.EventHandler?
+*REMOVED*System.Windows.Forms.AutoCompleteStringCollection.AddRange(string![]! value) -> void
+*REMOVED*System.Windows.Forms.ComboBox.ObjectCollection.AddRange(object![]! items) -> void
+*REMOVED*System.Windows.Forms.ImageList.ImageCollection.AddRange(System.Drawing.Image![]! images) -> void
+*REMOVED*System.Windows.Forms.ListBox.IntegerCollection.AddRange(int[]! items) -> void
+*REMOVED*System.Windows.Forms.ListBox.ObjectCollection.AddRange(object![]! items) -> void
+*REMOVED*System.Windows.Forms.ListView.ListViewItemCollection.AddRange(System.Windows.Forms.ListViewItem![]! items) -> void
+*REMOVED*System.Windows.Forms.ListViewGroupCollection.AddRange(System.Windows.Forms.ListViewGroup![]! groups) -> void
+*REMOVED*System.Windows.Forms.ListViewItem.ListViewSubItemCollection.AddRange(string![]! items) -> void
+*REMOVED*System.Windows.Forms.ListViewItem.ListViewSubItemCollection.AddRange(System.Windows.Forms.ListViewItem.ListViewSubItem![]! items) -> void
+*REMOVED*System.Windows.Forms.TabControl.TabPageCollection.AddRange(System.Windows.Forms.TabPage![]! pages) -> void
+*REMOVED*System.Windows.Forms.ToolStripItemCollection.AddRange(System.Windows.Forms.ToolStripItem![]! toolStripItems) -> void
+*REMOVED*System.Windows.Forms.ToolStripPanel.ToolStripPanelRowCollection.AddRange(System.Windows.Forms.ToolStripPanelRow![]! value) -> void
+*REMOVED*virtual System.Windows.Forms.Control.ControlCollection.AddRange(System.Windows.Forms.Control![]! controls) -> void
+*REMOVED*virtual System.Windows.Forms.ListView.ColumnHeaderCollection.AddRange(System.Windows.Forms.ColumnHeader![]! values) -> void
+*REMOVED*~virtual System.Windows.Forms.TreeNodeCollection.AddRange(System.Windows.Forms.TreeNode[] nodes) -> void
 System.Windows.Forms.AutoCompleteStringCollection.AddRange(params string![]! value) -> void
 System.Windows.Forms.ComboBox.ObjectCollection.AddRange(params object![]! items) -> void
 System.Windows.Forms.ImageList.ImageCollection.AddRange(params System.Drawing.Image![]! images) -> void

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AutoCompleteStringCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AutoCompleteStringCollection.cs
@@ -68,7 +68,7 @@ public class AutoCompleteStringCollection : IList
     /// <summary>
     ///  Copies the elements of a string array to the end of the <see cref="AutoCompleteStringCollection"/>.
     /// </summary>
-    public void AddRange(string[] value)
+    public void AddRange(params string[] value)
     {
         ArgumentNullException.ThrowIfNull(value);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ObjectCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ObjectCollection.cs
@@ -175,7 +175,7 @@ public partial class ComboBox
             return Add(item!);
         }
 
-        public void AddRange(object[] items)
+        public void AddRange(params object[] items)
         {
             _owner.CheckNoDataSource();
             _owner.BeginUpdate();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlCollection.cs
@@ -149,7 +149,7 @@ public partial class Control
         }
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public virtual void AddRange(Control[] controls)
+        public virtual void AddRange(params Control[] controls)
         {
             ArgumentNullException.ThrowIfNull(controls);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.ImageCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.ImageCollection.cs
@@ -374,7 +374,7 @@ public sealed partial class ImageList
             return index;
         }
 
-        public void AddRange(Image[] images)
+        public void AddRange(params Image[] images)
         {
             ArgumentNullException.ThrowIfNull(images);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.IntegerCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.IntegerCollection.cs
@@ -159,7 +159,7 @@ public partial class ListBox
             return Add((int)item);
         }
 
-        public void AddRange(int[] items)
+        public void AddRange(params int[] items)
         {
             AddRangeInternal(items);
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.ObjectCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.ObjectCollection.cs
@@ -169,7 +169,7 @@ public partial class ListBox
             AddRangeInternal(value);
         }
 
-        public void AddRange(object[] items)
+        public void AddRange(params object[] items)
         {
             ArgumentNullException.ThrowIfNull(items);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ColumnHeaderCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ColumnHeaderCollection.cs
@@ -268,7 +268,7 @@ public partial class ListView
 
         // END - NEW ADD OVERLOADS IN WHIDBEY  -->
 
-        public virtual void AddRange(ColumnHeader[] values)
+        public virtual void AddRange(params ColumnHeader[] values)
         {
             ArgumentNullException.ThrowIfNull(values);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewItemCollection.IInnerList.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewItemCollection.IInnerList.cs
@@ -18,7 +18,7 @@ public partial class ListView
             ListViewItem this[int index] { get; set; }
 
             ListViewItem Add(ListViewItem item);
-            void AddRange(ListViewItem[] items);
+            void AddRange(params ListViewItem[] items);
             void Clear();
             bool Contains(ListViewItem item);
             void CopyTo(Array dest, int index);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewItemCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewItemCollection.cs
@@ -246,7 +246,7 @@ public partial class ListView
 
         // END - NEW ADD OVERLOADS IN WHIDBEY  -->
 
-        public void AddRange(ListViewItem[] items)
+        public void AddRange(params ListViewItem[] items)
         {
             ArgumentNullException.ThrowIfNull(items);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewNativeItemCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewNativeItemCollection.cs
@@ -122,7 +122,7 @@ public partial class ListView
             }
         }
 
-        public void AddRange(ListViewItem[] values)
+        public void AddRange(params ListViewItem[] values)
         {
             ArgumentNullException.ThrowIfNull(values);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroupCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroupCollection.cs
@@ -149,7 +149,7 @@ public class ListViewGroupCollection : IList
         return Add(group);
     }
 
-    public void AddRange(ListViewGroup[] groups)
+    public void AddRange(params ListViewGroup[] groups)
     {
         ArgumentNullException.ThrowIfNull(groups);
         ThrowInvalidOperationExceptionIfVirtualMode();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroupItemCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroupItemCollection.cs
@@ -47,7 +47,7 @@ internal class ListViewGroupItemCollection : ListView.ListViewItemCollection.IIn
         return value;
     }
 
-    public void AddRange(ListViewItem[] items)
+    public void AddRange(params ListViewItem[] items)
     {
         for (int i = 0; i < items.Length; i++)
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewSubItemCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewSubItemCollection.cs
@@ -134,7 +134,7 @@ public partial class ListViewItem
             return item;
         }
 
-        public void AddRange(ListViewSubItem[] items)
+        public void AddRange(params ListViewSubItem[] items)
         {
             ArgumentNullException.ThrowIfNull(items);
 
@@ -152,7 +152,7 @@ public partial class ListViewItem
             _owner.UpdateSubItems(-1);
         }
 
-        public void AddRange(string[] items)
+        public void AddRange(params string[] items)
         {
             ArgumentNullException.ThrowIfNull(items);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.TabPageCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.TabPageCollection.cs
@@ -122,7 +122,7 @@ public partial class TabControl
             ImageKey = imageKey
         });
 
-        public void AddRange(TabPage[] pages)
+        public void AddRange(params TabPage[] pages)
         {
             ArgumentNullException.ThrowIfNull(pages);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItemCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItemCollection.cs
@@ -113,7 +113,7 @@ public class ToolStripItemCollection : ArrangedElementCollection, IList
         return retVal;
     }
 
-    public void AddRange(ToolStripItem[] toolStripItems)
+    public void AddRange(params ToolStripItem[] toolStripItems)
     {
         ArgumentNullException.ThrowIfNull(toolStripItems);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanel.ToolStripPanelRowCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanel.ToolStripPanelRowCollection.cs
@@ -46,7 +46,7 @@ public partial class ToolStripPanel
             return retVal;
         }
 
-        public void AddRange(ToolStripPanelRow[] value)
+        public void AddRange(params ToolStripPanelRow[] value)
         {
             ArgumentNullException.ThrowIfNull(value);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanelRow.ToolStripPanelRowControlCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanelRow.ToolStripPanelRowControlCollection.cs
@@ -86,7 +86,7 @@ public partial class ToolStripPanelRow
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void AddRange(Control[] value)
+        public void AddRange(params Control[] value)
         {
             ArgumentNullException.ThrowIfNull(value);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeNodeCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeNodeCollection.cs
@@ -259,7 +259,7 @@ public class TreeNodeCollection : IList
 
     // END - NEW ADD OVERLOADS IN WHIDBEY -->
 
-    public virtual void AddRange(TreeNode[] nodes)
+    public virtual void AddRange(params TreeNode[] nodes)
     {
         ArgumentNullException.ThrowIfNull(nodes);
 


### PR DESCRIPTION
Add `params` keyword to arguments of `ControlCollection.AddRange` method.

Fixes #8938

Based on: #8928

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9620)