### PR TITLE
Fix issue 9999: Update IconEditor to offset the icon within the property grid entry

### DIFF
--- a/src/System.Drawing.Common/src/System/Drawing/Icon.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Icon.cs
@@ -426,7 +426,9 @@ public sealed partial class Icon : MarshalByRefObject, ICloneable, IDisposable, 
         Rectangle copy = targetRect;
 
         using Matrix transform = graphics.Transform;
-        PointF offset = transform.Offset;
+        PointF point = new PointF(targetRect.X, targetRect.Y);
+        transform.TransformPoints(new PointF[] { point });
+        PointF offset = point;
         copy.X += (int)offset.X;
         copy.Y += (int)offset.Y;
 

--- a/src/System.Drawing.Common/src/System/Drawing/Icon.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Icon.cs
@@ -426,9 +426,7 @@ public sealed partial class Icon : MarshalByRefObject, ICloneable, IDisposable, 
         Rectangle copy = targetRect;
 
         using Matrix transform = graphics.Transform;
-        PointF point = new PointF(targetRect.X, targetRect.Y);
-        transform.TransformPoints(new PointF[] { point });
-        PointF offset = point;
+        PointF offset = transform.Offset;
         copy.X += (int)offset.X;
         copy.Y += (int)offset.Y;
 

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/IconEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/IconEditor.cs
@@ -116,6 +116,10 @@ public class IconEditor : UITypeEditor
 
         // If icon is smaller than rectangle, just center it unscaled in the rectangle.
         Rectangle rectangle = e.Bounds;
+        Graphics g = e.Graphics;
+        using Matrix transform = g.Transform;
+        rectangle.Offset(new Point(-(int)transform.OffsetX, -(int)transform.OffsetY));
+
         if (icon.Width < rectangle.Width)
         {
             rectangle.X = (rectangle.Width - icon.Width) / 2;

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/IconEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/IconEditor.cs
@@ -117,8 +117,9 @@ public class IconEditor : UITypeEditor
         // If icon is smaller than rectangle, just center it unscaled in the rectangle.
         Rectangle rectangle = e.Bounds;
         Graphics g = e.Graphics;
-        using Matrix transform = g.Transform;
-        rectangle.Offset(new Point(-(int)transform.OffsetX, -(int)transform.OffsetY));
+        using var transform = g.Transform;
+        rectangle.X -= (int)transform.OffsetX;
+        rectangle.Y -= (int)transform.OffsetY;
 
         if (icon.Width < rectangle.Width)
         {


### PR DESCRIPTION

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #9999


## Proposed changes

-  Update function Icon.Draw to use targetRect to calculate offset

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- The icon property of the NotifyIcon control can be modified

## Regression? 

-  No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

The icon property of the NotifyIcon control cannot be modified

https://github.com/dotnet/winforms/assets/56664234/dab536e8-e545-4370-a641-0008ba2bc5a8

### After
The icon property of the NotifyIcon control can be modified

![AfterChange](https://github.com/dotnet/winforms/assets/132890443/c89cdc0c-5283-4395-82d5-f22daf31e02e)



## Test methodology <!-- How did you ensure quality? -->

- Manually (Verified in Demo project)


## Test environment(s) <!-- Remove any that don't apply -->

- .net 9.0.0-alpha.1.23515.3


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10131)