### PR TITLE
Enable nullability in several internal CodeDomSerializers, part 2

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TableLayoutPanelCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TableLayoutPanelCodeDomSerializer.cs
@@ -38,23 +38,23 @@ internal class TableLayoutPanelCodeDomSerializer : CodeDomSerializer
 
         // Now push our layout settings stuff into the resx if we are not inherited read only and
         // are in a localizable Form.
-        TableLayoutPanel? tlp = value as TableLayoutPanel;
-        Debug.Assert(tlp is not null, "Huh? We were expecting to be serializing a TableLayoutPanel here.");
+        TableLayoutPanel? panel = value as TableLayoutPanel;
+        Debug.Assert(panel is not null, "Huh? We were expecting to be serializing a TableLayoutPanel here.");
 
-        if (tlp is not null)
+        if (panel is not null)
         {
-            if (!TypeDescriptorHelper.TryGetAttribute(tlp, out InheritanceAttribute? ia) || ia.InheritanceLevel != InheritanceLevel.InheritedReadOnly)
+            if (!TypeDescriptorHelper.TryGetAttribute(panel, out InheritanceAttribute? ia) || ia.InheritanceLevel != InheritanceLevel.InheritedReadOnly)
             {
                 IDesignerHost? host = manager.GetService<IDesignerHost>();
 
                 if (IsLocalizable(host))
                 {
-                    PropertyDescriptor? lsProp = TypeDescriptor.GetProperties(tlp)[LayoutSettingsPropName];
-                    object? val = lsProp?.GetValue(tlp);
+                    PropertyDescriptor? lsProp = TypeDescriptor.GetProperties(panel)[LayoutSettingsPropName];
+                    object? val = lsProp?.GetValue(panel);
 
                     if (val is not null)
                     {
-                        string key = $"{manager.GetName(tlp)}.{LayoutSettingsPropName}";
+                        string key = $"{manager.GetName(panel)}.{LayoutSettingsPropName}";
                         SerializeResourceInvariant(manager, key, val);
                     }
                 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TableLayoutPanelCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TableLayoutPanelCodeDomSerializer.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.ComponentModel;
 using System.ComponentModel.Design;
 using System.ComponentModel.Design.Serialization;
@@ -18,14 +16,14 @@ internal class TableLayoutPanelCodeDomSerializer : CodeDomSerializer
 {
     private const string LayoutSettingsPropName = "LayoutSettings";
 
-    public override object Deserialize(IDesignerSerializationManager manager, object codeObject)
+    public override object? Deserialize(IDesignerSerializationManager manager, object codeObject)
     {
         return GetBaseSerializer(manager).Deserialize(manager, codeObject);
     }
 
     private static CodeDomSerializer GetBaseSerializer(IDesignerSerializationManager manager)
     {
-        return (CodeDomSerializer)manager.GetSerializer(typeof(TableLayoutPanel).BaseType, typeof(CodeDomSerializer));
+        return manager.GetSerializer<CodeDomSerializer>(typeof(TableLayoutPanel).BaseType)!;
     }
 
     /// <summary>
@@ -33,28 +31,26 @@ internal class TableLayoutPanelCodeDomSerializer : CodeDomSerializer
     ///  serializer. All we want to do is if we are in a localizable form, we want to push a
     ///  'LayoutSettings' entry into the resx.
     /// </summary>
-    public override object Serialize(IDesignerSerializationManager manager, object value)
+    public override object? Serialize(IDesignerSerializationManager manager, object value)
     {
         // First call the base serializer to serialize the object.
-        object codeObject = GetBaseSerializer(manager).Serialize(manager, value);
+        object? codeObject = GetBaseSerializer(manager).Serialize(manager, value);
 
         // Now push our layout settings stuff into the resx if we are not inherited read only and
         // are in a localizable Form.
-        TableLayoutPanel tlp = value as TableLayoutPanel;
+        TableLayoutPanel? tlp = value as TableLayoutPanel;
         Debug.Assert(tlp is not null, "Huh? We were expecting to be serializing a TableLayoutPanel here.");
 
         if (tlp is not null)
         {
-            InheritanceAttribute ia = (InheritanceAttribute)TypeDescriptor.GetAttributes(tlp)[typeof(InheritanceAttribute)];
-
-            if (ia is null || ia.InheritanceLevel != InheritanceLevel.InheritedReadOnly)
+            if (!TypeDescriptorHelper.TryGetAttribute(tlp, out InheritanceAttribute? ia) || ia.InheritanceLevel != InheritanceLevel.InheritedReadOnly)
             {
-                IDesignerHost host = (IDesignerHost)manager.GetService(typeof(IDesignerHost));
+                IDesignerHost? host = manager.GetService<IDesignerHost>();
 
                 if (IsLocalizable(host))
                 {
-                    PropertyDescriptor lsProp = TypeDescriptor.GetProperties(tlp)[LayoutSettingsPropName];
-                    object val = lsProp?.GetValue(tlp);
+                    PropertyDescriptor? lsProp = TypeDescriptor.GetProperties(tlp)[LayoutSettingsPropName];
+                    object? val = lsProp?.GetValue(tlp);
 
                     if (val is not null)
                     {
@@ -68,15 +64,13 @@ internal class TableLayoutPanelCodeDomSerializer : CodeDomSerializer
         return codeObject;
     }
 
-    private static bool IsLocalizable(IDesignerHost host)
+    private static bool IsLocalizable([NotNullWhen(true)] IDesignerHost? host)
     {
         if (host is not null)
         {
-            PropertyDescriptor prop = TypeDescriptor.GetProperties(host.RootComponent)["Localizable"];
-
-            if (prop is not null && prop.PropertyType == typeof(bool))
+            if (TypeDescriptorHelper.TryGetPropertyValue(host.RootComponent, "Localizable", out bool b))
             {
-                return (bool)prop.GetValue(host.RootComponent);
+                return b;
             }
         }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripCodeDomSerializer.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.ComponentModel;
 
 namespace System.Windows.Forms.Design;
@@ -11,9 +9,7 @@ internal class ToolStripCodeDomSerializer : ControlCodeDomSerializer
 {
     protected override bool HasSitedNonReadonlyChildren(Control parent)
     {
-        ToolStrip toolStrip = parent as ToolStrip;
-
-        if (toolStrip is null)
+        if (parent is not ToolStrip toolStrip)
         {
             Debug.Fail("why were we passed a non winbar?");
             return false;
@@ -29,9 +25,7 @@ internal class ToolStripCodeDomSerializer : ControlCodeDomSerializer
             if (item.Site is not null && toolStrip.Site is not null && item.Site.Container == toolStrip.Site.Container)
             {
                 // We only emit Size/Location information for controls that are sited and not inherited readonly.
-                InheritanceAttribute ia = (InheritanceAttribute)TypeDescriptor.GetAttributes(item)[typeof(InheritanceAttribute)];
-
-                if (ia is not null && ia.InheritanceLevel != InheritanceLevel.InheritedReadOnly)
+                if (TypeDescriptorHelper.TryGetAttribute(item, out InheritanceAttribute? ia) && ia.InheritanceLevel != InheritanceLevel.InheritedReadOnly)
                 {
                     return true;
                 }


### PR DESCRIPTION
## Proposed changes

- Enable nullability in `ControlCodeDomSerializer`
- Enable nullability in `ToolStripCodeDomSerializer`
- Enable nullability in `TableLayoutPanelCodeDomSerializer`


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9904)