### PR TITLE
Enable nullability in CollectionCodeDomSerializer and child classes

### DIFF
--- a/src/System.Windows.Forms.Design/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms.Design/src/PublicAPI.Shipped.txt
@@ -39,7 +39,7 @@ override System.ComponentModel.Design.Serialization.BasicDesignerLoader.BeginLoa
 override System.ComponentModel.Design.Serialization.CodeDomDesignerLoader.OnEndLoad(bool successful, System.Collections.ICollection? errors) -> void
 override System.ComponentModel.Design.Serialization.CodeDomDesignerLoader.PerformFlush(System.ComponentModel.Design.Serialization.IDesignerSerializationManager! manager) -> void
 override System.ComponentModel.Design.Serialization.CodeDomDesignerLoader.PerformLoad(System.ComponentModel.Design.Serialization.IDesignerSerializationManager! manager) -> void
-~override System.ComponentModel.Design.Serialization.CollectionCodeDomSerializer.Serialize(System.ComponentModel.Design.Serialization.IDesignerSerializationManager manager, object value) -> object
+override System.ComponentModel.Design.Serialization.CollectionCodeDomSerializer.Serialize(System.ComponentModel.Design.Serialization.IDesignerSerializationManager! manager, object! value) -> object?
 override System.Drawing.Design.ToolboxItem.Equals(object? obj) -> bool
 override System.Drawing.Design.ToolboxItem.ToString() -> string!
 override System.Windows.Forms.Design.AnchorEditor.EditValue(System.ComponentModel.ITypeDescriptorContext? context, System.IServiceProvider! provider, object? value) -> object?
@@ -180,7 +180,7 @@ System.ComponentModel.Design.Serialization.BasicDesignerLoader.SetBaseComponentC
 ~System.ComponentModel.Design.Serialization.CodeDomComponentSerializationService.CodeDomComponentSerializationService(System.IServiceProvider provider) -> void
 System.ComponentModel.Design.Serialization.CodeDomLocalizationProvider.CodeDomLocalizationProvider(System.IServiceProvider! provider, System.ComponentModel.Design.Serialization.CodeDomLocalizationModel model) -> void
 System.ComponentModel.Design.Serialization.CodeDomLocalizationProvider.CodeDomLocalizationProvider(System.IServiceProvider! provider, System.ComponentModel.Design.Serialization.CodeDomLocalizationModel model, System.Globalization.CultureInfo?[]! supportedCultures) -> void
-~System.ComponentModel.Design.Serialization.CollectionCodeDomSerializer.MethodSupportsSerialization(System.Reflection.MethodInfo method) -> bool
+System.ComponentModel.Design.Serialization.CollectionCodeDomSerializer.MethodSupportsSerialization(System.Reflection.MethodInfo! method) -> bool
 ~System.Drawing.Design.IToolboxService.AddCreator(System.Drawing.Design.ToolboxItemCreatorCallback creator, string format) -> void
 ~System.Drawing.Design.IToolboxService.AddCreator(System.Drawing.Design.ToolboxItemCreatorCallback creator, string format, System.ComponentModel.Design.IDesignerHost host) -> void
 ~System.Drawing.Design.IToolboxService.AddLinkedToolboxItem(System.Drawing.Design.ToolboxItem toolboxItem, string category, System.ComponentModel.Design.IDesignerHost host) -> void
@@ -342,7 +342,7 @@ virtual System.ComponentModel.Design.MenuCommandService.Verbs.get -> System.Comp
 virtual System.ComponentModel.Design.Serialization.BasicDesignerLoader.OnEndLoad(bool successful, System.Collections.ICollection? errors) -> void
 virtual System.ComponentModel.Design.Serialization.BasicDesignerLoader.ReportFlushErrors(System.Collections.ICollection! errors) -> void
 virtual System.ComponentModel.Design.Serialization.CodeDomDesignerLoader.OnComponentRename(object! component, string? oldName, string? newName) -> void
