### PR TITLE
Fix Accessibility COM related issues (#9804)

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/Foundation/AgileComPointer.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/Foundation/AgileComPointer.cs
@@ -28,8 +28,20 @@ internal unsafe class AgileComPointer<TInterface> :
     where TInterface : unmanaged, IComIID
 {
     private uint _cookie;
+    private readonly TInterface* _originalPointer;
 
-    public TInterface* OriginalHandle { get; }
+    /// <summary>
+    ///  Returns <see langword="true"/> if the given <paramref name="interface"/> is the same pointer this
+    ///  <see cref="AgileComPointer{TInterface}"/> was created from.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   This is useful in avoiding recreating a new <see cref="AgileComPointer{TInterface}"/> for the same
+    ///   object.
+    ///  </para>
+    /// </remarks>
+    public bool MatchesOriginalPointer(TInterface* @interface)
+        => _cookie != 0 && @interface == _originalPointer;
 
 #if DEBUG
     public AgileComPointer(TInterface* @interface, bool takeOwnership, bool trackDisposal = true)
@@ -39,7 +51,7 @@ internal unsafe class AgileComPointer<TInterface> :
 #endif
     {
         _cookie = GlobalInterfaceTable.RegisterInterface(@interface);
-        OriginalHandle = @interface;
+        _originalPointer = @interface;
 
         if (takeOwnership)
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
@@ -236,16 +236,19 @@ public unsafe partial class AccessibleObject :
     internal virtual int[]? GetSysChildOrder() => null;
 
     /// <summary>
-    ///  Mechanism for overriding default IAccessible.accNavigate behavior of
-    ///  the 'inner' system accessible object (accNavigate is how you move
-    ///  between parent, child and sibling accessible objects).
-    ///
-    ///  USAGE: 'navdir' indicates navigation operation to perform, relative to
-    ///  this accessible object.
-    ///  If operation is unsupported, return false to allow fall-back to default
-    ///  system behavior. Otherwise return destination object in the out
-    ///  parameter, or null to indicate 'off end of list'.
+    ///  Mechanism for overriding default <see cref="UIA.IAccessible.accNavigate(int, VARIANT, VARIANT*)"/>
+    ///  behavior of the 'inner' system accessible object (accNavigate is how you move between parent, child and
+    ///  sibling accessible objects).
     /// </summary>
+    /// <param name="navdir">
+    ///  Navigation operation to perform, relative to this accessible object.
+    /// </param>
+    /// <param name="accessibleObject">
+    ///  The destination object or <see langword="null"/> to indicate 'off end of list'.
+    /// </param>
+    /// <returns>
+    ///  <see langword="false"/> to allow fall-back to default system behavior.
+    /// </returns>
     internal virtual bool GetSysChild(AccessibleNavigation navdir, out AccessibleObject? accessibleObject)
     {
         accessibleObject = null;
@@ -1163,19 +1166,19 @@ public unsafe partial class AccessibleObject :
             }
         }
 
-        if (!SysNavigate(navDir, childID, out object? retObject))
+        if (SysNavigate((AccessibleNavigation)navDir, childID, out AccessibleObject? accessibleObject))
         {
-            using var accessible = SystemIAccessible.TryGetIAccessible(out HRESULT result);
-            if (result.Failed)
-            {
-                return null;
-            }
-
-            result = accessible.Value->accNavigate(navDir, ChildIdToVARIANT(childID), out VARIANT endUpAt);
-            return endUpAt.ToObject();
+            return AsChildId(accessibleObject);
         }
 
-        return retObject;
+        using var accessible = SystemIAccessible.TryGetIAccessible(out HRESULT result);
+        if (result.Failed)
+        {
+            return null;
+        }
+
+        result = accessible.Value->accNavigate(navDir, ChildIdToVARIANT(childID), out VARIANT endUpAt);
+        return endUpAt.ToObject();
     }
 
     /// <summary>
@@ -1856,13 +1859,20 @@ public unsafe partial class AccessibleObject :
         }
 
         using var accessible = SystemIAccessible.TryGetIAccessible(out HRESULT result);
