### PR TITLE
Make sure no exception pop up when edit label is accessed in ListView with viewMode: LargeIcon,SmallIcon,Tile

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -115,7 +115,7 @@ public partial class ListView : Control
     private MouseButtons _downButton;
     private int _itemCount;
     private int _columnIndex;
-    private ListViewItem? _selectedItem;
+    internal ListViewItem? _selectedItem;
     private int _topIndex;
     private bool _hoveredAlready;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemTileAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemTileAccessibleObject.cs
@@ -17,7 +17,10 @@ public partial class ListViewItem
 
         protected override View View => View.Tile;
 
-        private ListViewLabelEditAccessibleObject? LabelEditAccessibleObject => _labelEditAccessibleObject ??= _owningListView._labelEdit is null ? null : new(_owningListView, _owningListView._labelEdit);
+        private ListViewLabelEditAccessibleObject? LabelEditAccessibleObject
+            => _labelEditAccessibleObject ??= _owningListView._labelEdit is null
+                ? null
+                : new(_owningListView, _owningListView._labelEdit);
 
         internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemTileAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemTileAccessibleObject.cs
@@ -10,18 +10,23 @@ public partial class ListViewItem
 {
     internal class ListViewItemTileAccessibleObject : ListViewItemBaseAccessibleObject
     {
+        private ListViewLabelEditAccessibleObject? _labelEditAccessibleObject;
         public ListViewItemTileAccessibleObject(ListViewItem owningItem) : base(owningItem)
         {
         }
 
         protected override View View => View.Tile;
 
+        private ListViewLabelEditAccessibleObject? LabelEditAccessibleObject => _labelEditAccessibleObject ??= _owningListView._labelEdit is null ? null : new(_owningListView, _owningListView._labelEdit);
+
         internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
         {
             switch (direction)
             {
                 case UiaCore.NavigateDirection.FirstChild:
-                    return GetChildInternal(1);
+                    return _owningListView._labelEdit is not null
+                        ? LabelEditAccessibleObject
+                        : GetChildInternal(1);
                 case UiaCore.NavigateDirection.LastChild:
                     return GetChildInternal(GetLastChildIndex());
             }
@@ -71,10 +76,10 @@ public partial class ListViewItem
 
             if (_owningItem.SubItems.Count == 1)
             {
-                return 0;
+                return _owningListView._labelEdit is not null ? 1 : 0;
             }
 
-            return GetLastChildIndex();
+            return _owningListView._labelEdit is not null ? GetLastChildIndex() + 1 : GetLastChildIndex();
         }
 
         internal override int GetChildIndex(AccessibleObject? child)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemWithImageAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemWithImageAccessibleObject.cs
@@ -23,10 +23,10 @@ public partial class ListViewItem
         internal override int FirstSubItemIndex => HasImage ? 1 : 0;
 
         private ListViewItemImageAccessibleObject ImageAccessibleObject => _imageAccessibleObject ??= new(_owningItem);
-        private ListViewLabelEditAccessibleObject? LabelEditAccessibleObject =>
-            _labelEditAccessibleObject ??= _owningListView._labelEdit is null
-            ? null
-            : new(_owningListView, _owningListView._labelEdit);
+        private ListViewLabelEditAccessibleObject? LabelEditAccessibleObject
+            => _labelEditAccessibleObject ??= _owningListView._labelEdit is null
+                ? null
+                : new(_owningListView, _owningListView._labelEdit);
 
         internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
         {
@@ -50,7 +50,7 @@ public partial class ListViewItem
 
         public override AccessibleObject? GetChild(int index)
         {
-            if (_owningListView.View != View || !_owningListView.IsHandleCreated)
+            if (_owningListView.View != View)
             {
                 throw new InvalidOperationException(string.Format(SR.ListViewItemAccessibilityObjectInvalidViewException, View.ToString()));
             }
@@ -75,12 +75,18 @@ public partial class ListViewItem
 
         public override int GetChildCount()
         {
-            if (_owningListView.View != View || !_owningListView.IsHandleCreated)
+            if (_owningListView.View != View)
             {
                 throw new InvalidOperationException(string.Format(SR.ListViewItemAccessibilityObjectInvalidViewException, View.ToString()));
             }
 
             int _childCount = 0;
+
+            if (!_owningListView.IsHandleCreated)
+            {
+                return InvalidIndex;
+            }
+
             if(HasImage)
             {
                 _childCount++;
@@ -91,7 +97,7 @@ public partial class ListViewItem
                 _childCount++;
             }
 
-            return _childCount;
+            return _childCount > 0 ? _childCount : InvalidIndex;
         }
 
         internal override int GetChildIndex(AccessibleObject? child)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemWithImageAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemWithImageAccessibleObject.cs
@@ -65,7 +65,7 @@ public partial class ListViewItem
                 return LabelEditAccessibleObject;
             }
 
-            return (AccessibleObject?)null;
+            return null;
         }
 
         public override int GetChildCount()

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemWithImageAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemWithImageAccessibleObject.cs
@@ -55,22 +55,17 @@ public partial class ListViewItem
                 throw new InvalidOperationException(string.Format(SR.ListViewItemAccessibilityObjectInvalidViewException, View.ToString()));
             }
 
-            if (index > GetChildCount() - 1)
-            {
-                return null;
-            }
-
             if (index == ImageAccessibleObjectIndex && HasImage)
             {
                 return ImageAccessibleObject;
             }
 
-            if(index >= ImageAccessibleObjectIndex || !HasImage)
+            if (index >= ImageAccessibleObjectIndex || !HasImage)
             {
                 return LabelEditAccessibleObject;
             }
 
-            return null;
+            return (AccessibleObject?)null;
         }
 
         public override int GetChildCount()
