### PR TITLE
Enable nullability in several UITypeEditors

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/MultilineStringEditor.MultilineStringEditorUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/MultilineStringEditor.MultilineStringEditorUI.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.Drawing;
 using System.Globalization;
 using System.Windows.Forms;
@@ -15,13 +13,13 @@ public sealed partial class MultilineStringEditor
 {
     private class MultilineStringEditorUI : RichTextBox
     {
-        private IWindowsFormsEditorService _editorService;
+        private IWindowsFormsEditorService? _editorService;
         private bool _editing;
         private bool _escapePressed;
         private bool _ctrlEnterPressed;
-        private SolidBrush _watermarkBrush;
+        private SolidBrush? _watermarkBrush;
         private Size _watermarkSize = Size.Empty;
-        private readonly Dictionary<int, Font> _fallbackFonts;
+        private readonly Dictionary<int, Font?> _fallbackFonts;
         private bool _firstTimeResizeToContent = true;
 
         private readonly StringFormat _watermarkFormat;
@@ -105,9 +103,9 @@ public sealed partial class MultilineStringEditor
             }
 
             // Ask the editor service to ask my parent to close when the user types "Ctrl+Enter".
-            if (e.Control && e.KeyCode == Keys.Return && e.Modifiers == Keys.Control)
+            if (e is { Control: true, KeyCode: Keys.Return, Modifiers: Keys.Control })
             {
-                _editorService.CloseDropDown();
+                _editorService!.CloseDropDown();
                 _ctrlEnterPressed = true;
             }
         }
@@ -123,7 +121,7 @@ public sealed partial class MultilineStringEditor
             }
         }
 
-        internal void BeginEdit(IWindowsFormsEditorService editorService, object value)
+        internal void BeginEdit(IWindowsFormsEditorService editorService, object? value)
         {
             _editing = true;
             _editorService = editorService;
@@ -246,6 +244,7 @@ public sealed partial class MultilineStringEditor
             }
         }
 
