### PR TITLE
Additional COM fixes (#9769)

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/DisposeHelper.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/DisposeHelper.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.CompilerServices;
+using Windows.Win32.System.Com;
 
 namespace System;
 
@@ -17,5 +18,20 @@ internal static class DisposeHelper
         IDisposable? localDisposable = disposable;
         disposable = null;
         localDisposable?.Dispose();
+    }
+
+    /// <summary>
+    ///  Sets <paramref name="comPointer"/> to null before releasing it. Useful for guarding against field
+    ///  access when releasing the field.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static unsafe void NullAndRelease<T>(ref T* comPointer) where T : unmanaged, IComIID
+    {
+        IUnknown* localComPointer = (IUnknown*)comPointer;
+        comPointer = null;
+        if (localComPointer is not null)
+        {
+            localComPointer->Release();
+        }
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/Foundation/AgileComPointer.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/Foundation/AgileComPointer.cs
@@ -99,14 +99,13 @@ internal unsafe class AgileComPointer<TInterface> :
 
     protected virtual void Dispose(bool disposing)
     {
-        if (_cookie == 0)
+        // Clear the cookie before revoking the interface to guard against re-entry.
+
+        uint cookie = Interlocked.Exchange(ref _cookie, 0);
+        if (cookie == 0)
         {
             return;
         }
-
-        // Clear the cookie before revoking the interface to guard against re-entry.
-        uint cookie = _cookie;
-        _cookie = 0;
 
         HRESULT hr = GlobalInterfaceTable.RevokeInterface(cookie);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxContainer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxContainer.cs
@@ -684,7 +684,12 @@ public abstract partial class AxHost
                 // Release the field before disposing to avoid accessing it during disposal on callbacks.
                 activeHost._iOleInPlaceActiveObjectExternal = null;
                 existing.Dispose();
-                activeHost._iOleInPlaceActiveObjectExternal = new(pActiveObject, takeOwnership: true);
+
+                if (pActiveObject is not null)
+                {
+                    pActiveObject->AddRef();
+                    activeHost._iOleInPlaceActiveObjectExternal = new(pActiveObject, takeOwnership: true);
+                }
             }
 
             if (pActiveObject is null)
@@ -741,7 +746,7 @@ public abstract partial class AxHost
             return HRESULT.S_OK;
         }
 
-        unsafe HRESULT IOleInPlaceFrame.Interface.InsertMenus(HMENU hmenuShared, OLEMENUGROUPWIDTHS* lpMenuWidths)
+        HRESULT IOleInPlaceFrame.Interface.InsertMenus(HMENU hmenuShared, OLEMENUGROUPWIDTHS* lpMenuWidths)
         {
             s_axHTraceSwitch.TraceVerbose("in InsertMenus");
             return HRESULT.S_OK;


### PR DESCRIPTION
Port of #9769 - do not squash

COM code audit fixes:

- AxContainer.IOleInPlaceFrame.SetActiveObject was not ref counting correctly or checking for null
- OleInterfaces.IOleControlSite.GetExtendedControl was unnecessarily using Marshal
- OleIntefaces.IOleInPlaceSite.GetWindowContext brought in line with MFC behavior with null pointers
- Use SearchValues in ActiveXImpl (minor perf fix)
- ActiveXImpl.InPlaceActivate was incorrectly ref counting
- ActiveXImpl Save/Load were releasing IPropertyBag when it was passed directly from native code, move the using local to the internal code
- ActiveXImpl.QuickActivate should not fail if we cannot get IConnectionPointContainer
- Add DisposeHelper.NullAndRelease helper for safer release of pointer fields
- Harden AgileComPointer a bit more by using Interlocked

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9780)