### PR TITLE
Create IUnknownStrategy for GlobalInterfaceTable

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/OleAut32/Interop.VARIANT.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/OleAut32/Interop.VARIANT.cs
@@ -151,13 +151,13 @@ internal unsafe partial struct VARIANT : IDisposable
                 return Marshal.PtrToStringAnsi(*(IntPtr*)data);
             case VT_DISPATCH:
             case VT_UNKNOWN:
-                IntPtr pInterface = *(IntPtr*)data;
-                if (pInterface == IntPtr.Zero)
+                IUnknown* pInterface = *(IUnknown**)data;
+                if (pInterface is null)
                 {
                     return null;
                 }
 
-                return Marshal.GetObjectForIUnknown(pInterface);
+                return ComHelpers.GetObjectForIUnknown(pInterface);
             case VT_DECIMAL:
                 return ((DECIMAL*)data)->ToDecimal();
             case VT_BOOL:
@@ -380,7 +380,7 @@ internal unsafe partial struct VARIANT : IDisposable
                             var result = GetSpan<object?>(array);
                             for (int i = 0; i < data.Length; i++)
                             {
-                                result[i] = data[i] == IntPtr.Zero ? null : Marshal.GetObjectForIUnknown(data[i]);
+                                result[i] = data[i] == IntPtr.Zero ? null : ComHelpers.GetObjectForIUnknown((IUnknown*)data[i]);
                             }
 
                             break;
@@ -590,7 +590,7 @@ internal unsafe partial struct VARIANT : IDisposable
                     }
                     else
                     {
-                        SetValue(array, Marshal.GetObjectForIUnknown(data), indices, lowerBounds);
+                        SetValue(array, ComHelpers.GetObjectForIUnknown((IUnknown*)data), indices, lowerBounds);
                     }
 
                     break;

--- a/src/System.Windows.Forms.Primitives/src/Interop/WinFormsComStrategy.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/WinFormsComStrategy.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+using Windows.Win32.System.Com;
+
+internal partial class Interop
+{
+    /// <summary>
+    ///  Windows Forms <see cref="StrategyBasedComWrappers"/> implementation.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   Deriving from <see cref="StrategyBasedComWrappers"/> allows us to leverage the functionality the runtime
+    ///   has implemented for source generated "RCW"s, including support for <see cref="ComImportAttribute"/> adaption
+    ///   when built-in COM support is availalbe (EnableGeneratedComInterfaceComImportInterop).
+    ///  </para>
+    ///  <para>
+    ///   It isn't immediately clear how we could merge <see cref="WinFormsComWrappers"/> with this as there is no
+    ///   strategy for <see cref="ComWrappers.ComputeVtables(object, CreateComInterfaceFlags, out int)"/>. We rely
+    ///   on <see cref="IManagedWrapper"/> to apply the needed vtable functionality and it doesn't appear that we
+    ///   can apply <see cref="IComExposedDetails"/> without manually implementing (or source generating)
+    ///   <see cref="IComExposedDetails.GetComInterfaceEntries(out int)"/> on our exposed classes.
+    ///  </para>
+    /// </remarks>
+    internal unsafe class WinFormsComStrategy : StrategyBasedComWrappers
+    {
+        internal static WinFormsComStrategy Instance { get; } = new();
+
+        protected override IIUnknownStrategy GetOrCreateIUnknownStrategy() => GlobalInterfaceTable.CreateUnknownStrategy();
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/ComHelpers.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/ComHelpers.cs
@@ -13,6 +13,15 @@ internal static unsafe partial class ComHelpers
     //  using var stream = GetComScope<IStream>(obj, out bool success);
 
     /// <summary>
+    ///  Returns <see langword="true"/> if built-in COM interop is supported. When using AOT or trimming this will
+    ///  return <see langword="false"/>.
+    /// </summary>
+    internal static bool BuiltInComSupported { get; }
+        = AppContext.TryGetSwitch("System.Runtime.InteropServices.BuiltInComInterop.IsSupported", out bool supported)
+            ? supported
+            : true;
+
+    /// <summary>
     ///  Gets a pointer for the specified <typeparamref name="T"/> for the given <paramref name="object"/>. Throws if
     ///  the desired pointer can not be obtained.
     /// </summary>
@@ -180,8 +189,7 @@ internal static unsafe partial class ComHelpers
                 return true;
             }
 
-            // Fall back to Marshal.
-            @interface = (TWrapper)Marshal.GetObjectForIUnknown((nint)unknown);
+            @interface = (TWrapper)GetObjectForIUnknown(unknown);
             return true;
         }
         catch (Exception ex)
