### PR TITLE
Fix indentation in LocProject.json

### DIFF
--- a/eng/Localize/LocProject.json
+++ b/eng/Localize/LocProject.json
@@ -178,9 +178,9 @@
                                               "OutputPath":  ".\\src\\System.Windows.Forms.Design\\src\\System\\Windows\\Forms\\Design\\xlf\\"
                                           },
                                           {
-                                            "SourceFile":  ".\\src\\System.Windows.Forms.Design\\src\\System\\Windows\\Forms\\Design\\xlf\\StyleCollectionEditor.xlf",
-                                            "CopyOption":  "LangIDOnName",
-                                            "OutputPath":  ".\\src\\System.Windows.Forms.Design\\src\\System\\Windows\\Forms\\Design\\xlf\\"
+                                              "SourceFile":  ".\\src\\System.Windows.Forms.Design\\src\\System\\Windows\\Forms\\Design\\xlf\\StyleCollectionEditor.xlf",
+                                              "CopyOption":  "LangIDOnName",
+                                              "OutputPath":  ".\\src\\System.Windows.Forms.Design\\src\\System\\Windows\\Forms\\Design\\xlf\\"
                                           },
                                           {
                                               "SourceFile":  ".\\src\\System.Windows.Forms.Primitives\\src\\Resources\\xlf\\SR.xlf",


### PR DESCRIPTION
Following up to https://github.com/dotnet/winforms/pull/10346
CI is still failing due to indentation..

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10349)