### PR TITLE
Always Query for IUnknown when Comparing AgileComPointer for Identity

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/Foundation/AgileComPointer.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/Foundation/AgileComPointer.cs
@@ -57,8 +57,12 @@ internal unsafe class AgileComPointer<TInterface> :
     /// </summary>
     public bool IsSameNativeObject(AgileComPointer<TInterface> other)
     {
-        // There is a chance that we have a proxy. In order to determine
-        // identity we need to query for IUnknown and compare their values.
+        // There is a chance that this AgileComPointer or the other has a proxy registered to the GIT.
+        // A proxy's value can differ depending on the thread. In order to determine identity between two COM pointers,
+        // both must be registered in GIT (this is already done when initializing an AgileComPointer),
+        // queried for their IUnknowns on the same thread, and then have their values compared.
+        // If two proxies refer to the same native object, querying them for IUnknown
+        // on the same thread will always give the same value.
         using var currentUnknown = GetInterface<IUnknown>();
         using var otherUnknown = other.GetInterface<IUnknown>();
         return currentUnknown.Value == otherUnknown.Value;

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/Windows/Win32/AgileComPointerTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/Windows/Win32/AgileComPointerTests.cs
@@ -5,10 +5,10 @@ using Windows.Win32.System.Com;
 
 namespace System.Windows.Forms.Primitives.Tests.Windows.Win32;
 
-public unsafe class AgileComPointerTests
+public class AgileComPointerTests
 {
     [Fact]
-    public void AgileComPointer_CheckRefCounts()
+    public unsafe void AgileComPointer_CheckRefCounts()
     {
         IStream* stream = ComHelpers.GetComPointer<IStream>(new GlobalInterfaceTableTests.MyStream());
 
@@ -23,5 +23,28 @@ public unsafe class AgileComPointerTests
 
         count = stream->Release();
         Assert.Equal(0u, count);
+    }
+
+    [StaFact]
+    public async Task AgileComPointer_IsSameNativeObject_True_ForMultiThread()
+    {
+        using AgileComPointer<IStream> agileStream = CreateMyStreamAgileComPointer();
+        using AgileComPointer<IStream> agileStream2 = await CloneFromDifferentThread(agileStream);
+        Assert.True(agileStream.IsSameNativeObject(agileStream2));
+
+        unsafe AgileComPointer<IStream> CreateMyStreamAgileComPointer()
+        {
+            GlobalInterfaceTableTests.MyStream myStream = new();
+            AgileComPointer<IStream> agile = new(ComHelpers.GetComPointer<IStream>(myStream), takeOwnership: true);
+            return agile;
+        }
+
+        unsafe Task<AgileComPointer<IStream>> CloneFromDifferentThread(AgileComPointer<IStream> stream)
+        {
+            return Task.Run(() =>
+            {
+                return new AgileComPointer<IStream>(stream.GetInterface(), takeOwnership: true);
+            });
+        }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
@@ -2045,22 +2045,22 @@ public unsafe partial class AccessibleObject :
             return null;
         }
 
+        AgileComPointer<UIA.IAccessible> agileAccessible =
+#if DEBUG
+            // AccessibleObject is not disposable so we shouldn't be tracking it.
+            new(accessible, takeOwnership: true, trackDisposal: false);
+#else
+            new(accessible, takeOwnership: true);
+#endif
         // Check to see if this object already wraps the given pointer.
         if (SystemIAccessible is { } systemAccessible
-            && systemAccessible.IsSameNativeObject(accessible))
+            && systemAccessible.IsSameNativeObject(agileAccessible))
         {
-            accessible->Release();
+            agileAccessible.Dispose();
             return this;
         }
 
-        return new AccessibleObject(
-#if DEBUG
-            // AccessibleObject is not disposable so we shouldn't be tracking it.
-            new AgileComPointer<UIA.IAccessible>(accessible, takeOwnership: true, trackDisposal: false)
-#else
-            new AgileComPointer<UIA.IAccessible>(accessible, takeOwnership: true)
-#endif
-            );
+        return new AccessibleObject(agileAccessible);
     }
 
     [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxContainer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxContainer.cs
@@ -636,19 +636,14 @@ public abstract partial class AxHost
 
         HRESULT IOleInPlaceFrame.Interface.SetActiveObject(IOleInPlaceActiveObject* pActiveObject, PCWSTR pszObjName)
         {
-            if (_siteUIActive is { } activeHost
-                && activeHost._iOleInPlaceActiveObjectExternal is { } existing
-                && !existing.IsSameNativeObject(pActiveObject))
+            if (_siteUIActive is { } activeHost)
             {
-                // Release the field before disposing to avoid accessing it during disposal on callbacks.
-                activeHost._iOleInPlaceActiveObjectExternal = null;
-                existing.Dispose();
+                var existing = activeHost._iOleInPlaceActiveObjectExternal;
+                activeHost._iOleInPlaceActiveObjectExternal = pActiveObject is null
+                    ? null
+                    : new(pActiveObject, takeOwnership: false);
 
-                if (pActiveObject is not null)
-                {
-                    pActiveObject->AddRef();
-                    activeHost._iOleInPlaceActiveObjectExternal = new(pActiveObject, takeOwnership: true);
-                }
+                existing?.Dispose();
             }
 
             if (pActiveObject is null)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/HtmlDocument.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/HtmlDocument.cs
@@ -25,6 +25,7 @@ public sealed unsafe partial class HtmlDocument
 
     private readonly AgileComPointer<IHTMLDocument2> _htmlDocument2;
     private readonly HtmlShimManager _shimManager;
+    private readonly int _hashCode;
 
     internal HtmlDocument(HtmlShimManager shimManager, IHTMLDocument* doc)
     {
@@ -36,6 +37,8 @@ public sealed unsafe partial class HtmlDocument
         _htmlDocument2 = new(htmlDoc2, takeOwnership: true);
 #endif
         Debug.Assert(NativeHtmlDocument2 is not null, "The document should implement IHtmlDocument2");
+        using var scope = _htmlDocument2.GetInterface<IUnknown>();
+        _hashCode = HashCode.Combine((nint)scope.Value);
 
         _shimManager = shimManager;
     }
@@ -690,7 +693,7 @@ public sealed unsafe partial class HtmlDocument
 
     public static bool operator !=(HtmlDocument? left, HtmlDocument? right) => !(left == right);
 
-    public override int GetHashCode() => _htmlDocument2.GetHashCode();
+    public override int GetHashCode() => _hashCode;
 
     public override bool Equals(object? obj) => this == (HtmlDocument?)obj;
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/HtmlElement.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/HtmlElement.cs
@@ -33,6 +33,7 @@ public sealed unsafe partial class HtmlElement
 
     private readonly AgileComPointer<IHTMLElement> _htmlElement;
     private readonly HtmlShimManager _shimManager;
+    private readonly int _hashCode;
 
     internal HtmlElement(HtmlShimManager shimManager, IHTMLElement* element)
     {
@@ -42,6 +43,8 @@ public sealed unsafe partial class HtmlElement
         _htmlElement = new(element, takeOwnership: true);
 #endif
         Debug.Assert(NativeHtmlElement is not null, "The element object should implement IHTMLElement");
+        using var scope = _htmlElement.GetInterface<IUnknown>();
+        _hashCode = HashCode.Combine((nint)scope.Value);
 
         _shimManager = shimManager;
     }
@@ -806,7 +809,7 @@ public sealed unsafe partial class HtmlElement
 
     public static bool operator !=(HtmlElement? left, HtmlElement? right) => !(left == right);
 
-    public override int GetHashCode() => _htmlElement.GetHashCode();
+    public override int GetHashCode() => _hashCode;
 
     public override bool Equals(object? obj) => this == (obj as HtmlElement);
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/HtmlWindow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/HtmlWindow.cs
@@ -20,6 +20,7 @@ public sealed unsafe partial class HtmlWindow
 
     private readonly HtmlShimManager _shimManager;
     private readonly AgileComPointer<IHTMLWindow2> _htmlWindow2;
+    private readonly int _hashCode;
 
     internal HtmlWindow(HtmlShimManager shimManager, IHTMLWindow2* window)
     {
@@ -29,6 +30,8 @@ public sealed unsafe partial class HtmlWindow
         _htmlWindow2 = new(window, takeOwnership: true);
 #endif
         Debug.Assert(NativeHtmlWindow is not null, "The window object should implement IHTMLWindow2");
+        using var scope = _htmlWindow2.GetInterface<IUnknown>();
+        _hashCode = HashCode.Combine((nint)scope.Value);
 
         _shimManager = shimManager;
     }
@@ -471,7 +474,7 @@ public sealed unsafe partial class HtmlWindow
 
     public static bool operator !=(HtmlWindow? left, HtmlWindow? right) => !(left == right);
 
-    public override int GetHashCode() => _htmlWindow2.GetHashCode();
+    public override int GetHashCode() => _hashCode;
 
     public override bool Equals(object? obj) => this == (HtmlWindow?)obj;
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/HtmlWindowTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/HtmlWindowTests.cs
@@ -62,6 +62,33 @@ public class HtmlWindowTests
         domWindow.Should().BeAssignableTo<IHTMLWindow4.Interface>();
     }
 
+    [WinFormsFact]
+    public async Task HtmlWindow_NavigateAround_MaintainsEquality()
+    {
+        using var parent = new Control();
+        using var control = new WebBrowser
+        {
+            Parent = parent,
+        };
+
+        string Html =
+            $"""
+            <html>
+                <frameset rows="1,1,1" cols="1">
+                    <frame id="1" name="1">
+                    <frame id="2" name="2">
+                </frameset>
+            </html>
+            """;
+
+        HtmlDocument document = await GetDocument(control, Html);
+        HtmlWindow window = document.Window;
+        window.Should().Be(document.Window);
+        window.Should().Be(document.GetElementById("1").Parent.Document.Window);
+        window.Should().Be(window.Frames[0].Parent.Document.Window);
+        window.Should().Be(window.Frames[1].Parent.Document.Window);
+    }
+
     private static async Task<HtmlDocument> GetDocument(WebBrowser control, string html)
     {
         var source = new TaskCompletionSource<bool>();


### PR DESCRIPTION
Fixes #10261

When obtaining a COM pointer to an object that was created on a different thread, we get a proxy so we cannot just directly compare for identity like we had been doing with maintaining `_originalObject` in `AgileComPointer`. If we want to know identity, we need to register the COM pointers in the GIT, query for the IUnknowns on the _same_ thread, and then compare the values.

As a consequence of this, updated `GetHashCode()` on HTMLX. We can no longer get the hashcode the same manner we were doing so before (getting the interface and using the value) because it would change depending on the thread if we had an AgileComPointer created from a proxy. So, we will now get the initial value of the `AgileComPointer` and use that for the hash code to make it constant. 

Added a regression test for this specific scenario that issue outlines, but also added a general test to categorize this a bit more in `AgileComPointerTest` - this test was failing before changes.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10318)