-~virtual System.ComponentModel.Design.Serialization.CollectionCodeDomSerializer.SerializeCollection(System.ComponentModel.Design.Serialization.IDesignerSerializationManager manager, System.CodeDom.CodeExpression targetExpression, System.Type targetType, System.Collections.ICollection originalCollection, System.Collections.ICollection valuesToSerialize) -> object
+virtual System.ComponentModel.Design.Serialization.CollectionCodeDomSerializer.SerializeCollection(System.ComponentModel.Design.Serialization.IDesignerSerializationManager! manager, System.CodeDom.CodeExpression? targetExpression, System.Type! targetType, System.Collections.ICollection! originalCollection, System.Collections.ICollection! valuesToSerialize) -> object?
 ~virtual System.ComponentModel.Design.Serialization.TypeCodeDomSerializer.Deserialize(System.ComponentModel.Design.Serialization.IDesignerSerializationManager manager, System.CodeDom.CodeTypeDeclaration declaration) -> object
 ~virtual System.ComponentModel.Design.Serialization.TypeCodeDomSerializer.GetInitializeMethod(System.ComponentModel.Design.Serialization.IDesignerSerializationManager manager, System.CodeDom.CodeTypeDeclaration declaration, object value) -> System.CodeDom.CodeMemberMethod
 ~virtual System.ComponentModel.Design.Serialization.TypeCodeDomSerializer.GetInitializeMethods(System.ComponentModel.Design.Serialization.IDesignerSerializationManager manager, System.CodeDom.CodeTypeDeclaration declaration) -> System.CodeDom.CodeMemberMethod[]

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CollectionCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CollectionCodeDomSerializer.cs
@@ -235,13 +235,13 @@ public class CollectionCodeDomSerializer : CodeDomSerializer
                     ParameterInfo parameter = method.GetParameters()[0];
                     if (parameter is not null)
                     {
-                        Type? type = parameter.ParameterType;
+                        Type type = parameter.ParameterType;
                         if (type.IsArray)
                         {
-                            type = type.GetElementType();
+                            type = type.GetElementType()!;
                         }
 
-                        if (type is not null && type.IsAssignableFrom(objType))
+                        if (type.IsAssignableFrom(objType))
                         {
                             if (final is not null)
                             {
@@ -324,23 +324,17 @@ public class CollectionCodeDomSerializer : CodeDomSerializer
                 {
                     case "AddRange":
                         ParameterInfo[] parameters = method.GetParameters();
-                        if (parameters is [{ ParameterType.IsArray: true }])
+                        if (parameters is [{ ParameterType.IsArray: true }] && MethodSupportsSerialization(method))
                         {
-                            if (MethodSupportsSerialization(method))
-                            {
-                                addRangeMethods.Add(method);
-                            }
+                            addRangeMethods.Add(method);
                         }
 
                         break;
 
                     case "Add":
-                        if (method.GetParameters().Length == 1)
+                        if (method.GetParameters().Length == 1 && MethodSupportsSerialization(method))
                         {
-                            if (MethodSupportsSerialization(method))
-                            {
-                                addMethods.Add(method);
-                            }
+                            addMethods.Add(method);
                         }
 
                         break;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.DesignerControlCollectionCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.DesignerControlCollectionCodeDomSerializer.cs
@@ -14,9 +14,9 @@ public partial class ControlDesigner
     // that aren't sited in the host's container.
     internal class DesignerControlCollectionCodeDomSerializer : CollectionCodeDomSerializer
     {
-        protected override object SerializeCollection(
+        protected override object? SerializeCollection(
             IDesignerSerializationManager manager,
-            CodeExpression targetExpression,
+            CodeExpression? targetExpression,
             Type targetType,
             ICollection originalCollection,
             ICollection valuesToSerialize)

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewRowCollectionCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewRowCollectionCodeDomSerializer.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.CodeDom;
 using System.Collections;
 using System.ComponentModel.Design.Serialization;
@@ -11,7 +9,7 @@ namespace System.Windows.Forms.Design;
 
 internal class DataGridViewRowCollectionCodeDomSerializer : CollectionCodeDomSerializer
 {
-    private static DataGridViewRowCollectionCodeDomSerializer s_defaultSerializer;
+    private static DataGridViewRowCollectionCodeDomSerializer? s_defaultSerializer;
 
     // FxCop made me add this constructor
     private DataGridViewRowCollectionCodeDomSerializer() { }
@@ -19,30 +17,22 @@ internal class DataGridViewRowCollectionCodeDomSerializer : CollectionCodeDomSer
     /// <summery>
     ///  Retrieves a default static instance of this serializer.
     /// </summery>
-    internal static DataGridViewRowCollectionCodeDomSerializer DefaultSerializer
-    {
-        get
-        {
-            s_defaultSerializer ??= new DataGridViewRowCollectionCodeDomSerializer();
-
-            return s_defaultSerializer;
-        }
-    }
+    internal static DataGridViewRowCollectionCodeDomSerializer DefaultSerializer => s_defaultSerializer ??= new DataGridViewRowCollectionCodeDomSerializer();
 
     /// <summery>
     ///  Serializes the given collection.  targetExpression will refer to the expression used to rever to the
     ///  collection, but it can be null.
     /// </summery>
-    protected override object SerializeCollection(IDesignerSerializationManager manager, CodeExpression targetExpression, Type targetType, ICollection originalCollection, ICollection valuesToSerialize)
+    protected override object SerializeCollection(IDesignerSerializationManager manager, CodeExpression? targetExpression, Type targetType, ICollection originalCollection, ICollection valuesToSerialize)
     {
 #if DEBUG
         // some checks
-        DataGridViewRowCollection rowCollection = originalCollection as DataGridViewRowCollection;
+        DataGridViewRowCollection rowCollection = (DataGridViewRowCollection)originalCollection;
 
         if (rowCollection.Count > 0)
         {
             Debug.Assert(rowCollection.Count == 1, " we should have only the add new row");
-            DataGridView dataGridView = rowCollection[0].DataGridView;
+            DataGridView dataGridView = rowCollection[0].DataGridView!;
             Debug.Assert(dataGridView.AllowUserToAddRows, "we only have the add new row when the data grid view allows users to add rows");
         }
 #endif // DEBUG

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TableLayoutControlCollectionCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TableLayoutControlCollectionCodeDomSerializer.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.CodeDom;
 using System.Collections;
 using System.ComponentModel;
@@ -19,7 +17,7 @@ internal class TableLayoutControlCollectionCodeDomSerializer : CollectionCodeDom
     ///  Serializes the given collection.  targetExpression will refer to the expression used to rever to the
     ///  collection, but it can be null.
     /// </summary>
-    protected override object SerializeCollection(IDesignerSerializationManager manager, CodeExpression targetExpression, Type targetType, ICollection originalCollection, ICollection valuesToSerialize)
+    protected override object SerializeCollection(IDesignerSerializationManager manager, CodeExpression? targetExpression, Type targetType, ICollection originalCollection, ICollection valuesToSerialize)
     {
         // Here we need to invoke Add once for each and every item in the collection. We can re-use the property
         // reference and method reference, but we will need to recreate the invoke statement each time.
@@ -30,28 +28,22 @@ internal class TableLayoutControlCollectionCodeDomSerializer : CollectionCodeDom
         if (valuesToSerialize.Count > 0)
         {
             bool isTargetInherited = false;
-            ExpressionContext ctx = manager.Context[typeof(ExpressionContext)] as ExpressionContext;
 
-            if (ctx is not null && ctx.Expression == targetExpression)
+            if (manager.TryGetContext(out ExpressionContext? ctx) && ctx.Expression == targetExpression)
             {
-                IComponent comp = ctx.Owner as IComponent;
-
-                if (comp is not null)
+                if (ctx.Owner is IComponent comp)
                 {
-                    InheritanceAttribute ia = (InheritanceAttribute)TypeDescriptor.GetAttributes(comp)[typeof(InheritanceAttribute)];
-                    isTargetInherited = (ia is not null && ia.InheritanceLevel == InheritanceLevel.Inherited);
+                    isTargetInherited = TypeDescriptorHelper.TryGetAttribute(comp, out InheritanceAttribute? ia) && ia.InheritanceLevel == InheritanceLevel.Inherited;
                 }
             }
 
             foreach (object o in valuesToSerialize)
             {
-                bool genCode = !(o is IComponent);
+                bool genCode = o is not IComponent;
 
                 if (!genCode)
                 {
-                    InheritanceAttribute ia = (InheritanceAttribute)TypeDescriptor.GetAttributes(o)[typeof(InheritanceAttribute)];
-
-                    if (ia is not null)
+                    if (TypeDescriptorHelper.TryGetAttribute(o, out InheritanceAttribute? ia))
                     {
                         if (ia.InheritanceLevel == InheritanceLevel.InheritedReadOnly)
                             genCode = false;
@@ -70,7 +62,7 @@ internal class TableLayoutControlCollectionCodeDomSerializer : CollectionCodeDom
                 {
                     CodeMethodInvokeExpression statement = new CodeMethodInvokeExpression();
                     statement.Method = methodRef;
-                    CodeExpression serializedObj = SerializeToExpression(manager, o);
+                    CodeExpression? serializedObj = SerializeToExpression(manager, o);
 
                     if (serializedObj is not null && !typeof(Control).IsAssignableFrom(o.GetType()))
                     {

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TableLayoutControlCollectionCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TableLayoutControlCollectionCodeDomSerializer.cs
@@ -29,12 +29,9 @@ internal class TableLayoutControlCollectionCodeDomSerializer : CollectionCodeDom
         {
             bool isTargetInherited = false;
 
-            if (manager.TryGetContext(out ExpressionContext? ctx) && ctx.Expression == targetExpression)
+            if (manager.TryGetContext(out ExpressionContext? ctx) && ctx.Expression == targetExpression && ctx.Owner is IComponent comp)
             {
-                if (ctx.Owner is IComponent comp)
-                {
-                    isTargetInherited = TypeDescriptorHelper.TryGetAttribute(comp, out InheritanceAttribute? ia) && ia.InheritanceLevel == InheritanceLevel.Inherited;
-                }
+                isTargetInherited = TypeDescriptorHelper.TryGetAttribute(comp, out InheritanceAttribute? ia) && ia.InheritanceLevel == InheritanceLevel.Inherited;
             }
 
             foreach (object o in valuesToSerialize)


### PR DESCRIPTION
I think this is the last public serializer that wasn't annotated (counting open PRs)

## Proposed changes

- Enable nullability in `CollectionCodeDomSerializer`
- Enable nullability in `DataGridViewRowCollectionCodeDomSerializer`
- Enable nullability in `TableLayoutControlCollectionCodeDomSerializer`


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9927)