### PR TITLE
Enable nullability in DataGridViewHeaderCell

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -99,7 +99,7 @@ override System.Windows.Forms.DataGridViewColumnHeaderCell.GetInheritedContextMe
 override System.Windows.Forms.DataGridViewColumnHeaderCell.GetInheritedStyle(System.Windows.Forms.DataGridViewCellStyle? inheritedCellStyle, int rowIndex, bool includeColors) -> System.Windows.Forms.DataGridViewCellStyle!
 override System.Windows.Forms.DataGridViewColumnHeaderCell.GetPreferredSize(System.Drawing.Graphics! graphics, System.Windows.Forms.DataGridViewCellStyle! cellStyle, int rowIndex, System.Drawing.Size constraintSize) -> System.Drawing.Size
 override System.Windows.Forms.DataGridViewColumnHeaderCell.GetValue(int rowIndex) -> object?
-override System.Windows.Forms.DataGridViewColumnHeaderCell.Paint(System.Drawing.Graphics! graphics, System.Drawing.Rectangle clipBounds, System.Drawing.Rectangle cellBounds, int rowIndex, System.Windows.Forms.DataGridViewElementStates dataGridViewElementState, object! value, object? formattedValue, string? errorText, System.Windows.Forms.DataGridViewCellStyle! cellStyle, System.Windows.Forms.DataGridViewAdvancedBorderStyle! advancedBorderStyle, System.Windows.Forms.DataGridViewPaintParts paintParts) -> void
+override System.Windows.Forms.DataGridViewColumnHeaderCell.Paint(System.Drawing.Graphics! graphics, System.Drawing.Rectangle clipBounds, System.Drawing.Rectangle cellBounds, int rowIndex, System.Windows.Forms.DataGridViewElementStates dataGridViewElementState, object? value, object? formattedValue, string? errorText, System.Windows.Forms.DataGridViewCellStyle! cellStyle, System.Windows.Forms.DataGridViewAdvancedBorderStyle! advancedBorderStyle, System.Windows.Forms.DataGridViewPaintParts paintParts) -> void
 override System.Windows.Forms.DataGridViewColumnHeaderCell.SetValue(int rowIndex, object? value) -> bool
 override System.Windows.Forms.DataGridViewColumnHeaderCell.ToString() -> string!
 override System.Windows.Forms.DataGridViewComboBoxCell.Clone() -> object!
@@ -122,18 +122,18 @@ override System.Windows.Forms.DataGridViewComboBoxColumn.CellTemplate.get -> Sys
 override System.Windows.Forms.DataGridViewComboBoxColumn.CellTemplate.set -> void
 override System.Windows.Forms.DataGridViewComboBoxColumn.Clone() -> object!
 override System.Windows.Forms.DataGridViewComboBoxColumn.ToString() -> string!
