### PR TITLE
Ensure Indexing HtmlElementCollection By String Doesn't Throw

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/HtmlElementCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/HtmlElementCollection.cs
@@ -79,7 +79,7 @@ public sealed unsafe class HtmlElementCollection : ICollection
                 using ComScope<IDispatch> dispatch = new(null);
                 nativeHtmlElementCollection.Value->item(variantElementId, (VARIANT)0, dispatch).ThrowOnFailure();;
                 IHTMLElement* htmlElement;
-                return dispatch.Value->QueryInterface(IID.Get<IHTMLElement>(), (void**)&htmlElement).Succeeded
+                return !dispatch.IsNull && dispatch.Value->QueryInterface(IID.Get<IHTMLElement>(), (void**)&htmlElement).Succeeded
                     ? new(_shimManager, htmlElement)
                     : null;
             }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/HtmlDocumentTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/HtmlDocumentTests.cs
@@ -1779,6 +1779,26 @@ public class HtmlDocumentTests
     }
 
     [WinFormsFact]
+    public async Task HtmlDocument_GetElementsByTagName_IndexIntoByString_ReturnsExpected()
+    {
+        using var parent = new Control();
+        using var control = new WebBrowser
+        {
+            Parent = parent
+        };
+
+        const string Html = "<html><body><img id=\"img1\" /><img id=\"img2\" /><a id=\"link1\">Href</a><a id=\"link2\">Href</a><form id=\"form1\"></form><form id=\"form2\"></form></body></html>";
+        HtmlDocument document = await GetDocument(control, Html);
+
+        HtmlElementCollection collection = document.GetElementsByTagName("form");
+        Assert.NotSame(collection, document.GetElementsByTagName("form"));
+        Assert.Equal(2, collection.Count);
+        Assert.NotNull(collection["form1"]);
+        Assert.NotNull(collection["form2"]);
+        Assert.Null(collection["form3"]);
+    }
+
+    [WinFormsFact]
     public async Task HtmlDocument_GetElementsByTagName_NullTagName_ThrowsArgumentException()
     {
         using var parent = new Control();


### PR DESCRIPTION
Fixes #10188 

When indexing into a `HtmlElementCollection` via `string`, there is a chance that the id given does not exist in which case we will get null back for the `IDispatch`. Add a null check to the string indexing method to ensure it is nonnull before querying it. If the `IDispatch` is null, we will simply return null as we did before. 
Note that indexing via `int` should not have this same issue since we already do bounds checking and throw if there is any illegal argument.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10191)