-        if (result.Succeeded && !SysNavigate((int)navdir, (int)PInvoke.CHILDID_SELF, out object? retObject))
+        if (result.Failed)
+        {
+            return null;
+        }
+
+        if (SysNavigate(navdir, (int)PInvoke.CHILDID_SELF, out AccessibleObject? accessibleObject))
+        {
+            return accessibleObject;
+        }
+        else
         {
             result = accessible.Value->accNavigate((int)navdir, CHILDID_SELF, out VARIANT endUpAt);
             return TryGetAccessibleObject(endUpAt);
         }
-
-        return null;
     }
 
     /// <summary>
@@ -1873,7 +1883,7 @@ public unsafe partial class AccessibleObject :
         using var accessible = SystemIAccessible.TryGetIAccessible(out HRESULT result);
         if (result.Succeeded)
         {
-            accessible.Value->accSelect((int)flags, CHILDID_SELF);
+            result = accessible.Value->accSelect((int)flags, CHILDID_SELF);
         }
     }
 
@@ -1892,6 +1902,7 @@ public unsafe partial class AccessibleObject :
     {
         if (obj is not null && obj._isSystemWrapper && obj.SystemIAccessible is { } accessible)
         {
+            // We're just a simple system wrapper, return the pointer.
             return new VARIANT()
             {
                 vt = VARENUM.VT_DISPATCH,
@@ -1986,16 +1997,19 @@ public unsafe partial class AccessibleObject :
     }
 
     /// <summary>
-    ///  Performs custom navigation between parent/child/sibling accessible
-    ///  objects. This is basically just a wrapper for GetSysChild(), that
-    ///  does some of the dirty work, such as wrapping the returned object
-    ///  in a VARIANT. Usage is similar to GetSysChild(). Called prior to
-    ///  calling IAccessible.accNavigate on the 'inner' system accessible
-    ///  object.
+    ///  Performs custom navigation between parent, child, and sibling accessible objects.
     /// </summary>
-    private bool SysNavigate(int navDir, object childID, out object? retObject)
+    /// <remarks>
+    ///  <para>
+    ///   This is basically just a wrapper for <see cref="GetSysChild(AccessibleNavigation, out AccessibleObject?)"/>
+    ///   that does some of the dirty work. Usage is similar to <see cref="GetSysChild(AccessibleNavigation, out AccessibleObject?)"/>.
+    ///   Called prior to calling <see cref="UIA.IAccessible.get_accName(VARIANT, BSTR*)"/> on the 'inner' system
+    ///   accessible object.
+    ///  </para>
+    /// </remarks>
+    private bool SysNavigate(AccessibleNavigation direction, object childID, out AccessibleObject? accessibleObject)
     {
-        retObject = null;
+        accessibleObject = null;
 
         // Only override system navigation relative to ourselves (since we can't interpret OLEACC child ids)
         if (!childID.Equals((int)PInvoke.CHILDID_SELF))
@@ -2004,16 +2018,7 @@ public unsafe partial class AccessibleObject :
         }
 
         // Perform any supported navigation operation (fall back on system for unsupported navigation ops)
-        if (!GetSysChild((AccessibleNavigation)navDir, out AccessibleObject? newObject))
-        {
-            return false;
-        }
-
-        // If object found, wrap in a VARIANT. Otherwise return null for 'end of list' (OLEACC expects this)
-        retObject = (newObject is null) ? null : AsChildId(newObject);
-
-        // Tell caller not to fall back on system behavior now
-        return true;
+        return GetSysChild(direction, out accessibleObject);
     }
 
     /// <summary>
@@ -2079,9 +2084,10 @@ public unsafe partial class AccessibleObject :
         }
 
         UIA.IAccessible* accessible;
-        if (dispatch->QueryInterface(IID.Get<IDispatch>(), (void**)&accessible).Failed)
+        if (dispatch->QueryInterface(IID.Get<UIA.IAccessible>(), (void**)&accessible).Failed)
         {
             Debug.Fail("This should never happen");
+            dispatch->Release();
             return null;
         }
 