-~override System.Windows.Forms.DataGridViewHeaderCell.Clone() -> object
-~override System.Windows.Forms.DataGridViewHeaderCell.FormattedValueType.get -> System.Type
-~override System.Windows.Forms.DataGridViewHeaderCell.GetInheritedContextMenuStrip(int rowIndex) -> System.Windows.Forms.ContextMenuStrip
-~override System.Windows.Forms.DataGridViewHeaderCell.GetValue(int rowIndex) -> object
-~override System.Windows.Forms.DataGridViewHeaderCell.MouseDownUnsharesRow(System.Windows.Forms.DataGridViewCellMouseEventArgs e) -> bool
-~override System.Windows.Forms.DataGridViewHeaderCell.MouseUpUnsharesRow(System.Windows.Forms.DataGridViewCellMouseEventArgs e) -> bool
-~override System.Windows.Forms.DataGridViewHeaderCell.OnMouseDown(System.Windows.Forms.DataGridViewCellMouseEventArgs e) -> void
-~override System.Windows.Forms.DataGridViewHeaderCell.OnMouseUp(System.Windows.Forms.DataGridViewCellMouseEventArgs e) -> void
-~override System.Windows.Forms.DataGridViewHeaderCell.Paint(System.Drawing.Graphics graphics, System.Drawing.Rectangle clipBounds, System.Drawing.Rectangle cellBounds, int rowIndex, System.Windows.Forms.DataGridViewElementStates dataGridViewElementState, object value, object formattedValue, string errorText, System.Windows.Forms.DataGridViewCellStyle cellStyle, System.Windows.Forms.DataGridViewAdvancedBorderStyle advancedBorderStyle, System.Windows.Forms.DataGridViewPaintParts paintParts) -> void
-~override System.Windows.Forms.DataGridViewHeaderCell.ToString() -> string
-~override System.Windows.Forms.DataGridViewHeaderCell.ValueType.get -> System.Type
-~override System.Windows.Forms.DataGridViewHeaderCell.ValueType.set -> void
+override System.Windows.Forms.DataGridViewHeaderCell.Clone() -> object!
+override System.Windows.Forms.DataGridViewHeaderCell.FormattedValueType.get -> System.Type!
+override System.Windows.Forms.DataGridViewHeaderCell.GetInheritedContextMenuStrip(int rowIndex) -> System.Windows.Forms.ContextMenuStrip?
+override System.Windows.Forms.DataGridViewHeaderCell.GetValue(int rowIndex) -> object?
+override System.Windows.Forms.DataGridViewHeaderCell.MouseDownUnsharesRow(System.Windows.Forms.DataGridViewCellMouseEventArgs! e) -> bool
+override System.Windows.Forms.DataGridViewHeaderCell.MouseUpUnsharesRow(System.Windows.Forms.DataGridViewCellMouseEventArgs! e) -> bool
+override System.Windows.Forms.DataGridViewHeaderCell.OnMouseDown(System.Windows.Forms.DataGridViewCellMouseEventArgs! e) -> void
+override System.Windows.Forms.DataGridViewHeaderCell.OnMouseUp(System.Windows.Forms.DataGridViewCellMouseEventArgs! e) -> void
+override System.Windows.Forms.DataGridViewHeaderCell.Paint(System.Drawing.Graphics! graphics, System.Drawing.Rectangle clipBounds, System.Drawing.Rectangle cellBounds, int rowIndex, System.Windows.Forms.DataGridViewElementStates dataGridViewElementState, object? value, object? formattedValue, string? errorText, System.Windows.Forms.DataGridViewCellStyle! cellStyle, System.Windows.Forms.DataGridViewAdvancedBorderStyle! advancedBorderStyle, System.Windows.Forms.DataGridViewPaintParts paintParts) -> void
+override System.Windows.Forms.DataGridViewHeaderCell.ToString() -> string!
+override System.Windows.Forms.DataGridViewHeaderCell.ValueType.get -> System.Type?
+override System.Windows.Forms.DataGridViewHeaderCell.ValueType.set -> void
 override System.Windows.Forms.DataGridViewImageCell.Clone() -> object!
 override System.Windows.Forms.DataGridViewImageCell.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject!
 override System.Windows.Forms.DataGridViewImageCell.DefaultNewRowValue.get -> object?
@@ -194,7 +194,7 @@ override System.Windows.Forms.DataGridViewRowHeaderCell.GetInheritedContextMenuS
 override System.Windows.Forms.DataGridViewRowHeaderCell.GetInheritedStyle(System.Windows.Forms.DataGridViewCellStyle? inheritedCellStyle, int rowIndex, bool includeColors) -> System.Windows.Forms.DataGridViewCellStyle!
 override System.Windows.Forms.DataGridViewRowHeaderCell.GetPreferredSize(System.Drawing.Graphics! graphics, System.Windows.Forms.DataGridViewCellStyle! cellStyle, int rowIndex, System.Drawing.Size constraintSize) -> System.Drawing.Size
 override System.Windows.Forms.DataGridViewRowHeaderCell.GetValue(int rowIndex) -> object?
-override System.Windows.Forms.DataGridViewRowHeaderCell.Paint(System.Drawing.Graphics! graphics, System.Drawing.Rectangle clipBounds, System.Drawing.Rectangle cellBounds, int rowIndex, System.Windows.Forms.DataGridViewElementStates cellState, object! value, object? formattedValue, string? errorText, System.Windows.Forms.DataGridViewCellStyle! cellStyle, System.Windows.Forms.DataGridViewAdvancedBorderStyle! advancedBorderStyle, System.Windows.Forms.DataGridViewPaintParts paintParts) -> void
+override System.Windows.Forms.DataGridViewRowHeaderCell.Paint(System.Drawing.Graphics! graphics, System.Drawing.Rectangle clipBounds, System.Drawing.Rectangle cellBounds, int rowIndex, System.Windows.Forms.DataGridViewElementStates cellState, object? value, object? formattedValue, string? errorText, System.Windows.Forms.DataGridViewCellStyle! cellStyle, System.Windows.Forms.DataGridViewAdvancedBorderStyle! advancedBorderStyle, System.Windows.Forms.DataGridViewPaintParts paintParts) -> void
 override System.Windows.Forms.DataGridViewRowHeaderCell.SetValue(int rowIndex, object? value) -> bool
 override System.Windows.Forms.DataGridViewRowHeaderCell.ToString() -> string!
 override System.Windows.Forms.DataGridViewTextBoxCell.Clone() -> object!

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnHeaderCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnHeaderCell.cs
@@ -717,7 +717,7 @@ public partial class DataGridViewColumnHeaderCell : DataGridViewHeaderCell
         Rectangle cellBounds,
         int rowIndex,
         DataGridViewElementStates dataGridViewElementState,
