### PR TITLE
Activate and fix missing analyzers in System.Drawing.Common

### DIFF
--- a/src/Common/src/PlatformAttributes.cs
+++ b/src/Common/src/PlatformAttributes.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace System.Runtime.Versioning;
@@ -19,6 +19,7 @@ internal
     {
         PlatformName = platformName;
     }
+
     public string PlatformName { get; }
 }
 
@@ -102,10 +103,12 @@ internal
     public UnsupportedOSPlatformAttribute(string platformName) : base(platformName)
     {
     }
+
     public UnsupportedOSPlatformAttribute(string platformName, string? message) : base(platformName)
     {
         Message = message;
     }
+
     public string? Message { get; }
 }
 
@@ -137,10 +140,12 @@ internal
     public ObsoletedOSPlatformAttribute(string platformName) : base(platformName)
     {
     }
+
     public ObsoletedOSPlatformAttribute(string platformName, string? message) : base(platformName)
     {
         Message = message;
     }
+
     public string? Message { get; }
     public string? Url { get; set; }
 }

--- a/src/Common/src/ValueStringBuilder.cs
+++ b/src/Common/src/ValueStringBuilder.cs
@@ -74,6 +74,7 @@ internal ref partial struct ValueStringBuilder
             EnsureCapacity(Length + 1);
             _chars[Length] = '\0';
         }
+
         return ref MemoryMarshal.GetReference(_chars);
     }
 
@@ -107,6 +108,7 @@ internal ref partial struct ValueStringBuilder
             EnsureCapacity(Length + 1);
             _chars[Length] = '\0';
         }
+
         return _chars.Slice(0, _pos);
     }
 
@@ -230,6 +232,7 @@ internal ref partial struct ValueStringBuilder
         {
             dst[i] = c;
         }
+
         _pos += count;
     }
 
@@ -246,6 +249,7 @@ internal ref partial struct ValueStringBuilder
         {
             dst[i] = *value++;
         }
+
         _pos += length;
     }
 

--- a/src/System.Drawing.Common/Directory.Build.props
+++ b/src/System.Drawing.Common/Directory.Build.props
@@ -7,6 +7,6 @@
     <EnableDefaultItems>false</EnableDefaultItems>
     <!-- Code warnings that weren't enabled in dotnet/runtime but are raised in winforms.
          TODO: Clean the code up and remove the NoWarns. -->
-    <NoWarn>$(NoWarn);SA1513;SA1129;SA1408</NoWarn>
+    <NoWarn>$(NoWarn);SA1129;SA1408</NoWarn>
   </PropertyGroup>
 </Project>

--- a/src/System.Drawing.Common/Directory.Build.props
+++ b/src/System.Drawing.Common/Directory.Build.props
@@ -7,6 +7,6 @@
     <EnableDefaultItems>false</EnableDefaultItems>
     <!-- Code warnings that weren't enabled in dotnet/runtime but are raised in winforms.
          TODO: Clean the code up and remove the NoWarns. -->
-    <NoWarn>$(NoWarn);SA1500;SA1513;SA1129;SA1408;SA1507;SA1508</NoWarn>
+    <NoWarn>$(NoWarn);SA1513;SA1129;SA1408;SA1507</NoWarn>
   </PropertyGroup>
 </Project>

--- a/src/System.Drawing.Common/Directory.Build.props
+++ b/src/System.Drawing.Common/Directory.Build.props
@@ -7,6 +7,6 @@
     <EnableDefaultItems>false</EnableDefaultItems>
     <!-- Code warnings that weren't enabled in dotnet/runtime but are raised in winforms.
          TODO: Clean the code up and remove the NoWarns. -->
-    <NoWarn>$(NoWarn);SA1513;SA1129;SA1408;SA1507</NoWarn>
+    <NoWarn>$(NoWarn);SA1513;SA1129;SA1408</NoWarn>
   </PropertyGroup>
 </Project>

--- a/src/System.Drawing.Common/Directory.Build.props
+++ b/src/System.Drawing.Common/Directory.Build.props
@@ -5,8 +5,5 @@
     <SupportedOSPlatforms>windows</SupportedOSPlatforms>
     <UsingToolXliff>false</UsingToolXliff>
     <EnableDefaultItems>false</EnableDefaultItems>
-    <!-- Code warnings that weren't enabled in dotnet/runtime but are raised in winforms.
-         TODO: Clean the code up and remove the NoWarns. -->
-    <NoWarn>$(NoWarn);SA1129</NoWarn>
   </PropertyGroup>
 </Project>

--- a/src/System.Drawing.Common/Directory.Build.props
+++ b/src/System.Drawing.Common/Directory.Build.props
@@ -7,6 +7,6 @@
     <EnableDefaultItems>false</EnableDefaultItems>
     <!-- Code warnings that weren't enabled in dotnet/runtime but are raised in winforms.
          TODO: Clean the code up and remove the NoWarns. -->
-    <NoWarn>$(NoWarn);SA1129;SA1408</NoWarn>
+    <NoWarn>$(NoWarn);SA1129</NoWarn>
   </PropertyGroup>
 </Project>

--- a/src/System.Drawing.Common/src/Interop/Windows/Gdi32/Interop.DEVMODE.cs
+++ b/src/System.Drawing.Common/src/Interop/Windows/Gdi32/Interop.DEVMODE.cs
@@ -49,7 +49,6 @@ internal static partial class Interop
             public int dmPanningWidth;
             public int dmPanningHeight;
 
-
             public override string ToString()
             {
                 return $"[DEVMODE: dmDeviceName={dmDeviceName}, dmSpecVersion={dmSpecVersion}, dmDriverVersion={dmDriverVersion}, dmSize={dmSize}, dmDriverExtra={dmDriverExtra}, dmFields={dmFields}, dmOrientation={dmOrientation}, dmPaperSize={dmPaperSize}, dmPaperLength={dmPaperLength}, dmPaperWidth={dmPaperWidth}, dmScale={dmScale}, dmCopies={dmCopies}, dmDefaultSource={dmDefaultSource}, dmPrintQuality={dmPrintQuality}, dmColor={dmColor}, dmDuplex={dmDuplex}, dmYResolution={dmYResolution}, dmTTOption={dmTTOption}, dmCollate={dmCollate}, dmFormName={dmFormName}, dmLogPixels={dmLogPixels}, dmBitsPerPel={dmBitsPerPel}, dmPelsWidth={dmPelsWidth}, dmPelsHeight={dmPelsHeight}, dmDisplayFlags={dmDisplayFlags}, dmDisplayFrequency={dmDisplayFrequency}, dmICMMethod={dmICMMethod}, dmICMIntent={dmICMIntent}, dmMediaType={dmMediaType}, dmDitherType={dmDitherType}, dmICCManufacturer={dmICCManufacturer}, dmICCModel={dmICCModel}, dmPanningWidth={dmPanningWidth}, dmPanningHeight={dmPanningHeight}]";

--- a/src/System.Drawing.Common/src/Interop/Windows/Gdi32/Interop.GetDIBits.cs
+++ b/src/System.Drawing.Common/src/Interop/Windows/Gdi32/Interop.GetDIBits.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -29,6 +29,5 @@ internal static partial class Interop
             IntPtr arg3,
             ref BITMAPINFO_FLAT bmi,
             int arg5);
-
     }
 }

--- a/src/System.Drawing.Common/src/NotSupported.cs
+++ b/src/System.Drawing.Common/src/NotSupported.cs
@@ -43,16 +43,19 @@ namespace System.Drawing
         public void SetResolution(float xDpi, float yDpi) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
         public void UnlockBits(System.Drawing.Imaging.BitmapData bitmapdata) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
     }
+
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly)]
     public partial class BitmapSuffixInSameAssemblyAttribute : System.Attribute
     {
         public BitmapSuffixInSameAssemblyAttribute() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
     }
+
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly)]
     public partial class BitmapSuffixInSatelliteAssemblyAttribute : System.Attribute
     {
         public BitmapSuffixInSatelliteAssemblyAttribute() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
     }
+
     public abstract partial class Brush : System.MarshalByRefObject, System.ICloneable, System.IDisposable
     {
         protected Brush() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
@@ -62,6 +65,7 @@ namespace System.Drawing
         ~Brush() { }
         protected internal void SetNativeBrush(System.IntPtr brush) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
     }
+
     public static partial class Brushes
     {
         public static System.Drawing.Brush AliceBlue { get { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } }
@@ -206,6 +210,7 @@ namespace System.Drawing
         public static System.Drawing.Brush Yellow { get { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } }
         public static System.Drawing.Brush YellowGreen { get { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } }
     }
+
     public sealed partial class BufferedGraphics : System.IDisposable
     {
         internal BufferedGraphics() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
@@ -215,6 +220,7 @@ namespace System.Drawing
         public void Render(System.Drawing.Graphics? target) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
         public void Render(System.IntPtr targetDC) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
     }
+
     public sealed partial class BufferedGraphicsContext : System.IDisposable
     {
         public BufferedGraphicsContext() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
@@ -225,10 +231,12 @@ namespace System.Drawing
         ~BufferedGraphicsContext() { }
         public void Invalidate() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
     }
+
     public static partial class BufferedGraphicsManager
     {
         public static System.Drawing.BufferedGraphicsContext Current { get { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } }
     }
+
     public partial struct CharacterRange
     {
         private int _dummyPrimitive;
@@ -240,6 +248,7 @@ namespace System.Drawing
         public static bool operator ==(System.Drawing.CharacterRange cr1, System.Drawing.CharacterRange cr2) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
         public static bool operator !=(System.Drawing.CharacterRange cr1, System.Drawing.CharacterRange cr2) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
     }
+
     public static partial class ColorTranslator
     {
         public static System.Drawing.Color FromHtml(string htmlColor) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
@@ -249,6 +258,7 @@ namespace System.Drawing
         public static int ToOle(System.Drawing.Color c) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
         public static int ToWin32(System.Drawing.Color c) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
     }
+
     [System.ComponentModel.EditorAttribute("System.Drawing.Design.ContentAlignmentEditor, System.Drawing.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", "System.Drawing.Design.UITypeEditor, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
     public enum ContentAlignment
     {
@@ -262,6 +272,7 @@ namespace System.Drawing
         BottomCenter = 512,
         BottomRight = 1024,
     }
+
     public enum CopyPixelOperation
     {
         NoMirrorBitmap = -2147483648,
@@ -282,6 +293,7 @@ namespace System.Drawing
         Whiteness = 16711778,
         CaptureBlt = 1073741824,
     }
+
     [System.ComponentModel.EditorAttribute("System.Drawing.Design.FontEditor, System.Drawing.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", "System.Drawing.Design.UITypeEditor, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
     [System.ComponentModel.TypeConverterAttribute(typeof(System.Drawing.FontConverter))]
     public sealed partial class Font : System.MarshalByRefObject, System.ICloneable, System.IDisposable, System.Runtime.Serialization.ISerializable
@@ -350,6 +362,7 @@ namespace System.Drawing
         public void ToLogFont(object logFont, System.Drawing.Graphics graphics) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
         public override string ToString() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
     }
+
     public partial class FontConverter : System.ComponentModel.TypeConverter
     {
         public FontConverter() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
@@ -372,12 +385,14 @@ namespace System.Drawing
             public override bool GetStandardValuesSupported(System.ComponentModel.ITypeDescriptorContext? context) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
             void System.IDisposable.Dispose() { }
         }
+
         public partial class FontUnitConverter : System.ComponentModel.EnumConverter
         {
             public FontUnitConverter() : base (default(System.Type)) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
             public override System.ComponentModel.TypeConverter.StandardValuesCollection GetStandardValues(System.ComponentModel.ITypeDescriptorContext? context) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
         }
     }
+
     public sealed partial class FontFamily : System.MarshalByRefObject, System.IDisposable
     {
         public FontFamily(System.Drawing.Text.GenericFontFamilies genericFamily) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
@@ -402,6 +417,7 @@ namespace System.Drawing
         public bool IsStyleAvailable(System.Drawing.FontStyle style) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
         public override string ToString() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
     }
+
     [System.FlagsAttribute]
     public enum FontStyle
     {
@@ -411,6 +427,7 @@ namespace System.Drawing
         Underline = 4,
         Strikeout = 8,
     }
+
     public sealed partial class Graphics : System.MarshalByRefObject, System.Drawing.IDeviceContext, System.IDisposable
     {
         internal Graphics() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
@@ -663,6 +680,7 @@ namespace System.Drawing
         public delegate bool DrawImageAbort(System.IntPtr callbackdata);
         public delegate bool EnumerateMetafileProc(System.Drawing.Imaging.EmfPlusRecordType recordType, int flags, int dataSize, System.IntPtr data, System.Drawing.Imaging.PlayRecordCallback? callbackData);
     }
+
     public enum GraphicsUnit
     {
         World = 0,
@@ -673,6 +691,7 @@ namespace System.Drawing
         Document = 5,
         Millimeter = 6,
     }
+
     [System.ComponentModel.EditorAttribute("System.Drawing.Design.IconEditor, System.Drawing.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", "System.Drawing.Design.UITypeEditor, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
     [System.ComponentModel.TypeConverterAttribute(typeof(System.Drawing.IconConverter))]
     public sealed partial class Icon : System.MarshalByRefObject, System.ICloneable, System.IDisposable, System.Runtime.Serialization.ISerializable
@@ -703,6 +722,7 @@ namespace System.Drawing
         public System.Drawing.Bitmap ToBitmap() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
         public override string ToString() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
     }
+
     public partial class IconConverter : System.ComponentModel.ExpandableObjectConverter
     {
         public IconConverter() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
@@ -711,11 +731,13 @@ namespace System.Drawing
         public override object? ConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object value) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
         public override object? ConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object? value, System.Type destinationType) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
     }
+
     public partial interface IDeviceContext : System.IDisposable
     {
         System.IntPtr GetHdc();
         void ReleaseHdc();
     }
+
     [System.ComponentModel.EditorAttribute("System.Drawing.Design.ImageEditor, System.Drawing.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", "System.Drawing.Design.UITypeEditor, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
     [System.ComponentModel.ImmutableObjectAttribute(true)]
     [System.ComponentModel.TypeConverterAttribute(typeof(System.Drawing.ImageConverter))]
@@ -783,6 +805,7 @@ namespace System.Drawing
         void System.Runtime.Serialization.ISerializable.GetObjectData(System.Runtime.Serialization.SerializationInfo si, System.Runtime.Serialization.StreamingContext context) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
         public delegate bool GetThumbnailImageAbort();
     }
+
     public sealed partial class ImageAnimator
     {
         internal ImageAnimator() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
@@ -792,6 +815,7 @@ namespace System.Drawing
         public static void UpdateFrames() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
         public static void UpdateFrames(System.Drawing.Image? image) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
     }
+
     public partial class ImageConverter : System.ComponentModel.TypeConverter
     {
         public ImageConverter() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
@@ -803,6 +827,7 @@ namespace System.Drawing
         public override System.ComponentModel.PropertyDescriptorCollection GetProperties(System.ComponentModel.ITypeDescriptorContext? context, object? value, System.Attribute[]? attributes) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
         public override bool GetPropertiesSupported(System.ComponentModel.ITypeDescriptorContext? context) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
     }
+
     public partial class ImageFormatConverter : System.ComponentModel.TypeConverter
     {
         public ImageFormatConverter() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
@@ -813,6 +838,7 @@ namespace System.Drawing
         public override System.ComponentModel.TypeConverter.StandardValuesCollection GetStandardValues(System.ComponentModel.ITypeDescriptorContext? context) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
         public override bool GetStandardValuesSupported(System.ComponentModel.ITypeDescriptorContext? context) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
     }
+
     public sealed partial class Pen : System.MarshalByRefObject, System.ICloneable, System.IDisposable
     {
         public Pen(System.Drawing.Brush brush) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
@@ -850,6 +876,7 @@ namespace System.Drawing
         public void TranslateTransform(float dx, float dy) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
         public void TranslateTransform(float dx, float dy, System.Drawing.Drawing2D.MatrixOrder order) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
     }
+
     public static partial class Pens
     {
         public static System.Drawing.Pen AliceBlue { get { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } }
@@ -994,6 +1021,7 @@ namespace System.Drawing
         public static System.Drawing.Pen Yellow { get { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } }
         public static System.Drawing.Pen YellowGreen { get { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } }
     }
+
     public sealed partial class Region : System.MarshalByRefObject, System.IDisposable
     {
         public Region() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
@@ -1054,6 +1082,7 @@ namespace System.Drawing
         public void Xor(System.Drawing.RectangleF rect) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
         public void Xor(System.Drawing.Region region) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
     }
+
     public enum RotateFlipType
     {
         Rotate180FlipXY = 0,
@@ -1073,6 +1102,7 @@ namespace System.Drawing
         Rotate270FlipX = 7,
         Rotate90FlipY = 7,
     }
+
     public sealed partial class SolidBrush : System.Drawing.Brush
     {
         public SolidBrush(System.Drawing.Color color) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
@@ -1080,12 +1110,14 @@ namespace System.Drawing
         public override object Clone() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
         protected override void Dispose(bool disposing) { }
     }
+
     public enum StringAlignment
     {
         Near = 0,
         Center = 1,
         Far = 2,
     }
+
     public enum StringDigitSubstitute
     {
         User = 0,
@@ -1093,6 +1125,7 @@ namespace System.Drawing
         National = 2,
         Traditional = 3,
     }
+
     public sealed partial class StringFormat : System.MarshalByRefObject, System.ICloneable, System.IDisposable
     {
         public StringFormat() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
@@ -1117,6 +1150,7 @@ namespace System.Drawing
         public void SetTabStops(float firstTabOffset, float[] tabStops) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
         public override string ToString() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
     }
+
     [System.FlagsAttribute]
     public enum StringFormatFlags
     {
@@ -1130,6 +1164,7 @@ namespace System.Drawing
         LineLimit = 8192,
         NoClip = 16384,
     }
+
     public enum StringTrimming
     {
         None = 0,
@@ -1139,6 +1174,7 @@ namespace System.Drawing
         EllipsisWord = 4,
         EllipsisPath = 5,
     }
+
     public enum StringUnit
     {
         World = 0,
@@ -1150,6 +1186,7 @@ namespace System.Drawing
         Millimeter = 6,
         Em = 32,
     }
+
     public static partial class SystemBrushes
     {
         public static System.Drawing.Brush ActiveBorder { get { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } }
@@ -1187,6 +1224,7 @@ namespace System.Drawing
         public static System.Drawing.Brush WindowText { get { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } }
         public static System.Drawing.Brush FromSystemColor(System.Drawing.Color c) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
     }
+
     public static partial class SystemColors
     {
         public static System.Drawing.Color ActiveBorder { get { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } }
@@ -1223,6 +1261,7 @@ namespace System.Drawing
         public static System.Drawing.Color WindowFrame { get { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } }
         public static System.Drawing.Color WindowText { get { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } }
     }
+
     public static partial class SystemFonts
     {
         public static System.Drawing.Font? CaptionFont { get { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } }
@@ -1235,6 +1274,7 @@ namespace System.Drawing
         public static System.Drawing.Font? StatusFont { get { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } }
         public static System.Drawing.Font? GetFontByName(string systemFontName) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
     }
+
     public static partial class SystemIcons
     {
         public static System.Drawing.Icon Application { get { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } }
@@ -1248,6 +1288,7 @@ namespace System.Drawing
         public static System.Drawing.Icon Warning { get { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } }
         public static System.Drawing.Icon WinLogo { get { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } }
     }
+
     public static partial class SystemPens
     {
         public static System.Drawing.Pen ActiveBorder { get { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } }
@@ -1285,6 +1326,7 @@ namespace System.Drawing
         public static System.Drawing.Pen WindowText { get { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } }
         public static System.Drawing.Pen FromSystemColor(System.Drawing.Color c) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
     }
+
     public sealed partial class TextureBrush : System.Drawing.Brush
     {
         public TextureBrush(System.Drawing.Image bitmap) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
@@ -1309,6 +1351,7 @@ namespace System.Drawing
         public void TranslateTransform(float dx, float dy) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
         public void TranslateTransform(float dx, float dy, System.Drawing.Drawing2D.MatrixOrder order) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
     }
+
     [System.AttributeUsageAttribute(System.AttributeTargets.Class)]
     public partial class ToolboxBitmapAttribute : System.Attribute
     {
@@ -1326,6 +1369,7 @@ namespace System.Drawing
         public static System.Drawing.Image? GetImageFromResource(System.Type t, string? imageName, bool large) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
     }
 }
+
 namespace System.Drawing.Design
 {
     public sealed partial class CategoryNameCollection : System.Collections.ReadOnlyCollectionBase
@@ -1338,6 +1382,7 @@ namespace System.Drawing.Design
         public int IndexOf(string value) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
     }
 }
