### PR TITLE
Use List<T> instead of ICollection in BehaviorDataObject

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DropSourceBehavior.BehaviorDataObject.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DropSourceBehavior.BehaviorDataObject.cs
@@ -33,6 +33,6 @@ internal sealed partial class DropSourceBehavior
 
         internal void CleanupDrag() => _sourceBehavior.CleanupDrag();
 
-        internal List<IComponent> GetSortedDragControls(ref int primaryControlIndex) => _sourceBehavior.GetSortedDragControls(ref primaryControlIndex);
+        internal List<IComponent> GetSortedDragControls(out int primaryControlIndex) => _sourceBehavior.GetSortedDragControls(out primaryControlIndex);
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DropSourceBehavior.BehaviorDataObject.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DropSourceBehavior.BehaviorDataObject.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections;
 using System.ComponentModel;
 
 namespace System.Windows.Forms.Design.Behavior;
@@ -16,7 +15,7 @@ internal sealed partial class DropSourceBehavior
     {
         private readonly DropSourceBehavior _sourceBehavior;
 
-        public BehaviorDataObject(ICollection dragComponents, Control source, DropSourceBehavior sourceBehavior) : base()
+        public BehaviorDataObject(List<IComponent> dragComponents, Control source, DropSourceBehavior sourceBehavior) : base()
         {
             DragComponents = dragComponents;
             Source = source;
@@ -26,7 +25,7 @@ internal sealed partial class DropSourceBehavior
 
         public Control Source { get; }
 
-        public ICollection DragComponents { get; }
+        public List<IComponent> DragComponents { get; }
 
         public IComponent? Target { get; set; }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DropSourceBehavior.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DropSourceBehavior.cs
@@ -1003,7 +1003,7 @@ internal sealed partial class DropSourceBehavior : Behavior, IComparer
         cleanedUpDrag = false;
     }
 
-    internal List<IComponent> GetSortedDragControls(ref int primaryControlIndex)
+    internal List<IComponent> GetSortedDragControls(out int primaryControlIndex)
     {
         //create our list of controls-to-drag
         List<IComponent> dragControls = new();

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/ToolStripPanelSelectionBehavior.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/ToolStripPanelSelectionBehavior.cs
@@ -125,7 +125,7 @@ internal sealed class ToolStripPanelSelectionBehavior : Behavior
         return false;
     }
 
-    private void ReParentControls(IList<IComponent> controls, bool copy)
+    private void ReParentControls(List<IComponent> controls, bool copy)
     {
         if (controls.Count <= 0)
         {
@@ -223,11 +223,7 @@ internal sealed class ToolStripPanelSelectionBehavior : Behavior
 
         if (e.Data is DropSourceBehavior.BehaviorDataObject data)
         {
-            components = new List<IComponent>(data.DragComponents.Count);
-            foreach (var component in data.DragComponents)
-            {
-                components.Add((IComponent)component);
-            }
+            components = new List<IComponent>(data.DragComponents);
 
             foreach (IComponent dragComponent in components)
             {

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FlowLayoutPanelDesigner .cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FlowLayoutPanelDesigner .cs
@@ -771,8 +771,7 @@ internal partial class FlowLayoutPanelDesigner : FlowPanelDesigner
         // Get the sorted drag controls. We use these for an internal drag.
         if (de.Data is DropSourceBehavior.BehaviorDataObject data)
         {
-            var primaryIndex = -1;
-            _dragControls = data.GetSortedDragControls(ref primaryIndex).OfType<Control>().ToList();
+            _dragControls = data.GetSortedDragControls(out int primaryIndex).OfType<Control>().ToList();
             _primaryDragControl = _dragControls[primaryIndex];
         }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ParentControlDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ParentControlDesigner.cs
@@ -1478,8 +1478,7 @@ public partial class ParentControlDesigner : ControlDesigner, IOleDragClient
         object[] dragComps;
         if (behDataObject is not null && behDataObject.DragComponents is not null)
         {
-            dragComps = new object[behDataObject.DragComponents.Count];
-            behDataObject.DragComponents.CopyTo(dragComps, 0);
+            dragComps = behDataObject.DragComponents.ToArray();
         }
         else
         {

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TabControlDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TabControlDesigner.cs
@@ -519,8 +519,7 @@ internal class TabControlDesigner : ParentControlDesigner
         if (data is not null)
         {
             ArrayList dragControls;
-            int primaryIndex = -1;
-            dragControls = new ArrayList(data.GetSortedDragControls(ref primaryIndex));
+            dragControls = new ArrayList(data.GetSortedDragControls(out _));
             if (dragControls is not null)
             {
                 for (int i = 0; i < dragControls.Count; i++)


### PR DESCRIPTION
Finish work started in #8673 
Related: #8140

Now that `DropSourceBehavior` is passed a `List<IComponent>` in its constructor, we can update `BehaviorDataObject` to do the same instead of using `ICollection`

## Proposed changes

- Refactor `BehaviorDataObject.DragComponents` to be a `List<IComponent>` and update code accordingly
- Another small `BehaviorDataObject` refacto while we're touching this code, but in a separate commit


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10278)