-        object value,
+        object? value,
         object? formattedValue,
         string? errorText,
         DataGridViewCellStyle cellStyle,
@@ -829,7 +829,7 @@ public partial class DataGridViewColumnHeaderCell : DataGridViewHeaderCell
                 if (DataGridView.RightToLeftInternal)
                 {
                     // Flip the column header background
-                    Bitmap bmFlipXPThemes = FlipXPThemesBitmap;
+                    Bitmap? bmFlipXPThemes = FlipXPThemesBitmap;
                     if (bmFlipXPThemes is null ||
                         bmFlipXPThemes.Width < backgroundBounds.Width || bmFlipXPThemes.Width > 2 * backgroundBounds.Width ||
                         bmFlipXPThemes.Height < backgroundBounds.Height || bmFlipXPThemes.Height > 2 * backgroundBounds.Height)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewHeaderCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewHeaderCell.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.ComponentModel;
 using System.Drawing;
 
@@ -96,11 +94,11 @@ public partial class DataGridViewHeaderCell : DataGridViewCell
         }
     }
 
-    internal Bitmap FlipXPThemesBitmap
+    internal Bitmap? FlipXPThemesBitmap
     {
         get
         {
-            return (Bitmap)Properties.GetObject(s_propFlipXPThemesBitmap);
+            return (Bitmap?)Properties.GetObject(s_propFlipXPThemesBitmap);
         }
         set
         {
@@ -197,11 +195,11 @@ public partial class DataGridViewHeaderCell : DataGridViewCell
         }
     }
 
