### PR TITLE
Review usage of string.Split across codebase

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/ComponentModel/TypeConverterHelper.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/ComponentModel/TypeConverterHelper.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Globalization;
+
+namespace System.ComponentModel;
+
+internal static class TypeConverterHelper
+{
+    public static bool TryParseAsSpan<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(ITypeDescriptorContext? context, CultureInfo? culture, ReadOnlySpan<char> text, Span<T> output)
+    {
+        culture ??= CultureInfo.CurrentCulture;
+
+        Span<Range> tokens = stackalloc Range[output.Length + 1];
+        int tokensCount = text.Split(tokens, culture.TextInfo.ListSeparator[0]);
+
+        if (tokensCount != output.Length)
+        {
+            return false;
+        }
+
+        TypeConverter converter = TypeDescriptor.GetConverter(typeof(T));
+        for (int i = 0; i < output.Length; i++)
+        {
+            // Note: ConvertFromString will raise exception if value cannot be converted.
+            output[i] = (T)converter.ConvertFromString(context, culture, text[tokens[i]].ToString())!;
+        }
+
+        return true;
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/ComponentModel/TypeConverterHelper.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/ComponentModel/TypeConverterHelper.cs
@@ -7,11 +7,20 @@ namespace System.ComponentModel;
 
 internal static class TypeConverterHelper
 {
+    /// <summary>
+    /// Converts the given text to list of objects, using the specified context and culture information.
+    /// </summary>
+    /// <param name="context">An ITypeDescriptorContext that provides a format context.</param>
+    /// <param name="culture">A CultureInfo. If null is passed, the current culture is assumed.</param>
+    /// <param name="text">The chars to convert.</param>
+    /// <param name="output">The converted text chunks</param>
+    /// <typeparam name="T"></typeparam>
+    /// <returns>true if text was converted successfully; otherwise, false.</returns>
     public static bool TryParseAsSpan<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(ITypeDescriptorContext? context, CultureInfo? culture, ReadOnlySpan<char> text, Span<T> output)
     {
         culture ??= CultureInfo.CurrentCulture;
 
-        Span<Range> tokens = stackalloc Range[output.Length + 1];
+        using BufferScope<Range> tokens = new BufferScope<Range>(stackalloc Range[16]);
         int tokensCount = text.Split(tokens, culture.TextInfo.ListSeparator[0]);
 
         if (tokensCount != output.Length)

--- a/src/System.Windows.Forms/src/System/Resources/ResXDataNode.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResXDataNode.cs
@@ -671,12 +671,12 @@ public sealed class ResXDataNode : ISerializable
             resolvedType = typeResolver.GetType(typeName, false);
             if (resolvedType is null)
             {
-                string[] typeParts = typeName.Split(',');
+                string[] typeParts = typeName.Split(',', StringSplitOptions.TrimEntries);
 
                 // Break up the type name from the rest of the assembly strong name.
                 if (typeParts is not null && typeParts.Length >= 2)
                 {
-                    resolvedType = typeResolver.GetType($"{typeParts[0].Trim()}, {typeParts[1].Trim()}", false);
+                    resolvedType = typeResolver.GetType($"{typeParts[0]}, {typeParts[1]}", false);
                 }
             }
         }

--- a/src/System.Windows.Forms/src/System/Resources/ResXResourceReader.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResXResourceReader.cs
@@ -422,17 +422,8 @@ public partial class ResXResourceReader : IResourceReader
             Type readerType = typeof(ResXResourceReader);
             Type writerType = typeof(ResXResourceWriter);
 
-            string? readerTypeName = _resHeaderReaderType;
-            string? writerTypeName = _resHeaderWriterType;
-            if (readerTypeName is not null && readerTypeName.IndexOf(',') != -1)
-            {
-                readerTypeName = readerTypeName.Split(',')[0].Trim();
-            }
-
-            if (writerTypeName is not null && writerTypeName.IndexOf(',') != -1)
-            {
-                writerTypeName = writerTypeName.Split(',')[0].Trim();
-            }
+            string? readerTypeName = GetPrefix(_resHeaderReaderType);
+            string? writerTypeName = GetPrefix(_resHeaderWriterType);
 
             if (readerTypeName is not null &&
                 writerTypeName is not null &&
@@ -448,6 +439,22 @@ public partial class ResXResourceReader : IResourceReader
             _resData = null;
             _resMetadata = null;
             throw new ArgumentException(SR.InvalidResXFileReaderWriterTypes);
+        }
+
+        static string? GetPrefix(string? typeName)
+        {
+            if (typeName is null)
+            {
+                return null;
+            }
+
+            int index = typeName.IndexOf(',');
+            if (index != -1)
+            {
+                return typeName.AsSpan(0, index).Trim().ToString();
+            }
+
+            return typeName;
         }
     }
 

--- a/src/System.Windows.Forms/src/System/Resources/ResXSerializationBinder.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResXSerializationBinder.cs
@@ -50,16 +50,16 @@ internal class ResXSerializationBinder : SerializationBinder
             return type;
         }
 
-        string[] typeParts = typeName.Split(',');
+        string[] typeParts = typeName.Split(',', StringSplitOptions.TrimEntries);
 
-        if (typeParts is not null && typeParts.Length > 2)
+        if (typeParts.Length > 2)
         {
-            string partialName = typeParts[0].Trim();
+            string partialName = typeParts[0];
 
             // Strip out the version.
             for (int i = 1; i < typeParts.Length; ++i)
             {
-                string typePart = typeParts[i].Trim();
+                string typePart = typeParts[i];
                 if (!typePart.StartsWith("Version=", StringComparison.Ordinal)
                     && !typePart.StartsWith("version=", StringComparison.Ordinal))
                 {
@@ -71,7 +71,7 @@ internal class ResXSerializationBinder : SerializationBinder
             type = _typeResolver.GetType(partialName);
 
             // If that didn't work, try the simple name.
-            type ??= _typeResolver.GetType(typeParts[0].Trim());
+            type ??= _typeResolver.GetType(typeParts[0]);
         }
 
         // Hand back what we found or null to let the default loader take over.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/BindingSource.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/BindingSource.cs
@@ -4,7 +4,6 @@
 using System.Collections;
 using System.ComponentModel;
 using System.Drawing.Design;
-using System.Globalization;
 using System.Reflection;
 using System.Text;
 
@@ -980,22 +979,22 @@ public class BindingSource : Component,
             return new ListSortDescriptionCollection();
         }
 
-        List<ListSortDescription> sorts = new();
         PropertyDescriptorCollection props = _currencyManager.GetItemProperties();
 
-        string[] split = sortString.Split(new char[] { ',' });
+        string[] split = sortString.Split(',', StringSplitOptions.TrimEntries);
+        ListSortDescription[] sorts = new ListSortDescription[split.Length];
         for (int i = 0; i < split.Length; i++)
         {
-            string current = split[i].Trim();
+            string current = split[i];
 
             // Handle ASC and DESC
             int length = current.Length;
             bool ascending = true;
-            if (length >= 5 && string.Compare(current, length - 4, " ASC", 0, 4, true, CultureInfo.InvariantCulture) == 0)
+            if (current.EndsWith(" ASC", StringComparison.InvariantCulture))
             {
                 current = current.Substring(0, length - 4).Trim();
             }
-            else if (length >= 6 && string.Compare(current, length - 5, " DESC", 0, 5, true, CultureInfo.InvariantCulture) == 0)
+            else if (current.EndsWith(" DESC", StringComparison.InvariantCulture))
             {
                 ascending = false;
                 current = current.Substring(0, length - 5).Trim();
@@ -1017,10 +1016,10 @@ public class BindingSource : Component,
             }
 
             // Add the sort description
-            sorts.Add(new ListSortDescription(prop, ascending ? ListSortDirection.Ascending : ListSortDirection.Descending));
+            sorts[i] = new ListSortDescription(prop, ascending ? ListSortDirection.Ascending : ListSortDirection.Descending);
         }
 
-        return new ListSortDescriptionCollection(sorts.ToArray());
+        return new ListSortDescriptionCollection(sorts);
     }
 
     public void RemoveCurrent()

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
@@ -1481,7 +1481,7 @@ public partial class Control
                 if (controlType.GetCustomAttributes<ComSourceInterfacesAttribute>(inherit: false).FirstOrDefault()
                     is { } comSourceInterfaces)
                 {
-                    string eventName = comSourceInterfaces.Value.Split('\0')[0];
+                    string eventName = comSourceInterfaces.Value.AsSpan().SliceAtFirstNull().ToString();
                     eventInterface = controlType.Module.Assembly.GetType(eventName, throwOnError: false);
                     eventInterface ??= Type.GetType(eventName, throwOnError: false);
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.cs
@@ -200,8 +200,8 @@ public abstract partial class FileDialog : CommonDialog
 
             if (!string.IsNullOrEmpty(value))
             {
-                string[] formats = value.Split('|');
-                if (formats is null || formats.Length % 2 != 0)
+                int pipeCount = value.AsSpan().Count('|');
+                if (pipeCount % 2 == 0)
                 {
                     throw new ArgumentException(SR.FileDialogInvalidFilter, nameof(value));
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/KeysConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/KeysConverter.cs
@@ -150,11 +150,9 @@ public class KeysConverter : TypeConverter, IComparer
     /// </summary>
     public override object? ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object value)
     {
-        if (value is string valueAsString)
+        if (value is string text)
         {
-            string text = valueAsString.Trim();
-
-            if (text.Length == 0)
+            if (string.IsNullOrWhiteSpace(text))
             {
                 return null;
             }
@@ -162,11 +160,7 @@ public class KeysConverter : TypeConverter, IComparer
             IDictionary<string, Keys> keyNames = GetKeyNames(culture);
 
             // Parse an array of key tokens.
-            string[] tokens = text.Split(new char[] { '+' });
-            for (int i = 0; i < tokens.Length; i++)
-            {
-                tokens[i] = tokens[i].Trim();
-            }
+            string[] tokens = text.Split('+', StringSplitOptions.TrimEntries);
 
             // Now lookup each key token in our key hashtable.
             Keys key = 0;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/LinkArea.LinkAreaConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/LinkArea.LinkAreaConverter.cs
@@ -51,32 +51,23 @@ public partial struct LinkArea
         {
             if (value is string valueStr)
             {
-                string text = valueStr.Trim();
-                if (text.Length == 0)
+                ReadOnlySpan<char> text = valueStr.AsSpan().Trim();
+                if (text.IsEmpty)
                 {
                     return null;
                 }
 
                 // Parse 2 integer values.
                 culture ??= CultureInfo.CurrentCulture;
+                Span<int> values = stackalloc int[2];
 
-                char sep = culture.TextInfo.ListSeparator[0];
-                string[] tokens = text.Split(new char[] { sep });
-                int[] values = new int[tokens.Length];
-
-                if (values.Length != 2)
+                if (!TypeConverterHelper.TryParseAsSpan(context, culture, text, values))
                 {
                     throw new ArgumentException(
                         string.Format(
                             SR.TextParseFailedFormat,
-                            text,
+                            valueStr,
                             "start, length"));
-                }
-
-                TypeConverter intConverter = TypeDescriptor.GetConverter(typeof(int));
-                for (int i = 0; i < values.Length; i++)
-                {
-                    values[i] = (int)intConverter.ConvertFromString(context, culture, tokens[i])!;
                 }
 
                 return new LinkArea(values[0], values[1]);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/LinkConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/LinkConverter.cs
@@ -47,32 +47,23 @@ public class LinkConverter : TypeConverter
     {
         if (value is string valueStr)
         {
-            string text = valueStr.Trim();
-            if (text.Length == 0)
+            ReadOnlySpan<char> text = valueStr.AsSpan().Trim();
+            if (text.IsEmpty)
             {
                 return null;
             }
 
             // Parse 2 integer values.
             culture ??= CultureInfo.CurrentCulture;
+            Span<int> values = stackalloc int[2];
 
-            char sep = culture.TextInfo.ListSeparator[0];
-            string[] tokens = text.Split(new char[] { sep });
-            int[] values = new int[tokens.Length];
-
-            if (values.Length != 2)
+            if (!TypeConverterHelper.TryParseAsSpan(context, culture, text, values))
             {
                 throw new ArgumentException(
                     string.Format(
                         SR.TextParseFailedFormat,
-                        text,
+                        valueStr,
                         "Start, Length"));
-            }
-
-            TypeConverter intConverter = TypeDescriptor.GetConverter(typeof(int));
-            for (int i = 0; i < values.Length; i++)
-            {
-                values[i] = (int)intConverter.ConvertFromString(context, culture, tokens[i])!;
             }
 
             return new LinkLabel.Link(values[0], values[1]);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/LinkUtilities.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/LinkUtilities.cs
@@ -36,15 +36,17 @@ internal static class LinkUtilities
 
             if (s is not null)
             {
-                string[] rgbs = s.Split(new char[] { ',' });
-                int[] rgb = new int[3];
+                Span<Range> rgbs = stackalloc Range[4];
+                int rgbsCount = s.AsSpan().Split(rgbs, ',');
+                Span<int> rgb = stackalloc int[3];
+                rgb.Clear();
 
-                int nMax = Math.Min(rgb.Length, rgbs.Length);
+                int nMax = Math.Min(rgb.Length, rgbsCount);
 
                 // NOTE: if we can't parse rgbs[i], rgb[i] will be set to 0.
                 for (int i = 0; i < nMax; i++)
                 {
-                    int.TryParse(rgbs[i], out rgb[i]);
+                    int.TryParse(s.AsSpan(rgbs[i]), out rgb[i]);
                 }
 
                 return Color.FromArgb(rgb[0], rgb[1], rgb[2]);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutPanelCellPositionTypeConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutPanelCellPositionTypeConverter.cs
@@ -34,8 +34,8 @@ internal class TableLayoutPanelCellPositionTypeConverter : TypeConverter
     {
         if (value is string stringValue)
         {
-            stringValue = stringValue.Trim();
-            if (stringValue.Length == 0)
+            ReadOnlySpan<char> text = stringValue.AsSpan().Trim();
+            if (text.IsEmpty)
             {
                 return null;
             }
@@ -43,10 +43,9 @@ internal class TableLayoutPanelCellPositionTypeConverter : TypeConverter
             // Parse 2 integer values.
             culture ??= CultureInfo.CurrentCulture;
 
-            string[] tokens = stringValue.Split(new char[] { culture.TextInfo.ListSeparator[0] });
-            int[] values = new int[tokens.Length];
+            Span<int> values = stackalloc int[2];
 
-            if (values.Length != 2)
+            if (!TypeConverterHelper.TryParseAsSpan(context, culture, text, values))
             {
                 throw new ArgumentException(
                     string.Format(
@@ -54,13 +53,6 @@ internal class TableLayoutPanelCellPositionTypeConverter : TypeConverter
                         stringValue,
                         "column, row"),
                     nameof(value));
-            }
-
-            TypeConverter intConverter = TypeDescriptor.GetConverter(typeof(int));
-            for (int i = 0; i < values.Length; i++)
-            {
-                // Note: ConvertFromString will raise exception if value cannot be converted.
-                values[i] = (int)intConverter.ConvertFromString(context, culture, tokens[i])!;
             }
 
             return new TableLayoutPanelCellPosition(values[0], values[1]);


### PR DESCRIPTION
There is no issue tied to this, but I encountered several times pieces of code that could use more recent overloads of `string.Split` to reduce allocations, and I thought I'd let the team decide if it's worth the effort or not.

I split the work in four distinct commits. Each one can be spun out in a separate PR or simply discarded

## Proposed changes

- Use `StringSplitOptions.TrimEntries` where relevant. This includes a bit of cleanup in BindingSource that helps readability quite a bit
- Remove useless usage of string.Split. Sometimes it's not even more readable anyway
- Introduce and use TypeConverterHelper. This factorise a pattern often found in `TypeConverter`s in a way that reduces allocations
- Remove allocs in LinkUtilities.GetIELinkBehavior


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10172)