### PR TITLE
Introduce generic ServiceContainerExtensions.AddService and RemoveService

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ComponentDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ComponentDesigner.cs
@@ -382,7 +382,7 @@ public partial class ComponentDesigner : ITreeDesigner, IDesignerFilter, ICompon
 
         if (component?.Site is IServiceContainer sc && GetService(typeof(DesignerCommandSet)) is null)
         {
-            sc.AddService(typeof(DesignerCommandSet), new CDDesignerCommandSet(this));
+            sc.AddService<DesignerCommandSet>(new CDDesignerCommandSet(this));
         }
 
         if (TryGetService(out IComponentChangeService cs))

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignSurface.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignSurface.cs
@@ -33,13 +33,13 @@ public class DesignSurface : IDisposable, IServiceProvider
 
         // Configure our default services
         ServiceCreatorCallback callback = new ServiceCreatorCallback(OnCreateService);
-        ServiceContainer.AddService(typeof(ISelectionService), callback);
-        ServiceContainer.AddService(typeof(IExtenderProviderService), callback);
-        ServiceContainer.AddService(typeof(IExtenderListService), callback);
-        ServiceContainer.AddService(typeof(ITypeDescriptorFilterService), callback);
-        ServiceContainer.AddService(typeof(IReferenceService), callback);
+        ServiceContainer.AddService<ISelectionService>(callback);
+        ServiceContainer.AddService<IExtenderProviderService>(callback);
+        ServiceContainer.AddService<IExtenderListService>(callback);
+        ServiceContainer.AddService<ITypeDescriptorFilterService>(callback);
+        ServiceContainer.AddService<IReferenceService>(callback);
 
-        ServiceContainer.AddService(typeof(DesignSurface), this);
+        ServiceContainer.AddService(this);
         _host = new DesignerHost(this);
     }
 
@@ -329,7 +329,7 @@ public class DesignSurface : IDisposable, IServiceProvider
                 {
                     if (_serviceContainer is not null)
                     {
-                        _serviceContainer.RemoveService(typeof(DesignSurface));
+                        _serviceContainer.RemoveService<DesignSurface>();
                         _serviceContainer.Dispose();
                     }
                 }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignSurfaceManager.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignSurfaceManager.cs
@@ -33,7 +33,7 @@ public class DesignSurfaceManager : IServiceProvider, IDisposable
         _parentProvider = parentProvider;
 
         ServiceCreatorCallback callback = new ServiceCreatorCallback(OnCreateService);
