### PR TITLE
Add `ArgumentException` to `Bitmap` constructor to fail early on null filename

### DIFF
--- a/src/System.Drawing.Common/src/System/Drawing/Bitmap.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Bitmap.cs
@@ -27,6 +27,9 @@ public sealed class Bitmap : Image
 
     public Bitmap(string filename, bool useIcm)
     {
+        // Validate the filename.
+        ArgumentException.ThrowIfNullOrWhiteSpace(filename, nameof(filename));
+
         // GDI+ will read this file multiple times. Get the fully qualified path
         // so if the app's default directory changes we won't get an error.
         filename = Path.GetFullPath(filename);


### PR DESCRIPTION
Fixes #8809

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10234)