### PR TITLE
Use throw helpers for ArgumentOutOfRangeException

### DIFF
--- a/src/Common/tests/TestUtilities/ComparisonHelpers.cs
+++ b/src/Common/tests/TestUtilities/ComparisonHelpers.cs
@@ -10,10 +10,7 @@ public static class ComparisonHelpers
     public static bool EqualsInteger<T>(T x, T y, T variance)
         where T : struct, IBinaryInteger<T>
     {
-        if (variance < T.Zero)
-        {
-            throw new ArgumentOutOfRangeException(nameof(variance));
-        }
+        ArgumentOutOfRangeException.ThrowIfLessThan(variance, T.Zero);
 
         return T.Abs(x > y ? x - y : y - x) <= variance;
     }
@@ -21,10 +18,7 @@ public static class ComparisonHelpers
     public static bool EqualsFloating<T>(T x, T y, T variance)
         where T : struct, IFloatingPoint<T>
     {
-        if (variance < T.Zero)
-        {
-            throw new ArgumentOutOfRangeException(nameof(variance));
-        }
+        ArgumentOutOfRangeException.ThrowIfLessThan(variance, T.Zero);
 
         if (T.IsNaN(x))
         {

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/NullRecord.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/NullRecord.cs
@@ -15,10 +15,7 @@ internal abstract partial class NullRecord
         get => _count;
         private protected set
         {
-            if (value == 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(value));
-            }
+            ArgumentOutOfRangeException.ThrowIfZero(value);
 
             _count = value;
         }

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/NullRecord.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/NullRecord.cs
@@ -15,7 +15,10 @@ internal abstract partial class NullRecord
         get => _count;
         private protected set
         {
-            ArgumentOutOfRangeException.ThrowIfZero(value);
+            if (value == 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value));
+            }
 
             _count = value;
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ControlPaint.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ControlPaint.cs
@@ -580,14 +580,10 @@ public static partial class ControlPaint
         Color bottomColor, int bottomWidth, ButtonBorderStyle bottomStyle)
     {
         // Very general, and very slow
-        if (leftWidth < 0)
-            throw new ArgumentOutOfRangeException(nameof(leftWidth));
-        if (topWidth < 0)
-            throw new ArgumentOutOfRangeException(nameof(topWidth));
-        if (rightWidth < 0)
-            throw new ArgumentOutOfRangeException(nameof(rightWidth));
-        if (bottomWidth < 0)
-            throw new ArgumentOutOfRangeException(nameof(bottomWidth));
+        ArgumentOutOfRangeException.ThrowIfNegative(leftWidth);
+        ArgumentOutOfRangeException.ThrowIfNegative(topWidth);
+        ArgumentOutOfRangeException.ThrowIfNegative(rightWidth);
+        ArgumentOutOfRangeException.ThrowIfNegative(bottomWidth);
 
         int totalData = (topWidth + leftWidth + bottomWidth + rightWidth) * 2;
         Span<int> allData;
@@ -1471,10 +1467,8 @@ public static partial class ControlPaint
         Color backColor)
     {
         ArgumentNullException.ThrowIfNull(graphics);
-        if (width < 0)
-            throw new ArgumentOutOfRangeException(nameof(width));
-        if (height < 0)
-            throw new ArgumentOutOfRangeException(nameof(height));
+        ArgumentOutOfRangeException.ThrowIfNegative(width);
+        ArgumentOutOfRangeException.ThrowIfNegative(height);
 
         RECT rcFrame = new RECT(0, 0, width, height);
         using Bitmap bitmap = new Bitmap(width, height);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
@@ -2478,15 +2478,9 @@ public partial class DataGridView
             throw new InvalidOperationException(SR.DataGridView_CannotAutoSizeRowsInvisibleRowHeader);
         }
 
-        if (rowsCount < 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(rowsCount));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(rowsCount);
 
