### PR TITLE
Fix TabPage cannot add to TablControl in DemoConsole

### DIFF
--- a/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/MainForm.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/MainForm.cs
@@ -259,7 +259,7 @@ public partial class MainForm : Form
                         bindingSource.DataSource = new List<string> { "a1", "b2", "c3", "d4", "e5", "f6" };
                         listBox.DataSource = bindingSource;
                         DataGridView dataGridView = surface.CreateControl<DataGridView>(new Size(200, 150), new Point(470, 220));
-                        DataGridViewComboBoxColumn comboBoxColumn = new DataGridViewComboBoxColumn();
+                        DataGridViewComboBoxColumn comboBoxColumn = surface.CreateComponent<DataGridViewComboBoxColumn>();
                         comboBoxColumn.HeaderText = "Column1";
                         dataGridView.Columns.AddRange([comboBoxColumn]);
                     }

--- a/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/MainForm.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/MainForm.cs
@@ -259,7 +259,7 @@ public partial class MainForm : Form
                         bindingSource.DataSource = new List<string> { "a1", "b2", "c3", "d4", "e5", "f6" };
                         listBox.DataSource = bindingSource;
                         DataGridView dataGridView = surface.CreateControl<DataGridView>(new Size(200, 150), new Point(470, 220));
-                        DataGridViewComboBoxColumn comboBoxColumn = surface.CreateComponent<DataGridViewComboBoxColumn>();
+                        DataGridViewComboBoxColumn comboBoxColumn = new DataGridViewComboBoxColumn();
                         comboBoxColumn.HeaderText = "Column1";
                         dataGridView.Columns.AddRange([comboBoxColumn]);
                     }

--- a/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DesignSurfaceExt/NameCreationServiceImp.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DesignSurfaceExt/NameCreationServiceImp.cs
@@ -24,9 +24,7 @@ internal class NameCreationServiceImp : INameCreationService
         int i = 0;
         while (i < cc.Count)
         {
-            Component comp = cc[i] as Component;
-
-            if (comp.GetType() == type)
+            if (cc[i] is Component comp && comp.GetType() == type)
             {
                 count++;
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #9968 

When we click the control of 'Add Tab', an exception message will be thrown in the CreateName method:
![image](https://github.com/dotnet/winforms/assets/133954995/e16811f8-19e8-4919-8f7d-75d3650cec26)
DataGridViewComboBoxColumn cannot be converted to component, 
![image](https://github.com/dotnet/winforms/assets/133954995/ab4056b7-d966-4b87-a169-d028e5e18fda)
![image](https://github.com/dotnet/winforms/assets/133954995/dce94a63-6e84-4b08-a86d-e2a09784b92a)

So we need to modify the creation method of the DataGridViewComboBoxColumn object.


## Proposed changes

- Modify the creation way of DataGridViewComboBoxColumn object.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- TabPage can add to TabControl in DemoConsole.

## Regression? 

- No

## Risk

-Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/dotnet/winforms/assets/133954995/6dbb188b-e34a-420d-b0f5-13386f3a4d91)

### After

![TabControl_Image](https://github.com/dotnet/winforms/assets/133954995/68acd370-2ea9-4567-bd82-2a56a7d04bc7)


## Test methodology <!-- How did you ensure quality? -->

- Manual(DemoConsole)

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

- 8.0.100-preview.7.23376.3


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9979)