### PR TITLE
add missing UseDefaultXunitCulture attributes

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/KeysConverterTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/KeysConverterTests.cs
@@ -8,6 +8,7 @@ namespace System.Windows.Forms.Tests;
 public class KeysConverterTests
 {
     [Theory]
+    [UseDefaultXunitCulture]
     [InlineData("Ctrl+Alt+Shift+A", Keys.Control | Keys.Alt | Keys.Shift | Keys.A)]
     [InlineData("Ctrl+Alt+Shift+F1", Keys.Control | Keys.Alt | Keys.Shift | Keys.F1)]
     [InlineData("Ctrl+Alt+D", Keys.Control | Keys.Alt | Keys.D)]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PaddingConverterTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PaddingConverterTests.cs
@@ -32,6 +32,7 @@ public class PaddingConverterTests
     }
 
     [Theory]
+    [UseDefaultXunitCulture]
     [MemberData(nameof(ConvertFrom_TestData))]
     public void PaddingConverter_ConvertFrom_String_ReturnsExpected(string value, object expected)
     {
@@ -72,6 +73,7 @@ public class PaddingConverterTests
     }
 
     [Fact]
+    [UseDefaultXunitCulture]
     public void PaddingConverter_ConvertTo_String_ReturnsExpected()
     {
         var converter = new PaddingConverter();


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Contributes to #2734

## Proposed changes

- add missing UseDefaultXunitCulture attributes

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- none, only affects unit tests on developer machines

## Regression? 

- no

## Risk

- minimal, should only affect developers running tests locally

<!-- end TELL-MODE -->

### Before

- tests failing when running on german machine.

### After

- less tests failing when running on german machine.

## Test methodology <!-- How did you ensure quality? -->

- run tests in Visual Studio on a german machine.

## Test environment(s) <!-- Remove any that don't apply -->

- german machine (de-de culture)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9744)