### PR TITLE
Fix nullability annotations in TypeCodeDomSerializer

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/TypeCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/TypeCodeDomSerializer.cs
@@ -548,7 +548,7 @@ public partial class TypeCodeDomSerializer : CodeDomSerializerBase
         {
             map.Combine();
             typeDecl.Members.Add(map.Method);
-            Trace(TraceLevel.Verbose, $"...generated {map.Method.Statements.Count} statements into method {map.Method.Name}");
+            Trace(TraceLevel.Verbose, $"...generated {map.Method!.Statements.Count} statements into method {map.Method.Name}");
         }
     }
 }


### PR DESCRIPTION
This should fix CI. #9529 was missing a `!`. For some reason it did not show in CI in the PR itself, but once merged it started to appear
