### PR TITLE
Enable nullability in some DataGridView.Methods members

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -36,8 +36,8 @@ override System.Windows.Forms.DataGridView.OnMouseMove(System.Windows.Forms.Mous
 override System.Windows.Forms.DataGridView.OnMouseUp(System.Windows.Forms.MouseEventArgs! e) -> void
 override System.Windows.Forms.DataGridView.OnMouseWheel(System.Windows.Forms.MouseEventArgs! e) -> void
 override System.Windows.Forms.DataGridView.OnPaint(System.Windows.Forms.PaintEventArgs! e) -> void
-~override System.Windows.Forms.DataGridView.OnResize(System.EventArgs e) -> void
-~override System.Windows.Forms.DataGridView.OnRightToLeftChanged(System.EventArgs e) -> void
+override System.Windows.Forms.DataGridView.OnResize(System.EventArgs! e) -> void
+override System.Windows.Forms.DataGridView.OnRightToLeftChanged(System.EventArgs! e) -> void
 ~override System.Windows.Forms.DataGridView.OnValidating(System.ComponentModel.CancelEventArgs e) -> void
 ~override System.Windows.Forms.DataGridView.OnVisibleChanged(System.EventArgs e) -> void
 override System.Windows.Forms.DataGridView.Text.get -> string!
@@ -753,20 +753,20 @@ virtual System.Windows.Forms.DataGridView.OnGridColorChanged(System.EventArgs! e
 virtual System.Windows.Forms.DataGridView.OnMultiSelectChanged(System.EventArgs! e) -> void
 virtual System.Windows.Forms.DataGridView.OnNewRowNeeded(System.Windows.Forms.DataGridViewRowEventArgs! e) -> void
 virtual System.Windows.Forms.DataGridView.OnReadOnlyChanged(System.EventArgs! e) -> void
-~virtual System.Windows.Forms.DataGridView.OnRowContextMenuStripChanged(System.Windows.Forms.DataGridViewRowEventArgs e) -> void
-~virtual System.Windows.Forms.DataGridView.OnRowContextMenuStripNeeded(System.Windows.Forms.DataGridViewRowContextMenuStripNeededEventArgs e) -> void
-~virtual System.Windows.Forms.DataGridView.OnRowDefaultCellStyleChanged(System.Windows.Forms.DataGridViewRowEventArgs e) -> void
-~virtual System.Windows.Forms.DataGridView.OnRowDirtyStateNeeded(System.Windows.Forms.QuestionEventArgs e) -> void
-~virtual System.Windows.Forms.DataGridView.OnRowDividerDoubleClick(System.Windows.Forms.DataGridViewRowDividerDoubleClickEventArgs e) -> void
-~virtual System.Windows.Forms.DataGridView.OnRowDividerHeightChanged(System.Windows.Forms.DataGridViewRowEventArgs e) -> void
-~virtual System.Windows.Forms.DataGridView.OnRowEnter(System.Windows.Forms.DataGridViewCellEventArgs e) -> void
-~virtual System.Windows.Forms.DataGridView.OnRowErrorTextChanged(System.Windows.Forms.DataGridViewRowEventArgs e) -> void
-~virtual System.Windows.Forms.DataGridView.OnRowErrorTextNeeded(System.Windows.Forms.DataGridViewRowErrorTextNeededEventArgs e) -> void
-~virtual System.Windows.Forms.DataGridView.OnRowHeaderCellChanged(System.Windows.Forms.DataGridViewRowEventArgs e) -> void
-~virtual System.Windows.Forms.DataGridView.OnRowHeaderMouseClick(System.Windows.Forms.DataGridViewCellMouseEventArgs e) -> void
-~virtual System.Windows.Forms.DataGridView.OnRowHeaderMouseDoubleClick(System.Windows.Forms.DataGridViewCellMouseEventArgs e) -> void
-~virtual System.Windows.Forms.DataGridView.OnRowHeadersBorderStyleChanged(System.EventArgs e) -> void
-~virtual System.Windows.Forms.DataGridView.OnRowHeadersDefaultCellStyleChanged(System.EventArgs e) -> void
+virtual System.Windows.Forms.DataGridView.OnRowContextMenuStripChanged(System.Windows.Forms.DataGridViewRowEventArgs! e) -> void
+virtual System.Windows.Forms.DataGridView.OnRowContextMenuStripNeeded(System.Windows.Forms.DataGridViewRowContextMenuStripNeededEventArgs! e) -> void
+virtual System.Windows.Forms.DataGridView.OnRowDefaultCellStyleChanged(System.Windows.Forms.DataGridViewRowEventArgs! e) -> void
+virtual System.Windows.Forms.DataGridView.OnRowDirtyStateNeeded(System.Windows.Forms.QuestionEventArgs! e) -> void
+virtual System.Windows.Forms.DataGridView.OnRowDividerDoubleClick(System.Windows.Forms.DataGridViewRowDividerDoubleClickEventArgs! e) -> void
+virtual System.Windows.Forms.DataGridView.OnRowDividerHeightChanged(System.Windows.Forms.DataGridViewRowEventArgs! e) -> void
+virtual System.Windows.Forms.DataGridView.OnRowEnter(System.Windows.Forms.DataGridViewCellEventArgs! e) -> void
+virtual System.Windows.Forms.DataGridView.OnRowErrorTextChanged(System.Windows.Forms.DataGridViewRowEventArgs! e) -> void
+virtual System.Windows.Forms.DataGridView.OnRowErrorTextNeeded(System.Windows.Forms.DataGridViewRowErrorTextNeededEventArgs! e) -> void
+virtual System.Windows.Forms.DataGridView.OnRowHeaderCellChanged(System.Windows.Forms.DataGridViewRowEventArgs! e) -> void
+virtual System.Windows.Forms.DataGridView.OnRowHeaderMouseClick(System.Windows.Forms.DataGridViewCellMouseEventArgs! e) -> void
+virtual System.Windows.Forms.DataGridView.OnRowHeaderMouseDoubleClick(System.Windows.Forms.DataGridViewCellMouseEventArgs! e) -> void
+virtual System.Windows.Forms.DataGridView.OnRowHeadersBorderStyleChanged(System.EventArgs! e) -> void
+virtual System.Windows.Forms.DataGridView.OnRowHeadersDefaultCellStyleChanged(System.EventArgs! e) -> void
 ~virtual System.Windows.Forms.DataGridView.OnRowHeadersWidthChanged(System.EventArgs e) -> void
 ~virtual System.Windows.Forms.DataGridView.OnRowHeadersWidthSizeModeChanged(System.Windows.Forms.DataGridViewAutoSizeModeEventArgs e) -> void
 ~virtual System.Windows.Forms.DataGridView.OnRowHeightChanged(System.Windows.Forms.DataGridViewRowEventArgs e) -> void
@@ -6130,7 +6130,7 @@ System.Windows.Forms.DataGridViewRowDividerDoubleClickEventArgs.DataGridViewRowD
 System.Windows.Forms.DataGridViewRowDividerDoubleClickEventArgs.RowIndex.get -> int
 System.Windows.Forms.DataGridViewRowDividerDoubleClickEventHandler
 System.Windows.Forms.DataGridViewRowErrorTextNeededEventArgs
-System.Windows.Forms.DataGridViewRowErrorTextNeededEventArgs.ErrorText.get -> string?
+System.Windows.Forms.DataGridViewRowErrorTextNeededEventArgs.ErrorText.get -> string!
 System.Windows.Forms.DataGridViewRowErrorTextNeededEventArgs.ErrorText.set -> void
 System.Windows.Forms.DataGridViewRowErrorTextNeededEventArgs.RowIndex.get -> int
 System.Windows.Forms.DataGridViewRowErrorTextNeededEventHandler

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView/DataGridView.Methods.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView/DataGridView.Methods.cs
@@ -11232,7 +11232,6 @@ public partial class DataGridView
                         dataGridViewCellNew.OwningRow = dataGridViewRow;
                         dataGridViewCellNew.OwningColumn = dataGridViewColumn;
 
-                        Debug.Assert(KeyboardToolTip is not null);
                         KeyboardToolTipStateMachine.Instance.Hook(dataGridViewCellNew, KeyboardToolTip);
                     }
                 }
