### PR TITLE
Made argument non-nullable to match the new interface definition for IWindowsFormsEditorService.DropDownControl

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -1458,10 +1458,16 @@ internal sealed partial class PropertyGridView :
 
     public int ValueWidth => (int)(LabelWidth * (_labelRatio - 1));
 
-    public void DropDownControl(Control? control)
+    public void DropDownControl(Control control)
     {
         CompModSwitches.DebugGridView.TraceVerbose("PropertyGridView:DropDownControl");
-        s_gridViewDebugPaint.TraceVerbose($"DropDownControl(ctl = {control!.GetType().Name})");
+
+        if (control is null)
+        {
+            return;
+        }
+
+        s_gridViewDebugPaint.TraceVerbose($"DropDownControl(ctl = {control.GetType().Name})");
 
         _dropDownHolder ??= new(this);
         _dropDownHolder.Visible = false;


### PR DESCRIPTION
PR https://github.com/dotnet/winforms/pull/10088/ had changed nullability of the argument in - https://learn.microsoft.com/dotnet/api/system.windows.forms.design.iwindowsformseditorservice.dropdowncontrol?view=windowsdesktop-7.0

I'm updating implementation of this service in the PropertyGrid to match the new definition and to handle a null argument gracefully. This method displays a control in a property grid's value cell's dropdown holder, if there is no control, then there is nothing to show. This method is invoked from the property grid and property grid is not expecting or handling a null reference exception any more gracefully than "do nothing", so I opted for immediately returning from this method if a null is passed in.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10178)