### PR TITLE
When the cursor is not over any control and not in a row/column, chan…

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FlowLayoutPanelDesigner .cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FlowLayoutPanelDesigner .cs
@@ -898,6 +898,7 @@ internal partial class FlowLayoutPanelDesigner : FlowPanelDesigner
         {
             // Here, we're at the 'end' of the FlowLayoutPanel - not over
             // any controls and not in a row/column.
+            _insertionIndex = FlowLayoutPanel.Controls.Count;
             EraseIBar();
         }
     }


### PR DESCRIPTION
Porting fix from the Out-Of-Process designer

## Proposed changes
When the cursor is not over any control and not in a row/column, change insertIndex to the last one.

## Root cause of this bug
In the original code, when the cursor is not on any control and not in a row/column, only the IBar is erased without processing the InsertionIndex of the control, so the top control cannot move to the bottom.

## Before
The top control cannot be moved to the bottom, it always backs to the original position.
![BeforeChange](https://github.com/dotnet/winforms/assets/132890443/f280c608-3f4b-4a27-b2bb-af69dc087528)

## After
The top control can be moved to the bottom
![AfterChange](https://github.com/dotnet/winforms/assets/132890443/32e8d9d0-bf61-4124-96ce-ce25ca94707d)





## Test methodology <!-- How did you ensure quality? -->

- Manually


## Test environment(s) <!-- Remove any that don't apply -->
- .Net 9.0.0-alpha.1.23519.1


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10230)