### PR TITLE
Additional COM fixes

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/DisposeHelper.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/DisposeHelper.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.CompilerServices;
+using Windows.Win32.System.Com;
 
 namespace System;
 
@@ -17,5 +18,20 @@ internal static class DisposeHelper
         IDisposable? localDisposable = disposable;
         disposable = null;
         localDisposable?.Dispose();
+    }
+
+    /// <summary>
+    ///  Sets <paramref name="comPointer"/> to null before releasing it. Useful for guarding against field
+    ///  access when releasing the field.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static unsafe void NullAndRelease<T>(ref T* comPointer) where T : unmanaged, IComIID
+    {
+        IUnknown* localComPointer = (IUnknown*)comPointer;
+        comPointer = null;
+        if (localComPointer is not null)
+        {
+            localComPointer->Release();
+        }
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/Foundation/AgileComPointer.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/Foundation/AgileComPointer.cs
@@ -102,7 +102,7 @@ internal unsafe class AgileComPointer<TInterface> :
         // Clear the cookie before revoking the interface to guard against re-entry.
 
         uint cookie = Interlocked.Exchange(ref _cookie, 0);
-        if (_cookie == 0)
+        if (cookie == 0)
         {
             return;
         }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/Foundation/AgileComPointer.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/Foundation/AgileComPointer.cs
@@ -99,14 +99,13 @@ internal unsafe class AgileComPointer<TInterface> :
 
     protected virtual void Dispose(bool disposing)
     {
+        // Clear the cookie before revoking the interface to guard against re-entry.
+
+        uint cookie = Interlocked.Exchange(ref _cookie, 0);
         if (_cookie == 0)
         {
             return;
         }
-
-        // Clear the cookie before revoking the interface to guard against re-entry.
-        uint cookie = _cookie;
-        _cookie = 0;
 
         HRESULT hr = GlobalInterfaceTable.RevokeInterface(cookie);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxContainer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxContainer.cs
@@ -684,7 +684,12 @@ public abstract partial class AxHost
                 // Release the field before disposing to avoid accessing it during disposal on callbacks.
                 activeHost._iOleInPlaceActiveObjectExternal = null;
                 existing.Dispose();
-                activeHost._iOleInPlaceActiveObjectExternal = new(pActiveObject, takeOwnership: true);
+
+                if (pActiveObject is not null)
+                {
+                    pActiveObject->AddRef();
+                    activeHost._iOleInPlaceActiveObjectExternal = new(pActiveObject, takeOwnership: true);
+                }
             }
 
             if (pActiveObject is null)
@@ -741,7 +746,7 @@ public abstract partial class AxHost
             return HRESULT.S_OK;
         }
 
-        unsafe HRESULT IOleInPlaceFrame.Interface.InsertMenus(HMENU hmenuShared, OLEMENUGROUPWIDTHS* lpMenuWidths)
+        HRESULT IOleInPlaceFrame.Interface.InsertMenus(HMENU hmenuShared, OLEMENUGROUPWIDTHS* lpMenuWidths)
         {
             s_axHTraceSwitch.TraceVerbose("in InsertMenus");
             return HRESULT.S_OK;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.OleInterfaces.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.OleInterfaces.cs
@@ -429,7 +429,6 @@ public abstract partial class AxHost
                 return HRESULT.E_POINTER;
             }
 
-            *ppDoc = null;
             *ppFrame = ComHelpers.GetComPointer<IOleInPlaceFrame>(_host.GetParentContainer());
             *lprcPosRect = _host.Bounds;
             *lprcClipRect = WebBrowserHelper.GetClipRect();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.OleInterfaces.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.OleInterfaces.cs
