### PR TITLE
Fix a few more ref counts in ActiveXImpl

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.ThreadContext.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.ThreadContext.cs
@@ -796,23 +796,18 @@ public sealed partial class Application
         /// </summary>
         internal bool IsValidComponentId() => _componentID != s_invalidId;
 
-        internal ApartmentState OleRequired()
+        internal unsafe ApartmentState OleRequired()
         {
-            _ = Thread.CurrentThread;
             if (!GetState(STATE_OLEINITIALIZED))
             {
-                HRESULT ret;
-                unsafe
-                {
-                    ret = PInvoke.OleInitialize(pvReserved: (void*)null);
-                }
+                HRESULT hr = PInvoke.OleInitialize(pvReserved: (void*)null);
 
                 SetState(STATE_OLEINITIALIZED, true);
-                if (ret == HRESULT.RPC_E_CHANGED_MODE)
+                if (hr == HRESULT.RPC_E_CHANGED_MODE)
                 {
                     // This could happen if the thread was already initialized for MTA
-                    // and then we call OleInitialize which tries to initialized it for STA
-                    // This currently happens while profiling...
+                    // and then we call OleInitialize which tries to initialize it for STA
+                    // This currently happens while profiling.
                     SetState(STATE_EXTERNALOLEINIT, true);
                 }
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
@@ -555,7 +555,7 @@ public partial class Control
             }
         }
 
-        // <inheritdoc cref="IViewObject.GetAdvise(uint*, uint*, IAdviseSink**)"/>
+        /// <inheritdoc cref="IViewObject.GetAdvise(uint*, uint*, IAdviseSink**)"/>
         internal unsafe HRESULT GetAdvise(DVASPECT* pAspects, ADVF* pAdvf, IAdviseSink** ppAdvSink)
         {
             if (pAspects is not null)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
@@ -6,6 +6,7 @@ using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Drawing;
 using System.Globalization;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
@@ -408,9 +409,7 @@ public partial class Control
             return HRESULT.S_OK;
         }
 
-        /// <summary>
-        ///  Implements IViewObject2::Draw.
-        /// </summary>
+        /// <inheritdoc cref="IViewObject.Interface.Draw(DVASPECT, int, void*, DVTARGETDEVICE*, HDC, HDC, RECTL*, RECTL*, nint, nuint)"/>
         internal HRESULT Draw(
             DVASPECT dwDrawAspect,
             int lindex,
@@ -556,9 +555,7 @@ public partial class Control
             }
         }
 
-        /// <summary>
-        ///  Implements IViewObject2::GetAdvise.
-        /// </summary>
+        // <inheritdoc cref="IViewObject.GetAdvise(uint*, uint*, IAdviseSink**)"/>
         internal unsafe HRESULT GetAdvise(DVASPECT* pAspects, ADVF* pAdvf, IAdviseSink** ppAdvSink)
         {
             if (pAspects is not null)
@@ -584,6 +581,11 @@ public partial class Control
             if (ppAdvSink is not null)
             {
                 *ppAdvSink = _viewAdviseSink;
+
+                if (_viewAdviseSink is not null)
+                {
+                    _viewAdviseSink->AddRef();
+                }
             }
 
             return HRESULT.S_OK;
@@ -963,9 +965,7 @@ public partial class Control
             }
         }
 
-        /// <summary>
-        ///  Implements IOleInPlaceObject::InPlaceDeactivate.
-        /// </summary>
+        /// <inheritdoc cref="IOleInPlaceObject.InPlaceDeactivate"/>
         internal HRESULT InPlaceDeactivate()
         {
             // Only do this if we're already in place active.
@@ -1004,9 +1004,7 @@ public partial class Control
             return HRESULT.S_OK;
         }
 
