### PR TITLE
Enable nullability in ByteViewer and remove allocations when drawing

### DIFF
--- a/src/System.Windows.Forms.Design/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms.Design/src/PublicAPI.Shipped.txt
@@ -19,9 +19,9 @@ abstract System.Windows.Forms.Design.MaskDescriptor.ValidatingType.get -> System
 ~override System.ComponentModel.Design.ArrayEditor.SetItems(object editValue, object[] value) -> object
 override System.ComponentModel.Design.BinaryEditor.EditValue(System.ComponentModel.ITypeDescriptorContext? context, System.IServiceProvider! provider, object? value) -> object?
 override System.ComponentModel.Design.BinaryEditor.GetEditStyle(System.ComponentModel.ITypeDescriptorContext? context) -> System.Drawing.Design.UITypeEditorEditStyle
-~override System.ComponentModel.Design.ByteViewer.OnKeyDown(System.Windows.Forms.KeyEventArgs e) -> void
-~override System.ComponentModel.Design.ByteViewer.OnLayout(System.Windows.Forms.LayoutEventArgs e) -> void
-~override System.ComponentModel.Design.ByteViewer.OnPaint(System.Windows.Forms.PaintEventArgs e) -> void
+override System.ComponentModel.Design.ByteViewer.OnKeyDown(System.Windows.Forms.KeyEventArgs! e) -> void
+override System.ComponentModel.Design.ByteViewer.OnLayout(System.Windows.Forms.LayoutEventArgs! e) -> void
+override System.ComponentModel.Design.ByteViewer.OnPaint(System.Windows.Forms.PaintEventArgs! e) -> void
 override System.ComponentModel.Design.CollectionEditor.EditValue(System.ComponentModel.ITypeDescriptorContext? context, System.IServiceProvider! provider, object? value) -> object?
 override System.ComponentModel.Design.CollectionEditor.GetEditStyle(System.ComponentModel.ITypeDescriptorContext? context) -> System.Drawing.Design.UITypeEditorEditStyle
 override System.ComponentModel.Design.DateTimeEditor.EditValue(System.ComponentModel.ITypeDescriptorContext? context, System.IServiceProvider! provider, object? value) -> object?
@@ -292,11 +292,11 @@ System.Windows.Forms.Design.Behavior.GlyphCollection.this[int index].set -> void
 ~System.Windows.Forms.Design.ParentControlDesigner.CreateTool(System.Drawing.Design.ToolboxItem tool, System.Drawing.Rectangle bounds) -> void
 ~System.Windows.Forms.Design.ParentControlDesigner.GetControl(object component) -> System.Windows.Forms.Control
 ~System.Windows.Forms.Design.ParentControlDesigner.MouseDragTool.get -> System.Drawing.Design.ToolboxItem
-~virtual System.ComponentModel.Design.ByteViewer.GetBytes() -> byte[]
-~virtual System.ComponentModel.Design.ByteViewer.SaveToFile(string path) -> void
-~virtual System.ComponentModel.Design.ByteViewer.ScrollChanged(object source, System.EventArgs e) -> void
-~virtual System.ComponentModel.Design.ByteViewer.SetBytes(byte[] bytes) -> void
-~virtual System.ComponentModel.Design.ByteViewer.SetFile(string path) -> void
+virtual System.ComponentModel.Design.ByteViewer.GetBytes() -> byte[]?
+virtual System.ComponentModel.Design.ByteViewer.SaveToFile(string! path) -> void
+virtual System.ComponentModel.Design.ByteViewer.ScrollChanged(object? source, System.EventArgs! e) -> void
+virtual System.ComponentModel.Design.ByteViewer.SetBytes(byte[]! bytes) -> void
+virtual System.ComponentModel.Design.ByteViewer.SetFile(string! path) -> void
 virtual System.ComponentModel.Design.CollectionEditor.CanRemoveInstance(object! value) -> bool
 virtual System.ComponentModel.Design.CollectionEditor.CreateCollectionForm() -> System.ComponentModel.Design.CollectionEditor.CollectionForm!
 virtual System.ComponentModel.Design.CollectionEditor.CreateCollectionItemType() -> System.Type!

