### PR TITLE
Fixes in Selection pattern for ListBox and ListView items

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/OleAut32/Interop.VARIANT.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/OleAut32/Interop.VARIANT.cs
@@ -15,15 +15,15 @@ internal unsafe partial struct VARIANT : IDisposable
 {
     public static VARIANT Empty { get; }
 
-    public static VARIANT True { get; } = InitBoolVariant(value: true);
+    public static VARIANT True { get; } = CreateBoolVariant(value: true);
 
-    public static VARIANT False { get; } = InitBoolVariant(value: false);
+    public static VARIANT False { get; } = CreateBoolVariant(value: false);
 
-    private static VARIANT InitBoolVariant(bool value)
+    private static VARIANT CreateBoolVariant(bool value)
     {
-        VARIANT temp = new() { vt = VT_BOOL };
-        temp.data.boolVal = value ? VARIANT_BOOL.VARIANT_TRUE : VARIANT_BOOL.VARIANT_FALSE;
-        return temp;
+        VARIANT variant = new() { vt = VT_BOOL };
+        variant.data.boolVal = value ? VARIANT_BOOL.VARIANT_TRUE : VARIANT_BOOL.VARIANT_FALSE;
+        return variant;
     }
 
     public bool IsEmpty => vt == VT_EMPTY && data.llVal == 0;

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/UI/Accessibility/UIAHelper.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/UI/Accessibility/UIAHelper.cs
@@ -28,6 +28,8 @@ internal static class UIAHelper
         => new()
         {
             vt = VARENUM.VT_I4,
-            data = new() { intVal = (int)handle }
+            // Only the lower 32 bits in window handles contain significant information -
+            // https://learn.microsoft.com/windows/win32/winprog64/interprocess-communication
+            data = new() { intVal = (int)(handle & 0xFFFF_FFFF) }
         };
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlAccessibleObject.cs
@@ -486,18 +486,21 @@ public partial class Control
         internal override VARIANT GetPropertyValue(UIA_PROPERTY_ID propertyID) =>
             propertyID switch
             {
-                UIA_PROPERTY_ID.UIA_ControlTypePropertyId =>
+                UIA_PROPERTY_ID.UIA_ControlTypePropertyId
                     // "ControlType" value depends on owner's AccessibleRole value.
                     // See: docs/accessibility/accessible-role-controltype.md
-                    (VARIANT)(int)AccessibleRoleControlTypeMap.GetControlType(Role),
-                UIA_PROPERTY_ID.UIA_IsEnabledPropertyId => (VARIANT)(Owner?.Enabled ?? false),
+                    => (VARIANT)(int)AccessibleRoleControlTypeMap.GetControlType(Role),
+                UIA_PROPERTY_ID.UIA_IsEnabledPropertyId
+                    => Owner?.Enabled == true ? VARIANT.True : VARIANT.False,
                 UIA_PROPERTY_ID.UIA_IsKeyboardFocusablePropertyId when
                     Owner?.SupportsUiaProviders ?? false
                     => (VARIANT)Owner.CanSelect,
-                UIA_PROPERTY_ID.UIA_LiveSettingPropertyId => Owner is IAutomationLiveRegion owner
-                    ? (VARIANT)(int)owner.LiveSetting
-                    : base.GetPropertyValue(propertyID),
-                UIA_PROPERTY_ID.UIA_NativeWindowHandlePropertyId => UIAHelper.WindowHandleToVariant(Owner?.InternalHandle ?? HWND.Null),
+                UIA_PROPERTY_ID.UIA_LiveSettingPropertyId
+                    => Owner is IAutomationLiveRegion owner
+                        ? (VARIANT)(int)owner.LiveSetting
+                        : base.GetPropertyValue(propertyID),
+                UIA_PROPERTY_ID.UIA_NativeWindowHandlePropertyId
+                    => UIAHelper.WindowHandleToVariant(Owner?.InternalHandle ?? HWND.Null),
                 _ => base.GetPropertyValue(propertyID)
             };
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.ControlItem.ControlItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.ControlItem.ControlItemAccessibleObject.cs
@@ -96,10 +96,10 @@ public partial class ErrorProvider
             internal override VARIANT GetPropertyValue(UIA_PROPERTY_ID propertyID) =>
                 propertyID switch
                 {
-                    UIA_PROPERTY_ID.UIA_ControlTypePropertyId => (VARIANT)(int)UIA_CONTROLTYPE_ID.UIA_ImageControlTypeId,
-                    UIA_PROPERTY_ID.UIA_NativeWindowHandlePropertyId => _window?.Handle is { } handle
-                        ? UIAHelper.WindowHandleToVariant(handle)
-                        : VARIANT.Empty,
+                    UIA_PROPERTY_ID.UIA_ControlTypePropertyId
+                        => (VARIANT)(int)UIA_CONTROLTYPE_ID.UIA_ImageControlTypeId,
+                    UIA_PROPERTY_ID.UIA_NativeWindowHandlePropertyId
+                        => UIAHelper.WindowHandleToVariant(_window?.Handle ?? HWND.Null),
                     _ => base.GetPropertyValue(propertyID)
                 };
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/LabelEditAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/LabelEditAccessibleObject.cs
@@ -39,7 +39,7 @@ internal unsafe class LabelEditAccessibleObject : AccessibleObject
             UIA_PROPERTY_ID.UIA_HasKeyboardFocusPropertyId => VARIANT.True,
             UIA_PROPERTY_ID.UIA_IsKeyboardFocusablePropertyId => (VARIANT)State.HasFlag(AccessibleStates.Focusable),
             UIA_PROPERTY_ID.UIA_IsContentElementPropertyId => VARIANT.True,
-            UIA_PROPERTY_ID.UIA_NativeWindowHandlePropertyId => UIAHelper.WindowHandleToVariant(_labelEdit.TryGetTarget(out var target) ? target.HWND : 0),
+            UIA_PROPERTY_ID.UIA_NativeWindowHandlePropertyId => UIAHelper.WindowHandleToVariant(_labelEdit.TryGetTarget(out var target) ? target.HWND : HWND.Null),
             _ => base.GetPropertyValue(propertyID),
         };
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.AccessibleObject.cs
@@ -32,7 +32,13 @@ public partial class ListBox
 
         internal override UiaCore.IRawElementProviderFragmentRoot FragmentRoot => this;
 