+
 namespace System.Drawing.Drawing2D
 {
     public sealed partial class AdjustableArrowCap : System.Drawing.Drawing2D.CustomLineCap
@@ -1349,6 +1394,7 @@ namespace System.Drawing.Drawing2D
         public float MiddleInset { get { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } set { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } }
         public float Width { get { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } set { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } }
     }
+
     public sealed partial class Blend
     {
         public Blend() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
@@ -1356,6 +1402,7 @@ namespace System.Drawing.Drawing2D
         public float[] Factors { get { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } set { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } }
         public float[] Positions { get { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } set { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } }
     }
+
     public sealed partial class ColorBlend
     {
         public ColorBlend() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
@@ -1363,6 +1410,7 @@ namespace System.Drawing.Drawing2D
         public System.Drawing.Color[] Colors { get { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } set { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } }
         public float[] Positions { get { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } set { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } }
     }
+
     public enum CombineMode
     {
         Replace = 0,
@@ -1372,11 +1420,13 @@ namespace System.Drawing.Drawing2D
         Exclude = 4,
         Complement = 5,
     }
+
     public enum CompositingMode
     {
         SourceOver = 0,
         SourceCopy = 1,
     }
+
     public enum CompositingQuality
     {
         Invalid = -1,
@@ -1386,12 +1436,14 @@ namespace System.Drawing.Drawing2D
         GammaCorrected = 3,
         AssumeLinear = 4,
     }
+
     public enum CoordinateSpace
     {
         World = 0,
         Page = 1,
         Device = 2,
     }
+
     public partial class CustomLineCap : System.MarshalByRefObject, System.ICloneable, System.IDisposable
     {
         public CustomLineCap(System.Drawing.Drawing2D.GraphicsPath? fillPath, System.Drawing.Drawing2D.GraphicsPath? strokePath) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
@@ -1408,12 +1460,14 @@ namespace System.Drawing.Drawing2D
         public void GetStrokeCaps(out System.Drawing.Drawing2D.LineCap startCap, out System.Drawing.Drawing2D.LineCap endCap) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
         public void SetStrokeCaps(System.Drawing.Drawing2D.LineCap startCap, System.Drawing.Drawing2D.LineCap endCap) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
     }
+
     public enum DashCap
     {
         Flat = 0,
         Round = 2,
         Triangle = 3,
     }
+
     public enum DashStyle
     {
         Solid = 0,
@@ -1423,20 +1477,24 @@ namespace System.Drawing.Drawing2D
         DashDotDot = 4,
         Custom = 5,
     }
+
     public enum FillMode
     {
         Alternate = 0,
         Winding = 1,
     }
+
     public enum FlushIntention
     {
         Flush = 0,
         Sync = 1,
     }
+
     public sealed partial class GraphicsContainer : System.MarshalByRefObject
     {
         internal GraphicsContainer() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
     }
+
     public sealed partial class GraphicsPath : System.MarshalByRefObject, System.ICloneable, System.IDisposable
     {
         public GraphicsPath() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
@@ -1536,6 +1594,7 @@ namespace System.Drawing.Drawing2D
         public void Widen(System.Drawing.Pen pen, System.Drawing.Drawing2D.Matrix? matrix) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
         public void Widen(System.Drawing.Pen pen, System.Drawing.Drawing2D.Matrix? matrix, float flatness) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
     }
+
     public sealed partial class GraphicsPathIterator : System.MarshalByRefObject, System.IDisposable
     {
         public GraphicsPathIterator(System.Drawing.Drawing2D.GraphicsPath? path) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
@@ -1553,10 +1612,12 @@ namespace System.Drawing.Drawing2D
         public int NextSubpath(out int startIndex, out int endIndex, out bool isClosed) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
         public void Rewind() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
     }
+
     public sealed partial class GraphicsState : System.MarshalByRefObject
     {
         internal GraphicsState() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
     }
+
     public sealed partial class HatchBrush : System.Drawing.Brush
     {
         public HatchBrush(System.Drawing.Drawing2D.HatchStyle hatchstyle, System.Drawing.Color foreColor) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
@@ -1566,6 +1627,7 @@ namespace System.Drawing.Drawing2D
         public System.Drawing.Drawing2D.HatchStyle HatchStyle { get { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } }
         public override object Clone() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
     }
+
     public enum HatchStyle
     {
         Horizontal = 0,
@@ -1625,6 +1687,7 @@ namespace System.Drawing.Drawing2D
         OutlinedDiamond = 51,
         SolidDiamond = 52,
     }
+
     public enum InterpolationMode
     {
         Invalid = -1,
@@ -1637,6 +1700,7 @@ namespace System.Drawing.Drawing2D
         HighQualityBilinear = 6,
         HighQualityBicubic = 7,
     }
+
     public sealed partial class LinearGradientBrush : System.Drawing.Brush
     {
         public LinearGradientBrush(System.Drawing.Point point1, System.Drawing.Point point2, System.Drawing.Color color1, System.Drawing.Color color2) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
@@ -1669,6 +1733,7 @@ namespace System.Drawing.Drawing2D
         public void TranslateTransform(float dx, float dy) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
         public void TranslateTransform(float dx, float dy, System.Drawing.Drawing2D.MatrixOrder order) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
     }
+
     public enum LinearGradientMode
     {
         Horizontal = 0,
@@ -1676,6 +1741,7 @@ namespace System.Drawing.Drawing2D
         ForwardDiagonal = 2,
         BackwardDiagonal = 3,
     }
+
     public enum LineCap
     {
         Flat = 0,
@@ -1690,6 +1756,7 @@ namespace System.Drawing.Drawing2D
         AnchorMask = 240,
         Custom = 255,
     }
+
     public enum LineJoin
     {
         Miter = 0,
@@ -1697,6 +1764,7 @@ namespace System.Drawing.Drawing2D
         Round = 2,
         MiterClipped = 3,
     }
+
     public sealed partial class Matrix : System.MarshalByRefObject, System.IDisposable
     {
         public Matrix() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
@@ -1733,17 +1801,20 @@ namespace System.Drawing.Drawing2D
         public void Translate(float offsetX, float offsetY, System.Drawing.Drawing2D.MatrixOrder order) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
         public void VectorTransformPoints(System.Drawing.Point[] pts) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
     }
+
     public enum MatrixOrder
     {
         Prepend = 0,
         Append = 1,
     }
+
     public sealed partial class PathData
     {
         public PathData() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
         public System.Drawing.PointF[]? Points { get { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } set { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } }
         public byte[]? Types { get { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } set { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } }
     }
+
     public sealed partial class PathGradientBrush : System.Drawing.Brush
     {
         public PathGradientBrush(System.Drawing.Drawing2D.GraphicsPath path) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
@@ -1775,6 +1846,7 @@ namespace System.Drawing.Drawing2D
         public void TranslateTransform(float dx, float dy) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
         public void TranslateTransform(float dx, float dy, System.Drawing.Drawing2D.MatrixOrder order) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
     }
+
     public enum PathPointType
     {
         Start = 0,
@@ -1786,6 +1858,7 @@ namespace System.Drawing.Drawing2D
         PathMarker = 32,
         CloseSubpath = 128,
     }
+
     public enum PenAlignment
     {
         Center = 0,
@@ -1794,6 +1867,7 @@ namespace System.Drawing.Drawing2D
         Left = 3,
         Right = 4,
     }
+
     public enum PenType
     {
         SolidColor = 0,
@@ -1802,6 +1876,7 @@ namespace System.Drawing.Drawing2D
         PathGradient = 3,
         LinearGradient = 4,
     }
+
     public enum PixelOffsetMode
     {
         Invalid = -1,
@@ -1811,6 +1886,7 @@ namespace System.Drawing.Drawing2D
         None = 3,
         Half = 4,
     }
+
     public enum QualityMode
     {
         Invalid = -1,
@@ -1818,11 +1894,13 @@ namespace System.Drawing.Drawing2D
         Low = 1,
         High = 2,
     }
+
     public sealed partial class RegionData
     {
         internal RegionData() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
         public byte[] Data { get { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } set { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } }
     }
+
     public enum SmoothingMode
     {
         Invalid = -1,
@@ -1832,11 +1910,13 @@ namespace System.Drawing.Drawing2D
         None = 3,
         AntiAlias = 4,
     }
+
     public enum WarpMode
     {
         Perspective = 0,
         Bilinear = 1,
     }
+
     public enum WrapMode
     {
         Tile = 0,
@@ -1846,6 +1926,7 @@ namespace System.Drawing.Drawing2D
         Clamp = 4,
     }
 }
+
 namespace System.Drawing.Imaging
 {
     public sealed partial class BitmapData
@@ -1858,6 +1939,7 @@ namespace System.Drawing.Imaging
         public int Stride { get { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } set { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } }
         public int Width { get { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } set { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } }
     }
+
     public enum ColorAdjustType
     {
         Default = 0,
@@ -1868,6 +1950,7 @@ namespace System.Drawing.Imaging
         Count = 5,
         Any = 6,
     }
+
     public enum ColorChannelFlag
     {
         ColorChannelC = 0,
@@ -1876,17 +1959,20 @@ namespace System.Drawing.Imaging
         ColorChannelK = 3,
         ColorChannelLast = 4,
     }
+
     public sealed partial class ColorMap
     {
         public ColorMap() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
         public System.Drawing.Color NewColor { get { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } set { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } }
         public System.Drawing.Color OldColor { get { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } set { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } }
     }
+
     public enum ColorMapType
     {
         Default = 0,
         Brush = 1,
     }
+
     public sealed partial class ColorMatrix
     {
         public ColorMatrix() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
@@ -1919,23 +2005,27 @@ namespace System.Drawing.Imaging
         public float Matrix43 { get { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } set { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } }
         public float Matrix44 { get { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } set { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } }
     }
+
     public enum ColorMatrixFlag
     {
         Default = 0,
         SkipGrays = 1,
         AltGrays = 2,
     }
+
     public enum ColorMode
     {
         Argb32Mode = 0,
         Argb64Mode = 1,
     }
+
     public sealed partial class ColorPalette
     {
         internal ColorPalette() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
         public System.Drawing.Color[] Entries { get { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } }
         public int Flags { get { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } }
     }
+
     public enum EmfPlusRecordType
     {
         EmfHeader = 1,
@@ -2192,12 +2282,14 @@ namespace System.Drawing.Imaging
         WmfSetDibToDev = 68915,
         WmfStretchDib = 69443,
     }
