### PR TITLE
add shortcut on Control.Invoke when the delegate is SendOrPostCallback

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -6510,6 +6510,12 @@ public unsafe partial class Control :
                          "Arguments are wrong for WaitCallback");
             ((WaitCallback)tme._method)(tme._args[0]);
         }
+        else if (tme._method is SendOrPostCallback)
+        {
+            Debug.Assert(tme._args!.Length == 1,
+                         "Arguments are wrong for SendOrPostCallback");
+            ((SendOrPostCallback)tme._method)(tme._args[0]);
+        }
         else
         {
             tme._retVal = tme._method!.DynamicInvoke(tme._args);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/WindowsFormsSynchronizationContextTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/WindowsFormsSynchronizationContextTests.cs
@@ -150,7 +150,6 @@ public partial class WindowsFormsSynchronizationContextTests
     }
 
     [WinFormsFact]
-    [ActiveIssue("https://github.com/dotnet/winforms/issues/9965")]
     public void WindowsFormsSynchronizationContext_Send_NoDynamicInvoke()
     {
         string stackTrace = null;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/WindowsFormsSynchronizationContextTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/WindowsFormsSynchronizationContextTests.cs
@@ -148,4 +148,16 @@ public partial class WindowsFormsSynchronizationContextTests
         context.Post(callback, state);
         Assert.Equal(0, callCount);
     }
+
+    [WinFormsFact]
+    [ActiveIssue("https://github.com/dotnet/winforms/issues/9965")]
+    public void WindowsFormsSynchronizationContext_Send_NoDynamicInvoke()
+    {
+        string stackTrace = null;
+        var context = new WindowsFormsSynchronizationContext();
+        context.Send(_ => { stackTrace = Environment.StackTrace; }, null);
+
+        Assert.NotNull(stackTrace);
+        Assert.DoesNotContain("System.Delegate.DynamicInvokeImpl", stackTrace);
+    }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/WindowsFormsSynchronizationContextTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/WindowsFormsSynchronizationContextTests.cs
@@ -150,6 +150,7 @@ public partial class WindowsFormsSynchronizationContextTests
     }
 
     [WinFormsFact]
+    [ActiveIssue("https://github.com/dotnet/winforms/issues/9965")]
     public void WindowsFormsSynchronizationContext_Send_NoDynamicInvoke()
     {
         string stackTrace = null;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/WindowsFormsSynchronizationContextTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/WindowsFormsSynchronizationContextTests.cs
@@ -150,7 +150,6 @@ public partial class WindowsFormsSynchronizationContextTests
     }
 
     [WinFormsFact]
-    [ActiveIssue("https://github.com/dotnet/winforms/issues/9965")]
     public void WindowsFormsSynchronizationContext_Send_NoDynamicInvoke()
     {
         string stackTrace = null;
@@ -158,6 +157,9 @@ public partial class WindowsFormsSynchronizationContextTests
         context.Send(_ => { stackTrace = Environment.StackTrace; }, null);
 
         Assert.NotNull(stackTrace);
+
+        // check that the WindowsFormsSynchronizationContext.Send does not involve DynamicInvoke, for performance reasons.
+        // see https://github.com/dotnet/winforms/issues/9965
         Assert.DoesNotContain("System.Delegate.DynamicInvokeImpl", stackTrace);
     }
 }


### PR DESCRIPTION
Fixes #9965

## Proposed changes

- add a specific test in Control.InvokeMarshaledCallbackDo to detect when the delegate is of type SendOrPostCallback

## Customer Impact

- better performances when using WindowsFormSynchronizationContext.Post or Send and TaskScheduler when derived from WindowsFormSynchronizationContext

## Regression? 

- No

### Before

