### PR TITLE
Fix the ToolstripMenuItem under menubar cannot clearly distinguish ch…

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolstripProfessionalRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolstripProfessionalRenderer.cs
@@ -664,6 +664,15 @@ public class ToolStripProfessionalRenderer : ToolStripRenderer
                     using var brush = item.BackColor.GetCachedSolidBrushScope();
                     g.FillRectangle(brush, fillRect);
                 }
+                else if (item.GetType() == typeof(ToolStripMenuItem))
+                {
+                    ToolStripMenuItem? menuItem = item as ToolStripMenuItem;
+                    if (menuItem is not null && menuItem.CheckState == CheckState.Checked)
+                    {
+                        using var pen = ColorTable.ButtonSelectedBorder.GetCachedPenScope();
+                        g.DrawRectangle(pen, bounds.X, bounds.Y, bounds.Width - 1, bounds.Height - 1);
+                    }
+                }
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolstripProfessionalRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolstripProfessionalRenderer.cs
@@ -664,13 +664,10 @@ public class ToolStripProfessionalRenderer : ToolStripRenderer
                     using var brush = item.BackColor.GetCachedSolidBrushScope();
                     g.FillRectangle(brush, fillRect);
                 }
-                else if (item.GetType() == typeof(ToolStripMenuItem) && item is ToolStripMenuItem menuItem)
+                else if (item is ToolStripMenuItem menuItem && menuItem.CheckState == CheckState.Checked)
                 {
-                    if (menuItem.CheckState == CheckState.Checked)
-                    {
-                        using var pen = ColorTable.ButtonSelectedBorder.GetCachedPenScope();
-                        g.DrawRectangle(pen, bounds.X, bounds.Y, bounds.Width - 1, bounds.Height - 1);
-                    }
+                    using var pen = ColorTable.MenuItemSelected.GetCachedPenScope();
+                    g.DrawRectangle(pen, bounds.X, bounds.Y, bounds.Width - 1, bounds.Height - 1);
                 }
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolstripProfessionalRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolstripProfessionalRenderer.cs
@@ -664,10 +664,9 @@ public class ToolStripProfessionalRenderer : ToolStripRenderer
                     using var brush = item.BackColor.GetCachedSolidBrushScope();
                     g.FillRectangle(brush, fillRect);
                 }
-                else if (item.GetType() == typeof(ToolStripMenuItem))
+                else if (item.GetType() == typeof(ToolStripMenuItem) && item is ToolStripMenuItem menuItem)
                 {
-                    ToolStripMenuItem? menuItem = item as ToolStripMenuItem;
-                    if (menuItem is not null && menuItem.CheckState == CheckState.Checked)
+                    if (menuItem.CheckState == CheckState.Checked)
                     {
                         using var pen = ColorTable.ButtonSelectedBorder.GetCachedPenScope();
                         g.DrawRectangle(pen, bounds.X, bounds.Y, bounds.Width - 1, bounds.Height - 1);


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #9173 


## Proposed changes

- Modify the ToolStripItemRender method and add a check for CheckState. If the status of ToolStripMenuItem is Checked, we will redraw the border of the ToolStripMenuItem.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Toolstripmenuitem under menubar can clearly distinguish checkstate is checked or unchecked.

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Toolstripmenuitem under menubar cannot clearly distinguish checkstate is checked or unchecked.
![image](https://github.com/dotnet/winforms/assets/133954995/0622e3a6-00c8-438e-aaed-50ac73c263c7)


### After
Toolstripmenuitem under menubar can clearly distinguish checkstate is checked or unchecked.
![image](https://github.com/dotnet/winforms/assets/133954995/b6657738-b0cd-4fb9-8912-f31f73403504)


## Test methodology <!-- How did you ensure quality? -->

- Manual 

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

- 8.0.100-preview.7.23376.3

<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9878)