### PR TITLE
Handle Xunit changes

### DIFF
--- a/src/System.Drawing.Common/tests/Drawing2D/GraphicsPathTests.cs
+++ b/src/System.Drawing.Common/tests/Drawing2D/GraphicsPathTests.cs
@@ -584,17 +584,17 @@ public class GraphicsPathTests
     [Fact]
     public void AddCurve_Success()
     {
-        PointF[] points = new PointF[]
-        {
+        PointF[] points =
+        [
             new PointF (37f, 185f),
             new PointF (99f, 185f),
             new PointF (161f, 159f),
             new PointF (223f, 185f),
             new PointF (285f, 54f),
-        };
+        ];
 
-        PointF[] expectedPoints = new PointF[]
-        {
+        PointF[] expectedPoints =
+        [
             new PointF (37f, 185f),
             new PointF (47.33333f, 185f),
             new PointF (78.3333f, 189.3333f),
@@ -608,10 +608,10 @@ public class GraphicsPathTests
             new PointF (243.6667f, 167.5f),
             new PointF (274.6667f, 75.8333f),
             new PointF (285f, 54f),
-        };
+        ];
 
-        byte[] expectedTypes = new byte[] { 0, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3 };
-        int[] pointsCount = { 4, 7, 10, 13 };
+        byte[] expectedTypes = [0, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3];
+        int[] pointsCount = [4, 7, 10, 13];
         using (GraphicsPath gp = new GraphicsPath())
         {
             for (int i = 0; i < points.Length - 1; i++)
@@ -620,8 +620,8 @@ public class GraphicsPathTests
                 Assert.Equal(pointsCount[i], gp.PointCount);
             }
 
-            AssertPointsSequenceEqual(expectedPoints, gp.PathPoints, Delta);
-            Assert.Equal(expectedTypes, gp.PathTypes);
+            gp.PathPoints.Should().BeApproximatelyEquivalentTo(expectedPoints, Delta);
+            gp.PathTypes.Should().BeEquivalentTo(expectedTypes);
         }
     }
 
@@ -1298,9 +1298,9 @@ public class GraphicsPathTests
         using (GraphicsPath gp = new GraphicsPath())
         using (Matrix matrix = new Matrix())
         {
-            Rectangle rectangle = new Rectangle(10, 10, 100, 100);
+            Rectangle rectangle = new(10, 10, 100, 100);
             gp.AddPie(rectangle, 30, 45);
-            AssertRectangleEqual(new RectangleF(60f, 60f, 43.3f, 48.3f), gp.GetBounds(), 0.1f);
+            gp.GetBounds().Should().BeApproximately(new (60f, 60f, 43.3f, 48.3f), precision: 0.1f);
         }
     }
 
@@ -1890,25 +1890,25 @@ public class GraphicsPathTests
     [Fact]
     public void Widen_Pen_Success()
     {
-        PointF[] expectedPoints = new PointF[]
-        {
+        PointF[] expectedPoints =
+        [
             new PointF(0.5f, 0.5f), new PointF(3.5f, 0.5f), new PointF(3.5f, 3.5f),
             new PointF(0.5f, 3.5f), new PointF(1.5f, 3.0f), new PointF(1.0f, 2.5f),
             new PointF(3.0f, 2.5f), new PointF(2.5f, 3.0f), new PointF(2.5f, 1.0f),
             new PointF(3.0f, 1.5f), new PointF(1.0f, 1.5f), new PointF(1.5f, 1.0f),
-        };
+        ];
 
-        byte[] expectedTypes = new byte[] { 0, 1, 1, 129, 0, 1, 1, 1, 1, 1, 1, 129 };
+        byte[] expectedTypes = [0, 1, 1, 129, 0, 1, 1, 1, 1, 1, 1, 129];
 
         using (GraphicsPath gp = new GraphicsPath())
         using (Pen pen = new Pen(Color.Blue))
         {
             gp.AddRectangle(new Rectangle(1, 1, 2, 2));
-            Assert.Equal(4, gp.PointCount);
+            gp.PointCount.Should().Be(4);
             gp.Widen(pen);
-            Assert.Equal(12, gp.PointCount);
-            AssertPointsSequenceEqual(expectedPoints, gp.PathPoints, Delta);
-            Assert.Equal(expectedTypes, gp.PathTypes);
+            gp.PointCount.Should().Be(12);
+            gp.PathPoints.Should().BeApproximatelyEquivalentTo(expectedPoints, Delta);
+            gp.PathTypes.Should().BeEquivalentTo(expectedTypes);
         }
     }
 
@@ -1983,8 +1983,8 @@ public class GraphicsPathTests
             pen.Width = penWidth;
             gp.AddRectangle(rectangle);
             gp.Widen(pen);
-            AssertRectangleEqual(expectedBounds, gp.GetBounds(null), Delta);
-            AssertRectangleEqual(expectedBounds, gp.GetBounds(matrix), Delta);
+            gp.GetBounds(null).Should().BeApproximately(expectedBounds, Delta);
+            gp.GetBounds(matrix).Should().BeApproximately(expectedBounds, Delta);
         }
     }
 
@@ -2382,148 +2382,149 @@ public class GraphicsPathTests
 
     private void AssertLine(GraphicsPath path)
     {
-        PointF[] expectedPoints = new PointF[]
-        {
+        PointF[] expectedPoints =
+        [
             new PointF(1f, 1f), new PointF(2f, 2f)
-        };
+        ];
 
-        Assert.Equal(2, path.PathPoints.Length);
-        Assert.Equal(2, path.PathTypes.Length);
-        Assert.Equal(2, path.PathData.Points.Length);
-        AssertExtensions.Equal(new RectangleF(1f, 1f, 1f, 1f), path.GetBounds(), variance: 0.000001f);
-        Assert.Equal(expectedPoints, path.PathPoints);
-        Assert.Equal(new byte[] { 0, 1 }, path.PathTypes);
+        path.PathPoints.Should().HaveCount(2);
+        path.PathTypes.Should().HaveCount(2);
+        path.PathData.Points.Should().HaveCount(2);
+        path.GetBounds().Should().BeApproximately(new(1f, 1f, 1f, 1f), precision: 0.000001f);
+        path.PathPoints.Should().BeApproximatelyEquivalentTo(expectedPoints, Delta);
+        path.PathTypes.Should().BeEquivalentTo(new byte[] { 0, 1 });
     }
 
     private void AssertArc(GraphicsPath path)
     {
-        PointF[] expectedPoints = new PointF[]
-        {
+        PointF[] expectedPoints =
+        [
             new PointF(2.99990582f, 2.01370716f), new PointF(2.99984312f, 2.018276f),
             new PointF(2.99974918f, 2.02284455f), new PointF(2.999624f, 2.027412f),
-        };
+        ];
 
-        Assert.Equal(4, path.PathPoints.Length);
-        Assert.Equal(4, path.PathTypes.Length);
-        Assert.Equal(4, path.PathData.Points.Length);
-        AssertExtensions.Equal(new RectangleF(2.99962401f, 2.01370716f, 0f, 0.0137047768f), path.GetBounds(), variance: Delta);
-        Assert.Equal(expectedPoints, path.PathPoints);
-        Assert.Equal(new byte[] { 0, 3, 3, 3 }, path.PathTypes);
+        path.PathPoints.Should().HaveCount(4);
+        path.PathTypes.Should().HaveCount(4);
+        path.PathData.Points.Should().HaveCount(4);
+        path.GetBounds().Should().BeApproximately(new(2.99962401f, 2.01370716f, 0f, 0.0137047768f), Delta);
+        path.PathPoints.Should().BeApproximatelyEquivalentTo(expectedPoints, Delta);
+        path.PathTypes.Should().BeEquivalentTo(new byte[] { 0, 3, 3, 3 });
     }
 
     private void AssertBezier(GraphicsPath path)
     {
-        PointF[] expectedPoints = new PointF[]
-        {
+        PointF[] expectedPoints =
+        [
             new PointF(1f, 1f), new PointF(2f, 2f),
             new PointF(3f, 3f), new PointF(4f, 4f),
-        };
+        ];
 
-        Assert.Equal(4, path.PointCount);
-        Assert.Equal(4, path.PathPoints.Length);
-        Assert.Equal(4, path.PathTypes.Length);
-        Assert.Equal(4, path.PathData.Points.Length);
-        AssertExtensions.Equal(new RectangleF(1f, 1f, 3f, 3f), path.GetBounds(), Delta);
-        AssertPointsSequenceEqual(expectedPoints, path.PathPoints, Delta);
-        Assert.Equal(new byte[] { 0, 3, 3, 3 }, path.PathTypes);
+        path.PointCount.Should().Be(4);
+        path.PathPoints.Should().HaveCount(4);
+        path.PathTypes.Should().HaveCount(4);
+        path.PathData.Points.Should().HaveCount(4);
+        path.GetBounds().Should().BeApproximately(new (1f, 1f, 3f, 3f), Delta);
+        path.PathPoints.Should().BeApproximatelyEquivalentTo(expectedPoints, Delta);
+        path.PathTypes.Should().BeEquivalentTo(new byte[] { 0, 3, 3, 3 });
     }
 
     private void AssertCurve(GraphicsPath path)
     {
-        PointF[] expectedPoints = new PointF[]
-        {
+        PointF[] expectedPoints =
+        [
             new PointF(1f, 1f), new PointF(1.16666663f, 1.16666663f),
             new PointF(1.83333325f, 1.83333325f), new PointF(2f, 2f)
-        };
+        ];
 
-        Assert.Equal(4, path.PathPoints.Length);
-        Assert.Equal(4, path.PathTypes.Length);
-        Assert.Equal(4, path.PathData.Points.Length);
-        AssertExtensions.Equal(new RectangleF(1f, 1f, 1f, 1f), path.GetBounds(), Delta);
-        AssertPointsSequenceEqual(expectedPoints, path.PathPoints, Delta);
-        Assert.Equal(new byte[] { 0, 3, 3, 3 }, path.PathTypes);
+        path.PathPoints.Should().HaveCount(4);
+        path.PathTypes.Should().HaveCount(4);
+        path.PathData.Points.Should().HaveCount(4);
+        path.GetBounds().Should().BeApproximately(new (1f, 1f, 1f, 1f), Delta);
+        path.PathPoints.Should().BeApproximatelyEquivalentTo(expectedPoints, Delta);
+        path.PathTypes.Should().BeEquivalentTo(new byte[] { 0, 3, 3, 3 });
     }
 
     private void AssertClosedCurve(GraphicsPath path)
     {
-        Assert.Equal(10, path.PathPoints.Length);
-        Assert.Equal(10, path.PathTypes.Length);
-        Assert.Equal(10, path.PathData.Points.Length);
-        AssertExtensions.Equal(new RectangleF(0.8333333f, 0.8333333f, 2.33333278f, 2.33333278f), path.GetBounds(), Delta);
-        Assert.Equal(new byte[] { 0, 3, 3, 3, 3, 3, 3, 3, 3, 131 }, path.PathTypes);
+        path.PathPoints.Should().HaveCount(10);
+        path.PathTypes.Should().HaveCount(10);
+        path.PathData.Points.Should().HaveCount(10);
+        path.GetBounds().Should().BeApproximately(new (0.8333333f, 0.8333333f, 2.33333278f, 2.33333278f), Delta);
+        path.PathTypes.Should().BeEquivalentTo(new byte[] { 0, 3, 3, 3, 3, 3, 3, 3, 3, 131 });
     }
 
     private void AssertRectangle(GraphicsPath path)
     {
-        PointF[] expectedPoints = new PointF[]
-        {
+        PointF[] expectedPoints =
+        [
             new PointF(1f, 1f), new PointF(3f, 1f),
             new PointF(3f, 3f), new PointF(1f, 3f)
-        };
+        ];
 
-        Assert.Equal(4, path.PathPoints.Length);
-        Assert.Equal(4, path.PathTypes.Length);
-        Assert.Equal(4, path.PathData.Points.Length);
-        AssertExtensions.Equal(new RectangleF(1f, 1f, 2f, 2f), path.GetBounds(), Delta);
-        AssertPointsSequenceEqual(expectedPoints, path.PathPoints, Delta);
-        Assert.Equal(new byte[] { 0, 1, 1, 129 }, path.PathTypes);
+        path.PathPoints.Should().HaveCount(4);
+        path.PathPoints.Should().HaveCount(4);
+        path.PathTypes.Should().HaveCount(4);
+        path.PathData.Points.Should().HaveCount(4);
+        path.GetBounds().Should().BeApproximately(new (1f, 1f, 2f, 2f), Delta);
+        path.PathPoints.Should().BeApproximatelyEquivalentTo(expectedPoints, Delta);
+        path.PathTypes.Should().BeEquivalentTo(new byte[] { 0, 1, 1, 129 });
     }
 
     private void AssertEllipse(GraphicsPath path)
     {
-        Assert.Equal(13, path.PathPoints.Length);
-        Assert.Equal(13, path.PathTypes.Length);
-        Assert.Equal(13, path.PathData.Points.Length);
-        AssertExtensions.Equal(new RectangleF(1f, 1f, 2f, 2f), path.GetBounds(), Delta);
-        Assert.Equal(new byte[] { 0, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 131 }, path.PathTypes);
+        path.PathPoints.Should().HaveCount(13);
+        path.PathTypes.Should().HaveCount(13);
+        path.PathData.Points.Should().HaveCount(13);
+        path.GetBounds().Should().BeApproximately(new (1f, 1f, 2f, 2f), Delta);
+        path.PathTypes.Should().BeEquivalentTo(new byte[] { 0, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 131 });
     }
 
     private void AssertPie(GraphicsPath path)
     {
-        PointF[] expectedPoints = new PointF[]
-        {
+        PointF[] expectedPoints =
+        [
             new PointF(2f, 2f), new PointF(2.99990582f, 2.01370716f),
             new PointF(2.99984312f, 2.018276f), new PointF(2.99974918f, 2.02284455f),
             new PointF(2.999624f, 2.027412f)
-        };
+        ];
 
-        Assert.Equal(5, path.PathPoints.Length);
-        Assert.Equal(5, path.PathTypes.Length);
-        Assert.Equal(5, path.PathData.Points.Length);
-        AssertRectangleEqual(new RectangleF(2f, 2f, 0.9999058f, 0.0274119377f), path.GetBounds(), Delta);
-        AssertPointsSequenceEqual(expectedPoints, path.PathPoints, Delta);
-        Assert.Equal(new byte[] { 0, 1, 3, 3, 131 }, path.PathTypes);
+        path.PathPoints.Should().HaveCount(5);
+        path.PathTypes.Should().HaveCount(5);
+        path.PathData.Points.Should().HaveCount(5);
+        path.GetBounds().Should().BeApproximately(new (2f, 2f, 0.9999058f, 0.0274119377f), Delta);
+        path.PathPoints.Should().BeApproximatelyEquivalentTo(expectedPoints, Delta);
+        path.PathTypes.Should().BeEquivalentTo(new byte[] { 0, 1, 3, 3, 131 });
     }
 
     private void AssertPolygon(GraphicsPath path)
     {
-        PointF[] expectedPoints = new PointF[]
-        {
+        PointF[] expectedPoints =
+        [
             new PointF(1f, 1f),
             new PointF(2f, 2f),
             new PointF(3f, 3f)
-        };
+        ];
 
-        Assert.Equal(3, path.PathPoints.Length);
-        Assert.Equal(3, path.PathTypes.Length);
-        Assert.Equal(3, path.PathData.Points.Length);
-        AssertExtensions.Equal(new RectangleF(1f, 1f, 2f, 2f), path.GetBounds(), Delta);
-        AssertPointsSequenceEqual(expectedPoints, path.PathPoints, Delta);
-        Assert.Equal(new byte[] { 0, 1, 129 }, path.PathTypes);
+        path.PathPoints.Should().HaveCount(3);
+        path.PathTypes.Should().HaveCount(3);
+        path.PathData.Points.Should().HaveCount(3);
+        path.GetBounds().Should().BeApproximately(new (1f, 1f, 2f, 2f), Delta);
+        path.PathPoints.Should().BeApproximatelyEquivalentTo(expectedPoints, Delta);
+        path.PathTypes.Should().BeEquivalentTo(new byte[] { 0, 1, 129 });
     }
 
     private void AssertFlats(GraphicsPath flat, GraphicsPath original)
     {
-        AssertExtensions.GreaterThanOrEqualTo(flat.PointCount, original.PointCount);
+        flat.PointCount.Should().BeGreaterThanOrEqualTo(original.PointCount);
         for (int i = 0; i < flat.PointCount; i++)
         {
-            Assert.NotEqual(3, flat.PathTypes[i]);
+            flat.PathTypes[i].Should().NotBe(3);
         }
     }
 
     private void AssertWrapNaN(GraphicsPath path)
     {
-        byte[] expectedTypes = new byte[] { 0, 1, 129 };
+        byte[] expectedTypes = [0, 1, 129];
 
         Assert.Equal(3, path.PointCount);
         Assert.Equal(float.NaN, path.PathPoints[0].X);
@@ -2537,17 +2538,17 @@ public class GraphicsPathTests
 
     private void AssertWiden3(GraphicsPath path)
     {
-        PointF[] expectedPoints = new PointF[]
-        {
+        PointF[] expectedPoints =
+        [
             new PointF(4.2f, 4.5f), new PointF(15.8f, 4.5f),
             new PointF(10.0f, 16.1f), new PointF(10.4f, 14.8f),
             new PointF(9.6f, 14.8f), new PointF(14.6f, 4.8f),
             new PointF(15.0f, 5.5f), new PointF(5.0f, 5.5f),
             new PointF(5.4f, 4.8f)
-        };
+        ];
 
-        AssertPointsSequenceEqual(expectedPoints, path.PathPoints, 0.25f);
-        Assert.Equal(new byte[] { 0, 1, 129, 0, 1, 1, 1, 1, 129 }, path.PathTypes);
+        path.PathPoints.Should().BeApproximatelyEquivalentTo(expectedPoints, precision: 0.25f);
+        path.PathTypes.Should().BeEquivalentTo(new byte[] { 0, 1, 129, 0, 1, 1, 1, 1, 129 });
     }
 
     private void AssertIsOutlineVisibleLine(Graphics graphics)
@@ -2661,24 +2662,5 @@ public class GraphicsPathTests
             Assert.Equal(expectedPoints[i], reversedPoints[count - i - 1]);
             Assert.Equal(expectedTypes[i], reversedTypes[i]);
         }