-    public override Type ValueType
+    public override Type? ValueType
     {
         get
         {
-            Type valueType = (Type)Properties.GetObject(s_propValueType);
+            Type? valueType = (Type?)Properties.GetObject(s_propValueType);
             if (valueType is not null)
             {
                 return valueType;
@@ -257,9 +255,7 @@ public partial class DataGridViewHeaderCell : DataGridViewCell
         }
         else
         {
-            //
-
-            dataGridViewCell = (DataGridViewHeaderCell)System.Activator.CreateInstance(thisType);
+            dataGridViewCell = (DataGridViewHeaderCell)Activator.CreateInstance(thisType)!;
         }
 
         base.CloneInternal(dataGridViewCell);
@@ -267,7 +263,7 @@ public partial class DataGridViewHeaderCell : DataGridViewCell
         return dataGridViewCell;
     }
 
-    public override ContextMenuStrip GetInheritedContextMenuStrip(int rowIndex)
+    public override ContextMenuStrip? GetInheritedContextMenuStrip(int rowIndex)
     {
         ContextMenuStrip contextMenuStrip = GetContextMenuStrip(rowIndex);
         if (contextMenuStrip is not null)
@@ -478,7 +474,7 @@ public partial class DataGridViewHeaderCell : DataGridViewCell
         return s_rectThemeMargins;
     }
 
-    protected override object GetValue(int rowIndex)
+    protected override object? GetValue(int rowIndex)
     {
         ArgumentOutOfRangeException.ThrowIfNotEqual(rowIndex, -1);
 
@@ -487,24 +483,24 @@ public partial class DataGridViewHeaderCell : DataGridViewCell
 
     protected override bool MouseDownUnsharesRow(DataGridViewCellMouseEventArgs e)
     {
-        return e.Button == MouseButtons.Left && DataGridView.ApplyVisualStylesToHeaderCells;
+        return e.Button == MouseButtons.Left && DataGridView!.ApplyVisualStylesToHeaderCells;
     }
 
     protected override bool MouseEnterUnsharesRow(int rowIndex)
     {
-        return ColumnIndex == DataGridView.MouseDownCellAddress.X &&
+        return ColumnIndex == DataGridView!.MouseDownCellAddress.X &&
                rowIndex == DataGridView.MouseDownCellAddress.Y &&
                DataGridView.ApplyVisualStylesToHeaderCells;
     }
 
     protected override bool MouseLeaveUnsharesRow(int rowIndex)
     {
-        return ButtonState != ButtonState.Normal && DataGridView.ApplyVisualStylesToHeaderCells;
+        return ButtonState != ButtonState.Normal && DataGridView!.ApplyVisualStylesToHeaderCells;
     }
 
     protected override bool MouseUpUnsharesRow(DataGridViewCellMouseEventArgs e)
     {
-        return e.Button == MouseButtons.Left && DataGridView.ApplyVisualStylesToHeaderCells;
+        return e.Button == MouseButtons.Left && DataGridView!.ApplyVisualStylesToHeaderCells;
     }
 
     protected override void OnMouseDown(DataGridViewCellMouseEventArgs e)
@@ -584,9 +580,9 @@ public partial class DataGridViewHeaderCell : DataGridViewCell
         Rectangle cellBounds,
         int rowIndex,
         DataGridViewElementStates dataGridViewElementState,
-        object value,
-        object formattedValue,
-        string errorText,
+        object? value,
+        object? formattedValue,
+        string? errorText,
         DataGridViewCellStyle cellStyle,
         DataGridViewAdvancedBorderStyle advancedBorderStyle,
         DataGridViewPaintParts paintParts)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewHeaderCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewHeaderCell.cs
@@ -148,14 +148,8 @@ public partial class DataGridViewHeaderCell : DataGridViewCell
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public override bool ReadOnly
     {
-        get
-        {
-            return true;
-        }
-        set
-        {
-            throw new InvalidOperationException(string.Format(SR.DataGridView_HeaderCellReadOnlyProperty, "ReadOnly"));
-        }
+        get => true;
+        set => throw new InvalidOperationException(string.Format(SR.DataGridView_HeaderCellReadOnlyProperty, "ReadOnly"));
     }
 
     [Browsable(false)]
@@ -185,14 +179,8 @@ public partial class DataGridViewHeaderCell : DataGridViewCell
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public override bool Selected
     {
-        get
-        {
-            return false;
-        }
-        set
-        {
-            throw new InvalidOperationException(string.Format(SR.DataGridView_HeaderCellReadOnlyProperty, "Selected"));
-        }
+        get => false;
+        set => throw new InvalidOperationException(string.Format(SR.DataGridView_HeaderCellReadOnlyProperty, "Selected"));
     }
 
     public override Type? ValueType

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewHeaderCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewHeaderCell.cs
@@ -469,27 +469,27 @@ public partial class DataGridViewHeaderCell : DataGridViewCell
         return Properties.GetObject(s_propCellValue);
     }
 
-    protected override bool MouseDownUnsharesRow(DataGridViewCellMouseEventArgs e)
-    {
-        return e.Button == MouseButtons.Left && DataGridView!.ApplyVisualStylesToHeaderCells;
-    }
+    protected override bool MouseDownUnsharesRow(DataGridViewCellMouseEventArgs e) =>
+        DataGridView is null
+            ? false
+            : e.Button == MouseButtons.Left && DataGridView.ApplyVisualStylesToHeaderCells;
 
-    protected override bool MouseEnterUnsharesRow(int rowIndex)
-    {
-        return ColumnIndex == DataGridView!.MouseDownCellAddress.X &&
+    protected override bool MouseEnterUnsharesRow(int rowIndex) =>
+        DataGridView is null
+            ? false
+            : ColumnIndex == DataGridView.MouseDownCellAddress.X &&
                rowIndex == DataGridView.MouseDownCellAddress.Y &&
                DataGridView.ApplyVisualStylesToHeaderCells;
-    }
 
-    protected override bool MouseLeaveUnsharesRow(int rowIndex)
-    {
-        return ButtonState != ButtonState.Normal && DataGridView!.ApplyVisualStylesToHeaderCells;
-    }
+    protected override bool MouseLeaveUnsharesRow(int rowIndex) =>
+        DataGridView is null
+            ? false
+            : ButtonState != ButtonState.Normal && DataGridView.ApplyVisualStylesToHeaderCells;
 
-    protected override bool MouseUpUnsharesRow(DataGridViewCellMouseEventArgs e)
-    {
-        return e.Button == MouseButtons.Left && DataGridView!.ApplyVisualStylesToHeaderCells;
-    }
+    protected override bool MouseUpUnsharesRow(DataGridViewCellMouseEventArgs e) =>
+        DataGridView is null
+            ? false
+            : e.Button == MouseButtons.Left && DataGridView.ApplyVisualStylesToHeaderCells;
 
     protected override void OnMouseDown(DataGridViewCellMouseEventArgs e)
     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowHeaderCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowHeaderCell.cs
