### PR TITLE
Add missing DataGridViewCellStyleBuilder.resx

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewCellStyleBuilder.resx
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewCellStyleBuilder.resx
@@ -1,0 +1,543 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="cellStyleProperties.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>None</value>
+  </data>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="cellStyleProperties.HelpVisible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="cellStyleProperties.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="cellStyleProperties.Size" type="System.Drawing.Size, System.Drawing">
+    <value>441, 326</value>
+  </data>
+  <data name="cellStyleProperties.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="sampleViewTableLayoutPanel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
+  </data>
+  <data name="sampleViewTableLayoutPanel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="sampleViewTableLayoutPanel.ColumnCount" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="sampleViewGridsTableLayoutPanel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left, Right</value>
+  </data>
+  <data name="sampleViewGridsTableLayoutPanel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="sampleViewGridsTableLayoutPanel.ColumnCount" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="normalLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="normalLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="normalLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>42, 0</value>
+  </data>
+  <data name="normalLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>39, 13</value>
+  </data>
+  <data name="normalLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="normalLabel.Text">
+    <value xml:space="preserve">Normal:</value>
+  </data>
+  <data name="&gt;&gt;normalLabel.Name">
+    <value xml:space="preserve">normalLabel</value>
+  </data>
+  <data name="&gt;&gt;normalLabel.Type">
+    <value xml:space="preserve">System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;normalLabel.Parent">
+    <value xml:space="preserve">sampleViewGridsTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;normalLabel.ZOrder">
+    <value xml:space="preserve">0</value>
+  </data>
+  <data name="sampleDataGridView.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="sampleDataGridView.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="sampleDataGridView.Location" type="System.Drawing.Point, System.Drawing">
+    <value>42, 13</value>
+  </data>
+  <data name="sampleDataGridView.ScrollBars" type="System.Windows.Forms.ScrollBars, System.Windows.Forms">
+    <value>None</value>
+  </data>
+  <data name="sampleDataGridView.Size" type="System.Drawing.Size, System.Drawing">
+    <value>10, 10</value>
+  </data>
+  <data name="sampleDataGridView.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;sampleDataGridView.Name">
+    <value xml:space="preserve">sampleDataGridView</value>
+  </data>
+  <data name="&gt;&gt;sampleDataGridView.Type">
+    <value xml:space="preserve">System.Windows.Forms.DataGridView, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;sampleDataGridView.Parent">
+    <value xml:space="preserve">sampleViewGridsTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;sampleDataGridView.ZOrder">
+    <value xml:space="preserve">1</value>
+  </data>
+  <data name="selectedLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="selectedLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="selectedLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>252, 0</value>
+  </data>
+  <data name="selectedLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>48, 13</value>
+  </data>
+  <data name="selectedLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="selectedLabel.Text">
+    <value xml:space="preserve">Selected:</value>
+  </data>
+  <data name="&gt;&gt;selectedLabel.Name">
+    <value xml:space="preserve">selectedLabel</value>
+  </data>
+  <data name="&gt;&gt;selectedLabel.Type">
+    <value xml:space="preserve">System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;selectedLabel.Parent">
+    <value xml:space="preserve">sampleViewGridsTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;selectedLabel.ZOrder">
+    <value xml:space="preserve">2</value>
+  </data>
+  <data name="sampleDataGridViewSelected.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="sampleDataGridViewSelected.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="sampleDataGridViewSelected.Location" type="System.Drawing.Point, System.Drawing">
+    <value>252, 13</value>
+  </data>
+  <data name="sampleDataGridViewSelected.ScrollBars" type="System.Windows.Forms.ScrollBars, System.Windows.Forms">
+    <value>None</value>
+  </data>
+  <data name="sampleDataGridViewSelected.Size" type="System.Drawing.Size, System.Drawing">
+    <value>10, 10</value>
+  </data>
+  <data name="sampleDataGridViewSelected.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;sampleDataGridViewSelected.Name">
+    <value xml:space="preserve">sampleDataGridViewSelected</value>
+  </data>
+  <data name="&gt;&gt;sampleDataGridViewSelected.Type">
+    <value xml:space="preserve">System.Windows.Forms.DataGridView, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;sampleDataGridViewSelected.Parent">
+    <value xml:space="preserve">sampleViewGridsTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;sampleDataGridViewSelected.ZOrder">
+    <value xml:space="preserve">3</value>
+  </data>
+  <data name="sampleViewGridsTableLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 20</value>
+  </data>
+  <data name="sampleViewGridsTableLayoutPanel.RowCount" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="sampleViewGridsTableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>423, 23</value>
+  </data>
+  <data name="sampleViewGridsTableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="&gt;&gt;sampleViewGridsTableLayoutPanel.Name">
+    <value xml:space="preserve">sampleViewGridsTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;sampleViewGridsTableLayoutPanel.Type">
+    <value xml:space="preserve">System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;sampleViewGridsTableLayoutPanel.Parent">
+    <value xml:space="preserve">sampleViewTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;sampleViewGridsTableLayoutPanel.ZOrder">
+    <value xml:space="preserve">0</value>
+  </data>
+  <data name="sampleViewGridsTableLayoutPanel.LayoutSettings">
+    <value xml:space="preserve">&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="normalLabel" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="sampleDataGridView" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="selectedLabel" Row="0" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;Control Name="sampleDataGridViewSelected" Row="1" RowSpan="1" Column="3" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,10,Percent,30,Percent,20,Percent,30,Percent,10" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
+  <data name="label1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="label1.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>364, 13</value>
+  </data>
+  <data name="label1.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="label1.Text">
+    <value xml:space="preserve">This preview shows properties from inherited CellStyles (Table, Column, Row)</value>
+  </data>
+  <data name="&gt;&gt;label1.Name">
+    <value xml:space="preserve">label1</value>
+  </data>
+  <data name="&gt;&gt;label1.Type">
+    <value xml:space="preserve">System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label1.Parent">
+    <value xml:space="preserve">sampleViewTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;label1.ZOrder">
+    <value xml:space="preserve">1</value>
+  </data>
+  <data name="sampleViewTableLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 19</value>
+  </data>
+  <data name="sampleViewTableLayoutPanel.RowCount" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="sampleViewTableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>423, 44</value>
+  </data>
+  <data name="sampleViewTableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;sampleViewTableLayoutPanel.Name">
+    <value xml:space="preserve">sampleViewTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;sampleViewTableLayoutPanel.Type">
+    <value xml:space="preserve">System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;sampleViewTableLayoutPanel.Parent">
+    <value xml:space="preserve">previewGroupBox</value>
+  </data>
+  <data name="&gt;&gt;sampleViewTableLayoutPanel.ZOrder">
+    <value xml:space="preserve">0</value>
+  </data>
+  <data name="sampleViewTableLayoutPanel.LayoutSettings">
+    <value xml:space="preserve">&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="sampleViewGridsTableLayoutPanel" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="label1" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Absolute,423" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
+  <data name="okButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left, Right</value>
+  </data>
+  <data name="okButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="okButton.FlatStyle" type="System.Windows.Forms.FlatStyle, System.Windows.Forms">
+    <value>System</value>
+  </data>
+  <data name="okButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="okButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="okButton.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="okButton.Text">
+    <value xml:space="preserve">OK</value>
+  </data>
+  <data name="&gt;&gt;okButton.Name">
+    <value xml:space="preserve">okButton</value>
+  </data>
+  <data name="&gt;&gt;okButton.Type">
+    <value xml:space="preserve">System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;okButton.Parent">
+    <value xml:space="preserve">okCancelTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;okButton.ZOrder">
+    <value xml:space="preserve">0</value>
+  </data>
+  <data name="cancelButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left, Right</value>
+  </data>
+  <data name="cancelButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cancelButton.FlatStyle" type="System.Windows.Forms.FlatStyle, System.Windows.Forms">
+    <value>System</value>
+  </data>
+  <data name="cancelButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>81, 0</value>
+  </data>
+  <data name="cancelButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="cancelButton.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="cancelButton.Text">
+    <value xml:space="preserve">Cancel</value>
+  </data>
+  <data name="&gt;&gt;cancelButton.Name">
+    <value xml:space="preserve">cancelButton</value>
+  </data>
+  <data name="&gt;&gt;cancelButton.Type">
+    <value xml:space="preserve">System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cancelButton.Parent">
+    <value xml:space="preserve">okCancelTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;cancelButton.ZOrder">
+    <value xml:space="preserve">1</value>
+  </data>
+  <data name="okCancelTableLayoutPanel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Right</value>
+  </data>
+  <data name="okCancelTableLayoutPanel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="okCancelTableLayoutPanel.ColumnCount" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="okCancelTableLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>285, 413</value>
+  </data>
+  <data name="okCancelTableLayoutPanel.RowCount" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="okCancelTableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>156, 23</value>
+  </data>
+  <data name="okCancelTableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;okCancelTableLayoutPanel.Name">
+    <value xml:space="preserve">okCancelTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;okCancelTableLayoutPanel.Type">
+    <value xml:space="preserve">System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;okCancelTableLayoutPanel.Parent">
+    <value xml:space="preserve">overarchingTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;okCancelTableLayoutPanel.ZOrder">
+    <value xml:space="preserve">1</value>
+  </data>
+  <data name="okCancelTableLayoutPanel.LayoutSettings">
+    <value xml:space="preserve">&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="okButton" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="cancelButton" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,50,Percent,50" /&gt;&lt;Rows Styles="AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
+  <data name="previewGroupBox.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left, Right</value>
+  </data>
+  <data name="previewGroupBox.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="previewGroupBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 332</value>
+  </data>
+  <data name="previewGroupBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>441, 75</value>
+  </data>
+  <data name="previewGroupBox.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="previewGroupBox.Text">
+    <value xml:space="preserve">Preview</value>
+  </data>
+  <data name="&gt;&gt;previewGroupBox.Name">
+    <value xml:space="preserve">previewGroupBox</value>
+  </data>
+  <data name="&gt;&gt;previewGroupBox.Type">
+    <value xml:space="preserve">System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;previewGroupBox.Parent">
+    <value xml:space="preserve">overarchingTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;previewGroupBox.ZOrder">
+    <value xml:space="preserve">2</value>
+  </data>
+  <data name="overarchingTableLayoutPanel.ColumnCount" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="overarchingTableLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 12</value>
+  </data>
+  <data name="overarchingTableLayoutPanel.RowCount" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="overarchingTableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>441, 436</value>
+  </data>
+  <data name="overarchingTableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;overarchingTableLayoutPanel.Name">
+    <value xml:space="preserve">overarchingTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;overarchingTableLayoutPanel.Type">
+    <value xml:space="preserve">System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;overarchingTableLayoutPanel.Parent">
+    <value xml:space="preserve">$this</value>
+  </data>
+  <data name="&gt;&gt;overarchingTableLayoutPanel.ZOrder">
+    <value xml:space="preserve">0</value>
+  </data>
+  <data name="overarchingTableLayoutPanel.LayoutSettings">
+    <value xml:space="preserve">&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="cellStyleProperties" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="okCancelTableLayoutPanel" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="previewGroupBox" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0" /&gt;&lt;Rows Styles="Percent,100,AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="$this.AutoScaleBaseSize" type="System.Drawing.Size, System.Drawing">
+    <value>5, 13</value>
+  </data>
+  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
+    <value>465, 460</value>
+  </data>
+  <data name="$this.MinimumSize" type="System.Drawing.Size, System.Drawing">
+    <value>471, 492</value>
+  </data>
+  <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
+    <value>CenterScreen</value>
+  </data>
+  <data name="$this.Text">
+    <value xml:space="preserve">CellStyle Builder</value>
+  </data>
+  <data name="&gt;&gt;$this.Name">
+    <value xml:space="preserve">DataGridViewCellStyleBuilder</value>
+  </data>
+  <data name="&gt;&gt;$this.Type">
+    <value xml:space="preserve">System.Windows.Forms.Form, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+</root>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/xlf/DataGridViewCellStyleBuilder.cs.xlf
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/xlf/DataGridViewCellStyleBuilder.cs.xlf
@@ -1,0 +1,42 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="cs" original="../DataGridViewCellStyleBuilder.resx">
+    <body>
+      <trans-unit id="$this.Text">
+        <source>CellStyle Builder</source>
+        <target state="new">CellStyle Builder</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cancelButton.Text">
+        <source>Cancel</source>
+        <target state="new">Cancel</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="label1.Text">
+        <source>This preview shows properties from inherited CellStyles (Table, Column, Row)</source>
+        <target state="new">This preview shows properties from inherited CellStyles (Table, Column, Row)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="normalLabel.Text">
+        <source>Normal:</source>
+        <target state="new">Normal:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="okButton.Text">
+        <source>OK</source>
+        <target state="new">OK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="previewGroupBox.Text">
+        <source>Preview</source>
+        <target state="new">Preview</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="selectedLabel.Text">
+        <source>Selected:</source>
+        <target state="new">Selected:</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/xlf/DataGridViewCellStyleBuilder.de.xlf
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/xlf/DataGridViewCellStyleBuilder.de.xlf
@@ -1,0 +1,42 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="de" original="../DataGridViewCellStyleBuilder.resx">
+    <body>
+      <trans-unit id="$this.Text">
+        <source>CellStyle Builder</source>
+        <target state="new">CellStyle Builder</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cancelButton.Text">
+        <source>Cancel</source>
+        <target state="new">Cancel</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="label1.Text">
+        <source>This preview shows properties from inherited CellStyles (Table, Column, Row)</source>
+        <target state="new">This preview shows properties from inherited CellStyles (Table, Column, Row)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="normalLabel.Text">
+        <source>Normal:</source>
+        <target state="new">Normal:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="okButton.Text">
+        <source>OK</source>
+        <target state="new">OK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="previewGroupBox.Text">
+        <source>Preview</source>
+        <target state="new">Preview</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="selectedLabel.Text">
+        <source>Selected:</source>
+        <target state="new">Selected:</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/xlf/DataGridViewCellStyleBuilder.es.xlf
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/xlf/DataGridViewCellStyleBuilder.es.xlf
@@ -1,0 +1,42 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="es" original="../DataGridViewCellStyleBuilder.resx">
+    <body>
+      <trans-unit id="$this.Text">
+        <source>CellStyle Builder</source>
+        <target state="new">CellStyle Builder</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cancelButton.Text">
+        <source>Cancel</source>
+        <target state="new">Cancel</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="label1.Text">
+        <source>This preview shows properties from inherited CellStyles (Table, Column, Row)</source>
+        <target state="new">This preview shows properties from inherited CellStyles (Table, Column, Row)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="normalLabel.Text">
+        <source>Normal:</source>
+        <target state="new">Normal:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="okButton.Text">
+        <source>OK</source>
+        <target state="new">OK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="previewGroupBox.Text">
+        <source>Preview</source>
+        <target state="new">Preview</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="selectedLabel.Text">
+        <source>Selected:</source>
+        <target state="new">Selected:</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/xlf/DataGridViewCellStyleBuilder.fr.xlf
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/xlf/DataGridViewCellStyleBuilder.fr.xlf
@@ -1,0 +1,42 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="fr" original="../DataGridViewCellStyleBuilder.resx">
+    <body>
+      <trans-unit id="$this.Text">
+        <source>CellStyle Builder</source>
+        <target state="new">CellStyle Builder</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cancelButton.Text">
+        <source>Cancel</source>
+        <target state="new">Cancel</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="label1.Text">
+        <source>This preview shows properties from inherited CellStyles (Table, Column, Row)</source>
+        <target state="new">This preview shows properties from inherited CellStyles (Table, Column, Row)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="normalLabel.Text">
+        <source>Normal:</source>
+        <target state="new">Normal:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="okButton.Text">
+        <source>OK</source>
+        <target state="new">OK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="previewGroupBox.Text">
+        <source>Preview</source>
+        <target state="new">Preview</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="selectedLabel.Text">
+        <source>Selected:</source>
+        <target state="new">Selected:</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/xlf/DataGridViewCellStyleBuilder.it.xlf
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/xlf/DataGridViewCellStyleBuilder.it.xlf
@@ -1,0 +1,42 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="it" original="../DataGridViewCellStyleBuilder.resx">
+    <body>
+      <trans-unit id="$this.Text">
+        <source>CellStyle Builder</source>
+        <target state="new">CellStyle Builder</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cancelButton.Text">
+        <source>Cancel</source>
+        <target state="new">Cancel</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="label1.Text">
+        <source>This preview shows properties from inherited CellStyles (Table, Column, Row)</source>
+        <target state="new">This preview shows properties from inherited CellStyles (Table, Column, Row)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="normalLabel.Text">
+        <source>Normal:</source>
+        <target state="new">Normal:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="okButton.Text">
+        <source>OK</source>
+        <target state="new">OK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="previewGroupBox.Text">
+        <source>Preview</source>
+        <target state="new">Preview</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="selectedLabel.Text">
+        <source>Selected:</source>
+        <target state="new">Selected:</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/xlf/DataGridViewCellStyleBuilder.ja.xlf
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/xlf/DataGridViewCellStyleBuilder.ja.xlf
@@ -1,0 +1,42 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ja" original="../DataGridViewCellStyleBuilder.resx">
+    <body>
+      <trans-unit id="$this.Text">
+        <source>CellStyle Builder</source>
+        <target state="new">CellStyle Builder</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cancelButton.Text">
+        <source>Cancel</source>
+        <target state="new">Cancel</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="label1.Text">
+        <source>This preview shows properties from inherited CellStyles (Table, Column, Row)</source>
+        <target state="new">This preview shows properties from inherited CellStyles (Table, Column, Row)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="normalLabel.Text">
+        <source>Normal:</source>
+        <target state="new">Normal:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="okButton.Text">
+        <source>OK</source>
+        <target state="new">OK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="previewGroupBox.Text">
+        <source>Preview</source>
+        <target state="new">Preview</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="selectedLabel.Text">
+        <source>Selected:</source>
+        <target state="new">Selected:</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/xlf/DataGridViewCellStyleBuilder.ko.xlf
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/xlf/DataGridViewCellStyleBuilder.ko.xlf
@@ -1,0 +1,42 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ko" original="../DataGridViewCellStyleBuilder.resx">
+    <body>
+      <trans-unit id="$this.Text">
+        <source>CellStyle Builder</source>
+        <target state="new">CellStyle Builder</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cancelButton.Text">
+        <source>Cancel</source>
+        <target state="new">Cancel</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="label1.Text">
+        <source>This preview shows properties from inherited CellStyles (Table, Column, Row)</source>
+        <target state="new">This preview shows properties from inherited CellStyles (Table, Column, Row)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="normalLabel.Text">
+        <source>Normal:</source>
+        <target state="new">Normal:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="okButton.Text">
+        <source>OK</source>
+        <target state="new">OK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="previewGroupBox.Text">
+        <source>Preview</source>
+        <target state="new">Preview</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="selectedLabel.Text">
+        <source>Selected:</source>
+        <target state="new">Selected:</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/xlf/DataGridViewCellStyleBuilder.pl.xlf
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/xlf/DataGridViewCellStyleBuilder.pl.xlf
@@ -1,0 +1,42 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pl" original="../DataGridViewCellStyleBuilder.resx">
+    <body>
+      <trans-unit id="$this.Text">
+        <source>CellStyle Builder</source>
+        <target state="new">CellStyle Builder</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cancelButton.Text">
+        <source>Cancel</source>
+        <target state="new">Cancel</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="label1.Text">
+        <source>This preview shows properties from inherited CellStyles (Table, Column, Row)</source>
+        <target state="new">This preview shows properties from inherited CellStyles (Table, Column, Row)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="normalLabel.Text">
+        <source>Normal:</source>
+        <target state="new">Normal:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="okButton.Text">
+        <source>OK</source>
+        <target state="new">OK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="previewGroupBox.Text">
+        <source>Preview</source>
+        <target state="new">Preview</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="selectedLabel.Text">
+        <source>Selected:</source>
+        <target state="new">Selected:</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/xlf/DataGridViewCellStyleBuilder.pt-BR.xlf
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/xlf/DataGridViewCellStyleBuilder.pt-BR.xlf
@@ -1,0 +1,42 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pt-BR" original="../DataGridViewCellStyleBuilder.resx">
+    <body>
+      <trans-unit id="$this.Text">
+        <source>CellStyle Builder</source>
+        <target state="new">CellStyle Builder</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cancelButton.Text">
+        <source>Cancel</source>
+        <target state="new">Cancel</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="label1.Text">
+        <source>This preview shows properties from inherited CellStyles (Table, Column, Row)</source>
+        <target state="new">This preview shows properties from inherited CellStyles (Table, Column, Row)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="normalLabel.Text">
+        <source>Normal:</source>
+        <target state="new">Normal:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="okButton.Text">
+        <source>OK</source>
+        <target state="new">OK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="previewGroupBox.Text">
+        <source>Preview</source>
+        <target state="new">Preview</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="selectedLabel.Text">
+        <source>Selected:</source>
+        <target state="new">Selected:</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/xlf/DataGridViewCellStyleBuilder.ru.xlf
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/xlf/DataGridViewCellStyleBuilder.ru.xlf
@@ -1,0 +1,42 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ru" original="../DataGridViewCellStyleBuilder.resx">
+    <body>
+      <trans-unit id="$this.Text">
+        <source>CellStyle Builder</source>
+        <target state="new">CellStyle Builder</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cancelButton.Text">
+        <source>Cancel</source>
+        <target state="new">Cancel</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="label1.Text">
+        <source>This preview shows properties from inherited CellStyles (Table, Column, Row)</source>
+        <target state="new">This preview shows properties from inherited CellStyles (Table, Column, Row)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="normalLabel.Text">
+        <source>Normal:</source>
+        <target state="new">Normal:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="okButton.Text">
+        <source>OK</source>
+        <target state="new">OK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="previewGroupBox.Text">
+        <source>Preview</source>
+        <target state="new">Preview</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="selectedLabel.Text">
+        <source>Selected:</source>
+        <target state="new">Selected:</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/xlf/DataGridViewCellStyleBuilder.tr.xlf
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/xlf/DataGridViewCellStyleBuilder.tr.xlf
@@ -1,0 +1,42 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="tr" original="../DataGridViewCellStyleBuilder.resx">
+    <body>
+      <trans-unit id="$this.Text">
+        <source>CellStyle Builder</source>
+        <target state="new">CellStyle Builder</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cancelButton.Text">
+        <source>Cancel</source>
+        <target state="new">Cancel</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="label1.Text">
+        <source>This preview shows properties from inherited CellStyles (Table, Column, Row)</source>
+        <target state="new">This preview shows properties from inherited CellStyles (Table, Column, Row)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="normalLabel.Text">
+        <source>Normal:</source>
+        <target state="new">Normal:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="okButton.Text">
+        <source>OK</source>
+        <target state="new">OK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="previewGroupBox.Text">
+        <source>Preview</source>
+        <target state="new">Preview</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="selectedLabel.Text">
+        <source>Selected:</source>
+        <target state="new">Selected:</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/xlf/DataGridViewCellStyleBuilder.zh-Hans.xlf
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/xlf/DataGridViewCellStyleBuilder.zh-Hans.xlf
@@ -1,0 +1,42 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hans" original="../DataGridViewCellStyleBuilder.resx">
+    <body>
+      <trans-unit id="$this.Text">
+        <source>CellStyle Builder</source>
+        <target state="new">CellStyle Builder</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cancelButton.Text">
+        <source>Cancel</source>
+        <target state="new">Cancel</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="label1.Text">
+        <source>This preview shows properties from inherited CellStyles (Table, Column, Row)</source>
+        <target state="new">This preview shows properties from inherited CellStyles (Table, Column, Row)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="normalLabel.Text">
+        <source>Normal:</source>
+        <target state="new">Normal:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="okButton.Text">
+        <source>OK</source>
+        <target state="new">OK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="previewGroupBox.Text">
+        <source>Preview</source>
+        <target state="new">Preview</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="selectedLabel.Text">
+        <source>Selected:</source>
+        <target state="new">Selected:</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/xlf/DataGridViewCellStyleBuilder.zh-Hant.xlf
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/xlf/DataGridViewCellStyleBuilder.zh-Hant.xlf
@@ -1,0 +1,42 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hant" original="../DataGridViewCellStyleBuilder.resx">
+    <body>
+      <trans-unit id="$this.Text">
+        <source>CellStyle Builder</source>
+        <target state="new">CellStyle Builder</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cancelButton.Text">
+        <source>Cancel</source>
+        <target state="new">Cancel</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="label1.Text">
+        <source>This preview shows properties from inherited CellStyles (Table, Column, Row)</source>
+        <target state="new">This preview shows properties from inherited CellStyles (Table, Column, Row)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="normalLabel.Text">
+        <source>Normal:</source>
+        <target state="new">Normal:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="okButton.Text">
+        <source>OK</source>
+        <target state="new">OK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="previewGroupBox.Text">
+        <source>Preview</source>
+        <target state="new">Preview</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="selectedLabel.Text">
+        <source>Selected:</source>
+        <target state="new">Selected:</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/EmbeddedResourceTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/EmbeddedResourceTests.cs
@@ -114,6 +114,7 @@ public class EmbeddedResourceTests
             System.Windows.Forms.Design.BorderSidesEditor.resources
             System.Windows.Forms.Design.colordlg.data
             System.Windows.Forms.Design.DataGridViewAddColumnDialog.resources
+            System.Windows.Forms.Design.DataGridViewCellStyleBuilder.resources
             System.Windows.Forms.Design.DataGridViewColumnCollectionDialog.resources
             System.Windows.Forms.Design.FormatControl.resources
             System.Windows.Forms.Design.LinkAreaEditor.resources


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #3047


## Proposed changes

- Add missing file DataGridViewCellStyleBuilder.resx

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

-  The cell style properties can be updated normally

## Regression? 

-  No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
When edit the cell style properties for a DataGridView control in PropertyGrid, an error dialog pop-up.
![image](https://github.com/dotnet/winforms/assets/132890443/a16dc244-a489-4c8b-be2b-9f9843a28a74)

### After
The CellStyle Builder dialog can be opened.
![image](https://github.com/dotnet/winforms/assets/132890443/00544ad0-7cb6-4052-bd47-0203d669463d)

## Test methodology <!-- How did you ensure quality? -->

- Manually (Add test to Dome project)


## Test environment(s) <!-- Remove any that don't apply -->

- .net 9.0.0-alpha.1.23470.17


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9990)