-        /// <summary>
-        ///  Implements IPersistStreamInit::IsDirty.
-        /// </summary>
+        /// <inheritdoc cref="IPersistStorage.IsDirty"/>
         internal HRESULT IsDirty() => _activeXState[s_isDirty] ? HRESULT.S_OK : HRESULT.S_FALSE;
 
         /// <summary>
@@ -1034,9 +1032,7 @@ public partial class Control
                 || property.GetValue(_control) is ISerializable;
         }
 
-        /// <summary>
-        ///  Implements IPersistStorage::Load
-        /// </summary>
+        /// <inheritdoc cref="IPersistStorage.Load(IStorage*)"/>
         internal HRESULT Load(IStorage* stg)
         {
             using ComScope<IStream> stream = new(null);
@@ -1065,9 +1061,7 @@ public partial class Control
             return hr;
         }
 
-        /// <summary>
-        ///  Implements IPersistStreamInit::Load
-        /// </summary>
+        /// <inheritdoc cref="IPersistStreamInit.Load(IStream*)"/>
         internal void Load(IStream* stream)
         {
             // We do everything through property bags because we support full fidelity
@@ -1077,9 +1071,7 @@ public partial class Control
             Load(ComHelpers.GetComPointer<IPropertyBag>(bagStream), errorLog: null);
         }
 
-        /// <summary>
-        ///  Implements IPersistPropertyBag::Load
-        /// </summary>
+        /// <inheritdoc cref="IPersistPropertyBag.Load(IPropertyBag*, IErrorLog*)"/>
         internal unsafe void Load(IPropertyBag* propertyBag, IErrorLog* errorLog)
         {
             PropertyDescriptorCollection props = TypeDescriptor.GetProperties(
@@ -1401,9 +1393,7 @@ public partial class Control
             Y = (HiMetricPerInch * y + (LogPixels.Y >> 1)) / LogPixels.Y
         };
 
-        /// <summary>
-        ///  Our implementation of IQuickActivate::QuickActivate
-        /// </summary>
+        /// <inheritdoc cref="IQuickActivate.QuickActivate(QACONTAINER*, QACONTROL*)"/>
         internal unsafe HRESULT QuickActivate(QACONTAINER* pQaContainer, QACONTROL* pQaControl)
         {
             if (pQaControl is null)
@@ -1461,9 +1451,7 @@ public partial class Control
             if ((pQaContainer->pUnkEventSink is not null) && (_control is UserControl))
             {
                 // Check if this control exposes events to COM.
-                Type? eventInterface = GetDefaultEventsInterface(_control.GetType());
-
-                if (eventInterface is not null)
+                if (GetDefaultEventsInterface(_control.GetType()) is { } eventInterface)
                 {
                     // Control doesn't explicitly implement IConnectionPointContainer, but it is generated with a CCW by
                     // COM interop.
@@ -1481,43 +1469,27 @@ public partial class Control
                 }
             }
 
-            if (pQaContainer->pPropertyNotifySink is not null)
-            {
-                pQaContainer->pPropertyNotifySink->Release();
-            }
-
-            if (pQaContainer->pUnkEventSink is not null)
-            {
-                pQaContainer->pUnkEventSink->Release();
-            }
-
             return HRESULT.S_OK;
-        }
 
-        /// <summary>
-        ///  Return the default COM events interface declared on a .NET class.
-        ///  This looks for the ComSourceInterfacesAttribute and returns the .NET
-        ///  interface type of the first interface declared.
-        /// </summary>
-        private static Type? GetDefaultEventsInterface(Type controlType)
-        {
-            Type? eventInterface = null;
-            object[] custom = controlType.GetCustomAttributes(typeof(ComSourceInterfacesAttribute), inherit: false);
-
-            if (custom.Length > 0)
+            // Get the default COM events interface declared on a .NET class.
+            static Type? GetDefaultEventsInterface(Type controlType)
             {
-                ComSourceInterfacesAttribute coms = (ComSourceInterfacesAttribute)custom[0];
-                string eventName = coms.Value.Split('\0')[0];
-                eventInterface = controlType.Module.Assembly.GetType(eventName, throwOnError: false);
-                eventInterface ??= Type.GetType(eventName, throwOnError: false);
-            }
+                Type? eventInterface = null;
 
-            return eventInterface;
+                // Get the first declared interface, if any.
+                if (controlType.GetCustomAttributes<ComSourceInterfacesAttribute>(inherit: false).FirstOrDefault()
+                    is { } comSourceInterfaces)
+                {
+                    string eventName = comSourceInterfaces.Value.Split('\0')[0];
+                    eventInterface = controlType.Module.Assembly.GetType(eventName, throwOnError: false);
+                    eventInterface ??= Type.GetType(eventName, throwOnError: false);
+                }
+
+                return eventInterface;
+            }
         }
 
