### PR TITLE
Remove Tracing from AxHost

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxComponentEditor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxComponentEditor.cs
@@ -17,17 +17,8 @@ public abstract partial class AxHost
         {
             if (obj is AxHost host)
             {
-                try
-                {
-                    s_axHTraceSwitch.TraceVerbose("in AxComponentEditor.EditComponent");
-                    ((IOleControlSite.Interface)host._oleSite).ShowPropertyFrame();
-                    return true;
-                }
-                catch (Exception ex)
-                {
-                    Debug.Fail(ex.ToString());
-                    throw;
-                }
+                ((IOleControlSite.Interface)host._oleSite).ShowPropertyFrame().ThrowOnFailure();
+                return true;
             }
 
             return false;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxContainer.ExtenderProxy.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxContainer.ExtenderProxy.cs
@@ -53,7 +53,6 @@ public abstract partial class AxHost
                 ENUM_CONTROLS_WHICH_FLAGS dwWhich,
                 IEnumUnknown** ppenum)
             {
-                s_axHTraceSwitch.TraceVerbose("in EnumControls for proxy");
                 if (ppenum is null)
                 {
                     return HRESULT.E_POINTER;
@@ -68,7 +67,6 @@ public abstract partial class AxHost
 
             HRESULT IGetOleObject.Interface.GetOleObject(Guid* riid, void** ppvObj)
             {
-                s_axHTraceSwitch.TraceVerbose("in GetOleObject for proxy");
                 if (ppvObj is null)
                 {
                     return HRESULT.E_POINTER;
@@ -92,7 +90,6 @@ public abstract partial class AxHost
 
             HRESULT IGetVBAObject.Interface.GetObject(Guid* riid, void** ppvObj, uint dwReserved)
             {
-                s_axHTraceSwitch.TraceVerbose("in GetObject for proxy");
                 if (ppvObj is null || riid is null)
                 {
                     return HRESULT.E_INVALIDARG;
@@ -112,7 +109,6 @@ public abstract partial class AxHost
             {
                 get
                 {
-                    s_axHTraceSwitch.TraceVerbose($"in getAlign for proxy for {GetControl()}");
                     int result = (int)(GetControl()?.Dock ?? NativeMethods.ActiveX.ALIGN_NO_CHANGE);
                     if (result is < NativeMethods.ActiveX.ALIGN_MIN or > NativeMethods.ActiveX.ALIGN_MAX)
                     {
@@ -123,7 +119,6 @@ public abstract partial class AxHost
                 }
                 set
                 {
-                    s_axHTraceSwitch.TraceVerbose($"in setAlign for proxy for {GetControl()} {value}");
                     if (GetControl() is { } control)
                     {
                         control.Dock = (DockStyle)value;
@@ -133,14 +128,9 @@ public abstract partial class AxHost
 
             public uint BackColor
             {
-                get
-                {
-                    s_axHTraceSwitch.TraceVerbose($"in getBackColor for proxy for {GetControl()}");
-                    return GetOleColorFromColor(GetControl()?.BackColor ?? default);
-                }
+                get => GetOleColorFromColor(GetControl()?.BackColor ?? default);
                 set
                 {
-                    s_axHTraceSwitch.TraceVerbose($"in setBackColor for proxy for {GetControl()} {value}");
                     if (GetControl() is { } control)
                     {
                         control.BackColor = GetColorFromOleColor(value);
@@ -150,14 +140,9 @@ public abstract partial class AxHost
 
             public BOOL Enabled
             {
-                get
-                {
-                    s_axHTraceSwitch.TraceVerbose($"in getEnabled for proxy for {GetControl()}");
-                    return GetControl()?.Enabled ?? BOOL.FALSE;
-                }
+                get => GetControl()?.Enabled ?? BOOL.FALSE;
                 set
                 {
-                    s_axHTraceSwitch.TraceVerbose($"in setEnabled for proxy for {GetControl()} {value}");
                     if (GetControl() is { } control)
                     {
                         control.Enabled = value;
@@ -167,14 +152,9 @@ public abstract partial class AxHost
 
             public uint ForeColor
             {
-                get
-                {
-                    s_axHTraceSwitch.TraceVerbose($"in getForeColor for proxy for {GetControl()}");
-                    return GetOleColorFromColor(GetControl()?.ForeColor ?? default);
-                }
+                get => GetOleColorFromColor(GetControl()?.ForeColor ?? default);
                 set
                 {
-                    s_axHTraceSwitch.TraceVerbose($"in setForeColor for proxy for {GetControl()} {value}");
                     if (GetControl() is { } control)
                     {
                         control.ForeColor = GetColorFromOleColor(value);
@@ -184,14 +164,9 @@ public abstract partial class AxHost
 
             public int Height
             {
-                get
-                {
-                    s_axHTraceSwitch.TraceVerbose($"in getHeight for proxy for {GetControl()}");
-                    return Pixel2Twip(GetControl()?.Height ?? 0, xDirection: false);
-                }
+                get => Pixel2Twip(GetControl()?.Height ?? 0, xDirection: false);
                 set
                 {
-                    s_axHTraceSwitch.TraceVerbose($"in setHeight for proxy for {GetControl()} {Twip2Pixel(value, false)}");
                     if (GetControl() is { } control)
                     {
                         control.Height = Twip2Pixel(value, xDirection: false);
@@ -201,14 +176,9 @@ public abstract partial class AxHost
 
             public int Left
             {
-                get
-                {
-                    s_axHTraceSwitch.TraceVerbose($"in getLeft for proxy for {GetControl()}");
-                    return Pixel2Twip(GetControl()?.Left ?? 0, xDirection: true);
-                }
+                get => Pixel2Twip(GetControl()?.Left ?? 0, xDirection: true);
                 set
                 {
-                    s_axHTraceSwitch.TraceVerbose($"in setLeft for proxy for {GetControl()} {Twip2Pixel(value, true)}");
                     if (GetControl() is { } control)
                     {
                         control.Left = Twip2Pixel(value, xDirection: true);
@@ -220,7 +190,6 @@ public abstract partial class AxHost
             {
                 get
                 {
-                    s_axHTraceSwitch.TraceVerbose($"in getParent for proxy for {GetControl()}");
                     IExtender.Interface? extender = GetContainer() is { } container
                         ? container.GetExtenderProxyForControl(container._parent)
                         : null;
@@ -231,14 +200,9 @@ public abstract partial class AxHost
 
             public short TabIndex
             {
-                get
-                {
-                    s_axHTraceSwitch.TraceVerbose($"in getTabIndex for proxy for {GetControl()}");
-                    return (short)(GetControl()?.TabIndex ?? 0);
-                }
+                get => (short)(GetControl()?.TabIndex ?? 0);
                 set
                 {
-                    s_axHTraceSwitch.TraceVerbose($"in setTabIndex for proxy for {GetControl()} {value}");
                     if (GetControl() is { } control)
                     {
                         control.TabIndex = value;
@@ -248,14 +212,9 @@ public abstract partial class AxHost
 
             public BOOL TabStop
             {
-                get
-                {
-                    s_axHTraceSwitch.TraceVerbose($"in getTabStop for proxy for {GetControl()}");
-                    return GetControl()?.TabStop ?? BOOL.FALSE;
-                }
+                get => GetControl()?.TabStop ?? BOOL.FALSE;
                 set
                 {
-                    s_axHTraceSwitch.TraceVerbose($"in setTabStop for proxy for {GetControl()} {value}");
                     if (GetControl() is { } control)
                     {
                         control.TabStop = value;
@@ -265,14 +224,9 @@ public abstract partial class AxHost
 
             public int Top
             {
-                get
-                {
-                    s_axHTraceSwitch.TraceVerbose($"in getTop for proxy for {GetControl()}");
-                    return Pixel2Twip(GetControl()?.Top ?? 0, xDirection: false);
-                }
+                get => Pixel2Twip(GetControl()?.Top ?? 0, xDirection: false);
                 set
                 {
-                    s_axHTraceSwitch.TraceVerbose($"in setTop for proxy for {GetControl()} {Twip2Pixel(value, false)}");
                     if (GetControl() is { } control)
                     {
                         control.Top = Twip2Pixel(value, xDirection: false);
@@ -282,14 +236,9 @@ public abstract partial class AxHost
 
             public BOOL Visible
             {
-                get
-                {
-                    s_axHTraceSwitch.TraceVerbose($"in getVisible for proxy for {GetControl()}");
-                    return GetControl()?.Visible ?? false;
-                }
+                get => GetControl()?.Visible ?? false;
                 set
                 {
-                    s_axHTraceSwitch.TraceVerbose($"in setVisible for proxy for {GetControl()} {value}");
                     if (GetControl() is { } control)
                     {
                         control.Visible = value;
@@ -299,14 +248,9 @@ public abstract partial class AxHost
 
             public int Width
             {
-                get
-                {
-                    s_axHTraceSwitch.TraceVerbose($"in getWidth for proxy for {GetControl()}");
-                    return Pixel2Twip(GetControl()?.Width ?? 0, xDirection: true);
-                }
+                get => Pixel2Twip(GetControl()?.Width ?? 0, xDirection: true);
                 set
                 {
-                    s_axHTraceSwitch.TraceVerbose($"in setWidth for proxy for {GetControl()} {Twip2Pixel(value, true)}");
                     if (GetControl() is { } control)
                     {
                         control.Width = Twip2Pixel(value, xDirection: true);
@@ -314,23 +258,9 @@ public abstract partial class AxHost
                 }
             }
 
-            public BSTR Name
-            {
-                get
-                {
-                    s_axHTraceSwitch.TraceVerbose($"in getName for proxy for {GetControl()}");
-                    return new(GetControl() is { } control ? GetNameForControl(control) : string.Empty);
-                }
-            }
+            public BSTR Name => new(GetControl() is { } control ? GetNameForControl(control) : string.Empty);
 
-            public HWND Hwnd
-            {
-                get
-                {
-                    s_axHTraceSwitch.TraceVerbose($"in getHwnd for proxy for {GetControl()}");
-                    return GetControl()?.HWND ?? HWND.Null;
-                }
-            }
+            public HWND Hwnd => GetControl()?.HWND ?? HWND.Null;
 
             public IUnknown* Container
             {
@@ -343,14 +273,9 @@ public abstract partial class AxHost
 
             public string Text
             {
-                get
-                {
-                    s_axHTraceSwitch.TraceVerbose($"in getText for proxy for {GetControl()}");
-                    return GetControl()?.Text ?? string.Empty;
-                }
+                get => GetControl()?.Text ?? string.Empty;
                 set
                 {
-                    s_axHTraceSwitch.TraceVerbose($"in setText for proxy for {GetControl()}");
                     if (GetControl() is { } control)
                     {
                         control.Text = value;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxContainer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxContainer.cs
@@ -36,7 +36,6 @@ public abstract partial class AxHost
 
         internal AxContainer(ContainerControl parent)
         {
-            s_axHTraceSwitch.TraceVerbose($"in constructor.  Parent created : {parent.Created}");
             _parent = parent;
             if (parent.Created)
             {
@@ -95,7 +94,6 @@ public abstract partial class AxHost
             {
                 if (control != _parent && !GetComponents().Contains(control))
                 {
-                    s_axHTraceSwitch.TraceVerbose("!parent || !belongs NYI");
                     AxContainer? container = FindContainerForControl(control);
                     if (container is not null)
                     {
@@ -103,7 +101,6 @@ public abstract partial class AxHost
                     }
                     else
                     {
-                        s_axHTraceSwitch.TraceVerbose("unable to find proxy, returning null");
                         return null;
                     }
                 }
@@ -115,7 +112,6 @@ public abstract partial class AxHost
                 _extenderCache.Add(control, extender);
             }
 
-            s_axHTraceSwitch.TraceVerbose($"found proxy {extender}");
             return extender;
         }
 
@@ -146,15 +142,6 @@ public abstract partial class AxHost
                             changeService.ComponentRemoved += OnComponentRemoved;
                         }
                     }
-                }
-                else
-                {
-#if DEBUG
-                    if (control.Site is { } site && _associatedContainer != site.Container)
-                    {
-                        s_axHTraceSwitch.TraceVerbose("mismatch between assoc container & added control");
-                    }
-#endif
                 }
             }
         }
@@ -343,7 +330,6 @@ public abstract partial class AxHost
             }
 
             Debug.Assert(_parent.Site is null, "Parent is sited but we could not find IContainer");
-            s_axHTraceSwitch.TraceVerbose("Did not find a container in FillComponentsTable");
 
             if (_containerCache.Count > 0)
             {
@@ -512,7 +498,6 @@ public abstract partial class AxHost
             // The ShDocVw control repeatedly calls OnUIActivate() with the same site.
             // This causes the assert below to fire.
             Debug.Assert(_siteUIActive is null, "Object did not call OnUIDeactivate");
-            s_axHTraceSwitch.TraceVerbose($"active Object is now {site}");
             _siteUIActive = site;
             if (site.ContainingControl is { } container)
             {
@@ -522,7 +507,6 @@ public abstract partial class AxHost
 
         internal void ControlCreated(AxHost invoker)
         {
-            s_axHTraceSwitch.TraceVerbose($"in controlCreated for {invoker} fAC: {_formAlreadyCreated}");
             if (_formAlreadyCreated)
             {
                 if (invoker.IsUserMode() && invoker.AwaitingDefreezing())
@@ -578,7 +562,6 @@ public abstract partial class AxHost
             uint* pchEaten,
             IMoniker** ppmkOut)
         {
-            s_axHTraceSwitch.TraceVerbose("in ParseDisplayName");
             if (ppmkOut is not null)
             {
                 *ppmkOut = null;
@@ -593,8 +576,6 @@ public abstract partial class AxHost
             {
                 return HRESULT.E_POINTER;
             }
-
-            s_axHTraceSwitch.TraceVerbose("in EnumObjects");
 
             if (((OLECONTF)grfFlags).HasFlag(OLECONTF.OLECONTF_EMBEDDINGS))
             {
@@ -620,11 +601,7 @@ public abstract partial class AxHost
             return HRESULT.S_OK;
         }
 
-        HRESULT IOleContainer.Interface.LockContainer(BOOL fLock)
-        {
-            s_axHTraceSwitch.TraceVerbose("in LockContainer");
-            return HRESULT.E_NOTIMPL;
-        }
+        HRESULT IOleContainer.Interface.LockContainer(BOOL fLock) => HRESULT.E_NOTIMPL;
 
         // IOleInPlaceFrame methods:
         HRESULT IOleInPlaceFrame.Interface.GetWindow(HWND* phwnd)
@@ -634,34 +611,17 @@ public abstract partial class AxHost
                 return HRESULT.E_POINTER;
             }
 
-            s_axHTraceSwitch.TraceVerbose("in GetWindow");
             *phwnd = _parent.HWND;
             return HRESULT.S_OK;
         }
 
-        HRESULT IOleInPlaceFrame.Interface.ContextSensitiveHelp(BOOL fEnterMode)
-        {
-            s_axHTraceSwitch.TraceVerbose("in ContextSensitiveHelp");
-            return HRESULT.S_OK;
-        }
+        HRESULT IOleInPlaceFrame.Interface.ContextSensitiveHelp(BOOL fEnterMode) => HRESULT.S_OK;
 
-        HRESULT IOleInPlaceFrame.Interface.GetBorder(RECT* lprectBorder)
-        {
-            s_axHTraceSwitch.TraceVerbose("in GetBorder");
-            return HRESULT.E_NOTIMPL;
-        }
+        HRESULT IOleInPlaceFrame.Interface.GetBorder(RECT* lprectBorder) => HRESULT.E_NOTIMPL;
 
-        HRESULT IOleInPlaceFrame.Interface.RequestBorderSpace(RECT* pborderwidths)
-        {
-            s_axHTraceSwitch.TraceVerbose("in RequestBorderSpace");
-            return HRESULT.E_NOTIMPL;
-        }
+        HRESULT IOleInPlaceFrame.Interface.RequestBorderSpace(RECT* pborderwidths) => HRESULT.E_NOTIMPL;
 
-        HRESULT IOleInPlaceFrame.Interface.SetBorderSpace(RECT* pborderwidths)
-        {
-            s_axHTraceSwitch.TraceVerbose("in SetBorderSpace");
-            return HRESULT.E_NOTIMPL;
-        }
+        HRESULT IOleInPlaceFrame.Interface.SetBorderSpace(RECT* pborderwidths) => HRESULT.E_NOTIMPL;
 
         internal void OnExitEditMode(AxHost ctl)
         {
@@ -676,7 +636,6 @@ public abstract partial class AxHost
 
         HRESULT IOleInPlaceFrame.Interface.SetActiveObject(IOleInPlaceActiveObject* pActiveObject, PCWSTR pszObjName)
         {
-            s_axHTraceSwitch.TraceVerbose($"in SetActiveObject {pszObjName.ToString() ?? "<null>"}");
             if (_siteUIActive is { } activeHost
                 && activeHost._iOleInPlaceActiveObjectExternal is { } existing
                 && !existing.MatchesOriginalPointer(pActiveObject))
@@ -728,12 +687,10 @@ public abstract partial class AxHost
 
             if (host is null)
             {
-                s_axHTraceSwitch.TraceVerbose("control w/o a valid site called setactiveobject");
                 _controlInEditMode = null;
             }
             else
             {
-                s_axHTraceSwitch.TraceVerbose($"resolved to {host}");
                 if (!host.IsUserMode())
                 {
                     _controlInEditMode = host;
@@ -746,41 +703,17 @@ public abstract partial class AxHost
             return HRESULT.S_OK;
         }
 
-        HRESULT IOleInPlaceFrame.Interface.InsertMenus(HMENU hmenuShared, OLEMENUGROUPWIDTHS* lpMenuWidths)
-        {
-            s_axHTraceSwitch.TraceVerbose("in InsertMenus");
-            return HRESULT.S_OK;
-        }
+        HRESULT IOleInPlaceFrame.Interface.InsertMenus(HMENU hmenuShared, OLEMENUGROUPWIDTHS* lpMenuWidths) => HRESULT.S_OK;
 
-        HRESULT IOleInPlaceFrame.Interface.SetMenu(HMENU hmenuShared, nint holemenu, HWND hwndActiveObject)
-        {
-            s_axHTraceSwitch.TraceVerbose("in SetMenu");
-            return HRESULT.E_NOTIMPL;
-        }
+        HRESULT IOleInPlaceFrame.Interface.SetMenu(HMENU hmenuShared, nint holemenu, HWND hwndActiveObject) => HRESULT.E_NOTIMPL;
 
-        HRESULT IOleInPlaceFrame.Interface.RemoveMenus(HMENU hmenuShared)
-        {
-            s_axHTraceSwitch.TraceVerbose("in RemoveMenus");
-            return HRESULT.E_NOTIMPL;
-        }
+        HRESULT IOleInPlaceFrame.Interface.RemoveMenus(HMENU hmenuShared) => HRESULT.E_NOTIMPL;
 
-        HRESULT IOleInPlaceFrame.Interface.SetStatusText(PCWSTR pszStatusText)
-        {
-            s_axHTraceSwitch.TraceVerbose("in SetStatusText");
-            return HRESULT.E_NOTIMPL;
-        }
+        HRESULT IOleInPlaceFrame.Interface.SetStatusText(PCWSTR pszStatusText) => HRESULT.E_NOTIMPL;
 
-        HRESULT IOleInPlaceFrame.Interface.EnableModeless(BOOL fEnable)
-        {
-            s_axHTraceSwitch.TraceVerbose("in EnableModeless");
-            return HRESULT.E_NOTIMPL;
-        }
+        HRESULT IOleInPlaceFrame.Interface.EnableModeless(BOOL fEnable) => HRESULT.E_NOTIMPL;
 
-        HRESULT IOleInPlaceFrame.Interface.TranslateAccelerator(MSG* lpmsg, ushort wID)
-        {
-            s_axHTraceSwitch.TraceVerbose("in IOleInPlaceFrame.TranslateAccelerator");
-            return HRESULT.S_FALSE;
-        }
+        HRESULT IOleInPlaceFrame.Interface.TranslateAccelerator(MSG* lpmsg, ushort wID) => HRESULT.S_FALSE;
 
         HRESULT IOleInPlaceUIWindow.Interface.GetWindow(HWND* phwnd)
             => ((IOleInPlaceFrame.Interface)this).GetWindow(phwnd);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxPropertyDescriptor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxPropertyDescriptor.cs
@@ -44,7 +44,6 @@ public abstract partial class AxHost
                     Guid g = GetPropertyPage(_dispid.Value);
                     if (!Guid.Empty.Equals(g))
                     {
-                        s_axPropTraceSwitch.TraceVerbose($"Making property: {Name} browsable because we found an property page.");
                         AddAttribute(new BrowsableAttribute(true));
                     }
                 }
@@ -170,12 +169,10 @@ public abstract partial class AxHost
                 _owner.NoComponentChangeEvents++;
                 return _baseDescriptor.GetValue(component);
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 if (!GetFlag(FlagCheckGetter))
                 {
-                    s_axPropTraceSwitch.TraceVerbose(
-                        $"Get failed for : {Name} with exception: {e.Message}. Making property non-browsable.");
                     SetFlag(FlagCheckGetter, true);
                     AddAttribute(new BrowsableAttribute(false));
                     _owner.RefreshAllProperties = true;
@@ -361,14 +358,12 @@ public abstract partial class AxHost
                     // Show any non-browsable property that has an editor through a property page.
                     if (!IsBrowsable)
                     {
-                        s_axPropTraceSwitch.TraceVerbose($"Making property: {Name} browsable because we found an editor.");
                         AddAttribute(new BrowsableAttribute(true));
                     }
                 }
             }
-            catch (Exception ex)
+            catch (Exception)
             {
-                s_axPropTraceSwitch.TraceVerbose($"Could not get the type editor for property: {Name} Exception: {ex}");
             }
             finally
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.OleInterfaces.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.OleInterfaces.cs
@@ -68,8 +68,6 @@ public abstract partial class AxHost
         // IGetVBAObject methods:
         HRESULT IGetVBAObject.Interface.GetObject(Guid* riid, void** ppvObj, uint dwReserved)
         {
-            s_axHTraceSwitch.TraceVerbose("in GetObject");
-
             if (ppvObj is null || riid is null)
             {
                 return HRESULT.E_INVALIDARG;
@@ -92,7 +90,6 @@ public abstract partial class AxHost
             ENUM_CONTROLS_WHICH_FLAGS dwWhich,
             IEnumUnknown** ppenum)
         {
-            s_axHTraceSwitch.TraceVerbose("in EnumControls");
             *ppenum = ComHelpers.GetComPointer<IEnumUnknown>(
                 _host.GetParentContainer().EnumControls(_host, dwOleContF, dwWhich));
             return HRESULT.S_OK;
@@ -140,21 +137,12 @@ public abstract partial class AxHost
         }
 
         // IOleControlSite methods:
-        HRESULT IOleControlSite.Interface.OnControlInfoChanged()
-        {
-            s_axHTraceSwitch.TraceVerbose("in OnControlInfoChanged");
-            return HRESULT.S_OK;
-        }
+        HRESULT IOleControlSite.Interface.OnControlInfoChanged() => HRESULT.S_OK;
 
-        HRESULT IOleControlSite.Interface.LockInPlaceActive(BOOL fLock)
-        {
-            s_axHTraceSwitch.TraceVerbose("in LockInPlaceActive");
-            return HRESULT.E_NOTIMPL;
-        }
+        HRESULT IOleControlSite.Interface.LockInPlaceActive(BOOL fLock) => HRESULT.E_NOTIMPL;
 
         HRESULT IOleControlSite.Interface.GetExtendedControl(IDispatch** ppDisp)
         {
-            s_axHTraceSwitch.TraceVerbose($"in GetExtendedControl {_host}");
             if (ppDisp is null)
             {
                 return HRESULT.E_POINTER;
@@ -178,7 +166,7 @@ public abstract partial class AxHost
             }
 
             HRESULT hr = SetupLogPixels(force: false);
-            if (hr < 0)
+            if (hr.Failed)
             {
                 return hr;
             }
@@ -198,7 +186,6 @@ public abstract partial class AxHost
                 }
                 else
                 {
-                    s_axHTraceSwitch.TraceVerbose($"\t dwFlags not supported: {dwFlags}");
                     return HRESULT.E_INVALIDARG;
                 }
             }
@@ -216,13 +203,11 @@ public abstract partial class AxHost
                 }
                 else
                 {
-                    s_axHTraceSwitch.TraceVerbose($"\t dwFlags not supported: {dwFlags}");
                     return HRESULT.E_INVALIDARG;
                 }
             }
             else
             {
-                s_axHTraceSwitch.TraceVerbose($"\t dwFlags not supported: {dwFlags}");
                 return HRESULT.E_INVALIDARG;
             }
 
@@ -265,11 +250,7 @@ public abstract partial class AxHost
         }
 
         // IOleClientSite methods:
-        HRESULT IOleClientSite.Interface.SaveObject()
-        {
-            s_axHTraceSwitch.TraceVerbose("in SaveObject");
-            return HRESULT.E_NOTIMPL;
-        }
+        HRESULT IOleClientSite.Interface.SaveObject() => HRESULT.E_NOTIMPL;
 
         unsafe HRESULT IOleClientSite.Interface.GetMoniker(uint dwAssign, uint dwWhichMoniker, IMoniker** ppmk)
         {
@@ -278,7 +259,6 @@ public abstract partial class AxHost
                 return HRESULT.E_POINTER;
             }
 
-            Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "AxSource:GetMoniker");
             *ppmk = null;
             return HRESULT.E_NOTIMPL;
         }
@@ -290,14 +270,12 @@ public abstract partial class AxHost
                 return HRESULT.E_POINTER;
             }
 
-            s_axHTraceSwitch.TraceVerbose("in getContainer");
             *ppContainer = ComHelpers.GetComPointer<IOleContainer>(_host.GetParentContainer());
             return HRESULT.S_OK;
         }
 
         unsafe HRESULT IOleClientSite.Interface.ShowObject()
         {
-            s_axHTraceSwitch.TraceVerbose("in ShowObject");
             if (_host.GetAxState(s_fOwnWindow))
             {
                 Debug.Fail("we can't be in showobject if we own our window...");
@@ -337,24 +315,15 @@ public abstract partial class AxHost
             }
             else if (inPlaceObject.SupportsInterface<IOleInPlaceObjectWindowless>())
             {
-                s_axHTraceSwitch.TraceVerbose("Windowless control.");
                 throw new InvalidOperationException(SR.AXWindowlessControl);
             }
 
             return HRESULT.S_OK;
         }
 
-        HRESULT IOleClientSite.Interface.OnShowWindow(BOOL fShow)
-        {
-            s_axHTraceSwitch.TraceVerbose("in OnShowWindow");
-            return HRESULT.S_OK;
-        }
+        HRESULT IOleClientSite.Interface.OnShowWindow(BOOL fShow) => HRESULT.S_OK;
 
-        HRESULT IOleClientSite.Interface.RequestNewObjectLayout()
-        {
-            s_axHTraceSwitch.TraceVerbose("in RequestNewObjectLayout");
-            return HRESULT.E_NOTIMPL;
-        }
+        HRESULT IOleClientSite.Interface.RequestNewObjectLayout() => HRESULT.E_NOTIMPL;
 
         // IOleInPlaceSite methods:
 
@@ -371,26 +340,16 @@ public abstract partial class AxHost
                 return HRESULT.E_POINTER;
             }
 
-            s_axHTraceSwitch.TraceVerbose("in GetWindow");
             *phwnd = _host.ParentInternal?.HWND ?? HWND.Null;
             return HRESULT.S_OK;
         }
 
-        HRESULT IOleInPlaceSite.Interface.ContextSensitiveHelp(BOOL fEnterMode)
-        {
-            s_axHTraceSwitch.TraceVerbose("in ContextSensitiveHelp");
-            return HRESULT.E_NOTIMPL;
-        }
+        HRESULT IOleInPlaceSite.Interface.ContextSensitiveHelp(BOOL fEnterMode) => HRESULT.E_NOTIMPL;
 
-        HRESULT IOleInPlaceSite.Interface.CanInPlaceActivate()
-        {
-            s_axHTraceSwitch.TraceVerbose("in CanInPlaceActivate");
-            return HRESULT.S_OK;
-        }
+        HRESULT IOleInPlaceSite.Interface.CanInPlaceActivate() => HRESULT.S_OK;
 
         HRESULT IOleInPlaceSite.Interface.OnInPlaceActivate()
         {
-            s_axHTraceSwitch.TraceVerbose("in OnInPlaceActivate");
             _host.SetAxState(s_ownDisposing, false);
             _host.SetAxState(s_rejectSelection, false);
             _host.SetOcState(OC_INPLACE);
@@ -399,7 +358,6 @@ public abstract partial class AxHost
 
         HRESULT IOleInPlaceSite.Interface.OnUIActivate()
         {
-            s_axHTraceSwitch.TraceVerbose($"in OnUIActivate for {_host}");
             _host.SetOcState(OC_UIACTIVE);
             _host.GetParentContainer().OnUIActivate(_host);
             return HRESULT.S_OK;
@@ -449,7 +407,6 @@ public abstract partial class AxHost
 
         HRESULT IOleInPlaceSite.Interface.OnUIDeactivate(BOOL fUndoable)
         {
-            s_axHTraceSwitch.TraceVerbose($"in OnUIDeactivate for {_host}");
             _host.GetParentContainer().OnUIDeactivate(_host);
             if (_host.GetOcState() > OC_INPLACE)
             {
@@ -461,10 +418,9 @@ public abstract partial class AxHost
 
         HRESULT IOleInPlaceSite.Interface.OnInPlaceDeactivate()
         {
-            s_axHTraceSwitch.TraceVerbose("in OnInPlaceDeactivate");
             if (_host.GetOcState() == OC_UIACTIVE)
             {
-                ((IOleInPlaceSite.Interface)this).OnUIDeactivate(fUndoable: false);
+                ((IOleInPlaceSite.Interface)this).OnUIDeactivate(fUndoable: false).AssertSuccess();
             }
 
             _host.GetParentContainer().OnInPlaceDeactivate(_host);
@@ -473,15 +429,10 @@ public abstract partial class AxHost
             return HRESULT.S_OK;
         }
 
-        HRESULT IOleInPlaceSite.Interface.DiscardUndoState()
-        {
-            s_axHTraceSwitch.TraceVerbose("in DiscardUndoState");
-            return HRESULT.S_OK;
-        }
+        HRESULT IOleInPlaceSite.Interface.DiscardUndoState() => HRESULT.S_OK;
 
         HRESULT IOleInPlaceSite.Interface.DeactivateAndUndo()
         {
-            s_axHTraceSwitch.TraceVerbose($"in DeactivateAndUndo for {_host}");
             using var inPlaceObject = _host.GetComScope<IOleInPlaceObject>();
             return inPlaceObject.Value->UIDeactivate();
         }
@@ -504,15 +455,10 @@ public abstract partial class AxHost
 
             if (useRect)
             {
-                s_axHTraceSwitch.TraceVerbose($"in OnPosRectChange{lprcPosRect->ToString()}");
                 RECT clipRect = WebBrowserHelper.GetClipRect();
                 using var inPlaceObject = _host.GetComScope<IOleInPlaceObject>();
                 inPlaceObject.Value->SetObjectRects(lprcPosRect, &clipRect).ThrowOnFailure();
                 _host.MakeDirty();
-            }
-            else
-            {
-                s_axHTraceSwitch.TraceVerbose("Control directly called OnPosRectChange... ignoring the new size");
             }
 
             return HRESULT.S_OK;
@@ -533,8 +479,6 @@ public abstract partial class AxHost
             try
             {
                 AxPropertyDescriptor? prop = null;
-
-                s_axHTraceSwitch.TraceVerbose("in OnChanged");
 
                 if (dispid != PInvoke.DISPID_UNKNOWN)
                 {
@@ -590,10 +534,6 @@ public abstract partial class AxHost
             return HRESULT.S_OK;
         }
 
-        HRESULT IPropertyNotifySink.Interface.OnRequestEdit(int dispid)
-        {
-            s_axHTraceSwitch.TraceVerbose($"in OnRequestEdit for {_host}");
-            return HRESULT.S_OK;
-        }
+        HRESULT IPropertyNotifySink.Interface.OnRequestEdit(int dispid) => HRESULT.S_OK;
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.PropertyBagStream.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.PropertyBagStream.cs
@@ -62,8 +62,6 @@ public abstract unsafe partial class AxHost
 
             string name = pszPropName.ToString();
 
-            s_axHTraceSwitch.TraceVerbose($"Reading property {name} from OCXState propertybag.");
-
             if (!_bag.Contains(name))
             {
                 *pVar = default;
@@ -72,7 +70,6 @@ public abstract unsafe partial class AxHost
 
             object? value = _bag[name];
             *pVar = VARIANT.FromObject(value);
-            s_axHTraceSwitch.TraceVerbose($"\tValue={value ?? "<null>"}");
 
             // The EE returns a VT_EMPTY for a null. The problem is that Visual Basic 6 expects the caller to respect
             // the "hint" it gives in the VariantType. For eg., for a VT_BSTR, it expects that the callee will null
@@ -92,7 +89,6 @@ public abstract unsafe partial class AxHost
             string name = pszPropName.ToString();
             object? value = pVar->ToObject();
 
-            s_axHTraceSwitch.TraceVerbose($"Writing property {name} [{*pVar}] into OCXState propertybag.");
             _bag[name] = value;
             return HRESULT.S_OK;
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.State.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.State.cs
@@ -103,7 +103,6 @@ public abstract partial class AxHost
                 {
                     try
                     {
-                        s_axHTraceSwitch.TraceVerbose("Loading up property bag from stream...");
                         byte[]? data = enumerator.Value as byte[];
                         if (data is not null)
                         {
@@ -339,9 +338,8 @@ public abstract partial class AxHost
                     _propertyBag.Save(propertyBagBinaryStream);
                     info.AddValue(PropertyBagSerializationName, propertyBagBinaryStream.ToArray());
                 }
-                catch (Exception e)
+                catch (Exception)
                 {
-                    s_axHTraceSwitch.TraceVerbose($"Failed to serialize the property bag into ResX : {e}");
                 }
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.VBFormat.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.VBFormat.cs
@@ -21,7 +21,6 @@ public abstract partial class AxHost
             ushort sFirstWeekOfYear,
             ushort* rcb)
         {
-            s_axHTraceSwitch.TraceVerbose("in Format");
             if (rcb is null)
             {
                 return HRESULT.E_INVALIDARG;


### PR DESCRIPTION
We have trace statements everywhere in AxHost and most of our trace statements do not seem to add much value as it just highlights what methods were entered. If needed, we can use debug actions in VS to output messages capturing points of interest when debugging instead of having traces throughout our code, so removing them.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9834)