### PR TITLE
Refactor `SnapLines` to use `IList` directly instead of casting to `ArrayList`

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/AdapterHelpers.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/AdapterHelpers.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections;
+
+namespace System.Windows.Forms.Design;
+
+/// <summary>
+/// Helpers for adapting between generic and non-generic lists.
+/// </summary>
+internal static class AdapterHelpers
+{
+    /// <summary>
+    ///  Provides an extension method to safely extract the underlying non-generic <see cref="IList"/>
+    ///  from a wrapped <see cref="IList&lt;T&gt;"/> when available.
+    /// </summary>
+    /// <typeparam name="T">The type of elements in the <see cref="IList&lt;T&gt;"/>.</typeparam>
+    /// <param name="list">The IList&lt;T&gt; to unwrap.</param>
+    /// <returns>The underlying non-generic <see cref="IList"/> if available; otherwise, the original <see cref="IList&lt;T&gt;"/>.</returns>
+    internal static IList Unwrap<T>(this IList<T> list) => list is IWrapper<IList> wrapper ? wrapper.Unwrap() : (IList)list;
+
+    /// <summary>
+    ///  Provides an extension method to adapt a non-generic IList to a generic <see cref="IList&lt;T&gt;"/> by creating
+    ///  a <see cref="ListAdapter&lt;T&gt;"/> when needed.
+    /// </summary>
+    /// <typeparam name="T">The desired type of elements in the resulting <see cref="IList&lt;T&gt;"/>.</typeparam>
+    /// <param name="list">The non-generic <see cref="IList"/> to adapt.</param>
+    /// <returns>
+    /// A generic <see cref="IList&lt;T&gt;"/> if the input IList can be cast to <see cref="IList&lt;T&gt;"/> otherwise, a new <see cref="ListAdapter&lt;T&gt;"/> wrapping the input IList.
+    /// </returns>
+    internal static IList<T> Adapt<T>(this IList list) => list is IList<T> iList ? iList : new ListAdapter<T>(list);
+}

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/AdapterHelpers.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/AdapterHelpers.cs
@@ -6,7 +6,7 @@ using System.Collections;
 namespace System.Windows.Forms.Design;
 
 /// <summary>
