### PR TITLE
Don't invalidate Cursors cursors (#9994)

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Cursor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Cursor.cs
@@ -72,6 +72,11 @@ namespace System.Windows.Forms
         public Cursor(Type type, string resource)
             : this((type.OrThrowIfNull()).Module.Assembly.GetManifestResourceStream(type, resource)!)
         {
+            if (type == typeof(Cursor))
+            {
+                // This came from the Cursors class, we shouldn't be disposing them.
+                _ownHandle = false;
+            }
         }
 
         /// <summary>
@@ -223,13 +228,11 @@ namespace System.Windows.Forms
 
         private void Dispose(bool disposing)
         {
-            if (_handle != IntPtr.Zero)
+            if (_handle != IntPtr.Zero && _ownHandle)
             {
-                if (_ownHandle)
-                {
-                    User32.DestroyCursor(_handle);
-                }
-
+                // If we don't own the handle we should never _actually_ dispose or set to null.
+                // Doing so would make the static cursors in Cursors unusable.
+                User32.DestroyCursor(_handle);
                 _handle = IntPtr.Zero;
             }
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CursorTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CursorTests.cs
@@ -324,12 +324,12 @@ namespace System.Windows.Forms.Tests
         {
             var cursor = new Cursor((IntPtr)2);
             cursor.Dispose();
-            Assert.Throws<ObjectDisposedException>(() => cursor.Handle);
-            Assert.Throws<ObjectDisposedException>(() => cursor.HotSpot);
+            _ = cursor.Handle;
+            _ = cursor.HotSpot;
 
             cursor.Dispose();
-            Assert.Throws<ObjectDisposedException>(() => cursor.Handle);
-            Assert.Throws<ObjectDisposedException>(() => cursor.HotSpot);
+            _ = cursor.Handle;
+            _ = cursor.HotSpot;
         }
 
         public static IEnumerable<object[]> Draw_TestData()


### PR DESCRIPTION
### Port of #9994

DO NOT REBASE/SQUASH

Our static Cursors should never be disposed. This was a regression for the ones wrapped around system cursors. Our own resource cursors were never properly guarded, this fixes them.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10003)