### PR TITLE
Fix Misdefined P/Invoke GetExitCodeThread

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.GetExitCodeThread.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.GetExitCodeThread.cs
@@ -8,7 +8,7 @@ internal partial class Interop
 {
     internal partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32, ExactSpelling = true)]
+        [DllImport(Libraries.Kernel32, ExactSpelling = true, SetLastError = true)]
         public static extern BOOL GetExitCodeThread(IntPtr hWnd, out uint lpdwExitCode);
     }
 }


### PR DESCRIPTION
In .NET 7, we had gotten a report for WinForms application hanging on exit and found that due to changes to SystemEvent thread, it exposed a P/Invoke that was misdefined on our end. The fix for this has been serviced for .NET 7 (https://github.com/dotnet/winforms/pull/9861). Although we haven't received a customer report nor do we have issues in the exact same scenario that we had gotten in .NET 7, given that the P/Invoke definition is misdefined in the same way, issues around this P/Invoke being misdefined may resurface in other code paths.