### PR TITLE
Fix missing category attribute for BindableComponent's DataBinding property.

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/BindableComponent.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/BindableComponent.cs
@@ -73,6 +73,7 @@ public abstract class BindableComponent : Component, IBindableComponent
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
     [RefreshProperties(RefreshProperties.All)]
     [ParenthesizePropertyName(true)]
+    [SRCategory(nameof(SR.CatData))]
     public ControlBindingsCollection DataBindings
         => _dataBindings ??= new ControlBindingsCollection(this);
 


### PR DESCRIPTION
Fixes #8154.

![image](https://github.com/dotnet/winforms/assets/9663150/357c1097-f307-40f1-a9b4-d5195cadfccb)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9799)