-        /// <summary>
-        ///  Implements IPersistStorage::Save
-        /// </summary>
+        /// <inheritdoc cref="IPersistStorage.Save(IStorage*, BOOL)"/>
         internal HRESULT Save(IStorage* storage, BOOL fSameAsLoad)
         {
             using ComScope<IStream> stream = new(null);
@@ -1538,9 +1510,7 @@ public partial class Control
             return hr;
         }
 
-        /// <summary>
-        ///  Implements IPersistStreamInit::Save
-        /// </summary>
+        /// <inheritdoc cref="IPersistStreamInit.Save(IStream*, BOOL)"/>
         internal void Save(IStream* stream, BOOL fClearDirty)
         {
             // We do everything through property bags because we support full fidelity in them.
@@ -1550,9 +1520,7 @@ public partial class Control
             bagStream.Write(stream);
         }
 
-        /// <summary>
-        ///  Implements IPersistPropertyBag::Save. Releases <paramref name="propertyBag"/> when finished.
-        /// </summary>
+        /// <inheritdoc cref="IPersistPropertyBag.Save(IPropertyBag*, BOOL, BOOL)"/>
         internal void Save(IPropertyBag* propertyBag, BOOL clearDirty, BOOL saveAllProperties)
         {
             PropertyDescriptorCollection props = TypeDescriptor.GetProperties(
@@ -1655,9 +1623,7 @@ public partial class Control
             holder.Value->SendOnSave();
         }
 
-        /// <summary>
-        ///  Implements IViewObject2::SetAdvise.
-        /// </summary>
+        /// <inheritdoc cref="IViewObject.SetAdvise(DVASPECT, uint, IAdviseSink*)"/>
         internal HRESULT SetAdvise(DVASPECT aspects, ADVF advf, IAdviseSink* pAdvSink)
         {
             // If it's not a content aspect, we don't support it.
@@ -1675,9 +1641,14 @@ public partial class Control
                 _viewAdviseSink->Release();
             }
 
+            if (pAdvSink is not null)
+            {
+                pAdvSink->AddRef();
+            }
+
             _viewAdviseSink = pAdvSink;
 
-            // prime them if they want it [we need to store this so they can get flags later]
+            // Prime them if they want it [we need to store this so they can get flags later]
             if (_activeXState[s_viewAdvisePrimeFirst])
             {
                 ViewChanged();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control_ActiveXControlInterfaces.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control_ActiveXControlInterfaces.cs
@@ -485,12 +485,14 @@ public unsafe partial class Control :
         return HRESULT.S_OK;
     }
 
+    /// <inheritdoc cref="IPersistPropertyBag.InitNew"/>
     HRESULT IPersistPropertyBag.Interface.InitNew()
     {
         Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "AxSource:IPersistPropertyBag.InitNew");
         return HRESULT.S_OK;
     }
 
+    /// <inheritdoc cref="IPersist.GetClassID(Guid*)"/>
     HRESULT IPersistPropertyBag.Interface.GetClassID(Guid* pClassID)
     {
         if (pClassID is null)
@@ -503,6 +505,7 @@ public unsafe partial class Control :
         return HRESULT.S_OK;
     }
 