-        if (rowIndexStart < 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(rowIndexStart));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(rowIndexStart);
 
         if (!IsHandleCreated)
         {
@@ -7153,19 +7147,13 @@ public partial class DataGridView
 
         if (columnIndex >= 0)
         {
-            if (columnIndex >= Columns.Count)
-            {
-                throw new ArgumentOutOfRangeException(nameof(columnIndex));
-            }
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(columnIndex, Columns.Count);
 
             columnRect = GetColumnDisplayRectanglePrivate(columnIndex, cutOverflow);
         }
         else
         {
-            if (columnIndex != -1)
-            {
-                throw new ArgumentOutOfRangeException(nameof(columnIndex));
-            }
+            ArgumentOutOfRangeException.ThrowIfNotEqual(columnIndex, -1);
 
             if (rowIndex >= 0)
             {
@@ -7179,19 +7167,13 @@ public partial class DataGridView
 
         if (rowIndex >= 0)
         {
-            if (rowIndex >= Rows.Count)
-            {
-                throw new ArgumentOutOfRangeException(nameof(rowIndex));
-            }
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(rowIndex, Rows.Count);
 
             rowRect = GetRowDisplayRectanglePrivate(rowIndex, cutOverflow);
         }
         else
         {
-            if (rowIndex != -1)
-            {
-                throw new ArgumentOutOfRangeException(nameof(rowIndex));
-            }
+            ArgumentOutOfRangeException.ThrowIfNotEqual(rowIndex, -1);
 
             if (columnIndex >= 0)
             {
@@ -29421,10 +29403,7 @@ public partial class DataGridView
             throw new ArgumentOutOfRangeException(nameof(rowIndexEnd));
         }
 
-        if (rowIndexEnd < rowIndexStart)
-        {
-            throw new ArgumentOutOfRangeException(nameof(rowIndexEnd));
-        }
+        ArgumentOutOfRangeException.ThrowIfLessThan(rowIndexEnd, rowIndexStart);
 
         if (IsHandleCreated && _layout.RowHeadersVisible)
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.TopRowAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.TopRowAccessibleObject.cs
@@ -111,10 +111,7 @@ public partial class DataGridView
                 throw new InvalidOperationException(SR.DataGridViewTopRowAccessibleObject_OwnerNotSet);
             }
 
-            if (index < 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(index));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
 
             if (index > GetChildCount() - 1)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellCancelEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellCancelEventArgs.cs
@@ -14,15 +14,8 @@ public class DataGridViewCellCancelEventArgs : CancelEventArgs
 
     public DataGridViewCellCancelEventArgs(int columnIndex, int rowIndex)
     {
-        if (columnIndex < -1)
-        {
-            throw new ArgumentOutOfRangeException(nameof(columnIndex));
-        }
-
-        if (rowIndex < -1)
-        {
-            throw new ArgumentOutOfRangeException(nameof(rowIndex));
-        }
+        ArgumentOutOfRangeException.ThrowIfLessThan(columnIndex, -1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(rowIndex, -1);
 
         ColumnIndex = columnIndex;
         RowIndex = rowIndex;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellEventArgs.cs
@@ -12,15 +12,8 @@ public class DataGridViewCellEventArgs : EventArgs
 
     public DataGridViewCellEventArgs(int columnIndex, int rowIndex)
     {
-        if (columnIndex < -1)
-        {
-            throw new ArgumentOutOfRangeException(nameof(columnIndex));
-        }
-
-        if (rowIndex < -1)
-        {
-            throw new ArgumentOutOfRangeException(nameof(rowIndex));
-        }
+        ArgumentOutOfRangeException.ThrowIfLessThan(columnIndex, -1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(rowIndex, -1);
 
         ColumnIndex = columnIndex;
         RowIndex = rowIndex;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellFormattingEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellFormattingEventArgs.cs
@@ -13,15 +13,8 @@ public class DataGridViewCellFormattingEventArgs : ConvertEventArgs
         DataGridViewCellStyle? cellStyle)
         : base(value, desiredType)
     {
-        if (columnIndex < -1)
-        {
-            throw new ArgumentOutOfRangeException(nameof(columnIndex));
-        }
-
-        if (rowIndex < -1)
-        {
-            throw new ArgumentOutOfRangeException(nameof(rowIndex));
-        }
+        ArgumentOutOfRangeException.ThrowIfLessThan(columnIndex, -1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(rowIndex, -1);
 
         ColumnIndex = columnIndex;
         RowIndex = rowIndex;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellMouseEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellMouseEventArgs.cs
@@ -13,16 +13,8 @@ public class DataGridViewCellMouseEventArgs : MouseEventArgs
         MouseEventArgs? e)
         : base(e?.Button ?? MouseButtons.None, e?.Clicks ?? 0, localX, localY, e?.Delta ?? 0)
     {
-        if (columnIndex < -1)
-        {
-            throw new ArgumentOutOfRangeException(nameof(columnIndex));
-        }
-
-        if (rowIndex < -1)
-        {
-            throw new ArgumentOutOfRangeException(nameof(rowIndex));
-        }
-
+        ArgumentOutOfRangeException.ThrowIfLessThan(columnIndex, -1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(rowIndex, -1);
         ArgumentNullException.ThrowIfNull(e);
 
         ColumnIndex = columnIndex;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellValueEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellValueEventArgs.cs
@@ -13,15 +13,8 @@ public class DataGridViewCellValueEventArgs : EventArgs
 
     public DataGridViewCellValueEventArgs(int columnIndex, int rowIndex)
     {
-        if (columnIndex < 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(columnIndex));
-        }
-
-        if (rowIndex < 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(rowIndex));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(columnIndex);
+        ArgumentOutOfRangeException.ThrowIfNegative(rowIndex);
 
         ColumnIndex = columnIndex;
         RowIndex = rowIndex;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnDividerDoubleClickEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnDividerDoubleClickEventArgs.cs
@@ -8,11 +8,7 @@ public class DataGridViewColumnDividerDoubleClickEventArgs : HandledMouseEventAr
     public DataGridViewColumnDividerDoubleClickEventArgs(int columnIndex, HandledMouseEventArgs? e)
         : base(e?.Button ?? MouseButtons.None, e?.Clicks ?? 0, e?.X ?? 0, e?.Y ?? 0, e?.Delta ?? 0, e?.Handled ?? false)
     {
-        if (columnIndex < -1)
-        {
-            throw new ArgumentOutOfRangeException(nameof(columnIndex));
-        }
-
+        ArgumentOutOfRangeException.ThrowIfLessThan(columnIndex, -1);
         ArgumentNullException.ThrowIfNull(e);
 
         ColumnIndex = columnIndex;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnHeaderCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnHeaderCell.cs
@@ -136,10 +136,7 @@ public partial class DataGridViewColumnHeaderCell : DataGridViewHeaderCell
                                                   bool inLastRow,
                                                   string format)
     {
-        if (rowIndex != -1)
-        {
-            throw new ArgumentOutOfRangeException(nameof(rowIndex));
-        }
+        ArgumentOutOfRangeException.ThrowIfNotEqual(rowIndex, -1);
 
         if (DataGridView is null)
         {
@@ -229,10 +226,7 @@ public partial class DataGridViewColumnHeaderCell : DataGridViewHeaderCell
     {
         ArgumentNullException.ThrowIfNull(cellStyle);
 
-        if (rowIndex != -1)
-        {
-            throw new ArgumentOutOfRangeException(nameof(rowIndex));
-        }
+        ArgumentOutOfRangeException.ThrowIfNotEqual(rowIndex, -1);
 
         if (DataGridView is null || OwningColumn is null)
         {
@@ -279,10 +273,7 @@ public partial class DataGridViewColumnHeaderCell : DataGridViewHeaderCell
 
     public override ContextMenuStrip GetInheritedContextMenuStrip(int rowIndex)
     {
-        if (rowIndex != -1)
-        {
-            throw new ArgumentOutOfRangeException(nameof(rowIndex));
-        }
+        ArgumentOutOfRangeException.ThrowIfNotEqual(rowIndex, -1);
 
         ContextMenuStrip contextMenuStrip = GetContextMenuStrip(-1);
         if (contextMenuStrip is not null)
@@ -307,10 +298,7 @@ public partial class DataGridViewColumnHeaderCell : DataGridViewHeaderCell
             throw new InvalidOperationException(SR.DataGridView_CellNeedsDataGridViewForInheritedStyle);
         }
 
-        if (rowIndex != -1)
-        {
-            throw new ArgumentOutOfRangeException(nameof(rowIndex));
-        }
+        ArgumentOutOfRangeException.ThrowIfNotEqual(rowIndex, -1);
 
         DataGridViewCellStyle inheritedCellStyleTmp = inheritedCellStyle ?? new DataGridViewCellStyle();
 
@@ -506,10 +494,7 @@ public partial class DataGridViewColumnHeaderCell : DataGridViewHeaderCell
 
     protected override Size GetPreferredSize(Graphics graphics, DataGridViewCellStyle cellStyle, int rowIndex, Size constraintSize)
     {
-        if (rowIndex != -1)
-        {
-            throw new ArgumentOutOfRangeException(nameof(rowIndex));
-        }
+        ArgumentOutOfRangeException.ThrowIfNotEqual(rowIndex, -1);
 
         if (DataGridView is null)
         {
@@ -715,10 +700,7 @@ public partial class DataGridViewColumnHeaderCell : DataGridViewHeaderCell
 
     protected override object GetValue(int rowIndex)
     {
-        if (rowIndex != -1)
-        {
-            throw new ArgumentOutOfRangeException(nameof(rowIndex));
-        }
+        ArgumentOutOfRangeException.ThrowIfNotEqual(rowIndex, -1);
 
         if (ContainsLocalValue)
         {
@@ -1205,10 +1187,7 @@ public partial class DataGridViewColumnHeaderCell : DataGridViewHeaderCell
 
     protected override bool SetValue(int rowIndex, object value)
     {
-        if (rowIndex != -1)
-        {
-            throw new ArgumentOutOfRangeException(nameof(rowIndex));
-        }
+        ArgumentOutOfRangeException.ThrowIfNotEqual(rowIndex, -1);
 
         object originalValue = GetValue(rowIndex);
         Properties.SetObject(s_propCellValue, value);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewHeaderCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewHeaderCell.cs
@@ -321,10 +321,7 @@ public partial class DataGridViewHeaderCell : DataGridViewCell
         else if (OwningColumn is not null)
         {
             // column header cell
-            if (rowIndex != -1)
-            {
-                throw new ArgumentOutOfRangeException(nameof(rowIndex));
-            }
+            ArgumentOutOfRangeException.ThrowIfNotEqual(rowIndex, -1);
 
             state |= (OwningColumn.State & DataGridViewElementStates.Frozen);
             if (OwningColumn.Resizable == DataGridViewTriState.True ||
@@ -345,10 +342,7 @@ public partial class DataGridViewHeaderCell : DataGridViewCell
         else if (DataGridView is not null)
         {
             // top left header cell
-            if (rowIndex != -1)
-            {
-                throw new ArgumentOutOfRangeException(nameof(rowIndex));
-            }
+            ArgumentOutOfRangeException.ThrowIfNotEqual(rowIndex, -1);
 
             state |= DataGridViewElementStates.Frozen;
             if (DataGridView.RowHeadersWidthSizeMode == DataGridViewRowHeadersWidthSizeMode.EnableResizing || DataGridView.ColumnHeadersHeightSizeMode == DataGridViewColumnHeadersHeightSizeMode.EnableResizing)
@@ -412,10 +406,7 @@ public partial class DataGridViewHeaderCell : DataGridViewCell
         if (DataGridView is null)
         {
             // detached cell
-            if (rowIndex != -1)
-            {
-                throw new ArgumentOutOfRangeException(nameof(rowIndex));
-            }
+            ArgumentOutOfRangeException.ThrowIfNotEqual(rowIndex, -1);
 
             return new Size(-1, -1);
         }
@@ -423,10 +414,7 @@ public partial class DataGridViewHeaderCell : DataGridViewCell
         if (OwningColumn is not null)
         {
             // must be a column header cell
-            if (rowIndex != -1)
-            {
-                throw new ArgumentOutOfRangeException(nameof(rowIndex));
-            }
+            ArgumentOutOfRangeException.ThrowIfNotEqual(rowIndex, -1);
 
             return new Size(OwningColumn.Thickness, DataGridView.ColumnHeadersHeight);
         }
@@ -448,10 +436,7 @@ public partial class DataGridViewHeaderCell : DataGridViewCell
         else
         {
             // must be the top left header cell
-            if (rowIndex != -1)
-            {
-                throw new ArgumentOutOfRangeException(nameof(rowIndex));
-            }
+            ArgumentOutOfRangeException.ThrowIfNotEqual(rowIndex, -1);
 
             return new Size(DataGridView.RowHeadersWidth, DataGridView.ColumnHeadersHeight);
         }
@@ -497,10 +482,7 @@ public partial class DataGridViewHeaderCell : DataGridViewCell
 
     protected override object GetValue(int rowIndex)
     {
-        if (rowIndex != -1)
-        {
-            throw new ArgumentOutOfRangeException(nameof(rowIndex));
-        }
+        ArgumentOutOfRangeException.ThrowIfNotEqual(rowIndex, -1);
 
         return Properties.GetObject(s_propCellValue);
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.DataGridViewRowAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.DataGridViewRowAccessibleObject.cs
@@ -242,10 +242,7 @@ public partial class DataGridViewRow
 
         public override AccessibleObject? GetChild(int index)
         {
-            if (index < 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(index));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
 
             if (_owningDataGridViewRow is null)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowContextMenuStripNeededEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowContextMenuStripNeededEventArgs.cs
@@ -7,10 +7,7 @@ public class DataGridViewRowContextMenuStripNeededEventArgs : EventArgs
 {
     public DataGridViewRowContextMenuStripNeededEventArgs(int rowIndex)
     {
-        if (rowIndex < -1)
-        {
-            throw new ArgumentOutOfRangeException(nameof(rowIndex));
-        }
+        ArgumentOutOfRangeException.ThrowIfLessThan(rowIndex, -1);
 
         RowIndex = rowIndex;
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowDividerDoubleClickEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowDividerDoubleClickEventArgs.cs
@@ -8,10 +8,7 @@ public class DataGridViewRowDividerDoubleClickEventArgs : HandledMouseEventArgs
     public DataGridViewRowDividerDoubleClickEventArgs(int rowIndex, HandledMouseEventArgs e)
         : base((e.OrThrowIfNull()).Button, e.Clicks, e.X, e.Y, e.Delta, e.Handled)
     {
-        if (rowIndex < -1)
-        {
-            throw new ArgumentOutOfRangeException(nameof(rowIndex));
-        }
+        ArgumentOutOfRangeException.ThrowIfLessThan(rowIndex, -1);
 
         RowIndex = rowIndex;
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTopLeftHeaderCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTopLeftHeaderCell.cs
@@ -27,10 +27,7 @@ public partial class DataGridViewTopLeftHeaderCell : DataGridViewColumnHeaderCel
     {
         ArgumentNullException.ThrowIfNull(cellStyle);
 
-        if (rowIndex != -1)
-        {
-            throw new ArgumentOutOfRangeException(nameof(rowIndex));
-        }
+        ArgumentOutOfRangeException.ThrowIfNotEqual(rowIndex, -1);
 
         if (DataGridView is null)
         {
@@ -85,10 +82,7 @@ public partial class DataGridViewTopLeftHeaderCell : DataGridViewColumnHeaderCel
 
     protected override Rectangle GetErrorIconBounds(Graphics graphics, DataGridViewCellStyle cellStyle, int rowIndex)
     {
-        if (rowIndex != -1)
-        {
-            throw new ArgumentOutOfRangeException(nameof(rowIndex));
-        }
+        ArgumentOutOfRangeException.ThrowIfNotEqual(rowIndex, -1);
 
         if (DataGridView is null)
         {
@@ -139,10 +133,7 @@ public partial class DataGridViewTopLeftHeaderCell : DataGridViewColumnHeaderCel
 
     protected override Size GetPreferredSize(Graphics graphics, DataGridViewCellStyle cellStyle, int rowIndex, Size constraintSize)
     {
-        if (rowIndex != -1)
-        {
-            throw new ArgumentOutOfRangeException(nameof(rowIndex));
-        }
+        ArgumentOutOfRangeException.ThrowIfNotEqual(rowIndex, -1);
 
         if (DataGridView is null)
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/LinkClickedEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/LinkClickedEventArgs.cs
@@ -27,8 +27,7 @@ public class LinkClickedEventArgs : EventArgs
     /// </exception>
     public LinkClickedEventArgs(string? linkText, int linkStart, int linkLength)
     {
-        if (linkStart < 0)
-            throw new ArgumentOutOfRangeException(nameof(linkStart));
+        ArgumentOutOfRangeException.ThrowIfNegative(linkStart);
 
         if (linkLength < 0 || linkStart + linkLength < 0)
             throw new ArgumentOutOfRangeException(nameof(linkLength));

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialog.cs
@@ -612,10 +612,7 @@ public partial class TaskDialog : IWin32Window
     /// </param>
     internal unsafe void SetProgressBarMarquee(bool enableMarquee, int animationSpeed = 0)
     {
-        if (animationSpeed < 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(animationSpeed));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(animationSpeed);
 
         SendTaskDialogMessage(
             TASKDIALOG_MESSAGES.TDM_SET_PROGRESS_BAR_MARQUEE,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanelRow.ToolStripPanelRowControlCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanelRow.ToolStripPanelRowControlCollection.cs
@@ -285,10 +285,7 @@ public partial class ToolStripPanelRow
         {
             ArgumentNullException.ThrowIfNull(array);
 
-            if (index < 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(index));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
 
             if (index >= array.Length || InnerList.Count > array.Length - index)
             {


### PR DESCRIPTION
I applied the CA1512 fixer across the codebase, and just deleted some blank lines manually.

There are places that the analyzer did not fix. I'm doing a manual pass locally and can follow-up on that.

Also, in dotnet/runtime#79460, custom error messages were replaced by the standard one. If that's something that we are willing to consider here, I can follow-up with another commit/PR

## Proposed changes

- Apply CA1512 fixer: Use ArgumentOutOfRangeException throw helper

## Risk

- low: changes are from anaylzers

<!-- end TELL-MODE -->


## Test methodology <!-- How did you ensure quality? -->

- CI


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9713)