### PR TITLE
Undo Localization Changes

### DIFF
--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.cs.xlf
@@ -229,7 +229,7 @@
       </trans-unit>
       <trans-unit id="ChooseIconDisplayName">
         <source>Choose Icon...</source>
-        <target state="new">Choose Icon...</target>
+        <target state="new">Vybrat ikonu...</target>
         <note />
       </trans-unit>
       <trans-unit id="ChooseImageDescription">

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.de.xlf
@@ -229,7 +229,7 @@
       </trans-unit>
       <trans-unit id="ChooseIconDisplayName">
         <source>Choose Icon...</source>
-        <target state="new">Choose Icon...</target>
+        <target state="new">Symbol auswählen...</target>
         <note />
       </trans-unit>
       <trans-unit id="ChooseImageDescription">

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.es.xlf
@@ -229,7 +229,7 @@
       </trans-unit>
       <trans-unit id="ChooseIconDisplayName">
         <source>Choose Icon...</source>
-        <target state="new">Choose Icon...</target>
+        <target state="new">Elegir icono...</target>
         <note />
       </trans-unit>
       <trans-unit id="ChooseImageDescription">

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.fr.xlf
@@ -229,7 +229,7 @@
       </trans-unit>
       <trans-unit id="ChooseIconDisplayName">
         <source>Choose Icon...</source>
-        <target state="new">Choose Icon...</target>
+        <target state="new">Choisir une icône...</target>
         <note />
       </trans-unit>
       <trans-unit id="ChooseImageDescription">

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.it.xlf
@@ -229,7 +229,7 @@
       </trans-unit>
       <trans-unit id="ChooseIconDisplayName">
         <source>Choose Icon...</source>
-        <target state="new">Choose Icon...</target>
+        <target state="new">Seleziona icona...</target>
         <note />
       </trans-unit>
       <trans-unit id="ChooseImageDescription">

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.ja.xlf
@@ -229,7 +229,7 @@
       </trans-unit>
       <trans-unit id="ChooseIconDisplayName">
         <source>Choose Icon...</source>
-        <target state="new">Choose Icon...</target>
+        <target state="new">アイコンの選択...</target>
         <note />
       </trans-unit>
       <trans-unit id="ChooseImageDescription">

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.ko.xlf
@@ -229,7 +229,7 @@
       </trans-unit>
       <trans-unit id="ChooseIconDisplayName">
         <source>Choose Icon...</source>
-        <target state="new">Choose Icon...</target>
+        <target state="new">아이콘 선택...</target>
         <note />
       </trans-unit>
       <trans-unit id="ChooseImageDescription">

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.pl.xlf
@@ -229,7 +229,7 @@
       </trans-unit>
       <trans-unit id="ChooseIconDisplayName">
         <source>Choose Icon...</source>
-        <target state="new">Choose Icon...</target>
+        <target state="new">Wybierz ikonę...</target>
         <note />
       </trans-unit>
       <trans-unit id="ChooseImageDescription">

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.pt-BR.xlf
@@ -229,7 +229,7 @@
       </trans-unit>
       <trans-unit id="ChooseIconDisplayName">
         <source>Choose Icon...</source>
-        <target state="new">Choose Icon...</target>
+        <target state="new">Escolher Ícone...</target>
         <note />
       </trans-unit>
       <trans-unit id="ChooseImageDescription">

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.ru.xlf
@@ -229,7 +229,7 @@
       </trans-unit>
       <trans-unit id="ChooseIconDisplayName">
         <source>Choose Icon...</source>
-        <target state="new">Choose Icon...</target>
+        <target state="new">Выбрать значок…</target>
         <note />
       </trans-unit>
       <trans-unit id="ChooseImageDescription">

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.tr.xlf
@@ -229,7 +229,7 @@
       </trans-unit>
       <trans-unit id="ChooseIconDisplayName">
         <source>Choose Icon...</source>
-        <target state="new">Choose Icon...</target>
+        <target state="new">Simge Seç...</target>
         <note />
       </trans-unit>
       <trans-unit id="ChooseImageDescription">

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.zh-Hans.xlf
@@ -229,7 +229,7 @@
       </trans-unit>
       <trans-unit id="ChooseIconDisplayName">
         <source>Choose Icon...</source>
-        <target state="new">Choose Icon...</target>
+        <target state="new">选择图标...</target>
         <note />
       </trans-unit>
       <trans-unit id="ChooseImageDescription">

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.zh-Hant.xlf
@@ -229,7 +229,7 @@
       </trans-unit>
       <trans-unit id="ChooseIconDisplayName">
         <source>Choose Icon...</source>
-        <target state="new">Choose Icon...</target>
+        <target state="new">選擇圖示...</target>
         <note />
       </trans-unit>
       <trans-unit id="ChooseImageDescription">


### PR DESCRIPTION
Noticed that while trying to port some localization changes from https://github.com/dotnet/winforms/pull/9739 to release/8.0 that some changes translated strings to english, which seems unintentional. Undoing these in main branch. 

@cristianosuzuki77 Is there something that needs to be fixed with the setup on our side?

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9754)