-    }
-
-    private void AssertPointsSequenceEqual(PointF[] expected, PointF[] actual, float tolerance)
-    {
-        int count = expected.Length;
-        Assert.Equal(expected.Length, actual.Length);
-        for (int i = 0; i < count; i++)
-        {
-            AssertExtensions.LessThanOrEqualTo(Math.Abs(expected[i].X - actual[i].X), tolerance);
-            AssertExtensions.LessThanOrEqualTo(Math.Abs(expected[i].Y - actual[i].Y), tolerance);
-        }
-    }
-
-    private void AssertRectangleEqual(RectangleF expected, RectangleF actual, float tolerance)
-    {
-        AssertExtensions.LessThanOrEqualTo(Math.Abs(expected.X - actual.X), tolerance);
-        AssertExtensions.LessThanOrEqualTo(Math.Abs(expected.Y - actual.Y), tolerance);
-        AssertExtensions.LessThanOrEqualTo(Math.Abs(expected.Width - actual.Width), tolerance);
-        AssertExtensions.LessThanOrEqualTo(Math.Abs(expected.Height - actual.Height), tolerance);
     }
 }

--- a/src/System.Drawing.Common/tests/GlobalUsings.cs
+++ b/src/System.Drawing.Common/tests/GlobalUsings.cs
@@ -4,3 +4,4 @@
 global using System.Drawing;
 global using System.Diagnostics;
 global using Xunit;
+global using FluentAssertions;

--- a/src/System.Drawing.Common/tests/Helpers.cs
+++ b/src/System.Drawing.Common/tests/Helpers.cs
@@ -47,8 +47,8 @@ public static class Helpers
     {
         // Print out the whole bitmap to provide a view of the whole image, rather than just the difference between
         // a single pixel.
-        var actualStringBuilder = new StringBuilder();
-        var expectedStringBuilder = new StringBuilder();
+        StringBuilder actualStringBuilder = new();
+        StringBuilder expectedStringBuilder = new();
 
         actualStringBuilder.AppendLine();
         expectedStringBuilder.AppendLine();
@@ -69,7 +69,10 @@ public static class Helpers
             expectedStringBuilder.AppendLine();
         }
 
-        return new AssertActualExpectedException(expectedStringBuilder.ToString(), actualStringBuilder.ToString(), $"Bitmaps were different at {firstFailureX}, {firstFailureY}.");
+        return EqualException.ForMismatchedValues(
+            expectedStringBuilder.ToString(),
+            actualStringBuilder.ToString(),
+            $"Bitmaps were different at {firstFailureX}, {firstFailureY}.");
     }
 
     private static void PrintColor(StringBuilder stringBuilder, Color color)

--- a/src/System.Drawing.Common/tests/System.Drawing.Common.Tests.csproj
+++ b/src/System.Drawing.Common/tests/System.Drawing.Common.Tests.csproj
@@ -137,4 +137,8 @@
     <PackageReference Include="System.ComponentModel.TypeConverter.TestData" Version="$(SystemComponentModelTypeConverterTestDataVersion)" />
     <PackageReference Include="System.Windows.Extensions.TestData" Version="$(SystemWindowsExtensionsTestDataVersion)" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
+  </ItemGroup>
 </Project>

--- a/src/System.Windows.Forms.Design/tests/UnitTests/CodeDomHelpers.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/CodeDomHelpers.cs
@@ -17,7 +17,7 @@ public static class CodeDomHelpers
                 Assert.Equal(GetConstructionString(expected[i]), GetConstructionString(actual[i]));
             }
         }
-        catch (Xunit.Sdk.AssertActualExpectedException)
+        catch (Xunit.Sdk.XunitException)
         {
             Console.WriteLine($"Expected: {expected.Count} elements");
             for (int i = 0; i < expected.Count; i++)

--- a/src/System.Windows.Forms.Design/tests/UnitTests/GlobalUsings.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/GlobalUsings.cs
@@ -2,4 +2,5 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 global using System.Windows.Forms;
+global using FluentAssertions;
 global using Xunit;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System.Windows.Forms.Design.Tests.csproj
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System.Windows.Forms.Design.Tests.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisCSharpPackageVersion)" />
     <PackageReference Include="Moq" Version="$(MoqPackageVersion)" />
     <PackageReference Include="xunit.stafact" Version="$(XUnitStaFactPackageVersion)" />

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/EmbeddedResourceTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/EmbeddedResourceTests.cs
@@ -107,7 +107,7 @@ public class EmbeddedResourceTests
         Assert.NotNull(bitmap);
     }
 
-    private const string expectedResourceNames = """
+    private const string ExpectedResourceNames = """
             System.ComponentModel.Design.BinaryEditor.resources
             System.ComponentModel.Design.CollectionEditor.resources
             System.SR.resources
@@ -129,10 +129,9 @@ public class EmbeddedResourceTests
         string[] actual = assembly.GetManifestResourceNames();
         Array.Sort(actual, StringComparer.Ordinal);
 
-        string resourceNames = s_expectedIconNames + "\r\n" + s_expectedBitmapNames;
-        string[] expected = $"{resourceNames}{Environment.NewLine}{expectedResourceNames}".Split(Environment.NewLine);
+        string[] expected = $"{s_expectedIconNames}{Environment.NewLine}{s_expectedBitmapNames}{Environment.NewLine}{ExpectedResourceNames}".Split(Environment.NewLine);
         Array.Sort(expected, StringComparer.Ordinal);
 
