### PR TITLE
fix bug: TreeView control has no highlighting of selected node first time if the control has first TabIndex on the form

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
@@ -3447,7 +3447,9 @@ public partial class TreeView : Control
 
                 break;
             case PInvoke.WM_GETOBJECT:
-                // Adding these steps is to fix a bug, please refer to this PR. https://github.com/dotnet/winforms/pull/9925
+                // When TreeView is the first control in TabOrder on a form, selection will not be announced when the forms is first opened
+                // because TreeView's AccessibilityObject has not been created yet. We create this object proactively to support that case.
+                // You can also refer to this PR. https://github.com/dotnet/winforms/pull/9925
                 if (m.LParamInternal == PInvoke.UiaRootObjectId && SupportsUiaProviders && !IsAccessibilityObjectCreated && Focused)
                 {
                     base.WndProc(ref m);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
@@ -3447,7 +3447,7 @@ public partial class TreeView : Control
 
                 break;
             case PInvoke.WM_GETOBJECT:
-                if (m.LParamInternal == PInvoke.UiaRootObjectId && SupportsUiaProviders && !IsAccessibilityObjectCreated)
+                if (m.LParamInternal == PInvoke.UiaRootObjectId && SupportsUiaProviders && !IsAccessibilityObjectCreated && Focused)
                 {
                     base.WndProc(ref m);
                     SelectedNode?.AccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
@@ -52,7 +52,7 @@ public partial class TreeView : Control
     private bool _hoveredAlready;
     private bool _rightToLeftLayout;
 
-    private nint _mouseDownNode = 0; // ensures we fire nodeclick on the correct node
+    private nint _mouseDownNode = 0; // ensures we fire nodeClick on the correct node
 
     private const int TREEVIEWSTATE_hideSelection = 0x00000001;
     private const int TREEVIEWSTATE_labelEdit = 0x00000002;
@@ -496,7 +496,7 @@ public partial class TreeView : Control
 
     /// <summary>
     ///  The value of the HotTracking property. The HotTracking
-    ///  property determines if nodes are highlighted as the mousepointer
+    ///  property determines if nodes are highlighted as the mousePointer
     ///  passes over them.
     /// </summary>
     [SRCategory(nameof(SR.CatBehavior))]
@@ -549,8 +549,8 @@ public partial class TreeView : Control
         set
         {
             // If (none) is selected in the image index editor, we'll just adjust this to
-            // mean image index 0. This is because a treeview must always have an image index -
-            // even if no imagelist exists we want the image index to be 0.
+            // mean image index 0. This is because a treeView must always have an image index -
+            // even if no imageList exists we want the image index to be 0.
             if (value == ImageList.Indexer.DefaultIndex)
             {
                 value = 0;
@@ -705,7 +705,7 @@ public partial class TreeView : Control
                     UpdateNativeStateImageList();
 
                     // We need to update the checks
-                    // and stateimage value for each node.
+                    // and stateImage value for each node.
                     UpdateCheckedState(_root, true);
 
                     if ((_stateImageList is null || _stateImageList.Images.Count == 0) && CheckBoxes)
@@ -861,7 +861,7 @@ public partial class TreeView : Control
     }
 
     /// <summary>
-    ///  This is the color of the lines that connect the nodes of the Treeview.
+    ///  This is the color of the lines that connect the nodes of the TreeView.
     /// </summary>
     [SRCategory(nameof(SR.CatBehavior))]
     [SRDescription(nameof(SR.TreeViewLineColorDescr))]
@@ -937,7 +937,7 @@ public partial class TreeView : Control
     }
 
     /// <summary>
-    ///  The delimeter string used by TreeNode.getFullPath().
+    ///  The delimiter string used by TreeNode.getFullPath().
     /// </summary>
     [SRCategory(nameof(SR.CatBehavior))]
     [DefaultValue("\\")]
@@ -1036,8 +1036,8 @@ public partial class TreeView : Control
         set
         {
             // If (none) is selected in the image index editor, we'll just adjust this to
-            // mean image index 0. This is because a treeview must always have an image index -
-            // even if no imagelist exists we want the image index to be 0.
+            // mean image index 0. This is because a treeView must always have an image index -
+            // even if no imageList exists we want the image index to be 0.
             //
             if (value == ImageList.Indexer.DefaultIndex)
             {
@@ -1128,7 +1128,7 @@ public partial class TreeView : Control
         {
             if (IsHandleCreated && (value is null || value.TreeView == this))
             {
-                // This class invariant is not quite correct -- if the selected node does not belong to this Treeview,
+                // This class invariant is not quite correct -- if the selected node does not belong to this TreeView,
                 // selectedNode is not null even though the handle is created.  We will call set_SelectedNode
                 // to inform the handle that the selected node has been added to the TreeView.
                 Debug.Assert(_selectedNode is null || _selectedNode.TreeView != this, "handle is created, but we're still caching selectedNode");
@@ -1325,7 +1325,7 @@ public partial class TreeView : Control
         {
             if (IsHandleCreated && (value is null || value.TreeView == this))
             {
-                // This class invariant is not quite correct -- if the selected node does not belong to this Treeview,
+                // This class invariant is not quite correct -- if the selected node does not belong to this TreeView,
                 // selectedNode is not null even though the handle is created.  We will call set_SelectedNode
                 // to inform the handle that the selected node has been added to the TreeView.
                 Debug.Assert(_topNode is null || _topNode.TreeView != this, "handle is created, but we're still caching selectedNode");
@@ -1461,7 +1461,7 @@ public partial class TreeView : Control
     }
 
     /// <summary>
-    ///  TreeView Onpaint.
+    ///  TreeView OnPaint.
     /// </summary>
     /// <hideinheritance/>
     [Browsable(false)]
@@ -1549,8 +1549,8 @@ public partial class TreeView : Control
     }
 
     /// <summary>
-    ///  Resets the stateimageList to null.  We wire this method up to the stateimageList's
-    ///  Dispose event, so that we don't hang onto an stateimageList that's gone away.
+    ///  Resets the stateImageList to null.  We wire this method up to the stateImageList's
+    ///  Dispose event, so that we don't hang onto an stateImageList that's gone away.
     /// </summary>
     private void DetachStateImageList(object? sender, EventArgs e)
     {
@@ -1665,9 +1665,9 @@ public partial class TreeView : Control
     /// </summary>
     internal bool TreeViewBeforeCheck(TreeNode node, TreeViewAction actionTaken)
     {
-        TreeViewCancelEventArgs tvce = new TreeViewCancelEventArgs(node, false, actionTaken);
-        OnBeforeCheck(tvce);
-        return (tvce.Cancel);
+        TreeViewCancelEventArgs viewCancelEventArgs = new TreeViewCancelEventArgs(node, false, actionTaken);
+        OnBeforeCheck(viewCancelEventArgs);
+        return (viewCancelEventArgs.Cancel);
     }
 
     internal void TreeViewAfterCheck(TreeNode node, TreeViewAction actionTaken)
@@ -1773,7 +1773,7 @@ public partial class TreeView : Control
             return;
         }
 
-        // Since the native treeview requires the state imagelist to be 1-indexed we need to
+        // Since the native treeView requires the state imageList to be 1-indexed we need to
         // re add the images if the original collection had changed.
         if (_stateImageList is null || _stateImageList.Images.Count <= 0)
         {
@@ -1880,7 +1880,7 @@ public partial class TreeView : Control
         // style if it is set before the window is created.  To get around the problem,
         // we set it here after the window is created, and we make sure we don't set it
         // in getCreateParams so that this will actually change the value of the bit.
-        // This seems to make the Treeview happy.
+        // This seems to make the TreeView happy.
         if (CheckBoxes)
         {
             int style = (int)PInvoke.GetWindowLong(this, WINDOW_LONG_PTR_INDEX.GWL_STYLE);
@@ -2009,7 +2009,7 @@ public partial class TreeView : Control
 
     private void SetStateImageList(IntPtr handle)
     {
-        // In certain cases (TREEVIEWSTATE_checkBoxes) e.g., the Native TreeView leaks the imagelist
+        // In certain cases (TREEVIEWSTATE_checkBoxes) e.g., the Native TreeView leaks the imageList
         // even if set by us. To prevent any leaks, we always destroy what was there after setting a new list.
         IntPtr handleOld = PInvoke.SendMessage(this, PInvoke.TVM_SETIMAGELIST, (WPARAM)(uint)PInvoke.TVSIL_STATE, (LPARAM)handle);
         if ((handleOld != IntPtr.Zero) && (handleOld != handle))
@@ -2041,7 +2041,7 @@ public partial class TreeView : Control
         // destroy it ourselves here.
         DestroyNativeStateImageList(true);
 
-        // for the case when we are NOT being disposed, we'll be recreating the internal state imagelist
+        // for the case when we are NOT being disposed, we'll be recreating the internal state imageList
         // in OnHandleCreate, so it is ok to completely Dispose here
         if (_internalStateImageList is not null)
         {
@@ -2190,7 +2190,7 @@ public partial class TreeView : Control
     {
         _onAfterExpand?.Invoke(this, e);
 
-        // Raise anevent to announce the expand-collapse state change.
+        // Raise an event to announce the expand-collapse state change.
         if (IsAccessibilityObjectCreated)
         {
             e.Node!.AccessibilityObject.RaiseAutomationPropertyChangedEvent(
@@ -2678,7 +2678,7 @@ public partial class TreeView : Control
     private void WmMouseDown(ref Message m, MouseButtons button, int clicks)
     {
         // Required to put the TreeView in sane-state for painting proper highlighting of selectedNodes.
-        // If the user shows the ContextMenu bu overriding the WndProc( ), then the treeview
+        // If the user shows the ContextMenu bu overriding the WndProc( ), then the treeView
         // goes into the weird state where the high-light gets locked to the node on which the ContextMenu was shown.
         // So we need to get the native TREEVIEW out of this weird state.
         PInvoke.SendMessage(this, PInvoke.TVM_SELECTITEM, (WPARAM)(uint)PInvoke.TVGN_DROPHILITE);
@@ -2801,8 +2801,8 @@ public partial class TreeView : Control
                     // Mess with the DC directly...
                     PInvoke.SelectObject(nmtvcd->nmcd.hdc, renderinfo.FontHandle);
 
-                    // There is a problem in winctl that clips node fonts if the fontsize
-                    // is larger than the treeview font size. The behavior is much better in comctl 5 and above.
+                    // There is a problem in winctl that clips node fonts if the fontSize
+                    // is larger than the treeView font size. The behavior is much better in comctl 5 and above.
                     m.ResultInternal = (LRESULT)(nint)PInvoke.CDRF_NEWFONT;
                     return;
                 }
@@ -3039,7 +3039,7 @@ public partial class TreeView : Control
                         button = (int)nmtv->nmhdr.code == (int)NM.CLICK ? MouseButtons.Left : MouseButtons.Right;
                     }
 
-                    // The treeview's WndProc doesn't get the WM_LBUTTONUP messages when
+                    // The treeView's WndProc doesn't get the WM_LBUTTONUP messages when
                     // LBUTTONUP happens on TVHT_ONITEM. This is a comctl quirk.
                     // We work around that by calling OnMouseUp here.
                     if ((int)nmtv->nmhdr.code != (int)NM.CLICK
@@ -3074,7 +3074,7 @@ public partial class TreeView : Control
                         if ((int)nmtv->nmhdr.code != (int)NM.CLICK
                         || (tvhip.flags & TVHT.ONITEM) != 0)
                         {
-                            // The treeview's WndProc doesn't get the WM_LBUTTONUP messages when
+                            // The treeView's WndProc doesn't get the WM_LBUTTONUP messages when
                             // LBUTTONUP happens on TVHT_ONITEM. This is a comctl quirk.
                             // We work around that by calling OnMouseUp here.
                             OnMouseUp(new MouseEventArgs(button, 1, pos.X, pos.Y, 0));
@@ -3121,7 +3121,7 @@ public partial class TreeView : Control
         }
     }
 
-    // Need to send TVM_SELECTITEM to reset the node-highlighting while the contextMenuStrip is being closed so that the treeview reselects the SelectedNode.
+    // Need to send TVM_SELECTITEM to reset the node-highlighting while the contextMenuStrip is being closed so that the treeView reselects the SelectedNode.
     private void ContextMenuStripClosing(object sender, ToolStripDropDownClosingEventArgs e)
     {
         ContextMenuStrip strip = sender as ContextMenuStrip;
@@ -3266,7 +3266,7 @@ public partial class TreeView : Control
                     _treeViewState[TREEVIEWSTATE_ignoreSelects] = false;
                 }
 
-                // Always reset the MouseupFired.
+                // Always reset the MouseUpFired.
                 _treeViewState[TREEVIEWSTATE_mouseUpFired] = false;
                 TVHITTESTINFO tvhip = new()
                 {
@@ -3318,7 +3318,7 @@ public partial class TreeView : Control
                     if (!ValidationCancelled && !_treeViewState[TREEVIEWSTATE_doubleclickFired] & !_treeViewState[TREEVIEWSTATE_mouseUpFired])
                     {
                         // If the hit-tested node here is the same as the node we hit-tested
-                        // on mouse down then we will fire our OnNodeMoseClick event.
+                        // on mouse down then we will fire our OnNodeMouseClick event.
                         if (hnode == _mouseDownNode)
                         {
                             OnNodeMouseClick(new TreeNodeMouseClickEventArgs(NodeFromHandle(hnode), _downButton, 1, point.X, point.Y));
@@ -3358,7 +3358,7 @@ public partial class TreeView : Control
                 WmMouseDown(ref m, MouseButtons.Middle, 2);
                 break;
             case PInvoke.WM_MBUTTONDOWN:
-                // Always reset MouseupFired.
+                // Always reset MouseUpFired.
                 _treeViewState[TREEVIEWSTATE_mouseUpFired] = false;
                 WmMouseDown(ref m, MouseButtons.Middle, 1);
                 _downButton = MouseButtons.Middle;
@@ -3382,7 +3382,7 @@ public partial class TreeView : Control
                 Capture = true;
                 break;
             case PInvoke.WM_RBUTTONDOWN:
-                // Always Reset the MouseupFired....
+                // Always Reset the MouseUpFired....
                 _treeViewState[TREEVIEWSTATE_mouseUpFired] = false;
 
                 //Cache the hit-tested node for verification when mouse up is fired
@@ -3446,7 +3446,18 @@ public partial class TreeView : Control
                 }
 
                 break;
+            case PInvoke.WM_GETOBJECT:
+                if (m.LParamInternal == PInvoke.UiaRootObjectId && SupportsUiaProviders && !IsAccessibilityObjectCreated)
+                {
+                    base.WndProc(ref m);
+                    SelectedNode?.AccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
+                }
+                else
+                {
+                    base.WndProc(ref m);
+                }
 
+                break;
             default:
                 base.WndProc(ref m);
                 break;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
@@ -3447,6 +3447,7 @@ public partial class TreeView : Control
 
                 break;
             case PInvoke.WM_GETOBJECT:
+                // Adding these steps is to fix a bug, please refer to this PR. https://github.com/dotnet/winforms/pull/9925
                 if (m.LParamInternal == PInvoke.UiaRootObjectId && SupportsUiaProviders && !IsAccessibilityObjectCreated && Focused)
                 {
                     base.WndProc(ref m);


### PR DESCRIPTION
fix #6559

<!-- Please read CONTRIBUTING.md before submitting a pull request -->



## Cause of this bug
`TreeView.cs`
After TreeNode is selected or TreeView is fouced, `AutomationFocusChangedEvent` will be raised.
``` c#
    protected virtual void OnAfterSelect(TreeViewEventArgs e)
    {
        _onAfterSelect?.Invoke(this, e);

        // Raise an event to highlight & announce the selected node.
        if (IsAccessibilityObjectCreated)
        {
            AccessibleObject nodeAccessibleObject = e.Node!.AccessibilityObject;
            nodeAccessibleObject.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
            nodeAccessibleObject.RaiseAutomationEvent(UiaCore.UIA.SelectionItem_ElementSelectedEventId);

            // Raise to say "Selected" after announcing the node.
            nodeAccessibleObject.RaiseAutomationPropertyChangedEvent(
                UiaCore.UIA.SelectionItemIsSelectedPropertyId,
                oldValue: !nodeAccessibleObject.IsItemSelected,
                newValue: nodeAccessibleObject.IsItemSelected);
        }
    }

    protected override void OnGotFocus(EventArgs e)
    {
        base.OnGotFocus(e);
        NotifyAboutGotFocus(SelectedNode);

        // Raise an event to highlight & announce the selected node.
        if (IsAccessibilityObjectCreated)
        {
            SelectedNode?.AccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
        }
    }
```
But neither method will work, because first time either method is involved, `IsAccessibilityObjectCreated` is false.
because `WM_GETOBJECT` message is posted so late.

I think this is the cause of this bug.


## Proposed changes

After `WM_GETOBJECT` message if posted, raise `AutomationFocusChangedEvent `

<!-- We are in TELL-MODE the following section must be completed -->

<!-- 
## Customer Impact

- 
- 
 -->


## Regression? 

-  
- No
-

<!-- 
## Risk
 -->
<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->
![6559_before](https://github.com/dotnet/winforms/assets/135201996/9b7830a5-6ea2-49c0-90c7-ab505601bd7e)


### After

<!-- TODO -->

![6559_after](https://github.com/dotnet/winforms/assets/135201996/9ddaddd7-2568-405b-af41-096106c28f81)

## Test methodology <!-- How did you ensure quality? -->

- 
- Manually 
- 

<!-- 
## Accessibility testing  Remove this section if PR does not change UI 
 -->


<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

9.0.0-alpha.1.23464.1

- <!-- use `dotnet --info` -->


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9925)