-/// Helpers for adapting between generic and non-generic lists.
+///  Helpers for adapting between generic and non-generic lists.
 /// </summary>
 internal static class AdapterHelpers
 {

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.cs
@@ -816,7 +816,7 @@ public sealed partial class BehaviorService : IDisposable
 
             if (host.GetDesigner(comp) is ControlDesigner designer)
             {
-                foreach (SnapLine line in designer.SnapLines)
+                foreach (SnapLine line in designer.SnapLinesInternal)
                 {
                     snapLineInfo.Append($"{line}\tAssociated Control = {designer.Control.Name}:::");
                 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DragAssistanceManager.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DragAssistanceManager.cs
@@ -130,7 +130,7 @@ internal sealed class DragAssistanceManager
     /// </summary>
     private void AddSnapLines(ControlDesigner controlDesigner, List<SnapLine> horizontalList, List<SnapLine> verticalList, bool isTarget, bool validTarget)
     {
-        IList snapLines = controlDesigner.SnapLines;
+        IList<SnapLine> snapLines = controlDesigner.SnapLinesInternal;
         // Used for padding snaplines
         Rectangle controlRect = controlDesigner.Control.ClientRectangle;
         // Used for all others

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ButtonBaseDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ButtonBaseDesigner.cs
@@ -103,7 +103,7 @@ internal class ButtonBaseDesigner : ControlDesigner
 
             snapLines.Add(new SnapLine(SnapLineType.Baseline, baseline, SnapLinePriority.Medium));
 
-            return (IList)snapLines;
+            return snapLines.Unwrap();
         }
     }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ButtonBaseDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ButtonBaseDesigner.cs
@@ -49,7 +49,7 @@ internal class ButtonBaseDesigner : ControlDesigner
     {
         get
         {
-            ArrayList snapLines = base.SnapLines as ArrayList;
+            IList snapLines = base.SnapLines;
             FlatStyle flatStyle = FlatStyle.Standard;
             ContentAlignment alignment = ContentAlignment.MiddleCenter;
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ButtonBaseDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ButtonBaseDesigner.cs
@@ -49,7 +49,7 @@ internal class ButtonBaseDesigner : ControlDesigner
     {
         get
         {
-            IList snapLines = base.SnapLines;
+            IList<SnapLine> snapLines = SnapLinesInternal;
             FlatStyle flatStyle = FlatStyle.Standard;
             ContentAlignment alignment = ContentAlignment.MiddleCenter;
 
@@ -103,7 +103,7 @@ internal class ButtonBaseDesigner : ControlDesigner
 
             snapLines.Add(new SnapLine(SnapLineType.Baseline, baseline, SnapLinePriority.Medium));
 
-            return snapLines;
+            return (IList)snapLines;
         }
     }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ComboBoxDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ComboBoxDesigner.cs
@@ -34,7 +34,7 @@ internal class ComboBoxDesigner : ControlDesigner
             baseline += 3;
             snapLines.Add(new SnapLine(SnapLineType.Baseline, baseline, SnapLinePriority.Medium));
 
-            return (IList)snapLines;
+            return snapLines.Unwrap();
         }
     }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ComboBoxDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ComboBoxDesigner.cs
@@ -27,7 +27,7 @@ internal class ComboBoxDesigner : ControlDesigner
     {
         get
         {
-            ArrayList snapLines = base.SnapLines as ArrayList;
+            IList snapLines = base.SnapLines;
 
             // a single text-baseline for the label (and linklabel) control
             int baseline = DesignerUtils.GetTextBaseline(Control, Drawing.ContentAlignment.TopLeft);

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ComboBoxDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ComboBoxDesigner.cs
@@ -27,14 +27,14 @@ internal class ComboBoxDesigner : ControlDesigner
     {
         get
         {
-            IList snapLines = base.SnapLines;
+            IList<SnapLine> snapLines = SnapLinesInternal;
 
             // a single text-baseline for the label (and linklabel) control
             int baseline = DesignerUtils.GetTextBaseline(Control, Drawing.ContentAlignment.TopLeft);
             baseline += 3;
             snapLines.Add(new SnapLine(SnapLineType.Baseline, baseline, SnapLinePriority.Medium));
 
-            return snapLines;
+            return (IList)snapLines;
         }
     }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
@@ -356,7 +356,7 @@ public partial class ControlDesigner : ComponentDesigner
     ///  Returns a list of SnapLine objects representing interesting alignment points for this control.
     ///  These SnapLines are used to assist in the positioning of the control on a parent's surface.
     /// </summary>
-    public virtual IList SnapLines => (IList)EdgeAndMarginSnapLines();
+    public virtual IList SnapLines => EdgeAndMarginSnapLines().Unwrap();
 
     internal IList<SnapLine> SnapLinesInternal => SnapLines.Adapt<SnapLine>();
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
@@ -356,13 +356,15 @@ public partial class ControlDesigner : ComponentDesigner
     ///  Returns a list of SnapLine objects representing interesting alignment points for this control.
     ///  These SnapLines are used to assist in the positioning of the control on a parent's surface.
     /// </summary>
-    public virtual IList SnapLines => SnapLinesInternal();
+    public virtual IList SnapLines => (IList)EdgeAndMarginSnapLines();
 
-    internal IList SnapLinesInternal() => SnapLinesInternal(Control.Margin);
+    internal IList<SnapLine> SnapLinesInternal => ListAdapter<SnapLine>.AsList(SnapLines);
 
-    internal IList SnapLinesInternal(Padding margin)
+    internal IList<SnapLine> EdgeAndMarginSnapLines() => EdgeAndMarginSnapLines(Control.Margin);
+
+    internal IList<SnapLine> EdgeAndMarginSnapLines(Padding margin)
     {
-        ArrayList snapLines = new(8);
+        List<SnapLine> snapLines = new(8);
         int width = Control.Width;
         int height = Control.Height;
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
@@ -358,7 +358,7 @@ public partial class ControlDesigner : ComponentDesigner
     /// </summary>
     public virtual IList SnapLines => (IList)EdgeAndMarginSnapLines();
 
-    internal IList<SnapLine> SnapLinesInternal => ListAdapter<SnapLine>.AsList(SnapLines);
+    internal IList<SnapLine> SnapLinesInternal => SnapLines.Adapt<SnapLine>();
 
     internal IList<SnapLine> EdgeAndMarginSnapLines() => EdgeAndMarginSnapLines(Control.Margin);
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
@@ -362,7 +362,7 @@ public partial class ControlDesigner : ComponentDesigner
 
     internal IList SnapLinesInternal(Padding margin)
     {
-        ArrayList snapLines = new(4);
+        ArrayList snapLines = new(8);
         int width = Control.Width;
         int height = Control.Height;
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DateTimePickerDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DateTimePickerDesigner.cs
@@ -21,7 +21,7 @@ internal class DateTimePickerDesigner : ControlDesigner
     {
         get
         {
-            IList snapLines = base.SnapLines;
+            IList<SnapLine> snapLines = SnapLinesInternal;
 
             // A single text-baseline for the label (and linklabel) control.
             int baseline = DesignerUtils.GetTextBaseline(Control, ContentAlignment.MiddleLeft);
@@ -30,7 +30,7 @@ internal class DateTimePickerDesigner : ControlDesigner
             baseline += 2;
             snapLines.Add(new SnapLine(SnapLineType.Baseline, baseline, SnapLinePriority.Medium));
 
-            return snapLines;
+            return (IList)snapLines;
         }
     }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DateTimePickerDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DateTimePickerDesigner.cs
@@ -30,7 +30,7 @@ internal class DateTimePickerDesigner : ControlDesigner
             baseline += 2;
             snapLines.Add(new SnapLine(SnapLineType.Baseline, baseline, SnapLinePriority.Medium));
 
-            return (IList)snapLines;
+            return snapLines.Unwrap();
         }
     }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FlowPanelDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FlowPanelDesigner.cs
@@ -14,7 +14,7 @@ internal class FlowPanelDesigner : PanelDesigner
     {
         get
         {
-            IList snapLines = base.SnapLines;
+            IList<SnapLine> snapLines = SnapLinesInternal;
 
             // identify and remove all paddings
             for (int i = snapLines.Count - 1; i >= 0; i--)
@@ -26,7 +26,7 @@ internal class FlowPanelDesigner : PanelDesigner
                 }
             }
 
-            return snapLines;
+            return (IList)snapLines;
         }
     }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FlowPanelDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FlowPanelDesigner.cs
@@ -26,7 +26,7 @@ internal class FlowPanelDesigner : PanelDesigner
                 }
             }
 
