### PR TITLE
Enable nullability in DesignerActionPanel

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.CheckBoxPropertyLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.CheckBoxPropertyLine.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.Drawing;
 using System.Windows.Forms;
 
@@ -44,14 +42,14 @@ internal sealed partial class DesignerActionPanel
             return checkBoxPreferredSize + new Size(LineLeftMargin + LineRightMargin, LineVerticalPadding);
         }
 
-        private void OnCheckBoxCheckedChanged(object sender, EventArgs e)
+        private void OnCheckBoxCheckedChanged(object? sender, EventArgs e)
         {
             SetValue(_checkBox.Checked);
         }
 
         protected override void OnPropertyTaskItemUpdated(ToolTip toolTip, ref int currentTabIndex)
         {
-            _checkBox.Text = StripAmpersands(PropertyItem.DisplayName);
+            _checkBox.Text = StripAmpersands(PropertyItem!.DisplayName);
             _checkBox.AccessibleDescription = PropertyItem.Description;
             _checkBox.TabIndex = currentTabIndex++;
 
@@ -60,7 +58,7 @@ internal sealed partial class DesignerActionPanel
 
         protected override void OnValueChanged()
         {
-            _checkBox.Checked = (bool)Value;
+            _checkBox.Checked = (bool)Value!;
         }
 
         public sealed class Info(DesignerActionList list, DesignerActionPropertyItem item) : PropertyLineInfo(list, item)

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.DesignerActionPanelHeaderItem.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.DesignerActionPanelHeaderItem.cs
@@ -7,16 +7,11 @@ internal sealed partial class DesignerActionPanel
 {
     private sealed class DesignerActionPanelHeaderItem : DesignerActionItem
     {
-        private readonly string _subtitle;
-
-        public DesignerActionPanelHeaderItem(string title, string subtitle) : base(title, null, null)
+        public DesignerActionPanelHeaderItem(string title, string? subtitle) : base(title, null, null)
         {
-            _subtitle = subtitle;
+            Subtitle = subtitle;
         }
 
-        public string Subtitle
-        {
-            get => _subtitle;
-        }
+        public string? Subtitle { get; }
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.EditorPropertyLine.EditorButton.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.EditorPropertyLine.EditorButton.cs
@@ -17,7 +17,6 @@ internal sealed partial class DesignerActionPanel
         {
             private bool _mouseOver;
             private bool _mouseDown;
-            private bool _ellipsis;
 
             protected override void OnMouseDown(MouseEventArgs e)
             {
@@ -51,16 +50,12 @@ internal sealed partial class DesignerActionPanel
                 }
             }
 
-            public bool Ellipsis
-            {
-                get => _ellipsis;
-                set => _ellipsis = value;
-            }
+            public bool Ellipsis { get; set; }
 
             protected override void OnPaint(PaintEventArgs e)
             {
                 Graphics g = e.Graphics;
-                if (_ellipsis)
+                if (Ellipsis)
                 {
                     PushButtonState buttonState = PushButtonState.Normal;
                     if (_mouseDown)
@@ -161,7 +156,7 @@ internal sealed partial class DesignerActionPanel
                             }
                             finally
                             {
-                                icon?.Dispose();
+                                icon.Dispose();
                             }
                         }
                         catch

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.EditorPropertyLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.EditorPropertyLine.cs
@@ -15,7 +15,8 @@ internal sealed partial class DesignerActionPanel
     {
         private readonly EditorButton _button;
         private UITypeEditor? _editor;
-        private bool _hasSwatch;
+        [MemberNotNullWhen(true, nameof(_editor))]
+        private bool HasSwatch { get; set; }
         private Image? _swatch;
         private FlyoutDialog? _dropDownHolder;
         private bool _ignoreNextSelectChange;
@@ -59,7 +60,7 @@ internal sealed partial class DesignerActionPanel
                 TypeConverter.StandardValuesCollection? standardValues = GetStandardValues();
                 if (standardValues is not null)
                 {
-                    foreach (object standardValue in standardValues)
+                    foreach (object? standardValue in standardValues)
                     {
                         string newItem = PropertyDescriptor.Converter.ConvertToString(TypeDescriptorContext, CultureInfo.CurrentCulture, standardValue)!;
                         listBox.Items.Add(newItem);
@@ -135,7 +136,7 @@ internal sealed partial class DesignerActionPanel
 
         protected override int GetTextBoxLeftPadding(int textBoxHeight)
         {
-            if (_hasSwatch)
+            if (HasSwatch)
             {
                 return base.GetTextBoxLeftPadding(textBoxHeight) + textBoxHeight + 2 * EditorLineSwatchPadding;
             }
@@ -230,14 +231,14 @@ internal sealed partial class DesignerActionPanel
             if (_editor is not null)
             {
                 _button.Ellipsis = (_editor.GetEditStyle(TypeDescriptorContext) == UITypeEditorEditStyle.Modal);
-                _hasSwatch = _editor.GetPaintValueSupported(TypeDescriptorContext);
+                HasSwatch = _editor.GetPaintValueSupported(TypeDescriptorContext);
             }
             else
             {
                 _button.Ellipsis = false;
             }
 
-            EditControl!.AccessibleRole = _button.Ellipsis
+            EditControl.AccessibleRole = _button.Ellipsis
                 ? IsReadOnly() ? AccessibleRole.StaticText : AccessibleRole.Text
                 : IsReadOnly() ? AccessibleRole.DropList : AccessibleRole.ComboBox;
 
@@ -272,7 +273,7 @@ internal sealed partial class DesignerActionPanel
             base.OnValueChanged();
 
             _swatch = null;
-            if (_hasSwatch)
+            if (HasSwatch)
             {
                 ActionPanel.Invalidate(new Rectangle(EditRegionLocation, EditRegionSize), false);
             }
@@ -282,7 +283,7 @@ internal sealed partial class DesignerActionPanel
         {
             base.PaintLine(g, lineWidth, lineHeight);
 
-            if (_hasSwatch)
+            if (HasSwatch)
             {
                 if (_swatch is null)
                 {
@@ -292,7 +293,7 @@ internal sealed partial class DesignerActionPanel
                     Rectangle rect = new Rectangle(1, 1, width - 2, height - 2);
                     using (Graphics swatchGraphics = Graphics.FromImage(_swatch))
                     {
-                        _editor!.PaintValue(Value, swatchGraphics, rect);
+                        _editor.PaintValue(Value, swatchGraphics, rect);
                         swatchGraphics.DrawRectangle(SystemPens.ControlDark, new Rectangle(0, 0, width - 1, height - 1));
                     }
                 }
@@ -408,7 +409,10 @@ internal sealed partial class DesignerActionPanel
 
         void IWindowsFormsEditorService.DropDownControl(Control control)
         {
-            ShowDropDown(control, ActionPanel.BorderColor);
+            if (control is not null)
+            {
+                ShowDropDown(control, ActionPanel.BorderColor);
+            }
         }
 
         DialogResult IWindowsFormsEditorService.ShowDialog(Form dialog)

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.EditorPropertyLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.EditorPropertyLine.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.Drawing;
 using System.Drawing.Design;
 using System.Globalization;
@@ -16,10 +14,10 @@ internal sealed partial class DesignerActionPanel
     private sealed partial class EditorPropertyLine : TextBoxPropertyLine, IWindowsFormsEditorService, IServiceProvider
     {
         private readonly EditorButton _button;
-        private UITypeEditor _editor;
+        private UITypeEditor? _editor;
         private bool _hasSwatch;
-        private Image _swatch;
-        private FlyoutDialog _dropDownHolder;
+        private Image? _swatch;
+        private FlyoutDialog? _dropDownHolder;
         private bool _ignoreNextSelectChange;
         private bool _ignoreDropDownValue;
 
@@ -39,7 +37,7 @@ internal sealed partial class DesignerActionPanel
             {
                 try
                 {
-                    object newValue = _editor.EditValue(TypeDescriptorContext, this, Value);
+                    object? newValue = _editor.EditValue(TypeDescriptorContext, this, Value);
                     SetValue(newValue);
                 }
                 catch (Exception ex)
@@ -58,12 +56,12 @@ internal sealed partial class DesignerActionPanel
                 listBox.SelectedIndexChanged += new EventHandler(OnListBoxSelectedIndexChanged);
                 listBox.KeyDown += new KeyEventHandler(OnListBoxKeyDown);
 
-                TypeConverter.StandardValuesCollection standardValues = GetStandardValues();
+                TypeConverter.StandardValuesCollection? standardValues = GetStandardValues();
                 if (standardValues is not null)
                 {
                     foreach (object o in standardValues)
                     {
-                        string newItem = PropertyDescriptor.Converter.ConvertToString(TypeDescriptorContext, CultureInfo.CurrentCulture, o);
+                        string newItem = PropertyDescriptor.Converter.ConvertToString(TypeDescriptorContext, CultureInfo.CurrentCulture, o)!;
                         listBox.Items.Add(newItem);
 
                         if ((o is not null) && o.Equals(Value))
@@ -181,12 +179,12 @@ internal sealed partial class DesignerActionPanel
             return size;
         }
 
-        private void OnButtonClick(object sender, EventArgs e)
+        private void OnButtonClick(object? sender, EventArgs e)
         {
             ActivateDropDown();
         }
 
-        private void OnButtonGotFocus(object sender, EventArgs e)
+        private void OnButtonGotFocus(object? sender, EventArgs e)
         {
             if (!_button.Ellipsis)
             {
@@ -194,7 +192,7 @@ internal sealed partial class DesignerActionPanel
             }
         }
 
-        private void OnListBoxKeyDown(object sender, KeyEventArgs e)
+        private void OnListBoxKeyDown(object? sender, KeyEventArgs e)
         {
             // Always respect the enter key and F4
             if (e.KeyData == Keys.Enter)
@@ -210,7 +208,7 @@ internal sealed partial class DesignerActionPanel
             }
         }
 
-        private void OnListBoxSelectedIndexChanged(object sender, EventArgs e)
+        private void OnListBoxSelectedIndexChanged(object? sender, EventArgs e)
         {
             // If we're ignoring this selected index change, do nothing
             if (_ignoreNextSelectChange)
@@ -241,11 +239,11 @@ internal sealed partial class DesignerActionPanel
 
             if (_button.Ellipsis)
             {
-                EditControl.AccessibleRole = (IsReadOnly() ? AccessibleRole.StaticText : AccessibleRole.Text);
+                EditControl!.AccessibleRole = (IsReadOnly() ? AccessibleRole.StaticText : AccessibleRole.Text);
             }
             else
             {
-                EditControl.AccessibleRole = (IsReadOnly() ? AccessibleRole.DropList : AccessibleRole.ComboBox);
+                EditControl!.AccessibleRole = (IsReadOnly() ? AccessibleRole.DropList : AccessibleRole.ComboBox);
             }
 
             _button.TabStop = _button.Ellipsis;
@@ -256,7 +254,7 @@ internal sealed partial class DesignerActionPanel
             _button.AccessibleName = EditControl.AccessibleName;
         }
 
-        protected override void OnReadOnlyTextBoxLabelClick(object sender, MouseEventArgs e)
+        protected override void OnReadOnlyTextBoxLabelClick(object? sender, MouseEventArgs e)
         {
             base.OnReadOnlyTextBoxLabelClick(sender, e);
 
@@ -299,7 +297,7 @@ internal sealed partial class DesignerActionPanel
                     Rectangle rect = new Rectangle(1, 1, width - 2, height - 2);
                     using (Graphics swatchGraphics = Graphics.FromImage(_swatch))
                     {
-                        _editor.PaintValue(Value, swatchGraphics, rect);
+                        _editor!.PaintValue(Value, swatchGraphics, rect);
                         swatchGraphics.DrawRectangle(SystemPens.ControlDark, new Rectangle(0, 0, width - 1, height - 1));
                     }
                 }
@@ -420,7 +418,7 @@ internal sealed partial class DesignerActionPanel
 
         DialogResult IWindowsFormsEditorService.ShowDialog(Form dialog)
         {
-            IUIService uiService = ServiceProvider.GetService<IUIService>();
+            IUIService? uiService = ServiceProvider.GetService<IUIService>();
             if (uiService is not null)
             {
                 return uiService.ShowDialog(dialog);
@@ -431,7 +429,7 @@ internal sealed partial class DesignerActionPanel
         #endregion
 
         #region IServiceProvider implementation
-        object IServiceProvider.GetService(Type serviceType)
+        object? IServiceProvider.GetService(Type serviceType)
         {
             // Inject this class as the IWindowsFormsEditorService
             // so drop-down custom editors can work

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.EditorPropertyLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.EditorPropertyLine.cs
@@ -59,12 +59,12 @@ internal sealed partial class DesignerActionPanel
                 TypeConverter.StandardValuesCollection? standardValues = GetStandardValues();
                 if (standardValues is not null)
                 {
-                    foreach (object o in standardValues)
+                    foreach (object standardValue in standardValues)
                     {
-                        string newItem = PropertyDescriptor.Converter.ConvertToString(TypeDescriptorContext, CultureInfo.CurrentCulture, o)!;
+                        string newItem = PropertyDescriptor.Converter.ConvertToString(TypeDescriptorContext, CultureInfo.CurrentCulture, standardValue)!;
                         listBox.Items.Add(newItem);
 
-                        if ((o is not null) && o.Equals(Value))
+                        if ((standardValue is not null) && standardValue.Equals(Value))
                         {
                             listBox.SelectedItem = newItem;
                         }
@@ -237,14 +237,9 @@ internal sealed partial class DesignerActionPanel
                 _button.Ellipsis = false;
             }
 
-            if (_button.Ellipsis)
-            {
-                EditControl!.AccessibleRole = (IsReadOnly() ? AccessibleRole.StaticText : AccessibleRole.Text);
-            }
-            else
-            {
-                EditControl!.AccessibleRole = (IsReadOnly() ? AccessibleRole.DropList : AccessibleRole.ComboBox);
-            }
+            EditControl!.AccessibleRole = _button.Ellipsis
+                ? IsReadOnly() ? AccessibleRole.StaticText : AccessibleRole.Text
+                : IsReadOnly() ? AccessibleRole.DropList : AccessibleRole.ComboBox;
 
             _button.TabStop = _button.Ellipsis;
             _button.TabIndex = currentTabIndex++;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.Line.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.Line.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.Drawing;
 using System.Windows.Forms;
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.MethodLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.MethodLine.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.Drawing;
 using System.Reflection;
 using System.Windows.Forms;
@@ -13,8 +11,8 @@ internal sealed partial class DesignerActionPanel
 {
     private sealed class MethodLine : Line
     {
-        private DesignerActionList _actionList;
-        private DesignerActionMethodItem _methodItem;
+        private DesignerActionList? _actionList;
+        private DesignerActionMethodItem? _methodItem;
         private readonly MethodItemLinkLabel _linkLabel;
         private MethodLine(IServiceProvider serviceProvider, DesignerActionPanel actionPanel) : base(serviceProvider, actionPanel)
         {
@@ -33,7 +31,7 @@ internal sealed partial class DesignerActionPanel
             AddedControls.Add(_linkLabel);
         }
 
-        public override string FocusId => $"METHOD:{_actionList.GetType().FullName}.{_methodItem.MemberName}";
+        public override string FocusId => $"METHOD:{_actionList!.GetType().FullName}.{_methodItem!.MemberName}";
 
         public override void Focus()
         {
@@ -52,19 +50,19 @@ internal sealed partial class DesignerActionPanel
             return linkLabelSize + new Size(LineLeftMargin + LineRightMargin, LineVerticalPadding);
         }
 
-        private void OnLinkLabelLinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+        private void OnLinkLabelLinkClicked(object? sender, LinkLabelLinkClickedEventArgs e)
         {
             Debug.Assert(!ActionPanel.InMethodInvoke, "Nested method invocation");
             ActionPanel.InMethodInvoke = true;
             try
             {
-                _methodItem.Invoke();
+                _methodItem!.Invoke();
             }
             catch (Exception ex)
             {
                 if (ex is TargetInvocationException)
                 {
-                    ex = ex.InnerException;
+                    ex = ex.InnerException!;
                 }
 
                 //NOTE: We had code to rethrow if this was one of [NullReferenceException, StackOverflowException, OutOfMemoryException,
@@ -72,7 +70,7 @@ internal sealed partial class DesignerActionPanel
                 //NullRef and OutOfMemory really shouldn't be caught.  Out of these, OOM is the most correct one to call, but OOM is
                 //thrown by GDI+ for pretty much any problem, so isn't reliable as an actual indicator that you're out of memory.  If
                 //you really are out of memory, it's very likely you'll get another OOM shortly.
-                ActionPanel.ShowError(string.Format(SR.DesignerActionPanel_ErrorInvokingAction, _methodItem.DisplayName, Environment.NewLine + ex.Message));
+                ActionPanel.ShowError(string.Format(SR.DesignerActionPanel_ErrorInvokingAction, _methodItem!.DisplayName, Environment.NewLine + ex.Message));
             }
             finally
             {

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.MethodLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.MethodLine.cs
@@ -31,6 +31,7 @@ internal sealed partial class DesignerActionPanel
             AddedControls.Add(_linkLabel);
         }
 
+        // _methodItem and _actionList are set in UpdateActionItem, which is always called right after the MethodLine object creation
         public override string FocusId => $"METHOD:{_actionList!.GetType().FullName}.{_methodItem!.MemberName}";
 
         public override void Focus()
@@ -56,6 +57,7 @@ internal sealed partial class DesignerActionPanel
             ActionPanel.InMethodInvoke = true;
             try
             {
+                // _methodItem is set in UpdateActionItem, which is always called right after the MethodLine object creation
                 _methodItem!.Invoke();
             }
             catch (Exception ex)

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.PanelHeaderLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.PanelHeaderLine.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.Drawing;
 using System.Windows.Forms;
 
@@ -12,7 +10,7 @@ internal sealed partial class DesignerActionPanel
 {
     private sealed class PanelHeaderLine : Line
     {
-        private DesignerActionPanelHeaderItem _panelHeaderItem;
+        private DesignerActionPanelHeaderItem? _panelHeaderItem;
         private readonly Label _titleLabel;
         private readonly Label _subtitleLabel;
         private bool _formActive;
@@ -57,7 +55,7 @@ internal sealed partial class DesignerActionPanel
         {
             Size titleSize = _titleLabel.GetPreferredSize(new Size(int.MaxValue, int.MaxValue));
             Size subtitleSize = Size.Empty;
-            if (!string.IsNullOrEmpty(_panelHeaderItem.Subtitle))
+            if (!string.IsNullOrEmpty(_panelHeaderItem!.Subtitle))
             {
                 subtitleSize = _subtitleLabel.GetPreferredSize(new Size(int.MaxValue, int.MaxValue));
             }
@@ -76,7 +74,7 @@ internal sealed partial class DesignerActionPanel
             return new Size(newWidth + 2, newHeight + 1);
         }
 
-        private void OnFormActivated(object sender, EventArgs e)
+        private void OnFormActivated(object? sender, EventArgs e)
         {
             // TODO: Figure out better rect
             _formActive = true;
@@ -84,14 +82,14 @@ internal sealed partial class DesignerActionPanel
             //ActionPanel.Invalidate(new Rectangle(EditRegionLocation, EditRegionSize), false);
         }
 
-        private void OnFormDeactivate(object sender, EventArgs e)
+        private void OnFormDeactivate(object? sender, EventArgs e)
         {
             // TODO: Figure out better rect
             _formActive = false;
             ActionPanel.Invalidate();
         }
 
-        private void OnParentControlFontChanged(object sender, EventArgs e)
+        private void OnParentControlFontChanged(object? sender, EventArgs e)
         {
             _titleLabel.Font = new Font(ActionPanel.Font, FontStyle.Bold);
             _subtitleLabel.Font = ActionPanel.Font;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.PropertyLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.PropertyLine.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.Globalization;
 using System.Reflection;
 using System.Windows.Forms;
@@ -13,30 +11,30 @@ internal sealed partial class DesignerActionPanel
 {
     private abstract class PropertyLine : Line
     {
-        private DesignerActionList _actionList;
+        private DesignerActionList? _actionList;
         private bool _pushingValue;
-        private PropertyDescriptor _propDesc;
-        private ITypeDescriptorContext _typeDescriptorContext;
+        private PropertyDescriptor? _propDesc;
+        private ITypeDescriptorContext? _typeDescriptorContext;
 
         protected PropertyLine(IServiceProvider serviceProvider, DesignerActionPanel actionPanel) : base(serviceProvider, actionPanel)
         {
         }
 
-        public sealed override string FocusId => $"PROPERTY:{_actionList.GetType().FullName}.{PropertyItem.MemberName}";
+        public sealed override string FocusId => $"PROPERTY:{_actionList!.GetType().FullName}.{PropertyItem!.MemberName}";
 
-        protected PropertyDescriptor PropertyDescriptor => _propDesc ??= TypeDescriptor.GetProperties(_actionList)[PropertyItem.MemberName];
+        protected PropertyDescriptor PropertyDescriptor => _propDesc ??= TypeDescriptor.GetProperties(_actionList!)[PropertyItem!.MemberName]!;
 
-        protected DesignerActionPropertyItem PropertyItem { get; private set; }
+        protected DesignerActionPropertyItem? PropertyItem { get; private set; }
 
-        protected ITypeDescriptorContext TypeDescriptorContext => _typeDescriptorContext ??= new TypeDescriptorContext(ServiceProvider, PropertyDescriptor, _actionList);
+        protected ITypeDescriptorContext TypeDescriptorContext => _typeDescriptorContext ??= new TypeDescriptorContext(ServiceProvider, PropertyDescriptor, _actionList!);
 
-        protected object Value { get; private set; }
+        protected object? Value { get; private set; }
 
         protected abstract void OnPropertyTaskItemUpdated(ToolTip toolTip, ref int currentTabIndex);
 
         protected abstract void OnValueChanged();
 
-        protected void SetValue(object newValue)
+        protected void SetValue(object? newValue)
         {
             if (_pushingValue || ActionPanel._dropDownActive)
             {
@@ -58,7 +56,7 @@ internal sealed partial class DesignerActionPanel
                             // If we can't convert it, show an error
                             if (!PropertyDescriptor.Converter.CanConvertFrom(_typeDescriptorContext, valueType))
                             {
-                                ActionPanel.ShowError(string.Format(SR.DesignerActionPanel_CouldNotConvertValue, newValue, _propDesc.PropertyType));
+                                ActionPanel.ShowError(string.Format(SR.DesignerActionPanel_CouldNotConvertValue, newValue, _propDesc!.PropertyType));
                                 return;
                             }
                             else
@@ -81,7 +79,7 @@ internal sealed partial class DesignerActionPanel
             {
                 if (e is TargetInvocationException)
                 {
-                    e = e.InnerException;
+                    e = e.InnerException!;
                 }
 
                 ActionPanel.ShowError(string.Format(SR.DesignerActionPanel_ErrorSettingValue, newValue, PropertyDescriptor.Name, e.Message));

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.PropertyLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.PropertyLine.cs
@@ -56,7 +56,7 @@ internal sealed partial class DesignerActionPanel
                             // If we can't convert it, show an error
                             if (!PropertyDescriptor.Converter.CanConvertFrom(_typeDescriptorContext, valueType))
                             {
-                                ActionPanel.ShowError(string.Format(SR.DesignerActionPanel_CouldNotConvertValue, newValue, _propDesc!.PropertyType));
+                                ActionPanel.ShowError(string.Format(SR.DesignerActionPanel_CouldNotConvertValue, newValue, PropertyDescriptor.PropertyType));
                                 return;
                             }
                             else

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.TextBoxPropertyLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.TextBoxPropertyLine.cs
@@ -118,6 +118,7 @@ internal sealed partial class DesignerActionPanel
 
         protected virtual bool IsReadOnly() => IsReadOnlyProperty(PropertyDescriptor);
 
+        [MemberNotNull(nameof(EditControl))]
         protected override void OnPropertyTaskItemUpdated(ToolTip toolTip, ref int currentTabIndex)
         {
             _label.Text = StripAmpersands(PropertyItem!.DisplayName);
@@ -349,7 +350,7 @@ internal sealed partial class DesignerActionPanel
                 {
                 }
 
-                public override string Value => Owner!.Text;
+                public override string? Value => Owner?.Text;
             }
         }
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.TextBoxPropertyLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.TextBoxPropertyLine.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.Drawing;
 using System.Windows.Forms;
 
@@ -60,7 +58,7 @@ internal sealed partial class DesignerActionPanel
             AddedControls.Add(_label);
         }
 
-        protected Control EditControl { get; private set; }
+        protected Control? EditControl { get; private set; }
 
         protected Point EditRegionLocation => _editRegionLocation;
 
@@ -70,7 +68,7 @@ internal sealed partial class DesignerActionPanel
 
         public sealed override void Focus()
         {
-            EditControl.Focus();
+            EditControl!.Focus();
         }
 
         internal int GetEditRegionXPos()
@@ -108,13 +106,9 @@ internal sealed partial class DesignerActionPanel
                 _label.Location = new Point(LineLeftMargin, top);
                 int labelPreferredWidth = _label.GetPreferredSize(new Size(int.MaxValue, int.MaxValue)).Width;
                 _label.Size = new Size(labelPreferredWidth, height);
-                int specialPadding = 0;
-                if (EditControl is TextBox)
-                {
-                    specialPadding = 2;
-                }
+                int specialPadding = EditControl is TextBox ? 2 : 0;
 
-                EditControl.Location = new Point(_editRegionLocation.X + GetTextBoxLeftPadding(textBoxPreferredHeight) + 1 + specialPadding, _editRegionLocation.Y + TextBoxLineInnerPadding + 1);
+                EditControl!.Location = new Point(_editRegionLocation.X + GetTextBoxLeftPadding(textBoxPreferredHeight) + 1 + specialPadding, _editRegionLocation.Y + TextBoxLineInnerPadding + 1);
                 EditControl.Width = _editRegionSize.Width - GetTextBoxRightPadding(textBoxPreferredHeight) - GetTextBoxLeftPadding(textBoxPreferredHeight) - specialPadding;
                 EditControl.Height = _editRegionSize.Height - TextBoxLineInnerPadding * 2 - 1;
             }
@@ -126,7 +120,7 @@ internal sealed partial class DesignerActionPanel
 
         protected override void OnPropertyTaskItemUpdated(ToolTip toolTip, ref int currentTabIndex)
         {
-            _label.Text = StripAmpersands(PropertyItem.DisplayName);
+            _label.Text = StripAmpersands(PropertyItem!.DisplayName);
             _label.TabIndex = currentTabIndex++;
             toolTip.SetToolTip(_label, PropertyItem.Description);
             _textBoxDirty = false;
@@ -154,7 +148,7 @@ internal sealed partial class DesignerActionPanel
             EditControl.BringToFront();
         }
 
-        protected virtual void OnReadOnlyTextBoxLabelClick(object sender, MouseEventArgs e)
+        protected virtual void OnReadOnlyTextBoxLabelClick(object? sender, MouseEventArgs e)
         {
             if (e.Button == MouseButtons.Left)
             {
@@ -162,19 +156,19 @@ internal sealed partial class DesignerActionPanel
             }
         }
 
-        private void OnReadOnlyTextBoxLabelEnter(object sender, EventArgs e)
+        private void OnReadOnlyTextBoxLabelEnter(object? sender, EventArgs e)
         {
             _readOnlyTextBoxLabel.ForeColor = SystemColors.HighlightText;
             _readOnlyTextBoxLabel.BackColor = SystemColors.Highlight;
         }
 
-        private void OnReadOnlyTextBoxLabelLeave(object sender, EventArgs e)
+        private void OnReadOnlyTextBoxLabelLeave(object? sender, EventArgs e)
         {
             _readOnlyTextBoxLabel.ForeColor = SystemColors.WindowText;
             _readOnlyTextBoxLabel.BackColor = SystemColors.Window;
         }
 
-        protected TypeConverter.StandardValuesCollection GetStandardValues()
+        protected TypeConverter.StandardValuesCollection? GetStandardValues()
         {
             TypeConverter converter = PropertyDescriptor.Converter;
             if (converter is not null &&
@@ -192,7 +186,7 @@ internal sealed partial class DesignerActionPanel
             {
                 e.Handled = true;
                 // Try to find the existing value and then pick the one after it
-                TypeConverter.StandardValuesCollection standardValues = GetStandardValues();
+                TypeConverter.StandardValuesCollection? standardValues = GetStandardValues();
                 if (standardValues is not null)
                 {
                     for (int i = 0; i < standardValues.Count; i++)
@@ -222,7 +216,7 @@ internal sealed partial class DesignerActionPanel
             {
                 e.Handled = true;
                 // Try to find the existing value and then pick the one before it
-                TypeConverter.StandardValuesCollection standardValues = GetStandardValues();
+                TypeConverter.StandardValuesCollection? standardValues = GetStandardValues();
                 if (standardValues is not null)
                 {
                     for (int i = 0; i < standardValues.Count; i++)
@@ -249,13 +243,13 @@ internal sealed partial class DesignerActionPanel
             }
         }
 
-        private void OnReadOnlyTextBoxLabelKeyDown(object sender, KeyEventArgs e)
+        private void OnReadOnlyTextBoxLabelKeyDown(object? sender, KeyEventArgs e)
         {
             // Delegate the rest of the processing to a common helper
             OnEditControlKeyDown(e);
         }
 
-        private void OnTextBoxKeyDown(object sender, KeyEventArgs e)
+        private void OnTextBoxKeyDown(object? sender, KeyEventArgs e)
         {
             if (ActionPanel._dropDownActive)
             {
@@ -273,7 +267,7 @@ internal sealed partial class DesignerActionPanel
             OnEditControlKeyDown(e);
         }
 
-        private void OnTextBoxLostFocus(object sender, EventArgs e)
+        private void OnTextBoxLostFocus(object? sender, EventArgs e)
         {
             if (ActionPanel._dropDownActive)
             {
@@ -283,9 +277,9 @@ internal sealed partial class DesignerActionPanel
             UpdateValue();
         }
 
-        private void OnTextBoxTextChanged(object sender, EventArgs e) => _textBoxDirty = true;
+        private void OnTextBoxTextChanged(object? sender, EventArgs e) => _textBoxDirty = true;
 
-        protected override void OnValueChanged() => EditControl.Text = PropertyDescriptor.Converter.ConvertToString(TypeDescriptorContext, Value);
+        protected override void OnValueChanged() => EditControl!.Text = PropertyDescriptor.Converter.ConvertToString(TypeDescriptorContext, Value);
 
         public override void PaintLine(Graphics g, int lineWidth, int lineHeight)
         {
@@ -311,7 +305,7 @@ internal sealed partial class DesignerActionPanel
         {
             if (_textBoxDirty)
             {
-                SetValue(EditControl.Text);
+                SetValue(EditControl!.Text);
                 _textBoxDirty = false;
             }
         }
@@ -355,7 +349,7 @@ internal sealed partial class DesignerActionPanel
                 {
                 }
 
-                public override string Value => Owner.Text;
+                public override string Value => Owner!.Text;
             }
         }
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.TextLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.TextLine.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.Drawing;
 using System.Windows.Forms;
 
@@ -13,7 +11,7 @@ internal sealed partial class DesignerActionPanel
     private class TextLine : Line
     {
         private readonly Label _label;
-        private DesignerActionTextItem _textItem;
+        private DesignerActionTextItem? _textItem;
 
         protected TextLine(IServiceProvider serviceProvider, DesignerActionPanel actionPanel)
             : base(serviceProvider, actionPanel)
@@ -48,7 +46,7 @@ internal sealed partial class DesignerActionPanel
             return labelSize + new Size(LineLeftMargin + LineRightMargin, LineVerticalPadding);
         }
 
-        private void OnParentControlFontChanged(object sender, EventArgs e)
+        private void OnParentControlFontChanged(object? sender, EventArgs e)
         {
             if (_label.Font is not null)
             {

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.TypeDescriptorContext.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.TypeDescriptorContext.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 namespace System.ComponentModel.Design;
 
 internal sealed partial class DesignerActionPanel
@@ -10,31 +8,29 @@ internal sealed partial class DesignerActionPanel
     internal sealed class TypeDescriptorContext : ITypeDescriptorContext
     {
         private readonly IServiceProvider _serviceProvider;
-        private readonly PropertyDescriptor _propertyDescriptor;
-        private readonly object _instance;
 
         public TypeDescriptorContext(IServiceProvider serviceProvider, PropertyDescriptor propertyDescriptor, object instance)
         {
             _serviceProvider = serviceProvider;
-            _propertyDescriptor = propertyDescriptor;
-            _instance = instance;
+            PropertyDescriptor = propertyDescriptor;
+            Instance = instance;
         }
 
-        private IComponentChangeService ComponentChangeService => _serviceProvider.GetService<IComponentChangeService>();
+        private IComponentChangeService? ComponentChangeService => _serviceProvider.GetService<IComponentChangeService>();
 
-        public IContainer Container => _serviceProvider.GetService<IContainer>();
+        public IContainer? Container => _serviceProvider.GetService<IContainer>();
 
-        public object Instance => _instance;
+        public object Instance { get; }
 
-        public PropertyDescriptor PropertyDescriptor => _propertyDescriptor;
+        public PropertyDescriptor PropertyDescriptor { get; }
 
-        public object GetService(Type serviceType) => _serviceProvider.GetService(serviceType);
+        public object? GetService(Type serviceType) => _serviceProvider.GetService(serviceType);
 
         public bool OnComponentChanging()
         {
             try
             {
-                ComponentChangeService?.OnComponentChanging(_instance, _propertyDescriptor);
+                ComponentChangeService?.OnComponentChanging(Instance, PropertyDescriptor);
                 return true;
             }
             catch (CheckoutException ce) when (ce == CheckoutException.Canceled)
@@ -43,6 +39,6 @@ internal sealed partial class DesignerActionPanel
             }
         }
 
-        public void OnComponentChanged() => ComponentChangeService?.OnComponentChanged(_instance, _propertyDescriptor);
+        public void OnComponentChanged() => ComponentChangeService?.OnComponentChanged(Instance, PropertyDescriptor);
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.Collections;
 using System.Drawing;
 using System.Drawing.Design;
@@ -37,7 +35,7 @@ internal sealed partial class DesignerActionPanel : ContainerControl
     private const int PanelHeaderHorizontalPadding = 5; // Horizontal padding within the header of the panel
 
     private const int TextBoxHeightFixup = 2; // Countereffects the fix for VSWhidbey 359726 - we relied on the broken behavior before
-    private CommandID[] _filteredCommandIDs;
+    private CommandID[]? _filteredCommandIDs;
     private readonly ToolTip _toolTip;
     private readonly List<Line> _lines;
     private readonly List<int> _lineYPositions;
@@ -61,10 +59,10 @@ internal sealed partial class DesignerActionPanel : ContainerControl
         _lineYPositions = new List<int>();
         _toolTip = new ToolTip();
         // Try to get the font from the IUIService, otherwise, use the default
-        IUIService uiService = _serviceProvider.GetService<IUIService>();
+        IUIService? uiService = _serviceProvider.GetService<IUIService>();
         if (uiService is not null)
         {
-            Font = (Font)uiService.Styles["DialogFont"];
+            Font = (Font)uiService.Styles["DialogFont"]!;
             if (uiService.Styles["VsColorPanelGradientDark"] is Color vsColorPanelGradientDarkColor)
             {
                 GradientDarkColor = vsColorPanelGradientDarkColor;
@@ -167,7 +165,7 @@ internal sealed partial class DesignerActionPanel : ContainerControl
     /// <summary>
     ///  Gets the Line that currently has input focus.
     /// </summary>
-    private Line FocusedLine => ActiveControl?.Tag as Line;
+    private Line? FocusedLine => ActiveControl?.Tag as Line;
 
     public Color GradientDarkColor { get; } = SystemColors.Control;
 
@@ -207,16 +205,16 @@ internal sealed partial class DesignerActionPanel : ContainerControl
 
     private static void AddToCategories(StandardLineInfo lineInfo, Dictionary<string, Dictionary<DesignerActionList, List<LineInfo>>> categories)
     {
-        string categoryName = lineInfo.Item.Category;
+        string? categoryName = lineInfo.Item.Category;
         categoryName ??= string.Empty;
 
-        if (!categories.TryGetValue(categoryName, out Dictionary<DesignerActionList, List<LineInfo>> category))
+        if (!categories.TryGetValue(categoryName, out Dictionary<DesignerActionList, List<LineInfo>>? category))
         {
             category = new Dictionary<DesignerActionList, List<LineInfo>>();
             categories.Add(categoryName, category);
         }
 
-        if (!category.TryGetValue(lineInfo.List, out List<LineInfo> categoryList))
+        if (!category.TryGetValue(lineInfo.List, out List<LineInfo>? categoryList))
         {
             categoryList = new List<LineInfo>();
             category.Add(lineInfo.List, categoryList);
@@ -404,7 +402,7 @@ internal sealed partial class DesignerActionPanel : ContainerControl
             return true;
         }
 
-        return (pd.ComponentType.GetProperty(pd.Name).GetSetMethod() is null);
+        return (pd.ComponentType.GetProperty(pd.Name)!.GetSetMethod() is null);
     }
 
     protected override void OnFontChanged(EventArgs e)
@@ -416,10 +414,10 @@ internal sealed partial class DesignerActionPanel : ContainerControl
 
     private void OnFormActivated(object sender, EventArgs e)
     {
-        ((EventHandler)Events[s_eventFormActivated])?.Invoke(sender, e);
+        ((EventHandler?)Events[s_eventFormActivated])?.Invoke(sender, e);
     }
 
-    private void OnFormClosing(object sender, CancelEventArgs e)
+    private void OnFormClosing(object? sender, CancelEventArgs e)
     {
         if (!e.Cancel && TopLevelControl is not null)
         {
@@ -434,7 +432,7 @@ internal sealed partial class DesignerActionPanel : ContainerControl
 
     private void OnFormDeactivate(object sender, EventArgs e)
     {
-        ((EventHandler)Events[s_eventFormDeactivate])?.Invoke(sender, e);
+        ((EventHandler?)Events[s_eventFormDeactivate])?.Invoke(sender, e);
     }
 
     protected override void OnHandleCreated(EventArgs e)
@@ -524,7 +522,7 @@ internal sealed partial class DesignerActionPanel : ContainerControl
     protected override bool ProcessDialogKey(Keys keyData)
     {
         // TODO: RightToLeft management for left/right arrow keys (from old DesignerActionPanel)
-        Line focusedLine = FocusedLine;
+        Line? focusedLine = FocusedLine;
         if (focusedLine is not null)
         {
             if (focusedLine.ProcessDialogKey(keyData))
@@ -542,7 +540,7 @@ internal sealed partial class DesignerActionPanel : ContainerControl
         return (SelectNextControl(ActiveControl, forward, true, true, true));
     }
 
-    private void ProcessLists(DesignerActionListCollection lists, Dictionary<string, Dictionary<DesignerActionList, List<LineInfo>>> categories)
+    private void ProcessLists(DesignerActionListCollection? lists, Dictionary<string, Dictionary<DesignerActionList, List<LineInfo>>> categories)
     {
         if (lists is null)
         {
@@ -563,7 +561,7 @@ internal sealed partial class DesignerActionPanel : ContainerControl
                             continue;
                         }
 
-                        StandardLineInfo lineInfo = ProcessTaskItem(list, item);
+                        StandardLineInfo? lineInfo = ProcessTaskItem(list, item);
                         if (lineInfo is null)
                         {
                             continue;
@@ -571,22 +569,19 @@ internal sealed partial class DesignerActionPanel : ContainerControl
 
                         AddToCategories(lineInfo, categories);
                         // Process lists from related component
-                        IComponent relatedComponent = null;
+                        IComponent? relatedComponent = null;
                         if (item is DesignerActionPropertyItem propItem)
                         {
                             relatedComponent = propItem.RelatedComponent;
                         }
-                        else
+                        else if (item is DesignerActionMethodItem methodItem)
                         {
-                            if (item is DesignerActionMethodItem methodItem)
-                            {
-                                relatedComponent = methodItem.RelatedComponent;
-                            }
+                            relatedComponent = methodItem.RelatedComponent;
                         }
 
                         if (relatedComponent is not null)
                         {
-                            IEnumerable<StandardLineInfo> relatedLineInfos = ProcessRelatedTaskItems(relatedComponent);
+                            IEnumerable<StandardLineInfo>? relatedLineInfos = ProcessRelatedTaskItems(relatedComponent);
                             if (relatedLineInfos is not null)
                             {
                                 foreach (StandardLineInfo relatedLineInfo in relatedLineInfos)
@@ -605,8 +600,8 @@ internal sealed partial class DesignerActionPanel : ContainerControl
     {
         // Add the related tasks
         Debug.Assert(relatedComponent is not null);
-        DesignerActionListCollection relatedLists = null;
-        DesignerActionService actionService = _serviceProvider.GetService<DesignerActionService>();
+        DesignerActionListCollection? relatedLists = null;
+        DesignerActionService? actionService = _serviceProvider.GetService<DesignerActionService>();
         if (actionService is not null)
         {
             relatedLists = actionService.GetComponentActions(relatedComponent);
@@ -614,10 +609,10 @@ internal sealed partial class DesignerActionPanel : ContainerControl
         else
         {
             // Try to use the component's service provider if it exists so that we end up getting the right IDesignerHost.
-            IServiceProvider serviceProvider = relatedComponent.Site;
+            IServiceProvider? serviceProvider = relatedComponent.Site;
             serviceProvider ??= _serviceProvider;
 
-            IDesignerHost host = serviceProvider.GetService<IDesignerHost>();
+            IDesignerHost? host = serviceProvider.GetService<IDesignerHost>();
             if (host?.GetDesigner(relatedComponent) is ComponentDesigner componentDesigner)
             {
                 relatedLists = componentDesigner.ActionLists;
@@ -641,7 +636,7 @@ internal sealed partial class DesignerActionPanel : ContainerControl
                             {
                                 if (relatedItem.AllowAssociate)
                                 {
-                                    StandardLineInfo lineInfo = ProcessTaskItem(relatedList, relatedItem);
+                                    StandardLineInfo? lineInfo = ProcessTaskItem(relatedList, relatedItem);
                                     if (lineInfo is not null)
                                     {
                                         lineInfos.Add(lineInfo);
@@ -657,7 +652,7 @@ internal sealed partial class DesignerActionPanel : ContainerControl
         return lineInfos;
     }
 
-    private StandardLineInfo ProcessTaskItem(DesignerActionList list, DesignerActionItem item)
+    private StandardLineInfo? ProcessTaskItem(DesignerActionList list, DesignerActionItem item)
     {
         if (item is DesignerActionMethodItem methodItem)
         {
@@ -665,7 +660,7 @@ internal sealed partial class DesignerActionPanel : ContainerControl
         }
         else if (item is DesignerActionPropertyItem pti)
         {
-            PropertyDescriptor pd = TypeDescriptor.GetProperties(list)[pti.MemberName];
+            PropertyDescriptor? pd = TypeDescriptor.GetProperties(list)[pti.MemberName];
             if (pd is null)
             {
                 throw new InvalidOperationException(string.Format(SR.DesignerActionPanel_CouldNotFindProperty, pti.MemberName, list.GetType().FullName));
@@ -673,7 +668,7 @@ internal sealed partial class DesignerActionPanel : ContainerControl
 
             TypeDescriptorContext context = new TypeDescriptorContext(_serviceProvider, pd, list);
             bool standardValuesSupported = pd.Converter.GetStandardValuesSupported(context);
-            if (pd.TryGetEditor(out UITypeEditor _))
+            if (pd.TryGetEditor(out UITypeEditor? _))
             {
                 return new EditorPropertyLine.Info(list, pti);
             }
@@ -722,7 +717,7 @@ internal sealed partial class DesignerActionPanel : ContainerControl
 
     private void ShowError(string errorMessage)
     {
-        IUIService uiService = _serviceProvider.GetService<IUIService>();
+        IUIService? uiService = _serviceProvider.GetService<IUIService>();
         if (uiService is not null)
         {
             uiService.ShowError(errorMessage);
@@ -745,7 +740,7 @@ internal sealed partial class DesignerActionPanel : ContainerControl
     ///  - Convert "&amp;x" to "x"
     ///  - An ampersand by itself at the end of a string is displayed as-is
     /// </summary>
-    private static string StripAmpersands(string s)
+    private static string StripAmpersands(string? s)
     {
         if (string.IsNullOrEmpty(s))
         {
@@ -795,7 +790,7 @@ internal sealed partial class DesignerActionPanel : ContainerControl
         }
     }
 
-    public void UpdateTasks(DesignerActionListCollection actionLists, DesignerActionListCollection serviceActionLists, string title, string subtitle)
+    public void UpdateTasks(DesignerActionListCollection actionLists, DesignerActionListCollection serviceActionLists, string title, string? subtitle)
     {
         _updatingTasks = true;
         SuspendLayout();
@@ -806,7 +801,7 @@ internal sealed partial class DesignerActionPanel : ContainerControl
 
             // Store the focus state
             string focusId = string.Empty;
-            Line focusedLine = FocusedLine;
+            Line? focusedLine = FocusedLine;
             if (focusedLine is not null)
             {
                 focusId = focusedLine.FocusId;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.cs
@@ -395,14 +395,14 @@ internal sealed partial class DesignerActionPanel : ContainerControl
         return DoLayout(proposedSize, true);
     }
 
-    private static bool IsReadOnlyProperty(PropertyDescriptor pd)
+    private static bool IsReadOnlyProperty(PropertyDescriptor propertyDescriptor)
     {
-        if (pd.IsReadOnly)
+        if (propertyDescriptor.IsReadOnly)
         {
             return true;
         }
 
-        return (pd.ComponentType.GetProperty(pd.Name)!.GetSetMethod() is null);
+        return (propertyDescriptor.ComponentType.GetProperty(propertyDescriptor.Name)!.GetSetMethod() is null);
     }
 
     protected override void OnFontChanged(EventArgs e)

--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -6398,7 +6398,7 @@ System.Windows.Forms.Design.IUIService.ShowToolWindow(System.Guid toolWindow) ->
 System.Windows.Forms.Design.IUIService.Styles.get -> System.Collections.IDictionary!
 System.Windows.Forms.Design.IWindowsFormsEditorService
 System.Windows.Forms.Design.IWindowsFormsEditorService.CloseDropDown() -> void
-System.Windows.Forms.Design.IWindowsFormsEditorService.DropDownControl(System.Windows.Forms.Control? control) -> void
+System.Windows.Forms.Design.IWindowsFormsEditorService.DropDownControl(System.Windows.Forms.Control! control) -> void
 System.Windows.Forms.Design.IWindowsFormsEditorService.ShowDialog(System.Windows.Forms.Form! dialog) -> System.Windows.Forms.DialogResult
 System.Windows.Forms.Design.PropertyTab
 System.Windows.Forms.Design.PropertyTab.~PropertyTab() -> void

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Design/IWindowsFormsEditorService.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Design/IWindowsFormsEditorService.cs
@@ -50,7 +50,7 @@ public interface IWindowsFormsEditorService
     ///   no other stored reference to the control.
     ///  </para>
     /// </remarks>
-    void DropDownControl(Control? control);
+    void DropDownControl(Control control);
 
     /// <summary>
     ///  Shows the specified <see cref="Form"/> as a dialog and returns its result. You should always use this


### PR DESCRIPTION
Now that #10035 is merged, my plan is to annotate just `DesignerActionPanel`, and then rebase #9367 to remove the annotation changes I made on it there, but keep all the other changes with their review.

My changes here include the modification of the annotation of a public interface. The two internal implementers of method `IWindowsFormsEditorService.DropDownControl` cannot handle a null `Control` as argument, and nothing in the docs said the implementers should prepare for that scenario

## Proposed changes

- Enable nullability in `DesignerActionPanel`
- Update nullability annotations of interface `IWindowsFormsEditorService`


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10088)