### PR TITLE
Fix thread-safety issue of reading last accessed index in `ImageList.ImageCollection.IndexOfKey`

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.ImageCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.ImageCollection.cs
@@ -475,17 +475,18 @@ public sealed partial class ImageList
             }
 
             // Check the last cached item
-            if (IsValidIndex(_lastAccessedIndex))
+            int i = _lastAccessedIndex;
+            if (IsValidIndex(i))
             {
-                if ((_imageInfoCollection[_lastAccessedIndex] is not null) &&
-                    (WindowsFormsUtils.SafeCompareStrings(_imageInfoCollection[_lastAccessedIndex].Name, key, ignoreCase: true)))
+                if ((_imageInfoCollection[i] is not null) &&
+                    (WindowsFormsUtils.SafeCompareStrings(_imageInfoCollection[i].Name, key, ignoreCase: true)))
                 {
-                    return _lastAccessedIndex;
+                    return i;
                 }
             }
 
             // Search for the item
-            for (int i = 0; i < Count; i++)
+            for (i = 0; i < Count; i++)
             {
                 if ((_imageInfoCollection[i] is not null) &&
                         (WindowsFormsUtils.SafeCompareStrings(_imageInfoCollection[i].Name, key, ignoreCase: true)))


### PR DESCRIPTION
## Proposed changes

When multiple threads call `Images.IndexOfKey`, it is possible to get `System.ArgumentOutOfRangeException: 'Index was out of range. Must be non-negative and less than the size of the collection. (Parameter 'index')` exception when one of the calls returns -1.

Debugging this, the first `IsValidIndex` check passes, but the `_imageInfoCollection[]` accessor throws, which should not be possible, especially when the collection is not modified.

Another thing that could be optimized is removing the double list accessor by doing `_imageInfoCollection[i] is {} image`, so that next `SafeCompareStrings` call does not read from the list again.

## Regression? 

- No

## Risk

- None


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9986)