-        ServiceContainer.AddService(typeof(IDesignerEventService), callback);
+        ServiceContainer.AddService<IDesignerEventService>(callback);
     }
 
     /// <summary>

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionService.cs
@@ -124,7 +124,7 @@ public class DesignerActionService : IDisposable
         if (disposing && _serviceProvider is not null)
         {
             IDesignerHost? host = _serviceProvider.GetService<IDesignerHost>();
-            host?.RemoveService(typeof(DesignerActionService));
+            host?.RemoveService<DesignerActionService>();
 
             if (_serviceProvider.TryGetService(out IComponentChangeService? componentChangeService))
             {

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionUIService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionUIService.cs
@@ -20,7 +20,7 @@ public sealed class DesignerActionUIService : IDisposable
         {
             _serviceProvider = serviceProvider;
             IDesignerHost host = (IDesignerHost)serviceProvider.GetService(typeof(IDesignerHost));
-            host.AddService(typeof(DesignerActionUIService), this);
+            host.AddService(this);
             _designerActionService = serviceProvider.GetService(typeof(DesignerActionService)) as DesignerActionService;
             Debug.Assert(_designerActionService is not null, "we should have created and registered the DAService first");
         }
@@ -34,7 +34,7 @@ public sealed class DesignerActionUIService : IDisposable
         if (_serviceProvider is not null)
         {
             IDesignerHost host = (IDesignerHost)_serviceProvider.GetService(typeof(IDesignerHost));
-            host?.RemoveService(typeof(DesignerActionUIService));
+            host?.RemoveService<DesignerActionUIService>();
         }
     }
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/BasicDesignerLoader.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/BasicDesignerLoader.cs
@@ -173,7 +173,7 @@ public abstract partial class BasicDesignerLoader : DesignerLoader, IDesignerLoa
             else
             {
                 IServiceContainer sc = GetRequiredService<IServiceContainer>();
-                sc.AddService(typeof(IDesignerSerializationManager), _serializationManager);
+                sc.AddService<IDesignerSerializationManager>(_serializationManager);
             }
 
             Initialize();
@@ -257,7 +257,7 @@ public abstract partial class BasicDesignerLoader : DesignerLoader, IDesignerLoa
 
         if (_host is not null)
         {
-            _host.RemoveService(typeof(IDesignerLoaderService));
+            _host.RemoveService<IDesignerLoaderService>();
             _host.Activated -= new EventHandler(OnDesignerActivate);
             _host.Deactivated -= new EventHandler(OnDesignerDeactivate);
             _host = null;
@@ -378,7 +378,7 @@ public abstract partial class BasicDesignerLoader : DesignerLoader, IDesignerLoa
     ///  remove any custom services you add here by overriding
     ///  Dispose.
     /// </summary>
-    protected virtual void Initialize() => LoaderHost.AddService(typeof(IDesignerLoaderService), this);
+    protected virtual void Initialize() => LoaderHost.AddService<IDesignerLoaderService>(this);
 
     /// <summary>
     ///  This method an be overridden to provide some intelligent

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomDesignerLoader.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomDesignerLoader.cs
@@ -71,7 +71,7 @@ public abstract partial class CodeDomDesignerLoader : BasicDesignerLoader, IName
     {
         if (_documentType is not null)
         {
-            LoaderHost.RemoveService(typeof(CodeTypeDeclaration));
+            LoaderHost.RemoveService<CodeTypeDeclaration>();
             _documentType = null;
             _documentNamespace = null;
             _documentCompileUnit = null;
@@ -97,13 +97,13 @@ public abstract partial class CodeDomDesignerLoader : BasicDesignerLoader, IName
 
         if (TryGetService(out IDesignerHost? host))
         {
-            host.RemoveService(typeof(INameCreationService));
-            host.RemoveService(typeof(IDesignerSerializationService));
-            host.RemoveService(typeof(ComponentSerializationService));
+            host.RemoveService<INameCreationService>();
+            host.RemoveService<IDesignerSerializationService>();
+            host.RemoveService<ComponentSerializationService>();
 
             if (_state[s_stateOwnTypeResolution])
             {
-                host.RemoveService(typeof(ITypeResolutionService));
+                host.RemoveService<ITypeResolutionService>();
                 _state[s_stateOwnTypeResolution] = false;
             }
         }
@@ -364,7 +364,7 @@ public abstract partial class CodeDomDesignerLoader : BasicDesignerLoader, IName
             {
                 // We are successful.  At this point, we want to provide some of these
                 // code dom elements as services for outside parties to use.
-                LoaderHost.AddService(typeof(CodeTypeDeclaration), _documentType);
+                LoaderHost.AddService(_documentType);
             }
         }
     }
@@ -579,9 +579,9 @@ public abstract partial class CodeDomDesignerLoader : BasicDesignerLoader, IName
 
         ServiceCreatorCallback callback = new ServiceCreatorCallback(OnCreateService);
 
-        LoaderHost.AddService(typeof(ComponentSerializationService), callback);
-        LoaderHost.AddService(typeof(INameCreationService), this);
-        LoaderHost.AddService(typeof(IDesignerSerializationService), this);
+        LoaderHost.AddService<ComponentSerializationService>(callback);
+        LoaderHost.AddService<INameCreationService>(this);
+        LoaderHost.AddService<IDesignerSerializationService>(this);
 
         // The code dom designer loader requires a working ITypeResolutionService to
         // function.  See if someone added one already, and if not, provide
@@ -595,7 +595,7 @@ public abstract partial class CodeDomDesignerLoader : BasicDesignerLoader, IName
                 throw new InvalidOperationException(SR.CodeDomDesignerLoaderNoTypeResolution);
             }
 
-            LoaderHost.AddService(typeof(ITypeResolutionService), typeResolutionService);
+            LoaderHost.AddService(typeResolutionService);
             _state[s_stateOwnTypeResolution] = true;
         }
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ComponentCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ComponentCodeDomSerializer.cs
@@ -374,7 +374,7 @@ internal class ComponentCodeDomSerializer : CodeDomSerializer
                             if (manager.GetService(typeof(IServiceContainer)) is ServiceContainer sc)
                             {
                                 cache = new ComponentCache(manager);
-                                sc.AddService(typeof(ComponentCache), cache);
+                                sc.AddService(cache);
                             }
                         }
                         else

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ServiceContainerExtensions.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ServiceContainerExtensions.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.ComponentModel.Design;
+
+internal static class ServiceContainerExtensions
+{
+    public static void AddService<T>(this IServiceContainer serviceContainer, T serviceInstance) where T : class =>
+        serviceContainer.AddService(typeof(T), serviceInstance);
+
+    public static void AddService<T>(this IServiceContainer serviceContainer, ServiceCreatorCallback callback) =>
+        serviceContainer.AddService(typeof(T), callback);
+
+    public static void RemoveService<T>(this IServiceContainer serviceContainer) => serviceContainer.RemoveService(typeof(T));
+}

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.cs
@@ -84,8 +84,8 @@ public sealed partial class BehaviorService : IDisposable
         if (menuCommandService is not null && host is not null)
         {
             MenuCommandHandler menuCommandHandler = new(this, menuCommandService);
-            host.RemoveService(typeof(IMenuCommandService));
-            host.AddService(typeof(IMenuCommandService), menuCommandHandler);
+            host.RemoveService<IMenuCommandService>();
+            host.AddService<IMenuCommandService>(menuCommandHandler);
         }
 
         // Default layoutmode is SnapToGrid.