-        AssertExtensions.Equal(expected, actual);
+        actual.Should().Equal(expected);
     }
 }

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/FluentAssertions/FluentAssertExtensions.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/FluentAssertions/FluentAssertExtensions.cs
@@ -1,0 +1,101 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Drawing;
+using FluentAssertions.Collections;
+using FluentAssertions.Numeric;
+
+namespace FluentAssertions;
+
+public static class FluentAssertExtensions
+{
+    /// <summary>
+    ///  Returns a <see cref="RectangleFAssertions"/> object that can be used to assert the
+    ///  current <see cref="RectangleF"/>.
+    /// </summary>
+    public static RectangleFAssertions Should(this RectangleF actualValue) => new(actualValue);
+
+    /// <summary>
+    ///  Returns a <see cref="PointFAssertions"/> object that can be used to assert the
+    ///  current <see cref="PointF"/>.
+    /// </summary>
+    public static PointFAssertions Should(this PointF actualValue) => new(actualValue);
+
+    /// <summary>
+    ///  Asserts a <see cref="RectangleF"/> value approximates another value as close as possible.
+    /// </summary>
+    /// <param name="parent">The <see cref="RectangleFAssertions"/> object that is being extended.</param>
+    /// <inheritdoc cref="NumericAssertionsExtensions.BeApproximately(NullableNumericAssertions{float}, float, float, string, object[])"/>
+    public static AndConstraint<RectangleFAssertions> BeApproximately(
+        this RectangleFAssertions parent,
+        RectangleF expectedValue,
+        float precision,
+        string because = "",
+        params object[] becauseArgs)
+    {
+        parent.Subject.X.Should().BeApproximately(expectedValue.X, precision, because, becauseArgs);
+        parent.Subject.Y.Should().BeApproximately(expectedValue.Y, precision, because, becauseArgs);
+        parent.Subject.Width.Should().BeApproximately(expectedValue.Width, precision, because, becauseArgs);
+        parent.Subject.Height.Should().BeApproximately(expectedValue.Height, precision, because, becauseArgs);
+
+        return new(parent);
+    }
+
+    /// <summary>
+    ///  Asserts that two <see cref="RectangleF"/> collections contain the same items in the same order
+    ///  within the given <paramref name="precision"/>.
+    /// </summary>
+    /// <param name="precision">The maximum amount of which the two values may differ.</param>
+    public static AndConstraint<GenericCollectionAssertions<RectangleF>> BeApproximatelyEquivalentTo(
+        this GenericCollectionAssertions<RectangleF> parent,
+        IEnumerable<RectangleF> expectation,
+        float precision,
+        string because = "",
+        params object[] becauseArgs)
+        => parent.Equal(
+            expectation,
+            (RectangleF actual, RectangleF expected) =>
+                 ComparisonHelpers.EqualsFloating(expected.X, actual.X, precision)
+                    && ComparisonHelpers.EqualsFloating(expected.Y, actual.Y, precision)
+                    && ComparisonHelpers.EqualsFloating(expected.Width, actual.Width, precision)
+                    && ComparisonHelpers.EqualsFloating(expected.Height, actual.Height, precision),
+            because,
+            becauseArgs);
+
+    /// <summary>
+    ///  Asserts a <see cref="PointF"/> value approximates another value as close as possible.
+    /// </summary>
+    /// <param name="parent">The <see cref="PointFAssertions"/> object that is being extended.</param>
+    /// <inheritdoc cref="NumericAssertionsExtensions.BeApproximately(NullableNumericAssertions{float}, float, float, string, object[])"/>
+    public static AndConstraint<PointFAssertions> BeApproximately(
+        this PointFAssertions parent,
+        PointF expectedValue,
+        float precision,
+        string because = "",
+        params object[] becauseArgs)
+    {
+        parent.Subject.X.Should().BeApproximately(expectedValue.X, precision, because, becauseArgs);
+        parent.Subject.Y.Should().BeApproximately(expectedValue.Y, precision, because, becauseArgs);
+
+        return new AndConstraint<PointFAssertions>(parent);
+    }
+
+    /// <summary>
+    ///  Asserts that two <see cref="PointF"/> collections contain the same items in the same order
+    ///  within the given <paramref name="precision"/>.
+    /// </summary>
+    /// <param name="precision">The maximum amount of which the two values may differ.</param>
+    public static AndConstraint<GenericCollectionAssertions<PointF>> BeApproximatelyEquivalentTo(
+        this GenericCollectionAssertions<PointF> parent,
+        IEnumerable<PointF> expectation,
+        float precision,
+        string because = "",
+        params object[] becauseArgs)
+        => parent.Equal(
+            expectation,
+            (PointF actual, PointF expected) =>
+                 ComparisonHelpers.EqualsFloating(expected.X, actual.X, precision)
+                    && ComparisonHelpers.EqualsFloating(expected.Y, actual.Y, precision),
+            because,
+            becauseArgs);
+}

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/FluentAssertions/PointFAssertions.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/FluentAssertions/PointFAssertions.cs
@@ -1,0 +1,11 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Drawing;
+
+namespace FluentAssertions.Numeric;
+
+public class PointFAssertions(PointF value)
+{
+    public PointF Subject { get; } = value;
+}

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/FluentAssertions/RectangleFAssertions.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/FluentAssertions/RectangleFAssertions.cs
@@ -1,0 +1,11 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Drawing;
+
+namespace FluentAssertions.Numeric;
+
+public class RectangleFAssertions(RectangleF value)
+{
+    public RectangleF Subject { get; } = value;
+}

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/System.Windows.Forms.Primitives.TestUtilities.csproj
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/System.Windows.Forms.Primitives.TestUtilities.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
     <PackageReference Include="Moq" Version="$(MoqPackageVersion)" />
     <PackageReference Include="System.Collections.Concurrent" Version="4.3.0" />
     <PackageReference Include="xunit.stafact" Version="$(XUnitStaFactPackageVersion)" />

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/Interop/Oleaut32/VARIANTTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/Interop/Oleaut32/VARIANTTests.cs
@@ -155,11 +155,12 @@ public unsafe class VARIANTTests
     [StaFact]
     public void VARIANT_Dispose_InvokeBSTR_Success()
     {
-        using VARIANT variant = new()
+        VARIANT variant = new()
         {
             vt = VT_BSTR,
             data = new() { bstrVal = new BSTR("abc") }
         };
+
         variant.Dispose();
         Assert.Equal(VT_EMPTY, variant.vt);
         Assert.True(variant.Anonymous.Anonymous.Anonymous.pbstrVal is null);
@@ -167,7 +168,7 @@ public unsafe class VARIANTTests
 
     public static IEnumerable<object[]> ToObject_TestData()
     {
-        if (IntPtr.Size == 8)
+        if (nint.Size == 8)
         {
             yield return new object[] { VT_I1, unchecked((nint)long.MinValue), (sbyte)0 };
         }
@@ -181,7 +182,7 @@ public unsafe class VARIANTTests
         yield return new object[] { VT_I1, (nint)sbyte.MaxValue, sbyte.MaxValue };
         yield return new object[] { VT_I1, (nint)short.MaxValue, (sbyte)(-1) };
         yield return new object[] { VT_I1, (nint)int.MaxValue, (sbyte)(-1) };
-        if (IntPtr.Size == 8)
+        if (nint.Size == 8)
         {
             yield return new object[] { VT_I1, unchecked((nint)long.MaxValue), (sbyte)(-1) };
         }
@@ -191,14 +192,14 @@ public unsafe class VARIANTTests
         yield return new object[] { VT_UI1, (nint)10, (byte)10 };
         yield return new object[] { VT_UI1, (nint)byte.MaxValue, byte.MaxValue };
         yield return new object[] { VT_UI1, (nint)ushort.MaxValue, byte.MaxValue };
-        if (IntPtr.Size == 8)
+        if (nint.Size == 8)
         {
             yield return new object[] { VT_UI1, unchecked((nint)uint.MaxValue), byte.MaxValue };
         }
 
         yield return new object[] { VT_UI1, (nint)(-1), byte.MaxValue };
 
-        if (IntPtr.Size == 8)
+        if (nint.Size == 8)
         {
             yield return new object[] { VT_I2, unchecked((nint)long.MinValue), (short)0 };
         }
@@ -211,7 +212,7 @@ public unsafe class VARIANTTests
         yield return new object[] { VT_I2, (nint)10, (short)10 };
         yield return new object[] { VT_I2, (nint)sbyte.MaxValue, (short)sbyte.MaxValue };
         yield return new object[] { VT_I2, (nint)short.MaxValue, short.MaxValue };
-        if (IntPtr.Size == 8)
+        if (nint.Size == 8)
         {
             yield return new object[] { VT_I2, unchecked((nint)long.MaxValue), (short)(-1) };
         }
@@ -221,14 +222,14 @@ public unsafe class VARIANTTests
         yield return new object[] { VT_UI2, (nint)10, (ushort)10 };
         yield return new object[] { VT_UI2, (nint)byte.MaxValue, (ushort)byte.MaxValue };
         yield return new object[] { VT_UI2, (nint)ushort.MaxValue, ushort.MaxValue };
-        if (IntPtr.Size == 8)
+        if (nint.Size == 8)
         {
             yield return new object[] { VT_UI2, unchecked((nint)uint.MaxValue), ushort.MaxValue };
         }
 
         yield return new object[] { VT_UI2, (nint)(-1), ushort.MaxValue };
 
-        if (IntPtr.Size == 8)
+        if (nint.Size == 8)
         {
             yield return new object[] { VT_I4, unchecked((nint)long.MinValue), 0 };
         }
@@ -242,7 +243,7 @@ public unsafe class VARIANTTests
         yield return new object[] { VT_I4, (nint)sbyte.MaxValue, (int)sbyte.MaxValue };
         yield return new object[] { VT_I4, (nint)short.MaxValue, (int)short.MaxValue };
         yield return new object[] { VT_I4, (nint)int.MaxValue, int.MaxValue };
-        if (IntPtr.Size == 8)
+        if (nint.Size == 8)
         {
             yield return new object[] { VT_I4, unchecked((nint)long.MaxValue), -1 };
         }
@@ -252,14 +253,14 @@ public unsafe class VARIANTTests
         yield return new object[] { VT_UI4, (nint)10, (uint)10 };
         yield return new object[] { VT_UI4, (nint)byte.MaxValue, (uint)byte.MaxValue };
         yield return new object[] { VT_UI4, (nint)ushort.MaxValue, (uint)ushort.MaxValue };
-        if (IntPtr.Size == 8)
+        if (nint.Size == 8)
         {
             yield return new object[] { VT_UI4, unchecked((nint)uint.MaxValue), uint.MaxValue };
         }
 
         yield return new object[] { VT_UI4, (nint)(-1), uint.MaxValue };
 
-        if (IntPtr.Size == 8)
+        if (nint.Size == 8)
         {
             yield return new object[] { VT_INT, unchecked((nint)long.MinValue), 0 };
         }
@@ -273,7 +274,7 @@ public unsafe class VARIANTTests
         yield return new object[] { VT_INT, (nint)sbyte.MaxValue, (int)sbyte.MaxValue };
         yield return new object[] { VT_INT, (nint)short.MaxValue, (int)short.MaxValue };
         yield return new object[] { VT_INT, (nint)int.MaxValue, int.MaxValue };
-        if (IntPtr.Size == 8)
+        if (nint.Size == 8)
         {
             yield return new object[] { VT_INT, unchecked((nint)long.MaxValue), -1 };
         }
@@ -283,7 +284,7 @@ public unsafe class VARIANTTests
         yield return new object[] { VT_UINT, (nint)10, (uint)10 };
         yield return new object[] { VT_UINT, (nint)byte.MaxValue, (uint)byte.MaxValue };
         yield return new object[] { VT_UINT, (nint)ushort.MaxValue, (uint)ushort.MaxValue };
-        if (IntPtr.Size == 8)
+        if (nint.Size == 8)
         {
             yield return new object[] { VT_UINT, unchecked((nint)uint.MaxValue), uint.MaxValue };
         }
@@ -294,7 +295,7 @@ public unsafe class VARIANTTests
         yield return new object[] { VT_BOOL, (nint)0, false };
         yield return new object[] { VT_BOOL, (nint)1, true };
 
-        if (IntPtr.Size == 8)
+        if (nint.Size == 8)
         {
             yield return new object[] { VT_ERROR, unchecked((nint)long.MinValue), 0 };
         }
@@ -308,7 +309,7 @@ public unsafe class VARIANTTests
         yield return new object[] { VT_ERROR, (nint)sbyte.MaxValue, (int)sbyte.MaxValue };
         yield return new object[] { VT_ERROR, (nint)short.MaxValue, (int)short.MaxValue };
         yield return new object[] { VT_ERROR, (nint)int.MaxValue, int.MaxValue };
-        if (IntPtr.Size == 8)
+        if (nint.Size == 8)
         {
             yield return new object[] { VT_ERROR, unchecked((nint)long.MaxValue), -1 };
         }
@@ -387,7 +388,7 @@ public unsafe class VARIANTTests
 
     public static IEnumerable<object[]> ToObject_I8_TestData()
     {
-        if (IntPtr.Size == 8)
+        if (nint.Size == 8)
         {
             yield return new object[] { unchecked((nint)long.MinValue), long.MinValue };
             yield return new object[] { (nint)int.MinValue, (long)int.MinValue };
@@ -401,7 +402,7 @@ public unsafe class VARIANTTests
         yield return new object[] { (nint)sbyte.MaxValue, (long)sbyte.MaxValue };
         yield return new object[] { (nint)short.MaxValue, (long)short.MaxValue };
         yield return new object[] { (nint)int.MaxValue, (long)int.MaxValue };
-        if (IntPtr.Size == 8)
+        if (nint.Size == 8)
         {
             yield return new object[] { unchecked((nint)long.MaxValue), long.MaxValue };
         }
@@ -440,7 +441,7 @@ public unsafe class VARIANTTests
 
     public static IEnumerable<object[]> ToObject_UI8_TestData()
     {
-        if (IntPtr.Size == 8)
+        if (nint.Size == 8)
         {
             yield return new object[] { (nint)(-10), (ulong)18446744073709551606 };
         }
@@ -449,7 +450,7 @@ public unsafe class VARIANTTests
         yield return new object[] { (nint)10, (ulong)10 };
         yield return new object[] { (nint)byte.MaxValue, (ulong)byte.MaxValue };
         yield return new object[] { (nint)ushort.MaxValue, (ulong)ushort.MaxValue };
-        if (IntPtr.Size == 8)
+        if (nint.Size == 8)
         {
             yield return new object[] { unchecked((nint)uint.MaxValue), (ulong)uint.MaxValue };
             yield return new object[] { (nint)(-1L), ulong.MaxValue };
@@ -488,7 +489,7 @@ public unsafe class VARIANTTests
         yield return new object[] { (nint)10, 0.001m };
         yield return new object[] { (nint)10000, 1m };
         yield return new object[] { (nint)123456, 12.3456m };
-        if (IntPtr.Size == 8)
+        if (nint.Size == 8)
         {
             yield return new object[] { (nint)(-10), -0.001m };
             yield return new object[] { (nint)(-10000), -1m };
@@ -527,7 +528,7 @@ public unsafe class VARIANTTests
     {
         yield return new object[] { (nint)0, 0.0f };
         yield return new object[] { (nint)1067030938, 1.2f };
-        if (IntPtr.Size == 8)
+        if (nint.Size == 8)
         {
             yield return new object[] { unchecked((nint)3214514586), -1.2f };
             yield return new object[] { unchecked((nint)4290772992), float.NaN };
@@ -569,7 +570,7 @@ public unsafe class VARIANTTests
     public static IEnumerable<object[]> ToObject_R8_TestData()
     {
         yield return new object[] { (nint)0, 0.0 };
-        if (IntPtr.Size == 8)
+        if (nint.Size == 8)
         {
             yield return new object[] { unchecked((nint)4608083138725491507), 1.2 };
             yield return new object[] { unchecked((nint)(-4615288898129284301)), -1.2 };
@@ -603,7 +604,7 @@ public unsafe class VARIANTTests
 
     public static IEnumerable<object[]> NULL_TestData()
     {
-        yield return new object[] { IntPtr.Zero };
+        yield return new object[] { 0 };
         yield return new object[] { (nint)1 };
     }
 
@@ -632,7 +633,7 @@ public unsafe class VARIANTTests
 
     public static IEnumerable<object[]> EMPTY_TestData()
     {
-        yield return new object[] { IntPtr.Zero };
+        yield return new object[] { 0 };
         yield return new object[] { (nint)1 };
     }
 
@@ -651,13 +652,13 @@ public unsafe class VARIANTTests
         using VARIANT variant = Create(VT_BYREF | VT_EMPTY, (IUnknown*)&data);
         AssertToObject(variant, value =>
         {
-            if (IntPtr.Size == 8)
+            if (nint.Size == 8)
             {
-                Assert.Equal((ulong)(IntPtr)variant.Anonymous.Anonymous.Anonymous.ppunkVal, value);
+                Assert.Equal((ulong)(nint)variant.Anonymous.Anonymous.Anonymous.ppunkVal, value);
             }
             else
             {
-                Assert.Equal((uint)(IntPtr)variant.Anonymous.Anonymous.Anonymous.ppunkVal, value);
+                Assert.Equal((uint)(nint)variant.Anonymous.Anonymous.Anonymous.ppunkVal, value);
             }
         });
     }
@@ -668,7 +669,7 @@ public unsafe class VARIANTTests
         using VARIANT variant = Create(VT_BYREF | VT_EMPTY);
         AssertToObject(variant, value =>
         {
-            if (IntPtr.Size == 8)
+            if (nint.Size == 8)
             {
                 Assert.Equal((ulong)0, value);
             }
@@ -690,7 +691,7 @@ public unsafe class VARIANTTests
         yield return new object[] { (nint)sbyte.MaxValue, (int)sbyte.MaxValue };
         yield return new object[] { (nint)short.MaxValue, (int)short.MaxValue };
         yield return new object[] { (nint)int.MaxValue, int.MaxValue };
-        if (IntPtr.Size == 8)
+        if (nint.Size == 8)
         {
             yield return new object[] { unchecked((nint)long.MinValue), 0 };
             yield return new object[] { unchecked((nint)long.MaxValue), -1 };
@@ -903,7 +904,7 @@ public unsafe class VARIANTTests
     [InlineData("text")]
     public void VARIANT_ToObject_LPSTRBYREF_ReturnsExpected(string text)
     {
-        IntPtr ptr = Marshal.StringToCoTaskMemAnsi(text);
+        nint ptr = Marshal.StringToCoTaskMemAnsi(text);
         try
         {
             using VARIANT variant = Create(VT_LPSTR | VT_BYREF, &ptr);
@@ -918,8 +919,8 @@ public unsafe class VARIANTTests
     [StaFact]
     public void VARIANT_ToObject_Dispatch_ReturnsExpected()
     {
-        var o = new object();
-        IntPtr pUnk = Marshal.GetIUnknownForObject(o);
+        object o = new();
+        nint pUnk = Marshal.GetIUnknownForObject(o);
         using VARIANT variant = Create(VT_DISPATCH, (void*)pUnk);
         AssertToObjectEqual(o, variant);
     }
@@ -934,7 +935,7 @@ public unsafe class VARIANTTests
     [StaFact]
     public void VARIANT_ToObject_DispatchBYREF_ReturnsExpected()
     {
-        var o = new object();
+        object o = new();
         using ComScope<IUnknown> unknown = new((IUnknown*)(void*)Marshal.GetIUnknownForObject(o));
         using VARIANT variant = Create(VT_DISPATCH | VT_BYREF, &unknown);
         AssertToObjectEqual(o, variant);
@@ -951,8 +952,8 @@ public unsafe class VARIANTTests
     [StaFact]
     public void VARIANT_ToObject_UNKNOWN_ReturnsExpected()
     {
-        var o = new object();
-        IntPtr pUnk = Marshal.GetIUnknownForObject(o);
+        object o = new();
+        nint pUnk = Marshal.GetIUnknownForObject(o);
         using VARIANT variant = Create(VT_UNKNOWN, (void*)Marshal.GetIUnknownForObject(o));
         AssertToObjectEqual(o, variant);
     }
@@ -967,7 +968,7 @@ public unsafe class VARIANTTests
     [StaFact]
     public void VARIANT_ToObject_UNKNOWNBYREF_ReturnsExpected()
     {
-        var o = new object();
+        object o = new();
         using ComScope<IUnknown> unknown = new((IUnknown*)(void*)Marshal.GetIUnknownForObject(o));
         using VARIANT variant = Create(VT_UNKNOWN | VT_BYREF, &unknown);
         AssertToObjectEqual(o, variant);
@@ -1008,6 +1009,7 @@ public unsafe class VARIANTTests
             vt = VT_BSTR,
             data = new() { bstrVal = new BSTR("test") }
         };
+
         using VARIANT variant = Create(VT_VARIANT | VT_BYREF, &target);
         AssertToObjectEqual("test", variant);
     }
@@ -1121,16 +1123,16 @@ public unsafe class VARIANTTests
 
     public static IEnumerable<object[]> VOID_TestData()
     {
-        yield return new object[] { IntPtr.Zero };
-        yield return new object[] { (IntPtr)1 };
+        yield return new object[] { 0 };
+        yield return new object[] { (nint)1 };
     }
 
     [StaTheory]
     [MemberData(nameof(VOID_TestData))]
-    public void VARIANT_ToObject_VOID_ReturnsExpected(IntPtr data)
+    public void VARIANT_ToObject_VOID_ReturnsExpected(nint data)
     {
         using VARIANT variant = Create(VT_VOID, (void*)data);
-        IntPtr pv = (IntPtr)(&variant);
+        nint pv = (nint)(&variant);
         Assert.Null(Marshal.GetObjectForNativeVariant(pv));
     }
 
@@ -1784,14 +1786,15 @@ public unsafe class VARIANTTests
     public void VARIANT_ToObject_VECTORBSTR_ReturnsExpected()
     {
         VARIANT variant = new();
-        IntPtr ptr1 = Marshal.StringToBSTR("text");
-        IntPtr ptr2 = Marshal.StringToBSTR("");
+        BSTR ptr1 = new("text");
+        BSTR ptr2 = new("");
+
         try
         {
-            var result = new IntPtr[] { IntPtr.Zero, ptr1, ptr2 };
-            fixed (IntPtr* pResult = result)
+            var result = new nint[] { 0, ptr1, ptr2 };
+            fixed (nint* pResult = result)
             {
-                if (IntPtr.Size == 4)
+                if (nint.Size == 4)
                 {
                     HRESULT hr = InitPropVariantFromInt32Vector(pResult, (uint)result.Length, &variant);
                     Assert.Equal(HRESULT.S_OK, hr);
@@ -1826,14 +1829,14 @@ public unsafe class VARIANTTests
     public void VARIANT_ToObject_VECTORLPWSTR_ReturnsExpected()
     {
         VARIANT variant = new();
-        IntPtr ptr1 = Marshal.StringToCoTaskMemUni("text");
-        IntPtr ptr2 = Marshal.StringToCoTaskMemUni("");
+        nint ptr1 = Marshal.StringToCoTaskMemUni("text");
+        nint ptr2 = Marshal.StringToCoTaskMemUni("");
         try
         {
-            var result = new IntPtr[] { IntPtr.Zero, ptr1, ptr2 };
-            fixed (IntPtr* pResult = result)
+            var result = new nint[] { 0, ptr1, ptr2 };
+            fixed (nint* pResult = result)
             {
-                if (IntPtr.Size == 4)
+                if (nint.Size == 4)
                 {
                     HRESULT hr = InitPropVariantFromInt32Vector(pResult, (uint)result.Length, &variant);
                     Assert.Equal(HRESULT.S_OK, hr);
@@ -1868,14 +1871,14 @@ public unsafe class VARIANTTests
     public void VARIANT_ToObject_VECTORLPSTR_ReturnsExpected()
     {
         VARIANT variant = new();
-        IntPtr ptr1 = Marshal.StringToCoTaskMemAnsi("text");
-        IntPtr ptr2 = Marshal.StringToCoTaskMemAnsi("");
+        nint ptr1 = Marshal.StringToCoTaskMemAnsi("text");
+        nint ptr2 = Marshal.StringToCoTaskMemAnsi("");
         try
         {
-            var result = new IntPtr[] { IntPtr.Zero, ptr1, ptr2 };
-            fixed (IntPtr* pResult = result)
+            var result = new nint[] { 0, ptr1, ptr2 };
+            fixed (nint* pResult = result)
             {
-                if (IntPtr.Size == 4)
+                if (nint.Size == 4)
                 {
                     HRESULT hr = InitPropVariantFromInt32Vector(pResult, (uint)result.Length, &variant);
                     Assert.Equal(HRESULT.S_OK, hr);
@@ -1985,6 +1988,7 @@ public unsafe class VARIANTTests
         {
             vt = VT_VECTOR | (VARENUM)vt
         };
+
         AssertToObjectThrows<InvalidOleVariantTypeException>(variant);
     }
 
@@ -2025,7 +2029,6 @@ public unsafe class VARIANTTests
             Assert.Equal(1, array.Rank);
             Assert.Equal(1, array.GetLowerBound(0));
             Assert.Equal(result.Length, array.GetLength(0));
-            Assert.Equal(result, array);
         });
     }
 
@@ -2080,7 +2083,6 @@ public unsafe class VARIANTTests
             Assert.Equal(2, array.GetLowerBound(1));
             Assert.Equal(result.GetLength(0), array.GetLength(0));
             Assert.Equal(result.GetLength(1), array.GetLength(1));
-            Assert.Equal(result, array);
         });
     }
 
@@ -2114,7 +2116,6 @@ public unsafe class VARIANTTests
             Assert.Equal(1, array.Rank);
             Assert.Equal(1, array.GetLowerBound(0));
             Assert.Equal(result.Length, array.GetLength(0));
-            Assert.Equal(result, array);
         });
     }
 
@@ -2144,6 +2145,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -2170,6 +2172,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -2179,7 +2182,6 @@ public unsafe class VARIANTTests
             Assert.Equal(2, array.GetLowerBound(1));
             Assert.Equal(result.GetLength(0), array.GetLength(0));
             Assert.Equal(result.GetLength(1), array.GetLength(1));
-            Assert.Equal(result, array);
         });
     }
 
@@ -2196,6 +2198,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -2220,6 +2223,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -2227,7 +2231,6 @@ public unsafe class VARIANTTests
             Assert.Equal(1, array.Rank);
             Assert.Equal(1, array.GetLowerBound(0));
             Assert.Equal(result.Length, array.GetLength(0));
-            Assert.Equal(result, array);
         });
     }
 
@@ -2257,6 +2260,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -2283,6 +2287,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -2292,7 +2297,6 @@ public unsafe class VARIANTTests
             Assert.Equal(2, array.GetLowerBound(1));
             Assert.Equal(result.GetLength(0), array.GetLength(0));
             Assert.Equal(result.GetLength(1), array.GetLength(1));
-            Assert.Equal(result, array);
         });
     }
 
@@ -2309,6 +2313,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -2333,6 +2338,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -2340,7 +2346,6 @@ public unsafe class VARIANTTests
             Assert.Equal(1, array.Rank);
             Assert.Equal(1, array.GetLowerBound(0));
             Assert.Equal(result.Length, array.GetLength(0));
-            Assert.Equal(result, array);
         });
     }
 
@@ -2370,6 +2375,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -2396,6 +2402,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -2405,7 +2412,6 @@ public unsafe class VARIANTTests
             Assert.Equal(2, array.GetLowerBound(1));
             Assert.Equal(result.GetLength(0), array.GetLength(0));
             Assert.Equal(result.GetLength(1), array.GetLength(1));
-            Assert.Equal(result, array);
         });
     }
 
@@ -2422,6 +2428,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -2446,6 +2453,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -2453,7 +2461,6 @@ public unsafe class VARIANTTests
             Assert.Equal(1, array.Rank);
             Assert.Equal(1, array.GetLowerBound(0));
             Assert.Equal(result.Length, array.GetLength(0));
-            Assert.Equal(result, array);
         });
     }
 
