### PR TITLE
Enable nullability in remaining DataGridViewColumnCollection members

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewColumnCollectionDialog.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewColumnCollectionDialog.cs
@@ -96,7 +96,7 @@ internal class DataGridViewColumnCollectionDialog : Form
 
         if (e.Action == CollectionChangeAction.Add)
         {
-            _selectedColumns.SelectedIndex = _columnsPrivateCopy.IndexOf(e.Element as DataGridViewColumn);
+            _selectedColumns.SelectedIndex = _columnsPrivateCopy.IndexOf((DataGridViewColumn)e.Element!);
             ListBoxItem lbi = (ListBoxItem)_selectedColumns.SelectedItem!;
             _userAddedColumns.Add(lbi.DataGridViewColumn);
             _columnsNames[lbi.DataGridViewColumn] = lbi.DataGridViewColumn.Name;

--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -445,12 +445,12 @@ System.Windows.Forms.DataGridViewColumn.ValueType.set -> void
 System.Windows.Forms.DataGridViewColumnCollection.CopyTo(System.Windows.Forms.DataGridViewColumn![]! array, int index) -> void
 System.Windows.Forms.DataGridViewColumnCollection.DataGridView.get -> System.Windows.Forms.DataGridView!
 System.Windows.Forms.DataGridViewColumnCollection.DataGridViewColumnCollection(System.Windows.Forms.DataGridView! dataGridView) -> void
-~System.Windows.Forms.DataGridViewColumnCollection.GetFirstColumn(System.Windows.Forms.DataGridViewElementStates includeFilter) -> System.Windows.Forms.DataGridViewColumn
-~System.Windows.Forms.DataGridViewColumnCollection.GetFirstColumn(System.Windows.Forms.DataGridViewElementStates includeFilter, System.Windows.Forms.DataGridViewElementStates excludeFilter) -> System.Windows.Forms.DataGridViewColumn
-~System.Windows.Forms.DataGridViewColumnCollection.GetLastColumn(System.Windows.Forms.DataGridViewElementStates includeFilter, System.Windows.Forms.DataGridViewElementStates excludeFilter) -> System.Windows.Forms.DataGridViewColumn
-~System.Windows.Forms.DataGridViewColumnCollection.GetNextColumn(System.Windows.Forms.DataGridViewColumn dataGridViewColumnStart, System.Windows.Forms.DataGridViewElementStates includeFilter, System.Windows.Forms.DataGridViewElementStates excludeFilter) -> System.Windows.Forms.DataGridViewColumn
-~System.Windows.Forms.DataGridViewColumnCollection.GetPreviousColumn(System.Windows.Forms.DataGridViewColumn dataGridViewColumnStart, System.Windows.Forms.DataGridViewElementStates includeFilter, System.Windows.Forms.DataGridViewElementStates excludeFilter) -> System.Windows.Forms.DataGridViewColumn
-~System.Windows.Forms.DataGridViewColumnCollection.IndexOf(System.Windows.Forms.DataGridViewColumn dataGridViewColumn) -> int
+System.Windows.Forms.DataGridViewColumnCollection.GetFirstColumn(System.Windows.Forms.DataGridViewElementStates includeFilter) -> System.Windows.Forms.DataGridViewColumn?
+System.Windows.Forms.DataGridViewColumnCollection.GetFirstColumn(System.Windows.Forms.DataGridViewElementStates includeFilter, System.Windows.Forms.DataGridViewElementStates excludeFilter) -> System.Windows.Forms.DataGridViewColumn?
+System.Windows.Forms.DataGridViewColumnCollection.GetLastColumn(System.Windows.Forms.DataGridViewElementStates includeFilter, System.Windows.Forms.DataGridViewElementStates excludeFilter) -> System.Windows.Forms.DataGridViewColumn?
+System.Windows.Forms.DataGridViewColumnCollection.GetNextColumn(System.Windows.Forms.DataGridViewColumn! dataGridViewColumnStart, System.Windows.Forms.DataGridViewElementStates includeFilter, System.Windows.Forms.DataGridViewElementStates excludeFilter) -> System.Windows.Forms.DataGridViewColumn?
+System.Windows.Forms.DataGridViewColumnCollection.GetPreviousColumn(System.Windows.Forms.DataGridViewColumn! dataGridViewColumnStart, System.Windows.Forms.DataGridViewElementStates includeFilter, System.Windows.Forms.DataGridViewElementStates excludeFilter) -> System.Windows.Forms.DataGridViewColumn?
+System.Windows.Forms.DataGridViewColumnCollection.IndexOf(System.Windows.Forms.DataGridViewColumn! dataGridViewColumn) -> int
 System.Windows.Forms.DataGridViewColumnCollection.this[int index].get -> System.Windows.Forms.DataGridViewColumn!
 System.Windows.Forms.DataGridViewColumnCollection.this[string! columnName].get -> System.Windows.Forms.DataGridViewColumn?
 System.Windows.Forms.DataGridViewComboBoxCell.ObjectCollection.Add(object! item) -> int
@@ -864,10 +864,10 @@ virtual System.Windows.Forms.DataGridViewColumnCollection.Add(System.Windows.For
 virtual System.Windows.Forms.DataGridViewColumnCollection.AddRange(params System.Windows.Forms.DataGridViewColumn![]! dataGridViewColumns) -> void
 virtual System.Windows.Forms.DataGridViewColumnCollection.Contains(string! columnName) -> bool
 virtual System.Windows.Forms.DataGridViewColumnCollection.Contains(System.Windows.Forms.DataGridViewColumn! dataGridViewColumn) -> bool
-~virtual System.Windows.Forms.DataGridViewColumnCollection.Insert(int columnIndex, System.Windows.Forms.DataGridViewColumn dataGridViewColumn) -> void
-~virtual System.Windows.Forms.DataGridViewColumnCollection.OnCollectionChanged(System.ComponentModel.CollectionChangeEventArgs e) -> void
-~virtual System.Windows.Forms.DataGridViewColumnCollection.Remove(string columnName) -> void
-~virtual System.Windows.Forms.DataGridViewColumnCollection.Remove(System.Windows.Forms.DataGridViewColumn dataGridViewColumn) -> void
+virtual System.Windows.Forms.DataGridViewColumnCollection.Insert(int columnIndex, System.Windows.Forms.DataGridViewColumn! dataGridViewColumn) -> void
+virtual System.Windows.Forms.DataGridViewColumnCollection.OnCollectionChanged(System.ComponentModel.CollectionChangeEventArgs! e) -> void
+virtual System.Windows.Forms.DataGridViewColumnCollection.Remove(string! columnName) -> void
+virtual System.Windows.Forms.DataGridViewColumnCollection.Remove(System.Windows.Forms.DataGridViewColumn! dataGridViewColumn) -> void
 virtual System.Windows.Forms.DataGridViewComboBoxCell.DataSource.get -> object?
 virtual System.Windows.Forms.DataGridViewComboBoxCell.DataSource.set -> void
 virtual System.Windows.Forms.DataGridViewComboBoxCell.DisplayMember.get -> string!

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
@@ -364,7 +364,7 @@ public partial class DataGridView
         Debug.Assert((autoSizeColumnCriteriaFilter & DataGridViewAutoSizeColumnCriteriaInternal.Fill) == 0);
 
         bool ret = false; // No column autosizes by default
-        DataGridViewColumn dataGridViewColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible);
+        DataGridViewColumn? dataGridViewColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible);
         while (dataGridViewColumn is not null)
         {
             DataGridViewAutoSizeColumnCriteriaInternal inheritedAutoSizeColumnCriteria = (DataGridViewAutoSizeColumnCriteriaInternal)dataGridViewColumn.InheritedAutoSizeMode;
@@ -1441,7 +1441,7 @@ public partial class DataGridView
                         {
                             dataGridViewRow = Rows[rowIndex]; // unshares this row
 
-                            DataGridViewColumn dataGridViewColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible);
+                            DataGridViewColumn? dataGridViewColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible);
                             while (dataGridViewColumn is not null)
                             {
                                 if (!dataGridViewRow.Cells[dataGridViewColumn.Index].Selected)
@@ -1469,7 +1469,7 @@ public partial class DataGridView
                     }
                     else
                     {
-                        DataGridViewColumn dataGridViewColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible);
+                        DataGridViewColumn? dataGridViewColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible);
                         while (dataGridViewColumn is not null)
                         {
                             if (!_selectedBandIndexes.Contains(dataGridViewColumn.Index))
@@ -1514,7 +1514,7 @@ public partial class DataGridView
                             if ((Rows.GetRowState(rowIndex) & DataGridViewElementStates.Selected) == 0)
                             {
                                 dataGridViewRow = Rows[rowIndex]; // unshares this row
-                                DataGridViewColumn dataGridViewColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible);
+                                DataGridViewColumn? dataGridViewColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible);
                                 while (dataGridViewColumn is not null)
                                 {
                                     if (!dataGridViewRow.Cells[dataGridViewColumn.Index].Selected)
@@ -1690,7 +1690,7 @@ public partial class DataGridView
         Debug.Assert((autoSizeColumnCriteriaFilter & DataGridViewAutoSizeColumnCriteriaInternal.Fill) == 0);
 
         bool ret = false; // No column autosizes by default
-        DataGridViewColumn dataGridViewColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible);
+        DataGridViewColumn? dataGridViewColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible);
         while (dataGridViewColumn is not null)
         {
             DataGridViewAutoSizeColumnCriteriaInternal inheritedAutoSizeColumnCriteria = (DataGridViewAutoSizeColumnCriteriaInternal)dataGridViewColumn.InheritedAutoSizeMode;
@@ -1700,7 +1700,8 @@ public partial class DataGridView
                 ret |= AutoResizeColumnInternal(dataGridViewColumn.Index, inheritedAutoSizeColumnCriteria, fixedHeight);
             }
 
