### PR TITLE
Simplify Cursor code

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Cursor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Cursor.cs
@@ -459,8 +459,6 @@ public sealed class Cursor : IDisposable, ISerializable, IHandle<HICON>, IHandle
         return (byte[])_cursorData.Clone();
     }
 
-    internal bool IsValid() => _handle != IntPtr.Zero;
-
     /// <summary>
     ///  Displays the cursor. For every call to Cursor.show() there must have been
     ///  a previous call to Cursor.hide().

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Cursor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Cursor.cs
@@ -26,6 +26,9 @@ public sealed class Cursor : IDisposable, ISerializable, IHandle<HICON>, IHandle
     private HCURSOR _handle;
     private readonly bool _freeHandle;
 
+    /// <summary>
+    ///  If created by the <see cref="Cursors"/> class, this is the property name that created it.
+    /// </summary>
     internal string? CursorsProperty { get; }
 
     internal unsafe Cursor(PCWSTR nResourceId, string cursorsProperty)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Cursor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Cursor.cs
@@ -24,22 +24,14 @@ public sealed class Cursor : IDisposable, ISerializable, IHandle<HICON>, IHandle
 
     private readonly byte[]? _cursorData;
     private HCURSOR _handle;
-    private readonly Flags _flags;
-    private readonly PCWSTR _resourceId;
+    private readonly bool _freeHandle;
 
-    private bool OwnHandle => (_flags & Flags.OwnHandle) != 0;
-    private bool IsWellKnown => (_flags & Flags.InternalCursor) != 0;
+    internal string? CursorsProperty { get; }
 
-    /// <summary>
-    ///  Private constructor. If you want a standard system cursor, use one of the
-    ///  definitions in the Cursors class.
-    /// </summary>
-    internal unsafe Cursor(PCWSTR nResourceId)
+    internal unsafe Cursor(PCWSTR nResourceId, string cursorsProperty)
     {
-        // We don't delete stock cursors.
-        _flags &= ~Flags.OwnHandle;
-        _flags |= Flags.InternalCursor;
-        _resourceId = nResourceId;
+        _freeHandle = false;
+        CursorsProperty = cursorsProperty;
         _handle = PInvoke.LoadCursor((HINSTANCE)0, nResourceId);
         if (_handle.IsNull)
         {
@@ -47,18 +39,25 @@ public sealed class Cursor : IDisposable, ISerializable, IHandle<HICON>, IHandle
         }
     }
 
+    internal Cursor(string resource, string cursorsProperty)
+        : this(typeof(Cursors).Assembly.GetManifestResourceStream(typeof(Cursor), resource).OrThrowIfNull())
+    {
+        CursorsProperty = cursorsProperty;
+        _freeHandle = false;
+    }
+
     /// <summary>
     ///  Initializes a new instance of the <see cref="Cursor"/> class from the specified <paramref name="handle"/>.
     /// </summary>
     public Cursor(IntPtr handle)
     {
-        if (handle == IntPtr.Zero)
+        if (handle == 0)
         {
             throw new ArgumentException(string.Format(SR.InvalidGDIHandle, (typeof(Cursor)).Name), nameof(handle));
         }
 
+        _freeHandle = false;
         _handle = (HCURSOR)handle;
-        _flags &= ~Flags.OwnHandle;
     }
 
     /// <summary>
