### PR TITLE
[RC2] Can't select TreeView items using UIAutomation SelectionItem.Select 

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeNode.TreeNodeAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeNode.TreeNodeAccessibleObject.cs
@@ -97,6 +97,11 @@ public partial class TreeNode
                 _ => base.FragmentNavigate(direction),
             };
 
+        internal override void SelectItem()
+        {
+            _owningTreeView.SelectedNode = _owningTreeNode;
+        }
+
         internal override object? GetPropertyValue(UiaCore.UIA propertyID)
             => propertyID switch
             {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNode.TreeNodeAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNode.TreeNodeAccessibleObjectTests.cs
@@ -464,6 +464,27 @@ public class TreeNodeAccessibleObjectTests
     }
 
     [WinFormsFact]
+    public void TreeNodeAccessibleObject_SelectItem_WorksExpected()
+    {
+        using TreeView control = new();
+
+        control.Nodes.Add("Node1");
+        control.Nodes.Add("Node2");
+        control.Nodes.Add("Node3");
+        control.Nodes.Add("Node4");
+
+        Assert.Null(control.SelectedNode);
+
+        control.Nodes[1].AccessibilityObject.SelectItem();
+        Assert.Equal("Node2", control.SelectedNode?.Text);
+
+        control.Nodes[3].AccessibilityObject.SelectItem();
+        Assert.Equal("Node4", control.SelectedNode?.Text);
+
+        Assert.False(control.IsHandleCreated);
+    }
+
+    [WinFormsFact]
     public void TreeNodeAccessibleObject_Value_EqualsText()
     {
         using TreeView control = new() { LabelEdit = true };


### PR DESCRIPTION
[This PR is a correction on incorrectly merged PR - #9955 ]

Fix #9822

<!-- Please read CONTRIBUTING.md before submitting a pull request -->




## Proposed changes

- 
- TreeViewItem add `SelectItem` method.
- 

<!-- We are in TELL-MODE the following section must be completed -->


## Regression? 

- Yes 



<!-- end TELL-MODE -->




### Before

![9955_before](https://github.com/dotnet/winforms/assets/135201996/5b540a54-d3bc-4f6b-9f4b-2e36bca47d9d)

### After

![9955_after](https://github.com/dotnet/winforms/assets/135201996/403409a3-c30f-4fa9-b07b-95718a8f28a4)


## Test methodology <!-- How did you ensure quality? -->

- 
- unit test
- 




## Test environment(s) <!-- Remove any that don't apply -->
8.0.0-preview.7.23375.6
- <!-- use `dotnet --info` -->


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9955)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9974)