### PR TITLE
Enable nullability in missing Toolbox classes

### DIFF
--- a/src/System.Windows.Forms.Design/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms.Design/src/PublicAPI.Shipped.txt
@@ -210,8 +210,8 @@ System.ComponentModel.Design.Serialization.CodeDomLocalizationProvider.CodeDomLo
 ~System.Drawing.Design.IToolboxService.SetSelectedToolboxItem(System.Drawing.Design.ToolboxItem toolboxItem) -> void
 ~System.Drawing.Design.IToolboxUser.GetToolSupported(System.Drawing.Design.ToolboxItem tool) -> bool
 ~System.Drawing.Design.IToolboxUser.ToolPicked(System.Drawing.Design.ToolboxItem tool) -> void
-~System.Drawing.Design.ToolboxComponentsCreatingEventArgs.DesignerHost.get -> System.ComponentModel.Design.IDesignerHost
-~System.Drawing.Design.ToolboxComponentsCreatingEventArgs.ToolboxComponentsCreatingEventArgs(System.ComponentModel.Design.IDesignerHost host) -> void
+System.Drawing.Design.ToolboxComponentsCreatingEventArgs.DesignerHost.get -> System.ComponentModel.Design.IDesignerHost?
+System.Drawing.Design.ToolboxComponentsCreatingEventArgs.ToolboxComponentsCreatingEventArgs(System.ComponentModel.Design.IDesignerHost? host) -> void
 System.Drawing.Design.ToolboxItem.AssemblyName.get -> System.Reflection.AssemblyName?
 System.Drawing.Design.ToolboxItem.AssemblyName.set -> void
 System.Drawing.Design.ToolboxItem.Bitmap.get -> System.Drawing.Bitmap?

--- a/src/System.Windows.Forms.Design/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms.Design/src/PublicAPI.Shipped.txt
@@ -237,12 +237,12 @@ System.Drawing.Design.ToolboxItem.ToolboxItem(System.Type? toolType) -> void
 System.Drawing.Design.ToolboxItem.TypeName.get -> string!
 System.Drawing.Design.ToolboxItem.TypeName.set -> void
 System.Drawing.Design.ToolboxItem.ValidatePropertyType(string! propertyName, object? value, System.Type! expectedType, bool allowNull) -> void
-~System.Drawing.Design.ToolboxItemCollection.Contains(System.Drawing.Design.ToolboxItem value) -> bool
-~System.Drawing.Design.ToolboxItemCollection.CopyTo(System.Drawing.Design.ToolboxItem[] array, int index) -> void
-~System.Drawing.Design.ToolboxItemCollection.IndexOf(System.Drawing.Design.ToolboxItem value) -> int
-~System.Drawing.Design.ToolboxItemCollection.this[int index].get -> System.Drawing.Design.ToolboxItem
-~System.Drawing.Design.ToolboxItemCollection.ToolboxItemCollection(System.Drawing.Design.ToolboxItem[] value) -> void
-~System.Drawing.Design.ToolboxItemCollection.ToolboxItemCollection(System.Drawing.Design.ToolboxItemCollection value) -> void
+System.Drawing.Design.ToolboxItemCollection.Contains(System.Drawing.Design.ToolboxItem! value) -> bool
+System.Drawing.Design.ToolboxItemCollection.CopyTo(System.Drawing.Design.ToolboxItem![]! array, int index) -> void
+System.Drawing.Design.ToolboxItemCollection.IndexOf(System.Drawing.Design.ToolboxItem! value) -> int
+System.Drawing.Design.ToolboxItemCollection.this[int index].get -> System.Drawing.Design.ToolboxItem!
+System.Drawing.Design.ToolboxItemCollection.ToolboxItemCollection(System.Drawing.Design.ToolboxItem![]! value) -> void
+System.Drawing.Design.ToolboxItemCollection.ToolboxItemCollection(System.Drawing.Design.ToolboxItemCollection! value) -> void
 System.Windows.Forms.Design.Behavior.BehaviorServiceAdornerCollection.Add(System.Windows.Forms.Design.Behavior.Adorner! value) -> int
 System.Windows.Forms.Design.Behavior.BehaviorServiceAdornerCollection.AddRange(params System.Windows.Forms.Design.Behavior.Adorner![]! value) -> void
 System.Windows.Forms.Design.Behavior.BehaviorServiceAdornerCollection.AddRange(System.Windows.Forms.Design.Behavior.BehaviorServiceAdornerCollection! value) -> void

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/ToolboxComponentsCreatingEventArgs.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/ToolboxComponentsCreatingEventArgs.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.ComponentModel.Design;
 
 namespace System.Drawing.Design;
@@ -16,7 +14,7 @@ public class ToolboxComponentsCreatingEventArgs : EventArgs
     /// <summary>
     ///  Initializes a new instance of the <see cref="ToolboxComponentsCreatingEventArgs"/> object.
     /// </summary>
-    public ToolboxComponentsCreatingEventArgs(IDesignerHost host)
+    public ToolboxComponentsCreatingEventArgs(IDesignerHost? host)
     {
         DesignerHost = host;
     }
@@ -25,5 +23,5 @@ public class ToolboxComponentsCreatingEventArgs : EventArgs
     ///  An instance of IDesignerHost that has made the creat request.
     ///  This can be null if no designer host was provided to the toolbox item.
     /// </summary>
-    public IDesignerHost DesignerHost { get; }
+    public IDesignerHost? DesignerHost { get; }
 }

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/ToolboxItemCollection.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/ToolboxItemCollection.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.Collections;
 
 namespace System.Drawing.Design;
@@ -31,22 +29,13 @@ public sealed class ToolboxItemCollection : ReadOnlyCollectionBase
     /// <summary>
     ///  Represents the entry at the specified index of the <see cref="ToolboxItem"/>.
     /// </summary>
-    public ToolboxItem this[int index]
-    {
-        get
-        {
-            return ((ToolboxItem)(InnerList[index]));
-        }
-    }
+    public ToolboxItem this[int index] => (ToolboxItem)InnerList[index]!;
 
     /// <summary>
     ///  Gets a value indicating whether the
     /// <see cref="ToolboxItemCollection"/> contains the specified <see cref="ToolboxItem"/>.
     /// </summary>
-    public bool Contains(ToolboxItem value)
-    {
-        return InnerList.Contains(value);
-    }
+    public bool Contains(ToolboxItem value) => InnerList.Contains(value);
 
     /// <summary>
     ///  Copies the <see cref="ToolboxItemCollection"/> values to a one-dimensional <see cref="Array"/> instance at the
@@ -61,8 +50,5 @@ public sealed class ToolboxItemCollection : ReadOnlyCollectionBase
     ///  Returns the index of a <see cref="ToolboxItem"/> in
     ///  the <see cref="ToolboxItemCollection"/> .
     /// </summary>
-    public int IndexOf(ToolboxItem value)
-    {
-        return InnerList.IndexOf(value);
-    }
+    public int IndexOf(ToolboxItem value) => InnerList.IndexOf(value);
 }


### PR DESCRIPTION
## Proposed changes

- Enable nullability in `ToolboxItemCollection`
- Enable nullability in `ToolboxComponentsCreatingEventArgs`


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10036)