### PR TITLE
Add IAccessible dispatch support

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/UI/Accessibility/AccessibleDispatch.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/UI/Accessibility/AccessibleDispatch.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Windows.Win32.System.Com;
+
+namespace Windows.Win32.UI.Accessibility;
+
+/// <summary>
+///  Base <see cref="IDispatch"/> class for <see cref="IAccessible"/>.
+/// </summary>
+internal abstract unsafe class AccessibleDispatch : StandardDispatch<IAccessible>
+{
+    // The accessibility TypeLib- lives in oleacc.dll
+    private static readonly Guid s_accessibilityTypeLib = new("1ea4dbf0-3c3b-11cf-810c-00aa00389b71");
+
+    // We don't release the ITypeInfo to avoid unloading and reloading the IAccessible ITypeLib.
+    private static ITypeInfo* TypeInfo { get; } = ComHelpers.GetRegisteredTypeInfo(s_accessibilityTypeLib, 1, 1, IAccessible.IID_Guid);
+
+    public AccessibleDispatch() : base(TypeInfo) { }
+
+    public AccessibleDispatch(IAccessible.Interface instance) : base(TypeInfo, instance) { }
+}

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/Windows/Win32/UI/Accessibility/AccessibleDispatchTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/Windows/Win32/UI/Accessibility/AccessibleDispatchTests.cs
@@ -1,0 +1,54 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Windows.Win32.System.Com;
+using Windows.Win32.System.Ole;
+using Windows.Win32.System.Variant;
+using Windows.Win32.UI.Accessibility;
+
+namespace Windows.Win32.System.Accessibility.Tests;
+
+public partial class AccessibleDispatchTests
+{
+    [StaFact]
+    public unsafe void AccessibleDispatch_InvokeViaDispatch()
+    {
+        AccessibleTestObject accessibleObject = new();
+        using var dispatch = ComHelpers.GetComScope<IDispatch>(accessibleObject);
+        dispatch.Value->GetIDOfName("accChildCount", out int dispId).Should().Be(HRESULT.S_OK);
+        dispId.Should().Be(-5001);
+        using VARIANT result = dispatch.Value->GetProperty(dispId);
+        result.vt.Should().Be(VARENUM.VT_I4);
+        ((int)result).Should().Be(42);
+    }
+
+    private unsafe class AccessibleTestObject : AccessibleDispatch, IAccessible.Interface, IManagedWrapper<IAccessible, IDispatch, IDispatchEx>
+    {
+        HRESULT IAccessible.Interface.get_accParent(IDispatch** ppdispParent) => HRESULT.E_NOTIMPL;
+        HRESULT IAccessible.Interface.get_accChildCount(int* pcountChildren)
+        {
+            *pcountChildren = 42;
+            return HRESULT.S_OK;
+        }
+
+        HRESULT IAccessible.Interface.get_accChild(VARIANT varChild, IDispatch** ppdispChild) => HRESULT.E_NOTIMPL;
+        HRESULT IAccessible.Interface.get_accName(VARIANT varChild, BSTR* pszName) => HRESULT.E_NOTIMPL;
+        HRESULT IAccessible.Interface.get_accValue(VARIANT varChild, BSTR* pszValue) => HRESULT.E_NOTIMPL;
+        HRESULT IAccessible.Interface.get_accDescription(VARIANT varChild, BSTR* pszDescription) => HRESULT.E_NOTIMPL;
+        HRESULT IAccessible.Interface.get_accRole(VARIANT varChild, VARIANT* pvarRole) => HRESULT.E_NOTIMPL;
+        HRESULT IAccessible.Interface.get_accState(VARIANT varChild, VARIANT* pvarState) => HRESULT.E_NOTIMPL;
+        HRESULT IAccessible.Interface.get_accHelp(VARIANT varChild, BSTR* pszHelp) => HRESULT.E_NOTIMPL;
+        HRESULT IAccessible.Interface.get_accHelpTopic(BSTR* pszHelpFile, VARIANT varChild, int* pidTopic) => HRESULT.E_NOTIMPL;
+        HRESULT IAccessible.Interface.get_accKeyboardShortcut(VARIANT varChild, BSTR* pszKeyboardShortcut) => HRESULT.E_NOTIMPL;
+        HRESULT IAccessible.Interface.get_accFocus(VARIANT* pvarChild) => HRESULT.E_NOTIMPL;
+        HRESULT IAccessible.Interface.get_accSelection(VARIANT* pvarChildren) => HRESULT.E_NOTIMPL;
+        HRESULT IAccessible.Interface.get_accDefaultAction(VARIANT varChild, BSTR* pszDefaultAction) => HRESULT.E_NOTIMPL;
+        HRESULT IAccessible.Interface.accSelect(int flagsSelect, VARIANT varChild) => HRESULT.E_NOTIMPL;
+        HRESULT IAccessible.Interface.accLocation(int* pxLeft, int* pyTop, int* pcxWidth, int* pcyHeight, VARIANT varChild) => HRESULT.E_NOTIMPL;
+        HRESULT IAccessible.Interface.accNavigate(int navDir, VARIANT varStart, VARIANT* pvarEndUpAt) => HRESULT.E_NOTIMPL;
+        HRESULT IAccessible.Interface.accHitTest(int xLeft, int yTop, VARIANT* pvarChild) => HRESULT.E_NOTIMPL;
+        HRESULT IAccessible.Interface.accDoDefaultAction(VARIANT varChild) => HRESULT.E_NOTIMPL;
+        HRESULT IAccessible.Interface.put_accName(VARIANT varChild, BSTR szName) => HRESULT.E_NOTIMPL;
+        HRESULT IAccessible.Interface.put_accValue(VARIANT varChild, BSTR szValue) => HRESULT.E_NOTIMPL;
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.AccessibleDispatchAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.AccessibleDispatchAdapter.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Windows.Win32.UI.Accessibility;
+
+namespace System.Windows.Forms;
+
+public unsafe partial class AccessibleObject
+{
+    /// <summary>
+    ///  <see cref="AccessibleObject"/> can't derive directly from <see cref="AccessibleDispatch"/> as
+    ///  <see cref="AccessibleObject"/> is public and already has a public base class.
+    /// </summary>
+    private class AccessibleDispatchAdapter(AccessibleObject accessibleObject) : AccessibleDispatch(accessibleObject)
+    {
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComponentModel/Com2Interop/ComNativeDescriptorTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComponentModel/Com2Interop/ComNativeDescriptorTests.cs
@@ -233,19 +233,11 @@ public unsafe class ComNativeDescriptorTests
     ///  just forwards to the IDispatch ITypeInfo to exercise the IProvideMultipleClassInfo code path.
     /// </summary>
     private unsafe class StandardAccessibleObjectWithMultipleClassInfo :
-        StandardDispatch<IAccessible>,
+        AccessibleDispatch,
         IProvideMultipleClassInfo.Interface,
         IAccessible.Interface,
         IManagedWrapper<IAccessible, IDispatch, IProvideMultipleClassInfo>
     {
-        // The accessibility TypeLib- lives in oleacc.dll
-        private static readonly Guid s_accessibilityTypeLib = new("1ea4dbf0-3c3b-11cf-810c-00aa00389b71");
-
-        public StandardAccessibleObjectWithMultipleClassInfo()
-            : base(ComHelpers.GetRegisteredTypeInfo(s_accessibilityTypeLib, 1, 1, IAccessible.IID_Guid))
-        {
-        }
-
         HRESULT IProvideMultipleClassInfo.Interface.GetClassInfo(ITypeInfo** ppTI) => HRESULT.E_NOTIMPL;
 
         HRESULT IProvideMultipleClassInfo.Interface.GetGUID(uint dwGuidKind, Guid* pGUID) => HRESULT.E_NOTIMPL;


### PR DESCRIPTION
Adds IAccessible dispatch support through AccessibleDispatch.

AccessibleObject has the requisite interfaces defined. IAccessible is currently just stubbed out (all return E_NOTIMPL). When IAccessible is implemented and `IManagedWrapper` is added to AccessibleObject, it will get IDispatch support.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10267)