+
     public enum EmfType
     {
         EmfOnly = 3,
         EmfPlusOnly = 4,
         EmfPlusDual = 5,
     }
+
     public sealed partial class Encoder
     {
         public static readonly System.Drawing.Imaging.Encoder ChrominanceTable;
@@ -2216,6 +2308,7 @@ namespace System.Drawing.Imaging
         public Encoder(System.Guid guid) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
         public System.Guid Guid { get { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } }
     }
+
     public sealed partial class EncoderParameter : System.IDisposable
     {
         public EncoderParameter(System.Drawing.Imaging.Encoder encoder, byte value) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
@@ -2243,6 +2336,7 @@ namespace System.Drawing.Imaging
         public void Dispose() { }
         ~EncoderParameter() { }
     }
+
     public sealed partial class EncoderParameters : System.IDisposable
     {
         public EncoderParameters() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
@@ -2250,6 +2344,7 @@ namespace System.Drawing.Imaging
         public System.Drawing.Imaging.EncoderParameter[] Param { get { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } set { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } }
         public void Dispose() { }
     }
+
     public enum EncoderParameterValueType
     {
         ValueTypeByte = 1,
@@ -2262,6 +2357,7 @@ namespace System.Drawing.Imaging
         ValueTypeRationalRange = 8,
         ValueTypePointer = 9,
     }
+
     public enum EncoderValue
     {
         ColorTypeCMYK = 0,
@@ -2289,6 +2385,7 @@ namespace System.Drawing.Imaging
         FrameDimensionResolution = 22,
         FrameDimensionPage = 23,
     }
+
     public sealed partial class FrameDimension
     {
         public FrameDimension(System.Guid guid) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
@@ -2300,6 +2397,7 @@ namespace System.Drawing.Imaging
         public override int GetHashCode() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
         public override string ToString() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
     }
+
     public sealed partial class ImageAttributes : System.ICloneable, System.IDisposable
     {
         public ImageAttributes() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
@@ -2349,6 +2447,7 @@ namespace System.Drawing.Imaging
         public void SetWrapMode(System.Drawing.Drawing2D.WrapMode mode, System.Drawing.Color color) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
         public void SetWrapMode(System.Drawing.Drawing2D.WrapMode mode, System.Drawing.Color color, bool clamp) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
     }
+
     [System.FlagsAttribute]
     public enum ImageCodecFlags
     {
@@ -2362,6 +2461,7 @@ namespace System.Drawing.Imaging
         System = 131072,
         User = 262144,
     }
+
     public sealed partial class ImageCodecInfo
     {
         internal ImageCodecInfo() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
@@ -2381,6 +2481,7 @@ namespace System.Drawing.Imaging
         public static System.Drawing.Imaging.ImageCodecInfo[] GetImageDecoders() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
         public static System.Drawing.Imaging.ImageCodecInfo[] GetImageEncoders() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
     }
+
     [System.FlagsAttribute]
     public enum ImageFlags
     {
@@ -2399,6 +2500,7 @@ namespace System.Drawing.Imaging
         ReadOnly = 65536,
         Caching = 131072,
     }
+
     [System.ComponentModel.TypeConverterAttribute(typeof(System.Drawing.ImageFormatConverter))]
     public sealed partial class ImageFormat
     {
@@ -2418,6 +2520,7 @@ namespace System.Drawing.Imaging
         public override int GetHashCode() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
         public override string ToString() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
     }
+
     public enum ImageLockMode
     {
         ReadOnly = 1,
@@ -2425,6 +2528,7 @@ namespace System.Drawing.Imaging
         ReadWrite = 3,
         UserInputBuffer = 4,
     }
+
     [System.ComponentModel.EditorAttribute("System.Drawing.Design.MetafileEditor, System.Drawing.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", "System.Drawing.Design.UITypeEditor, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")]
     public sealed partial class Metafile : System.Drawing.Image
     {
@@ -2475,6 +2579,7 @@ namespace System.Drawing.Imaging
         public static System.Drawing.Imaging.MetafileHeader GetMetafileHeader(string fileName) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
         public void PlayRecord(System.Drawing.Imaging.EmfPlusRecordType recordType, int flags, int dataSize, byte[] data) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
     }
+
     public enum MetafileFrameUnit
     {
         Pixel = 2,
@@ -2484,6 +2589,7 @@ namespace System.Drawing.Imaging
         Millimeter = 6,
         GdiCompatible = 7,
     }
+
     public sealed partial class MetafileHeader
     {
         internal MetafileHeader() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
@@ -2506,6 +2612,7 @@ namespace System.Drawing.Imaging
         public bool IsWmf() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
         public bool IsWmfPlaceable() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
     }
+
     public enum MetafileType
     {
         Invalid = 0,
@@ -2515,6 +2622,7 @@ namespace System.Drawing.Imaging
         EmfPlusOnly = 4,
         EmfPlusDual = 5,
     }
+
     public sealed partial class MetaHeader
     {
         public MetaHeader() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
@@ -2526,6 +2634,7 @@ namespace System.Drawing.Imaging
         public short Type { get { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } set { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } }
         public short Version { get { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } set { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } }
     }
+
     [System.FlagsAttribute]
     public enum PaletteFlags
     {
@@ -2533,6 +2642,7 @@ namespace System.Drawing.Imaging
         GrayScale = 2,
         Halftone = 4,
     }
+
     public enum PixelFormat
     {
         DontCare = 0,
@@ -2559,6 +2669,7 @@ namespace System.Drawing.Imaging
         Format32bppArgb = 2498570,
         Format64bppArgb = 3424269,
     }
+
     public delegate void PlayRecordCallback(System.Drawing.Imaging.EmfPlusRecordType recordType, int flags, int dataSize, System.IntPtr recordData);
     public sealed partial class PropertyItem
     {
@@ -2568,6 +2679,7 @@ namespace System.Drawing.Imaging
         public short Type { get { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } set { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } }
         public byte[]? Value { get { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } set { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } }
     }
+
     public sealed partial class WmfPlaceableFileHeader
     {
         public WmfPlaceableFileHeader() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
@@ -2582,6 +2694,7 @@ namespace System.Drawing.Imaging
         public int Reserved { get { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } set { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } }
     }
 }
+
 namespace System.Drawing.Printing
 {
     public enum Duplex
@@ -2591,12 +2704,14 @@ namespace System.Drawing.Printing
         Vertical = 2,
         Horizontal = 3,
     }
+
     public partial class InvalidPrinterException : System.SystemException
     {
         public InvalidPrinterException(System.Drawing.Printing.PrinterSettings settings) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
         protected InvalidPrinterException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
     }
+
     [System.ComponentModel.TypeConverterAttribute(typeof(System.Drawing.Printing.MarginsConverter))]
     public partial class Margins : System.ICloneable
     {
@@ -2613,6 +2728,7 @@ namespace System.Drawing.Printing
         public static bool operator !=(System.Drawing.Printing.Margins? m1, System.Drawing.Printing.Margins? m2) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
         public override string ToString() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
     }
+
     public partial class MarginsConverter : System.ComponentModel.ExpandableObjectConverter
     {
         public MarginsConverter() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
@@ -2623,6 +2739,7 @@ namespace System.Drawing.Printing
         public override object CreateInstance(System.ComponentModel.ITypeDescriptorContext? context, System.Collections.IDictionary propertyValues) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
         public override bool GetCreateInstanceSupported(System.ComponentModel.ITypeDescriptorContext? context) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
     }
+
     public partial class PageSettings : System.ICloneable
     {
         public PageSettings() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
@@ -2643,6 +2760,7 @@ namespace System.Drawing.Printing
         public void SetHdevmode(System.IntPtr hdevmode) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
         public override string ToString() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
     }
+
     public enum PaperKind
     {
         Custom = 0,
@@ -2763,6 +2881,7 @@ namespace System.Drawing.Printing
         PrcEnvelopeNumber9Rotated = 117,
         PrcEnvelopeNumber10Rotated = 118,
     }
+
     public partial class PaperSize
     {
         public PaperSize() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
@@ -2774,6 +2893,7 @@ namespace System.Drawing.Printing
         public int Width { get { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } set { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } }
         public override string ToString() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
     }
+
     public partial class PaperSource
     {
         public PaperSource() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
@@ -2782,6 +2902,7 @@ namespace System.Drawing.Printing
         public string SourceName { get { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } set { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } }
         public override string ToString() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
     }
+
     public enum PaperSourceKind
     {
         Upper = 1,
@@ -2799,12 +2920,14 @@ namespace System.Drawing.Printing
         FormSource = 15,
         Custom = 257,
     }
+
     public sealed partial class PreviewPageInfo
     {
         public PreviewPageInfo(System.Drawing.Image image, System.Drawing.Size physicalSize) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
         public System.Drawing.Image Image { get { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } }
         public System.Drawing.Size PhysicalSize { get { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } }
     }
+
     public partial class PreviewPrintController : System.Drawing.Printing.PrintController
     {
         public PreviewPrintController() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
@@ -2816,12 +2939,14 @@ namespace System.Drawing.Printing
         public override System.Drawing.Graphics OnStartPage(System.Drawing.Printing.PrintDocument document, System.Drawing.Printing.PrintPageEventArgs e) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
         public override void OnStartPrint(System.Drawing.Printing.PrintDocument document, System.Drawing.Printing.PrintEventArgs e) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
     }
+
     public enum PrintAction
     {
         PrintToFile = 0,
         PrintToPreview = 1,
         PrintToPrinter = 2,
     }
+
     public abstract partial class PrintController
     {
         protected PrintController() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
@@ -2831,6 +2956,7 @@ namespace System.Drawing.Printing
         public virtual System.Drawing.Graphics? OnStartPage(System.Drawing.Printing.PrintDocument document, System.Drawing.Printing.PrintPageEventArgs e) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
         public virtual void OnStartPrint(System.Drawing.Printing.PrintDocument document, System.Drawing.Printing.PrintEventArgs e) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
     }
+
     [System.ComponentModel.DefaultEventAttribute("PrintPage")]
     [System.ComponentModel.DefaultPropertyAttribute("DocumentName")]
     public partial class PrintDocument : System.ComponentModel.Component
@@ -2860,6 +2986,7 @@ namespace System.Drawing.Printing
         public void Print() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
         public override string ToString() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
     }
+
     public partial class PrinterResolution
     {
         public PrinterResolution() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
@@ -2868,6 +2995,7 @@ namespace System.Drawing.Printing
         public int Y { get { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } set { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } }
         public override string ToString() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
     }
+
     public enum PrinterResolutionKind
     {
         High = -4,
@@ -2876,6 +3004,7 @@ namespace System.Drawing.Printing
         Draft = -1,
         Custom = 0,
     }
+
     public partial class PrinterSettings : System.ICloneable
     {
         public PrinterSettings() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
@@ -2930,6 +3059,7 @@ namespace System.Drawing.Printing
             void System.Collections.ICollection.CopyTo(System.Array array, int index) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
             System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
         }
+
         public partial class PaperSourceCollection : System.Collections.ICollection, System.Collections.IEnumerable
         {
             public PaperSourceCollection(System.Drawing.Printing.PaperSource[] array) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
@@ -2945,6 +3075,7 @@ namespace System.Drawing.Printing
             void System.Collections.ICollection.CopyTo(System.Array array, int index) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
             System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
         }
+
         public partial class PrinterResolutionCollection : System.Collections.ICollection, System.Collections.IEnumerable
         {
             public PrinterResolutionCollection(System.Drawing.Printing.PrinterResolution[] array) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
@@ -2960,6 +3091,7 @@ namespace System.Drawing.Printing
             void System.Collections.ICollection.CopyTo(System.Array array, int index) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
             System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
         }
+
         public partial class StringCollection : System.Collections.ICollection, System.Collections.IEnumerable
         {
             public StringCollection(string[] array) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
@@ -2976,6 +3108,7 @@ namespace System.Drawing.Printing
             System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
         }
     }
+
     public enum PrinterUnit
     {
         Display = 0,
@@ -2983,6 +3116,7 @@ namespace System.Drawing.Printing
         HundredthsOfAMillimeter = 2,
         TenthsOfAMillimeter = 3,
     }
+
     public sealed partial class PrinterUnitConvert
     {
         internal PrinterUnitConvert() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
@@ -2993,11 +3127,13 @@ namespace System.Drawing.Printing
         public static System.Drawing.Size Convert(System.Drawing.Size value, System.Drawing.Printing.PrinterUnit fromUnit, System.Drawing.Printing.PrinterUnit toUnit) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
         public static int Convert(int value, System.Drawing.Printing.PrinterUnit fromUnit, System.Drawing.Printing.PrinterUnit toUnit) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
     }
+
     public partial class PrintEventArgs : System.ComponentModel.CancelEventArgs
     {
         public PrintEventArgs() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
         public System.Drawing.Printing.PrintAction PrintAction { get { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } }
     }
+
     public delegate void PrintEventHandler(object sender, System.Drawing.Printing.PrintEventArgs e);
     public partial class PrintPageEventArgs : System.EventArgs
     {
@@ -3009,6 +3145,7 @@ namespace System.Drawing.Printing
         public System.Drawing.Rectangle PageBounds { get { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } }
         public System.Drawing.Printing.PageSettings PageSettings { get { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } }
     }
+
     public delegate void PrintPageEventHandler(object sender, System.Drawing.Printing.PrintPageEventArgs e);
     public enum PrintRange
     {
@@ -3017,11 +3154,13 @@ namespace System.Drawing.Printing
         SomePages = 2,
         CurrentPage = 4194304,
     }
+
     public partial class QueryPageSettingsEventArgs : System.Drawing.Printing.PrintEventArgs
     {
         public QueryPageSettingsEventArgs(System.Drawing.Printing.PageSettings pageSettings) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
         public System.Drawing.Printing.PageSettings PageSettings { get { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } set { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  } }
     }
+
     public delegate void QueryPageSettingsEventHandler(object sender, System.Drawing.Printing.QueryPageSettingsEventArgs e);
     public partial class StandardPrintController : System.Drawing.Printing.PrintController
     {
@@ -3032,6 +3171,7 @@ namespace System.Drawing.Printing
         public override void OnStartPrint(System.Drawing.Printing.PrintDocument document, System.Drawing.Printing.PrintEventArgs e) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
     }
 }
+
 namespace System.Drawing.Text
 {
     public abstract partial class FontCollection : System.IDisposable
@@ -3042,22 +3182,26 @@ namespace System.Drawing.Text
         protected virtual void Dispose(bool disposing) { }
         ~FontCollection() { }
     }
+
     public enum GenericFontFamilies
     {
         Serif = 0,
         SansSerif = 1,
         Monospace = 2,
     }
+
     public enum HotkeyPrefix
     {
         None = 0,
         Show = 1,
         Hide = 2,
     }
+
     public sealed partial class InstalledFontCollection : System.Drawing.Text.FontCollection
     {
         public InstalledFontCollection() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
     }
+
     public sealed partial class PrivateFontCollection : System.Drawing.Text.FontCollection
     {
         public PrivateFontCollection() { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
@@ -3065,6 +3209,7 @@ namespace System.Drawing.Text
         public void AddMemoryFont(System.IntPtr memory, int length) { throw new System.PlatformNotSupportedException(System.SR.SystemDrawingCommon_PlatformNotSupported);  }
         protected override void Dispose(bool disposing) { }
     }
+
     public enum TextRenderingHint
     {
         SystemDefault = 0,

--- a/src/System.Drawing.Common/src/SRDescriptionAttribute.cs
+++ b/src/System.Drawing.Common/src/SRDescriptionAttribute.cs
@@ -19,6 +19,7 @@ internal sealed class SRDescriptionAttribute : DescriptionAttribute
                 _replaced = true;
                 base.DescriptionValue = SR.GetResourceString(base.Description);
             }
+
             return base.Description;
         }
     }

