### PR TITLE
fix [Accessibility] Accessibility Insights tool keeps loading when mouse-over DataGridView #10343

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -13,6 +13,8 @@
 *REMOVED*virtual System.Windows.Forms.Control.ControlCollection.AddRange(System.Windows.Forms.Control![]! controls) -> void
 *REMOVED*virtual System.Windows.Forms.ListView.ColumnHeaderCollection.AddRange(System.Windows.Forms.ColumnHeader![]! values) -> void
 *REMOVED*virtual System.Windows.Forms.TreeNodeCollection.AddRange(System.Windows.Forms.TreeNode![]! nodes) -> void
+*REMOVED*override System.Windows.Forms.DataGridViewTextBoxEditingControl.OnHandleCreated(System.EventArgs! e) -> void
+*REMOVED*override System.Windows.Forms.DataGridViewComboBoxEditingControl.OnHandleCreated(System.EventArgs! e) -> void
 System.Windows.Forms.AutoCompleteStringCollection.AddRange(params string![]! value) -> void
 System.Windows.Forms.ComboBox.ObjectCollection.AddRange(params object![]! items) -> void
 System.Windows.Forms.ImageList.ImageCollection.AddRange(params System.Drawing.Image![]! images) -> void

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewComboBoxEditingControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewComboBoxEditingControl.cs
@@ -17,10 +17,12 @@ public partial class DataGridViewComboBoxEditingControl : ComboBox, IDataGridVie
         TabStop = false;
     }
 
-    protected override AccessibleObject CreateAccessibilityInstance() =>
-        new DataGridViewComboBoxEditingControlAccessibleObject(this);
-
-    // IDataGridViewEditingControl interface implementation
+    protected override AccessibleObject CreateAccessibilityInstance()
+    {
+        var controlAccessibleObject = new DataGridViewComboBoxEditingControlAccessibleObject(this);
+        _dataGridView?.SetAccessibleObjectParent(controlAccessibleObject);
+        return controlAccessibleObject;
+    }
 
     public virtual DataGridView? EditingControlDataGridView
     {
@@ -121,17 +123,6 @@ public partial class DataGridViewComboBoxEditingControl : ComboBox, IDataGridVie
         if (SelectedIndex != -1)
         {
             NotifyDataGridViewOfValueChange();
-        }
-    }
-
-    protected override void OnHandleCreated(EventArgs e)
-    {
-        base.OnHandleCreated(e);
-
-        // The null-check was added as a fix for a https://github.com/dotnet/winforms/issues/2138
-        if (_dataGridView?.IsAccessibilityObjectCreated == true)
-        {
-            _dataGridView.SetAccessibleObjectParent(AccessibilityObject);
         }
     }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewTextBoxEditingControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewTextBoxEditingControl.cs
@@ -22,7 +22,11 @@ public partial class DataGridViewTextBoxEditingControl : TextBox, IDataGridViewE
     }
 
     protected override AccessibleObject CreateAccessibilityInstance()
-        => new DataGridViewTextBoxEditingControlAccessibleObject(this);
+    {
+        var controlAccessibleObject = new DataGridViewTextBoxEditingControlAccessibleObject(this);
+        _dataGridView?.SetAccessibleObjectParent(controlAccessibleObject);
+        return controlAccessibleObject;
+    }
 
     public virtual DataGridView? EditingControlDataGridView
     {
@@ -307,17 +311,6 @@ public partial class DataGridViewTextBoxEditingControl : TextBox, IDataGridViewE
         else
         {
             return HorizontalAlignment.Left;
-        }
-    }
-
-    protected override void OnHandleCreated(EventArgs e)
-    {
-        base.OnHandleCreated(e);
-
-        // The null-check was added as a fix for a https://github.com/dotnet/winforms/issues/2138
-        if (IsHandleCreated && _dataGridView?.IsAccessibilityObjectCreated == true)
-        {
-            _dataGridView.SetAccessibleObjectParent(AccessibilityObject);
         }
     }
 }


### PR DESCRIPTION
Fix #10343

Related to [PR_7349](https://github.com/dotnet/winforms/pull/7349)

## Cause of this issue
Take a look here this [PR_7349](https://github.com/dotnet/winforms/pull/7349) had made
![image](https://github.com/dotnet/winforms/assets/135201996/d89747e4-9244-4870-8348-4abe86bb42e5)

Same as this:
https://github.com/dotnet/winforms/pull/7349/files#diff-2cdcad323e7cd83529f6ded1cfd60aa6906ccbb32755221d36cdb67f72b507c0L306-L315

We can see this [PR_7349](https://github.com/dotnet/winforms/pull/7349)  was to address memory leaks.

Indeed the code here was problematic because if there are no Accessibility Client listening to then there is no need to create AccessibilityObject
``` c#
        protected override void OnHandleCreated(EventArgs e)
        {
            base.OnHandleCreated(e);
            if (IsHandleCreated)
            {
                // The null-check was added as a fix for a https://github.com/dotnet/winforms/issues/2138
                _dataGridView?.SetAccessibleObjectParent(AccessibilityObject);
            }
        }
```
The author addressed this problem by this
```c#
        protected override void OnHandleCreated(EventArgs e)
        {
            base.OnHandleCreated(e);

            // The null-check was added as a fix for a https://github.com/dotnet/winforms/issues/2138
            if (IsHandleCreated && _dataGridView?.IsAccessibilityObjectCreated == true)
            {
                _dataGridView.SetAccessibleObjectParent(AccessibilityObject);
            }
        }
```
But this posed another problem, when the handle is created before Accessibility Client is activated, the code here `_dataGridView.SetAccessibleObjectParent(AccessibilityObject);` never get a chance to be involved.

https://github.com/dotnet/winforms/blob/71aeb2e40dc2d6d7972e86665857c84cc7e8e02e/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView/DataGridView.Methods.cs#L27496C4-L27507

As we can see: the editingControl has no parent.


<!-- Please read CONTRIBUTING.md before submitting a pull request -->



## Regression? 

- Yes


<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
![DataGridView_AccessibilityInsightIssue](https://github.com/dotnet/winforms/assets/26474449/fb8ccacd-9d93-4f0d-9ddc-eeda7e2291b0)

### After
![DataGridView_NET7 0](https://github.com/dotnet/winforms/assets/26474449/6743c7a0-1135-4be5-a728-02fb1e1f2f85)


## Test methodology <!-- How did you ensure quality? -->

- 
- manually 
- 


 

## Test environment(s) <!-- Remove any that don't apply -->

9.0.0-alpha.1.23572.27
