### PR TITLE
unpin the csc version, use compiler that comes with the arcade instead

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -8,7 +8,8 @@
     <PreReleaseVersionLabel>alpha</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
-    <UsingToolMicrosoftNetCompilers>true</UsingToolMicrosoftNetCompilers>
+    <!-- Use the compiler in the CLI instead of in the sdk, since CLI is newer. -->
+    <UsingToolMicrosoftNetCompilers>false</UsingToolMicrosoftNetCompilers>
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
   </PropertyGroup>
@@ -100,7 +101,6 @@
     <MicrosoftCodeAnalysisPackagesVersion>1.1.2-beta1.23322.1</MicrosoftCodeAnalysisPackagesVersion>
     <MicrosoftCodeAnalysisPublicApiAnalyzersVersion>$(MicrosoftCodeAnalysisAnalyzersVersion)</MicrosoftCodeAnalysisPublicApiAnalyzersVersion>
     <MicrosoftCodeAnalysisNetAnalyzersVersion>8.0.0-preview.23327.3</MicrosoftCodeAnalysisNetAnalyzersVersion>
-    <MicrosoftNetCompilersToolsetVersion>4.8.0-1.23403.1</MicrosoftNetCompilersToolsetVersion>
     <StyleCopAnalyzersVersion>1.2.0-beta.507</StyleCopAnalyzersVersion>
   </PropertyGroup>
   <!-- Additional unchanging dependencies -->


### PR DESCRIPTION
Partially reverted https://github.com/dotnet/winforms/pull/9654/files, to move forward https://github.com/dotnet/winforms/pull/10114 

After the change, according to the Build.binlog, command line build uses Roslyn binaries that are distributed with arcade - .dotnet\sdk\9.0.100-alpha.1.23511.2\Roslyn\bincore\csc.dll
Microsoft (R) Visual C# Compiler version 4.8.0-3.23477.1 (a0f63522)

Commit associated with this version was merged in September - https://github.com/dotnet/roslyn/commit/a0f63522, after the [commit](https://github.com/dotnet/roslyn/pull/69412) where the the inline arrays were introduced, which was in August. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10335)