-            dataGridViewColumn = Columns.GetNextColumn(dataGridViewColumn,
+            dataGridViewColumn = Columns.GetNextColumn(
+                dataGridViewColumn,
                 DataGridViewElementStates.Visible,
                 DataGridViewElementStates.None);
         }
@@ -3743,7 +3744,7 @@ public partial class DataGridView
 
         if (dataGridViewColumn.Frozen)
         {
-            DataGridViewColumn firstVisibleFrozenColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible | DataGridViewElementStates.Frozen);
+            DataGridViewColumn? firstVisibleFrozenColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible | DataGridViewElementStates.Frozen);
             Debug.Assert(firstVisibleFrozenColumn is not null);
             if (firstVisibleFrozenColumn.Index == dataGridViewColumn.Index)
             {
@@ -3798,7 +3799,7 @@ public partial class DataGridView
                 else
                 {
                     // Insert column on the left of hti.col
-                    DataGridViewColumn dataGridViewColumnPrev = Columns.GetPreviousColumn(
+                    DataGridViewColumn? dataGridViewColumnPrev = Columns.GetPreviousColumn(
                         Columns[hti._col],
                         DataGridViewElementStates.Visible,
                         DataGridViewElementStates.None);
@@ -4361,7 +4362,7 @@ public partial class DataGridView
             return -1;
         }
 
-        DataGridViewColumn dataGridViewColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible, DataGridViewElementStates.Frozen);
+        DataGridViewColumn? dataGridViewColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible, DataGridViewElementStates.Frozen);
 
         if (_horizontalOffset == 0)
         {
@@ -5239,17 +5240,18 @@ public partial class DataGridView
     private void CorrectColumnFrozenStates(DataGridViewColumn dataGridViewColumn, bool frozenStateChanging)
     {
         Debug.Assert(dataGridViewColumn is not null);
-        DataGridViewColumn dataGridViewColumnTmp;
+        DataGridViewColumn? dataGridViewColumnTmp;
         if ((dataGridViewColumn.Frozen && !frozenStateChanging) ||
             (!dataGridViewColumn.Frozen && frozenStateChanging))
         {
             // make sure the previous visible columns are frozen as well
-            dataGridViewColumnTmp = Columns.GetPreviousColumn(dataGridViewColumn,
+            dataGridViewColumnTmp = Columns.GetPreviousColumn(
+                dataGridViewColumn,
                 DataGridViewElementStates.Visible | DataGridViewElementStates.Frozen,
                 DataGridViewElementStates.None);
             if (dataGridViewColumnTmp is null)
             {
-                DataGridViewColumn dataGridViewColumnFirst = Columns.GetFirstColumn(DataGridViewElementStates.Visible);
+                DataGridViewColumn? dataGridViewColumnFirst = Columns.GetFirstColumn(DataGridViewElementStates.Visible);
                 if (dataGridViewColumnFirst != dataGridViewColumn)
                 {
                     dataGridViewColumnTmp = dataGridViewColumnFirst;
@@ -5692,7 +5694,7 @@ public partial class DataGridView
     {
         int cxMax = _layout.Data.Width, cx = 0;
         int completeColumns = 0, partialColumns = 0;
-        DataGridViewColumn dataGridViewColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible | DataGridViewElementStates.Frozen);
+        DataGridViewColumn? dataGridViewColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible | DataGridViewElementStates.Frozen);
         while (dataGridViewColumn is not null && cx < cxMax)
         {
             partialColumns++;
@@ -5803,7 +5805,7 @@ public partial class DataGridView
             if (_trackColumnEdge == -1)
             {
                 // Insert as first column
-                rectInsertionBar.X = GetColumnXFromIndex(Columns.GetFirstColumn(DataGridViewElementStates.Visible).Index);
+                rectInsertionBar.X = GetColumnXFromIndex(Columns.GetFirstColumn(DataGridViewElementStates.Visible)!.Index);
                 if (RightToLeftInternal)
                 {
                     rectInsertionBar.X -= InsertionBarWidth;
@@ -6830,7 +6832,7 @@ public partial class DataGridView
             else
             {
                 // Make sure all displayed scrolling columns have the Displayed state.
-                DataGridViewColumn dataGridViewColumnTmp;
+                DataGridViewColumn? dataGridViewColumnTmp;
                 int columnIndexTmp = DisplayedBandsInfo.FirstDisplayedScrollingCol;
                 if (columnIndexTmp != -1)
                 {
@@ -6849,7 +6851,7 @@ public partial class DataGridView
                         numDisplayedScrollingCols--;
                     }
 
-                    DataGridViewColumn dataGridViewColumnTmp2 = dataGridViewColumnTmp;
+                    DataGridViewColumn? dataGridViewColumnTmp2 = dataGridViewColumnTmp;
 
                     // Make sure all scrolling columns before FirstDisplayedScrollingCol have their Displayed state set to false
                     Debug.Assert(DisplayedBandsInfo.FirstDisplayedScrollingCol != -1);
@@ -7695,7 +7697,7 @@ public partial class DataGridView
                         if (RightToLeftInternal)
                         {
                             // Cycle through the visible & selected columns in their display order
-                            DataGridViewColumn lastDataGridViewColumn = Columns.GetLastColumn(DataGridViewElementStates.Visible | DataGridViewElementStates.Selected, DataGridViewElementStates.None);
+                            DataGridViewColumn? lastDataGridViewColumn = Columns.GetLastColumn(DataGridViewElementStates.Visible | DataGridViewElementStates.Selected, DataGridViewElementStates.None);
                             dataGridViewColumn = lastDataGridViewColumn;
                             Debug.Assert(dataGridViewColumn is not null);
                             if (dataGridViewColumn is not null)
@@ -7815,7 +7817,7 @@ public partial class DataGridView
                     {
                         if (RightToLeftInternal)
                         {
-                            DataGridViewColumn lastDataGridViewColumn = Columns.GetLastColumn(DataGridViewElementStates.Visible | DataGridViewElementStates.Selected, DataGridViewElementStates.None);
+                            DataGridViewColumn? lastDataGridViewColumn = Columns.GetLastColumn(DataGridViewElementStates.Visible | DataGridViewElementStates.Selected, DataGridViewElementStates.None);
 
                             // Cycle through the visible & selected columns in their reverse display order
                             dataGridViewColumn = lastDataGridViewColumn;
@@ -8039,8 +8041,8 @@ public partial class DataGridView
                 DataGridViewColumn? uColumn = null;
                 if (SelectionMode == DataGridViewSelectionMode.RowHeaderSelect)
                 {
-                    DataGridViewColumn firstVisibleColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible);
-                    DataGridViewColumn lastVisibleColumn = Columns.GetLastColumn(DataGridViewElementStates.Visible, DataGridViewElementStates.None);
+                    DataGridViewColumn? firstVisibleColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible);
+                    DataGridViewColumn? lastVisibleColumn = Columns.GetLastColumn(DataGridViewElementStates.Visible, DataGridViewElementStates.None);
 
                     Debug.Assert(firstVisibleColumn is not null);
                     Debug.Assert(lastVisibleColumn is not null);
@@ -8437,7 +8439,7 @@ public partial class DataGridView
         Rectangle data = _layout.Data;
         int cx;
         bool columnFound = false;
-        DataGridViewColumn dataGridViewColumn;
+        DataGridViewColumn? dataGridViewColumn;
         if (RightToLeftInternal)
         {
             cx = data.Right;
@@ -8599,7 +8601,7 @@ public partial class DataGridView
         }
 
         // first try to match x against a frozen column
-        DataGridViewColumn dataGridViewColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible | DataGridViewElementStates.Frozen);
+        DataGridViewColumn? dataGridViewColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible | DataGridViewElementStates.Frozen);
         while (dataGridViewColumn is not null &&
                ((!RightToLeftInternal && cx < data.Right) || (RightToLeftInternal && cx >= data.X)))
         {
@@ -8725,7 +8727,7 @@ public partial class DataGridView
             x = _layout.Data.X;
         }
 
-        DataGridViewColumn dataGridViewColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible | DataGridViewElementStates.Frozen);
+        DataGridViewColumn? dataGridViewColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible | DataGridViewElementStates.Frozen);
         while (dataGridViewColumn is not null)
         {
             if (index == dataGridViewColumn.Index)
@@ -8767,7 +8769,7 @@ public partial class DataGridView
             dataGridViewColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible, DataGridViewElementStates.Frozen);
         }
 
-        Debug.Assert(dataGridViewColumn.Visible && !dataGridViewColumn.Frozen);
+        Debug.Assert(dataGridViewColumn!.Visible && !dataGridViewColumn.Frozen);
 
         while (dataGridViewColumn is not null)
         {
@@ -8823,7 +8825,7 @@ public partial class DataGridView
 
     private int GetNegOffsetFromHorizontalOffset(int horizontalOffset)
     {
-        DataGridViewColumn dataGridViewColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible, DataGridViewElementStates.Frozen);
+        DataGridViewColumn? dataGridViewColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible, DataGridViewElementStates.Frozen);
         while (dataGridViewColumn is not null && dataGridViewColumn.Thickness <= horizontalOffset)
         {
             horizontalOffset -= dataGridViewColumn.Thickness;
@@ -8886,7 +8888,7 @@ public partial class DataGridView
                     }
                     else
                     {
-                        DataGridViewColumn dataGridViewColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible);
+                        DataGridViewColumn? dataGridViewColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible);
                         firstColumnIndex = (dataGridViewColumn is null) ? -1 : dataGridViewColumn.Index;
                     }
 
@@ -8984,7 +8986,7 @@ public partial class DataGridView
                 {
                     // Anchor cell is in frozen column and target cell is in unfrozen column. Make sure no column is scrolled off.
                     Debug.Assert(DisplayedBandsInfo.FirstDisplayedScrollingCol >= 0);
-                    int firstUnfrozenColumnIndex = Columns.GetFirstColumn(DataGridViewElementStates.Visible, DataGridViewElementStates.Frozen).Index;
+                    int firstUnfrozenColumnIndex = Columns.GetFirstColumn(DataGridViewElementStates.Visible, DataGridViewElementStates.Frozen)!.Index;
                     int firstRowIndex;
                     if (hti._row >= 0)
                     {
@@ -9051,18 +9053,21 @@ public partial class DataGridView
                         return true;
                     }
 
-                    DataGridViewColumn newFirstVisibleScrollingCol = Columns.GetNextColumn(Columns[DisplayedBandsInfo.FirstDisplayedScrollingCol],
-                                                                                                         DataGridViewElementStates.Visible,
-                                                                                                         DataGridViewElementStates.None);
-                    int newColOffset = 0;
-                    for (DataGridViewColumn dataGridViewColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible,
-                                                                                                      DataGridViewElementStates.Frozen);
-                        dataGridViewColumn != newFirstVisibleScrollingCol;
-                        dataGridViewColumn = Columns.GetNextColumn(dataGridViewColumn,
+                    DataGridViewColumn? newFirstVisibleScrollingCol = Columns.GetNextColumn(
+                        Columns[DisplayedBandsInfo.FirstDisplayedScrollingCol],
                         DataGridViewElementStates.Visible,
-                        DataGridViewElementStates.None))
+                        DataGridViewElementStates.None);
+                    int newColOffset = 0;
+                    for (DataGridViewColumn? dataGridViewColumn = Columns.GetFirstColumn(
+                            DataGridViewElementStates.Visible,
+                            DataGridViewElementStates.Frozen);
+                        dataGridViewColumn != newFirstVisibleScrollingCol;
+                        dataGridViewColumn = Columns.GetNextColumn(
+                            dataGridViewColumn,
+                            DataGridViewElementStates.Visible,
+                            DataGridViewElementStates.None))
                     {
-                        newColOffset += dataGridViewColumn.Thickness;
+                        newColOffset += dataGridViewColumn!.Thickness;
                     }
 
                     if (HorizontalOffset != newColOffset)
@@ -9206,18 +9211,21 @@ public partial class DataGridView
                     (DisplayedBandsInfo.LastTotallyDisplayedScrollingCol == -1 ||
                      Columns.GetNextColumn(Columns[DisplayedBandsInfo.LastTotallyDisplayedScrollingCol], DataGridViewElementStates.Visible, DataGridViewElementStates.None) is not null))
                 {
-                    DataGridViewColumn newFirstVisibleScrollingCol = Columns.GetNextColumn(Columns[DisplayedBandsInfo.FirstDisplayedScrollingCol],
-                                                                                                        DataGridViewElementStates.Visible,
-                                                                                                        DataGridViewElementStates.None);
-                    int newColOffset = 0;
-                    for (DataGridViewColumn dataGridViewColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible,
-                                                                                                      DataGridViewElementStates.Frozen);
-                        dataGridViewColumn != newFirstVisibleScrollingCol;
-                        dataGridViewColumn = Columns.GetNextColumn(dataGridViewColumn,
+                    DataGridViewColumn? newFirstVisibleScrollingCol = Columns.GetNextColumn(
+                        Columns[DisplayedBandsInfo.FirstDisplayedScrollingCol],
                         DataGridViewElementStates.Visible,
-                        DataGridViewElementStates.None))
+                        DataGridViewElementStates.None);
+                    int newColOffset = 0;
+                    for (DataGridViewColumn? dataGridViewColumn = Columns.GetFirstColumn(
+                            DataGridViewElementStates.Visible,
+                            DataGridViewElementStates.Frozen);
+                        dataGridViewColumn != newFirstVisibleScrollingCol;
+                        dataGridViewColumn = Columns.GetNextColumn(
+                            dataGridViewColumn,
+                            DataGridViewElementStates.Visible,
+                            DataGridViewElementStates.None))
                     {
-                        newColOffset += dataGridViewColumn.Thickness;
+                        newColOffset += dataGridViewColumn!.Thickness;
                     }
 
                     if (HorizontalOffset != newColOffset)
@@ -9714,7 +9722,7 @@ public partial class DataGridView
                      (RightToLeftInternal && xColumnLeftEdge - x < ColumnSizingHotZone))
             {
                 //hti.edge = DataGridViewHitTestTypeCloseEdge.Left;
-                DataGridViewColumn dataGridViewColumn = Columns.GetPreviousColumn(
+                DataGridViewColumn? dataGridViewColumn = Columns.GetPreviousColumn(
                     Columns[hti._col],
                     DataGridViewElementStates.Visible,
                     DataGridViewElementStates.None);
@@ -9943,7 +9951,7 @@ public partial class DataGridView
             else if ((!RightToLeftInternal && x - xColumnLeftEdge < ColumnSizingHotZone) ||
                      (RightToLeftInternal && xColumnLeftEdge - x < ColumnSizingHotZone))
             {
-                DataGridViewColumn dataGridViewColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible);
+                DataGridViewColumn? dataGridViewColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible);
                 Debug.Assert(dataGridViewColumn is not null);
                 if (hti._col == dataGridViewColumn.Index &&
                     RowHeadersVisible &&

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.cs
@@ -1681,7 +1681,7 @@ public partial class DataGridView : Control, ISupportInitialize
                 if (!value)
                 {
                     // Make sure that there is no visible column that only counts on the column headers to autosize
-                    DataGridViewColumn dataGridViewColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible);
+                    DataGridViewColumn? dataGridViewColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible);
                     while (dataGridViewColumn is not null)
                     {
                         if (dataGridViewColumn.InheritedAutoSizeMode == DataGridViewAutoSizeColumnMode.ColumnHeader)
@@ -2406,7 +2406,7 @@ public partial class DataGridView : Control, ISupportInitialize
             }
 
             int firstDisplayedColumnIndex = -1;
-            DataGridViewColumn dataGridViewColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible);
+            DataGridViewColumn? dataGridViewColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible);
             if (dataGridViewColumn is not null)
             {
                 if (dataGridViewColumn.Frozen)
@@ -2419,11 +2419,11 @@ public partial class DataGridView : Control, ISupportInitialize
                 }
             }
 #if DEBUG
