### PR TITLE
Enable nullability in remaining PropertyGridView members

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridErrorDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridErrorDialog.cs
@@ -28,6 +28,7 @@ internal partial class GridErrorDialog : Form
 
     public bool DetailsButtonExpanded { get; private set; }
 
+    [AllowNull]
     public string Details
     {
         set => _detailsTextBox.Text = value;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -2261,7 +2261,7 @@ internal sealed partial class PropertyGridView :
 
         if (_selectedGridEntry is not null && _selectedGridEntry.GetValueOwner() is not null)
         {
-            UpdateHelpAttributes(null, _selectedGridEntry);
+            UpdateHelpAttributes(oldEntry: null, _selectedGridEntry);
         }
 
         // For empty GridView, draw a focus-indicator rectangle, just inside GridView borders.
@@ -2732,7 +2732,7 @@ internal sealed partial class PropertyGridView :
             {
                 try
                 {
-                    success = CommitText(_originalTextValue);
+                    success = CommitText(_originalTextValue!);
                 }
                 catch
                 {
@@ -4131,7 +4131,7 @@ internal sealed partial class PropertyGridView :
                 CommonEditorHide(true);
             }
 
-            UpdateHelpAttributes(_selectedGridEntry, null);
+            UpdateHelpAttributes(_selectedGridEntry, newEntry: null);
             _selectedGridEntry = null;
             SetFlag(Flags.IsNewSelection, true);
             TopLevelGridEntries = OwnerGrid.GetCurrentEntries();
@@ -4304,8 +4304,8 @@ internal sealed partial class PropertyGridView :
         Invalidate();
         return true;
     }
-#nullable disable
-    internal void SelectGridEntry(GridEntry entry, bool pageIn)
+
+    internal void SelectGridEntry(GridEntry? entry, bool pageIn)
     {
         if (entry is null)
         {
@@ -4377,7 +4377,7 @@ internal sealed partial class PropertyGridView :
             }
         }
 
-        GridEntry gridEntry = GetGridEntryFromRow(row);
+        GridEntry? gridEntry = GetGridEntryFromRow(row);
 
         // Update our reset command.
         if (row != _selectedRow)
@@ -4504,7 +4504,7 @@ internal sealed partial class PropertyGridView :
             EditTextBox.UseSystemPasswordChar = gridEntry.ShouldRenderPassword;
         }
 
-        GridEntry oldSelectedGridEntry = _selectedGridEntry;
+        GridEntry? oldSelectedGridEntry = _selectedGridEntry;
         _selectedRow = row;
         _selectedGridEntry = gridEntry;
         OwnerGrid.SetStatusBox(gridEntry.PropertyLabel, gridEntry.PropertyDescription);
@@ -4558,7 +4558,7 @@ internal sealed partial class PropertyGridView :
         int oldWidth = _labelWidth;
 
         bool adjustWidth = SetScrollbarLength();
-        GridEntryCollection rgipesAll = GetAllGridEntries();
+        GridEntryCollection? rgipesAll = GetAllGridEntries();
         if (rgipesAll is not null)
         {
             int scroll = GetScrollOffset();
@@ -4660,10 +4660,10 @@ internal sealed partial class PropertyGridView :
         }
 
         RecalculateProperties();
