### PR TITLE
fix bug Painting bug in IconEditor

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/IconEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/IconEditor.cs
@@ -119,12 +119,14 @@ public class IconEditor : UITypeEditor
         if (icon.Width < rectangle.Width)
         {
             rectangle.X = (rectangle.Width - icon.Width) / 2;
+            rectangle.X += (rectangle.Width - icon.Width) / 2;
             rectangle.Width = icon.Width;
         }
 
         if (icon.Height < rectangle.Height)
         {
             rectangle.X = (rectangle.Height - icon.Height) / 2;
+            rectangle.Y += (rectangle.Height - icon.Height) / 2;
             rectangle.Height = icon.Height;
         }
 

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/IconEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/IconEditor.cs
@@ -118,14 +118,12 @@ public class IconEditor : UITypeEditor
         Rectangle rectangle = e.Bounds;
         if (icon.Width < rectangle.Width)
         {
-            rectangle.X = (rectangle.Width - icon.Width) / 2;
             rectangle.X += (rectangle.Width - icon.Width) / 2;
             rectangle.Width = icon.Width;
         }
 
         if (icon.Height < rectangle.Height)
         {
-            rectangle.X = (rectangle.Height - icon.Height) / 2;
             rectangle.Y += (rectangle.Height - icon.Height) / 2;
             rectangle.Height = icon.Height;
         }


### PR DESCRIPTION
Fix #[5092](https://github.com/dotnet/winforms/issues/5092)



## Regression? 

-  No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

The icon property of the NotifyIcon control cannot be modified

![image](https://github.com/dotnet/winforms/assets/135201996/508ef7ce-81df-40e3-8e43-6b16303831f4)

### After
The icon property of the NotifyIcon control can be modified

![image](https://github.com/dotnet/winforms/assets/135201996/684d1385-6983-4004-b410-9d7f869796cd)



## Test methodology <!-- How did you ensure quality? -->

- Manually (Verified in Scratch project)


## Test environment(s) <!-- Remove any that don't apply -->

- .net 9.0.0-alpha.1.23510.12


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10131)