### PR TITLE
Enable nullability in LoadedEventArgs

### DIFF
--- a/src/System.Windows.Forms.Design/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms.Design/src/PublicAPI.Shipped.txt
@@ -196,8 +196,8 @@ static System.ComponentModel.Design.ObjectSelectorEditor.ApplyTreeViewThemeStyle
 ~System.ComponentModel.Design.EventBindingService.GetService(System.Type serviceType) -> object
 System.ComponentModel.Design.InheritanceService.AddInheritedComponents(System.ComponentModel.IComponent! component, System.ComponentModel.IContainer! container) -> void
 System.ComponentModel.Design.InheritanceService.GetInheritanceAttribute(System.ComponentModel.IComponent! component) -> System.ComponentModel.InheritanceAttribute!
-~System.ComponentModel.Design.LoadedEventArgs.Errors.get -> System.Collections.ICollection
-~System.ComponentModel.Design.LoadedEventArgs.LoadedEventArgs(bool succeeded, System.Collections.ICollection errors) -> void
+System.ComponentModel.Design.LoadedEventArgs.Errors.get -> System.Collections.ICollection!
+System.ComponentModel.Design.LoadedEventArgs.LoadedEventArgs(bool succeeded, System.Collections.ICollection? errors) -> void
 ~System.ComponentModel.Design.MenuCommandService.FindCommand(System.ComponentModel.Design.CommandID commandID) -> System.ComponentModel.Design.MenuCommand
 ~System.ComponentModel.Design.MenuCommandService.FindCommand(System.Guid guid, int id) -> System.ComponentModel.Design.MenuCommand
 ~System.ComponentModel.Design.MenuCommandService.GetCommandList(System.Guid guid) -> System.Collections.ICollection

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/LoadedEventArgs.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/LoadedEventArgs.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.Collections;
 
 namespace System.ComponentModel.Design;
@@ -15,7 +13,7 @@ public sealed class LoadedEventArgs : EventArgs
     /// <summary>
     ///  Creates a new LoadedEventArgs object.
     /// </summary>
-    public LoadedEventArgs(bool succeeded, ICollection errors)
+    public LoadedEventArgs(bool succeeded, ICollection? errors)
     {
         HasSucceeded = succeeded;
         Errors = errors ?? Array.Empty<object>();


### PR DESCRIPTION
Sorry about the tiny PRs. I keep on looking for public types that are safe to annotate before .Net 8 cutoff, and push them as I find them.

## Proposed changes

- Enable nullability in `LoadedEventArgs`


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9692)