### PR TITLE
Fix folder browser code

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FolderNameEditor.FolderBrowserFolder.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FolderNameEditor.FolderBrowserFolder.cs
@@ -5,19 +5,26 @@ namespace System.Windows.Forms.Design;
 
 public partial class FolderNameEditor
 {
+    /// <devdoc>
+    ///  <para>
+    ///   <see cref="Environment.SpecialFolder"/> is also a list of CSIDL values. Unfortunately CSIDL_CONNECTIONS,
+    ///   CSIDL_NETWORK, and CSIDL_PRINTERS are not currently defined in that enum and can't be passed to
+    ///   <see cref="Environment.GetFolderPath(Environment.SpecialFolder)"/>.
+    ///  </para>
+    /// </devdoc>
     protected enum FolderBrowserFolder
     {
-        Desktop = 0x0000,
-        Favorites = 0x0006,
-        MyComputer = 0x0011,
-        MyDocuments = 0x0005,
-        MyPictures = 0x0027,
-        NetAndDialUpConnections = 0x0031,
-        NetworkNeighborhood = 0x0012,
-        Printers = 0x0004,
-        Recent = 0x0008,
-        SendTo = 0x0009,
-        StartMenu = 0x000b,
-        Templates = 0x0015
+        Desktop = (int)PInvoke.CSIDL_DESKTOP,
+        Favorites = (int)PInvoke.CSIDL_FAVORITES,
+        MyComputer = (int)PInvoke.CSIDL_DRIVES,
+        MyDocuments = (int)PInvoke.CSIDL_PERSONAL,
+        MyPictures = (int)PInvoke.CSIDL_MYPICTURES,
+        NetAndDialUpConnections = (int)PInvoke.CSIDL_CONNECTIONS,
+        NetworkNeighborhood = (int)PInvoke.CSIDL_NETWORK,
+        Printers = (int)PInvoke.CSIDL_PRINTERS,
+        Recent = (int)PInvoke.CSIDL_RECENT,
+        SendTo = (int)PInvoke.CSIDL_SENDTO,
+        StartMenu = (int)PInvoke.CSIDL_STARTMENU,
+        Templates = (int)PInvoke.CSIDL_TEMPLATES
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FolderNameEditor.FolderBrowserStyles.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FolderNameEditor.FolderBrowserStyles.cs
@@ -8,12 +8,12 @@ public partial class FolderNameEditor
     [Flags]
     protected enum FolderBrowserStyles
     {
-        BrowseForComputer        = unchecked((int)PInvoke.BIF_BROWSEFORCOMPUTER),
-        BrowseForEverything      = unchecked((int)PInvoke.BIF_BROWSEINCLUDEFILES),
-        BrowseForPrinter         = unchecked((int)PInvoke.BIF_BROWSEFORPRINTER),
-        RestrictToDomain         = unchecked((int)PInvoke.BIF_DONTGOBELOWDOMAIN),
-        RestrictToFilesystem     = unchecked((int)PInvoke.BIF_RETURNONLYFSDIRS),
-        RestrictToSubfolders     = unchecked((int)PInvoke.BIF_RETURNFSANCESTORS),
-        ShowTextBox              = unchecked((int)PInvoke.BIF_EDITBOX)
+        BrowseForComputer        = (int)PInvoke.BIF_BROWSEFORCOMPUTER,
+        BrowseForEverything      = (int)PInvoke.BIF_BROWSEINCLUDEFILES,
+        BrowseForPrinter         = (int)PInvoke.BIF_BROWSEFORPRINTER,
+        RestrictToDomain         = (int)PInvoke.BIF_DONTGOBELOWDOMAIN,
+        RestrictToFilesystem     = (int)PInvoke.BIF_RETURNONLYFSDIRS,
+        RestrictToSubfolders     = (int)PInvoke.BIF_RETURNFSANCESTORS,
+        ShowTextBox              = (int)PInvoke.BIF_EDITBOX
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/NativeMethods.txt
+++ b/src/System.Windows.Forms.Primitives/src/NativeMethods.txt
@@ -28,6 +28,7 @@ CDM_GETSPEC
 CDRF_*
 CHILDID_SELF
 ChildWindowFromPointEx
+CSIDL_*
 CLIENTCREATESTRUCT
 ClientToScreen
 ClipCursor
@@ -643,7 +644,7 @@ SHCreateShellItem
 SHDRAGIMAGE
 ShellExecute
 SHGetKnownFolderPath
-SHGetPathFromIDList
+SHGetPathFromIDListEx
 SHGetSpecialFolderLocation
 ShowCaret
 ShowCursor

--- a/src/System.Windows.Forms.Primitives/src/Resources/SR.resx
+++ b/src/System.Windows.Forms.Primitives/src/Resources/SR.resx
@@ -138,4 +138,7 @@
   <data name="Win32SetThreadsDpiHostingBehaviorFailed" xml:space="preserve">
     <value>Failed to set thread's DPI hosting behavior {0}.</value>
   </data>
+  <data name="FolderBrowserDialogNoRootFolder" xml:space="preserve">
+    <value>Unable to retrieve the root folder.</value>
+  </data>
 </root>

--- a/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.cs.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Nezpracovaná hodnota VT: {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FolderBrowserDialogNoRootFolder">
+        <source>Unable to retrieve the root folder.</source>
+        <target state="new">Unable to retrieve the root folder.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="General_MissingService">
         <source>The service '{0}' must be installed for this feature to work.  Ensure that this service is available.</source>
         <target state="translated">Pro využití této funkce musí být nainstalovaná služba {0}. Zkontrolujte, jestli je tato služba dostupná.</target>

--- a/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.de.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Unbehandelter VT: {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FolderBrowserDialogNoRootFolder">
+        <source>Unable to retrieve the root folder.</source>
+        <target state="new">Unable to retrieve the root folder.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="General_MissingService">
         <source>The service '{0}' must be installed for this feature to work.  Ensure that this service is available.</source>
         <target state="translated">Der Dienst "{0}" muss installiert sein, damit diese Funktion funktioniert. Stellen Sie sicher, dass der Dienst verfügbar ist.</target>

--- a/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.es.xlf
@@ -7,6 +7,11 @@
         <target state="translated">VT no controlado: {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FolderBrowserDialogNoRootFolder">
+        <source>Unable to retrieve the root folder.</source>
+        <target state="new">Unable to retrieve the root folder.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="General_MissingService">
         <source>The service '{0}' must be installed for this feature to work.  Ensure that this service is available.</source>
         <target state="translated">Debe instalar el servicio "{0}" para que esta funcionalidad funcione. Asegúrese de que este servicio está disponible.</target>

--- a/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.fr.xlf
@@ -7,6 +7,11 @@
         <target state="translated">VT non géré : {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FolderBrowserDialogNoRootFolder">
+        <source>Unable to retrieve the root folder.</source>
+        <target state="new">Unable to retrieve the root folder.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="General_MissingService">
         <source>The service '{0}' must be installed for this feature to work.  Ensure that this service is available.</source>
         <target state="translated">Le service '{0}' doit être installé afin que cette fonctionnalité soit activée. Assurez-vous que ce service est disponible.</target>

--- a/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.it.xlf
@@ -7,6 +7,11 @@
         <target state="translated">VT non gestito: {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FolderBrowserDialogNoRootFolder">
+        <source>Unable to retrieve the root folder.</source>
+        <target state="new">Unable to retrieve the root folder.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="General_MissingService">
         <source>The service '{0}' must be installed for this feature to work.  Ensure that this service is available.</source>
         <target state="translated">Per poter usare questa funzionalità, è necessario aver installato il servizio '{0}'. Verificare che il servizio sia disponibile.</target>

--- a/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.ja.xlf
@@ -7,6 +7,11 @@
         <target state="translated">ハンドルされていない VT: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FolderBrowserDialogNoRootFolder">
+        <source>Unable to retrieve the root folder.</source>
+        <target state="new">Unable to retrieve the root folder.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="General_MissingService">
         <source>The service '{0}' must be installed for this feature to work.  Ensure that this service is available.</source>
         <target state="translated">この機能が動作するためにはサービス '{0}' をインストールする必要があります。サービスが利用可能であることを確認してください。</target>

--- a/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.ko.xlf
@@ -7,6 +7,11 @@
         <target state="translated">처리되지 않은 VT입니다. {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="FolderBrowserDialogNoRootFolder">
+        <source>Unable to retrieve the root folder.</source>
+        <target state="new">Unable to retrieve the root folder.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="General_MissingService">
         <source>The service '{0}' must be installed for this feature to work.  Ensure that this service is available.</source>
         <target state="translated">이 기능을 제대로 사용하려면 '{0}' 서비스가 설치되어 있어야 합니다.  이 서비스를 사용할 수 있는지 확인하세요.</target>

--- a/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.pl.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Nieobsługiwany VT: {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FolderBrowserDialogNoRootFolder">
+        <source>Unable to retrieve the root folder.</source>
+        <target state="new">Unable to retrieve the root folder.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="General_MissingService">
         <source>The service '{0}' must be installed for this feature to work.  Ensure that this service is available.</source>
         <target state="translated">Usługa „{0}” musi być zainstalowana, aby ta funkcja działała. Sprawdź dostępność usługi.</target>

--- a/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.pt-BR.xlf
@@ -7,6 +7,11 @@
         <target state="translated">VT não tratado: {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FolderBrowserDialogNoRootFolder">
+        <source>Unable to retrieve the root folder.</source>
+        <target state="new">Unable to retrieve the root folder.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="General_MissingService">
         <source>The service '{0}' must be installed for this feature to work.  Ensure that this service is available.</source>
         <target state="translated">O serviço '{0}' deve estar instalado para que este recurso funcione. Verifique se esse serviço está disponível.</target>

--- a/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.ru.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Необработанный VT: {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FolderBrowserDialogNoRootFolder">
+        <source>Unable to retrieve the root folder.</source>
+        <target state="new">Unable to retrieve the root folder.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="General_MissingService">
         <source>The service '{0}' must be installed for this feature to work.  Ensure that this service is available.</source>
         <target state="translated">Для работы этой возможности должна быть установлена служба "{0}". Убедитесь, что эта служба доступна.</target>

--- a/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.tr.xlf
@@ -7,6 +7,11 @@
         <target state="translated">İşlenmemiş VT: {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FolderBrowserDialogNoRootFolder">
+        <source>Unable to retrieve the root folder.</source>
+        <target state="new">Unable to retrieve the root folder.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="General_MissingService">
         <source>The service '{0}' must be installed for this feature to work.  Ensure that this service is available.</source>
         <target state="translated">Bu özelliğin çalışması için '{0}' hizmetinin yüklenmesi gerekiyor. Bu hizmetin kullanılabildiğinden emin olun.</target>

--- a/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.zh-Hans.xlf
@@ -7,6 +7,11 @@
         <target state="translated">未处理的 VT: {0}。</target>
         <note />
       </trans-unit>
+      <trans-unit id="FolderBrowserDialogNoRootFolder">
+        <source>Unable to retrieve the root folder.</source>
+        <target state="new">Unable to retrieve the root folder.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="General_MissingService">
         <source>The service '{0}' must be installed for this feature to work.  Ensure that this service is available.</source>
         <target state="translated">要使此功能工作，必须安装服务“{0}”。 请确保此服务可用。</target>

--- a/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.zh-Hant.xlf
@@ -7,6 +7,11 @@
         <target state="translated">未處理的 VT: {0}。</target>
         <note />
       </trans-unit>
+      <trans-unit id="FolderBrowserDialogNoRootFolder">
+        <source>Unable to retrieve the root folder.</source>
+        <target state="new">Unable to retrieve the root folder.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="General_MissingService">
         <source>The service '{0}' must be installed for this feature to work.  Ensure that this service is available.</source>
         <target state="translated">必須安裝服務 '{0}'，才能讓這項功能運作。請確定這項服務可供使用。</target>

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/UI/Shell/FolderBrowserHelper.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/UI/Shell/FolderBrowserHelper.cs
@@ -1,0 +1,70 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+using System.Windows.Forms.Primitives.Resources;
+
+namespace Windows.Win32.UI.Shell;
+
+internal static class FolderBrowserHelper
+{
+    /// <summary>
+    ///  Helper for the legacy <see cref="PInvoke.SHGetPathFromIDListEx(ITEMIDLIST*, PWSTR, uint, GPFIDL_FLAGS)" /> API.
+    /// </summary>
+    /// <returns>The selected path if successful, <see langword="null"/> if failed.</returns>
+    /// <exception cref="InvalidOperationException">Could not get the root folder.</exception>
+    internal static unsafe string? BrowseForFolder(
+        string title,
+        int rootFolderCsidl,
+        uint flags,
+        HWND owner,
+        delegate* unmanaged[Stdcall]<HWND, uint, LPARAM, LPARAM, int> callback,
+        LPARAM lParam)
+    {
+        PInvoke.SHGetSpecialFolderLocation(rootFolderCsidl, out ITEMIDLIST* rootFolderId);
+        if (rootFolderId is null)
+        {
+            PInvoke.SHGetSpecialFolderLocation((int)Environment.SpecialFolder.Desktop, out rootFolderId);
+            if (rootFolderId is null)
+            {
+                throw new InvalidOperationException(SR.FolderBrowserDialogNoRootFolder);
+            }
+        }
+
+        using BufferScope<char> buffer = new(PInvoke.MAX_PATH + 1);
+
+        fixed (char* b = buffer)
+        fixed (char* t = title)
+        {
+            BROWSEINFOW bi = new()
+            {
+                pidlRoot = rootFolderId,
+                hwndOwner = owner,
+                // This is assumed to be MAX_PATH. We don't use it, but we need to have the buffer available.
+                pszDisplayName = b,
+                lpszTitle = t,
+                ulFlags = flags,
+                lpfn = callback,
+                lParam = lParam,
+                iImage = 0
+            };
+
+            // Show the dialog
+            ITEMIDLIST* resultId = PInvoke.SHBrowseForFolder(&bi);
+            Marshal.FreeCoTaskMem((nint)rootFolderId);
+
+            if (resultId is null)
+            {
+                return null;
+            }
+
+            // Retrieve the path from the IDList (GPFIDL_UNCPRINTER is what gets passed by SHGETPathFromWidList).
+            // In theory this will handle long paths, but the underlying HRESULT is lost and there is no other
+            // immediately apparent way to get the result. Could potentially retry a few times to catch the most common cases.
+            bool success = PInvoke.SHGetPathFromIDListEx(resultId, b, (uint)buffer.Length, GPFIDL_FLAGS.GPFIDL_UNCPRINTER);
+            Marshal.FreeCoTaskMem((nint)resultId);
+
+            return success ? new(b) : null;
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/Resources/SR.resx
+++ b/src/System.Windows.Forms/src/Resources/SR.resx
@@ -3100,9 +3100,6 @@ Do you want to replace it?</value>
   <data name="FolderBrowserDialogDescription" xml:space="preserve">
     <value>The string that is displayed above the tree view control in the dialog box. This string can be used to specify instructions to the user.</value>
   </data>
-  <data name="FolderBrowserDialogNoRootFolder" xml:space="preserve">
-    <value>Unable to retrieve the root folder.</value>
-  </data>
   <data name="FolderBrowserDialogRootFolder" xml:space="preserve">
     <value>The location of the root folder from which to start browsing. Only the specified folder and any subfolders that are beneath it will appear in the dialog box.</value>
   </data>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
@@ -5210,11 +5210,6 @@ Chcete jej nahradit?</target>
         <target state="translated">Řetězec zobrazený v dialogovém okně nad ovládacím prvkem zobrazení stromu. V řetězci můžete uvést pokyny pro uživatele.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FolderBrowserDialogNoRootFolder">
-        <source>Unable to retrieve the root folder.</source>
-        <target state="translated">Kořenovou složku nelze načíst.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FolderBrowserDialogOkRequiresInteraction">
         <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
         <target state="translated">Určuje, jestli je tlačítko OK v dialogovém okně zakázané, dokud uživatel neprojde zobrazením nebo neupraví název souboru (pokud je to možné). Poznámka: Zakázání tlačítka OK nezabrání odeslání dialogového okna klávesou Enter.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
@@ -5210,11 +5210,6 @@ Möchten Sie sie ersetzen?</target>
         <target state="translated">Die Zeichenfolge, die im Dialogfeld über dem Strukturansicht-Steuerelement angezeigt wird. Sie kann zum Angeben von Benutzeranweisungen verwendet werden.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FolderBrowserDialogNoRootFolder">
-        <source>Unable to retrieve the root folder.</source>
-        <target state="translated">Der Stammordner kann nicht abgerufen werden.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FolderBrowserDialogOkRequiresInteraction">
         <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
         <target state="translated">Steuert, ob die Schaltfläche „OK“ des Dialogfelds deaktiviert ist, bis der Benutzer in der Ansicht navigiert oder den Dateinamen bearbeitet (falls zutreffend). Hinweis: Das Deaktivieren der Schaltfläche „OK“ verhindert nicht, dass das Dialogfeld mit der EINGABETASTE übermittelt wird.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
@@ -5210,11 +5210,6 @@ Do you want to replace it?</source>
         <target state="translated">Cadena que aparece encima del control de vista de árbol en el cuadro de diálogo. Esta cadena se utiliza para especificar instrucciones al usuario.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FolderBrowserDialogNoRootFolder">
-        <source>Unable to retrieve the root folder.</source>
-        <target state="translated">No se puede recuperar la carpeta raíz.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FolderBrowserDialogOkRequiresInteraction">
         <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
         <target state="translated">Controla si el botón Aceptar del cuadro de diálogo está deshabilitado hasta que el usuario navega por la vista o edita el nombre de archivo (si corresponde). Nota: Deshabilitar el botón Aceptar no impide que la tecla Entrar envíe el cuadro de diálogo.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
@@ -5210,11 +5210,6 @@ Voulez-vous le remplacer ?</target>
         <target state="translated">Chaîne affichée au-dessus du contrôle TreeView dans la boîte de dialogue. Cette chaîne peut être utilisée pour spécifier des instructions à l'utilisateur.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FolderBrowserDialogNoRootFolder">
-        <source>Unable to retrieve the root folder.</source>
-        <target state="translated">Impossible de récupérer le dossier racine.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FolderBrowserDialogOkRequiresInteraction">
         <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
         <target state="translated">Contrôle si le bouton OK de la boîte de dialogue est désactivé jusqu'à ce que l'utilisateur navigue dans la vue ou modifie le nom de fichier (le cas échéant). Remarque : La désactivation du bouton OK n'empêche pas la soumission de la boîte de dialogue par la touche Entrée.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
@@ -5210,11 +5210,6 @@ Sostituirlo?</target>
         <target state="translated">Stringa visualizzata sopra il controllo TreeView nella finestra di dialogo. Può essere utilizzata per specificare istruzioni all'utente.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FolderBrowserDialogNoRootFolder">
-        <source>Unable to retrieve the root folder.</source>
-        <target state="translated">Impossibile recuperare la cartella radice.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FolderBrowserDialogOkRequiresInteraction">
         <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
         <target state="translated">Controlla se il pulsante OK della finestra di dialogo è disabilitato finché l'utente non passa alla visualizzazione o modifica il nome file (se applicabile). La disabilitazione del pulsante OK non impedisce l'invio della finestra di dialogo tramite il tasto INVIO.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
@@ -5210,11 +5210,6 @@ Do you want to replace it?</source>
         <target state="translated">ダイアログ ボックスのツリー ビュー コントロールの上に表示される文字列です。この文字列は、ユーザーに手順を指定するのに使用されます。</target>
         <note />
       </trans-unit>
-      <trans-unit id="FolderBrowserDialogNoRootFolder">
-        <source>Unable to retrieve the root folder.</source>
-        <target state="translated">ルート フォルダーを取得できません。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FolderBrowserDialogOkRequiresInteraction">
         <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
         <target state="translated">ユーザーがビュー内を移動するか、ファイル名を編集するまで (該当する場合)、ダイアログ ボックスの [OK] ボタンを無効にするかどうかを制御します。注: [OK] ボタンを無効にしても、Enter キーによってダイアログが送信されるのを防ぐことはできません。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
@@ -5210,11 +5210,6 @@ Do you want to replace it?</source>
         <target state="translated">대화 상자의 tree view 컨트롤 위에 표시되는 문자열입니다. 이 문자열을 사용하여 사용자에게 표시될 지시 사항을 지정할 수 있습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FolderBrowserDialogNoRootFolder">
-        <source>Unable to retrieve the root folder.</source>
-        <target state="translated">루트 폴더를 검색할 수 없습니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FolderBrowserDialogOkRequiresInteraction">
         <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
         <target state="translated">사용자가 파일 이름 보기 또는 편집으로 이동할 때까지 대화 상자의 확인 버튼을 사용하지 않을지를 제어합니다(해당하는 경우). 참고: 확인 버튼을 사용하지 않아도 Enter 키로 대화 상자를 제출할 수 있습니다.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
@@ -5210,11 +5210,6 @@ Czy chcesz go zamienić?</target>
         <target state="translated">Ciąg wyświetlony w oknie dialogowym nad formantem widoku drzewa. Ten ciąg może posłużyć do określenia instrukcji dla użytkownika.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FolderBrowserDialogNoRootFolder">
-        <source>Unable to retrieve the root folder.</source>
-        <target state="translated">Nie można pobrać folderu głównego.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FolderBrowserDialogOkRequiresInteraction">
         <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
         <target state="translated">Określa, czy przycisk OK okna dialogowego jest wyłączony, dopóki użytkownik nie nawiguje po widoku lub nie edytuje nazwy pliku (jeśli ma zastosowanie). Uwaga: wyłączenie przycisku OK nie zapobiega przesyłaniu okna dialogowego przez klawisz Enter.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
@@ -5210,11 +5210,6 @@ Deseja substituí-lo?</target>
         <target state="translated">A cadeia de caracteres exibida acima do controle do modo de exibição de árvore na caixa de diálogo. Esta cadeia de caracteres pode ser utilizada para especificar instruções para o usuário.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FolderBrowserDialogNoRootFolder">
-        <source>Unable to retrieve the root folder.</source>
-        <target state="translated">Não é possível recuperar a pasta raiz.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FolderBrowserDialogOkRequiresInteraction">
         <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
         <target state="translated">Controla se o botão OK da caixa de diálogo está desabilitado até que o usuário navegue pela exibição ou edite o nome do arquivo (se aplicável). Observação: A desativação do botão OK não impede que a caixa de diálogo seja enviada pela tecla Enter.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
@@ -5211,11 +5211,6 @@ Do you want to replace it?</source>
         <target state="translated">Строка, отображаемая над иерархическим представлением структуры дерева в данном диалоговом окне. Эта строка служит для задания инструкций для пользователя.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FolderBrowserDialogNoRootFolder">
-        <source>Unable to retrieve the root folder.</source>
-        <target state="translated">Не удалось извлечь корневую папку.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FolderBrowserDialogOkRequiresInteraction">
         <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
         <target state="translated">Определяет, отключена ли кнопка "ОК" в диалоговом окне, пока пользователь не перейдет в представление или не изменит имя файла (если применимо). Примечание. Отключение кнопки "ОК" не блокирует отправку сообщения из диалогового окна при нажатии клавиши ВВОД.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
@@ -5210,11 +5210,6 @@ Bunu değiştirmek istiyor musunuz?</target>
         <target state="translated">İletişim kutusundaki ağaç görünümü denetiminin üstünde görüntülenen dize. Bu dize kullanıcıya yönergeleri bildirmek için kullanılabilir.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FolderBrowserDialogNoRootFolder">
-        <source>Unable to retrieve the root folder.</source>
-        <target state="translated">Kök klasör alınamıyor.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FolderBrowserDialogOkRequiresInteraction">
         <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
         <target state="translated">Kullanıcı görünümde gezinene veya dosya adını düzenleyene (yapabiliyorsa) kadar iletişim kutusunun Tamam düğmesinin devre dışı bırakılıp bırakılmadığını kontrol eder. Not: Tamam düğmesinin devre dışı bırakılması, iletişim kutusunun Enter tuşuyla gönderilmesini engellemez.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
@@ -5210,11 +5210,6 @@ Do you want to replace it?</source>
         <target state="translated">显示在对话框的树视图控件上方的字符串。该字符串可用来指定显示给用户的指导信息。</target>
         <note />
       </trans-unit>
-      <trans-unit id="FolderBrowserDialogNoRootFolder">
-        <source>Unable to retrieve the root folder.</source>
-        <target state="translated">无法检索根文件夹。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FolderBrowserDialogOkRequiresInteraction">
         <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
         <target state="translated">控制在用户导航视图或编辑文件名(如果适用)之前是否禁用对话框的“确定”按钮。注意: 禁用“确定”按钮不会阻止 Enter 键提交对话框。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
@@ -5210,11 +5210,6 @@ Do you want to replace it?</source>
         <target state="translated">顯示在對話方塊中樹狀檢視控制項上方的字串。這個字串可以用來指定對使用者的指示。</target>
         <note />
       </trans-unit>
-      <trans-unit id="FolderBrowserDialogNoRootFolder">
-        <source>Unable to retrieve the root folder.</source>
-        <target state="translated">無法擷取根資料夾。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FolderBrowserDialogOkRequiresInteraction">
         <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
         <target state="translated">控制是否在使用者巡覽檢視或編輯檔案名稱 (如適用) 之前，停用對話方塊的 [確定] 按鈕。請注意: 停用 [確定] 按鈕無法防止透過 Enter 鍵送出對話方塊。</target>

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FolderBrowserDialogTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FolderBrowserDialogTests.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.ComponentModel;
-
 namespace System.Windows.Forms.Tests;
 
 public class FolderBrowserDialogTests
@@ -114,14 +112,6 @@ public class FolderBrowserDialogTests
         // Set same.
         dialog.RootFolder = value;
         Assert.Equal(value, dialog.RootFolder);
-    }
-
-    [WinFormsTheory]
-    [InvalidEnumData<Environment.SpecialFolder>]
-    public void FolderBrowserDialog_RootFolder_SetInvalid_ThrowsInvalidEnumArgumentException(Environment.SpecialFolder value)
-    {
-        using var dialog = new FolderBrowserDialog();
-        Assert.Throws<InvalidEnumArgumentException>("value", () => dialog.RootFolder = value);
     }
 
     [WinFormsTheory]


### PR DESCRIPTION
The old style folder browser was broken a few different ways:

- FolderBrowserDialog would mutate the managed result string, usually corrupting memory in terrible ways
- FolderNameEditor would AV
- All were leaking shell handles

This adds a centralized helper to avoid these problems. This also:

- Moves the exception string to primitives
- Uses CSIDL defines and clarifies usage
- Unblocks other CSIDL values
- Uses the updated API to get the path from the PIDL

We can't use the shared dialog in FolderNameEditor as we expose dialog styles there that are not exposed in FolderBrowserDialog.

Fixes #9859