### PR TITLE
Implement the ITypeDiscoveryService service

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignSurface.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignSurface.cs
@@ -37,6 +37,7 @@ public class DesignSurface : IDisposable, IServiceProvider
         ServiceContainer.AddService<IExtenderProviderService>(callback);
         ServiceContainer.AddService<IExtenderListService>(callback);
         ServiceContainer.AddService<ITypeDescriptorFilterService>(callback);
+        ServiceContainer.AddService<ITypeDiscoveryService>(callback);
         ServiceContainer.AddService<IReferenceService>(callback);
 
         ServiceContainer.AddService(this);
@@ -396,6 +397,11 @@ public class DesignSurface : IDisposable, IServiceProvider
         if (serviceType == typeof(ITypeDescriptorFilterService))
         {
             return new TypeDescriptorFilterService();
+        }
+
+        if (serviceType == typeof(ITypeDiscoveryService))
+        {
+            return new TypeDiscoveryService();
         }
 
         Debug.Assert(serviceType == typeof(IReferenceService), $"Demand created service not supported: {serviceType.Name}");

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/TypeDiscoveryService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/TypeDiscoveryService.cs
@@ -1,0 +1,56 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using System.Reflection;
+
+namespace System.ComponentModel.Design;
+
+/// <summary>
+///  This service is requested by TypeDescriptor when asking for type information for a component.
+/// </summary>
+internal sealed class TypeDiscoveryService : ITypeDiscoveryService
+{
+    internal TypeDiscoveryService()
+    {
+    }
+
+    private readonly ConcurrentDictionary<Type, ImmutableArray<Type>> _discoveredTypesCache = new();
+
+    public ICollection GetTypes(Type? baseType, bool excludeGlobalTypes)
+    {
+        return baseType is null
+            ? throw new ArgumentNullException(nameof(baseType))
+            : (ICollection)_discoveredTypesCache.GetOrAdd(baseType, type => FindTypes(type, AppDomain.CurrentDomain.GetAssemblies()));
+
+        static ImmutableArray<Type> FindTypes(Type baseType, Assembly[] assemblies)
+        {
+            var builder = ImmutableArray.CreateBuilder<Type>();
+
+            foreach (var assembly in assemblies)
+            {
+                Type[] types;
+                try
+                {
+                    types = assembly.GetTypes();
+                }
+                catch (ReflectionTypeLoadException exception)
+                {
+                    types = exception.Types!;
+                }
+
+                foreach (var type in types)
+                {
+                    if (baseType.IsAssignableFrom(type))
+                    {
+                        builder.Add(type);
+                    }
+                }
+            }
+
+            return builder.ToImmutable();
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #9870


## Proposed changes

- Add ITypeDiscoveryService in default service container `ServiceContainer `of IDesignerHost
- Implement the ITypeDiscoveryService service

## Root cause of this issue:
- In the `PopulateColumnTypesCombo ` function, the code attempts to obtain an `ITypeDiscoveryService `instance through the GetService method of `IDesignerHost `in order to discover all subtypes of `DataGridViewColumn`.
However, because `ITypeDiscoveryService` is not added in the default service container `ServiceContainer` of `IDesignerHost`, `GetService `returns null.

https://github.com/dotnet/winforms/blob/1d604b5425cbbaf54f2b5be181096d1cf6b0271d/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewAddColumnDialog.cs#L657-L673

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- The DataGridViewColumn can be added normally in DemoConsole project

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
The column type is empty
![image](https://github.com/dotnet/winforms/assets/132890443/30d3bd42-5617-4d50-aa0d-907e0429cccc)

### After
The DataGridView column can be added normally from the Add column page

![AfterChange](https://github.com/dotnet/winforms/assets/132890443/eb3b650e-7651-431c-92b6-fa9a80f88559)


## Test methodology <!-- How did you ensure quality? -->

- Manually (Add test to Dome project)

## Test environment(s) <!-- Remove any that don't apply -->

- .net 9.0.0-alpha.1.23519.1


<!-- Mention language, UI scaling, or anything else that might be relevant -->
