### PR TITLE
fix issue Short keys are inconsistent in Shortcut Keys property dialog and form designer

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Keys.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Keys.cs
@@ -852,12 +852,12 @@ public enum Keys
     /// <summary>
     ///  The Oem tilde key.
     /// </summary>
-    Oemtilde = 0xC0,
+    Oem3 = 0xC0,
 
     /// <summary>
     ///  The Oem 3 key.
     /// </summary>
-    Oem3 = Oemtilde,
+    Oemtilde = Oem3,
 
     /// <summary>
     ///  The Oem Open Brackets key.
@@ -892,12 +892,12 @@ public enum Keys
     /// <summary>
     ///  The Oem Quotes key.
     /// </summary>
-    OemQuotes = 0xDE,
+    Oem7 = 0xDE,
 
     /// <summary>
     ///  The Oem 7 key.
     /// </summary>
-    Oem7 = OemQuotes,
+    OemQuotes = Oem7,
 
     /// <summary>
     ///  The Oem8 key.


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes designer issue #https://github.com/microsoft/winforms-designer/issues/5383

## Cause of this issue
### `Framework`
![image](https://github.com/dotnet/winforms/assets/135201996/7248cc71-b588-40b6-89c7-894ee2c02a1f)
### `Net`
![image](https://github.com/dotnet/winforms/assets/135201996/c76b2a39-6eed-4c5e-b74e-5f98f9c0cb4d)



## Proposed changes

- 
- Switch the order of the Enum value
- 

<!-- We are in TELL-MODE the following section must be completed -->

<!-- 
## Regression? 

- Yes
 -->

## Test methodology <!-- How did you ensure quality? -->

- 
- manual 
- 


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10067)