### PR TITLE
fix bug The code generated by the ListBox control is not consistent with Framework

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ListBoxes/ListBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ListBoxes/ListBox.cs
@@ -90,7 +90,7 @@ public partial class ListBox : ListControl
     private int _itemsCount;
 
     /// <summary>
-    ///  This value stores the array of custom tabstops in the listbox. the array should be populated by
+    ///  This value stores the array of custom tabstops in the listBox. the array should be populated by
     ///  integers in a ascending order.
     /// </summary>
     private IntegerCollection? _customTabOffsets;
@@ -214,7 +214,7 @@ public partial class ListBox : ListControl
             {
                 _borderStyle = value;
                 RecreateHandle();
-                // Avoid the listbox and textbox behavior in Collection editors
+                // Avoid the listBox and textbox behavior in Collection editors
                 //
                 _integralHeightAdjust = true;
                 try
@@ -379,7 +379,7 @@ public partial class ListBox : ListControl
     }
 
     /// <summary>
-    ///  Retrieves the style of the listbox.  This will indicate if the system
+    ///  Retrieves the style of the listBox.  This will indicate if the system
     ///  draws it, or if the user paints each item manually.  It also indicates
     ///  whether or not items have to be of the same height.
     /// </summary>
@@ -507,12 +507,12 @@ public partial class ListBox : ListControl
 
                 // There seems to be a bug in the native ListBox in that the addition
                 // of the horizontal scroll bar does not get reflected in the control
-                // rightaway. So, we refresh the items here.
+                // right away. So, we refresh the items here.
 
                 RefreshItems();
 
                 // Only need to recreate the handle if not MultiColumn
-                // (HorizontalScrollbar has no effect on a MultiColumn listbox)
+                // (HorizontalScrollbar has no effect on a MultiColumn listBox)
                 //
                 if (!MultiColumn)
                 {
@@ -523,8 +523,8 @@ public partial class ListBox : ListControl
     }
 
     /// <summary>
-    ///  Indicates if the listbox should avoid showing partial Items.  If so,
-    ///  then only full items will be displayed, and the listbox will be resized
+    ///  Indicates if the listBox should avoid showing partial Items.  If so,
+    ///  then only full items will be displayed, and the listBox will be resized
     ///  to prevent partial items from being shown.  Otherwise, they will be
     ///  shown
     /// </summary>
@@ -546,8 +546,7 @@ public partial class ListBox : ListControl
             {
                 _integralHeight = value;
                 RecreateHandle();
-                // Avoid the listbox and textbox behaviour in Collection editors
-                //
+                // Avoid the listBox and textbox behaviour in Collection editors
 
                 _integralHeightAdjust = true;
                 try
@@ -611,7 +610,7 @@ public partial class ListBox : ListControl
     }
 
     /// <summary>
-    ///  Collection of items in this listbox.
+    ///  Collection of items in this listBox.
     /// </summary>
     [SRCategory(nameof(SR.CatData))]
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
@@ -670,7 +669,7 @@ public partial class ListBox : ListControl
     }
 
     /// <summary>
-    ///  Indicates if the listbox is multi-column
+    ///  Indicates if the listBox is multi-column
     ///  or not.
     /// </summary>
     [SRCategory(nameof(SR.CatBehavior))]
@@ -981,7 +980,7 @@ public partial class ListBox : ListControl
     }
 
     /// <summary>
-    ///  Controls how many items at a time can be selected in the listbox. Valid
+    ///  Controls how many items at a time can be selected in the listBox. Valid
     ///  values are from the System.Windows.Forms.SelectionMode enumeration.
     /// </summary>
     [SRCategory(nameof(SR.CatBehavior))]
@@ -1169,7 +1168,7 @@ public partial class ListBox : ListControl
     }
 
     /// <summary>
-    ///  Performs the work of adding the specified items to the Listbox
+    ///  Performs the work of adding the specified items to the ListBox
     /// </summary>
     [Obsolete("This method has been deprecated.  There is no replacement.  https://go.microsoft.com/fwlink/?linkid=14202")]
     protected virtual void AddItemsCore(object[] value)
@@ -1216,7 +1215,7 @@ public partial class ListBox : ListControl
     }
 
     /// <summary>
