### PR TITLE
Update WinForms assembly TFM to net9.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,13 +8,9 @@
   <PropertyGroup>
     <!-- Remove hardcoded .NET versions when Arcade is upgraded to .NET 9.0. https://github.com/dotnet/winforms/issues/9851-->
     <NetMinimum>net8.0</NetMinimum>
-    <NetPrevious>net8.0</NetPrevious>
     <NetCurrent>net9.0</NetCurrent>
-    <TargetFrameworkName>net</TargetFrameworkName>
-	  <TargetFrameworkMajorVersion>9</TargetFrameworkMajorVersion>
-	  <TargetFrameworkMinorVersion>0</TargetFrameworkMinorVersion>
-    <TargetFrameworkVersion>$(TargetFrameworkMajorVersion).$(TargetFrameworkMinorVersion)</TargetFrameworkVersion>
-    <TargetFramework>$(TargetFrameworkName)$(TargetFrameworkVersion)</TargetFramework>
+    <NetPrevious/>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
     <Product>Microsoft&#xAE; .NET</Product>
     <Copyright>$(CopyrightNetFoundation)</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,9 +9,9 @@
     <!-- Remove hardcoded .NET versions when Arcade is upgraded to .NET 9.0. https://github.com/dotnet/winforms/issues/9851-->
     <NetMinimum>net8.0</NetMinimum>
     <NetPrevious>net8.0</NetPrevious>
-    <NetCurrent>net8.0</NetCurrent>
+    <NetCurrent>net9.0</NetCurrent>
     <TargetFrameworkName>net</TargetFrameworkName>
-	  <TargetFrameworkMajorVersion>8</TargetFrameworkMajorVersion>
+	  <TargetFrameworkMajorVersion>9</TargetFrameworkMajorVersion>
 	  <TargetFrameworkMinorVersion>0</TargetFrameworkMinorVersion>
     <TargetFrameworkVersion>$(TargetFrameworkMajorVersion).$(TargetFrameworkMinorVersion)</TargetFrameworkVersion>
     <TargetFramework>$(TargetFrameworkName)$(TargetFrameworkVersion)</TargetFramework>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -40,7 +40,7 @@
     <_ProjectDirectoryRelativePath>$([MSBuild]::MakeRelative($(RepoRoot), $(MSBuildProjectDirectory)))</_ProjectDirectoryRelativePath>
     <_IsUnderTestsFolder>$(_ProjectDirectoryRelativePath.Contains("\tests\"))</_IsUnderTestsFolder>
     <IsShipping Condition="$(_IsUnderTestsFolder)">false</IsShipping>
-	<RedistTargetFrameworkName>$(TargetFrameworkName)$(TargetFrameworkMajorVersion).</RedistTargetFrameworkName>
+	<RedistTargetFrameworkName>$(NetCurrent)</RedistTargetFrameworkName>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IsTestProject)' == 'true' ">

--- a/eng/CodeCoverage.proj
+++ b/eng/CodeCoverage.proj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <!-- We need to specify a framework in order for the Restore target to work -->
-    <TargetFramework>$(TargetFrameworkName)$(TargetFrameworkVersion)</TargetFramework>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "9.0.100-alpha.1.23464.17",
+    "dotnet": "9.0.100-alpha.1.23511.2",
     "runtimes": {
       "dotnet/x64": [
         "$(VSRedistCommonNetCoreSharedFrameworkx6490PackageVersion)"
@@ -11,7 +11,7 @@
     }
   },
   "sdk": {
-    "version": "9.0.100-alpha.1.23464.17"
+    "version": "9.0.100-alpha.1.23511.2"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "9.0.0-beta.23510.4",

--- a/pkg/Microsoft.Private.Winforms/Microsoft.Private.Winforms.csproj
+++ b/pkg/Microsoft.Private.Winforms/Microsoft.Private.Winforms.csproj
@@ -14,7 +14,7 @@
   -->
 
   <PropertyGroup>
-    <TargetFramework>$(TargetFrameworkName)$(TargetFrameworkVersion)</TargetFramework>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
 
     <!-- Suppress some nuget warnings that are breaking our build until https://github.com/dotnet/arcade/issues/4337 is resolved -->
     <NoWarn>$(NoWarn);NU5100;NU5131;NU5128</NoWarn>

--- a/src/Accessibility/src/Accessibility.ilproj
+++ b/src/Accessibility/src/Accessibility.ilproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <TargetFramework>$(TargetFrameworkName)$(TargetFrameworkVersion)</TargetFramework>
+    <TargetFramework>$(NetCurrent)</TargetFramework>
     <!-- Package this as both a reference and implementation -->
     <PackageAsRefAndLib>true</PackageAsRefAndLib>
     <!-- ILAsm doesn't produce a PDB - https://github.com/dotnet/coreclr/issues/15299 -->


### PR DESCRIPTION
Updating TFM for WinForms assemblies.




###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10108)