@@ -412,23 +412,27 @@ public abstract partial class AxHost
             RECT* lprcClipRect,
             OLEINPLACEFRAMEINFO* lpFrameInfo)
         {
-            if (ppDoc is null || ppFrame is null)
+            // Following MFC CAxHostWindow::GetWindowContext handling
+
+            if (ppFrame is not null)
+            {
+                *ppFrame = null;
+            }
+
+            if (ppDoc is not null)
+            {
+                *ppDoc = null;
+            }
+
+            if (ppDoc is null || ppFrame is null || lprcPosRect is null || lprcClipRect is null)
             {
                 return HRESULT.E_POINTER;
             }
 
             *ppDoc = null;
             *ppFrame = ComHelpers.GetComPointer<IOleInPlaceFrame>(_host.GetParentContainer());
-
-            if (lprcPosRect is not null)
-            {
-                *lprcPosRect = _host.Bounds;
-            }
-
-            if (lprcClipRect is not null)
-            {
-                *lprcClipRect = WebBrowserHelper.GetClipRect();
-            }
+            *lprcPosRect = _host.Bounds;
+            *lprcClipRect = WebBrowserHelper.GetClipRect();
 
             if (lpFrameInfo is not null)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
@@ -117,7 +117,7 @@ public partial class Control
         private static readonly int s_uiActive = BitVector32.CreateMask(s_inPlaceVisible);
         private static readonly int s_uiDead = BitVector32.CreateMask(s_uiActive);
         private static readonly int s_adjustingRect = BitVector32.CreateMask(s_uiDead);
-        private static readonly SearchValues<char> s_whitespace = SearchValues.Create(new char[] { ' ', '\r', '\n' });
+        private static readonly SearchValues<char> s_whitespace = SearchValues.Create(" \r\n");
 
         private static Point s_logPixels = Point.Empty;
         private static OLEVERB[]? s_axVerbs;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Drawing;
@@ -116,7 +117,7 @@ public partial class Control
         private static readonly int s_uiActive = BitVector32.CreateMask(s_inPlaceVisible);
         private static readonly int s_uiDead = BitVector32.CreateMask(s_uiActive);
         private static readonly int s_adjustingRect = BitVector32.CreateMask(s_uiDead);
-        private static readonly char[] s_whitespace = new char[] { ' ', '\r', '\n' };
+        private static readonly SearchValues<char> s_whitespace = SearchValues.Create(new char[] { ' ', '\r', '\n' });
 
         private static Point s_logPixels = Point.Empty;
         private static OLEVERB[]? s_axVerbs;
@@ -530,7 +531,7 @@ public partial class Control
         /// </summary>
         private static byte[] FromBase64WrappedString(string text)
         {
-            if (text.IndexOfAny(s_whitespace) != -1)
+            if (text.AsSpan().ContainsAny(s_whitespace))
             {
                 StringBuilder sb = new StringBuilder(text.Length);
                 for (int i = 0; i < text.Length; i++)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
@@ -116,6 +116,7 @@ public partial class Control
         private static readonly int s_uiActive = BitVector32.CreateMask(s_inPlaceVisible);
         private static readonly int s_uiDead = BitVector32.CreateMask(s_uiActive);
         private static readonly int s_adjustingRect = BitVector32.CreateMask(s_uiDead);
+        private static readonly char[] s_whitespace = new char[] { ' ', '\r', '\n' };
 
         private static Point s_logPixels = Point.Empty;
         private static OLEVERB[]? s_axVerbs;
@@ -529,7 +530,7 @@ public partial class Control
         /// </summary>
         private static byte[] FromBase64WrappedString(string text)
         {
-            if (text.IndexOfAny(new char[] { ' ', '\r', '\n' }) != -1)
+            if (text.IndexOfAny(s_whitespace) != -1)
             {
                 StringBuilder sb = new StringBuilder(text.Length);
                 for (int i = 0; i < text.Length; i++)
@@ -806,7 +807,7 @@ public partial class Control
         }
 
         /// <summary>
-        ///  In place activates this Object.
+        ///  In place activates this object.
         /// </summary>
         internal unsafe void InPlaceActivate(OLEIVERB verb)
         {
@@ -930,14 +931,13 @@ public partial class Control
             // Set ourselves up in the host.
             Debug.Assert(_inPlaceFrame is not null, "Setting us to visible should have created the in place frame");
 
-            var activeObject = ComHelpers.GetComPointer<IOleInPlaceActiveObject>(_control);
+            using var activeObject = ComHelpers.GetComScope<IOleInPlaceActiveObject>(_control);
 
             using var inPlaceFrame = _inPlaceFrame.GetInterface();
             inPlaceFrame.Value->SetActiveObject(activeObject, (PCWSTR)null);
             using var inPlaceUiWindow = _inPlaceUiWindow is null ? default : _inPlaceUiWindow.GetInterface();
             if (_inPlaceUiWindow is not null)
             {
-                activeObject->AddRef();
                 inPlaceUiWindow.Value->SetActiveObject(activeObject, (PCWSTR)null);
             }
 
@@ -1064,10 +1064,11 @@ public partial class Control
         internal void Load(IStream* stream)
         {
             // We do everything through property bags because we support full fidelity
-            // in them.  So, load through that method.
+            // in them. So, load through that method.
             PropertyBagStream bagStream = new();
             bagStream.Read(stream);
-            Load(ComHelpers.GetComPointer<IPropertyBag>(bagStream), errorLog: null);
+            using var propertyBag = ComHelpers.GetComScope<IPropertyBag>(bagStream);
+            Load(propertyBag, errorLog: null);
         }
 
         /// <inheritdoc cref="IPersistPropertyBag.Load(IPropertyBag*, IErrorLog*)"/>
@@ -1076,8 +1077,6 @@ public partial class Control
             PropertyDescriptorCollection props = TypeDescriptor.GetProperties(
                 _control,
                 new Attribute[] { DesignerSerializationVisibilityAttribute.Visible });
-
-            using ComScope<IPropertyBag> scope = new(propertyBag);
 
             for (int i = 0; i < props.Count; i++)
             {
@@ -1455,10 +1454,12 @@ public partial class Control
                     // Control doesn't explicitly implement IConnectionPointContainer, but it is generated with a CCW by
                     // COM interop.
 
-                    using var container = ComHelpers.GetComScope<IConnectionPointContainer>(_control);
+                    using var container = ComHelpers.TryGetComScope<IConnectionPointContainer>(_control, out HRESULT hr);
+
+                    hr.AssertSuccess();
+
                     using ComScope<IConnectionPoint> connectionPoint = new(null);
-                    HRESULT hr = container.Value->FindConnectionPoint(eventInterface.GUID, connectionPoint);
-                    if (hr.Failed)
+                    if (hr.Failed || container.Value->FindConnectionPoint(eventInterface.GUID, connectionPoint).Failed)
                     {
                         throw new ArgumentException(string.Format(SR.AXNoConnectionPoint, eventInterface.Name));
                     }
@@ -1515,7 +1516,9 @@ public partial class Control
             // We do everything through property bags because we support full fidelity in them.
             // So, save through that method.
             PropertyBagStream bagStream = new();
-            Save(ComHelpers.GetComPointer<IPropertyBag>(bagStream), fClearDirty, saveAllProperties: false);
+
+            using var propertyBag = ComHelpers.GetComScope<IPropertyBag>(bagStream);
+            Save(propertyBag, fClearDirty, saveAllProperties: false);
             bagStream.Write(stream);
         }
 
@@ -1525,8 +1528,6 @@ public partial class Control
             PropertyDescriptorCollection props = TypeDescriptor.GetProperties(
                 _control,
                 new Attribute[] { DesignerSerializationVisibilityAttribute.Visible });
-
-            using ComScope<IPropertyBag> scope = new(propertyBag);
 
             for (int i = 0; i < props.Count; i++)
             {
@@ -1635,10 +1636,7 @@ public partial class Control
             _activeXState[s_viewAdvisePrimeFirst] = advf.HasFlag(ADVF.ADVF_PRIMEFIRST);
             _activeXState[s_viewAdviseOnlyOnce] = advf.HasFlag(ADVF.ADVF_ONLYONCE);
 
-            if (_viewAdviseSink is not null)
-            {
-                _viewAdviseSink->Release();
-            }
+            DisposeHelper.NullAndRelease(ref _viewAdviseSink);
 
             if (pAdvSink is not null)
             {
@@ -2044,7 +2042,7 @@ public partial class Control
                 using var inPlaceSite = _clientSite.TryGetInterface<IOleInPlaceSite>(out HRESULT hr);
                 if (hr.Succeeded)
                 {
-                    inPlaceSite.Value->OnUIDeactivate(BOOL.FALSE);
+                    inPlaceSite.Value->OnUIDeactivate(fUndoable: BOOL.FALSE);
                 }
             }
 
@@ -2175,8 +2173,7 @@ public partial class Control
 
             if (_activeXState[s_viewAdviseOnlyOnce])
             {
-                _viewAdviseSink->Release();
-                _viewAdviseSink = null;
+                DisposeHelper.NullAndRelease(ref _viewAdviseSink);
             }
         }
 


### PR DESCRIPTION
COM code audit fixes:

- AxContainer.IOleInPlaceFrame.SetActiveObject was not ref counting correctly or checking for null
- OleInterfaces.IOleControlSite.GetExtendedControl was unnecessarily using Marshal
- OleIntefaces.IOleInPlaceSite.GetWindowContext brought in line with MFC behavior with null pointers
- Use static char array in ActiveXImpl (minor perf fix)
- ActiveXImpl.InPlaceActivate was incorrectly ref counting
- ActiveXImpl Save/Load were releasing IPropertyBag when it was passed directly from native code, move the using local to the internal code
- ActiveXImpl.QuickActivate should not fail if we cannot get IConnectionPointContainer
- Add DisposeHelper.NullAndRelease helper for safer release of pointer fields
- Harden AgileComPointer a bit more by using Interlocked


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9769)