### PR TITLE
Include README.md in System.Drawing.Common package building.

### DIFF
--- a/src/System.Drawing.Common/README.md
+++ b/src/System.Drawing.Common/README.md
@@ -1,16 +1,16 @@
 # System.Drawing.Common
-This assembly provides access to GDI+ basic graphics functionality via types such as [`Bitmap`](https://learn.microsoft.com/en-us/dotnet/api/system.drawing.bitmap) and [`Font`](https://learn.microsoft.com/en-us/dotnet/api/system.drawing.font).
+This assembly provides access to GDI+ basic graphics functionality via types such as [`Bitmap`](https://learn.microsoft.com/dotnet/api/system.drawing.bitmap) and [`Font`](https://learn.microsoft.com/dotnet/api/system.drawing.font).
 
-Note that `System.Drawing.Common` is only supported on Windows: https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/system-drawing-common-windows-only.
+Note that `System.Drawing.Common` is only supported on Windows: https://learn.microsoft.com/dotnet/core/compatibility/core-libraries/6.0/system-drawing-common-windows-only.
 
-Documentation can be found at https://learn.microsoft.com/en-us/dotnet/api/system.drawing.
+Documentation can be found at https://learn.microsoft.com/dotnet/api/system.drawing.
 
 ## Contribution Bar
-- [x] [We consider new features, new APIs and performance changes](../README.md#primary-bar)
-- [x] [We consider PRs that target this library for new source code analyzers](../README.md#secondary-bars)
-- [ ] [We don't accept refactoring changes due to new language features](../README.md#secondary-bars)
+- [x] We consider new features, new APIs and performance changes
+- [x] We consider PRs that target this library for new source code analyzers
+- [ ] We don't accept refactoring changes due to new language features
 
-See the [Help Wanted](https://github.com/dotnet/runtime/issues?q=is%3Aissue+is%3Aopen+label%3Aarea-System.Drawing+label%3A%22help+wanted%22) issues.
+See the [Help Wanted](https://github.com/dotnet/winforms/labels/help%20wanted) issues.
 
 ## Deployment
 `System.Drawing.Common` is provided as a [NuGet package](https://www.nuget.org/packages/System.Drawing.Common) and part of the `Microsoft.WindowsDesktop.App` shared framework.

--- a/src/System.Drawing.Common/README.md
+++ b/src/System.Drawing.Common/README.md
@@ -1,72 +1,16 @@
 # System.Drawing.Common
+This assembly provides access to GDI+ basic graphics functionality via types such as [`Bitmap`](https://learn.microsoft.com/en-us/dotnet/api/system.drawing.bitmap) and [`Font`](https://learn.microsoft.com/en-us/dotnet/api/system.drawing.font).
 
-The `System.Drawing.Common` package allows .NET Core and .NET 5+ applications to access GDI+ graphics functionality. This package is especially useful for porting .NET Framework applications that rely on the `System.Drawing` namespace.
+Note that `System.Drawing.Common` is only supported on Windows: https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/system-drawing-common-windows-only.
 
-## Getting Started
-
-To get started with `System.Drawing.Common`, install it using the NuGet Package Manager, the .NET CLI, or by editing your project file directly.
-
-**NOTE:** If you are developing a **WinForms** application, you **do not** need to install the `System.Drawing.Common` package separately (to this end, you use the `Sdk` attribute for the `Project` element like `<Project Sdk="Microsoft.NET.Sdk">` in the .csproj or the .vbproj file and then specify `<UseWindowsForms>true</UseWindowsForms>`). This package is then automatically included as part of the .NET SDK for WinForms Apps, which means you can start using the `System.Drawing` namespace right away in your WinForms projects.
-
-## Usage
-
-The following examples demonstrate some basic tasks you can accomplish with `System.Drawing.Common`.
-
-### Create a Simple Bitmap and Save it
-
-#### C#
-```csharp
-using System.Drawing;
-
-class Program
-{
-    static void Main()
-    {
-        using (Bitmap bitmap = new Bitmap(100, 100))
-        {
-            using (Graphics g = Graphics.FromImage(bitmap))
-            {
-                g.Clear(Color.Red);
-            }
-            bitmap.Save("output.bmp");
-        }
-    }
-}
-```
-
-#### VB
-```vb
-Imports System.Drawing
-
-Module Program
-    Sub Main()
-        Using bitmap As New Bitmap(100, 100)
-            Using g As Graphics = Graphics.FromImage(bitmap)
-                g.Clear(Color.Red)
-            End Using
-            bitmap.Save("output.bmp")
-        End Using
-    End Sub
-End Module
-```
-
-## Additional Documentation
-
-For more in-depth tutorials and API references, you can check the following resources:
-
-- [NuGet Gallery | System.Drawing.Common](https://nuget.org/packages/System.Drawing.Common/)
-- [System.Drawing.Common Namespace | Microsoft Docs](https://docs.microsoft.com/dotnet/api/system.drawing)
-- [Drawing with System.Drawing.Common | Microsoft Learn](https://learn.microsoft.com/dotnet/core/drawing/)
+Documentation can be found at https://learn.microsoft.com/en-us/dotnet/api/system.drawing.
 
 ## Contribution Bar
-- [x] We consider new features, new APIs and performance changes
-- [x] We consider PRs that target this library for new source code analyzers
-- [ ] We don't accept refactoring changes due to new language features
+- [x] [We consider new features, new APIs and performance changes](../README.md#primary-bar)
+- [x] [We consider PRs that target this library for new source code analyzers](../README.md#secondary-bars)
+- [ ] [We don't accept refactoring changes due to new language features](../README.md#secondary-bars)
 
-See the [Help Wanted](https://github.com/dotnet/winforms/issues?q=is%3Aopen+is%3Aissue+label%3Aarea-System.Drawing+label%3A%22help+wanted%22) issues.
+See the [Help Wanted](https://github.com/dotnet/runtime/issues?q=is%3Aissue+is%3Aopen+label%3Aarea-System.Drawing+label%3A%22help+wanted%22) issues.
 
-## Feedback
-
-- Open an issue on the [GitHub repository](https://github.com/dotnet/winforms/issues)
-- Reach out on Twitter with the hashtag #winforms
-- Join our Discord channel: [dotnet/Discord](https://discord.com/invite/dotnet)
+## Deployment
+`System.Drawing.Common` is provided as a [NuGet package](https://www.nuget.org/packages/System.Drawing.Common) and part of the `Microsoft.WindowsDesktop.App` shared framework.

--- a/src/System.Drawing.Common/README.md
+++ b/src/System.Drawing.Common/README.md
@@ -8,22 +8,6 @@ To get started with `System.Drawing.Common`, install it using the NuGet Package 
 
 **NOTE:** If you are developing a **WinForms** application, you **do not** need to install the `System.Drawing.Common` package separately (to this end, you use the `Sdk` attribute for the `Project` element like `<Project Sdk="Microsoft.NET.Sdk">` in the .csproj or the .vbproj file and then specify `<UseWindowsForms>true</UseWindowsForms>`). This package is then automatically included as part of the .NET SDK for WinForms Apps, which means you can start using the `System.Drawing` namespace right away in your WinForms projects.
 
-### NuGet Package Manager
-```
-Install-Package System.Drawing.Common -Version [your_version_here]
-```
-
-### .NET CLI
-```
-dotnet add package System.Drawing.Common --version [your_version_here]
-```
-
-### Prerequisites
-
-- .NET Core 2.0+ (min .NET Core 3.1 for WinForms/WPF Apps)
-- .NET 5+
-- .NET Standard 2.0 or higher
-
 ## Usage
 
 The following examples demonstrate some basic tasks you can accomplish with `System.Drawing.Common`.

--- a/src/System.Drawing.Common/src/System.Drawing.Common.csproj
+++ b/src/System.Drawing.Common/src/System.Drawing.Common.csproj
@@ -24,8 +24,14 @@ System.Drawing.Font
 System.Drawing.Graphics
 System.Drawing.Icon
 
-Since .NET 7, non-Windows platforms are not supported, even with the runtime configuration switch. See https://aka.ms/systemdrawingnonwindows for more information.</PackageDescription>
+Since .NET 7, non-Windows platforms are not supported, even with the runtime configuration switch. See https://aka.ms/systemdrawingnonwindows for more information.
+    </PackageDescription>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\README.md" Pack="true" PackagePath="" />
+  </ItemGroup>
 
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->
   <PropertyGroup Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETStandard'">

--- a/src/System.Drawing.Common/src/System.Drawing.Common.csproj
+++ b/src/System.Drawing.Common/src/System.Drawing.Common.csproj
@@ -26,11 +26,11 @@ System.Drawing.Icon
 
 Since .NET 7, non-Windows platforms are not supported, even with the runtime configuration switch. See https://aka.ms/systemdrawingnonwindows for more information.
     </PackageDescription>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageReadmeFile>package.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="..\README.md" Pack="true" PackagePath="" />
+    <None Include="package.md" Pack="true" PackagePath="" />
   </ItemGroup>
 
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->

--- a/src/System.Drawing.Common/src/System.Drawing.Common.csproj
+++ b/src/System.Drawing.Common/src/System.Drawing.Common.csproj
@@ -26,11 +26,11 @@ System.Drawing.Icon
 
 Since .NET 7, non-Windows platforms are not supported, even with the runtime configuration switch. See https://aka.ms/systemdrawingnonwindows for more information.
     </PackageDescription>
-    <PackageReadmeFile>package.md</PackageReadmeFile>
+    <PackageReadmeFile>PACKAGE.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="package.md" Pack="true" PackagePath="" />
+    <None Include="PACKAGE.md" Pack="true" PackagePath="" />
   </ItemGroup>
 
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->

--- a/src/System.Drawing.Common/src/package.md
+++ b/src/System.Drawing.Common/src/package.md
@@ -1,6 +1,7 @@
 # System.Drawing.Common
 
-The `System.Drawing.Common` package allows .NET Core and .NET 5+ applications to access GDI+ graphics functionality. This package is especially useful for porting .NET Framework applications that rely on the `System.Drawing` namespace.
+The `System.Drawing.Common` package allows .NET Core and .NET 6+ applications to access GDI+ graphics functionality. 
+This package is especially useful for porting .NET Framework applications that rely on the `System.Drawing` namespace.
 
 ## Getting Started
 
@@ -57,13 +58,6 @@ For more in-depth tutorials and API references, you can check the following reso
 - [NuGet Gallery | System.Drawing.Common](https://nuget.org/packages/System.Drawing.Common/)
 - [System.Drawing.Common Namespace | Microsoft Docs](https://docs.microsoft.com/dotnet/api/system.drawing)
 - [Drawing with System.Drawing.Common | Microsoft Learn](https://learn.microsoft.com/dotnet/core/drawing/)
-
-## Contribution Bar
-- [x] We consider new features, new APIs and performance changes
-- [x] We consider PRs that target this library for new source code analyzers
-- [ ] We don't accept refactoring changes due to new language features
-
-See the [Help Wanted](https://github.com/dotnet/winforms/issues?q=is%3Aopen+is%3Aissue+label%3Aarea-System.Drawing+label%3A%22help+wanted%22) issues.
 
 ## Feedback
 

--- a/src/System.Drawing.Common/src/package.md
+++ b/src/System.Drawing.Common/src/package.md
@@ -1,0 +1,72 @@
+# System.Drawing.Common
+
+The `System.Drawing.Common` package allows .NET Core and .NET 5+ applications to access GDI+ graphics functionality. This package is especially useful for porting .NET Framework applications that rely on the `System.Drawing` namespace.
+
+## Getting Started
+
+To get started with `System.Drawing.Common`, install it using the NuGet Package Manager, the .NET CLI, or by editing your project file directly.
+
+**NOTE:** If you are developing a **WinForms** application, you **do not** need to install the `System.Drawing.Common` package separately (to this end, you use the `Sdk` attribute for the `Project` element like `<Project Sdk="Microsoft.NET.Sdk">` in the .csproj or the .vbproj file and then specify `<UseWindowsForms>true</UseWindowsForms>`). This package is then automatically included as part of the .NET SDK for WinForms Apps, which means you can start using the `System.Drawing` namespace right away in your WinForms projects.
+
+## Usage
+
+The following examples demonstrate some basic tasks you can accomplish with `System.Drawing.Common`.
+
+### Create a Simple Bitmap and Save it
+
+#### C#
+```csharp
+using System.Drawing;
+
+class Program
+{
+    static void Main()
+    {
+        using (Bitmap bitmap = new Bitmap(100, 100))
+        {
+            using (Graphics g = Graphics.FromImage(bitmap))
+            {
+                g.Clear(Color.Red);
+            }
+            bitmap.Save("output.bmp");
+        }
+    }
+}
+```
+
+#### VB
+```vb
+Imports System.Drawing
+
+Module Program
+    Sub Main()
+        Using bitmap As New Bitmap(100, 100)
+            Using g As Graphics = Graphics.FromImage(bitmap)
+                g.Clear(Color.Red)
+            End Using
+            bitmap.Save("output.bmp")
+        End Using
+    End Sub
+End Module
+```
+
+## Additional Documentation
+
+For more in-depth tutorials and API references, you can check the following resources:
+
+- [NuGet Gallery | System.Drawing.Common](https://nuget.org/packages/System.Drawing.Common/)
+- [System.Drawing.Common Namespace | Microsoft Docs](https://docs.microsoft.com/dotnet/api/system.drawing)
+- [Drawing with System.Drawing.Common | Microsoft Learn](https://learn.microsoft.com/dotnet/core/drawing/)
+
+## Contribution Bar
+- [x] We consider new features, new APIs and performance changes
+- [x] We consider PRs that target this library for new source code analyzers
+- [ ] We don't accept refactoring changes due to new language features
+
+See the [Help Wanted](https://github.com/dotnet/winforms/issues?q=is%3Aopen+is%3Aissue+label%3Aarea-System.Drawing+label%3A%22help+wanted%22) issues.
+
+## Feedback
+
+- Open an issue on the [GitHub repository](https://github.com/dotnet/winforms/issues)
+- Reach out on Twitter with the hashtag #winforms
+- Join our Discord channel: [dotnet/Discord](https://discord.com/invite/dotnet)

--- a/src/System.Drawing.Common/src/package.md
+++ b/src/System.Drawing.Common/src/package.md
@@ -62,5 +62,5 @@ For more in-depth tutorials and API references, you can check the following reso
 ## Feedback
 
 - Open an issue on the [GitHub repository](https://github.com/dotnet/winforms/issues)
-- Reach out on Twitter with the hashtag #winforms
+- Reach out on Twitter with the [hashtag #winforms](https://twitter.com/search?q=%23winforms)
 - Join our Discord channel: [dotnet/Discord](https://discord.com/invite/dotnet)


### PR DESCRIPTION
The README in `System.Drawing.Common` was never included in the package building.
This PR fixes that.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9844)