### PR TITLE
Refactor `ResizeBehavior` to use `List<T>` instead of `ArrayList`

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/ResizeBehavior.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/ResizeBehavior.cs
@@ -3,7 +3,6 @@
 
 #nullable disable
 
-using System.Collections;
 using System.ComponentModel;
 using System.ComponentModel.Design;
 using System.Drawing;
@@ -17,7 +16,7 @@ internal class ResizeBehavior : Behavior
 {
     private struct ResizeComponent
     {
-        public object resizeControl;
+        public Control resizeControl;
         public Rectangle resizeBounds;
         public SelectionRules resizeRules;
     }
@@ -200,19 +199,19 @@ internal class ResizeBehavior : Behavior
     private void InitiateResize()
     {
         bool useSnapLines = BehaviorService.UseSnapLines;
-        List<IComponent> components = new();
+        List<IComponent> components = [];
         //check to see if the current designer participate with SnapLines cache the control bounds
         for (int i = 0; i < _resizeComponents.Length; i++)
         {
-            _resizeComponents[i].resizeBounds = ((Control)(_resizeComponents[i].resizeControl)).Bounds;
+            _resizeComponents[i].resizeBounds = _resizeComponents[i].resizeControl.Bounds;
             if (useSnapLines)
             {
-                components.Add((Control)_resizeComponents[i].resizeControl);
+                components.Add(_resizeComponents[i].resizeControl);
             }
 
             if (_serviceProvider.GetService(typeof(IDesignerHost)) is IDesignerHost designerHost)
             {
-                if (designerHost.GetDesigner(_resizeComponents[i].resizeControl as Component) is ControlDesigner designer)
+                if (designerHost.GetDesigner(_resizeComponents[i].resizeControl) is ControlDesigner designer)
                 {
                     _resizeComponents[i].resizeRules = designer.SelectionRules;
                 }
@@ -316,22 +315,22 @@ internal class ResizeBehavior : Behavior
         _primaryControl = selSvc.PrimarySelection as Control;
 
         // Since we don't know exactly how many valid objects we are going to have we use this temp
-        ArrayList components = new ArrayList();
-        foreach (object o in selSvc.GetSelectedComponents())
+        List<Control> components = [];
+        foreach (object component in selSvc.GetSelectedComponents())
         {
-            if (o is Control)
+            if (component is Control control)
             {
                 //don't drag locked controls
-                PropertyDescriptor prop = TypeDescriptor.GetProperties(o)["Locked"];
+                PropertyDescriptor prop = TypeDescriptor.GetProperties(control)["Locked"];
                 if (prop is not null)
                 {
-                    if ((bool)prop.GetValue(o))
+                    if ((bool)prop.GetValue(control))
                     {
                         continue;
                     }
                 }
 
-                components.Add(o);
+                components.Add(control);
             }
         }
 
@@ -370,7 +369,7 @@ internal class ResizeBehavior : Behavior
                     //make sure we get rid of the selection rectangle
                     for (int i = 0; !_captureLost && i < _resizeComponents.Length; i++)
                     {
-                        Control control = _resizeComponents[i].resizeControl as Control;
+                        Control control = _resizeComponents[i].resizeControl;
                         Rectangle borderRect = BehaviorService.ControlRectInAdornerWindow(control);
                         if (!borderRect.IsEmpty)
                         {
@@ -531,7 +530,7 @@ internal class ResizeBehavior : Behavior
             }
         }
 
-        Control targetControl = _resizeComponents[0].resizeControl as Control;
+        Control targetControl = _resizeComponents[0].resizeControl;
         _lastMouseLoc = mouseLoc;
         _lastMouseAbs = new Point(mouseLoc.X, mouseLoc.Y);
         PInvoke.ClientToScreen(_behaviorService.AdornerWindowControl, ref _lastMouseAbs);
@@ -602,7 +601,7 @@ internal class ResizeBehavior : Behavior
         Color backColor = targetControl.Parent is not null ? targetControl.Parent.BackColor : Color.Empty;
         for (int i = 0; i < _resizeComponents.Length; i++)
         {
-            Control control = _resizeComponents[i].resizeControl as Control;
+            Control control = _resizeComponents[i].resizeControl;
             Rectangle bounds = control.Bounds;
             Rectangle oldBounds = bounds;
             // We need to compute the offset based on the original cached Bounds ... ListBox doesnt allow drag on the top boundary if this is not done when it is "IntegralHeight"
@@ -858,24 +857,24 @@ internal class ResizeBehavior : Behavior
                     PropertyDescriptor propLeft = TypeDescriptor.GetProperties(_resizeComponents[0].resizeControl)["Left"];
                     for (int i = 0; i < _resizeComponents.Length; i++)
                     {
-                        if (propWidth is not null && ((Control)_resizeComponents[i].resizeControl).Width != _resizeComponents[i].resizeBounds.Width)
+                        if (propWidth is not null && _resizeComponents[i].resizeControl.Width != _resizeComponents[i].resizeBounds.Width)
                         {
-                            propWidth.SetValue(_resizeComponents[i].resizeControl, ((Control)_resizeComponents[i].resizeControl).Width);
+                            propWidth.SetValue(_resizeComponents[i].resizeControl, _resizeComponents[i].resizeControl.Width);
                         }
 
-                        if (propHeight is not null && ((Control)_resizeComponents[i].resizeControl).Height != _resizeComponents[i].resizeBounds.Height)
+                        if (propHeight is not null && _resizeComponents[i].resizeControl.Height != _resizeComponents[i].resizeBounds.Height)
                         {
-                            propHeight.SetValue(_resizeComponents[i].resizeControl, ((Control)_resizeComponents[i].resizeControl).Height);
+                            propHeight.SetValue(_resizeComponents[i].resizeControl, _resizeComponents[i].resizeControl.Height);
                         }
 
-                        if (propTop is not null && ((Control)_resizeComponents[i].resizeControl).Top != _resizeComponents[i].resizeBounds.Y)
+                        if (propTop is not null && _resizeComponents[i].resizeControl.Top != _resizeComponents[i].resizeBounds.Y)
                         {
-                            propTop.SetValue(_resizeComponents[i].resizeControl, ((Control)_resizeComponents[i].resizeControl).Top);
+                            propTop.SetValue(_resizeComponents[i].resizeControl, _resizeComponents[i].resizeControl.Top);
                         }
 
-                        if (propLeft is not null && ((Control)_resizeComponents[i].resizeControl).Left != _resizeComponents[i].resizeBounds.X)
+                        if (propLeft is not null && _resizeComponents[i].resizeControl.Left != _resizeComponents[i].resizeBounds.X)
                         {
-                            propLeft.SetValue(_resizeComponents[i].resizeControl, ((Control)_resizeComponents[i].resizeControl).Left);
+                            propLeft.SetValue(_resizeComponents[i].resizeControl, _resizeComponents[i].resizeControl.Left);
                         }
 
                         if (_resizeComponents[i].resizeControl == _primaryControl && _statusCommandUI is not null)


### PR DESCRIPTION
- Refactor `ResizeBehavior` to use `List<T>` instead of `ArrayList`
- Refactor `ResizeComponent.resizeControl` from `object` to `Control` to remove casting

Related: #8140

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10236)