### PR TITLE
Clean DesignerTransaction after DesignerTransaction committed

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FlowLayoutPanelDesigner .cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FlowLayoutPanelDesigner .cs
@@ -714,7 +714,7 @@ internal partial class FlowLayoutPanelDesigner : FlowPanelDesigner
             designerTransaction?.Commit();
             designerTransaction = null;
         }
-        finally
+        catch (Exception)
         {
             designerTransaction?.Cancel();
         }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FlowLayoutPanelDesigner .cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FlowLayoutPanelDesigner .cs
@@ -910,14 +910,14 @@ internal partial class FlowLayoutPanelDesigner : FlowPanelDesigner
     ///  child to the appropriate index.  Otherwise, we'll do this in the ChildAdded
     ///  event.
     /// </summary>
-    protected override void OnDragDrop(DragEventArgs dragEvent)
+    protected override void OnDragDrop(DragEventArgs de)
     {
         if (_dragControls is not null &&
             _primaryDragControl is not null &&
             Control.Controls.Contains(_primaryDragControl))
         {
             // Manipulating our controls. We do it ourselves, so that we can set the indices right.
-            ReorderControls(dragEvent);
+            ReorderControls(de);
 
             _insertionIndex = s_invalidIndex;
         }
@@ -925,7 +925,7 @@ internal partial class FlowLayoutPanelDesigner : FlowPanelDesigner
         {
             // If we are not reordering our controls then just let the base handle it.
             Control.ControlAdded += OnChildControlAdded;
-            base.OnDragDrop(dragEvent);
+            base.OnDragDrop(de);
         }
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FlowLayoutPanelDesigner .cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FlowLayoutPanelDesigner .cs
@@ -578,139 +578,146 @@ internal partial class FlowLayoutPanelDesigner : FlowPanelDesigner
             ? host.CreateTransaction(GetTransactionDescription(performCopy))
             : null;
 
-        // In order to be able to set the index correctly, we need to create a backwards move.
-        // We do this by first finding the control foo that corresponds to _insertionIndex.
-        // We then remove all the drag controls from the FLP.
-        // Then we get the new childIndex for the control foo.
-        // Finally we loop:
-        //      add the ith drag control
-        //      set its child index to (index of control foo) - 1
-        // On each iteration, the child index of control foo will change.
-        //
-        // This ensures that we can move both contiguous and non-contiguous selections.
-
-        // Special case when the element we are inserting before is a part of the dragControls.
-        while (_insertionIndex < _childInfo.Length - 1 && _childInfo[_insertionIndex].InSelectionCollection)
+        try
         {
-            // Find the next control that is not a part of the selection.
-            ++_insertionIndex;
-        }
+            // In order to be able to set the index correctly, we need to create a backwards move.
+            // We do this by first finding the control foo that corresponds to _insertionIndex.
+            // We then remove all the drag controls from the FLP.
+            // Then we get the new childIndex for the control foo.
+            // Finally we loop:
+            //      add the ith drag control
+            //      set its child index to (index of control foo) - 1
+            // On each iteration, the child index of control foo will change.
+            //
+            // This ensures that we can move both contiguous and non-contiguous selections.
 
-        PropertyDescriptor controlsProperty = TypeDescriptor.GetProperties(Component)["Controls"];
-        if (controlsProperty is not null)
-        {
-            RaiseComponentChanging(controlsProperty);
-        }
-
-        Control control = null;
-        var children = Control.Controls;
-        if (_insertionIndex != _childInfo.Length)
-        {
-            control = children[_insertionIndex];
-        }
-        else
-        {
-            // We are inserting past the last control.
-            _insertionIndex = s_invalidIndex;
-        }
-
-        // We use this list when doing a Drag-Copy, so that we can correctly restore state when we are done.
-        //List<Control> originalControls = new();
-        ArrayList originalControls = new();
-
-        // Remove the controls in the drag collection - don't need to do this if we are copying.
-        if (!performCopy)
-        {
-            foreach (var dragControl in _dragControls)
+            // Special case when the element we are inserting before is a part of the dragControls.
+            while (_insertionIndex < _childInfo.Length - 1 && _childInfo[_insertionIndex].InSelectionCollection)
             {
-                children.Remove(dragControl);
+                // Find the next control that is not a part of the selection.
+                ++_insertionIndex;
             }
 
-            // Get the new index -- if we are performing a copy, then the index is the same.
-            if (control is not null)
+            PropertyDescriptor controlsProperty = TypeDescriptor.GetProperties(Component)["Controls"];
+            if (controlsProperty is not null)
             {
-                _insertionIndex = children.GetChildIndex(control, throwException: false);
-            }
-        }
-        else
-        {
-            // We are doing a copy, so let's copy the controls.
-            ArrayList tempList = new ArrayList();
-            tempList.AddRange(_dragControls);
-
-            DesignerUtils.CopyDragObjects(tempList, Component.Site);
-
-            if (tempList is null)
-            {
-                return;
+                RaiseComponentChanging(controlsProperty);
             }
 
-            // And stick the copied controls back into the dragControls array.
-            for (var j = 0; j < tempList.Count; j++)
+            Control control = null;
+            var children = Control.Controls;
+            if (_insertionIndex != _childInfo.Length)
             {
-                // Save off the old controls first.
-                originalControls.Add(_dragControls[j]);
+                control = children[_insertionIndex];
+            }
+            else
+            {
+                // We are inserting past the last control.
+                _insertionIndex = s_invalidIndex;
+            }
 
-                // Remember to set the new primary control.
-                if (_primaryDragControl.Equals(_dragControls[j]))
+            // We use this list when doing a Drag-Copy, so that we can correctly restore state when we are done.
+            //List<Control> originalControls = new();
+            ArrayList originalControls = new();
+
+            // Remove the controls in the drag collection - don't need to do this if we are copying.
+            if (!performCopy)
+            {
+                foreach (var dragControl in _dragControls)
                 {
-                    _primaryDragControl = tempList[j] as Control;
+                    children.Remove(dragControl);
                 }
 
-                _dragControls[j] = tempList[j] as Control;
+                // Get the new index -- if we are performing a copy, then the index is the same.
+                if (control is not null)
+                {
+                    _insertionIndex = children.GetChildIndex(control, throwException: false);
+                }
             }
-        }
-
-        if (_insertionIndex == s_invalidIndex)
-        {
-            // Either _insertionIndex was _childInfo.Length (inserting past the end) or
-            // _insertionIndex was _childInfo.Length - 1 and the control at that index was also
-            // a part of the dragCollection. In either case, the new index is equal to the count
-            // of existing controls in the ControlCollection. Helps to draw this out.
-            _insertionIndex = children.Count;
-        }
-
-        children.Add(_primaryDragControl);
-        children.SetChildIndex(_primaryDragControl, _insertionIndex);
-        ++_insertionIndex;
-
-        //Set the Selection ..
-        SelectionService.SetSelectedComponents(new IComponent[] { _primaryDragControl }, SelectionTypes.Primary | SelectionTypes.Replace);
-
-        // Note _dragControls are in opposite order than what FLP uses,
-        // so add from the end.
-        for (var i = _dragControls.Count - 1; i >= 0; i--)
-        {
-            if (_primaryDragControl.Equals(_dragControls[i]))
+            else
             {
-                continue;
+                // We are doing a copy, so let's copy the controls.
+                ArrayList tempList = new ArrayList();
+                tempList.AddRange(_dragControls);
+
+                DesignerUtils.CopyDragObjects(tempList, Component.Site);
+
+                if (tempList is null)
+                {
+                    return;
+                }
+
+                // And stick the copied controls back into the dragControls array.
+                for (var j = 0; j < tempList.Count; j++)
+                {
+                    // Save off the old controls first.
+                    originalControls.Add(_dragControls[j]);
+
+                    // Remember to set the new primary control.
+                    if (_primaryDragControl.Equals(_dragControls[j]))
+                    {
+                        _primaryDragControl = tempList[j] as Control;
+                    }
+
+                    _dragControls[j] = tempList[j] as Control;
+                }
             }
 
-            children.Add(_dragControls[i]);
-            children.SetChildIndex(_dragControls[i], _insertionIndex);
+            if (_insertionIndex == s_invalidIndex)
+            {
+                // Either _insertionIndex was _childInfo.Length (inserting past the end) or
+                // _insertionIndex was _childInfo.Length - 1 and the control at that index was also
+                // a part of the dragCollection. In either case, the new index is equal to the count
+                // of existing controls in the ControlCollection. Helps to draw this out.
+                _insertionIndex = children.Count;
+            }
+
+            children.Add(_primaryDragControl);
+            children.SetChildIndex(_primaryDragControl, _insertionIndex);
             ++_insertionIndex;
 
-            SelectionService.SetSelectedComponents(new IComponent[] { _dragControls[i] }, SelectionTypes.Add);
-        }
+            //Set the Selection ..
+            SelectionService.SetSelectedComponents(new IComponent[] { _primaryDragControl }, SelectionTypes.Primary | SelectionTypes.Replace);
 
-        if (controlsProperty is not null)
-        {
-            RaiseComponentChanging(controlsProperty);
-        }
-
-        // If we did a Copy, then restore the old controls to make sure we set state correctly.
-        if (originalControls is not null)
-        {
-            for (var i = 0; i < originalControls.Count; i++)
+            // Note _dragControls are in opposite order than what FLP uses,
+            // so add from the end.
+            for (var i = _dragControls.Count - 1; i >= 0; i--)
             {
-                _dragControls[i] = (Control)originalControls[i];
+                if (_primaryDragControl.Equals(_dragControls[i]))
+                {
+                    continue;
+                }
+
+                children.Add(_dragControls[i]);
+                children.SetChildIndex(_dragControls[i], _insertionIndex);
+                ++_insertionIndex;
+
+                SelectionService.SetSelectedComponents(new IComponent[] { _dragControls[i] }, SelectionTypes.Add);
             }
+
+            if (controlsProperty is not null)
+            {
+                RaiseComponentChanging(controlsProperty);
+            }
+
+            // If we did a Copy, then restore the old controls to make sure we set state correctly.
+            if (originalControls is not null)
+            {
+                for (var i = 0; i < originalControls.Count; i++)
+                {
+                    _dragControls[i] = (Control)originalControls[i];
+                }
+            }
+
+            base.OnDragComplete(de);
+
+            designerTransaction?.Commit();
+            designerTransaction = null;
         }
-
-        base.OnDragComplete(de);
-
-        designerTransaction?.Commit();
-        designerTransaction = null;
+        finally
+        {
+            designerTransaction?.Cancel();
+        }
     }
 
     /// <summary>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FlowLayoutPanelDesigner .cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FlowLayoutPanelDesigner .cs
