### PR TITLE
fix issue Short keys are inconsistent in Shortcut Keys property dialog and form designer

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Keys.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Keys.cs
@@ -907,12 +907,12 @@ public enum Keys
     /// <summary>
     ///  The Oem Backslash key.
     /// </summary>
-    OemBackslash = 0xE2,
+    Oem102 = 0xE2,
 
     /// <summary>
     ///  The Oem 102 key.
     /// </summary>
-    Oem102 = OemBackslash,
+    OemBackslash = Oem102,
 
     /// <summary>
     ///  The PROCESS KEY key.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Keys.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Keys.cs
@@ -850,12 +850,12 @@ public enum Keys
     Oem2 = OemQuestion,
 
     /// <summary>
-    ///  The Oem tilde key.
+    ///  The Oem 3 key.
     /// </summary>
     Oem3 = 0xC0,
 
     /// <summary>
-    ///  The Oem 3 key.
+    ///  The Oem tilde key.
     /// </summary>
     Oemtilde = Oem3,
 
@@ -890,12 +890,12 @@ public enum Keys
     Oem6 = OemCloseBrackets,
 
     /// <summary>
-    ///  The Oem Quotes key.
+    ///  The Oem 7 key.
     /// </summary>
     Oem7 = 0xDE,
 
     /// <summary>
-    ///  The Oem 7 key.
+    ///  The Oem Quotes key.
     /// </summary>
     OemQuotes = Oem7,
 
@@ -905,12 +905,12 @@ public enum Keys
     Oem8 = 0xDF,
 
     /// <summary>
-    ///  The Oem Backslash key.
+    ///  The Oem 102 key.
     /// </summary>
     Oem102 = 0xE2,
 
     /// <summary>
-    ///  The Oem 102 key.
+    ///  The Oem Backslash key.
     /// </summary>
     OemBackslash = Oem102,
 


### PR DESCRIPTION
related to  #https://github.com/microsoft/winforms-designer/issues/5383  and [PR 10067](https://github.com/dotnet/winforms/pull/10067)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10099)