### PR TITLE
Fix a bug introduced in the DesignerActionPanel refactoring

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.CheckBoxPropertyLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.CheckBoxPropertyLine.cs
@@ -63,7 +63,9 @@ internal sealed partial class DesignerActionPanel
             _checkBox.Checked = (bool)Value;
         }
 
-        public sealed class Info(DesignerActionList list, DesignerActionPropertyItem item) : PropertyLineInfo(list, item)
+        public static StandardLineInfo CreateLineInfo(DesignerActionList list, DesignerActionPropertyItem item) => new Info(list, item);
+
+        private sealed class Info(DesignerActionList list, DesignerActionPropertyItem item) : PropertyLineInfo(list, item)
         {
             public override Line CreateLine(IServiceProvider serviceProvider, DesignerActionPanel actionPanel)
             {

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.EditorPropertyLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.EditorPropertyLine.cs
@@ -475,7 +475,9 @@ internal sealed partial class DesignerActionPanel
             }
         }
 
-        public new sealed class Info(DesignerActionList list, DesignerActionPropertyItem item) : PropertyLineInfo(list, item)
+        public static new StandardLineInfo CreateLineInfo(DesignerActionList list, DesignerActionPropertyItem item) => new Info(list, item);
+
+        private sealed class Info(DesignerActionList list, DesignerActionPropertyItem item) : PropertyLineInfo(list, item)
         {
             public override Line CreateLine(IServiceProvider serviceProvider, DesignerActionPanel actionPanel)
             {

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.HeaderLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.HeaderLine.cs
@@ -15,9 +15,10 @@ internal sealed partial class DesignerActionPanel
 
         protected override Font GetFont() => new(ActionPanel.Font, FontStyle.Bold);
 
-        public new sealed class Info(DesignerActionList list, DesignerActionTextItem item) : StandardLineInfo(list)
+        public static new StandardLineInfo CreateLineInfo(DesignerActionList list, DesignerActionTextItem item) => new HeaderTextLineInfo(list, item);
+
+        private sealed class HeaderTextLineInfo(DesignerActionList list, DesignerActionTextItem item) : TextLineInfo(list, item)
         {
-            public override DesignerActionTextItem Item { get; } = item;
             public override Line CreateLine(IServiceProvider serviceProvider, DesignerActionPanel actionPanel)
             {
                 return new HeaderLine(serviceProvider, actionPanel);

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.MethodLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.MethodLine.cs
@@ -110,7 +110,8 @@ internal sealed partial class DesignerActionPanel
             }
         }
 
-        public sealed class Info(DesignerActionList list, DesignerActionMethodItem item) : StandardLineInfo(list)
+        public static StandardLineInfo CreateLineInfo(DesignerActionList list, DesignerActionMethodItem item) => new Info(list, item);
+        private sealed class Info(DesignerActionList list, DesignerActionMethodItem item) : StandardLineInfo(list)
         {
             public override DesignerActionMethodItem Item { get; } = item;
             public override Line CreateLine(IServiceProvider serviceProvider, DesignerActionPanel actionPanel)

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.PropertyLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.PropertyLine.cs
@@ -112,7 +112,7 @@ internal sealed partial class DesignerActionPanel
             }
         }
 
-        public abstract class PropertyLineInfo(DesignerActionList list, DesignerActionPropertyItem item) : StandardLineInfo(list)
+        protected abstract class PropertyLineInfo(DesignerActionList list, DesignerActionPropertyItem item) : StandardLineInfo(list)
         {
             public override DesignerActionPropertyItem Item { get; } = item;
         }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.TextBoxPropertyLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.TextBoxPropertyLine.cs
@@ -359,7 +359,9 @@ internal sealed partial class DesignerActionPanel
             }
         }
 