--- a/src/System.Drawing.Common/src/System/Drawing/Bitmap.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Bitmap.cs
@@ -42,6 +42,7 @@ public sealed class Bitmap : Image
         {
             status = Gdip.GdipCreateBitmapFromFile(filename, out bitmap);
         }
+
         Gdip.CheckStatus(status);
 
         ValidateImage(bitmap);
@@ -227,6 +228,7 @@ public sealed class Bitmap : Image
         {
             transparent = GetPixel(0, Size.Height - 1);
         }
+
         if (transparent.A < 255)
         {
             // It's already transparent, and if we proceeded, we will do something
@@ -283,6 +285,7 @@ public sealed class Bitmap : Image
         {
             status = 8;
         }
+
         Gdip.CheckStatus(status);
 
         return bitmapData;
@@ -339,6 +342,7 @@ public sealed class Bitmap : Image
         int status = Gdip.GdipBitmapSetResolution(new HandleRef(this, _nativeImage), xDpi, yDpi);
         Gdip.CheckStatus(status);
     }
+
     public Bitmap Clone(Rectangle rect, PixelFormat format)
     {
         if (rect.Width == 0 || rect.Height == 0)

--- a/src/System.Drawing.Common/src/System/Drawing/Brushes.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Brushes.cs
@@ -318,6 +318,7 @@ public static class Brushes
             brush = new SolidBrush(color);
             Gdip.ThreadData[key] = brush;
         }
+
         return brush;
     }
 }

--- a/src/System.Drawing.Common/src/System/Drawing/BufferedGraphicsContext.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/BufferedGraphicsContext.cs
@@ -244,6 +244,7 @@ public sealed class BufferedGraphicsContext : IDisposable
                         ref pbmi,
                         NativeMethods.DIB_RGB_COLORS);
                 }
+
                 bRet = true;
             }
         }
@@ -254,6 +255,7 @@ public sealed class BufferedGraphicsContext : IDisposable
                 Gdi32.DeleteObject(hbm);
             }
         }
+
         return bRet;
     }
 
@@ -408,6 +410,7 @@ public sealed class BufferedGraphicsContext : IDisposable
                     pbmi.bmiHeader_biSizeImage = 0;
                 }
             }
+
             pbmi.bmiHeader_biClrUsed = 0;
             pbmi.bmiHeader_biClrImportant = 0;
 

--- a/src/System.Drawing.Common/src/System/Drawing/Drawing2D/GraphicsPath.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Drawing2D/GraphicsPath.cs
@@ -769,6 +769,7 @@ public sealed class GraphicsPath : MarshalByRefObject, ICloneable, IDisposable
             {
                 Gdip.CheckStatus(Gdip.GdipGetPathPoints(new HandleRef(this, _nativePath), p, points.Length));
             }
+
             return points;
         }
     }

--- a/src/System.Drawing.Common/src/System/Drawing/Drawing2D/LinearGradientBrush.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Drawing2D/LinearGradientBrush.cs
@@ -215,6 +215,7 @@ public sealed class LinearGradientBrush : Brush
                 {
                     Marshal.FreeHGlobal(factors);
                 }
+
                 if (positions != IntPtr.Zero)
                 {
                     Marshal.FreeHGlobal(positions);
@@ -269,6 +270,7 @@ public sealed class LinearGradientBrush : Brush
                 {
                     Marshal.FreeHGlobal(factors);
                 }
+
                 if (positions != IntPtr.Zero)
                 {
                     Marshal.FreeHGlobal(positions);
@@ -357,6 +359,7 @@ public sealed class LinearGradientBrush : Brush
                 {
                     Marshal.FreeHGlobal(colors);
                 }
+
                 if (positions != IntPtr.Zero)
                 {
                     Marshal.FreeHGlobal(positions);
@@ -426,6 +429,7 @@ public sealed class LinearGradientBrush : Brush
                 {
                     Marshal.FreeHGlobal(colors);
                 }
+
                 if (positions != IntPtr.Zero)
                 {
                     Marshal.FreeHGlobal(positions);

--- a/src/System.Drawing.Common/src/System/Drawing/Drawing2D/LinearGradientBrush.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Drawing2D/LinearGradientBrush.cs
@@ -397,7 +397,6 @@ public sealed class LinearGradientBrush : Brush
                                             SR.InterpolationColorsInvalidEndPosition));
             }
 
-
             // Allocate a temporary native memory buffer and copy input blend factors into it.
             int count = value.Colors.Length;
             IntPtr colors = IntPtr.Zero;

--- a/src/System.Drawing.Common/src/System/Drawing/Drawing2D/Matrix.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Drawing2D/Matrix.cs
@@ -92,6 +92,7 @@ public sealed class Matrix : MarshalByRefObject, IDisposable
             {
                 Gdip.GdipDeleteMatrix(new HandleRef(this, NativeMatrix));
             }
+
             NativeMatrix = IntPtr.Zero;
         }
     }

--- a/src/System.Drawing.Common/src/System/Drawing/Drawing2D/PathGradientBrush.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Drawing2D/PathGradientBrush.cs
@@ -220,6 +220,7 @@ public sealed class PathGradientBrush : Brush
                 {
                     Marshal.FreeHGlobal(factors);
                 }
+
                 if (positions != IntPtr.Zero)
                 {
                     Marshal.FreeHGlobal(positions);

--- a/src/System.Drawing.Common/src/System/Drawing/Drawing2D/SafeCustomLineCapHandle.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Drawing2D/SafeCustomLineCapHandle.cs
@@ -46,8 +46,10 @@ internal sealed class SafeCustomLineCapHandle : SafeHandle
             {
                 handle = IntPtr.Zero;
             }
+
             Debug.Assert(status == Gdip.Ok, $"GDI+ returned an error status: {status.ToString(CultureInfo.InvariantCulture)}");
         }
+
         return status == Gdip.Ok;
     }
 

--- a/src/System.Drawing.Common/src/System/Drawing/FontConverter.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/FontConverter.cs
@@ -447,6 +447,7 @@ public class FontConverter : TypeConverter
             {
                 values[i] = _fonts[i].Name;
             }
+
             Array.Sort(values, Comparer.Default);
 
             return new TypeConverter.StandardValuesCollection(values);
@@ -472,6 +473,7 @@ public class FontConverter : TypeConverter
                     // For an exact match, return immediately
                     return fontName;
                 }
+
                 if (fontName.StartsWith(name, StringComparison.InvariantCultureIgnoreCase))
                 {
                     if (bestMatch is null || fontName.Length <= bestMatch.Length)
@@ -501,6 +503,7 @@ public class FontConverter : TypeConverter
                 filteredValues.Remove(GraphicsUnit.Display);
                 Values = new StandardValuesCollection(filteredValues);
             }
+
             return Values;
         }
     }

--- a/src/System.Drawing.Common/src/System/Drawing/FontFamily.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/FontFamily.cs
@@ -119,6 +119,7 @@ public sealed class FontFamily : MarshalByRefObject, IDisposable
                 status = Gdip.GdipGetGenericFontFamilyMonospace(out nativeFamily);
                 break;
         }
+
         Gdip.CheckStatus(status);
 
         SetNativeFamily(nativeFamily);

--- a/src/System.Drawing.Common/src/System/Drawing/GdiplusNative.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/GdiplusNative.cs
@@ -871,7 +871,6 @@ internal static partial class SafeNativeMethods
 #endif
         HandleRef brush, out int color);
 
-
         [LibraryImport(LibraryName)]
         internal static partial int GdipCreateTexture(
 #if NET7_0_OR_GREATER

--- a/src/System.Drawing.Common/src/System/Drawing/Graphics.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Graphics.cs
@@ -15,7 +15,6 @@ using System.Runtime.InteropServices.Marshalling;
 using Gdip = System.Drawing.SafeNativeMethods.Gdip;
 using static Interop;
 
-
 namespace System.Drawing;
 
 /// <summary>
@@ -2200,7 +2199,6 @@ public sealed class Graphics : MarshalByRefObject, IDisposable, IDeviceContext
     }
 #endif
 
-
     /// <summary>
     /// Draws the specified image at the specified location.
     /// </summary>
@@ -2719,7 +2717,6 @@ public sealed class Graphics : MarshalByRefObject, IDisposable, IDeviceContext
                 p, points.Length));
         }
     }
-
 
     /// <summary>
     /// Draws a line connecting the two specified points.

--- a/src/System.Drawing.Common/src/System/Drawing/Graphics.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Graphics.cs
@@ -3285,6 +3285,7 @@ public sealed class Graphics : MarshalByRefObject, IDisposable, IDeviceContext
             callbackData,
             new HandleRef(imageAttr, imageAttr?.nativeImageAttributes ?? IntPtr.Zero)));
     }
+
     public void EnumerateMetafile(
         Metafile metafile,
         Point destPoint,
@@ -3666,6 +3667,7 @@ public sealed class Graphics : MarshalByRefObject, IDisposable, IDeviceContext
             context.Previous = _previousContext;
             _previousContext.Next = context;
         }
+
         _previousContext = context;
     }
 
@@ -3688,8 +3690,10 @@ public sealed class Graphics : MarshalByRefObject, IDisposable, IDeviceContext
                 context.Dispose();
                 return;
             }
+
             context = context.Previous;
         }
+
         Debug.Fail("Warning: context state not found!");
     }
 
@@ -3802,6 +3806,7 @@ public sealed class Graphics : MarshalByRefObject, IDisposable, IDeviceContext
                 }
             }
         }
+
         return s_halftonePalette;
     }
 

--- a/src/System.Drawing.Common/src/System/Drawing/Graphics.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Graphics.cs
@@ -3600,7 +3600,8 @@ public sealed class Graphics : MarshalByRefObject, IDisposable, IDeviceContext
                 {
                     break;
                 }
-            } while (context.IsCumulative);
+            }
+            while (context.IsCumulative);
         }
 
         if (!totalOffset.IsEmpty())

--- a/src/System.Drawing.Common/src/System/Drawing/Icon.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Icon.cs
@@ -215,6 +215,7 @@ public sealed partial class Icon : MarshalByRefObject, ICloneable, IDisposable, 
             {
                 throw new ObjectDisposedException(GetType().Name);
             }
+
             return _handle;
         }
     }
@@ -619,6 +620,7 @@ public sealed partial class Icon : MarshalByRefObject, ICloneable, IDisposable, 
                 {
                     _handle = User32.CreateIconFromResourceEx(pbAlignedBuffer, _bestBytesInRes, true, 0x00030000, 0, 0, 0);
                 }
+
                 ArrayPool<byte>.Shared.Return(alignedBuffer);
             }
             else
@@ -777,11 +779,13 @@ public sealed partial class Icon : MarshalByRefObject, ICloneable, IDisposable, 
                             {
                                 tmpBitmap.UnlockBits(bmpData);
                             }
+
                             if (bitmap is not null && targetData is not null)
                             {
                                 bitmap.UnlockBits(targetData);
                             }
                         }
+
                         tmpBitmap.Dispose();
                     }
                 }
@@ -792,6 +796,7 @@ public sealed partial class Icon : MarshalByRefObject, ICloneable, IDisposable, 
                 {
                     Gdi32.DeleteObject(info.hbmColor);
                 }
+
                 if (info.hbmMask != IntPtr.Zero)
                 {
                     Gdi32.DeleteObject(info.hbmMask);

--- a/src/System.Drawing.Common/src/System/Drawing/Icon.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Icon.cs
@@ -568,7 +568,7 @@ public sealed partial class Icon : MarshalByRefObject, ICloneable, IDisposable, 
                     int thisDelta = Math.Abs(entry.bWidth - width) + Math.Abs(entry.bHeight - height);
 
                     if ((thisDelta < bestDelta) ||
-                        (thisDelta == bestDelta && (iconBitDepth <= s_bitDepth && iconBitDepth > _bestBitDepth || _bestBitDepth > s_bitDepth && iconBitDepth < _bestBitDepth)))
+                        (thisDelta == bestDelta && ((iconBitDepth <= s_bitDepth && iconBitDepth > _bestBitDepth) || (_bestBitDepth > s_bitDepth && iconBitDepth < _bestBitDepth))))
                     {
                         fUpdateBestFit = true;
                     }

--- a/src/System.Drawing.Common/src/System/Drawing/Icon.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Icon.cs
@@ -799,7 +799,6 @@ public sealed partial class Icon : MarshalByRefObject, ICloneable, IDisposable, 
             }
         }
 
-
         if (bitmap is null)
         {
             // last chance... all the other cases (ie non 32 bpp icons coming from a handle or from the bitmapData)
@@ -828,7 +827,6 @@ public sealed partial class Icon : MarshalByRefObject, ICloneable, IDisposable, 
                     Draw(graphics, new Rectangle(0, 0, size.Width, size.Height));
                 }
             }
-
 
             // GDI+ fills the surface with a sentinel color for GetDC, but does
             // not correctly clean it up again, so we have to do it.

--- a/src/System.Drawing.Common/src/System/Drawing/Image.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Image.cs
@@ -219,6 +219,7 @@ public abstract class Image : MarshalByRefObject, IDisposable, ICloneable, ISeri
         {
             Gdip.CheckStatus(Gdip.GdipLoadImageFromStream(streamWrapper.Ptr, &image));
         }
+
         return image;
     }
 
@@ -1066,6 +1067,7 @@ public abstract class Image : MarshalByRefObject, IDisposable, ICloneable, ISeri
                         }
                     }
                 }
+
                 // possible exceptions for reading the filename
                 catch (UnauthorizedAccessException)
                 {
@@ -1076,6 +1078,7 @@ public abstract class Image : MarshalByRefObject, IDisposable, ICloneable, ISeri
                 catch (IOException)
                 {
                 }
+
                 // possible exceptions for setting/getting the position inside dataStream
                 catch (NotSupportedException)
                 {
@@ -1083,6 +1086,7 @@ public abstract class Image : MarshalByRefObject, IDisposable, ICloneable, ISeri
                 catch (ObjectDisposedException)
                 {
                 }
+
                 // possible exception when reading stuff into dataStream
                 catch (ArgumentException)
                 {

--- a/src/System.Drawing.Common/src/System/Drawing/ImageAnimator.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/ImageAnimator.cs
@@ -81,9 +81,6 @@ public sealed partial class ImageAnimator
     ///     thread calling into ImageAnimator is guarded against this problem.
     /// </summary>
 
-
-
-
     [ThreadStatic]
     private static int t_threadWriterLockWaitCount;
 

--- a/src/System.Drawing.Common/src/System/Drawing/ImageAnimator.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/ImageAnimator.cs
@@ -352,6 +352,7 @@ public sealed partial class ImageAnimator
                     {
                         s_imageInfoList.Remove(imageInfo);
                     }
+
                     break;
                 }
             }

--- a/src/System.Drawing.Common/src/System/Drawing/ImageConverter.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/ImageConverter.cs
@@ -91,6 +91,7 @@ public class ImageConverter : TypeConverter
             if (codec.FormatID.Equals(imageformat.Guid))
                 return codec;
         }
+
         return null;
     }
 

--- a/src/System.Drawing.Common/src/System/Drawing/ImageFormatConverter.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/ImageFormatConverter.cs
@@ -24,6 +24,7 @@ public class ImageFormatConverter : TypeConverter
         {
             return true;
         }
+
         return base.CanConvertTo(context, destinationType);
     }
 

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/CachedBitmap.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/CachedBitmap.cs
@@ -5,7 +5,6 @@ using System.Threading;
 
 #if NET8_0_OR_GREATER
 
