### PR TITLE
Enable nullability in several internal CodeDomSerializers

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ComponentCache.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ComponentCache.cs
@@ -242,7 +242,7 @@ internal sealed class ComponentCache : IDisposable
         }
 
         public object? Component; // pointer back to the component that generated this entry
-        public CodeStatementCollection? Statements;
+        public CodeStatementCollection Statements = new();
 
         public ICollection<ResourceEntry>? Metadata => _metadata;
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ComponentCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ComponentCodeDomSerializer.cs
@@ -261,7 +261,11 @@ internal class ComponentCodeDomSerializer : CodeDomSerializer
                         IContainer? container = manager.GetService<IContainer>();
                         if (container is not null)
                         {
-                            ConstructorInfo? ctor = GetReflectionTypeHelper(manager, value).GetConstructor(BindingFlags.ExactBinding | BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly, null, GetContainerConstructor(manager), null);
+                            ConstructorInfo? ctor = GetReflectionTypeHelper(manager, value).GetConstructor(
+                                BindingFlags.ExactBinding | BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly,
+                                binder: null,
+                                GetContainerConstructor(manager),
+                                modifiers: null);
 
                             CodeExpression? assignRhs;
                             if (ctor is not null)

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ContainerCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ContainerCodeDomSerializer.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.CodeDom;
 
 namespace System.ComponentModel.Design.Serialization;
@@ -14,34 +12,26 @@ namespace System.ComponentModel.Design.Serialization;
 internal class ContainerCodeDomSerializer : CodeDomSerializer
 {
     private const string _containerName = "components";
-    private static ContainerCodeDomSerializer s_defaultSerializer;
+    private static ContainerCodeDomSerializer? s_defaultSerializer;
 
     /// <summary>
     ///  Retrieves a default static instance of this serializer.
     /// </summary>
-    internal static new ContainerCodeDomSerializer Default
-    {
-        get
-        {
-            s_defaultSerializer ??= new ContainerCodeDomSerializer();
-
-            return s_defaultSerializer;
-        }
-    }
+    internal static new ContainerCodeDomSerializer Default => s_defaultSerializer ??= new ContainerCodeDomSerializer();
 
     /// <summary>
     ///  We override this so we can always provide the correct container as a reference.
     /// </summary>
-    protected override object DeserializeInstance(IDesignerSerializationManager manager, Type type, object[] parameters, string name, bool addToContainer)
+    protected override object DeserializeInstance(IDesignerSerializationManager manager, Type type, object?[]? parameters, string? name, bool addToContainer)
     {
         if (typeof(IContainer).IsAssignableFrom(type))
         {
-            object obj = manager.GetService(typeof(IContainer));
+            object? obj = manager.GetService(typeof(IContainer));
 
             if (obj is not null)
             {
                 Trace(TraceLevel.Verbose, "Returning IContainer service as container");
-                manager.SetName(obj, name);
+                manager.SetName(obj, name!);
                 return obj;
             }
         }
@@ -59,7 +49,7 @@ internal class ContainerCodeDomSerializer : CodeDomSerializer
         CodeStatementCollection statements = new CodeStatementCollection();
         CodeExpression lhs;
 
-        if (manager.Context[typeof(CodeTypeDeclaration)] is CodeTypeDeclaration typeDecl && manager.Context[typeof(RootContext)] is RootContext rootCtx)
+        if (manager.TryGetContext(out CodeTypeDeclaration? typeDecl) && manager.TryGetContext(out RootContext? rootCtx))
         {
             CodeMemberField field = new CodeMemberField(typeof(IContainer), _containerName)
             {

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/EnumCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/EnumCodeDomSerializer.cs
@@ -27,68 +27,67 @@ internal class EnumCodeDomSerializer : CodeDomSerializer
         using (TraceScope($"EnumCodeDomSerializer::{nameof(Serialize)}"))
         {
             Trace(TraceLevel.Verbose, $"Type: {(value is null ? "(null)" : value.GetType().Name)}");
-            if (value is Enum enumValue)
-            {
-                bool needCast = false;
-                Enum[] values;
-                TypeConverter converter = TypeDescriptor.GetConverter(enumValue);
-                if (converter is not null && converter.CanConvertTo(typeof(Enum[])))
-                {
-                    values = (Enum[])converter.ConvertTo(enumValue, typeof(Enum[]))!;
-                    needCast = (values.Length > 1);
-                }
-                else
-                {
-                    values = new Enum[] { enumValue };
-                    needCast = true;
-                }
-
-                // EnumConverter (and anything that is overridden to support enums)
-                // should be providing us a conversion to Enum[] for flag styles.
-                // If it doesn't, we will emit a warning and just do a cast from the enum value.
-
-                CodeTypeReferenceExpression enumType = new CodeTypeReferenceExpression(enumValue.GetType());
-
-                // If names is of length 1, then this is a simple field reference. Otherwise,
-                // it is an or-d combination of expressions.
-                //
-                TraceIf(TraceLevel.Verbose, values.Length == 1, "Single field entity.");
-                TraceIf(TraceLevel.Verbose, values.Length > 1, "Multi field entity.");
-
-                // We now need to serialize the enum terms as fields. We new up an EnumConverter to do
-                // that. We cannot use the type's own converter since it might have a different string
-                // representation for its values. Hardcoding is okay in this case, since all we want is
-                // the enum's field name. Simply doing ToString() will not give us any validation.
-                TypeConverter enumConverter = new EnumConverter(enumValue.GetType());
-                foreach (Enum term in values)
-                {
-                    string? termString = enumConverter?.ConvertToString(term);
-
-                    if (!string.IsNullOrEmpty(termString))
-                    {
-                        CodeExpression newExpression = new CodeFieldReferenceExpression(enumType, termString);
-                        if (expression is null)
-                        {
-                            expression = newExpression;
-                        }
-                        else
-                        {
-                            expression = new CodeBinaryOperatorExpression(expression, CodeBinaryOperatorType.BitwiseOr, newExpression);
-                        }
-                    }
-                }
-
-                // If we had to combine multiple names, wrap the result in an appropriate cast.
-                //
-                if (expression is not null && needCast)
-                {
-                    expression = new CodeCastExpression(enumValue.GetType(), expression);
-                }
-            }
-            else
+            if (value is not Enum enumValue)
             {
                 Debug.Fail("Enum serializer called for non-enum object.");
                 Trace(TraceLevel.Error, $"Enum serializer called for non-enum object {(value is null ? "(null)" : value.GetType().Name)}");
+                return null!;
+            }
+
+            bool needCast = false;
+            Enum[] values;
+            TypeConverter? converter = TypeDescriptor.GetConverter(enumValue);
+            if (converter is not null && converter.CanConvertTo(typeof(Enum[])))
+            {
+                values = (Enum[])converter.ConvertTo(enumValue, typeof(Enum[]))!;
+                needCast = (values.Length > 1);
+            }
+            else
+            {
+                values = new Enum[] { enumValue };
+                needCast = true;
+            }
+
+            // EnumConverter (and anything that is overridden to support enums)
+            // should be providing us a conversion to Enum[] for flag styles.
+            // If it doesn't, we will emit a warning and just do a cast from the enum value.
+
+            CodeTypeReferenceExpression enumType = new CodeTypeReferenceExpression(enumValue.GetType());
+
+            // If names is of length 1, then this is a simple field reference. Otherwise,
+            // it is an or-d combination of expressions.
+            //
+            TraceIf(TraceLevel.Verbose, values.Length == 1, "Single field entity.");
+            TraceIf(TraceLevel.Verbose, values.Length > 1, "Multi field entity.");
+
+            // We now need to serialize the enum terms as fields. We new up an EnumConverter to do
+            // that. We cannot use the type's own converter since it might have a different string
+            // representation for its values. Hardcoding is okay in this case, since all we want is
+            // the enum's field name. Simply doing ToString() will not give us any validation.
+            TypeConverter enumConverter = new EnumConverter(enumValue.GetType());
+            foreach (Enum term in values)
+            {
+                string? termString = enumConverter?.ConvertToString(term);
+
+                if (!string.IsNullOrEmpty(termString))
+                {
+                    CodeExpression newExpression = new CodeFieldReferenceExpression(enumType, termString);
+                    if (expression is null)
+                    {
+                        expression = newExpression;
+                    }
+                    else
+                    {
+                        expression = new CodeBinaryOperatorExpression(expression, CodeBinaryOperatorType.BitwiseOr, newExpression);
+                    }
+                }
+            }
+
+            // If we had to combine multiple names, wrap the result in an appropriate cast.
+            //
+            if (expression is not null && needCast)
+            {
+                expression = new CodeCastExpression(enumValue.GetType(), expression);
             }
         }
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/EventMemberCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/EventMemberCodeDomSerializer.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.CodeDom;
 using System.Reflection;
 
@@ -13,18 +11,10 @@ namespace System.ComponentModel.Design.Serialization;
 /// </summary>
 internal sealed class EventMemberCodeDomSerializer : MemberCodeDomSerializer
 {
-    private static readonly CodeThisReferenceExpression _thisRef = new();
-    private static EventMemberCodeDomSerializer s_default;
+    private static readonly CodeThisReferenceExpression s_thisRef = new();
+    private static EventMemberCodeDomSerializer? s_default;
 
-    internal static EventMemberCodeDomSerializer Default
-    {
-        get
-        {
-            s_default ??= new EventMemberCodeDomSerializer();
-
-            return s_default;
-        }
-    }
+    internal static EventMemberCodeDomSerializer Default => s_default ??= new EventMemberCodeDomSerializer();
 
     /// <summary>
     ///  This method actually performs the serialization.  When the member is serialized
@@ -35,7 +25,7 @@ internal sealed class EventMemberCodeDomSerializer : MemberCodeDomSerializer
         ArgumentNullException.ThrowIfNull(manager);
         ArgumentNullException.ThrowIfNull(value);
 
-        if (!(descriptor is EventDescriptor eventToSerialize))
+        if (descriptor is not EventDescriptor eventToSerialize)
         {
             throw new ArgumentNullException(nameof(descriptor));
         }
@@ -44,21 +34,23 @@ internal sealed class EventMemberCodeDomSerializer : MemberCodeDomSerializer
 
         try
         {
+            IEventBindingService? eventBindings = manager.GetService<IEventBindingService>();
+
             // If the IEventBindingService is not available, we don't throw - we just don't do anything.
-            if (manager.GetService(typeof(IEventBindingService)) is IEventBindingService eventBindings)
+            if (eventBindings is not null)
             {
                 PropertyDescriptor prop = eventBindings.GetEventProperty(eventToSerialize);
-                string methodName = (string)prop.GetValue(value);
+                string? methodName = (string?)prop.GetValue(value);
 
                 if (methodName is not null)
                 {
                     Trace(TraceLevel.Verbose, $"Event {eventToSerialize.Name} bound to {methodName}");
-                    CodeExpression eventTarget = SerializeToExpression(manager, value);
+                    CodeExpression? eventTarget = SerializeToExpression(manager, value);
                     TraceIf(TraceLevel.Warning, eventTarget is null, $"Object has no name and no property ref in context so we cannot serialize events: {value}");
                     if (eventTarget is not null)
                     {
                         CodeTypeReference delegateTypeRef = new CodeTypeReference(eventToSerialize.EventType);
-                        CodeDelegateCreateExpression delegateCreate = new CodeDelegateCreateExpression(delegateTypeRef, _thisRef, methodName);
+                        CodeDelegateCreateExpression delegateCreate = new CodeDelegateCreateExpression(delegateTypeRef, s_thisRef, methodName);
                         CodeEventReferenceExpression eventRef = new CodeEventReferenceExpression(eventTarget, eventToSerialize.Name);
                         CodeAttachEventStatement attach = new CodeAttachEventStatement(eventRef, delegateCreate);
 
@@ -76,7 +68,7 @@ internal sealed class EventMemberCodeDomSerializer : MemberCodeDomSerializer
             //
             if (e is TargetInvocationException)
             {
-                e = e.InnerException;
+                e = e.InnerException!;
             }
 
             manager.ReportError(new CodeDomSerializerException(string.Format(SR.SerializerPropertyGenFailed, eventToSerialize.Name, e.Message), manager));

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ResourceCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ResourceCodeDomSerializer.cs
@@ -246,7 +246,7 @@ internal partial class ResourceCodeDomSerializer : CodeDomSerializer
     /// <summary>
     ///  This performs the actual work of serialization between Serialize and SerializeInvariant.
     /// </summary>
-    private object Serialize(IDesignerSerializationManager manager, object? value, bool forceInvariant, bool shouldSerializeInvariant, bool ensureInvariant)
+    private CodeExpression Serialize(IDesignerSerializationManager manager, object? value, bool forceInvariant, bool shouldSerializeInvariant, bool ensureInvariant)
     {
         using (TraceScope("ResourceCodeDomSerializer::Serialize"))
         {

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripMenuItemCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripMenuItemCodeDomSerializer.cs
@@ -18,17 +18,13 @@ internal class ToolStripMenuItemCodeDomSerializer : CodeDomSerializer
     /// We implement this for the abstract method on CodeDomSerializer.
     /// </summary>
     public override object? Deserialize(IDesignerSerializationManager manager, object codeObject)
-    {
-        return GetBaseSerializer(manager).Deserialize(manager, codeObject);
-    }
+        => GetBaseSerializer(manager).Deserialize(manager, codeObject);
 
     /// <summary>
     /// This is a small helper method that returns the serializer for base Class
     /// </summary>
     private static CodeDomSerializer GetBaseSerializer(IDesignerSerializationManager manager)
-    {
-        return manager.GetSerializer<CodeDomSerializer>(typeof(Component))!;
-    }
+        => manager.GetSerializer<CodeDomSerializer>(typeof(Component))!;
 
     /// <summary>
     /// We implement this for the abstract method on CodeDomSerializer.  This method

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripMenuItemCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripMenuItemCodeDomSerializer.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.ComponentModel;
 using System.ComponentModel.Design.Serialization;
 
@@ -19,7 +17,7 @@ internal class ToolStripMenuItemCodeDomSerializer : CodeDomSerializer
     /// <summary>
     /// We implement this for the abstract method on CodeDomSerializer.
     /// </summary>
-    public override object Deserialize(IDesignerSerializationManager manager, object codeObject)
+    public override object? Deserialize(IDesignerSerializationManager manager, object codeObject)
     {
         return GetBaseSerializer(manager).Deserialize(manager, codeObject);
     }
@@ -29,29 +27,28 @@ internal class ToolStripMenuItemCodeDomSerializer : CodeDomSerializer
     /// </summary>
     private static CodeDomSerializer GetBaseSerializer(IDesignerSerializationManager manager)
     {
-        return (CodeDomSerializer)manager.GetSerializer(typeof(Component), typeof(CodeDomSerializer));
+        return manager.GetSerializer<CodeDomSerializer>(typeof(Component))!;
     }
 
     /// <summary>
     /// We implement this for the abstract method on CodeDomSerializer.  This method
     /// takes an object graph, and serializes the object into CodeDom elements.
     /// </summary>
-    public override object Serialize(IDesignerSerializationManager manager, object value)
+    public override object? Serialize(IDesignerSerializationManager manager, object value)
     {
-        ToolStripMenuItem item = value as ToolStripMenuItem;
-        ToolStrip parent = item.GetCurrentParent();
-
         // Don't Serialize if we are Dummy Item ...
-        if ((item is not null) && !(item.IsOnDropDown) && (parent is not null) && (parent.Site is null))
+        if (value is ToolStripMenuItem {IsOnDropDown: false} item)
         {
-            //don't serialize anything...
-            return null;
+            ToolStrip? parent = item.GetCurrentParent();
+            if (parent is not null && parent.Site is null)
+            {
+                //don't serialize anything...
+                return null;
+            }
         }
-        else
-        {
-            CodeDomSerializer baseSerializer = (CodeDomSerializer)manager.GetSerializer(typeof(ImageList).BaseType, typeof(CodeDomSerializer));
 
-            return baseSerializer.Serialize(manager, value);
-        }
+        CodeDomSerializer baseSerializer = manager.GetSerializer<CodeDomSerializer>(typeof(ImageList).BaseType)!;
+
+        return baseSerializer.Serialize(manager, value);
     }
 }


### PR DESCRIPTION
## Proposed changes

- Enable nullability in `ContainerCodeDomSerializer`
- Enable nullability in `EnumCodeDomSerializer`
- Enable nullability in `EventMemberCodeDomSerializer`
- Enable nullability in `PrimitiveCodeDomSerializer`
- Enable nullability in `ResourceCodeDomSerializer`
- Enable nullability in `ToolStripMenuItemCodeDomSerializer`
- Enable nullability in `ComponentCodeDomSerializer` (2nd commit)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9842)