### PR TITLE
Return Interface for HtmlWindow.DomWindow

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/HtmlWindow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/HtmlWindow.cs
@@ -80,7 +80,7 @@ public sealed unsafe partial class HtmlWindow
         }
     }
 
-    public object DomWindow => NativeHtmlWindow;
+    public object DomWindow => NativeHtmlWindow.GetManagedObject();
 
     public HtmlWindowCollection? Frames
     {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/HtmlWindowTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/HtmlWindowTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text;
+using Windows.Win32.Web.MsHtml;
 
 namespace System.Windows.Forms.Tests;
 
@@ -38,6 +39,27 @@ public class HtmlWindowTests
         HtmlWindow window = document.Window;
         Assert.NotSame(window, document.Window);
         Assert.Null(window.WindowFrameElement);
+    }
+
+    [WinFormsFact]
+    public async Task HtmlWindow_DomWindow_Get_ReturnsExpected()
+    {
+        using var parent = new Control();
+        using var control = new WebBrowser
+        {
+            Parent = parent
+        };
+
+        const string Html = "<html><body>test</body></html>";
+        HtmlDocument document = await GetDocument(control, Html);
+        HtmlWindow window = document.Window;
+        object domWindow = window.DomWindow;
+
+        Assert.Same(domWindow, window.DomWindow);
+        Assert.True(domWindow.GetType().IsCOMObject);
+        Assert.True(domWindow is IHTMLWindow2.Interface);
+        Assert.True(domWindow is IHTMLWindow3.Interface);
+        Assert.True(domWindow is IHTMLWindow4.Interface);
     }
 
     private static async Task<HtmlDocument> GetDocument(WebBrowser control, string html)

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/HtmlWindowTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/HtmlWindowTests.cs
@@ -21,8 +21,8 @@ public class HtmlWindowTests
         const string Html = "<html><body>test</body></html>";
         HtmlDocument document = await GetDocument(control, Html);
         HtmlWindow window = document.Window;
-        Assert.NotSame(window, document.Window);
-        Assert.Null(window.Opener);
+        window.Should().NotBeSameAs(document.Window);
+        window.Opener.Should().BeNull();
     }
 
     [WinFormsFact]
@@ -37,8 +37,8 @@ public class HtmlWindowTests
         const string Html = "<html><body>test</body></html>";
         HtmlDocument document = await GetDocument(control, Html);
         HtmlWindow window = document.Window;
-        Assert.NotSame(window, document.Window);
-        Assert.Null(window.WindowFrameElement);
+        window.Should().NotBeSameAs(document.Window);
+        window.WindowFrameElement.Should().BeNull();
     }
 
     [WinFormsFact]
@@ -55,11 +55,11 @@ public class HtmlWindowTests
         HtmlWindow window = document.Window;
         object domWindow = window.DomWindow;
 
-        Assert.Same(domWindow, window.DomWindow);
-        Assert.True(domWindow.GetType().IsCOMObject);
-        Assert.True(domWindow is IHTMLWindow2.Interface);
-        Assert.True(domWindow is IHTMLWindow3.Interface);
-        Assert.True(domWindow is IHTMLWindow4.Interface);
+        domWindow.Should().BeSameAs(window.DomWindow);
+        domWindow.GetType().IsCOMObject.Should().BeTrue();
+        domWindow.Should().BeAssignableTo<IHTMLWindow2.Interface>();
+        domWindow.Should().BeAssignableTo<IHTMLWindow3.Interface>();
+        domWindow.Should().BeAssignableTo<IHTMLWindow4.Interface>();
     }
 
     private static async Task<HtmlDocument> GetDocument(WebBrowser control, string html)


### PR DESCRIPTION
Fixes https://github.com/dotnet/winforms/issues/10218

We previously changed internal `NativeHtmlWindow` to type `AgileComPointer` after removing old `IHTMLWindow2` Interface definition and did not update `DomWindow` to return the interface like it always had been. This was missed due to `DomWindow` being of type `object`. I've updated code to return the interface as well as added regression test for this.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10220)