-
 using static System.Drawing.SafeNativeMethods;
 
 namespace System.Drawing.Imaging;

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/ColorMap.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/ColorMap.cs
@@ -26,6 +26,7 @@ public sealed class ColorMap
         get { return _oldColor; }
         set { _oldColor = value; }
     }
+
     /// <summary>
     /// Specifies the new <see cref='Color'/> to which to convert.
     /// </summary>

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/ColorMatrix.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/ColorMatrix.cs
@@ -301,7 +301,6 @@ public sealed class ColorMatrix
         set { _matrix44 = value; }
     }
 
-
     /// <summary>
     /// Initializes a new instance of the <see cref='ColorMatrix'/> class with the elements in the specified matrix.
     /// </summary>

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/ColorMatrix.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/ColorMatrix.cs
@@ -85,6 +85,7 @@ public sealed class ColorMatrix
         get { return _matrix00; }
         set { _matrix00 = value; }
     }
+
     /// <summary>
     /// Represents the element at the 0th row and 1st column of this <see cref='ColorMatrix'/>.
     /// </summary>

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/EncoderParameter.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/EncoderParameter.cs
@@ -226,6 +226,7 @@ public sealed unsafe class EncoderParameter : IDisposable
                 dest[i] = unchecked((int)source[i]);
             }
         }
+
         GC.KeepAlive(this);
     }
 
@@ -245,6 +246,7 @@ public sealed unsafe class EncoderParameter : IDisposable
             ((int*)_parameterValue)[i * 2 + 0] = numerator[i];
             ((int*)_parameterValue)[i * 2 + 1] = denominator[i];
         }
+
         GC.KeepAlive(this);
     }
 
@@ -264,6 +266,7 @@ public sealed unsafe class EncoderParameter : IDisposable
             ((int*)_parameterValue)[i * 2 + 0] = unchecked((int)rangebegin[i]);
             ((int*)_parameterValue)[i * 2 + 1] = unchecked((int)rangeend[i]);
         }
+
         GC.KeepAlive(this);
     }
 
@@ -292,6 +295,7 @@ public sealed unsafe class EncoderParameter : IDisposable
             ((int*)_parameterValue)[i * 4 + 2] = numerator2[i];
             ((int*)_parameterValue)[i * 4 + 3] = denominator2[i];
         }
+
         GC.KeepAlive(this);
     }
 

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/FrameDimension.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/FrameDimension.cs
@@ -51,6 +51,7 @@ public sealed class FrameDimension
     {
         get { return s_page; }
     }
+
     /// <summary>
     /// Returns a value indicating whether the specified object is an <see cref='FrameDimension'/> equivalent to
     /// this <see cref='FrameDimension'/>.

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/ImageFormat.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/ImageFormat.cs
@@ -178,6 +178,7 @@ public sealed class ImageFormat
             if (codec.FormatID.Equals(_guid))
                 return codec;
         }
+
         return null;
     }
 

--- a/src/System.Drawing.Common/src/System/Drawing/Internal/GPStream.ComWrappers.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Internal/GPStream.ComWrappers.cs
@@ -55,6 +55,7 @@ internal sealed partial class GPStream : Ole32.IStream
                 {
                     return hr;
                 }
+
                 totalWritten += written;
             }
         }

--- a/src/System.Drawing.Common/src/System/Drawing/Internal/GPStream.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Internal/GPStream.cs
@@ -87,6 +87,7 @@ internal sealed partial class GPStream : Ole32.IStream
                 {
                     _virtualPosition = dlibMove;
                 }
+
                 break;
             case SeekOrigin.End:
                 if (dlibMove <= 0)
@@ -98,6 +99,7 @@ internal sealed partial class GPStream : Ole32.IStream
                 {
                     _virtualPosition = length + dlibMove;
                 }
+
                 break;
             case SeekOrigin.Current:
                 if (dlibMove + position <= length)
@@ -109,6 +111,7 @@ internal sealed partial class GPStream : Ole32.IStream
                 {
                     _virtualPosition = dlibMove + position;
                 }
+
                 break;
         }
 

--- a/src/System.Drawing.Common/src/System/Drawing/Pen.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Pen.cs
@@ -833,7 +833,6 @@ public sealed class Pen : MarshalByRefObject, ICloneable, IDisposable, ISystemCo
                 throw new ArgumentException(SR.Format(SR.CantChangeImmutableObjects, nameof(Pen)));
             }
 
-
             if (value is null || value.Length == 0)
             {
                 throw new ArgumentException(SR.InvalidDashPattern);

--- a/src/System.Drawing.Common/src/System/Drawing/Pen.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Pen.cs
@@ -240,6 +240,7 @@ public sealed class Pen : MarshalByRefObject, ICloneable, IDisposable, ISystemCo
                 default:
                     throw new InvalidEnumArgumentException(nameof(value), unchecked((int)value), typeof(LineCap));
             }
+
             if (_immutable)
             {
                 throw new ArgumentException(SR.Format(SR.CantChangeImmutableObjects, nameof(Pen)));

--- a/src/System.Drawing.Common/src/System/Drawing/Pens.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Pens.cs
@@ -318,6 +318,7 @@ public static class Pens
             Pen = new Pen(color, true);
             Gdip.ThreadData[key] = Pen;
         }
+
         return Pen;
     }
 }

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/DefaultPrintController.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/DefaultPrintController.cs
@@ -93,7 +93,6 @@ public class StandardPrintController : PrintController
             _graphics.TranslateTransform(document.DefaultPageSettings.Margins.Left, document.DefaultPageSettings.Margins.Top);
         }
 
-
         int result2 = Gdi32.StartPage(new HandleRef(_dc, _dc.Hdc));
         if (result2 <= 0)
             throw new Win32Exception();

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/DefaultPrintController.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/DefaultPrintController.cs
@@ -117,6 +117,7 @@ public class StandardPrintController : PrintController
             _graphics.Dispose(); // Dispose of GDI+ Graphics; keep the DC
             _graphics = null;
         }
+
         base.OnEndPage(document, e);
     }
 

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/Margins.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/Margins.cs
@@ -217,6 +217,7 @@ public partial class Margins : ICloneable
         {
             return m2 is null;
         }
+
         if (m2 is null)
         {
             return false;

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/MarginsConverter.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/MarginsConverter.cs
@@ -111,13 +111,17 @@ public class MarginsConverter : ExpandableObjectConverter
             }
             if (destinationType == typeof(InstanceDescriptor))
             {
-                ConstructorInfo? ctor = typeof(Margins).GetConstructor(new Type[] {
-                    typeof(int), typeof(int), typeof(int), typeof(int)});
+                ConstructorInfo? ctor = typeof(Margins).GetConstructor(new Type[]
+                {
+                    typeof(int), typeof(int), typeof(int), typeof(int)
+                });
 
                 if (ctor is not null)
                 {
-                    return new InstanceDescriptor(ctor, new object[] {
-                        margins.Left, margins.Right, margins.Top, margins.Bottom});
+                    return new InstanceDescriptor(ctor, new object[]
+                    {
+                        margins.Left, margins.Right, margins.Top, margins.Bottom
+                    });
                 }
             }
         }

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/MarginsConverter.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/MarginsConverter.cs
@@ -24,6 +24,7 @@ public class MarginsConverter : ExpandableObjectConverter
         {
             return true;
         }
+
         return base.CanConvertFrom(context, sourceType);
     }
 
@@ -37,6 +38,7 @@ public class MarginsConverter : ExpandableObjectConverter
         {
             return true;
         }
+
         return base.CanConvertTo(context, destinationType);
     }
 
@@ -66,13 +68,16 @@ public class MarginsConverter : ExpandableObjectConverter
                     // Note: ConvertFromString will raise exception if value cannot be converted.
                     values[i] = (int)intConverter.ConvertFromString(context, culture, tokens[i])!;
                 }
+
                 if (values.Length != 4)
                 {
                     throw new ArgumentException(SR.Format(SR.TextParseFailedFormat, text, "left, right, top, bottom"));
                 }
+
                 return new Margins(values[0], values[1], values[2], values[3]);
             }
         }
+
         return base.ConvertFrom(context, culture, value);
     }
 
@@ -109,6 +114,7 @@ public class MarginsConverter : ExpandableObjectConverter
 
                 return string.Join(sep, args);
             }
+
             if (destinationType == typeof(InstanceDescriptor))
             {
                 ConstructorInfo? ctor = typeof(Margins).GetConstructor(new Type[]
@@ -125,6 +131,7 @@ public class MarginsConverter : ExpandableObjectConverter
                 }
             }
         }
+
         return base.ConvertTo(context, culture, value, destinationType);
     }
 

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/PageSettings.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/PageSettings.cs
@@ -91,7 +91,6 @@ public partial class PageSettings : ICloneable
         }
     }
 
-
     /// <summary>
     /// Returns the y dimension of the hard margin.
     /// </summary>
@@ -386,7 +385,6 @@ public partial class PageSettings : ICloneable
             return result;
         }
     }
-
 
     // This function shows up big on profiles, so we need to make it fast
     internal Rectangle GetBounds(IntPtr modeHandle)

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/PageSettings.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/PageSettings.cs
@@ -87,6 +87,7 @@ public partial class PageSettings : ICloneable
             {
                 dc.Dispose();
             }
+
             return hardMarginX;
         }
     }
@@ -111,6 +112,7 @@ public partial class PageSettings : ICloneable
             {
                 dc.Dispose();
             }
+
             return hardMarginY;
         }
     }
@@ -299,6 +301,7 @@ public partial class PageSettings : ICloneable
                 mode.dmPaperLength = unchecked((short)length);
                 setLength = true;
             }
+
             if ((mode.dmFields & SafeNativeMethods.DM_PAPERWIDTH) == SafeNativeMethods.DM_PAPERWIDTH)
             {
                 int width = PrinterUnitConvert.Convert(_paperSize.Width, PrinterUnit.Display, PrinterUnit.TenthsOfAMillimeter);
@@ -314,6 +317,7 @@ public partial class PageSettings : ICloneable
                     int length = PrinterUnitConvert.Convert(_paperSize.Height, PrinterUnit.Display, PrinterUnit.TenthsOfAMillimeter);
                     mode.dmPaperLength = unchecked((short)length);
                 }
+
                 if (!setWidth)
                 {
                     mode.dmFields |= SafeNativeMethods.DM_PAPERWIDTH;
@@ -336,6 +340,7 @@ public partial class PageSettings : ICloneable
                 {
                     mode.dmPrintQuality = unchecked((short)_printerResolution.X);
                 }
+
                 if ((mode.dmFields & SafeNativeMethods.DM_YRESOLUTION) == SafeNativeMethods.DM_YRESOLUTION)
                 {
                     mode.dmYResolution = unchecked((short)_printerResolution.Y);
@@ -447,6 +452,7 @@ public partial class PageSettings : ICloneable
                     return sizes[i];
             }
         }
+
         return new PaperSize(PaperKind.Custom, "custom",
                                  //mode.dmPaperWidth, mode.dmPaperLength);
                                  PrinterUnitConvert.Convert(mode.dmPaperWidth, PrinterUnit.TenthsOfAMillimeter, PrinterUnit.Display),
@@ -468,6 +474,7 @@ public partial class PageSettings : ICloneable
                 }
             }
         }
+
         return new PaperSource((PaperSourceKind)mode.dmDefaultSource, "unknown");
     }
 
@@ -492,6 +499,7 @@ public partial class PageSettings : ICloneable
                 }
             }
         }
+
         return new PrinterResolution(PrinterResolutionKind.Custom,
                                      mode.dmPrintQuality, mode.dmYResolution);
     }

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/PreviewPrintController.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/PreviewPrintController.cs
@@ -99,6 +99,7 @@ public class PreviewPrintController : PrintController
             _graphics.TextRenderingHint = TextRenderingHint.AntiAlias;
             _graphics.SmoothingMode = SmoothingMode.AntiAlias;
         }
+
         return _graphics;
     }
 

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/PrintController.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/PrintController.cs
@@ -250,7 +250,6 @@ public abstract class PrintController
     {
         Debug.Assert((_modeHandle is not null), "modeHandle is null.  Someone must have forgot to call base.StartPrint");
 
-
         Rectangle pageBounds = pageSettings.GetBounds(_modeHandle);
         Rectangle marginBounds = new Rectangle(pageSettings.Margins.Left,
                                                pageSettings.Margins.Top,

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/PrintPageEventArgs.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/PrintPageEventArgs.cs
@@ -20,7 +20,6 @@ public class PrintPageEventArgs : EventArgs
     // Apply page settings to the printer.
     internal bool CopySettingsToDevMode = true;
 
-
     /// <summary>
     /// Initializes a new instance of the <see cref='PrintPageEventArgs'/> class.
     /// </summary>

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/PrinterResolution.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/PrinterResolution.cs
@@ -74,7 +74,6 @@ public partial class PrinterResolution
             return $"[PrinterResolution {Kind}]";
         }
 
-
         return FormattableString.Invariant($"[PrinterResolution X={X} Y={Y}]");
     }
 }

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/PrinterSettings.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/PrinterSettings.cs
@@ -323,6 +323,7 @@ public class PrinterSettings : ICloneable
             {
                 throw new ArgumentNullException(value);
             }
+
             OutputPort = value;
         }
     }
@@ -458,6 +459,7 @@ public class PrinterSettings : ICloneable
                 dc.Dispose();
             }
         }
+
         return isDirectPrintingSupported;
     }
 
@@ -504,6 +506,7 @@ public class PrinterSettings : ICloneable
                 stream.Close();
             }
         }
+
         return isDirectPrintingSupported;
     }
 
@@ -548,6 +551,7 @@ public class PrinterSettings : ICloneable
         clone._printDialogDisplayed = false;
         return clone;
     }
+
     // what is done in copytohdevmode cannot give unwanted access AllPrinting permission
     internal DeviceContext CreateDeviceContext(PageSettings pageSettings)
     {
@@ -564,6 +568,7 @@ public class PrinterSettings : ICloneable
         {
             Kernel32.GlobalFree(modeHandle);
         }
+
         return dc;
     }
 
@@ -592,6 +597,7 @@ public class PrinterSettings : ICloneable
         {
             Kernel32.GlobalFree(modeHandle);
         }
+
         return dc;
     }
 
@@ -618,6 +624,7 @@ public class PrinterSettings : ICloneable
             g.TranslateTransform(-_defaultPageSettings.HardMarginX, -_defaultPageSettings.HardMarginY);
             g.TranslateTransform(_defaultPageSettings.Margins.Left, _defaultPageSettings.Margins.Top);
         }
+
         return g;
     }
 
@@ -639,6 +646,7 @@ public class PrinterSettings : ICloneable
             g.TranslateTransform(-pageSettings.HardMarginX, -pageSettings.HardMarginY);
             g.TranslateTransform(pageSettings.Margins.Left, pageSettings.Margins.Top);
         }
+
         return g;
     }
 
@@ -823,6 +831,7 @@ public class PrinterSettings : ICloneable
         {
             throw new InvalidPrinterException(this);
         }
+
         IntPtr handle = Kernel32.GlobalAlloc(SafeNativeMethods.GMEM_MOVEABLE, (uint)modeSize); // cannot be <0 anyway
         IntPtr pointer = Kernel32.GlobalLock(handle);
 
@@ -852,6 +861,7 @@ public class PrinterSettings : ICloneable
                 Marshal.Copy(_extrainfo, 0, pointeroffset, _extrabytes);
             }
         }
+
         if ((mode.dmFields & SafeNativeMethods.DM_COPIES) == SafeNativeMethods.DM_COPIES)
         {
             if (_copies != -1)
@@ -1003,6 +1013,7 @@ public class PrinterSettings : ICloneable
                     result = defaultValue;
                     break;
             }
