### PR TITLE
Fix bugs in ResourceCodeDomSerializer.SerializationResourceManager

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ResourceCodeDomSerializer.SerializationResourceManager.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ResourceCodeDomSerializer.SerializationResourceManager.cs
@@ -227,7 +227,7 @@ internal partial class ResourceCodeDomSerializer
             Dictionary<string, object> resourceSet = GetResourceSet(culture);
             if (resourceSet is not null && resourceSet.TryGetValue(name, out object parentValue))
             {
-                return !parentValue.Equals(value) || parentValue is null ? CompareValue.Different : CompareValue.Same;
+                return parentValue is null || !parentValue.Equals(value) ? CompareValue.Different : CompareValue.Same;
             }
             else if (culture.Equals(CultureInfo.InvariantCulture))
             {


### PR DESCRIPTION
As discussed in #9457.

#8332 introduced bugs in `ResourceCodeDomSerializer.SerializationResourceManager`, in method `GetResourceSet`. When we fail to get a resource reader, the original code used to return a resource set for the invariant culture, and null otherwise. After #8332,,

- we're returning `null` the first time we fill the `ResourceTable` cache
- for the non-invariant culture case, we started filling the `ResourceTable` cache with a static dictionary,  which looks like a pretty big issue

These bugs were introduced in .Net 8 and we still have a chance to fix them before the release

@dreddy-work, @elachlan 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9642)