### PR TITLE
Fix the color contrast ratio of ToolStripMenuItem's checked style is less than 3 : 1

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripHighContrastRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripHighContrastRenderer.cs
@@ -180,7 +180,7 @@ internal class ToolStripHighContrastRenderer : ToolStripSystemRenderer
             e.Graphics.DrawRectangle(SystemPens.ButtonHighlight, 0, 0, e.Item.Width - 1, e.Item.Height - 1);
         }
 
-        if (e.Item is ToolStripMenuItem menuItem && (menuItem.CheckState == CheckState.Checked || menuItem.Selected))
+        if (e.Item is ToolStripMenuItem menuItem && (menuItem.Checked || menuItem.Selected))
         {
             Graphics g = e.Graphics;
             Rectangle bounds = new Rectangle(Point.Empty, menuItem.Size);
@@ -235,10 +235,10 @@ internal class ToolStripHighContrastRenderer : ToolStripSystemRenderer
         // background. In that case, set the text color to highlight as well.
         if ((typeof(ToolStripButton).IsAssignableFrom(e.Item.GetType()) &&
             ((ToolStripButton)e.Item).DisplayStyle != ToolStripItemDisplayStyle.Image &&
-            ((ToolStripButton)e.Item).Checked)||
+            ((ToolStripButton)e.Item).Checked) ||
             (typeof(ToolStripMenuItem).IsAssignableFrom(e.Item.GetType()) &&
             ((ToolStripMenuItem)e.Item).DisplayStyle != ToolStripItemDisplayStyle.Image &&
-            ((ToolStripMenuItem)e.Item).CheckState == CheckState.Checked))
+            ((ToolStripMenuItem)e.Item).Checked))
         {
             e.TextColor = SystemColors.HighlightText;
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripHighContrastRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripHighContrastRenderer.cs
@@ -179,6 +179,19 @@ internal class ToolStripHighContrastRenderer : ToolStripSystemRenderer
         {
             e.Graphics.DrawRectangle(SystemPens.ButtonHighlight, 0, 0, e.Item.Width - 1, e.Item.Height - 1);
         }
+
+        if (e.Item is ToolStripMenuItem menuItem && (menuItem.CheckState == CheckState.Checked || menuItem.Selected))
+        {
+            Graphics g = e.Graphics;
+            Rectangle bounds = new Rectangle(Point.Empty, menuItem.Size);
+
+            g.FillRectangle(SystemBrushes.Highlight, bounds);
+            g.DrawRectangle(SystemPens.ControlLight, bounds.X, bounds.Y, bounds.Width - 1, bounds.Height - 1);
+            if (menuItem.Selected)
+            {
+                DrawHightContrastDashedBorder(g, menuItem);
+            }
+        }
     }
 
     protected override void OnRenderOverflowButtonBackground(ToolStripItemRenderEventArgs e)
@@ -218,11 +231,14 @@ internal class ToolStripHighContrastRenderer : ToolStripSystemRenderer
             }
         }
 
-        // ToolstripButtons that are checked are rendered with a highlight
+        // ToolstripButtons and ToolstripMenuItems that are checked are rendered with a highlight
         // background. In that case, set the text color to highlight as well.
-        if (typeof(ToolStripButton).IsAssignableFrom(e.Item.GetType()) &&
+        if ((typeof(ToolStripButton).IsAssignableFrom(e.Item.GetType()) &&
             ((ToolStripButton)e.Item).DisplayStyle != ToolStripItemDisplayStyle.Image &&
-            ((ToolStripButton)e.Item).Checked)
+            ((ToolStripButton)e.Item).Checked)||
+            (typeof(ToolStripMenuItem).IsAssignableFrom(e.Item.GetType()) &&
+            ((ToolStripMenuItem)e.Item).DisplayStyle != ToolStripItemDisplayStyle.Image &&
+            ((ToolStripMenuItem)e.Item).CheckState == CheckState.Checked))
         {
             e.TextColor = SystemColors.HighlightText;
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolstripProfessionalRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolstripProfessionalRenderer.cs
@@ -666,7 +666,7 @@ public class ToolStripProfessionalRenderer : ToolStripRenderer
                 }
                 else if (item is ToolStripMenuItem menuItem && menuItem.CheckState == CheckState.Checked)
                 {
-                    using var pen = ColorTable.MenuItemSelected.GetCachedPenScope();
+                    using var pen = ColorTable.MenuItemBorder.GetCachedPenScope();
                     g.DrawRectangle(pen, bounds.X, bounds.Y, bounds.Width - 1, bounds.Height - 1);
                 }
             }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Relate #https://github.com/dotnet/winforms/pull/9878#issuecomment-1720807530


