### PR TITLE
Allows DataGridView to start row/column on index 1 on Narrator

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
@@ -20,12 +20,14 @@ internal static partial class LocalAppContextSwitches
     internal const string ServicePointManagerCheckCrlSwitchName = "System.Windows.Forms.ServicePointManagerCheckCrl";
     internal const string TrackBarModernRenderingSwitchName = "System.Windows.Forms.TrackBarModernRendering";
     private const string DoNotCatchUnhandledExceptionsSwitchName = "System.Windows.Forms.DoNotCatchUnhandledExceptions";
+    internal const string DataGridViewStartRowColumnIndexSwitchName = "System.Windows.Forms.DataGridViewRowColumnStartIndex";
 
     private static int s_scaleTopLevelFormMinMaxSizeForDpi;
     private static int s_anchorLayoutV2;
     private static int s_servicePointManagerCheckCrl;
     private static int s_trackBarModernRendering;
     private static int s_doNotCatchUnhandledExceptions;
+    private static int s_dataGridViewStartRowColumnIndex;
 
     private static FrameworkName? s_targetFrameworkName;
 
@@ -155,5 +157,11 @@ internal static partial class LocalAppContextSwitches
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get => GetCachedSwitchValue(ServicePointManagerCheckCrlSwitchName, ref s_servicePointManagerCheckCrl);
+    }
+
+    public static bool DataGridViewStartRowColumnIndex
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => GetCachedSwitchValue(DataGridViewStartRowColumnIndexSwitchName, ref s_dataGridViewStartRowColumnIndex);
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.DataGridViewCellAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.DataGridViewCellAccessibleObject.cs
@@ -3,6 +3,7 @@
 
 using System.ComponentModel;
 using System.Drawing;
+using System.Windows.Forms.Primitives;
 using Windows.Win32.System.Com;
 using Windows.Win32.System.Variant;
 using Windows.Win32.UI.Accessibility;
@@ -58,7 +59,7 @@ public abstract partial class DataGridViewCell
 
                 int rowIndex = _owner.DataGridView is null
                     ? -1
-                    : _owner.DataGridView.Rows.GetVisibleIndex(_owner.OwningRow);
+                    : _owner.DataGridView.Rows.GetVisibleIndex(_owner.OwningRow) + RowColumnStartIndex;
 
                 string name = string.Format(SR.DataGridView_AccDataGridViewCellName, _owner.OwningColumn.HeaderText, rowIndex);
 
@@ -115,6 +116,19 @@ public abstract partial class DataGridViewCell
         }
 
         public override AccessibleRole Role => AccessibleRole.Cell;
+
+        public int RowColumnStartIndex
+        {
+            get
+            {
+                if (LocalAppContextSwitches.DataGridViewStartRowColumnIndex)
+                {
+                    return 1;
+                }
+
+                return 0;
+            }
+        }
 
         public override AccessibleStates State
         {
@@ -725,12 +739,12 @@ public abstract partial class DataGridViewCell
 
         internal override int Row
             => _owner?.OwningRow?.Visible is true && _owner.DataGridView is not null
-                ? _owner.DataGridView.Rows.GetVisibleIndex(_owner.OwningRow)
+                ? _owner.DataGridView.Rows.GetVisibleIndex(_owner.OwningRow) 
                 : -1;
 
         internal override int Column
             => _owner?.OwningColumn?.Visible is true && _owner.DataGridView is not null
-                ? _owner.DataGridView.Columns.GetVisibleIndex(_owner.OwningColumn)
+                ? _owner.DataGridView.Columns.GetVisibleIndex(_owner.OwningColumn) 
                 : -1;
 
         internal override IRawElementProviderSimple.Interface? ContainingGrid => _owner?.DataGridView?.AccessibilityObject;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.DataGridViewRowAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.DataGridViewRowAccessibleObject.cs
@@ -4,6 +4,7 @@
 using System.Drawing;
 using System.Globalization;
 using System.Text;
+using System.Windows.Forms.Primitives;
 using Windows.Win32.System.Variant;
 using Windows.Win32.UI.Accessibility;
 using static Interop;
@@ -35,7 +36,7 @@ public partial class DataGridViewRow
                 ? dataGridView.ColumnHeadersVisible
                     ? dataGridView.Rows.GetVisibleIndex(_owningDataGridViewRow) + 1
                     : dataGridView.Rows.GetVisibleIndex(_owningDataGridViewRow)
-                : -1;
+            : -1;
 
         public override Rectangle Bounds
         {
@@ -96,7 +97,7 @@ public partial class DataGridViewRow
                 }
 
                 int index = _owningDataGridViewRow is { Visible: true, DataGridView: { } }
-                        ? _owningDataGridViewRow.DataGridView.Rows.GetVisibleIndex(_owningDataGridViewRow)
+                        ? _owningDataGridViewRow.DataGridView.Rows.GetVisibleIndex(_owningDataGridViewRow) + RowColumnStartIndex
                         : -1;
 
                 return string.Format(SR.DataGridView_AccRowName, index.ToString(CultureInfo.CurrentCulture));
@@ -133,6 +134,19 @@ public partial class DataGridViewRow
         }
 
         public override AccessibleRole Role => AccessibleRole.Row;
+
+        public int RowColumnStartIndex
+        {
+            get
+            {
+                if (LocalAppContextSwitches.DataGridViewStartRowColumnIndex)
+                {
+                    return 1;
+                }
+
+                return 0;
+            }
+        }
 
         internal override int[] RuntimeId
             => _runtimeId ??= new int[]


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #7154 

## Proposed changes

- Creates a new switch that allows developers to configure their application to make the starting index of rows/cells in DataGridView to be read by Narrator from 1, instead of 0;
- Adds checks on rows and cells of DataGridView to see if the switch is true. If true, starting index of rows/cells will be 1, instead of 0.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Developers will be able to configure their WinForms DataGridView rows/cells to be read by Narrator from index 1, instead of 0.

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/dotnet/winforms/assets/30190295/5bcc7595-2278-4a4c-bddc-fc4561a4c554)

### After

![image](https://github.com/dotnet/winforms/assets/30190295/ba65c3be-c486-460c-badd-2b7444109f0e)
![image](https://github.com/dotnet/winforms/assets/30190295/aadda98f-f2d9-42bb-9f2a-6ecab6cf8a00)


## Test methodology <!-- How did you ensure quality? -->

- Manual (Narrator)

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->
  
 

## Test environment(s) <!-- Remove any that don't apply -->

- 9.0.100-alpha.1.23511.2


<!-- Mention language, UI scaling, or anything else that might be relevant -->
