### PR TITLE
Enable nullability in remaining DataGridViewColumn members

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -83,13 +83,13 @@ override System.Windows.Forms.DataGridViewCellStyle.ToString() -> string!
 ~override System.Windows.Forms.DataGridViewCheckBoxColumn.DefaultCellStyle.get -> System.Windows.Forms.DataGridViewCellStyle
 ~override System.Windows.Forms.DataGridViewCheckBoxColumn.DefaultCellStyle.set -> void
 ~override System.Windows.Forms.DataGridViewCheckBoxColumn.ToString() -> string
-~override System.Windows.Forms.DataGridViewColumn.Clone() -> object
+override System.Windows.Forms.DataGridViewColumn.Clone() -> object!
 override System.Windows.Forms.DataGridViewColumn.ContextMenuStrip.get -> System.Windows.Forms.ContextMenuStrip?
 override System.Windows.Forms.DataGridViewColumn.ContextMenuStrip.set -> void
 override System.Windows.Forms.DataGridViewColumn.DefaultCellStyle.get -> System.Windows.Forms.DataGridViewCellStyle!
 override System.Windows.Forms.DataGridViewColumn.DefaultCellStyle.set -> void
 override System.Windows.Forms.DataGridViewColumn.InheritedStyle.get -> System.Windows.Forms.DataGridViewCellStyle?
-~override System.Windows.Forms.DataGridViewColumn.ToString() -> string
+override System.Windows.Forms.DataGridViewColumn.ToString() -> string!
 ~override System.Windows.Forms.DataGridViewColumnCollection.List.get -> System.Collections.ArrayList
 ~override System.Windows.Forms.DataGridViewColumnHeaderCell.Clone() -> object
 ~override System.Windows.Forms.DataGridViewColumnHeaderCell.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject
@@ -434,14 +434,14 @@ System.Windows.Forms.DataGridViewColumn.HeaderCell.get -> System.Windows.Forms.D
 System.Windows.Forms.DataGridViewColumn.HeaderCell.set -> void
 System.Windows.Forms.DataGridViewColumn.HeaderText.get -> string!
 System.Windows.Forms.DataGridViewColumn.HeaderText.set -> void