@@ -67,7 +66,7 @@ public sealed class Cursor : IDisposable, ISerializable, IHandle<HICON>, IHandle
     public Cursor(string fileName)
     {
         _cursorData = File.ReadAllBytes(fileName);
-        _flags |= Flags.OwnHandle;
+        _freeHandle = true;
         LoadPicture(
             new Ole32.GPStream(new MemoryStream(_cursorData)),
             nameof(fileName));
@@ -77,14 +76,8 @@ public sealed class Cursor : IDisposable, ISerializable, IHandle<HICON>, IHandle
     ///  Initializes a new instance of the <see cref="Cursor"/> class from the specified <paramref name="resource"/>.
     /// </summary>
     public Cursor(Type type, string resource)
-        : this((type.OrThrowIfNull()).Module.Assembly.GetManifestResourceStream(type, resource)!)
+        : this(type.OrThrowIfNull().Module.Assembly.GetManifestResourceStream(type, resource)!)
     {
-        _flags |= Flags.OwnHandle;
-
-        if (type == typeof(Cursor))
-        {
-            _flags |= Flags.InternalCursor;
-        }
     }
 
     /// <summary>
@@ -94,8 +87,9 @@ public sealed class Cursor : IDisposable, ISerializable, IHandle<HICON>, IHandle
     public Cursor(Stream stream)
     {
         ArgumentNullException.ThrowIfNull(stream);
-        MemoryStream memoryStream = new();
-        // reset stream position to start, there are no gaurantees it is at the start.
+        using MemoryStream memoryStream = new();
+
+        // Reset stream position to start, there are no gaurantees it is at the start.
         if (stream.CanSeek)
         {
             stream.Position = 0;
@@ -103,7 +97,7 @@ public sealed class Cursor : IDisposable, ISerializable, IHandle<HICON>, IHandle
 
         stream.CopyTo(memoryStream);
         _cursorData = memoryStream.ToArray();
-        _flags |= Flags.OwnHandle;
+        _freeHandle = true;
 
         // stream.CopyTo causes both streams to advance. So reset it for LoadPicture.
         memoryStream.Position = 0;
@@ -236,7 +230,7 @@ public sealed class Cursor : IDisposable, ISerializable, IHandle<HICON>, IHandle
 
     private void Dispose(bool disposing)
     {
-        if (!_handle.IsNull && OwnHandle)
+        if (!_handle.IsNull && _freeHandle)
         {
             PInvoke.DestroyCursor(_handle);
             _handle = HCURSOR.Null;
@@ -364,17 +358,11 @@ public sealed class Cursor : IDisposable, ISerializable, IHandle<HICON>, IHandle
         DrawImageCore(g, Rectangle.Empty, targetRect, stretch: true);
     }
 
-    /// <summary>
-    ///  Cleans up Windows resources for this object.
-    /// </summary>
     ~Cursor()
     {
         Dispose(disposing: false);
     }
 
-    /// <summary>
-    ///  ISerializable private implementation
-    /// </summary>
     void ISerializable.GetObjectData(SerializationInfo si, StreamingContext context)
     {
         throw new PlatformNotSupportedException();
@@ -461,14 +449,11 @@ public sealed class Cursor : IDisposable, ISerializable, IHandle<HICON>, IHandle
     /// </summary>
     internal unsafe byte[] GetData()
     {
-        if (_resourceId.Value is not null)
-        {
-            throw new FormatException(SR.CursorCannotCovertToBytes);
-        }
-
         if (_cursorData is null)
         {
-            throw new InvalidOperationException(SR.InvalidPictureFormat);
+            throw CursorsProperty is null
+                ? new InvalidOperationException(SR.InvalidPictureFormat)
+                : new FormatException(SR.CursorCannotCovertToBytes);
         }
 
         return (byte[])_cursorData.Clone();
@@ -485,11 +470,7 @@ public sealed class Cursor : IDisposable, ISerializable, IHandle<HICON>, IHandle
     /// <summary>
     ///  Retrieves a human readable string representing this <see cref="Cursor"/>.
     /// </summary>
-    public override string ToString()
-    {
-        string? cursorName = IsWellKnown || !OwnHandle ? TypeDescriptor.GetConverter(typeof(Cursor)).ConvertToString(this) : base.ToString();
-        return $"[Cursor: {cursorName}]";
-    }
+    public override string ToString() => $"[Cursor: {CursorsProperty ?? base.ToString()}]";
 
     public static bool operator ==(Cursor? left, Cursor? right)
     {
@@ -501,12 +482,4 @@ public sealed class Cursor : IDisposable, ISerializable, IHandle<HICON>, IHandle
     public override int GetHashCode() => (int)_handle.Value;
 
     public override bool Equals(object? obj) => obj is Cursor cursor && this == cursor;
-
-    [Flags]
-    private enum Flags : byte
-    {
-        None = 0,
-        OwnHandle = 1 << 0,
-        InternalCursor = 1 << 1,
-    }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/CursorConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CursorConverter.cs
@@ -86,30 +86,9 @@ public class CursorConverter : TypeConverter
         {
             if (destinationType == typeof(string))
             {
-                PropertyInfo[] props = GetProperties();
-                int bestMatch = -1;
-
-                for (int i = 0; i < props.Length; i++)
+                if (cursor.CursorsProperty is string propertyName)
                 {
-                    PropertyInfo prop = props[i];
-                    object[]? tempIndex = null;
-                    Cursor? c = (Cursor?)prop.GetValue(null, tempIndex);
-                    if (c == cursor)
-                    {
-                        if (ReferenceEquals(c, value))
-                        {
-                            return prop.Name;
-                        }
-                        else
-                        {
-                            bestMatch = i;
-                        }
-                    }
-                }
-
-                if (bestMatch != -1)
-                {
-                    return props[bestMatch].Name;
+                    return propertyName;
                 }
 
                 // We throw here because we cannot meaningfully convert a custom

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Cursors.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Cursors.cs
@@ -37,63 +37,32 @@ public static class Cursors
     private static Cursor? s_panWest;
     private static Cursor? s_hand;
 
-    public static Cursor AppStarting => s_appStarting ??= new Cursor(PInvoke.IDC_APPSTARTING);
-
-    public static Cursor Arrow => s_arrow ??= new Cursor(PInvoke.IDC_ARROW);
-
-    public static Cursor Cross => s_cross ??= new Cursor(PInvoke.IDC_CROSS);
-
-    public static Cursor Default => s_defaultCursor ??= new Cursor(PInvoke.IDC_ARROW);
-
-    public static Cursor IBeam => s_iBeam ??= new Cursor(PInvoke.IDC_IBEAM);
-
-    public static Cursor No => s_no ??= new Cursor(PInvoke.IDC_NO);
-
-    public static Cursor SizeAll => s_sizeAll ??= new Cursor(PInvoke.IDC_SIZEALL);
-
-    public static Cursor SizeNESW => s_sizeNESW ??= new Cursor(PInvoke.IDC_SIZENESW);
-
-    public static Cursor SizeNS => s_sizeNS ??= new Cursor(PInvoke.IDC_SIZENS);
-
-    public static Cursor SizeNWSE => s_sizeNWSE ??= new Cursor(PInvoke.IDC_SIZENWSE);
-
-    public static Cursor SizeWE => s_sizeWE ??= new Cursor(PInvoke.IDC_SIZEWE);
-
-    public static Cursor UpArrow => s_upArrow ??= new Cursor(PInvoke.IDC_UPARROW);
-
-    public static Cursor WaitCursor => s_wait ??= new Cursor(PInvoke.IDC_WAIT);
-
-    public static Cursor Help => s_help ??= new Cursor(PInvoke.IDC_HELP);
-    public static Cursor Hand => s_hand ??= new Cursor(PInvoke.IDC_HAND);
-
-    public static Cursor HSplit => GetCursor(ref s_hSplit, "hsplit.cur");
-
-    public static Cursor VSplit => GetCursor(ref s_vSplit, "vsplit.cur");
-
-    public static Cursor NoMove2D => GetCursor(ref s_noMove2D, "nomove2d.cur");
-
-    public static Cursor NoMoveHoriz => GetCursor(ref s_noMoveHoriz, "nomoveh.cur");
-
-    public static Cursor NoMoveVert => GetCursor(ref s_noMoveVert, "nomovev.cur");
-
-    public static Cursor PanEast => GetCursor(ref s_panEast, "east.cur");
-
-    public static Cursor PanNE => GetCursor(ref s_panNE, "ne.cur");
-
-    public static Cursor PanNorth => GetCursor(ref s_panNorth, "north.cur");
-
-    public static Cursor PanNW => GetCursor(ref s_panNW, "nw.cur");
-
-    public static Cursor PanSE => GetCursor(ref s_panSE, "se.cur");
-
-    public static Cursor PanSouth => GetCursor(ref s_panSouth, "south.cur");
-
-    public static Cursor PanSW => GetCursor(ref s_panSW, "sw.cur");
-
-    public static Cursor PanWest => GetCursor(ref s_panWest, "west.cur");
-
-    private static Cursor GetCursor(ref Cursor? cursor, string resource)
-        => cursor is not null && cursor.IsValid()
-            ? cursor
-            : cursor = new Cursor(typeof(Cursor), resource);
+    public static Cursor AppStarting => s_appStarting ??= new(PInvoke.IDC_APPSTARTING, nameof(AppStarting));
+    public static Cursor Arrow => s_arrow ??= new(PInvoke.IDC_ARROW, nameof(Arrow));
+    public static Cursor Cross => s_cross ??= new(PInvoke.IDC_CROSS, nameof(Cross));
+    public static Cursor Default => s_defaultCursor ??= new(PInvoke.IDC_ARROW, nameof(Default));
+    public static Cursor IBeam => s_iBeam ??= new(PInvoke.IDC_IBEAM, nameof(IBeam));
+    public static Cursor No => s_no ??= new(PInvoke.IDC_NO, nameof(No));
+    public static Cursor SizeAll => s_sizeAll ??= new(PInvoke.IDC_SIZEALL, nameof(SizeAll));
+    public static Cursor SizeNESW => s_sizeNESW ??= new(PInvoke.IDC_SIZENESW, nameof(SizeNESW));
+    public static Cursor SizeNS => s_sizeNS ??= new(PInvoke.IDC_SIZENS, nameof(SizeNS));
+    public static Cursor SizeNWSE => s_sizeNWSE ??= new(PInvoke.IDC_SIZENWSE, nameof(SizeNWSE));
+    public static Cursor SizeWE => s_sizeWE ??= new(PInvoke.IDC_SIZEWE, nameof(SizeWE));
+    public static Cursor UpArrow => s_upArrow ??= new(PInvoke.IDC_UPARROW, nameof(UpArrow));
+    public static Cursor WaitCursor => s_wait ??= new(PInvoke.IDC_WAIT, nameof(WaitCursor));
+    public static Cursor Help => s_help ??= new(PInvoke.IDC_HELP, nameof(Help));
+    public static Cursor Hand => s_hand ??= new(PInvoke.IDC_HAND, nameof(Hand));
+    public static Cursor HSplit => s_hSplit ??= new("hsplit.cur", nameof(HSplit));
+    public static Cursor VSplit => s_vSplit ??= new("vsplit.cur", nameof(VSplit));
+    public static Cursor NoMove2D => s_noMove2D ??= new("nomove2d.cur", nameof(NoMove2D));
+    public static Cursor NoMoveHoriz => s_noMoveHoriz ??= new("nomoveh.cur", nameof(NoMoveHoriz));
+    public static Cursor NoMoveVert => s_noMoveVert ??= new("nomovev.cur", nameof(NoMoveVert));
+    public static Cursor PanEast => s_panEast ??= new("east.cur", nameof(PanEast));
+    public static Cursor PanNE => s_panNE ??= new("ne.cur", nameof(PanNE));
+    public static Cursor PanNorth => s_panNorth ??= new("north.cur", nameof(PanNorth));
+    public static Cursor PanNW => s_panNW ??= new("nw.cur", nameof(PanNW));
+    public static Cursor PanSE => s_panSE ??= new("se.cur", nameof(PanSE));
+    public static Cursor PanSouth => s_panSouth ??= new("south.cur", nameof(PanSouth));
+    public static Cursor PanSW => s_panSW ??= new("sw.cur", nameof(PanSW));
+    public static Cursor PanWest => s_panWest ??= new("west.cur", nameof(PanWest));
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CursorConverterTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CursorConverterTests.cs
@@ -77,7 +77,6 @@ public class CursorConverterTests
     {
         var converter = new CursorConverter();
         Assert.Equal("AppStarting", converter.ConvertTo(Cursors.AppStarting, typeof(string)));
-        Assert.Equal("AppStarting", converter.ConvertTo(new Cursor(Cursors.AppStarting.Handle), typeof(string)));
     }
 
     [Fact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CursorTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CursorTests.cs
@@ -162,7 +162,7 @@ public class CursorTests
     [Fact]
     public void Cursor_Ctor_NullType_ThrowsArgumentNullException()
     {
-        Assert.Throws<ArgumentNullException>("type", () => new Cursor(null, "resource"));
+        Assert.Throws<ArgumentNullException>("type", () => new Cursor((Type)null, "resource"));
     }
 
     [Theory]
@@ -502,9 +502,9 @@ public class CursorTests
     }
 
     [Fact]
-    public void Cursor_ToString_InvalidCursor_ThrowsFormatException()
+    public void Cursor_ToString_InvalidCursor_DoesNotThrowFormatException()
     {
         using var cursor = new Cursor(2);
-        Assert.Throws<FormatException>(() => cursor.ToString());
+        _ = cursor.ToString();
     }
 }


### PR DESCRIPTION
Construction of Cursors statics had gotten a bit over complicated. ToString() was also very expensive when creating Cursors from handles.

The core of the change is to pass the property name when constructing a Cursor from Cursors for consistency and performance.

These changes will also allow making the CursorConverter reflection free in the future.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10005)