### PR TITLE
[release/8.0] Add ValuePattern.Value changed event to TextBox

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.TextBoxBaseAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.TextBoxBaseAccessibleObject.cs
@@ -70,9 +70,9 @@ public abstract partial class TextBoxBase
             get
             {
                 var name = base.Name;
-                return name is not null ||
-                    (this.TryGetOwnerAs(out TextBoxBase? owner) && !owner.PasswordProtect) ? name : string.Empty;
+                return name is not null ? name : string.Empty;
             }
+
             set => base.Name = value;
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
@@ -1582,6 +1582,8 @@ public abstract partial class TextBoxBase : Control
         if (IsAccessibilityObjectCreated)
         {
             AccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.Text_TextChangedEventId);
+            string textVariant = PasswordProtect ? string.Empty : Text;
+            AccessibilityObject.RaiseAutomationPropertyChangedEvent(UiaCore.UIA.ValueValuePropertyId, textVariant, textVariant);
         }
     }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WinFormsUtils.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WinFormsUtils.cs
@@ -244,7 +244,7 @@ internal sealed partial class WindowsFormsUtils
     {
         if (text is null)
         {
-            return null;
+            return string.Empty;
         }
 
         int index = text.IndexOf('&');

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WinFormsUtils.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WinFormsUtils.cs
@@ -244,7 +244,7 @@ internal sealed partial class WindowsFormsUtils
     {
         if (text is null)
         {
-            return string.Empty;
+            return null;
         }
 
         int index = text.IndexOf('&');

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ControlAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ControlAccessibleObjectTests.cs
@@ -1316,7 +1316,9 @@ public class Control_ControlAccessibleObjectTests
         {
             { typeof(DataGridViewTextBoxEditingControl), SR.DataGridView_AccEditingControlAccName },
             { typeof(DateTimePicker), string.Empty },
-            { typeof(PrintPreviewDialog), SR.PrintPreviewDialog_PrintPreview }
+            { typeof(PrintPreviewDialog), SR.PrintPreviewDialog_PrintPreview },
+            { typeof(TextBox), string.Empty },
+            { typeof(MaskedTextBox), string.Empty }
         };
 
         foreach (Type type in ReflectionHelper.GetPublicNotAbstractClasses<Control>())

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MaskedTextBox.MaskedTextBoxAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MaskedTextBox.MaskedTextBoxAccessibleObjectTests.cs
@@ -73,7 +73,7 @@ public class MaskedTextBoxAccessibilityObjectTests
     }
 
     [WinFormsTheory]
-    [InlineData(null, null)]
+    [InlineData(null, "")]
     [InlineData("Test", "Test")]
     public void MaskedTextBoxAccessibleObject_Name_IsExpected_WithoutMask(string accessibleName, string expectedAccessibleName)
     {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TextBoxBaseAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TextBoxBaseAccessibleObjectTests.cs
@@ -82,7 +82,7 @@ public class TextBoxBaseAccessibleObjectTests
         using TextBoxBase textBoxBase = new SubTextBoxBase();
         textBoxBase.CreateControl();
         AccessibleObject accessibleObject = textBoxBase.AccessibilityObject;
-        Assert.Null(accessibleObject.Name);
+        Assert.Empty(accessibleObject.Name);
         Assert.True(textBoxBase.IsHandleCreated);
     }
 


### PR DESCRIPTION
Backport of https://github.com/dotnet/winforms/pull/10295 to release/8.0

## Proposed changes

- Add raise ValuePattern.Value property changed event to TextBoxBase.

<!-- We are in TELL-MODE the following section must be completed -->
## Customer Impact

- ValuePattern.Value property changed event will be sent from TextBox control. 
- When we don't set the accessible name of the textbox or the previous label, the accessible name of the textbox will return "" not the value of textbox.

## Regression? 

- Yes

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

ValuePattern.Value property changed event is not sent from TextBox.
![image](https://github.com/dotnet/winforms/assets/133954995/e6e6dfb6-28dc-4867-bdbb-01f257e75c6e)

### After
When we make changes to the text in the textbox, it will send the ValuePattern.Value property changed event.
![TextBox_ValuePattern1](https://github.com/dotnet/winforms/assets/133954995/6bba8076-2d7d-44f0-b434-cdc66f95a0b9)


## Test methodology <!-- How did you ensure quality? -->

- Manual (Insights)

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

- 8.0.0-beta.23564.4


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10369)