-            return (IList)snapLines;
+            return snapLines.Unwrap();
         }
     }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FlowPanelDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FlowPanelDesigner.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.Collections;
 using System.Windows.Forms.Design.Behavior;
 
@@ -16,22 +14,16 @@ internal class FlowPanelDesigner : PanelDesigner
     {
         get
         {
-            ArrayList snapLines = (ArrayList)base.SnapLines;
+            IList snapLines = base.SnapLines;
 
-            // identify all the paddings to remove
-            ArrayList paddingsToRemove = new(4);
-            foreach (SnapLine line in snapLines)
+            // identify and remove all paddings
+            for (int i = snapLines.Count - 1; i >= 0; i--)
             {
-                if (line.Filter is not null && line.Filter.Contains(SnapLine.Padding))
+                if (snapLines[i] is SnapLine line
+                    && line.Filter?.Contains(SnapLine.Padding) == true)
                 {
-                    paddingsToRemove.Add(line);
+                    snapLines.RemoveAt(i);
                 }
-            }
-
-            // remove all padding
-            foreach (SnapLine line in paddingsToRemove)
-            {
-                snapLines.Remove(line);
             }
 
             return snapLines;
@@ -48,7 +40,7 @@ internal class FlowPanelDesigner : PanelDesigner
     {
         base.OnDragDrop(de);
 
-        SelectionManager sm = GetService(typeof(SelectionManager)) as SelectionManager;
+        SelectionManager? sm = GetService(typeof(SelectionManager)) as SelectionManager;
         sm?.Refresh();
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FormDocumentDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FormDocumentDesigner.cs
@@ -181,12 +181,12 @@ internal class FormDocumentDesigner : DocumentDesigner
     {
         get
         {
-            ArrayList snapLines = null;
+            IList<SnapLine> snapLines = null;
             AddPaddingSnapLines(ref snapLines);
             if (snapLines is null)
             {
                 Debug.Fail("why did base.AddPaddingSnapLines return null?");
-                snapLines = new ArrayList(4);
+                snapLines = new List<SnapLine>(4);
             }
 
             // if the padding has not been set - then we'll auto-add padding to form - this is a Usability request
@@ -218,7 +218,7 @@ internal class FormDocumentDesigner : DocumentDesigner
                 }
             }
 
-            return snapLines;
+            return (IList)snapLines;
         }
     }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/IWrapper.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/IWrapper.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Windows.Forms.Design;
+
+/// <summary>
+///  Interface to provide a contract to provide access to the underlying type.
+/// </summary>
+/// <typeparam name="T">The type of object being wrapped.</typeparam>
+internal interface IWrapper<T>
+{
+    T Unwrap();
+}

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/LabelDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/LabelDesigner.cs
@@ -31,7 +31,7 @@ internal class LabelDesigner : ControlDesigner
     {
         get
         {
-            IList snapLines = base.SnapLines;
+            IList<SnapLine> snapLines = SnapLinesInternal;
             ContentAlignment alignment = ContentAlignment.TopLeft;
 
             PropertyDescriptor prop;
@@ -93,7 +93,7 @@ internal class LabelDesigner : ControlDesigner
                 }
             }
 
-            return snapLines;
+            return (IList)snapLines;
         }
     }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/LabelDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/LabelDesigner.cs