+
             Kernel32.GlobalUnlock(new HandleRef(this, modeHandle));
         }
         finally
@@ -1012,6 +1023,7 @@ public class PrinterSettings : ICloneable
                 Kernel32.GlobalFree(new HandleRef(this, modeHandle));
             }
         }
+
         return result;
     }
 
@@ -1048,6 +1060,7 @@ public class PrinterSettings : ICloneable
             {
                 name = name.Substring(0, index);
             }
+
             short kind = pKindsBuffer[i];
             int width = pDimensionsBuffer[i * 2];
             int height = pDimensionsBuffer[i * 2 + 1];

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/PrinterSettings.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/PrinterSettings.cs
@@ -164,8 +164,6 @@ public class PrinterSettings : ICloneable
         }
     }
 
-
-
     /// <summary>
     /// Gets the names of all printers installed on the machine.
     /// </summary>
@@ -739,7 +737,6 @@ public class PrinterSettings : ICloneable
         }
     }
 
-
     // Called by get_OutputPort
     private static string GetOutputPort()
     {
@@ -882,7 +879,6 @@ public class PrinterSettings : ICloneable
             Kernel32.GlobalUnlock(handle);
             return IntPtr.Zero;
         }
-
 
         Kernel32.GlobalUnlock(handle);
         return handle;
@@ -1292,7 +1288,6 @@ public class PrinterSettings : ICloneable
             }
         }
 
-
         bool ICollection.IsSynchronized
         {
             get
@@ -1383,7 +1378,6 @@ public class PrinterSettings : ICloneable
                 return Count;
             }
         }
-
 
         bool ICollection.IsSynchronized
         {
@@ -1583,7 +1577,6 @@ public class PrinterSettings : ICloneable
         {
             Array.Copy(_array, index, array, 0, _array.Length);
         }
-
 
         public void CopyTo(string[] strings, int index)
         {

--- a/src/System.Drawing.Common/src/System/Drawing/Region.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Region.cs
@@ -75,6 +75,7 @@ public sealed class Region : MarshalByRefObject, IDisposable
         Gdip.CheckStatus(Gdip.GdipCloneRegion(new HandleRef(this, NativeRegion), out IntPtr region));
         return new Region(region);
     }
+
     public void ReleaseHrgn(IntPtr regionHandle)
     {
         if (regionHandle == IntPtr.Zero)

--- a/src/System.Drawing.Common/src/System/Drawing/StringDigitSubstitute.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/StringDigitSubstitute.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // font style constants (sdkinc\GDIplusEnums.h)
@@ -14,4 +14,4 @@ public enum StringDigitSubstitute
     None = 1,
     National = 2,
     Traditional = 3
-};
+}

--- a/src/System.Drawing.Common/src/System/Drawing/StringFormat.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/StringFormat.cs
@@ -117,7 +117,6 @@ public sealed class StringFormat : MarshalByRefObject, ICloneable, IDisposable
         return newCloneStringFormat;
     }
 
-
     /// <summary>
     /// Gets or sets a <see cref='StringFormatFlags'/> that contains formatting information.
     /// </summary>
@@ -288,7 +287,6 @@ public sealed class StringFormat : MarshalByRefObject, ICloneable, IDisposable
 
         return tabStops;
     }
-
 
     // String trimming. How to handle more text than can be displayed
     // in the limits available.

--- a/src/System.Drawing.Common/src/System/Drawing/SystemBrushes.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/SystemBrushes.cs
@@ -65,11 +65,13 @@ public static class SystemBrushes
             systemBrushes = new Brush[(int)KnownColor.WindowText + (int)KnownColor.MenuHighlight - (int)KnownColor.YellowGreen];
             Gdip.ThreadData[s_systemBrushesKey] = systemBrushes;
         }
+
         int idx = (int)c.ToKnownColor();
         if (idx > (int)KnownColor.YellowGreen)
         {
             idx -= (int)KnownColor.YellowGreen - (int)KnownColor.WindowText;
         }
+
         idx--;
 
         Debug.Assert(idx >= 0 && idx < systemBrushes.Length, "System colors have been added but our system color array has not been expanded.");

--- a/src/System.Drawing.Common/src/System/Drawing/SystemPens.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/SystemPens.cs
@@ -72,6 +72,7 @@ public static class SystemPens
         {
             idx -= (int)KnownColor.YellowGreen - (int)KnownColor.WindowText;
         }
+
         idx--;
         Debug.Assert(idx >= 0 && idx < systemPens.Length, "System colors have been added but our system color array has not been expanded.");
 

--- a/src/System.Drawing.Common/src/System/Drawing/ToolboxBitmapAttribute.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/ToolboxBitmapAttribute.cs
@@ -140,6 +140,7 @@ public class ToolboxBitmapAttribute : Attribute
         {
             return null;
         }
+
         Icon ico = new Icon(stream);
         Icon sizedico = new Icon(ico, large ? s_largeSize : s_smallSize);
         Bitmap? b = sizedico.ToBitmap();
@@ -147,6 +148,7 @@ public class ToolboxBitmapAttribute : Attribute
         {
             DpiHelper.ScaleBitmapLogicalToDevice(ref b);
         }
+
         return b;
     }
 
@@ -204,6 +206,7 @@ public class ToolboxBitmapAttribute : Attribute
             {
                 img = new Bitmap(b, s_largeSize.Width, s_largeSize.Height);
             }
+
             if (DpiHelper.IsScalingRequired && scaled)
             {
                 b = (Bitmap)img;
@@ -211,6 +214,7 @@ public class ToolboxBitmapAttribute : Attribute
                 img = b;
             }
         }
+
         return img;
     }
 
@@ -276,14 +280,17 @@ public class ToolboxBitmapAttribute : Attribute
                     iconname = name + ".ico";
                 }
             }
+
             if (rawbmpname is not null)
             {
                 img = GetBitmapFromResource(t, rawbmpname, large, scaled);
             }
+
             if (img is null && bmpname is not null)
             {
                 img = GetBitmapFromResource(t, bmpname, large, scaled);
             }
+
             if (img is null && iconname is not null)
             {
                 img = GetIconFromResource(t, iconname, large, scaled);

--- a/src/System.Drawing.Common/src/misc/DpiHelper.cs
+++ b/src/System.Drawing.Common/src/misc/DpiHelper.cs
@@ -101,6 +101,7 @@ internal static class DpiHelper
                     s_interpolationMode = InterpolationMode.HighQualityBicubic;
                 }
             }
+
             return s_interpolationMode;
         }
     }

--- a/src/System.Drawing.Common/src/misc/GDI/WindowsRegion.cs
+++ b/src/System.Drawing.Common/src/misc/GDI/WindowsRegion.cs
@@ -51,6 +51,7 @@ internal sealed partial class WindowsRegion : MarshalByRefObject, ICloneable, ID
                 wr._ownHandle = true;
             }
         }
+
         return wr;
     }
 

--- a/src/System.Drawing.Common/tests/BitmapTests.cs
+++ b/src/System.Drawing.Common/tests/BitmapTests.cs
@@ -1410,6 +1410,7 @@ public class BitmapTests : FileCleanupTestBase
                 {
                     Assert.Equal(33, c.G);
                 }
+
                 Assert.Equal(16, c.B);
 
                 Assert.Equal(255, d.A);
@@ -1422,6 +1423,7 @@ public class BitmapTests : FileCleanupTestBase
                 {
                     Assert.Equal(49, d.G);
                 }
+
                 Assert.Equal(24, d.B);
             }
             else if (alpha)
@@ -1449,6 +1451,7 @@ public class BitmapTests : FileCleanupTestBase
                 Assert.Equal(Color.FromArgb(255, 64, 32, 16), c);
                 Assert.Equal(Color.FromArgb(255, 96, 48, 24), d);
             }
+
             BitmapData bitmapData = bitmap.LockBits(new Rectangle(0, 0, 2, 1), ImageLockMode.ReadOnly, format);
             try
             {
@@ -1506,6 +1509,7 @@ public class BitmapTests : FileCleanupTestBase
                             Assert.Equal(c.A, data[n++]);
                         }
                     }
+
                     Assert.Equal(d.B, data[n++]);
                     Assert.Equal(d.G, data[n++]);
                     Assert.Equal(d.R, data[n++]);
@@ -1735,6 +1739,7 @@ public class BitmapTests : FileCleanupTestBase
             get => _stream.Position;
             set => _stream.Position = _canSeek ? value : throw new NotSupportedException();
         }
+
         public override void Flush() => _stream.Flush();
         public override int Read(byte[] buffer, int offset, int count) => _canRead ?  _stream.Read(buffer, offset, count) : throw new NotSupportedException();
         public override long Seek(long offset, SeekOrigin origin) => _stream.Seek(offset, origin);

--- a/src/System.Drawing.Common/tests/BitmapTests.cs
+++ b/src/System.Drawing.Common/tests/BitmapTests.cs
@@ -1119,7 +1119,6 @@ public class BitmapTests : FileCleanupTestBase
         yield return new object[] { new Bitmap(100, 100, PixelFormat.Format8bppIndexed), new Rectangle(0, 0, 100, 100), ImageLockMode.ReadWrite, PixelFormat.Format8bppIndexed, 100, 3 };
         yield return new object[] { new Bitmap(100, 100, PixelFormat.Format8bppIndexed), new Rectangle(0, 0, 100, 100), ImageLockMode.WriteOnly, PixelFormat.Format8bppIndexed, 100, 2 };
 
-
         yield return new object[] { new Bitmap(184, 184, PixelFormat.Format1bppIndexed), new Rectangle(0, 0, 184, 184), ImageLockMode.ReadOnly, PixelFormat.Format1bppIndexed, 24, 1 };
         yield return new object[] { new Bitmap(184, 184, PixelFormat.Format1bppIndexed), new Rectangle(0, 0, 184, 184), ImageLockMode.ReadWrite, PixelFormat.Format1bppIndexed, 24, 3 };
         yield return new object[] { new Bitmap(184, 184, PixelFormat.Format1bppIndexed), new Rectangle(0, 0, 184, 184), ImageLockMode.WriteOnly, PixelFormat.Format1bppIndexed, 24, 2 };

--- a/src/System.Drawing.Common/tests/BufferedGraphicsContextTests.cs
+++ b/src/System.Drawing.Common/tests/BufferedGraphicsContextTests.cs
@@ -244,7 +244,6 @@ public class BufferedGraphicsContextTests
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static void AllocateBufferedGraphicsContext() => new BufferedGraphicsContext();
 
-
     [Fact]
     public void Finalize_Invoke_Success()
     {

--- a/src/System.Drawing.Common/tests/ColorTranslatorTests.cs
+++ b/src/System.Drawing.Common/tests/ColorTranslatorTests.cs
@@ -93,7 +93,6 @@ public class ColorTranslatorTests
             yield return new object[] { color, oleColor };
         }
 
-
         // These system colors are equivalent to Control, ControlLight and ControlDark.
         yield return new object[] { SystemColors.ButtonFace, unchecked((int)0x8000000F) };
         yield return new object[] { SystemColors.ButtonHighlight, unchecked((int)0x80000014) };

--- a/src/System.Drawing.Common/tests/Drawing2D/GraphicsPathTests.cs
+++ b/src/System.Drawing.Common/tests/Drawing2D/GraphicsPathTests.cs
@@ -1505,7 +1505,6 @@ public class GraphicsPathTests
         }
     }
 
-
     [Fact]
     public void SetMarkers_EmptyPath_Success()
     {

--- a/src/System.Drawing.Common/tests/Drawing2D/GraphicsPathTests.cs
+++ b/src/System.Drawing.Common/tests/Drawing2D/GraphicsPathTests.cs
@@ -1952,7 +1952,6 @@ public class GraphicsPathTests
             Assert.Equal(9, gp.PointCount);
             AssertWiden3(gp);
         }
-
     }
 
     public static IEnumerable<object[]> Widen_PenSmallWidth_TestData()

--- a/src/System.Drawing.Common/tests/Drawing2D/LinearGradientBrushTests.cs
+++ b/src/System.Drawing.Common/tests/Drawing2D/LinearGradientBrushTests.cs
@@ -177,6 +177,7 @@ public class LinearGradientBrushTests
             yield return new object[] { testData[0], testData[1], testData[2], testData[3], false };
         }
     }
+
     [Theory]
     [MemberData(nameof(Ctor_Rectangle_Angle_IsAngleScalable_TestData))]
     public void Ctor_Rectangle_Color_Color_Angle_IsAngleScalable(Rectangle rectangle, Color color1, Color color2, float angle, bool isAngleScalable)

--- a/src/System.Drawing.Common/tests/Drawing2D/MatrixTests.cs
+++ b/src/System.Drawing.Common/tests/Drawing2D/MatrixTests.cs
@@ -338,6 +338,7 @@ public partial class MatrixTests
                     Assert.Equal(expected, clone1.Elements, new FloatingPointToleranceComparerer<float>(0.00001f));
                 }
             }
+
             matrix.Multiply(multiple, order);
             Assert.Equal(expected, matrix.Elements);
         }

--- a/src/System.Drawing.Common/tests/Drawing2D/MatrixTests.cs
+++ b/src/System.Drawing.Common/tests/Drawing2D/MatrixTests.cs
@@ -661,7 +661,6 @@ public partial class MatrixTests
         }
     }
 
-
     [Theory]
     [InlineData(MatrixOrder.Prepend - 1)]
     [InlineData(MatrixOrder.Append + 1)]

--- a/src/System.Drawing.Common/tests/GdiPlusHandlesTests.cs
+++ b/src/System.Drawing.Common/tests/GdiPlusHandlesTests.cs
@@ -51,5 +51,4 @@ public static class GdiPlusHandlesTests
                 throw new XunitException($"GetGuiResources failed with win32 error: {error}");
         }
     }
-
 }

--- a/src/System.Drawing.Common/tests/GraphicsTests.Core.cs
+++ b/src/System.Drawing.Common/tests/GraphicsTests.Core.cs
@@ -217,7 +217,4 @@ public partial class GraphicsTests
             // other FillPie overloads tested in FillPie_Disposed_ThrowsArgumentException()
         }
     }
-
-
-
 }

--- a/src/System.Drawing.Common/tests/GraphicsTests.Core.cs
+++ b/src/System.Drawing.Common/tests/GraphicsTests.Core.cs
@@ -10,7 +10,6 @@ public partial class GraphicsTests
 {
     private static Matrix3x2 s_testMatrix = Matrix3x2.CreateRotation(45) * Matrix3x2.CreateScale(2) * Matrix3x2.CreateTranslation(new Vector2(10, 20));
 
-
     [Fact]
     public void TransformElements_SetNonInvertibleMatrix_ThrowsArgumentException()
     {

--- a/src/System.Drawing.Common/tests/GraphicsTests.cs
+++ b/src/System.Drawing.Common/tests/GraphicsTests.cs
@@ -2468,7 +2468,6 @@ public partial class GraphicsTests
             var pen = new Pen(Color.Red);
             pen.Dispose();
 
-
             AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawEllipse(pen, new Rectangle(0, 0, 1, 1)));
             AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawEllipse(pen, 0, 0, 1, 1));
             AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawEllipse(pen, new RectangleF(0, 0, 1, 1)));

--- a/src/System.Drawing.Common/tests/Graphics_DrawLineTests.cs
+++ b/src/System.Drawing.Common/tests/Graphics_DrawLineTests.cs
@@ -184,5 +184,4 @@ public class Graphics_DrawLineTests : DrawingTest
             AssertExtensions.Throws<ArgumentException>(null, () => graphics.DrawLines(pen, new PointF[2]));
         }
     }