-            DataGridViewColumn dataGridViewColumnDbg1 = Columns.GetFirstColumn(DataGridViewElementStates.Displayed);
+            DataGridViewColumn? dataGridViewColumnDbg1 = Columns.GetFirstColumn(DataGridViewElementStates.Displayed);
             int firstDisplayedColumnIndexDbg1 = (dataGridViewColumnDbg1 is null) ? -1 : dataGridViewColumnDbg1.Index;
 
             int firstDisplayedColumnIndexDbg2 = -1;
-            DataGridViewColumn dataGridViewColumnDbg = Columns.GetFirstColumn(DataGridViewElementStates.Visible | DataGridViewElementStates.Frozen);
+            DataGridViewColumn? dataGridViewColumnDbg = Columns.GetFirstColumn(DataGridViewElementStates.Visible | DataGridViewElementStates.Frozen);
             if (dataGridViewColumnDbg is not null)
             {
                 firstDisplayedColumnIndexDbg2 = dataGridViewColumnDbg.Index;
@@ -3668,7 +3668,7 @@ public partial class DataGridView : Control, ISupportInitialize
                 {
                     // Before changing the value of this.scrollBars, we scroll to the top-left cell to
                     // avoid inconsistent state of scrollbars.
-                    DataGridViewColumn dataGridViewColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible);
+                    DataGridViewColumn? dataGridViewColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible);
                     int firstVisibleRowIndex = Rows.GetFirstRow(DataGridViewElementStates.Visible);
 
                     if (dataGridViewColumn is not null && firstVisibleRowIndex != -1)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.DataGridViewCellAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.DataGridViewCellAccessibleObject.cs
