### PR TITLE
Update LocProj to include StyleCollectionEditor.xlf

### DIFF
--- a/eng/Localize/LocProject.json
+++ b/eng/Localize/LocProject.json
@@ -178,6 +178,11 @@
                                               "OutputPath":  ".\\src\\System.Windows.Forms.Design\\src\\System\\Windows\\Forms\\Design\\xlf\\"
                                           },
                                           {
+                                            "SourceFile":  ".\\src\\System.Windows.Forms.Design\\src\\System\\Windows\\Forms\\Design\\xlf\\StyleCollectionEditor.xlf",
+                                            "CopyOption":  "LangIDOnName",
+                                            "OutputPath":  ".\\src\\System.Windows.Forms.Design\\src\\System\\Windows\\Forms\\Design\\xlf\\"
+                                          },
+                                          {
                                               "SourceFile":  ".\\src\\System.Windows.Forms.Primitives\\src\\Resources\\xlf\\SR.xlf",
                                               "CopyOption":  "LangIDOnName",
                                               "OutputPath":  ".\\src\\System.Windows.Forms.Primitives\\src\\Resources\\xlf\\"


### PR DESCRIPTION
This fixes CI failures in https://dev.azure.com/dnceng/internal/_build/results?buildId=2319748&view=logs&s=8942c932-824b-5cec-8f0c-ca2e44dadd6c . We had ported StyleCollectionEditor in https://github.com/dotnet/winforms/pull/10271, but did not updating LocProject.json to include StyleCollectionEditor.xlf

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10346)