@@ -11435,7 +11434,6 @@ public partial class DataGridView
                 dataGridViewCell.ReadOnlyInternal = false;
             }
 
-            Debug.Assert(KeyboardToolTip is not null);
             KeyboardToolTipStateMachine.Instance.Hook(dataGridViewCell, KeyboardToolTip);
 
             columnIndex++;
@@ -17494,7 +17492,6 @@ public partial class DataGridView
             DataGridViewRow dataGridViewRow = Rows.SharedRow(rowIndex);
             if (dataGridViewRow.Cells.Count > newColumnCount)
             {
-                Debug.Assert(KeyboardToolTip is not null);
                 KeyboardToolTipStateMachine.Instance.Unhook(dataGridViewRow.Cells[columnIndex], KeyboardToolTip);
                 dataGridViewRow.Cells.RemoveAtInternal(columnIndex);
             }
@@ -17621,7 +17618,6 @@ public partial class DataGridView
 
         if (rowIndexDeleted >= 0 && rowIndexDeleted < Rows.Count)
         {
-            Debug.Assert(KeyboardToolTip is not null);
             foreach (DataGridViewCell cell in Rows[rowIndexDeleted].Cells)
             {
                 KeyboardToolTipStateMachine.Instance.Unhook(cell, KeyboardToolTip);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView/DataGridView.Methods.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView/DataGridView.Methods.cs
@@ -3321,7 +3321,7 @@ public partial class DataGridView
                 {
                     int oldCurrentCellX = _ptCurrentCell.X;
                     DataConnection!.CancelRowEdit(restoreRow: true, addNewFinished: _dataGridViewState1[State1_NewRowEdited]);
-                    if (DataConnection.List!.Count == 0)
+                    if ((DataConnection.List?.Count ?? 0) == 0)
                     {
                         // There are no rows left in the back end.
                         if (currentCellDirty || _ptCurrentCell.Y == -1 || _ptCurrentCell.X == -1)
@@ -18103,7 +18103,7 @@ public partial class DataGridView
                 && DataConnection.InterestedInRowEvents
                 && !DataConnection.PositionChangingOutsideDataGridView
                 && !DataConnection.ListWasReset
-                && (!calledAddNewOnTheDataConnection || DataConnection.List!.Count > 0))
+                && (!calledAddNewOnTheDataConnection || (DataConnection.List?.Count ?? 0) > 0))
             {
                 DataConnection.OnRowEnter(dgvce);
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView/DataGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView/DataGridView.cs
@@ -2979,13 +2979,13 @@ public partial class DataGridView : Control, ISupportInitialize
             && dataGridViewCell.OwningColumn.Visible;
     }
 
-    internal ToolTip? KeyboardToolTip
+    internal ToolTip KeyboardToolTip
     {
         get
         {
             if (Properties.TryGetObject(s_propToolTip, out ToolTip? toolTip))
             {
-                return toolTip;
+                return toolTip!;
             }
 
             toolTip = new ToolTip

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView/DataGridViewColumnCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView/DataGridViewColumnCollection.cs
@@ -973,9 +973,8 @@ public partial class DataGridViewColumnCollection : BaseCollection, IList
         {
             DataGridView.OnInsertedColumn_PostNotification(newCurrentCell);
         }
-        else if (ccea.Action == CollectionChangeAction.Remove)
+        else if (ccea.Action == CollectionChangeAction.Remove && dataGridViewColumn is not null)
         {
-            Debug.Assert(dataGridViewColumn is not null);
             DataGridView.OnRemovedColumn_PostNotification(dataGridViewColumn, newCurrentCell);
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView/DataGridViewColumnCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView/DataGridViewColumnCollection.cs
@@ -975,6 +975,7 @@ public partial class DataGridViewColumnCollection : BaseCollection, IList
         }
         else if (ccea.Action == CollectionChangeAction.Remove)
         {
+            Debug.Assert(dataGridViewColumn is not null);
             DataGridView.OnRemovedColumn_PostNotification(dataGridViewColumn, newCurrentCell);
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView/DataGridViewRowErrorTextNeededEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView/DataGridViewRowErrorTextNeededEventArgs.cs
@@ -5,7 +5,7 @@ namespace System.Windows.Forms;
 
 public class DataGridViewRowErrorTextNeededEventArgs : EventArgs
 {
-    internal DataGridViewRowErrorTextNeededEventArgs(int rowIndex, string? errorText)
+    internal DataGridViewRowErrorTextNeededEventArgs(int rowIndex, string errorText)
     {
         Debug.Assert(rowIndex >= -1);
         RowIndex = rowIndex;
@@ -14,5 +14,5 @@ public class DataGridViewRowErrorTextNeededEventArgs : EventArgs
 
     public int RowIndex { get; }
 
-    public string? ErrorText { get; set; }
+    public string ErrorText { get; set; }
 }


### PR DESCRIPTION
## Proposed changes

- Enable nullability in some DataGridView.Methods members.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10353)