### PR TITLE
Enable nullability in MemberCodeDomSerializer and all derived classes

### DIFF
--- a/src/System.Windows.Forms.Design/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms.Design/src/PublicAPI.Shipped.txt
@@ -8,8 +8,8 @@ abstract System.ComponentModel.Design.Serialization.CodeDomDesignerLoader.CodeDo
 abstract System.ComponentModel.Design.Serialization.CodeDomDesignerLoader.Parse() -> System.CodeDom.CodeCompileUnit!
 abstract System.ComponentModel.Design.Serialization.CodeDomDesignerLoader.TypeResolutionService.get -> System.ComponentModel.Design.ITypeResolutionService?
 abstract System.ComponentModel.Design.Serialization.CodeDomDesignerLoader.Write(System.CodeDom.CodeCompileUnit! unit) -> void
-~abstract System.ComponentModel.Design.Serialization.MemberCodeDomSerializer.Serialize(System.ComponentModel.Design.Serialization.IDesignerSerializationManager manager, object value, System.ComponentModel.MemberDescriptor descriptor, System.CodeDom.CodeStatementCollection statements) -> void
-~abstract System.ComponentModel.Design.Serialization.MemberCodeDomSerializer.ShouldSerialize(System.ComponentModel.Design.Serialization.IDesignerSerializationManager manager, object value, System.ComponentModel.MemberDescriptor descriptor) -> bool
+abstract System.ComponentModel.Design.Serialization.MemberCodeDomSerializer.Serialize(System.ComponentModel.Design.Serialization.IDesignerSerializationManager! manager, object! value, System.ComponentModel.MemberDescriptor! descriptor, System.CodeDom.CodeStatementCollection! statements) -> void
+abstract System.ComponentModel.Design.Serialization.MemberCodeDomSerializer.ShouldSerialize(System.ComponentModel.Design.Serialization.IDesignerSerializationManager! manager, object! value, System.ComponentModel.MemberDescriptor! descriptor) -> bool
 abstract System.Windows.Forms.Design.MaskDescriptor.Mask.get -> string?
 abstract System.Windows.Forms.Design.MaskDescriptor.Name.get -> string?
 abstract System.Windows.Forms.Design.MaskDescriptor.Sample.get -> string?

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomLocalizationProvider.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomLocalizationProvider.cs
@@ -200,7 +200,7 @@ public sealed partial class CodeDomLocalizationProvider : IDisposable, IDesigner
 
         if (newSerializer is null)
         {
-            newSerializer = new ResourcePropertyMemberCodeDomSerializer((MemberCodeDomSerializer)currentSerializer, _extender, model);
+            newSerializer = new ResourcePropertyMemberCodeDomSerializer((MemberCodeDomSerializer)currentSerializer, model);
 
             if (model == CodeDomLocalizationModel.None)
             {

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/MemberCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/MemberCodeDomSerializer.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.CodeDom;
 
 namespace System.ComponentModel.Design.Serialization;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/PropertyMemberCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/PropertyMemberCodeDomSerializer.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.CodeDom;
 using System.Reflection;
 
@@ -13,26 +11,18 @@ namespace System.ComponentModel.Design.Serialization;
 /// </summary>
 internal sealed class PropertyMemberCodeDomSerializer : MemberCodeDomSerializer
 {
-    private static PropertyMemberCodeDomSerializer s_default;
+    private static PropertyMemberCodeDomSerializer? s_default;
 
-    internal static PropertyMemberCodeDomSerializer Default
-    {
-        get
-        {
-            s_default ??= new PropertyMemberCodeDomSerializer();
-
-            return s_default;
-        }
-    }
+    internal static PropertyMemberCodeDomSerializer Default => s_default ??= new PropertyMemberCodeDomSerializer();
 
     /// <summary>
     ///  This retrieves the value of this property.  If the property returns false
     ///  from ShouldSerializeValue (indicating the ambient value for this property)
     ///  This will look for an AmbientValueAttribute and use it if it can.
     /// </summary>
-    private static object GetPropertyValue(IDesignerSerializationManager manager, PropertyDescriptor property, object value, out bool validValue)
+    private static object? GetPropertyValue(IDesignerSerializationManager manager, PropertyDescriptor property, object value, out bool validValue)
     {
-        object propertyValue = null;
+        object? propertyValue = null;
         validValue = true;
         try
         {
@@ -41,26 +31,19 @@ internal sealed class PropertyMemberCodeDomSerializer : MemberCodeDomSerializer
                 // We aren't supposed to be serializing this property, but we decided to do
                 // it anyway.  Check the property for an AmbientValue attribute and if we
                 // find one, use it's value to serialize.
-                AmbientValueAttribute attr = (AmbientValueAttribute)property.Attributes[typeof(AmbientValueAttribute)];
-
-                if (attr is not null)
+                if (property.TryGetAttribute(out AmbientValueAttribute? attr))
                 {
                     return attr.Value;
                 }
+                else if (property.TryGetAttribute(out DefaultValueAttribute? defAttr))
+                {
+                    return defAttr.Value;
+                }
                 else
                 {
-                    DefaultValueAttribute defAttr = (DefaultValueAttribute)property.Attributes[typeof(DefaultValueAttribute)];
-
-                    if (defAttr is not null)
-                    {
-                        return defAttr.Value;
-                    }
-                    else
-                    {
-                        // nope, we're not valid...
-                        //
-                        validValue = false;
-                    }
+                    // nope, we're not valid...
+                    //
+                    validValue = false;
                 }
             }
 
@@ -74,7 +57,7 @@ internal sealed class PropertyMemberCodeDomSerializer : MemberCodeDomSerializer
             manager.ReportError(new CodeDomSerializerException(string.Format(SR.SerializerPropertyGenFailed, property.Name, e.Message), manager));
         }
 
-        if ((propertyValue is not null) && (!propertyValue.GetType().IsValueType) && !(propertyValue is Type))
+        if (propertyValue is not null and not Type && (!propertyValue.GetType().IsValueType))
         {
             // DevDiv2 (Dev11) bug 187766 : property whose type implements ISupportInitialize is not
             // serialized with Begin/EndInit.
@@ -82,7 +65,7 @@ internal sealed class PropertyMemberCodeDomSerializer : MemberCodeDomSerializer
             if (!type.IsDefined(typeof(ProjectTargetFrameworkAttribute), false))
             {
                 // TargetFrameworkProvider is not attached
-                TypeDescriptionProvider typeProvider = CodeDomSerializerBase.GetTargetFrameworkProvider(manager, propertyValue);
+                TypeDescriptionProvider? typeProvider = CodeDomSerializerBase.GetTargetFrameworkProvider(manager, propertyValue);
                 if (typeProvider is not null)
                 {
                     TypeDescriptor.AddProvider(typeProvider, propertyValue);
@@ -103,15 +86,15 @@ internal sealed class PropertyMemberCodeDomSerializer : MemberCodeDomSerializer
         ArgumentNullException.ThrowIfNull(value);
         ArgumentNullException.ThrowIfNull(statements);
 
-        if (!(descriptor is PropertyDescriptor propertyToSerialize))
+        if (descriptor is not PropertyDescriptor propertyToSerialize)
         {
             throw new ArgumentNullException(nameof(descriptor));
         }
 
         try
         {
-            ExtenderProvidedPropertyAttribute exAttr = (ExtenderProvidedPropertyAttribute)propertyToSerialize.Attributes[typeof(ExtenderProvidedPropertyAttribute)];
-            bool isExtender = (exAttr is not null && exAttr.Provider is not null);
+            ExtenderProvidedPropertyAttribute? exAttr = propertyToSerialize.GetAttribute<ExtenderProvidedPropertyAttribute>();
+            bool isExtender = exAttr?.Provider is not null;
             bool serializeContents = propertyToSerialize.Attributes.Contains(DesignerSerializationVisibilityAttribute.Content);
 
             CodeDomSerializer.Trace(TraceLevel.Verbose, $"Serializing property {propertyToSerialize.Name}");
@@ -135,7 +118,7 @@ internal sealed class PropertyMemberCodeDomSerializer : MemberCodeDomSerializer
             // the problem.
             if (e is TargetInvocationException)
             {
-                e = e.InnerException;
+                e = e.InnerException!;
             }
 
             manager.ReportError(new CodeDomSerializerException(string.Format(SR.SerializerPropertyGenFailed, propertyToSerialize.Name, e.Message), manager));
@@ -149,7 +132,7 @@ internal sealed class PropertyMemberCodeDomSerializer : MemberCodeDomSerializer
     {
         CodeDomSerializer.Trace(TraceLevel.Verbose, "Property is marked as Visibility.Content.  Recursing.");
 
-        object propertyValue = GetPropertyValue(manager, property, value, out bool validValue);
+        object? propertyValue = GetPropertyValue(manager, property, value, out _);
 
         // For persist contents objects, we don't just serialize the properties on the object; we
         // serialize everything.
@@ -158,107 +141,97 @@ internal sealed class PropertyMemberCodeDomSerializer : MemberCodeDomSerializer
         {
             CodeDomSerializer.Trace(TraceLevel.Error, $"Property {property.Name} is marked as Visibility.Content but it is returning null.");
 
-            string name = manager.GetName(value);
+            string? name = manager.GetName(value);
 
             name ??= value.GetType().FullName;
 
             manager.ReportError(new CodeDomSerializerException(string.Format(SR.SerializerNullNestedProperty, name, property.Name), manager));
         }
-        else
+        else if (manager.TryGetSerializer(propertyValue.GetType(), out CodeDomSerializer? serializer))
         {
-            var serializer = (CodeDomSerializer)manager.GetSerializer(propertyValue.GetType(), typeof(CodeDomSerializer));
-            if (serializer is not null)
+            // Create a property reference expression and push it on the context stack.
+            // This allows the serializer to gain some context as to what it should be
+            // serializing.
+            CodeExpression? target = SerializeToExpression(manager, value);
+
+            if (target is null)
             {
-                // Create a property reference expression and push it on the context stack.
-                // This allows the serializer to gain some context as to what it should be
-                // serializing.
-                CodeExpression target = SerializeToExpression(manager, value);
-
-                if (target is null)
-                {
-                    CodeDomSerializer.Trace(TraceLevel.Warning, "Unable to convert value to expression object");
-                }
-                else
-                {
-                    CodeExpression propertyRef = null;
-
-                    if (isExtender)
-                    {
-                        CodeDomSerializer.Trace(TraceLevel.Verbose, "Content property is an extender.");
-                        ExtenderProvidedPropertyAttribute exAttr = (ExtenderProvidedPropertyAttribute)property.Attributes[typeof(ExtenderProvidedPropertyAttribute)];
-
-                        // Extender properties are method invokes on a target "extender" object.
-                        //
-                        CodeExpression extender = SerializeToExpression(manager, exAttr.Provider);
-                        CodeExpression extended = SerializeToExpression(manager, value);
-
-                        CodeDomSerializer.TraceIf(TraceLevel.Warning, extender is null, $"Extender object {manager.GetName(exAttr.Provider)} could not be serialized.");
-                        CodeDomSerializer.TraceIf(TraceLevel.Warning, extended is null, $"Extended object {manager.GetName(value)} could not be serialized.");
-                        if (extender is not null && extended is not null)
-                        {
-                            CodeMethodReferenceExpression methodRef = new CodeMethodReferenceExpression(extender, $"Get{property.Name}");
-                            CodeMethodInvokeExpression methodInvoke = new CodeMethodInvokeExpression
-                            {
-                                Method = methodRef
-                            };
-                            methodInvoke.Parameters.Add(extended);
-                            propertyRef = methodInvoke;
-                        }
-                    }
-                    else
-                    {
-                        propertyRef = new CodePropertyReferenceExpression(target, property.Name);
-                    }
-
-                    if (propertyRef is not null)
-                    {
-                        ExpressionContext tree = new ExpressionContext(propertyRef, property.PropertyType, value, propertyValue);
-                        manager.Context.Push(tree);
-
-                        object result = null;
-
-                        try
-                        {
-                            SerializeAbsoluteContext absolute = (SerializeAbsoluteContext)manager.Context[typeof(SerializeAbsoluteContext)];
-
-                            if (IsSerialized(manager, propertyValue, absolute is not null))
-                            {
-                                result = GetExpression(manager, propertyValue);
-                            }
-                            else
-                            {
-                                result = serializer.Serialize(manager, propertyValue);
-                            }
-                        }
-                        finally
-                        {
-                            Debug.Assert(manager.Context.Current == tree, "Serializer added a context it didn't remove.");
-                            manager.Context.Pop();
-                        }
-
-                        if (result is CodeStatementCollection csc)
-                        {
-                            foreach (CodeStatement statement in csc)
-                            {
-                                statements.Add(statement);
-                            }
-                        }
-                        else
-                        {
-                            if (result is CodeStatement cs)
-                            {
-                                statements.Add(cs);
-                            }
-                        }
-                    }
-                }
+                CodeDomSerializer.Trace(TraceLevel.Warning, "Unable to convert value to expression object");
             }
             else
             {
-                CodeDomSerializer.Trace(TraceLevel.Error, $"Property {property.Name} is marked as Visibility.Content but there is no serializer for it.");
+                CodeExpression? propertyRef = null;
 
-                manager.ReportError(new CodeDomSerializerException(string.Format(SR.SerializerNoSerializerForComponent, property.PropertyType.FullName), manager));
+                if (isExtender)
+                {
+                    CodeDomSerializer.Trace(TraceLevel.Verbose, "Content property is an extender.");
+                    ExtenderProvidedPropertyAttribute exAttr = property.GetAttribute<ExtenderProvidedPropertyAttribute>()!;
+
+                    // Extender properties are method invokes on a target "extender" object.
+                    //
+                    CodeExpression? extender = SerializeToExpression(manager, exAttr.Provider);
+                    CodeExpression? extended = SerializeToExpression(manager, value);
+
+                    CodeDomSerializer.TraceIf(TraceLevel.Warning, extender is null, $"Extender object {manager.GetName(exAttr.Provider!)} could not be serialized.");
+                    CodeDomSerializer.TraceIf(TraceLevel.Warning, extended is null, $"Extended object {manager.GetName(value)} could not be serialized.");
+                    if (extender is not null && extended is not null)
+                    {
+                        CodeMethodReferenceExpression methodRef = new CodeMethodReferenceExpression(extender, $"Get{property.Name}");
+                        CodeMethodInvokeExpression methodInvoke = new CodeMethodInvokeExpression
+                        {
+                            Method = methodRef
+                        };
+                        methodInvoke.Parameters.Add(extended);
+                        propertyRef = methodInvoke;
+                    }
+                }
+                else
+                {
+                    propertyRef = new CodePropertyReferenceExpression(target, property.Name);
+                }
+
+                if (propertyRef is not null)
+                {
+                    ExpressionContext tree = new ExpressionContext(propertyRef, property.PropertyType, value, propertyValue);
+                    manager.Context.Push(tree);
+
+                    object? result = null;
+
+                    try
+                    {
+                        SerializeAbsoluteContext absolute = manager.GetContext<SerializeAbsoluteContext>()!;
+
+                        if (IsSerialized(manager, propertyValue, absolute is not null))
+                        {
+                            result = GetExpression(manager, propertyValue);
+                        }
+                        else
+                        {
+                            result = serializer.Serialize(manager, propertyValue);
+                        }
+                    }
+                    finally
+                    {
+                        Debug.Assert(manager.Context.Current == tree, "Serializer added a context it didn't remove.");
+                        manager.Context.Pop();
+                    }
+
+                    if (result is CodeStatementCollection csc)
+                    {
+                        statements.AddRange(csc);
+                    }
+                    else if (result is CodeStatement cs)
+                    {
+                        statements.Add(cs);
+                    }
+                }
             }
+        }
+        else
+        {
+            CodeDomSerializer.Trace(TraceLevel.Error, $"Property {property.Name} is marked as Visibility.Content but there is no serializer for it.");
+
+            manager.ReportError(new CodeDomSerializerException(string.Format(SR.SerializerNoSerializerForComponent, property.PropertyType.FullName), manager));
         }
     }
 
@@ -267,30 +240,28 @@ internal sealed class PropertyMemberCodeDomSerializer : MemberCodeDomSerializer
     /// </summary>
     private void SerializeExtenderProperty(IDesignerSerializationManager manager, object value, PropertyDescriptor property, CodeStatementCollection statements)
     {
-        AttributeCollection attributes = property.Attributes;
-
         using (CodeDomSerializer.TraceScope($"PropertyMemberCodeDomSerializer::{nameof(SerializeExtenderProperty)}"))
         {
-            ExtenderProvidedPropertyAttribute exAttr = (ExtenderProvidedPropertyAttribute)attributes[typeof(ExtenderProvidedPropertyAttribute)];
+            ExtenderProvidedPropertyAttribute exAttr = property.GetAttribute<ExtenderProvidedPropertyAttribute>()!;
 
             // Extender properties are method invokes on a target "extender" object.
             //
-            CodeExpression extender = SerializeToExpression(manager, exAttr.Provider);
-            CodeExpression extended = SerializeToExpression(manager, value);
+            CodeExpression? extender = SerializeToExpression(manager, exAttr.Provider);
+            CodeExpression? extended = SerializeToExpression(manager, value);
 
-            CodeDomSerializer.TraceIf(TraceLevel.Warning, extender is null, $"Extender object {manager.GetName(exAttr.Provider)} could not be serialized.");
+            CodeDomSerializer.TraceIf(TraceLevel.Warning, extender is null, $"Extender object {manager.GetName(exAttr.Provider!)} could not be serialized.");
             CodeDomSerializer.TraceIf(TraceLevel.Warning, extended is null, $"Extended object {manager.GetName(value)} could not be serialized.");
             if (extender is not null && extended is not null)
             {
                 CodeMethodReferenceExpression methodRef = new CodeMethodReferenceExpression(extender, $"Set{property.Name}");
-                object propValue = GetPropertyValue(manager, property, value, out bool validValue);
-                CodeExpression serializedPropertyValue = null;
+                object? propValue = GetPropertyValue(manager, property, value, out bool validValue);
+                CodeExpression? serializedPropertyValue = null;
 
                 // Serialize the value of this property into a code expression.  If we can't get one,
                 // then we won't serialize the property.
                 if (validValue)
                 {
-                    ExpressionContext tree = null;
+                    ExpressionContext? tree = null;
 
                     if (propValue != value)
                     {
@@ -335,27 +306,29 @@ internal sealed class PropertyMemberCodeDomSerializer : MemberCodeDomSerializer
     {
         using (CodeDomSerializer.TraceScope($"CodeDomSerializer::{nameof(SerializeProperty)}"))
         {
-            CodeExpression target = SerializeToExpression(manager, value);
+            CodeExpression? target = SerializeToExpression(manager, value);
 
             CodeDomSerializer.TraceIf(TraceLevel.Warning, target is null, $"Unable to serialize target for property {property.Name}");
             if (target is not null)
             {
                 CodeExpression propertyRef = new CodePropertyReferenceExpression(target, property.Name);
 
-                CodeExpression serializedPropertyValue = null;
+                CodeExpression? serializedPropertyValue = null;
 
                 // First check for a member relationship service to see if this property
                 // is related to another member.  If it is, then we will use that
                 // relationship to construct the property assign statement.  if
                 // it isn't, then we're serialize ourselves.
 
-                if (manager.GetService(typeof(MemberRelationshipService)) is MemberRelationshipService relationships)
+                MemberRelationshipService? relationships = manager.GetService<MemberRelationshipService>();
+
+                if (relationships is not null)
                 {
                     MemberRelationship relationship = relationships[value, property];
 
                     if (relationship != MemberRelationship.Empty)
                     {
-                        CodeExpression rhsTarget = SerializeToExpression(manager, relationship.Owner);
+                        CodeExpression? rhsTarget = SerializeToExpression(manager, relationship.Owner);
 
                         if (rhsTarget is not null)
                         {
@@ -369,11 +342,11 @@ internal sealed class PropertyMemberCodeDomSerializer : MemberCodeDomSerializer
                     // Serialize the value of this property into a code expression.  If we can't get one,
                     // then we won't serialize the property.
                     //
-                    object propValue = GetPropertyValue(manager, property, value, out bool validValue);
+                    object? propValue = GetPropertyValue(manager, property, value, out bool validValue);
 
                     if (validValue)
                     {
-                        ExpressionContext tree = null;
+                        ExpressionContext? tree = null;
 
                         if (propValue != value)
                         {
@@ -416,7 +389,7 @@ internal sealed class PropertyMemberCodeDomSerializer : MemberCodeDomSerializer
         ArgumentNullException.ThrowIfNull(manager);
         ArgumentNullException.ThrowIfNull(value);
 
-        if (!(descriptor is PropertyDescriptor propertyToSerialize))
+        if (descriptor is not PropertyDescriptor propertyToSerialize)
         {
             throw new ArgumentNullException(nameof(descriptor));
         }
@@ -425,9 +398,7 @@ internal sealed class PropertyMemberCodeDomSerializer : MemberCodeDomSerializer
 
         if (!shouldSerializeProperty)
         {
-            SerializeAbsoluteContext absolute = (SerializeAbsoluteContext)manager.Context[typeof(SerializeAbsoluteContext)];
-
-            if (absolute is not null && absolute.ShouldSerialize(propertyToSerialize))
+            if (manager.TryGetContext(out SerializeAbsoluteContext? absolute) && absolute.ShouldSerialize(propertyToSerialize))
             {
                 // For ReadOnly properties, we only want to override the value returned from
                 // ShouldSerializeValue() if the property is marked with DesignerSerializationVisibilityAttribute(Content).
@@ -456,7 +427,9 @@ internal sealed class PropertyMemberCodeDomSerializer : MemberCodeDomSerializer
         // If we don't have to serialize, we need to make sure there isn't a member
         // relationship with this property.  If there is, we still need to serialize.
 
-        if (manager.GetService(typeof(MemberRelationshipService)) is MemberRelationshipService relationships)
+        MemberRelationshipService? relationships = manager.GetService<MemberRelationshipService>();
+
+        if (relationships is not null)
         {
             MemberRelationship relationship = relationships[value, descriptor];
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ResourcePropertyMemberCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ResourcePropertyMemberCodeDomSerializer.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.CodeDom;
 using System.Globalization;
 
@@ -16,15 +14,13 @@ internal class ResourcePropertyMemberCodeDomSerializer : MemberCodeDomSerializer
 {
     private readonly CodeDomLocalizationModel _model;
     private readonly MemberCodeDomSerializer _serializer;
-    private readonly CodeDomLocalizationProvider.LanguageExtenders _extender;
-    private CultureInfo localizationLanguage;
+    private CultureInfo? localizationLanguage;
 
     internal ResourcePropertyMemberCodeDomSerializer(MemberCodeDomSerializer serializer, CodeDomLocalizationProvider.LanguageExtenders extender, CodeDomLocalizationModel model)
     {
         Debug.Assert(extender is not null, "Extender should have been created by now.");
 
         _serializer = serializer;
-        _extender = extender;
         _model = model;
     }
 
@@ -49,35 +45,29 @@ internal class ResourcePropertyMemberCodeDomSerializer : MemberCodeDomSerializer
         }
     }
 
-    private CultureInfo GetLocalizationLanguage(IDesignerSerializationManager manager)
+    private CultureInfo? GetLocalizationLanguage(IDesignerSerializationManager manager)
     {
         if (localizationLanguage is null)
         {
             // Check to see if our base component's localizable prop is true
-            RootContext rootCtx = manager.Context[typeof(RootContext)] as RootContext;
-
-            if (rootCtx is not null)
+            if (manager.TryGetContext(out RootContext? rootCtx))
             {
                 object comp = rootCtx.Value;
-                PropertyDescriptor prop = TypeDescriptor.GetProperties(comp)["LoadLanguage"];
-
-                if (prop is not null && prop.PropertyType == typeof(CultureInfo))
-                {
-                    localizationLanguage = (CultureInfo)prop.GetValue(comp);
-                }
+                PropertyDescriptor? prop = TypeDescriptor.GetProperties(comp)["LoadLanguage"];
+                localizationLanguage = prop?.GetValue<CultureInfo>(comp);
             }
         }
 
         return localizationLanguage;
     }
 
-    private void OnSerializationComplete(object sender, EventArgs e)
+    private void OnSerializationComplete(object? sender, EventArgs e)
     {
         // we do the cleanup here and clear out the cache of the localizedlanguage
         localizationLanguage = null;
 
         //unhook the event
-        IDesignerSerializationManager manager = sender as IDesignerSerializationManager;
+        IDesignerSerializationManager? manager = sender as IDesignerSerializationManager;
         Debug.Assert(manager is not null, "manager should not be null!");
 
         if (manager is not null)
@@ -119,12 +109,9 @@ internal class ResourcePropertyMemberCodeDomSerializer : MemberCodeDomSerializer
                     // If this property contains its default value, we still want to serialize it if we are in
                     // localization mode if we are writing to the default culture, but only if the object
                     // is not inherited.
-                    InheritanceAttribute inheritance = (InheritanceAttribute)manager.Context[typeof(InheritanceAttribute)];
-
-                    if (inheritance is null)
+                    if (!manager.TryGetContext(out InheritanceAttribute? inheritance) && !TypeDescriptorHelper.TryGetAttribute(value, out inheritance))
                     {
-                        inheritance = (InheritanceAttribute)TypeDescriptor.GetAttributes(value)[typeof(InheritanceAttribute)];
-                        inheritance ??= InheritanceAttribute.NotInherited;
+                        inheritance = InheritanceAttribute.NotInherited;
                     }
 
                     if (inheritance.InheritanceLevel != InheritanceLevel.InheritedReadOnly)

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ResourcePropertyMemberCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ResourcePropertyMemberCodeDomSerializer.cs
@@ -16,10 +16,8 @@ internal class ResourcePropertyMemberCodeDomSerializer : MemberCodeDomSerializer
     private readonly MemberCodeDomSerializer _serializer;
     private CultureInfo? _localizationLanguage;
 
-    internal ResourcePropertyMemberCodeDomSerializer(MemberCodeDomSerializer serializer, CodeDomLocalizationProvider.LanguageExtenders extender, CodeDomLocalizationModel model)
+    internal ResourcePropertyMemberCodeDomSerializer(MemberCodeDomSerializer serializer, CodeDomLocalizationModel model)
     {
-        Debug.Assert(extender is not null, "Extender should have been created by now.");
-
         _serializer = serializer;
         _model = model;
     }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ResourcePropertyMemberCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ResourcePropertyMemberCodeDomSerializer.cs
@@ -14,7 +14,7 @@ internal class ResourcePropertyMemberCodeDomSerializer : MemberCodeDomSerializer
 {
     private readonly CodeDomLocalizationModel _model;
     private readonly MemberCodeDomSerializer _serializer;
-    private CultureInfo? localizationLanguage;
+    private CultureInfo? _localizationLanguage;
 
     internal ResourcePropertyMemberCodeDomSerializer(MemberCodeDomSerializer serializer, CodeDomLocalizationProvider.LanguageExtenders extender, CodeDomLocalizationModel model)
     {
@@ -47,24 +47,24 @@ internal class ResourcePropertyMemberCodeDomSerializer : MemberCodeDomSerializer
 
     private CultureInfo? GetLocalizationLanguage(IDesignerSerializationManager manager)
     {
-        if (localizationLanguage is null)
+        if (_localizationLanguage is null)
         {
             // Check to see if our base component's localizable prop is true
             if (manager.TryGetContext(out RootContext? rootCtx))
             {
                 object comp = rootCtx.Value;
                 PropertyDescriptor? prop = TypeDescriptor.GetProperties(comp)["LoadLanguage"];
-                localizationLanguage = prop?.GetValue<CultureInfo>(comp);
+                _localizationLanguage = prop?.GetValue<CultureInfo>(comp);
             }
         }
 
-        return localizationLanguage;
+        return _localizationLanguage;
     }
 
     private void OnSerializationComplete(object? sender, EventArgs e)
     {
         // we do the cleanup here and clear out the cache of the localizedlanguage
-        localizationLanguage = null;
+        _localizationLanguage = null;
 
         //unhook the event
         IDesignerSerializationManager? manager = sender as IDesignerSerializationManager;
@@ -92,7 +92,7 @@ internal class ResourcePropertyMemberCodeDomSerializer : MemberCodeDomSerializer
                     if (!shouldSerialize)
                     {
                         // hook up the event the first time to clear out our cache at the end of the serialization
-                        if (localizationLanguage is null)
+                        if (_localizationLanguage is null)
                         {
                             manager.SerializationComplete += new EventHandler(OnSerializationComplete);
                         }


### PR DESCRIPTION
## Proposed changes

- Enable nullability in `MemberCodeDomSerializer`
- Enable nullability in `EventMemberCodeDomSerializer`
- Enable nullability in `PropertyMemberCodeDomSerializer`
- Enable nullability in `ResourcePropertyMemberCodeDomSerializer`, remove an unused field and rename another field


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9891)