### PR TITLE
Fix resource namespace for BinaryEditor

### DIFF
--- a/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
+++ b/src/System.Windows.Forms.Design/src/System.Windows.Forms.Design.csproj
@@ -49,15 +49,16 @@
     <EmbeddedResource Update="Resources\LinkAreaEditor.resx">
       <Namespace>System.Windows.Forms.Design</Namespace>
     </EmbeddedResource>
+    <EmbeddedResource Update="Resources\System\ComponentModel\Design\BinaryEditor.resx">
+      <Namespace>System.ComponentModel.Design</Namespace>
+    </EmbeddedResource>
     <EmbeddedResource Include="Resources\colordlg.data">
       <Link>colordlg.data</Link>
     </EmbeddedResource>
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\System.Windows.Forms.PrivateSourceGenerators\src\System.Windows.Forms.PrivateSourceGenerators.csproj"
-                      ReferenceOutputAssembly="false"
-                      OutputItemType="Analyzer" />
+    <ProjectReference Include="..\..\System.Windows.Forms.PrivateSourceGenerators\src\System.Windows.Forms.PrivateSourceGenerators.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/System.Windows.Forms.Design/tests/UnitTests/BinaryEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/BinaryEditorTests.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel.Design;
+using Moq;
+
+namespace System.Windows.Forms.Design.Editors.Tests;
+
+public class BinaryEditorTests
+{
+    [WinFormsFact]
+    public void BinaryEditor_EditValue()
+    {
+        // Ensure that we can instantiate the modal editor.
+
+        BinaryEditor editor = new();
+        var editorService = new Mock<IWindowsFormsEditorService>();
+        editorService.Setup(e => e.ShowDialog(It.IsAny<Form>()))
+            .Callback<Form>(f => { f.Show(); f.Close(); })
+            .Returns(DialogResult.OK);
+        var serviceProvider = new Mock<IServiceProvider>();
+        serviceProvider.Setup(s => s.GetService(typeof(IWindowsFormsEditorService))).Returns(editorService.Object);
+
+        var result = editor.EditValue(serviceProvider.Object, new byte[10]);
+    }
+}

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/EmbeddedResourceTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/EmbeddedResourceTests.cs
@@ -76,6 +76,7 @@ public class EmbeddedResourceTests
     }
 
     private const string expectedResourceNames = """
+            System.ComponentModel.Design.BinaryEditor.resources
             System.ComponentModel.Design.CollectionEditor.resources
             System.SR.resources
             System.Windows.Forms.Design.BorderSidesEditor.resources
@@ -83,7 +84,6 @@ public class EmbeddedResourceTests
             System.Windows.Forms.Design.FormatControl.resources
             System.Windows.Forms.Design.LinkAreaEditor.resources
             System.Windows.Forms.Design.MaskDesignerDialog.resources
-            System.Windows.Forms.Design.Resources.System.ComponentModel.Design.BinaryEditor.resources
             System.Windows.Forms.Design.ShortcutKeysEditor.resources
             System.Windows.Forms.Design.StringCollectionEditor.resources
             """;


### PR DESCRIPTION
The BinaryEditor dialog resources were not in the right namespace which was preventing the modal editor from launching successfully.

Fixes #7356


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9746)