+        [AllowNull]
         public override Font Font
         {
             get => base.Font;
@@ -291,14 +290,14 @@ public sealed partial class MultilineStringEditor
 
                 // Plane 0 is the default plane.
                 int planeNumber = (value[currentSurrogate] / 0x40) - (0xD800 / 0x40) + 1;
-                if (!_fallbackFonts.TryGetValue(planeNumber, out Font replaceFont))
+                if (!_fallbackFonts.TryGetValue(planeNumber, out Font? replaceFont))
                 {
-                    using RegistryKey regkey = Registry.LocalMachine.OpenSubKey(
+                    using RegistryKey? regkey = Registry.LocalMachine.OpenSubKey(
                         @"SOFTWARE\Microsoft\Windows NT\CurrentVersion\LanguagePack\SurrogateFallback");
 
                     if (regkey is not null)
                     {
-                        string fallBackFontName = (string)regkey.GetValue($"Plane{planeNumber}");
+                        string? fallBackFontName = (string?)regkey.GetValue($"Plane{planeNumber}");
                         if (!string.IsNullOrEmpty(fallBackFontName))
                         {
                             replaceFont = new Font(fallBackFontName, base.Font.Size, base.Font.Style);
@@ -319,6 +318,7 @@ public sealed partial class MultilineStringEditor
             }
         }
 
+        [AllowNull]
         public override string Text
         {
             get

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewCellStyleBuilder.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewCellStyleBuilder.cs
@@ -81,7 +81,7 @@ internal class DataGridViewCellStyleBuilder : Form
         }
     }
 
-    public ITypeDescriptorContext Context
+    public ITypeDescriptorContext? Context
     {
         set => _context = value;
     }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewCellStyleEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewCellStyleEditor.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.ComponentModel;
 using System.Drawing;
 using System.Drawing.Design;
@@ -11,25 +9,25 @@ namespace System.Windows.Forms.Design;
 
 internal class DataGridViewCellStyleEditor : UITypeEditor
 {
-    private DataGridViewCellStyleBuilder _builderDialog;
+    private DataGridViewCellStyleBuilder? _builderDialog;
 
-    public override object EditValue(ITypeDescriptorContext context, IServiceProvider provider, object value)
+    public override object? EditValue(ITypeDescriptorContext? context, IServiceProvider provider, object? value)
     {
         ArgumentNullException.ThrowIfNull(provider);
 
-        if (!provider.TryGetService(out IWindowsFormsEditorService editorService))
+        if (provider.GetService<IWindowsFormsEditorService>() is null)
         {
             throw new InvalidOperationException($"Service provider couldn't fetch {nameof(IWindowsFormsEditorService)}.");
         }
 
-        IUIService uiService = provider.GetService<IUIService>();
-        IComponent component = context.Instance as IComponent;
+        IUIService? uiService = provider.GetService<IUIService>();
+        IComponent? component = context?.Instance as IComponent;
         using (DpiHelper.EnterDpiAwarenessScope(DPI_AWARENESS_CONTEXT.DPI_AWARENESS_CONTEXT_SYSTEM_AWARE))
         {
-            _builderDialog ??= new DataGridViewCellStyleBuilder(provider, component);
+            _builderDialog ??= new DataGridViewCellStyleBuilder(provider, component!);
             if (uiService is not null)
             {
-                _builderDialog.Font = (Font)uiService.Styles["DialogFont"];
+                _builderDialog.Font = (Font)uiService.Styles["DialogFont"]!;
             }
 
             if (value is DataGridViewCellStyle style)
@@ -48,5 +46,5 @@ internal class DataGridViewCellStyleEditor : UITypeEditor
     }
 
     /// <inheritdoc />
-    public override UITypeEditorEditStyle GetEditStyle(ITypeDescriptorContext context) => UITypeEditorEditStyle.Modal;
+    public override UITypeEditorEditStyle GetEditStyle(ITypeDescriptorContext? context) => UITypeEditorEditStyle.Modal;
 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewComponentPropertyGridSite.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewComponentPropertyGridSite.cs
@@ -1,45 +1,42 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.ComponentModel;
 
 namespace System.Windows.Forms.Design;
 
 internal class DataGridViewComponentPropertyGridSite : ISite
 {
-    private readonly IServiceProvider _sp;
-    private readonly IComponent _comp;
+    private readonly IServiceProvider? _sp;
     private bool _inGetService;
 
-    public DataGridViewComponentPropertyGridSite(IServiceProvider sp, IComponent comp)
+    public DataGridViewComponentPropertyGridSite(IServiceProvider? sp, IComponent comp)
     {
         _sp = sp;
-        _comp = comp;
+        Component = comp;
     }
 
     /// <summary>
     ///  When implemented by a class, gets the component associated with the <see cref="ISite"/>.
     /// </summary>
-    public IComponent Component { get => _comp; }
+    public IComponent Component { get; }
 
     /// <summary>
     /// When implemented by a class, gets the container associated with the <see cref="ISite"/>.
     /// </summary>
-    public IContainer Container { get => null; }
+    public IContainer? Container => null;
 
     /// <summary>
     ///  When implemented by a class, determines whether the component is in design mode.
     /// </summary>
-    public bool DesignMode { get => false; }
+    public bool DesignMode => false;
 
     /// <summary>
     ///  When implemented by a class, gets or sets the name of the component associated with the <see cref="ISite"/>.
     /// </summary>
-    public string Name { get; set; }
+    public string? Name { get; set; }
 
-    public object GetService(Type t)
+    public object? GetService(Type t)
     {
         if (_inGetService || _sp is null)
         {

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewComponentPropertyGridSite.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewComponentPropertyGridSite.cs
@@ -7,13 +7,13 @@ namespace System.Windows.Forms.Design;
 
 internal class DataGridViewComponentPropertyGridSite : ISite
 {
-    private readonly IServiceProvider? _sp;
+    private readonly IServiceProvider? _serviceProvider;
     private bool _inGetService;
 
-    public DataGridViewComponentPropertyGridSite(IServiceProvider? sp, IComponent comp)
+    public DataGridViewComponentPropertyGridSite(IServiceProvider? serviceProvider, IComponent component)
     {
-        _sp = sp;
-        Component = comp;
+        _serviceProvider = serviceProvider;
+        Component = component;
     }
 
     /// <summary>
@@ -38,7 +38,7 @@ internal class DataGridViewComponentPropertyGridSite : ISite
 
     public object? GetService(Type t)
     {
-        if (_inGetService || _sp is null)
+        if (_inGetService || _serviceProvider is null)
         {
             return null;
         }
@@ -46,7 +46,7 @@ internal class DataGridViewComponentPropertyGridSite : ISite
         try
         {
             _inGetService = true;
-            return _sp.GetService(t);
+            return _serviceProvider.GetService(t);
         }
         finally
         {

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ImageIndexEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ImageIndexEditor.cs
@@ -48,7 +48,9 @@ internal class ImageIndexEditor : UITypeEditor
 
         if (_currentImageList is null
             || instance != _currentInstance
-            || (_currentImageListPropertyReference?.TryGetTarget(out PropertyDescriptor? currentProperty) is true && (ImageList?)currentProperty.GetValue(_currentInstance) != _currentImageList))
+            || (_currentImageListPropertyReference is not null &&
+                _currentImageListPropertyReference.TryGetTarget(out PropertyDescriptor? currentProperty) &&
+                (ImageList?)currentProperty.GetValue(_currentInstance) != _currentImageList))
         {
             _currentInstance = instance;
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ImageIndexEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ImageIndexEditor.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.ComponentModel;
 using System.Drawing;
 using System.Drawing.Design;
@@ -14,12 +12,11 @@ namespace System.Windows.Forms.Design;
 /// </summary>
 internal class ImageIndexEditor : UITypeEditor
 {
-    protected ImageList _currentImageList;
-    protected WeakReference _currentImageListPropertyReference;
-    protected object _currentInstance;
-    protected UITypeEditor _imageEditor;
+    protected ImageList? _currentImageList;
+    protected WeakReference<PropertyDescriptor>? _currentImageListPropertyReference;
+    protected object? _currentInstance;
     protected string _parentImageListProperty = "Parent";
-    protected string _imageListPropertyName;
+    protected string? _imageListPropertyName;
 
     /// <summary>
     ///  Initializes a new instance of the <see cref="ImageIndexEditor"/> class.
@@ -27,19 +24,19 @@ internal class ImageIndexEditor : UITypeEditor
     public ImageIndexEditor()
     {
         // Get the type editor for images. We use the properties on this to determine if we support value painting, etc.
-        _imageEditor = (UITypeEditor)TypeDescriptor.GetEditor(typeof(Image), typeof(UITypeEditor));
+        ImageEditor = TypeDescriptorHelper.GetEditor<UITypeEditor>(typeof(Image));
     }
 
-    internal UITypeEditor ImageEditor => _imageEditor;
+    internal UITypeEditor? ImageEditor { get; }
 
     internal string ParentImageListProperty => _parentImageListProperty;
 
     /// <summary>
     ///  Retrieves an image for the current context at current index.
     /// </summary>
-    protected virtual Image GetImage(ITypeDescriptorContext context, int index, string key, bool useIntIndex)
+    protected virtual Image? GetImage(ITypeDescriptorContext context, int index, string? key, bool useIntIndex)
     {
-        object instance = context.Instance;
+        object? instance = context.Instance;
 
         // We would not know what to do in this case anyway (i.e. multiple selection of objects)
         if (instance is object[] || (index < 0 && key is null))
@@ -49,16 +46,14 @@ internal class ImageIndexEditor : UITypeEditor
 
         // If the instances are different, then we need to re-acquire our image list.
 
-        PropertyDescriptor currentProperty = _currentImageListPropertyReference?.Target as PropertyDescriptor;
-
         if (_currentImageList is null
             || instance != _currentInstance
-            || (currentProperty is not null && (ImageList)currentProperty.GetValue(_currentInstance) != _currentImageList))
+            || (_currentImageListPropertyReference?.TryGetTarget(out PropertyDescriptor? currentProperty) is true && (ImageList?)currentProperty.GetValue(_currentInstance) != _currentImageList))
         {
             _currentInstance = instance;
 
             // First look for an attribute.
-            PropertyDescriptor imageListProperty = GetImageListProperty(context.PropertyDescriptor, ref instance);
+            PropertyDescriptor? imageListProperty = GetImageListProperty(context.PropertyDescriptor!, ref instance);
 
             // Not found as an attribute, do the old behavior.
             while (instance is not null && imageListProperty is null)
@@ -84,8 +79,8 @@ internal class ImageIndexEditor : UITypeEditor
 
             if (imageListProperty is not null)
             {
-                _currentImageList = (ImageList)imageListProperty.GetValue(instance);
-                _currentImageListPropertyReference = new WeakReference(imageListProperty);
+                _currentImageList = (ImageList?)imageListProperty.GetValue(instance);
+                _currentImageListPropertyReference = new WeakReference<PropertyDescriptor>(imageListProperty);
                 _currentInstance = instance;
             }
         }
@@ -101,7 +96,7 @@ internal class ImageIndexEditor : UITypeEditor
             }
             else
             {
-                return _currentImageList.Images[key];
+                return _currentImageList.Images[key!];
             }
         }
 
@@ -109,8 +104,8 @@ internal class ImageIndexEditor : UITypeEditor
     }
 
     /// <inheritdoc />
-    public override bool GetPaintValueSupported(ITypeDescriptorContext context)
-        => _imageEditor?.GetPaintValueSupported(context) ?? false;
+    public override bool GetPaintValueSupported(ITypeDescriptorContext? context)
+        => ImageEditor?.GetPaintValueSupported(context) ?? false;
 
     /// <inheritdoc />
     public override void PaintValue(PaintValueEventArgs e)
@@ -120,15 +115,15 @@ internal class ImageIndexEditor : UITypeEditor
             return;
         }
 
-        Image image = null;
+        Image? image = null;
 
         if (e.Value is int integer)
         {
-            image = GetImage(e.Context, integer, null, true);
+            image = GetImage(e.Context!, integer, null, true);
         }
         else if (e.Value is string text)
         {
-            image = GetImage(e.Context, -1, text, false);
+            image = GetImage(e.Context!, -1, text, false);
         }
 
         if (image is not null)
@@ -137,16 +132,16 @@ internal class ImageIndexEditor : UITypeEditor
         }
     }
 
-    internal static PropertyDescriptor GetImageListProperty(PropertyDescriptor currentComponent, ref object instance)
+    internal static PropertyDescriptor? GetImageListProperty(PropertyDescriptor currentComponent, ref object? instance)
     {
         // Multiple selection is not supported by this class.
         if (instance is object[]
-            || currentComponent.Attributes[typeof(RelatedImageListAttribute)] is not RelatedImageListAttribute imageListAttribute)
+            || !currentComponent.TryGetAttribute(out RelatedImageListAttribute? imageListAttribute))
         {
             return null;
         }
 
-        object parentInstance = instance;
+        object? parentInstance = instance;
 
         if (imageListAttribute.RelatedImageList is null)
         {
@@ -162,7 +157,7 @@ internal class ImageIndexEditor : UITypeEditor
                 break;
             }
 
-            var property = TypeDescriptor.GetProperties(parentInstance)[pathInfo[i]];
+            PropertyDescriptor? property = TypeDescriptor.GetProperties(parentInstance)[pathInfo[i]];
             if (property is null)
             {
                 Debug.Fail("The path specified to the property is wrong.");

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/LinkAreaEditor.LinkAreaUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/LinkAreaEditor.LinkAreaUI.cs
@@ -18,14 +18,15 @@ internal partial class LinkAreaEditor
         private Button _okButton = new();
         private Button _cancelButton = new();
         private TableLayoutPanel _okCancelTableLayoutPanel;
-        private readonly IHelpService _helpService;
+        private readonly IHelpService? _helpService;
 
-        public LinkAreaUI(IHelpService helpService)
+        public LinkAreaUI(IHelpService? helpService)
         {
             _helpService = helpService;
             InitializeComponent();
         }
 
+        [AllowNull]
         public string SampleText
         {
             get => _sampleEdit.Text;
@@ -125,7 +126,7 @@ internal partial class LinkAreaEditor
             _helpService?.ShowHelpFromKeyword("net.ComponentModel.LinkAreaEditor");
         }
 
-        public void Start(object value)
+        public void Start(object? value)
         {
             Value = value;
             UpdateSelection();

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/LinkAreaEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/LinkAreaEditor.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.ComponentModel;
 using System.ComponentModel.Design;
 using System.Drawing.Design;
@@ -14,36 +12,36 @@ namespace System.Windows.Forms.Design;
 /// </summary>
 internal partial class LinkAreaEditor : UITypeEditor
 {
-    private LinkAreaUI _linkAreaUI;
+    private LinkAreaUI? _linkAreaUI;
 
-    public override object EditValue(ITypeDescriptorContext context, IServiceProvider provider, object value)
+    public override object? EditValue(ITypeDescriptorContext? context, IServiceProvider provider, object? value)
     {
-        if (!provider.TryGetService(out IWindowsFormsEditorService editorService))
+        if (!provider.TryGetService(out IWindowsFormsEditorService? editorService))
         {
             return value;
         }
 
         if (_linkAreaUI is null)
         {
-            IHelpService helpService = (IHelpService)provider.GetService(typeof(IHelpService));
+            IHelpService? helpService = provider.GetService<IHelpService>();
 
             // Child modal dialog -launching in SystemAware mode.
             _linkAreaUI = DpiHelper.CreateInstanceInSystemAwareContext(() => new LinkAreaUI(helpService));
         }
 
-        string text = string.Empty;
-        PropertyDescriptor property = null;
+        string? text = string.Empty;
+        PropertyDescriptor? property = null;
 
         if (context?.Instance is not null)
         {
             property = TypeDescriptor.GetProperties(context.Instance)["Text"];
             if (property?.PropertyType == typeof(string))
             {
-                text = (string)property.GetValue(context.Instance);
+                text = (string?)property.GetValue(context.Instance);
             }
         }
 
-        string originalText = text;
+        string? originalText = text;
         _linkAreaUI.SampleText = text;
         _linkAreaUI.Start(value);
 
@@ -52,9 +50,9 @@ internal partial class LinkAreaEditor : UITypeEditor
             value = _linkAreaUI.Value;
 
             text = _linkAreaUI.SampleText;
-            if (!originalText.Equals(text) && property?.PropertyType == typeof(string))
+            if (!text.Equals(originalText) && property?.PropertyType == typeof(string))
             {
-                property.SetValue(context.Instance, text);
+                property.SetValue(context!.Instance, text);
             }
         }
 
@@ -64,6 +62,6 @@ internal partial class LinkAreaEditor : UITypeEditor
     }
 
     /// <inheritdoc />
-    public override UITypeEditorEditStyle GetEditStyle(ITypeDescriptorContext context)
+    public override UITypeEditorEditStyle GetEditStyle(ITypeDescriptorContext? context)
         => UITypeEditorEditStyle.Modal;
 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskDesignerDialog.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskDesignerDialog.cs
@@ -34,12 +34,12 @@ internal class MaskDesignerDialog : Form
     private MaskDescriptorTemplate _customMaskDescriptor;
     private SortOrder _listViewSortOrder = SortOrder.Ascending;
     private IContainer _components;
-    private readonly IHelpService _helpService;
+    private readonly IHelpService? _helpService;
 
     /// <summary>
     /// Constructor receiving a clone of the MaskedTextBox control under design.
     /// </summary>
-    public MaskDesignerDialog(MaskedTextBox instance, IHelpService helpService)
+    public MaskDesignerDialog(MaskedTextBox instance, IHelpService? helpService)
     {
         if (instance is null)
         {
@@ -363,7 +363,7 @@ internal class MaskDesignerDialog : Form
     /// Uses the specified ITypeDiscoveryService service provider to discover MaskDescriptor objects from
     /// the referenced assemblies.
     /// </summary>
-    public void DiscoverMaskDescriptors(ITypeDiscoveryService discoveryService)
+    public void DiscoverMaskDescriptors(ITypeDiscoveryService? discoveryService)
     {
         if (discoveryService is null)
         {

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskPropertyEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskPropertyEditor.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.ComponentModel.Design;
 using System.Drawing.Design;
 
@@ -22,14 +20,14 @@ internal class MaskPropertyEditor : UITypeEditor
     ///   blocked if focus is moved to another app.
     ///  </para>
     /// </remarks>
-    internal static string EditMask(
-        ITypeDiscoveryService discoveryService,
-        IUIService uiService,
+    internal static string? EditMask(
+        ITypeDiscoveryService? discoveryService,
+        IUIService? uiService,
         MaskedTextBox instance,
-        IHelpService helpService)
+        IHelpService? helpService)
     {
         Debug.Assert(instance is not null, "Null masked text box.");
-        string mask = null;
+        string? mask = null;
 
         // Launching modal dialog in System aware mode.
         using MaskDesignerDialog dialog = DpiHelper.CreateInstanceInSystemAwareContext(
@@ -57,17 +55,17 @@ internal class MaskPropertyEditor : UITypeEditor
     /// <summary>
     ///  Edits the Mask property of the MaskedTextBox control from the PropertyGrid.
     /// </summary>
-    public override object EditValue(System.ComponentModel.ITypeDescriptorContext context, IServiceProvider provider, object value)
+    public override object? EditValue(System.ComponentModel.ITypeDescriptorContext? context, IServiceProvider provider, object? value)
     {
         if (context is null || provider is null)
         {
             return value;
         }
 
-        string mask = EditMask(
+        string? mask = EditMask(
             provider.GetService<ITypeDiscoveryService>(),
             provider.GetService<IUIService>(),
-            context.Instance as MaskedTextBox,
+            (context.Instance as MaskedTextBox)!,
             provider.GetService<IHelpService>());
 
         return mask ?? value;
@@ -76,10 +74,10 @@ internal class MaskPropertyEditor : UITypeEditor
     /// <summary>
     ///  Painting a representation of the Mask value is not supported.
     /// </summary>
-    public override bool GetPaintValueSupported(System.ComponentModel.ITypeDescriptorContext context)
+    public override bool GetPaintValueSupported(System.ComponentModel.ITypeDescriptorContext? context)
         => false;
 
     /// <inheritdoc />
-    public override UITypeEditorEditStyle GetEditStyle(System.ComponentModel.ITypeDescriptorContext context)
+    public override UITypeEditorEditStyle GetEditStyle(System.ComponentModel.ITypeDescriptorContext? context)
         => UITypeEditorEditStyle.Modal;
 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskedTextBoxDesignerActionList.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskedTextBoxDesignerActionList.cs
@@ -41,7 +41,7 @@ internal class MaskedTextBoxDesignerActionList : DesignerActionList
     /// </summary>
     public void SetMask()
     {
-        string mask = MaskPropertyEditor.EditMask(_discoverySvc, _uiSvc, _maskedTextBox, _helpService);
+        string? mask = MaskPropertyEditor.EditMask(_discoverySvc, _uiSvc, _maskedTextBox, _helpService);
 
         if (mask is null)
         {

--- a/src/System.Windows.Forms.Primitives/src/System/ComponentModel/TypeDescriptorHelper.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/ComponentModel/TypeDescriptorHelper.cs
@@ -23,6 +23,16 @@ internal static class TypeDescriptorHelper
         return attribute is not null;
     }
 
+    public static T? GetEditor<T>(object component)
+    {
+        return (T?)TypeDescriptor.GetEditor(component, typeof(T));
+    }
+
+    public static T? GetEditor<T>([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type type)
+    {
+        return (T?)TypeDescriptor.GetEditor(type, typeof(T));
+    }
+
     public static bool TryGetPropertyValue<T>(
         object component,
         string name,

--- a/src/System.Windows.Forms.Primitives/src/System/ComponentModel/TypeDescriptorHelper.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/ComponentModel/TypeDescriptorHelper.cs
@@ -23,11 +23,6 @@ internal static class TypeDescriptorHelper
         return attribute is not null;
     }
 
-    public static T? GetEditor<T>(object component)
-    {
-        return (T?)TypeDescriptor.GetEditor(component, typeof(T));
-    }
-
     public static T? GetEditor<T>([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type type)
     {
         return (T?)TypeDescriptor.GetEditor(type, typeof(T));


### PR DESCRIPTION
After this PR (and the ones already opened), the only editors left to annotate will be the ones deriving from `CollectionEditor`

## Proposed changes

- Enable nullability in `DataGridViewCellStyleEditor` and `DataGridViewComponentPropertyGridSite`
- Enable nullability in `ImageIndexEditor`
- Enable nullability in `MaskPropertyEditor`
- Enable nullability in `MultilineStringEditor.MultilineStringEditorUI`
- Enable nullability in `LinkAreaEditor`

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10077)