@@ -213,6 +221,31 @@ internal static unsafe partial class ComHelpers
         return ccw.Value == unknown;
     }
 
+    /// <summary>
+    ///  <see cref="ComWrappers"/> capable wrapper for <see cref="Marshal.GetObjectForIUnknown(nint)"/>.
+    /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="unknown"/> is <see langword="null"/>.</exception>
+    internal static object GetObjectForIUnknown(IUnknown* unknown)
+    {
+        if (unknown is null)
+        {
+            throw new ArgumentNullException(nameof(unknown));
+        }
+
+        if (BuiltInComSupported)
+        {
+            return Marshal.GetObjectForIUnknown((nint)unknown);
+        }
+        else
+        {
+            // Analagous to ComInterfaceMarshaller<object>.ConvertToManaged(unknown), but we need our own strategy.
+            return Interop.WinFormsComStrategy.Instance.GetOrCreateObjectForComInstance((nint)unknown, CreateObjectFlags.Unwrap);
+        }
+    }
+
+    /// <summary>
+    ///  <see cref="IUnknown"/> vtable population hook for CsWin32's generated <see cref="IVTable"/> implementation.
+    /// </summary>
     static partial void PopulateIUnknownImpl<TComInterface>(IUnknown.Vtbl* vtable)
         where TComInterface : unmanaged
     {

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/Foundation/GlobalInterfaceTable.UnknownStrategy.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/Foundation/GlobalInterfaceTable.UnknownStrategy.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices.Marshalling;
+using Windows.Win32.System.Com;
+
+namespace Windows.Win32.Foundation;
+
+internal static unsafe partial class GlobalInterfaceTable
+{
+    /// <summary>
+    ///  Strategy for <see cref="StrategyBasedComWrappers"/> that uses the <see cref="GlobalInterfaceTable"/>.
+    /// </summary>
+    private unsafe class UnknownStrategy : IIUnknownStrategy
+    {
+        private uint _cookie;
+
+        void* IIUnknownStrategy.CreateInstancePointer(void* unknown)
+        {
+            Debug.Assert(_cookie == 0, "A cookie has already been generated for this instance.");
+            _cookie = RegisterInterface((IUnknown*)unknown);
+            return unknown;
+        }
+
+        int IIUnknownStrategy.QueryInterface(void* instancePtr, in Guid iid, out void* ppObj)
+            => s_globalInterfaceTable->GetInterfaceFromGlobal(_cookie, iid, out ppObj);
+
+        int IIUnknownStrategy.Release(void* instancePtr)
+        {
+            uint cookie = Interlocked.Exchange(ref _cookie, 0);
+            return cookie != 0 ? (int)HRESULT.S_OK : (int)RevokeInterface(_cookie);
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/Foundation/GlobalInterfaceTable.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/Foundation/GlobalInterfaceTable.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.InteropServices.Marshalling;
 using Windows.Win32.System.Com;
 
 namespace Windows.Win32.Foundation;
@@ -8,7 +9,7 @@ namespace Windows.Win32.Foundation;
 /// <summary>
 ///  Wrapper for the COM global interface table.
 /// </summary>
-internal static unsafe class GlobalInterfaceTable
+internal static unsafe partial class GlobalInterfaceTable
 {
     private static readonly IGlobalInterfaceTable* s_globalInterfaceTable;
 
@@ -65,4 +66,15 @@ internal static unsafe class GlobalInterfaceTable
         Debug.WriteLineIf(hr.Failed, $"{nameof(GlobalInterfaceTable)}: Failed to revoke interface.");
         return hr;
     }
+
+    /// <summary>
+    ///  Creates a new instance of an <see cref="IIUnknownStrategy"/> for <see cref="StrategyBasedComWrappers"/>
+    ///  that uses the Global Interface Table.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   The returned instance should not be cached.
+    ///  </para>
+    /// </remarks>
+    public static IIUnknownStrategy CreateUnknownStrategy() => new UnknownStrategy();
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
@@ -41,10 +41,6 @@ public sealed partial class Application
     private static readonly object s_internalSyncObject = new();
     private static bool s_useWaitCursor;
 
-    private static bool s_useEverettThreadAffinity;
-    private static bool s_checkedThreadAffinity;
-    private const string EverettThreadAffinityValue = "EnableSystemEventsThreadAffinityCompatibility";
-
     /// <summary>
     ///  Events the user can hook into
     /// </summary>
@@ -142,43 +138,6 @@ public sealed partial class Application
 
     internal static string CommonAppDataRegistryKeyName
         => $"Software\\{CompanyName}\\{ProductName}\\{ProductVersion}";
-
-    internal static bool UseEverettThreadAffinity
-    {
-        get
-        {
-            if (!s_checkedThreadAffinity)
-            {
-                s_checkedThreadAffinity = true;
-                try
-                {
-                    // We need access to be able to read from the registry here.  We're not creating a
-                    // registry key, nor are we returning information from the registry to the user.
-                    RegistryKey? key = Registry.LocalMachine.OpenSubKey(CommonAppDataRegistryKeyName);
-                    if (key is not null)
-                    {
-                        object? value = key.GetValue(EverettThreadAffinityValue);
-                        key.Close();
-
-                        if (value is not null && (int)value != 0)
-                        {
-                            s_useEverettThreadAffinity = true;
-                        }
-                    }
-                }
-                catch (Security.SecurityException)
-                {
-                    // Can't read the key: use default value (false)
-                }
-                catch (InvalidCastException)
-                {
-                    // Key is of wrong type: use default value (false)
-                }
-            }
-
-            return s_useEverettThreadAffinity;
-        }
-    }
 
     /// <summary>
     ///  Gets the path for the application data that is shared among all users.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.cs
@@ -2288,7 +2288,7 @@ public abstract unsafe partial class AxHost : Control, ISupportInitialize, ICust
             (void**)&unknown);
         hr.ThrowOnFailure();
 
-        _instance = Marshal.GetObjectForIUnknown((nint)unknown);
+        _instance = ComHelpers.GetObjectForIUnknown(unknown);
     }
 
     private void CreateWithLicense(string? license, Guid clsid)
@@ -2310,7 +2310,7 @@ public abstract unsafe partial class AxHost : Control, ISupportInitialize, ICust
                 hr = factory.Value->CreateInstanceLic(null, null, IID.Get<IUnknown>(), new BSTR(license), (void**)&unknown);
                 hr.ThrowOnFailure();
 
-                _instance = Marshal.GetObjectForIUnknown((nint)unknown);
+                _instance = ComHelpers.GetObjectForIUnknown(unknown);
             }
         }
 
