### PR TITLE
Use collection expressions to init spans where possible

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializerBase.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializerBase.cs
@@ -1425,8 +1425,8 @@ public abstract partial class CodeDomSerializerBase
         TypeCode rightType = right.GetTypeCode();
 
         // The compatible types are listed in order from lowest bitness to highest.  We must operate on the highest bitness to keep fidelity.
-        ReadOnlySpan<TypeCode> compatibleTypes = new TypeCode[]
-        {
+        ReadOnlySpan<TypeCode> compatibleTypes =
+        [
             TypeCode.Byte,
             TypeCode.Char,
             TypeCode.Int16,
@@ -1435,7 +1435,7 @@ public abstract partial class CodeDomSerializerBase
             TypeCode.UInt32,
             TypeCode.Int64,
             TypeCode.UInt64
-        };
+        ];
 
         int leftTypeIndex = -1;
         int rightTypeIndex = -1;

--- a/src/System.Windows.Forms.Design/src/System/Resources/Tools/StronglyTypedResourceBuilder.cs
+++ b/src/System.Windows.Forms.Design/src/System/Resources/Tools/StronglyTypedResourceBuilder.cs
@@ -47,11 +47,11 @@ public static partial class StronglyTypedResourceBuilder
     private const string CultureInfoPropertyName = "Culture";
 
     // When fixing up identifiers, we will replace all these chars with ReplacementChar ('_').
-    private static ReadOnlySpan<char> CharsToReplace => new char[]
-    {
+    private static ReadOnlySpan<char> CharsToReplace =>
+    [
         ' ', '\u00A0' /* non-breaking space */, '.', ',', ';', '|', '~', '@', '#', '%', '^', '&', '*', '+', '-',
         '/', '\\', '<', '>', '?', '[', ']', '(', ')', '{', '}', '\"', '\'', ':', '!'
-    };
+    ];
 
     private const char ReplacementChar = '_';
 

--- a/src/System.Windows.Forms.Primitives/src/Microsoft/VisualStudio/Shell/ICategorizeProperties.cs
+++ b/src/System.Windows.Forms.Primitives/src/Microsoft/VisualStudio/Shell/ICategorizeProperties.cs
@@ -17,13 +17,13 @@ internal unsafe struct ICategorizeProperties : IComIID
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get
         {
-            ReadOnlySpan<byte> data = new byte[]
-            {
+            ReadOnlySpan<byte> data =
+            [
                 0x10, 0xfc, 0x07, 0x4d,
                 0x31, 0xf9,
                 0xce, 0x11,
                 0xb0, 0x01, 0x00, 0xaa, 0x00, 0x68, 0x84, 0xe5
-            };
+            ];
 
             return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
         }

--- a/src/System.Windows.Forms.Primitives/src/Microsoft/VisualStudio/Shell/IProvidePropertyBuilder.cs
+++ b/src/System.Windows.Forms.Primitives/src/Microsoft/VisualStudio/Shell/IProvidePropertyBuilder.cs
@@ -17,13 +17,13 @@ internal unsafe struct IProvidePropertyBuilder : IComIID
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get
         {
-            ReadOnlySpan<byte> data = new byte[]
-            {
+            ReadOnlySpan<byte> data =
+            [
                 0xd8, 0xc1, 0xc0, 0x33,
                 0xcf, 0x33,
                 0xd3, 0x11,
                 0xbf, 0xf2, 0x00, 0xc0, 0x4f, 0x99, 0x02, 0x35
-            };
+            ];
 
             return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
         }

--- a/src/System.Windows.Forms.Primitives/src/Microsoft/VisualStudio/Shell/IVSMDPerPropertyBrowsing.cs
+++ b/src/System.Windows.Forms.Primitives/src/Microsoft/VisualStudio/Shell/IVSMDPerPropertyBrowsing.cs
@@ -18,13 +18,13 @@ internal unsafe struct IVSMDPerPropertyBrowsing : IComIID
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get
         {
-            ReadOnlySpan<byte> data = new byte[]
-            {
+            ReadOnlySpan<byte> data =
+            [
                 0x3c, 0x68, 0x94, 0x74,
                 0xa0, 0x37,
                 0xd2, 0x11,
                 0xa2, 0x73, 0x00, 0xc0, 0x4f, 0x8e, 0xf4, 0xFF
-            };
+            ];
 
             return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
         }