@@ -2098,7 +2104,7 @@ public unsafe partial class AccessibleObject :
 
         // Check to see if this object already wraps the given pointer.
         if (SystemIAccessible is { } systemAccessible
-            && systemAccessible.OriginalHandle == accessible)
+            && systemAccessible.MatchesOriginalPointer(accessible))
         {
             accessible->Release();
             return this;
@@ -2106,6 +2112,7 @@ public unsafe partial class AccessibleObject :
 
         return new AccessibleObject(
 #if DEBUG
+            // AccessibleObject is not disposable so we shouldn't be tracking it.
             new AgileComPointer<UIA.IAccessible>(accessible, takeOwnership: true, trackDisposal: false)
 #else
             new AgileComPointer<UIA.IAccessible>(accessible, takeOwnership: true)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObjectExtensions.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObjectExtensions.cs
@@ -194,7 +194,7 @@ internal static unsafe class AccessibleObjectExtensions
 
         Debug.Assert(result.Succeeded, $"{nameof(TryGetRole)}: get_accRole call failed with {result}");
 
-        return role.vt != VARENUM.VT_I4 ? AccessibleRole.None : (AccessibleRole)(int)role;
+        return role.vt is VARENUM.VT_I4 or VARENUM.VT_INT ? (AccessibleRole)(int)role : AccessibleRole.None;
     }
 
     public static AccessibleStates TryGetState(this AgileComPointer<IAccessible>? agile, int child)
@@ -215,7 +215,7 @@ internal static unsafe class AccessibleObjectExtensions
             result.Succeeded,
             $"{nameof(TryGetState)}: get_accState call for id {(int)child} failed with {result}");
 
-        return state.vt != VARENUM.VT_I4 ? AccessibleStates.None : (AccessibleStates)(int)state;
+        return state.vt is VARENUM.VT_I4 or VARENUM.VT_INT ? (AccessibleStates)(int)state : AccessibleStates.None;
     }
 
     public static string? TryGetValue(this AgileComPointer<IAccessible>? agile, VARIANT child)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxContainer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxContainer.cs