@@ -31,7 +31,7 @@ internal class LabelDesigner : ControlDesigner
     {
         get
         {
-            ArrayList snapLines = base.SnapLines as ArrayList;
+            IList snapLines = base.SnapLines;
             ContentAlignment alignment = ContentAlignment.TopLeft;
 
             PropertyDescriptor prop;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/LabelDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/LabelDesigner.cs
@@ -93,7 +93,7 @@ internal class LabelDesigner : ControlDesigner
                 }
             }
 
-            return (IList)snapLines;
+            return snapLines.Unwrap();
         }
     }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ListAdapter.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ListAdapter.cs
@@ -4,6 +4,14 @@
 using System.Collections;
 
 namespace System.Windows.Forms.Design;
+
+/// <summary>
+///  Adapter for bridging between generic and non-generic lists.
+///  It implements both the generic <see cref="IList&lt;T&gt;"/> and the non-generic
+///  <see cref="IWrapper&lt;IList&gt;"/> interfaces
+///  to provide a unified interface for working with IList collections.
+/// </summary>
+/// <typeparam name="T">The type of elements in the list.</typeparam>
 internal sealed class ListAdapter<T> : IList<T>, IWrapper<IList>
 {
     private readonly IList _list;
@@ -52,15 +60,4 @@ internal sealed class ListAdapter<T> : IList<T>, IWrapper<IList>
     }
 
     public IList Unwrap() => _list;
