### PR TITLE
Ensure Form Doesn't Prevent Shutdown

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -6238,7 +6238,7 @@ public partial class Form : ContainerControl
 
             if (m.MsgInternal == PInvoke.WM_QUERYENDSESSION)
             {
-                m.ResultInternal = (LRESULT)(nint)(BOOL)e.Cancel;
+                m.ResultInternal = (LRESULT)(BOOL)!e.Cancel;
             }
             else if (e.Cancel && (MdiParent is not null))
             {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FormTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FormTests.cs
@@ -2636,6 +2636,15 @@ public class FormTests
         parent.Dispose();
     }
 
+    [WinFormsFact]
+    public void Form_DoesNot_PreventShutDown()
+    {
+        using SubForm form = new();
+        var message = Message.Create(HWND.Null, PInvoke.WM_QUERYENDSESSION, wparam: default, lparam: default);
+        form.WndProc(ref message);
+        Assert.True((BOOL)message.ResultInternal);
+    }
+
     public partial class ParentedForm : Form
     {
         private ParentingForm _parentForm;


### PR DESCRIPTION
Fixes #9210 

In #7561 the result for `WM_QUERYENDSESSION` was accidentally flipped causing the return for `WM_QUERYENDSESSION` to be `false`, which would prevent shutdown/log off. This change fixes this and also adds a test that ensures that `Form` will return `true` for a `WM_QUERYENDSESSION` message.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9745)