### PR TITLE
Fix nullability annotations of ResXDataNode

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -4039,9 +4039,9 @@ System.Resources.ResXDataNode.Comment.set -> void
 System.Resources.ResXDataNode.FileRef.get -> System.Resources.ResXFileRef?
 System.Resources.ResXDataNode.GetNodePosition() -> System.Drawing.Point
 System.Resources.ResXDataNode.GetValue(System.ComponentModel.Design.ITypeResolutionService? typeResolver) -> object?
-System.Resources.ResXDataNode.GetValue(System.Reflection.AssemblyName![]! names) -> object?
+System.Resources.ResXDataNode.GetValue(System.Reflection.AssemblyName![]? names) -> object?
 System.Resources.ResXDataNode.GetValueTypeName(System.ComponentModel.Design.ITypeResolutionService? typeResolver) -> string?
-System.Resources.ResXDataNode.GetValueTypeName(System.Reflection.AssemblyName![]! names) -> string?
+System.Resources.ResXDataNode.GetValueTypeName(System.Reflection.AssemblyName![]? names) -> string?
 System.Resources.ResXDataNode.Name.get -> string!
 System.Resources.ResXDataNode.Name.set -> void
 System.Resources.ResXDataNode.ResXDataNode(string! name, object? value) -> void

--- a/src/System.Windows.Forms/src/System/Resources/AssemblyNamesTypeResolutionService.cs
+++ b/src/System.Windows.Forms/src/System/Resources/AssemblyNamesTypeResolutionService.cs
@@ -9,14 +9,14 @@ namespace System.Resources;
 
 internal class AssemblyNamesTypeResolutionService : ITypeResolutionService
 {
-    private AssemblyName[] _names;
+    private AssemblyName[]? _names;
     private ConcurrentDictionary<AssemblyName, Assembly>? _cachedAssemblies;
     private ConcurrentDictionary<string, Type>? _cachedTypes;
 
     private static readonly string s_dotNetPath = Path.Combine(Environment.GetEnvironmentVariable("ProgramFiles") ?? string.Empty, "dotnet\\shared");
     private static readonly string s_dotNetPathX86 = Path.Combine(Environment.GetEnvironmentVariable("ProgramFiles(x86)") ?? string.Empty, "dotnet\\shared");
 
-    internal AssemblyNamesTypeResolutionService(AssemblyName[] names) => _names = names;
+    internal AssemblyNamesTypeResolutionService(AssemblyName[]? names) => _names = names;
 
     public Assembly? GetAssembly(AssemblyName name) => GetAssembly(name, true);
 

--- a/src/System.Windows.Forms/src/System/Resources/ResXDataNode.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResXDataNode.cs
@@ -589,7 +589,7 @@ public sealed class ResXDataNode : ISerializable
     /// <summary>
     ///  Retrieves the type name for the value by examining the specified assemblies.
     /// </summary>
-    public string? GetValueTypeName(AssemblyName[] names)
+    public string? GetValueTypeName(AssemblyName[]? names)
         => GetValueTypeName(new AssemblyNamesTypeResolutionService(names));
 
     /// <summary>
@@ -632,7 +632,7 @@ public sealed class ResXDataNode : ISerializable
     /// <summary>
     ///  Retrieves the object that is stored by this node by searching the specified assemblies.
     /// </summary>
-    public object? GetValue(AssemblyName[] names) => GetValue(new AssemblyNamesTypeResolutionService(names));
+    public object? GetValue(AssemblyName[]? names) => GetValue(new AssemblyNamesTypeResolutionService(names));
 
     private static byte[] FromBase64WrappedString(string text)
     {


### PR DESCRIPTION
This is extracted from #9663. That PR is bound to be merged in .Net 9, but hopefully we can still fix the annotation of ResXDataNode before it's released in .Net 8
@dreddy-work 

## Proposed changes

- Fix nullability annotations of ResXDataNode


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9667)