+    /// <inheritdoc cref="IPersistPropertyBag.Load(IPropertyBag*, IErrorLog*)"/>
     HRESULT IPersistPropertyBag.Interface.Load(IPropertyBag* pPropBag, IErrorLog* pErrorLog)
     {
         Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "AxSource:Load (IPersistPropertyBag)");
@@ -512,6 +515,7 @@ public unsafe partial class Control :
         return HRESULT.S_OK;
     }
 
+    /// <inheritdoc cref="IPersistPropertyBag.Save(IPropertyBag*, BOOL, BOOL)"/>
     HRESULT IPersistPropertyBag.Interface.Save(IPropertyBag* pPropBag, BOOL fClearDirty, BOOL fSaveAllProperties)
     {
         Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "AxSource:Save (IPersistPropertyBag)");
@@ -521,6 +525,7 @@ public unsafe partial class Control :
         return HRESULT.S_OK;
     }
 
+    /// <inheritdoc cref="IPersist.GetClassID(Guid*)"/>
     HRESULT IPersistStorage.Interface.GetClassID(Guid* pClassID)
     {
         if (pClassID is null)
@@ -533,18 +538,21 @@ public unsafe partial class Control :
         return HRESULT.S_OK;
     }
 
+    /// <inheritdoc cref="IPersistStorage.IsDirty"/>
     HRESULT IPersistStorage.Interface.IsDirty()
     {
         Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "AxSource:IPersistStorage.IsDirty");
         return ActiveXInstance.IsDirty();
     }
 
+    /// <inheritdoc cref="IPersistStorage.InitNew(IStorage*)"/>
     HRESULT IPersistStorage.Interface.InitNew(IStorage* pStg)
     {
         Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "AxSource:IPersistStorage.InitNew");
         return HRESULT.S_OK;
     }
 
+    /// <inheritdoc cref="IPersistStorage.Load(IStorage*)"/>
     HRESULT IPersistStorage.Interface.Load(IStorage* pStg)
     {
         if (pStg is null)
@@ -559,6 +567,7 @@ public unsafe partial class Control :
         return result;
     }
 
+    /// <inheritdoc cref="IPersistStorage.Save(IStorage*, BOOL)"/>
     HRESULT IPersistStorage.Interface.Save(IStorage* pStgSave, BOOL fSameAsLoad)
     {
         if (pStgSave is null)
@@ -573,18 +582,21 @@ public unsafe partial class Control :
         return result;
     }
 
+    /// <inheritdoc cref="IPersistStorage.SaveCompleted(IStorage*)"/>
     HRESULT IPersistStorage.Interface.SaveCompleted(IStorage* pStgNew)
     {
         Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "AxSource:IPersistStorage.SaveCompleted");
         return HRESULT.S_OK;
     }
 
+    /// <inheritdoc cref="IPersistStorage.HandsOffStorage"/>
     HRESULT IPersistStorage.Interface.HandsOffStorage()
     {
         Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "AxSource:IPersistStorage.HandsOffStorage");
         return HRESULT.S_OK;
     }
 
+    /// <inheritdoc cref="IPersist.GetClassID(Guid*)"/>
     HRESULT IPersistStreamInit.Interface.GetClassID(Guid* pClassID)
     {
         if (pClassID is null)
@@ -597,12 +609,14 @@ public unsafe partial class Control :
         return HRESULT.S_OK;
     }
 
+    /// <inheritdoc cref="IPersistStorage.IsDirty"/>
     HRESULT IPersistStreamInit.Interface.IsDirty()
     {
         Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "AxSource:IPersistStreamInit.IsDirty");
         return ActiveXInstance.IsDirty();
     }
 
+    /// <inheritdoc cref="IPersistStreamInit.Load(IStream*)"/>
     HRESULT IPersistStreamInit.Interface.Load(IStream* pStm)
     {
         if (pStm is null)
@@ -617,6 +631,7 @@ public unsafe partial class Control :
         return HRESULT.S_OK;
     }
 