-        internal override bool IsSelectionRequired => true;
+        internal override bool IsSelectionRequired
+            => this.IsOwnerHandleCreated(out ListBox? owner) && owner.SelectionMode != SelectionMode.None;
+
+        internal override bool CanSelectMultiple
+            => this.IsOwnerHandleCreated(out ListBox? owner)
+                && owner.SelectionMode != SelectionMode.One
+                && owner.SelectionMode != SelectionMode.None;
 
         // We need to provide a unique ID. Others are implementing this in the same manner. First item is static - 0x2a (RuntimeIDFirstItem).
         // Second item can be anything, but it's good to supply HWND.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.ItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.ItemAccessibleObject.cs
@@ -190,7 +190,15 @@ public partial class ListBox
 
         internal override void RemoveFromSelection()
         {
-            // Do nothing, C++ implementation returns UIA_E_INVALIDOPERATION 0x80131509
+            if (!_owningListBox.IsHandleCreated
+                || _owningListBox.SelectionMode == SelectionMode.None
+                || _owningListBox.SelectionMode == SelectionMode.One
+                || !IsItemSelected)
+            {
+                return;
+            }
+
+            _owningListBox.SetSelected(CurrentIndex, value: false);
         }
 
         internal override void ScrollIntoView()

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewAccessibleObject.cs
@@ -32,7 +32,8 @@ public partial class ListView
             }
         }
 
-        internal override bool CanSelectMultiple => this.IsOwnerHandleCreated(out ListView? _);
+        internal override bool CanSelectMultiple
+            => this.IsOwnerHandleCreated(out ListView? listView) && listView.MultiSelect;
 
         internal override int ColumnCount
             => this.TryGetOwnerAs(out ListView? owningListView) ? owningListView.Columns.Count : base.ColumnCount;

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ListBoxes.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ListBoxes.Designer.cs
@@ -65,6 +65,7 @@ partial class ListBoxes
         this.listBox1.Name = "listBox1";
         this.listBox1.Size = new System.Drawing.Size(200, 150);
         this.listBox1.DrawMode = System.Windows.Forms.DrawMode.Normal;
+        this.listBox1.SelectionMode = SelectionMode.MultiSimple;
         // 
         // textBox1
         //

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/ListVIew.ListViewAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/ListVIew.ListViewAccessibleObjectTests.cs
@@ -1758,5 +1758,20 @@ public class ListView_ListViewAccessibleObjectTests
 
         Assert.Equal(expectedWidth, actual.width);
     }
+
+    [WinFormsFact]
+    public void ListViewItemAccessibleObject_GetPropertyValue_CanSelectMultiple()
+    {
+        using ListView listView = new();
+        listView.MultiSelect = true;
+        listView.CreateControl();
+
+        var listViewAccessibleObject = listView.AccessibilityObject;
+        var actual = listViewAccessibleObject.GetPropertyValue(UIA_PROPERTY_ID.UIA_SelectionCanSelectMultiplePropertyId);
+        Assert.True((bool)actual);
+
+        UiaCore.ISelectionProvider provider = listViewAccessibleObject;
+        Assert.True((bool)provider.CanSelectMultiple);
+    }
 }
 


### PR DESCRIPTION
We didn't handle multiple sections in accessibility tools correctly, for ListBox, we could add items to selection but not remove items from selection, I added that functionality.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10286)