@@ -712,9 +712,8 @@ internal partial class FlowLayoutPanelDesigner : FlowPanelDesigner
             base.OnDragComplete(de);
 
             designerTransaction?.Commit();
-            designerTransaction = null;
         }
-        catch (Exception)
+        catch
         {
             designerTransaction?.Cancel();
         }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FlowLayoutPanelDesigner .cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FlowLayoutPanelDesigner .cs
@@ -709,7 +709,8 @@ internal partial class FlowLayoutPanelDesigner : FlowPanelDesigner
 
         base.OnDragComplete(de);
 
-        designerTransaction.Commit();
+        designerTransaction?.Commit();
+        designerTransaction = null;
     }
 
     /// <summary>
@@ -902,14 +903,14 @@ internal partial class FlowLayoutPanelDesigner : FlowPanelDesigner
     ///  child to the appropriate index.  Otherwise, we'll do this in the ChildAdded
     ///  event.
     /// </summary>
-    protected override void OnDragDrop(DragEventArgs de)
+    protected override void OnDragDrop(DragEventArgs dragEvent)
     {
         if (_dragControls is not null &&
             _primaryDragControl is not null &&
             Control.Controls.Contains(_primaryDragControl))
         {
             // Manipulating our controls. We do it ourselves, so that we can set the indices right.
-            ReorderControls(de);
+            ReorderControls(dragEvent);
 
             _insertionIndex = s_invalidIndex;
         }
@@ -917,7 +918,7 @@ internal partial class FlowLayoutPanelDesigner : FlowPanelDesigner
         {
             // If we are not reordering our controls then just let the base handle it.
             Control.ControlAdded += OnChildControlAdded;
-            base.OnDragDrop(de);
+            base.OnDragDrop(dragEvent);
         }
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #10082 


## Proposed changes

- Set DesignerTransaction to null after submitting CleanDesignerTransaction
- When there is no substantial positional movement of the internal control, cancel the DesignerTransaction directly to avoid _insertionIndex=-1 causing an exception in code line [while (_insertionIndex < _childInfo.Length - 1 && _childInfo[_insertionIndex].InSelectionCollection) ](https://github.com/dotnet/winforms/blob/e6d1ad98adb7825970935942de483273912c82f1/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FlowLayoutPanelDesigner%20.cs#L593C8-L593C109)

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- All of the control can be selected normally in Demo project

## Regression? 

- Yes

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
https://github.com/dotnet/winforms/assets/108860782/e838fc43-2456-4b6f-8496-a2a5fcd843fe

### After

![AfterChanging](https://github.com/dotnet/winforms/assets/132890443/3c76229d-26fb-45b3-bb5a-5d1f00f9cb98)


## Test methodology <!-- How did you ensure quality? -->

- Manually

## Test environment(s) <!-- Remove any that don't apply -->

-  .net  9.0.0-alpha.1.23508.5


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10083)