-        GridEntry selectedEntry = _selectedGridEntry;
+        GridEntry? selectedEntry = _selectedGridEntry;
         if (!value)
         {
-            for (GridEntry currentEntry = selectedEntry; currentEntry is not null; currentEntry = currentEntry.ParentGridEntry)
+            for (GridEntry? currentEntry = selectedEntry; currentEntry is not null; currentEntry = currentEntry.ParentGridEntry)
             {
                 if (currentEntry.Equals(entry))
                 {
@@ -4775,7 +4775,7 @@ internal sealed partial class PropertyGridView :
 
     private bool CommitValue(object value)
     {
-        GridEntry currentEntry = _selectedGridEntry;
+        GridEntry? currentEntry = _selectedGridEntry;
 
         if (_selectedGridEntry is null && _selectedRow != -1)
         {
@@ -4797,7 +4797,7 @@ internal sealed partial class PropertyGridView :
 
         int propCount = entry.ChildCount;
         bool capture = EditTextBox.HookMouseDown;
-        object originalValue = null;
+        object? originalValue = null;
 
         try
         {
@@ -4826,7 +4826,7 @@ internal sealed partial class PropertyGridView :
                 try
                 {
                     EditTextBox.DisableMouseHook = true;
-                    entry.PropertyValue = value;
+                    entry!.PropertyValue = value;
                 }
                 finally
                 {
@@ -4874,7 +4874,7 @@ internal sealed partial class PropertyGridView :
 
             // Reselect the row to find the replacement.
             SelectGridEntry(entry, pageIn: true);
-            entry = _selectedGridEntry;
+            entry = _selectedGridEntry!;
 
             if (editfocused && _editTextBox is not null)
             {
@@ -4893,7 +4893,7 @@ internal sealed partial class PropertyGridView :
 
         object value;
 
-        GridEntry currentEntry = _selectedGridEntry;
+        GridEntry? currentEntry = _selectedGridEntry;
 
         if (_selectedGridEntry is null && _selectedRow != -1)
         {
@@ -5047,7 +5047,7 @@ internal sealed partial class PropertyGridView :
         HWND priorFocus = PInvoke.GetFocus();
 
         DialogResult result;
-        if (TryGetService(out IUIService uiService))
+        if (TryGetService(out IUIService? uiService))
         {
             result = uiService.ShowDialog(dialog);
         }
@@ -5064,7 +5064,7 @@ internal sealed partial class PropertyGridView :
         return result;
     }
 
-    private unsafe void ShowFormatExceptionMessage(string propertyName, Exception ex)
+    private unsafe void ShowFormatExceptionMessage(string propertyName, Exception? ex)
     {
         propertyName ??= "(unknown)";
 
@@ -5097,13 +5097,13 @@ internal sealed partial class PropertyGridView :
         }
 
         // Try to find an exception message to display
-        string exMessage = ex.Message;
+        string? exMessage = ex?.Message;
 
         bool revert;
 
         while (exMessage is null || exMessage.Length == 0)
         {
-            ex = ex.InnerException;
+            ex = ex?.InnerException;
             if (ex is null)
             {
                 break;
@@ -5116,7 +5116,7 @@ internal sealed partial class PropertyGridView :
         ErrorDialog.Text = SR.PBRSErrorTitle;
         ErrorDialog.Details = exMessage;
 
-        if (TryGetService(out IUIService uiService))
+        if (TryGetService(out IUIService? uiService))
         {
             revert = uiService.ShowDialog(ErrorDialog) == DialogResult.Cancel;
         }
@@ -5140,7 +5140,7 @@ internal sealed partial class PropertyGridView :
         }
     }
 
-    internal unsafe void ShowInvalidMessage(string propertyName, Exception ex)
+    internal unsafe void ShowInvalidMessage(string propertyName, Exception? ex)
     {
         propertyName ??= "(unknown)";
 
@@ -5174,13 +5174,13 @@ internal sealed partial class PropertyGridView :
         }
 
         // Try to find an exception message to display.
-        string message = ex.Message;
+        string? message = ex?.Message;
 
         bool revert;
 
         while (message is null || message.Length == 0)
         {
-            ex = ex.InnerException;
+            ex = ex?.InnerException;
             if (ex is null)
             {
                 break;
@@ -5193,7 +5193,7 @@ internal sealed partial class PropertyGridView :
         ErrorDialog.Text = SR.PBRSErrorTitle;
         ErrorDialog.Details = message;
 
-        if (TryGetService(out IUIService uiService))
+        if (TryGetService(out IUIService? uiService))
         {
             revert = uiService.ShowDialog(ErrorDialog) == DialogResult.Cancel;
         }
@@ -5221,7 +5221,7 @@ internal sealed partial class PropertyGridView :
 
     private void TabSelection()
     {
-        GridEntry gridEntry = GetGridEntryFromRow(_selectedRow);
+        GridEntry? gridEntry = GetGridEntryFromRow(_selectedRow);
         if (gridEntry is null)
         {
             return;
@@ -5244,10 +5244,10 @@ internal sealed partial class PropertyGridView :
 
     internal void RemoveSelectedEntryHelpAttributes()
     {
-        UpdateHelpAttributes(_selectedGridEntry, null);
+        UpdateHelpAttributes(_selectedGridEntry, newEntry: null);
     }
 
-    private void UpdateHelpAttributes(GridEntry oldEntry, GridEntry newEntry)
+    private void UpdateHelpAttributes(GridEntry? oldEntry, GridEntry? newEntry)
     {
         // Update the help context with the current property.
         if (_helpService is null && ServiceProvider.TryGetService(out _topHelpService!))
@@ -5260,7 +5260,7 @@ internal sealed partial class PropertyGridView :
             return;
         }
 
-        GridEntry temp = oldEntry;
+        GridEntry? temp = oldEntry;
         if (oldEntry is not null && !oldEntry.Disposed)
         {
             while (temp is not null)
@@ -5348,7 +5348,7 @@ internal sealed partial class PropertyGridView :
     private bool UnfocusSelection()
     {
         CompModSwitches.DebugGridView.TraceVerbose("PropertyGridView:UnfocusSelection()");
-        GridEntry gridEntry = GetGridEntryFromRow(_selectedRow);
+        GridEntry? gridEntry = GetGridEntryFromRow(_selectedRow);
         if (gridEntry is null)
         {
             return true;
@@ -5364,11 +5364,11 @@ internal sealed partial class PropertyGridView :
         return commit;
     }
 
-    private void UpdateResetCommand(GridEntry gridEntry)
+    private void UpdateResetCommand(GridEntry? gridEntry)
     {
-        if (TotalProperties > 0 && TryGetService(out IMenuCommandService menuCommandService))
+        if (TotalProperties > 0 && TryGetService(out IMenuCommandService? menuCommandService))
         {
-            MenuCommand reset = menuCommandService.FindCommand(PropertyGridCommands.Reset);
+            MenuCommand? reset = menuCommandService.FindCommand(PropertyGridCommands.Reset);
             if (reset is not null)
             {
                 reset.Enabled = gridEntry is not null && gridEntry.CanResetPropertyValue();
@@ -5433,7 +5433,7 @@ internal sealed partial class PropertyGridView :
                         break;
                     }
 
-                    GridEntry curEntry = GetGridEntryFromRow(mouseLoc.Y);
+                    GridEntry? curEntry = GetGridEntryFromRow(mouseLoc.Y);
 
                     if (curEntry is null)
                     {
@@ -5512,6 +5512,7 @@ internal sealed partial class PropertyGridView :
                 {
                     // If we're going backwards, we don't want the tab.
                     // Otherwise we only want it if we have an edit.
+                    Debug.Assert(_editTextBox is not null);
                     if (_editTextBox.Visible)
                     {
                         flags |= PInvoke.DLGC_WANTTAB;


### PR DESCRIPTION
## Proposed changes

- Enable nullability in remaining PropertyGridView members.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10053)