### PR TITLE
Enhance nullable annotations in DataGridViewColumnCollectionDialog and replace Hashtables

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewColumnCollectionDialog.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewColumnCollectionDialog.cs
@@ -10,29 +10,29 @@ namespace System.Windows.Forms.Design;
 
 internal class DataGridViewColumnCollectionDialog : Form
 {
-    private Label? _selectedColumnsLabel;
+    private Label _selectedColumnsLabel;
 
-    private ListBox? _selectedColumns;
-    private Button? _moveUp;
-    private Button? _moveDown;
-    private Button? _deleteButton;
-    private Button? _addButton;
+    private ListBox _selectedColumns;
+    private Button _moveUp;
+    private Button _moveDown;
+    private Button _deleteButton;
+    private Button _addButton;
 
-    private Label? _propertyGridLabel;
+    private Label _propertyGridLabel;
 
-    private PropertyGrid? _propertyGrid1;
-    private TableLayoutPanel? _okCancelTableLayoutPanel;
+    private PropertyGrid _propertyGrid1;
+    private TableLayoutPanel _okCancelTableLayoutPanel;
 
-    private Button? _okButton;
+    private Button _okButton;
 
-    private Button? _cancelButton;
+    private Button _cancelButton;
 
     private DataGridView? _liveDataGridView;
 
     private IComponentChangeService? _compChangeService;
 
-    private DataGridView _dataGridViewPrivateCopy;
-    private DataGridViewColumnCollection _columnsPrivateCopy;
+    private readonly DataGridView _dataGridViewPrivateCopy;
+    private readonly DataGridViewColumnCollection _columnsPrivateCopy;
     private Hashtable? _columnsNames;
     private DataGridViewAddColumnDialog? _addColumnDialog;
 
@@ -55,7 +55,7 @@ internal class DataGridViewColumnCollectionDialog : Form
     private TableLayoutPanel? _addRemoveTableLayoutPanel;
     private Hashtable? _userAddedColumns;
 
-    private IServiceProvider _serviceProvider;
+    private readonly IServiceProvider _serviceProvider;
 
     internal DataGridViewColumnCollectionDialog(IServiceProvider provider)
     {
@@ -66,7 +66,7 @@ internal class DataGridViewColumnCollectionDialog : Form
         //
         InitializeComponent();
 
-        if (DpiHelper.IsScalingRequired && _moveUp is not null && _moveDown is not null)
+        if (DpiHelper.IsScalingRequired)
         {
             _moveUp.Image = DpiHelper.ScaleButtonImageLogicalToDevice(_moveUp.Image);
             _moveDown.Image = DpiHelper.ScaleButtonImageLogicalToDevice(_moveDown.Image);
@@ -100,11 +100,11 @@ internal class DataGridViewColumnCollectionDialog : Form
 
         PopulateSelectedColumns();
 
-        if (e.Action == CollectionChangeAction.Add && _selectedColumns is not null)
+        if (e.Action == CollectionChangeAction.Add)
         {
             _selectedColumns.SelectedIndex = _columnsPrivateCopy.IndexOf(e.Element as DataGridViewColumn);
-            ListBoxItem? lbi = _selectedColumns.SelectedItem as ListBoxItem;
-            _userAddedColumns![lbi!.DataGridViewColumn] = true;
+            ListBoxItem lbi = (ListBoxItem)_selectedColumns.SelectedItem!;
+            _userAddedColumns![lbi.DataGridViewColumn] = true;
             _columnsNames![lbi.DataGridViewColumn] = lbi.DataGridViewColumn.Name;
         }
 
@@ -116,15 +116,15 @@ internal class DataGridViewColumnCollectionDialog : Form
     {
         DataGridViewColumn currentColumn = item.DataGridViewColumn;
         Debug.Assert(typeof(DataGridViewColumn).IsAssignableFrom(newType), "we should only have types that can be assigned to a DataGridViewColumn");
-        Debug.Assert(_selectedColumns?.SelectedItem == item, "we must have lost track of what item is in the property grid");
+        Debug.Assert(_selectedColumns.SelectedItem == item, "we must have lost track of what item is in the property grid");
 
-        DataGridViewColumn? newColumn = System.Activator.CreateInstance(newType) as DataGridViewColumn;
+        DataGridViewColumn newColumn = (DataGridViewColumn)Activator.CreateInstance(newType)!;
 
         ITypeResolutionService? tr = _liveDataGridView?.Site?.GetService(_iTypeResolutionServiceType) as ITypeResolutionService;
         ComponentDesigner newColumnDesigner = DataGridViewAddColumnDialog.GetComponentDesignerForType(tr, newType)!;
 
-        CopyDataGridViewColumnProperties(currentColumn /*srcColumn*/, newColumn! /*destColumn*/);
-        CopyDataGridViewColumnState(currentColumn /*srcColumn*/, newColumn! /*destColumn*/);
+        CopyDataGridViewColumnProperties(currentColumn /*srcColumn*/, newColumn /*destColumn*/);
+        CopyDataGridViewColumnState(currentColumn /*srcColumn*/, newColumn /*destColumn*/);
 
         _columnCollectionChanging = true;
         int selectedIndex = _selectedColumns.SelectedIndex;
@@ -162,7 +162,7 @@ internal class DataGridViewColumnCollectionDialog : Form
 
             _columnsPrivateCopy.RemoveAt(selectedIndex);
             // wipe out the display index
-            newColumn!.DisplayIndex = -1;
+            newColumn.DisplayIndex = -1;
             _columnsPrivateCopy.Insert(selectedIndex, newColumn);
 
             if (!string.IsNullOrEmpty(columnSiteName))
@@ -176,7 +176,7 @@ internal class DataGridViewColumnCollectionDialog : Form
             FixColumnCollectionDisplayIndices();
 
             _selectedColumns.SelectedIndex = selectedIndex;
-            _propertyGrid1!.SelectedObject = _selectedColumns.SelectedItem;
+            _propertyGrid1.SelectedObject = _selectedColumns.SelectedItem;
         }
         finally
         {
@@ -194,9 +194,9 @@ internal class DataGridViewColumnCollectionDialog : Form
 
         try
         {
-            IComponentChangeService? changeService = _liveDataGridView?.Site?.GetService(_iComponentChangeServiceType) as IComponentChangeService;
-            PropertyDescriptor? prop = TypeDescriptor.GetProperties(_liveDataGridView!)["Columns"];
-            IContainer? currentContainer = _liveDataGridView?.Site is not null ? _liveDataGridView.Site.Container : null;
+            IComponentChangeService? changeService = _liveDataGridView!.Site?.GetService(_iComponentChangeServiceType) as IComponentChangeService;
+            PropertyDescriptor? prop = TypeDescriptor.GetProperties(_liveDataGridView)["Columns"];
+            IContainer? currentContainer = _liveDataGridView.Site?.Container;
 
             // Here is the order in which we should do the ComponentChanging/ComponentChanged
             // Container.RemoveComponent, Container.AddComponent
@@ -210,7 +210,7 @@ internal class DataGridViewColumnCollectionDialog : Form
             // 7. DataGridView.Columns.Add( new DataGridViewColumns)
             // 8. OnComponentChanged DataGridView.Columns
 
-            DataGridViewColumn[] oldColumns = new DataGridViewColumn[_liveDataGridView!.Columns.Count];
+            DataGridViewColumn[] oldColumns = new DataGridViewColumn[_liveDataGridView.Columns.Count];
             _liveDataGridView.Columns.CopyTo(oldColumns, 0);
 
             // 1. OnComponentChanging DataGridView.Columns
@@ -234,7 +234,7 @@ internal class DataGridViewColumnCollectionDialog : Form
             DataGridViewColumn[] newColumns = new DataGridViewColumn[_columnsPrivateCopy.Count];
             bool[] userAddedColumnsInfo = new bool[_columnsPrivateCopy.Count];
             string[] compNames = new string[_columnsPrivateCopy.Count];
-            for (int i = 0; i < _columnsPrivateCopy!.Count; i++)
+            for (int i = 0; i < _columnsPrivateCopy.Count; i++)
             {
                 DataGridViewColumn newColumn = (DataGridViewColumn)_columnsPrivateCopy[i].Clone();
                 // at design time we need to do a shallow copy for ContextMenuStrip property
@@ -247,7 +247,7 @@ internal class DataGridViewColumnCollectionDialog : Form
                     userAddedColumnsInfo[i] = boolValue;
                 }
 
-                if (_columnsNames is not null && _columnsPrivateCopy is not null)
+                if (_columnsNames is not null)
                 {
 #pragma warning disable CS8601 // Possible null reference assignment.
                     compNames[i] = _columnsNames[_columnsPrivateCopy[i]] as string;
@@ -302,7 +302,7 @@ internal class DataGridViewColumnCollectionDialog : Form
 
     private void componentChanged(object? sender, ComponentChangedEventArgs e)
     {
-        if (e.Component is ListBoxItem && _selectedColumns!.Items.Contains(e.Component))
+        if (e.Component is ListBoxItem && _selectedColumns.Items.Contains(e.Component))
         {
             _formIsDirty = true;
         }
@@ -470,6 +470,19 @@ internal class DataGridViewColumnCollectionDialog : Form
     ///  Required method for Designer support - do not modify
     ///  the contents of this method with the code editor.
     /// </summary>
+    [MemberNotNull(nameof(_addButton))]
+    [MemberNotNull(nameof(_deleteButton))]
+    [MemberNotNull(nameof(_moveDown))]
+    [MemberNotNull(nameof(_moveUp))]
+    [MemberNotNull(nameof(_selectedColumns))]
+    [MemberNotNull(nameof(_overarchingTableLayoutPanel))]
+    [MemberNotNull(nameof(_addRemoveTableLayoutPanel))]
+    [MemberNotNull(nameof(_selectedColumnsLabel))]
+    [MemberNotNull(nameof(_propertyGridLabel))]
+    [MemberNotNull(nameof(_propertyGrid1))]
+    [MemberNotNull(nameof(_okCancelTableLayoutPanel))]
+    [MemberNotNull(nameof(_cancelButton))]
+    [MemberNotNull(nameof(_okButton))]
     private void InitializeComponent()
     {
         ComponentResourceManager resources = new ComponentResourceManager(typeof(DataGridViewColumnCollectionDialog));
@@ -647,7 +660,7 @@ internal class DataGridViewColumnCollectionDialog : Form
     {
         PropertyDescriptor? propertyDescriptor = TypeDescriptor.GetProperties(col)["UserAddedColumn"];
         object? val = propertyDescriptor?.GetValue(col);
-        if (propertyDescriptor is not null && val is not null)
+        if (val is not null)
         {
             return (bool)val;
         }
@@ -664,21 +677,21 @@ internal class DataGridViewColumnCollectionDialog : Form
 
     private void moveDown_Click(object? sender, EventArgs e)
     {
-        int selectedIndex = _selectedColumns!.SelectedIndex;
+        int selectedIndex = _selectedColumns.SelectedIndex;
         Debug.Assert(selectedIndex > -1 && selectedIndex < _selectedColumns.Items.Count - 1);
 
         _columnCollectionChanging = true;
         try
         {
-            ListBoxItem? item = _selectedColumns.SelectedItem as ListBoxItem;
+            ListBoxItem? item = (ListBoxItem)_selectedColumns.SelectedItem!;
             _selectedColumns.Items.RemoveAt(selectedIndex);
-            _selectedColumns.Items.Insert(selectedIndex + 1, item!);
+            _selectedColumns.Items.Insert(selectedIndex + 1, item);
 
             // now do the same thing to the column collection
             _columnsPrivateCopy.RemoveAt(selectedIndex);
 
             // if the column we moved was frozen, make sure the column below is frozen too
-            if (item!.DataGridViewColumn.Frozen)
+            if (item.DataGridViewColumn.Frozen)
             {
                 _columnsPrivateCopy[selectedIndex].Frozen = true;
 #if DEBUG
@@ -704,13 +717,13 @@ internal class DataGridViewColumnCollectionDialog : Form
 
         _formIsDirty = true;
         _selectedColumns.SelectedIndex = selectedIndex + 1;
-        _moveUp!.Enabled = _selectedColumns.SelectedIndex > 0;
-        _moveDown!.Enabled = _selectedColumns.SelectedIndex < _selectedColumns.Items.Count - 1;
+        _moveUp.Enabled = _selectedColumns.SelectedIndex > 0;
+        _moveDown.Enabled = _selectedColumns.SelectedIndex < _selectedColumns.Items.Count - 1;
     }
 
     private void moveUp_Click(object? sender, EventArgs e)
     {
-        int selectedIndex = _selectedColumns!.SelectedIndex;
+        int selectedIndex = _selectedColumns.SelectedIndex;
         Debug.Assert(selectedIndex > 0);
 
         _columnCollectionChanging = true;
@@ -748,8 +761,8 @@ internal class DataGridViewColumnCollectionDialog : Form
 
         _formIsDirty = true;
         _selectedColumns.SelectedIndex = selectedIndex - 1;
-        _moveUp!.Enabled = _selectedColumns.SelectedIndex > 0;
-        _moveDown!.Enabled = _selectedColumns.SelectedIndex < _selectedColumns.Items.Count - 1;
+        _moveUp.Enabled = _selectedColumns.SelectedIndex > 0;
+        _moveDown.Enabled = _selectedColumns.SelectedIndex < _selectedColumns.Items.Count - 1;
 
         // vsw 495403: keep the selected item visible.
         // For some reason, we only have to do this when we move a column up.
@@ -763,7 +776,7 @@ internal class DataGridViewColumnCollectionDialog : Form
     private void DataGridViewColumnCollectionDialog_Closed(object? sender, System.EventArgs e)
     {
         // scrub the TypeDescriptor association between DataGridViewColumns and their designers
-        for (int i = 0; i < _selectedColumns!.Items.Count; i++)
+        for (int i = 0; i < _selectedColumns.Items.Count; i++)
         {
             ListBoxItem? lbi = _selectedColumns.Items[i] as ListBoxItem;
             if (lbi?.DataGridViewColumnDesigner is not null)
@@ -809,12 +822,12 @@ internal class DataGridViewColumnCollectionDialog : Form
         Font = uiFont;
 
         // keep the selected index to 0 or -1 if there are no selected columns
-        _selectedColumns!.SelectedIndex = Math.Min(0, _selectedColumns.Items.Count - 1);
+        _selectedColumns.SelectedIndex = Math.Min(0, _selectedColumns.Items.Count - 1);
 
-        _moveUp!.Enabled = _selectedColumns.SelectedIndex > 0;
-        _moveDown!.Enabled = _selectedColumns.SelectedIndex < _selectedColumns.Items.Count - 1;
-        _deleteButton!.Enabled = _selectedColumns.Items.Count > 0 && _selectedColumns.SelectedIndex != -1;
-        _propertyGrid1!.SelectedObject = _selectedColumns.SelectedItem;
+        _moveUp.Enabled = _selectedColumns.SelectedIndex > 0;
+        _moveDown.Enabled = _selectedColumns.SelectedIndex < _selectedColumns.Items.Count - 1;
+        _deleteButton.Enabled = _selectedColumns.Items.Count > 0 && _selectedColumns.SelectedIndex != -1;
+        _propertyGrid1.SelectedObject = _selectedColumns.SelectedItem;
 
         _selectedColumns.ItemHeight = Font.Height + _OWNERDRAWVERTICALBUFFER;
 
@@ -829,7 +842,7 @@ internal class DataGridViewColumnCollectionDialog : Form
 
     private void deleteButton_Click(object? sender, EventArgs e)
     {
-        Debug.Assert(_selectedColumns!.SelectedIndex != -1);
+        Debug.Assert(_selectedColumns.SelectedIndex != -1);
         int selectedIndex = _selectedColumns.SelectedIndex;
 
         _columnsNames?.Remove(_columnsPrivateCopy[selectedIndex]);
@@ -840,15 +853,15 @@ internal class DataGridViewColumnCollectionDialog : Form
         // try to keep the same selected index
         _selectedColumns.SelectedIndex = Math.Min(_selectedColumns.Items.Count - 1, selectedIndex);
 
-        _moveUp!.Enabled = _selectedColumns.SelectedIndex > 0;
-        _moveDown!.Enabled = _selectedColumns.SelectedIndex < _selectedColumns.Items.Count - 1;
-        _deleteButton!.Enabled = _selectedColumns.Items.Count > 0 && _selectedColumns.SelectedIndex != -1;
-        _propertyGrid1!.SelectedObject = _selectedColumns.SelectedItem;
+        _moveUp.Enabled = _selectedColumns.SelectedIndex > 0;
+        _moveDown.Enabled = _selectedColumns.SelectedIndex < _selectedColumns.Items.Count - 1;
+        _deleteButton.Enabled = _selectedColumns.Items.Count > 0 && _selectedColumns.SelectedIndex != -1;
+        _propertyGrid1.SelectedObject = _selectedColumns.SelectedItem;
     }
 
     private void addButton_Click(object? sender, EventArgs e)
     {
-        int insertIndex = _selectedColumns!.SelectedIndex == -1 ? _selectedColumns.Items.Count : _selectedColumns.SelectedIndex + 1;
+        int insertIndex = _selectedColumns.SelectedIndex == -1 ? _selectedColumns.Items.Count : _selectedColumns.SelectedIndex + 1;
 
         if (_addColumnDialog is null)
         {
@@ -864,34 +877,34 @@ internal class DataGridViewColumnCollectionDialog : Form
 
     private void PopulateSelectedColumns()
     {
-        int selectedIndex = _selectedColumns!.SelectedIndex;
+        int selectedIndex = _selectedColumns.SelectedIndex;
 
         // scrub the TypeDescriptor association between DataGridViewColumns and their designers
-        for (int i = 0; i < _selectedColumns?.Items.Count; i++)
+        for (int i = 0; i < _selectedColumns.Items.Count; i++)
         {
-            ListBoxItem? lbi = _selectedColumns?.Items[i] as ListBoxItem;
+            ListBoxItem? lbi = _selectedColumns.Items[i] as ListBoxItem;
             if (lbi?.DataGridViewColumnDesigner is not null)
             {
                 TypeDescriptor.RemoveAssociation(lbi.DataGridViewColumn, lbi.DataGridViewColumnDesigner);
             }
         }
 
-        _selectedColumns?.Items.Clear();
+        _selectedColumns.Items.Clear();
         ITypeResolutionService? tr = _liveDataGridView?.Site?.GetService(_iTypeResolutionServiceType) as ITypeResolutionService;
 
         for (int i = 0; i < _columnsPrivateCopy.Count; i++)
         {
             ComponentDesigner columnDesigner = DataGridViewAddColumnDialog.GetComponentDesignerForType(tr, _columnsPrivateCopy[i].GetType())!;
-            _selectedColumns?.Items.Add(new ListBoxItem(_columnsPrivateCopy[i], this, columnDesigner));
+            _selectedColumns.Items.Add(new ListBoxItem(_columnsPrivateCopy[i], this, columnDesigner));
         }
 
-        _selectedColumns!.SelectedIndex = Math.Min(selectedIndex, _selectedColumns.Items.Count - 1);
+        _selectedColumns.SelectedIndex = Math.Min(selectedIndex, _selectedColumns.Items.Count - 1);
 
         SetSelectedColumnsHorizontalExtent();
 
         if (_selectedColumns.Items.Count == 0)
         {
-            _propertyGridLabel!.Text = string.Format(SR.DataGridViewProperties);
+            _propertyGridLabel.Text = string.Format(SR.DataGridViewProperties);
         }
     }
 
@@ -907,7 +920,7 @@ internal class DataGridViewColumnCollectionDialog : Form
         if (e.ChangedItem!.PropertyDescriptor!.Name.Equals("HeaderText"))
         {
             // invalidate the selected index only
-            int selectedIndex = _selectedColumns!.SelectedIndex;
+            int selectedIndex = _selectedColumns.SelectedIndex;
             Debug.Assert(selectedIndex != -1, "we forgot to take away the selected object from the property grid");
             Rectangle bounds = new Rectangle(0, selectedIndex * _selectedColumns.ItemHeight, _selectedColumns.Width, _selectedColumns.ItemHeight);
             _columnCollectionChanging = true;
@@ -928,21 +941,21 @@ internal class DataGridViewColumnCollectionDialog : Form
         }
         else if (e.ChangedItem.PropertyDescriptor.Name.Equals("DataPropertyName"))
         {
-            ListBoxItem? listBoxItem = _selectedColumns?.SelectedItem as ListBoxItem;
+            ListBoxItem? listBoxItem = _selectedColumns.SelectedItem as ListBoxItem;
             DataGridViewColumn? column = listBoxItem?.DataGridViewColumn;
 
             if (string.IsNullOrEmpty(column?.DataPropertyName))
             {
-                _propertyGridLabel!.Text = (SR.DataGridViewUnboundColumnProperties);
+                _propertyGridLabel.Text = (SR.DataGridViewUnboundColumnProperties);
             }
             else
             {
-                _propertyGridLabel!.Text = (SR.DataGridViewBoundColumnProperties);
+                _propertyGridLabel.Text = (SR.DataGridViewBoundColumnProperties);
             }
         }
         else if (e.ChangedItem.PropertyDescriptor.Name.Equals("Name"))
         {
-            ListBoxItem? listBoxItem = _selectedColumns?.SelectedItem as ListBoxItem;
+            ListBoxItem? listBoxItem = _selectedColumns.SelectedItem as ListBoxItem;
             DataGridViewColumn? col = listBoxItem?.DataGridViewColumn;
             if (_columnsNames is not null && col is not null)
             {
@@ -958,7 +971,7 @@ internal class DataGridViewColumnCollectionDialog : Form
             return;
         }
 
-        ListBoxItem? listBoxItem = _selectedColumns?.Items[e.Index] as ListBoxItem;
+        ListBoxItem? listBoxItem = _selectedColumns.Items[e.Index] as ListBoxItem;
 
 #if DGV_DITHERING
             if ((e.State & DrawItemState.Selected) == DrawItemState.Selected)
@@ -990,7 +1003,7 @@ internal class DataGridViewColumnCollectionDialog : Form
         e.Graphics.DrawImage(listBoxItem!.ToolboxBitmap!,
                              e.Bounds.X + _OWNERDRAWITEMIMAGEBUFFER,
                              e.Bounds.Y + _OWNERDRAWITEMIMAGEBUFFER,
-                             listBoxItem!.ToolboxBitmap!.Width,
+                             listBoxItem.ToolboxBitmap!.Width,
                              listBoxItem.ToolboxBitmap.Height);
 
         Rectangle bounds = e.Bounds;
@@ -1001,7 +1014,7 @@ internal class DataGridViewColumnCollectionDialog : Form
 
         Brush selectedBrush = new SolidBrush(e.BackColor);
         Brush foreBrush = new SolidBrush(e.ForeColor);
-        Brush backBrush = new SolidBrush(_selectedColumns!.BackColor);
+        Brush backBrush = new SolidBrush(_selectedColumns.BackColor);
 
         string columnName = ((ListBoxItem)_selectedColumns.Items[e.Index]).ToString();
 
@@ -1043,7 +1056,7 @@ internal class DataGridViewColumnCollectionDialog : Form
     {
         if ((e.Modifiers) == 0 && e.KeyCode == Keys.F4)
         {
-            _propertyGrid1?.Focus();
+            _propertyGrid1.Focus();
             e.Handled = true;
         }
     }
@@ -1067,28 +1080,28 @@ internal class DataGridViewColumnCollectionDialog : Form
             return;
         }
 
-        _propertyGrid1!.SelectedObject = _selectedColumns!.SelectedItem;
+        _propertyGrid1.SelectedObject = _selectedColumns.SelectedItem;
 
         // enable/disable up/down/delete buttons
-        _moveDown!.Enabled = _selectedColumns.Items.Count > 0 && _selectedColumns.SelectedIndex != _selectedColumns.Items.Count - 1;
-        _moveUp!.Enabled = _selectedColumns.Items.Count > 0 && _selectedColumns.SelectedIndex > 0;
-        _deleteButton!.Enabled = _selectedColumns.Items.Count > 0 && _selectedColumns.SelectedIndex != -1;
+        _moveDown.Enabled = _selectedColumns.Items.Count > 0 && _selectedColumns.SelectedIndex != _selectedColumns.Items.Count - 1;
+        _moveUp.Enabled = _selectedColumns.Items.Count > 0 && _selectedColumns.SelectedIndex > 0;
+        _deleteButton.Enabled = _selectedColumns.Items.Count > 0 && _selectedColumns.SelectedIndex != -1;
 
         if (_selectedColumns.SelectedItem is not null)
         {
             DataGridViewColumn column = ((ListBoxItem)_selectedColumns.SelectedItem).DataGridViewColumn;
             if (string.IsNullOrEmpty(column.DataPropertyName))
             {
-                _propertyGridLabel!.Text = (SR.DataGridViewUnboundColumnProperties);
+                _propertyGridLabel.Text = (SR.DataGridViewUnboundColumnProperties);
             }
             else
             {
-                _propertyGridLabel!.Text = (SR.DataGridViewBoundColumnProperties);
+                _propertyGridLabel.Text = (SR.DataGridViewBoundColumnProperties);
             }
         }
         else
         {
-            _propertyGridLabel!.Text = (SR.DataGridViewProperties);
+            _propertyGridLabel.Text = (SR.DataGridViewProperties);
         }
     }
 
@@ -1153,15 +1166,15 @@ internal class DataGridViewColumnCollectionDialog : Form
 
         PopulateSelectedColumns();
 
-        _propertyGrid1!.Site = new DataGridViewComponentPropertyGridSite(_liveDataGridView.Site, _liveDataGridView);
+        _propertyGrid1.Site = new DataGridViewComponentPropertyGridSite(_liveDataGridView.Site, _liveDataGridView);
 
-        _propertyGrid1.SelectedObject = _selectedColumns!.SelectedItem;
+        _propertyGrid1.SelectedObject = _selectedColumns.SelectedItem;
     }
 
     private void SetSelectedColumnsHorizontalExtent()
     {
         int maxItemWidth = 0;
-        for (int i = 0; i < _selectedColumns!.Items.Count; i++)
+        for (int i = 0; i < _selectedColumns.Items.Count; i++)
         {
             int itemWidth = TextRenderer.MeasureText(_selectedColumns.Items[i].ToString(), _selectedColumns.Font).Width;
             maxItemWidth = Math.Max(maxItemWidth, itemWidth);
@@ -1188,13 +1201,7 @@ internal class DataGridViewColumnCollectionDialog : Form
 
         for (int i = 0; i < components.Count; i++)
         {
-            IComponent? comp = components[i];
-            if (comp is null || comp.Site is null)
-            {
-                continue;
-            }
-
-            ISite s = comp.Site;
+            ISite? s = components[i]?.Site;
 
             if (s is not null && s.Name is not null && string.Equals(s.Name, siteName, StringComparison.OrdinalIgnoreCase) && s.Component != component)
             {


### PR DESCRIPTION
## Proposed changes

- Enhance nullable annotations in `DataGridViewColumnCollectionDialog`, removing almost all in the process `!`
- Replace `Hastable`s with `Dictionary`s and a `HashSet` (contributes to #8143)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9991)