### PR TITLE
Release COM object when wrapping in PictureWrapper

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/WinFormsComWrappers.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/WinFormsComWrappers.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -53,6 +53,7 @@ internal partial class Interop
             int hr = Marshal.QueryInterface(externalComObject, ref pictureIID, out IntPtr comObject);
             if (hr == S_OK)
             {
+                Marshal.Release(externalComObject);
                 return new PictureWrapper(comObject);
             }
 


### PR DESCRIPTION
We need to release the incoming pointer when returning a wrapped object. This was fixed in .NET 7 and removed completely in .NET 8 (where we access the COM object directly).

Without this any time we access IPicture we will permanently leak the incoming native class with no way for customers to fix it. This usually manifests as an exhaustion of GDI handles and will crash the application.

This is a regression from .NET 5.

Fixes #9774

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9853)