### PR TITLE
Fix IRawElementProviderSimple.GetPropertyValue (#9732)

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlAccessibleObject.cs
@@ -496,7 +496,7 @@ public partial class Control
                 UiaCore.UIA.LiveSettingPropertyId => Owner is IAutomationLiveRegion owner
                     ? owner.LiveSetting
                     : base.GetPropertyValue(propertyID),
-                UiaCore.UIA.NativeWindowHandlePropertyId => Owner?.InternalHandle ?? HWND.Null,
+                UiaCore.UIA.NativeWindowHandlePropertyId => (nint)(Owner?.InternalHandle ?? HWND.Null),
                 _ => base.GetPropertyValue(propertyID)
             };
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemBaseAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemBaseAccessibleObject.cs
@@ -177,7 +177,7 @@ public partial class ListViewItem
                 UiaCore.UIA.IsKeyboardFocusablePropertyId => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,
                 UiaCore.UIA.IsOffscreenPropertyId => OwningGroup?.CollapsedState == ListViewGroupCollapsedState.Collapsed ||
                                                      (bool)(base.GetPropertyValue(UiaCore.UIA.IsOffscreenPropertyId) ?? false),
-                UiaCore.UIA.NativeWindowHandlePropertyId => _owningListView.InternalHandle,
+                UiaCore.UIA.NativeWindowHandlePropertyId => (nint)_owningListView.InternalHandle,
                 _ => base.GetPropertyValue(propertyID)
             };
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBox.ComboBoxAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBox.ComboBoxAccessibleObjectTests.cs
@@ -272,7 +272,7 @@ public class ComboBox_ComboBoxAccessibleObjectTests
         object actual = comboBox.AccessibilityObject.GetPropertyValue(UiaCore.UIA.NativeWindowHandlePropertyId);
 
         Assert.True(comboBox.IsHandleCreated);
-        Assert.Equal(comboBox.InternalHandle, actual);
+        Assert.Equal((nint)comboBox.InternalHandle, actual);
     }
 
     [WinFormsTheory]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControl.TabControlAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControl.TabControlAccessibleObjectTests.cs
@@ -671,7 +671,7 @@ public class TabControl_TabControlAccessibilityObjectTests
 
         TabControlAccessibleObject accessibleObject = Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
 
-        Assert.Equal(tabControl.InternalHandle, (HWND)accessibleObject.GetPropertyValue(UIA.NativeWindowHandlePropertyId));
+        Assert.Equal((nint)tabControl.InternalHandle, (nint)accessibleObject.GetPropertyValue(UIA.NativeWindowHandlePropertyId));
         Assert.Equal(createControl, tabControl.IsHandleCreated);
     }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabPage.TabPageAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabPage.TabPageAccessibleObjectTests.cs
@@ -433,7 +433,7 @@ public class TabPage_TabPageAccessibilityObjectTests
 
         TabPageAccessibleObject accessibleObject = Assert.IsType<TabPageAccessibleObject>(tabPage.AccessibilityObject);
 
-        Assert.Equal(tabPage.InternalHandle, (HWND)accessibleObject.GetPropertyValue(UIA.NativeWindowHandlePropertyId));
+        Assert.Equal((nint)tabPage.InternalHandle, (nint)accessibleObject.GetPropertyValue(UIA.NativeWindowHandlePropertyId));
         Assert.Equal(createControl, tabPage.IsHandleCreated);
     }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TrackBar.TrackBarAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TrackBar.TrackBarAccessibleObjectTests.cs
@@ -436,7 +436,7 @@ public class TrackBarAccessibleObjectTests
         trackBar.CreateControl(false);
         object actual = trackBar.AccessibilityObject.GetPropertyValue(UiaCore.UIA.NativeWindowHandlePropertyId);
 
-        Assert.Equal(trackBar.InternalHandle, actual);
+        Assert.Equal((nint)trackBar.InternalHandle, actual);
     }
 
     [WinFormsTheory]


### PR DESCRIPTION
Our interop handle structs (such as HWND) cannot be marshalled directly and will fail "silently" on callbacks (they will throw but the marshaller will convert that to an HRESULT that we won't see unless first-chance exceptions are on when we're debugging).

### This change should be merged, not squashed- it ports #9732

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9737)