### PR TITLE
Look up Font on the parent before setting font for *strip controls

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -6604,7 +6604,7 @@ public unsafe partial class Control :
     /// <summary>
     ///  Determines whether the parent font is set.
     /// </summary>
-    internal bool IsParentFontSet() => ParentInternal is not null && ParentInternal.Font != DefaultFont;
+    internal bool IsParentFontSet() => ParentInternal is not null && ParentInternal.CanAccessProperties && ParentInternal.Font != DefaultFont;
 
     /// <summary>
     ///  Determines whether the font is set.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -6602,6 +6602,14 @@ public unsafe partial class Control :
     }
 
     /// <summary>
+    ///  Determines whether the parent font is set.
+    /// </summary>
+    internal bool IsParentFontSet()
+    {
+        return ParentInternal is not null && ParentInternal.CanAccessProperties;
+    }
+
+    /// <summary>
     ///  Determines whether the font is set.
     /// </summary>
     internal bool IsFontSet()

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -6604,10 +6604,7 @@ public unsafe partial class Control :
     /// <summary>
     ///  Determines whether the parent font is set.
     /// </summary>
-    internal bool IsParentFontSet()
-    {
-        return ParentInternal is not null && ParentInternal.CanAccessProperties;
-    }
+    internal bool IsParentFontSet() => ParentInternal is not null && ParentInternal.Font != DefaultFont;
 
     /// <summary>
     ///  Determines whether the font is set.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
@@ -547,7 +547,7 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
     {
         get
         {
-            if (IsFontSet())
+            if (IsFontSet() || (!IsFontSet() && IsParentFontSet()))
             {
                 return base.Font;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
@@ -547,7 +547,7 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
     {
         get
         {
-            if (IsFontSet() || (!IsFontSet() && IsParentFontSet()))
+            if (IsFontSet() || IsParentFontSet())
             {
                 return base.Font;
             }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.Methods.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.Methods.cs
@@ -4382,6 +4382,41 @@ public partial class ControlTests
         Assert.True(control.IsHandleCreated);
     }
 
+    [WinFormsFact]
+    public void Control_IsParentFontSet_ParentFontSet_ReturnsExpected()
+    {
+        using var font = new Font("Segoe UI", 9);
+
+        using var parent = new Control
+        {
+            Font = font
+        };
+
+        using var control = new SubControl
+        {
+            Parent = parent
+        };
+
+        Assert.True(control.IsParentFontSet());
+        Assert.NotSame(Control.DefaultFont, control.Font);
+    }
+
+     [WinFormsFact]
+    public void Control_IsParentFontSet_ParentFontNotSet_ReturnsExpected()
+    {
+        using var font = new Font("Segoe UI", 9);
+
+        using var parent = new Control();
+        using var control = new SubControl
+        {
+            Parent = parent,
+            Font = font
+        };
+
+        Assert.False(control.IsParentFontSet());
+        Assert.Same(font, control.Font);
+    }
+
     public static IEnumerable<object[]> IsInputKey_TestData()
     {
         yield return new object[] { Keys.Tab, false };

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripDropDownTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripDropDownTests.cs
@@ -1482,20 +1482,34 @@ public class ToolStripDropDownTests
     {
         using var font1 = new Font("Arial", 8.25f);
         using var font2 = new Font("Arial", 8.5f);
+        using var font3 = new Font("Arial", 6.5f);
+
         using var parent = new Control
         {
             Font = font1
         };
+
         using var control = new ToolStrip
         {
             Parent = parent
         };
-        Assert.NotSame(font1, control.Font);
-        Assert.Same(control.Font, control.Font);
+
+        // The font of the control is consistent with that of the parent control
+        Assert.Same(font1, control.Font);
 
         // Set custom.
         control.Font = font2;
         Assert.Same(font2, control.Font);
+
+        // When the parent window and the control itself set different fonts,
+        // the control is displayed with its own settings
+        using var control2 = new ToolStrip
+        {
+            Parent = parent,
+            Font = font3
+        };
+
+        Assert.Same(font3, control2.Font);
     }
 
     [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripTests.cs
@@ -1398,20 +1398,34 @@ public partial class ToolStripTests
     {
         using var font1 = new Font("Arial", 8.25f);
         using var font2 = new Font("Arial", 8.5f);
+        using var font3 = new Font("Arial", 6.5f);
+
         using var parent = new Control
         {
             Font = font1
         };
+
         using var control = new ToolStrip
         {
             Parent = parent
         };
-        Assert.NotSame(font1, control.Font);
-        Assert.Same(control.Font, control.Font);
+
+        // The font of the control is consistent with that of the parent control
+        Assert.Same(font1, control.Font);
 
         // Set custom.
         control.Font = font2;
         Assert.Same(font2, control.Font);
+
+        // When the parent window and the control itself set different fonts,
+        // the control is displayed with its own settings
+        using var control2 = new ToolStrip
+        {
+            Parent = parent,
+            Font = font3
+        };
+
+        Assert.Same(font3, control2.Font);
     }
 
     [WinFormsFact]


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #5391


## Proposed changes

- Add the judgment `IsParentFontSet()` of the parent window before setting the font of the Strip control

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- *Strips control fonts will be displayed based on their own font settings and application font settings

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

The font for these controls: ToolStrip/menuStrip/StatusStrip are not rendered after setting an application font, is not same as button's
![image](https://github.com/dotnet/winforms/assets/132890443/734f52a8-dda0-43f6-a407-56a3324efcce)

### After
The font for these controls: ToolStrip/menuStrip/StatusStrip are not rendered base on application font when its own font properties are not set
![image](https://github.com/dotnet/winforms/assets/132890443/8c4672b8-487a-433d-9dcf-eb5eb7dd7a92)


## Test methodology <!-- How did you ensure quality? -->

- Manually
- Unit tests


## Test environment(s) <!-- Remove any that don't apply -->

- .net 8.0.0-rc.1.23416.31


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9819)