### PR TITLE
Port DataGridViewComboBoxColumnDesigner to runtime

### DIFF
--- a/src/System.Design/src/System.Design.Forwards.cs
+++ b/src/System.Design/src/System.Design.Forwards.cs
@@ -39,6 +39,7 @@ using System.Runtime.CompilerServices;
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.ComboBoxDesigner))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.DataGridViewDesigner))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.DataGridViewColumnDesigner))]
+[assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.DataGridViewComboBoxColumnDesigner))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.DateTimePickerDesigner))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.FormDocumentDesigner))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.FlowPanelDesigner))]

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewComboBoxColumnDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewComboBoxColumnDesigner.cs
@@ -1,0 +1,115 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel;
+using System.Collections;
+
+namespace System.Windows.Forms.Design;
+
+/// <summary>
+/// Provides a base designer for data grid view columns.
+/// </summary>
+internal class DataGridViewComboBoxColumnDesigner : DataGridViewColumnDesigner
+{
+    private static BindingContext? s_bindingContext;
+
+    private string ValueMember
+    {
+        get
+        {
+            DataGridViewComboBoxColumn dataGridViewComboBoxColumn = (DataGridViewComboBoxColumn)Component;
+            return dataGridViewComboBoxColumn.ValueMember;
+        }
+        set
+        {
+            DataGridViewComboBoxColumn dataGridViewComboBoxColumn = (DataGridViewComboBoxColumn)Component;
+            if (dataGridViewComboBoxColumn.DataSource is null)
+            {
+                return;
+            }
+
+            if (ValidDataMember(dataGridViewComboBoxColumn.DataSource, dataMember: value))
+            {
+                dataGridViewComboBoxColumn.ValueMember = value;
+            }
+        }
+    }
+
+    private string DisplayMember
+    {
+        get
+        {
+            DataGridViewComboBoxColumn dataGridViewComboBoxColumn = (DataGridViewComboBoxColumn)Component;
+            return dataGridViewComboBoxColumn.DisplayMember;
+        }
+        set
+        {
+            DataGridViewComboBoxColumn dataGridViewComboBoxColumn = (DataGridViewComboBoxColumn)Component;
+            if (dataGridViewComboBoxColumn.DataSource is null)
+            {
+                return;
+            }
+
+            if (ValidDataMember(dataGridViewComboBoxColumn.DataSource, value))
+            {
+                dataGridViewComboBoxColumn.DisplayMember = value;
+            }
+        }
+    }
+
+    private bool ShouldSerializeDisplayMember()
+    {
+        DataGridViewComboBoxColumn dataGridViewComboBoxColumn = (DataGridViewComboBoxColumn)Component;
+        return !string.IsNullOrEmpty(dataGridViewComboBoxColumn.DisplayMember);
+    }
+
+    private bool ShouldSerializeValueMember()
+    {
+        DataGridViewComboBoxColumn dataGridViewComboBoxColumn = (DataGridViewComboBoxColumn)Component;
+        return !string.IsNullOrEmpty(dataGridViewComboBoxColumn.ValueMember);
+    }
+
+    private static bool ValidDataMember(object dataSource, string dataMember)
+    {
+        if (string.IsNullOrEmpty(dataMember))
+        {
+            // A null string is a valid value
+            return true;
+        }
+
+        s_bindingContext ??= new BindingContext();
+
+        BindingMemberInfo bindingMemberInfo = new BindingMemberInfo(dataMember);
+        BindingManagerBase bindingManagerBase;
+
+        try
+        {
+            bindingManagerBase = s_bindingContext[dataSource, bindingMemberInfo.BindingPath];
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+
+        return bindingManagerBase is null
+            ? false
+            : (bindingManagerBase.GetItemProperties()?[bindingMemberInfo.BindingField]) is not null;
+    }
+
+    protected override void PreFilterProperties(IDictionary properties)
+    {
+        base.PreFilterProperties(properties);
+
+        PropertyDescriptor? property = (PropertyDescriptor?)properties["ValueMember"];
+        if (property is not null)
+        {
+            properties["ValueMember"] = TypeDescriptor.CreateProperty(typeof(DataGridViewComboBoxColumnDesigner), property, Array.Empty<Attribute>());
+        }
+
+        property = (PropertyDescriptor?)properties["DisplayMember"];
+        if (property is not null)
+        {
+            properties["DisplayMember"] = TypeDescriptor.CreateProperty(typeof(DataGridViewComboBoxColumnDesigner), property, Array.Empty<Attribute>());
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/MainForm.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/MainForm.cs
@@ -258,7 +258,10 @@ public partial class MainForm : Form
                         BindingSource bindingSource = surface.CreateComponent<BindingSource>();
                         bindingSource.DataSource = new List<string> { "a1", "b2", "c3", "d4", "e5", "f6" };
                         listBox.DataSource = bindingSource;
-                        surface.CreateControl<DataGridView>(new Size(200, 150), new Point(470, 220));
+                        DataGridView dataGridView = surface.CreateControl<DataGridView>(new Size(200, 150), new Point(470, 220));
+                        DataGridViewComboBoxColumn comboBoxColumn = surface.CreateComponent<DataGridViewComboBoxColumn>();
+                        comboBoxColumn.HeaderText = "Column1";
+                        dataGridView.Columns.AddRange([comboBoxColumn]);
                     }
 
                     break;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Design/DesignerAttributeTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Design/DesignerAttributeTests.cs
@@ -24,7 +24,6 @@ public class DesignerAttributeTests
         // https://github.com/dotnet/winforms/issues/2411
         "System.Windows.Forms.Design.AxDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
         "System.Windows.Forms.Design.AxHostDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
-        "System.Windows.Forms.Design.DataGridViewComboBoxColumnDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
         "System.Windows.Forms.Design.StatusBarDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
         "System.Windows.Forms.Design.WebBrowserDesigner, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Related to #4908 


## Proposed changes

- Add DataGridViewComboBoxColumnDesigner.cs

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- DataGridViewComboBoxColumnDesigner can be designed in runtime

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
The ComboBoxColumn cannot be added to DataGridView

### After

![AfterChang](https://github.com/dotnet/winforms/assets/132890443/dbe7a28f-73d2-45eb-966c-76da09160266)


## Test methodology <!-- How did you ensure quality? -->

- Manually (added DataGridViewComboBoxColumnDesigner to DemoConsole test app)

## Test environment(s) <!-- Remove any that don't apply -->

- .net 8.0.0-rc.1.23421.3

<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9869)