-}
-
-internal interface IWrapper<T>
-{
-    T Unwrap();
-}
-
-internal static class AdapterHelpers
-{
-    internal static IList Unwrap<T>(this IList<T> list) => list is IWrapper<IList> wrapper ? wrapper.Unwrap() : (IList)list;
-    internal static IList<T> Adapt<T>(this IList list) => list is IList<T> iList ? iList : new ListAdapter<T>(list);
 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ListAdapter.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ListAdapter.cs
@@ -1,0 +1,55 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections;
+
+namespace System.Windows.Forms.Design;
+internal sealed class ListAdapter<T> : IList<T>
+{
+    private readonly IList _list;
+    private ListAdapter(IList list) => _list = list.OrThrowIfNull();
+
+    T IList<T>.this[int index]
+    {
+        get => (T?)_list[index] ?? throw new InvalidOperationException();
+        set => _list[index] = value.OrThrowIfNull();
+    }
+
+    int ICollection<T>.Count => _list.Count;
+
+    bool ICollection<T>.IsReadOnly => _list.IsReadOnly;
+
+    void ICollection<T>.Add(T item) => _list.Add(item.OrThrowIfNull());
+    void ICollection<T>.Clear() => _list.Clear();
+    bool ICollection<T>.Contains(T item) => _list.Contains(item);
+    void ICollection<T>.CopyTo(T[] array, int arrayIndex) => _list.CopyTo(array, arrayIndex);
+    IEnumerator IEnumerable.GetEnumerator() => _list.GetEnumerator();
+    int IList<T>.IndexOf(T item) => _list.IndexOf(item);
+    void IList<T>.Insert(int index, T item) => _list.Insert(index, item.OrThrowIfNull());
+    void IList<T>.RemoveAt(int index) => _list.RemoveAt(index);
+
+    bool ICollection<T>.Remove(T item)
+    {
+        if (_list.IsReadOnly || !_list.Contains(item))
+        {
+            return false;
+        }
+
+        _list.Remove(item);
+        return true;
+    }
+
+    IEnumerator<T> IEnumerable<T>.GetEnumerator() => new Enumerator(_list.GetEnumerator());
+
+    private sealed class Enumerator(IEnumerator _enumerator) : IEnumerator<T>
+    {
+        T IEnumerator<T>.Current => (T)_enumerator.Current;
+        object IEnumerator.Current => _enumerator.Current;
+
+        void IDisposable.Dispose() { }
+        bool IEnumerator.MoveNext() => _enumerator.MoveNext();
+        void IEnumerator.Reset() => _enumerator.Reset();
+    }
+
+    public static IList<T> AsList(IList list) => list as IList<T> ?? new ListAdapter<T>(list);
+}

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ListAdapter.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ListAdapter.cs
@@ -4,10 +4,10 @@
 using System.Collections;
 
 namespace System.Windows.Forms.Design;
-internal sealed class ListAdapter<T> : IList<T>
+internal sealed class ListAdapter<T> : IList<T>, IWrapper<IList>
 {
     private readonly IList _list;
-    private ListAdapter(IList list) => _list = list.OrThrowIfNull();
+    internal ListAdapter(IList list) => _list = list.OrThrowIfNull();
 
     T IList<T>.this[int index]
     {
@@ -51,5 +51,16 @@ internal sealed class ListAdapter<T> : IList<T>
         void IEnumerator.Reset() => _enumerator.Reset();
     }
 
-    public static IList<T> AsList(IList list) => list as IList<T> ?? new ListAdapter<T>(list);
+    public IList Unwrap() => _list;
+}
+
+internal interface IWrapper<T>
+{
+    T Unwrap();
+}
+
+internal static class AdapterHelpers
+{
+    internal static IList Unwrap<T>(this IList<T> list) => list is IWrapper<IList> wrapper ? wrapper.Unwrap() : (IList)list;
+    internal static IList<T> Adapt<T>(this IList list) => list is IList<T> iList ? iList : new ListAdapter<T>(list);
 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ParentControlDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ParentControlDesigner.cs
@@ -295,9 +295,13 @@ public partial class ParentControlDesigner : ControlDesigner, IOleDragClient
     // We need to allocation new ArrayList and pass it to the caller..
     // So its ok to Suppress this.
     protected void AddPaddingSnapLines(ref ArrayList snapLines)
-    {
-        snapLines ??= new ArrayList(4);
+        => AddPaddingSnapLinesCommon(ListAdapter<SnapLine>.AsList(snapLines ??= new(4)));
 
+    internal void AddPaddingSnapLines(ref IList<SnapLine> snapLines)
+        => AddPaddingSnapLinesCommon(snapLines ??= new List<SnapLine>(4));
+
+    private void AddPaddingSnapLinesCommon(IList<SnapLine> snapLines)
+    {
         // In order to add padding, we need to get the offset from the usable client area of our control
         // and the actual origin of our control.  In other words: how big is the non-client area here?
         // Ex: we want to add padding on a form to the insides of the borders and below the titlebar.
@@ -328,16 +332,16 @@ public partial class ParentControlDesigner : ControlDesigner, IOleDragClient
     {
         get
         {
-            ArrayList snapLines = base.SnapLines as ArrayList;
+            IList<SnapLine> snapLines = SnapLinesInternal;
 
             if (snapLines is null)
             {
                 Debug.Fail("why did base.SnapLines return null?");
-                snapLines = new ArrayList(4);
+                snapLines = new List<SnapLine>(4);
             }
 
             AddPaddingSnapLines(ref snapLines);
-            return snapLines;
+            return (IList)snapLines;
         }
     }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ParentControlDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ParentControlDesigner.cs
@@ -295,7 +295,7 @@ public partial class ParentControlDesigner : ControlDesigner, IOleDragClient
     // We need to allocation new ArrayList and pass it to the caller..
     // So its ok to Suppress this.
     protected void AddPaddingSnapLines(ref ArrayList snapLines)
-        => AddPaddingSnapLinesCommon(ListAdapter<SnapLine>.AsList(snapLines ??= new(4)));
+        => AddPaddingSnapLinesCommon((snapLines ??= new(4)).Adapt<SnapLine>());
 
     internal void AddPaddingSnapLines(ref IList<SnapLine> snapLines)
         => AddPaddingSnapLinesCommon(snapLines ??= new List<SnapLine>(4));

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ParentControlDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ParentControlDesigner.cs
@@ -341,7 +341,7 @@ public partial class ParentControlDesigner : ControlDesigner, IOleDragClient
             }
 
             AddPaddingSnapLines(ref snapLines);
-            return (IList)snapLines;
+            return snapLines.Unwrap();
         }
     }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/SplitContainerDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/SplitContainerDesigner.cs
@@ -61,7 +61,7 @@ internal partial class SplitContainerDesigner : ParentControlDesigner
     /// </summary>
     public override IList SnapLines =>
         // We don't want padding snaplines, so call directly to the internal method.
-        (IList)EdgeAndMarginSnapLines();
+        EdgeAndMarginSnapLines().Unwrap();
 
     /// <summary>
     ///  Returns the number of internal control designers in the <see cref="SplitContainerDesigner"/>. An internal control is a control that is not in the

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/SplitContainerDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/SplitContainerDesigner.cs
@@ -61,7 +61,7 @@ internal partial class SplitContainerDesigner : ParentControlDesigner
     /// </summary>
     public override IList SnapLines =>
         // We don't want padding snaplines, so call directly to the internal method.
-        SnapLinesInternal();
+        (IList)EdgeAndMarginSnapLines();
 
     /// <summary>
     ///  Returns the number of internal control designers in the <see cref="SplitContainerDesigner"/>. An internal control is a control that is not in the

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TextBoxBaseDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TextBoxBaseDesigner.cs
@@ -51,9 +51,9 @@ internal class TextBoxBaseDesigner : ControlDesigner
                 baseline += 0;
             }
 
