### PR TITLE
Fixing issue 10213 by adding missed class StyleCollectionEditor

### DIFF
--- a/src/System.Design/src/System.Design.Forwards.cs
+++ b/src/System.Design/src/System.Design.Forwards.cs
@@ -21,6 +21,7 @@ using System.Runtime.CompilerServices;
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.ListViewSubItemCollectionEditor))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.MaskPropertyEditor))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.MaskedTextBoxTextEditor))]
+[assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.StyleCollectionEditor))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.SelectedPathEditor))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.StringArrayEditor))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.StringCollectionEditor))]

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/NavigationalTableLayoutPanel.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/NavigationalTableLayoutPanel.cs
@@ -11,7 +11,7 @@ internal partial class StyleCollectionEditor
         {
             get
             {
-                List<RadioButton> radioButtons = new List<RadioButton>();
+                List<RadioButton> radioButtons = new();
                 foreach (Control control in Controls)
                 {
                     RadioButton radioButton = (RadioButton)control;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/NavigationalTableLayoutPanel.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/NavigationalTableLayoutPanel.cs
@@ -1,0 +1,61 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Windows.Forms.Design;
+
+internal partial class StyleCollectionEditor
+{
+    protected class NavigationalTableLayoutPanel : TableLayoutPanel
+    {
+        private List<RadioButton> RadioButtons
+        {
+            get
+            {
+                List<RadioButton> radioButtons = new List<RadioButton>();
+                foreach (Control control in Controls)
+                {
+                    RadioButton radioButton = (RadioButton)control;
+                    if (radioButton is not null)
+                    {
+                        radioButtons.Add(radioButton);
+                    }
+                }
+
+                return radioButtons;
+            }
+        }
+
+        protected override bool ProcessDialogKey(Keys keyData)
+        {
+            bool down = keyData == Keys.Down;
+            bool up = keyData == Keys.Up;
+
+            if (down || up)
+            {
+                List<RadioButton> radioButtons = RadioButtons;
+
+                for (int i = 0; i < radioButtons.Count; i++)
+                {
+                    RadioButton radioButton = radioButtons[i];
+                    if (radioButton.Focused)
+                    {
+                        int focusIndex;
+                        if (down)
+                        {
+                            focusIndex = i == RadioButtons.Count - 1 ? 0 : i + 1;
+                        }
+                        else
+                        {
+                            focusIndex = i == 0 ? RadioButtons.Count - 1 : i - 1;
+                        }
+
+                        radioButtons[focusIndex].Focus();
+                        return true;
+                    }
+                }
+            }
+
+            return base.ProcessDialogKey(keyData);
+        }
+    }
+}

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/StyleCollectionEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/StyleCollectionEditor.cs
@@ -13,7 +13,7 @@ namespace System.Windows.Forms.Design
     /// </summary>
     internal partial class StyleCollectionEditor(Type type) : CollectionEditor(type)
     {
-        private bool isRowCollection = type.IsAssignableFrom(typeof(TableLayoutRowStyleCollection));
+        private readonly bool isRowCollection = type.IsAssignableFrom(typeof(TableLayoutRowStyleCollection));
         protected string? _helpTopic;
 
         /// <summary>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/StyleCollectionEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/StyleCollectionEditor.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel.Design;
+
+namespace System.Windows.Forms.Design
+{
+    /// <summary>
+    ///  This collection editor is used to add value to the TableLayoutPanel's
+    ///  'Style' collections: RowStyle and ColumnStyle.  Here, we override the
+    ///  CreateInstance method and set the width or height of the new style
+    ///  to a default minimum size.
+    /// </summary>
+    internal partial class StyleCollectionEditor(Type type) : CollectionEditor(type)
+    {
+        private bool isRowCollection = type.IsAssignableFrom(typeof(TableLayoutRowStyleCollection));
+        protected string? _helpTopic;
+
+        /// <summary>
+        ///  Overridden to create our editor form instead of the standard collection editor form.
+        /// </summary>
+        /// <returns>An instance of a StyleEditorForm</returns>
+        protected override CollectionForm CreateCollectionForm()
+        {
+            return new StyleEditorForm(this, isRowCollection);
+        }
+
+        /// <summary>
+        ///  Gets the help topic to display for the dialog help button or pressing F1.
+        ///  Override to display a different help topic.
+        /// </summary>
+        protected override string HelpTopic => _helpTopic ?? base.HelpTopic;
+    }
+}

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/StyleCollectionEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/StyleCollectionEditor.cs
@@ -11,7 +11,7 @@ namespace System.Windows.Forms.Design
         protected string? _helpTopic;
 
         /// <summary>
-        ///  This collection editor is used to add value to the TableLayoutPanel's
+        ///  This collection editor is used to add value to the <see cref="TableLayoutPanel" />'s
         ///  'Style' collections: RowStyle and ColumnStyle.
         /// </summary>
         /// <param name="type">A specified collection type.</param>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/StyleCollectionEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/StyleCollectionEditor.cs
@@ -5,16 +5,20 @@ using System.ComponentModel.Design;
 
 namespace System.Windows.Forms.Design
 {
-    /// <summary>
-    ///  This collection editor is used to add value to the TableLayoutPanel's
-    ///  'Style' collections: RowStyle and ColumnStyle.  Here, we override the
-    ///  CreateInstance method and set the width or height of the new style
-    ///  to a default minimum size.
-    /// </summary>
-    internal partial class StyleCollectionEditor(Type type) : CollectionEditor(type)
+    internal partial class StyleCollectionEditor : CollectionEditor
     {
-        private readonly bool isRowCollection = type.IsAssignableFrom(typeof(TableLayoutRowStyleCollection));
+        private bool _isRowCollection;
         protected string? _helpTopic;
+
+        /// <summary>
+        ///  This collection editor is used to add value to the TableLayoutPanel's
+        ///  'Style' collections: RowStyle and ColumnStyle.
+        /// </summary>
+        /// <param name="type">A specified collection type.</param>
+        public StyleCollectionEditor(Type type) : base(type)
+        {
+            _isRowCollection = type.IsAssignableFrom(typeof(TableLayoutRowStyleCollection));
+        }
 
         /// <summary>
         ///  Overridden to create our editor form instead of the standard collection editor form.
@@ -22,7 +26,7 @@ namespace System.Windows.Forms.Design
         /// <returns>An instance of a StyleEditorForm</returns>
         protected override CollectionForm CreateCollectionForm()
         {
-            return new StyleEditorForm(this, isRowCollection);
+            return new StyleEditorForm(this, _isRowCollection);
         }
 
         /// <summary>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/StyleCollectionEditor.resx
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/StyleCollectionEditor.resx
@@ -1,0 +1,1026 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="addRemoveInsertTableLayoutPanel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="addRemoveInsertTableLayoutPanel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="addRemoveInsertTableLayoutPanel.ColumnCount" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="addButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left, Right</value>
+  </data>
+  <data name="addButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="addButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="addButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="addButton.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="addButton.Text">
+    <value xml:space="preserve">&amp;Add</value>
+  </data>
+  <data name="&gt;&gt;addButton.Name">
+    <value xml:space="preserve">addButton</value>
+  </data>
+  <data name="&gt;&gt;addButton.Type">
+    <value xml:space="preserve">System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;addButton.Parent">
+    <value xml:space="preserve">addRemoveInsertTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;addButton.ZOrder">
+    <value xml:space="preserve">0</value>
+  </data>
+  <data name="removeButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left, Right</value>
+  </data>
+  <data name="removeButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="removeButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>81, 0</value>
+  </data>
+  <data name="removeButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="removeButton.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="removeButton.Text">
+    <value xml:space="preserve">&amp;Delete</value>
+  </data>
+  <data name="&gt;&gt;removeButton.Name">
+    <value xml:space="preserve">removeButton</value>
+  </data>
+  <data name="&gt;&gt;removeButton.Type">
+    <value xml:space="preserve">System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;removeButton.Parent">
+    <value xml:space="preserve">addRemoveInsertTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;removeButton.ZOrder">
+    <value xml:space="preserve">1</value>
+  </data>
+  <data name="insertButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left, Right</value>
+  </data>
+  <data name="insertButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="insertButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>162, 0</value>
+  </data>
+  <data name="insertButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="insertButton.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="insertButton.Text">
+    <value xml:space="preserve">&amp;Insert</value>
+  </data>
+  <data name="&gt;&gt;insertButton.Name">
+    <value xml:space="preserve">insertButton</value>
+  </data>
+  <data name="&gt;&gt;insertButton.Type">
+    <value xml:space="preserve">System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;insertButton.Parent">
+    <value xml:space="preserve">addRemoveInsertTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;insertButton.ZOrder">
+    <value xml:space="preserve">2</value>
+  </data>
+  <data name="addRemoveInsertTableLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 304</value>
+  </data>
+  <data name="addRemoveInsertTableLayoutPanel.RowCount" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="addRemoveInsertTableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>237, 23</value>
+  </data>
+  <data name="addRemoveInsertTableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;addRemoveInsertTableLayoutPanel.Name">
+    <value xml:space="preserve">addRemoveInsertTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;addRemoveInsertTableLayoutPanel.Type">
+    <value xml:space="preserve">System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;addRemoveInsertTableLayoutPanel.Parent">
+    <value xml:space="preserve">overarchingTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;addRemoveInsertTableLayoutPanel.ZOrder">
+    <value xml:space="preserve">3</value>
+  </data>
+  <data name="addRemoveInsertTableLayoutPanel.LayoutSettings">
+    <value xml:space="preserve">&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="addButton" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="removeButton" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="insertButton" Row="0" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,33,Percent,33,Percent,33" /&gt;&lt;Rows Styles="AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
+  <data name="okCancelTableLayoutPanel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Right</value>
+  </data>
+  <data name="okCancelTableLayoutPanel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="okCancelTableLayoutPanel.ColumnCount" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="overarchingTableLayoutPanel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Bottom, Left, Right</value>
+  </data>
+  <data name="overarchingTableLayoutPanel.ColumnCount" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="sizeTypeGroupBox.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
+  </data>
+  <data name="sizeTypeTableLayoutPanel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Bottom</value>
+  </data>
+  <data name="sizeTypeTableLayoutPanel.ColumnCount" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="sizeTypeTableLayoutPanel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>  
+  <data name="sizeTypeGroupBox.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>      
+  <data name="absoluteNumericUpDown.AccessibleName">
+    <value xml:space="preserve">Absolute</value>
+  </data>
+  <data name="absoluteNumericUpDown.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left, Right</value>
+  </data>
+  <data name="absoluteNumericUpDown.Location" type="System.Drawing.Point, System.Drawing">
+    <value>69, 3</value>
+  </data>
+  <data name="absoluteNumericUpDown.Size" type="System.Drawing.Size, System.Drawing">
+    <value>134, 20</value>
+  </data>
+  <data name="absoluteNumericUpDown.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="absoluteNumericUpDown.TextAlign" type="System.Windows.Forms.HorizontalAlignment, System.Windows.Forms">
+    <value>Right</value>
+  </data>
+  <data name="&gt;&gt;absoluteNumericUpDown.Name">
+    <value xml:space="preserve">absoluteNumericUpDown</value>
+  </data>
+  <data name="&gt;&gt;absoluteNumericUpDown.Type">
+    <value xml:space="preserve">System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;absoluteNumericUpDown.Parent">
+    <value xml:space="preserve">sizeTypeTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;absoluteNumericUpDown.ZOrder">
+    <value xml:space="preserve">0</value>
+  </data>
+  <data name="absoluteRadioButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="absoluteRadioButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="absoluteRadioButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 6</value>
+  </data>
+  <data name="absoluteRadioButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>62, 17</value>
+  </data>
+  <data name="absoluteRadioButton.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="absoluteRadioButton.Text">
+    <value xml:space="preserve">A&amp;bsolute</value>
+  </data>
+  <data name="&gt;&gt;absoluteRadioButton.Name">
+    <value xml:space="preserve">absoluteRadioButton</value>
+  </data>
+  <data name="&gt;&gt;absoluteRadioButton.Type">
+    <value xml:space="preserve">System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;absoluteRadioButton.Parent">
+    <value xml:space="preserve">sizeTypeTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;absoluteRadioButton.ZOrder">
+    <value xml:space="preserve">1</value>
+  </data>
+  <data name="pixelsLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="pixelsLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="pixelsLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>209, 6</value>
+  </data>
+  <data name="pixelsLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>32, 13</value>
+  </data>
+  <data name="pixelsLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="pixelsLabel.Text">
+    <value xml:space="preserve">pixels</value>
+  </data>
+  <data name="&gt;&gt;pixelsLabel.Name">
+    <value xml:space="preserve">pixelsLabel</value>
+  </data>
+  <data name="&gt;&gt;pixelsLabel.Type">
+    <value xml:space="preserve">System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pixelsLabel.Parent">
+    <value xml:space="preserve">sizeTypeTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;pixelsLabel.ZOrder">
+    <value xml:space="preserve">2</value>
+  </data>
+  <data name="percentLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="percentLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="percentLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>209, 32</value>
+  </data>
+  <data name="percentLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>14, 13</value>
+  </data>
+  <data name="percentLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="percentLabel.Text">
+    <value xml:space="preserve">%</value>
+  </data>
+  <data name="&gt;&gt;percentLabel.Name">
+    <value xml:space="preserve">percentLabel</value>
+  </data>
+  <data name="&gt;&gt;percentLabel.Type">
+    <value xml:space="preserve">System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;percentLabel.Parent">
+    <value xml:space="preserve">sizeTypeTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;percentLabel.ZOrder">
+    <value xml:space="preserve">3</value>
+  </data>
+  <data name="percentRadioButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="percentRadioButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="percentRadioButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 32</value>
+  </data>
+  <data name="percentRadioButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>58, 17</value>
+  </data>
+  <data name="percentRadioButton.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="percentRadioButton.Text">
+    <value xml:space="preserve">&amp;Percent</value>
+  </data>
+  <data name="&gt;&gt;percentRadioButton.Name">
+    <value xml:space="preserve">percentRadioButton</value>
+  </data>
+  <data name="&gt;&gt;percentRadioButton.Type">
+    <value xml:space="preserve">System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;percentRadioButton.Parent">
+    <value xml:space="preserve">sizeTypeTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;percentRadioButton.ZOrder">
+    <value xml:space="preserve">4</value>
+  </data>
+  <data name="autoSizedRadioButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="autoSizedRadioButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="autoSizedRadioButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 55</value>
+  </data>
+  <data name="autoSizedRadioButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>63, 17</value>
+  </data>
+  <data name="autoSizedRadioButton.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="autoSizedRadioButton.Text">
+    <value xml:space="preserve">A&amp;utoSize</value>
+  </data>
+  <data name="&gt;&gt;autoSizedRadioButton.Name">
+    <value xml:space="preserve">autoSizedRadioButton</value>
+  </data>
+  <data name="&gt;&gt;autoSizedRadioButton.Type">
+    <value xml:space="preserve">System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;autoSizedRadioButton.Parent">
+    <value xml:space="preserve">sizeTypeTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;autoSizedRadioButton.ZOrder">
+    <value xml:space="preserve">5</value>
+  </data>
+  <data name="percentNumericUpDown.AccessibleName">
+    <value xml:space="preserve">Percent</value>
+  </data>
+  <data name="percentNumericUpDown.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left, Right</value>
+  </data>
+  <data name="percentNumericUpDown.Location" type="System.Drawing.Point, System.Drawing">
+    <value>69, 29</value>
+  </data>
+  <data name="percentNumericUpDown.Size" type="System.Drawing.Size, System.Drawing">
+    <value>134, 20</value>
+  </data>
+  <data name="percentNumericUpDown.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="percentNumericUpDown.TextAlign" type="System.Windows.Forms.HorizontalAlignment, System.Windows.Forms">
+    <value>Right</value>
+  </data>
+  <data name="&gt;&gt;percentNumericUpDown.Name">
+    <value xml:space="preserve">percentNumericUpDown</value>
+  </data>
+  <data name="&gt;&gt;percentNumericUpDown.Type">
+    <value xml:space="preserve">System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;percentNumericUpDown.Parent">
+    <value xml:space="preserve">sizeTypeTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;percentNumericUpDown.ZOrder">
+    <value xml:space="preserve">6</value>
+  </data>
+  <data name="sizeTypeTableLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 22</value>
+  </data>
+  <data name="sizeTypeTableLayoutPanel.RowCount" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="sizeTypeTableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>244, 74</value>
+  </data>
+  <data name="sizeTypeTableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;sizeTypeTableLayoutPanel.Name">
+    <value xml:space="preserve">sizeTypeTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;sizeTypeTableLayoutPanel.Type">
+    <value xml:space="preserve">System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;sizeTypeTableLayoutPanel.Parent">
+    <value xml:space="preserve">sizeTypeGroupBox</value>
+  </data>
+  <data name="&gt;&gt;sizeTypeTableLayoutPanel.ZOrder">
+    <value xml:space="preserve">0</value>
+  </data>
+  <data name="sizeTypeTableLayoutPanel.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value xml:space="preserve">&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="absoluteNumericUpDown" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="absoluteRadioButton" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="pixelsLabel" Row="0" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="percentLabel" Row="1" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="percentRadioButton" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="autoSizedRadioButton" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="percentNumericUpDown" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Absolute,134,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
+  <data name="sizeTypeGroupBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>326, 0</value>
+  </data>
+  <data name="sizeTypeGroupBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>262, 103</value>
+  </data>
+  <data name="sizeTypeGroupBox.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="sizeTypeGroupBox.Text">
+    <value xml:space="preserve">Size Type</value>
+  </data>
+  <data name="&gt;&gt;sizeTypeGroupBox.Name">
+    <value xml:space="preserve">sizeTypeGroupBox</value>
+  </data>
+  <data name="&gt;&gt;sizeTypeGroupBox.Type">
+    <value xml:space="preserve">System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;sizeTypeGroupBox.Parent">
+    <value xml:space="preserve">overarchingTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;sizeTypeGroupBox.ZOrder">
+    <value xml:space="preserve">0</value>
+  </data>
+  <data name="showTableLayoutPanel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left, Right</value>
+  </data>
+  <data name="showTableLayoutPanel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="showTableLayoutPanel.ColumnCount" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="memberTypeLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="memberTypeLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="memberTypeLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 4</value>
+  </data>
+  <data name="memberTypeLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>36, 13</value>
+  </data>
+  <data name="memberTypeLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="memberTypeLabel.Text">
+    <value xml:space="preserve">&amp;Show:</value>
+  </data>
+  <data name="&gt;&gt;memberTypeLabel.Name">
+    <value xml:space="preserve">memberTypeLabel</value>
+  </data>
+  <data name="&gt;&gt;memberTypeLabel.Type">
+    <value xml:space="preserve">System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;memberTypeLabel.Parent">
+    <value xml:space="preserve">showTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;memberTypeLabel.ZOrder">
+    <value xml:space="preserve">0</value>
+  </data>
+  <data name="columnsOrRowsComboBox.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left, Right</value>
+  </data>
+  <data name="columnsOrRowsComboBox.Items">
+    <value xml:space="preserve">Columns</value>
+  </data>
+  <data name="columnsOrRowsComboBox.Items1">
+    <value xml:space="preserve">Rows</value>
+  </data>
+  <data name="columnsOrRowsComboBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>42, 0</value>
+  </data>
+  <data name="columnsOrRowsComboBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>275, 21</value>
+  </data>
+  <data name="columnsOrRowsComboBox.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;columnsOrRowsComboBox.Name">
+    <value xml:space="preserve">columnsOrRowsComboBox</value>
+  </data>
+  <data name="&gt;&gt;columnsOrRowsComboBox.Type">
+    <value xml:space="preserve">System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;columnsOrRowsComboBox.Parent">
+    <value xml:space="preserve">showTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;columnsOrRowsComboBox.ZOrder">
+    <value xml:space="preserve">1</value>
+  </data>
+  <data name="showTableLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="showTableLayoutPanel.RowCount" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="showTableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>317, 21</value>
+  </data>
+  <data name="showTableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;showTableLayoutPanel.Name">
+    <value xml:space="preserve">showTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;showTableLayoutPanel.Type">
+    <value xml:space="preserve">System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;showTableLayoutPanel.Parent">
+    <value xml:space="preserve">overarchingTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;showTableLayoutPanel.ZOrder">
+    <value xml:space="preserve">2</value>
+  </data>
+  <data name="showTableLayoutPanel.LayoutSettings">
+    <value xml:space="preserve">&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="memberTypeLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="columnsOrRowsComboBox" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,50" /&gt;&lt;Rows Styles="AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
+  <data name="columnsAndRowsListView.AccessibleName">
+    <value xml:space="preserve">Columns and Rows List</value>
+  </data>
+  <data name="columnsAndRowsListView.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Bottom, Left, Right</value>
+  </data>
+  <data name="columnsAndRowsListView.Columns">
+    <value />
+  </data>
+  <data name="membersColumnHeader.Text">
+    <value xml:space="preserve">Member</value>
+  </data>
+  <data name="membersColumnHeader.Width" type="System.Int32, mscorlib">
+    <value>75</value>
+  </data>
+  <data name="columnsAndRowsListView.Columns1">
+    <value />
+  </data>
+  <data name="sizeTypeColumnHeader.Text">
+    <value xml:space="preserve">Size Type</value>
+  </data>
+  <data name="sizeTypeColumnHeader.Width" type="System.Int32, mscorlib">
+    <value>75</value>
+  </data>
+  <data name="columnsAndRowsListView.Columns2">
+    <value />
+  </data>
+  <data name="valueColumnHeader.Text">
+    <value xml:space="preserve">Value</value>
+  </data>
+  <data name="valueColumnHeader.Width" type="System.Int32, mscorlib">
+    <value>75</value>
+  </data>
+  <data name="columnsAndRowsListView.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 27</value>
+  </data>
+  <data name="columnsAndRowsListView.Size" type="System.Drawing.Size, System.Drawing">
+    <value>317, 271</value>
+  </data>
+  <data name="columnsAndRowsListView.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;columnsAndRowsListView.Name">
+    <value xml:space="preserve">columnsAndRowsListView</value>
+  </data>
+  <data name="&gt;&gt;columnsAndRowsListView.Type">
+    <value xml:space="preserve">System.Windows.Forms.ListView, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;columnsAndRowsListView.Parent">
+    <value xml:space="preserve">overarchingTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;columnsAndRowsListView.ZOrder">
+    <value xml:space="preserve">4</value>
+  </data>
+  <data name="helperTextTableLayoutPanel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="helperTextTableLayoutPanel.ColumnCount" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="infoPictureBox2.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="infoPictureBox2.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAARJJREFUOE+tk7ER
+        wjAMRTMPSzBFakbxKOkovERScyldcscK9BRGT1g62wmhwXe6JIr0pf8lD8O/T3rkvK45X29PN77xH9bK
+        ciyR4NqW+6JgcY6EbYFwWkWNeD310bwLKDEhCIj8b7qhGj/rRHynS1RzvyTGKeYg1gCQTEJTWT7DhH3a
+        rs8oXUBLQeC9FwSY6dDTIRkqCqDi7FTBT/tU6zVJc1b/IQCdmQZKrxK16eAbBZJGOqhFLBMCwDsgcKNB
+        4a8UxFI9UolPsg8OAA800DFWRymcZYxiNiF7kkyOj9K7qBZIRQRAOvAdKXvQVDcU08L3AbDOWGUo+Q70
+        l8NAmDFBBkAiPuznpVJNikg2BQPcu41vTqCLc6qWWUUAAAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="infoPictureBox2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 58</value>
+  </data>
+  <data name="infoPictureBox2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>16, 16</value>
+  </data>
+  <data name="infoPictureBox2.SizeMode" type="System.Windows.Forms.PictureBoxSizeMode, System.Windows.Forms">
+    <value>AutoSize</value>
+  </data>
+  <data name="infoPictureBox2.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="&gt;&gt;infoPictureBox2.Name">
+    <value xml:space="preserve">infoPictureBox2</value>
+  </data>
+  <data name="&gt;&gt;infoPictureBox2.Type">
+    <value xml:space="preserve">System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;infoPictureBox2.Parent">
+    <value xml:space="preserve">helperTextTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;infoPictureBox2.ZOrder">
+    <value xml:space="preserve">0</value>
+  </data>
+  <data name="infoPictureBox1.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="infoPictureBox1.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
+        YQUAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAARJJREFUOE+tk7ER
+        wjAMRTMPSzBFakbxKOkovERScyldcscK9BRGT1g62wmhwXe6JIr0pf8lD8O/T3rkvK45X29PN77xH9bK
+        ciyR4NqW+6JgcY6EbYFwWkWNeD310bwLKDEhCIj8b7qhGj/rRHynS1RzvyTGKeYg1gCQTEJTWT7DhH3a
+        rs8oXUBLQeC9FwSY6dDTIRkqCqDi7FTBT/tU6zVJc1b/IQCdmQZKrxK16eAbBZJGOqhFLBMCwDsgcKNB
+        4a8UxFI9UolPsg8OAA800DFWRymcZYxiNiF7kkyOj9K7qBZIRQRAOvAdKXvQVDcU08L3AbDOWGUo+Q70
+        l8NAmDFBBkAiPuznpVJNikg2BQPcu41vTqCLc6qWWUUAAAAASUVORK5CYII=
+</value>
+  </data>
+  <data name="infoPictureBox1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 3</value>
+  </data>
+  <data name="infoPictureBox1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>16, 16</value>
+  </data>
+  <data name="infoPictureBox1.SizeMode" type="System.Windows.Forms.PictureBoxSizeMode, System.Windows.Forms">
+    <value>AutoSize</value>
+  </data>
+  <data name="infoPictureBox1.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;infoPictureBox1.Name">
+    <value xml:space="preserve">infoPictureBox1</value>
+  </data>
+  <data name="&gt;&gt;infoPictureBox1.Type">
+    <value xml:space="preserve">System.Windows.Forms.PictureBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;infoPictureBox1.Parent">
+    <value xml:space="preserve">helperTextTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;infoPictureBox1.ZOrder">
+    <value xml:space="preserve">1</value>
+  </data>
+  <data name="helperLinkLabel1.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="helperLinkLabel1.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="helperLinkLabel1.MaximumSize" type="System.Drawing.Size, System.Drawing">
+    <value>237,0</value>
+  </data>
+  <data name="helperLinkLabel1.LinkArea" type="System.Windows.Forms.LinkArea, System.Windows.Forms">
+    <value>51, 29</value>
+  </data>
+  <data name="helperLinkLabel1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>25, 0</value>
+  </data>
+  <data name="helperLinkLabel1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>229, 52</value>
+  </data>
+  <data name="helperLinkLabel1.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="helperLinkLabel1.Text">
+    <value xml:space="preserve">Column and row spanning:
+If you want a control to span multiple rows or columns, set the RowSpan and ColumnSpan properties on the control.</value>
+  </data>
+  <data name="&gt;&gt;helperLinkLabel1.Name">
+    <value xml:space="preserve">helperLinkLabel1</value>
+  </data>
+  <data name="&gt;&gt;helperLinkLabel1.Type">
+    <value xml:space="preserve">System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;helperLinkLabel1.Parent">
+    <value xml:space="preserve">helperTextTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;helperLinkLabel1.ZOrder">
+    <value xml:space="preserve">2</value>
+  </data>
+  <data name="helperLinkLabel2.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="helperLinkLabel2.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="helperLinkLabel2.LinkArea" type="System.Windows.Forms.LinkArea, System.Windows.Forms">
+    <value>42, 15</value>
+  </data>
+  <data name="helperLinkLabel2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>25, 58</value>
+  </data>
+  <data name="helperLinkLabel2.MaximumSize" type="System.Drawing.Size, System.Drawing">
+    <value>237,0</value>
+  </data>  
+  <data name="helperLinkLabel2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>231, 52</value>
+  </data>
+  <data name="helperLinkLabel2.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="helperLinkLabel2.Text">
+    <value xml:space="preserve">Alignment and stretching:
+If you want to align a control within a cell, or if you want a control to stretch within a cell, use the control's Anchor property.</value>
+  </data>
+  <data name="&gt;&gt;helperLinkLabel2.Name">
+    <value xml:space="preserve">helperLinkLabel2</value>
+  </data>
+  <data name="&gt;&gt;helperLinkLabel2.Type">
+    <value xml:space="preserve">System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;helperLinkLabel2.Parent">
+    <value xml:space="preserve">helperTextTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;helperLinkLabel2.ZOrder">
+    <value xml:space="preserve">3</value>
+  </data>
+  <data name="helperTextTableLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>326, 112</value>
+  </data>
+  <data name="helperTextTableLayoutPanel.RowCount" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="helperTextTableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>262, 110</value>
+  </data>
+  <data name="helperTextTableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;helperTextTableLayoutPanel.Name">
+    <value xml:space="preserve">helperTextTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;helperTextTableLayoutPanel.Type">
+    <value xml:space="preserve">System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;helperTextTableLayoutPanel.Parent">
+    <value xml:space="preserve">overarchingTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;helperTextTableLayoutPanel.ZOrder">
+    <value xml:space="preserve">5</value>
+  </data>
+  <data name="helperTextTableLayoutPanel.LayoutSettings">
+    <value xml:space="preserve">&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="infoPictureBox2" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="infoPictureBox1" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="helperLinkLabel1" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="helperLinkLabel2" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
+  <data name="overarchingTableLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 12</value>
+  </data>
+  <data name="overarchingTableLayoutPanel.RowCount" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="overarchingTableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>588, 359</value>
+  </data>
+  <data name="overarchingTableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;overarchingTableLayoutPanel.Name">
+    <value xml:space="preserve">overarchingTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;overarchingTableLayoutPanel.Type">
+    <value xml:space="preserve">System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;overarchingTableLayoutPanel.Parent">
+    <value xml:space="preserve">$this</value>
+  </data>
+  <data name="&gt;&gt;overarchingTableLayoutPanel.ZOrder">
+    <value xml:space="preserve">0</value>
+  </data>
+  <data name="overarchingTableLayoutPanel.LayoutSettings">
+    <value xml:space="preserve">&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="sizeTypeGroupBox" Row="0" RowSpan="2" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="okCancelTableLayoutPanel" Row="4" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="showTableLayoutPanel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="addRemoveInsertTableLayoutPanel" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="columnsAndRowsListView" Row="1" RowSpan="2" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="helperTextTableLayoutPanel" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,100,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,Percent,50,AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
+  <data name="okButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left, Right</value>
+  </data>
+  <data name="okButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="okButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="okButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="okButton.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="okButton.Text">
+    <value xml:space="preserve">OK</value>
+  </data>
+  <data name="&gt;&gt;okButton.Name">
+    <value xml:space="preserve">okButton</value>
+  </data>
+  <data name="&gt;&gt;okButton.Type">
+    <value xml:space="preserve">System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;okButton.Parent">
+    <value xml:space="preserve">okCancelTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;okButton.ZOrder">
+    <value xml:space="preserve">0</value>
+  </data>
+  <data name="cancelButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left, Right</value>
+  </data>
+  <data name="cancelButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cancelButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>81, 0</value>
+  </data>
+  <data name="cancelButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 23</value>
+  </data>
+  <data name="cancelButton.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="cancelButton.Text">
+    <value xml:space="preserve">Cancel</value>
+  </data>
+  <data name="&gt;&gt;cancelButton.Name">
+    <value xml:space="preserve">cancelButton</value>
+  </data>
+  <data name="&gt;&gt;cancelButton.Type">
+    <value xml:space="preserve">System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cancelButton.Parent">
+    <value xml:space="preserve">okCancelTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;cancelButton.ZOrder">
+    <value xml:space="preserve">1</value>
+  </data>
+  <data name="okCancelTableLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>432, 336</value>
+  </data>
+  <data name="okCancelTableLayoutPanel.RowCount" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="okCancelTableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>156, 23</value>
+  </data>
+  <data name="okCancelTableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;okCancelTableLayoutPanel.Name">
+    <value xml:space="preserve">okCancelTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;okCancelTableLayoutPanel.Type">
+    <value xml:space="preserve">System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;okCancelTableLayoutPanel.Parent">
+    <value xml:space="preserve">overarchingTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;okCancelTableLayoutPanel.ZOrder">
+    <value xml:space="preserve">1</value>
+  </data>
+  <data name="okCancelTableLayoutPanel.LayoutSettings">
+    <value xml:space="preserve">&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="okButton" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="cancelButton" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,50,Percent,50" /&gt;&lt;Rows Styles="AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
+    <value>612, 383</value>
+  </data>
+  <data name="$this.MinimumSize" type="System.Drawing.Size, System.Drawing">
+    <value>620,350</value>
+  </data>
+  <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
+    <value>CenterParent</value>
+  </data>
+  <data name="$this.Text">
+    <value xml:space="preserve">Column and Row Styles</value>
+  </data>
+  <data name="&gt;&gt;membersColumnHeader.Name">
+    <value xml:space="preserve">membersColumnHeader</value>
+  </data>
+  <data name="&gt;&gt;membersColumnHeader.Type">
+    <value xml:space="preserve">System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;sizeTypeColumnHeader.Name">
+    <value xml:space="preserve">sizeTypeColumnHeader</value>
+  </data>
+  <data name="&gt;&gt;sizeTypeColumnHeader.Type">
+    <value xml:space="preserve">System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;valueColumnHeader.Name">
+    <value xml:space="preserve">valueColumnHeader</value>
+  </data>
+  <data name="&gt;&gt;valueColumnHeader.Type">
+    <value xml:space="preserve">System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;$this.Name">
+    <value xml:space="preserve">StyleCollectionEditor</value>
+  </data>
+  <data name="&gt;&gt;$this.Type">
+    <value xml:space="preserve">System.Windows.Forms.Form, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+</root>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/StyleEditorForm.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/StyleEditorForm.cs
@@ -1,0 +1,1098 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
+
+using System.ComponentModel;
+using System.Collections;
+using System.ComponentModel.Design;
+using System.Drawing;
+using System.Globalization;
+
+namespace System.Windows.Forms.Design;
+
+internal partial class StyleCollectionEditor
+{
+    protected class StyleEditorForm : CollectionForm
+    {
+        private readonly StyleCollectionEditor _editor;
+        private bool _isRowCollection;
+        private readonly TableLayoutPanel _tableLayoutPanel;
+        private readonly TableLayoutPanelDesigner _tlpDesigner;
+        private readonly IComponentChangeService _componentChangeService;
+        private readonly ArrayList _deleteList;
+
+        private bool _isDialogDirty;
+        private bool _haveInvoked;
+
+        //listView subitem indices
+        private const int s_memberIndex = 0;
+        private const int s_typeIndex = 1;
+        private const int s_valueIndex = 2;
+
+        private readonly PropertyDescriptor _rowStyleProp;
+        private readonly PropertyDescriptor _colStyleProp;
+
+        /// <summary>
+        /// All our control instance variables.
+        /// </summary>
+
+        private TableLayoutPanel _overarchingTableLayoutPanel;
+
+        private TableLayoutPanel _addRemoveInsertTableLayoutPanel;
+        private Button _addButton;
+        private Button _removeButton;
+        private Button _insertButton;
+
+        private TableLayoutPanel _okCancelTableLayoutPanel;
+        private Button _okButton;
+        private Button _cancelButton;
+
+        private Label _memberTypeLabel;
+        private ComboBox _columnsOrRowsComboBox;
+
+        private GroupBox _sizeTypeGroupBox;
+        private RadioButton _absoluteRadioButton;
+        private RadioButton _percentRadioButton;
+        private RadioButton _autoSizedRadioButton;
+
+        private NavigationalTableLayoutPanel _sizeTypeTableLayoutPanel;
+        private Label _pixelsLabel;
+        private NumericUpDown _absoluteNumericUpDown;
+        private Label _percentLabel;
+        private NumericUpDown _percentNumericUpDown;
+
+        private ListView _columnsAndRowsListView;
+        private ColumnHeader _membersColumnHeader;
+        private ColumnHeader _sizeTypeColumnHeader;
+        private TableLayoutPanel _helperTextTableLayoutPanel;
+        private PictureBox _infoPictureBox1;
+        private PictureBox _infoPictureBox2;
+        private LinkLabel _helperLinkLabel1;
+        private LinkLabel _helperLinkLabel2;
+        private TableLayoutPanel _showTableLayoutPanel;
+        private ColumnHeader _valueColumnHeader;
+
+        private const int UpDownLeftMargin = 10;
+        private int _scaledUpDownLeftMargin = UpDownLeftMargin;
+
+        private const int UpDownTopMargin = 4;
+        private int _scaledUpDownTopMargin = UpDownTopMargin;
+
+        private const int LabelRightMargin = 5;
+        private int _scaledLabelRightMargin = LabelRightMargin;
+
+        internal StyleEditorForm(CollectionEditor editor, bool isRowCollection) : base(editor)
+        {
+            editor = (StyleCollectionEditor)editor;
+            _isRowCollection = isRowCollection;
+            InitializeComponent();
+            HookEvents();
+
+            // Enable Vista explorer list view style
+            DesignerUtils.ApplyListViewThemeStyles(_columnsAndRowsListView);
+
+            ActiveControl = _columnsAndRowsListView;
+            _tableLayoutPanel = Context.Instance as TableLayoutPanel;
+            _tableLayoutPanel.SuspendLayout();
+
+            _deleteList = new ArrayList();
+
+            // Get the designer associated with the TLP
+            IDesignerHost host = _tableLayoutPanel.Site.GetService(typeof(IDesignerHost)) as IDesignerHost;
+            if (host is not null)
+            {
+                _tlpDesigner = host.GetDesigner(_tableLayoutPanel) as TableLayoutPanelDesigner;
+                _componentChangeService = host.GetService(typeof(IComponentChangeService)) as IComponentChangeService;
+            }
+
+            _rowStyleProp = TypeDescriptor.GetProperties(_tableLayoutPanel)["RowStyles"];
+            _colStyleProp = TypeDescriptor.GetProperties(_tableLayoutPanel)["ColumnStyles"];
+
+            _tlpDesigner.SuspendEnsureAvailableStyles();
+        }
+
+        private void HookEvents()
+        {
+            HelpButtonClicked += new CancelEventHandler(OnHelpButtonClicked);
+
+            _columnsAndRowsListView.SelectedIndexChanged += new EventHandler(OnListViewSelectedIndexChanged);
+            _columnsOrRowsComboBox.SelectionChangeCommitted += new EventHandler(OnComboBoxSelectionChangeCommitted);
+
+            _okButton.Click += new EventHandler(OnOkButtonClick);
+            _cancelButton.Click += new EventHandler(OnCancelButtonClick);
+
+            _addButton.Click += new EventHandler(OnAddButtonClick);
+            _removeButton.Click += new EventHandler(OnRemoveButtonClick);
+            _insertButton.Click += new EventHandler(OnInsertButtonClick);
+
+            _absoluteRadioButton.Enter += new EventHandler(OnAbsoluteEnter);
+            _absoluteNumericUpDown.ValueChanged += new EventHandler(OnValueChanged);
+
+            _percentRadioButton.Enter += new EventHandler(OnPercentEnter);
+            _percentNumericUpDown.ValueChanged += new EventHandler(OnValueChanged);
+
+            _autoSizedRadioButton.Enter += new EventHandler(OnAutoSizeEnter);
+
+            Shown += new EventHandler(OnShown);
+
+            _helperLinkLabel1.LinkClicked += new LinkLabelLinkClickedEventHandler(OnLink1Click);
+            _helperLinkLabel2.LinkClicked += new LinkLabelLinkClickedEventHandler(OnLink2Click);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(StyleCollectionEditor));
+            _addRemoveInsertTableLayoutPanel = new TableLayoutPanel();
+            _addButton = new Button();
+            _removeButton = new Button();
+            _insertButton = new Button();
+            _okCancelTableLayoutPanel = new TableLayoutPanel();
+            _okButton = new Button();
+            _cancelButton = new Button();
+            _overarchingTableLayoutPanel = new TableLayoutPanel();
+            _showTableLayoutPanel = new TableLayoutPanel();
+            _memberTypeLabel = new Label();
+            _columnsOrRowsComboBox = new ComboBox();
+            _columnsAndRowsListView = new ListView();
+            _membersColumnHeader = new ColumnHeader(resources.GetString("columnsAndRowsListView.Columns"));
+            _sizeTypeColumnHeader = new ColumnHeader(resources.GetString("columnsAndRowsListView.Columns1"));
+            _valueColumnHeader = new ColumnHeader(resources.GetString("columnsAndRowsListView.Columns2"));
+            _helperTextTableLayoutPanel = new TableLayoutPanel();
+            _infoPictureBox2 = new PictureBox();
+            _infoPictureBox1 = new PictureBox();
+            _helperLinkLabel1 = new LinkLabel();
+            _helperLinkLabel2 = new LinkLabel();
+            _sizeTypeGroupBox = new GroupBox();
+            _sizeTypeTableLayoutPanel = new NavigationalTableLayoutPanel();
+            _absoluteNumericUpDown = new NumericUpDown();
+            _absoluteRadioButton = new RadioButton();
+            _pixelsLabel = new Label();
+            _percentLabel = new Label();
+            _percentRadioButton = new RadioButton();
+            _autoSizedRadioButton = new RadioButton();
+            _percentNumericUpDown = new NumericUpDown();
+            _addRemoveInsertTableLayoutPanel.SuspendLayout();
+            _okCancelTableLayoutPanel.SuspendLayout();
+            _overarchingTableLayoutPanel.SuspendLayout();
+            _showTableLayoutPanel.SuspendLayout();
+            _helperTextTableLayoutPanel.SuspendLayout();
+            ((ISupportInitialize)_infoPictureBox2).BeginInit();
+            ((ISupportInitialize)_infoPictureBox1).BeginInit();
+            _sizeTypeGroupBox.SuspendLayout();
+            _sizeTypeTableLayoutPanel.SuspendLayout();
+            ((ISupportInitialize)_absoluteNumericUpDown).BeginInit();
+            ((ISupportInitialize)_percentNumericUpDown).BeginInit();
+            SuspendLayout();
+            // addRemoveInsertTableLayoutPanel
+            resources.ApplyResources(_addRemoveInsertTableLayoutPanel, "addRemoveInsertTableLayoutPanel");
+            _addRemoveInsertTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 33F));
+            _addRemoveInsertTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 33F));
+            _addRemoveInsertTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 33F));
+            _addRemoveInsertTableLayoutPanel.Controls.Add(_addButton, 0, 0);
+            _addRemoveInsertTableLayoutPanel.Controls.Add(_removeButton, 1, 0);
+            _addRemoveInsertTableLayoutPanel.Controls.Add(_insertButton, 2, 0);
+            _addRemoveInsertTableLayoutPanel.Margin = new Padding(0, 3, 3, 3);
+            _addRemoveInsertTableLayoutPanel.Name = "addRemoveInsertTableLayoutPanel";
+            _addRemoveInsertTableLayoutPanel.RowStyles.Add(new RowStyle());
+            // addButton
+            resources.ApplyResources(_addButton, "addButton");
+            _addButton.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            _addButton.Margin = new Padding(0, 0, 4, 0);
+            _addButton.MinimumSize = new Size(75, 23);
+            _addButton.Name = "addButton";
+            _addButton.Padding = new Padding(10, 0, 10, 0);
+            // removeButton
+            resources.ApplyResources(_removeButton, "removeButton");
+            _removeButton.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            _removeButton.Margin = new Padding(2, 0, 2, 0);
+            _removeButton.MinimumSize = new Size(75, 23);
+            _removeButton.Name = "removeButton";
+            _removeButton.Padding = new Padding(10, 0, 10, 0);
+            // insertButton
+            resources.ApplyResources(_insertButton, "insertButton");
+            _insertButton.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            _insertButton.Margin = new Padding(4, 0, 0, 0);
+            _insertButton.MinimumSize = new Size(75, 23);
+            _insertButton.Name = "insertButton";
+            _insertButton.Padding = new Padding(10, 0, 10, 0);
+            // okCancelTableLayoutPanel
+            resources.ApplyResources(_okCancelTableLayoutPanel, "okCancelTableLayoutPanel");
+            _overarchingTableLayoutPanel.SetColumnSpan(_okCancelTableLayoutPanel, 2);
+            _okCancelTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
+            _okCancelTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
+            _okCancelTableLayoutPanel.Controls.Add(_okButton, 0, 0);
+            _okCancelTableLayoutPanel.Controls.Add(_cancelButton, 1, 0);
+            _okCancelTableLayoutPanel.Margin = new Padding(0, 6, 0, 0);
+            _okCancelTableLayoutPanel.Name = "okCancelTableLayoutPanel";
+            _okCancelTableLayoutPanel.RowStyles.Add(new RowStyle());
+            // okButton
+            resources.ApplyResources(_okButton, "okButton");
+            _okButton.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            _okButton.Margin = new Padding(0, 0, 3, 0);
+            _okButton.MinimumSize = new Size(75, 23);
+            _okButton.Name = "okButton";
+            _okButton.Padding = new Padding(10, 0, 10, 0);
+            // cancelButton
+            resources.ApplyResources(_cancelButton, "cancelButton");
+            _cancelButton.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            _cancelButton.DialogResult = DialogResult.Cancel;
+            _cancelButton.Margin = new Padding(3, 0, 0, 0);
+            _cancelButton.MinimumSize = new Size(75, 23);
+            _cancelButton.Name = "cancelButton";
+            _cancelButton.Padding = new Padding(10, 0, 10, 0);
+            // overarchingTableLayoutPanel
+            resources.ApplyResources(_overarchingTableLayoutPanel, "overarchingTableLayoutPanel");
+            _overarchingTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+            _overarchingTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
+            _overarchingTableLayoutPanel.Controls.Add(_sizeTypeGroupBox, 1, 0);
+            _overarchingTableLayoutPanel.Controls.Add(_okCancelTableLayoutPanel, 0, 4);
+            _overarchingTableLayoutPanel.Controls.Add(_showTableLayoutPanel, 0, 0);
+            _overarchingTableLayoutPanel.Controls.Add(_addRemoveInsertTableLayoutPanel, 0, 3);
+            _overarchingTableLayoutPanel.Controls.Add(_columnsAndRowsListView, 0, 1);
+            _overarchingTableLayoutPanel.Controls.Add(_helperTextTableLayoutPanel, 1, 2);
+            _overarchingTableLayoutPanel.Name = "overarchingTableLayoutPanel";
+            _overarchingTableLayoutPanel.RowStyles.Add(new RowStyle());
+            _overarchingTableLayoutPanel.RowStyles.Add(new RowStyle());
+            _overarchingTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Percent, 50F));
+            _overarchingTableLayoutPanel.RowStyles.Add(new RowStyle());
+            _overarchingTableLayoutPanel.RowStyles.Add(new RowStyle());
+            // showTableLayoutPanel
+            resources.ApplyResources(_showTableLayoutPanel, "showTableLayoutPanel");
+            _showTableLayoutPanel.ColumnStyles.Add(new ColumnStyle());
+            _showTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
+            _showTableLayoutPanel.Controls.Add(_memberTypeLabel, 0, 0);
+            _showTableLayoutPanel.Controls.Add(_columnsOrRowsComboBox, 1, 0);
+            _showTableLayoutPanel.Margin = new Padding(0, 0, 3, 3);
+            _showTableLayoutPanel.Name = "showTableLayoutPanel";
+            _showTableLayoutPanel.RowStyles.Add(new RowStyle());
+            // memberTypeLabel
+            resources.ApplyResources(_memberTypeLabel, "memberTypeLabel");
+            _memberTypeLabel.Margin = new Padding(0, 0, 3, 0);
+            _memberTypeLabel.Name = "memberTypeLabel";
+            // columnsOrRowsComboBox
+            resources.ApplyResources(_columnsOrRowsComboBox, "columnsOrRowsComboBox");
+            _columnsOrRowsComboBox.DropDownStyle = ComboBoxStyle.DropDownList;
+            _columnsOrRowsComboBox.FormattingEnabled = true;
+            _columnsOrRowsComboBox.Items.AddRange(
+            [
+                resources.GetString("columnsOrRowsComboBox.Items"),
+                resources.GetString("columnsOrRowsComboBox.Items1")
+            ]);
+            _columnsOrRowsComboBox.Margin = new Padding(3, 0, 0, 0);
+            _columnsOrRowsComboBox.Name = "columnsOrRowsComboBox";
+            // columnsAndRowsListView
+            resources.ApplyResources(_columnsAndRowsListView, "columnsAndRowsListView");
+            _columnsAndRowsListView.Columns.AddRange(new ColumnHeader[]
+            {
+                 _membersColumnHeader,
+                 _sizeTypeColumnHeader,
+                 _valueColumnHeader
+            });
+            _columnsAndRowsListView.FullRowSelect = true;
+            _columnsAndRowsListView.HeaderStyle = ColumnHeaderStyle.Nonclickable;
+            _columnsAndRowsListView.HideSelection = false;
+            _columnsAndRowsListView.Margin = new Padding(0, 3, 3, 3);
+            _columnsAndRowsListView.Name = "columnsAndRowsListView";
+            _overarchingTableLayoutPanel.SetRowSpan(_columnsAndRowsListView, 2);
+            _columnsAndRowsListView.View = View.Details;
+            // membersColumnHeader
+            resources.ApplyResources(_membersColumnHeader, "membersColumnHeader");
+            // sizeTypeColumnHeader
+            resources.ApplyResources(_sizeTypeColumnHeader, "sizeTypeColumnHeader");
+            // valueColumnHeader
+            resources.ApplyResources(_valueColumnHeader, "valueColumnHeader");
+            // helperTextTableLayoutPanel
+            resources.ApplyResources(_helperTextTableLayoutPanel, "helperTextTableLayoutPanel");
+            _helperTextTableLayoutPanel.ColumnStyles.Add(new ColumnStyle());
+            _helperTextTableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+            _helperTextTableLayoutPanel.Controls.Add(_infoPictureBox2, 0, 1);
+            _helperTextTableLayoutPanel.Controls.Add(_infoPictureBox1, 0, 0);
+            _helperTextTableLayoutPanel.Controls.Add(_helperLinkLabel1, 1, 0);
+            _helperTextTableLayoutPanel.Controls.Add(_helperLinkLabel2, 1, 1);
+            _helperTextTableLayoutPanel.Margin = new Padding(6, 6, 0, 3);
+            _helperTextTableLayoutPanel.Name = "helperTextTableLayoutPanel";
+            _helperTextTableLayoutPanel.RowStyles.Add(new RowStyle());
+            _helperTextTableLayoutPanel.RowStyles.Add(new RowStyle());
+            // infoPictureBox2
+            resources.ApplyResources(_infoPictureBox2, "infoPictureBox2");
+            _infoPictureBox2.Name = "infoPictureBox2";
+            _infoPictureBox2.TabStop = false;
+            // infoPictureBox1
+            resources.ApplyResources(_infoPictureBox1, "infoPictureBox1");
+            _infoPictureBox1.Name = "infoPictureBox1";
+            _infoPictureBox1.TabStop = false;
+            if (DpiHelper.IsScalingRequired)
+            {
+                Bitmap bitmap = _infoPictureBox1.Image as Bitmap;
+                DpiHelper.ScaleBitmapLogicalToDevice(ref bitmap);
+                _infoPictureBox1.Image = bitmap;
+                bitmap = _infoPictureBox2.Image as Bitmap;
+                DpiHelper.ScaleBitmapLogicalToDevice(ref bitmap);
+                _infoPictureBox2.Image = bitmap;
+
+                _scaledUpDownLeftMargin = DpiHelper.LogicalToDeviceUnitsX(UpDownLeftMargin);
+                _scaledUpDownTopMargin = DpiHelper.LogicalToDeviceUnitsY(UpDownTopMargin);
+                _scaledLabelRightMargin = DpiHelper.LogicalToDeviceUnitsX(LabelRightMargin);
+            }
+
+            // helperLinkLabel1
+            resources.ApplyResources(_helperLinkLabel1, "helperLinkLabel1");
+            _helperLinkLabel1.Margin = new Padding(3, 0, 0, 3);
+            _helperLinkLabel1.Name = "helperLinkLabel1";
+            _helperLinkLabel1.TabStop = true;
+            _helperLinkLabel1.UseCompatibleTextRendering = true;
+            // helperLinkLabel2
+            resources.ApplyResources(_helperLinkLabel2, "helperLinkLabel2");
+            _helperLinkLabel2.Margin = new Padding(3, 3, 0, 0);
+            _helperLinkLabel2.Name = "helperLinkLabel2";
+            _helperLinkLabel2.TabStop = true;
+            _helperLinkLabel2.UseCompatibleTextRendering = true;
+            // sizeTypeGroupBox
+            resources.ApplyResources(_sizeTypeGroupBox, "sizeTypeGroupBox");
+            _sizeTypeGroupBox.Controls.Add(_sizeTypeTableLayoutPanel);
+            _sizeTypeGroupBox.Margin = new Padding(6, 0, 0, 3);
+            _sizeTypeGroupBox.Name = "sizeTypeGroupBox";
+            _sizeTypeGroupBox.Padding = new Padding(0);
+            _overarchingTableLayoutPanel.SetRowSpan(_sizeTypeGroupBox, 2);
+            _sizeTypeGroupBox.TabStop = false;
+            // sizeTypeTableLayoutPanel
+            resources.ApplyResources(_sizeTypeTableLayoutPanel, "sizeTypeTableLayoutPanel");
+            _sizeTypeTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Percent, 33.3F));
+            _sizeTypeTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Percent, 33.3F));
+            _sizeTypeTableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Percent, 33.3F));
+            _sizeTypeTableLayoutPanel.Controls.Add(_absoluteNumericUpDown, 1, 0);
+            _sizeTypeTableLayoutPanel.Controls.Add(_absoluteRadioButton, 0, 0);
+            _sizeTypeTableLayoutPanel.Controls.Add(_pixelsLabel, 2, 0);
+            _sizeTypeTableLayoutPanel.Controls.Add(_percentLabel, 2, 1);
+            _sizeTypeTableLayoutPanel.Controls.Add(_percentRadioButton, 0, 1);
+            _sizeTypeTableLayoutPanel.Controls.Add(_autoSizedRadioButton, 0, 2);
+            _sizeTypeTableLayoutPanel.Controls.Add(_percentNumericUpDown, 1, 1);
+            _sizeTypeTableLayoutPanel.Margin = new Padding(9);
+            _sizeTypeTableLayoutPanel.Name = "sizeTypeTableLayoutPanel";
+            _sizeTypeTableLayoutPanel.AutoSize = true;
+            _sizeTypeTableLayoutPanel.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            // absoluteNumericUpDown
+            resources.ApplyResources(_absoluteNumericUpDown, "absoluteNumericUpDown");
+            _absoluteNumericUpDown.Maximum = new decimal(new int[]
+            {
+                99999,
+                0,
+                0,
+                0
+            });
+            _absoluteNumericUpDown.Name = "absoluteNumericUpDown";
+            _absoluteNumericUpDown.Margin = new Padding(_scaledUpDownLeftMargin, _scaledUpDownTopMargin, 0, 0);
+            _absoluteNumericUpDown.AutoScaleMode = Forms.AutoScaleMode.Font;
+            // absoluteRadioButton
+            resources.ApplyResources(_absoluteRadioButton, "absoluteRadioButton");
+            _absoluteRadioButton.Margin = new Padding(0, 3, 3, 0);
+            _absoluteRadioButton.Name = "absoluteRadioButton";
+            // pixelsLabel
+            resources.ApplyResources(_pixelsLabel, "pixelsLabel");
+            _pixelsLabel.Name = "pixelsLabel";
+            _pixelsLabel.Margin = new Padding(0, 0, _scaledLabelRightMargin, 0);
+            // percentLabel
+            resources.ApplyResources(_percentLabel, "percentLabel");
+            _percentLabel.Name = "percentLabel";
+            _percentLabel.Margin = new Padding(0, 0, _scaledLabelRightMargin, 0);
+            // percentRadioButton
+            resources.ApplyResources(_percentRadioButton, "percentRadioButton");
+            _percentRadioButton.Margin = new Padding(0, 3, 3, 0);
+            _percentRadioButton.Name = "percentRadioButton";
+            // autoSizedRadioButton
+            resources.ApplyResources(_autoSizedRadioButton, "autoSizedRadioButton");
+            _autoSizedRadioButton.Margin = new Padding(0, 3, 3, 0);
+            _autoSizedRadioButton.Name = "autoSizedRadioButton";
+            // percentNumericUpDown
+            resources.ApplyResources(_percentNumericUpDown, "percentNumericUpDown");
+            _percentNumericUpDown.DecimalPlaces = 2;
+            _percentNumericUpDown.Maximum = new decimal(new int[]
+            {
+                9999,
+                0,
+                0,
+                0
+            });
+            _percentNumericUpDown.Name = "percentNumericUpDown";
+            _percentNumericUpDown.Margin = new Padding(_scaledUpDownLeftMargin, _scaledUpDownTopMargin, 0, 0);
+            _percentNumericUpDown.AutoScaleMode = Forms.AutoScaleMode.Font;
+            // StyleCollectionEditor
+            AcceptButton = _okButton;
+            resources.ApplyResources(this, "$this");
+            AutoScaleMode = AutoScaleMode.Font;
+            CancelButton = _cancelButton;
+            Controls.Add(_overarchingTableLayoutPanel);
+            HelpButton = true;
+            MaximizeBox = false;
+            MinimizeBox = false;
+            Name = "Form1";
+            ShowIcon = false;
+            ShowInTaskbar = false;
+            _addRemoveInsertTableLayoutPanel.ResumeLayout(false);
+            _addRemoveInsertTableLayoutPanel.PerformLayout();
+            _okCancelTableLayoutPanel.ResumeLayout(false);
+            _okCancelTableLayoutPanel.PerformLayout();
+            _overarchingTableLayoutPanel.ResumeLayout(false);
+            _overarchingTableLayoutPanel.PerformLayout();
+            _showTableLayoutPanel.ResumeLayout(false);
+            _showTableLayoutPanel.PerformLayout();
+            _helperTextTableLayoutPanel.ResumeLayout(false);
+            _helperTextTableLayoutPanel.PerformLayout();
+            ((ISupportInitialize)_infoPictureBox2).EndInit();
+            ((ISupportInitialize)_infoPictureBox1).EndInit();
+            _sizeTypeGroupBox.ResumeLayout(false);
+            _sizeTypeTableLayoutPanel.ResumeLayout(false);
+            _sizeTypeTableLayoutPanel.PerformLayout();
+            ((ISupportInitialize)_absoluteNumericUpDown).EndInit();
+            ((ISupportInitialize)_percentNumericUpDown).EndInit();
+            ResumeLayout(false);
+        }
+
+        #endregion
+
+        private void OnShown(object sender, EventArgs e)
+        {
+            //We need to set the dirty flag here, since the initialization down above, might
+            //cause it to get set in one of the methods below.
+            _isDialogDirty = false;
+            _columnsAndRowsListView.AutoResizeColumns(ColumnHeaderAutoResizeStyle.HeaderSize);
+        }
+
+        private void OnLink1Click(object sender, LinkLabelLinkClickedEventArgs e)
+        {
+            CancelEventArgs c = new CancelEventArgs();
+            _editor._helpTopic = "net.ComponentModel.StyleCollectionEditor.TLP.SpanRowsColumns";
+            OnHelpButtonClicked(sender, c);
+        }
+
+        private void OnLink2Click(object sender, LinkLabelLinkClickedEventArgs e)
+        {
+            CancelEventArgs c = new CancelEventArgs();
+            _editor._helpTopic = "net.ComponentModel.StyleCollectionEditor.TLP.AnchorDock";
+            OnHelpButtonClicked(sender, c);
+        }
+
+        private void OnHelpButtonClicked(object sender, CancelEventArgs e)
+        {
+            e.Cancel = true;
+            _editor._helpTopic = "net.ComponentModel.StyleCollectionEditor";
+            _editor.ShowHelp();
+        }
+
+        protected override void OnEditValueChanged()
+        {
+        }
+
+        protected internal override DialogResult ShowEditorDialog(IWindowsFormsEditorService edSvc)
+        {
+            if (_componentChangeService is not null)
+            {
+                if (_rowStyleProp is not null)
+                {
+                    _componentChangeService.OnComponentChanging(_tableLayoutPanel, _rowStyleProp);
+                }
+
+                if (_colStyleProp is not null)
+                {
+                    _componentChangeService.OnComponentChanging(_tableLayoutPanel, _colStyleProp);
+                }
+            }
+
+            // We can't use ColumnCount/RowCount, since they are only guaranteed to reflect the true count
+            // when GrowMode == Fixed
+            int[] cw = _tableLayoutPanel.GetColumnWidths();
+            int[] rh = _tableLayoutPanel.GetRowHeights();
+
+            // We should have at least as many <Col|Row>Styles as <Cols|Rows> -- the designer guarantees that
+            Debug.Assert(_tableLayoutPanel.ColumnStyles.Count >= cw.Length, "Why is ColumnStyle.Count not the same as ColumnCount?");
+            Debug.Assert(_tableLayoutPanel.RowStyles.Count >= rh.Length, "Why is RowStyle.Count not the same as RowCount?");
+
+            // If we have more, then let's remove the extra ones. This is because we don't want any new row/col that we might add
+            // to inherit leftover styles. We want to make sure than any new rol/col is of type Absolute and of size 20.
+            if (_tableLayoutPanel.ColumnStyles.Count > cw.Length)
+            {
+                int diff = _tableLayoutPanel.ColumnStyles.Count - cw.Length;
+                for (int i = 0; i < diff; ++i)
+                {
+                    _tableLayoutPanel.ColumnStyles.RemoveAt(_tableLayoutPanel.ColumnStyles.Count - 1);
+                }
+            }
+
+            if (_tableLayoutPanel.RowStyles.Count > rh.Length)
+            {
+                int diff = _tableLayoutPanel.RowStyles.Count - rh.Length;
+                for (int i = 0; i < diff; ++i)
+                {
+                    _tableLayoutPanel.RowStyles.RemoveAt(_tableLayoutPanel.RowStyles.Count - 1);
+                }
+            }
+
+            //this will cause the listView to be initialized
+            _columnsOrRowsComboBox.SelectedIndex = _isRowCollection ? 1 : 0;
+            InitListView();
+            return base.ShowEditorDialog(edSvc);
+        }
+
+        private static string FormatValueString(SizeType type, float value)
+        {
+            if (type == SizeType.Absolute)
+            {
+                return value.ToString(CultureInfo.CurrentCulture);
+            }
+            else if (type == SizeType.Percent)
+            {
+                // value will be multiplied by 100, so let's adjust for that
+                return (value / 100).ToString("P", CultureInfo.CurrentCulture);
+            }
+            else
+            {
+                return string.Empty;
+            }
+        }
+
+        // Populate the listView with the correct values - happens when the dialog is brought up, or
+        // when the user changes the selection in the comboBox
+        private void InitListView()
+        {
+            _columnsAndRowsListView.Items.Clear();
+
+            string baseName = _isRowCollection ? "Row" : "Column"; //these should not be localized
+
+            int styleCount = _isRowCollection ? _tableLayoutPanel.RowStyles.Count : _tableLayoutPanel.ColumnStyles.Count;
+
+            for (int i = 0; i < styleCount; ++i)
+            {
+                string sizeType;
+                string sizeValue;
+
+                if (_isRowCollection)
+                {
+                    RowStyle rowStyle = _tableLayoutPanel.RowStyles[i];
+                    sizeType = rowStyle.SizeType.ToString();
+                    sizeValue = FormatValueString(rowStyle.SizeType, rowStyle.Height);
+                }
+                else
+                {
+                    ColumnStyle colStyle = _tableLayoutPanel.ColumnStyles[i];
+                    sizeType = colStyle.SizeType.ToString();
+                    sizeValue = FormatValueString(colStyle.SizeType, colStyle.Width);
+                }
+
+                //We add 1, since we want the Member to read <Column|Row>1,2,3...
+                _columnsAndRowsListView.Items.Add(new ListViewItem(new string[] { baseName + (i + 1).ToString(CultureInfo.InvariantCulture), sizeType, sizeValue }));
+            }
+
+            if (styleCount > 0)
+            {
+                ClearAndSetSelectionAndFocus(0);
+            }
+
+            // We should already have something selected
+            _removeButton.Enabled = _columnsAndRowsListView.Items.Count > 1;
+        }
+
+        private void UpdateListViewItem(int index, string member, string type, string value)
+        {
+            _columnsAndRowsListView.Items[index].SubItems[s_memberIndex].Text = member;
+            _columnsAndRowsListView.Items[index].SubItems[s_typeIndex].Text = type;
+            _columnsAndRowsListView.Items[index].SubItems[s_valueIndex].Text = value;
+        }
+
+        private void UpdateListViewMember()
+        {
+            // let's do a for loop rather than for-each, don't have to do the object creation
+            for (int i = 0; i < _columnsAndRowsListView.Items.Count; ++i)
+            {
+                _columnsAndRowsListView.Items[i].SubItems[s_memberIndex].Text = (_isRowCollection ? "Row" : "Column") + (i + 1).ToString(CultureInfo.InvariantCulture);
+            }
+        }
+
+        private void OnComboBoxSelectionChangeCommitted(object sender, EventArgs e)
+        {
+            _isRowCollection = _columnsOrRowsComboBox.SelectedIndex != 0;
+            InitListView();
+        }
+
+        private void OnListViewSelectedIndexChanged(object sender, EventArgs e)
+        {
+            ListView.SelectedListViewItemCollection coll = _columnsAndRowsListView.SelectedItems;
+
+            if (coll.Count == 0)
+            {
+                //When the selection changes from one item to another, we will get a temporary state
+                //where the selection collection is empty. We don't want to disable buttons in this case
+                //since that will cause flashing, so let's do a begininvoke here. In the delegate we check
+                //if the collection really is empty and then disable buttons and whatever else we have to do.
+                if (!_haveInvoked)
+                {
+                    BeginInvoke(new EventHandler(OnListSelectionComplete));
+                    _haveInvoked = true;
+                }
+
+                return;
+            }
+
+            _sizeTypeGroupBox.Enabled = true;
+            _insertButton.Enabled = true;
+            _removeButton.Enabled = coll.Count == _columnsAndRowsListView.Items.Count ? false : _columnsAndRowsListView.Items.Count > 1;
+
+            if (coll.Count == 1)
+            {
+                //Get the index
+                int index = _columnsAndRowsListView.Items.IndexOf(coll[0]);
+                if (_isRowCollection)
+                {
+                    UpdateGroupBox(_tableLayoutPanel.RowStyles[index].SizeType, _tableLayoutPanel.RowStyles[index].Height);
+                }
+                else
+                {
+                    UpdateGroupBox(_tableLayoutPanel.ColumnStyles[index].SizeType, _tableLayoutPanel.ColumnStyles[index].Width);
+                }
+            }
+            else
+            {
+                //multi-selection
+                //Check if all the items in the selection are of the same type and value
+                SizeType type;
+                float value = 0;
+                bool sameValues = true;
+                int index = _columnsAndRowsListView.Items.IndexOf(coll[0]);
+
+                type = _isRowCollection ? _tableLayoutPanel.RowStyles[index].SizeType : _tableLayoutPanel.ColumnStyles[index].SizeType;
+                value = _isRowCollection ? _tableLayoutPanel.RowStyles[index].Height : _tableLayoutPanel.ColumnStyles[index].Width;
+                for (int i = 1; i < coll.Count; i++)
+                {
+                    index = _columnsAndRowsListView.Items.IndexOf(coll[i]);
+                    if (type != (_isRowCollection ? _tableLayoutPanel.RowStyles[index].SizeType : _tableLayoutPanel.ColumnStyles[index].SizeType))
+                    {
+                        sameValues = false;
+                        break;
+                    }
+
+                    if (value != (_isRowCollection ? _tableLayoutPanel.RowStyles[index].Height : _tableLayoutPanel.ColumnStyles[index].Width))
+                    {
+                        sameValues = false;
+                        break;
+                    }
+                }
+
+                if (!sameValues)
+                {
+                    ResetAllRadioButtons();
+                }
+                else
+                {
+                    UpdateGroupBox(type, value);
+                }
+            }
+        }
+
+        private void OnListSelectionComplete(object sender, EventArgs e)
+        {
+            _haveInvoked = false;
+            // Nothing is truly selected in the listView
+            if (_columnsAndRowsListView.SelectedItems.Count == 0)
+            {
+                ResetAllRadioButtons();
+                _sizeTypeGroupBox.Enabled = false;
+                _insertButton.Enabled = false;
+                _removeButton.Enabled = false;
+            }
+        }
+
+        private void ResetAllRadioButtons()
+        {
+            _absoluteRadioButton.Checked = false;
+            ResetAbsolute();
+
+            _percentRadioButton.Checked = false;
+            ResetPercent();
+
+            _autoSizedRadioButton.Checked = false;
+        }
+
+        private void ResetAbsolute()
+        {
+            //Unhook the event while we reset.
+            //If we didn't the setting the value would cause OnValueChanged below to get called.
+            //If we then go ahead and update the listView, which we don't want in the reset case.
+            //VSWhidbey # 384035.
+            _absoluteNumericUpDown.ValueChanged -= new EventHandler(OnValueChanged);
+            _absoluteNumericUpDown.Enabled = false;
+            _absoluteNumericUpDown.Value = DesignerUtils.MINIMUMSTYLESIZE;
+            _absoluteNumericUpDown.ValueChanged += new EventHandler(OnValueChanged);
+        }
+
+        private void ResetPercent()
+        {
+            //Unhook the event while we reset.
+            //If we didn't the setting the value would cause OnValueChanged below to get called.
+            //If we then go ahead and update the listView, which we don't want in the reset case.
+            _percentNumericUpDown.ValueChanged -= new EventHandler(OnValueChanged);
+            _percentNumericUpDown.Enabled = false;
+            _percentNumericUpDown.Value = DesignerUtils.MINIMUMSTYLEPERCENT;
+            _percentNumericUpDown.ValueChanged += new EventHandler(OnValueChanged);
+        }
+
+        private void UpdateGroupBox(SizeType type, float value)
+        {
+            switch (type)
+            {
+                case SizeType.Absolute:
+                    _absoluteRadioButton.Checked = true;
+                    _absoluteNumericUpDown.Enabled = true;
+                    try
+                    {
+                        _absoluteNumericUpDown.Value = (decimal)value;
+                    }
+
+                    catch (ArgumentOutOfRangeException)
+                    {
+                        _absoluteNumericUpDown.Value = DesignerUtils.MINIMUMSTYLESIZE;
+                    }
+
+                    ResetPercent();
+                    break;
+                case SizeType.Percent:
+                    _percentRadioButton.Checked = true;
+                    _percentNumericUpDown.Enabled = true;
+                    try
+                    {
+                        _percentNumericUpDown.Value = (decimal)value;
+                    }
+
+                    catch (ArgumentOutOfRangeException)
+                    {
+                        _percentNumericUpDown.Value = DesignerUtils.MINIMUMSTYLEPERCENT;
+                    }
+
+                    ResetAbsolute();
+                    break;
+                case SizeType.AutoSize:
+                    _autoSizedRadioButton.Checked = true;
+                    ResetAbsolute();
+                    ResetPercent();
+                    break;
+                default:
+                    Debug.Fail("Unsupported SizeType");
+                    break;
+            }
+        }
+
+        private void ClearAndSetSelectionAndFocus(int index)
+        {
+            _columnsAndRowsListView.BeginUpdate();
+            _columnsAndRowsListView.Focus();
+            if (_columnsAndRowsListView.FocusedItem is not null)
+            {
+                _columnsAndRowsListView.FocusedItem.Focused = false;
+            }
+
+            _columnsAndRowsListView.SelectedItems.Clear();
+            _columnsAndRowsListView.Items[index].Selected = true;
+            _columnsAndRowsListView.Items[index].Focused = true;
+            _columnsAndRowsListView.Items[index].EnsureVisible();
+            _columnsAndRowsListView.EndUpdate();
+        }
+
+        /// <summary>
+        ///     Adds an item to the listView at the specified index
+        /// </summary>
+        private void AddItem(int index)
+        {
+            string member = null;
+            _tlpDesigner.InsertRowCol(_isRowCollection, index);
+
+            member = _isRowCollection
+                ? "Row" + _tableLayoutPanel.RowStyles.Count.ToString(CultureInfo.InvariantCulture)
+                : "Column" + _tableLayoutPanel.RowStyles.Count.ToString(CultureInfo.InvariantCulture);
+
+            if (member is not null)
+            {
+                _columnsAndRowsListView.Items.Insert(index,
+                                                    new ListViewItem(new string[] { member, SizeType.Absolute.ToString(), DesignerUtils.MINIMUMSTYLESIZE.ToString(CultureInfo.InvariantCulture) }));
+
+                // If we inserted at the beginning, then we have to change the Member of string of all the existing listView items,
+                // so we might as well just update the entire listView.
+                UpdateListViewMember();
+                ClearAndSetSelectionAndFocus(index);
+            }
+        }
+
+        private void OnAddButtonClick(object sender, EventArgs e)
+        {
+            _isDialogDirty = true;
+            // Add an item to the end of the listView
+            AddItem(_columnsAndRowsListView.Items.Count);
+        }
+
+        private void OnInsertButtonClick(object sender, EventArgs e)
+        {
+            _isDialogDirty = true;
+            // Insert an item before the 1st selected item
+            AddItem(_columnsAndRowsListView.SelectedIndices[0]);
+            _tlpDesigner.FixUpControlsOnInsert(_isRowCollection, _columnsAndRowsListView.SelectedIndices[0]);
+        }
+
+        private void OnRemoveButtonClick(object sender, EventArgs e)
+        {
+            if ((_columnsAndRowsListView.Items.Count == 1) || (_columnsAndRowsListView.Items.Count == _columnsAndRowsListView.SelectedIndices.Count))
+            {
+                Debug.Fail("We should never get here!");
+                return; // we can't remove anything when we have just 1 row/col or if all rows/cols are selected
+            }
+
+            _isDialogDirty = true;
+
+            // store the new index
+            int newIndex = _columnsAndRowsListView.SelectedIndices[0];
+
+            // Remove from the end of the selection -- that way we have less things to adjust
+            for (int i = _columnsAndRowsListView.SelectedIndices.Count - 1; i >= 0; i--)
+            {
+                int index = _columnsAndRowsListView.SelectedIndices[i];
+
+                // First update any controls in any row/col that's AFTER the row/col we are deleting
+                _tlpDesigner.FixUpControlsOnDelete(_isRowCollection, index, _deleteList);
+                // Then remove the row/col
+                _tlpDesigner.DeleteRowCol(_isRowCollection, index);
+
+                // Then remove the listView item
+                if (_isRowCollection)
+                {
+                    _columnsAndRowsListView.Items.RemoveAt(index);
+                }
+                else
+                {
+                    _columnsAndRowsListView.Items.RemoveAt(index);
+                }
+            }
+
+            if (newIndex >= _columnsAndRowsListView.Items.Count)
+            {
+                newIndex -= 1;
+            }
+
+            // If we removed at the beginning, then we have to change the Member of string of all the existing listView items,
+            // so we might as well just update the entire listView.
+            UpdateListViewMember();
+            ClearAndSetSelectionAndFocus(newIndex);
+        }
+
+        private void UpdateTypeAndValue(SizeType type, float value)
+        {
+            for (int i = 0; i < _columnsAndRowsListView.SelectedIndices.Count; i++)
+            {
+                int index = _columnsAndRowsListView.SelectedIndices[i];
+
+                if (_isRowCollection)
+                {
+                    _tableLayoutPanel.RowStyles[index].SizeType = type;
+                    _tableLayoutPanel.RowStyles[index].Height = value;
+                }
+                else
+                {
+                    _tableLayoutPanel.ColumnStyles[index].SizeType = type;
+                    _tableLayoutPanel.ColumnStyles[index].Width = value;
+                }
+
+                UpdateListViewItem(index, _columnsAndRowsListView.Items[index].SubItems[s_memberIndex].Text, type.ToString(), FormatValueString(type, value));
+            }
+        }
+
+        private void OnAbsoluteEnter(object sender, EventArgs e)
+        {
+            _isDialogDirty = true;
+            UpdateTypeAndValue(SizeType.Absolute, (float)_absoluteNumericUpDown.Value);
+            _absoluteNumericUpDown.Enabled = true;
+            ResetPercent();
+        }
+
+        private void OnPercentEnter(object sender, EventArgs e)
+        {
+            _isDialogDirty = true;
+            UpdateTypeAndValue(SizeType.Percent, (float)_percentNumericUpDown.Value);
+            _percentNumericUpDown.Enabled = true;
+            ResetAbsolute();
+        }
+
+        private void OnAutoSizeEnter(object sender, EventArgs e)
+        {
+            _isDialogDirty = true;
+            UpdateTypeAndValue(SizeType.AutoSize, 0);
+            ResetAbsolute();
+            ResetPercent();
+        }
+
+        private void OnValueChanged(object sender, EventArgs e)
+        {
+            if (_absoluteNumericUpDown == sender && _absoluteRadioButton.Checked)
+            {
+                _isDialogDirty = true;
+                UpdateTypeAndValue(SizeType.Absolute, (float)_absoluteNumericUpDown.Value);
+            }
+            else if (_percentNumericUpDown == sender && _percentRadioButton.Checked)
+            {
+                _isDialogDirty = true;
+                UpdateTypeAndValue(SizeType.Percent, (float)_percentNumericUpDown.Value);
+            }
+        }
+
+        private void NormalizePercentStyle(bool normalizeRow)
+        {
+            int count = normalizeRow ? _tableLayoutPanel.RowStyles.Count : _tableLayoutPanel.ColumnStyles.Count;
+            float total = 0;
+
+            // Loop through an calculate the percentage total
+            for (int i = 0; i < count; i++)
+            {
+                if (normalizeRow)
+                {
+                    if (_tableLayoutPanel.RowStyles[i].SizeType != SizeType.Percent)
+                    {
+                        continue;
+                    }
+
+                    total += _tableLayoutPanel.RowStyles[i].Height;
+                }
+                else
+                {
+                    if (_tableLayoutPanel.ColumnStyles[i].SizeType != SizeType.Percent)
+                    {
+                        continue;
+                    }
+
+                    total += _tableLayoutPanel.ColumnStyles[i].Width;
+                }
+            }
+
+            if ((total == 100) || (total == 0))
+            {
+                return;
+            }
+
+            // now loop through and set the normalized value
+            for (int i = 0; i < count; i++)
+            {
+                if (normalizeRow)
+                {
+                    if (_tableLayoutPanel.RowStyles[i].SizeType != SizeType.Percent)
+                    {
+                        continue;
+                    }
+
+                    _tableLayoutPanel.RowStyles[i].Height = (_tableLayoutPanel.RowStyles[i].Height * 100) / total;
+                }
+                else
+                {
+                    if (_tableLayoutPanel.ColumnStyles[i].SizeType != SizeType.Percent)
+                    {
+                        continue;
+                    }
+
+                    _tableLayoutPanel.ColumnStyles[i].Width = (_tableLayoutPanel.ColumnStyles[i].Width * 100) / total;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Take all the styles of SizeType.Percent and normalize them to 100%
+        /// </summary>
+        private void NormalizePercentStyles()
+        {
+            NormalizePercentStyle(normalizeRow: true);
+            NormalizePercentStyle(normalizeRow: false);
+        }
+
+        private void OnOkButtonClick(object sender, EventArgs e)
+        {
+            if (_isDialogDirty)
+            {
+                if (_absoluteRadioButton.Checked)
+                {
+                    UpdateTypeAndValue(SizeType.Absolute, (float)_absoluteNumericUpDown.Value);
+                }
+                else if (_percentRadioButton.Checked)
+                {
+                    UpdateTypeAndValue(SizeType.Percent, (float)_percentNumericUpDown.Value);
+                }
+                else if (_autoSizedRadioButton.Checked)
+                {
+                    UpdateTypeAndValue(SizeType.AutoSize, 0);
+                }
+
+                // Now normalize all percentages.
+                NormalizePercentStyles();
+
+                // IF YOU CHANGE THIS, YOU SHOULD ALSO CHANGE THE CODE IN TableLayoutPanelDesigner.OnRemoveInternal
+                if (_deleteList.Count > 0)
+                {
+                    PropertyDescriptor childProp = TypeDescriptor.GetProperties(_tableLayoutPanel)["Controls"];
+                    if (_componentChangeService is not null && childProp is not null)
+                    {
+                        _componentChangeService.OnComponentChanging(_tableLayoutPanel, childProp);
+                    }
+
+                    IDesignerHost host = _tableLayoutPanel.Site.GetService(typeof(IDesignerHost)) as IDesignerHost;
+
+                    if (host is not null)
+                    {
+                        foreach (object o in _deleteList)
+                        {
+                            List<IComponent> al = new();
+                            //ArrayList al = new ArrayList();
+                            DesignerUtils.GetAssociatedComponents((IComponent)o, host, al);
+                            foreach (IComponent comp in al)
+                            {
+                                _componentChangeService.OnComponentChanging(comp, null);
+                            }
+
+                            host.DestroyComponent(o as Component);
+                        }
+                    }
+
+                    if (_componentChangeService is not null && childProp is not null)
+                    {
+                        _componentChangeService.OnComponentChanged(_tableLayoutPanel, childProp, null, null);
+                    }
+                }
+
+                if (_componentChangeService is not null)
+                {
+                    if (_rowStyleProp is not null)
+                    {
+                        _componentChangeService.OnComponentChanged(_tableLayoutPanel, _rowStyleProp, null, null);
+                    }
+
+                    if (_colStyleProp is not null)
+                    {
+                        _componentChangeService.OnComponentChanged(_tableLayoutPanel, _colStyleProp, null, null);
+                    }
+                }
+
+                DialogResult = DialogResult.OK;
+            }
+            else
+            {
+                DialogResult = DialogResult.Cancel;
+            }
+
+            _tlpDesigner.ResumeEnsureAvailableStyles(true);
+            _tableLayoutPanel.ResumeLayout();
+        }
+
+        private void OnCancelButtonClick(object sender, EventArgs e)
+        {
+            _tlpDesigner.ResumeEnsureAvailableStyles(false);
+            _tableLayoutPanel.ResumeLayout();
+            DialogResult = DialogResult.Cancel;
+        }
+    }
+}

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/StyleEditorForm.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/StyleEditorForm.cs
@@ -4,7 +4,6 @@
 #nullable disable
 
 using System.ComponentModel;
-using System.Collections;
 using System.ComponentModel.Design;
 using System.Drawing;
 using System.Globalization;
@@ -20,7 +19,7 @@ internal partial class StyleCollectionEditor
         private readonly TableLayoutPanel _tableLayoutPanel;
         private readonly TableLayoutPanelDesigner _tableLayoutPanelDesigner;
         private readonly IComponentChangeService _componentChangeService;
-        private readonly ArrayList _deleteList;
+        private readonly List<Control> _deleteList;
 
         private bool _isDialogDirty;
         private bool _haveInvoked;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/StyleEditorForm.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/StyleEditorForm.cs
@@ -25,7 +25,7 @@ internal partial class StyleCollectionEditor
         private bool _haveInvoked;
         private bool _performEnsure;
 
-        //listView subitem indices
+        // ListView subitem indices.
         private const int s_memberIndex = 0;
         private const int s_typeIndex = 1;
         private const int s_valueIndex = 2;
@@ -99,11 +99,11 @@ internal partial class StyleCollectionEditor
             _deleteList = [];
 
             // Get the designer associated with the TLP
-            IDesignerHost host = _tableLayoutPanel.Site.GetService(typeof(IDesignerHost)) as IDesignerHost;
+            var host = _tableLayoutPanel.Site.GetService(typeof(IDesignerHost)) as IDesignerHost;
             if (host is not null)
             {
                 _tableLayoutPanelDesigner = host.GetDesigner(_tableLayoutPanel) as TableLayoutPanelDesigner;
-                _componentChangeService = host.GetService(typeof(IComponentChangeService)) as IComponentChangeService;
+                _componentChangeService = host.GetService<IComponentChangeService>();
             }
 
             _rowStyleProp = TypeDescriptor.GetProperties(_tableLayoutPanel)["RowStyles"];
@@ -501,14 +501,14 @@ internal partial class StyleCollectionEditor
 
         private void OnLink1Click(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            CancelEventArgs cancelEvent = new CancelEventArgs();
+            CancelEventArgs cancelEvent = new();
             _editor._helpTopic = "net.ComponentModel.StyleCollectionEditor.TLP.SpanRowsColumns";
             OnHelpButtonClicked(sender, cancelEvent);
         }
 
         private void OnLink2Click(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            CancelEventArgs cancelEvent = new CancelEventArgs();
+            CancelEventArgs cancelEvent = new();
             _editor._helpTopic = "net.ComponentModel.StyleCollectionEditor.TLP.AnchorDock";
             OnHelpButtonClicked(sender, cancelEvent);
         }
@@ -675,7 +675,7 @@ internal partial class StyleCollectionEditor
 
             if (coll.Count == 1)
             {
-                //Get the index
+                // Get the index
                 int index = _columnsAndRowsListView.Items.IndexOf(coll[0]);
                 if (_isRowCollection)
                 {
@@ -846,8 +846,13 @@ internal partial class StyleCollectionEditor
 
             if (member is not null)
             {
-                _columnsAndRowsListView.Items.Insert(index,
-                                                    new ListViewItem(new string[] { member, SizeType.Absolute.ToString(), DesignerUtils.MINIMUMSTYLESIZE.ToString(CultureInfo.InvariantCulture) }));
+                _columnsAndRowsListView.Items.Insert(
+                    index,
+                    new ListViewItem(new string[]
+                    {
+                        member, SizeType.Absolute.ToString(),
+                        DesignerUtils.MINIMUMSTYLESIZE.ToString(CultureInfo.InvariantCulture)
+                     }));
 
                 // If we inserted at the beginning, then we have to change the Member of string of all the existing listView items,
                 // so we might as well just update the entire listView.
@@ -874,7 +879,8 @@ internal partial class StyleCollectionEditor
 
         private void OnRemoveButtonClick(object sender, EventArgs e)
         {
-            if ((_columnsAndRowsListView.Items.Count == 1) || (_columnsAndRowsListView.Items.Count == _columnsAndRowsListView.SelectedIndices.Count))
+            if ((_columnsAndRowsListView.Items.Count == 1)
+                || (_columnsAndRowsListView.Items.Count == _columnsAndRowsListView.SelectedIndices.Count))
             {
                 // We can't remove anything when we have just 1 row/col or if all rows/cols are selected
                 return;
@@ -1005,7 +1011,7 @@ internal partial class StyleCollectionEditor
                 }
             }
 
-            if ((total == 100) || (total == 0))
+            if (total == 100 || total == 0)
             {
                 return;
             }
@@ -1068,32 +1074,32 @@ internal partial class StyleCollectionEditor
                     // If you change this,you should also change the code in TableLayoutPanelDesigner.OnRemoveInternal
                     if (_deleteList.Count > 0)
                     {
-                        PropertyDescriptor childProp = TypeDescriptor.GetProperties(_tableLayoutPanel)["Controls"];
-                        if (_componentChangeService is not null && childProp is not null)
+                        PropertyDescriptor childProperty = TypeDescriptor.GetProperties(_tableLayoutPanel)[nameof(TableLayoutPanel.Controls)];
+                        if (_componentChangeService is not null && childProperty is not null)
                         {
-                            _componentChangeService.OnComponentChanging(_tableLayoutPanel, childProp);
+                            _componentChangeService.OnComponentChanging(_tableLayoutPanel, childProperty);
                         }
 
-                        IDesignerHost host = _tableLayoutPanel.Site.GetService(typeof(IDesignerHost)) as IDesignerHost;
+                        var host = _tableLayoutPanel.Site.GetService<IDesignerHost>();
 
                         if (host is not null)
                         {
-                            foreach (object o in _deleteList)
+                            foreach (object obj in _deleteList)
                             {
-                                List<IComponent> al = new();
-                                DesignerUtils.GetAssociatedComponents((IComponent)o, host, al);
-                                foreach (IComponent comp in al)
+                                List<IComponent> componentList = new();
+                                DesignerUtils.GetAssociatedComponents((IComponent)obj, host, componentList);
+                                foreach (IComponent component in componentList)
                                 {
-                                    _componentChangeService.OnComponentChanging(comp, null);
+                                    _componentChangeService.OnComponentChanging(component, null);
                                 }
 
-                                host.DestroyComponent(o as Component);
+                                host.DestroyComponent(obj as Component);
                             }
                         }
 
-                        if (_componentChangeService is not null && childProp is not null)
+                        if (_componentChangeService is not null && childProperty is not null)
                         {
-                            _componentChangeService.OnComponentChanged(_tableLayoutPanel, childProp, null, null);
+                            _componentChangeService.OnComponentChanged(_tableLayoutPanel, childProperty, null, null);
                         }
                     }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/StyleEditorForm.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/StyleEditorForm.cs
@@ -99,7 +99,7 @@ internal partial class StyleCollectionEditor
             _deleteList = [];
 
             // Get the designer associated with the TLP
-            var host = _tableLayoutPanel.Site.GetService(typeof(IDesignerHost)) as IDesignerHost;
+            var host = _tableLayoutPanel.Site.GetService<IDesignerHost>();
             if (host is not null)
             {
                 _tableLayoutPanelDesigner = host.GetDesigner(_tableLayoutPanel) as TableLayoutPanelDesigner;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/xlf/StyleCollectionEditor.cs.xlf
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/xlf/StyleCollectionEditor.cs.xlf
@@ -1,0 +1,126 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="cs" original="../StyleCollectionEditor.resx">
+    <body>
+      <trans-unit id="$this.Text">
+        <source>Column and Row Styles</source>
+        <target state="new">Column and Row Styles</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="absoluteNumericUpDown.AccessibleName">
+        <source>Absolute</source>
+        <target state="new">Absolute</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="absoluteRadioButton.Text">
+        <source>A&amp;bsolute</source>
+        <target state="new">A&amp;bsolute</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="addButton.Text">
+        <source>&amp;Add</source>
+        <target state="new">&amp;Add</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="autoSizedRadioButton.Text">
+        <source>A&amp;utoSize</source>
+        <target state="new">A&amp;utoSize</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cancelButton.Text">
+        <source>Cancel</source>
+        <target state="new">Cancel</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="columnsAndRowsListView.AccessibleName">
+        <source>Columns and Rows List</source>
+        <target state="new">Columns and Rows List</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="columnsOrRowsComboBox.Items">
+        <source>Columns</source>
+        <target state="new">Columns</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="columnsOrRowsComboBox.Items1">
+        <source>Rows</source>
+        <target state="new">Rows</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="helperLinkLabel1.Text">
+        <source>Column and row spanning:
+If you want a control to span multiple rows or columns, set the RowSpan and ColumnSpan properties on the control.</source>
+        <target state="new">Column and row spanning:
+If you want a control to span multiple rows or columns, set the RowSpan and ColumnSpan properties on the control.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="helperLinkLabel2.Text">
+        <source>Alignment and stretching:
+If you want to align a control within a cell, or if you want a control to stretch within a cell, use the control's Anchor property.</source>
+        <target state="new">Alignment and stretching:
+If you want to align a control within a cell, or if you want a control to stretch within a cell, use the control's Anchor property.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="insertButton.Text">
+        <source>&amp;Insert</source>
+        <target state="new">&amp;Insert</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="memberTypeLabel.Text">
+        <source>&amp;Show:</source>
+        <target state="new">&amp;Show:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="membersColumnHeader.Text">
+        <source>Member</source>
+        <target state="new">Member</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="okButton.Text">
+        <source>OK</source>
+        <target state="new">OK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="percentLabel.Text">
+        <source>%</source>
+        <target state="new">%</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="percentNumericUpDown.AccessibleName">
+        <source>Percent</source>
+        <target state="new">Percent</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="percentRadioButton.Text">
+        <source>&amp;Percent</source>
+        <target state="new">&amp;Percent</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="pixelsLabel.Text">
+        <source>pixels</source>
+        <target state="new">pixels</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="removeButton.Text">
+        <source>&amp;Delete</source>
+        <target state="new">&amp;Delete</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="sizeTypeColumnHeader.Text">
+        <source>Size Type</source>
+        <target state="new">Size Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="sizeTypeGroupBox.Text">
+        <source>Size Type</source>
+        <target state="new">Size Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="valueColumnHeader.Text">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/xlf/StyleCollectionEditor.de.xlf
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/xlf/StyleCollectionEditor.de.xlf
@@ -1,0 +1,126 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="de" original="../StyleCollectionEditor.resx">
+    <body>
+      <trans-unit id="$this.Text">
+        <source>Column and Row Styles</source>
+        <target state="new">Column and Row Styles</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="absoluteNumericUpDown.AccessibleName">
+        <source>Absolute</source>
+        <target state="new">Absolute</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="absoluteRadioButton.Text">
+        <source>A&amp;bsolute</source>
+        <target state="new">A&amp;bsolute</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="addButton.Text">
+        <source>&amp;Add</source>
+        <target state="new">&amp;Add</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="autoSizedRadioButton.Text">
+        <source>A&amp;utoSize</source>
+        <target state="new">A&amp;utoSize</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cancelButton.Text">
+        <source>Cancel</source>
+        <target state="new">Cancel</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="columnsAndRowsListView.AccessibleName">
+        <source>Columns and Rows List</source>
+        <target state="new">Columns and Rows List</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="columnsOrRowsComboBox.Items">
+        <source>Columns</source>
+        <target state="new">Columns</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="columnsOrRowsComboBox.Items1">
+        <source>Rows</source>
+        <target state="new">Rows</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="helperLinkLabel1.Text">
+        <source>Column and row spanning:
+If you want a control to span multiple rows or columns, set the RowSpan and ColumnSpan properties on the control.</source>
+        <target state="new">Column and row spanning:
+If you want a control to span multiple rows or columns, set the RowSpan and ColumnSpan properties on the control.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="helperLinkLabel2.Text">
+        <source>Alignment and stretching:
+If you want to align a control within a cell, or if you want a control to stretch within a cell, use the control's Anchor property.</source>
+        <target state="new">Alignment and stretching:
+If you want to align a control within a cell, or if you want a control to stretch within a cell, use the control's Anchor property.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="insertButton.Text">
+        <source>&amp;Insert</source>
+        <target state="new">&amp;Insert</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="memberTypeLabel.Text">
+        <source>&amp;Show:</source>
+        <target state="new">&amp;Show:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="membersColumnHeader.Text">
+        <source>Member</source>
+        <target state="new">Member</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="okButton.Text">
+        <source>OK</source>
+        <target state="new">OK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="percentLabel.Text">
+        <source>%</source>
+        <target state="new">%</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="percentNumericUpDown.AccessibleName">
+        <source>Percent</source>
+        <target state="new">Percent</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="percentRadioButton.Text">
+        <source>&amp;Percent</source>
+        <target state="new">&amp;Percent</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="pixelsLabel.Text">
+        <source>pixels</source>
+        <target state="new">pixels</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="removeButton.Text">
+        <source>&amp;Delete</source>
+        <target state="new">&amp;Delete</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="sizeTypeColumnHeader.Text">
+        <source>Size Type</source>
+        <target state="new">Size Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="sizeTypeGroupBox.Text">
+        <source>Size Type</source>
+        <target state="new">Size Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="valueColumnHeader.Text">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/xlf/StyleCollectionEditor.es.xlf
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/xlf/StyleCollectionEditor.es.xlf
@@ -1,0 +1,126 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="es" original="../StyleCollectionEditor.resx">
+    <body>
+      <trans-unit id="$this.Text">
+        <source>Column and Row Styles</source>
+        <target state="new">Column and Row Styles</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="absoluteNumericUpDown.AccessibleName">
+        <source>Absolute</source>
+        <target state="new">Absolute</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="absoluteRadioButton.Text">
+        <source>A&amp;bsolute</source>
+        <target state="new">A&amp;bsolute</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="addButton.Text">
+        <source>&amp;Add</source>
+        <target state="new">&amp;Add</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="autoSizedRadioButton.Text">
+        <source>A&amp;utoSize</source>
+        <target state="new">A&amp;utoSize</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cancelButton.Text">
+        <source>Cancel</source>
+        <target state="new">Cancel</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="columnsAndRowsListView.AccessibleName">
+        <source>Columns and Rows List</source>
+        <target state="new">Columns and Rows List</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="columnsOrRowsComboBox.Items">
+        <source>Columns</source>
+        <target state="new">Columns</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="columnsOrRowsComboBox.Items1">
+        <source>Rows</source>
+        <target state="new">Rows</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="helperLinkLabel1.Text">
+        <source>Column and row spanning:
+If you want a control to span multiple rows or columns, set the RowSpan and ColumnSpan properties on the control.</source>
+        <target state="new">Column and row spanning:
+If you want a control to span multiple rows or columns, set the RowSpan and ColumnSpan properties on the control.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="helperLinkLabel2.Text">
+        <source>Alignment and stretching:
+If you want to align a control within a cell, or if you want a control to stretch within a cell, use the control's Anchor property.</source>
+        <target state="new">Alignment and stretching:
+If you want to align a control within a cell, or if you want a control to stretch within a cell, use the control's Anchor property.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="insertButton.Text">
+        <source>&amp;Insert</source>
+        <target state="new">&amp;Insert</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="memberTypeLabel.Text">
+        <source>&amp;Show:</source>
+        <target state="new">&amp;Show:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="membersColumnHeader.Text">
+        <source>Member</source>
+        <target state="new">Member</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="okButton.Text">
+        <source>OK</source>
+        <target state="new">OK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="percentLabel.Text">
+        <source>%</source>
+        <target state="new">%</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="percentNumericUpDown.AccessibleName">
+        <source>Percent</source>
+        <target state="new">Percent</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="percentRadioButton.Text">
+        <source>&amp;Percent</source>
+        <target state="new">&amp;Percent</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="pixelsLabel.Text">
+        <source>pixels</source>
+        <target state="new">pixels</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="removeButton.Text">
+        <source>&amp;Delete</source>
+        <target state="new">&amp;Delete</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="sizeTypeColumnHeader.Text">
+        <source>Size Type</source>
+        <target state="new">Size Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="sizeTypeGroupBox.Text">
+        <source>Size Type</source>
+        <target state="new">Size Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="valueColumnHeader.Text">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/xlf/StyleCollectionEditor.fr.xlf
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/xlf/StyleCollectionEditor.fr.xlf
@@ -1,0 +1,126 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="fr" original="../StyleCollectionEditor.resx">
+    <body>
+      <trans-unit id="$this.Text">
+        <source>Column and Row Styles</source>
+        <target state="new">Column and Row Styles</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="absoluteNumericUpDown.AccessibleName">
+        <source>Absolute</source>
+        <target state="new">Absolute</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="absoluteRadioButton.Text">
+        <source>A&amp;bsolute</source>
+        <target state="new">A&amp;bsolute</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="addButton.Text">
+        <source>&amp;Add</source>
+        <target state="new">&amp;Add</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="autoSizedRadioButton.Text">
+        <source>A&amp;utoSize</source>
+        <target state="new">A&amp;utoSize</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cancelButton.Text">
+        <source>Cancel</source>
+        <target state="new">Cancel</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="columnsAndRowsListView.AccessibleName">
+        <source>Columns and Rows List</source>
+        <target state="new">Columns and Rows List</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="columnsOrRowsComboBox.Items">
+        <source>Columns</source>
+        <target state="new">Columns</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="columnsOrRowsComboBox.Items1">
+        <source>Rows</source>
+        <target state="new">Rows</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="helperLinkLabel1.Text">
+        <source>Column and row spanning:
+If you want a control to span multiple rows or columns, set the RowSpan and ColumnSpan properties on the control.</source>
+        <target state="new">Column and row spanning:
+If you want a control to span multiple rows or columns, set the RowSpan and ColumnSpan properties on the control.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="helperLinkLabel2.Text">
+        <source>Alignment and stretching:
+If you want to align a control within a cell, or if you want a control to stretch within a cell, use the control's Anchor property.</source>
+        <target state="new">Alignment and stretching:
+If you want to align a control within a cell, or if you want a control to stretch within a cell, use the control's Anchor property.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="insertButton.Text">
+        <source>&amp;Insert</source>
+        <target state="new">&amp;Insert</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="memberTypeLabel.Text">
+        <source>&amp;Show:</source>
+        <target state="new">&amp;Show:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="membersColumnHeader.Text">
+        <source>Member</source>
+        <target state="new">Member</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="okButton.Text">
+        <source>OK</source>
+        <target state="new">OK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="percentLabel.Text">
+        <source>%</source>
+        <target state="new">%</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="percentNumericUpDown.AccessibleName">
+        <source>Percent</source>
+        <target state="new">Percent</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="percentRadioButton.Text">
+        <source>&amp;Percent</source>
+        <target state="new">&amp;Percent</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="pixelsLabel.Text">
+        <source>pixels</source>
+        <target state="new">pixels</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="removeButton.Text">
+        <source>&amp;Delete</source>
+        <target state="new">&amp;Delete</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="sizeTypeColumnHeader.Text">
+        <source>Size Type</source>
+        <target state="new">Size Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="sizeTypeGroupBox.Text">
+        <source>Size Type</source>
+        <target state="new">Size Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="valueColumnHeader.Text">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/xlf/StyleCollectionEditor.it.xlf
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/xlf/StyleCollectionEditor.it.xlf
@@ -1,0 +1,126 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="it" original="../StyleCollectionEditor.resx">
+    <body>
+      <trans-unit id="$this.Text">
+        <source>Column and Row Styles</source>
+        <target state="new">Column and Row Styles</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="absoluteNumericUpDown.AccessibleName">
+        <source>Absolute</source>
+        <target state="new">Absolute</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="absoluteRadioButton.Text">
+        <source>A&amp;bsolute</source>
+        <target state="new">A&amp;bsolute</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="addButton.Text">
+        <source>&amp;Add</source>
+        <target state="new">&amp;Add</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="autoSizedRadioButton.Text">
+        <source>A&amp;utoSize</source>
+        <target state="new">A&amp;utoSize</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cancelButton.Text">
+        <source>Cancel</source>
+        <target state="new">Cancel</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="columnsAndRowsListView.AccessibleName">
+        <source>Columns and Rows List</source>
+        <target state="new">Columns and Rows List</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="columnsOrRowsComboBox.Items">
+        <source>Columns</source>
+        <target state="new">Columns</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="columnsOrRowsComboBox.Items1">
+        <source>Rows</source>
+        <target state="new">Rows</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="helperLinkLabel1.Text">
+        <source>Column and row spanning:
+If you want a control to span multiple rows or columns, set the RowSpan and ColumnSpan properties on the control.</source>
+        <target state="new">Column and row spanning:
+If you want a control to span multiple rows or columns, set the RowSpan and ColumnSpan properties on the control.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="helperLinkLabel2.Text">
+        <source>Alignment and stretching:
+If you want to align a control within a cell, or if you want a control to stretch within a cell, use the control's Anchor property.</source>
+        <target state="new">Alignment and stretching:
+If you want to align a control within a cell, or if you want a control to stretch within a cell, use the control's Anchor property.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="insertButton.Text">
+        <source>&amp;Insert</source>
+        <target state="new">&amp;Insert</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="memberTypeLabel.Text">
+        <source>&amp;Show:</source>
+        <target state="new">&amp;Show:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="membersColumnHeader.Text">
+        <source>Member</source>
+        <target state="new">Member</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="okButton.Text">
+        <source>OK</source>
+        <target state="new">OK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="percentLabel.Text">
+        <source>%</source>
+        <target state="new">%</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="percentNumericUpDown.AccessibleName">
+        <source>Percent</source>
+        <target state="new">Percent</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="percentRadioButton.Text">
+        <source>&amp;Percent</source>
+        <target state="new">&amp;Percent</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="pixelsLabel.Text">
+        <source>pixels</source>
+        <target state="new">pixels</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="removeButton.Text">
+        <source>&amp;Delete</source>
+        <target state="new">&amp;Delete</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="sizeTypeColumnHeader.Text">
+        <source>Size Type</source>
+        <target state="new">Size Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="sizeTypeGroupBox.Text">
+        <source>Size Type</source>
+        <target state="new">Size Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="valueColumnHeader.Text">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/xlf/StyleCollectionEditor.ja.xlf
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/xlf/StyleCollectionEditor.ja.xlf
@@ -1,0 +1,126 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ja" original="../StyleCollectionEditor.resx">
+    <body>
+      <trans-unit id="$this.Text">
+        <source>Column and Row Styles</source>
+        <target state="new">Column and Row Styles</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="absoluteNumericUpDown.AccessibleName">
+        <source>Absolute</source>
+        <target state="new">Absolute</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="absoluteRadioButton.Text">
+        <source>A&amp;bsolute</source>
+        <target state="new">A&amp;bsolute</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="addButton.Text">
+        <source>&amp;Add</source>
+        <target state="new">&amp;Add</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="autoSizedRadioButton.Text">
+        <source>A&amp;utoSize</source>
+        <target state="new">A&amp;utoSize</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cancelButton.Text">
+        <source>Cancel</source>
+        <target state="new">Cancel</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="columnsAndRowsListView.AccessibleName">
+        <source>Columns and Rows List</source>
+        <target state="new">Columns and Rows List</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="columnsOrRowsComboBox.Items">
+        <source>Columns</source>
+        <target state="new">Columns</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="columnsOrRowsComboBox.Items1">
+        <source>Rows</source>
+        <target state="new">Rows</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="helperLinkLabel1.Text">
+        <source>Column and row spanning:
+If you want a control to span multiple rows or columns, set the RowSpan and ColumnSpan properties on the control.</source>
+        <target state="new">Column and row spanning:
+If you want a control to span multiple rows or columns, set the RowSpan and ColumnSpan properties on the control.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="helperLinkLabel2.Text">
+        <source>Alignment and stretching:
+If you want to align a control within a cell, or if you want a control to stretch within a cell, use the control's Anchor property.</source>
+        <target state="new">Alignment and stretching:
+If you want to align a control within a cell, or if you want a control to stretch within a cell, use the control's Anchor property.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="insertButton.Text">
+        <source>&amp;Insert</source>
+        <target state="new">&amp;Insert</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="memberTypeLabel.Text">
+        <source>&amp;Show:</source>
+        <target state="new">&amp;Show:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="membersColumnHeader.Text">
+        <source>Member</source>
+        <target state="new">Member</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="okButton.Text">
+        <source>OK</source>
+        <target state="new">OK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="percentLabel.Text">
+        <source>%</source>
+        <target state="new">%</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="percentNumericUpDown.AccessibleName">
+        <source>Percent</source>
+        <target state="new">Percent</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="percentRadioButton.Text">
+        <source>&amp;Percent</source>
+        <target state="new">&amp;Percent</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="pixelsLabel.Text">
+        <source>pixels</source>
+        <target state="new">pixels</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="removeButton.Text">
+        <source>&amp;Delete</source>
+        <target state="new">&amp;Delete</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="sizeTypeColumnHeader.Text">
+        <source>Size Type</source>
+        <target state="new">Size Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="sizeTypeGroupBox.Text">
+        <source>Size Type</source>
+        <target state="new">Size Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="valueColumnHeader.Text">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/xlf/StyleCollectionEditor.ko.xlf
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/xlf/StyleCollectionEditor.ko.xlf
@@ -1,0 +1,126 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ko" original="../StyleCollectionEditor.resx">
+    <body>
+      <trans-unit id="$this.Text">
+        <source>Column and Row Styles</source>
+        <target state="new">Column and Row Styles</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="absoluteNumericUpDown.AccessibleName">
+        <source>Absolute</source>
+        <target state="new">Absolute</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="absoluteRadioButton.Text">
+        <source>A&amp;bsolute</source>
+        <target state="new">A&amp;bsolute</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="addButton.Text">
+        <source>&amp;Add</source>
+        <target state="new">&amp;Add</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="autoSizedRadioButton.Text">
+        <source>A&amp;utoSize</source>
+        <target state="new">A&amp;utoSize</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cancelButton.Text">
+        <source>Cancel</source>
+        <target state="new">Cancel</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="columnsAndRowsListView.AccessibleName">
+        <source>Columns and Rows List</source>
+        <target state="new">Columns and Rows List</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="columnsOrRowsComboBox.Items">
+        <source>Columns</source>
+        <target state="new">Columns</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="columnsOrRowsComboBox.Items1">
+        <source>Rows</source>
+        <target state="new">Rows</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="helperLinkLabel1.Text">
+        <source>Column and row spanning:
+If you want a control to span multiple rows or columns, set the RowSpan and ColumnSpan properties on the control.</source>
+        <target state="new">Column and row spanning:
+If you want a control to span multiple rows or columns, set the RowSpan and ColumnSpan properties on the control.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="helperLinkLabel2.Text">
+        <source>Alignment and stretching:
+If you want to align a control within a cell, or if you want a control to stretch within a cell, use the control's Anchor property.</source>
+        <target state="new">Alignment and stretching:
+If you want to align a control within a cell, or if you want a control to stretch within a cell, use the control's Anchor property.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="insertButton.Text">
+        <source>&amp;Insert</source>
+        <target state="new">&amp;Insert</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="memberTypeLabel.Text">
+        <source>&amp;Show:</source>
+        <target state="new">&amp;Show:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="membersColumnHeader.Text">
+        <source>Member</source>
+        <target state="new">Member</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="okButton.Text">
+        <source>OK</source>
+        <target state="new">OK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="percentLabel.Text">
+        <source>%</source>
+        <target state="new">%</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="percentNumericUpDown.AccessibleName">
+        <source>Percent</source>
+        <target state="new">Percent</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="percentRadioButton.Text">
+        <source>&amp;Percent</source>
+        <target state="new">&amp;Percent</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="pixelsLabel.Text">
+        <source>pixels</source>
+        <target state="new">pixels</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="removeButton.Text">
+        <source>&amp;Delete</source>
+        <target state="new">&amp;Delete</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="sizeTypeColumnHeader.Text">
+        <source>Size Type</source>
+        <target state="new">Size Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="sizeTypeGroupBox.Text">
+        <source>Size Type</source>
+        <target state="new">Size Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="valueColumnHeader.Text">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/xlf/StyleCollectionEditor.pl.xlf
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/xlf/StyleCollectionEditor.pl.xlf
@@ -1,0 +1,126 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pl" original="../StyleCollectionEditor.resx">
+    <body>
+      <trans-unit id="$this.Text">
+        <source>Column and Row Styles</source>
+        <target state="new">Column and Row Styles</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="absoluteNumericUpDown.AccessibleName">
+        <source>Absolute</source>
+        <target state="new">Absolute</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="absoluteRadioButton.Text">
+        <source>A&amp;bsolute</source>
+        <target state="new">A&amp;bsolute</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="addButton.Text">
+        <source>&amp;Add</source>
+        <target state="new">&amp;Add</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="autoSizedRadioButton.Text">
+        <source>A&amp;utoSize</source>
+        <target state="new">A&amp;utoSize</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cancelButton.Text">
+        <source>Cancel</source>
+        <target state="new">Cancel</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="columnsAndRowsListView.AccessibleName">
+        <source>Columns and Rows List</source>
+        <target state="new">Columns and Rows List</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="columnsOrRowsComboBox.Items">
+        <source>Columns</source>
+        <target state="new">Columns</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="columnsOrRowsComboBox.Items1">
+        <source>Rows</source>
+        <target state="new">Rows</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="helperLinkLabel1.Text">
+        <source>Column and row spanning:
+If you want a control to span multiple rows or columns, set the RowSpan and ColumnSpan properties on the control.</source>
+        <target state="new">Column and row spanning:
+If you want a control to span multiple rows or columns, set the RowSpan and ColumnSpan properties on the control.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="helperLinkLabel2.Text">
+        <source>Alignment and stretching:
+If you want to align a control within a cell, or if you want a control to stretch within a cell, use the control's Anchor property.</source>
+        <target state="new">Alignment and stretching:
+If you want to align a control within a cell, or if you want a control to stretch within a cell, use the control's Anchor property.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="insertButton.Text">
+        <source>&amp;Insert</source>
+        <target state="new">&amp;Insert</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="memberTypeLabel.Text">
+        <source>&amp;Show:</source>
+        <target state="new">&amp;Show:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="membersColumnHeader.Text">
+        <source>Member</source>
+        <target state="new">Member</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="okButton.Text">
+        <source>OK</source>
+        <target state="new">OK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="percentLabel.Text">
+        <source>%</source>
+        <target state="new">%</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="percentNumericUpDown.AccessibleName">
+        <source>Percent</source>
+        <target state="new">Percent</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="percentRadioButton.Text">
+        <source>&amp;Percent</source>
+        <target state="new">&amp;Percent</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="pixelsLabel.Text">
+        <source>pixels</source>
+        <target state="new">pixels</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="removeButton.Text">
+        <source>&amp;Delete</source>
+        <target state="new">&amp;Delete</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="sizeTypeColumnHeader.Text">
+        <source>Size Type</source>
+        <target state="new">Size Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="sizeTypeGroupBox.Text">
+        <source>Size Type</source>
+        <target state="new">Size Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="valueColumnHeader.Text">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/xlf/StyleCollectionEditor.pt-BR.xlf
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/xlf/StyleCollectionEditor.pt-BR.xlf
@@ -1,0 +1,126 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pt-BR" original="../StyleCollectionEditor.resx">
+    <body>
+      <trans-unit id="$this.Text">
+        <source>Column and Row Styles</source>
+        <target state="new">Column and Row Styles</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="absoluteNumericUpDown.AccessibleName">
+        <source>Absolute</source>
+        <target state="new">Absolute</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="absoluteRadioButton.Text">
+        <source>A&amp;bsolute</source>
+        <target state="new">A&amp;bsolute</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="addButton.Text">
+        <source>&amp;Add</source>
+        <target state="new">&amp;Add</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="autoSizedRadioButton.Text">
+        <source>A&amp;utoSize</source>
+        <target state="new">A&amp;utoSize</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cancelButton.Text">
+        <source>Cancel</source>
+        <target state="new">Cancel</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="columnsAndRowsListView.AccessibleName">
+        <source>Columns and Rows List</source>
+        <target state="new">Columns and Rows List</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="columnsOrRowsComboBox.Items">
+        <source>Columns</source>
+        <target state="new">Columns</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="columnsOrRowsComboBox.Items1">
+        <source>Rows</source>
+        <target state="new">Rows</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="helperLinkLabel1.Text">
+        <source>Column and row spanning:
+If you want a control to span multiple rows or columns, set the RowSpan and ColumnSpan properties on the control.</source>
+        <target state="new">Column and row spanning:
+If you want a control to span multiple rows or columns, set the RowSpan and ColumnSpan properties on the control.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="helperLinkLabel2.Text">
+        <source>Alignment and stretching:
+If you want to align a control within a cell, or if you want a control to stretch within a cell, use the control's Anchor property.</source>
+        <target state="new">Alignment and stretching:
+If you want to align a control within a cell, or if you want a control to stretch within a cell, use the control's Anchor property.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="insertButton.Text">
+        <source>&amp;Insert</source>
+        <target state="new">&amp;Insert</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="memberTypeLabel.Text">
+        <source>&amp;Show:</source>
+        <target state="new">&amp;Show:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="membersColumnHeader.Text">
+        <source>Member</source>
+        <target state="new">Member</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="okButton.Text">
+        <source>OK</source>
+        <target state="new">OK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="percentLabel.Text">
+        <source>%</source>
+        <target state="new">%</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="percentNumericUpDown.AccessibleName">
+        <source>Percent</source>
+        <target state="new">Percent</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="percentRadioButton.Text">
+        <source>&amp;Percent</source>
+        <target state="new">&amp;Percent</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="pixelsLabel.Text">
+        <source>pixels</source>
+        <target state="new">pixels</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="removeButton.Text">
+        <source>&amp;Delete</source>
+        <target state="new">&amp;Delete</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="sizeTypeColumnHeader.Text">
+        <source>Size Type</source>
+        <target state="new">Size Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="sizeTypeGroupBox.Text">
+        <source>Size Type</source>
+        <target state="new">Size Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="valueColumnHeader.Text">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/xlf/StyleCollectionEditor.ru.xlf
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/xlf/StyleCollectionEditor.ru.xlf
@@ -1,0 +1,126 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ru" original="../StyleCollectionEditor.resx">
+    <body>
+      <trans-unit id="$this.Text">
+        <source>Column and Row Styles</source>
+        <target state="new">Column and Row Styles</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="absoluteNumericUpDown.AccessibleName">
+        <source>Absolute</source>
+        <target state="new">Absolute</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="absoluteRadioButton.Text">
+        <source>A&amp;bsolute</source>
+        <target state="new">A&amp;bsolute</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="addButton.Text">
+        <source>&amp;Add</source>
+        <target state="new">&amp;Add</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="autoSizedRadioButton.Text">
+        <source>A&amp;utoSize</source>
+        <target state="new">A&amp;utoSize</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cancelButton.Text">
+        <source>Cancel</source>
+        <target state="new">Cancel</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="columnsAndRowsListView.AccessibleName">
+        <source>Columns and Rows List</source>
+        <target state="new">Columns and Rows List</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="columnsOrRowsComboBox.Items">
+        <source>Columns</source>
+        <target state="new">Columns</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="columnsOrRowsComboBox.Items1">
+        <source>Rows</source>
+        <target state="new">Rows</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="helperLinkLabel1.Text">
+        <source>Column and row spanning:
+If you want a control to span multiple rows or columns, set the RowSpan and ColumnSpan properties on the control.</source>
+        <target state="new">Column and row spanning:
+If you want a control to span multiple rows or columns, set the RowSpan and ColumnSpan properties on the control.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="helperLinkLabel2.Text">
+        <source>Alignment and stretching:
+If you want to align a control within a cell, or if you want a control to stretch within a cell, use the control's Anchor property.</source>
+        <target state="new">Alignment and stretching:
+If you want to align a control within a cell, or if you want a control to stretch within a cell, use the control's Anchor property.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="insertButton.Text">
+        <source>&amp;Insert</source>
+        <target state="new">&amp;Insert</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="memberTypeLabel.Text">
+        <source>&amp;Show:</source>
+        <target state="new">&amp;Show:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="membersColumnHeader.Text">
+        <source>Member</source>
+        <target state="new">Member</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="okButton.Text">
+        <source>OK</source>
+        <target state="new">OK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="percentLabel.Text">
+        <source>%</source>
+        <target state="new">%</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="percentNumericUpDown.AccessibleName">
+        <source>Percent</source>
+        <target state="new">Percent</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="percentRadioButton.Text">
+        <source>&amp;Percent</source>
+        <target state="new">&amp;Percent</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="pixelsLabel.Text">
+        <source>pixels</source>
+        <target state="new">pixels</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="removeButton.Text">
+        <source>&amp;Delete</source>
+        <target state="new">&amp;Delete</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="sizeTypeColumnHeader.Text">
+        <source>Size Type</source>
+        <target state="new">Size Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="sizeTypeGroupBox.Text">
+        <source>Size Type</source>
+        <target state="new">Size Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="valueColumnHeader.Text">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/xlf/StyleCollectionEditor.tr.xlf
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/xlf/StyleCollectionEditor.tr.xlf
@@ -1,0 +1,126 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="tr" original="../StyleCollectionEditor.resx">
+    <body>
+      <trans-unit id="$this.Text">
+        <source>Column and Row Styles</source>
+        <target state="new">Column and Row Styles</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="absoluteNumericUpDown.AccessibleName">
+        <source>Absolute</source>
+        <target state="new">Absolute</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="absoluteRadioButton.Text">
+        <source>A&amp;bsolute</source>
+        <target state="new">A&amp;bsolute</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="addButton.Text">
+        <source>&amp;Add</source>
+        <target state="new">&amp;Add</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="autoSizedRadioButton.Text">
+        <source>A&amp;utoSize</source>
+        <target state="new">A&amp;utoSize</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cancelButton.Text">
+        <source>Cancel</source>
+        <target state="new">Cancel</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="columnsAndRowsListView.AccessibleName">
+        <source>Columns and Rows List</source>
+        <target state="new">Columns and Rows List</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="columnsOrRowsComboBox.Items">
+        <source>Columns</source>
+        <target state="new">Columns</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="columnsOrRowsComboBox.Items1">
+        <source>Rows</source>
+        <target state="new">Rows</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="helperLinkLabel1.Text">
+        <source>Column and row spanning:
+If you want a control to span multiple rows or columns, set the RowSpan and ColumnSpan properties on the control.</source>
+        <target state="new">Column and row spanning:
+If you want a control to span multiple rows or columns, set the RowSpan and ColumnSpan properties on the control.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="helperLinkLabel2.Text">
+        <source>Alignment and stretching:
+If you want to align a control within a cell, or if you want a control to stretch within a cell, use the control's Anchor property.</source>
+        <target state="new">Alignment and stretching:
+If you want to align a control within a cell, or if you want a control to stretch within a cell, use the control's Anchor property.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="insertButton.Text">
+        <source>&amp;Insert</source>
+        <target state="new">&amp;Insert</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="memberTypeLabel.Text">
+        <source>&amp;Show:</source>
+        <target state="new">&amp;Show:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="membersColumnHeader.Text">
+        <source>Member</source>
+        <target state="new">Member</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="okButton.Text">
+        <source>OK</source>
+        <target state="new">OK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="percentLabel.Text">
+        <source>%</source>
+        <target state="new">%</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="percentNumericUpDown.AccessibleName">
+        <source>Percent</source>
+        <target state="new">Percent</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="percentRadioButton.Text">
+        <source>&amp;Percent</source>
+        <target state="new">&amp;Percent</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="pixelsLabel.Text">
+        <source>pixels</source>
+        <target state="new">pixels</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="removeButton.Text">
+        <source>&amp;Delete</source>
+        <target state="new">&amp;Delete</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="sizeTypeColumnHeader.Text">
+        <source>Size Type</source>
+        <target state="new">Size Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="sizeTypeGroupBox.Text">
+        <source>Size Type</source>
+        <target state="new">Size Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="valueColumnHeader.Text">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/xlf/StyleCollectionEditor.zh-Hans.xlf
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/xlf/StyleCollectionEditor.zh-Hans.xlf
@@ -1,0 +1,126 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hans" original="../StyleCollectionEditor.resx">
+    <body>
+      <trans-unit id="$this.Text">
+        <source>Column and Row Styles</source>
+        <target state="new">Column and Row Styles</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="absoluteNumericUpDown.AccessibleName">
+        <source>Absolute</source>
+        <target state="new">Absolute</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="absoluteRadioButton.Text">
+        <source>A&amp;bsolute</source>
+        <target state="new">A&amp;bsolute</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="addButton.Text">
+        <source>&amp;Add</source>
+        <target state="new">&amp;Add</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="autoSizedRadioButton.Text">
+        <source>A&amp;utoSize</source>
+        <target state="new">A&amp;utoSize</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cancelButton.Text">
+        <source>Cancel</source>
+        <target state="new">Cancel</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="columnsAndRowsListView.AccessibleName">
+        <source>Columns and Rows List</source>
+        <target state="new">Columns and Rows List</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="columnsOrRowsComboBox.Items">
+        <source>Columns</source>
+        <target state="new">Columns</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="columnsOrRowsComboBox.Items1">
+        <source>Rows</source>
+        <target state="new">Rows</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="helperLinkLabel1.Text">
+        <source>Column and row spanning:
+If you want a control to span multiple rows or columns, set the RowSpan and ColumnSpan properties on the control.</source>
+        <target state="new">Column and row spanning:
+If you want a control to span multiple rows or columns, set the RowSpan and ColumnSpan properties on the control.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="helperLinkLabel2.Text">
+        <source>Alignment and stretching:
+If you want to align a control within a cell, or if you want a control to stretch within a cell, use the control's Anchor property.</source>
+        <target state="new">Alignment and stretching:
+If you want to align a control within a cell, or if you want a control to stretch within a cell, use the control's Anchor property.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="insertButton.Text">
+        <source>&amp;Insert</source>
+        <target state="new">&amp;Insert</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="memberTypeLabel.Text">
+        <source>&amp;Show:</source>
+        <target state="new">&amp;Show:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="membersColumnHeader.Text">
+        <source>Member</source>
+        <target state="new">Member</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="okButton.Text">
+        <source>OK</source>
+        <target state="new">OK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="percentLabel.Text">
+        <source>%</source>
+        <target state="new">%</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="percentNumericUpDown.AccessibleName">
+        <source>Percent</source>
+        <target state="new">Percent</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="percentRadioButton.Text">
+        <source>&amp;Percent</source>
+        <target state="new">&amp;Percent</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="pixelsLabel.Text">
+        <source>pixels</source>
+        <target state="new">pixels</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="removeButton.Text">
+        <source>&amp;Delete</source>
+        <target state="new">&amp;Delete</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="sizeTypeColumnHeader.Text">
+        <source>Size Type</source>
+        <target state="new">Size Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="sizeTypeGroupBox.Text">
+        <source>Size Type</source>
+        <target state="new">Size Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="valueColumnHeader.Text">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/xlf/StyleCollectionEditor.zh-Hant.xlf
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/xlf/StyleCollectionEditor.zh-Hant.xlf
@@ -1,0 +1,126 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hant" original="../StyleCollectionEditor.resx">
+    <body>
+      <trans-unit id="$this.Text">
+        <source>Column and Row Styles</source>
+        <target state="new">Column and Row Styles</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="absoluteNumericUpDown.AccessibleName">
+        <source>Absolute</source>
+        <target state="new">Absolute</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="absoluteRadioButton.Text">
+        <source>A&amp;bsolute</source>
+        <target state="new">A&amp;bsolute</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="addButton.Text">
+        <source>&amp;Add</source>
+        <target state="new">&amp;Add</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="autoSizedRadioButton.Text">
+        <source>A&amp;utoSize</source>
+        <target state="new">A&amp;utoSize</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cancelButton.Text">
+        <source>Cancel</source>
+        <target state="new">Cancel</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="columnsAndRowsListView.AccessibleName">
+        <source>Columns and Rows List</source>
+        <target state="new">Columns and Rows List</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="columnsOrRowsComboBox.Items">
+        <source>Columns</source>
+        <target state="new">Columns</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="columnsOrRowsComboBox.Items1">
+        <source>Rows</source>
+        <target state="new">Rows</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="helperLinkLabel1.Text">
+        <source>Column and row spanning:
+If you want a control to span multiple rows or columns, set the RowSpan and ColumnSpan properties on the control.</source>
+        <target state="new">Column and row spanning:
+If you want a control to span multiple rows or columns, set the RowSpan and ColumnSpan properties on the control.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="helperLinkLabel2.Text">
+        <source>Alignment and stretching:
+If you want to align a control within a cell, or if you want a control to stretch within a cell, use the control's Anchor property.</source>
+        <target state="new">Alignment and stretching:
+If you want to align a control within a cell, or if you want a control to stretch within a cell, use the control's Anchor property.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="insertButton.Text">
+        <source>&amp;Insert</source>
+        <target state="new">&amp;Insert</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="memberTypeLabel.Text">
+        <source>&amp;Show:</source>
+        <target state="new">&amp;Show:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="membersColumnHeader.Text">
+        <source>Member</source>
+        <target state="new">Member</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="okButton.Text">
+        <source>OK</source>
+        <target state="new">OK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="percentLabel.Text">
+        <source>%</source>
+        <target state="new">%</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="percentNumericUpDown.AccessibleName">
+        <source>Percent</source>
+        <target state="new">Percent</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="percentRadioButton.Text">
+        <source>&amp;Percent</source>
+        <target state="new">&amp;Percent</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="pixelsLabel.Text">
+        <source>pixels</source>
+        <target state="new">pixels</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="removeButton.Text">
+        <source>&amp;Delete</source>
+        <target state="new">&amp;Delete</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="sizeTypeColumnHeader.Text">
+        <source>Size Type</source>
+        <target state="new">Size Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="sizeTypeGroupBox.Text">
+        <source>Size Type</source>
+        <target state="new">Size Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="valueColumnHeader.Text">
+        <source>Value</source>
+        <target state="new">Value</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/EmbeddedResourceTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/EmbeddedResourceTests.cs
@@ -121,6 +121,7 @@ public class EmbeddedResourceTests
             System.Windows.Forms.Design.MaskDesignerDialog.resources
             System.Windows.Forms.Design.ShortcutKeysEditor.resources
             System.Windows.Forms.Design.StringCollectionEditor.resources
+            System.Windows.Forms.Design.StyleCollectionEditor.resources
             """;
 
     [Fact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Design/DesignerAttributeTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Design/DesignerAttributeTests.cs
@@ -33,7 +33,6 @@ public class DesignerAttributeTests
         "System.Windows.Forms.Design.DataGridViewComponentEditor, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
         "System.Windows.Forms.Design.DataMemberFieldEditor, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
         "System.Windows.Forms.Design.DataMemberListEditor, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
-        "System.Windows.Forms.Design.StyleCollectionEditor, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
         "System.Windows.Forms.Design.ToolStripCollectionEditor, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
         "System.Windows.Forms.Design.ToolStripImageIndexEditor, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
         "System.Windows.Forms.Design.TreeNodeCollectionEditor, System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #10213 


## Proposed changes

- Adding class StyleCollectionEditor，NavigationalTableLayoutPanel.cs and StyleEditorForm.cs

## Cause of this issue:

- Due to the missing StyleCollectionEditor, rows and columns cannot be added to the TableLayoutPanel control normally.

<!-- We are in TELL-MODE the following section must be completed -->


## Risk
- minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

In [DemoConsole](https://github.com/dotnet/winforms/tree/main/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole) test app of Winforms repo, unable to add columns/rows via the Edit Rows and Columns window of the TableLayoutPanel control.

https://github.com/dotnet/winforms/assets/94418985/8734d29d-5db7-4674-8065-339b38f22e35

### After

![AfterChange](https://github.com/dotnet/winforms/assets/132890443/da14bf19-d463-4123-ae4b-c3c78a4179e1)



## Test methodology <!-- How did you ensure quality? -->

- Manually


## Test environment(s) <!-- Remove any that don't apply -->

- .net 9.0.0-alpha.1.23559.1


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10271)