### PR TITLE
Fix Narrator cannot announce correctly and getting incorrect rectanges

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Automation/UiaTextRange.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Automation/UiaTextRange.cs
@@ -276,7 +276,7 @@ internal class UiaTextRange : ITextRangeProvider
 
     double[] ITextRangeProvider.GetBoundingRectangles()
     {
-        if (_enclosingElement.GetPropertyValue(UIA.BoundingRectanglePropertyId) is not Rectangle ownerBounds)
+        if (_enclosingElement.GetPropertyValue(UIA.BoundingRectanglePropertyId) is not double[] ownerBounds || !ownerBounds.Length.Equals(4))
         {
             return Array.Empty<double>();
         }
@@ -287,8 +287,7 @@ internal class UiaTextRange : ITextRangeProvider
 
         if (text.Length == 0)
         {
-            rectangles.Add(ownerBounds);
-            return UiaTextProvider.RectListToDoubleArray(rectangles);
+            return ownerBounds;
         }
 
         // If this is an end of a line.
@@ -312,7 +311,7 @@ internal class UiaTextRange : ITextRangeProvider
         ValidateEndpoints();
 
         // Get the mapping from client coordinates to screen coordinates.
-        Point mapClientToScreen = new Point(ownerBounds.X, ownerBounds.Y);
+        Point mapClientToScreen = new Point((int)ownerBounds[0], (int)ownerBounds[1]);
 
         // Clip the rectangles to the edit control's formatting rectangle.
         Rectangle clippingRectangle = _provider.BoundingRectangle;

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/Automation/UiaTextRangeTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/Automation/UiaTextRangeTests.cs
@@ -518,7 +518,7 @@ this is the third line.";
     {
         Mock<IRawElementProviderSimple> enclosingElementMock = new Mock<IRawElementProviderSimple>(MockBehavior.Strict);
         Rectangle expected = new Rectangle(10, 33, 96, 19);
-        enclosingElementMock.Setup(m => m.GetPropertyValue(UIA.BoundingRectanglePropertyId)).Returns(expected);
+        enclosingElementMock.Setup(m => m.GetPropertyValue(UIA.BoundingRectanglePropertyId)).Returns(new double[] { 10, 33, 96, 19 });
         IRawElementProviderSimple enclosingElement = enclosingElementMock.Object;
         Mock<UiaTextProvider> providerMock = new Mock<UiaTextProvider>(MockBehavior.Strict);
         providerMock.Setup(p => p.Text).Returns("");
@@ -549,7 +549,7 @@ this is the third line.";
     public void UiaTextRange_ITextRangeProvider_GetBoundingRectangles_ReturnsExpected_for_Endline()
     {
         Mock<IRawElementProviderSimple> enclosingElementMock = new Mock<IRawElementProviderSimple>(MockBehavior.Strict);
-        enclosingElementMock.Setup(m => m.GetPropertyValue(UIA.BoundingRectanglePropertyId)).Returns(new Rectangle(10, 33, 96, 19));
+        enclosingElementMock.Setup(m => m.GetPropertyValue(UIA.BoundingRectanglePropertyId)).Returns(new double[] {10, 33, 96, 19 });
         IRawElementProviderSimple enclosingElement = enclosingElementMock.Object;
         Mock<UiaTextProvider> providerMock = new Mock<UiaTextProvider>(MockBehavior.Strict);
         providerMock.Setup(p => p.Text).Returns("abc");
@@ -616,7 +616,7 @@ test text with several lines
 and numbers 12345";
 
         Mock<IRawElementProviderSimple> enclosingElementMock = new Mock<IRawElementProviderSimple>(MockBehavior.Strict);
-        enclosingElementMock.Setup(m => m.GetPropertyValue(UIA.BoundingRectanglePropertyId)).Returns(new Rectangle(27, 128, 128, 155));
+        enclosingElementMock.Setup(m => m.GetPropertyValue(UIA.BoundingRectanglePropertyId)).Returns(new double[] {27, 128, 128, 155 });
 
         Mock<UiaTextProvider> providerMock = new Mock<UiaTextProvider>(MockBehavior.Strict);
         providerMock.Setup(m => m.IsReadingRTL).Returns(false);
@@ -683,7 +683,7 @@ test text with several lines
 and numbers 12345";
 
         Mock<IRawElementProviderSimple> enclosingElementMock = new Mock<IRawElementProviderSimple>(MockBehavior.Strict);
-        enclosingElementMock.Setup(m => m.GetPropertyValue(UIA.BoundingRectanglePropertyId)).Returns(new Rectangle(27, 128, 128, 155));
+        enclosingElementMock.Setup(m => m.GetPropertyValue(UIA.BoundingRectanglePropertyId)).Returns(new double[] { 27, 128, 128, 155 });
 
         Mock<UiaTextProvider> providerMock = new Mock<UiaTextProvider>(MockBehavior.Strict);
         providerMock.Setup(m => m.IsReadingRTL).Returns(true);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBox.cs
@@ -691,11 +691,6 @@ public partial class TextBox : TextBoxBase
         bool returnValue = base.ProcessCmdKey(ref m, keyData);
         if (!returnValue && ShortcutsEnabled && (keyData == (Keys.Control | Keys.A)))
         {
-            if (Multiline)
-            {
-                return returnValue;
-            }
-
             SelectAll();
             return true;
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBox.cs
@@ -689,8 +689,13 @@ public partial class TextBox : TextBoxBase
     protected override bool ProcessCmdKey(ref Message m, Keys keyData)
     {
         bool returnValue = base.ProcessCmdKey(ref m, keyData);
-        if (!returnValue && Multiline && ShortcutsEnabled && (keyData == (Keys.Control | Keys.A)))
+        if (!returnValue && ShortcutsEnabled && (keyData == (Keys.Control | Keys.A)))
         {
+            if (Multiline)
+            {
+                return returnValue;
+            }
+
             SelectAll();
             return true;
         }

--- a/src/System.Windows.Forms/tests/UnitTests/TextBoxBaseTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/TextBoxBaseTests.cs
@@ -6015,7 +6015,7 @@ public partial class TextBoxBaseTests
                 yield return new object[] { shortcutsEnabled, readOnly, (Keys)Shortcut.CtrlC, !shortcutsEnabled };
                 yield return new object[] { shortcutsEnabled, readOnly, (Keys)Shortcut.CtrlX, !shortcutsEnabled };
                 yield return new object[] { shortcutsEnabled, readOnly, (Keys)Shortcut.CtrlV, !shortcutsEnabled };
-                yield return new object[] { shortcutsEnabled, readOnly, (Keys)Shortcut.CtrlA, !shortcutsEnabled };
+                yield return new object[] { shortcutsEnabled, readOnly, (Keys)Shortcut.CtrlA, true };
                 yield return new object[] { shortcutsEnabled, readOnly, (Keys)Shortcut.CtrlL, !shortcutsEnabled || readOnly };
                 yield return new object[] { shortcutsEnabled, readOnly, (Keys)Shortcut.CtrlR, !shortcutsEnabled || readOnly };
                 yield return new object[] { shortcutsEnabled, readOnly, (Keys)Shortcut.CtrlE, !shortcutsEnabled || readOnly };
@@ -6085,7 +6085,7 @@ public partial class TextBoxBaseTests
 
     [WinFormsTheory]
     [InlineData(true, false, (Keys)Shortcut.CtrlA, true, true)]
-    [InlineData(true, false, (Keys)Shortcut.CtrlA, false, false)]
+    [InlineData(true, false, (Keys)Shortcut.CtrlA, false, true)]
     [InlineData(false, false, (Keys)Shortcut.CtrlA, true, true)]
     [InlineData(false, false, (Keys)Shortcut.CtrlA, false, true)]
     [InlineData(true, true, (Keys)Shortcut.CtrlL, true, true)]


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #9828


## Proposed changes

- Base on [PR 9960](https://github.com/dotnet/winforms/pull/9960), we need update the ITextRangeProvider.GetBoundingRectangles() method to make sure the rectangeles for the selection text in TextBox can be correctly drawn.
- Update the method of ProcessCmdKey(ref Message m, Keys keyData) in TextBox class.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- When using keyboard: Ctrl+A or mouse to choose all texts in TextBox/ComboBox/DomainUpDown/NumericUpDown, Narrator cannot focus entire texts and announce "Document selected" to user

## Regression? 

- Yes 

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/dotnet/winforms/assets/133954995/7b1e7b37-49e8-4d62-b155-99d8c5e14cdd)

### After

Keep the same behavior with .Net 7.0, narrator can focus entire texts and announce "Document selected" to user.
![image](https://github.com/dotnet/winforms/assets/133954995/b2ad15c4-5781-4b2b-a30f-bd8c7a3d45e2)


## Test methodology <!-- How did you ensure quality? -->

- Manual (Narrator)

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

- 8.0.100-preview.7.23376.3


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9970)