## Proposed changes

- Update the checked style of ToolstripMenuItem.
- Update the TextColor under HighContrast environment.
- Update the border of ToolstripMenuItem under HighContrast environment.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- The color contrast of ToolStripMenuItem's checked style is consistent with the ToolStripButton.

## Regression? 

- Yes

## Risk

-Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
The color contrast ratio of the rectangle box is less than 3:1
![image](https://github.com/dotnet/winforms/assets/133954995/89eb4a94-923c-4c23-94db-0f3f1a607a52)
![image](https://github.com/dotnet/winforms/assets/133954995/75c376f0-3e75-429a-8392-0eb73950d7fa)
**HighContrast Aquatic:**
(checked)
![image](https://github.com/dotnet/winforms/assets/133954995/3c9a7580-5e65-487f-a043-2393f9b69cb3)
(selected and checked)
![image](https://github.com/dotnet/winforms/assets/133954995/2bcfef5d-b32b-407b-83e2-9bc6c5cc7bdc)
**Desert:**
(checked)
![image](https://github.com/dotnet/winforms/assets/133954995/7d38d2c9-7915-4b7b-a993-7863edc435ca)
(selected and checked)
![image](https://github.com/dotnet/winforms/assets/133954995/51ed16bf-17a4-4812-81ce-22095c647e62)

**Dusk:**
(checked)
![image](https://github.com/dotnet/winforms/assets/133954995/5770bd40-5292-46ef-ba3a-e9ec7e71267d)
(selected and checked)
![image](https://github.com/dotnet/winforms/assets/133954995/3cac8ed6-f817-488a-9f4b-07e14a53938b)

**Night sky:**
(checked)
![image](https://github.com/dotnet/winforms/assets/133954995/422100ab-5b25-4598-ab0f-7da5811c6c79)
(selected and checked)
![image](https://github.com/dotnet/winforms/assets/133954995/e28d5112-f17b-4b3c-913a-5e7f43f87b24)

### After
The color contrast of the rectangle box meets the normal proportions.
![image](https://github.com/dotnet/winforms/assets/133954995/d12f63aa-1d78-4900-8daa-8c82fa5ecc8f)
![image](https://github.com/dotnet/winforms/assets/133954995/9532fb5f-10bf-496e-b489-5b7f1ad8f92d)
**HighContrast Aquatic:**
(checked)
![image](https://github.com/dotnet/winforms/assets/133954995/5b984663-b14e-45fa-91be-815ca30b0761)
(selected and checked)
![image](https://github.com/dotnet/winforms/assets/133954995/4af4daf6-8ab0-46f3-afaf-cbcbaaa4bb1e)
**Desert:**
(checked)
![image](https://github.com/dotnet/winforms/assets/133954995/9efb009a-a99f-461c-81ce-7a4d94525ace)
(selected and checked)
![image](https://github.com/dotnet/winforms/assets/133954995/3fdbc246-2a4d-4aa6-9855-6857154f0aa2)
**Dusk:**
(checked)
![image](https://github.com/dotnet/winforms/assets/133954995/8e2b303b-9ab3-490d-a785-c942acef38aa)
(selected and checked)
![image](https://github.com/dotnet/winforms/assets/133954995/e55da38f-8436-43a2-92d0-0e26a1a86d50)
**Night sky:**
(checked)
![image](https://github.com/dotnet/winforms/assets/133954995/7bfb2c28-15bc-4a8f-9494-4912e59d55c5)
(selected and checked)
![image](https://github.com/dotnet/winforms/assets/133954995/65b14a00-dde4-4aa2-8af4-2fd0b4e18ab5)


## Test methodology <!-- How did you ensure quality? -->

- Manual (Accessibility Insights)

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

- 8.0.100-preview.7.23376.3


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9933)