-
 }

--- a/src/System.Drawing.Common/tests/Helpers.cs
+++ b/src/System.Drawing.Common/tests/Helpers.cs
@@ -65,6 +65,7 @@ public static class Helpers
                     expectedStringBuilder.Append(", ");
                 }
             }
+
             actualStringBuilder.AppendLine();
             expectedStringBuilder.AppendLine();
         }

--- a/src/System.Drawing.Common/tests/IconTests.cs
+++ b/src/System.Drawing.Common/tests/IconTests.cs
@@ -439,7 +439,6 @@ public class IconTests
         AssertExtensions.Throws<ArgumentException>("filePath", null, () => Icon.ExtractAssociatedIcon(""));
     }
 
-
     [Fact]
     public void ExtractAssociatedIcon_NoSuchPath_ThrowsFileNotFoundException()
     {

--- a/src/System.Drawing.Common/tests/IconTests.cs
+++ b/src/System.Drawing.Common/tests/IconTests.cs
@@ -608,6 +608,7 @@ public class IconTests
                 {
                     Assert.NotSame(icon.ToBitmap(), bitmap);
                 }
+
                 Assert.Equal(PixelFormat.Format32bppArgb, bitmap.PixelFormat);
                 Assert.Empty(bitmap.Palette.Entries);
                 Assert.Equal(icon.Width, bitmap.Width);
@@ -706,6 +707,7 @@ public class IconTests
                 Assert.Equal(icon1.Size, icon2.Size);
                 SaveAndCompare(icon2, false);
             }
+
             using (Icon icon3 = Icon.FromHandle(icon1.Handle))
             {
                 Assert.Equal(icon1.Handle, icon3.Handle);
@@ -723,6 +725,7 @@ public class IconTests
         {
             handle = icon1.ToBitmap().GetHicon();
         }
+
         using (Icon icon2 = Icon.FromHandle(handle))
         {
             Assert.Equal(handle, icon2.Handle);
@@ -739,12 +742,14 @@ public class IconTests
         {
             handle = icon1.ToBitmap().GetHicon();
         }
+
         using (Icon icon2 = Icon.FromHandle(handle))
         {
             Assert.Equal(handle, icon2.Handle);
             Assert.Equal(new Size(16, 16), icon2.Size);
             SaveAndCompare(icon2, false);
         }
+
         using (Icon icon3 = Icon.FromHandle(handle))
         {
             Assert.Equal(handle, icon3.Handle);
@@ -798,6 +803,7 @@ public class IconTests
                             {
                                 Assert.Equal(e.A, a.A);
                             }
+
                             Assert.Equal(e.R, a.R);
                             Assert.Equal(e.G, a.G);
                             Assert.Equal(e.B, a.B);

--- a/src/System.Drawing.Common/tests/Imaging/ColorMatrixTests.cs
+++ b/src/System.Drawing.Common/tests/Imaging/ColorMatrixTests.cs
@@ -71,14 +71,19 @@ public class ColorMatrixTests
             yield return new object[] { null, typeof(NullReferenceException) };
             yield return new object[] { new float[][] { }, typeof(IndexOutOfRangeException) };
             yield return new object[] { new float[][] { new float[] { 0.0f, 0.1f, 0.2f, 0.3f, 0.4f, 0.5f } }, typeof(IndexOutOfRangeException) };
-            yield return new object[] { new float[][] {
+            yield return new object[]
+            {
+                new float[][]
+            {
                 new float[] { 0.0f },
                 new float[] { 1.0f },
                 new float[] { 2.0f },
                 new float[] { 3.0f },
                 new float[] { 4.0f },
-                new float[] { 5.0f } }
-            , typeof(IndexOutOfRangeException) };
+                new float[] { 5.0f }
+            }
+            , typeof(IndexOutOfRangeException)
+            };
         }
     }
 
@@ -86,7 +91,8 @@ public class ColorMatrixTests
     {
         get
         {
-            return new float[][] {
+            return new float[][]
+            {
             new float[] { 0.0f, 0.1f, 0.2f, 0.3f, 0.4f},
             new float[] { 1.0f, 1.1f, 1.2f, 1.3f, 1.4f},
             new float[] { 2.0f, 2.1f, 2.2f, 2.3f, 2.4f},
@@ -106,7 +112,8 @@ public class ColorMatrixTests
     [Fact]
     public void Ctor_TooBigArraySize_MapOnly4and4Elements()
     {
-        ColorMatrix cm = new ColorMatrix(new float[][] {
+        ColorMatrix cm = new ColorMatrix(new float[][]
+        {
             new float[] { 0.0f, 0.1f, 0.2f, 0.3f, 0.4f, 0.5f },
             new float[] { 1.0f, 1.1f, 1.2f, 1.3f, 1.4f, 1.5f },
             new float[] { 2.0f, 2.1f, 2.2f, 2.3f, 2.4f, 2.5f },
@@ -145,7 +152,8 @@ public class ColorMatrixTests
     [Fact]
     public void AccessToNotExistingElement_ThrowsIndexOutOfRangeException()
     {
-        ColorMatrix cm = new ColorMatrix(new float[][] {
+        ColorMatrix cm = new ColorMatrix(new float[][]
+        {
             new float[] { 0.0f, 0.1f, 0.2f, 0.3f, 0.4f, 0.5f },
             new float[] { 1.0f, 1.1f, 1.2f, 1.3f, 1.4f, 1.5f },
             new float[] { 2.0f, 2.1f, 2.2f, 2.3f, 2.4f, 2.5f },

--- a/src/System.Drawing.Common/tests/Imaging/ImageAttributesTests.cs
+++ b/src/System.Drawing.Common/tests/Imaging/ImageAttributesTests.cs
@@ -43,7 +43,8 @@ public class ImageAttributesTests
         new float[] {0, 0, 0, 0, 0},
     });
 
-    private readonly ColorMatrix _grayMatrix = new(new float[][] {
+    private readonly ColorMatrix _grayMatrix = new(new float[][]
+    {
         new float[] {1, 0, 0, 0, 0},
         new float[] {0, 2, 0, 0, 0},
         new float[] {0, 0, 3, 0, 0},

--- a/src/System.Drawing.Common/tests/Imaging/ImageCodecInfoTests.cs
+++ b/src/System.Drawing.Common/tests/Imaging/ImageCodecInfoTests.cs
@@ -79,6 +79,7 @@ public class ImageCodecInfoTests
         {
             CheckImageCodecInfo(format, CodecName, DllName, FilenameExtension, Flags, FormatDescription, MimeType, signatureLength, mask, pattern, pattern2, encoder);
         }
+
         if (decoder is not null)
         {
             CheckImageCodecInfo(format, CodecName, DllName, FilenameExtension, Flags, FormatDescription, MimeType, signatureLength, mask, pattern, pattern2, decoder);

--- a/src/System.Drawing.Common/tests/Imaging/ImageCodecInfoTests.cs
+++ b/src/System.Drawing.Common/tests/Imaging/ImageCodecInfoTests.cs
@@ -115,46 +115,70 @@ public class ImageCodecInfoTests
     {
         get
         {
-            yield return new object[] { WMF_CSID, ImageFormat.Wmf,
-            "WMF", null, "*.WMF",
-            ImageCodecFlags.Builtin | ImageCodecFlags.Decoder | ImageCodecFlags.SupportBitmap,
-            "WMF", "image/x-wmf", 1, 1, "FF-FF-FF-FF", "D7-CD-C6-9A", null};
+            yield return new object[]
+            {
+                WMF_CSID, ImageFormat.Wmf,
+                "WMF", null, "*.WMF",
+                ImageCodecFlags.Builtin | ImageCodecFlags.Decoder | ImageCodecFlags.SupportBitmap,
+                "WMF", "image/x-wmf", 1, 1, "FF-FF-FF-FF", "D7-CD-C6-9A", null
+            };
 
-            yield return new object[] { EMF_CSID, ImageFormat.Emf,
-            "EMF", null, "*.EMF",
-            ImageCodecFlags.Builtin | ImageCodecFlags.Decoder | ImageCodecFlags.SupportBitmap,
-            "EMF", "image/x-emf", 1, 1, "00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-FF-FF-FF-FF",
-            "00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-20-45-4D-46", null};
+            yield return new object[]
+            {
+                EMF_CSID, ImageFormat.Emf,
+                "EMF", null, "*.EMF",
+                ImageCodecFlags.Builtin | ImageCodecFlags.Decoder | ImageCodecFlags.SupportBitmap,
+                "EMF", "image/x-emf", 1, 1, "00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-FF-FF-FF-FF",
+                "00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-20-45-4D-46", null
+            };
 
-            yield return new object[] { ICO_CSID, ImageFormat.Icon,
-            "ICO", null, "*.ICO",
-            ImageCodecFlags.Builtin | ImageCodecFlags.Decoder | ImageCodecFlags.SupportBitmap,
-            "ICO", "image/x-icon", 1, 1, "FF-FF-FF-FF", "00-00-01-00", null};
+            yield return new object[]
+            {
+                ICO_CSID, ImageFormat.Icon,
+                "ICO", null, "*.ICO",
+                ImageCodecFlags.Builtin | ImageCodecFlags.Decoder | ImageCodecFlags.SupportBitmap,
+                "ICO", "image/x-icon", 1, 1, "FF-FF-FF-FF", "00-00-01-00", null
+            };
 
-            yield return new object[] { TIF_CSID, ImageFormat.Tiff,
-            "TIFF", null, "*.TIF;*.TIFF",
-            ImageCodecFlags.Builtin | ImageCodecFlags.Encoder | ImageCodecFlags.Decoder | ImageCodecFlags.SupportBitmap,
-            "TIFF", "image/tiff", 1, 2, "FF-FF", "49-49", "4D-4D" };
+            yield return new object[]
+            {
+                TIF_CSID, ImageFormat.Tiff,
+                "TIFF", null, "*.TIF;*.TIFF",
+                ImageCodecFlags.Builtin | ImageCodecFlags.Encoder | ImageCodecFlags.Decoder | ImageCodecFlags.SupportBitmap,
+                "TIFF", "image/tiff", 1, 2, "FF-FF", "49-49", "4D-4D"
+            };
 
-            yield return new object[] { PNG_CSID, ImageFormat.Png,
-            "PNG", null, "*.PNG",
-            ImageCodecFlags.Builtin | ImageCodecFlags.Encoder | ImageCodecFlags.Decoder | ImageCodecFlags.SupportBitmap,
-            "PNG", "image/png", 1, 1, "FF-FF-FF-FF-FF-FF-FF-FF", "89-50-4E-47-0D-0A-1A-0A", null };
+            yield return new object[]
+            {
+                PNG_CSID, ImageFormat.Png,
+                "PNG", null, "*.PNG",
+                ImageCodecFlags.Builtin | ImageCodecFlags.Encoder | ImageCodecFlags.Decoder | ImageCodecFlags.SupportBitmap,
+                "PNG", "image/png", 1, 1, "FF-FF-FF-FF-FF-FF-FF-FF", "89-50-4E-47-0D-0A-1A-0A", null
+            };
 
-            yield return new object[] { JPG_JPEG_JPE_JFIF_CSID, ImageFormat.Jpeg,
-            "JPEG", null, "*.JPG",
-            ImageCodecFlags.Builtin | ImageCodecFlags.Encoder | ImageCodecFlags.Decoder | ImageCodecFlags.SupportBitmap,
-            "JPEG", "image/jpeg", 1, 1, "FF-FF", "FF-D8", null};
+            yield return new object[]
+            {
+                JPG_JPEG_JPE_JFIF_CSID, ImageFormat.Jpeg,
+                "JPEG", null, "*.JPG",
+                ImageCodecFlags.Builtin | ImageCodecFlags.Encoder | ImageCodecFlags.Decoder | ImageCodecFlags.SupportBitmap,
+                "JPEG", "image/jpeg", 1, 1, "FF-FF", "FF-D8", null
+            };
 
-            yield return new object[] { GIF_CSID, ImageFormat.Gif,
-            "GIF", null, "*.GIF",
-            ImageCodecFlags.Builtin | ImageCodecFlags.Encoder | ImageCodecFlags.Decoder | ImageCodecFlags.SupportBitmap,
-            "GIF", "image/gif", 1, 2, "FF-FF-FF-FF-FF-FF", "47-49-46-38-39-61", "47-49-46-38-37-61"};
+            yield return new object[]
+            {
+                GIF_CSID, ImageFormat.Gif,
+                "GIF", null, "*.GIF",
+                ImageCodecFlags.Builtin | ImageCodecFlags.Encoder | ImageCodecFlags.Decoder | ImageCodecFlags.SupportBitmap,
+                "GIF", "image/gif", 1, 2, "FF-FF-FF-FF-FF-FF", "47-49-46-38-39-61", "47-49-46-38-37-61"
+            };
 
-            yield return new object[] { BMP_DIB_RLE_CSID, ImageFormat.Bmp,
-            "BMP", null, "*.BMP",
-            ImageCodecFlags.Builtin | ImageCodecFlags.Encoder | ImageCodecFlags.Decoder | ImageCodecFlags.SupportBitmap,
-            "BMP", "image/bmp", 1, 1, "FF-FF", "42-4D", null };
+            yield return new object[]
+            {
+                BMP_DIB_RLE_CSID, ImageFormat.Bmp,
+                "BMP", null, "*.BMP",
+                ImageCodecFlags.Builtin | ImageCodecFlags.Encoder | ImageCodecFlags.Decoder | ImageCodecFlags.SupportBitmap,
+                "BMP", "image/bmp", 1, 1, "FF-FF", "42-4D", null
+            };
         }
     }
 

--- a/src/System.Drawing.Common/tests/PenTests.cs
+++ b/src/System.Drawing.Common/tests/PenTests.cs
@@ -998,6 +998,7 @@ public class PenTests
             AssertExtensions.Throws<ArgumentException>(null, () => pen.ResetTransform());
         }
     }
+
     public static IEnumerable<object[]> RotateTransform_TestData()
     {
         yield return new object[] { new Matrix(), 90, MatrixOrder.Prepend };
@@ -1380,6 +1381,7 @@ public class PenTests
         {
             Assert.Equal(new Matrix(), pen.Transform);
         }
+
         Assert.Equal(expectedWidth, pen.Width);
     }
 }

--- a/src/System.Drawing.Common/tests/Printing/PrinterSettingsTests.cs
+++ b/src/System.Drawing.Common/tests/Printing/PrinterSettingsTests.cs
@@ -576,6 +576,7 @@ public class PrinterSettingsTests
             if (printerSettings.IsValid)
                 return candidate;
         }
+
         return null;
     }
 

--- a/src/System.Drawing.Common/tests/StringFormatTests.cs
+++ b/src/System.Drawing.Common/tests/StringFormatTests.cs
@@ -426,7 +426,6 @@ public class StringFormatTests
         var format = new StringFormat();
         format.Dispose();
 
-
         AssertExtensions.Throws<ArgumentException>(null, () => format.Trimming);
         AssertExtensions.Throws<ArgumentException>(null, () => format.Trimming = StringTrimming.Word);
     }

--- a/src/System.Drawing.Common/tests/System/Drawing/FontConverterTests.cs
+++ b/src/System.Drawing.Common/tests/System/Drawing/FontConverterTests.cs
@@ -23,6 +23,7 @@ public class FontNameConverterTest
         {
             Assert.Equal("Times", converter.ConvertFrom("Times") as string);
         }
+
         Assert.True(converter.GetStandardValuesSupported(), "standard values supported");
         Assert.False(converter.GetStandardValuesExclusive(), "standard values exclusive");
     }

--- a/src/System.Drawing.Common/tests/System/Drawing/IconConverterTests.cs
+++ b/src/System.Drawing.Common/tests/System/Drawing/IconConverterTests.cs
@@ -116,7 +116,6 @@ public class IconConverterTest
         Assert.Throws<NotSupportedException>(() => _icoConv.ConvertFrom(null, CultureInfo.InvariantCulture, new SizeF(10, 10)));
         Assert.Throws<NotSupportedException>(() => _icoConv.ConvertFrom(null, CultureInfo.InvariantCulture, new object()));
 
-
         newIcon = (Icon)_icoConvFrmTD.ConvertFrom(null, CultureInfo.InvariantCulture, _iconBytes);
 
         Assert.Equal(_icon.Height, newIcon.Height);
@@ -152,7 +151,6 @@ public class IconConverterTest
 
         Assert.Equal(_iconStr, (string)_icoConvFrmTD.ConvertTo(null, CultureInfo.InvariantCulture, _icon, typeof(string)));
         Assert.Equal(_iconStr, (string)_icoConvFrmTD.ConvertTo(_icon, typeof(string)));
-
 
         newIconBytes = (byte[])_icoConvFrmTD.ConvertTo(null, CultureInfo.InvariantCulture, _icon, _iconBytes.GetType());
         Assert.Equal(_iconBytes, newIconBytes);

--- a/src/System.Drawing.Common/tests/System/Drawing/ImageConverterTests.cs
+++ b/src/System.Drawing.Common/tests/System/Drawing/ImageConverterTests.cs
@@ -244,7 +244,6 @@ public class ImageConverterTest
         propsColl = _imgConv.GetProperties(_image);
         Assert.Equal(browsablePropertiesCount, propsColl.Count);
 
-
         // Returns all properties of Image class.
         propsColl = TypeDescriptor.GetProperties(typeof(Image));
         Assert.Equal(allPropertiesCount, propsColl.Count);

--- a/src/System.Drawing.Common/tests/System/Drawing/ImageFormatConverterTests.cs
+++ b/src/System.Drawing.Common/tests/System/Drawing/ImageFormatConverterTests.cs
@@ -224,6 +224,7 @@ public class ImageFormatConverterTest
                     throw new InvalidOperationException($"Unknown GUID {iformat.Guid}.");
             }
         }
+
         Assert.True(memorybmp, "MemoryBMP");
         Assert.True(bmp, "Bmp");
         Assert.True(emf, "Emf");

--- a/src/System.Drawing.Common/tests/SystemFontsTests.cs
+++ b/src/System.Drawing.Common/tests/SystemFontsTests.cs
@@ -72,6 +72,7 @@ public class SystemFontsTests
                         throw new InvalidOperationException("The primary language ID is Chinese, however it was not able to" +
                                                             $" determine the user locale from the LCID with value: {userLangId & 0xFFFF:X4}.");
                 }
+
                 break;
             case 0x1E: // th-TH
             case 0x54: // lo-LA

--- a/src/System.Drawing.Common/tests/SystemPensTest.cs
+++ b/src/System.Drawing.Common/tests/SystemPensTest.cs
@@ -76,6 +76,7 @@ public class SystemPensTests
         {
             AssertExtensions.Throws<ArgumentException>(null, () => pen.Transform = matrix);
         }
+
         AssertExtensions.Throws<ArgumentException>(null, () => pen.Width = 10);
     }
 

--- a/src/System.Drawing.Common/tests/ToolboxBitmapAttributeTests.cs
+++ b/src/System.Drawing.Common/tests/ToolboxBitmapAttributeTests.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-
 #pragma warning disable CA1050 // Declare types in namespaces
 public class ClassWithNoNamespace { }
 #pragma warning restore CA1050

--- a/src/System.Drawing.Common/tests/mono/System.Drawing/BitmapTests.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing/BitmapTests.cs
@@ -850,7 +850,8 @@ public class TestBitmap
         }
     }
 
-    static int[] palette1 = {
+    static int[] palette1 =
+    {
         -16777216,
         -1,
     };
@@ -870,7 +871,8 @@ public class TestBitmap
         }
     }
 
-    static int[] palette16 = {
+    static int[] palette16 =
+    {
         -16777216,
         -8388608,
         -16744448,
@@ -904,7 +906,8 @@ public class TestBitmap
         }
     }
 
-    static int[] palette256 = {
+    static int[] palette256 =
+    {
         -16777216,
         -8388608,
         -16744448,

--- a/src/System.Drawing.Common/tests/mono/System.Drawing/BitmapTests.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing/BitmapTests.cs
@@ -182,6 +182,7 @@ public class TestBitmap
                 {
                     Assert.Equal(33, c.G);
                 }
+
                 Assert.Equal(16, c.B);
 
                 Assert.Equal(255, d.A);
@@ -194,6 +195,7 @@ public class TestBitmap
                 {
                     Assert.Equal(49, d.G);
                 }
+
                 Assert.Equal(24, d.B);
             }
             else if (alpha)
@@ -223,6 +225,7 @@ public class TestBitmap
                 Assert.Equal(Color.FromArgb(255, 64, 32, 16), c);
                 Assert.Equal(Color.FromArgb(255, 96, 48, 24), d);
             }
+
             BitmapData bd = bmp.LockBits(new Rectangle(0, 0, 2, 1), ImageLockMode.ReadOnly, format);
             try
             {
@@ -393,6 +396,7 @@ public class TestBitmap
         {
             sOutput.Append(arrInput[i].ToString("X2"));
         }
+
         return sOutput.ToString();
     }
 
@@ -422,6 +426,7 @@ public class TestBitmap
             return ByteArrayToString(hash);
         }
     }
+
     public string RotateIndexedBmp(Bitmap src, RotateFlipType type)
     {
         int pixels_per_byte;
@@ -513,6 +518,7 @@ public class TestBitmap
                 bmp.SetPixel(x, 78, c);
                 bmp.SetPixel(x, 79, c);
             }
+
             for (int y = 3; y < 78; y++)
             {
                 bmp.SetPixel(1, y, c);
@@ -521,6 +527,7 @@ public class TestBitmap
                 bmp.SetPixel(79, y, c);
             }
         }
+
         return bmp;
     }
 