@@ -80,14 +75,14 @@ public partial class ListViewItem
                 throw new InvalidOperationException(string.Format(SR.ListViewItemAccessibilityObjectInvalidViewException, View.ToString()));
             }
 
-            int _childCount = 0;
-
             if (!_owningListView.IsHandleCreated)
             {
                 return InvalidIndex;
             }
 
-            if(HasImage)
+            int _childCount = 0;
+
+            if (HasImage)
             {
                 _childCount++;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewLabelEditAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewLabelEditAccessibleObject.cs
@@ -33,8 +33,8 @@ internal class ListViewLabelEditAccessibleObject : AccessibleObject
     public override AccessibleObject? Parent => _owningListViewSubItem is null
         ? _owingListViewItem?.AccessibilityObject
         : _owningListView.View == View.Tile
-        ? _owingListViewItem?.AccessibilityObject
-        : _owningListViewSubItem?.AccessibilityObject;
+            ? _owingListViewItem?.AccessibilityObject
+            : _owningListViewSubItem?.AccessibilityObject;
 
     internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
     {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemWithImageAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemWithImageAccessibleObjectTests.cs
@@ -37,6 +37,11 @@ public class ListViewItem_ListViewItemWithImageAccessibleObjectTests
             SmallImageList = imageCollection,
             LargeImageList = imageCollection
         };
+        if(!control.IsHandleCreated)
+        {
+            Assert.NotEqual(IntPtr.Zero, control.Handle);
+        }
+
         control.Items.Add(listViewItem);
 
         AccessibleObject listViewItemAccessibleObject = control.Items[0].AccessibilityObject;
@@ -46,7 +51,7 @@ public class ListViewItem_ListViewItemWithImageAccessibleObjectTests
         Assert.IsType<ListViewItemImageAccessibleObject>(firstChild);
         Assert.IsType<ListViewItemImageAccessibleObject>(lastChild);
         Assert.Same(firstChild, lastChild);
-        Assert.False(control.IsHandleCreated);
+        Assert.True(control.IsHandleCreated);
     }
 
     [WinFormsTheory]


### PR DESCRIPTION
Fixes #9829 
The parent node of the edit label in the ListView may be one of SubItem or ListViewItem, so the tree structure needs to be drawn according to different view modes.

## Proposed changes

- Modify the access level of the selected  ListViewItem in ListView class so that ListViewLabelEditAccessibleObject can access it.
- Modify the ListViewItemTileAccessibleObject and ListViewItemWithImageAccessibleObject classes so that when the ListView is enabled for editing, the tree structure can correctly load the AccessibleObject of Edit label.
- Modify the ListViewLabelEditAccessibleObject class to make sure the edit label can find correctly parent node in different ViewModel.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- No Excepiton pop up when Accessibility tools accessed the edit label in ListView.
- Edit label can correctly find parent nodes in all view modes.

## Regression? 

- Yes 

## Risk

-Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
An exception unhandled when using Accessibility tools to edit ListItem with View modes: LargeIcon/SmallIcon/List.
![image](https://github.com/dotnet/winforms/assets/133954995/10bd5282-fb67-4649-b98c-34506dde36d1)

<!-- TODO -->

### After
No more exceptions are generated and the tree structure can be drawn correctly. 
**Details Model:**
![Details_Image](https://github.com/dotnet/winforms/assets/133954995/bc3322f4-c4d3-49a6-b19d-05f6ea0f9bee)
![Details_NoImage](https://github.com/dotnet/winforms/assets/133954995/d2c9eabd-efb5-495a-b56c-8b4f00ece974)

**List Model:**
![List_Image](https://github.com/dotnet/winforms/assets/133954995/98328a02-f0ff-4077-b260-e25197f4b751)
![List_NoImage](https://github.com/dotnet/winforms/assets/133954995/254fcb66-e5ef-4d97-a308-0a36c9c8c543)

**SmallIcon Model:**
![Small_Image](https://github.com/dotnet/winforms/assets/133954995/e2c7e76b-d3eb-4025-b1a6-051e5063cf04)
![Small_NoImage](https://github.com/dotnet/winforms/assets/133954995/2510ef5d-89c4-401a-bbcf-a56a7cbc7803)

**LargeIcon Model:**
![Large_Image](https://github.com/dotnet/winforms/assets/133954995/1d5abb6e-7531-4215-a779-b01f2585aa16)
![Large_NoImage](https://github.com/dotnet/winforms/assets/133954995/62a1109a-5d34-47b4-8320-f04d6396ffe8)

**Tile Model:**
![Title_Image](https://github.com/dotnet/winforms/assets/133954995/f1d28533-552a-4104-874b-eede8f6ab425)
![Title_NoImage](https://github.com/dotnet/winforms/assets/133954995/174f2d51-1162-4096-98fe-98178aa6c577)
<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- Manual (using inspect )

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

- 8.0.100-preview.7.23376.3


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9856)