### PR TITLE
Add missing NRT annotations for ColorEditor nested classes

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/ColorEditor.ColorPalette.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/ColorEditor.ColorPalette.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.Windows.Forms;
 
 namespace System.Drawing.Design;
@@ -51,7 +49,7 @@ public partial class ColorEditor
         private readonly Color[] _staticColors;
         private Color _selectedColor;
         private Point _focus;
-        private EventHandler _onPicked;
+        protected EventHandler? _onPicked;
         private readonly ColorUI _colorUI;
 
         public ColorPalette(ColorUI colorUI, Color[] customColors)
@@ -116,12 +114,12 @@ public partial class ColorEditor
 
         protected override AccessibleObject CreateAccessibilityInstance() => new ColorPaletteAccessibleObject(this);
 
-        protected EventHandler Get_onPicked()
+        protected EventHandler? Get_onPicked()
         {
             return _onPicked;
         }
 
-        protected void OnPicked(EventArgs e, EventHandler _onPicked) => _onPicked?.Invoke(this, e);
+        protected void OnPicked(EventArgs e, EventHandler? onPicked) => onPicked?.Invoke(this, e);
 
         private static void FillRectWithCellBounds(int across, int down, ref Rectangle rect)
         {
@@ -241,7 +239,7 @@ public partial class ColorEditor
         protected virtual void LaunchDialog(int customIndex)
         {
             Invalidate();
-            _colorUI.EditorService.CloseDropDown(); // It will be closed anyway as soon as it sees the WM_ACTIVATE
+            _colorUI.EditorService!.CloseDropDown(); // It will be closed anyway as soon as it sees the WM_ACTIVATE
             CustomColorDialog dialog = new CustomColorDialog();
 
             HWND hwndFocus = PInvoke.GetFocus();
@@ -250,7 +248,6 @@ public partial class ColorEditor
                 DialogResult result = dialog.ShowDialog();
                 if (result != DialogResult.Cancel)
                 {
-                    Color color = dialog.Color;
                     CustomColors[customIndex] = dialog.Color;
                     SelectedColor = CustomColors[customIndex];
                     OnPicked(EventArgs.Empty, Get_onPicked());
@@ -288,16 +285,16 @@ public partial class ColorEditor
                     InvalidateFocus();
                     break;
                 case Keys.Left:
-                    SetFocus(new Point(_focus.X - 1, _focus.Y));
+                    SetFocus(_focus with { X = _focus.X - 1 });
                     break;
                 case Keys.Right:
-                    SetFocus(new Point(_focus.X + 1, _focus.Y));
+                    SetFocus(_focus with { X = _focus.X + 1 });
                     break;
                 case Keys.Up:
-                    SetFocus(new Point(_focus.X, _focus.Y - 1));
+                    SetFocus(_focus with { Y = _focus.Y - 1 });
                     break;
                 case Keys.Down:
-                    SetFocus(new Point(_focus.X, _focus.Y + 1));
+                    SetFocus(_focus with { Y = _focus.Y + 1 });
                     break;
             }
         }
@@ -353,7 +350,7 @@ public partial class ColorEditor
             else if (me.Button == MouseButtons.Right)
             {
                 int cell = GetCellFromLocationMouse(me.X, me.Y);
-                if (cell != -1 && cell >= (TotalCells - CellsCustom) && cell < TotalCells)
+                if (cell is >= TotalCells - CellsCustom and < TotalCells)
                 {
                     LaunchDialog(cell - TotalCells + CellsCustom);
                 }
@@ -429,7 +426,7 @@ public partial class ColorEditor
             {
                 // No ctrl, alt, shift.
                 int cell = Get1DFrom2D(_focus.X, _focus.Y);
-                if (cell >= (TotalCells - CellsCustom) && cell < TotalCells)
+                if (cell is >= TotalCells - CellsCustom and < TotalCells)
                 {
                     LaunchDialog(cell - TotalCells + CellsCustom);
                     return true;

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/ColorEditor.ColorUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/ColorEditor.ColorUI.cs
@@ -200,7 +200,7 @@ public partial class ColorEditor
             lbCommon.KeyDown += new KeyEventHandler(OnListKeyDown);
             lbCommon.Dock = DockStyle.Fill;
 
-            Array.Sort(ColorValues, new StandardColorComparer());
+            Array.Sort(ColorValues, StandardColorComparer.Instance);
             Array.Sort(SystemColorValues, comparer: new SystemColorComparer());
 
             lbCommon.Items.Clear();

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/ColorEditor.StandardColorComparer.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/ColorEditor.StandardColorComparer.cs
@@ -1,10 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
-using System.Collections;
-
 namespace System.Drawing.Design;
 
 public partial class ColorEditor
@@ -12,13 +8,13 @@ public partial class ColorEditor
     /// <summary>
     ///  Comparer for standard colors.
     /// </summary>
-    private class StandardColorComparer : IComparer
+    private class StandardColorComparer : IComparer<Color>
     {
-        public int Compare(object x, object y)
-        {
-            Color left = (Color)x;
-            Color right = (Color)y;
+        public static StandardColorComparer Instance { get; } = new();
 
+        private StandardColorComparer() { }
+        public int Compare(Color left, Color right)
+        {
             if (left.A < right.A)
             {
                 return -1;
@@ -29,32 +25,32 @@ public partial class ColorEditor
                 return 1;
             }
 
-            if ((float)left.GetHue() < (float)right.GetHue())
+            if (left.GetHue() < right.GetHue())
             {
                 return -1;
             }
 
-            if ((float)left.GetHue() > (float)right.GetHue())
+            if (left.GetHue() > right.GetHue())
             {
                 return 1;
             }
 
-            if ((float)left.GetSaturation() < (float)right.GetSaturation())
+            if (left.GetSaturation() < right.GetSaturation())
             {
                 return -1;
             }
 
-            if ((float)left.GetSaturation() > (float)right.GetSaturation())
+            if (left.GetSaturation() > right.GetSaturation())
             {
                 return 1;
             }
 
-            if ((float)left.GetBrightness() < (float)right.GetBrightness())
+            if (left.GetBrightness() < right.GetBrightness())
             {
                 return -1;
             }
 
-            if ((float)left.GetBrightness() > (float)right.GetBrightness())
+            if (left.GetBrightness() > right.GetBrightness())
             {
                 return 1;
             }


### PR DESCRIPTION
## Proposed changes

- Annotate `ColorEditor.ColorPalette` and `ColorEditor.StandardColorComparer`
- Make `ColorEditor.StandardColorComparer` an `IComparer<Color>`


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10037)