### PR TITLE
use generic overload of Enum.IsDefined to avoid boxing

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/DpiHelper.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/DpiHelper.cs
@@ -65,7 +65,7 @@ internal static partial class DpiHelper
             out PROCESS_DPI_AWARENESS processDpiAwareness);
 
         Debug.Assert(result.Succeeded, $"Failed to get ProcessDpi HRESULT: {result}");
-        Debug.Assert(Enum.IsDefined(typeof(PROCESS_DPI_AWARENESS), processDpiAwareness));
+        Debug.Assert(Enum.IsDefined(processDpiAwareness));
 
         return result.Succeeded && processDpiAwareness switch
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewBand.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewBand.cs
@@ -532,7 +532,7 @@ public class DataGridViewBand : DataGridViewElement, ICloneable, IDisposable
         }
         set
         {
-            if (!Enum.IsDefined(typeof(DataGridViewTriState), value))
+            if (!Enum.IsDefined(value))
             {
                 throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(DataGridViewTriState));
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellStyle.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellStyle.cs
@@ -108,7 +108,7 @@ public class DataGridViewCellStyle : ICloneable
     {
         set
         {
-            Debug.Assert(Enum.IsDefined(typeof(DataGridViewContentAlignment), value));
+            Debug.Assert(Enum.IsDefined(value));
             if (Alignment != value)
             {
                 Properties.SetInteger(PropAlignment, (int)value);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewHeaderCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewHeaderCell.cs
@@ -46,7 +46,7 @@ public partial class DataGridViewHeaderCell : DataGridViewCell
     {
         set
         {
-            Debug.Assert(Enum.IsDefined(typeof(ButtonState), value));
+            Debug.Assert(Enum.IsDefined(value));
             if (ButtonState != value)
             {
                 Properties.SetInteger(s_propButtonState, (int)value);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/KeyEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/KeyEventArgs.cs
@@ -45,7 +45,7 @@ public class KeyEventArgs : EventArgs
             Keys keyGenerated = KeyData & Keys.KeyCode;
 
             // since Keys can be discontiguous, keeping Enum.IsDefined.
-            if (!Enum.IsDefined(typeof(Keys), (int)keyGenerated))
+            if (!Enum.IsDefined(keyGenerated))
             {
                 return Keys.None;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/KeysConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/KeysConverter.cs
@@ -249,7 +249,7 @@ public class KeysConverter : TypeConverter, IComparer
             {
                 // First, iterate through and do the modifiers. These are
                 // additive, so we support things like Ctrl + Alt
-                foreach (var keyString in displayOrder)
+                foreach (string keyString in displayOrder)
                 {
                     Keys keyValue = keyNames[keyString];
                     if (keyValue != Keys.None && modifiers.HasFlag(keyValue))
@@ -264,7 +264,7 @@ public class KeysConverter : TypeConverter, IComparer
             Keys keyOnly = key & Keys.KeyCode;
             bool foundKey = false;
 
-            foreach (var keyString in displayOrder)
+            foreach (string keyString in displayOrder)
             {
                 Keys keyValue = keyNames[keyString];
                 if (keyValue.Equals(keyOnly))
@@ -278,7 +278,7 @@ public class KeysConverter : TypeConverter, IComparer
             // Finally, if the key wasn't in our list, add it to
             // the end anyway. Here we just pull the key value out
             // of the enum.
-            if (!foundKey && Enum.IsDefined(typeof(Keys), (int)keyOnly))
+            if (!foundKey && Enum.IsDefined(keyOnly))
             {
                 termKeys.Add(keyOnly);
             }
@@ -326,7 +326,7 @@ public class KeysConverter : TypeConverter, IComparer
             // Finally, if the key wasn't in our list, add it to
             // the end anyway. Here we just pull the key value out
             // of the enum.
-            if (!foundKey && Enum.IsDefined(typeof(Keys), (int)keyOnly))
+            if (!foundKey && Enum.IsDefined(keyOnly))
             {
                 termStrings.Append(Enum.GetName(keyOnly));
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PreviewKeyDownEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PreviewKeyDownEventArgs.cs
@@ -35,7 +35,7 @@ public class PreviewKeyDownEventArgs : EventArgs
         get
         {
             Keys keyGenerated = KeyData & Keys.KeyCode;
-            if (!Enum.IsDefined(typeof(Keys), (int)keyGenerated))
+            if (!Enum.IsDefined(keyGenerated))
             {
                 return Keys.None;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowser.WebBrowserSite.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowser.WebBrowserSite.cs
@@ -162,7 +162,7 @@ public partial class WebBrowser
             if (!wb.WebBrowserShortcutsEnabled)
             {
                 int keyCode = (int)(uint)lpMsg->wParam | (int)ModifierKeys;
-                if (lpMsg->message != (uint)PInvoke.WM_CHAR && Enum.IsDefined(typeof(Shortcut), (Shortcut)keyCode))
+                if (lpMsg->message != (uint)PInvoke.WM_CHAR && Enum.IsDefined((Shortcut)keyCode))
                 {
                     return HRESULT.S_OK;
                 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ApplicationTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ApplicationTests.cs
@@ -109,7 +109,7 @@ public class ApplicationTests
     public void Application_VisualStyleState_Get_ReturnsExpected()
     {
         VisualStyleState state = Application.VisualStyleState;
-        Assert.True(Enum.IsDefined(typeof(VisualStyleState), state));
+        Assert.True(Enum.IsDefined(state));
         Assert.Equal(state, Application.VisualStyleState);
     }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PowerStatusTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PowerStatusTests.cs
@@ -64,6 +64,6 @@ public class PowerStatusTests
     public void PowerStatus_PowerLineStatus_Get_ReturnsExpected()
     {
         PowerStatus status = SystemInformation.PowerStatus;
-        Assert.True(Enum.IsDefined(typeof(PowerLineStatus), status.PowerLineStatus));
+        Assert.True(Enum.IsDefined(status.PowerLineStatus));
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/SystemInformationTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/SystemInformationTests.cs
@@ -38,7 +38,7 @@ public class SystemInformationTests
     public void SystemInformation_BootMode_Get_ReturnsExpected()
     {
         BootMode bootMode = SystemInformation.BootMode;
-        Assert.True(Enum.IsDefined(typeof(BootMode), bootMode));
+        Assert.True(Enum.IsDefined(bootMode));
         Assert.Equal(bootMode, SystemInformation.BootMode);
     }
 
@@ -609,7 +609,7 @@ public class SystemInformationTests
     public void SystemInformation_PopupMenuAlignment_Get_ReturnsExpected()
     {
         LeftRightAlignment alignment = SystemInformation.PopupMenuAlignment;
-        Assert.True(Enum.IsDefined(typeof(LeftRightAlignment), alignment));
+        Assert.True(Enum.IsDefined(alignment));
         Assert.Equal(alignment, SystemInformation.PopupMenuAlignment);
     }
 
@@ -649,7 +649,7 @@ public class SystemInformationTests
     public void SystemInformation_ScreenOrientation_Get_ReturnsExpected()
     {
         ScreenOrientation orientation = SystemInformation.ScreenOrientation;
-        Assert.True(Enum.IsDefined(typeof(ScreenOrientation), orientation));
+        Assert.True(Enum.IsDefined(orientation));
         Assert.Equal(orientation, SystemInformation.ScreenOrientation);
     }
 


### PR DESCRIPTION
## Proposed changes

- Replace usage of `Enum.IsDefined` by `Enum.IsDefined<T>` across codebase


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9622)