### PR TITLE
Make sure the Label Edit in ListView has correct position in accessibility tree 

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewAccessibleObject.cs
@@ -95,11 +95,6 @@ public partial class ListView
                 return null;
             }
 
-            if (owningListView._labelEdit is {} labelEdit && index == GetChildCount() - 1)
-            {
-                return labelEdit.AccessibilityObject;
-            }
-
             if (owningListView.GroupsDisplayed)
             {
                 IReadOnlyList<ListViewGroup> visibleGroups = GetVisibleGroups();
@@ -117,10 +112,6 @@ public partial class ListView
             }
 
             int count = owningListView.GroupsDisplayed ? GetVisibleGroups().Count : owningListView.Items.Count;
-            if (owningListView._labelEdit is not null)
-            {
-                count++;
-            }
 
             return count;
         }
@@ -167,9 +158,7 @@ public partial class ListView
                 return base.GetChildIndex(child);
             }
 
-            return owningListView._labelEdit is { } labelEdit && child == labelEdit.AccessibilityObject
-                     ? GetChildCount() - 1
-                     : owningListView.GroupsDisplayed ? GetGroupIndex(child) : GetItemIndex(child);
+            return owningListView.GroupsDisplayed ? GetGroupIndex(child) : GetItemIndex(child);
         }
 
         private string GetItemStatus()
@@ -237,11 +226,6 @@ public partial class ListView
             if (!this.TryGetOwnerAs(out ListView? owningListView))
             {
                 return null;
-            }
-
-            if (owningListView._labelEdit is {} labelEdit)
-            {
-                return labelEdit.AccessibilityObject;
             }
 
             if (owningListView.GroupsDisplayed)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -12,6 +12,7 @@ using System.Windows.Forms.Layout;
 using System.Windows.Forms.VisualStyles;
 using Windows.Win32.UI.Input.KeyboardAndMouse;
 using static System.Windows.Forms.ListViewGroup;
+using static System.Windows.Forms.ListViewItem;
 using static Interop;
 using static Interop.ComCtl32;
 
@@ -175,7 +176,9 @@ public partial class ListView : Control
 
     private bool _blockLabelEdit;
 
-    private ListViewLabelEditNativeWindow? _labelEdit;
+    internal ListViewLabelEditNativeWindow? _labelEdit;
+
+    internal ListViewSubItem? _listViewSubItem;
 
     // Background image stuff
     // Because we have to create a temporary file and the OS does not clean up the temporary files from the machine