+    /// <inheritdoc cref="IPersistStreamInit.Save(IStream*, BOOL)"/>
     HRESULT IPersistStreamInit.Interface.Save(IStream* pStm, BOOL fClearDirty)
     {
         if (pStm is null)
@@ -631,18 +646,21 @@ public unsafe partial class Control :
         return HRESULT.S_OK;
     }
 
+    /// <inheritdoc cref="IPersistStreamInit.GetSizeMax(ulong*)"/>
     HRESULT IPersistStreamInit.Interface.GetSizeMax(ulong* pCbSize)
     {
         Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "AxSource:GetSizeMax");
         return HRESULT.S_OK;
     }
 
+    /// <inheritdoc cref="IPersistStreamInit.InitNew"/>
     HRESULT IPersistStreamInit.Interface.InitNew()
     {
         Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "AxSource:IPersistStreamInit.InitNew");
         return HRESULT.S_OK;
     }
 
+    /// <inheritdoc cref="IQuickActivate.QuickActivate(QACONTAINER*, QACONTROL*)"/>
     HRESULT IQuickActivate.Interface.QuickActivate(QACONTAINER* pQaContainer, QACONTROL* pQaControl)
     {
         Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "AxSource:QuickActivate");
@@ -652,6 +670,7 @@ public unsafe partial class Control :
         return hr;
     }
 
+    /// <inheritdoc cref="IQuickActivate.SetContentExtent(SIZE*)"/>
     HRESULT IQuickActivate.Interface.SetContentExtent(SIZE* pSizel)
     {
         if (pSizel is null)
@@ -666,6 +685,7 @@ public unsafe partial class Control :
         return HRESULT.S_OK;
     }
 
+    /// <inheritdoc cref="IQuickActivate.GetContentExtent(SIZE*)"/>
     HRESULT IQuickActivate.Interface.GetContentExtent(SIZE* pSizel)
     {
         if (pSizel is null)
@@ -680,6 +700,7 @@ public unsafe partial class Control :
         return HRESULT.S_OK;
     }
 
+    /// <inheritdoc cref="IViewObject.Draw(DVASPECT, int, void*, DVTARGETDEVICE*, HDC, HDC, RECTL*, RECTL*, nint, nuint)"/>
     HRESULT IViewObject.Interface.Draw(
         DVASPECT dwDrawAspect,
         int lindex,
@@ -710,6 +731,7 @@ public unsafe partial class Control :
         return HRESULT.S_OK;
     }
 
+    /// <inheritdoc cref="IViewObject.GetColorSet(DVASPECT, int, void*, DVTARGETDEVICE*, HDC, LOGPALETTE**)"/>
     HRESULT IViewObject.Interface.GetColorSet(
         DVASPECT dwDrawAspect,
         int lindex,
@@ -724,30 +746,35 @@ public unsafe partial class Control :
         return HRESULT.E_NOTIMPL;
     }
 
+    /// <inheritdoc cref="IViewObject.Freeze(DVASPECT, int, void*, uint*)"/>
     HRESULT IViewObject.Interface.Freeze(DVASPECT dwDrawAspect, int lindex, void* pvAspect, uint* pdwFreeze)
     {
         Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "AxSource:Freezes");
         return HRESULT.E_NOTIMPL;
     }
 
+    /// <inheritdoc cref="IViewObject.Unfreeze(uint)"/>
     HRESULT IViewObject.Interface.Unfreeze(uint dwFreeze)
     {
         Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "AxSource:Unfreeze");
         return HRESULT.E_NOTIMPL;
     }
 
+    /// <inheritdoc cref="IViewObject.SetAdvise(DVASPECT, uint, IAdviseSink*)"/>
     HRESULT IViewObject.Interface.SetAdvise(DVASPECT aspects, uint advf, IAdviseSink* pAdvSink)
     {
         Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "AxSource:SetAdvise");
         return ActiveXInstance.SetAdvise(aspects, (ADVF)advf, pAdvSink);
     }
 
