### PR TITLE
Update LocProj to help CI verification

### DIFF
--- a/eng/Localize/LocProject.json
+++ b/eng/Localize/LocProject.json
@@ -163,6 +163,16 @@
                                               "OutputPath":  ".\\src\\System.Windows.Forms.Design\\src\\Resources\\xlf\\"
                                           },
                                           {
+                                              "SourceFile":  ".\\src\\System.Windows.Forms.Design\\src\\System\\Windows\\Forms\\Design\\xlf\\DataGridViewAddColumnDialog.xlf",
+                                              "CopyOption":  "LangIDOnName",
+                                              "OutputPath":  ".\\src\\System.Windows.Forms.Design\\src\\System\\Windows\\Forms\\Design\\xlf\\"
+                                          },
+                                          {
+                                              "SourceFile":  ".\\src\\System.Windows.Forms.Design\\src\\System\\Windows\\Forms\\Design\\xlf\\DataGridViewColumnCollectionDialog.xlf",
+                                              "CopyOption":  "LangIDOnName",
+                                              "OutputPath":  ".\\src\\System.Windows.Forms.Design\\src\\System\\Windows\\Forms\\Design\\xlf\\"
+                                          },
+                                          {
                                               "SourceFile":  ".\\src\\System.Windows.Forms.Primitives\\src\\Resources\\xlf\\SR.xlf",
                                               "CopyOption":  "LangIDOnName",
                                               "OutputPath":  ".\\src\\System.Windows.Forms.Primitives\\src\\Resources\\xlf\\"


### PR DESCRIPTION
We ported DataGridviewDesigner via https://github.com/dotnet/winforms/pull/9677 in main branch but failed to update stored LocProj file to reflect the resource content that came with this porting.

Fixing issue in CI https://dev.azure.com/dnceng/internal/_build/results?buildId=2266578&view=logs&j=c2111129-d6a3-58de-e667-00e5a0966c99&t=04624205-1088-500d-206a-392ceb108efa with this update.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9907)