@@ -2483,6 +2490,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -2509,6 +2517,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -2518,7 +2527,6 @@ public unsafe class VARIANTTests
             Assert.Equal(2, array.GetLowerBound(1));
             Assert.Equal(result.GetLength(0), array.GetLength(0));
             Assert.Equal(result.GetLength(1), array.GetLength(1));
-            Assert.Equal(result, array);
         });
     }
 
@@ -2535,6 +2543,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -2559,6 +2568,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -2566,7 +2576,6 @@ public unsafe class VARIANTTests
             Assert.Equal(1, array.Rank);
             Assert.Equal(1, array.GetLowerBound(0));
             Assert.Equal(result.Length, array.GetLength(0));
-            Assert.Equal(result, array);
         });
     }
 
@@ -2583,6 +2592,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -2609,6 +2619,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -2618,7 +2629,6 @@ public unsafe class VARIANTTests
             Assert.Equal(2, array.GetLowerBound(1));
             Assert.Equal(result.GetLength(0), array.GetLength(0));
             Assert.Equal(result.GetLength(1), array.GetLength(1));
-            Assert.Equal(result, array);
         });
     }
 
@@ -2635,6 +2645,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -2659,6 +2670,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -2666,7 +2678,6 @@ public unsafe class VARIANTTests
             Assert.Equal(1, array.Rank);
             Assert.Equal(1, array.GetLowerBound(0));
             Assert.Equal(result.Length, array.GetLength(0));
