### PR TITLE
Use throw helpers for ArgumentOutOfRangeException: manual cases

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Automation/UiaTextRange.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Automation/UiaTextRange.cs
@@ -1044,8 +1044,11 @@ internal class UiaTextRange : ITextRangeProvider
     /// </summary>
     private void MoveTo(int start, int end)
     {
-        _start = start >= 0 ? start : throw new ArgumentOutOfRangeException(nameof(start));
-        _end = end >= start ? end : throw new ArgumentOutOfRangeException(nameof(end));
+        ArgumentOutOfRangeException.ThrowIfNegative(start);
+        ArgumentOutOfRangeException.ThrowIfLessThan(end, start);
+
+        _start = start;
+        _end = end;
     }
 
     private void ValidateEndpoints()

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
@@ -1734,10 +1734,8 @@ public partial class DataGridView
                 throw new InvalidEnumArgumentException(nameof(autoSizeColumnMode), (int)autoSizeColumnMode, typeof(DataGridViewAutoSizeColumnMode));
         }
 
-        if (columnIndex < 0 || columnIndex >= Columns.Count)
-        {
-            throw new ArgumentOutOfRangeException(nameof(columnIndex));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(columnIndex);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(columnIndex, Columns.Count);
 
         if (autoSizeColumnMode == DataGridViewAutoSizeColumnMode.ColumnHeader && !ColumnHeadersVisible)
         {
@@ -1830,10 +1828,8 @@ public partial class DataGridView
 
     protected void AutoResizeColumnHeadersHeight(int columnIndex, bool fixedRowHeadersWidth, bool fixedColumnWidth)
     {
-        if (columnIndex < -1 || columnIndex >= Columns.Count)
-        {
-            throw new ArgumentOutOfRangeException(nameof(columnIndex));
-        }
+        ArgumentOutOfRangeException.ThrowIfLessThan(columnIndex, -1);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(columnIndex, Columns.Count);
 
         if (!ColumnHeadersVisible)
         {
@@ -1993,10 +1989,8 @@ public partial class DataGridView
 
     protected void AutoResizeRow(int rowIndex, DataGridViewAutoSizeRowMode autoSizeRowMode, bool fixedWidth)
     {
-        if (rowIndex < 0 || rowIndex >= Rows.Count)
-        {
-            throw new ArgumentOutOfRangeException(nameof(rowIndex));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(rowIndex);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(rowIndex, Rows.Count);
 
         // not using ClientUtils here because it's a flags enum, masking instead.
         if (((DataGridViewAutoSizeRowCriteriaInternal)autoSizeRowMode & InvalidDataGridViewAutoSizeRowCriteriaInternalMask) != 0)
@@ -2190,10 +2184,8 @@ public partial class DataGridView
                                              bool fixedColumnHeadersHeight,
                                              bool fixedRowHeight)
     {
-        if (rowIndex < -1 || rowIndex >= Rows.Count)
-        {
-            throw new ArgumentOutOfRangeException(nameof(rowIndex));
-        }
+        ArgumentOutOfRangeException.ThrowIfLessThan(rowIndex, -1);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(rowIndex, Rows.Count);
 
         if (rowHeadersWidthSizeMode == DataGridViewRowHeadersWidthSizeMode.EnableResizing ||
             rowHeadersWidthSizeMode == DataGridViewRowHeadersWidthSizeMode.DisableResizing)
@@ -3569,10 +3561,8 @@ public partial class DataGridView
             case DataGridViewSelectionMode.FullColumnSelect:
             case DataGridViewSelectionMode.ColumnHeaderSelect:
                 {
-                    if (columnIndexException < 0 || columnIndexException >= Columns.Count)
-                    {
-                        throw new ArgumentOutOfRangeException(nameof(columnIndexException));
-                    }
+                    ArgumentOutOfRangeException.ThrowIfNegative(columnIndexException);
+                    ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(columnIndexException, Columns.Count);
 
                     break;
                 }
@@ -3580,10 +3570,8 @@ public partial class DataGridView
             case DataGridViewSelectionMode.FullRowSelect:
             case DataGridViewSelectionMode.RowHeaderSelect:
                 {
-                    if (columnIndexException < -1 || columnIndexException >= Columns.Count)
-                    {
-                        throw new ArgumentOutOfRangeException(nameof(columnIndexException));
-                    }
+                    ArgumentOutOfRangeException.ThrowIfLessThan(columnIndexException, -1);
+                    ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(columnIndexException, Columns.Count);
 
                     break;
                 }
@@ -3595,10 +3583,8 @@ public partial class DataGridView
             case DataGridViewSelectionMode.FullRowSelect:
             case DataGridViewSelectionMode.RowHeaderSelect:
                 {
-                    if (rowIndexException < 0 || rowIndexException >= Rows.Count)
-                    {
-                        throw new ArgumentOutOfRangeException(nameof(rowIndexException));
-                    }
+                    ArgumentOutOfRangeException.ThrowIfNegative(rowIndexException);
+                    ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(rowIndexException, Rows.Count);
 
                     break;
                 }
@@ -3606,10 +3592,8 @@ public partial class DataGridView
             case DataGridViewSelectionMode.FullColumnSelect:
             case DataGridViewSelectionMode.ColumnHeaderSelect:
                 {
-                    if (rowIndexException < -1 || rowIndexException >= Rows.Count)
-                    {
-                        throw new ArgumentOutOfRangeException(nameof(rowIndexException));
-                    }
+                    ArgumentOutOfRangeException.ThrowIfLessThan(rowIndexException, -1);
+                    ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(rowIndexException, Rows.Count);
 
                     break;
                 }
@@ -8252,10 +8236,8 @@ public partial class DataGridView
     // Rectangle returned includes the potential column header
     public Rectangle GetColumnDisplayRectangle(int columnIndex, bool cutOverflow)
     {
-        if (columnIndex < 0 || columnIndex >= Columns.Count)
-        {
-            throw new ArgumentOutOfRangeException(nameof(columnIndex));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(columnIndex);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(columnIndex, Columns.Count);
 
         return GetColumnDisplayRectanglePrivate(columnIndex, cutOverflow);
     }
@@ -9148,10 +9130,8 @@ public partial class DataGridView
     // Rectangle returned includes the potential row header
     public Rectangle GetRowDisplayRectangle(int rowIndex, bool cutOverflow)
     {
-        if (rowIndex < 0 || rowIndex >= Rows.Count)
-        {
-            throw new ArgumentOutOfRangeException(nameof(rowIndex));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(rowIndex);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(rowIndex, Rows.Count);
 
         return GetRowDisplayRectanglePrivate(rowIndex, cutOverflow);
     }
@@ -10018,15 +9998,11 @@ public partial class DataGridView
 
     public void InvalidateCell(int columnIndex, int rowIndex)
     {
-        if (columnIndex < -1 || columnIndex >= Columns.Count)
-        {
-            throw new ArgumentOutOfRangeException(nameof(columnIndex));
-        }
+        ArgumentOutOfRangeException.ThrowIfLessThan(columnIndex, -1);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(columnIndex, Columns.Count);
 
-        if (rowIndex < -1 || rowIndex >= Rows.Count)
-        {
-            throw new ArgumentOutOfRangeException(nameof(rowIndex));
-        }
+        ArgumentOutOfRangeException.ThrowIfLessThan(rowIndex, -1);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(rowIndex, Rows.Count);
 
         InvalidateCellPrivate(columnIndex, rowIndex);
     }
@@ -10048,10 +10024,8 @@ public partial class DataGridView
     /// </summary>
     public void InvalidateColumn(int columnIndex)
     {
-        if (columnIndex < 0 || columnIndex >= Columns.Count)
-        {
-            throw new ArgumentOutOfRangeException(nameof(columnIndex));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(columnIndex);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(columnIndex, Columns.Count);
 
         InvalidateColumnInternal(columnIndex);
     }
@@ -10094,10 +10068,8 @@ public partial class DataGridView
     /// </summary>
     public void InvalidateRow(int rowIndex)
     {
-        if (rowIndex < 0 || rowIndex >= Rows.Count)
-        {
-            throw new ArgumentOutOfRangeException(nameof(rowIndex));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(rowIndex);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(rowIndex, Rows.Count);
 
         InvalidateRowPrivate(rowIndex);
     }
@@ -27205,18 +27177,21 @@ public partial class DataGridView
         bool validateCurrentCell,
         bool throughMouseClick)
     {
-        if (columnIndex < -1 ||
-            (columnIndex >= 0 && rowIndex == -1) ||
-            columnIndex >= Columns.Count)
-        {
-            throw new ArgumentOutOfRangeException(nameof(columnIndex));
-        }
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(columnIndex, Columns.Count);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(rowIndex, Rows.Count);
 
-        if (rowIndex < -1 ||
-            (columnIndex == -1 && rowIndex >= 0) ||
-            rowIndex >= Rows.Count)
+        if (rowIndex == -1)
         {
-            throw new ArgumentOutOfRangeException(nameof(rowIndex));
+            ArgumentOutOfRangeException.ThrowIfNotEqual(columnIndex, -1);
+        }
+        else if (columnIndex == -1)
+        {
+            ArgumentOutOfRangeException.ThrowIfNotEqual(rowIndex, -1);
+        }
+        else
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(columnIndex);
+            ArgumentOutOfRangeException.ThrowIfNegative(rowIndex);
         }
 
         if (columnIndex > -1 &&
@@ -28048,15 +28023,11 @@ public partial class DataGridView
 
     protected virtual void SetSelectedCellCore(int columnIndex, int rowIndex, bool selected)
     {
-        if (columnIndex < 0 || columnIndex >= Columns.Count)
-        {
-            throw new ArgumentOutOfRangeException(nameof(columnIndex));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(columnIndex);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(columnIndex, Columns.Count);
 
-        if (rowIndex < 0 || rowIndex >= Rows.Count)
-        {
-            throw new ArgumentOutOfRangeException(nameof(rowIndex));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(rowIndex);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(rowIndex, Rows.Count);
 
         // cell selection changes
         DataGridViewRow dataGridViewRow = Rows.SharedRow(rowIndex);
@@ -28384,10 +28355,8 @@ public partial class DataGridView
 
     protected virtual void SetSelectedColumnCore(int columnIndex, bool selected)
     {
-        if (columnIndex < 0 || columnIndex >= Columns.Count)
-        {
-            throw new ArgumentOutOfRangeException(nameof(columnIndex));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(columnIndex);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(columnIndex, Columns.Count);
 
         _noSelectionChangeCount++;
         try
@@ -28505,10 +28474,8 @@ public partial class DataGridView
 
     protected virtual void SetSelectedRowCore(int rowIndex, bool selected)
     {
-        if (rowIndex < 0 || rowIndex >= Rows.Count)
-        {
-            throw new ArgumentOutOfRangeException(nameof(rowIndex));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(rowIndex);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(rowIndex, Rows.Count);
 
         _noSelectionChangeCount++;
         try
@@ -29300,15 +29267,10 @@ public partial class DataGridView
 
     public void UpdateCellErrorText(int columnIndex, int rowIndex)
     {
-        if (columnIndex < -1 || columnIndex >= Columns.Count)
-        {
-            throw new ArgumentOutOfRangeException(nameof(columnIndex));
-        }
-
-        if (rowIndex < -1 || rowIndex >= Rows.Count)
-        {
-            throw new ArgumentOutOfRangeException(nameof(rowIndex));
-        }
+        ArgumentOutOfRangeException.ThrowIfLessThan(columnIndex, -1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(rowIndex, -1);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(columnIndex, Columns.Count);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(rowIndex, Rows.Count);
 
         if (IsHandleCreated)
         {
@@ -29318,15 +29280,11 @@ public partial class DataGridView
 
     public void UpdateCellValue(int columnIndex, int rowIndex)
     {
-        if (columnIndex < 0 || columnIndex >= Columns.Count)
-        {
-            throw new ArgumentOutOfRangeException(nameof(columnIndex));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(columnIndex);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(columnIndex, Columns.Count);
 
-        if (rowIndex < 0 || rowIndex >= Rows.Count)
-        {
-            throw new ArgumentOutOfRangeException(nameof(rowIndex));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(rowIndex);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(rowIndex, Rows.Count);
 
         if (IsHandleCreated)
         {
@@ -29380,10 +29338,8 @@ public partial class DataGridView
 
     public void UpdateRowErrorText(int rowIndex)
     {
-        if (rowIndex < 0 || rowIndex >= Rows.Count)
-        {
-            throw new ArgumentOutOfRangeException(nameof(rowIndex));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(rowIndex);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(rowIndex, Rows.Count);
 
         if (IsHandleCreated && _layout.RowHeadersVisible)
         {
@@ -29393,15 +29349,11 @@ public partial class DataGridView
 
     public void UpdateRowErrorText(int rowIndexStart, int rowIndexEnd)
     {
-        if (rowIndexStart < 0 || rowIndexStart >= Rows.Count)
-        {
-            throw new ArgumentOutOfRangeException(nameof(rowIndexStart));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(rowIndexStart);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(rowIndexStart, Rows.Count);
 
-        if (rowIndexEnd < 0 || rowIndexEnd >= Rows.Count)
-        {
-            throw new ArgumentOutOfRangeException(nameof(rowIndexEnd));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(rowIndexEnd);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(rowIndexEnd, Rows.Count);
 
         ArgumentOutOfRangeException.ThrowIfLessThan(rowIndexEnd, rowIndexStart);
 
@@ -29430,10 +29382,8 @@ public partial class DataGridView
 
     private void UpdateRowHeightInfoPrivate(int rowIndex, bool updateToEnd, bool invalidInAdjustFillingColumns)
     {
-        if ((updateToEnd && rowIndex < 0) || (!updateToEnd && rowIndex < -1) || rowIndex >= Rows.Count)
-        {
-            throw new ArgumentOutOfRangeException(nameof(rowIndex));
-        }
+        ArgumentOutOfRangeException.ThrowIfLessThan(rowIndex, updateToEnd ? 0 : -1);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(rowIndex, Rows.Count);
 
         Rows.InvalidateCachedRowsHeights();
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.cs
@@ -2623,10 +2623,8 @@ public partial class DataGridView : Control, ISupportInitialize
         }
         set
         {
-            if (value < 0 || value >= Columns.Count)
-            {
-                throw new ArgumentOutOfRangeException(nameof(value));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(value, Columns.Count);
 
             if (!Columns[value].Visible)
             {
@@ -2700,10 +2698,8 @@ public partial class DataGridView : Control, ISupportInitialize
         }
         set
         {
-            if (value < 0 || value >= Rows.Count)
-            {
-                throw new ArgumentOutOfRangeException(nameof(value));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(value, Rows.Count);
 
             if ((Rows.GetRowState(value) & DataGridViewElementStates.Visible) == 0)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
@@ -1471,10 +1471,8 @@ public abstract partial class DataGridViewCell : DataGridViewElement, ICloneable
         }
 
         // Header Cell classes override this implementation - this implementation is only for inner cells
-        if (rowIndex < 0 || rowIndex >= DataGridView.Rows.Count)
-        {
-            throw new ArgumentOutOfRangeException(nameof(rowIndex));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(rowIndex);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(rowIndex, DataGridView.Rows.Count);
 
         // Assuming (like in other places in this class) that the formatted value is independent of the style colors.
         DataGridViewCellStyle dataGridViewCellStyle = GetInheritedStyle(null, rowIndex, false);
@@ -1870,10 +1868,8 @@ public abstract partial class DataGridViewCell : DataGridViewElement, ICloneable
     {
         if (DataGridView is not null)
         {
-            if (rowIndex < 0 || rowIndex >= DataGridView.Rows.Count)
-            {
-                throw new ArgumentOutOfRangeException(nameof(rowIndex));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(rowIndex);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(rowIndex, DataGridView.Rows.Count);
 
             if (ColumnIndex < 0)
             {
@@ -1942,10 +1938,8 @@ public abstract partial class DataGridViewCell : DataGridViewElement, ICloneable
         }
 
         // Header Cell classes override this implementation - this implementation is only for inner cells
-        if (rowIndex < 0 || rowIndex >= DataGridView.Rows.Count)
-        {
-            throw new ArgumentOutOfRangeException(nameof(rowIndex));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(rowIndex);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(rowIndex, DataGridView.Rows.Count);
 
         Debug.Assert(OwningColumn is not null);
         Debug.Assert(OwningRow is not null);
@@ -2024,10 +2018,8 @@ public abstract partial class DataGridViewCell : DataGridViewElement, ICloneable
             throw new InvalidOperationException(SR.DataGridView_CellNeedsDataGridViewForInheritedStyle);
         }
 
-        if (rowIndex < 0 || rowIndex >= DataGridView.Rows.Count)
-        {
-            throw new ArgumentOutOfRangeException(nameof(rowIndex));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(rowIndex);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(rowIndex, DataGridView.Rows.Count);
 
         if (ColumnIndex < 0)
         {
@@ -2564,10 +2556,8 @@ public abstract partial class DataGridViewCell : DataGridViewElement, ICloneable
         DataGridView dataGridView = DataGridView;
         if (dataGridView is not null)
         {
-            if (rowIndex < 0 || rowIndex >= dataGridView.Rows.Count)
-            {
-                throw new ArgumentOutOfRangeException(nameof(rowIndex));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(rowIndex);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(rowIndex, DataGridView.Rows.Count);
 
             if (ColumnIndex < 0)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewHeaderCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewHeaderCell.cs
@@ -421,10 +421,8 @@ public partial class DataGridViewHeaderCell : DataGridViewCell
         else if (OwningRow is not null)
         {
             // must be a row header cell
-            if (rowIndex < 0 || rowIndex >= DataGridView.Rows.Count)
-            {
-                throw new ArgumentOutOfRangeException(nameof(rowIndex));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(rowIndex);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(rowIndex, DataGridView.Rows.Count);
 
             if (DataGridView.Rows.SharedRow(rowIndex) != OwningRow)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.cs
@@ -1217,10 +1217,8 @@ public partial class DataGridViewRow : DataGridViewBand
                 throw new InvalidOperationException(SR.DataGridView_InvalidOperationOnSharedRow);
             }
 
-            if (rowIndex < 0 || rowIndex >= DataGridView.Rows.Count)
-            {
-                throw new ArgumentOutOfRangeException(nameof(rowIndex));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(rowIndex);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(rowIndex, DataGridView.Rows.Count);
 
             if (DataGridView.VirtualMode || DataGridView.DataSource is not null)
             {
@@ -1246,10 +1244,8 @@ public partial class DataGridViewRow : DataGridViewBand
                 throw new InvalidOperationException(SR.DataGridView_InvalidOperationOnSharedRow);
             }
 
-            if (rowIndex < 0 || rowIndex >= DataGridView.Rows.Count)
-            {
-                throw new ArgumentOutOfRangeException(nameof(rowIndex));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(rowIndex);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(rowIndex, DataGridView.Rows.Count);
 
             if (string.IsNullOrEmpty(errorText) &&
                 DataGridView.DataSource is not null &&
@@ -1292,15 +1288,13 @@ public partial class DataGridViewRow : DataGridViewBand
             throw new InvalidEnumArgumentException(nameof(autoSizeRowMode), (int)autoSizeRowMode, typeof(DataGridViewAutoSizeRowMode));
         }
 
-        if (!(DataGridView is null || (rowIndex >= 0 && rowIndex < DataGridView.Rows.Count)))
-        {
-            throw new ArgumentOutOfRangeException(nameof(rowIndex));
-        }
-
         if (DataGridView is null)
         {
             return -1;
         }
+
+        ArgumentOutOfRangeException.ThrowIfNegative(rowIndex);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(rowIndex, DataGridView.Rows.Count);
 
         int preferredRowThickness = 0, preferredCellThickness;
         // take into account the preferred height of the header cell if displayed and cared about
@@ -1378,9 +1372,10 @@ public partial class DataGridViewRow : DataGridViewBand
     [EditorBrowsable(EditorBrowsableState.Advanced)]
     public virtual DataGridViewElementStates GetState(int rowIndex)
     {
-        if (!(DataGridView is null || (rowIndex >= 0 && rowIndex < DataGridView.Rows.Count)))
+        if (DataGridView is not null)
         {
-            throw new ArgumentOutOfRangeException(nameof(rowIndex));
+            ArgumentOutOfRangeException.ThrowIfNegative(rowIndex);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(rowIndex, DataGridView.Rows.Count);
         }
 
         if (DataGridView is null || DataGridView.Rows.SharedRow(rowIndex).Index != -1)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowHeaderCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowHeaderCell.cs
@@ -178,10 +178,8 @@ public partial class DataGridViewRowHeaderCell : DataGridViewHeaderCell
             return null;
         }
 
-        if (rowIndex < 0 || rowIndex >= DataGridView.Rows.Count)
-        {
-            throw new ArgumentOutOfRangeException(nameof(rowIndex));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(rowIndex);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(rowIndex, DataGridView.Rows.Count);
 
         // Not using formatted values for header cells.
         object val = GetValue(rowIndex);
@@ -365,9 +363,10 @@ public partial class DataGridViewRowHeaderCell : DataGridViewHeaderCell
 
     public override ContextMenuStrip GetInheritedContextMenuStrip(int rowIndex)
     {
-        if (DataGridView is not null && (rowIndex < 0 || rowIndex >= DataGridView.Rows.Count))
+        if (DataGridView is not null)
         {
-            throw new ArgumentOutOfRangeException(nameof(rowIndex));
+            ArgumentOutOfRangeException.ThrowIfNegative(rowIndex);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(rowIndex, DataGridView.Rows.Count);
         }
 
         ContextMenuStrip contextMenuStrip = GetContextMenuStrip(rowIndex);
@@ -641,9 +640,10 @@ public partial class DataGridViewRowHeaderCell : DataGridViewHeaderCell
     {
         // We allow multiple rows to share the same row header value. The row header cell's cloning does this.
         // So here we need to allow rowIndex == -1.
-        if (DataGridView is not null && (rowIndex < -1 || rowIndex >= DataGridView.Rows.Count))
+        if (DataGridView is not null)
         {
-            throw new ArgumentOutOfRangeException(nameof(rowIndex));
+            ArgumentOutOfRangeException.ThrowIfLessThan(rowIndex, -1);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(rowIndex, DataGridView.Rows.Count);
         }
 
         return Properties.GetObject(s_propCellValue);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/LinkClickedEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/LinkClickedEventArgs.cs
@@ -28,8 +28,9 @@ public class LinkClickedEventArgs : EventArgs
     public LinkClickedEventArgs(string? linkText, int linkStart, int linkLength)
     {
         ArgumentOutOfRangeException.ThrowIfNegative(linkStart);
+        ArgumentOutOfRangeException.ThrowIfNegative(linkLength);
 
-        if (linkLength < 0 || linkStart + linkLength < 0)
+        if (linkStart + linkLength < 0)
             throw new ArgumentOutOfRangeException(nameof(linkLength));
 
         LinkText = linkText;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListControl.cs
@@ -464,10 +464,8 @@ public abstract class ListControl : Control
             return -1;
         }
 
-        if (startIndex < -1 || startIndex >= items.Count)
-        {
-            throw new ArgumentOutOfRangeException(nameof(startIndex));
-        }
+        ArgumentOutOfRangeException.ThrowIfLessThan(startIndex, -1);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(startIndex, items.Count);
 
         // Start from the start index and wrap around until we find the string
         // in question. Use a separate counter to ensure that we aren't cycling through the list infinitely.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewSubItemCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewSubItemCollection.cs
@@ -304,11 +304,8 @@ public partial class ListViewItem
 
         public void Insert(int index, ListViewSubItem item)
         {
-            if (index < 0 || index > Count)
-            {
-                throw new ArgumentOutOfRangeException(nameof(index));
-            }
-
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, Count);
             ArgumentNullException.ThrowIfNull(item);
 
             item._owner = _owner;
@@ -350,10 +347,8 @@ public partial class ListViewItem
 
         public void RemoveAt(int index)
         {
-            if (index < 0 || index >= Count)
-            {
-                throw new ArgumentOutOfRangeException(nameof(index));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
 
             // Remove ourselves as the owner.
             _owner._subItems[index]._owner = null;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialog.cs
@@ -630,15 +630,11 @@ public partial class TaskDialog : IWin32Window
     /// </remarks>
     internal unsafe void SetProgressBarRange(int min, int max)
     {
-        if (min < 0 || min > ushort.MaxValue)
-        {
-            throw new ArgumentOutOfRangeException(nameof(min));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(min);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(min, ushort.MaxValue);
 
-        if (max < 0 || max > ushort.MaxValue)
-        {
-            throw new ArgumentOutOfRangeException(nameof(max));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(max);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(max, ushort.MaxValue);
 
         SendTaskDialogMessage(
             TASKDIALOG_MESSAGES.TDM_SET_PROGRESS_BAR_RANGE,
@@ -652,10 +648,8 @@ public partial class TaskDialog : IWin32Window
     /// <param name="pos"></param>
     internal void SetProgressBarPosition(int pos)
     {
-        if (pos < 0 || pos > ushort.MaxValue)
-        {
-            throw new ArgumentOutOfRangeException(nameof(pos));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(pos);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(pos, ushort.MaxValue);
 
         SendTaskDialogMessage(
             TASKDIALOG_MESSAGES.TDM_SET_PROGRESS_BAR_POS,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogProgressBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialogProgressBar.cs
@@ -130,10 +130,8 @@ public sealed class TaskDialogProgressBar : TaskDialogControl
         get => _minimum;
         set
         {
-            if (value < 0 || value > ushort.MaxValue)
-            {
-                throw new ArgumentOutOfRangeException(nameof(value));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(value, ushort.MaxValue);
 
             DenyIfBoundAndNotCreated();
 
@@ -178,10 +176,8 @@ public sealed class TaskDialogProgressBar : TaskDialogControl
         get => _maximum;
         set
         {
-            if (value < 0 || value > ushort.MaxValue)
-            {
-                throw new ArgumentOutOfRangeException(nameof(value));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(value, ushort.MaxValue);
 
             DenyIfBoundAndNotCreated();
 
@@ -226,10 +222,8 @@ public sealed class TaskDialogProgressBar : TaskDialogControl
         get => _value;
         set
         {
-            if (value < 0 || value > ushort.MaxValue)
-            {
-                throw new ArgumentOutOfRangeException(nameof(value));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(value, ushort.MaxValue);
 
             DenyIfBoundAndNotCreated();
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeNodeCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeNodeCollection.cs
@@ -31,10 +31,8 @@ public class TreeNodeCollection : IList
     {
         get
         {
-            if (index < 0 || index >= _owner.childNodes.Count)
-            {
-                throw new ArgumentOutOfRangeException(nameof(index));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, _owner.childNodes.Count);
 
             return _owner.childNodes[index];
         }


### PR DESCRIPTION
This is the first follow-up to #9713. These are all the cases not caught by CA1512 but are legitimate uses of the new `ArgumentOutOfRangeException` throw helpers, because the error message is not overridden.

## Proposed changes

- Use ArgumentOutOfRangeException throw helpers

## Risk

- low, but higher than the pure fixer modifications. I still used the IDE as much as possible (e.g. to break if clauses into 2) so that CA1512 could apply

## Test methodology

- CI


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9728)