### PR TITLE
Harden Against Null in HTMLX files

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/HtmlDocument.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/HtmlDocument.cs
@@ -477,6 +477,10 @@ public sealed unsafe partial class HtmlDocument
         using var htmlDoc2 = NativeHtmlDocument2.GetInterface();
         using ComScope<IDispatch> dispatch = new(null);
         htmlDoc2.Value->open(url, name, VARIANT.Empty, VARIANT.Empty, dispatch).ThrowOnFailure();
+        if (dispatch.IsNull)
+        {
+            return null;
+        }
 
         using var htmlDoc = dispatch.TryQuery<IHTMLDocument>(out HRESULT hr);
         return hr.Succeeded ? new HtmlDocument(ShimManager, htmlDoc) : null;
@@ -498,7 +502,7 @@ public sealed unsafe partial class HtmlDocument
             using var htmlDoc2 = NativeHtmlDocument2.GetInterface();
             using ComScope<IDispatch> scriptDispatch = new(null);
             HRESULT hr = htmlDoc2.Value->get_Script(scriptDispatch);
-            if (hr.Failed)
+            if (hr.Failed || scriptDispatch.IsNull)
             {
                 return null;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/HtmlElement.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/HtmlElement.cs
@@ -54,7 +54,7 @@ public sealed unsafe partial class HtmlElement
             using ComScope<IDispatch> dispatch = new(null);
             htmlElement.Value->get_all(dispatch).ThrowOnFailure();
             IHTMLElementCollection* htmlElementCollection;
-            return dispatch.Value->QueryInterface(IID.Get<IHTMLElementCollection>(), (void**)&htmlElementCollection).Succeeded
+            return !dispatch.IsNull && dispatch.Value->QueryInterface(IID.Get<IHTMLElementCollection>(), (void**)&htmlElementCollection).Succeeded
                 ? new(_shimManager, htmlElementCollection)
                 : new(_shimManager);
         }
@@ -68,7 +68,7 @@ public sealed unsafe partial class HtmlElement
             using ComScope<IDispatch> dispatch = new(null);
             htmlElement.Value->get_children(dispatch).ThrowOnFailure();
             IHTMLElementCollection* htmlElementCollection;
-            return dispatch.Value->QueryInterface(IID.Get<IHTMLElementCollection>(), (void**)&htmlElementCollection).Succeeded
+            return !dispatch.IsNull && dispatch.Value->QueryInterface(IID.Get<IHTMLElementCollection>(), (void**)&htmlElementCollection).Succeeded
                 ? new(_shimManager, htmlElementCollection)
                 : new(_shimManager);
         }
@@ -110,6 +110,11 @@ public sealed unsafe partial class HtmlElement
             using var nativeHtmlElement = NativeHtmlElement.GetInterface();
             using ComScope<IDispatch> dispatch = new(null);
             nativeHtmlElement.Value->get_document(dispatch).ThrowOnFailure();
+            if (dispatch.IsNull)
+            {
+                return null;
+            }
+
             using var htmlDocument = dispatch.TryQuery<IHTMLDocument>(out HRESULT hr);
             return hr.Succeeded ? new HtmlDocument(_shimManager, htmlDocument) : null;
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/HtmlElementCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/HtmlElementCollection.cs
@@ -59,7 +59,7 @@ public sealed unsafe class HtmlElementCollection : ICollection
                 using ComScope<IDispatch> dispatch = new(null);
                 htmlElementCollection.Value->item((VARIANT)index, (VARIANT)0, dispatch).ThrowOnFailure();
                 IHTMLElement* htmlElement;
-                return dispatch.TryQuery<IHTMLElement>(out HRESULT hr).Value->QueryInterface(IID.Get<IHTMLElement>(), (void**)&htmlElement).Succeeded
+                return !dispatch.IsNull && dispatch.Value->QueryInterface(IID.Get<IHTMLElement>(), (void**)&htmlElement).Succeeded
                     ? new HtmlElement(_shimManager, htmlElement)
                     : null;
             }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/HtmlWindowTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/HtmlWindowTests.cs
@@ -1,0 +1,60 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text;
+
+namespace System.Windows.Forms.Tests;
+
+[Collection("Sequential")] // workaround for WebBrowser control corrupting memory when run on multiple UI threads
+public class HtmlWindowTests
+{
+    [WinFormsFact]
+    public async Task HtmlWindow_Opener_NoneReturnsNull()
+    {
+        using var parent = new Control();
+        using var control = new WebBrowser
+        {
+            Parent = parent
+        };
+
+        const string Html = "<html><body>test</body></html>";
+        HtmlDocument document = await GetDocument(control, Html);
+        HtmlWindow window = document.Window;
+        Assert.NotSame(window, document.Window);
+        Assert.Null(window.Opener);
+    }
+
+    [WinFormsFact]
+    public async Task HtmlWindow_WindowFrameElement_NoneReturnsNull()
+    {
+        using var parent = new Control();
+        using var control = new WebBrowser
+        {
+            Parent = parent
+        };
+
+        const string Html = "<html><body>test</body></html>";
+        HtmlDocument document = await GetDocument(control, Html);
+        HtmlWindow window = document.Window;
+        Assert.NotSame(window, document.Window);
+        Assert.Null(window.WindowFrameElement);
+    }
+
+    private static async Task<HtmlDocument> GetDocument(WebBrowser control, string html)
+    {
+        var source = new TaskCompletionSource<bool>();
+        control.DocumentCompleted += (sender, e) => source.SetResult(true);
+
+        using var file = CreateTempFile(html);
+        await Task.Run(() => control.Navigate(file.Path));
+        Assert.True(await source.Task);
+
+        return control.Document;
+    }
+
+    private static TempFile CreateTempFile(string html)
+    {
+        byte[] data = Encoding.UTF8.GetBytes(html);
+        return TempFile.Create(data);
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/dotnet/winforms/issues/10193


- Add null check to `HtmlWindow.Opener` and `HtmlWindow.WindowFrameElement` and add regression tests
- Also went ahead and looked through HTMLX files and added additional null checks where it is valid to receive an empty pointer and using it would result in null reference.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10198)