--- a/src/System.Windows.Forms.Primitives/src/Microsoft/VisualStudio/Shell/IVsPerPropertyBrowsing.cs
+++ b/src/System.Windows.Forms.Primitives/src/Microsoft/VisualStudio/Shell/IVsPerPropertyBrowsing.cs
@@ -17,13 +17,13 @@ internal unsafe struct IVsPerPropertyBrowsing : IComIID
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get
         {
-            ReadOnlySpan<byte> data = new byte[]
-            {
+            ReadOnlySpan<byte> data =
+            [
                 0xa3, 0x10, 0xf5, 0x0f,
                 0xa5, 0x5f,
                 0xf1, 0x49,
                 0x8c, 0xcc, 0x19, 0x0d, 0x71, 0x08, 0x3f, 0x3e
-            };
+            ];
 
             return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
         }

--- a/src/System.Windows.Forms.Primitives/src/System/CharacterConstants.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/CharacterConstants.cs
@@ -5,5 +5,5 @@ namespace System;
 
 internal static class CharacterConstants
 {
-    public static ReadOnlySpan<char> NewLine => new char[] { '\n', '\r' };
+    public static ReadOnlySpan<char> NewLine => [ '\n', '\r' ];
 }

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Automation/UiaTextProvider.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Automation/UiaTextProvider.cs
@@ -116,13 +116,7 @@ internal abstract unsafe class UiaTextProvider : ITextProvider.Interface, ITextP
     internal static VARIANT BoundingRectangleAsVariant(Rectangle bounds)
         => (VARIANT)BoundingRectangleAsArray(bounds);
 