@@ -176,8 +176,8 @@ public sealed partial class BehaviorService : IDisposable
             _serviceProvider.GetService(typeof(IDesignerHost)) is IDesignerHost host)
         {
             IMenuCommandService oldMenuCommandService = menuCommandHandler.MenuService;
-            host.RemoveService(typeof(IMenuCommandService));
-            host.AddService(typeof(IMenuCommandService), oldMenuCommandService);
+            host.RemoveService<IMenuCommandService>();
+            host.AddService(oldMenuCommandService);
         }
 
         _adornerWindow.Dispose();

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ComponentTray.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ComponentTray.cs
@@ -93,7 +93,7 @@ public class ComponentTray : ScrollableControl, IExtenderProvider, ISelectionUIH
             if (host is not null)
             {
                 eventHandlerService = new EventHandlerService(this);
-                host.AddService(typeof(IEventHandlerService), eventHandlerService);
+                host.AddService(eventHandlerService);
             }
         }
 
@@ -690,7 +690,7 @@ public class ComponentTray : ScrollableControl, IExtenderProvider, ISelectionUIH
             if (selectionUISvc is null)
             {
                 selectionUISvc = new SelectionUIService(host);
-                host.AddService(typeof(ISelectionUIService), selectionUISvc);
+                host.AddService(selectionUISvc);
             }
 
             grabHandle = selectionUISvc.GetAdornmentDimensions(AdornmentType.GrabHandle);
@@ -856,7 +856,7 @@ public class ComponentTray : ScrollableControl, IExtenderProvider, ISelectionUIH
             {
                 if (host is not null)
                 {
-                    host.RemoveService(typeof(IEventHandlerService));
+                    host.RemoveService<IEventHandlerService>();
                     eventHandlerService = null;
                 }
             }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DocumentDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DocumentDesigner.cs