@@ -679,7 +679,7 @@ public abstract partial class AxHost
             s_axHTraceSwitch.TraceVerbose($"in SetActiveObject {pszObjName.ToString() ?? "<null>"}");
             if (_siteUIActive is { } activeHost
                 && activeHost._iOleInPlaceActiveObjectExternal is { } existing
-                && existing.OriginalHandle != pActiveObject)
+                && !existing.MatchesOriginalPointer(pActiveObject))
             {
                 // Release the field before disposing to avoid accessing it during disposal on callbacks.
                 activeHost._iOleInPlaceActiveObjectExternal = null;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlAccessibleObject.cs
@@ -132,11 +132,11 @@ public partial class Control
             // Get the owning control's parent, if it has one
             Control? parentControl = owner.ParentInternal;
 
-            // ctrls[index] will indicate the control at the destination of this navigation operation
+            // ctrls[index] will indicate the control at the destination of this navigation operation.
             int index = -1;
             Control[]? ctrls = null;
 
-            // Now handle any 'appropriate' navigation requests...
+            // Now handle any 'appropriate' navigation requests.
             switch (navdir)
             {
                 case AccessibleNavigation.FirstChild:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlTabOrderComparer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlTabOrderComparer.cs
@@ -10,17 +10,24 @@ public partial class Control
     /// </summary>
     private class ControlTabOrderComparer : IComparer<ControlTabOrderHolder>
     {
-        public int Compare(ControlTabOrderHolder? x, ControlTabOrderHolder? y)
+        private ControlTabOrderComparer() { }
+
+        internal static ControlTabOrderComparer Instance { get; } = new();
+
+        public int Compare(ControlTabOrderHolder x, ControlTabOrderHolder y)
         {
             if (IComparerHelpers.CompareReturnIfNull(x, y, out int? returnValue))
             {
                 return (int)returnValue;
             }
 
-            int delta = x._newOrder - y._newOrder;
+            // If there is a specified tab index, use it for comparison, otherwise use the original index (which
+            // would be the index in the control collection or how Windows returns children using GW_HWNDNEXT from
+            // GW_HWNDCHILD).
+            int delta = x.TabIndex - y.TabIndex;
             if (delta == 0)
             {
-                delta = x._oldOrder - y._oldOrder;
+                delta = x.OriginalIndex - y.OriginalIndex;
             }
 
             return delta;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlTabOrderHolder.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlTabOrderHolder.cs
@@ -6,21 +6,10 @@ namespace System.Windows.Forms;
 public partial class Control
 {
     /// <summary>
-    ///  This class contains a control and associates it with a z-order.
-    ///  This is used when sorting controls based on tab index first,
-    ///  z-order second.
+    ///  This record contains a control and associates it with a z-order.
+    ///  This is used when sorting controls based on tab index first, z-order second.
     /// </summary>
-    private class ControlTabOrderHolder
+    private readonly record struct ControlTabOrderHolder(int OriginalIndex, int TabIndex, Control? Control)
     {
-        internal readonly int _oldOrder;
-        internal readonly int _newOrder;
-        internal readonly Control? _control;
-
-        internal ControlTabOrderHolder(int oldOrder, int newOrder, Control? control)
-        {
-            _oldOrder = oldOrder;
-            _newOrder = newOrder;
-            _control = control;
-        }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.OleCallback.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.OleCallback.cs
@@ -87,6 +87,7 @@ public partial class RichTextBox
             return HRESULT.S_OK;
         }
 
+        /// <inheritdoc cref="IRichEditOleCallback.QueryAcceptData(Com.IDataObject*, ushort*, RECO_FLAGS, BOOL, HGLOBAL)"/>
         public HRESULT QueryAcceptData(Com.IDataObject* lpdataobj, ushort* lpcfFormat, RECO_FLAGS reco, BOOL fReally, HGLOBAL hMetaPict)
         {
             RichTextDbg.TraceVerbose($"IRichEditOleCallback::QueryAcceptData(reco={reco})");
@@ -162,7 +163,7 @@ public partial class RichTextBox
                     _lastDragEventArgs.Message ?? string.Empty,
                     _lastDragEventArgs.MessageReplacementToken ?? string.Empty);
 
-            if (fReally == 0)
+            if (!fReally)
             {
                 // We are just querying
 

--- a/src/System.Windows.Forms/tests/InteropTests/PropertyGridTests.cs
+++ b/src/System.Windows.Forms/tests/InteropTests/PropertyGridTests.cs
@@ -27,7 +27,7 @@ public class PropertyGridTests
                 try
                 {
                     encodingEntry.SetPropertyTextValue("333");
-                    Assert.False(true, "Invalid set values should produce ExternalException which will be presented to the user.");
+                    Assert.Fail("Invalid set values should produce ExternalException which will be presented to the user.");
                 }
                 catch (ExternalException ex)
                 {
@@ -61,7 +61,7 @@ public class PropertyGridTests
                 try
                 {
                     encodingEntry.SetPropertyTextValue("123");
-                    Assert.False(true, "Invalid set values should produce ExternalException which will be presenttted to the user.");
+                    Assert.Fail("Invalid set values should produce ExternalException which will be presenttted to the user.");
                 }
                 catch (ExternalException ex)
                 {


### PR DESCRIPTION
## Ports #9804

- AccessibleObject.Navigate was not returning results from SysNavigate
- Change SysNavigate to return AccessibleObject to allow both use cases
- Update comments around SysNavigate/GetSysChild
- Add release for IDispatch in TryGetAccessibleObject when it fails
- Various other comment cleanup
- Tolerate incoming VT_INT in AccessibleObjectExtensions
- Turn ControlTabOrderHolder into record struct with clearer terms
- Make ControlTabOrderComparer static and add comments
- Use Assert.Fail for clarity in PropertyGridTests
- Add tests for AccessibleObject.Navigate
- Avoid potential issues trying to use the original AgileComPointer pointer.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9818)