@@ -3397,7 +3400,7 @@ public partial class ListView : Control
                         ListViewItem lvi = Items[i];
                         for (int j = 0; j < lvi.SubItems.Count; j++)
                         {
-                            ListViewItem.ListViewSubItem lvsi = lvi.SubItems[j];
+                            ListViewSubItem lvsi = lvi.SubItems[j];
                             // the win32 list view search for items w/ text is case insensitive
                             // do the same for sub items
                             // because we are comparing user defined strings we have to do the slower String search
@@ -3825,6 +3828,7 @@ public partial class ListView : Control
         {
             if (lvhi.iSubItem < item.SubItems.Count)
             {
+                _listViewSubItem = item.SubItems[lvhi.iSubItem];
                 return new ListViewHitTestInfo(item, item.SubItems[lvhi.iSubItem], location);
             }
             else

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -3397,24 +3397,24 @@ public partial class ListView : Control
                     // win32 listView control can't search inside sub items
                     for (int i = startIndex; i < Items.Count; i++)
                     {
-                        ListViewItem lvi = Items[i];
-                        for (int j = 0; j < lvi.SubItems.Count; j++)
+                        ListViewItem listViewItem = Items[i];
+                        for (int j = 0; j < listViewItem.SubItems.Count; j++)
                         {
-                            ListViewSubItem lvsi = lvi.SubItems[j];
+                            ListViewSubItem listViewSubItem = listViewItem.SubItems[j];
                             // the win32 list view search for items w/ text is case insensitive
                             // do the same for sub items
                             // because we are comparing user defined strings we have to do the slower String search
                             // ie, use String.Compare(string, string, case sensitive, CultureInfo)
                             // instead of new Whidbey String.Equals overload
                             // String.Equals(string, string, StringComparison.OrdinalIgnoreCase
-                            if (string.Equals(text, lvsi.Text, StringComparison.OrdinalIgnoreCase))
+                            if (string.Equals(text, listViewSubItem.Text, StringComparison.OrdinalIgnoreCase))
                             {
-                                return lvi;
+                                return listViewItem;
                             }
 
-                            if (isPrefixSearch && CultureInfo.CurrentCulture.CompareInfo.IsPrefix(lvsi.Text, text, CompareOptions.IgnoreCase))
+                            if (isPrefixSearch && CultureInfo.CurrentCulture.CompareInfo.IsPrefix(listViewSubItem.Text, text, CompareOptions.IgnoreCase))
                             {
-                                return lvi;
+                                return listViewItem;
                             }
                         }
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -178,6 +178,7 @@ public partial class ListView : Control
 
     internal ListViewLabelEditNativeWindow? _labelEdit;
 
+    // Used to record the SubItem to which the Label Edit belongs.
     internal ListViewSubItem? _listViewSubItem;
 
     // Background image stuff
@@ -3829,7 +3830,7 @@ public partial class ListView : Control
             if (lvhi.iSubItem < item.SubItems.Count)
             {
                 _listViewSubItem = item.SubItems[lvhi.iSubItem];
-                return new ListViewHitTestInfo(item, item.SubItems[lvhi.iSubItem], location);
+                return new ListViewHitTestInfo(item, _listViewSubItem, location);
             }
             else
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObject.cs
@@ -76,6 +76,8 @@ public partial class ListViewItem
                         => ParentInternal.GetChildInternal(ParentInternal.GetChildIndex(this) + 1),
                     UiaCore.NavigateDirection.PreviousSibling
                         => ParentInternal.GetChildInternal(ParentInternal.GetChildIndex(this) - 1),
+                    UiaCore.NavigateDirection.FirstChild => GetChild(),
+                    UiaCore.NavigateDirection.LastChild => GetChild(),
                     _ => base.FragmentNavigate(direction)
                 };
 
@@ -161,6 +163,16 @@ public partial class ListViewItem
 
             private protected override string AutomationId
                 => $"{nameof(ListViewSubItem)}-{ParentInternal.GetChildIndex(this)}";
+
+            public AccessibleObject? GetChild()
+            {
+                if (_owningListView._labelEdit is { } labelEdit)
+                {
+                    return labelEdit.AccessibilityObject;
+                }
+
+                return null;
+            }
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObject.cs
@@ -164,7 +164,7 @@ public partial class ListViewItem
             private protected override string AutomationId
                 => $"{nameof(ListViewSubItem)}-{ParentInternal.GetChildIndex(this)}";
 
-            public AccessibleObject? GetChild()
+            private AccessibleObject? GetChild()
             {
                 if (_owningListView._labelEdit is { } labelEdit)
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewLabelEditAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewLabelEditAccessibleObject.cs
@@ -36,8 +36,6 @@ internal class ListViewLabelEditAccessibleObject : AccessibleObject
         return direction switch
         {
             UiaCore.NavigateDirection.Parent => Parent,
-            UiaCore.NavigateDirection.NextSibling => Parent?.GetChildIndex(this) is int childId and >= 0 ? Parent.GetChild(childId + 1) : null,
-            UiaCore.NavigateDirection.PreviousSibling => Parent?.GetChildIndex(this) is int childId and >= 0 ? Parent.GetChild(childId - 1) : null,
             _ => base.FragmentNavigate(direction),
         };
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewLabelEditAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewLabelEditAccessibleObject.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Drawing;
-
 using static System.Windows.Forms.ListViewItem;
 using static Interop;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewLabelEditAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewLabelEditAccessibleObject.cs
@@ -40,6 +40,8 @@ internal class ListViewLabelEditAccessibleObject : AccessibleObject
         };
     }
 
+    internal override UiaCore.IRawElementProviderFragmentRoot FragmentRoot => _owningListView.AccessibilityObject;
+
     internal override object? GetPropertyValue(UiaCore.UIA propertyID)
         => propertyID switch
         {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewLabelEditAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewLabelEditAccessibleObjectTests.cs
@@ -80,6 +80,17 @@ public class ListViewLabelEditAccessibleObjectTests
     }
 
     [WinFormsFact]
+    public void ListViewLabelEditAccessibleObject_FragmentRoot_ReturnsExpected()
+    {
+        using ListView listView = CreateListViewAndStartEditing();
+
+        ListViewLabelEditNativeWindow labelEdit = listView.TestAccessor().Dynamic._labelEdit;
+        ListViewLabelEditAccessibleObject accessibilityObject = (ListViewLabelEditAccessibleObject)labelEdit.AccessibilityObject;
+
+        Assert.Equal(listView.AccessibilityObject, accessibilityObject.FragmentRoot);
+    }
+
+    [WinFormsFact]
     public void ListViewLabelEditAccessibleObject_HostRawElementProvider_ReturnsExpected()
     {
         using ListView listView = CreateListViewAndStartEditing();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewLabelEditAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewLabelEditAccessibleObjectTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Drawing;
+using static System.Windows.Forms.ListViewItem;
 using static Interop;
 
 namespace System.Windows.Forms.Tests;
@@ -49,11 +50,8 @@ public class ListViewLabelEditAccessibleObjectTests
         ListViewLabelEditNativeWindow labelEdit = listView.TestAccessor().Dynamic._labelEdit;
         ListViewLabelEditAccessibleObject accessibilityObject = (ListViewLabelEditAccessibleObject)labelEdit.AccessibilityObject;
 
-        Assert.Equal(listView.AccessibilityObject, accessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.Parent));
-        Assert.Equal(listView.Items[0].AccessibilityObject, accessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-        Assert.Null(accessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
-        Assert.Null(accessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
-        Assert.Null(accessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
+        Assert.Equal(listView._listViewSubItem.AccessibilityObject, accessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.Parent));
+        Assert.NotNull(accessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.Parent));
     }
 
     [WinFormsFact]
@@ -79,17 +77,6 @@ public class ListViewLabelEditAccessibleObjectTests
         ListViewLabelEditAccessibleObject accessibilityObject = (ListViewLabelEditAccessibleObject)labelEdit.AccessibilityObject;
 
         Assert.Equal(new int[] { AccessibleObject.RuntimeIDFirstItem, PARAM.ToInt(labelEdit.Handle) }, accessibilityObject.RuntimeId);
-    }
-
-    [WinFormsFact]
-    public void ListViewLabelEditAccessibleObject_FragmentRoot_ReturnsExpected()
-    {
-        using ListView listView = CreateListViewAndStartEditing();
-
-        ListViewLabelEditNativeWindow labelEdit = listView.TestAccessor().Dynamic._labelEdit;
-        ListViewLabelEditAccessibleObject accessibilityObject = (ListViewLabelEditAccessibleObject)labelEdit.AccessibilityObject;
-
-        Assert.Equal(listView.AccessibilityObject, accessibilityObject.FragmentRoot);
     }
 
     [WinFormsFact]
@@ -158,9 +145,11 @@ public class ListViewLabelEditAccessibleObjectTests
 
         listView.Columns.Add(new ColumnHeader() { Text = "Column 1", Width = 100 });
 
-        ListViewItem item = new("Test");
+        ListViewItem item = new("Test",0);
+        ListViewSubItem subItem = new ListViewSubItem(item, "Test");
+        item.SubItems.Add(subItem);
         listView.Items.Add(item);
-
+        listView._listViewSubItem = subItem;
         listView.CreateControl();
 
         PInvoke.SetFocus(listView);


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #7263


## Proposed changes

- Add a variable to the ListView to record the ListViewSubItem to which the Label Edit belongs.
- Remove the code related to Label Edit in ListViewAccessibleObject class.
- Adjust the ListViewSubItemAccessibleObject and ListViewLabelEditAccessibleObject classes so that the Label Edit will be displayed under the ListViewSubItem node when constructing the tree structure.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- The control of LabelEdit will show under ListViewSubItem.

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
Label Edit is at the same level as the List item and is displayed under the root node of the List.
![image](https://github.com/dotnet/winforms/assets/133954995/619a5fa0-7f23-4687-a299-fc0e381e8cbf)

### After
Label Edit displays under the edited cell.
![image](https://github.com/dotnet/winforms/assets/133954995/8b878aec-9a77-4fff-a3ee-a5786fc64d9f)

<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- Manual (using inspect )

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

- 8.0.100-preview.7.23376.3


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9782)