### PR TITLE
Enable nullability in CollectionEditor

### DIFF
--- a/src/System.Windows.Forms.Design/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms.Design/src/PublicAPI.Shipped.txt
@@ -22,8 +22,8 @@ override System.ComponentModel.Design.BinaryEditor.GetEditStyle(System.Component
 ~override System.ComponentModel.Design.ByteViewer.OnKeyDown(System.Windows.Forms.KeyEventArgs e) -> void
 ~override System.ComponentModel.Design.ByteViewer.OnLayout(System.Windows.Forms.LayoutEventArgs e) -> void
 ~override System.ComponentModel.Design.ByteViewer.OnPaint(System.Windows.Forms.PaintEventArgs e) -> void
-~override System.ComponentModel.Design.CollectionEditor.EditValue(System.ComponentModel.ITypeDescriptorContext context, System.IServiceProvider provider, object value) -> object
-~override System.ComponentModel.Design.CollectionEditor.GetEditStyle(System.ComponentModel.ITypeDescriptorContext context) -> System.Drawing.Design.UITypeEditorEditStyle
+override System.ComponentModel.Design.CollectionEditor.EditValue(System.ComponentModel.ITypeDescriptorContext? context, System.IServiceProvider! provider, object? value) -> object?
+override System.ComponentModel.Design.CollectionEditor.GetEditStyle(System.ComponentModel.ITypeDescriptorContext? context) -> System.Drawing.Design.UITypeEditorEditStyle
 override System.ComponentModel.Design.DateTimeEditor.EditValue(System.ComponentModel.ITypeDescriptorContext? context, System.IServiceProvider! provider, object? value) -> object?
 override System.ComponentModel.Design.DateTimeEditor.GetEditStyle(System.ComponentModel.ITypeDescriptorContext? context) -> System.Drawing.Design.UITypeEditorEditStyle
 override System.ComponentModel.Design.Serialization.BasicDesignerLoader.BeginLoad(System.ComponentModel.Design.Serialization.IDesignerLoaderHost! host) -> void
@@ -129,12 +129,12 @@ static System.Windows.Forms.Design.MaskDescriptor.IsValidMaskDescriptor(System.W
 static System.Windows.Forms.Design.MaskDescriptor.IsValidMaskDescriptor(System.Windows.Forms.Design.MaskDescriptor? maskDescriptor, out string! validationErrorDescription) -> bool
 ~static System.Windows.Forms.Design.ParentControlDesigner.InvokeCreateTool(System.Windows.Forms.Design.ParentControlDesigner toInvoke, System.Drawing.Design.ToolboxItem tool) -> void
 ~System.ComponentModel.Design.ArrayEditor.ArrayEditor(System.Type type) -> void
-~System.ComponentModel.Design.CollectionEditor.CollectionEditor(System.Type type) -> void
-~System.ComponentModel.Design.CollectionEditor.CollectionItemType.get -> System.Type
-~System.ComponentModel.Design.CollectionEditor.CollectionType.get -> System.Type
-~System.ComponentModel.Design.CollectionEditor.Context.get -> System.ComponentModel.ITypeDescriptorContext
-~System.ComponentModel.Design.CollectionEditor.GetService(System.Type serviceType) -> object
-~System.ComponentModel.Design.CollectionEditor.NewItemTypes.get -> System.Type[]
+System.ComponentModel.Design.CollectionEditor.CollectionEditor(System.Type! type) -> void
+System.ComponentModel.Design.CollectionEditor.CollectionItemType.get -> System.Type!
+System.ComponentModel.Design.CollectionEditor.CollectionType.get -> System.Type!
+System.ComponentModel.Design.CollectionEditor.Context.get -> System.ComponentModel.ITypeDescriptorContext?
+System.ComponentModel.Design.CollectionEditor.GetService(System.Type! serviceType) -> object?
+System.ComponentModel.Design.CollectionEditor.NewItemTypes.get -> System.Type![]!
 ~System.ComponentModel.Design.ComponentDesigner.Component.get -> System.ComponentModel.IComponent
 ~System.ComponentModel.Design.ComponentDesigner.InvokeGetInheritanceAttribute(System.ComponentModel.Design.ComponentDesigner toInvoke) -> System.ComponentModel.InheritanceAttribute
 ~System.ComponentModel.Design.ComponentDesigner.RaiseComponentChanged(System.ComponentModel.MemberDescriptor member, object oldValue, object newValue) -> void
@@ -297,17 +297,17 @@ System.Windows.Forms.Design.Behavior.GlyphCollection.this[int index].set -> void
 ~virtual System.ComponentModel.Design.ByteViewer.ScrollChanged(object source, System.EventArgs e) -> void
 ~virtual System.ComponentModel.Design.ByteViewer.SetBytes(byte[] bytes) -> void
 ~virtual System.ComponentModel.Design.ByteViewer.SetFile(string path) -> void
-~virtual System.ComponentModel.Design.CollectionEditor.CanRemoveInstance(object value) -> bool
-~virtual System.ComponentModel.Design.CollectionEditor.CreateCollectionForm() -> System.ComponentModel.Design.CollectionEditor.CollectionForm
-~virtual System.ComponentModel.Design.CollectionEditor.CreateCollectionItemType() -> System.Type
-~virtual System.ComponentModel.Design.CollectionEditor.CreateInstance(System.Type itemType) -> object
-~virtual System.ComponentModel.Design.CollectionEditor.CreateNewItemTypes() -> System.Type[]
-~virtual System.ComponentModel.Design.CollectionEditor.DestroyInstance(object instance) -> void
-~virtual System.ComponentModel.Design.CollectionEditor.GetDisplayText(object value) -> string
-~virtual System.ComponentModel.Design.CollectionEditor.GetItems(object editValue) -> object[]
-~virtual System.ComponentModel.Design.CollectionEditor.GetObjectsFromInstance(object instance) -> System.Collections.IList
-~virtual System.ComponentModel.Design.CollectionEditor.HelpTopic.get -> string
-~virtual System.ComponentModel.Design.CollectionEditor.SetItems(object editValue, object[] value) -> object
+virtual System.ComponentModel.Design.CollectionEditor.CanRemoveInstance(object! value) -> bool
+virtual System.ComponentModel.Design.CollectionEditor.CreateCollectionForm() -> System.ComponentModel.Design.CollectionEditor.CollectionForm!
+virtual System.ComponentModel.Design.CollectionEditor.CreateCollectionItemType() -> System.Type!
+virtual System.ComponentModel.Design.CollectionEditor.CreateInstance(System.Type! itemType) -> object!
+virtual System.ComponentModel.Design.CollectionEditor.CreateNewItemTypes() -> System.Type![]!
+virtual System.ComponentModel.Design.CollectionEditor.DestroyInstance(object! instance) -> void
+virtual System.ComponentModel.Design.CollectionEditor.GetDisplayText(object? value) -> string!
+virtual System.ComponentModel.Design.CollectionEditor.GetItems(object? editValue) -> object![]!
+virtual System.ComponentModel.Design.CollectionEditor.GetObjectsFromInstance(object? instance) -> System.Collections.IList!
+virtual System.ComponentModel.Design.CollectionEditor.HelpTopic.get -> string!
+virtual System.ComponentModel.Design.CollectionEditor.SetItems(object? editValue, object![]? value) -> object?
 ~virtual System.ComponentModel.Design.ComponentDesigner.ActionLists.get -> System.ComponentModel.Design.DesignerActionListCollection
 ~virtual System.ComponentModel.Design.ComponentDesigner.AssociatedComponents.get -> System.Collections.ICollection
 ~virtual System.ComponentModel.Design.ComponentDesigner.GetService(System.Type serviceType) -> object
@@ -393,7 +393,7 @@ abstract System.ComponentModel.Design.EventBindingService.ShowCode(int lineNumbe
 abstract System.ComponentModel.Design.UndoEngine.AddUndoUnit(System.ComponentModel.Design.UndoEngine.UndoUnit! unit) -> void
 abstract System.Windows.Forms.Design.Behavior.Glyph.GetHitTest(System.Drawing.Point p) -> System.Windows.Forms.Cursor?
 abstract System.Windows.Forms.Design.Behavior.Glyph.Paint(System.Windows.Forms.PaintEventArgs! pe) -> void
-override System.ComponentModel.Design.CollectionEditor.CollectionForm.GetService(System.Type! serviceType) -> object!
+override System.ComponentModel.Design.CollectionEditor.CollectionForm.GetService(System.Type! serviceType) -> object?
 override System.ComponentModel.Design.DesignerActionListCollection.OnValidate(object! value) -> void
 override System.ComponentModel.Design.ExceptionCollection.GetObjectData(System.Runtime.Serialization.SerializationInfo! info, System.Runtime.Serialization.StreamingContext context) -> void
 override System.ComponentModel.Design.MultilineStringEditor.EditValue(System.ComponentModel.ITypeDescriptorContext? context, System.IServiceProvider! provider, object? value) -> object?
@@ -518,7 +518,7 @@ System.ComponentModel.Design.CollectionEditor.CollectionForm.CanRemoveInstance(o
 System.ComponentModel.Design.CollectionEditor.CollectionForm.CollectionForm(System.ComponentModel.Design.CollectionEditor! editor) -> void
 System.ComponentModel.Design.CollectionEditor.CollectionForm.CollectionItemType.get -> System.Type!
 System.ComponentModel.Design.CollectionEditor.CollectionForm.CollectionType.get -> System.Type!
-System.ComponentModel.Design.CollectionEditor.CollectionForm.Context.get -> System.ComponentModel.ITypeDescriptorContext!
+System.ComponentModel.Design.CollectionEditor.CollectionForm.Context.get -> System.ComponentModel.ITypeDescriptorContext?
 System.ComponentModel.Design.CollectionEditor.CollectionForm.CreateInstance(System.Type! itemType) -> object!
 System.ComponentModel.Design.CollectionEditor.CollectionForm.DestroyInstance(object! instance) -> void
 System.ComponentModel.Design.CollectionEditor.CollectionForm.EditValue.get -> object?

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CollectionEditor.CollectionEditorCollectionForm.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CollectionEditor.CollectionEditorCollectionForm.cs
@@ -957,7 +957,7 @@ public partial class CollectionEditor
         /// </summary>
         protected internal override DialogResult ShowEditorDialog(IWindowsFormsEditorService edSvc)
         {
-            IComponentChangeService? changeService = _editor.Context!.GetService<IComponentChangeService>();
+            IComponentChangeService? changeService = _editor.Context?.GetService<IComponentChangeService>();
             DialogResult result = DialogResult.OK;
             try
             {
@@ -1237,10 +1237,7 @@ public partial class CollectionEditor
             /// <summary>
             ///  Retrieves an array of member attributes for the given object.
             /// </summary>
-            AttributeCollection ICustomTypeDescriptor.GetAttributes()
-            {
-                return TypeDescriptor.GetAttributes(PropertyType);
-            }
+            AttributeCollection ICustomTypeDescriptor.GetAttributes() => TypeDescriptor.GetAttributes(PropertyType);
 
             /// <summary>
             ///  Retrieves the class name for this object. If null is returned, the type name is used.
@@ -1288,20 +1285,14 @@ public partial class CollectionEditor
             ///  If the component is sited, the site may add or remove additional events.
             ///  The returned array of events will be filtered by the given set of attributes.
             /// </summary>
-            EventDescriptorCollection ICustomTypeDescriptor.GetEvents(Attribute[]? attributes)
-            {
-                return EventDescriptorCollection.Empty;
-            }
+            EventDescriptorCollection ICustomTypeDescriptor.GetEvents(Attribute[]? attributes) => EventDescriptorCollection.Empty;
 
             /// <summary>
             ///  Retrieves an array of properties that the given component instance provides.
             ///  This may differ from the set of properties the class provides.
             ///  If the component is sited, the site may add or remove additional properties.
             /// </summary>
-            PropertyDescriptorCollection ICustomTypeDescriptor.GetProperties()
-            {
-                return _properties;
-            }
+            PropertyDescriptorCollection ICustomTypeDescriptor.GetProperties() => _properties;
 
             /// <summary>
             ///  Retrieves an array of properties that the given component instance provides.
@@ -1309,10 +1300,7 @@ public partial class CollectionEditor
             ///  If the component is sited, the site may add or remove additional properties.
             ///  The returned array of properties will be filtered by the given set of attributes.
             /// </summary>
-            PropertyDescriptorCollection ICustomTypeDescriptor.GetProperties(Attribute[]? attributes)
-            {
-                return _properties;
-            }
+            PropertyDescriptorCollection ICustomTypeDescriptor.GetProperties(Attribute[]? attributes) => _properties;
 
             /// <summary>
             ///  Retrieves the object that directly depends on this value being edited.
@@ -1320,10 +1308,7 @@ public partial class CollectionEditor
             ///  If 'null' is passed for the PropertyDescriptor, the ICustomComponent descriptor implementation should return the default object,
             ///  that is the main object that exposes the properties and attributes
             /// </summary>
-            object ICustomTypeDescriptor.GetPropertyOwner(PropertyDescriptor? pd)
-            {
-                return this;
-            }
+            object ICustomTypeDescriptor.GetPropertyOwner(PropertyDescriptor? pd) => this;
         }
 
         /// <summary>
@@ -1342,10 +1327,7 @@ public partial class CollectionEditor
                 _parentCollectionEditor = parentCollectionEditor;
             }
 
-            public override string ToString()
-            {
-                return _parentCollectionEditor.GetDisplayText(_value);
-            }
+            public override string ToString() => _parentCollectionEditor.GetDisplayText(_value);
 
             public UITypeEditor? Editor
             {

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CollectionEditor.CollectionForm.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CollectionEditor.CollectionForm.cs
@@ -67,7 +67,7 @@ public partial class CollectionEditor
         /// <summary>
         ///  Gets or sets a type descriptor that indicates the current context.
         /// </summary>
-        protected ITypeDescriptorContext Context => _editor.Context;
+        protected ITypeDescriptorContext? Context => _editor.Context;
 
         /// <summary>
         ///  Gets or sets the value of the item being edited.
@@ -85,6 +85,7 @@ public partial class CollectionEditor
         /// <summary>
         ///  Gets or sets the array of items this form is to display.
         /// </summary>
+        [AllowNull]
         protected object[] Items
         {
             get => _editor.GetItems(EditValue);
@@ -106,7 +107,7 @@ public partial class CollectionEditor
 
                 if (canChange)
                 {
-                    object newValue = _editor.SetItems(EditValue, value);
+                    object? newValue = _editor.SetItems(EditValue, value);
                     if (newValue != EditValue)
                     {
                         EditValue = newValue;
@@ -173,7 +174,7 @@ public partial class CollectionEditor
         /// <summary>
         ///  Gets the requested service, if it is available.
         /// </summary>
-        protected override object GetService(Type serviceType) => _editor.GetService(serviceType);
+        protected override object? GetService(Type serviceType) => _editor.GetService(serviceType);
 
         /// <summary>
         ///  Called to show the dialog via the IWindowsFormsEditorService

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CollectionEditor.FilterListBox.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CollectionEditor.FilterListBox.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.Windows.Forms;
 
 namespace System.ComponentModel.Design;
@@ -15,20 +13,20 @@ public partial class CollectionEditor
     internal class FilterListBox : ListBox
     {
         private const int VK_PROCESSKEY = 0xE5;
-        private PropertyGrid _grid;
+        private PropertyGrid? _grid;
         private Message _lastKeyDown;
 
-        private PropertyGrid PropertyGrid
+        private PropertyGrid? PropertyGrid
         {
             get
             {
                 if (_grid is null)
                 {
-                    foreach (Control c in Parent.Controls)
+                    foreach (Control c in Parent!.Controls)
                     {
-                        if (c is PropertyGrid)
+                        if (c is PropertyGrid grid)
                         {
-                            _grid = (PropertyGrid)c;
+                            _grid = grid;
                             break;
                         }
                     }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CollectionEditor.FilterListBox.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CollectionEditor.FilterListBox.cs
@@ -20,9 +20,9 @@ public partial class CollectionEditor
         {
             get
             {
-                if (_grid is null)
+                if (_grid is null && Parent is not null)
                 {
-                    foreach (Control c in Parent!.Controls)
+                    foreach (Control c in Parent.Controls)
                     {
                         if (c is PropertyGrid grid)
                         {

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CollectionEditor.PropertyGridSite.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CollectionEditor.PropertyGridSite.cs
@@ -1,18 +1,16 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 namespace System.ComponentModel.Design;
 
 public partial class CollectionEditor
 {
     internal class PropertyGridSite : ISite
     {
-        private readonly IServiceProvider _sp;
+        private readonly IServiceProvider? _sp;
         private bool _inGetService;
 
-        public PropertyGridSite(IServiceProvider sp, IComponent comp)
+        public PropertyGridSite(IServiceProvider? sp, IComponent comp)
         {
             _sp = sp;
             Component = comp;
@@ -20,17 +18,17 @@ public partial class CollectionEditor
 
         public IComponent Component { get; }
 
-        public IContainer Container => null;
+        public IContainer? Container => null;
 
         public bool DesignMode => false;
 
-        public string Name
+        public string? Name
         {
             get => null;
             set { }
         }
 
-        public object GetService(Type t)
+        public object? GetService(Type t)
         {
             if (!_inGetService && _sp is not null)
             {

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CollectionEditor.SplitButton.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CollectionEditor.SplitButton.cs
@@ -73,7 +73,7 @@ public partial class CollectionEditor
 
         protected override bool IsInputKey(Keys keyData)
         {
-            if (keyData.Equals(Keys.Down) && _showSplit)
+            if (keyData is Keys.Down && _showSplit)
             {
                 return true;
             }
@@ -89,7 +89,7 @@ public partial class CollectionEditor
                 return;
             }
 
-            if (!State.Equals(PushButtonState.Pressed) && !State.Equals(PushButtonState.Disabled))
+            if (State is not (PushButtonState.Pressed or PushButtonState.Disabled))
             {
                 State = PushButtonState.Default;
             }
@@ -97,7 +97,7 @@ public partial class CollectionEditor
 
         protected override void OnKeyDown(KeyEventArgs kevent)
         {
-            if (kevent.KeyCode.Equals(Keys.Down) && _showSplit)
+            if (kevent.KeyCode is Keys.Down && _showSplit)
             {
                 ShowContextMenuStrip();
             }
@@ -117,7 +117,7 @@ public partial class CollectionEditor
                 return;
             }
 
-            if (!State.Equals(PushButtonState.Pressed) && !State.Equals(PushButtonState.Disabled))
+            if (State is not (PushButtonState.Pressed or PushButtonState.Disabled))
             {
                 State = PushButtonState.Normal;
             }
@@ -149,7 +149,7 @@ public partial class CollectionEditor
                 return;
             }
 
-            if (!State.Equals(PushButtonState.Pressed) && !State.Equals(PushButtonState.Disabled))
+            if (State is not (PushButtonState.Pressed or PushButtonState.Disabled))
             {
                 State = PushButtonState.Hot;
             }
@@ -163,16 +163,9 @@ public partial class CollectionEditor
                 return;
             }
 
-            if (!State.Equals(PushButtonState.Pressed) && !State.Equals(PushButtonState.Disabled))
+            if (State is not (PushButtonState.Pressed or PushButtonState.Disabled))
             {
-                if (Focused)
-                {
-                    State = PushButtonState.Default;
-                }
-                else
-                {
-                    State = PushButtonState.Normal;
-                }
+                State = Focused ? PushButtonState.Default : PushButtonState.Normal;
             }
         }
 
@@ -184,12 +177,12 @@ public partial class CollectionEditor
                 return;
             }
 
-            if (ContextMenuStrip is null || !ContextMenuStrip.Visible)
+            if (ContextMenuStrip is not {Visible: true})
             {
                 SetButtonDrawState();
                 if (Parent is not null && Bounds.Contains(Parent.PointToClient(Cursor.Position)) && !_dropDownRectangle.Contains(mevent.Location))
                 {
-                    OnClick(new EventArgs());
+                    OnClick(EventArgs.Empty);
                 }
             }
         }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CollectionEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CollectionEditor.cs
@@ -94,7 +94,7 @@ public partial class CollectionEditor : UITypeEditor
 
         if (Context.TryGetService(out IDesignerHost? host) && typeof(IComponent).IsAssignableFrom(itemType))
         {
-            IComponent instance = host.CreateComponent(itemType, null!);
+            IComponent instance = host.CreateComponent(itemType);
 
             // Set component defaults
             if (host.GetDesigner(instance) is IComponentInitializer initializer)
@@ -337,7 +337,8 @@ public partial class CollectionEditor : UITypeEditor
     /// </summary>
     private void OnComponentChanged(object? sender, ComponentChangedEventArgs e)
     {
-        if (!_ignoreChangedEvents && sender != Context!.Instance)
+        Debug.Assert(Context is not null);
+        if (!_ignoreChangedEvents && sender != Context.Instance)
         {
             _ignoreChangedEvents = true;
             Context.OnComponentChanged();
@@ -349,7 +350,8 @@ public partial class CollectionEditor : UITypeEditor
     /// </summary>
     private void OnComponentChanging(object? sender, ComponentChangingEventArgs e)
     {
-        if (!_ignoreChangingEvents && sender != Context!.Instance)
+        Debug.Assert(Context is not null);
+        if (!_ignoreChangingEvents && sender != Context.Instance)
         {
             _ignoreChangingEvents = true;
             Context.OnComponentChanging();

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CollectionEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CollectionEditor.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.Collections;
 using System.Drawing.Design;
 using System.Reflection;
@@ -16,9 +14,8 @@ namespace System.ComponentModel.Design;
 /// </summary>
 public partial class CollectionEditor : UITypeEditor
 {
-    private Type _collectionItemType;
-    private Type[] _newItemTypes;
-    private ITypeDescriptorContext _currentContext;
+    private Type? _collectionItemType;
+    private Type[]? _newItemTypes;
 
     private bool _ignoreChangedEvents;
     private bool _ignoreChangingEvents;
@@ -29,19 +26,19 @@ public partial class CollectionEditor : UITypeEditor
     public CollectionEditor(Type type) => CollectionType = type;
 
     /// <summary>
-    ///  Gets or sets the data type of each item in the collection.
+    ///  Gets the data type of each item in the collection.
     /// </summary>
     protected Type CollectionItemType => _collectionItemType ??= CreateCollectionItemType();
 
     /// <summary>
-    ///  Gets or sets the type of the collection.
+    ///  Gets the type of the collection.
     /// </summary>
     protected Type CollectionType { get; }
 
     /// <summary>
     ///  Gets or sets a type descriptor that indicates the current context.
     /// </summary>
-    protected ITypeDescriptorContext Context => _currentContext;
+    protected ITypeDescriptorContext? Context { get; private set; }
 
     /// <summary>
     ///  Gets or sets the available item types that can be created for this collection.
@@ -54,14 +51,14 @@ public partial class CollectionEditor : UITypeEditor
     protected virtual string HelpTopic => "net.ComponentModel.CollectionEditor";
 
     /// <summary>
-    ///  Gets or sets a value indicating whether original members of the collection can be removed.
+    ///  Gets a value indicating whether original members of the collection can be removed.
     /// </summary>
     protected virtual bool CanRemoveInstance(object value)
     {
         if (value is IComponent component)
         {
             // Make sure the component is not being inherited -- we can't delete these!
-            if (TypeDescriptorHelper.TryGetAttribute(component, out InheritanceAttribute attribute)
+            if (TypeDescriptorHelper.TryGetAttribute(component, out InheritanceAttribute? attribute)
                 && attribute.InheritanceLevel != InheritanceLevel.NotInherited)
             {
                 return false;
@@ -93,9 +90,11 @@ public partial class CollectionEditor : UITypeEditor
     /// </summary>
     protected virtual object CreateInstance(Type itemType)
     {
-        if (Context.TryGetService(out IDesignerHost host) && typeof(IComponent).IsAssignableFrom(itemType))
+        ArgumentNullException.ThrowIfNull(itemType);
+
+        if (Context.TryGetService(out IDesignerHost? host) && typeof(IComponent).IsAssignableFrom(itemType))
         {
-            IComponent instance = host.CreateComponent(itemType, null);
+            IComponent instance = host.CreateComponent(itemType, null!);
 
             // Set component defaults
             if (host.GetDesigner(instance) is IComponentInitializer initializer)
@@ -109,43 +108,38 @@ public partial class CollectionEditor : UITypeEditor
             }
         }
 
-        return itemType?.UnderlyingSystemType == typeof(string)
+        return itemType.UnderlyingSystemType == typeof(string)
             ? string.Empty
-            : TypeDescriptor.CreateInstance(host, itemType, null, null);
+            : TypeDescriptor.CreateInstance(host, itemType, argTypes: null, args: null)!;
     }
 
     /// <summary>
     ///  This method gets the object from the given object. The input is an arrayList returned as an Object.
     ///  The output is a arraylist which contains the individual objects that need to be created.
     /// </summary>
-    protected virtual IList GetObjectsFromInstance(object instance) => new ArrayList { instance };
+    protected virtual IList GetObjectsFromInstance(object? instance) => new ArrayList { instance };
 
     /// <summary>
     ///  Retrieves the display text for the given list item.
     /// </summary>
-    protected virtual string GetDisplayText(object value)
+    protected virtual string GetDisplayText(object? value)
     {
-        string text;
-
         if (value is null)
         {
             return string.Empty;
         }
 
-        PropertyDescriptor property = TypeDescriptor.GetProperties(value)["Name"];
-        if (property?.PropertyType == typeof(string))
+        if (TypeDescriptorHelper.TryGetPropertyValue(value, "Name", out string? text))
         {
-            text = (string)property.GetValue(value);
             if (!string.IsNullOrEmpty(text))
             {
                 return text;
             }
         }
 
-        property = TypeDescriptor.GetDefaultProperty(CollectionType);
-        if (property?.PropertyType == typeof(string))
+        PropertyDescriptor? property = TypeDescriptor.GetDefaultProperty(CollectionType);
+        if (property is not null && property.TryGetValue(value, out text))
         {
-            text = (string)property.GetValue(value);
             if (!string.IsNullOrEmpty(text))
             {
                 return text;
@@ -170,7 +164,7 @@ public partial class CollectionEditor : UITypeEditor
 
         foreach (var property in properties)
         {
-            if (property.Name.Equals("Item") || property.Name.Equals("Items"))
+            if (property.Name is "Item" or "Items")
             {
                 return property.PropertyType;
             }
@@ -191,7 +185,7 @@ public partial class CollectionEditor : UITypeEditor
     {
         if (instance is IComponent component)
         {
-            if (Context.TryGetService(out IDesignerHost host))
+            if (Context.TryGetService(out IDesignerHost? host))
             {
                 host.DestroyComponent(component);
             }
@@ -209,26 +203,26 @@ public partial class CollectionEditor : UITypeEditor
     /// <summary>
     ///  Edits the specified object value using the editor style  provided by <see cref="GetEditStyle"/>.
     /// </summary>
-    public override object EditValue(ITypeDescriptorContext context, IServiceProvider provider, object value)
+    public override object? EditValue(ITypeDescriptorContext? context, IServiceProvider provider, object? value)
     {
-        if (!provider.TryGetService(out IWindowsFormsEditorService editorService))
+        if (!provider.TryGetService(out IWindowsFormsEditorService? editorService))
         {
             return value;
         }
 
-        _currentContext = context;
+        Context = context;
 
         // Child modal dialog - launching in SystemAware mode.
         CollectionForm localCollectionForm = DpiHelper.CreateInstanceInSystemAwareContext(CreateCollectionForm);
-        ITypeDescriptorContext lastContext = _currentContext;
+        ITypeDescriptorContext? lastContext = Context;
         localCollectionForm.EditValue = value;
         _ignoreChangingEvents = false;
         _ignoreChangedEvents = false;
-        DesignerTransaction transaction = null;
+        DesignerTransaction? transaction = null;
 
         bool commitChange = true;
-        IComponentChangeService changeService = null;
-        IDesignerHost host = Context?.GetService<IDesignerHost>();
+        IComponentChangeService? changeService = null;
+        IDesignerHost? host = Context?.GetService<IDesignerHost>();
 
         try
         {
@@ -259,7 +253,7 @@ public partial class CollectionEditor : UITypeEditor
         finally
         {
             localCollectionForm.EditValue = null;
-            _currentContext = lastContext;
+            Context = lastContext;
 
             if (commitChange)
             {
@@ -283,7 +277,7 @@ public partial class CollectionEditor : UITypeEditor
     }
 
     /// <inheritdoc />
-    public override UITypeEditorEditStyle GetEditStyle(ITypeDescriptorContext context) => UITypeEditorEditStyle.Modal;
+    public override UITypeEditorEditStyle GetEditStyle(ITypeDescriptorContext? context) => UITypeEditorEditStyle.Modal;
 
     private bool IsAnyObjectInheritedReadOnly(object[] items)
     {
@@ -292,12 +286,12 @@ public partial class CollectionEditor : UITypeEditor
         // to place it in the collection editor. If the inheritance service chose not to site the component, that
         // indicates it should be hidden from  the user.
 
-        IInheritanceService inheritanceService = null;
+        IInheritanceService? inheritanceService = null;
         bool isInheritanceServiceInitialized = false;
 
         foreach (object item in items)
         {
-            if (item is not IComponent component || component.Site is not null)
+            if (item is not IComponent { Site: null } component)
             {
                 continue;
             }
@@ -321,7 +315,7 @@ public partial class CollectionEditor : UITypeEditor
     /// <summary>
     ///  Converts the specified collection into an array of objects.
     /// </summary>
-    protected virtual object[] GetItems(object editValue)
+    protected virtual object[] GetItems(object? editValue)
     {
         if (editValue is ICollection collection)
         {
@@ -336,14 +330,14 @@ public partial class CollectionEditor : UITypeEditor
     /// <summary>
     ///  Gets the requested service, if it is available.
     /// </summary>
-    protected object GetService(Type serviceType) => Context?.GetService(serviceType);
+    protected object? GetService(Type serviceType) => Context?.GetService(serviceType);
 
     /// <summary>
     ///  Reflect any change events to the instance object
     /// </summary>
-    private void OnComponentChanged(object sender, ComponentChangedEventArgs e)
+    private void OnComponentChanged(object? sender, ComponentChangedEventArgs e)
     {
-        if (!_ignoreChangedEvents && sender != Context.Instance)
+        if (!_ignoreChangedEvents && sender != Context!.Instance)
         {
             _ignoreChangedEvents = true;
             Context.OnComponentChanged();
@@ -353,9 +347,9 @@ public partial class CollectionEditor : UITypeEditor
     /// <summary>
     ///  Reflect any changed events to the instance object
     /// </summary>
-    private void OnComponentChanging(object sender, ComponentChangingEventArgs e)
+    private void OnComponentChanging(object? sender, ComponentChangingEventArgs e)
     {
-        if (!_ignoreChangingEvents && sender != Context.Instance)
+        if (!_ignoreChangingEvents && sender != Context!.Instance)
         {
             _ignoreChangingEvents = true;
             Context.OnComponentChanging();
@@ -365,14 +359,14 @@ public partial class CollectionEditor : UITypeEditor
     /// <summary>
     ///  Removes the item from the column header from the listview column header collection
     /// </summary>
-    internal virtual void OnItemRemoving(object item)
+    internal virtual void OnItemRemoving(object? item)
     {
     }
 
     /// <summary>
     ///  Sets the specified collection to have the specified array of items.
     /// </summary>
-    protected virtual object SetItems(object editValue, object[] value)
+    protected virtual object? SetItems(object? editValue, object[]? value)
     {
         // We look to see if the value implements IList, and if it does, we set through that.
         if (editValue is IList list)
@@ -395,7 +389,7 @@ public partial class CollectionEditor : UITypeEditor
     /// </summary>
     protected virtual void ShowHelp()
     {
-        if (Context.TryGetService(out IHelpService helpService))
+        if (Context.TryGetService(out IHelpService? helpService))
         {
             helpService.ShowHelpFromKeyword(HelpTopic);
         }

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/CollectionEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/CollectionEditorTests.cs
@@ -210,7 +210,7 @@ public class CollectionEditorTests
             .Setup(c => c.GetService(typeof(IComponentChangeService)))
             .Returns(null);
         mockHost
-            .Setup(h => h.CreateComponent(typeof(Component), null))
+            .Setup(h => h.CreateComponent(typeof(Component)))
             .Returns(result);
         mockHost
             .Setup(h => h.GetDesigner(result))
@@ -257,7 +257,7 @@ public class CollectionEditorTests
             .Setup(c => c.GetService(typeof(IComponentChangeService)))
             .Returns(null);
         mockHost
-            .Setup(h => h.CreateComponent(typeof(Component), null))
+            .Setup(h => h.CreateComponent(typeof(Component)))
             .Returns((IComponent)null);
         mockHost
             .Setup(h => h.GetDesigner(null))
@@ -314,7 +314,7 @@ public class CollectionEditorTests
             .Setup(c => c.GetService(typeof(IComponentChangeService)))
             .Returns(null);
         mockHost
-            .Setup(h => h.CreateComponent(typeof(Component), null))
+            .Setup(h => h.CreateComponent(typeof(Component)))
             .Returns(result);
         mockHost
             .Setup(h => h.GetDesigner(result))

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/CollectionEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/CollectionEditorTests.cs
@@ -358,7 +358,7 @@ public class CollectionEditorTests
     public void CollectionEditor_CreateInstance_NullItemType_ThrowsArgumentNullException()
     {
         SubCollectionEditor editor = new(null);
-        Assert.Throws<ArgumentNullException>("objectType", () => editor.CreateInstance(null));
+        Assert.Throws<ArgumentNullException>("itemType", () => editor.CreateInstance(null));
     }
 
     [Theory]

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/CollectionFormTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/CollectionFormTests.cs
@@ -705,7 +705,7 @@ public class CollectionFormTests : CollectionEditor
     {
         SubCollectionEditor editor = new(null);
         SubCollectionForm form = new(editor);
-        Assert.Throws<ArgumentNullException>("objectType", () => form.CreateInstance(null));
+        Assert.Throws<ArgumentNullException>("itemType", () => form.CreateInstance(null));
     }
 
     [Fact]

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/CollectionFormTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/CollectionFormTests.cs
@@ -559,7 +559,7 @@ public class CollectionFormTests : CollectionEditor
             .Setup(c => c.GetService(typeof(IComponentChangeService)))
             .Returns(null);
         mockHost
-            .Setup(h => h.CreateComponent(typeof(Component), null))
+            .Setup(h => h.CreateComponent(typeof(Component)))
             .Returns(result);
         mockHost
             .Setup(h => h.GetDesigner(result))
@@ -607,7 +607,7 @@ public class CollectionFormTests : CollectionEditor
             .Setup(c => c.GetService(typeof(IComponentChangeService)))
             .Returns(null);
         mockHost
-            .Setup(h => h.CreateComponent(typeof(Component), null))
+            .Setup(h => h.CreateComponent(typeof(Component)))
             .Returns((IComponent)null);
         mockHost
             .Setup(h => h.GetDesigner(null))
@@ -665,7 +665,7 @@ public class CollectionFormTests : CollectionEditor
             .Setup(c => c.GetService(typeof(IComponentChangeService)))
             .Returns(null);
         mockHost
-            .Setup(h => h.CreateComponent(typeof(Component), null))
+            .Setup(h => h.CreateComponent(typeof(Component)))
             .Returns(result);
         mockHost
             .Setup(h => h.GetDesigner(result))


### PR DESCRIPTION
In the process, I had to revisit the annotations of `CollectionEditor.CollectionForm`. These are new in .NET 8. and some annotations look incorrect...

## Proposed changes

- Enable nullability in `CollectionEditor`
- Replace `ArrayList`s with `List<T>`s in `CollectionEditor` (contributes to #8140)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10065)