### PR TITLE
Return 0 on UIA_PROPERTY_ID.UIA_NativeWindowHandlePropertyId for Objects with No Handle

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.ItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.ItemAccessibleObject.cs
@@ -171,7 +171,7 @@ public partial class ListBox
                  UIA_PROPERTY_ID.UIA_HasKeyboardFocusPropertyId => (VARIANT)(_owningListBox.Focused && _owningListBox.FocusedIndex == CurrentIndex),
                  UIA_PROPERTY_ID.UIA_IsEnabledPropertyId => (VARIANT)_owningListBox.Enabled,
                  UIA_PROPERTY_ID.UIA_IsKeyboardFocusablePropertyId => (VARIANT)State.HasFlag(AccessibleStates.Focusable),
-                 UIA_PROPERTY_ID.UIA_NativeWindowHandlePropertyId => UIAHelper.WindowHandleToVariant(_owningListBox.IsHandleCreated ? _owningListBox.Handle : 0),
+                 UIA_PROPERTY_ID.UIA_NativeWindowHandlePropertyId => UIAHelper.WindowHandleToVariant(HWND.Null),
                  _ => base.GetPropertyValue(propertyID)
              };
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObject.cs
@@ -188,7 +188,7 @@ public partial class ListViewGroup
                 UIA_PROPERTY_ID.UIA_HasKeyboardFocusPropertyId => (VARIANT)(_owningListView.Focused && Focused),
                 UIA_PROPERTY_ID.UIA_IsEnabledPropertyId => (VARIANT)_owningListView.Enabled,
                 UIA_PROPERTY_ID.UIA_IsKeyboardFocusablePropertyId => (VARIANT)State.HasFlag(AccessibleStates.Focusable),
-                UIA_PROPERTY_ID.UIA_NativeWindowHandlePropertyId => UIAHelper.WindowHandleToVariant(_owningListView.IsHandleCreated ? _owningListView.Handle : 0),
+                UIA_PROPERTY_ID.UIA_NativeWindowHandlePropertyId => UIAHelper.WindowHandleToVariant(HWND.Null),
                 _ => base.GetPropertyValue(propertyID)
             };
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemBaseAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemBaseAccessibleObject.cs
@@ -187,7 +187,7 @@ public partial class ListViewItem
                     VARIANT result = base.GetPropertyValue(UIA_PROPERTY_ID.UIA_IsOffscreenPropertyId);
                     return result.IsEmpty ? VARIANT.False : result;
                 case UIA_PROPERTY_ID.UIA_NativeWindowHandlePropertyId:
-                    return UIAHelper.WindowHandleToVariant(_owningListView.InternalHandle);
+                    return UIAHelper.WindowHandleToVariant(HWND.Null);
                 default: return base.GetPropertyValue(propertyID);
             }
         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/winforms/issues/10259
Fixes https://github.com/dotnet/winforms/issues/10258

These AccessibleObjects were added in early .NET Core and did not exist in Framework. Since these objects do not have windows handles, we should be returning `HWND.Null` (0) on `GetPropertyValue(UIA_PROPERTY_ID.UIA_NativeWindowHandlePropertyId)`. We had recently changed to stop doing legacy marshaling for `GetPropertyValue`, which brought this to light. Did manual testing to verify issue no longer repros.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10284)