@@ -396,7 +396,7 @@ public partial class DocumentDesigner : ScrollableControlDesigner, IRootDesigner
                 if (toolWindow is not null)
                 {
                     toolWindow.Dispose();
-                    host.RemoveService(typeof(ToolStripAdornerWindowService));
+                    host.RemoveService<ToolStripAdornerWindowService>();
                 }
 
                 host.Activated -= new EventHandler(OnDesignerActivate);
@@ -415,7 +415,7 @@ public partial class DocumentDesigner : ScrollableControlDesigner, IRootDesigner
                         componentTray = null;
                     }
 
-                    host.RemoveService(typeof(ComponentTray));
+                    host.RemoveService<ComponentTray>();
                 }
 
                 IComponentChangeService cs = (IComponentChangeService)GetService(typeof(IComponentChangeService));
@@ -535,14 +535,14 @@ public partial class DocumentDesigner : ScrollableControlDesigner, IRootDesigner
 
             if (host is not null)
             {
-                host.RemoveService(typeof(BehaviorService));
-                host.RemoveService(typeof(ToolStripAdornerWindowService));
-                host.RemoveService(typeof(SelectionManager));
-                host.RemoveService(typeof(IInheritanceService));
-                host.RemoveService(typeof(IEventHandlerService));
-                host.RemoveService(typeof(IOverlayService));
-                host.RemoveService(typeof(ISplitWindowService));
-                host.RemoveService(typeof(InheritanceUI));
+                host.RemoveService<BehaviorService>();
+                host.RemoveService<ToolStripAdornerWindowService>();
+                host.RemoveService<SelectionManager>();
+                host.RemoveService<IInheritanceService>();
+                host.RemoveService<IEventHandlerService>();
+                host.RemoveService<IOverlayService>();
+                host.RemoveService<ISplitWindowService>();
+                host.RemoveService<InheritanceUI>();
             }
         }
 
@@ -745,7 +745,7 @@ public partial class DocumentDesigner : ScrollableControlDesigner, IRootDesigner
             host.Deactivated += new EventHandler(OnDesignerDeactivate);
 
             ServiceCreatorCallback callback = new ServiceCreatorCallback(OnCreateService);
-            host.AddService(typeof(IEventHandlerService), callback);
+            host.AddService<IEventHandlerService>(callback);
 
             // M3.2 CONTROL ARRAY IS CUT
 
@@ -756,16 +756,16 @@ public partial class DocumentDesigner : ScrollableControlDesigner, IRootDesigner
             frame = new DesignerFrame(component.Site);
 
             IOverlayService os = frame;
-            host.AddService(typeof(IOverlayService), os);
-            host.AddService(typeof(ISplitWindowService), frame);
+            host.AddService(os);
+            host.AddService<ISplitWindowService>(frame);
 
             behaviorService = new BehaviorService(Component.Site, frame);
-            host.AddService(typeof(BehaviorService), behaviorService);
+            host.AddService(behaviorService);
 
             selectionManager = new SelectionManager(host, behaviorService);
 
-            host.AddService(typeof(SelectionManager), selectionManager);
-            host.AddService(typeof(ToolStripAdornerWindowService), callback);
+            host.AddService(selectionManager);
+            host.AddService<ToolStripAdornerWindowService>(callback);
 
             // And component add and remove events for our tray
             //
@@ -785,10 +785,10 @@ public partial class DocumentDesigner : ScrollableControlDesigner, IRootDesigner
             // scan, assign the variable, and then call OnCreateHandle if needed.
             //
             inheritanceUI = new InheritanceUI();
-            host.AddService(typeof(InheritanceUI), inheritanceUI);
+            host.AddService(inheritanceUI);
 
             InheritanceService isvc = new DocumentInheritanceService(this);