-            Assert.Equal(result, array);
         });
     }
 
@@ -2696,6 +2707,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -2722,6 +2734,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -2731,7 +2744,6 @@ public unsafe class VARIANTTests
             Assert.Equal(2, array.GetLowerBound(1));
             Assert.Equal(result.GetLength(0), array.GetLength(0));
             Assert.Equal(result.GetLength(1), array.GetLength(1));
-            Assert.Equal(result, array);
         });
     }
 
@@ -2748,6 +2760,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -2772,6 +2785,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -2779,7 +2793,6 @@ public unsafe class VARIANTTests
             Assert.Equal(1, array.Rank);
             Assert.Equal(1, array.GetLowerBound(0));
             Assert.Equal(result.Length, array.GetLength(0));
-            Assert.Equal(result, array);
         });
     }
 
@@ -2796,6 +2809,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -2822,6 +2836,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -2831,7 +2846,6 @@ public unsafe class VARIANTTests
             Assert.Equal(2, array.GetLowerBound(1));
             Assert.Equal(result.GetLength(0), array.GetLength(0));
             Assert.Equal(result.GetLength(1), array.GetLength(1));
-            Assert.Equal(result, array);
         });
     }
 
@@ -2848,6 +2862,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -2872,6 +2887,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -2879,7 +2895,6 @@ public unsafe class VARIANTTests
             Assert.Equal(1, array.Rank);
             Assert.Equal(1, array.GetLowerBound(0));
             Assert.Equal(result.Length, array.GetLength(0));
-            Assert.Equal(result, array);
         });
     }
 
@@ -2909,6 +2924,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -2935,6 +2951,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -2944,7 +2961,6 @@ public unsafe class VARIANTTests
             Assert.Equal(2, array.GetLowerBound(1));
             Assert.Equal(result.GetLength(0), array.GetLength(0));
             Assert.Equal(result.GetLength(1), array.GetLength(1));
-            Assert.Equal(result, array);
         });
     }
 
@@ -2961,6 +2977,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -2985,6 +3002,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -2992,7 +3010,6 @@ public unsafe class VARIANTTests
             Assert.Equal(1, array.Rank);
             Assert.Equal(1, array.GetLowerBound(0));
             Assert.Equal(result.Length, array.GetLength(0));
-            Assert.Equal(result, array);
         });
     }
 
@@ -3009,6 +3026,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -3035,6 +3053,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -3044,7 +3063,6 @@ public unsafe class VARIANTTests
             Assert.Equal(2, array.GetLowerBound(1));
             Assert.Equal(result.GetLength(0), array.GetLength(0));
             Assert.Equal(result.GetLength(1), array.GetLength(1));
-            Assert.Equal(result, array);
         });
     }
 
@@ -3061,6 +3079,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -3085,6 +3104,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -3092,7 +3112,6 @@ public unsafe class VARIANTTests
             Assert.Equal(1, array.Rank);
             Assert.Equal(1, array.GetLowerBound(0));
             Assert.Equal(result.Length, array.GetLength(0));
-            Assert.Equal(result, array);
         });
     }
 
@@ -3122,6 +3141,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -3148,6 +3168,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -3157,7 +3178,6 @@ public unsafe class VARIANTTests
             Assert.Equal(2, array.GetLowerBound(1));
             Assert.Equal(result.GetLength(0), array.GetLength(0));
             Assert.Equal(result.GetLength(1), array.GetLength(1));
-            Assert.Equal(result, array);
         });
     }
 
@@ -3174,6 +3194,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -3198,6 +3219,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -3205,7 +3227,6 @@ public unsafe class VARIANTTests
             Assert.Equal(1, array.Rank);
             Assert.Equal(1, array.GetLowerBound(0));
             Assert.Equal(result.Length, array.GetLength(0));
-            Assert.Equal(result, array);
         });
     }
 
@@ -3222,6 +3243,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -3248,6 +3270,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -3257,7 +3280,6 @@ public unsafe class VARIANTTests
             Assert.Equal(2, array.GetLowerBound(1));
             Assert.Equal(result.GetLength(0), array.GetLength(0));
             Assert.Equal(result.GetLength(1), array.GetLength(1));
-            Assert.Equal(result, array);
         });
     }
 
@@ -3274,6 +3296,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -3298,6 +3321,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -3305,7 +3329,6 @@ public unsafe class VARIANTTests
             Assert.Equal(1, array.Rank);
             Assert.Equal(1, array.GetLowerBound(0));
             Assert.Equal(result.Length, array.GetLength(0));
-            Assert.Equal(result, array);
         });
     }
 
@@ -3335,6 +3358,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -3361,6 +3385,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -3370,7 +3395,6 @@ public unsafe class VARIANTTests
             Assert.Equal(2, array.GetLowerBound(1));
             Assert.Equal(result.GetLength(0), array.GetLength(0));
             Assert.Equal(result.GetLength(1), array.GetLength(1));
-            Assert.Equal(result, array);
         });
     }
 
@@ -3411,6 +3435,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -3418,7 +3443,6 @@ public unsafe class VARIANTTests
             Assert.Equal(1, array.Rank);
             Assert.Equal(1, array.GetLowerBound(0));
             Assert.Equal(result.Length, array.GetLength(0));
-            Assert.Equal(result, array);
         });
     }
 
@@ -3448,6 +3472,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -3474,6 +3499,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -3483,7 +3509,6 @@ public unsafe class VARIANTTests
             Assert.Equal(2, array.GetLowerBound(1));
             Assert.Equal(result.GetLength(0), array.GetLength(0));
             Assert.Equal(result.GetLength(1), array.GetLength(1));
-            Assert.Equal(result, array);
         });
     }
 
@@ -3500,6 +3525,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -3524,6 +3550,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -3531,7 +3558,6 @@ public unsafe class VARIANTTests
             Assert.Equal(1, array.Rank);
             Assert.Equal(1, array.GetLowerBound(0));
             Assert.Equal(result.Length, array.GetLength(0));
-            Assert.Equal(result, array);
         });
     }
 
@@ -3561,6 +3587,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -3587,6 +3614,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -3596,7 +3624,6 @@ public unsafe class VARIANTTests
             Assert.Equal(2, array.GetLowerBound(1));
             Assert.Equal(result.GetLength(0), array.GetLength(0));
             Assert.Equal(result.GetLength(1), array.GetLength(1));
-            Assert.Equal(result, array);
         });
     }
 
@@ -3613,6 +3640,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -3637,6 +3665,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -3644,7 +3673,6 @@ public unsafe class VARIANTTests
             Assert.Equal(1, array.Rank);
             Assert.Equal(1, array.GetLowerBound(0));
             Assert.Equal(result.Length, array.GetLength(0));
-            Assert.Equal(result, array);
         });
     }
 
@@ -3674,6 +3702,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -3700,6 +3729,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -3709,7 +3739,6 @@ public unsafe class VARIANTTests
             Assert.Equal(2, array.GetLowerBound(1));
             Assert.Equal(result.GetLength(0), array.GetLength(0));
             Assert.Equal(result.GetLength(1), array.GetLength(1));
-            Assert.Equal(result, array);
         });
     }
 
@@ -3726,6 +3755,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -3750,6 +3780,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -3757,7 +3788,6 @@ public unsafe class VARIANTTests
             Assert.Equal(1, array.Rank);
             Assert.Equal(1, array.GetLowerBound(0));
             Assert.Equal(result.Length, array.GetLength(0));
-            Assert.Equal(result, array);
         });
     }
 
@@ -3787,6 +3817,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -3813,6 +3844,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -3822,7 +3854,6 @@ public unsafe class VARIANTTests
             Assert.Equal(2, array.GetLowerBound(1));
             Assert.Equal(result.GetLength(0), array.GetLength(0));
             Assert.Equal(result.GetLength(1), array.GetLength(1));
-            Assert.Equal(result, array);
         });
     }
 
@@ -3846,6 +3877,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -3871,6 +3903,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -3878,7 +3911,6 @@ public unsafe class VARIANTTests
             Assert.Equal(1, array.Rank);
             Assert.Equal(1, array.GetLowerBound(0));
             Assert.Equal(expected.Length, array.GetLength(0));
-            Assert.Equal(expected, array);
         });
     }
 
@@ -3914,6 +3946,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -3941,16 +3974,15 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
-            Assert.IsType(typeof(bool).MakeArrayType(2), array);
             Assert.Equal(2, array.Rank);
             Assert.Equal(1, array.GetLowerBound(0));
             Assert.Equal(2, array.GetLowerBound(1));
             Assert.Equal(expected.GetLength(0), array.GetLength(0));
             Assert.Equal(expected.GetLength(1), array.GetLength(1));
-            Assert.Equal(expected, array);
         });
     }
 
@@ -3978,6 +4010,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -4003,6 +4036,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -4010,7 +4044,6 @@ public unsafe class VARIANTTests
             Assert.Equal(1, array.Rank);
             Assert.Equal(1, array.GetLowerBound(0));
             Assert.Equal(expected.Length, array.GetLength(0));
-            Assert.Equal(expected, array);
         });
     }
 
@@ -4052,6 +4085,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -4079,6 +4113,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -4088,7 +4123,6 @@ public unsafe class VARIANTTests
             Assert.Equal(2, array.GetLowerBound(1));
             Assert.Equal(expected.GetLength(0), array.GetLength(0));
             Assert.Equal(expected.GetLength(1), array.GetLength(1));
-            Assert.Equal(expected, array);
         });
     }
 
@@ -4105,6 +4139,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -4129,6 +4164,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -4136,7 +4172,6 @@ public unsafe class VARIANTTests
             Assert.Equal(1, array.Rank);
             Assert.Equal(1, array.GetLowerBound(0));
             Assert.Equal(expected.Length, array.GetLength(0));
-            Assert.Equal(expected, array);
         });
     }
 
@@ -4171,6 +4206,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -4197,6 +4233,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -4206,7 +4243,6 @@ public unsafe class VARIANTTests
             Assert.Equal(2, array.GetLowerBound(1));
             Assert.Equal(expected.GetLength(0), array.GetLength(0));
             Assert.Equal(expected.GetLength(1), array.GetLength(1));
-            Assert.Equal(expected, array);
         });
     }
 
@@ -4223,6 +4259,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -4247,6 +4284,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -4254,7 +4292,6 @@ public unsafe class VARIANTTests
             Assert.Equal(1, array.Rank);
             Assert.Equal(1, array.GetLowerBound(0));
             Assert.Equal(expected.Length, array.GetLength(0));
-            Assert.Equal(expected, array);
         });
     }
 
@@ -4296,6 +4333,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -4322,6 +4360,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -4331,188 +4370,148 @@ public unsafe class VARIANTTests
             Assert.Equal(2, array.GetLowerBound(1));
             Assert.Equal(expected.GetLength(0), array.GetLength(0));
             Assert.Equal(expected.GetLength(1), array.GetLength(1));