-~System.Windows.Forms.DataGridViewColumn.Name.get -> string
-~System.Windows.Forms.DataGridViewColumn.Name.set -> void
-~System.Windows.Forms.DataGridViewColumn.Site.get -> System.ComponentModel.ISite
-~System.Windows.Forms.DataGridViewColumn.Site.set -> void
-~System.Windows.Forms.DataGridViewColumn.ToolTipText.get -> string
-~System.Windows.Forms.DataGridViewColumn.ToolTipText.set -> void
-~System.Windows.Forms.DataGridViewColumn.ValueType.get -> System.Type
-~System.Windows.Forms.DataGridViewColumn.ValueType.set -> void
+System.Windows.Forms.DataGridViewColumn.Name.get -> string!
+System.Windows.Forms.DataGridViewColumn.Name.set -> void
+System.Windows.Forms.DataGridViewColumn.Site.get -> System.ComponentModel.ISite?
+System.Windows.Forms.DataGridViewColumn.Site.set -> void
+System.Windows.Forms.DataGridViewColumn.ToolTipText.get -> string!
+System.Windows.Forms.DataGridViewColumn.ToolTipText.set -> void
+System.Windows.Forms.DataGridViewColumn.ValueType.get -> System.Type?
+System.Windows.Forms.DataGridViewColumn.ValueType.set -> void
 ~System.Windows.Forms.DataGridViewColumnCollection.CopyTo(System.Windows.Forms.DataGridViewColumn[] array, int index) -> void
 ~System.Windows.Forms.DataGridViewColumnCollection.DataGridView.get -> System.Windows.Forms.DataGridView
 ~System.Windows.Forms.DataGridViewColumnCollection.DataGridViewColumnCollection(System.Windows.Forms.DataGridView dataGridView) -> void

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumn.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumn.cs
@@ -591,20 +591,11 @@ public class DataGridViewColumn : DataGridViewBand, IComponent
 
     [Browsable(false)]
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    public bool IsDataBound
-    {
-        get
-        {
-            return IsDataBoundInternal;
-        }
-    }
+    public bool IsDataBound => IsDataBoundInternal;
 
     internal bool IsDataBoundInternal
     {
-        get
-        {
-            return (_flags & ColumnIsDataBound) != 0;
-        }
+        get => (_flags & ColumnIsDataBound) != 0;
         set
         {
             if (value)
@@ -625,14 +616,8 @@ public class DataGridViewColumn : DataGridViewBand, IComponent
     [RefreshProperties(RefreshProperties.Repaint)]
     public int MinimumWidth
     {
-        get
-        {
-            return MinimumThickness;
-        }
-        set
-        {
-            MinimumThickness = value;
-        }
+        get => MinimumThickness;
+        set => MinimumThickness = value;
     }
 
     [Browsable(false)]
@@ -782,10 +767,7 @@ public class DataGridViewColumn : DataGridViewBand, IComponent
     [AllowNull]
     public string ToolTipText
     {
-        get
-        {
-            return HeaderCell.ToolTipText;
-        }
+        get => HeaderCell.ToolTipText;
         set
         {
             if (string.Compare(ToolTipText, value, ignoreCase: false, CultureInfo.InvariantCulture) != 0)
@@ -799,10 +781,7 @@ public class DataGridViewColumn : DataGridViewBand, IComponent
 
     internal float UsedFillWeight
     {
-        get
-        {
-            return _usedFillWeight;
-        }
+        get => _usedFillWeight;
         set
         {
             Debug.Assert(value > 0);
@@ -815,10 +794,7 @@ public class DataGridViewColumn : DataGridViewBand, IComponent
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public Type? ValueType
     {
-        get
-        {
-            return (Type?)Properties.GetObject(s_propDataGridViewColumnValueType);
-        }
+        get => (Type?)Properties.GetObject(s_propDataGridViewColumnValueType);
         set
         {
             // what should we do when we modify the ValueType in the dataGridView column???
@@ -842,14 +818,8 @@ public class DataGridViewColumn : DataGridViewBand, IComponent
     [RefreshProperties(RefreshProperties.Repaint)]
     public int Width
     {
-        get
-        {
-            return Thickness;
-        }
-        set
-        {
-            Thickness = value;
-        }
+        get => Thickness;
+        set => Thickness = value;
     }
 
     public override object Clone()
@@ -1077,8 +1047,6 @@ public class DataGridViewColumn : DataGridViewBand, IComponent
         return preferredColumnThickness;
     }
 
-    public override string ToString()
-    {
-        return $"DataGridViewColumn {{ Name={Name}, Index={Index} }}";
-    }
+    public override string ToString() =>
+        $"DataGridViewColumn {{ Name={Name}, Index={Index} }}";
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumn.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumn.cs
@@ -588,7 +588,7 @@ public class DataGridViewColumn : DataGridViewBand, IComponent
             }
         }
     }
-#nullable disable
+
     [Browsable(false)]
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public bool IsDataBound
@@ -636,6 +636,7 @@ public class DataGridViewColumn : DataGridViewBand, IComponent
     }
 
     [Browsable(false)]
+    [AllowNull]
     public string Name
     {
         get
@@ -715,7 +716,7 @@ public class DataGridViewColumn : DataGridViewBand, IComponent
 
     [Browsable(false)]
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    public ISite Site { get; set; }
+    public ISite? Site { get; set; }
 
     [DefaultValue(DataGridViewColumnSortMode.NotSortable)]
     [SRCategory(nameof(SR.CatBehavior))]
@@ -778,6 +779,7 @@ public class DataGridViewColumn : DataGridViewBand, IComponent
     [Localizable(true)]
     [SRCategory(nameof(SR.CatAppearance))]
     [SRDescription(nameof(SR.DataGridView_ColumnToolTipTextDescr))]
+    [AllowNull]
     public string ToolTipText
     {
         get
@@ -786,7 +788,7 @@ public class DataGridViewColumn : DataGridViewBand, IComponent
         }
         set
         {
-            if (string.Compare(ToolTipText, value, false /*ignore case*/, CultureInfo.InvariantCulture) != 0)
+            if (string.Compare(ToolTipText, value, ignoreCase: false, CultureInfo.InvariantCulture) != 0)
             {
                 HeaderCell.ToolTipText = value;
 
@@ -811,11 +813,11 @@ public class DataGridViewColumn : DataGridViewBand, IComponent
     [Browsable(false)]
     [DefaultValue(null)]
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    public Type ValueType
+    public Type? ValueType
     {
         get
         {
-            return (Type)Properties.GetObject(s_propDataGridViewColumnValueType);
+            return (Type?)Properties.GetObject(s_propDataGridViewColumnValueType);
         }
         set
         {
@@ -852,13 +854,8 @@ public class DataGridViewColumn : DataGridViewBand, IComponent
 
     public override object Clone()
     {
-        //
-
-        DataGridViewColumn dataGridViewColumn = (DataGridViewColumn)System.Activator.CreateInstance(GetType());
-        if (dataGridViewColumn is not null)
-        {
-            CloneInternal(dataGridViewColumn);
-        }
+        DataGridViewColumn dataGridViewColumn = (DataGridViewColumn)Activator.CreateInstance(GetType())!;
+        CloneInternal(dataGridViewColumn);
 
         return dataGridViewColumn;
     }
@@ -871,7 +868,7 @@ public class DataGridViewColumn : DataGridViewBand, IComponent
         dataGridViewColumn._displayIndex = -1;
         dataGridViewColumn.HeaderText = HeaderText;
         dataGridViewColumn.DataPropertyName = DataPropertyName;
-        dataGridViewColumn.CellTemplate = (DataGridViewCell)CellTemplate?.Clone();
+        dataGridViewColumn.CellTemplate = (DataGridViewCell?)CellTemplate?.Clone();
 
         if (HasHeaderCell)
         {
@@ -906,7 +903,7 @@ public class DataGridViewColumn : DataGridViewBand, IComponent
         }
     }
 
-    internal DataGridViewAutoSizeColumnMode GetInheritedAutoSizeMode(DataGridView dataGridView)
+    internal DataGridViewAutoSizeColumnMode GetInheritedAutoSizeMode(DataGridView? dataGridView)
     {
         if (dataGridView is not null && _autoSizeMode == DataGridViewAutoSizeColumnMode.NotSet)
         {
@@ -962,7 +959,7 @@ public class DataGridViewColumn : DataGridViewBand, IComponent
                 throw new InvalidEnumArgumentException(nameof(autoSizeColumnMode), (int)autoSizeColumnMode, typeof(DataGridViewAutoSizeColumnMode));
         }
 
-        DataGridView dataGridView = DataGridView;
+        DataGridView? dataGridView = DataGridView;
 
         Debug.Assert(dataGridView is null || Index > -1);
 


### PR DESCRIPTION
## Proposed changes

- Enable nullability in remaining DataGridViewColumn members.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10039)