-    ///  ListBox / CheckedListBox Onpaint.
+    ///  ListBox / CheckedListBox OnPaint.
     /// </summary>
     [Browsable(false)]
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -1509,7 +1508,7 @@ public partial class ListBox : ListControl
     public int IndexFromPoint(int x, int y)
     {
         // NT4 SP6A : SendMessage Fails. So First check whether the point is in Client Co-ordinates and then
-        // call Sendmessage.
+        // call SendMessage.
         PInvoke.GetClientRect(this, out RECT r);
         if (r.left <= x && x < r.right && r.top <= y && y < r.bottom)
         {
@@ -1615,7 +1614,7 @@ public partial class ListBox : ListControl
         bool selected = (int)PInvoke.SendMessage(this, PInvoke.LB_GETSEL, (WPARAM)index) > 0;
         PInvoke.SendMessage(this, PInvoke.LB_DELETESTRING, (WPARAM)index);
 
-        // If the item currently selected is removed then we should fire a Selectionchanged event
+        // If the item currently selected is removed then we should fire a SelectionChanged event
         // as the next time selected index returns -1.
 
         if (selected)
@@ -1827,7 +1826,7 @@ public partial class ListBox : ListControl
         // Changing the font causes us to resize, always rounding down.
         // Make sure we do this after base.OnPropertyChanged, which sends the WM_SETFONT message
 
-        // Avoid the listbox and textbox behaviour in Collection editors
+        // Avoid the listBox and textbox behaviour in Collection editors
         UpdateFontCache();
     }
 
@@ -1837,7 +1836,7 @@ public partial class ListBox : ListControl
     protected override void OnParentChanged(EventArgs e)
     {
         base.OnParentChanged(e);
-        // No need to RecreateHandle if we are removing the Listbox from controls collection...
+        // No need to RecreateHandle if we are removing the ListBox from controls collection...
         // so check the parent before recreating the handle...
         if (ParentInternal is not null)
         {
@@ -1947,7 +1946,7 @@ public partial class ListBox : ListControl
     {
         if (_drawMode == DrawMode.OwnerDrawVariable)
         {
-            // Fire MeasureItem for Each Item in the Listbox...
+            // Fire MeasureItem for Each Item in the ListBox...
             int cnt = Items.Count;
             Graphics graphics = CreateGraphicsInternal();
 
@@ -2087,7 +2086,7 @@ public partial class ListBox : ListControl
     /// </summary>
     protected override void SetBoundsCore(int x, int y, int width, int height, BoundsSpecified specified)
     {
-        // Avoid the listbox and textbox behaviour in Collection editors
+        // Avoid the listBox and textbox behaviour in Collection editors
         if (!_integralHeightAdjust && height != Height)
         {
             _requestedHeight = height;
@@ -2125,7 +2124,7 @@ public partial class ListBox : ListControl
             }
 
             // if the list changed and we still did not fire the
-            // onselectedChanged event, then fire it now;
+            // onSelectedChanged event, then fire it now;
             if (!_selectedValueChangedFired)
             {
                 OnSelectedValueChanged(EventArgs.Empty);
@@ -2170,11 +2169,11 @@ public partial class ListBox : ListControl
     // ShouldSerialize and Reset Methods are being used by Designer via reflection.
     private bool ShouldSerializeItemHeight()
     {
-        return ItemHeight != DefaultListBoxItemHeight;
+        return ItemHeight != DefaultListBoxItemHeight && _drawMode != DrawMode.Normal;
     }
 
     /// <summary>
-    ///  Sorts the items in the listbox.
+    ///  Sorts the items in the listBox.
     /// </summary>
     protected virtual void Sort()
     {
@@ -2474,8 +2473,8 @@ public partial class ListBox : ListControl
                 break;
 
             case PInvoke.WM_LBUTTONDBLCLK:
-                // The Listbox gets  WM_LBUTTONDOWN - WM_LBUTTONUP -WM_LBUTTONDBLCLK - WM_LBUTTONUP sequence for
-                // doubleclick. The first WM_LBUTTONUP, resets the flag for double click so its necessary for us
+                // The ListBox gets  WM_LBUTTONDOWN - WM_LBUTTONUP -WM_LBUTTONDBLCLK - WM_LBUTTONUP sequence for
+                // doubleClick. The first WM_LBUTTONUP, resets the flag for double click so its necessary for us
                 // to set it again.
                 _doubleClickFired = true;
                 base.WndProc(ref m);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListBoxTests.cs
@@ -1815,11 +1815,12 @@ public class ListBoxTests
     {
         PropertyDescriptor property = TypeDescriptor.GetProperties(typeof(ListBox))[nameof(ListBox.ItemHeight)];
         using ListBox control = new();
+        Assert.True(control.DrawMode is DrawMode.Normal);
         Assert.False(property.CanResetValue(control));
 
         control.ItemHeight = 15;
         Assert.Equal(15, control.ItemHeight);
-        Assert.True(property.CanResetValue(control));
+        Assert.False(property.CanResetValue(control));
 
         property.ResetValue(control);
         Assert.Equal(Control.DefaultFont.Height, control.ItemHeight);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListBoxTests.cs
@@ -1836,7 +1836,7 @@ public class ListBoxTests
 
         control.ItemHeight = 15;
         Assert.Equal(15, control.ItemHeight);
-        Assert.True(property.ShouldSerializeValue(control));
+        Assert.False(property.ShouldSerializeValue(control));
 
         property.ResetValue(control);
         Assert.Equal(Control.DefaultFont.Height, control.ItemHeight);


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #4463


## Proposed changes

- 
-  when `DrawMode` is `DrawMode.Normal `, the ItemHeight can not be set to ListBox. So, ItemHeight should not be serialized.
- 
https://github.com/dotnet/winforms/blob/5234e14330d5379bab230817df65bb4d8c1af28c/src/System.Windows.Forms/src/System/Windows/Forms/DrawMode.cs#L6-L28
https://github.com/dotnet/winforms/blob/5234e14330d5379bab230817df65bb4d8c1af28c/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs#L582-L622

<!-- 

## Customer Impact
- 
- 
 -->

## Before
The generated code for ListBox1 have extra code: this.listBox1.ItemHeight = 15;
![image](https://user-images.githubusercontent.com/15823268/104525385-e63a8080-55b4-11eb-8018-1cd886b658a0.png)

## After

https://github.com/dotnet/winforms/assets/135201996/73544c63-e0cf-4c06-a829-56bfc5d09ebb



## Regression? 

- Yes / No

## Risk

- minimal




## Test methodology <!-- How did you ensure quality? -->

- 
- Manually 
-


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10142)