### PR TITLE
Update richCodeNavigationEnvironment in pipelines

### DIFF
--- a/azure-pipelines-richnav.yml
+++ b/azure-pipelines-richnav.yml
@@ -17,7 +17,6 @@ stages:
       jobs:
       - job: Windows
         enableRichCodeNavigation: true
-        richCodeNavigationEnvironment: 'production'
         pool:
           name: $(DncEngPublicBuildPool)
           demands: ImageOverride -equals windows.vs2022preview.amd64.open

--- a/eng/pipelines/post-build.yml
+++ b/eng/pipelines/post-build.yml
@@ -9,14 +9,6 @@ parameters:
   testResultsFormat: 'xunit'
 
 steps:
-  - ${{ if eq(parameters.enableRichCodeNavigation, true) }}:
-    - task: RichCodeNavIndexer@0
-      displayName: RichCodeNav Upload
-      inputs:
-        languages: ${{ coalesce(parameters.richCodeNavigationLanguage, 'csharp') }}
-        environment: ${{ coalesce(parameters.richCodeNavigationEnvironment, 'production') }}
-        richNavLogOutputDirectory: $(Build.SourcesDirectory)/artifacts/bin
-      continueOnError: true
 
   - ${{ if eq(parameters.enableMicrobuild, 'true') }}:
     - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:


### PR DESCRIPTION
The RichNav team reached out to me to update the "environment", this was done in arcade and flowed to winforms but the pipeline was overriding the value here.

Also deleted a duplicated RichCodeNavIndexer@0 task in the repo-local post-build.yml which is not actually used.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10134)