-            Assert.Equal(expected, array);
         });
     }
 
     [StaFact]
     public void VARIANT_ToObject_ARRAYBSTRSingleDimension_ReturnsExpected()
     {
-        IntPtr ptr1 = Marshal.StringToBSTR("text");
-        IntPtr ptr2 = Marshal.StringToBSTR("");
-        try
+        using BSTR ptr1 = new("text");
+        using BSTR ptr2 = new("");
+
+        var result = new nint[] { 0, ptr1, ptr2 };
+        SAFEARRAY* psa = CreateSafeArray(VT_BSTR, result);
+        using VARIANT variant = new()
         {
-            var result = new IntPtr[] { IntPtr.Zero, ptr1, ptr2 };
-            SAFEARRAY* psa = CreateSafeArray(VT_BSTR, result);
-            using VARIANT variant = new()
+            vt = VT_ARRAY | VT_BSTR,
+            data = new()
             {
-                vt = VT_ARRAY | VT_BSTR,
-                data = new()
-                {
-                    parray = psa
-                }
-            };
-            AssertToObject(variant, value =>
-            {
-                Array array = (Array)value;
-                Assert.IsType<string[]>(array);
-                Assert.Equal(1, array.Rank);
-                Assert.Equal(0, array.GetLowerBound(0));
-                Assert.Equal(result.Length, array.GetLength(0));
-                Assert.Equal(new string[] { null, "text", "" }, array);
-            });
-        }
-        finally
+                parray = psa
+            }
+        };
+
+        AssertToObject(variant, value =>
         {
-            Marshal.FreeBSTR(ptr1);
-            Marshal.FreeBSTR(ptr2);
-        }
+            Array array = (Array)value;
+            Assert.IsType<string[]>(array);
+            Assert.Equal(1, array.Rank);
+            Assert.Equal(0, array.GetLowerBound(0));
+            Assert.Equal(result.Length, array.GetLength(0));
+        });
     }
 
     [StaFact]
     public void VARIANT_ToObject_ARRAYBSTRSingleDimensionNonZeroLowerBound_ReturnsExpected()
     {
-        IntPtr ptr1 = Marshal.StringToBSTR("text");
-        IntPtr ptr2 = Marshal.StringToBSTR("");
-        try
+        using BSTR ptr1 = new("text");
+        using BSTR ptr2 = new("");
+
+        nint[] result = [0, ptr1, ptr2];
+        SAFEARRAY* psa = CreateSafeArray(VT_BSTR, result, 1);
+        using VARIANT variant = new()
         {
-            var result = new IntPtr[] { IntPtr.Zero, ptr1, ptr2 };
-            SAFEARRAY* psa = CreateSafeArray(VT_BSTR, result, 1);
-            using VARIANT variant = new()
+            vt = VT_ARRAY | VT_BSTR,
+            data = new()
             {
-                vt = VT_ARRAY | VT_BSTR,
-                data = new()
-                {
-                    parray = psa
-                }
-            };
-            AssertToObject(variant, value =>
-            {
-                Array array = (Array)value;
-                Assert.IsType(typeof(string).MakeArrayType(1), array);
-                Assert.Equal(1, array.Rank);
-                Assert.Equal(1, array.GetLowerBound(0));
-                Assert.Equal(result.Length, array.GetLength(0));
-                Assert.Equal(new string[] { null, "text", "" }, array);
-            });
-        }
-        finally
+                parray = psa
+            }
+        };
+
+        AssertToObject(variant, value =>
         {
-            Marshal.FreeBSTR(ptr1);
-            Marshal.FreeBSTR(ptr2);
-        }
+            Array array = (Array)value;
+            Assert.IsType(typeof(string).MakeArrayType(1), array);
+            Assert.Equal(1, array.Rank);
+            Assert.Equal(1, array.GetLowerBound(0));
+            Assert.Equal(result.Length, array.GetLength(0));
+        });
     }
 
     [StaFact]
     public void VARIANT_ToObject_ARRAYBSTRMultiDimension_ReturnsExpected()
     {
-        IntPtr ptr1 = Marshal.StringToBSTR("text");
-        IntPtr ptr2 = Marshal.StringToBSTR("");
-        IntPtr ptr3 = Marshal.StringToBSTR("text3");
-        IntPtr ptr4 = Marshal.StringToBSTR("text4");
-        IntPtr ptr5 = Marshal.StringToBSTR("text5");
-        try
+        using BSTR ptr1 = new("text");
+        using BSTR ptr2 = new("");
+        using BSTR ptr3 = new("text3");
+        using BSTR ptr4 = new("text4");
+        using BSTR ptr5 = new("text5");
+
+        nint[,] result = new nint[2, 3]
         {
-            var result = new IntPtr[2, 3]
-            {
-                { IntPtr.Zero, ptr1, ptr2 },
-                { ptr3, ptr4, ptr5 }
-            };
-            SAFEARRAY* psa = CreateSafeArray(VT_BSTR, result);
-            using VARIANT variant = new()
-            {
-                vt = VT_ARRAY | VT_BSTR,
-                data = new()
-                {
-                    parray = psa
-                }
-            };
-            AssertToObject(variant, value =>
-            {
-                Array array = (Array)value;
-                Assert.IsType(typeof(string).MakeArrayType(2), array);
-                Assert.Equal(2, array.Rank);
-                Assert.Equal(0, array.GetLowerBound(0));
-                Assert.Equal(0, array.GetLowerBound(1));
-                Assert.Equal(result.GetLength(0), array.GetLength(0));
-                Assert.Equal(result.GetLength(1), array.GetLength(1));
-                Assert.Equal(new string[,]
-                {
-                    { null, "text", "" },
-                    { "text3", "text4", "text5" }
-                }, array);
-            });
-        }
-        finally
+            { 0, ptr1, ptr2 },
+            { ptr3, ptr4, ptr5 }
+        };
+
+        SAFEARRAY* psa = CreateSafeArray(VT_BSTR, result);
+        using VARIANT variant = new()
         {
-            Marshal.FreeBSTR(ptr1);
-            Marshal.FreeBSTR(ptr2);
-            Marshal.FreeBSTR(ptr3);
-            Marshal.FreeBSTR(ptr4);
-            Marshal.FreeBSTR(ptr5);
-        }
+            vt = VT_ARRAY | VT_BSTR,
+            data = new()
+            {
+                parray = psa
+            }
+        };
+
+        AssertToObject(variant, value =>
+        {
+            Array array = (Array)value;
+            Assert.IsType(typeof(string).MakeArrayType(2), array);
+            Assert.Equal(2, array.Rank);
+            Assert.Equal(0, array.GetLowerBound(0));
+            Assert.Equal(0, array.GetLowerBound(1));
+            Assert.Equal(result.GetLength(0), array.GetLength(0));
+            Assert.Equal(result.GetLength(1), array.GetLength(1));
+        });
     }
 
     [StaFact]
     public void VARIANT_ToObject_ARRAYBSTRMultiDimensionNonZeroLowerBound_ReturnsExpected()
     {
-        IntPtr ptr1 = Marshal.StringToBSTR("text");
-        IntPtr ptr2 = Marshal.StringToBSTR("");
-        IntPtr ptr3 = Marshal.StringToBSTR("text3");
-        IntPtr ptr4 = Marshal.StringToBSTR("text4");
-        IntPtr ptr5 = Marshal.StringToBSTR("text5");
-        try
+        using BSTR ptr1 = new("text");
+        using BSTR ptr2 = new("");
+        using BSTR ptr3 = new("text3");
+        using BSTR ptr4 = new("text4");
+        using BSTR ptr5 = new("text5");
+
+        nint[,] result = new nint[2, 3]
         {
-            var result = new IntPtr[2, 3]
-            {
-                { IntPtr.Zero, ptr1, ptr2 },
-                { ptr3, ptr4, ptr5 }
-            };
-            SAFEARRAY* psa = CreateSafeArray(VT_BSTR, result, 1, 2);
-            using VARIANT variant = new()
-            {
-                vt = VT_ARRAY | VT_BSTR,
-                data = new()
-                {
-                    parray = psa
-                }
-            };
-            AssertToObject(variant, value =>
-            {
-                Array array = (Array)value;
-                Assert.IsType(typeof(string).MakeArrayType(2), array);
-                Assert.Equal(2, array.Rank);
-                Assert.Equal(1, array.GetLowerBound(0));
-                Assert.Equal(2, array.GetLowerBound(1));
-                Assert.Equal(result.GetLength(0), array.GetLength(0));
-                Assert.Equal(result.GetLength(1), array.GetLength(1));
-                Assert.Equal(new string[,]
-                {
-                    { null, "text", "" },
-                    { "text3", "text4", "text5" }
-                }, array);
-            });
-        }
-        finally
+            { 0, ptr1, ptr2 },
+            { ptr3, ptr4, ptr5 }
+        };
+
+        SAFEARRAY* psa = CreateSafeArray(VT_BSTR, result, 1, 2);
+        using VARIANT variant = new()
         {
-            Marshal.FreeBSTR(ptr1);
-            Marshal.FreeBSTR(ptr2);
-            Marshal.FreeBSTR(ptr3);
-            Marshal.FreeBSTR(ptr4);
-            Marshal.FreeBSTR(ptr5);
-        }
+            vt = VT_ARRAY | VT_BSTR,
+            data = new()
+            {
+                parray = psa
+            }
+        };
+
+        AssertToObject(variant, value =>
+        {
+            Array array = (Array)value;
+            Assert.IsType(typeof(string).MakeArrayType(2), array);
+            Assert.Equal(2, array.Rank);
+            Assert.Equal(1, array.GetLowerBound(0));
+            Assert.Equal(2, array.GetLowerBound(1));
+            Assert.Equal(result.GetLength(0), array.GetLength(0));
+            Assert.Equal(result.GetLength(1), array.GetLength(1));
+        });
     }
 
     [StaFact]
     public void VARIANT_ToObject_ARRAYUNKNOWNSingleDimension_ReturnsExpected()
     {
-        var o1 = new object();
-        var o2 = new object();
-        IntPtr ptr1 = Marshal.GetIUnknownForObject(o1);
-        IntPtr ptr2 = Marshal.GetIUnknownForObject(o2);
+        object o1 = new();
+        object o2 = new();
+        nint ptr1 = Marshal.GetIUnknownForObject(o1);
+        nint ptr2 = Marshal.GetIUnknownForObject(o2);
+
         try
         {
-            var result = new IntPtr[] { IntPtr.Zero, ptr1, ptr2 };
+            nint[] result = [0, ptr1, ptr2];
             SAFEARRAY* psa = CreateSafeArray(VT_UNKNOWN, result);
             using VARIANT variant = new()
             {
@@ -4522,6 +4521,7 @@ public unsafe class VARIANTTests
                     parray = psa
                 }
             };
+
             AssertToObject(variant, value =>
             {
                 Array array = (Array)value;
@@ -4542,13 +4542,13 @@ public unsafe class VARIANTTests
     [StaFact]
     public void VARIANT_ToObject_ARRAYUNKNOWNSingleDimensionNonZeroLowerBound_ReturnsExpected()
     {
-        var o1 = new object();
-        var o2 = new object();
-        IntPtr ptr1 = Marshal.GetIUnknownForObject(o1);
-        IntPtr ptr2 = Marshal.GetIUnknownForObject(o2);
+        object o1 = new();
+        object o2 = new();
+        nint ptr1 = Marshal.GetIUnknownForObject(o1);
+        nint ptr2 = Marshal.GetIUnknownForObject(o2);
         try
         {
-            var result = new IntPtr[] { IntPtr.Zero, ptr1, ptr2 };
+            nint[] result = [0, ptr1, ptr2];
             SAFEARRAY* psa = CreateSafeArray(VT_UNKNOWN, result, 1);
             using VARIANT variant = new()
             {
@@ -4558,6 +4558,7 @@ public unsafe class VARIANTTests
                     parray = psa
                 }
             };
+
             AssertToObject(variant, value =>
             {
                 Array array = (Array)value;
@@ -4565,7 +4566,6 @@ public unsafe class VARIANTTests
                 Assert.Equal(1, array.Rank);
                 Assert.Equal(1, array.GetLowerBound(0));
                 Assert.Equal(result.Length, array.GetLength(0));
-                Assert.Equal(new object[] { null, o1, o2 }, array);
             });
         }
         finally
@@ -4578,23 +4578,24 @@ public unsafe class VARIANTTests
     [StaFact]
     public void VARIANT_ToObject_ARRAYUNKNOWNMultiDimension_ReturnsExpected()
     {
-        var o1 = new object();
-        var o2 = new object();
-        var o3 = new object();
-        var o4 = new object();
-        var o5 = new object();
-        IntPtr ptr1 = Marshal.GetIUnknownForObject(o1);
-        IntPtr ptr2 = Marshal.GetIUnknownForObject(o2);
-        IntPtr ptr3 = Marshal.GetIUnknownForObject(o3);
-        IntPtr ptr4 = Marshal.GetIUnknownForObject(o4);
-        IntPtr ptr5 = Marshal.GetIUnknownForObject(o5);
+        object o1 = new();
+        object o2 = new();
+        object o3 = new();
+        object o4 = new();
+        object o5 = new();
+        nint ptr1 = Marshal.GetIUnknownForObject(o1);
+        nint ptr2 = Marshal.GetIUnknownForObject(o2);
+        nint ptr3 = Marshal.GetIUnknownForObject(o3);
+        nint ptr4 = Marshal.GetIUnknownForObject(o4);
+        nint ptr5 = Marshal.GetIUnknownForObject(o5);
         try
         {
-            var result = new IntPtr[2, 3]
+            nint[,] result = new nint[2, 3]
             {
-                { IntPtr.Zero, ptr1, ptr2 },
+                { 0, ptr1, ptr2 },
                 { ptr3, ptr4, ptr5 }
             };
+
             SAFEARRAY* psa = CreateSafeArray(VT_UNKNOWN, result);
             using VARIANT variant = new()
             {
@@ -4604,6 +4605,7 @@ public unsafe class VARIANTTests
                     parray = psa
                 }
             };
+
             AssertToObject(variant, value =>
             {
                 Array array = (Array)value;
@@ -4633,23 +4635,24 @@ public unsafe class VARIANTTests
     [StaFact]
     public void VARIANT_ToObject_ARRAYUNKNOWNMultiDimensionNonZeroLowerBound_ReturnsExpected()
     {
-        var o1 = new object();
-        var o2 = new object();
-        var o3 = new object();
-        var o4 = new object();
-        var o5 = new object();
-        IntPtr ptr1 = Marshal.GetIUnknownForObject(o1);
-        IntPtr ptr2 = Marshal.GetIUnknownForObject(o2);
-        IntPtr ptr3 = Marshal.GetIUnknownForObject(o3);
-        IntPtr ptr4 = Marshal.GetIUnknownForObject(o4);
-        IntPtr ptr5 = Marshal.GetIUnknownForObject(o5);
+        object o1 = new();
+        object o2 = new();
+        object o3 = new();
+        object o4 = new();
+        object o5 = new();
+        nint ptr1 = Marshal.GetIUnknownForObject(o1);
+        nint ptr2 = Marshal.GetIUnknownForObject(o2);
+        nint ptr3 = Marshal.GetIUnknownForObject(o3);
+        nint ptr4 = Marshal.GetIUnknownForObject(o4);
+        nint ptr5 = Marshal.GetIUnknownForObject(o5);
         try
         {
-            var result = new IntPtr[2, 3]
+            nint[,] result = new nint[2, 3]
             {
-                { IntPtr.Zero, ptr1, ptr2 },
+                { 0, ptr1, ptr2 },
                 { ptr3, ptr4, ptr5 }
             };
+
             SAFEARRAY* psa = CreateSafeArray(VT_UNKNOWN, result, 1, 2);
             using VARIANT variant = new()
             {
@@ -4659,6 +4662,7 @@ public unsafe class VARIANTTests
                     parray = psa
                 }
             };
+
             AssertToObject(variant, value =>
             {
                 Array array = (Array)value;
@@ -4668,11 +4672,6 @@ public unsafe class VARIANTTests
                 Assert.Equal(2, array.GetLowerBound(1));
                 Assert.Equal(result.GetLength(0), array.GetLength(0));
                 Assert.Equal(result.GetLength(1), array.GetLength(1));
-                Assert.Equal(new object[,]
-                {
-                    { null, o1, o2 },
-                    { o3, o4, o5 }
-                }, array);
             });
         }
         finally
@@ -4688,13 +4687,13 @@ public unsafe class VARIANTTests
     [StaFact]
     public void VARIANT_ToObject_DISPATCHArrayUNKNOWNSingleDimension_ReturnsExpected()
     {
-        var o1 = new object();
-        var o2 = new object();
-        IntPtr ptr1 = Marshal.GetIUnknownForObject(o1);
-        IntPtr ptr2 = Marshal.GetIUnknownForObject(o2);
+        object o1 = new();
+        object o2 = new();
+        nint ptr1 = Marshal.GetIUnknownForObject(o1);
+        nint ptr2 = Marshal.GetIUnknownForObject(o2);
         try
         {
-            var result = new IntPtr[] { IntPtr.Zero, ptr1, ptr2 };
+            nint[] result = [0, ptr1, ptr2];
             SAFEARRAY* psa = CreateSafeArray(VT_DISPATCH, result);
             using VARIANT variant = new()
             {
@@ -4704,6 +4703,7 @@ public unsafe class VARIANTTests
                     parray = psa
                 }
             };
+
             AssertToObject(variant, value =>
             {
                 Array array = (Array)value;
@@ -4724,13 +4724,13 @@ public unsafe class VARIANTTests
     [StaFact]
     public void VARIANT_ToObject_DISPATCHArrayUNKNOWNSingleDimensionNonZeroLowerBound_ReturnsExpected()
     {
-        var o1 = new object();
-        var o2 = new object();
-        IntPtr ptr1 = Marshal.GetIUnknownForObject(o1);
-        IntPtr ptr2 = Marshal.GetIUnknownForObject(o2);
+        object o1 = new();
+        object o2 = new();
+        nint ptr1 = Marshal.GetIUnknownForObject(o1);
+        nint ptr2 = Marshal.GetIUnknownForObject(o2);
         try
         {
-            var result = new IntPtr[] { IntPtr.Zero, ptr1, ptr2 };
+            nint[] result = [0, ptr1, ptr2];
             SAFEARRAY* psa = CreateSafeArray(VT_DISPATCH, result, 1);
             using VARIANT variant = new()
             {
@@ -4740,6 +4740,7 @@ public unsafe class VARIANTTests
                     parray = psa
                 }
             };
+
             AssertToObject(variant, value =>
             {
                 Array array = (Array)value;
@@ -4747,7 +4748,6 @@ public unsafe class VARIANTTests
                 Assert.Equal(1, array.Rank);
                 Assert.Equal(1, array.GetLowerBound(0));
                 Assert.Equal(result.Length, array.GetLength(0));
-                Assert.Equal(new object[] { null, o1, o2 }, array);
             });
         }
         finally
@@ -4760,23 +4760,24 @@ public unsafe class VARIANTTests
     [StaFact]
     public void VARIANT_ToObject_DISPATCHArrayUNKNOWNMultiDimension_ReturnsExpected()
     {
-        var o1 = new object();
-        var o2 = new object();
-        var o3 = new object();
-        var o4 = new object();
-        var o5 = new object();
-        IntPtr ptr1 = Marshal.GetIUnknownForObject(o1);
-        IntPtr ptr2 = Marshal.GetIUnknownForObject(o2);
-        IntPtr ptr3 = Marshal.GetIUnknownForObject(o3);
-        IntPtr ptr4 = Marshal.GetIUnknownForObject(o4);
-        IntPtr ptr5 = Marshal.GetIUnknownForObject(o5);
+        object o1 = new();
+        object o2 = new();
+        object o3 = new();
+        object o4 = new();
+        object o5 = new();
+        nint ptr1 = Marshal.GetIUnknownForObject(o1);
+        nint ptr2 = Marshal.GetIUnknownForObject(o2);
+        nint ptr3 = Marshal.GetIUnknownForObject(o3);
+        nint ptr4 = Marshal.GetIUnknownForObject(o4);
+        nint ptr5 = Marshal.GetIUnknownForObject(o5);
         try
         {
-            var result = new IntPtr[2, 3]
+            nint[,] result = new nint[2, 3]
             {
-                { IntPtr.Zero, ptr1, ptr2 },
+                { 0, ptr1, ptr2 },
                 { ptr3, ptr4, ptr5 }
             };
+
             SAFEARRAY* psa = CreateSafeArray(VT_DISPATCH, result);
             using VARIANT variant = new()
             {
@@ -4786,6 +4787,7 @@ public unsafe class VARIANTTests
                     parray = psa
                 }
             };
+
             AssertToObject(variant, value =>
             {
                 Array array = (Array)value;
@@ -4815,23 +4817,24 @@ public unsafe class VARIANTTests
     [StaFact]
     public void VARIANT_ToObject_DISPATCHArrayUNKNOWNMultiDimensionNonZeroLowerBound_ReturnsExpected()
     {
-        var o1 = new object();
-        var o2 = new object();
-        var o3 = new object();
-        var o4 = new object();
-        var o5 = new object();
-        IntPtr ptr1 = Marshal.GetIUnknownForObject(o1);
-        IntPtr ptr2 = Marshal.GetIUnknownForObject(o2);
-        IntPtr ptr3 = Marshal.GetIUnknownForObject(o3);
-        IntPtr ptr4 = Marshal.GetIUnknownForObject(o4);
-        IntPtr ptr5 = Marshal.GetIUnknownForObject(o5);
+        object o1 = new();
+        object o2 = new();
+        object o3 = new();
+        object o4 = new();
+        object o5 = new();
+        nint ptr1 = Marshal.GetIUnknownForObject(o1);
+        nint ptr2 = Marshal.GetIUnknownForObject(o2);
+        nint ptr3 = Marshal.GetIUnknownForObject(o3);
+        nint ptr4 = Marshal.GetIUnknownForObject(o4);
+        nint ptr5 = Marshal.GetIUnknownForObject(o5);
         try
         {
-            var result = new IntPtr[2, 3]
+            nint[,] result = new nint[2, 3]
             {
-                { IntPtr.Zero, ptr1, ptr2 },
+                { 0, ptr1, ptr2 },
                 { ptr3, ptr4, ptr5 }
             };
+
             SAFEARRAY* psa = CreateSafeArray(VT_DISPATCH, result, 1, 2);
             using VARIANT variant = new()
             {
@@ -4841,6 +4844,7 @@ public unsafe class VARIANTTests
                     parray = psa
                 }
             };
+
             AssertToObject(variant, value =>
             {
                 Array array = (Array)value;
@@ -4850,11 +4854,6 @@ public unsafe class VARIANTTests
                 Assert.Equal(2, array.GetLowerBound(1));
                 Assert.Equal(result.GetLength(0), array.GetLength(0));
                 Assert.Equal(result.GetLength(1), array.GetLength(1));
-                Assert.Equal(new object[,]
-                {
-                    { null, o1, o2 },
-                    { o3, o4, o5 }
-                }, array);
             });
         }
         finally
@@ -4870,13 +4869,14 @@ public unsafe class VARIANTTests
     [StaFact]
     public void VARIANT_ToObject_ARRAYDISPATCHSingleDimension_ReturnsExpected()
     {
-        var o1 = new object();
-        var o2 = new object();
-        IntPtr ptr1 = Marshal.GetIUnknownForObject(o1);
-        IntPtr ptr2 = Marshal.GetIUnknownForObject(o2);
+        object o1 = new();
+        object o2 = new();
+        nint ptr1 = Marshal.GetIUnknownForObject(o1);
+        nint ptr2 = Marshal.GetIUnknownForObject(o2);
+
         try
         {
-            var result = new IntPtr[] { IntPtr.Zero, ptr1, ptr2 };
+            nint[] result = [0, ptr1, ptr2];
             SAFEARRAY* psa = CreateSafeArray(VT_DISPATCH, result);
             using VARIANT variant = new()
             {
@@ -4886,6 +4886,7 @@ public unsafe class VARIANTTests
                     parray = psa
                 }
             };
+
             AssertToObject(variant, value =>
             {
                 Array array = (Array)value;
@@ -4906,13 +4907,14 @@ public unsafe class VARIANTTests
     [StaFact]
     public void VARIANT_ToObject_ARRAYDISPATCHSingleDimensionNonZeroLowerBound_ReturnsExpected()
     {
-        var o1 = new object();
-        var o2 = new object();
-        IntPtr ptr1 = Marshal.GetIUnknownForObject(o1);
-        IntPtr ptr2 = Marshal.GetIUnknownForObject(o2);
+        object o1 = new();
+        object o2 = new();
+        nint ptr1 = Marshal.GetIUnknownForObject(o1);
+        nint ptr2 = Marshal.GetIUnknownForObject(o2);
+
         try
         {
-            var result = new IntPtr[] { IntPtr.Zero, ptr1, ptr2 };
+            nint[] result = [0, ptr1, ptr2];
             SAFEARRAY* psa = CreateSafeArray(VT_DISPATCH, result, 1);
             using VARIANT variant = new()
             {
@@ -4922,6 +4924,7 @@ public unsafe class VARIANTTests
                     parray = psa
                 }
             };
+
             AssertToObject(variant, value =>
             {
                 Array array = (Array)value;
@@ -4929,7 +4932,6 @@ public unsafe class VARIANTTests
                 Assert.Equal(1, array.Rank);
                 Assert.Equal(1, array.GetLowerBound(0));
                 Assert.Equal(result.Length, array.GetLength(0));
-                Assert.Equal(new object[] { null, o1, o2 }, array);
             });
         }
         finally
@@ -4942,23 +4944,25 @@ public unsafe class VARIANTTests
     [StaFact]
     public void VARIANT_ToObject_ARRAYDISPATCHMultiDimension_ReturnsExpected()
     {
-        var o1 = new object();
-        var o2 = new object();
-        var o3 = new object();
-        var o4 = new object();
-        var o5 = new object();
-        IntPtr ptr1 = Marshal.GetIUnknownForObject(o1);
-        IntPtr ptr2 = Marshal.GetIUnknownForObject(o2);
-        IntPtr ptr3 = Marshal.GetIUnknownForObject(o3);
-        IntPtr ptr4 = Marshal.GetIUnknownForObject(o4);
-        IntPtr ptr5 = Marshal.GetIUnknownForObject(o5);
+        object o1 = new();
+        object o2 = new();
+        object o3 = new();
+        object o4 = new();
+        object o5 = new();
+        nint ptr1 = Marshal.GetIUnknownForObject(o1);
+        nint ptr2 = Marshal.GetIUnknownForObject(o2);
+        nint ptr3 = Marshal.GetIUnknownForObject(o3);
+        nint ptr4 = Marshal.GetIUnknownForObject(o4);
+        nint ptr5 = Marshal.GetIUnknownForObject(o5);
+
         try
         {
-            var result = new IntPtr[2, 3]
+            nint[,] result = new nint[2, 3]
             {
-                { IntPtr.Zero, ptr1, ptr2 },
+                { 0, ptr1, ptr2 },
                 { ptr3, ptr4, ptr5 }
             };
+
             SAFEARRAY* psa = CreateSafeArray(VT_DISPATCH, result);
             using VARIANT variant = new()
             {
@@ -4968,6 +4972,7 @@ public unsafe class VARIANTTests
                     parray = psa
                 }
             };
+
             AssertToObject(variant, value =>
             {
                 Array array = (Array)value;
@@ -4997,23 +5002,25 @@ public unsafe class VARIANTTests
     [StaFact]
     public void VARIANT_ToObject_ARRAYDISPATCHMultiDimensionNonZeroLowerBound_ReturnsExpected()
     {
-        var o1 = new object();
-        var o2 = new object();
-        var o3 = new object();
-        var o4 = new object();
-        var o5 = new object();
-        IntPtr ptr1 = Marshal.GetIUnknownForObject(o1);
-        IntPtr ptr2 = Marshal.GetIUnknownForObject(o2);
-        IntPtr ptr3 = Marshal.GetIUnknownForObject(o3);
-        IntPtr ptr4 = Marshal.GetIUnknownForObject(o4);
-        IntPtr ptr5 = Marshal.GetIUnknownForObject(o5);
+        object o1 = new();
+        object o2 = new();
+        object o3 = new();
+        object o4 = new();
+        object o5 = new();
+        nint ptr1 = Marshal.GetIUnknownForObject(o1);
+        nint ptr2 = Marshal.GetIUnknownForObject(o2);
+        nint ptr3 = Marshal.GetIUnknownForObject(o3);
+        nint ptr4 = Marshal.GetIUnknownForObject(o4);
+        nint ptr5 = Marshal.GetIUnknownForObject(o5);
+
         try
         {
-            var result = new IntPtr[2, 3]
+            nint[,] result = new nint[2, 3]
             {
-                { IntPtr.Zero, ptr1, ptr2 },
+                { 0, ptr1, ptr2 },
                 { ptr3, ptr4, ptr5 }
             };
+
             SAFEARRAY* psa = CreateSafeArray(VT_DISPATCH, result, 1, 2);
             using VARIANT variant = new()
             {
@@ -5023,6 +5030,7 @@ public unsafe class VARIANTTests
                     parray = psa
                 }
             };
+
             AssertToObject(variant, value =>
             {
                 Array array = (Array)value;
@@ -5032,11 +5040,6 @@ public unsafe class VARIANTTests
                 Assert.Equal(2, array.GetLowerBound(1));
                 Assert.Equal(result.GetLength(0), array.GetLength(0));
                 Assert.Equal(result.GetLength(1), array.GetLength(1));
-                Assert.Equal(new object[,]
-                {
-                    { null, o1, o2 },
-                    { o3, o4, o5 }
-                }, array);
             });
         }
         finally
@@ -5060,6 +5063,7 @@ public unsafe class VARIANTTests
                 llVal = 1
             }
         };
+
         using VARIANT v2 = new()
         {
             vt = VT_I4,
@@ -5068,6 +5072,7 @@ public unsafe class VARIANTTests
                 llVal = 2
             }
         };
+
         using VARIANT v3 = new()
         {
             vt = VT_I4,
@@ -5076,7 +5081,8 @@ public unsafe class VARIANTTests
                 llVal = 3
             }
         };
-        var result = new VARIANT[] { v1, v2, v3 };
+
+        VARIANT[] result = [v1, v2, v3];
         SAFEARRAY* psa = CreateSafeArray(VT_VARIANT, result);
         using VARIANT variant = new()
         {
@@ -5086,6 +5092,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -5108,6 +5115,7 @@ public unsafe class VARIANTTests
                 llVal = 1
             }
         };
+
         using VARIANT v2 = new()
         {
             vt = VT_I4,
@@ -5116,6 +5124,7 @@ public unsafe class VARIANTTests
                 llVal = 2
             }
         };
+
         using VARIANT v3 = new()
         {
             vt = VT_I4,
@@ -5124,7 +5133,8 @@ public unsafe class VARIANTTests
                 llVal = 3
             }
         };
-        var result = new VARIANT[] { v1, v2, v3 };
+
+        VARIANT[] result = [v1, v2, v3];
         SAFEARRAY* psa = CreateSafeArray(VT_VARIANT, result, 1);
         using VARIANT variant = new()
         {
@@ -5134,6 +5144,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -5141,7 +5152,6 @@ public unsafe class VARIANTTests
             Assert.Equal(1, array.Rank);
             Assert.Equal(1, array.GetLowerBound(0));
             Assert.Equal(result.Length, array.GetLength(0));
-            Assert.Equal(new object[] { 1, 2, 3 }, array);
         });
     }
 
@@ -5156,6 +5166,7 @@ public unsafe class VARIANTTests
                 llVal = 1
             }
         };
+
         using VARIANT v2 = new()
         {
             vt = VT_I4,
@@ -5164,6 +5175,7 @@ public unsafe class VARIANTTests
                 llVal = 2
             }
         };
+
         using VARIANT v3 = new()
         {
             vt = VT_I4,
@@ -5172,6 +5184,7 @@ public unsafe class VARIANTTests
                 llVal = 3
             }
         };
+
         using VARIANT v4 = new()
         {
             vt = VT_I4,
@@ -5180,6 +5193,7 @@ public unsafe class VARIANTTests
                 llVal = 4
             }
         };
+
         using VARIANT v5 = new()
         {
             vt = VT_I4,
@@ -5188,6 +5202,7 @@ public unsafe class VARIANTTests
                 llVal = 5
             }
         };
+
         using VARIANT v6 = new()
         {
             vt = VT_I4,
@@ -5197,11 +5212,12 @@ public unsafe class VARIANTTests
             }
         };
 
-        var result = new VARIANT[2, 3]
+        VARIANT[,] result = new VARIANT[2, 3]
         {
             { v1, v2, v3 },
             { v4, v5, v6 }
         };
+
         SAFEARRAY* psa = CreateSafeArray(VT_VARIANT, result);
         using VARIANT variant = new()
         {
@@ -5211,6 +5227,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObject(variant, value =>
         {
             Array array = (Array)value;
@@ -5263,6 +5280,7 @@ public unsafe class VARIANTTests
         {
             vt = VT_ARRAY | (VARENUM)vt
         };
+
         AssertToObjectEqual(null, variant);
     }
 
@@ -5277,6 +5295,7 @@ public unsafe class VARIANTTests
         {
             vt = VT_ARRAY | (VARENUM)vt
         };
+
         AssertToObjectThrows<InvalidOleVariantTypeException>(variant);
     }
 
@@ -5303,6 +5322,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObjectThrows<InvalidOleVariantTypeException>(variant);
     }
 
@@ -5341,6 +5361,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObjectThrows<SafeArrayTypeMismatchException>(variant);
     }
 
@@ -5358,6 +5379,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObjectThrows<ArgumentException>(variant);
     }
 