-            IList snapLines = base.SnapLines;
+            IList<SnapLine> snapLines = SnapLinesInternal;
             snapLines.Add(new SnapLine(SnapLineType.Baseline, baseline, SnapLinePriority.Medium));
-            return snapLines;
+            return (IList)snapLines;
         }
     }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TextBoxBaseDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TextBoxBaseDesigner.cs
@@ -53,7 +53,7 @@ internal class TextBoxBaseDesigner : ControlDesigner
 
             IList<SnapLine> snapLines = SnapLinesInternal;
             snapLines.Add(new SnapLine(SnapLineType.Baseline, baseline, SnapLinePriority.Medium));
-            return (IList)snapLines;
+            return snapLines.Unwrap();
         }
     }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TextBoxBaseDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TextBoxBaseDesigner.cs
@@ -28,12 +28,10 @@ internal class TextBoxBaseDesigner : ControlDesigner
         {
             int baseline = DesignerUtils.GetTextBaseline(Control, Drawing.ContentAlignment.TopLeft);
 
-            BorderStyle borderStyle = BorderStyle.Fixed3D;
             PropertyDescriptor? prop = TypeDescriptor.GetProperties(Component)["BorderStyle"];
-            if (prop is not null)
-            {
-                borderStyle = (BorderStyle)prop.GetValue(Component)!;
-            }
+            BorderStyle borderStyle = prop is not null
+                ? (BorderStyle)prop.GetValue(Component)!
+                : BorderStyle.Fixed3D;
 
             if (borderStyle == BorderStyle.None)
             {
@@ -54,9 +52,7 @@ internal class TextBoxBaseDesigner : ControlDesigner
             }
 
             IList snapLines = base.SnapLines;
-
             snapLines.Add(new SnapLine(SnapLineType.Baseline, baseline, SnapLinePriority.Medium));
-
             return snapLines;
         }
     }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripContainerDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripContainerDesigner.cs