@@ -506,9 +506,10 @@ public abstract partial class DataGridViewCell
             }
             else
             {
-                int previousVisibleColumnIndex = _owner.DataGridView.Columns.GetPreviousColumn(_owner.OwningColumn,
-                                                                                               DataGridViewElementStates.Visible,
-                                                                                               DataGridViewElementStates.None).Index;
+                int previousVisibleColumnIndex = _owner.DataGridView.Columns.GetPreviousColumn(
+                    _owner.OwningColumn,
+                    DataGridViewElementStates.Visible,
+                    DataGridViewElementStates.None)!.Index;
                 return _owner.OwningRow.Cells[previousVisibleColumnIndex].AccessibilityObject;
             }
         }
@@ -520,8 +521,9 @@ public abstract partial class DataGridViewCell
             Debug.Assert(_owner.OwningColumn is not null);
             Debug.Assert(_owner.OwningRow is not null);
 
-            if (_owner.OwningColumn == _owner.DataGridView.Columns.GetLastColumn(DataGridViewElementStates.Visible,
-                                                                                    DataGridViewElementStates.None))
+            if (_owner.OwningColumn == _owner.DataGridView.Columns.GetLastColumn(
+                DataGridViewElementStates.Visible,
+                DataGridViewElementStates.None))
             {
                 if (wrapAround)
                 {
@@ -537,9 +539,10 @@ public abstract partial class DataGridViewCell
             }
             else
             {
-                int nextVisibleColumnIndex = _owner.DataGridView.Columns.GetNextColumn(_owner.OwningColumn,
-                                                                                       DataGridViewElementStates.Visible,
-                                                                                       DataGridViewElementStates.None).Index;
+                int nextVisibleColumnIndex = _owner.DataGridView.Columns.GetNextColumn(
+                    _owner.OwningColumn,
+                    DataGridViewElementStates.Visible,
+                    DataGridViewElementStates.None)!.Index;
                 return _owner.OwningRow.Cells[nextVisibleColumnIndex].AccessibilityObject;
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
@@ -1031,7 +1031,7 @@ public abstract partial class DataGridViewCell : DataGridViewElement, ICloneable
             // Column header cell case
             Debug.Assert(rowIndex == -1);
             Debug.Assert(this is DataGridViewColumnHeaderCell, "if the row index == -1 and we have an owning column this should be a column header cell");
-            DataGridViewColumn dataGridViewColumn = DataGridView.Columns.GetLastColumn(DataGridViewElementStates.Visible, DataGridViewElementStates.None);
+            DataGridViewColumn? dataGridViewColumn = DataGridView.Columns.GetLastColumn(DataGridViewElementStates.Visible, DataGridViewElementStates.None);
             bool isLastVisibleColumn = (dataGridViewColumn is not null && dataGridViewColumn.Index == ColumnIndex);
             dgvabsEffective = DataGridView.AdjustColumnHeaderBorderStyle(DataGridView.AdvancedColumnHeadersBorderStyle,
                 dataGridViewAdvancedBorderStylePlaceholder,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnCollection.cs
@@ -114,10 +114,10 @@ public partial class DataGridViewColumnCollection : BaseCollection, IList
     internal int ActualDisplayIndexToColumnIndex(int actualDisplayIndex, DataGridViewElementStates includeFilter)
     {
         // Microsoft: is there a faster way to get the column index?
-        DataGridViewColumn dataGridViewColumn = GetFirstColumn(includeFilter);
+        DataGridViewColumn? dataGridViewColumn = GetFirstColumn(includeFilter);
         for (int i = 0; i < actualDisplayIndex; i++)
         {
-            dataGridViewColumn = GetNextColumn(dataGridViewColumn, includeFilter, DataGridViewElementStates.None);
+            dataGridViewColumn = GetNextColumn(dataGridViewColumn!, includeFilter, DataGridViewElementStates.None);
         }
 
         return dataGridViewColumn?.Index ?? -1;
@@ -312,7 +312,7 @@ public partial class DataGridViewColumnCollection : BaseCollection, IList
     internal int ColumnIndexToActualDisplayIndex(int columnIndex, DataGridViewElementStates includeFilter)
     {
         // map the column index to the actual display index
-        DataGridViewColumn dataGridViewColumn = GetFirstColumn(includeFilter);
+        DataGridViewColumn? dataGridViewColumn = GetFirstColumn(includeFilter);
         int actualDisplayIndex = 0;
         while (dataGridViewColumn is not null && dataGridViewColumn.Index != columnIndex)
         {
@@ -477,11 +477,12 @@ public partial class DataGridViewColumnCollection : BaseCollection, IList
         Debug.Assert(_items[toColumnIndex].StateIncludes(includeFilter));
 
         int jumpColumns = 0;
-        DataGridViewColumn dataGridViewColumn = _items[fromColumnIndex];
+        DataGridViewColumn? dataGridViewColumn = _items[fromColumnIndex];
 
         while (dataGridViewColumn != _items[toColumnIndex])
         {
-            dataGridViewColumn = GetNextColumn(dataGridViewColumn, includeFilter,
+            dataGridViewColumn = GetNextColumn(
+                dataGridViewColumn, includeFilter,
                 DataGridViewElementStates.None);
             Debug.Assert(dataGridViewColumn is not null);
             if (dataGridViewColumn.StateIncludes(includeFilter))
@@ -523,7 +524,7 @@ public partial class DataGridViewColumnCollection : BaseCollection, IList
 
         return -1;
     }
-#nullable disable
+
     internal float GetColumnsFillWeight(DataGridViewElementStates includeFilter)
     {
         Debug.Assert((includeFilter & ~(DataGridViewElementStates.Displayed | DataGridViewElementStates.Frozen | DataGridViewElementStates.Resizable |
@@ -591,7 +592,7 @@ public partial class DataGridViewColumnCollection : BaseCollection, IList
         return columnsWidth;
     }
 
-    public DataGridViewColumn GetFirstColumn(DataGridViewElementStates includeFilter)
+    public DataGridViewColumn? GetFirstColumn(DataGridViewElementStates includeFilter)
     {
         if ((includeFilter & ~(DataGridViewElementStates.Displayed | DataGridViewElementStates.Frozen | DataGridViewElementStates.Resizable |
             DataGridViewElementStates.ReadOnly | DataGridViewElementStates.Selected | DataGridViewElementStates.Visible)) != 0)
@@ -622,8 +623,9 @@ public partial class DataGridViewColumnCollection : BaseCollection, IList
         return null;
     }
 
-    public DataGridViewColumn GetFirstColumn(DataGridViewElementStates includeFilter,
-                                             DataGridViewElementStates excludeFilter)
+    public DataGridViewColumn? GetFirstColumn(
+        DataGridViewElementStates includeFilter,
+        DataGridViewElementStates excludeFilter)
     {
         if (excludeFilter == DataGridViewElementStates.None)
         {
@@ -666,8 +668,9 @@ public partial class DataGridViewColumnCollection : BaseCollection, IList
         return null;
     }
 
-    public DataGridViewColumn GetLastColumn(DataGridViewElementStates includeFilter,
-                                            DataGridViewElementStates excludeFilter)
+    public DataGridViewColumn? GetLastColumn(
+        DataGridViewElementStates includeFilter,
+        DataGridViewElementStates excludeFilter)
     {
         if ((includeFilter & ~(DataGridViewElementStates.Displayed | DataGridViewElementStates.Frozen | DataGridViewElementStates.Resizable |
             DataGridViewElementStates.ReadOnly | DataGridViewElementStates.Selected | DataGridViewElementStates.Visible)) != 0)
@@ -705,9 +708,10 @@ public partial class DataGridViewColumnCollection : BaseCollection, IList
         return null;
     }
 
-    public DataGridViewColumn GetNextColumn(DataGridViewColumn dataGridViewColumnStart,
-                                            DataGridViewElementStates includeFilter,
-                                            DataGridViewElementStates excludeFilter)
+    public DataGridViewColumn? GetNextColumn(
+        DataGridViewColumn dataGridViewColumnStart,
+        DataGridViewElementStates includeFilter,
+        DataGridViewElementStates excludeFilter)
     {
         ArgumentNullException.ThrowIfNull(dataGridViewColumnStart);
 
@@ -777,9 +781,10 @@ public partial class DataGridViewColumnCollection : BaseCollection, IList
         return null;
     }
 
-    public DataGridViewColumn GetPreviousColumn(DataGridViewColumn dataGridViewColumnStart,
-                                                         DataGridViewElementStates includeFilter,
-                                                         DataGridViewElementStates excludeFilter)
+    public DataGridViewColumn? GetPreviousColumn(
+        DataGridViewColumn dataGridViewColumnStart,
+        DataGridViewElementStates includeFilter,
+        DataGridViewElementStates excludeFilter)
     {
         ArgumentNullException.ThrowIfNull(dataGridViewColumnStart);
 
@@ -963,7 +968,7 @@ public partial class DataGridViewColumnCollection : BaseCollection, IList
     private void OnCollectionChanged_PostNotification(CollectionChangeEventArgs ccea, bool changeIsInsertion, Point newCurrentCell)
     {
         Debug.Assert(DataGridView is not null);
-        DataGridViewColumn dataGridViewColumn = (DataGridViewColumn)ccea.Element;
+        DataGridViewColumn? dataGridViewColumn = (DataGridViewColumn?)ccea.Element;
         if (ccea.Action == CollectionChangeAction.Add && changeIsInsertion)
         {
             DataGridView.OnInsertedColumn_PostNotification(newCurrentCell);
@@ -1122,6 +1127,7 @@ public partial class DataGridViewColumnCollection : BaseCollection, IList
         }
     }
 
+    [MemberNotNull(nameof(_itemsSorted))]
     private void UpdateColumnOrderCache()
     {
         _itemsSorted = _items.ToList();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.DataGridViewRowAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.DataGridViewRowAccessibleObject.cs
@@ -417,7 +417,7 @@ public partial class DataGridViewRow
                     }
                     else
                     {
-                        int firstVisibleCell = dataGridView.Columns.GetFirstColumn(DataGridViewElementStates.Visible).Index;
+                        int firstVisibleCell = dataGridView.Columns.GetFirstColumn(DataGridViewElementStates.Visible)!.Index;
                         if (firstVisibleCell > -1)
                         {
                             dataGridView.CurrentCell = _owningDataGridViewRow.Cells[firstVisibleCell]; // Do not change old selection

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.cs
@@ -1523,7 +1523,7 @@ public partial class DataGridViewRow : DataGridViewBand
         DataGridViewAdvancedBorderStyle dataGridViewAdvancedBorderStylePlaceholder = new(), dgvabsEffective;
 
         // first paint the potential visible frozen cells
-        DataGridViewColumn dataGridViewColumn = dataGridView.Columns.GetFirstColumn(DataGridViewElementStates.Visible | DataGridViewElementStates.Frozen);
+        DataGridViewColumn? dataGridViewColumn = dataGridView.Columns.GetFirstColumn(DataGridViewElementStates.Visible | DataGridViewElementStates.Frozen);
         while (dataGridViewColumn is not null)
         {
             cell = Cells[dataGridViewColumn.Index];

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTopLeftHeaderCell.DataGridViewTopLeftHeaderCellAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTopLeftHeaderCell.DataGridViewTopLeftHeaderCellAccessibleObject.cs
@@ -211,11 +211,16 @@ public partial class DataGridViewTopLeftHeaderCell
                     // This means that there are visible rows and columns.
                     // Focus the first data cell.
                     DataGridViewRow row = Owner.DataGridView.Rows[Owner.DataGridView.Rows.GetFirstRow(DataGridViewElementStates.Visible)];
-                    DataGridViewColumn col = Owner.DataGridView.Columns.GetFirstColumn(DataGridViewElementStates.Visible);
+                    DataGridViewColumn col = Owner.DataGridView.Columns.GetFirstColumn(DataGridViewElementStates.Visible)!;
 
                     // DataGridView::set_CurrentCell clears the previous selection.
                     // So use SetCurrenCellAddressCore directly.
-                    Owner.DataGridView.SetCurrentCellAddressCoreInternal(col.Index, row.Index, false /*setAnchorCellAddress*/, true /*validateCurrentCell*/, false /*thoughMouseClick*/);
+                    Owner.DataGridView.SetCurrentCellAddressCoreInternal(
+                        col.Index,
+                        row.Index,
+                        setAnchorCellAddress: false,
+                        validateCurrentCell: true,
+                        throughMouseClick: false);
                 }
             }
 


### PR DESCRIPTION
## Proposed changes

- Enable nullability in remaining DataGridViewColumnCollection members.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10140)