@@ -5387,6 +5409,7 @@ public unsafe class VARIANTTests
                 parray = psa
             }
         };
+
         AssertToObjectThrows<TypeLoadException>(variant);
     }
 
@@ -5410,7 +5433,7 @@ public unsafe class VARIANTTests
             T value = result[i];
             int index = i + lbound;
             // Insert pointers directly.
-            if (value is IntPtr valuePtr)
+            if (value is nint valuePtr)
             {
                 hr = PInvoke.SafeArrayPutElement(psa, &index, (void*)valuePtr);
             }
@@ -5433,11 +5456,13 @@ public unsafe class VARIANTTests
             cElements = (uint)multiDimArray.GetLength(0),
             lLbound = lbound1
         };
+
         saBounds[1] = new SAFEARRAYBOUND
         {
             cElements = (uint)multiDimArray.GetLength(1),
             lLbound = lbound2
         };
+
         SAFEARRAY* psa = PInvoke.SafeArrayCreate(vt, 2, saBounds);
         Assert.True(psa != null);
 
@@ -5453,7 +5478,7 @@ public unsafe class VARIANTTests
                 int* indices = stackalloc int[] { i + lbound1, j + lbound2 };
                 T value = multiDimArray[i, j];
                 // Insert pointers directly.
-                if (value is IntPtr valuePtr)
+                if (value is nint valuePtr)
                 {
                     hr = PInvoke.SafeArrayPutElement(psa, indices, (void*)valuePtr);
                 }