-    public int SendInput(int inputs, ref INPUT input, int size)
-    {
-        Span<INPUT> currentInput = stackalloc INPUT[1];
-        currentInput[0] = input;
-
-        return (int)PInvoke.SendInput(currentInput, size);
-    }
+    public int SendInput(int inputs, ref INPUT input, int size) => (int)PInvoke.SendInput([input], size);
 
     public unsafe int SendKeyboardInputVK(VIRTUAL_KEY vk, bool press)
     {

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/BinaryFormattedObjectExtensions.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/BinaryFormattedObjectExtensions.cs
@@ -154,13 +154,13 @@ internal static class BinaryFormattedObjectExtensions
                     value = Unsafe.As<ulong, DateTime>(ref ulongValue);
                     return true;
                 case TypeInfo.DecimalType:
-                    ReadOnlySpan<int> bits = stackalloc int[4]
-                    {
+                    ReadOnlySpan<int> bits =
+                    [
                         (int)systemClass["lo"],
                         (int)systemClass["mid"],
                         (int)systemClass["hi"],
                         (int)systemClass["flags"]
-                    };
+                    ];
 
                     value = new decimal(bits);
                     return true;

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/DeviceContextExtensions.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/DeviceContextExtensions.cs
@@ -56,13 +56,12 @@ internal static class DeviceContextExtensions
     internal static void DrawLine(this HDC hdc, HPEN hpen, Point p1, Point p2)
         => DrawLine(hdc, hpen, p1.X, p1.Y, p2.X, p2.Y);
 
-    internal static unsafe void DrawLine(this DeviceContextHdcScope hdc, HPEN hpen, int x1, int y1, int x2, int y2)
+    internal static void DrawLine(this DeviceContextHdcScope hdc, HPEN hpen, int x1, int y1, int x2, int y2)
         => DrawLine(hdc.HDC, hpen, x1, y1, x2, y2);
 
-    internal static unsafe void DrawLine(this HDC hdc, HPEN hpen, int x1, int y1, int x2, int y2)
+    internal static void DrawLine(this HDC hdc, HPEN hpen, int x1, int y1, int x2, int y2)
     {
-        ReadOnlySpan<int> lines = stackalloc int[] { x1, y1, x2, y2 };
-        DrawLines(hdc, hpen, lines);
+        DrawLines(hdc, hpen, [ x1, y1, x2, y2 ]);
     }
 
     /// <summary>
@@ -71,7 +70,7 @@ internal static class DeviceContextExtensions
     /// <param name="lines">
     ///  MUST be a multiple of 4. Each group of 4 represents x1, y1, x2, y2.
     /// </param>
-    internal static unsafe void DrawLines(this DeviceContextHdcScope hdc, HPEN hpen, ReadOnlySpan<int> lines)
+    internal static void DrawLines(this DeviceContextHdcScope hdc, HPEN hpen, ReadOnlySpan<int> lines)
         => DrawLines(hdc.HDC, hpen, lines);
 
     /// <summary>

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/IExtender.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/IExtender.cs
@@ -88,13 +88,13 @@ internal unsafe struct IExtender : IComIID, IVTable<IExtender, IExtender.Vtbl>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get
         {
-            ReadOnlySpan<byte> data = new byte[]
-            {
+            ReadOnlySpan<byte> data =
+            [
                 0x7e, 0x8d, 0x08, 0x39,
                 0x1e, 0xb7,
                 0xd1, 0x11,
                 0x8f, 0x39, 0x00, 0xc0, 0x4f, 0xd9, 0x46, 0xd0
-            };
+            ];
 
             return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
         }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/Foundation/IID.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/Foundation/IID.cs
@@ -13,10 +13,10 @@ internal static unsafe class IID
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get
         {
-            ReadOnlySpan<byte> data = new byte[]
-            {
+            ReadOnlySpan<byte> data =
+            [
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
-            };
+            ];
 
             return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
         }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Com/IComCallableWrapper.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Com/IComCallableWrapper.cs
@@ -19,11 +19,11 @@ internal unsafe struct IComCallableWrapper : IComIID, IVTable<IComCallableWrappe
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get
         {
-            ReadOnlySpan<byte> data = new byte[]
-            {
+            ReadOnlySpan<byte> data =
+            [
                 // 0x73b17daf, 0x0480, 0x4702, 0xaf, 0x7c, 0xaf, 0x3b, 0xd4, 0x71, 0x5d, 0x71);
                 0xaf, 0x7d, 0xb1, 0x73, 0x80, 0x04, 0x02, 0x47, 0xaf, 0x7c, 0xaf, 0x3b, 0xd4, 0x71, 0x5d, 0x71
-            };
+            ];
 
             return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
         }

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/Interop/Oleaut32/SAFEARRAYTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/Interop/Oleaut32/SAFEARRAYTests.cs
@@ -220,8 +220,8 @@ public unsafe class SAFEARRAYTests
 
         try
         {
-            Span<int> indices1 = stackalloc int[] { 0 };
-            Span<int> indices2 = stackalloc int[] { 1 };
+            Span<int> indices1 = [0];
+            Span<int> indices2 = [1];
 
             fixed (int* pIndices1 = indices1)
             fixed (int* pIndices2 = indices2)
@@ -266,8 +266,8 @@ public unsafe class SAFEARRAYTests
 
         try
         {
-            Span<int> indices1 = stackalloc int[] { -5 };
-            Span<int> indices2 = stackalloc int[] { -4 };
+            Span<int> indices1 = [-5];
+            Span<int> indices2 = [-4];
 
             fixed (int* pIndices1 = indices1)
             fixed (int* pIndices2 = indices2)
@@ -318,8 +318,8 @@ public unsafe class SAFEARRAYTests
 
         try
         {
-            Span<int> indices1 = stackalloc int[] { 0, 0 };
-            Span<int> indices2 = stackalloc int[] { 1, 2 };
+            Span<int> indices1 = [0, 0];
+            Span<int> indices2 = [1, 2];
 
             fixed (int* pIndices1 = indices1)
             fixed (int* pIndices2 = indices2)
@@ -370,8 +370,8 @@ public unsafe class SAFEARRAYTests
 
         try
         {
-            Span<int> indices1 = stackalloc int[] { -5, -4 };
-            Span<int> indices2 = stackalloc int[] { -4, -3 };
+            Span<int> indices1 = [-5, -4];
+            Span<int> indices2 = [-4, -3];
 
             fixed (int* pIndices1 = indices1)
             fixed (int* pIndices2 = indices2)

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/Windows/Win32/System/Com/ComScopeTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/Windows/Win32/System/Com/ComScopeTests.cs
@@ -50,11 +50,11 @@ public unsafe class ComScopeTests
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
-                ReadOnlySpan<byte> data = new byte[]
-                {
+                ReadOnlySpan<byte> data =
+                [
                     // "3BE9EE32-26FB-4E7A-B8A8-25795A7EFB53"
                     0x70, 0x73, 0x0A, 0x63, 0x3D, 0x73, 0xE9, 0x43, 0x81, 0x41, 0x68, 0x5D, 0xAE, 0x2B, 0xDB, 0x44
-                };
+                ];
 
                 return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.BitmapBinder.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.BitmapBinder.cs
@@ -27,7 +27,7 @@ public partial class DataObject
         private const string AllowedAssemblyName = "System.Drawing";
 
         // .NET Framework PublicKeyToken=b03f5f7f11d50a3a
-        private static ReadOnlySpan<byte> AllowedToken => new byte[] { 0xB0, 0x3F, 0x5F, 0x7F, 0x11, 0xD5, 0x0A, 0x3A };
+        private static ReadOnlySpan<byte> AllowedToken => [ 0xB0, 0x3F, 0x5F, 0x7F, 0x11, 0xD5, 0x0A, 0x3A ];
 
         public override Type? BindToType(string assemblyName, string typeName)
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker/DateTimePicker.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker/DateTimePicker.cs
@@ -1328,9 +1328,7 @@ public partial class DateTimePicker : Control
     {
         if (IsHandleCreated)
         {
-            Span<SYSTEMTIME> times = stackalloc SYSTEMTIME[2];
-            times[0] = (SYSTEMTIME)min;
-            times[1] = (SYSTEMTIME)max;
+            Span<SYSTEMTIME> times = [(SYSTEMTIME)min, (SYSTEMTIME)max];
             uint flags = PInvoke.GDTR_MIN | PInvoke.GDTR_MAX;
             PInvoke.SendMessage(this, PInvoke.DTM_SETRANGE, (WPARAM)(uint)flags, ref times[0]);
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/GroupBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/GroupBox.cs
@@ -539,14 +539,14 @@ public partial class GroupBox : Control
         {
             Color boxColor = Enabled ? ForeColor : SystemColors.GrayText;
 
-            ReadOnlySpan<int> lines = stackalloc int[]
-            {
+            ReadOnlySpan<int> lines =
+            [
                 0, boxTop, 0, Height,                       // Left
                 0, Height - 1, Width, Height - 1,           // Bottom
                 0, boxTop, textLeft, boxTop,                // Top-left
                 textRight, boxTop, Width - 1, boxTop,       // Top-right
                 Width - 1, boxTop, Width - 1, Height - 1    // Right
-            };
+            ];
 
             if (boxColor.HasTransparency())
             {
@@ -563,23 +563,23 @@ public partial class GroupBox : Control
         }
         else
         {
-            ReadOnlySpan<int> lightLines = stackalloc int[]
-            {
+            ReadOnlySpan<int> lightLines =
+            [
                 1, boxTop, 1, Height - 1,                       // Left
                 0, Height - 1, Width, Height - 1,               // Bottom
                 1, boxTop, textLeft, boxTop,                    // Top-left
                 textRight, boxTop, Width - 1, boxTop,           // Top-right
                 Width - 1, boxTop - 1, Width - 1, Height - 1    // Right
-            };
+            ];
 
-            ReadOnlySpan<int> darkLines = stackalloc int[]
-            {
+            ReadOnlySpan<int> darkLines =
+            [
                 0, boxTop, 0, Height - 2,                       // Left
                 0, Height - 2, Width - 1, Height - 2,           // Bottom
                 0, boxTop - 1, textLeft, boxTop - 1,            // Top-left
                 textRight, boxTop - 1, Width - 2, boxTop - 1,   // Top-right
                 Width - 2, boxTop - 1, Width - 2, Height - 2    // Right
-            };
+            ];
 
             using DeviceContextHdcScope hdc = new(e);
             using PInvoke.CreatePenScope hpenLight = new(ControlPaint.Light(backColor, 1.0f));

--- a/src/System.Windows.Forms/src/System/Windows/Forms/GroupBoxRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/GroupBoxRenderer.cs
@@ -316,26 +316,26 @@ public static class GroupBoxRenderer
 
         using DeviceContextHdcScope hdc = new(deviceContext);
 
-        ReadOnlySpan<int> darkLines = stackalloc int[]
-        {
+        ReadOnlySpan<int> darkLines =
+        [
             bounds.Left, boxTop - 1, bounds.Left, bounds.Height - 2,                            // Left
             bounds.Left, bounds.Height - 2, bounds.Width - 1, bounds.Height - 2,                // Right
             bounds.Left, boxTop - 1, textBounds.X - 3, boxTop - 1,                              // Top-left
             textBounds.X + textBounds.Width + 2, boxTop - 1, bounds.Width - 2, boxTop - 1,      // Top-right
             bounds.Width - 2, boxTop - 1, bounds.Width - 2, bounds.Height - 2                   // Right
-        };
+        ];
 
         using PInvoke.CreatePenScope hpenDark = new(SystemColors.ControlDark);
         hdc.DrawLines(hpenDark, darkLines);
 
-        ReadOnlySpan<int> lightLines = stackalloc int[]
-        {
+        ReadOnlySpan<int> lightLines =
+        [
             bounds.Left + 1, boxTop, bounds.Left + 1, bounds.Height - 1,                        // Left
             bounds.Left, bounds.Height - 1, bounds.Width, bounds.Height - 1,                    // Right
             bounds.Left + 1, boxTop, textBounds.X - 2, boxTop,                                  // Top-left
             textBounds.X + textBounds.Width + 1, boxTop, bounds.Width - 1, boxTop,              // Top-right
             bounds.Width - 1, boxTop, bounds.Width - 1, bounds.Height - 1                       // Right
-        };
+        ];
 
         using PInvoke.CreatePenScope hpenLight = new(SystemColors.ControlLight);
         hdc.DrawLines(hpenLight, lightLines);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar/MonthCalendar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar/MonthCalendar.cs
@@ -1826,9 +1826,7 @@ public partial class MonthCalendar : Control
         // Updated the calendar range
         if (IsHandleCreated)
         {
-            Span<SYSTEMTIME> times = stackalloc SYSTEMTIME[2];
-            times[0] = (SYSTEMTIME)minDate;
-            times[1] = (SYSTEMTIME)maxDate;
+            Span<SYSTEMTIME> times = [(SYSTEMTIME)minDate, (SYSTEMTIME)maxDate];
             uint flags = PInvoke.GDTR_MIN | PInvoke.GDTR_MAX;
             if (PInvoke.SendMessage(this, PInvoke.MCM_SETRANGE, (WPARAM)(uint)flags, ref times[0]) == 0)
             {
@@ -1996,9 +1994,7 @@ public partial class MonthCalendar : Control
         // Always set the value on the control, to ensure that it is up to date.
         if (IsHandleCreated)
         {
-            Span<SYSTEMTIME> times = stackalloc SYSTEMTIME[2];
-            times[0] = (SYSTEMTIME)lower;
-            times[1] = (SYSTEMTIME)upper;
+            Span<SYSTEMTIME> times = [(SYSTEMTIME)lower, (SYSTEMTIME)upper];
             PInvoke.SendMessage(this, PInvoke.MCM_SETSELRANGE, 0, ref times[0]);
         }
 

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Input/KeyboardSimulator.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Input/KeyboardSimulator.cs
@@ -19,10 +19,10 @@ internal class KeyboardSimulator
 
     internal KeyboardSimulator KeyDown(VIRTUAL_KEY key)
     {
-        Span<INPUT> inputs = stackalloc INPUT[]
-        {
+        Span<INPUT> inputs =
+        [
             InputBuilder.KeyDown(key),
-        };
+        ];
 
         PInvoke.SendInput(inputs, Marshal.SizeOf<INPUT>());
         return this;
@@ -30,10 +30,10 @@ internal class KeyboardSimulator
 
     internal KeyboardSimulator KeyUp(VIRTUAL_KEY key)
     {
-        Span<INPUT> inputs = stackalloc INPUT[]
-        {
+        Span<INPUT> inputs =
+        [
             InputBuilder.KeyUp(key),
-        };
+        ];
 
         PInvoke.SendInput(inputs, Marshal.SizeOf<INPUT>());
         return this;
@@ -41,11 +41,11 @@ internal class KeyboardSimulator
 
     internal KeyboardSimulator KeyPress(VIRTUAL_KEY key)
     {
-        Span<INPUT> inputs = stackalloc INPUT[]
-        {
+        Span<INPUT> inputs =
+        [
             InputBuilder.KeyDown(key),
             InputBuilder.KeyUp(key),
-        };
+        ];
 
         PInvoke.SendInput(inputs, Marshal.SizeOf<INPUT>());
         return this;
@@ -53,11 +53,11 @@ internal class KeyboardSimulator
 
     internal KeyboardSimulator TextEntry(char character)
     {
-        Span<INPUT> inputs = stackalloc INPUT[]
-        {
+        Span<INPUT> inputs =
+        [
             InputBuilder.CharacterDown(character),
             InputBuilder.CharacterUp(character),
-        };
+        ];
 
         PInvoke.SendInput(inputs, Marshal.SizeOf<INPUT>());
         return this;

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Input/MouseSimulator.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Input/MouseSimulator.cs
@@ -80,10 +80,10 @@ internal class MouseSimulator
 
     private MouseSimulator ButtonDown(MouseButtons button)
     {
-        Span<INPUT> inputs = stackalloc INPUT[]
-        {
+        Span<INPUT> inputs =
+        [
             InputBuilder.MouseButtonDown(button),
-        };
+        ];
 
         PInvoke.SendInput(inputs, Marshal.SizeOf<INPUT>());
         return this;
@@ -91,10 +91,10 @@ internal class MouseSimulator
 
     private MouseSimulator ButtonUp(MouseButtons button)
     {
-        Span<INPUT> inputs = stackalloc INPUT[]
-        {
+        Span<INPUT> inputs =
+        [
             InputBuilder.MouseButtonUp(button),
-        };
+        ];
 
         PInvoke.SendInput(inputs, Marshal.SizeOf<INPUT>());
         return this;
@@ -102,11 +102,11 @@ internal class MouseSimulator
 
     private MouseSimulator ButtonClick(MouseButtons button)
     {
-        Span<INPUT> inputs = stackalloc INPUT[]
-        {
+        Span<INPUT> inputs =
+        [
             InputBuilder.MouseButtonDown(button),
             InputBuilder.MouseButtonUp(button),
-        };
+        ];
 
         PInvoke.SendInput(inputs, Marshal.SizeOf<INPUT>());
         return this;
@@ -114,13 +114,13 @@ internal class MouseSimulator
 
     private MouseSimulator ButtonDoubleClick(MouseButtons button)
     {
-        Span<INPUT> inputs = stackalloc INPUT[]
-        {
+        Span<INPUT> inputs =
+        [
             InputBuilder.MouseButtonDown(button),
             InputBuilder.MouseButtonUp(button),
             InputBuilder.MouseButtonDown(button),
             InputBuilder.MouseButtonUp(button),
-        };
+        ];
 
         PInvoke.SendInput(inputs, Marshal.SizeOf<INPUT>());
         return this;
@@ -137,10 +137,10 @@ internal class MouseSimulator
             return MoveMouseTo(virtualPoint.X, virtualPoint.Y);
         }
 
-        Span<INPUT> inputs = stackalloc INPUT[]
-        {
+        Span<INPUT> inputs =
+        [
             InputBuilder.RelativeMouseMovement(x, y),
-        };
+        ];
 
         PInvoke.SendInput(inputs, Marshal.SizeOf<INPUT>());
         return this;
@@ -148,10 +148,10 @@ internal class MouseSimulator
 
     internal MouseSimulator MoveMouseTo(double absoluteX, double absoluteY)
     {
-        Span<INPUT> inputs = stackalloc INPUT[]
-        {
+        Span<INPUT> inputs =
+        [
             InputBuilder.AbsoluteMouseMovement((int)absoluteX, (int)absoluteY),
-        };
+        ];
 
         PInvoke.SendInput(inputs, Marshal.SizeOf<INPUT>());
         return this;
@@ -159,10 +159,10 @@ internal class MouseSimulator
 
     internal MouseSimulator MoveMouseToPositionOnVirtualDesktop(double absoluteX, double absoluteY)
     {
-        Span<INPUT> inputs = stackalloc INPUT[]
-        {
+        Span<INPUT> inputs =
+        [
             InputBuilder.AbsoluteMouseMovementOnVirtualDesktop((int)absoluteX, (int)absoluteY),
-        };
+        ];
 
         PInvoke.SendInput(inputs, Marshal.SizeOf<INPUT>());
         return this;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RichTextBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RichTextBoxTests.cs
@@ -9753,8 +9753,8 @@ public class RichTextBoxTests
 
         using var control = new RichTextBox();
 
-        Span<char> input = stackalloc char[] { (char)0xA0 };
-        control.Rtf = $"{{\\rtf1\\ansi {input[0]}}}";
+        char input = (char)0xA0;
+        control.Rtf = $"{{\\rtf1\\ansi {input}}}";
 
         Span<byte> output = stackalloc byte[16];
 
@@ -9763,7 +9763,7 @@ public class RichTextBoxTests
         // The non-lossy conversion of nbsp only works single byte Windows code pages (e.g. not Japanese).
         if (currentCodePage >= 1250 && currentCodePage <= 1258)
         {
-            Assert.Equal(input[0], control.Text[0]);
+            Assert.Equal(input, control.Text[0]);
         }
     }
 


### PR DESCRIPTION
This is the same thing that was done in dotnet/runtime#93125

## Proposed changes

- Use collection expressions to init spans where possible


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10114)