### PR TITLE
Removed a noisy Debug.Assert

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
@@ -10863,8 +10863,9 @@ public partial class DataGridView
         _lastRowSplitBar = _currentRowSplitBar;
         _currentRowSplitBar = e.Y;
         Rectangle lastSplitBarRect = CalcRowResizeFeedbackRect(_lastRowSplitBar);
-        Debug.Assert(_editingPanel is not null);
+
         if (EditingControl is not null &&
+            _editingPanel is not null &&
             !_dataGridViewState1[State1_EditingControlHidden] &&
             _editingPanel.Bounds.IntersectsWith(lastSplitBarRect))
         {
@@ -10930,8 +10931,9 @@ public partial class DataGridView
         _lastColSplitBar = _currentColSplitBar;
         _currentColSplitBar = x;
         Rectangle lastSplitBarRect = CalcColResizeFeedbackRect(_lastColSplitBar);
-        Debug.Assert(_editingPanel is not null);
+
         if (EditingControl is not null &&
+            _editingPanel is not null &&
             !_dataGridViewState1[State1_EditingControlHidden] &&
             _editingPanel.Bounds.IntersectsWith(lastSplitBarRect))
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxCell.cs
@@ -1311,7 +1311,6 @@ public partial class DataGridViewComboBoxCell : DataGridViewCell
     public override void InitializeEditingControl(int rowIndex, object initialFormattedValue, DataGridViewCellStyle dataGridViewCellStyle)
     {
         Debug.Assert(DataGridView is not null &&
-                     DataGridView.EditingPanel is not null &&
                      DataGridView.EditingControl is not null);
         Debug.Assert(!ReadOnly);
         base.InitializeEditingControl(rowIndex, initialFormattedValue, dataGridViewCellStyle);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxCell.cs
@@ -526,7 +526,6 @@ public partial class DataGridViewTextBoxCell : DataGridViewCell
     public override void InitializeEditingControl(int rowIndex, object? initialFormattedValue, DataGridViewCellStyle dataGridViewCellStyle)
     {
         Debug.Assert(DataGridView is not null &&
-                     DataGridView.EditingPanel is not null &&
                      DataGridView.EditingControl is not null);
         Debug.Assert(!ReadOnly);
         base.InitializeEditingControl(rowIndex, initialFormattedValue, dataGridViewCellStyle);


### PR DESCRIPTION
Steps:
Run a debug build of WinformsControlsTest app,
open the DataGridView page and resize columns or rows

Result: an Assert.

We assumed that lifetime of editing control is not longer than that of its container panel, and tested only the editing control for null. However their lifetimes are not tied explicitly, it's safer to have an explicit null-check. It's unlikely that anyone was processing this NRE other than by ignoring it, as it happens on mouse move.

Another change is a removal of null check for EditingPanel get property as this property allocated the panel on the first access.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10199)