### PR TITLE
Replacing some ArgumentOutOfRangeException with custom messages with throw helpers

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ImageListDesigner.OriginalImageCollection.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ImageListDesigner.OriginalImageCollection.cs
@@ -6,7 +6,6 @@ using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Drawing;
 using System.Drawing.Design;
-using System.Globalization;
 
 namespace System.Windows.Forms.Design;
 
@@ -50,23 +49,16 @@ internal partial class ImageListDesigner
         {
             get
             {
-                return index < 0 || index >= Count
-                    ? throw new ArgumentOutOfRangeException(string.Format(SR.InvalidArgument,
-                                                              nameof(index),
-                                                              index.ToString(CultureInfo.CurrentCulture)))
-                    : (ImageListImage)_items[index];
+                ArgumentOutOfRangeException.ThrowIfNegative(index);
+                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
+
+                return (ImageListImage)_items[index];
             }
             set
             {
-                if (index < 0 || index >= Count)
-                    throw new ArgumentOutOfRangeException(string.Format(SR.InvalidArgument,
-                                                              nameof(index),
-                                                              index.ToString(CultureInfo.CurrentCulture)));
-
-                if (value is null)
-                    throw new ArgumentException(string.Format(SR.InvalidArgument,
-                                                              nameof(value),
-                                                              "null"));
+                ArgumentOutOfRangeException.ThrowIfNegative(index);
+                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
+                ArgumentNullException.ThrowIfNull(value);
 
                 AssertInvariant();
                 _items[index] = value;
@@ -187,10 +179,8 @@ internal partial class ImageListDesigner
         public void RemoveAt(int index)
         {
             ArgumentOutOfRangeException.ThrowIfLessThan(index, 0, nameof(index));
-            if (index < 0 || index >= Count)
-                throw new ArgumentOutOfRangeException(string.Format(SR.InvalidArgument,
-                                                          nameof(index),
-                                                          index.ToString(CultureInfo.CurrentCulture)));
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
 
             AssertInvariant();
             _items.RemoveAt(index);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.cs
@@ -373,10 +373,8 @@ public partial class CheckedListBox : ListBox
     /// </summary>
     public CheckState GetItemCheckState(int index)
     {
-        if (index < 0 || index >= Items.Count)
-        {
-            throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(index);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Items.Count);
 
         return CheckedItems.GetCheckedState(index);
     }
@@ -864,10 +862,8 @@ public partial class CheckedListBox : ListBox
     /// </summary>
     public void SetItemCheckState(int index, CheckState value)
     {
-        if (index < 0 || index >= Items.Count)
-        {
-            throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(index);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Items.Count);
 
         // valid values are 0-2 inclusive.
         SourceGenerated.EnumValidator.Validate(value);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Clipboard.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Clipboard.cs
@@ -37,22 +37,8 @@ public static class Clipboard
         }
 
         ArgumentNullException.ThrowIfNull(data);
-
-        if (retryTimes < 0)
-        {
-            throw new ArgumentOutOfRangeException(
-                nameof(retryTimes),
-                retryTimes,
-                string.Format(SR.InvalidLowBoundArgumentEx, nameof(retryTimes), retryTimes, 0));
-        }
-
-        if (retryDelay < 0)
-        {
-            throw new ArgumentOutOfRangeException(
-                nameof(retryDelay),
-                retryDelay,
-                string.Format(SR.InvalidLowBoundArgumentEx, nameof(retryDelay), retryDelay, 0));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(retryTimes);
+        ArgumentOutOfRangeException.ThrowIfNegative(retryDelay);
 
         IComDataObject dataObject = data as IComDataObject ?? new DataObject(data);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ObjectCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ObjectCollection.cs
@@ -215,10 +215,8 @@ public partial class ComboBox
         {
             get
             {
-                if (index < 0 || index >= Count)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
-                }
+                ArgumentOutOfRangeException.ThrowIfNegative(index);
+                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
 
                 return InnerList[index].Item;
             }
@@ -269,9 +267,11 @@ public partial class ComboBox
 
             int count = InnerList.Count;
 
-            if (arrayIndex < 0 || count + arrayIndex > destination.Length)
+            ArgumentOutOfRangeException.ThrowIfNegative(arrayIndex);
+
+            if (count + arrayIndex > destination.Length)
             {
-                throw new ArgumentOutOfRangeException(nameof(arrayIndex), arrayIndex, string.Format(SR.InvalidArgument, nameof(arrayIndex), arrayIndex));
+                throw new ArgumentOutOfRangeException(nameof(arrayIndex));
             }
 
             for (int i = 0; i < count; i++)
@@ -286,9 +286,11 @@ public partial class ComboBox
 
             int count = InnerList.Count;
 
-            if (index < 0 || count + index > destination.Length)
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+
+            if (count + index > destination.Length)
             {
-                throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
+                throw new ArgumentOutOfRangeException(nameof(index));
             }
 
             for (int i = 0; i < count; i++)
@@ -316,11 +318,8 @@ public partial class ComboBox
             _owner.CheckNoDataSource();
 
             ArgumentNullException.ThrowIfNull(item);
-
-            if (index < 0 || index > Count)
-            {
-                throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, Count);
 
             // If the combo box is sorted, then nust treat this like an add
             // because we are going to twiddle the index anyway.
@@ -367,10 +366,8 @@ public partial class ComboBox
         {
             _owner.CheckNoDataSource();
 
-            if (index < 0 || index >= Count)
-            {
-                throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
 
             if (_owner.IsHandleCreated)
             {
@@ -415,10 +412,8 @@ public partial class ComboBox
 
         internal void SetItemInternal(int index, object value)
         {
-            if (index < 0 || index >= Count)
-            {
-                throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
 
             InnerList[index].Item = value.OrThrowIfNull();
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -2100,13 +2100,8 @@ public partial class ComboBox : ListControl
             return ItemHeight;
         }
 
-        if (index < 0 || _itemsCollection is null || index >= _itemsCollection.Count)
-        {
-            throw new ArgumentOutOfRangeException(
-                nameof(index),
-                index,
-                string.Format(SR.InvalidArgument, nameof(index), index));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(index);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, _itemsCollection?.Count ?? 0);
 
         if (IsHandleCreated)
         {
@@ -3386,10 +3381,7 @@ public partial class ComboBox : ListControl
     /// </summary>
     public void Select(int start, int length)
     {
-        if (start < 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(start), start, string.Format(SR.InvalidArgument, nameof(start), start));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(start);
 
         // the Length can be negative to support Selecting in the "reverse" direction..
         int end = start + length;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlCollection.cs
@@ -3,7 +3,6 @@
 
 using System.Collections;
 using System.ComponentModel;
-using System.Globalization;
 using System.Windows.Forms.Layout;
 
 namespace System.Windows.Forms;
@@ -365,12 +364,8 @@ public partial class Control
             get
             {
                 //do some bounds checking here...
-                if (index < 0 || index >= Count)
-                {
-                    throw new ArgumentOutOfRangeException(
-                        nameof(index),
-                        string.Format(SR.IndexOutOfRange, index.ToString(CultureInfo.CurrentCulture)));
-                }
+                ArgumentOutOfRangeException.ThrowIfNegative(index);
+                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
 
                 Control control = (Control)InnerList[index]!;
                 Debug.Assert(control is not null, "Why are we returning null controls from a valid index?");

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
@@ -2592,11 +2592,7 @@ public abstract partial class DataGridViewCell : DataGridViewElement, ICloneable
     {
         ArgumentNullException.ThrowIfNull(graphics);
         ArgumentNullException.ThrowIfNull(font);
-
-        if (maxWidth <= 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(maxWidth), string.Format(SR.InvalidLowBoundArgument, "maxWidth", (maxWidth).ToString(CultureInfo.CurrentCulture), 0));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxWidth);
 
         if (!DataGridViewUtilities.ValidTextFormatFlags(flags))
         {
@@ -2615,11 +2611,7 @@ public abstract partial class DataGridViewCell : DataGridViewElement, ICloneable
     {
         ArgumentNullException.ThrowIfNull(graphics);
         ArgumentNullException.ThrowIfNull(font);
-
-        if (maxRatio <= 0.0F)
-        {
-            throw new ArgumentOutOfRangeException(nameof(maxRatio), string.Format(SR.InvalidLowBoundArgument, "maxRatio", (maxRatio).ToString(CultureInfo.CurrentCulture), "0.0"));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxRatio);
 
         if (!DataGridViewUtilities.ValidTextFormatFlags(flags))
         {
@@ -2674,10 +2666,7 @@ public abstract partial class DataGridViewCell : DataGridViewElement, ICloneable
     [EditorBrowsable(EditorBrowsableState.Advanced)]
     public static int MeasureTextWidth(Graphics graphics, string text, Font font, int maxHeight, TextFormatFlags flags)
     {
-        if (maxHeight <= 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(maxHeight), string.Format(SR.InvalidLowBoundArgument, "maxHeight", (maxHeight).ToString(CultureInfo.CurrentCulture), 0));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxHeight);
 
         Size oneLineSize = DataGridViewCell.MeasureTextSize(graphics, text, font, flags);
         if (oneLineSize.Height >= maxHeight || (flags & TextFormatFlags.SingleLine) != 0)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnCollection.cs
@@ -1022,10 +1022,8 @@ public partial class DataGridViewColumnCollection : BaseCollection, IList
 
     public virtual void RemoveAt(int index)
     {
-        if (index < 0 || index >= Count)
-        {
-            throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(index);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
 
         if (DataGridView.NoDimensionChangeAllowed)
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxCell.ObjectCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxCell.ObjectCollection.cs
@@ -129,10 +129,8 @@ public partial class DataGridViewComboBoxCell : DataGridViewCell
         {
             get
             {
-                if (index < 0 || index >= InnerArray.Count)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
-                }
+                ArgumentOutOfRangeException.ThrowIfNegative(index);
+                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, InnerArray.Count);
 
                 return InnerArray[index];
             }
@@ -140,10 +138,8 @@ public partial class DataGridViewComboBoxCell : DataGridViewCell
             {
                 _owner.CheckNoDataSource();
 
-                if (index < 0 || index >= InnerArray.Count)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
-                }
+                ArgumentOutOfRangeException.ThrowIfNegative(index);
+                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, InnerArray.Count);
 
                 InnerArray[index] = value.OrThrowIfNull();
                 _owner.OnItemsCollectionChanged();
@@ -200,11 +196,8 @@ public partial class DataGridViewComboBoxCell : DataGridViewCell
             _owner.CheckNoDataSource();
 
             ArgumentNullException.ThrowIfNull(item);
-
-            if (index < 0 || index > InnerArray.Count)
-            {
-                throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), nameof(index)));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, InnerArray.Count);
 
             // If the combo box is sorted, then just treat this like an add
             // because we are going to twiddle the index anyway.
@@ -240,10 +233,8 @@ public partial class DataGridViewComboBoxCell : DataGridViewCell
         {
             _owner.CheckNoDataSource();
 
-            if (index < 0 || index >= InnerArray.Count)
-            {
-                throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, InnerArray.Count);
 
             InnerArray.RemoveAt(index);
             _owner.OnItemsCollectionChanged();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowCollection.cs
@@ -1042,10 +1042,7 @@ public partial class DataGridViewRowCollection : ICollection, IList
             throw new ArgumentException(string.Format(SR.DataGridView_InvalidDataGridViewElementStateCombination, nameof(includeFilter)));
         }
 
-        if (indexStart < -1)
-        {
-            throw new ArgumentOutOfRangeException(nameof(indexStart), indexStart, string.Format(SR.InvalidLowBoundArgumentEx, nameof(indexStart), indexStart, -1));
-        }
+        ArgumentOutOfRangeException.ThrowIfLessThan(indexStart, -1);
 
         int index = indexStart + 1;
         while (index < _items.Count && !((GetRowState(index) & includeFilter) == includeFilter))
@@ -1077,10 +1074,7 @@ public partial class DataGridViewRowCollection : ICollection, IList
             throw new ArgumentException(string.Format(SR.DataGridView_InvalidDataGridViewElementStateCombination, nameof(excludeFilter)));
         }
 
-        if (indexStart < -1)
-        {
-            throw new ArgumentOutOfRangeException(nameof(indexStart), indexStart, string.Format(SR.InvalidLowBoundArgumentEx, nameof(indexStart), indexStart, -1));
-        }
+        ArgumentOutOfRangeException.ThrowIfLessThan(indexStart, -1);
 
         int index = indexStart + 1;
         while (index < _items.Count && (!((GetRowState(index) & includeFilter) == includeFilter) || !((GetRowState(index) & excludeFilter) == 0)))
@@ -1099,10 +1093,7 @@ public partial class DataGridViewRowCollection : ICollection, IList
             throw new ArgumentException(string.Format(SR.DataGridView_InvalidDataGridViewElementStateCombination, nameof(includeFilter)));
         }
 
-        if (indexStart > _items.Count)
-        {
-            throw new ArgumentOutOfRangeException(nameof(indexStart), indexStart, string.Format(SR.InvalidHighBoundArgumentEx, nameof(indexStart), indexStart, _items.Count));
-        }
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(indexStart, _items.Count);
 
         int index = indexStart - 1;
         while (index >= 0 && !((GetRowState(index) & includeFilter) == includeFilter))
@@ -1134,10 +1125,7 @@ public partial class DataGridViewRowCollection : ICollection, IList
             throw new ArgumentException(string.Format(SR.DataGridView_InvalidDataGridViewElementStateCombination, nameof(excludeFilter)));
         }
 
-        if (indexStart > _items.Count)
-        {
-            throw new ArgumentOutOfRangeException(nameof(indexStart), indexStart, string.Format(SR.InvalidHighBoundArgumentEx, nameof(indexStart), indexStart, _items.Count));
-        }
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(indexStart, _items.Count);
 
         int index = indexStart - 1;
         while (index >= 0 && (!((GetRowState(index) & includeFilter) == includeFilter) || !((GetRowState(index) & excludeFilter) == 0)))

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowsRemovedEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowsRemovedEventArgs.cs
@@ -1,23 +1,14 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Globalization;
-
 namespace System.Windows.Forms;
 
 public class DataGridViewRowsRemovedEventArgs : EventArgs
 {
     public DataGridViewRowsRemovedEventArgs(int rowIndex, int rowCount)
     {
-        if (rowIndex < 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(rowIndex), string.Format(SR.InvalidLowBoundArgumentEx, nameof(rowIndex), rowIndex.ToString(CultureInfo.CurrentCulture), 0));
-        }
-
-        if (rowCount < 1)
-        {
-            throw new ArgumentOutOfRangeException(nameof(rowCount), string.Format(SR.InvalidLowBoundArgumentEx, nameof(rowCount), rowCount.ToString(CultureInfo.CurrentCulture), 1));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(rowIndex);
+        ArgumentOutOfRangeException.ThrowIfLessThan(rowCount, 1);
 
         RowIndex = rowIndex;
         RowCount = rowCount;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/HtmlElementCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/HtmlElementCollection.cs
@@ -48,10 +48,8 @@ public sealed unsafe class HtmlElementCollection : ICollection
         get
         {
             //do some bounds checking here...
-            if (index < 0 || index >= Count)
-            {
-                throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidBoundArgument, nameof(index), index, 0, Count - 1));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
 
             if (NativeHtmlElementCollection is not null)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/HtmlHistory.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/HtmlHistory.cs
@@ -44,11 +44,9 @@ public sealed unsafe class HtmlHistory : IDisposable
 
     public void Back(int numberBack)
     {
-        if (numberBack < 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(numberBack), numberBack, string.Format(SR.InvalidLowBoundArgumentEx, nameof(numberBack), numberBack, 0));
-        }
-        else if (numberBack > 0)
+        ArgumentOutOfRangeException.ThrowIfNegative(numberBack);
+
+        if (numberBack > 0)
         {
             var oNumForward = (VARIANT)(-numberBack);
             using var omHistory = NativeOmHistory.GetInterface();
@@ -58,11 +56,9 @@ public sealed unsafe class HtmlHistory : IDisposable
 
     public void Forward(int numberForward)
     {
-        if (numberForward < 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(numberForward), numberForward, string.Format(SR.InvalidLowBoundArgumentEx, nameof(numberForward), numberForward, 0));
-        }
-        else if (numberForward > 0)
+        ArgumentOutOfRangeException.ThrowIfNegative(numberForward);
+
+        if (numberForward > 0)
         {
             var oNumForward = (VARIANT)numberForward;
             using var omHistory = NativeOmHistory.GetInterface();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/HtmlWindowCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/HtmlWindowCollection.cs
@@ -31,10 +31,8 @@ public unsafe class HtmlWindowCollection : ICollection
     {
         get
         {
-            if (index < 0 || index >= Count)
-            {
-                throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidBoundArgument, nameof(index), index, 0, Count - 1));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
 
             var oIndex = (VARIANT)index;
             using var htmlFrames2 = NativeHTMLFramesCollection2.GetInterface();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.ImageCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.ImageCollection.cs
@@ -126,20 +126,15 @@ public sealed partial class ImageList
         {
             get
             {
-                if (index < 0 || index >= Count)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
-                }
+                ArgumentOutOfRangeException.ThrowIfNegative(index);
+                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
 
                 return _owner.GetBitmap(index);
             }
             set
             {
-                if (index < 0 || index >= Count)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
-                }
-
+                ArgumentOutOfRangeException.ThrowIfNegative(index);
+                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
                 ArgumentNullException.ThrowIfNull(value);
 
                 if (value is not Bitmap bitmap)
@@ -546,10 +541,8 @@ public sealed partial class ImageList
 
         public void RemoveAt(int index)
         {
-            if (index < 0 || index >= Count)
-            {
-                throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
 
             AssertInvariant();
             if (!PInvoke.ImageList.Remove(_owner, index))

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.cs
@@ -536,10 +536,8 @@ public sealed partial class ImageList : Component, IHandle<HIMAGELIST>
     /// </summary>
     public void Draw(Graphics g, int x, int y, int width, int height, int index)
     {
-        if (index < 0 || index >= Images.Count)
-        {
-            throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(index);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Images.Count);
 
         HDC dc = (HDC)g.GetHdc();
         try
@@ -615,10 +613,8 @@ public sealed partial class ImageList : Component, IHandle<HIMAGELIST>
 
     private Bitmap GetBitmap(int index)
     {
-        if (index < 0 || index >= Images.Count)
-        {
-            throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(index);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Images.Count);
 
         Bitmap? result = null;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.IntegerCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.IntegerCollection.cs
@@ -262,10 +262,8 @@ public partial class ListBox
         /// </summary>
         public void RemoveAt(int index)
         {
-            if (index < 0 || index >= _count)
-            {
-                throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, _count);
 
             _count--;
             for (int i = index; i < _count; i++)
@@ -281,20 +279,16 @@ public partial class ListBox
         {
             get
             {
-                if (index < 0 || index >= _count)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
-                }
+                ArgumentOutOfRangeException.ThrowIfNegative(index);
+                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, _count);
 
                 return _innerArray![index];
             }
 
             set
             {
-                if (index < 0 || index >= _count)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
-                }
+                ArgumentOutOfRangeException.ThrowIfNegative(index);
+                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, _count);
 
                 _innerArray![index] = value;
                 _owner.UpdateCustomTabOffsets();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.ObjectCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.ObjectCollection.cs
@@ -207,10 +207,8 @@ public partial class ListBox
         {
             get
             {
-                if (index < 0 || index >= InnerArray.Count)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
-                }
+                ArgumentOutOfRangeException.ThrowIfNegative(index);
+                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, InnerArray.Count);
 
                 return InnerArray.GetItem(index);
             }
@@ -326,11 +324,8 @@ public partial class ListBox
         {
             _owner.CheckNoDataSource();
 
-            if (index < 0 || index > InnerArray.Count)
-            {
-                throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
-            }
-
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, InnerArray.Count);
             ArgumentNullException.ThrowIfNull(item);
 
             // If the List box is sorted, then nust treat this like an add
@@ -391,10 +386,8 @@ public partial class ListBox
         {
             _owner.CheckNoDataSource();
 
-            if (index < 0 || index >= InnerArray.Count)
-            {
-                throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, InnerArray.Count);
 
             _owner.UpdateMaxItemWidth(InnerArray.GetItem(index), true);
 
@@ -417,11 +410,8 @@ public partial class ListBox
         internal void SetItemInternal(int index, object value)
         {
             ArgumentNullException.ThrowIfNull(value);
-
-            if (index < 0 || index >= InnerArray.Count)
-            {
-                throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, InnerArray.Count);
 
             _owner.UpdateMaxItemWidth(InnerArray.GetItem(index), true);
             InnerArray.SetItem(index, value);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
@@ -248,10 +248,7 @@ public partial class ListBox : ListControl
 
         set
         {
-            if (value < 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(value), value, string.Format(SR.InvalidLowBoundArgumentEx, nameof(value), value, 0));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
 
             if (_columnWidth != value)
             {
@@ -1282,10 +1279,8 @@ public partial class ListBox : ListControl
 
     private void CheckIndex(int index)
     {
-        if (index < 0 || index >= Items.Count)
-        {
-            throw new ArgumentOutOfRangeException(nameof(index), string.Format(SR.IndexOutOfRange, index.ToString(CultureInfo.CurrentCulture)));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(index);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Items.Count);
     }
 
     private void CheckNoDataSource()
@@ -1426,11 +1421,10 @@ public partial class ListBox : ListControl
     {
         int itemCount = (_itemsCollection is null) ? 0 : _itemsCollection.Count;
 
+        ArgumentOutOfRangeException.ThrowIfNegative(index);
+
         // Note: index == 0 is OK even if the ListBox currently has no items.
-        if (index < 0 || (index > 0 && index >= itemCount))
-        {
-            throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
-        }
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Math.Max(1, itemCount));
 
         if (_drawMode != DrawMode.OwnerDrawVariable)
         {
@@ -2166,10 +2160,9 @@ public partial class ListBox : ListControl
     public void SetSelected(int index, bool value)
     {
         int itemCount = (_itemsCollection is null) ? 0 : _itemsCollection.Count;
-        if (index < 0 || index >= itemCount)
-        {
-            throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
-        }
+
+        ArgumentOutOfRangeException.ThrowIfNegative(index);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, itemCount);
 
         if (_selectionMode == SelectionMode.None)
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.CheckedIndexCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.CheckedIndexCollection.cs
@@ -71,10 +71,7 @@ public partial class ListView
         {
             get
             {
-                if (index < 0)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
-                }
+                ArgumentOutOfRangeException.ThrowIfNegative(index);
 
                 // Loop through the main collection until we find the right index.
                 int cnt = _owner.Items.Count;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ColumnHeaderCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ColumnHeaderCollection.cs
@@ -26,9 +26,11 @@ public partial class ListView
         {
             get
             {
-                if (_owner._columnHeaders is null || index < 0 || index >= _owner._columnHeaders.Length)
+                ArgumentOutOfRangeException.ThrowIfNegative(index);
+
+                if (_owner._columnHeaders is null || index >= _owner._columnHeaders.Length)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
+                    throw new ArgumentOutOfRangeException(nameof(index));
                 }
 
                 return _owner._columnHeaders[index];
@@ -410,10 +412,8 @@ public partial class ListView
 
         public void Insert(int index, ColumnHeader value)
         {
-            if (index < 0 || index > Count)
-            {
-                throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, Count);
 
             _owner.InsertColumn(index, value);
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ColumnHeaderCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ColumnHeaderCollection.cs
@@ -22,20 +22,7 @@ public partial class ListView
         ///  Given a Zero based index, returns the ColumnHeader object
         ///  for the column at that index
         /// </summary>
-        public virtual ColumnHeader this[int index]
-        {
-            get
-            {
-                ArgumentOutOfRangeException.ThrowIfNegative(index);
-
-                if (_owner._columnHeaders is null || index >= _owner._columnHeaders.Length)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(index));
-                }
-
-                return _owner._columnHeaders[index];
-            }
-        }
+        public virtual ColumnHeader this[int index] => _owner.GetColumnHeader(index);
 
         object? IList.this[int index]
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewItemCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewItemCollection.cs
@@ -95,19 +95,15 @@ public partial class ListView
         {
             get
             {
-                if (index < 0 || index >= InnerList.Count)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
-                }
+                ArgumentOutOfRangeException.ThrowIfNegative(index);
+                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, InnerList.Count);
 
                 return InnerList[index];
             }
             set
             {
-                if (index < 0 || index >= InnerList.Count)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
-                }
+                ArgumentOutOfRangeException.ThrowIfNegative(index);
+                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, InnerList.Count);
 
                 InnerList[index] = value;
             }
@@ -406,10 +402,8 @@ public partial class ListView
 
         public ListViewItem Insert(int index, ListViewItem item)
         {
-            if (index < 0 || index > Count)
-            {
-                throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, Count);
 
             InnerList.Insert(index, item);
             return item;
@@ -469,10 +463,8 @@ public partial class ListView
         /// </summary>
         public virtual void RemoveAt(int index)
         {
-            if (index < 0 || index >= Count)
-            {
-                throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
 
             InnerList.RemoveAt(index);
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewNativeItemCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewNativeItemCollection.cs
@@ -49,10 +49,8 @@ public partial class ListView
                 }
                 else
                 {
-                    if (displayIndex < 0 || displayIndex >= _owner._itemCount)
-                    {
-                        throw new ArgumentOutOfRangeException(nameof(displayIndex), displayIndex, string.Format(SR.InvalidArgument, nameof(displayIndex), displayIndex));
-                    }
+                    ArgumentOutOfRangeException.ThrowIfNegative(displayIndex);
+                    ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(displayIndex, _owner._itemCount);
 
                     if (_owner.IsHandleCreated && !_owner.ListViewHandleDestroyed)
                     {
@@ -74,10 +72,8 @@ public partial class ListView
                     throw new InvalidOperationException(SR.ListViewCantModifyTheItemCollInAVirtualListView);
                 }
 
-                if (displayIndex < 0 || displayIndex >= _owner._itemCount)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(displayIndex), displayIndex, string.Format(SR.InvalidArgument, nameof(displayIndex), displayIndex));
-                }
+                ArgumentOutOfRangeException.ThrowIfNegative(displayIndex);
+                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(displayIndex, _owner._itemCount);
 
                 if (_owner.ExpectingMouseUp)
                 {
@@ -324,10 +320,8 @@ public partial class ListView
                 count = _owner._itemCount;
             }
 
-            if (index < 0 || index > count)
-            {
-                throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(index, count);
 
             if (_owner.VirtualMode)
             {
@@ -394,10 +388,8 @@ public partial class ListView
                 throw new InvalidOperationException(SR.ListViewCantRemoveItemsFromAVirtualListView);
             }
 
-            if (index < 0 || index >= _owner._itemCount)
-            {
-                throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
-            }
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, _owner._itemCount);
 
             Debug.Assert(!_owner.FlipViewToLargeIconAndSmallIcon || Count == 0, "the FlipView... bit is turned off after adding 1 item.");
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.SelectedIndexCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.SelectedIndexCollection.cs
@@ -94,10 +94,8 @@ public partial class ListView
         {
             get
             {
-                if (index < 0 || index >= Count)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
-                }
+                ArgumentOutOfRangeException.ThrowIfNegative(index);
+                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
 
                 if (_owner.IsHandleCreated)
                 {
@@ -256,12 +254,10 @@ public partial class ListView
 
         public int Add(int itemIndex)
         {
+            ArgumentOutOfRangeException.ThrowIfNegative(itemIndex);
             if (_owner.VirtualMode)
             {
-                if (itemIndex < 0 || itemIndex >= _owner.VirtualListSize)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(itemIndex), itemIndex, string.Format(SR.InvalidArgument, nameof(itemIndex), itemIndex));
-                }
+                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(itemIndex, _owner.VirtualListSize);
 
                 if (_owner.IsHandleCreated)
                 {
@@ -275,10 +271,7 @@ public partial class ListView
             }
             else
             {
-                if (itemIndex < 0 || itemIndex >= _owner.Items.Count)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(itemIndex), itemIndex, string.Format(SR.InvalidArgument, nameof(itemIndex), itemIndex));
-                }
+                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(itemIndex, _owner.Items.Count);
 
                 _owner.Items[itemIndex].Selected = true;
                 return Count;
@@ -321,12 +314,10 @@ public partial class ListView
 
         public void Remove(int itemIndex)
         {
+            ArgumentOutOfRangeException.ThrowIfNegative(itemIndex);
             if (_owner.VirtualMode)
             {
-                if (itemIndex < 0 || itemIndex >= _owner.VirtualListSize)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(itemIndex), itemIndex, string.Format(SR.InvalidArgument, nameof(itemIndex), itemIndex));
-                }
+                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(itemIndex, _owner.VirtualListSize);
 
                 if (_owner.IsHandleCreated)
                 {
@@ -335,10 +326,7 @@ public partial class ListView
             }
             else
             {
-                if (itemIndex < 0 || itemIndex >= _owner.Items.Count)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(itemIndex), itemIndex, string.Format(SR.InvalidArgument, nameof(itemIndex), itemIndex));
-                }
+                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(itemIndex, _owner.Items.Count);
 
                 _owner.Items[itemIndex].Selected = false;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.SelectedListViewItemCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.SelectedListViewItemCollection.cs
@@ -118,10 +118,8 @@ public partial class ListView
                     throw new InvalidOperationException(SR.ListViewCantAccessSelectedItemsCollectionWhenInVirtualMode);
                 }
 
-                if (index < 0 || index >= Count)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
-                }
+                ArgumentOutOfRangeException.ThrowIfNegative(index);
+                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
 
                 if (_owner.IsHandleCreated)
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -5320,18 +5320,22 @@ public partial class ListView : Control
         InvalidateColumnHeaders();
     }
 
+    [MemberNotNull(nameof(_columnHeaders))]
+    private ColumnHeader GetColumnHeader(int index)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(index);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, _columnHeaders?.Length ?? 0);
+
+        return _columnHeaders![index];
+    }
+
     /// <summary>
     ///  Setting width is a special case 'cuz LVM_SETCOLUMNWIDTH accepts more values
     ///  for width than LVM_SETCOLUMN does.
     /// </summary>
     internal void SetColumnWidth(int columnIndex, ColumnHeaderAutoResizeStyle headerAutoResize)
     {
-        ArgumentOutOfRangeException.ThrowIfNegative(columnIndex);
-
-        if (_columnHeaders is null || columnIndex >= _columnHeaders.Length)
-        {
-            throw new ArgumentOutOfRangeException(nameof(columnIndex), columnIndex, string.Format(SR.InvalidArgument, nameof(columnIndex), columnIndex));
-        }
+        ColumnHeader columnHeader = GetColumnHeader(columnIndex);
 
         //valid values are 0x0 to 0x2
         SourceGenerated.EnumValidator.Validate(headerAutoResize, nameof(headerAutoResize));
@@ -5341,7 +5345,7 @@ public partial class ListView : Control
 
         if (headerAutoResize == ColumnHeaderAutoResizeStyle.None)
         {
-            width = _columnHeaders[columnIndex].WidthInternal;
+            width = columnHeader.WidthInternal;
 
             // If the width maps to a LVCSW_ const, then native control will autoresize.
             // We may need to compensate for that.
@@ -5377,7 +5381,7 @@ public partial class ListView : Control
         {
             if (compensate != 0)
             {
-                int newWidth = _columnHeaders[columnIndex].Width + compensate;
+                int newWidth = columnHeader.Width + compensate;
                 PInvoke.SendMessage(
                     this,
                     PInvoke.LVM_SETCOLUMNWIDTH,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -3242,10 +3242,8 @@ public partial class ListView : Control
     /// </summary>
     public void EnsureVisible(int index)
     {
-        if (index < 0 || index >= Items.Count)
-        {
-            throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(index);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Items.Count);
 
         if (IsHandleCreated)
         {
@@ -3271,10 +3269,8 @@ public partial class ListView : Control
 
     public ListViewItem? FindItemWithText(string text, bool includeSubItemsInSearch, int startIndex, bool isPrefixSearch)
     {
-        if (startIndex < 0 || startIndex >= Items.Count)
-        {
-            throw new ArgumentOutOfRangeException(nameof(startIndex), startIndex, string.Format(SR.InvalidArgument, nameof(startIndex), startIndex));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(startIndex);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(startIndex, Items.Count);
 
         return FindItem(true, text, isPrefixSearch, new Point(0, 0), SearchDirectionHint.Down, startIndex, includeSubItemsInSearch);
     }
@@ -3634,10 +3630,8 @@ public partial class ListView : Control
 
     internal LIST_VIEW_ITEM_STATE_FLAGS GetItemState(int index, LIST_VIEW_ITEM_STATE_FLAGS mask)
     {
-        if (index < 0 || (VirtualMode && index >= VirtualListSize) || (!VirtualMode && index >= _itemCount))
-        {
-            throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(index);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, VirtualMode ? VirtualListSize : _itemCount);
 
         Debug.Assert(IsHandleCreated, "How did we add items without a handle?");
         return (LIST_VIEW_ITEM_STATE_FLAGS)(uint)PInvoke.SendMessage(this, PInvoke.LVM_GETITEMSTATE, (WPARAM)index, (LPARAM)(uint)mask);
@@ -3653,10 +3647,8 @@ public partial class ListView : Control
     /// </summary>
     public Rectangle GetItemRect(int index, ItemBoundsPortion portion)
     {
-        if (index < 0 || index >= Items.Count)
-        {
-            throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(index);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Items.Count);
 
         // Valid values are 0x0 to 0x3
         SourceGenerated.EnumValidator.Validate(portion, nameof(portion));
@@ -3726,18 +3718,18 @@ public partial class ListView : Control
             return Rectangle.Empty;
         }
 
-        if (itemIndex < 0 || itemIndex >= Items.Count)
+        ArgumentOutOfRangeException.ThrowIfNegative(itemIndex);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(itemIndex, Items.Count);
+        ArgumentOutOfRangeException.ThrowIfNegative(subItemIndex);
+
+        if (View == View.Tile)
         {
-            throw new ArgumentOutOfRangeException(nameof(itemIndex), itemIndex, string.Format(SR.InvalidArgument, nameof(itemIndex), itemIndex));
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(subItemIndex, Items[itemIndex].SubItems.Count);
         }
 
-        int subItemCount = Items[itemIndex].SubItems.Count;
-
-        if (subItemIndex < 0
-            || (View == View.Tile && subItemIndex >= subItemCount)
-            || (View == View.Details && subItemIndex >= Columns.Count))
+        if (View == View.Details)
         {
-            throw new ArgumentOutOfRangeException(nameof(subItemIndex), subItemIndex, string.Format(SR.InvalidArgument, nameof(subItemIndex), subItemIndex));
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(subItemIndex, Columns.Count);
         }
 
         //valid values are 0x0 to 0x3
@@ -5066,30 +5058,12 @@ public partial class ListView : Control
     [EditorBrowsable(EditorBrowsableState.Advanced)]
     public void RedrawItems(int startIndex, int endIndex, bool invalidateOnly)
     {
-        if (VirtualMode)
-        {
-            if (startIndex < 0 || startIndex >= VirtualListSize)
-            {
-                throw new ArgumentOutOfRangeException(nameof(startIndex), startIndex, string.Format(SR.InvalidArgument, nameof(startIndex), startIndex));
-            }
+        ArgumentOutOfRangeException.ThrowIfNegative(startIndex);
+        ArgumentOutOfRangeException.ThrowIfNegative(endIndex);
 
-            if (endIndex < 0 || endIndex >= VirtualListSize)
-            {
-                throw new ArgumentOutOfRangeException(nameof(endIndex), endIndex, string.Format(SR.InvalidArgument, nameof(endIndex), endIndex));
-            }
-        }
-        else
-        {
-            if (startIndex < 0 || startIndex >= Items.Count)
-            {
-                throw new ArgumentOutOfRangeException(nameof(startIndex), startIndex, string.Format(SR.InvalidArgument, nameof(startIndex), startIndex));
-            }
-
-            if (endIndex < 0 || endIndex >= Items.Count)
-            {
-                throw new ArgumentOutOfRangeException(nameof(endIndex), endIndex, string.Format(SR.InvalidArgument, nameof(endIndex), endIndex));
-            }
-        }
+        int maxSize = VirtualMode ? VirtualListSize : Items.Count;
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(startIndex, maxSize);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(endIndex, maxSize);
 
         if (startIndex > endIndex)
         {
@@ -5352,9 +5326,9 @@ public partial class ListView : Control
     /// </summary>
     internal void SetColumnWidth(int columnIndex, ColumnHeaderAutoResizeStyle headerAutoResize)
     {
-        if ((columnIndex < 0) ||
-            (columnIndex >= 0 && _columnHeaders is null) ||
-            (columnIndex >= _columnHeaders!.Length))
+        ArgumentOutOfRangeException.ThrowIfNegative(columnIndex);
+
+        if (_columnHeaders is null || columnIndex >= _columnHeaders.Length)
         {
             throw new ArgumentOutOfRangeException(nameof(columnIndex), columnIndex, string.Format(SR.InvalidArgument, nameof(columnIndex), columnIndex));
         }
@@ -5482,10 +5456,8 @@ public partial class ListView : Control
 
     internal void SetItemImage(int itemIndex, int imageIndex)
     {
-        if (itemIndex < 0 || (VirtualMode && itemIndex >= VirtualListSize) || (!VirtualMode && itemIndex >= _itemCount))
-        {
-            throw new ArgumentOutOfRangeException(nameof(itemIndex), itemIndex, string.Format(SR.InvalidArgument, nameof(itemIndex), itemIndex));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(itemIndex);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(itemIndex, VirtualMode ? VirtualListSize : _itemCount);
 
         if (!IsHandleCreated)
         {
@@ -5504,10 +5476,8 @@ public partial class ListView : Control
 
     internal void SetItemIndentCount(int index, int indentCount)
     {
-        if (index < 0 || (VirtualMode && index >= VirtualListSize) || (!VirtualMode && index >= _itemCount))
-        {
-            throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(index);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, VirtualMode ? VirtualListSize : _itemCount);
 
         if (!IsHandleCreated)
         {
@@ -5531,10 +5501,8 @@ public partial class ListView : Control
             return;
         }
 
-        if (index < 0 || index >= _itemCount)
-        {
-            throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(index);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, _itemCount);
 
         Debug.Assert(IsHandleCreated, "How did we add items without a handle?");
 
@@ -5544,10 +5512,8 @@ public partial class ListView : Control
 
     internal void SetItemState(int index, LIST_VIEW_ITEM_STATE_FLAGS state, LIST_VIEW_ITEM_STATE_FLAGS mask)
     {
-        if (index < -1 || (VirtualMode && index >= VirtualListSize) || (!VirtualMode && index >= _itemCount))
-        {
-            throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
-        }
+        ArgumentOutOfRangeException.ThrowIfLessThan(index, -1);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, VirtualMode ? VirtualListSize : _itemCount);
 
         if (!IsHandleCreated)
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewSubItemCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewSubItemCollection.cs
@@ -44,19 +44,15 @@ public partial class ListViewItem
         {
             get
             {
-                if (index < 0 || index >= Count)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
-                }
+                ArgumentOutOfRangeException.ThrowIfNegative(index);
+                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
 
                 return _owner._subItems[index];
             }
             set
             {
-                if (index < 0 || index >= Count)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
-                }
+                ArgumentOutOfRangeException.ThrowIfNegative(index);
+                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
 
                 ListViewSubItem oldSubItem = _owner._subItems[index];
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NotifyIcon.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NotifyIcon.cs
@@ -545,10 +545,7 @@ public sealed partial class NotifyIcon : Component
     /// </summary>
     public unsafe void ShowBalloonTip(int timeout, string tipTitle, string tipText, ToolTipIcon tipIcon)
     {
-        if (timeout < 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(timeout), timeout, string.Format(SR.InvalidArgument, nameof(timeout), timeout));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(timeout);
 
         if (string.IsNullOrEmpty(tipText))
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
@@ -1825,10 +1825,8 @@ public partial class RichTextBox : TextBoxBase
         ArgumentNullException.ThrowIfNull(str);
 
         int textLen = TextLength;
-        if (start < 0 || start > textLen)
-        {
-            throw new ArgumentOutOfRangeException(nameof(start), start, string.Format(SR.InvalidBoundArgument, nameof(start), start, 0, textLen));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(start);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(start, textLen);
 
         if (end < -1)
         {
@@ -1978,11 +1976,8 @@ public partial class RichTextBox : TextBoxBase
         int textLength = TextLength;
 
         ArgumentNullException.ThrowIfNull(characterSet);
-
-        if (start < 0 || start > textLength)
-        {
-            throw new ArgumentOutOfRangeException(nameof(start), start, string.Format(SR.InvalidBoundArgument, nameof(start), start, 0, textLength));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(start);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(start, textLength);
 
         if (end < start && end != -1)
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
@@ -1055,10 +1055,8 @@ public partial class TabControl : Control
 
     internal TabPage GetTabPage(int index)
     {
-        if (index < 0 || index >= TabCount)
-        {
-            throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(index);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, TabCount);
 
         return _tabPages[index];
     }
@@ -1104,9 +1102,11 @@ public partial class TabControl : Control
     /// </summary>
     public Rectangle GetTabRect(int index)
     {
-        if (index < 0 || (index >= TabCount && !GetState(State.GetTabRectfromItemSize)))
+        ArgumentOutOfRangeException.ThrowIfNegative(index);
+
+        if (!GetState(State.GetTabRectfromItemSize))
         {
-            throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, TabCount);
         }
 
         SetState(State.GetTabRectfromItemSize, false);
@@ -1160,11 +1160,8 @@ public partial class TabControl : Control
     /// </summary>
     private void InsertItem(int index, TabPage tabPage)
     {
-        if (index < 0 || index > TabCount)
-        {
-            throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
-        }
-
+        ArgumentOutOfRangeException.ThrowIfNegative(index);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(index, TabCount);
         ArgumentNullException.ThrowIfNull(tabPage);
 
         index = IsHandleCreated ? SendMessage(PInvoke.TCM_INSERTITEMW, index, tabPage) : index;
@@ -1590,10 +1587,8 @@ public partial class TabControl : Control
 
     private void RemoveTabPage(int index)
     {
-        if (index < 0 || index >= TabCount)
-        {
-            throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(index);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, TabCount);
 
         if (index < _tabPages.Count)
         {
@@ -1645,11 +1640,8 @@ public partial class TabControl : Control
 
     private void SetTabPage(int index, TabPage value)
     {
-        if (index < 0 || index >= TabCount)
-        {
-            throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
-        }
-
+        ArgumentOutOfRangeException.ThrowIfNegative(index);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, TabCount);
         ArgumentNullException.ThrowIfNull(value);
 
         if (IsHandleCreated)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutPanelCellPosition.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutPanelCellPosition.cs
@@ -10,15 +10,8 @@ public struct TableLayoutPanelCellPosition : IEquatable<TableLayoutPanelCellPosi
 {
     public TableLayoutPanelCellPosition(int column, int row)
     {
-        if (row < -1)
-        {
-            throw new ArgumentOutOfRangeException(nameof(row), row, string.Format(SR.InvalidArgument, nameof(row), row));
-        }
-
-        if (column < -1)
-        {
-            throw new ArgumentOutOfRangeException(nameof(column), column, string.Format(SR.InvalidArgument, nameof(column), column));
-        }
+        ArgumentOutOfRangeException.ThrowIfLessThan(row, -1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(column, -1);
 
         Row = row;
         Column = column;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutSettings.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutSettings.cs
@@ -256,11 +256,7 @@ public sealed partial class TableLayoutSettings : LayoutSettings, ISerializable
     public void SetColumnSpan(object control, int value)
     {
         ArgumentNullException.ThrowIfNull(control);
-
-        if (value < 1)
-        {
-            throw new ArgumentOutOfRangeException(nameof(value), value, string.Format(SR.InvalidArgument, nameof(value), value));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(value);
 
         if (IsStub)
         {
@@ -298,11 +294,7 @@ public sealed partial class TableLayoutSettings : LayoutSettings, ISerializable
     public void SetRowSpan(object control, int value)
     {
         ArgumentNullException.ThrowIfNull(control);
-
-        if (value < 1)
-        {
-            throw new ArgumentOutOfRangeException(nameof(value), value, string.Format(SR.InvalidArgument, nameof(value), value));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(value);
 
         if (IsStub)
         {
@@ -352,11 +344,7 @@ public sealed partial class TableLayoutSettings : LayoutSettings, ISerializable
     public void SetRow(object control, int row)
     {
         ArgumentNullException.ThrowIfNull(control);
-
-        if (row < -1)
-        {
-            throw new ArgumentOutOfRangeException(nameof(row), row, string.Format(SR.InvalidArgument, nameof(row), row));
-        }
+        ArgumentOutOfRangeException.ThrowIfLessThan(row, -1);
 
         SetCellPosition(control, row, -1, rowSpecified: true, colSpecified: false);
     }
@@ -417,11 +405,7 @@ public sealed partial class TableLayoutSettings : LayoutSettings, ISerializable
     public void SetColumn(object control, int column)
     {
         ArgumentNullException.ThrowIfNull(control);
-
-        if (column < -1)
-        {
-            throw new ArgumentOutOfRangeException(nameof(column), column, string.Format(SR.InvalidArgument, nameof(column), column));
-        }
+        ArgumentOutOfRangeException.ThrowIfLessThan(column, -1);
 
         if (IsStub)
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
@@ -1653,10 +1653,7 @@ public abstract partial class TextBoxBase : Control
     /// </summary>
     public int GetFirstCharIndexFromLine(int lineNumber)
     {
-        if (lineNumber < 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(lineNumber), lineNumber, string.Format(SR.InvalidArgument, nameof(lineNumber), lineNumber));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(lineNumber);
 
         return (int)PInvoke.SendMessage(this, PInvoke.EM_LINEINDEX, (WPARAM)lineNumber);
     }
@@ -1768,10 +1765,7 @@ public abstract partial class TextBoxBase : Control
     /// </summary>
     public void Select(int start, int length)
     {
-        if (start < 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(start), start, string.Format(SR.InvalidArgument, nameof(start), start));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(start);
 
         int textLen = TextLength;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanel.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanel.cs
@@ -4,7 +4,6 @@
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Drawing;
-using System.Globalization;
 using System.Windows.Forms.Layout;
 
 namespace System.Windows.Forms;
@@ -760,10 +759,7 @@ public partial class ToolStripPanel : ContainerControl, IArrangedElement
 
     public void Join(ToolStrip toolStripToDrag, int row)
     {
-        if (row < 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(row), string.Format(SR.IndexOutOfRange, row.ToString(CultureInfo.CurrentCulture)));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(row);
 
         Rectangle dragRect;
         if (row >= RowsInternal.Count)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
@@ -3,7 +3,6 @@
 
 using System.ComponentModel;
 using System.Drawing;
-using System.Globalization;
 using static Interop;
 using static Interop.ComCtl32;
 
@@ -1402,11 +1401,7 @@ public partial class ToolTip : Component, IExtenderProvider, IHandle<HWND>
     public void Show(string? text, IWin32Window window, int duration)
     {
         ArgumentNullException.ThrowIfNull(window);
-
-        if (duration < 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(duration), duration, string.Format(SR.InvalidLowBoundArgumentEx, nameof(duration), duration, 0));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(duration);
 
         if (IsWindowActive(window))
         {
@@ -1439,14 +1434,7 @@ public partial class ToolTip : Component, IExtenderProvider, IHandle<HWND>
     public void Show(string? text, IWin32Window window, Point point, int duration)
     {
         ArgumentNullException.ThrowIfNull(window);
-
-        if (duration < 0)
-        {
-            throw new ArgumentOutOfRangeException(
-                nameof(duration),
-                duration,
-                string.Format(SR.InvalidLowBoundArgumentEx, nameof(duration), duration, 0));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(duration);
 
         if (IsWindowActive(window))
         {
@@ -1483,14 +1471,7 @@ public partial class ToolTip : Component, IExtenderProvider, IHandle<HWND>
     public void Show(string? text, IWin32Window window, int x, int y, int duration)
     {
         ArgumentNullException.ThrowIfNull(window);
-
-        if (duration < 0)
-        {
-            throw new ArgumentOutOfRangeException(
-                nameof(duration),
-                duration,
-                string.Format(SR.InvalidLowBoundArgumentEx, nameof(duration), duration, 0));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(duration);
 
         if (IsWindowActive(window))
         {
@@ -1506,13 +1487,7 @@ public partial class ToolTip : Component, IExtenderProvider, IHandle<HWND>
     internal void ShowKeyboardToolTip(string? text, IKeyboardToolTip tool, int duration)
     {
         ArgumentNullException.ThrowIfNull(tool);
-
-        if (duration < 0)
-        {
-            throw new ArgumentOutOfRangeException(
-                nameof(duration),
-                string.Format(SR.InvalidLowBoundArgumentEx, nameof(duration), (duration).ToString(CultureInfo.CurrentCulture), 0));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(duration);
 
         Rectangle toolRectangle = tool.GetNativeScreenRectangle();
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeNodeCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeNodeCollection.cs
@@ -38,11 +38,8 @@ public class TreeNodeCollection : IList
         }
         set
         {
-            if (index < 0 || index >= _owner._childNodes.Count)
-            {
-                throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
-            }
-
+            ArgumentOutOfRangeException.ThrowIfNegative(index);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, _owner._childNodes.Count);
             ArgumentNullException.ThrowIfNull(value);
 
             TreeView tv = _owner._treeView!;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleRenderer.cs
@@ -316,8 +316,8 @@ public sealed class VisualStyleRenderer : IHandle<HTHEME>
         ArgumentNullException.ThrowIfNull(g);
         ArgumentNullException.ThrowIfNull(imageList);
 
-        if (imageIndex < 0 || imageIndex >= imageList.Images.Count)
-            throw new ArgumentOutOfRangeException(nameof(imageIndex), imageIndex, string.Format(SR.InvalidArgument, nameof(imageIndex), imageIndex));
+        ArgumentOutOfRangeException.ThrowIfNegative(imageIndex);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(imageIndex, imageList.Images.Count);
 
         if (bounds.Width < 0 || bounds.Height < 0)
             return;


### PR DESCRIPTION
Contributes to #9726


## Proposed changes

This is a follow-up to #9728, only this time we are dealing with less standard `ArgumentOutOfRangeException`s, so the message will change a bit. Here, I made changes only to cases where I figured the messages added little value to the default ones:

- SR.InvalidArgument
- SR.InvalidLowBoundArgumentEx
- SR.InvalidLowBoundArgument
- SR.InvalidHighBoundArgumentEx
- SR.InvalidHighBoundArgument
- SR.InvalidBoundArgument
- SR.IndexOutOfRange

## Risk

- low, but higher than the pure fixer modifications. I still used the IDE as much as possible (e.g. to break if clauses into 2) so that CA1512 could apply. To do so, I manually modified the exception to remove the custom message after verfying that we do not lose any information by doing so.

## Test methodology

- CI


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9755)