### PR TITLE
Improve nullable annotations in ListBindingHelper

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -3160,7 +3160,7 @@ static System.Windows.Forms.ListBindingHelper.GetList(object? list) -> object?
 static System.Windows.Forms.ListBindingHelper.GetListItemProperties(object? dataSource, string? dataMember, System.ComponentModel.PropertyDescriptor![]? listAccessors) -> System.ComponentModel.PropertyDescriptorCollection!
 static System.Windows.Forms.ListBindingHelper.GetListItemProperties(object? list) -> System.ComponentModel.PropertyDescriptorCollection!
 static System.Windows.Forms.ListBindingHelper.GetListItemProperties(object? list, System.ComponentModel.PropertyDescriptor![]? listAccessors) -> System.ComponentModel.PropertyDescriptorCollection!
-static System.Windows.Forms.ListBindingHelper.GetListItemType(object? dataSource, string? dataMember) -> System.Type?
+static System.Windows.Forms.ListBindingHelper.GetListItemType(object? dataSource, string? dataMember) -> System.Type!
 static System.Windows.Forms.ListBindingHelper.GetListItemType(object? list) -> System.Type?
 static System.Windows.Forms.ListBindingHelper.GetListName(object? list, System.ComponentModel.PropertyDescriptor![]? listAccessors) -> string!
 static System.Windows.Forms.MessageBox.Show(string? text) -> System.Windows.Forms.DialogResult

--- a/src/System.Windows.Forms/src/System/Windows/Forms/BindingManagerBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/BindingManagerBase.cs
@@ -67,7 +67,7 @@ public abstract class BindingManagerBase
         SetDataSource(dataSource);
     }
 
-    internal abstract Type? BindType { get; }
+    internal abstract Type BindType { get; }
 
     internal abstract PropertyDescriptorCollection GetItemProperties(PropertyDescriptor[]? listAccessors);
 
@@ -88,7 +88,7 @@ public abstract class BindingManagerBase
             return typedList.GetItemProperties(properties);
         }
 
-        return GetItemProperties(BindType!, 0, dataSources, listAccessors);
+        return GetItemProperties(BindType, 0, dataSources, listAccessors);
     }
 
     protected virtual PropertyDescriptorCollection? GetItemProperties([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]Type listType, int offset, ArrayList dataSources, ArrayList listAccessors)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/CurrencyManager.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CurrencyManager.cs
@@ -134,7 +134,7 @@ public class CurrencyManager : BindingManagerBase
     /// </summary>
     public override object? Current => this[Position];
 
-    internal override Type? BindType => ListBindingHelper.GetListItemType(List);
+    internal override Type BindType => ListBindingHelper.GetListItemType(List);
 
     /// <summary>
     ///  Gets the data source of the list.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBindingHelper.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBindingHelper.cs
@@ -208,6 +208,7 @@ public static class ListBindingHelper
         return GetListItemProperties(dataSource, listAccessors);
     }
 
+    [return: NotNullIfNotNull(nameof(list))]
     public static Type? GetListItemType(object? list)
     {
         if (list is null)
@@ -232,7 +233,7 @@ public static class ListBindingHelper
 
         if (typeof(Array).IsAssignableFrom(listType))
         {
-            return listType.GetElementType();
+            return listType.GetElementType()!;
         }
 
         PropertyInfo? indexer = GetTypedIndexer(listType);
@@ -280,7 +281,7 @@ public static class ListBindingHelper
         return instancedObject;
     }
 
-    public static Type? GetListItemType(object? dataSource, string? dataMember)
+    public static Type GetListItemType(object? dataSource, string? dataMember)
     {
         // No data source
         if (dataSource is null)
@@ -573,7 +574,7 @@ public static class ListBindingHelper
 
     private static PropertyDescriptorCollection GetListItemPropertiesByType(Type type)
     {
-        return TypeDescriptor.GetProperties(GetListItemType(type)!, BrowsableAttributeList);
+        return TypeDescriptor.GetProperties(GetListItemType(type), BrowsableAttributeList);
     }
 
     private static PropertyDescriptorCollection GetListItemPropertiesByEnumerable(IEnumerable enumerable)


### PR DESCRIPTION
I noticed that `ListBindingHelper.GetListItemType` annotations could be improved. I updated other annotations accordingly.

Fixes #


## Proposed changes

- Change NRT annotations of `ListBindingHelper.GetListItemType`