@@ -3728,7 +3728,7 @@ public abstract unsafe partial class AxHost : Control, ISupportInitialize, ICust
 
         try
         {
-            return Marshal.GetObjectForIUnknown((nint)ifont);
+            return ComHelpers.GetObjectForIUnknown((IUnknown*)ifont);
         }
         catch
         {
@@ -3809,7 +3809,7 @@ public abstract unsafe partial class AxHost : Control, ISupportInitialize, ICust
             FONTDESC fontdesc = GetFONTDESCFromFont(font);
             fontdesc.lpstrName = n;
             PInvoke.OleCreateFontIndirect(in fontdesc, in IID.GetRef<IFontDisp>(), out void* lplpvObj).ThrowOnFailure();
-            return Marshal.GetObjectForIUnknown((nint)lplpvObj);
+            return ComHelpers.GetObjectForIUnknown((IUnknown*)lplpvObj);
         }
     }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.AxSourcingSite.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.AxSourcingSite.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel;
-using System.Runtime.InteropServices;
+using Windows.Win32.System.Com;
 using Windows.Win32.System.Ole;
 using static Interop;
 
@@ -41,7 +41,7 @@ public partial class Control
                 using ComScope<IOleContainer> container = new(null);
                 clientSite.Value->GetContainer(container);
 
