### PR TITLE
[RTM] Convert structs to primitive types when passing them to the interop methods that expect VARIANTs

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Automation/UiaTextProvider.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Automation/UiaTextProvider.cs
@@ -95,6 +95,15 @@ internal abstract class UiaTextProvider : ITextProvider
         return doubles;
     }
 
+    /// <summary>
+    ///  Bounding rectangles are represented by a VT_ARRAY of doubles in a native VARIANT
+    ///  in accessibility interfaces. This method does the conversion. Accessibility will then convert it to an UiaRect.
+    ///  https://learn.microsoft.com/windows/win32/api/uiautomationcore/nf-uiautomationcore-irawelementproviderfragment-get_boundingrectangle
+    ///  https://learn.microsoft.com/windows/win32/api/uiautomationcore/ns-uiautomationcore-uiarect
+    /// </summary>
+    internal static double[] BoundingRectangleAsArray(Rectangle bounds)
+        => new double[] { bounds.X, bounds.Y, bounds.Width, bounds.Height };
+
     public int SendInput(int inputs, ref INPUT input, int size)
     {
         Span<INPUT> currentInput = stackalloc INPUT[1];

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/Automation/UiaTextRangeTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/Automation/UiaTextRangeTests.cs
@@ -451,12 +451,12 @@ this is the third line.";
 
     public static IEnumerable<object[]> UiaTextRange_ITextRangeProvider_GetAttributeValue_Returns_Correct_TestData()
     {
-        yield return new object[] { TextAttributeIdentifier.BackgroundColorAttributeId, (COLORREF)PInvoke.GetSysColor(SYS_COLOR_INDEX.COLOR_WINDOW) };
+        yield return new object[] { TextAttributeIdentifier.BackgroundColorAttributeId, (int)(uint)(COLORREF)PInvoke.GetSysColor(SYS_COLOR_INDEX.COLOR_WINDOW) };
         yield return new object[] { TextAttributeIdentifier.CapStyleAttributeId, CapStyle.None };
         yield return new object[] { TextAttributeIdentifier.FontNameAttributeId, "Segoe UI" };
         yield return new object[] { TextAttributeIdentifier.FontSizeAttributeId, 9.0 };
         yield return new object[] { TextAttributeIdentifier.FontWeightAttributeId, FW.NORMAL };
-        yield return new object[] { TextAttributeIdentifier.ForegroundColorAttributeId, new COLORREF() };
+        yield return new object[] { TextAttributeIdentifier.ForegroundColorAttributeId, (int)(uint)new COLORREF() };
         yield return new object[] { TextAttributeIdentifier.HorizontalTextAlignmentAttributeId, HorizontalTextAlignment.Left };
         yield return new object[] { TextAttributeIdentifier.IsItalicAttributeId, false };
         yield return new object[] { TextAttributeIdentifier.IsReadOnlyAttributeId, false };
@@ -517,7 +517,8 @@ this is the third line.";
     public void UiaTextRange_ITextRangeProvider_GetBoundingRectangles_ReturnsEmpty_for_EmptyText()
     {
         Mock<IRawElementProviderSimple> enclosingElementMock = new Mock<IRawElementProviderSimple>(MockBehavior.Strict);
-        enclosingElementMock.Setup(m => m.GetPropertyValue(UIA.BoundingRectanglePropertyId)).Returns(new Rectangle(10, 33, 96, 19));
+        Rectangle expected = new Rectangle(10, 33, 96, 19);
+        enclosingElementMock.Setup(m => m.GetPropertyValue(UIA.BoundingRectanglePropertyId)).Returns(expected);
         IRawElementProviderSimple enclosingElement = enclosingElementMock.Object;
         Mock<UiaTextProvider> providerMock = new Mock<UiaTextProvider>(MockBehavior.Strict);
         providerMock.Setup(p => p.Text).Returns("");
@@ -525,7 +526,7 @@ this is the third line.";
         UiaTextProvider provider = providerMock.Object;
         UiaTextRange textRange = new UiaTextRange(enclosingElement, provider, start: 0, end: 0);
         var actual = ((ITextRangeProvider)textRange).GetBoundingRectangles();
-        Assert.Equal(new double[] { 10, 33, 96, 19 }, actual);
+        Assert.Equal(UiaTextProvider.BoundingRectangleAsArray(expected), actual);
     }
 
     [StaFact]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
@@ -427,7 +427,7 @@ public unsafe partial class AccessibleObject :
         {
             UiaCore.UIA.AccessKeyPropertyId => KeyboardShortcut ?? string.Empty,
             UiaCore.UIA.AutomationIdPropertyId => AutomationId,
-            UiaCore.UIA.BoundingRectanglePropertyId => Bounds,
+            UiaCore.UIA.BoundingRectanglePropertyId => UiaTextProvider.BoundingRectangleAsArray(Bounds),
             UiaCore.UIA.FrameworkIdPropertyId => "WinForm",
             UiaCore.UIA.IsExpandCollapsePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.ExpandCollapsePatternId),
             UiaCore.UIA.IsGridItemPatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.GridItemPatternId),

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.AccessibleObject.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Drawing;
+using System.Windows.Forms.Automation;
 using static Interop;
 
 namespace System.Windows.Forms;
@@ -122,7 +123,7 @@ public partial class ListBox
             switch (propertyID)
             {
                 case UiaCore.UIA.BoundingRectanglePropertyId:
-                    return BoundingRectangle;
+                    return UiaTextProvider.BoundingRectangleAsArray(BoundingRectangle);
                 case UiaCore.UIA.ControlTypePropertyId:
                     // If we don't set a default role for the accessible object
                     // it will be retrieved from Windows.

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListBox.ListBoxItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListBox.ListBoxItemAccessibleObjectTests.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Windows.Forms.Automation;
 using System.Windows.Forms.IntegrationTests.Common;
 using static Interop;
 
@@ -87,7 +88,7 @@ public class ListBox_ListBoxItemAccessibleObjectTests
 
         object actual = itemAccessibleObject.GetPropertyValue(UiaCore.UIA.BoundingRectanglePropertyId);
 
-        Assert.Equal(itemAccessibleObject.BoundingRectangle, actual);
+        Assert.Equal(UiaTextProvider.BoundingRectangleAsArray(itemAccessibleObject.BoundingRectangle), actual);
         Assert.False(listBox.IsHandleCreated);
     }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObjectTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Drawing;
+using System.Windows.Forms.Automation;
 using static System.Windows.Forms.ListViewItem.ListViewSubItem;
 using static Interop;
 
@@ -925,7 +926,7 @@ public class ListViewItem_ListViewSubItem_ListViewSubItemAccessibleObjectTests
         ListViewSubItemAccessibleObject listViewSubItemAccessibleObject = new(listViewSubItem, listViewItem);
         object actual = listViewSubItemAccessibleObject.GetPropertyValue(UiaCore.UIA.BoundingRectanglePropertyId);
 
-        Assert.Equal(listViewSubItem.AccessibilityObject.BoundingRectangle, actual);
+        Assert.Equal(UiaTextProvider.BoundingRectangleAsArray(listViewSubItem.AccessibilityObject.BoundingRectangle), actual);
         Assert.False(listView.IsHandleCreated);
     }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewLabelEditAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewLabelEditAccessibleObjectTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Drawing;
