### PR TITLE
Add commentary to TextRenderer assert

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextRenderer.cs
@@ -619,6 +619,18 @@ public static class TextRenderer
 #if DEBUG
         if ((textFormatFlags & SkipAssertFlag) == 0)
         {
+            // Clipping and translation transforms applied to Graphics objects are not done on the underlying HDC.
+            // When we're rendering text to the HDC we, by default, should apply both. If it is *known* that these
+            // aren't wanted we can get a _slight_ performance benefit by not applying them and in that case the
+            // SkipAssertFlag bit can be set to skip this check.
+            //
+            // This application of clipping and translation is meant to make Graphics.DrawText and TextRenderer.DrawText
+            // roughly equivalent in the way they render.
+            //
+            // Note that there aren't flags for other transforms. Windows 9x doesn't support HDC transforms outside of
+            // translation (rotation for example), and this likely impacted the decision to only have a translation
+            // flag when this was originally written.
+
             Debug.Assert(apply.HasFlag(ApplyGraphicsProperties.Clipping)
                 || graphics.Clip is null
                 || graphics.Clip.GetHrgn(graphics) == IntPtr.Zero,


### PR DESCRIPTION
This assert has come up a number of times recently. Adding some informational text to clarify why this assert exists and what the guidelines are.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9630)