### PR TITLE
Handle `ref` to `in` change

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -8,8 +8,7 @@
     <PreReleaseVersionLabel>rc</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
-    <!-- Use the compiler in the CLI instead of in the sdk, since the sdk one doesn't work with netcoreapp5.0 yet -->
-    <UsingToolMicrosoftNetCompilers>false</UsingToolMicrosoftNetCompilers>
+    <UsingToolMicrosoftNetCompilers>true</UsingToolMicrosoftNetCompilers>
   </PropertyGroup>
   <!-- Below have corresponding entries in Versions.Details.XML because they are updated via Maestro -->
   <PropertyGroup>
@@ -91,7 +90,7 @@
     <CSharpIsNullAnalyzersVersion>0.1.329</CSharpIsNullAnalyzersVersion>
     <DotNetAnalyzersDocumentationAnalyzersVersion>1.0.0-beta.59</DotNetAnalyzersDocumentationAnalyzersVersion>
     <MicrosoftCodeAnalysisAnalyzersVersion>3.3.5-beta1.23327.3</MicrosoftCodeAnalysisAnalyzersVersion>
-    <MicrosoftCodeAnalysisCommonPackageVersion>4.4.0</MicrosoftCodeAnalysisCommonPackageVersion>
+    <MicrosoftCodeAnalysisCommonPackageVersion>4.8.0-1.23378.8</MicrosoftCodeAnalysisCommonPackageVersion>
     <MicrosoftCodeAnalysisCSharpPackageVersion>$(MicrosoftCodeAnalysisCommonPackageVersion)</MicrosoftCodeAnalysisCSharpPackageVersion>
     <MicrosoftCodeAnalysisVisualBasicPackageVersion>$(MicrosoftCodeAnalysisCommonPackageVersion)</MicrosoftCodeAnalysisVisualBasicPackageVersion>
     <MicrosoftCodeAnalysisCSharpWorkspacesVersion>$(MicrosoftCodeAnalysisCommonPackageVersion)</MicrosoftCodeAnalysisCSharpWorkspacesVersion>
@@ -99,6 +98,7 @@
     <MicrosoftCodeAnalysisPackagesVersion>1.1.2-beta1.23322.1</MicrosoftCodeAnalysisPackagesVersion>
     <MicrosoftCodeAnalysisPublicApiAnalyzersVersion>$(MicrosoftCodeAnalysisAnalyzersVersion)</MicrosoftCodeAnalysisPublicApiAnalyzersVersion>
     <MicrosoftCodeAnalysisNetAnalyzersVersion>8.0.0-preview.23327.3</MicrosoftCodeAnalysisNetAnalyzersVersion>
+    <MicrosoftNetCompilersToolsetVersion>4.8.0-1.23403.1</MicrosoftNetCompilersToolsetVersion>
     <StyleCopAnalyzersVersion>1.2.0-beta.507</StyleCopAnalyzersVersion>
   </PropertyGroup>
   <!-- Additional unchanging dependencies -->

--- a/src/System.Windows.Forms.Primitives/src/Interop/WinFormsComWrappers.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/WinFormsComWrappers.cs
@@ -47,7 +47,7 @@ internal partial class Interop
                 || flags == CreateObjectFlags.None
                 || flags == CreateObjectFlags.Unwrap);
 
-            int hr = Marshal.QueryInterface(externalComObject, ref IID.GetRef<IErrorInfo>(), out IntPtr errorInfoComObject);
+            int hr = Marshal.QueryInterface(externalComObject, in IID.GetRef<IErrorInfo>(), out IntPtr errorInfoComObject);
             if (hr == S_OK)
             {
                 Marshal.Release(externalComObject);

--- a/src/System.Windows.Forms.Primitives/src/System.Windows.Forms.Primitives.csproj
+++ b/src/System.Windows.Forms.Primitives/src/System.Windows.Forms.Primitives.csproj
@@ -21,6 +21,11 @@
       See https://github.com/dotnet/winforms/issues/4649
     -->
     <NoWarn>$(NoWarn);IL2026;IL2050</NoWarn>
+    <!--
+      Libraries code has changed a number of APIs from `ref` to `in`. CSWin32 generates code that passes by `ref`
+      to some of these. Disabling for now until we can get https://github.com/microsoft/CsWin32/issues/1014 resolved.
+    -->
+    <NoWarn>$(NoWarn);CS9195</NoWarn>
     <Deterministic>true</Deterministic>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <UsePublicApiAnalyzers>true</UsePublicApiAnalyzers>

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/Foundation/BSTR.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/Foundation/BSTR.cs
@@ -19,7 +19,7 @@ internal readonly unsafe partial struct BSTR : IDisposable
         if (Value is not null)
         {
             Marshal.FreeBSTR((nint)Value);
-            Unsafe.AsRef(this) = default;
+            Unsafe.AsRef(in this) = default;
         }
     }
 

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/Foundation/ComScope.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/Foundation/ComScope.cs
@@ -46,10 +46,10 @@ internal readonly unsafe ref struct ComScope<T> where T : unmanaged, IComIID
     public static implicit operator nint(in ComScope<T> scope) => scope._value;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static implicit operator T**(in ComScope<T> scope) => (T**)Unsafe.AsPointer(ref Unsafe.AsRef(scope._value));
+    public static implicit operator T**(in ComScope<T> scope) => (T**)Unsafe.AsPointer(ref Unsafe.AsRef(in scope._value));
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static implicit operator void**(in ComScope<T> scope) => (void**)Unsafe.AsPointer(ref Unsafe.AsRef(scope._value));
+    public static implicit operator void**(in ComScope<T> scope) => (void**)Unsafe.AsPointer(ref Unsafe.AsRef(in scope._value));
 
     public bool IsNull => _value == 0;
 

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.FillRect.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.FillRect.cs
@@ -8,7 +8,7 @@ internal static partial class PInvoke
     public static int FillRect<T>(T hDC, ref RECT lprc, HBRUSH hbr)
         where T : IHandle<HDC>
     {
-        int result = FillRect(hDC.Handle, ref lprc, hbr);
+        int result = FillRect(hDC.Handle, in lprc, hbr);
         GC.KeepAlive(hDC.Wrapper);
         return result;
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
@@ -1693,7 +1693,7 @@ public abstract partial class TextBoxBase : Control
 
                 try
                 {
-                    Marshal.QueryInterface(editOlePtr, ref iiTextDocumentGuid, out iTextDocument);
+                    Marshal.QueryInterface(editOlePtr, in iiTextDocumentGuid, out iTextDocument);
 
                     if (Marshal.GetObjectForIUnknown(iTextDocument) is Richedit.ITextDocument textDocument)
                     {


### PR DESCRIPTION
A number of Libarary APIs have had their parameters changed from `ref` to `in` (or `readonly ref`).

This change modifies code that we control and disables the "passing ref to in" warning for the interop assembly until we can get https://github.com/microsoft/CsWin32/issues/1014 resolved.

This change requires a more current Roslyn build and as such I've updated it. Note that VS Intellisense does not support this new feature yet. You can filter out intellisense errors by selecting "Build Only" in the error pane in the meantime (this will not remove red squiggles unfortunately).

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9654)