### PR TITLE
Enable nullability in some DataGridViewCheckBoxCell members

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -52,22 +52,22 @@ override System.Windows.Forms.DataGridViewButtonColumn.ToString() -> string!
 override System.Windows.Forms.DataGridViewCellCollection.List.get -> System.Collections.ArrayList!
 override System.Windows.Forms.DataGridViewCellStyle.Equals(object? o) -> bool
 override System.Windows.Forms.DataGridViewCellStyle.ToString() -> string!
-~override System.Windows.Forms.DataGridViewCheckBoxCell.Clone() -> object
-~override System.Windows.Forms.DataGridViewCheckBoxCell.ContentClickUnsharesRow(System.Windows.Forms.DataGridViewCellEventArgs e) -> bool
-~override System.Windows.Forms.DataGridViewCheckBoxCell.ContentDoubleClickUnsharesRow(System.Windows.Forms.DataGridViewCellEventArgs e) -> bool
-~override System.Windows.Forms.DataGridViewCheckBoxCell.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject
-~override System.Windows.Forms.DataGridViewCheckBoxCell.EditType.get -> System.Type
-~override System.Windows.Forms.DataGridViewCheckBoxCell.FormattedValueType.get -> System.Type
-~override System.Windows.Forms.DataGridViewCheckBoxCell.GetContentBounds(System.Drawing.Graphics graphics, System.Windows.Forms.DataGridViewCellStyle cellStyle, int rowIndex) -> System.Drawing.Rectangle
-~override System.Windows.Forms.DataGridViewCheckBoxCell.GetErrorIconBounds(System.Drawing.Graphics graphics, System.Windows.Forms.DataGridViewCellStyle cellStyle, int rowIndex) -> System.Drawing.Rectangle
-~override System.Windows.Forms.DataGridViewCheckBoxCell.GetFormattedValue(object value, int rowIndex, ref System.Windows.Forms.DataGridViewCellStyle cellStyle, System.ComponentModel.TypeConverter valueTypeConverter, System.ComponentModel.TypeConverter formattedValueTypeConverter, System.Windows.Forms.DataGridViewDataErrorContexts context) -> object
-~override System.Windows.Forms.DataGridViewCheckBoxCell.GetPreferredSize(System.Drawing.Graphics graphics, System.Windows.Forms.DataGridViewCellStyle cellStyle, int rowIndex, System.Drawing.Size constraintSize) -> System.Drawing.Size
-~override System.Windows.Forms.DataGridViewCheckBoxCell.KeyDownUnsharesRow(System.Windows.Forms.KeyEventArgs e, int rowIndex) -> bool
-~override System.Windows.Forms.DataGridViewCheckBoxCell.KeyUpUnsharesRow(System.Windows.Forms.KeyEventArgs e, int rowIndex) -> bool
-~override System.Windows.Forms.DataGridViewCheckBoxCell.MouseDownUnsharesRow(System.Windows.Forms.DataGridViewCellMouseEventArgs e) -> bool
-~override System.Windows.Forms.DataGridViewCheckBoxCell.MouseUpUnsharesRow(System.Windows.Forms.DataGridViewCellMouseEventArgs e) -> bool
-~override System.Windows.Forms.DataGridViewCheckBoxCell.OnContentClick(System.Windows.Forms.DataGridViewCellEventArgs e) -> void
-~override System.Windows.Forms.DataGridViewCheckBoxCell.OnContentDoubleClick(System.Windows.Forms.DataGridViewCellEventArgs e) -> void
+override System.Windows.Forms.DataGridViewCheckBoxCell.Clone() -> object!
+override System.Windows.Forms.DataGridViewCheckBoxCell.ContentClickUnsharesRow(System.Windows.Forms.DataGridViewCellEventArgs! e) -> bool
+override System.Windows.Forms.DataGridViewCheckBoxCell.ContentDoubleClickUnsharesRow(System.Windows.Forms.DataGridViewCellEventArgs! e) -> bool
+override System.Windows.Forms.DataGridViewCheckBoxCell.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject!
+override System.Windows.Forms.DataGridViewCheckBoxCell.EditType.get -> System.Type?
+override System.Windows.Forms.DataGridViewCheckBoxCell.FormattedValueType.get -> System.Type!
+override System.Windows.Forms.DataGridViewCheckBoxCell.GetContentBounds(System.Drawing.Graphics! graphics, System.Windows.Forms.DataGridViewCellStyle! cellStyle, int rowIndex) -> System.Drawing.Rectangle
+override System.Windows.Forms.DataGridViewCheckBoxCell.GetErrorIconBounds(System.Drawing.Graphics! graphics, System.Windows.Forms.DataGridViewCellStyle! cellStyle, int rowIndex) -> System.Drawing.Rectangle
+override System.Windows.Forms.DataGridViewCheckBoxCell.GetFormattedValue(object? value, int rowIndex, ref System.Windows.Forms.DataGridViewCellStyle! cellStyle, System.ComponentModel.TypeConverter? valueTypeConverter, System.ComponentModel.TypeConverter? formattedValueTypeConverter, System.Windows.Forms.DataGridViewDataErrorContexts context) -> object?
+override System.Windows.Forms.DataGridViewCheckBoxCell.GetPreferredSize(System.Drawing.Graphics! graphics, System.Windows.Forms.DataGridViewCellStyle! cellStyle, int rowIndex, System.Drawing.Size constraintSize) -> System.Drawing.Size
+override System.Windows.Forms.DataGridViewCheckBoxCell.KeyDownUnsharesRow(System.Windows.Forms.KeyEventArgs! e, int rowIndex) -> bool
+override System.Windows.Forms.DataGridViewCheckBoxCell.KeyUpUnsharesRow(System.Windows.Forms.KeyEventArgs! e, int rowIndex) -> bool
+override System.Windows.Forms.DataGridViewCheckBoxCell.MouseDownUnsharesRow(System.Windows.Forms.DataGridViewCellMouseEventArgs! e) -> bool
+override System.Windows.Forms.DataGridViewCheckBoxCell.MouseUpUnsharesRow(System.Windows.Forms.DataGridViewCellMouseEventArgs! e) -> bool
+override System.Windows.Forms.DataGridViewCheckBoxCell.OnContentClick(System.Windows.Forms.DataGridViewCellEventArgs! e) -> void
+override System.Windows.Forms.DataGridViewCheckBoxCell.OnContentDoubleClick(System.Windows.Forms.DataGridViewCellEventArgs! e) -> void
 ~override System.Windows.Forms.DataGridViewCheckBoxCell.OnKeyDown(System.Windows.Forms.KeyEventArgs e, int rowIndex) -> void
 ~override System.Windows.Forms.DataGridViewCheckBoxCell.OnKeyUp(System.Windows.Forms.KeyEventArgs e, int rowIndex) -> void
 ~override System.Windows.Forms.DataGridViewCheckBoxCell.OnMouseDown(System.Windows.Forms.DataGridViewCellMouseEventArgs e) -> void
@@ -76,8 +76,8 @@ override System.Windows.Forms.DataGridViewCellStyle.ToString() -> string!
 ~override System.Windows.Forms.DataGridViewCheckBoxCell.Paint(System.Drawing.Graphics graphics, System.Drawing.Rectangle clipBounds, System.Drawing.Rectangle cellBounds, int rowIndex, System.Windows.Forms.DataGridViewElementStates elementState, object value, object formattedValue, string errorText, System.Windows.Forms.DataGridViewCellStyle cellStyle, System.Windows.Forms.DataGridViewAdvancedBorderStyle advancedBorderStyle, System.Windows.Forms.DataGridViewPaintParts paintParts) -> void
 ~override System.Windows.Forms.DataGridViewCheckBoxCell.ParseFormattedValue(object formattedValue, System.Windows.Forms.DataGridViewCellStyle cellStyle, System.ComponentModel.TypeConverter formattedValueTypeConverter, System.ComponentModel.TypeConverter valueTypeConverter) -> object
 ~override System.Windows.Forms.DataGridViewCheckBoxCell.ToString() -> string