-                if (Marshal.GetObjectForIUnknown((nint)container) is Mshtml.IHTMLDocument document)
+                if (ComHelpers.GetObjectForIUnknown((IUnknown*)container) is Mshtml.IHTMLDocument document)
                 {
                     _shimManager ??= new HtmlShimManager();
                     return new HtmlDocument(_shimManager, document);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.cs
@@ -968,7 +968,7 @@ public unsafe partial class DataObject :
 
     HRESULT Com.IDataObject.Interface.DAdvise(Com.FORMATETC* pformatetc, uint advf, Com.IAdviseSink* pAdvSink, uint* pdwConnection)
     {
-        var adviseSink = (IAdviseSink)Marshal.GetObjectForIUnknown((nint)(void*)pAdvSink);
+        var adviseSink = (IAdviseSink)ComHelpers.GetObjectForIUnknown((Com.IUnknown*)pAdvSink);
         return (HRESULT)((ComTypes.IDataObject)this).DAdvise(ref *(FORMATETC*)pformatetc, (ADVF)advf, adviseSink, out *(int*)pdwConnection);
     }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DropTarget.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DropTarget.cs
@@ -6,7 +6,6 @@ using Windows.Win32.System.SystemServices;
 using Ole = Windows.Win32.System.Ole;
 using Com = Windows.Win32.System.Com;
 using ComTypes = System.Runtime.InteropServices.ComTypes;
-using System.Runtime.InteropServices;
 using Windows.Win32.System.Com;
 
 namespace System.Windows.Forms;
@@ -59,7 +58,7 @@ internal unsafe class DropTarget : Ole.IDropTarget.Interface, IManagedWrapper<Ol
         }
         else
         {
-            object? obj = Marshal.GetObjectForIUnknown((nint)pDataObj);
+            object obj = ComHelpers.GetObjectForIUnknown((Com.IUnknown*)pDataObj);
             if (obj is IDataObject dataObject)
             {
                 data = dataObject;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
@@ -8,6 +8,7 @@ using System.Drawing.Design;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Windows.Forms.Layout;
+using Windows.Win32.System.Com;
 using static Interop;
 
 namespace System.Windows.Forms;
@@ -1695,7 +1696,7 @@ public abstract partial class TextBoxBase : Control
                 {
                     Marshal.QueryInterface(editOlePtr, in iiTextDocumentGuid, out iTextDocument);
 
-                    if (Marshal.GetObjectForIUnknown(iTextDocument) is Richedit.ITextDocument textDocument)
+                    if (ComHelpers.GetObjectForIUnknown((IUnknown*)iTextDocument) is Richedit.ITextDocument textDocument)
                     {
                         // When the user calls RichTextBox::ScrollToCaret we want the RichTextBox to show as
                         // much text as possible.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserBase.cs
@@ -865,7 +865,7 @@ public unsafe partial class WebBrowserBase : Control
 
             hr.ThrowOnFailure();
 
-            _activeXInstance = Marshal.GetObjectForIUnknown((nint)unknown);
+            _activeXInstance = ComHelpers.GetObjectForIUnknown((IUnknown*)unknown);
 
             Debug.Assert(_activeXInstance is not null, "w/o an exception being thrown we must have an object...");
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserContainer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserContainer.cs
@@ -3,7 +3,6 @@
 
 using System.ComponentModel;
 using System.ComponentModel.Design;
-using System.Runtime.InteropServices;
 using Windows.Win32.System.Com;
 using Windows.Win32.System.Ole;
 
@@ -110,7 +109,7 @@ internal unsafe class WebBrowserContainer : IOleContainer.Interface, IOleInPlace
 
         IOleClientSite* clientSite;
         oleObject.Value->GetClientSite(&clientSite);
-        var clientSiteObject = Marshal.GetObjectForIUnknown((nint)clientSite);
+        object clientSiteObject = ComHelpers.GetObjectForIUnknown((IUnknown*)clientSite);
         if (clientSiteObject is WebBrowserSiteBase webBrowserSiteBase)
         {
             control = webBrowserSiteBase.Host;

--- a/src/System.Windows.Forms/tests/UnitTests/TextBoxBaseTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/TextBoxBaseTests.cs
@@ -6416,7 +6416,7 @@ public partial class TextBoxBaseTests
         };
         Assert.NotEqual(IntPtr.Zero, control.Handle);
 
-        Assert.Throws<ArgumentNullException>("pUnk", () => control.ScrollToCaret());
+        Assert.Throws<ArgumentNullException>("unknown", () => control.ScrollToCaret());
     }
 
     private class CustomGetOleInterfaceTextBox : TextBox


### PR DESCRIPTION
Create a Global Interface Table IUnknownStrategy so we can use the same machinery the runtime uses to expose COM interfaces as objects with AgileComPointer-like support.

Change all of the direct Marshal calls to use a ComHelpers wrapper method.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9845)