+using System.Windows.Forms.Automation;
 using static Interop;
 
 namespace System.Windows.Forms.Tests;
@@ -18,7 +19,7 @@ public class ListViewLabelEditAccessibleObjectTests
 
         Assert.Equal(accessibilityObject.RuntimeId, accessibilityObject.GetPropertyValue(UiaCore.UIA.RuntimeIdPropertyId));
         PInvoke.GetWindowRect(labelEdit, out RECT r);
-        Assert.Equal((Rectangle)r, accessibilityObject.GetPropertyValue(UiaCore.UIA.BoundingRectanglePropertyId));
+        Assert.Equal(UiaTextProvider.BoundingRectangleAsArray((Rectangle)r), accessibilityObject.GetPropertyValue(UiaCore.UIA.BoundingRectanglePropertyId));
         Assert.Equal(Environment.ProcessId, accessibilityObject.GetPropertyValue(UiaCore.UIA.ProcessIdPropertyId));
         Assert.Equal(UiaCore.UIA.EditControlTypeId, accessibilityObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId));
         Assert.Equal(accessibilityObject.Name, accessibilityObject.GetPropertyValue(UiaCore.UIA.NamePropertyId));

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/UpDownBase.UpDownButtons.UpDownButtonsAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/UpDownBase.UpDownButtons.UpDownButtonsAccessibleObjectTests.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Windows.Forms.Automation;
 using static System.Windows.Forms.UpDownBase;
 using static System.Windows.Forms.UpDownBase.UpDownButtons;
 using static Interop;
@@ -110,7 +111,7 @@ public class UpDownBase_UpDownButtons_UpDownButtonsAccessibleObject
         UpDownButtons upDownButtons = upDownBase.UpDownButtonsInternal;
         object actual = upDownButtons.AccessibilityObject.GetPropertyValue(UiaCore.UIA.BoundingRectanglePropertyId);
 
-        Assert.Equal(upDownButtons.AccessibilityObject.BoundingRectangle, actual);
+        Assert.Equal(UiaTextProvider.BoundingRectangleAsArray(upDownButtons.AccessibilityObject.BoundingRectangle), actual);
         Assert.False(upDownBase.IsHandleCreated);
     }
 


### PR DESCRIPTION
Porting a regression fix from main - https://github.com/dotnet/winforms/pull/9960

## Customer Impact
Accessibility model data will be incorrect for Accessibility tools 

## Regression
Yes, related to the interop/CS-Win32 work 
 
## Testing
Manual testing under UIA accessibility tools – Narrator, Inspect and Accessibility Insights
 
## Risk
Low – only accessibility scenarios are affected.

## Details

I noticed this as  NotSupportedException at System.StubHelpers.ObjectMarshaler.ConvertToNative(Object objSrc, IntPtr pDstVariant)
```
System.NotSupportedException
  HResult=0x80131515
  Message=Type 'Windows.Win32.Foundation.COLORREF' cannot be marshalled to a Variant. Type library is not registered.
  Source=<Cannot evaluate the exception source>
  StackTrace:
<Cannot evaluate the exception stack trace>
```
As a result of this exception UIA Accessibility tools will not get correct values for Bounding rectangles or colors.
 
This exception is thrown when the user is selecting text in a text box (or any text control that has a UIA text provider) under a Narrator. UIA is querying the foreground and background text colors and the bounding rectangle of the control. Colors and bounding rectangle are C# structs, and our UIA implementations cast these structs to an object. However, the interop layer can't convert such objects to VARIANT types expected by the UIA.

## Fix

The fix is a copy of #9732, i.e. explicitly convert struct to a primitive type that has a conversion to a VARIANT. Specific types are documented with the UIA property or attribute definitions - https://learn.microsoft.com/en-us/windows/win32/winauto/uiauto-textattribute-ids and https://learn.microsoft.com/windows/win32/api/uiautomationcore/nf-uiautomationcore-irawelementproviderfragment-get_boundingrectangle.

I had reviewed all overrides of GetPropertyValue and GetAttributeValue methods, and did not find any other non-primitive values that require additional conversion.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9963)