### PR TITLE
Update .editorconfig to add comment for file_header_template

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,6 +14,7 @@ indent_size = 4
 [*.json]
 indent_size = 2
 
+# Bvc.dll crashed in the CI build when this rule is enabled for VB.
 # C# files
 [src/**/*.cs]
 file_header_template = Licensed to the .NET Foundation under one or more agreements.\nThe .NET Foundation licenses this file to you under the MIT license.


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Related #9615 


## Proposed changes

- when adding the file_header_template  for .vb in .editorconfig , the build error "[.dotnet\sdk\8.0.100-preview.6.23330.14\Roslyn\Microsoft.VisualBasic.Core.targets(43,5): error MSB6006: (NETCORE_ENGINEERING_TELEMETRY=Build) "vbc.dll" exited with code 1](https://dev.azure.com/dnceng-public/public/_build/results?buildId=358645&view=logs&j=fdea2036-e6b2-512d-a259-98f88c972586&t=e85b1de4-8dce-50bb-88c3-24524432e33a&l=176)." appeared, so remove the template for vb files and a comment for it.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9674)