### PR TITLE
Remove unneeded catch

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Containers/ContainerControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Containers/ContainerControl.cs
@@ -1967,15 +1967,7 @@ public class ContainerControl : ScrollableControl, IContainerControl
         {
             while (currentValidatingControl is not null && currentValidatingControl != ancestorControl)
             {
-                try
-                {
-                    cancel = currentValidatingControl.PerformControlValidation(false);
-                }
-                catch
-                {
-                    cancel = true;
-                    throw;
-                }
+                cancel = currentValidatingControl.PerformControlValidation(false);
 
                 if (cancel)
                 {


### PR DESCRIPTION
This catch is unneeded, its setting a value that never escapes in the case of an exception. This ruins debugging crashes caused by this path and I hit this trying to look at crashes tracked by 1906584 internally.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10347)