@@ -596,7 +596,7 @@ public partial class DataGridViewRowHeaderCell : DataGridViewHeaderCell
         Rectangle cellBounds,
         int rowIndex,
         DataGridViewElementStates cellState,
-        object value,
+        object? value,
         object? formattedValue,
         string? errorText,
         DataGridViewCellStyle cellStyle,

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewHeaderCellTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewHeaderCellTests.cs
@@ -3904,18 +3904,18 @@ public class DataGridViewHeaderCellTests
 
     [WinFormsTheory]
     [MemberData(nameof(MouseDownUnsharesRow_ButtonLeftNullDataGridView_TestData))]
-    public void DataGridViewHeaderCell_MouseDownUnsharesRow_ButtonLeftNullDataGridView_ThrowsNullReferenceException(DataGridViewCellMouseEventArgs e)
+    public void DataGridViewHeaderCell_MouseDownUnsharesRow_ButtonLeftNullDataGridView_ReturnsFalse(DataGridViewCellMouseEventArgs e)
     {
         using var cell = new SubDataGridViewHeaderCell();
-        Assert.Throws<NullReferenceException>(() => cell.MouseDownUnsharesRow(e));
+        Assert.False(cell.MouseDownUnsharesRow(e));
         Assert.Equal(ButtonState.Normal, cell.ButtonState);
     }
 
     [WinFormsFact]
-    public void DataGridViewHeaderCell_MouseDownUnsharesRow_NullE_ThrowsNullReferenceException()
+    public void DataGridViewHeaderCell_MouseDownUnsharesRow_NullE_ReturnsFalse()
     {
         using var cell = new SubDataGridViewHeaderCell();
-        Assert.Throws<NullReferenceException>(() => cell.MouseDownUnsharesRow(null));
+        Assert.False(cell.MouseDownUnsharesRow(null));
         Assert.Equal(ButtonState.Normal, cell.ButtonState);
     }
 
@@ -3924,10 +3924,10 @@ public class DataGridViewHeaderCellTests
     [InlineData(-1)]
     [InlineData(0)]
     [InlineData(1)]
-    public void DataGridViewHeaderCell_MouseEnterUnsharesRow_InvokeWithoutDataGridView_ThrowsNullReferenceException(int rowIndex)
+    public void DataGridViewHeaderCell_MouseEnterUnsharesRow_InvokeWithoutDataGridView_ReturnsFalse(int rowIndex)
     {
         using var cell = new SubDataGridViewHeaderCell();
-        Assert.Throws<NullReferenceException>(() => cell.MouseEnterUnsharesRow(rowIndex));
+        Assert.False(cell.MouseEnterUnsharesRow(rowIndex));
         Assert.Equal(ButtonState.Normal, cell.ButtonState);
     }
 
@@ -4083,19 +4083,19 @@ public class DataGridViewHeaderCellTests
     }
 
     [WinFormsFact]
-    public void DataGridViewHeaderCell_MouseUpUnsharesRow_NullE_ThrowsNullReferenceException()
+    public void DataGridViewHeaderCell_MouseUpUnsharesRow_NullE_ReturnsFalse()
     {
         using var cell = new SubDataGridViewHeaderCell();
-        Assert.Throws<NullReferenceException>(() => cell.MouseUpUnsharesRow(null));
+        Assert.False(cell.MouseUpUnsharesRow(null));
         Assert.Equal(ButtonState.Normal, cell.ButtonState);
     }
 
     [WinFormsTheory]
     [MemberData(nameof(MouseDownUnsharesRow_ButtonLeftNullDataGridView_TestData))]
-    public void DataGridViewHeaderCell_MouseUpUnsharesRow_ButtonLeftNullDataGridView_ThrowsNullReferenceException(DataGridViewCellMouseEventArgs e)
+    public void DataGridViewHeaderCell_MouseUpUnsharesRow_ButtonLeftNullDataGridView_ReturnsFalse(DataGridViewCellMouseEventArgs e)
     {
         using var cell = new SubDataGridViewHeaderCell();
-        Assert.Throws<NullReferenceException>(() => cell.MouseUpUnsharesRow(e));
+        Assert.False(cell.MouseUpUnsharesRow(e));
         Assert.Equal(ButtonState.Normal, cell.ButtonState);
     }
 


### PR DESCRIPTION
## Proposed changes

- Enable nullability in DataGridViewHeaderCell.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10158)