### PR TITLE
Fix application hang on exit

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.GetExitCodeThread.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.GetExitCodeThread.cs
@@ -8,7 +8,7 @@ internal partial class Interop
 {
     internal partial class Kernel32
     {
-        [LibraryImport(Libraries.Kernel32)]
+        [LibraryImport(Libraries.Kernel32, SetLastError = true)]
         public static partial BOOL GetExitCodeThread(IntPtr hWnd, out uint lpdwExitCode);
     }
 }


### PR DESCRIPTION
Fixes #9721

`PInvoke.GetExitCodeThread()` is incorrectly wrapped. It doesn't define `SetLastError = true`, which causes `Marshal.GetLastWin32Error()` to not return the invalid handle error code that would terminate [this loop ](https://github.com/dotnet/winforms/blob/main/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs#L3840) we eventually get into, ultimately causing WinForms app to hang on exit.

This is not an issue in .NET 8 as we are leveraging Cswin32, which defines PInvokes correctly.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9861)