-            host.AddService(typeof(IInheritanceService), isvc);
+            host.AddService<IInheritanceService>(isvc);
 
             manager = host.GetService(typeof(IDesignerSerializationManager)) as IDesignerSerializationManager;
             isvc.AddInheritedComponents(component, component.Site.Container);
@@ -982,7 +982,7 @@ public partial class DocumentDesigner : ScrollableControlDesigner, IRootDesigner
                         componentTray.ShowLargeIcons = trayLargeIcon;
                         componentTray.AutoArrange = trayAutoArrange;
 
-                        host.AddService(typeof(ComponentTray), componentTray);
+                        host.AddService(componentTray);
                     }
                 }
 
@@ -1026,7 +1026,7 @@ public partial class DocumentDesigner : ScrollableControlDesigner, IRootDesigner
                 {
                     sws.RemoveSplitWindow(componentTray);
                     IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
-                    host?.RemoveService(typeof(ComponentTray));
+                    host?.RemoveService<ComponentTray>();
 
                     componentTray.Dispose();
                     componentTray = null;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripInSituService.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripInSituService.cs
@@ -28,7 +28,7 @@ internal class ToolStripInSituService : ISupportInSituService, IDisposable
         _sp = provider;
         _designerHost = (IDesignerHost)provider.GetService(typeof(IDesignerHost));
         Debug.Assert(_designerHost is not null, "ToolStripKeyboardHandlingService relies on the selection service, which is unavailable.");
-        _designerHost?.AddService(typeof(ISupportInSituService), this);
+        _designerHost?.AddService<ISupportInSituService>(this);
 
         _componentChangeService = (IComponentChangeService)_designerHost.GetService(typeof(IComponentChangeService));
         Debug.Assert(_componentChangeService is not null, "ToolStripKeyboardHandlingService relies on the componentChange service, which is unavailable.");
@@ -243,7 +243,7 @@ internal class ToolStripInSituService : ISupportInSituService, IDisposable
             if (inSituService is not null)
             {
                 //since we are going away .. restore the old commands.
-                _designerHost.RemoveService(typeof(ISupportInSituService));
+                _designerHost.RemoveService<ISupportInSituService>();
             }
         }
     }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripKeyboardHandlingService.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripKeyboardHandlingService.cs
@@ -57,7 +57,7 @@ internal class ToolStripKeyboardHandlingService
 
         _designerHost = (IDesignerHost)_provider.GetService(typeof(IDesignerHost));
         Debug.Assert(_designerHost is not null, "ToolStripKeyboardHandlingService relies on the selection service, which is unavailable.");
-        _designerHost?.AddService(typeof(ToolStripKeyboardHandlingService), this);
+        _designerHost?.AddService(this);
 
         _componentChangeService = (IComponentChangeService)_designerHost.GetService(typeof(IComponentChangeService));
         Debug.Assert(_componentChangeService is not null, "ToolStripKeyboardHandlingService relies on the componentChange service, which is unavailable.");
@@ -448,7 +448,7 @@ internal class ToolStripKeyboardHandlingService
                 keyboardHandlingService.RestoreCommands();
                 // clean up.
                 keyboardHandlingService.RemoveCommands();
-                _designerHost.RemoveService(typeof(ToolStripKeyboardHandlingService));
+                _designerHost.RemoveService<ToolStripKeyboardHandlingService>();
             }
         }
     }


### PR DESCRIPTION
`IServiceContainer` has methods that take a type as argument. We introduce here a generic extension method to encapsulate the type argument


## Proposed changes

- Introduce method `AddService<T>(this IServiceContainer serviceContainer, T serviceInstance)`
- Introduce method `AddService<T>(this IServiceContainer serviceContainer, ServiceCreatorCallback callback)`
- Introduce method `RemoveService<T>(this IServiceContainer serviceContainer)`
- Use the new methods across the codebase


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10164)