```csharp
   at System.Environment.get_StackTrace()
   at System.Windows.Forms.Tests.WindowsFormsSynchronizationContextTests.<>c__DisplayClass9_0.<WindowsFormsSynchronizationContext_Send_NoDynamicInvoke>g__Callback|0(Object _) in C:\code\external\dotnet\winforms\src\System.Windows.Forms\tests\UnitTests\System\Windows\Forms\WindowsFormsSynchronizationContextTests.cs:line 164
   at InvokeStub_SendOrPostCallback.Invoke(Object, Span`1)
   at System.Reflection.MethodBaseInvoker.InvokeWithOneArg(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at System.Delegate.DynamicInvokeImpl(Object[] args)
   at System.Windows.Forms.Control.InvokeMarshaledCallbackDo(ThreadMethodEntry tme) in C:\code\external\dotnet\winforms\src\System.Windows.Forms\src\System\Windows\Forms\Control.cs:line 6521
   at System.Windows.Forms.Control.InvokeMarshaledCallbackHelper(Object obj) in C:\code\external\dotnet\winforms\src\System.Windows.Forms\src\System\Windows\Forms\Control.cs:line 6472
   at System.Windows.Forms.Control.InvokeMarshaledCallback(ThreadMethodEntry tme) in C:\code\external\dotnet\winforms\src\System.Windows.Forms\src\System\Windows\Forms\Control.cs:line 6444
   at System.Windows.Forms.Control.InvokeMarshaledCallbacks() in C:\code\external\dotnet\winforms\src\System.Windows.Forms\src\System\Windows\Forms\Control.cs:line 6562
   at System.Windows.Forms.Control.MarshaledInvoke(Control caller, Delegate method, Object[] args, Boolean synchronous) in C:\code\external\dotnet\winforms\src\System.Windows.Forms\src\System\Windows\Forms\Control.cs:line 6930
   at System.Windows.Forms.Control.Invoke(Delegate method, Object[] args) in C:\code\external\dotnet\winforms\src\System.Windows.Forms\src\System\Windows\Forms\Control.cs:line 6401
   at System.Windows.Forms.WindowsFormsSynchronizationContext.Send(SendOrPostCallback d, Object state) in C:\code\external\dotnet\winforms\src\System.Windows.Forms\src\System\Windows\Forms\WindowsFormsSynchronizationContext.cs:line 87
```

### After

```csharp
   at System.Environment.get_StackTrace()
   at System.Windows.Forms.Tests.WindowsFormsSynchronizationContextTests.<>c__DisplayClass9_0.<WindowsFormsSynchronizationContext_Send_NoDynamicInvoke>g__Callback|0(Object _) in C:\code\external\dotnet\winforms\src\System.Windows.Forms\tests\UnitTests\System\Windows\Forms\WindowsFormsSynchronizationContextTests.cs:line 164
   at System.Windows.Forms.Control.InvokeMarshaledCallbackDo(ThreadMethodEntry tme) in C:\code\external\dotnet\winforms\src\System.Windows.Forms\src\System\Windows\Forms\Control.cs:line 6517
   at System.Windows.Forms.Control.InvokeMarshaledCallbackHelper(Object obj) in C:\code\external\dotnet\winforms\src\System.Windows.Forms\src\System\Windows\Forms\Control.cs:line 6472
   at System.Windows.Forms.Control.InvokeMarshaledCallback(ThreadMethodEntry tme) in C:\code\external\dotnet\winforms\src\System.Windows.Forms\src\System\Windows\Forms\Control.cs:line 6444
   at System.Windows.Forms.Control.InvokeMarshaledCallbacks() in C:\code\external\dotnet\winforms\src\System.Windows.Forms\src\System\Windows\Forms\Control.cs:line 6562
   at System.Windows.Forms.Control.MarshaledInvoke(Control caller, Delegate method, Object[] args, Boolean synchronous) in C:\code\external\dotnet\winforms\src\System.Windows.Forms\src\System\Windows\Forms\Control.cs:line 6930
   at System.Windows.Forms.Control.Invoke(Delegate method, Object[] args) in C:\code\external\dotnet\winforms\src\System.Windows.Forms\src\System\Windows\Forms\Control.cs:line 6401
   at System.Windows.Forms.WindowsFormsSynchronizationContext.Send(SendOrPostCallback d, Object state) in C:\code\external\dotnet\winforms\src\System.Windows.Forms\src\System\Windows\Forms\WindowsFormsSynchronizationContext.cs:line 87
```


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9967)