@@ -117,7 +117,7 @@ internal class ToolStripContainerDesigner : ParentControlDesigner
 
     public override IList SnapLines
         // We don't want padding SnapLines, so call directly to the internal method.
-        => SnapLinesInternal();
+        => (IList)EdgeAndMarginSnapLines();
 
     /// <summary>
     ///  Returns the internal control designer with the specified index in the ControlDesigner.

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripContainerDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripContainerDesigner.cs
@@ -117,7 +117,7 @@ internal class ToolStripContainerDesigner : ParentControlDesigner
 
     public override IList SnapLines
         // We don't want padding SnapLines, so call directly to the internal method.
-        => (IList)EdgeAndMarginSnapLines();
+        => EdgeAndMarginSnapLines().Unwrap();
 
     /// <summary>
     ///  Returns the internal control designer with the specified index in the ControlDesigner.

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/UpDownBaseDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/UpDownBaseDesigner.cs
@@ -43,28 +43,16 @@ internal class UpDownBaseDesigner : ControlDesigner
     {
         get
         {
-            ArrayList snapLines = base.SnapLines as ArrayList;
-
+            IList snapLines = base.SnapLines;
             int baseline = DesignerUtils.GetTextBaseline(Control, Drawing.ContentAlignment.TopLeft);
 
-            BorderStyle borderStyle = BorderStyle.Fixed3D;
             PropertyDescriptor prop = TypeDescriptor.GetProperties(Component)["BorderStyle"];
-            if (prop is not null)
-            {
-                borderStyle = (BorderStyle)prop.GetValue(Component);
-            }
+            BorderStyle borderStyle = prop is not null
+                ? (BorderStyle)prop.GetValue(Component)
+                : BorderStyle.Fixed3D;
 
-            if (borderStyle == BorderStyle.None)
-            {
-                baseline -= 1;
-            }
-            else
-            {
-                baseline += 2;
-            }
-
+            baseline += borderStyle == BorderStyle.None ? -1 : 2;
             snapLines.Add(new SnapLine(SnapLineType.Baseline, baseline, SnapLinePriority.Medium));
-
             return snapLines;
         }
     }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/UpDownBaseDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/UpDownBaseDesigner.cs
@@ -43,7 +43,7 @@ internal class UpDownBaseDesigner : ControlDesigner
     {
         get
         {
-            IList snapLines = base.SnapLines;
+            IList<SnapLine> snapLines = SnapLinesInternal;
             int baseline = DesignerUtils.GetTextBaseline(Control, Drawing.ContentAlignment.TopLeft);
 
             PropertyDescriptor prop = TypeDescriptor.GetProperties(Component)["BorderStyle"];
@@ -53,7 +53,7 @@ internal class UpDownBaseDesigner : ControlDesigner
 
             baseline += borderStyle == BorderStyle.None ? -1 : 2;
             snapLines.Add(new SnapLine(SnapLineType.Baseline, baseline, SnapLinePriority.Medium));
-            return snapLines;
+            return (IList)snapLines;
         }
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/UpDownBaseDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/UpDownBaseDesigner.cs
@@ -53,7 +53,7 @@ internal class UpDownBaseDesigner : ControlDesigner
 
             baseline += borderStyle == BorderStyle.None ? -1 : 2;
             snapLines.Add(new SnapLine(SnapLineType.Baseline, baseline, SnapLinePriority.Medium));
-            return (IList)snapLines;
+            return snapLines.Unwrap();
         }
     }
 }


### PR DESCRIPTION
Kind of related: #8140

Mostly trying to remove `ArrayList` usage through the code base. This code is using a typesafe cast to `ArrayList`, where it can just use IList directly.

We cannot convert to `List<T>` because we have a public API that uses `ArrayList` ParentControlDesigner.AddPaddingSnapLines:
https://github.com/dotnet/winforms/blob/cc1a96870bfb794efc2005b843f3908e422865fe/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ParentControlDesigner.cs#L295-L319

Ultimately it would be great if the public API could be changed to `List<SnapLine>` to be more explicit.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10279)