### PR TITLE
Fix Accessibility COM related issues

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/Foundation/AgileComPointer.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/Foundation/AgileComPointer.cs
@@ -28,8 +28,20 @@ internal unsafe class AgileComPointer<TInterface> :
     where TInterface : unmanaged, IComIID
 {
     private uint _cookie;
+    private readonly TInterface* _originalPointer;
 
-    public TInterface* OriginalHandle { get; }
+    /// <summary>
+    ///  Returns <see langword="true"/> if the given <paramref name="interface"/> is the same pointer this
+    ///  <see cref="AgileComPointer{TInterface}"/> was created from.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   This is useful in avoiding recreating a new <see cref="AgileComPointer{TInterface}"/> for the same
+    ///   object.
+    ///  </para>
+    /// </remarks>
+    public bool MatchesOriginalPointer(TInterface* @interface)
+        => _cookie != 0 && @interface == _originalPointer;
 
 #if DEBUG
     public AgileComPointer(TInterface* @interface, bool takeOwnership, bool trackDisposal = true)
@@ -39,7 +51,7 @@ internal unsafe class AgileComPointer<TInterface> :
 #endif
     {
         _cookie = GlobalInterfaceTable.RegisterInterface(@interface);
-        OriginalHandle = @interface;
+        _originalPointer = @interface;
 
         if (takeOwnership)
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
@@ -2002,9 +2002,9 @@ public unsafe partial class AccessibleObject :
     /// <remarks>
     ///  <para>
     ///   This is basically just a wrapper for <see cref="GetSysChild(AccessibleNavigation, out AccessibleObject?)"/>
-    ///   that does some of the dirty work, such as wrapping the returned object in a VARIANT. Usage is similar to
-    ///   <see cref="GetSysChild(AccessibleNavigation, out AccessibleObject?)"/> GetSysChild(). Called prior to calling
-    ///   IAccessible.accNavigate on the 'inner' system accessible object.
+    ///   that does some of the dirty work. Usage is similar to <see cref="GetSysChild(AccessibleNavigation, out AccessibleObject?)"/>.
+    ///   Called prior to calling <see cref="UIA.IAccessible.get_accName(VARIANT, BSTR*)"/> on the 'inner' system
+    ///   accessible object.
     ///  </para>
     /// </remarks>
     private bool SysNavigate(AccessibleNavigation direction, object childID, out AccessibleObject? accessibleObject)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
@@ -2104,7 +2104,7 @@ public unsafe partial class AccessibleObject :
 
         // Check to see if this object already wraps the given pointer.
         if (SystemIAccessible is { } systemAccessible
-            && systemAccessible.OriginalHandle == accessible)
+            && systemAccessible.MatchesOriginalPointer(accessible))
         {
             accessible->Release();
             return this;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObjectExtensions.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObjectExtensions.cs
@@ -194,7 +194,7 @@ internal static unsafe class AccessibleObjectExtensions
 
         Debug.Assert(result.Succeeded, $"{nameof(TryGetRole)}: get_accRole call failed with {result}");
 
-        return role.vt != VARENUM.VT_I4 ? AccessibleRole.None : (AccessibleRole)(int)role;
+        return role.vt is VARENUM.VT_I4 or VARENUM.VT_INT ? (AccessibleRole)(int)role : AccessibleRole.None;
     }
 
     public static AccessibleStates TryGetState(this AgileComPointer<IAccessible>? agile, int child)
@@ -215,7 +215,7 @@ internal static unsafe class AccessibleObjectExtensions
             result.Succeeded,
             $"{nameof(TryGetState)}: get_accState call for id {(int)child} failed with {result}");
 
-        return state.vt != VARENUM.VT_I4 ? AccessibleStates.None : (AccessibleStates)(int)state;
+        return state.vt is VARENUM.VT_I4 or VARENUM.VT_INT ? (AccessibleStates)(int)state : AccessibleStates.None;
     }
 
     public static string? TryGetValue(this AgileComPointer<IAccessible>? agile, VARIANT child)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxContainer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxContainer.cs
