### PR TITLE
fix [Accessibility] SubItems displayed incorrectly in Inspect or AccessibilityInsights after a column is removed from the ListView. #7492

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ColumnHeader.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ColumnHeader.cs
@@ -25,6 +25,7 @@ public partial class ColumnHeader : Component, ICloneable
     internal string? _text;
     internal string _name;
     internal int _width = 60;
+    internal int _correspondingListViewSubItemIndex = -1;
 
     // Use TextAlign property instead of this member variable, always
     private HorizontalAlignment _textAlign = HorizontalAlignment.Left;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -3881,6 +3881,19 @@ public partial class ListView : Control
         }
     }
 
+    internal void UpdateColumnHeaderCorrespondingListViewSubItemIndex()
+    {
+        if (_columnHeaders is null)
+        {
+            return;
+        }
+
+        for (int i = 0; i < _columnHeaders.Length; i++)
+        {
+            _columnHeaders[i]._correspondingListViewSubItemIndex = i;
+        }
+    }
+
     /// <summary>
     ///  Inserts a new Column into the ListView
     /// </summary>
@@ -3978,6 +3991,8 @@ public partial class ListView : Control
         {
             RealizeAllSubItems();
         }
+
+        UpdateColumnHeaderCorrespondingListViewSubItemIndex();
 
         return ch;
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemDetailsAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemDetailsAccessibleObject.cs
@@ -30,7 +30,8 @@ public partial class ListViewItem
         /// </summary>
         /// <param name="accessibleChildIndex">The index of the child <see cref="AccessibleObject"/>.</param>
         /// <returns>The index of an owning <see cref="ListViewSubItem"/>'s object.</returns>
-        private int AccessibleChildToSubItemIndex(int accessibleChildIndex) => HasImage ? _owningListView.Columns[accessibleChildIndex - 1]._correspondingListViewSubItemIndex
+        private int AccessibleChildToSubItemIndex(int accessibleChildIndex) => HasImage
+            ? _owningListView.Columns[accessibleChildIndex - 1]._correspondingListViewSubItemIndex
             : _owningListView.Columns[accessibleChildIndex]._correspondingListViewSubItemIndex;
 
         internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemDetailsAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemDetailsAccessibleObject.cs
@@ -30,7 +30,8 @@ public partial class ListViewItem
         /// </summary>
         /// <param name="accessibleChildIndex">The index of the child <see cref="AccessibleObject"/>.</param>
         /// <returns>The index of an owning <see cref="ListViewSubItem"/>'s object.</returns>
-        private int AccessibleChildToSubItemIndex(int accessibleChildIndex) => HasImage ? accessibleChildIndex - 1 : accessibleChildIndex;
+        private int AccessibleChildToSubItemIndex(int accessibleChildIndex) => HasImage ? _owningListView.Columns[accessibleChildIndex - 1]._correspondingListViewSubItemIndex
+            : _owningListView.Columns[accessibleChildIndex]._correspondingListViewSubItemIndex;
 
         internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
         {
@@ -107,7 +108,16 @@ public partial class ListViewItem
             }
 
             int subItemIndex = _owningItem.SubItems.IndexOf(subItemAccessibleObject.OwningSubItem);
-            int accessibleChildIndex = SubItemToAccessibleChildIndex(subItemIndex);
+            int accessibleChildIndex = InvalidIndex;
+            for (int i = 0; i < _owningListView.Columns.Count; i++)
+            {
+                if (_owningListView.Columns[i]._correspondingListViewSubItemIndex == subItemIndex)
+                {
+                    accessibleChildIndex = i + (HasImage ? 1 : 0);
+                    break;
+                }
+            }
+
             return accessibleChildIndex > LastChildIndex ? InvalidIndex : accessibleChildIndex;
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemDetailsAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemDetailsAccessibleObject.cs
@@ -126,7 +126,7 @@ public partial class ListViewItem
         // when there is no ListViewSubItem, but the cell for it is displayed and the user can interact with it.
         internal AccessibleObject? GetDetailsSubItemOrFake(int subItemIndex)
         {
-            int accessibleChildIndex = SubItemToAccessibleChildIndex(subItemIndex);
+            int accessibleChildIndex = HasImage ? subItemIndex + 1 : subItemIndex;
             return GetDetailsSubItemOrFakeInternal(accessibleChildIndex);
         }
 
