### PR TITLE
[release/6.0] Upgrade MicrosoftNETTestSdkVersion

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -54,7 +54,7 @@
     <MicrosoftDotNetGenFacadesPackageVersion>6.0.0-beta.23511.8</MicrosoftDotNetGenFacadesPackageVersion>
     <MicrosoftDotNetRemoteExecutorVersion>6.0.0-beta.23511.8</MicrosoftDotNetRemoteExecutorVersion>
     <MicrosoftDotNetXUnitExtensionsPackageVersion>6.0.0-beta.23511.8</MicrosoftDotNetXUnitExtensionsPackageVersion>
-    <MicrosoftNETTestSdkVersion>16.5.0</MicrosoftNETTestSdkVersion>
+    <MicrosoftNETTestSdkVersion>17.4.0-preview-20220707-01</MicrosoftNETTestSdkVersion>
   </PropertyGroup>
   <!-- Below have no corresponding entries in Versions.Details.XML because they are not updated via Maestro -->
   <!-- XUnit-related (not extensions) -->


### PR DESCRIPTION
MicrosoftNETTestSdkVersion holds reference to NewtonsoftJsonVersion 9.0.1 which is out of compliance.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10266)