+    /// <inheritdoc cref="IViewObject.GetAdvise(uint*, uint*, IAdviseSink**)"/>
     HRESULT IViewObject.Interface.GetAdvise(uint* pAspects, uint* pAdvf, IAdviseSink** ppAdvSink)
     {
         Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "AxSource:GetAdvise");
         return ActiveXInstance.GetAdvise((DVASPECT*)pAspects, (ADVF*)pAdvf, ppAdvSink);
     }
 
+    /// <inheritdoc cref="IViewObject.Draw(DVASPECT, int, void*, DVTARGETDEVICE*, HDC, HDC, RECTL*, RECTL*, nint, nuint)"/>
     HRESULT IViewObject2.Interface.Draw(
         DVASPECT dwDrawAspect,
         int lindex,
@@ -771,6 +798,7 @@ public unsafe partial class Control :
             pfnContinue,
             dwContinue);
 
+    /// <inheritdoc cref="IViewObject.GetColorSet(DVASPECT, int, void*, DVTARGETDEVICE*, HDC, LOGPALETTE**)"/>
     HRESULT IViewObject2.Interface.GetColorSet(
         DVASPECT dwDrawAspect,
         int lindex,
@@ -780,18 +808,23 @@ public unsafe partial class Control :
         LOGPALETTE** ppColorSet)
         => ((IViewObject.Interface)this).GetColorSet(dwDrawAspect, lindex, pvAspect, ptd, hdcTargetDev, ppColorSet);
 
+    /// <inheritdoc cref="IViewObject.Freeze(DVASPECT, int, void*, uint*)"/>
     HRESULT IViewObject2.Interface.Freeze(DVASPECT dwDrawAspect, int lindex, void* pvAspect, uint* pdwFreeze)
         => ((IViewObject.Interface)this).Freeze(dwDrawAspect, lindex, pvAspect, pdwFreeze);
 
+    /// <inheritdoc cref="IViewObject.Unfreeze(uint)"/>
     HRESULT IViewObject2.Interface.Unfreeze(uint dwFreeze)
         => ((IViewObject.Interface)this).Unfreeze(dwFreeze);
 
+    /// <inheritdoc cref="IViewObject.SetAdvise(DVASPECT, uint, IAdviseSink*)"/>
     HRESULT IViewObject2.Interface.SetAdvise(DVASPECT aspects, uint advf, IAdviseSink* pAdvSink)
         => ((IViewObject.Interface)this).SetAdvise(aspects, advf, pAdvSink);
 
+    /// <inheritdoc cref="IViewObject.GetAdvise(uint*, uint*, IAdviseSink**)"/>
     HRESULT IViewObject2.Interface.GetAdvise(uint* pAspects, uint* pAdvf, IAdviseSink** ppAdvSink)
         => ((IViewObject.Interface)this).GetAdvise(pAspects, pAdvf, ppAdvSink);
 
+    /// <inheritdoc cref="IOleObject.GetExtent(DVASPECT, SIZE*)"/>
     HRESULT IViewObject2.Interface.GetExtent(DVASPECT dwDrawAspect, int lindex, DVTARGETDEVICE* ptd, SIZE* lpsizel)
-        => ((IOleObject.Interface)this).GetExtent((DVASPECT)dwDrawAspect, lpsizel);
+        => ((IOleObject.Interface)this).GetExtent(dwDrawAspect, lpsizel);
 }


### PR DESCRIPTION
This is the last audit change of `ActiveXImpl`. Changes were vetted against docs and MFC implementations.

- `QuickActivate`` was releasing pointers it shouldn't have been.
- `SetAdvise` and `GetAdvise` were not AddRef'ing appropriately.
- Update comments.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9634)