### PR TITLE
Fixing indeterminate image color

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripRenderer.cs
@@ -841,13 +841,27 @@ public abstract class ToolStripRenderer
 
         if (imageRect != Rectangle.Empty && image is not null)
         {
-            if (e.Item is not null && !e.Item.Enabled)
+            if (e.Item is not null)
             {
-                image = CreateDisabledImage(image, e.ImageAttributes);
+                if (!e.Item.Enabled)
+                {
+                    image = CreateDisabledImage(image, e.ImageAttributes);
+                }
+
+                if (SystemInformation.HighContrast && image is Bitmap bitmap)
+                {
+                    Color backgroundColor = e.Item.Selected ? SystemColors.Highlight : e.Item.BackColor;
+
+                    if (ControlPaint.IsDark(backgroundColor))
+                    {
+                        Image invertedImage = ControlPaint.CreateBitmapWithInvertedForeColor(bitmap, e.Item.BackColor);
+                        image = invertedImage;
+                    }
+                }
             }
 
             e.Graphics.DrawImage(image, imageRect, 0, 0, imageRect.Width,
-                imageRect.Height, GraphicsUnit.Pixel, e.ImageAttributes);
+            imageRect.Height, GraphicsUnit.Pixel, e.ImageAttributes);
         }
     }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #9166 


## Proposed changes

- Add HighContrast judgment when drawing indeterminate image in file ToolStripRenderer.cs
- When the item is selected or under HC black theme, revert the image color

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- The color contrast of indeterminate state icon can be showed clearly

## Regression? 

-  No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
**Windows 11 non-focused:**
![image](https://github.com/dotnet/winforms/assets/132890443/7431f34e-95e4-42d8-b9e9-6abb5e4a4597)

**Windows 11 mouse over:**
![image](https://github.com/dotnet/winforms/assets/132890443/83ff5a06-ffec-4e61-9e06-bcaf0fdadd14)

### After
![image](https://github.com/dotnet/winforms/assets/132890443/e133d8a0-839b-4d64-adb9-637ab605af92)


## Test methodology <!-- How did you ensure quality? -->

- Manually

## Test environment(s) <!-- Remove any that don't apply -->

- .net 8.0.0-rc.1.23409.17


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9710)