@@ -540,6 +547,7 @@ public class TestBitmap
                 pixels[index++] = clr.B;
             }
         }
+
         return MD5.Create().ComputeHash(pixels);
     }
 
@@ -585,6 +593,7 @@ public class TestBitmap
         {
             bmp.UnlockBits(bd);
         }
+
         return MD5.Create().ComputeHash(pixels);
     }
 
@@ -807,6 +816,7 @@ public class TestBitmap
             }
         }
     }
+
     [Fact]
     public void DefaultFormat1()
     {
@@ -829,6 +839,7 @@ public class TestBitmap
         {
             Assert.Equal(ImageFormat.Png, other.RawFormat);
         }
+
         File.Delete(filename);
     }
 
@@ -865,6 +876,7 @@ public class TestBitmap
             {
                 Assert.Equal(palette1[i], pal.Entries[i].ToArgb());
             }
+
             Assert.Equal(2, pal.Flags);
         }
     }
@@ -900,6 +912,7 @@ public class TestBitmap
             {
                 Assert.Equal(palette16[i], pal.Entries[i].ToArgb());
             }
+
             Assert.Equal(0, pal.Flags);
         }
     }
@@ -1175,6 +1188,7 @@ public class TestBitmap
             {
                 Assert.Equal(palette256[i], pal.Entries[i].ToArgb());
             }
+
             Assert.Equal(4, pal.Flags);
         }
     }
@@ -1272,6 +1286,7 @@ public class BitmapFullTrustTest
                 hicon = bitmap.GetHicon();
             }
         }
+
         using (Bitmap bitmap2 = Bitmap.FromHicon(hicon))
         {
             // hicon survives bitmap and icon disposal
@@ -1293,6 +1308,7 @@ public class BitmapFullTrustTest
                 hicon = bitmap.GetHicon();
             }
         }
+
         using (Bitmap bitmap2 = Bitmap.FromHicon(hicon))
         {
             // hicon survives bitmap and icon disposal
@@ -1314,6 +1330,7 @@ public class BitmapFullTrustTest
                 hicon = bitmap.GetHicon();
             }
         }
+
         using (Bitmap bitmap2 = Bitmap.FromHicon(hicon))
         {
             // hicon survives bitmap and icon disposal
@@ -1335,6 +1352,7 @@ public class BitmapFullTrustTest
                 hicon = bitmap.GetHicon();
             }
         }
+
         using (Bitmap bitmap2 = Bitmap.FromHicon(hicon))
         {
             // hicon survives bitmap and icon disposal
@@ -1385,6 +1403,7 @@ public class BitmapFullTrustTest
             Assert.Equal(bitmap.RawFormat, ImageFormat.Bmp);
             hbitmap = bitmap.GetHbitmap();
         }
+
         // hbitmap survives original bitmap disposal
         using (Image image = Image.FromHbitmap(hbitmap))
         {
@@ -1395,6 +1414,7 @@ public class BitmapFullTrustTest
             Assert.Equal(335888, image.Flags);
             Assert.Equal(image.RawFormat, ImageFormat.MemoryBmp);
         }
+
         using (Image image2 = Image.FromHbitmap(hbitmap))
         {
             //Assert.Equal (PixelFormat.Format32bppRgb, image2.PixelFormat);

--- a/src/System.Drawing.Common/tests/mono/System.Drawing/BitmapTests.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing/BitmapTests.cs
@@ -396,7 +396,6 @@ public class TestBitmap
         return sOutput.ToString();
     }
 
-
     public string RotateBmp(Bitmap src, RotateFlipType rotate)
     {
         int width = 150, height = 150, index = 0;
@@ -482,7 +481,6 @@ public class TestBitmap
             return ByteArrayToString(hash);
         }
     }
-
 
     // Rotate bitmap in diffent ways, and check the result
     // pixels using MD5

--- a/src/System.Drawing.Common/tests/mono/System.Drawing/GraphicsTests.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing/GraphicsTests.cs
@@ -314,7 +314,6 @@ public class GraphicsTest : IDisposable
             g.SmoothingMode = SmoothingMode.AntiAlias;
             g.TextRenderingHint = TextRenderingHint.ClearTypeGridFit;
 
-
             state_modified = g.Save(); // Modified
 
             g.CompositingMode = CompositingMode.SourceOver;
@@ -454,7 +453,6 @@ public class GraphicsTest : IDisposable
             Assert.Throws<ArgumentException>(() => g.Transform = matrix);
         }
     }
-
 
     [Fact]
     public void Multiply_NonInvertibleMatrix()

--- a/src/System.Drawing.Common/tests/mono/System.Drawing/GraphicsTests.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing/GraphicsTests.cs
@@ -383,6 +383,7 @@ public class GraphicsTest : IDisposable
             Graphics = Graphics.FromImage(_bitmap);
             Graphics.Clip = new Region(new Rectangle(0, 0, width, height));
         }
+
         public void Dispose() { Graphics.Dispose(); _bitmap.Dispose(); }
     }
 
@@ -1309,6 +1310,7 @@ public class GraphicsTest : IDisposable
                 g.Clip = new Region(rect);
                 g.FillRectangle(Brushes.Red, rect);
             }
+
             Assert.Equal(Color.Red.ToArgb(), bitmap.GetPixel(5, 5).ToArgb());
             Assert.Equal(Color.Red.ToArgb(), bitmap.GetPixel(14, 5).ToArgb());
             Assert.Equal(Color.Red.ToArgb(), bitmap.GetPixel(5, 14).ToArgb());
@@ -1340,6 +1342,7 @@ public class GraphicsTest : IDisposable
                 g.DrawRectangle(Pens.Blue, rect);
             }
         }
+
         return bitmap;
     }
 
@@ -1509,8 +1512,10 @@ public class GraphicsTest : IDisposable
             {
                 g.DrawRectangle(Pens.Blue, rect);
             }
+
             g.FillRectangle(Brushes.Green, rect);
         }
+
         return bitmap;
     }
 
@@ -1662,6 +1667,7 @@ public class GraphicsTest : IDisposable
                 g.DrawLines(Pens.Blue, pts);
             }
         }
+
         return bitmap;
     }
 
@@ -2352,6 +2358,7 @@ public class GraphicsTest : IDisposable
             Assert.Throws<ArgumentException>(() => g.ReleaseHdcInternal(hdc));
         }
     }
+
     [Fact]
     public void TestReleaseHdc()
     {
@@ -2387,6 +2394,7 @@ public class GraphicsTest : IDisposable
             Assert.Throws<ArgumentException>(() => g.ReleaseHdc());
         }
     }
+
     [ConditionalFact]
     public void VisibleClipBound()
     {
@@ -3289,6 +3297,7 @@ public class GraphicsTest : IDisposable
                 x = g.DpiX - 10;
                 y = g.DpiY + 10;
             }
+
             bmp.SetResolution(x, y);
             using (Graphics g = Graphics.FromImage(bmp))
             {

--- a/src/System.Drawing.Common/tests/mono/System.Drawing/GraphicsTests.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing/GraphicsTests.cs
@@ -2699,8 +2699,10 @@ public class GraphicsTest : IDisposable
         using (Bitmap bmp = new Bitmap(40, 40))
         using (Graphics g = Graphics.FromImage(bmp))
         {
-            g.DrawImage(bmp, new PointF[] {
-                    new(0, 0), new(1, 1), new(2, 2) });
+            g.DrawImage(bmp, new PointF[]
+            {
+                    new(0, 0), new(1, 1), new(2, 2)
+            });
         }
     }
 
@@ -2787,8 +2789,10 @@ public class GraphicsTest : IDisposable
         using (Bitmap bmp = new Bitmap(40, 40))
         using (Graphics g = Graphics.FromImage(bmp))
         {
-            g.DrawImage(bmp, new Point[] {
-                    new(0, 0), new(1, 1), new(2, 2) });
+            g.DrawImage(bmp, new Point[]
+            {
+                    new(0, 0), new(1, 1), new(2, 2)
+            });
         }
     }
 

--- a/src/System.Drawing.Common/tests/mono/System.Imaging/MetafileTest.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Imaging/MetafileTest.cs
@@ -344,6 +344,7 @@ public class MetafileFulltrustTest
                     g.ReleaseHdc(hdc);
                 }
             }
+
             long size = 0;
             using (Graphics g = Graphics.FromImage(mf))
             {
@@ -359,6 +360,7 @@ public class MetafileFulltrustTest
                     g.DrawRectangle(Pens.Azure, 10, 10, 80, 80);
                 }
             }
+
             mf.Dispose();
             Assert.Equal(size, new FileInfo(filename).Length);
         }
@@ -383,6 +385,7 @@ public class MetafileFulltrustTest
                 g.ReleaseHdc(hdc);
             }
         }
+
         using (Graphics g = Graphics.FromImage(mf))
         {
             string text = "this\nis a test";
@@ -425,6 +428,7 @@ public class MetafileFulltrustTest
                     g.ReleaseHdc(hdc);
                 }
             }
+
             using (Graphics g = Graphics.FromImage(mf))
             {
                 Assert.True(g.Transform.IsIdentity);
@@ -455,6 +459,7 @@ public class MetafileFulltrustTest
                 g.ResetTransform();
                 Assert.True(g.Transform.IsIdentity);
             }
+
             mf.Dispose();
         }
     }


### PR DESCRIPTION
Fix #10285

This is mostly whitespace changes.

## Proposed changes

- Activate and fix SA1500 and SA1508 in System.Drawing.Common
- Activate and fix SA1507 in System.Drawing.Common
- Activate and fix SA1513 in System.Drawing.Common
- Activate and fix SA1408 in System.Drawing.Common
- Activate SA1129
