### PR TITLE
Change default opt-in to false for AnchorLayoutV2 in .Net 8.0

### DIFF
--- a/docs/design/anchor-layout-changes-in-net80.md
+++ b/docs/design/anchor-layout-changes-in-net80.md
@@ -110,14 +110,14 @@ private static void ComputeAnchorInfo(IArrangedElement element)
 
 ## Risk mitigation
 
-The layout engine, in general, is quite complex, and any changes in it carry a very high risk. In order to reduce the risks and to provide backward compatibility, the new anchor calculations are put behind a feature switch `System.Windows.Forms.AnchorLayoutV2`. The switch is enabled by default for Windows Forms applications targeting .NET 8.
+The layout engine, in general, is quite complex, and any changes in it carry a very high risk. In order to reduce the risks and to provide backward compatibility, the new anchor calculations are put behind a feature switch `System.Windows.Forms.AnchorLayoutV2`. The switch is disabled by default for Windows Forms applications.
 
-It is possible to retain the original anchor calculations by setting the swtich to `false` in the [runtimeconfig.json](https://learn.microsoft.com/dotnet/core/runtime-config/#runtimeconfigjson).
+Developers need to opt-in to get this new feature by setting the switch value to `true` in the [runtimeconfig.json](https://learn.microsoft.com/dotnet/core/runtime-config/#runtimeconfigjson).
 Snippet for runtimeconfig.template.json:
 ```JSON
 {
   "configProperties": {
-    "System.Windows.Forms.AnchorLayoutV2": false
+    "System.Windows.Forms.AnchorLayoutV2": true
   }
 }
 ```

--- a/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
@@ -100,11 +100,6 @@ internal static partial class LocalAppContextSwitches
                     return true;
                 }
 
-                if (switchName == AnchorLayoutV2SwitchName)
-                {
-                    return true;
-                }
-
                 if (switchName == TrackBarModernRenderingSwitchName)
                 {
                     return true;
@@ -124,7 +119,7 @@ internal static partial class LocalAppContextSwitches
     ///  Indicates whether AnchorLayoutV2 feature is enabled.
     /// </summary>
     /// <devdoc>
-    ///  Returns AnchorLayoutV2 switch value from runtimeconfig.json. Defaults to true if application is targeting .NET 8.0 and beyond.
+    ///  Returns AnchorLayoutV2 switch value from runtimeconfig.json. Defaults to false.
     ///  Refer to
     ///  https://github.com/dotnet/winforms/blob/tree/main/docs/design/anchor-layout-changes-in-net80.md for more details.
     /// </devdoc>

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/LocalAppContextSwitchesTest.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/LocalAppContextSwitchesTest.cs
@@ -17,7 +17,7 @@ public class LocalAppContextSwitchesTest
     }
 
     [WinFormsTheory]
-    [InlineData(".NETCoreApp,Version=v8.0", false)]
+    [InlineData(".NETCoreApp,Version=v8.0", true)]
     [InlineData(".NETCoreApp,Version=v7.0", false)]
     [InlineData(".NET Framework,Version=v4.8", false)]
     public void Validate_Default_Switch_Values(string targetFrameworkName, bool expected)
@@ -31,7 +31,6 @@ public class LocalAppContextSwitchesTest
             testAccessor.s_targetFrameworkName = new FrameworkName(targetFrameworkName);
 
             Assert.Equal(expected, LocalAppContextSwitches.TrackBarModernRendering);
-            Assert.Equal(expected, LocalAppContextSwitches.AnchorLayoutV2);
             Assert.Equal(expected, LocalAppContextSwitches.ScaleTopLevelFormMinMaxSizeForDpi);
             Assert.Equal(expected, LocalAppContextSwitches.ServicePointManagerCheckCrl);
         }

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/LocalAppContextSwitchesTest.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/LocalAppContextSwitchesTest.cs
@@ -17,7 +17,7 @@ public class LocalAppContextSwitchesTest
     }
 
     [WinFormsTheory]
-    [InlineData(".NETCoreApp,Version=v8.0", true)]
+    [InlineData(".NETCoreApp,Version=v8.0", false)]
     [InlineData(".NETCoreApp,Version=v7.0", false)]
     [InlineData(".NET Framework,Version=v4.8", false)]
     public void Validate_Default_Switch_Values(string targetFrameworkName, bool expected)


### PR DESCRIPTION
AnchorLayoutV2 was introduced during the early preview of .NET 8.0 with the intention of making it the default option to gather user feedback on its functionality. Currently, there are two unresolved issues, namely [9740](https://github.com/dotnet/winforms/issues/9740) and [5136](https://github.com/microsoft/winforms-designer/issues/5136), which must be addressed before this feature can be widely adopted.

While we are actively working on resolving these issues, given the nature of fixes needed, we have decided to change the status of this feature to an explicit opt-in for .NET 8.0. This allows us to focus on addressing these issues and incorporating feedback that has been received thus far.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9942)