-~override System.Windows.Forms.DataGridViewCheckBoxCell.ValueType.get -> System.Type
-~override System.Windows.Forms.DataGridViewCheckBoxCell.ValueType.set -> void
+override System.Windows.Forms.DataGridViewCheckBoxCell.ValueType.get -> System.Type?
+override System.Windows.Forms.DataGridViewCheckBoxCell.ValueType.set -> void
 override System.Windows.Forms.DataGridViewCheckBoxColumn.CellTemplate.get -> System.Windows.Forms.DataGridViewCell?
 override System.Windows.Forms.DataGridViewCheckBoxColumn.CellTemplate.set -> void
 override System.Windows.Forms.DataGridViewCheckBoxColumn.DefaultCellStyle.get -> System.Windows.Forms.DataGridViewCellStyle!
@@ -414,12 +414,12 @@ System.Windows.Forms.DataGridViewCellStyle.NullValue.get -> object?
 System.Windows.Forms.DataGridViewCellStyle.NullValue.set -> void
 System.Windows.Forms.DataGridViewCellStyle.Tag.get -> object?
 System.Windows.Forms.DataGridViewCellStyle.Tag.set -> void
-~System.Windows.Forms.DataGridViewCheckBoxCell.FalseValue.get -> object
-~System.Windows.Forms.DataGridViewCheckBoxCell.FalseValue.set -> void
-~System.Windows.Forms.DataGridViewCheckBoxCell.IndeterminateValue.get -> object
-~System.Windows.Forms.DataGridViewCheckBoxCell.IndeterminateValue.set -> void
-~System.Windows.Forms.DataGridViewCheckBoxCell.TrueValue.get -> object
-~System.Windows.Forms.DataGridViewCheckBoxCell.TrueValue.set -> void
+System.Windows.Forms.DataGridViewCheckBoxCell.FalseValue.get -> object?
+System.Windows.Forms.DataGridViewCheckBoxCell.FalseValue.set -> void
+System.Windows.Forms.DataGridViewCheckBoxCell.IndeterminateValue.get -> object?
+System.Windows.Forms.DataGridViewCheckBoxCell.IndeterminateValue.set -> void
+System.Windows.Forms.DataGridViewCheckBoxCell.TrueValue.get -> object?
+System.Windows.Forms.DataGridViewCheckBoxCell.TrueValue.set -> void
 System.Windows.Forms.DataGridViewCheckBoxColumn.FalseValue.get -> object?
 System.Windows.Forms.DataGridViewCheckBoxColumn.FalseValue.set -> void
 System.Windows.Forms.DataGridViewCheckBoxColumn.IndeterminateValue.get -> object?
@@ -854,9 +854,9 @@ virtual System.Windows.Forms.DataGridViewCellCollection.Insert(int index, System
 virtual System.Windows.Forms.DataGridViewCellCollection.Remove(System.Windows.Forms.DataGridViewCell! cell) -> void
 virtual System.Windows.Forms.DataGridViewCellStyle.ApplyStyle(System.Windows.Forms.DataGridViewCellStyle! dataGridViewCellStyle) -> void
 virtual System.Windows.Forms.DataGridViewCellStyle.Clone() -> System.Windows.Forms.DataGridViewCellStyle!
-~virtual System.Windows.Forms.DataGridViewCheckBoxCell.EditingCellFormattedValue.get -> object
-~virtual System.Windows.Forms.DataGridViewCheckBoxCell.EditingCellFormattedValue.set -> void
-~virtual System.Windows.Forms.DataGridViewCheckBoxCell.GetEditingCellFormattedValue(System.Windows.Forms.DataGridViewDataErrorContexts context) -> object
+virtual System.Windows.Forms.DataGridViewCheckBoxCell.EditingCellFormattedValue.get -> object?
+virtual System.Windows.Forms.DataGridViewCheckBoxCell.EditingCellFormattedValue.set -> void
+virtual System.Windows.Forms.DataGridViewCheckBoxCell.GetEditingCellFormattedValue(System.Windows.Forms.DataGridViewDataErrorContexts context) -> object?
 virtual System.Windows.Forms.DataGridViewColumn.CellTemplate.get -> System.Windows.Forms.DataGridViewCell?
 virtual System.Windows.Forms.DataGridViewColumn.CellTemplate.set -> void
 virtual System.Windows.Forms.DataGridViewColumnCollection.Add(string? columnName, string? headerText) -> int
@@ -7216,11 +7216,11 @@ System.Windows.Forms.ICurrencyManagerProvider.GetRelatedCurrencyManager(string? 
 System.Windows.Forms.IDataGridColumnStyleEditingNotificationService
 System.Windows.Forms.IDataGridColumnStyleEditingNotificationService.ColumnStartedEditing(System.Windows.Forms.Control! editingControl) -> void
 System.Windows.Forms.IDataGridViewEditingCell
-System.Windows.Forms.IDataGridViewEditingCell.EditingCellFormattedValue.get -> object!
+System.Windows.Forms.IDataGridViewEditingCell.EditingCellFormattedValue.get -> object?
 System.Windows.Forms.IDataGridViewEditingCell.EditingCellFormattedValue.set -> void
 System.Windows.Forms.IDataGridViewEditingCell.EditingCellValueChanged.get -> bool
 System.Windows.Forms.IDataGridViewEditingCell.EditingCellValueChanged.set -> void
-System.Windows.Forms.IDataGridViewEditingCell.GetEditingCellFormattedValue(System.Windows.Forms.DataGridViewDataErrorContexts context) -> object!
+System.Windows.Forms.IDataGridViewEditingCell.GetEditingCellFormattedValue(System.Windows.Forms.DataGridViewDataErrorContexts context) -> object?
 System.Windows.Forms.IDataGridViewEditingCell.PrepareEditingCellForEdit(bool selectAll) -> void
 System.Windows.Forms.IDataGridViewEditingControl
 System.Windows.Forms.IDataGridViewEditingControl.ApplyCellStyleToEditingControl(System.Windows.Forms.DataGridViewCellStyle! dataGridViewCellStyle) -> void

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
@@ -4039,7 +4039,7 @@ public partial class DataGridView
                     }
                 }
 
-                object formattedValue;
+                object? formattedValue;
 
                 if (EditingControl is not null)
                 {
@@ -10090,7 +10090,7 @@ public partial class DataGridView
         try
         {
             IDataGridViewEditingCell dataGridViewEditingCell = (IDataGridViewEditingCell)dataGridViewCell;
-            object currentFormattedValue = dataGridViewEditingCell.GetEditingCellFormattedValue(DataGridViewDataErrorContexts.Formatting);
+            object? currentFormattedValue = dataGridViewEditingCell.GetEditingCellFormattedValue(DataGridViewDataErrorContexts.Formatting);
             if ((currentFormattedValue is null && _uneditedFormattedValue is not null) ||
                 (currentFormattedValue is not null && _uneditedFormattedValue is null) ||
                 (currentFormattedValue is not null && !_uneditedFormattedValue!.Equals(currentFormattedValue)))

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewButtonCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewButtonCell.cs
@@ -471,7 +471,7 @@ public partial class DataGridViewButtonCell : DataGridViewCell
         ColumnIndex == DataGridView!.MouseDownCellAddress.X && rowIndex == DataGridView.MouseDownCellAddress.Y;
 
     protected override bool MouseLeaveUnsharesRow(int rowIndex) =>
-        (ButtonState & ButtonState.Pushed) != 0;
+        ButtonState.HasFlag(ButtonState.Pushed);
 
     protected override bool MouseUpUnsharesRow(DataGridViewCellMouseEventArgs e) =>
         e.Button == MouseButtons.Left;
@@ -561,7 +561,7 @@ public partial class DataGridViewButtonCell : DataGridViewCell
             }
         }
 