@@ -679,7 +679,7 @@ public abstract partial class AxHost
             s_axHTraceSwitch.TraceVerbose($"in SetActiveObject {pszObjName.ToString() ?? "<null>"}");
             if (_siteUIActive is { } activeHost
                 && activeHost._iOleInPlaceActiveObjectExternal is { } existing
-                && existing.OriginalHandle != pActiveObject)
+                && !existing.MatchesOriginalPointer(pActiveObject))
             {
                 // Release the field before disposing to avoid accessing it during disposal on callbacks.
                 activeHost._iOleInPlaceActiveObjectExternal = null;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlAccessibleObject.cs
@@ -132,11 +132,11 @@ public partial class Control
             // Get the owning control's parent, if it has one
             Control? parentControl = owner.ParentInternal;
 
-            // ctrls[index] will indicate the control at the destination of this navigation operation
+            // ctrls[index] will indicate the control at the destination of this navigation operation.
             int index = -1;
             Control[]? ctrls = null;
 
-            // Now handle any 'appropriate' navigation requests...
+            // Now handle any 'appropriate' navigation requests.
             switch (navdir)
             {
                 case AccessibleNavigation.FirstChild:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlTabOrderComparer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlTabOrderComparer.cs
@@ -10,17 +10,24 @@ public partial class Control
     /// </summary>
     private class ControlTabOrderComparer : IComparer<ControlTabOrderHolder>
     {
-        public int Compare(ControlTabOrderHolder? x, ControlTabOrderHolder? y)
+        private ControlTabOrderComparer() { }
+
+        internal static ControlTabOrderComparer Instance { get; } = new();
+
+        public int Compare(ControlTabOrderHolder x, ControlTabOrderHolder y)
         {
             if (IComparerHelpers.CompareReturnIfNull(x, y, out int? returnValue))
             {
                 return (int)returnValue;
             }
 
-            int delta = x._newOrder - y._newOrder;
+            // If there is a specified tab index, use it for comparison, otherwise use the original index (which
+            // would be the index in the control collection or how Windows returns children using GW_HWNDNEXT from
+            // GW_HWNDCHILD).
+            int delta = x.TabIndex - y.TabIndex;
             if (delta == 0)
             {
-                delta = x._oldOrder - y._oldOrder;
+                delta = x.OriginalIndex - y.OriginalIndex;
             }
 
             return delta;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlTabOrderHolder.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlTabOrderHolder.cs
@@ -6,21 +6,10 @@ namespace System.Windows.Forms;
 public partial class Control
 {
     /// <summary>
-    ///  This class contains a control and associates it with a z-order.
-    ///  This is used when sorting controls based on tab index first,
-    ///  z-order second.
+    ///  This record contains a control and associates it with a z-order.
+    ///  This is used when sorting controls based on tab index first, z-order second.
     /// </summary>
-    private class ControlTabOrderHolder
+    private readonly record struct ControlTabOrderHolder(int OriginalIndex, int TabIndex, Control? Control)
     {
-        internal readonly int _oldOrder;
-        internal readonly int _newOrder;
-        internal readonly Control? _control;
-
-        internal ControlTabOrderHolder(int oldOrder, int newOrder, Control? control)
-        {
-            _oldOrder = oldOrder;
-            _newOrder = newOrder;
-            _control = control;
-        }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.OleCallback.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.OleCallback.cs
@@ -87,6 +87,7 @@ public partial class RichTextBox
             return HRESULT.S_OK;
         }
 
+        /// <inheritdoc cref="IRichEditOleCallback.QueryAcceptData(Com.IDataObject*, ushort*, RECO_FLAGS, BOOL, HGLOBAL)"/>
         public HRESULT QueryAcceptData(Com.IDataObject* lpdataobj, ushort* lpcfFormat, RECO_FLAGS reco, BOOL fReally, HGLOBAL hMetaPict)
         {
             RichTextDbg.TraceVerbose($"IRichEditOleCallback::QueryAcceptData(reco={reco})");
@@ -162,7 +163,7 @@ public partial class RichTextBox
                     _lastDragEventArgs.Message ?? string.Empty,
                     _lastDragEventArgs.MessageReplacementToken ?? string.Empty);
 
-            if (fReally == 0)
+            if (!fReally)
             {
                 // We are just querying
 

--- a/src/System.Windows.Forms/tests/InteropTests/PropertyGridTests.cs
+++ b/src/System.Windows.Forms/tests/InteropTests/PropertyGridTests.cs
@@ -27,7 +27,7 @@ public class PropertyGridTests
                 try
                 {
                     encodingEntry.SetPropertyTextValue("333");
-                    Assert.False(true, "Invalid set values should produce ExternalException which will be presented to the user.");
+                    Assert.Fail("Invalid set values should produce ExternalException which will be presented to the user.");
                 }
                 catch (ExternalException ex)
                 {
@@ -61,7 +61,7 @@ public class PropertyGridTests
                 try
                 {
                     encodingEntry.SetPropertyTextValue("123");
-                    Assert.False(true, "Invalid set values should produce ExternalException which will be presenttted to the user.");
+                    Assert.Fail("Invalid set values should produce ExternalException which will be presenttted to the user.");
                 }
                 catch (ExternalException ex)
                 {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjectTests.cs
@@ -547,8 +547,11 @@ public partial class AccessibleObjectTests
 
         AccessibleObject firstChild = form.AccessibilityObject.Navigate(AccessibleNavigation.FirstChild);
         Assert.NotNull(firstChild);
+        Assert.Equal((AccessibleObject)first.TestAccessor().Dynamic.NcAccessibilityObject, firstChild);
+
         AccessibleObject next = firstChild.Navigate(AccessibleNavigation.Next);
         Assert.NotNull(next);
+
         AccessibleObject previous = next.Navigate(AccessibleNavigation.Previous);
         Assert.NotNull(previous);
         Assert.Same(firstChild, previous);
@@ -561,13 +564,15 @@ public partial class AccessibleObjectTests
     [InlineData(AccessibleNavigation.Previous, true, true)]
     [InlineData(AccessibleNavigation.Right, false, false)]
     [InlineData(AccessibleNavigation.Up, true, true)]
-    public void AccessibleObject_Navigate_FromForm_OneChild(AccessibleNavigation navigate, bool returnsObject, bool isSystemAccessible)
+    public void AccessibleObject_Navigate_FromForm_OneChild(AccessibleNavigation direction, bool returnsObject, bool isSystemAccessible)
     {
         using Form form = new();
         using Control control = new();
         form.Controls.Add(control);
         form.Show();
-        AccessibleObject target = form.AccessibilityObject.Navigate(navigate);
+
+        AccessibleObject target = form.AccessibilityObject.Navigate(direction);
+
         Assert.Equal(returnsObject, target is not null);
         if (target is not null)
         {
@@ -576,21 +581,21 @@ public partial class AccessibleObjectTests
     }
 
     [WinFormsTheory]
-    [InlineData(AccessibleNavigation.FirstChild, false, false)]
-    [InlineData(AccessibleNavigation.LastChild, false, false)]
-    [InlineData(AccessibleNavigation.Next, false, false)]
-    [InlineData(AccessibleNavigation.Previous, true, true)]
-    [InlineData(AccessibleNavigation.Right, false, false)]
-    [InlineData(AccessibleNavigation.Up, true, true)]
-    public void AccessibleObject_Navigate_FromForm_NoChildren(AccessibleNavigation navigate, bool returnsObject, bool isSystemAccessible)
+    [InlineData(AccessibleNavigation.FirstChild, false)]
+    [InlineData(AccessibleNavigation.LastChild, false)]
+    [InlineData(AccessibleNavigation.Next, false)]
+    [InlineData(AccessibleNavigation.Previous, true)]
+    [InlineData(AccessibleNavigation.Right, false)]
+    [InlineData(AccessibleNavigation.Up, true)]
+    public void AccessibleObject_Navigate_FromForm_NoChildren(AccessibleNavigation direction, bool returnsObject)
     {
         using Form form = new();
         form.Show();
-        AccessibleObject target = form.AccessibilityObject.Navigate(navigate);
+        AccessibleObject target = form.AccessibilityObject.Navigate(direction);
         Assert.Equal(returnsObject, target is not null);
         if (target is not null)
         {
-            Assert.Equal(isSystemAccessible, (bool)target.TestAccessor().Dynamic._isSystemWrapper);
+            Assert.True((bool)target.TestAccessor().Dynamic._isSystemWrapper);
         }
     }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjectTests.cs
@@ -535,6 +535,65 @@ public partial class AccessibleObjectTests
         accessibleObject.Select(flags);
     }
 
+    [WinFormsFact]
+    public void AccessibleObject_Navigate_FormChildren()
+    {
+        using Form form = new();
+        using Control first = new();
+        using Control second = new();
+        form.Controls.Add(first);
+        form.Controls.Add(second);
+        form.Show();
+
+        AccessibleObject firstChild = form.AccessibilityObject.Navigate(AccessibleNavigation.FirstChild);
+        Assert.NotNull(firstChild);
+        AccessibleObject next = firstChild.Navigate(AccessibleNavigation.Next);
+        Assert.NotNull(next);
+        AccessibleObject previous = next.Navigate(AccessibleNavigation.Previous);
+        Assert.NotNull(previous);
+        Assert.Same(firstChild, previous);
+    }
+
+    [WinFormsTheory]
+    [InlineData(AccessibleNavigation.FirstChild, true, false)]
+    [InlineData(AccessibleNavigation.LastChild, true, false)]
+    [InlineData(AccessibleNavigation.Next, false, false)]
+    [InlineData(AccessibleNavigation.Previous, true, true)]
+    [InlineData(AccessibleNavigation.Right, false, false)]
+    [InlineData(AccessibleNavigation.Up, true, true)]
+    public void AccessibleObject_Navigate_FromForm_OneChild(AccessibleNavigation navigate, bool returnsObject, bool isSystemAccessible)
+    {
+        using Form form = new();
+        using Control control = new();
+        form.Controls.Add(control);
+        form.Show();
+        AccessibleObject target = form.AccessibilityObject.Navigate(navigate);
+        Assert.Equal(returnsObject, target is not null);
+        if (target is not null)
+        {
+            Assert.Equal(isSystemAccessible, (bool)target.TestAccessor().Dynamic._isSystemWrapper);
+        }
+    }
+
+    [WinFormsTheory]
+    [InlineData(AccessibleNavigation.FirstChild, false, false)]
+    [InlineData(AccessibleNavigation.LastChild, false, false)]
+    [InlineData(AccessibleNavigation.Next, false, false)]
+    [InlineData(AccessibleNavigation.Previous, true, true)]
+    [InlineData(AccessibleNavigation.Right, false, false)]
+    [InlineData(AccessibleNavigation.Up, true, true)]
+    public void AccessibleObject_Navigate_FromForm_NoChildren(AccessibleNavigation navigate, bool returnsObject, bool isSystemAccessible)
+    {
+        using Form form = new();
+        form.Show();
+        AccessibleObject target = form.AccessibilityObject.Navigate(navigate);
+        Assert.Equal(returnsObject, target is not null);
+        if (target is not null)
+        {
+            Assert.Equal(isSystemAccessible, (bool)target.TestAccessor().Dynamic._isSystemWrapper);
+        }
+    }
+
     public static IEnumerable<object[]> UseStdAccessibleObjects_IntPtr_InvalidHandle_TestData()
     {
         yield return new object[] { IntPtr.Zero };


### PR DESCRIPTION
- AccessibleObject.Navigate was not returning results from SysNavigate
- Change SysNavigate to return AccessibleObject to allow both use cases
- Update comments around SysNavigate/GetSysChild
- Add release for IDispatch in TryGetAccessibleObject when it fails
- Various other comment cleanup
- Tolerate incoming VT_INT in AccessibleObjectExtensions
- Turn ControlTabOrderHolder into record struct with clearer terms
- Make ControlTabOrderComparer static and add comments
- Use Assert.Fail for clarity in PropertyGridTests
- Add tests for AccessibleObject.Navigate


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9804)