--- a/src/System.Windows.Forms.Design/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms.Design/src/PublicAPI.Shipped.txt
@@ -292,7 +292,7 @@ System.Windows.Forms.Design.Behavior.GlyphCollection.this[int index].set -> void
 ~System.Windows.Forms.Design.ParentControlDesigner.CreateTool(System.Drawing.Design.ToolboxItem tool, System.Drawing.Rectangle bounds) -> void
 ~System.Windows.Forms.Design.ParentControlDesigner.GetControl(object component) -> System.Windows.Forms.Control
 ~System.Windows.Forms.Design.ParentControlDesigner.MouseDragTool.get -> System.Drawing.Design.ToolboxItem
-virtual System.ComponentModel.Design.ByteViewer.GetBytes() -> byte[]?
+virtual System.ComponentModel.Design.ByteViewer.GetBytes() -> byte[]!
 virtual System.ComponentModel.Design.ByteViewer.SaveToFile(string! path) -> void
 virtual System.ComponentModel.Design.ByteViewer.ScrollChanged(object? source, System.EventArgs! e) -> void
 virtual System.ComponentModel.Design.ByteViewer.SetBytes(byte[]! bytes) -> void

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/BinaryEditor.BinaryUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/BinaryEditor.BinaryUI.cs
@@ -95,7 +95,7 @@ public sealed partial class BinaryEditor
         private void ButtonOK_click(object? source, EventArgs e)
         {
             object localValue = _value!;
-            ConvertToValue(_byteViewer.GetBytes()!, ref localValue);
+            ConvertToValue(_byteViewer.GetBytes(), ref localValue);
             _value = localValue;
         }
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/BinaryEditor.BinaryUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/BinaryEditor.BinaryUI.cs
@@ -95,7 +95,7 @@ public sealed partial class BinaryEditor
         private void ButtonOK_click(object? source, EventArgs e)
         {
             object localValue = _value!;
-            ConvertToValue(_byteViewer.GetBytes(), ref localValue);
+            ConvertToValue(_byteViewer.GetBytes()!, ref localValue);
             _value = localValue;
         }
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ByteViewer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ByteViewer.cs
@@ -427,7 +427,7 @@ public class ByteViewer : TableLayoutPanel
     /// </summary>
     private void InitUnicode()
     {
-        _edit.Text = string.Create(_dataBuf.Length / 2 + 1, _dataBuf, static (text, dataBuf) =>
+        _edit.Text = string.Create(_dataBuf.Length / sizeof(char) + 1, _dataBuf, static (text, dataBuf) =>
         {
             Encoding.Unicode.GetChars(dataBuf.AsSpan(), text);
             text.Replace('\0', '\v');

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ByteViewer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ByteViewer.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.Drawing;
 using System.Globalization;
 using System.Text;
@@ -45,7 +43,7 @@ public class ByteViewer : TableLayoutPanel
     private TextBox _edit;
     private readonly int _columnCount = DEFAULT_COLUMN_COUNT;
     private int _rowCount = DEFAULT_ROW_COUNT;
-    private byte[] _dataBuf;
+    private byte[]? _dataBuf;
     private int _startLine;
     private int _displayLinesCount;
     private int _linesCount;
@@ -134,7 +132,7 @@ public class ByteViewer : TableLayoutPanel
         byte[] lineBuffer;
 
         int offset = startLine * _columnCount;
-        if (offset + (line + 1) * _columnCount > _dataBuf.Length)
+        if (offset + (line + 1) * _columnCount > _dataBuf!.Length)
         {
             lineBuffer = new byte[_dataBuf.Length % _columnCount];
         }
@@ -368,18 +366,12 @@ public class ByteViewer : TableLayoutPanel
     /// <summary>
     ///  Gets the bytes in the buffer.
     /// </summary>
-    public virtual byte[] GetBytes()
-    {
-        return _dataBuf;
-    }
+    public virtual byte[]? GetBytes() => _dataBuf;
 
     /// <summary>
     ///  Gets the display mode for the control.
     /// </summary>
-    public virtual DisplayMode GetDisplayMode()
-    {
-        return _displayMode;
-    }
+    public virtual DisplayMode GetDisplayMode() => _displayMode;
 
     // Stole this code from  XmlScanner
     private static int GetEncodingIndex(int c1)
@@ -424,7 +416,7 @@ public class ByteViewer : TableLayoutPanel
         int size;
         fixed (byte* pDataBuff = _dataBuf)
         {
-            size = PInvoke.MultiByteToWideChar(PInvoke.CP_ACP, 0, (PCSTR)pDataBuff, _dataBuf.Length, null, 0);
+            size = PInvoke.MultiByteToWideChar(PInvoke.CP_ACP, 0, (PCSTR)pDataBuff, _dataBuf!.Length, null, 0);
             text = new char[size + 1];
             fixed (char* pText = text)
             {
@@ -450,7 +442,7 @@ public class ByteViewer : TableLayoutPanel
     /// </summary>
     private void InitUnicode()
     {
-        char[] text = new char[_dataBuf.Length / 2 + 1];
+        char[] text = new char[_dataBuf!.Length / 2 + 1];
         Encoding.Unicode.GetChars(_dataBuf, 0, _dataBuf.Length, text, 0);
         for (int i = 0; i < text.Length; i++)
             if (text[i] == '\0')
@@ -463,6 +455,8 @@ public class ByteViewer : TableLayoutPanel
     /// <summary>
     ///  Initializes the UI components of a control
     /// </summary>
+    [MemberNotNull(nameof(_edit))]
+    [MemberNotNull(nameof(_scrollBar))]
     private void InitUI()
     {
         SCROLLBAR_HEIGHT = SystemInformation.HorizontalScrollBarHeight;
@@ -501,7 +495,7 @@ public class ByteViewer : TableLayoutPanel
     private void InitState()
     {
         // calculate number of lines required (being careful to count 1 for the last partial line)
-        _linesCount = (_dataBuf.Length + _columnCount - 1) / _columnCount;
+        _linesCount = (_dataBuf!.Length + _columnCount - 1) / _columnCount;
 
         _startLine = 0;
         if (_linesCount > _rowCount)
@@ -635,7 +629,7 @@ public class ByteViewer : TableLayoutPanel
     /// <summary>
     ///  Scroll event handler.
     /// </summary>
-    protected virtual void ScrollChanged(object source, EventArgs e)
+    protected virtual void ScrollChanged(object? source, EventArgs e)
     {
         _startLine = _scrollBar.Value;
 
@@ -692,19 +686,12 @@ public class ByteViewer : TableLayoutPanel
             case DisplayMode.Hexdump:
                 SuspendLayout();
                 _edit.Hide();
-                if (_linesCount > _rowCount)
+                if (_linesCount > _rowCount && !_scrollBar.Visible)
                 {
-                    if (!_scrollBar.Visible)
-                    {
-                        _scrollBar.Show();
-                        ResumeLayout();
-                        _scrollBar.Invalidate();
-                        _scrollBar.Select();
-                    }
-                    else
-                    {
-                        ResumeLayout();
-                    }
+                    _scrollBar.Show();
+                    ResumeLayout();
+                    _scrollBar.Invalidate();
+                    _scrollBar.Select();
                 }
                 else
                 {
@@ -741,7 +728,7 @@ public class ByteViewer : TableLayoutPanel
     /// </summary>
     public virtual void SetStartLine(int line)
     {
-        if (line < 0 || line >= _linesCount || line > _dataBuf.Length / _columnCount)
+        if (line < 0 || line >= _linesCount || line > _dataBuf?.Length / _columnCount)
         {
             _startLine = 0;
         }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ByteViewer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ByteViewer.cs
@@ -247,16 +247,8 @@ public class ByteViewer : TableLayoutPanel
 
         ReadOnlySpan<byte> GetLineBytes(int line)
         {
-            int offset = (startLine + line) * _columnCount;
-            int length;
-            if (offset + _columnCount > _dataBuf.Length)
-            {
-                length = _dataBuf.Length % _columnCount;
-            }
-            else
-            {
-                length = _columnCount;
-            }
+            int offset = line * _columnCount;
+            int length = offset + _columnCount > _dataBuf.Length ? _dataBuf.Length % _columnCount : _columnCount;
 
             return _dataBuf.AsSpan(offset, length);
         }

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/ByteViewerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/ByteViewerTests.cs
@@ -160,7 +160,7 @@ public class ByteViewerTests
     public void ByteViewer_GetBytes_Invoke_ReturnsExpected()
     {
         using ByteViewer control = new();
-        Assert.Null(control.GetBytes());
+        Assert.Empty(control.GetBytes());
         Assert.False(control.IsHandleCreated);
     }
 
@@ -587,15 +587,6 @@ public class ByteViewerTests
         Assert.Throws<NullReferenceException>(() => control.OnPaint(null));
     }
 
-    [WinFormsTheory]
-    [InlineData(null)]
-    [InlineData("*")] // Invalid path
-    public void ByteViewer_SaveToFile_InvokeNoBytes_Nop(string path)
-    {
-        using ByteViewer control = new();
-        control.SaveToFile(path);
-    }
-
     [WinFormsFact]
     public void ByteViewer_SaveToFile_InvokeWithBytes_Success()
     {
@@ -729,6 +720,8 @@ public class ByteViewerTests
     [WinFormsTheory]
     [InlineData(DisplayMode.Auto)]
     [InlineData(DisplayMode.Hexdump)]
+    [InlineData(DisplayMode.Ansi)]
+    [InlineData(DisplayMode.Unicode)]
     public void ByteViewer_SetDisplayMode_InvokeNoBytes_GetReturnsExpected(DisplayMode value)
     {
         using ByteViewer control = new();
@@ -849,22 +842,6 @@ public class ByteViewerTests
         Assert.Equal("123", textBox.Text);
         Assert.True(textBox.Visible);
         Assert.False(scrollBar.Visible);
-        Assert.False(control.IsHandleCreated);
-    }
-
-    [WinFormsTheory]
-    [InlineData(DisplayMode.Ansi)]
-    [InlineData(DisplayMode.Unicode)]
-    public void ByteViewer_SetDisplayMode_InvokeNoBytes_ThrowsNullReferenceException(DisplayMode value)
-    {
-        using ByteViewer control = new();
-        Assert.Throws<NullReferenceException>(() => control.SetDisplayMode(value));
-        Assert.Equal(value, control.GetDisplayMode());
-        Assert.False(control.IsHandleCreated);
-
-        // Set same.
-        Assert.Throws<NullReferenceException>(() => control.SetDisplayMode(value));
-        Assert.Equal(value, control.GetDisplayMode());
         Assert.False(control.IsHandleCreated);
     }
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/ByteViewerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/ByteViewerTests.cs
@@ -882,7 +882,7 @@ public class ByteViewerTests
         using ByteViewer control = new();
         using TempFile file = TempFile.Create(new byte[] { 1, 2, 3 });
         control.SetFile(file.Path);
-        Assert.Equal(new byte[] { 1, 2, 3, 0 }, control.GetBytes());
+        Assert.Equal(new byte[] { 1, 2, 3 }, control.GetBytes());
     }
 
     [WinFormsFact]
@@ -893,7 +893,7 @@ public class ByteViewerTests
 
         using TempFile file = TempFile.Create(new byte[] { 1, 2, 3 });
         control.SetFile(file.Path);
-        Assert.Equal(new byte[] { 1, 2, 3, 0 }, control.GetBytes());
+        Assert.Equal(new byte[] { 1, 2, 3 }, control.GetBytes());
     }
 
     [WinFormsFact]


### PR DESCRIPTION
## Proposed changes

- Enable nullability in `ByteViewer`
- Cleanup code and remove most allocations when drawing


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/9998)