-        public sealed class Info(DesignerActionList list, DesignerActionPropertyItem item) : PropertyLineInfo(list, item)
+        public static StandardLineInfo CreateLineInfo(DesignerActionList list, DesignerActionPropertyItem item) => new Info(list, item);
+
+        private sealed class Info(DesignerActionList list, DesignerActionPropertyItem item) : PropertyLineInfo(list, item)
         {
             public override Line CreateLine(IServiceProvider serviceProvider, DesignerActionPanel actionPanel)
             {

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.TextLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.TextLine.cs
@@ -63,15 +63,17 @@ internal sealed partial class DesignerActionPanel
 
         internal override void UpdateActionItem(LineInfo lineInfo, ToolTip toolTip, ref int currentTabIndex)
         {
-            Info info = (Info)lineInfo;
-            _textItem = info.Item;
+            TextLineInfo textLineInfo = (TextLineInfo)lineInfo;
+            _textItem = textLineInfo.Item;
             _label.Text = StripAmpersands(_textItem.DisplayName);
             _label.Font = GetFont();
             _label.TabIndex = currentTabIndex++;
             toolTip.SetToolTip(_label, _textItem.Description);
         }
 
-        public sealed class Info(DesignerActionList list, DesignerActionTextItem item) : StandardLineInfo(list)
+        public static StandardLineInfo CreateLineInfo(DesignerActionList list, DesignerActionTextItem item) => new TextLineInfo(list, item);
+
+        protected class TextLineInfo(DesignerActionList list, DesignerActionTextItem item) : StandardLineInfo(list)
         {
             public override DesignerActionTextItem Item { get; } = item;
             public override Line CreateLine(IServiceProvider serviceProvider, DesignerActionPanel actionPanel)

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.cs
@@ -661,7 +661,7 @@ internal sealed partial class DesignerActionPanel : ContainerControl
     {
         if (item is DesignerActionMethodItem methodItem)
         {
-            return new MethodLine.Info(list, methodItem);
+            return MethodLine.CreateLineInfo(list, methodItem);
         }
         else if (item is DesignerActionPropertyItem pti)
         {
@@ -675,37 +675,37 @@ internal sealed partial class DesignerActionPanel : ContainerControl
             bool standardValuesSupported = pd.Converter.GetStandardValuesSupported(context);
             if (pd.TryGetEditor(out UITypeEditor _))
             {
-                return new EditorPropertyLine.Info(list, pti);
+                return EditorPropertyLine.CreateLineInfo(list, pti);
             }
             else if (pd.PropertyType == typeof(bool))
             {
                 if (IsReadOnlyProperty(pd))
                 {
-                    return new TextBoxPropertyLine.Info(list, pti);
+                    return TextBoxPropertyLine.CreateLineInfo(list, pti);
                 }
                 else
                 {
-                    return new CheckBoxPropertyLine.Info(list, pti);
+                    return CheckBoxPropertyLine.CreateLineInfo(list, pti);
                 }
             }
             else if (standardValuesSupported)
             {
-                return new EditorPropertyLine.Info(list, pti);
+                return EditorPropertyLine.CreateLineInfo(list, pti);
             }
             else
             {
-                return new TextBoxPropertyLine.Info(list, pti);
+                return TextBoxPropertyLine.CreateLineInfo(list, pti);
             }
         }
         else if (item is DesignerActionTextItem textItem)
         {
             if (item is DesignerActionHeaderItem)
             {
-                return new HeaderLine.Info(list, textItem);
+                return HeaderLine.CreateLineInfo(list, textItem);
             }
             else
             {
-                return new TextLine.Info(list, textItem);
+                return TextLine.CreateLineInfo(list, textItem);
             }
         }
         else


### PR DESCRIPTION
Fix a bug introduced in #10035

Fixes #10095
Fixes #10097

I refactored a bit the code to make the mistake more obvious.

## Proposed changes

- HeaderLine being a TextLine, HeaderInfo also needs to be a TextInfo

## Test methodology <!-- How did you ensure quality? -->

- I ran DemoConsole and verified manually that the bugs no longer reproduce


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10123)