-        if ((ButtonState & ButtonState.Pushed) != 0 &&
+        if (ButtonState.HasFlag(ButtonState.Pushed) &&
             ColumnIndex == DataGridView.MouseDownCellAddress.X &&
             rowIndex == DataGridView.MouseDownCellAddress.Y)
         {
@@ -589,13 +589,13 @@ public partial class DataGridViewButtonCell : DataGridViewCell
                 e.RowIndex == DataGridView.MouseDownCellAddress.Y &&
                 Control.MouseButtons == MouseButtons.Left)
             {
-                if ((ButtonState & ButtonState.Pushed) == 0 &&
+                if (!ButtonState.HasFlag(ButtonState.Pushed) &&
                     s_mouseInContentBounds &&
                     DataGridView.CellMouseDownInContentBounds)
                 {
                     UpdateButtonState(ButtonState | ButtonState.Pushed, e.RowIndex);
                 }
-                else if ((ButtonState & ButtonState.Pushed) != 0 && !s_mouseInContentBounds)
+                else if (ButtonState.HasFlag(ButtonState.Pushed) && !s_mouseInContentBounds)
                 {
                     UpdateButtonState(ButtonState & ~ButtonState.Pushed, e.RowIndex);
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCheckBoxCell.DataGridViewCheckBoxCellFlags.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCheckBoxCell.DataGridViewCheckBoxCellFlags.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Windows.Forms;
+
+public partial class DataGridViewCheckBoxCell
+{
+    [Flags]
+    private enum DataGridViewCheckBoxCellFlags : byte
+    {
+        ThreeState = 0x01,
+        ValueChanged = 0x02,
+        Checked = 0x10,
+        Indeterminate = 0x20
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCheckBoxCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCheckBoxCell.cs
@@ -26,7 +26,7 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
     private static readonly int PropFalseValue = PropertyStore.CreateKey();
     private static readonly int PropFlatStyle = PropertyStore.CreateKey();
     private static readonly int PropIndeterminateValue = PropertyStore.CreateKey();
-    private static Bitmap? checkImage;
+    private static Bitmap? s_checkImage;
 
     private const byte DATAGRIDVIEWCHECKBOXCELL_threeState = 0x01;
     private const byte DATAGRIDVIEWCHECKBOXCELL_valueChanged = 0x02;
@@ -35,11 +35,11 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
 
     private const byte DATAGRIDVIEWCHECKBOXCELL_margin = 2;  // horizontal and vertical margins for preferred sizes
 
-    private byte flags;  // see DATAGRIDVIEWCHECKBOXCELL_ consts above
-    private static bool mouseInContentBounds;
-    private static readonly Type defaultCheckStateType = typeof(CheckState);
-    private static readonly Type defaultBooleanType = typeof(bool);
-    private static readonly Type cellType = typeof(DataGridViewCheckBoxCell);
+    private byte _flags;  // see DATAGRIDVIEWCHECKBOXCELL_ consts above
+    private static bool s_mouseInContentBounds;
+    private static readonly Type s_defaultCheckStateType = typeof(CheckState);
+    private static readonly Type s_defaultBooleanType = typeof(bool);
+    private static readonly Type s_cellType = typeof(DataGridViewCheckBoxCell);
 
     public DataGridViewCheckBoxCell()
         : this(threeState: false)
@@ -50,7 +50,7 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
     {
         if (threeState)
         {
-            flags = DATAGRIDVIEWCHECKBOXCELL_threeState;
+            _flags = DATAGRIDVIEWCHECKBOXCELL_threeState;
         }
     }
 
@@ -78,32 +78,32 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
             {
                 if (((CheckState)value) == System.Windows.Forms.CheckState.Checked)
                 {
-                    flags |= (byte)DATAGRIDVIEWCHECKBOXCELL_checked;
-                    flags = (byte)(flags & ~DATAGRIDVIEWCHECKBOXCELL_indeterminate);
+                    _flags |= (byte)DATAGRIDVIEWCHECKBOXCELL_checked;
+                    _flags = (byte)(_flags & ~DATAGRIDVIEWCHECKBOXCELL_indeterminate);
                 }
                 else if (((CheckState)value) == System.Windows.Forms.CheckState.Indeterminate)
                 {
-                    flags |= (byte)DATAGRIDVIEWCHECKBOXCELL_indeterminate;
-                    flags = (byte)(flags & ~DATAGRIDVIEWCHECKBOXCELL_checked);
+                    _flags |= (byte)DATAGRIDVIEWCHECKBOXCELL_indeterminate;
+                    _flags = (byte)(_flags & ~DATAGRIDVIEWCHECKBOXCELL_checked);
                 }
                 else
                 {
-                    flags = (byte)(flags & ~DATAGRIDVIEWCHECKBOXCELL_checked);
-                    flags = (byte)(flags & ~DATAGRIDVIEWCHECKBOXCELL_indeterminate);
+                    _flags = (byte)(_flags & ~DATAGRIDVIEWCHECKBOXCELL_checked);
+                    _flags = (byte)(_flags & ~DATAGRIDVIEWCHECKBOXCELL_indeterminate);
                 }
             }
             else if (value is bool valueAsBool)
             {
                 if (valueAsBool)
                 {
-                    flags |= (byte)DATAGRIDVIEWCHECKBOXCELL_checked;
+                    _flags |= (byte)DATAGRIDVIEWCHECKBOXCELL_checked;
                 }
                 else
                 {
-                    flags = (byte)(flags & ~DATAGRIDVIEWCHECKBOXCELL_checked);
+                    _flags = (byte)(_flags & ~DATAGRIDVIEWCHECKBOXCELL_checked);
                 }
 
-                flags = (byte)(flags & ~DATAGRIDVIEWCHECKBOXCELL_indeterminate);
+                _flags = (byte)(_flags & ~DATAGRIDVIEWCHECKBOXCELL_indeterminate);
             }
             else
             {
@@ -116,17 +116,17 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
     {
         get
         {
-            return ((flags & DATAGRIDVIEWCHECKBOXCELL_valueChanged) != 0);
+            return ((_flags & DATAGRIDVIEWCHECKBOXCELL_valueChanged) != 0);
         }
         set
         {
             if (value)
             {
-                flags |= (byte)DATAGRIDVIEWCHECKBOXCELL_valueChanged;
+                _flags |= (byte)DATAGRIDVIEWCHECKBOXCELL_valueChanged;
             }
             else
             {
-                flags = (byte)(flags & ~DATAGRIDVIEWCHECKBOXCELL_valueChanged);
+                _flags = (byte)(_flags & ~DATAGRIDVIEWCHECKBOXCELL_valueChanged);
             }
         }
     }
@@ -138,9 +138,9 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
             throw new InvalidOperationException(SR.DataGridViewCell_FormattedValueTypeNull);
         }
 
-        if (FormattedValueType.IsAssignableFrom(defaultCheckStateType))
+        if (FormattedValueType.IsAssignableFrom(s_defaultCheckStateType))
         {
-            if ((flags & DATAGRIDVIEWCHECKBOXCELL_checked) != 0)
+            if ((_flags & DATAGRIDVIEWCHECKBOXCELL_checked) != 0)
             {
                 if ((context & DataGridViewDataErrorContexts.ClipboardContent) != 0)
                 {
@@ -149,7 +149,7 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
 
                 return System.Windows.Forms.CheckState.Checked;
             }
-            else if ((flags & DATAGRIDVIEWCHECKBOXCELL_indeterminate) != 0)
+            else if ((_flags & DATAGRIDVIEWCHECKBOXCELL_indeterminate) != 0)
             {
                 if ((context & DataGridViewDataErrorContexts.ClipboardContent) != 0)
                 {
@@ -168,9 +168,9 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
                 return System.Windows.Forms.CheckState.Unchecked;
             }
         }
-        else if (FormattedValueType.IsAssignableFrom(defaultBooleanType))
+        else if (FormattedValueType.IsAssignableFrom(s_defaultBooleanType))
         {
-            bool ret = (bool)((flags & DATAGRIDVIEWCHECKBOXCELL_checked) != 0);
+            bool ret = (bool)((_flags & DATAGRIDVIEWCHECKBOXCELL_checked) != 0);
             if ((context & DataGridViewDataErrorContexts.ClipboardContent) != 0)
             {
                 return ret ? SR.DataGridViewCheckBoxCell_ClipboardTrue : SR.DataGridViewCheckBoxCell_ClipboardFalse;
@@ -304,11 +304,11 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
         {
             if (ThreeState)
             {
-                return defaultCheckStateType;
+                return s_defaultCheckStateType;
             }
             else
             {
-                return defaultBooleanType;
+                return s_defaultBooleanType;
             }
         }
     }
@@ -356,7 +356,7 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
     {
         get
         {
-            return ((flags & DATAGRIDVIEWCHECKBOXCELL_threeState) != 0);
+            return ((_flags & DATAGRIDVIEWCHECKBOXCELL_threeState) != 0);
         }
         set
         {
@@ -386,11 +386,11 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
             {
                 if (value)
                 {
-                    flags |= (byte)DATAGRIDVIEWCHECKBOXCELL_threeState;
+                    _flags |= (byte)DATAGRIDVIEWCHECKBOXCELL_threeState;
                 }
                 else
                 {
-                    flags = (byte)(flags & ~DATAGRIDVIEWCHECKBOXCELL_threeState);
+                    _flags = (byte)(_flags & ~DATAGRIDVIEWCHECKBOXCELL_threeState);
                 }
             }
         }
@@ -405,19 +405,19 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
             // When users change the CheckBoxCell's CheckState but don't commit the value,
             // FormattedValue is not updated, but flags are, so in this case, we use flags to determine CheckState.
             if ((!EditingCellValueChanged && FormattedValue is CheckState checkState && checkState == CheckState.Indeterminate) ||
-                (flags & DATAGRIDVIEWCHECKBOXCELL_indeterminate) != 0)
+                (_flags & DATAGRIDVIEWCHECKBOXCELL_indeterminate) != 0)
             {
                 return CheckState.Indeterminate;
             }
 
             if ((!EditingCellValueChanged && FormattedValue is CheckState checkState2 && checkState2 == CheckState.Checked) ||
-                (flags & DATAGRIDVIEWCHECKBOXCELL_checked) != 0)
+                (_flags & DATAGRIDVIEWCHECKBOXCELL_checked) != 0)
             {
                 return CheckState.Checked;
             }
 
             if ((!EditingCellValueChanged && FormattedValue is bool boolValue && boolValue) ||
-                (flags & DATAGRIDVIEWCHECKBOXCELL_checked) != 0)
+                (_flags & DATAGRIDVIEWCHECKBOXCELL_checked) != 0)
             {
                 return CheckState.Checked;
             }
@@ -476,17 +476,17 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
 
             if (ThreeState)
             {
-                return defaultCheckStateType;
+                return s_defaultCheckStateType;
             }
             else
             {
-                return defaultBooleanType;
+                return s_defaultBooleanType;
             }
         }
         set
         {
             base.ValueType = value;
-            ThreeState = (value is not null && defaultCheckStateType.IsAssignableFrom(value));
+            ThreeState = (value is not null && s_defaultCheckStateType.IsAssignableFrom(value));
         }
     }
 
@@ -494,7 +494,7 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
     {
         DataGridViewCheckBoxCell dataGridViewCell;
         Type thisType = GetType();
-        if (thisType == cellType) //performance improvement
+        if (thisType == s_cellType) //performance improvement
         {
             dataGridViewCell = new DataGridViewCheckBoxCell();
         }
@@ -888,7 +888,7 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
 
     private void NotifyDataGridViewOfValueChange()
     {
-        flags |= (byte)DATAGRIDVIEWCHECKBOXCELL_valueChanged;
+        _flags |= (byte)DATAGRIDVIEWCHECKBOXCELL_valueChanged;
         Debug.Assert(DataGridView is not null);
         DataGridView.NotifyCurrentCellDirty(true);
     }
@@ -985,7 +985,7 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
             return;
         }
 
-        if (e.Button == MouseButtons.Left && mouseInContentBounds)
+        if (e.Button == MouseButtons.Left && s_mouseInContentBounds)
         {
             Debug.Assert(DataGridView.CellMouseDownInContentBounds);
             UpdateButtonState(ButtonState | ButtonState.Pushed, e.RowIndex);
@@ -999,9 +999,9 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
             return;
         }
 
-        if (mouseInContentBounds)
+        if (s_mouseInContentBounds)
         {
-            mouseInContentBounds = false;
+            s_mouseInContentBounds = false;
             if (ColumnIndex >= 0 &&
                 rowIndex >= 0 &&
                 (DataGridView.ApplyVisualStylesToInnerCells || FlatStyle == FlatStyle.Flat || FlatStyle == FlatStyle.Popup))
@@ -1025,9 +1025,9 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
             return;
         }
 
-        bool oldMouseInContentBounds = mouseInContentBounds;
-        mouseInContentBounds = GetContentBounds(e.RowIndex).Contains(e.X, e.Y);
-        if (oldMouseInContentBounds != mouseInContentBounds)
+        bool oldMouseInContentBounds = s_mouseInContentBounds;
+        s_mouseInContentBounds = GetContentBounds(e.RowIndex).Contains(e.X, e.Y);
+        if (oldMouseInContentBounds != s_mouseInContentBounds)
         {
             if (DataGridView.ApplyVisualStylesToInnerCells || FlatStyle == FlatStyle.Flat || FlatStyle == FlatStyle.Popup)
             {
@@ -1039,12 +1039,12 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
                 Control.MouseButtons == MouseButtons.Left)
             {
                 if ((ButtonState & ButtonState.Pushed) == 0 &&
-                    mouseInContentBounds &&
+                    s_mouseInContentBounds &&
                     DataGridView.CellMouseDownInContentBounds)
                 {
                     UpdateButtonState(ButtonState | ButtonState.Pushed, e.RowIndex);
                 }
-                else if ((ButtonState & ButtonState.Pushed) != 0 && !mouseInContentBounds)
+                else if ((ButtonState & ButtonState.Pushed) != 0 && !s_mouseInContentBounds)
                 {
                     UpdateButtonState(ButtonState & ~ButtonState.Pushed, e.RowIndex);
                 }
@@ -1274,7 +1274,7 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
                 drawAsMixedCheckBox,
                 isHot: DataGridView.MouseEnteredCellAddress.Y == rowIndex
                     && DataGridView.MouseEnteredCellAddress.X == ColumnIndex
-                    && mouseInContentBounds);
+                    && s_mouseInContentBounds);
 
             checkBoxSize = CheckBoxRenderer.GetGlyphSize(g, themeCheckBoxState);
             switch (FlatStyle)
@@ -1408,7 +1408,7 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
 
                         if (DataGridView.MouseEnteredCellAddress.Y == rowIndex &&
                             DataGridView.MouseEnteredCellAddress.X == ColumnIndex &&
-                            mouseInContentBounds)
+                            s_mouseInContentBounds)
                         {
                             const float lowlight = .1f;
                             float adjust = 1 - lowlight;
@@ -1453,12 +1453,12 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
                             fullSize.Width++;
                             fullSize.Height++;
 
-                            if (checkImage is null || checkImage.Width != fullSize.Width || checkImage.Height != fullSize.Height)
+                            if (s_checkImage is null || s_checkImage.Width != fullSize.Width || s_checkImage.Height != fullSize.Height)
                             {
-                                if (checkImage is not null)
+                                if (s_checkImage is not null)
                                 {
-                                    checkImage.Dispose();
-                                    checkImage = null;
+                                    s_checkImage.Dispose();
+                                    s_checkImage = null;
                                 }
 
                                 // We draw the checkmark slightly off center to eliminate 3-D border artifacts,
@@ -1477,13 +1477,13 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
                                 }
 
                                 bitmap.MakeTransparent();
-                                checkImage = bitmap;
+                                s_checkImage = bitmap;
                             }
 
                             fullSize.Y--;
                             ControlPaint.DrawImageColorized(
                                 g,
-                                checkImage,
+                                s_checkImage,
                                 fullSize,
                                 checkState == CheckState.Indeterminate
                                     ? ControlPaint.LightLight(foreBrushColor)
@@ -1550,7 +1550,7 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
                     }
                     else if (DataGridView.MouseEnteredCellAddress.Y == rowIndex
                         && DataGridView.MouseEnteredCellAddress.X == ColumnIndex
-                        && mouseInContentBounds)
+                        && s_mouseInContentBounds)
                     {
                         // paint over
 
@@ -1691,11 +1691,11 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
                     {
                         return TrueValue;
                     }
-                    else if (ValueType is not null && ValueType.IsAssignableFrom(defaultBooleanType))
+                    else if (ValueType is not null && ValueType.IsAssignableFrom(s_defaultBooleanType))
                     {
                         return true;
                     }
-                    else if (ValueType is not null && ValueType.IsAssignableFrom(defaultCheckStateType))
+                    else if (ValueType is not null && ValueType.IsAssignableFrom(s_defaultCheckStateType))
                     {
                         return CheckState.Checked;
                     }
@@ -1706,11 +1706,11 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
                     {
                         return FalseValue;
                     }
-                    else if (ValueType is not null && ValueType.IsAssignableFrom(defaultBooleanType))
+                    else if (ValueType is not null && ValueType.IsAssignableFrom(s_defaultBooleanType))
                     {
                         return false;
                     }
-                    else if (ValueType is not null && ValueType.IsAssignableFrom(defaultCheckStateType))
+                    else if (ValueType is not null && ValueType.IsAssignableFrom(s_defaultCheckStateType))
                     {
                         return CheckState.Unchecked;
                     }
@@ -1725,11 +1725,11 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
                         {
                             return TrueValue;
                         }
-                        else if (ValueType is not null && ValueType.IsAssignableFrom(defaultBooleanType))
+                        else if (ValueType is not null && ValueType.IsAssignableFrom(s_defaultBooleanType))
                         {
                             return true;
                         }
-                        else if (ValueType is not null && ValueType.IsAssignableFrom(defaultCheckStateType))
+                        else if (ValueType is not null && ValueType.IsAssignableFrom(s_defaultCheckStateType))
                         {
                             return CheckState.Checked;
                         }
@@ -1740,11 +1740,11 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
                         {
                             return FalseValue;
                         }
-                        else if (ValueType is not null && ValueType.IsAssignableFrom(defaultBooleanType))
+                        else if (ValueType is not null && ValueType.IsAssignableFrom(s_defaultBooleanType))
                         {
                             return false;
                         }
-                        else if (ValueType is not null && ValueType.IsAssignableFrom(defaultCheckStateType))
+                        else if (ValueType is not null && ValueType.IsAssignableFrom(s_defaultCheckStateType))
                         {
                             return CheckState.Unchecked;
                         }
@@ -1755,7 +1755,7 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
                         {
                             return IndeterminateValue;
                         }
-                        else if (ValueType is not null && ValueType.IsAssignableFrom(defaultCheckStateType))
+                        else if (ValueType is not null && ValueType.IsAssignableFrom(s_defaultCheckStateType))
                         {
                             return CheckState.Indeterminate;
                         }
@@ -1779,11 +1779,11 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
         IDataGridViewEditingCell editingCell = (IDataGridViewEditingCell)this;
         if (FormattedValueType.IsAssignableFrom(typeof(CheckState)))
         {
-            if ((flags & DATAGRIDVIEWCHECKBOXCELL_checked) != 0)
+            if ((_flags & DATAGRIDVIEWCHECKBOXCELL_checked) != 0)
             {
                 editingCell.EditingCellFormattedValue = System.Windows.Forms.CheckState.Indeterminate;
             }
-            else if ((flags & DATAGRIDVIEWCHECKBOXCELL_indeterminate) != 0)
+            else if ((_flags & DATAGRIDVIEWCHECKBOXCELL_indeterminate) != 0)
             {
                 editingCell.EditingCellFormattedValue = System.Windows.Forms.CheckState.Unchecked;
             }
@@ -1792,7 +1792,7 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
                 editingCell.EditingCellFormattedValue = System.Windows.Forms.CheckState.Checked;
             }
         }
-        else if (FormattedValueType.IsAssignableFrom(defaultBooleanType))
+        else if (FormattedValueType.IsAssignableFrom(s_defaultBooleanType))
         {
             editingCell.EditingCellFormattedValue = !((bool)editingCell.GetEditingCellFormattedValue(DataGridViewDataErrorContexts.Formatting));
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCheckBoxCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCheckBoxCell.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.ComponentModel;
 using System.Drawing;
 using System.Windows.Forms.ButtonInternal;
@@ -28,7 +26,7 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
     private static readonly int PropFalseValue = PropertyStore.CreateKey();
     private static readonly int PropFlatStyle = PropertyStore.CreateKey();
     private static readonly int PropIndeterminateValue = PropertyStore.CreateKey();
-    private static Bitmap checkImage;
+    private static Bitmap? checkImage;
 
     private const byte DATAGRIDVIEWCHECKBOXCELL_threeState = 0x01;
     private const byte DATAGRIDVIEWCHECKBOXCELL_valueChanged = 0x02;
@@ -43,7 +41,8 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
     private static readonly Type defaultBooleanType = typeof(bool);
     private static readonly Type cellType = typeof(DataGridViewCheckBoxCell);
 
-    public DataGridViewCheckBoxCell() : this(false /*threeState*/)
+    public DataGridViewCheckBoxCell()
+        : this(threeState: false)
     {
     }
 
@@ -55,7 +54,7 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
         }
     }
 
-    public virtual object EditingCellFormattedValue
+    public virtual object? EditingCellFormattedValue
     {
         get
         {
@@ -93,9 +92,9 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
                     flags = (byte)(flags & ~DATAGRIDVIEWCHECKBOXCELL_indeterminate);
                 }
             }
-            else if (value is bool)
+            else if (value is bool valueAsBool)
             {
-                if ((bool)value)
+                if (valueAsBool)
                 {
                     flags |= (byte)DATAGRIDVIEWCHECKBOXCELL_checked;
                 }
@@ -132,7 +131,7 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
         }
     }
 
-    public virtual object GetEditingCellFormattedValue(DataGridViewDataErrorContexts context)
+    public virtual object? GetEditingCellFormattedValue(DataGridViewDataErrorContexts context)
     {
         if (FormattedValueType is null)
         {
@@ -214,7 +213,7 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
     }
 
     [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.Interfaces)]
-    public override Type EditType
+    public override Type? EditType
     {
         get
         {
@@ -225,7 +224,7 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
     }
 
     [DefaultValue(null)]
-    public object FalseValue
+    public object? FalseValue
     {
         get
         {
@@ -251,7 +250,7 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
         }
     }
 
-    internal object FalseValueInternal
+    internal object? FalseValueInternal
     {
         set
         {
@@ -315,7 +314,7 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
     }
 
     [DefaultValue(null)]
-    public object IndeterminateValue
+    public object? IndeterminateValue
     {
         get
         {
@@ -341,7 +340,7 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
         }
     }
 
-    internal object IndeterminateValueInternal
+    internal object? IndeterminateValueInternal
     {
         set
         {
@@ -428,7 +427,7 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
     }
 
     [DefaultValue(null)]
-    public object TrueValue
+    public object? TrueValue
     {
         get
         {
@@ -454,7 +453,7 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
         }
     }
 
-    internal object TrueValueInternal
+    internal object? TrueValueInternal
     {
         set
         {
@@ -465,11 +464,11 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
         }
     }
 
-    public override Type ValueType
+    public override Type? ValueType
     {
         get
         {
-            Type valueType = base.ValueType;
+            Type? valueType = base.ValueType;
             if (valueType is not null)
             {
                 return valueType;
@@ -501,9 +500,7 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
         }
         else
         {
-            //
-
-            dataGridViewCell = (DataGridViewCheckBoxCell)System.Activator.CreateInstance(thisType);
+            dataGridViewCell = (DataGridViewCheckBoxCell)Activator.CreateInstance(thisType)!;
         }
 
         base.CloneInternal(dataGridViewCell);
@@ -517,6 +514,7 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
 
     private bool CommonContentClickUnsharesRow(DataGridViewCellEventArgs e)
     {
+        Debug.Assert(DataGridView is not null);
         Point ptCurrentCell = DataGridView.CurrentCellAddress;
         return ptCurrentCell.X == ColumnIndex &&
                ptCurrentCell.Y == e.RowIndex &&
@@ -547,25 +545,31 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
             return Rectangle.Empty;
         }
 
-        ComputeBorderStyleCellStateAndCellBounds(rowIndex, out DataGridViewAdvancedBorderStyle dgvabsEffective, out DataGridViewElementStates cellState, out Rectangle cellBounds);
+        ComputeBorderStyleCellStateAndCellBounds(
+            rowIndex,
+            out DataGridViewAdvancedBorderStyle dgvabsEffective,
+            out DataGridViewElementStates cellState,
+            out Rectangle cellBounds);
 
-        Rectangle checkBoxBounds = PaintPrivate(graphics,
+        Rectangle checkBoxBounds = PaintPrivate(
+            graphics,
             cellBounds,
             cellBounds,
             rowIndex,
             cellState,
-            null /*formattedValue*/,            // checkBoxBounds is independent of formattedValue
-            null /*errorText*/,                 // checkBoxBounds is independent of errorText
+            formattedValue: null,   // checkBoxBounds is independent of formattedValue
+            errorText: null,    // checkBoxBounds is independent of errorText
             cellStyle,
             dgvabsEffective,
             DataGridViewPaintParts.ContentForeground,
-            true  /*computeContentBounds*/,
-            false /*computeErrorIconBounds*/,
-            false /*paint*/);
+            computeContentBounds: true,
+            computeErrorIconBounds: false,
+            paint: false);
 
 #if DEBUG
         object value = GetValue(rowIndex);
-        Rectangle checkBoxBoundsDebug = PaintPrivate(graphics,
+        Rectangle checkBoxBoundsDebug = PaintPrivate(
+            graphics,
             cellBounds,
             cellBounds,
             rowIndex,
@@ -575,16 +579,16 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
             cellStyle,
             dgvabsEffective,
             DataGridViewPaintParts.ContentForeground,
-            true  /*computeContentBounds*/,
-            false /*computeErrorIconBounds*/,
-            false /*paint*/);
+            computeContentBounds: true,
+            computeErrorIconBounds: false,
+            paint: false);
         Debug.Assert(checkBoxBoundsDebug.Equals(checkBoxBounds));
 #endif
 
         return checkBoxBounds;
     }
 
-    private protected override string GetDefaultToolTipText()
+    private protected override string? GetDefaultToolTipText()
     {
         if (string.IsNullOrEmpty(Value?.ToString()?.Trim(' ')) || Value is DBNull)
         {
@@ -616,31 +620,37 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
             return Rectangle.Empty;
         }
 
-        ComputeBorderStyleCellStateAndCellBounds(rowIndex, out DataGridViewAdvancedBorderStyle dgvabsEffective, out DataGridViewElementStates cellState, out Rectangle cellBounds);
+        ComputeBorderStyleCellStateAndCellBounds(
+            rowIndex,
+            out DataGridViewAdvancedBorderStyle dgvabsEffective,
+            out DataGridViewElementStates cellState,
+            out Rectangle cellBounds);
 
-        Rectangle errorIconBounds = PaintPrivate(graphics,
+        Rectangle errorIconBounds = PaintPrivate(
+            graphics,
             cellBounds,
             cellBounds,
             rowIndex,
             cellState,
-            null /*formattedValue*/,            // errorIconBounds is independent of formattedValue
+            formattedValue: null,   // errorIconBounds is independent of formattedValue
             GetErrorText(rowIndex),
             cellStyle,
             dgvabsEffective,
             DataGridViewPaintParts.ContentForeground,
-            false /*computeContentBounds*/,
-            true  /*computeErrorIconBound*/,
-            false /*paint*/);
+            computeContentBounds: false,
+            computeErrorIconBounds: true,
+            paint: false);
 
         return errorIconBounds;
     }
 
-    protected override object GetFormattedValue(object value,
-                                                int rowIndex,
-                                                ref DataGridViewCellStyle cellStyle,
-                                                TypeConverter valueTypeConverter,
-                                                TypeConverter formattedValueTypeConverter,
-                                                DataGridViewDataErrorContexts context)
+    protected override object? GetFormattedValue(
+        object? value,
+        int rowIndex,
+        ref DataGridViewCellStyle cellStyle,
+        TypeConverter? valueTypeConverter,
+        TypeConverter? formattedValueTypeConverter,
+        DataGridViewDataErrorContexts context)
     {
         if (value is not null)
         {
@@ -677,7 +687,13 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
             }
         }
 
-        object ret = base.GetFormattedValue(value, rowIndex, ref cellStyle, valueTypeConverter, formattedValueTypeConverter, context);
+        object ret = base.GetFormattedValue(
+            value,
+            rowIndex,
+            ref cellStyle,
+            valueTypeConverter,
+            formattedValueTypeConverter,
+            context);
         if (ret is not null && (context & DataGridViewDataErrorContexts.ClipboardContent) != 0)
         {
             if (ret is bool retBool)
@@ -712,7 +728,11 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
         return ret;
     }
 
-    protected override Size GetPreferredSize(Graphics graphics, DataGridViewCellStyle cellStyle, int rowIndex, Size constraintSize)
+    protected override Size GetPreferredSize(
+        Graphics graphics,
+        DataGridViewCellStyle cellStyle,
+        int rowIndex,
+        Size constraintSize)
     {
         if (DataGridView is null)
         {
@@ -807,7 +827,11 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
 
         // We should consider the border size when calculating the preferred size.
 
-        ComputeBorderStyleCellStateAndCellBounds(rowIndex, out DataGridViewAdvancedBorderStyle dgvabsEffective, out DataGridViewElementStates cellState, out Rectangle cellBounds);
+        ComputeBorderStyleCellStateAndCellBounds(
+            rowIndex,
+            out DataGridViewAdvancedBorderStyle dgvabsEffective,
+            out DataGridViewElementStates cellState,
+            out Rectangle cellBounds);
         Rectangle borderWidths = BorderWidths(dgvabsEffective);
         preferredSize.Width += borderWidths.X;
         preferredSize.Height += borderWidths.Y;
@@ -848,6 +872,7 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
 
     protected override bool MouseEnterUnsharesRow(int rowIndex)
     {
+        Debug.Assert(DataGridView is not null);
         return ColumnIndex == DataGridView.MouseDownCellAddress.X && rowIndex == DataGridView.MouseDownCellAddress.Y;
     }
 
@@ -864,6 +889,7 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
     private void NotifyDataGridViewOfValueChange()
     {
         flags |= (byte)DATAGRIDVIEWCHECKBOXCELL_valueChanged;
+        Debug.Assert(DataGridView is not null);
         DataGridView.NotifyCurrentCellDirty(true);
     }
 
@@ -896,7 +922,7 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
     {
         OnCommonContentClick(e);
     }
-
+#nullable disable
     protected override void OnKeyDown(KeyEventArgs e, int rowIndex)
     {
         if (DataGridView is null)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCheckBoxCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCheckBoxCell.cs
@@ -56,10 +56,7 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
 
     public virtual object? EditingCellFormattedValue
     {
-        get
-        {
-            return GetEditingCellFormattedValue(DataGridViewDataErrorContexts.Formatting);
-        }
+        get => GetEditingCellFormattedValue(DataGridViewDataErrorContexts.Formatting);
         set
         {
             if (FormattedValueType is null)
@@ -114,10 +111,7 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
 
     public virtual bool EditingCellValueChanged
     {
-        get
-        {
-            return ((_flags & DATAGRIDVIEWCHECKBOXCELL_valueChanged) != 0);
-        }
+        get => (_flags & DATAGRIDVIEWCHECKBOXCELL_valueChanged) != 0;
         set
         {
             if (value)
@@ -226,10 +220,7 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
     [DefaultValue(null)]
     public object? FalseValue
     {
-        get
-        {
-            return Properties.GetObject(PropFalseValue);
-        }
+        get => Properties.GetObject(PropFalseValue);
         set
         {
             if (value is not null || Properties.ContainsObject(PropFalseValue))
@@ -298,28 +289,12 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
         }
     }
 
-    public override Type FormattedValueType
-    {
-        get
-        {
-            if (ThreeState)
-            {
-                return s_defaultCheckStateType;
-            }
-            else
-            {
-                return s_defaultBooleanType;
-            }
-        }
-    }
+    public override Type FormattedValueType => ThreeState ? s_defaultCheckStateType : s_defaultBooleanType;
 
     [DefaultValue(null)]
     public object? IndeterminateValue
     {
-        get
-        {
-            return Properties.GetObject(PropIndeterminateValue);
-        }
+        get => Properties.GetObject(PropIndeterminateValue);
         set
         {
             if (value is not null || Properties.ContainsObject(PropIndeterminateValue))
@@ -354,10 +329,7 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
     [DefaultValue(false)]
     public bool ThreeState
     {
-        get
-        {
-            return ((_flags & DATAGRIDVIEWCHECKBOXCELL_threeState) != 0);
-        }
+        get => (_flags & DATAGRIDVIEWCHECKBOXCELL_threeState) != 0;
         set
         {
             if (ThreeState != value)
@@ -429,10 +401,7 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
     [DefaultValue(null)]
     public object? TrueValue
     {
-        get
-        {
-            return Properties.GetObject(PropTrueValue);
-        }
+        get => Properties.GetObject(PropTrueValue);
         set
         {
             if (value is not null || Properties.ContainsObject(PropTrueValue))
@@ -521,20 +490,11 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
                DataGridView.IsCurrentCellInEditMode;
     }
 
-    protected override bool ContentClickUnsharesRow(DataGridViewCellEventArgs e)
-    {
-        return CommonContentClickUnsharesRow(e);
-    }
+    protected override bool ContentClickUnsharesRow(DataGridViewCellEventArgs e) => CommonContentClickUnsharesRow(e);
 
-    protected override bool ContentDoubleClickUnsharesRow(DataGridViewCellEventArgs e)
-    {
-        return CommonContentClickUnsharesRow(e);
-    }
+    protected override bool ContentDoubleClickUnsharesRow(DataGridViewCellEventArgs e) => CommonContentClickUnsharesRow(e);
 
-    protected override AccessibleObject CreateAccessibilityInstance()
-    {
-        return new DataGridViewCheckBoxCellAccessibleObject(this);
-    }
+    protected override AccessibleObject CreateAccessibilityInstance() => new DataGridViewCheckBoxCellAccessibleObject(this);
 
     protected override Rectangle GetContentBounds(Graphics graphics, DataGridViewCellStyle cellStyle, int rowIndex)
     {
@@ -855,20 +815,12 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
         return preferredSize;
     }
 
-    protected override bool KeyDownUnsharesRow(KeyEventArgs e, int rowIndex)
-    {
-        return e.KeyCode == Keys.Space && !e.Alt && !e.Control && !e.Shift;
-    }
+    protected override bool KeyDownUnsharesRow(KeyEventArgs e, int rowIndex) =>
+        e.KeyCode == Keys.Space && !e.Alt && !e.Control && !e.Shift;
 
-    protected override bool KeyUpUnsharesRow(KeyEventArgs e, int rowIndex)
-    {
-        return e.KeyCode == Keys.Space;
-    }
+    protected override bool KeyUpUnsharesRow(KeyEventArgs e, int rowIndex) => e.KeyCode == Keys.Space;
 
-    protected override bool MouseDownUnsharesRow(DataGridViewCellMouseEventArgs e)
-    {
-        return e.Button == MouseButtons.Left;
-    }
+    protected override bool MouseDownUnsharesRow(DataGridViewCellMouseEventArgs e) => e.Button == MouseButtons.Left;
 
     protected override bool MouseEnterUnsharesRow(int rowIndex)
     {
@@ -876,15 +828,9 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
         return ColumnIndex == DataGridView.MouseDownCellAddress.X && rowIndex == DataGridView.MouseDownCellAddress.Y;
     }
 
-    protected override bool MouseLeaveUnsharesRow(int rowIndex)
-    {
-        return (ButtonState & ButtonState.Pushed) != 0;
-    }
+    protected override bool MouseLeaveUnsharesRow(int rowIndex) => (ButtonState & ButtonState.Pushed) != 0;
 
-    protected override bool MouseUpUnsharesRow(DataGridViewCellMouseEventArgs e)
-    {
-        return e.Button == MouseButtons.Left;
-    }
+    protected override bool MouseUpUnsharesRow(DataGridViewCellMouseEventArgs e) => e.Button == MouseButtons.Left;
 
     private void NotifyDataGridViewOfValueChange()
     {
@@ -913,15 +859,9 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
         }
     }
 
-    protected override void OnContentClick(DataGridViewCellEventArgs e)
-    {
-        OnCommonContentClick(e);
-    }
+    protected override void OnContentClick(DataGridViewCellEventArgs e) => OnCommonContentClick(e);
 
-    protected override void OnContentDoubleClick(DataGridViewCellEventArgs e)
-    {
-        OnCommonContentClick(e);
-    }
+    protected override void OnContentDoubleClick(DataGridViewCellEventArgs e) => OnCommonContentClick(e);
 #nullable disable
     protected override void OnKeyDown(KeyEventArgs e, int rowIndex)
     {
@@ -1803,10 +1743,8 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
     /// <summary>
     ///  Gets the row Index and column Index of the cell.
     /// </summary>
-    public override string ToString()
-    {
-        return $"DataGridViewCheckBoxCell {{ ColumnIndex={ColumnIndex}, RowIndex={RowIndex} }}";
-    }
+    public override string ToString() =>
+        $"DataGridViewCheckBoxCell {{ ColumnIndex={ColumnIndex}, RowIndex={RowIndex} }}";
 
     private void UpdateButtonState(ButtonState newButtonState, int rowIndex)
     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCheckBoxCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCheckBoxCell.cs
@@ -438,14 +438,7 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
                 return valueType;
             }
 
-            if (ThreeState)
-            {
-                return s_defaultCheckStateType;
-            }
-            else
-            {
-                return s_defaultBooleanType;
-            }
+            return ThreeState ? s_defaultCheckStateType : s_defaultBooleanType;
         }
         set
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCheckBoxCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCheckBoxCell.cs
@@ -816,7 +816,7 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
         return ColumnIndex == DataGridView.MouseDownCellAddress.X && rowIndex == DataGridView.MouseDownCellAddress.Y;
     }
 
-    protected override bool MouseLeaveUnsharesRow(int rowIndex) => (ButtonState & ButtonState.Pushed) != 0;
+    protected override bool MouseLeaveUnsharesRow(int rowIndex) => ButtonState.HasFlag(ButtonState.Pushed);
 
     protected override bool MouseUpUnsharesRow(DataGridViewCellMouseEventArgs e) => e.Button == MouseButtons.Left;
 
@@ -938,7 +938,7 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
             }
         }
 
-        if ((ButtonState & ButtonState.Pushed) != 0 &&
+        if (ButtonState.HasFlag(ButtonState.Pushed) &&
             ColumnIndex == DataGridView.MouseDownCellAddress.X &&
             rowIndex == DataGridView.MouseDownCellAddress.Y)
         {
@@ -966,13 +966,13 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
                 e.RowIndex == DataGridView.MouseDownCellAddress.Y &&
                 Control.MouseButtons == MouseButtons.Left)
             {
-                if ((ButtonState & ButtonState.Pushed) == 0 &&
+                if (!ButtonState.HasFlag(ButtonState.Pushed) &&
                     s_mouseInContentBounds &&
                     DataGridView.CellMouseDownInContentBounds)
                 {
                     UpdateButtonState(ButtonState | ButtonState.Pushed, e.RowIndex);
                 }
-                else if ((ButtonState & ButtonState.Pushed) != 0 && !s_mouseInContentBounds)
+                else if (ButtonState.HasFlag(ButtonState.Pushed) && !s_mouseInContentBounds)
                 {
                     UpdateButtonState(ButtonState & ~ButtonState.Pushed, e.RowIndex);
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCheckBoxCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCheckBoxCell.cs
@@ -28,14 +28,9 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
     private static readonly int PropIndeterminateValue = PropertyStore.CreateKey();
     private static Bitmap? s_checkImage;
 
-    private const byte DATAGRIDVIEWCHECKBOXCELL_threeState = 0x01;
-    private const byte DATAGRIDVIEWCHECKBOXCELL_valueChanged = 0x02;
-    private const byte DATAGRIDVIEWCHECKBOXCELL_checked = 0x10;
-    private const byte DATAGRIDVIEWCHECKBOXCELL_indeterminate = 0x20;
-
     private const byte DATAGRIDVIEWCHECKBOXCELL_margin = 2;  // horizontal and vertical margins for preferred sizes
 
-    private byte _flags;  // see DATAGRIDVIEWCHECKBOXCELL_ consts above
+    private DataGridViewCheckBoxCellFlags _flags;
     private static bool s_mouseInContentBounds;
     private static readonly Type s_defaultCheckStateType = typeof(CheckState);
     private static readonly Type s_defaultBooleanType = typeof(bool);
@@ -50,7 +45,7 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
     {
         if (threeState)
         {
-            _flags = DATAGRIDVIEWCHECKBOXCELL_threeState;
+            _flags = DataGridViewCheckBoxCellFlags.ThreeState;
         }
     }
 
@@ -73,34 +68,34 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
 
             if (value is CheckState)
             {
-                if (((CheckState)value) == System.Windows.Forms.CheckState.Checked)
+                if (((CheckState)value) == CheckState.Checked)
                 {
-                    _flags |= (byte)DATAGRIDVIEWCHECKBOXCELL_checked;
-                    _flags = (byte)(_flags & ~DATAGRIDVIEWCHECKBOXCELL_indeterminate);
+                    _flags |= DataGridViewCheckBoxCellFlags.Checked;
+                    _flags &= ~DataGridViewCheckBoxCellFlags.Indeterminate;
                 }
-                else if (((CheckState)value) == System.Windows.Forms.CheckState.Indeterminate)
+                else if (((CheckState)value) == CheckState.Indeterminate)
                 {
-                    _flags |= (byte)DATAGRIDVIEWCHECKBOXCELL_indeterminate;
-                    _flags = (byte)(_flags & ~DATAGRIDVIEWCHECKBOXCELL_checked);
+                    _flags |= DataGridViewCheckBoxCellFlags.Indeterminate;
+                    _flags &= ~DataGridViewCheckBoxCellFlags.Checked;
                 }
                 else
                 {
-                    _flags = (byte)(_flags & ~DATAGRIDVIEWCHECKBOXCELL_checked);
-                    _flags = (byte)(_flags & ~DATAGRIDVIEWCHECKBOXCELL_indeterminate);
+                    _flags &= ~DataGridViewCheckBoxCellFlags.Checked;
+                    _flags &= ~DataGridViewCheckBoxCellFlags.Indeterminate;
                 }
             }
             else if (value is bool valueAsBool)
             {
                 if (valueAsBool)
                 {
-                    _flags |= (byte)DATAGRIDVIEWCHECKBOXCELL_checked;
+                    _flags |= DataGridViewCheckBoxCellFlags.Checked;
                 }
                 else
                 {
-                    _flags = (byte)(_flags & ~DATAGRIDVIEWCHECKBOXCELL_checked);
+                    _flags &= ~DataGridViewCheckBoxCellFlags.Checked;
                 }
 
-                _flags = (byte)(_flags & ~DATAGRIDVIEWCHECKBOXCELL_indeterminate);
+                _flags &= ~DataGridViewCheckBoxCellFlags.Indeterminate;
             }
             else
             {
@@ -111,16 +106,16 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
 
     public virtual bool EditingCellValueChanged
     {
-        get => (_flags & DATAGRIDVIEWCHECKBOXCELL_valueChanged) != 0;
+        get => _flags.HasFlag(DataGridViewCheckBoxCellFlags.ValueChanged);
         set
         {
             if (value)
             {
-                _flags |= (byte)DATAGRIDVIEWCHECKBOXCELL_valueChanged;
+                _flags |= DataGridViewCheckBoxCellFlags.ValueChanged;
             }
             else
             {
-                _flags = (byte)(_flags & ~DATAGRIDVIEWCHECKBOXCELL_valueChanged);
+                _flags &= ~DataGridViewCheckBoxCellFlags.ValueChanged;
             }
         }
     }
@@ -134,7 +129,7 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
 
         if (FormattedValueType.IsAssignableFrom(s_defaultCheckStateType))
         {
-            if ((_flags & DATAGRIDVIEWCHECKBOXCELL_checked) != 0)
+            if (_flags.HasFlag(DataGridViewCheckBoxCellFlags.Checked))
             {
                 if ((context & DataGridViewDataErrorContexts.ClipboardContent) != 0)
                 {
@@ -143,7 +138,7 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
 
                 return System.Windows.Forms.CheckState.Checked;
             }
-            else if ((_flags & DATAGRIDVIEWCHECKBOXCELL_indeterminate) != 0)
+            else if (_flags.HasFlag(DataGridViewCheckBoxCellFlags.Indeterminate))
             {
                 if ((context & DataGridViewDataErrorContexts.ClipboardContent) != 0)
                 {
@@ -164,7 +159,7 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
         }
         else if (FormattedValueType.IsAssignableFrom(s_defaultBooleanType))
         {
-            bool ret = (bool)((_flags & DATAGRIDVIEWCHECKBOXCELL_checked) != 0);
+            bool ret = _flags.HasFlag(DataGridViewCheckBoxCellFlags.Checked);
             if ((context & DataGridViewDataErrorContexts.ClipboardContent) != 0)
             {
                 return ret ? SR.DataGridViewCheckBoxCell_ClipboardTrue : SR.DataGridViewCheckBoxCell_ClipboardFalse;
@@ -329,7 +324,7 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
     [DefaultValue(false)]
     public bool ThreeState
     {
-        get => (_flags & DATAGRIDVIEWCHECKBOXCELL_threeState) != 0;
+        get => _flags.HasFlag(DataGridViewCheckBoxCellFlags.ThreeState);
         set
         {
             if (ThreeState != value)
@@ -358,11 +353,11 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
             {
                 if (value)
                 {
-                    _flags |= (byte)DATAGRIDVIEWCHECKBOXCELL_threeState;
+                    _flags |= DataGridViewCheckBoxCellFlags.ThreeState;
                 }
                 else
                 {
-                    _flags = (byte)(_flags & ~DATAGRIDVIEWCHECKBOXCELL_threeState);
+                    _flags &= ~DataGridViewCheckBoxCellFlags.ThreeState;
                 }
             }
         }
@@ -377,19 +372,19 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
             // When users change the CheckBoxCell's CheckState but don't commit the value,
             // FormattedValue is not updated, but flags are, so in this case, we use flags to determine CheckState.
             if ((!EditingCellValueChanged && FormattedValue is CheckState checkState && checkState == CheckState.Indeterminate) ||
-                (_flags & DATAGRIDVIEWCHECKBOXCELL_indeterminate) != 0)
+                (_flags.HasFlag(DataGridViewCheckBoxCellFlags.Indeterminate)))
             {
                 return CheckState.Indeterminate;
             }
 
             if ((!EditingCellValueChanged && FormattedValue is CheckState checkState2 && checkState2 == CheckState.Checked) ||
-                (_flags & DATAGRIDVIEWCHECKBOXCELL_checked) != 0)
+                (_flags.HasFlag(DataGridViewCheckBoxCellFlags.Checked)))
             {
                 return CheckState.Checked;
             }
 
             if ((!EditingCellValueChanged && FormattedValue is bool boolValue && boolValue) ||
-                (_flags & DATAGRIDVIEWCHECKBOXCELL_checked) != 0)
+                (_flags.HasFlag(DataGridViewCheckBoxCellFlags.Checked)))
             {
                 return CheckState.Checked;
             }
@@ -834,7 +829,7 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
 
     private void NotifyDataGridViewOfValueChange()
     {
-        _flags |= (byte)DATAGRIDVIEWCHECKBOXCELL_valueChanged;
+        _flags |= DataGridViewCheckBoxCellFlags.ValueChanged;
         Debug.Assert(DataGridView is not null);
         DataGridView.NotifyCurrentCellDirty(true);
     }
@@ -1719,11 +1714,11 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
         IDataGridViewEditingCell editingCell = (IDataGridViewEditingCell)this;
         if (FormattedValueType.IsAssignableFrom(typeof(CheckState)))
         {
-            if ((_flags & DATAGRIDVIEWCHECKBOXCELL_checked) != 0)
+            if (_flags.HasFlag(DataGridViewCheckBoxCellFlags.Checked))
             {
                 editingCell.EditingCellFormattedValue = System.Windows.Forms.CheckState.Indeterminate;
             }
-            else if ((_flags & DATAGRIDVIEWCHECKBOXCELL_indeterminate) != 0)
+            else if ((_flags.HasFlag(DataGridViewCheckBoxCellFlags.Indeterminate)))
             {
                 editingCell.EditingCellFormattedValue = System.Windows.Forms.CheckState.Unchecked;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewEditingCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewEditingCell.cs
@@ -5,8 +5,7 @@ namespace System.Windows.Forms;
 
 public interface IDataGridViewEditingCell
 {
-    [AllowNull]
-    object EditingCellFormattedValue
+    object? EditingCellFormattedValue
     {
         get;
         set;
@@ -18,7 +17,7 @@ public interface IDataGridViewEditingCell
         set;
     }
 
-    object GetEditingCellFormattedValue(DataGridViewDataErrorContexts context);
+    object? GetEditingCellFormattedValue(DataGridViewDataErrorContexts context);
 
     void PrepareEditingCellForEdit(bool selectAll);
 }


### PR DESCRIPTION
## Proposed changes

- Enable nullability in some DataGridViewCheckBoxCell members.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10166)