### PR TITLE
[release/8.0] Make System.Drawing.Common stable for rtm

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -9,6 +9,9 @@
     <PreReleaseVersionIteration>2</PreReleaseVersionIteration>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <UsingToolMicrosoftNetCompilers>true</UsingToolMicrosoftNetCompilers>
+    <!-- StabilizePackageVersion should be switched to true for rtm -->
+    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
+    <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
   </PropertyGroup>
   <!-- Below have corresponding entries in Versions.Details.XML because they are updated via Maestro -->
   <PropertyGroup>

--- a/src/System.Drawing.Common/src/System.Drawing.Common.csproj
+++ b/src/System.Drawing.Common/src/System.Drawing.Common.csproj
@@ -10,6 +10,8 @@
     <CLSCompliant>true</CLSCompliant>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <IsPackable>true</IsPackable>
+    <IsShipping>true</IsShipping>
+    <IsShippingPackage>true</IsShippingPackage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <!-- This should point to the last stable released version of this package. -->
     <PackageValidationBaselineVersion>7.0.0</PackageValidationBaselineVersion>


### PR DESCRIPTION
System.Drawing.Common has been ported from runtime during the .NET 8 previews. In it's current form, it will have an unstable version when we switch to rtm. This PR fixes that

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9949)