@@ -196,12 +196,5 @@ public partial class ListViewItem
 
             _listViewSubItemAccessibleObjects.Clear();
         }
-
-        /// <summary>
-        ///  Converts the provided index of a <see cref="ListViewSubItem"/> to an index of the <see cref="AccessibleObject"/>'s child.
-        /// </summary>
-        /// <param name="subItemIndex">The index of an owning <see cref="ListViewSubItem"/>'s object.</param>
-        /// <returns>The index of the child <see cref="AccessibleObject"/>.</returns>
-        private int SubItemToAccessibleChildIndex(int subItemIndex) => HasImage ? subItemIndex + 1 : subItemIndex;
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemDetailsAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemDetailsAccessibleObject.cs
@@ -179,7 +179,7 @@ public partial class ListViewItem
 
         internal override Rectangle GetSubItemBounds(int accessibleChildIndex)
             => _owningListView.IsHandleCreated
-                ? _owningListView.GetSubItemRect(_owningItem.Index, AccessibleChildToSubItemIndex(accessibleChildIndex))
+                ? _owningListView.GetSubItemRect(_owningItem.Index, HasImage ? accessibleChildIndex - 1 : accessibleChildIndex)
                 : Rectangle.Empty;
 
         /// <devdoc>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObject.cs
@@ -145,7 +145,7 @@ public partial class ListViewItem
             internal override int Row => _owningItem.Index;
 
             internal override UiaCore.IRawElementProviderSimple[]? GetColumnHeaderItems()
-                => _owningListView.View == View.Details
+                => _owningListView.View == View.Details && Column > -1
                     ? new UiaCore.IRawElementProviderSimple[] { _owningListView.Columns[Column].AccessibilityObject }
                     : null;
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemDetailsAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemDetailsAccessibleObjectTests.cs
@@ -194,13 +194,18 @@ public class ListViewItem_ListViewItemDetailsAccessibleObjectTests
         form.Controls.Add(listView1);
         form.Show();
 
-        AccessibleObject listItemAO = listView1.AccessibilityObject.GetChild(1);
+        AccessibleObject listItemAccessibleObject = listView1.AccessibilityObject.GetChild(1);
 
-        Assert.Equal("sub1", listItemAO.GetChild(2).Name);
+        Assert.Equal("sub1", listItemAccessibleObject.GetChild(2).Name);
 
         listView1.Columns.RemoveAt(0);
 
-        Assert.Equal("sub2", listItemAO.GetChild(2).Name);
+        Assert.Equal("sub2", listItemAccessibleObject.GetChild(2).Name);
+
+        foreach (ColumnHeader col in listView1.Columns)
+        {
+            col.Dispose();
+        }
     }
 
     // Unit test for https://github.com/dotnet/winforms/issues/7492.
@@ -213,12 +218,17 @@ public class ListViewItem_ListViewItemDetailsAccessibleObjectTests
         form.Controls.Add(listView1);
         form.Show();
 
-        AccessibleObject listItemAO = listView1.AccessibilityObject.GetChild(1);
+        AccessibleObject listItemAccessibleObject = listView1.AccessibilityObject.GetChild(1);
 
-        Assert.Equal("sub1", listItemAO.GetChild(1).Name);
+        Assert.Equal("sub1", listItemAccessibleObject.GetChild(1).Name);
 
         listView1.Columns.RemoveAt(0);
 
-        Assert.Equal("sub2", listItemAO.GetChild(1).Name);
+        Assert.Equal("sub2", listItemAccessibleObject.GetChild(1).Name);
+
+        foreach (ColumnHeader col in listView1.Columns)
+        {
+            col.Dispose();
+        }
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #7492


## Proposed changes

- 
- Change the way to get childAO of a ListViewItem
- 

<!-- We are in TELL-MODE the following section must be completed -->



## Regression? 

- Yes 


<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![001](https://github.com/dotnet/winforms/assets/135201996/f1021c3d-4f54-4e0f-b34c-56a704dbd0a6)

### After

![002](https://github.com/dotnet/winforms/assets/135201996/e991434d-7553-47a4-bf63-54f19be1a9aa)


## Test methodology <!-- How did you ensure quality? -->

- 
- Manual and Automation 
- 


## Test environment(s) <!-- Remove any that don't apply -->


8.0.0-rc.1.23376.5

<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9624)