### PR TITLE
Refactor `RichTextBox.Find` to use `EM_FINDTEXT` when checking for kashida

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/RichTextBox/RichTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/RichTextBox/RichTextBox.cs
@@ -8,12 +8,11 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Windows.Forms.Layout;
 using Microsoft.Win32;
-using RichEdit = Windows.Win32.UI.Controls.RichEdit;
+using Windows.Win32.UI.Controls.Dialogs;
+using Windows.Win32.UI.Controls.RichEdit;
 using static Interop;
 using static Interop.Richedit;
-using Windows.Win32.UI.Controls.RichEdit;
-using Windows.Win32.UI.Controls.Dialogs;
-using System.Runtime.CompilerServices;
+using RichEdit = Windows.Win32.UI.Controls.RichEdit;
 
 namespace System.Windows.Forms;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/RichTextBox/RichTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/RichTextBox/RichTextBox.cs
@@ -292,7 +292,7 @@ public partial class RichTextBox : TextBoxBase
                 Debug.Assert(versionInfo is not null && !string.IsNullOrEmpty(versionInfo.ProductVersion), "Couldn't get the version info for the richedit dll");
                 if (versionInfo is not null && !string.IsNullOrEmpty(versionInfo.ProductVersion))
                 {
-                    //Note: this only allows for one digit version
+                    // Note: this only allows for one digit version
                     if (int.TryParse(versionInfo.ProductVersion.AsSpan(0, 1), out int parsedValue))
                     {
                         s_richEditMajorVersion = parsedValue;
@@ -445,7 +445,7 @@ public partial class RichTextBox : TextBoxBase
     {
         Size scrollBarPadding = Size.Empty;
 
-        //If the RTB is multiline, we won't have a horizontal scrollbar.
+        // If the RTB is multiline, we won't have a horizontal scrollbar.
         if (!WordWrap && Multiline && (ScrollBars & RichTextBoxScrollBars.Horizontal) != 0)
         {
             scrollBarPadding.Height += SystemInformation.HorizontalScrollBarHeight;
@@ -531,7 +531,7 @@ public partial class RichTextBox : TextBoxBase
     ///  Redo's their last Undone operation. If no operation can be redone,
     ///  an empty string ("") is returned.
     /// </summary>
-    //NOTE: This is overridable, because we want people to be able to
+    // NOTE: This is overridable, because we want people to be able to
     //      mess with the names if necessary...?
     [SRCategory(nameof(SR.CatBehavior))]
     [Browsable(false)]
@@ -551,7 +551,7 @@ public partial class RichTextBox : TextBoxBase
         }
     }
 
-    //Description: Specifies whether rich text formatting keyboard shortcuts are enabled.
+    // Description: Specifies whether rich text formatting keyboard shortcuts are enabled.
     [DefaultValue(true)]
     [Browsable(false)]
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -717,7 +717,7 @@ public partial class RichTextBox : TextBoxBase
         }
         set
         {
-            //valid values are 0x0 to 0x2
+            // valid values are 0x0 to 0x2
             SourceGenerated.EnumValidator.Validate(value);
 
             ForceHandleCreate();
@@ -927,8 +927,8 @@ public partial class RichTextBox : TextBoxBase
         }
         set
         {
-            //Note: don't compare the value to the old value here: it's possible that
-            //you have a different range selected.
+            // Note: don't compare the value to the old value here: it's possible that
+            // you have a different range selected.
             _selectionBackColorToSetOnHandleCreated = value;
             if (IsHandleCreated)
             {
@@ -1429,7 +1429,7 @@ public partial class RichTextBox : TextBoxBase
     ///  Undo's their last operation. If no operation can be undone, it will
     ///  return an empty string ("").
     /// </summary>
-    //NOTE: This is overridable, because we want people to be able to
+    // NOTE: This is overridable, because we want people to be able to
     //      mess with the names if necessary...?
     [SRCategory(nameof(SR.CatBehavior))]
     [Browsable(false)]
@@ -1640,8 +1640,8 @@ public partial class RichTextBox : TextBoxBase
     public bool CanPaste(DataFormats.Format clipFormat)
         => PInvoke.SendMessage(this, PInvoke.EM_CANPASTE, (WPARAM)clipFormat.Id) != 0;
 
-    //DrawToBitmap doesn't work for this control, so we should hide it.  We'll
-    //still call base so that this has a chance to work if it can.
+    // DrawToBitmap doesn't work for this control, so we should hide it.  We'll
+    // still call base so that this has a chance to work if it can.
     [EditorBrowsable(EditorBrowsableState.Never)]
     public new void DrawToBitmap(Bitmap bitmap, Rectangle targetBounds)
     {
@@ -2333,7 +2333,7 @@ public partial class RichTextBox : TextBoxBase
     /// </summary>
     public void LoadFile(string path, RichTextBoxStreamType fileType)
     {
-        //valid values are 0x0 to 0x4
+        // valid values are 0x0 to 0x4
         SourceGenerated.EnumValidator.Validate(fileType, nameof(fileType));
 
         Stream file = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
@@ -2644,7 +2644,7 @@ public partial class RichTextBox : TextBoxBase
     /// </summary>
     public void Redo() => PInvoke.SendMessage(this, PInvoke.EM_REDO);
 
-    //NOTE: Undo is implemented on TextBox
+    // NOTE: Undo is implemented on TextBox
 
     /// <summary>
     ///  Saves the contents of a RichTextBox control to a file.
@@ -2659,7 +2659,7 @@ public partial class RichTextBox : TextBoxBase
     /// </summary>
     public void SaveFile(string path, RichTextBoxStreamType fileType)
     {
-        //valid values are 0x0 to 0x4
+        // valid values are 0x0 to 0x4
         SourceGenerated.EnumValidator.Validate(fileType, nameof(fileType));
 
         Stream file = File.Create(path);
@@ -3157,8 +3157,8 @@ public partial class RichTextBox : TextBoxBase
         PInvoke.DragAcceptFiles(this, fAccept: false);
     }
 
-    //Note: RichTextBox doesn't work like other controls as far as setting ForeColor/
-    //BackColor -- you need to send messages to update the colors
+    // Note: RichTextBox doesn't work like other controls as far as setting ForeColor/
+    // BackColor -- you need to send messages to update the colors
     private void UserPreferenceChangedHandler(object o, UserPreferenceChangedEventArgs e)
     {
         if (IsHandleCreated)
@@ -3495,7 +3495,7 @@ public partial class RichTextBox : TextBoxBase
                 break;
 
             case PInvoke.WM_SETCURSOR:
-                //NOTE: RichTextBox uses the WM_SETCURSOR message over links to allow us to
+                // NOTE: RichTextBox uses the WM_SETCURSOR message over links to allow us to
                 //      change the cursor to a hand. It does this through a synchronous notification
                 //      message. So we have to pass the message to the DefWndProc first, and
                 //      then, if we receive a notification message in the meantime (indicated by
@@ -3545,10 +3545,10 @@ public partial class RichTextBox : TextBoxBase
                 break;
 
             case PInvoke.WM_RBUTTONUP:
-                //since RichEdit eats up the WM_CONTEXTMENU message, we need to force DefWndProc
-                //to spit out this message again on receiving WM_RBUTTONUP message. By setting UserMouse
-                //style to true, we effectively let the WmMouseUp method in Control.cs to generate
-                //the WM_CONTEXTMENU message for us.
+                // since RichEdit eats up the WM_CONTEXTMENU message, we need to force DefWndProc
+                // to spit out this message again on receiving WM_RBUTTONUP message. By setting UserMouse
+                // style to true, we effectively let the WmMouseUp method in Control.cs to generate
+                // the WM_CONTEXTMENU message for us.
                 bool oldStyle = GetStyle(ControlStyles.UserMouse);
                 SetStyle(ControlStyles.UserMouse, true);
                 base.WndProc(ref m);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/RichTextBox/RichTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/RichTextBox/RichTextBox.cs
@@ -1841,7 +1841,7 @@ public partial class RichTextBox : TextBoxBase
             //represent Arabic characters and _ represents a kashida).  We should highlight the text
             //including the kashida.
             char kashida = (char)0x640;
-            string kashidaString = kashida.ToString();
+            ReadOnlySpan<char> kashidaString = [kashida];
             int startIndex = FindInternal(kashidaString, position, position + str.Length, options);
             if (startIndex == -1)
             {
@@ -1872,10 +1872,8 @@ public partial class RichTextBox : TextBoxBase
         return position;
     }
 
-    private unsafe int FindInternal(string str, int start, int end, RichTextBoxFinds options)
+    private unsafe int FindInternal(ReadOnlySpan<char> str, int start, int end, RichTextBoxFinds options)
     {
-        ArgumentNullException.ThrowIfNull(str);
-
         int textLen = TextLength;
         ArgumentOutOfRangeException.ThrowIfNegative(start);
         ArgumentOutOfRangeException.ThrowIfGreaterThan(start, textLen);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/RichTextBox/RichTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/RichTextBox/RichTextBox.cs
@@ -274,8 +274,7 @@ public partial class RichTextBox : TextBoxBase
             // Check for library
             if (s_moduleHandle == IntPtr.Zero)
             {
-                string richEditControlDllVersion = Libraries.RichEdit41;
-                s_moduleHandle = PInvoke.LoadLibraryFromSystemPathIfAvailable(richEditControlDllVersion);
+                s_moduleHandle = PInvoke.LoadLibraryFromSystemPathIfAvailable(Libraries.RichEdit41);
 
                 int lastWin32Error = Marshal.GetLastWin32Error();
 
@@ -284,7 +283,7 @@ public partial class RichTextBox : TextBoxBase
                 // This fails on 3-GB mode, (once the dll is loaded above 3GB memory space)
                 if ((ulong)s_moduleHandle < (ulong)32)
                 {
-                    throw new Win32Exception(lastWin32Error, string.Format(SR.LoadDLLError, richEditControlDllVersion));
+                    throw new Win32Exception(lastWin32Error, string.Format(SR.LoadDLLError, Libraries.RichEdit41));
                 }
 
                 string path = PInvoke.GetModuleFileNameLongPath(new HINSTANCE(s_moduleHandle));
@@ -1840,7 +1839,7 @@ public partial class RichTextBox : TextBoxBase
             //that's not semantically meaningful.  Searching for ABC might find AB_C (where A,B, and C
             //represent Arabic characters and _ represents a kashida).  We should highlight the text
             //including the kashida.
-            char kashida = (char)0x640;
+            const char kashida = (char)0x640;
             ReadOnlySpan<char> kashidaString = [kashida];
             int startIndex = FindInternal(kashidaString, position, position + str.Length, options);
             if (startIndex == -1)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/RichTextBox/RichTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/RichTextBox/RichTextBox.cs
@@ -1821,6 +1821,8 @@ public partial class RichTextBox : TextBoxBase
     /// </summary>
     public unsafe int Find(string str, int start, int end, RichTextBoxFinds options)
     {
+        ArgumentNullException.ThrowIfNull(str);
+
         // Perform the find, will return ubyte position
         int position = FindInternal(str, start, end, options);
 

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/RichTextBoxes.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/RichTextBoxes.Designer.cs
@@ -43,7 +43,8 @@ partial class RichTextBoxes
         this.richTextBox1.Size = new System.Drawing.Size(455, 104);
         this.richTextBox1.TabIndex = 0;
         this.richTextBox1.Text = "";
-        this.richTextBox1.LinkClicked += new System.Windows.Forms.LinkClickedEventHandler(this.richTextBox1_LinkClicked);
+        this.richTextBox1.KeyDown += new System.Windows.Forms.KeyEventHandler(this.RichTextKeyDown);
+        this.richTextBox1.LinkClicked += new System.Windows.Forms.LinkClickedEventHandler(this.LinkClicked);
         // 
         // richTextBox2
         // 
@@ -53,7 +54,8 @@ partial class RichTextBoxes
         this.richTextBox2.Size = new System.Drawing.Size(455, 99);
         this.richTextBox2.TabIndex = 1;
         this.richTextBox2.Text = "";
-        this.richTextBox2.LinkClicked += new System.Windows.Forms.LinkClickedEventHandler(this.richTextBox2_LinkClicked);
+        this.richTextBox2.KeyDown += new System.Windows.Forms.KeyEventHandler(this.RichTextKeyDown);
+        this.richTextBox2.LinkClicked += new System.Windows.Forms.LinkClickedEventHandler(this.LinkClicked);
         // 
         // RichTextBoxes
         // 

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/RichTextBoxes.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/RichTextBoxes.cs
@@ -25,6 +25,7 @@ public partial class RichTextBoxes : Form
 \pard\sa200\sl276\slmult1\f0\fs22\lang9  for more information.\par
 This is a \v #data#\v0 custom link with hidden text before the link.\par
 This is a custom link\v #data#\v0  with hidden text after the link.\par
+\trowd\pard\intbl Test\cell Example\cell Meow\cell Woof\cell \row
 }";
 
         // Allow setting custom links.
@@ -85,13 +86,54 @@ This is a custom link\v #data#\v0  with hidden text after the link.\par
                 """;
     }
 
-    private void richTextBox1_LinkClicked(object sender, LinkClickedEventArgs e)
+    private void RichTextKeyDown(object sender, KeyEventArgs e)
+    {
+        if (sender is RichTextBox richTextBox)
+        {
+            try
+            {
+                if (e.Control && e.KeyCode == Keys.F)
+                {
+                    richTextBox.Select();
+                    var location = richTextBox.Find(Prompt.ShowDialog(this, "", ""));
+                    Debug.WriteLine(location.ToString());
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(this, ex.Message);
+            }
+        }
+    }
+
+    private void LinkClicked(object sender, LinkClickedEventArgs e)
     {
         MessageBox.Show(this, ReportLinkClickedEventArgs(sender, e), "link clicked");
     }
 
-    private void richTextBox2_LinkClicked(object sender, LinkClickedEventArgs e)
+    private static class Prompt
     {
-        MessageBox.Show(this, ReportLinkClickedEventArgs(sender, e), "link clicked");
+        public static string ShowDialog(Form owner, string text, string caption)
+        {
+            Form prompt = new Form()
+            {
+                Width = 500,
+                Height = 150,
+                FormBorderStyle = FormBorderStyle.FixedDialog,
+                Text = caption,
+                StartPosition = FormStartPosition.CenterScreen,
+                Owner = owner,
+            };
+            Label textLabel = new Label() { Left = 50, Top = 20, Text = text };
+            TextBox textBox = new TextBox() { Left = 50, Top = 50, Width = 400 };
+            Button confirmation = new Button() { Text = "Ok", Left = 350, Width = 100, Top = 70, DialogResult = DialogResult.OK };
+            confirmation.Click += (sender, e) => { prompt.Close(); };
+            prompt.Controls.Add(textBox);
+            prompt.Controls.Add(confirmation);
+            prompt.Controls.Add(textLabel);
+            prompt.AcceptButton = confirmation;
+
+            return prompt.ShowDialog() == DialogResult.OK ? textBox.Text : "";
+        }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RichTextBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RichTextBoxTests.cs
@@ -7931,6 +7931,20 @@ public class RichTextBoxTests
         Assert.Throws<NullReferenceException>(() => control.CanPaste(null));
     }
 
+    [WinFormsFact]
+    public void RichTextBox_Find_String_Table_ReturnsExpected()
+    {
+        using var control = new RichTextBox
+        {
+            Rtf = "{\\rtf1\\ansi\\deff0\\trowd\\pard\\intbl Test\\cell Example\\cell Meow\\cell Woof\\cell \\row}"
+        };
+
+        Assert.Equal(2, control.Find("Test"));
+        Assert.Equal(7, control.Find("Example"));
+        Assert.Equal(15, control.Find("Meow"));
+        Assert.Equal(20, control.Find("Woof"));
+    }
+
     public static IEnumerable<object[]> Find_String_TestData()
     {
         yield return new object[] { string.Empty, string.Empty, -1 };


### PR DESCRIPTION
- Refactor `RichTextBox.Find` to use `EM_FINDTEXT` when checking for kashida instead of relying on internal text.
- Change the WinformsControlsTest/RichTextBoxes to add an example and a find function.
- Add unit tests for find function with table.

Fixes #10322

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10329)