### PR TITLE
Constructor for `Decimal` expects a ReadOnlySpan, updating a call site.

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/BinaryFormattedObjectExtensions.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/BinaryFormattedObjectExtensions.cs
@@ -154,7 +154,7 @@ internal static class BinaryFormattedObjectExtensions
                     value = Unsafe.As<ulong, DateTime>(ref ulongValue);
                     return true;
                 case TypeInfo.DecimalType:
-                    Span<int> bits = stackalloc int[4]
+                    ReadOnlySpan<int> bits = stackalloc int[4]
                     {
                         (int)systemClass["lo"],
                         (int)systemClass["mid"],


### PR DESCRIPTION
This is inspired by https://github.com/dotnet/winforms/pull/10114

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10212)