### PR TITLE
Enable nullability in FontEditor and FontNameEditor

### DIFF
--- a/src/System.Windows.Forms.Design/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms.Design/src/PublicAPI.Shipped.txt
@@ -52,8 +52,8 @@
 ~override System.Drawing.Design.ContentAlignmentEditor.GetEditStyle(System.ComponentModel.ITypeDescriptorContext context) -> System.Drawing.Design.UITypeEditorEditStyle
 ~override System.Drawing.Design.CursorEditor.EditValue(System.ComponentModel.ITypeDescriptorContext context, System.IServiceProvider provider, object value) -> object
 ~override System.Drawing.Design.CursorEditor.GetEditStyle(System.ComponentModel.ITypeDescriptorContext context) -> System.Drawing.Design.UITypeEditorEditStyle
-~override System.Drawing.Design.FontEditor.EditValue(System.ComponentModel.ITypeDescriptorContext context, System.IServiceProvider provider, object value) -> object
-~override System.Drawing.Design.FontEditor.GetEditStyle(System.ComponentModel.ITypeDescriptorContext context) -> System.Drawing.Design.UITypeEditorEditStyle
+override System.Drawing.Design.FontEditor.EditValue(System.ComponentModel.ITypeDescriptorContext? context, System.IServiceProvider! provider, object? value) -> object?
+override System.Drawing.Design.FontEditor.GetEditStyle(System.ComponentModel.ITypeDescriptorContext? context) -> System.Drawing.Design.UITypeEditorEditStyle
 ~override System.Drawing.Design.FontNameEditor.GetPaintValueSupported(System.ComponentModel.ITypeDescriptorContext context) -> bool
 ~override System.Drawing.Design.FontNameEditor.PaintValue(System.Drawing.Design.PaintValueEventArgs e) -> void
 ~override System.Drawing.Design.ToolboxItem.Equals(object obj) -> bool

--- a/src/System.Windows.Forms.Design/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms.Design/src/PublicAPI.Shipped.txt
@@ -54,8 +54,8 @@
 ~override System.Drawing.Design.CursorEditor.GetEditStyle(System.ComponentModel.ITypeDescriptorContext context) -> System.Drawing.Design.UITypeEditorEditStyle
 override System.Drawing.Design.FontEditor.EditValue(System.ComponentModel.ITypeDescriptorContext? context, System.IServiceProvider! provider, object? value) -> object?
 override System.Drawing.Design.FontEditor.GetEditStyle(System.ComponentModel.ITypeDescriptorContext? context) -> System.Drawing.Design.UITypeEditorEditStyle
-~override System.Drawing.Design.FontNameEditor.GetPaintValueSupported(System.ComponentModel.ITypeDescriptorContext context) -> bool
-~override System.Drawing.Design.FontNameEditor.PaintValue(System.Drawing.Design.PaintValueEventArgs e) -> void
+override System.Drawing.Design.FontNameEditor.GetPaintValueSupported(System.ComponentModel.ITypeDescriptorContext? context) -> bool
+override System.Drawing.Design.FontNameEditor.PaintValue(System.Drawing.Design.PaintValueEventArgs! e) -> void
 ~override System.Drawing.Design.ToolboxItem.Equals(object obj) -> bool
 ~override System.Drawing.Design.ToolboxItem.ToString() -> string
 ~override System.Windows.Forms.Design.AnchorEditor.EditValue(System.ComponentModel.ITypeDescriptorContext context, System.IServiceProvider provider, object value) -> object

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/FontEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/FontEditor.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 using System.Windows.Forms;
 using System.Windows.Forms.Design;
@@ -16,12 +14,12 @@ namespace System.Drawing.Design;
 [CLSCompliant(false)]
 public class FontEditor : UITypeEditor
 {
-    private FontDialog _fontDialog;
+    private FontDialog? _fontDialog;
 
-    public override object EditValue(ITypeDescriptorContext context, IServiceProvider provider, object value)
+    public override object? EditValue(ITypeDescriptorContext? context, IServiceProvider provider, object? value)
     {
         // Even though we don't use the editor service this is historically what we did.
-        if (!provider.TryGetService(out IWindowsFormsEditorService _))
+        if (!provider.TryGetService(out IWindowsFormsEditorService? _))
         {
             return value;
         }
@@ -57,5 +55,5 @@ public class FontEditor : UITypeEditor
         return value;
     }
 
-    public override UITypeEditorEditStyle GetEditStyle(ITypeDescriptorContext context) => UITypeEditorEditStyle.Modal;
+    public override UITypeEditorEditStyle GetEditStyle(ITypeDescriptorContext? context) => UITypeEditorEditStyle.Modal;
 }

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/FontNameEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/FontNameEditor.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 
 namespace System.Drawing.Design;
@@ -15,7 +13,7 @@ public class FontNameEditor : UITypeEditor
 {
     private const float ScaleFactor = 1.5f;
 
-    private static readonly FontStyle[] s_fontStyles = new[]
+    private static readonly FontStyle[] s_fontStyles =
     {
          FontStyle.Regular,
          FontStyle.Italic,
@@ -27,12 +25,12 @@ public class FontNameEditor : UITypeEditor
     /// <returns>
     ///  <see langword="true" /> as this editor supports the painting of a representation of an object's value.
     /// </returns>
-    public override bool GetPaintValueSupported(ITypeDescriptorContext context) => true;
+    public override bool GetPaintValueSupported(ITypeDescriptorContext? context) => true;
 
     /// <inheritdoc />
     public override void PaintValue(PaintValueEventArgs e)
     {
-        string fontName = e.Value as string;
+        string? fontName = e.Value as string;
         if (string.IsNullOrWhiteSpace(fontName))
         {
             // Don't draw anything if we don't have a value.
@@ -41,7 +39,7 @@ public class FontNameEditor : UITypeEditor
 
         try
         {
-            using var fontFamily = new FontFamily(fontName);
+            using FontFamily fontFamily = new(fontName);
             e.Graphics.FillRectangle(SystemBrushes.ActiveCaption, e.Bounds);
 
             // Believe it or not, not all font families have a "normal" face. Try normal, then italic,
@@ -72,9 +70,9 @@ public class FontNameEditor : UITypeEditor
     private static void DrawFontSample(PaintValueEventArgs e, FontFamily fontFamily, FontStyle fontStyle)
     {
         float fontSize = e.Bounds.Height / ScaleFactor;
-        using var font = new Font(fontFamily, fontSize, fontStyle, GraphicsUnit.Pixel);
+        using Font font = new(fontFamily, fontSize, fontStyle, GraphicsUnit.Pixel);
 
-        var format = new StringFormat(StringFormatFlags.NoWrap | StringFormatFlags.NoFontFallback)
+        StringFormat format = new(StringFormatFlags.NoWrap | StringFormatFlags.NoFontFallback)
         {
             LineAlignment = StringAlignment.Far
         };


### PR DESCRIPTION
## Proposed changes

- Enable nullability in `FontEditor`
- Enable nullability in `FontNameEditor` and use target-typed new

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9636)