@@ -5473,8 +5498,8 @@ public unsafe class VARIANTTests
     public void ToObject_RECORDRecordData_ReturnsExpected()
     {
         int record = 1;
-        IntPtr mem = Marshal.AllocCoTaskMem(sizeof(int));
-        (*(int*)mem) = record;
+        nint mem = Marshal.AllocCoTaskMem(sizeof(int));
+        *(int*)mem = record;
         CustomRecordInfo recordInfo = new()
         {
             GetGuidAction = () => (typeof(int).GUID, HRESULT.S_OK)
@@ -5505,7 +5530,7 @@ public unsafe class VARIANTTests
     public void ToObject_RECORDNullRecordInfo_ThrowsArgumentException()
     {
         int record = 1;
-        IntPtr mem = Marshal.AllocCoTaskMem(sizeof(int));
+        nint mem = Marshal.AllocCoTaskMem(sizeof(int));
         (*(int*)mem) = record;
 
         using VARIANT variant = new() { vt = VT_RECORD };
@@ -5517,7 +5542,7 @@ public unsafe class VARIANTTests
     public void ToObject_RECORDInvalidGetGuidHRData_ThrowsArgumentException()
     {
         int record = 1;
-        IntPtr mem = Marshal.AllocCoTaskMem(sizeof(int));
+        nint mem = Marshal.AllocCoTaskMem(sizeof(int));
         (*(int*)mem) = record;
 
         CustomRecordInfo recordInfo = new()
@@ -5559,7 +5584,7 @@ public unsafe class VARIANTTests
     public void ToObject_RECORDInvalidGuidData_ThrowsArgumentException(Guid guid)
     {
         int record = 1;
-        IntPtr mem = Marshal.AllocCoTaskMem(sizeof(int));
+        nint mem = Marshal.AllocCoTaskMem(sizeof(int));
         (*(int*)mem) = record;
 
         CustomRecordInfo recordInfo = new CustomRecordInfo
@@ -5642,7 +5667,7 @@ public unsafe class VARIANTTests
         variant.data.parray = CreateRecordSafeArray(result, pRecordInfo);
 
         VARIANT copy = variant;
-        IntPtr pv = (IntPtr)(&copy);
+        nint pv = (nint)(&copy);
         Assert.Throws<ArgumentException>(() => Marshal.GetObjectForNativeVariant(pv));
         Assert.Throws<ArgumentException>(() => variant.ToObject());
     }
@@ -5738,7 +5763,7 @@ public unsafe class VARIANTTests
     private static void AssertToObjectThrows<T>(VARIANT variant) where T : Exception
     {
         VARIANT copy = variant;
-        IntPtr pv = (IntPtr)(&copy);
+        nint pv = (nint)(&copy);
         Assert.Throws<T>(() => Marshal.GetObjectForNativeVariant(pv));
 
         Assert.Throws<T>(() => variant.ToObject());
@@ -5751,7 +5776,7 @@ public unsafe class VARIANTTests
     {
         // Not supported type.
         VARIANT copy = variant;
-        IntPtr pv = (IntPtr)(&copy);
+        nint pv = (nint)(&copy);
         Assert.Throws<T>(() => Marshal.GetObjectForNativeVariant(pv));
 
         Assert.Equal(expected, variant.ToObject());
@@ -5759,10 +5784,13 @@ public unsafe class VARIANTTests
 
     private static void AssertToObject(VARIANT variant, Action<object> action)
     {
-        IntPtr pv = (IntPtr)(&variant);
-        action(Marshal.GetObjectForNativeVariant(pv));
+        object marshaller = Marshal.GetObjectForNativeVariant((nint)(void*)&variant);
+        action(marshaller);
 
-        action(variant.ToObject());
+        object toObject = variant.ToObject();
+        action(toObject);
+
+        Assert.Equal(marshaller, toObject);
     }
 
     [Fact]

--- a/src/System.Windows.Forms/tests/UnitTests/GlobalUsings.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/GlobalUsings.cs
@@ -12,3 +12,4 @@ global using Windows.Win32.UI.HiDpi;
 global using Windows.Win32.UI.Shell;
 global using Windows.Win32.UI.WindowsAndMessaging;
 global using Xunit;
+global using FluentAssertions;

--- a/src/System.Windows.Forms/tests/UnitTests/System.Windows.Forms.Tests.csproj
+++ b/src/System.Windows.Forms/tests/UnitTests/System.Windows.Forms.Tests.csproj
@@ -14,6 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
     <PackageReference Include="Moq" Version="$(MoqPackageVersion)" />
     <PackageReference Include="xunit.stafact" Version="$(XUnitStaFactPackageVersion)" />
     <PackageReference Include="coverlet.msbuild" Version="$(CoverletMSBuildPackageVersion)" />

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/EmbeddedResourceTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/EmbeddedResourceTests.cs
@@ -257,6 +257,6 @@ public class EmbeddedResourceTests
         string[] expected = allNames.Split(Environment.NewLine);
         Array.Sort(expected, StringComparer.Ordinal);
 
-        AssertExtensions.Equal(expected, actual);
+        actual.Should().Equal(expected);
     }
 }


### PR DESCRIPTION
Xunit removed some public constructors on exception objects and moved them to static factory methods. Changed a few of the usages.

Xunit validation of arrays that aren't 0 based also changed (Xunit validates them correctly). Changed VARIANT tests to compare the output of Marshal and VARIANT.ToObject directly to address this. Removed checking against non-equivalent expected arrays in the non-0 case.

Added FluentAssertions in more of the test projects and moved RectangleF and PointF validation to that model.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10062)