### PR TITLE
Fix Clear and Remove after Sort in TreeView

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeNode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeNode.cs
@@ -1194,81 +1194,83 @@ public partial class TreeNode : MarshalByRefObject, ICloneable, ISerializable
 
     private void SortChildren(TreeView? parentTreeView)
     {
-        if (_childNodes.Count > 0)
+        if (_childNodes.Count <= 0)
         {
-            List<TreeNode> newOrder = new(_childNodes.Count);
-            if (parentTreeView is null || parentTreeView.TreeViewNodeSorter is null)
+            return;
+        }
+
+        List<TreeNode> newOrder = new(_childNodes.Count);
+        if (parentTreeView is null || parentTreeView.TreeViewNodeSorter is null)
+        {
+            CompareInfo compare = Application.CurrentCulture.CompareInfo;
+            for (int i = 0; i < _childNodes.Count; i++)
             {
-                CompareInfo compare = Application.CurrentCulture.CompareInfo;
-                for (int i = 0; i < _childNodes.Count; i++)
+                newOrder.Add(_childNodes[i]);
+
+                int min = -1;
+                for (int j = 0; j < _childNodes.Count; j++)
                 {
-                    newOrder.Add(_childNodes[i]);
-
-                    int min = -1;
-                    for (int j = 0; j < _childNodes.Count; j++)
+                    if (_childNodes[j] is null)
                     {
-                        if (_childNodes[j] is null)
-                        {
-                            continue;
-                        }
-
-                        if (min == -1)
-                        {
-                            min = j;
-                            continue;
-                        }
-
-                        if (compare.Compare(_childNodes[j].Text, _childNodes[min].Text) <= 0)
-                        {
-                            min = j;
-                        }
+                        continue;
                     }
 
-                    Debug.Assert(min != -1, "Bad sorting");
-                    newOrder[i] = _childNodes[min];
-                    _childNodes[min] = null!;
-                    newOrder[i]._index = i;
-                    newOrder[i].SortChildren(parentTreeView);
-                }
-
-                _childNodes = newOrder;
-            }
-            else
-            {
-                IComparer sorter = parentTreeView.TreeViewNodeSorter;
-                for (int i = 0; i < _childNodes.Count; i++)
-                {
-                    newOrder.Add(_childNodes[i]);
-
-                    int min = -1;
-                    for (int j = 0; j < _childNodes.Count; j++)
+                    if (min == -1)
                     {
-                        if (_childNodes[j] is null)
-                        {
-                            continue;
-                        }
-
-                        if (min == -1)
-                        {
-                            min = j;
-                            continue;
-                        }
-
-                        if (sorter.Compare(_childNodes[j] /*previous*/, _childNodes[min] /*current*/) <= 0)
-                        {
-                            min = j;
-                        }
+                        min = j;
+                        continue;
                     }
 
-                    Debug.Assert(min != -1, "Bad sorting");
-                    newOrder[i] = _childNodes[min];
-                    _childNodes[min] = null!;
-                    newOrder[i]._index = i;
-                    newOrder[i].SortChildren(parentTreeView);
+                    if (compare.Compare(_childNodes[j].Text, _childNodes[min].Text) <= 0)
+                    {
+                        min = j;
+                    }
                 }
 
-                _childNodes = newOrder;
+                Debug.Assert(min != -1, "Bad sorting");
+                newOrder[i] = _childNodes[min];
+                _childNodes[min] = null!;
+                newOrder[i]._index = i;
+                newOrder[i].SortChildren(parentTreeView);
             }
+
+            _childNodes = newOrder;
+        }
+        else
+        {
+            IComparer sorter = parentTreeView.TreeViewNodeSorter;
+            for (int i = 0; i < _childNodes.Count; i++)
+            {
+                newOrder.Add(_childNodes[i]);
+
+                int min = -1;
+                for (int j = 0; j < _childNodes.Count; j++)
+                {
+                    if (_childNodes[j] is null)
+                    {
+                        continue;
+                    }
+
+                    if (min == -1)
+                    {
+                        min = j;
+                        continue;
+                    }
+
+                    if (sorter.Compare(_childNodes[j] /*previous*/, _childNodes[min] /*current*/) <= 0)
+                    {
+                        min = j;
+                    }
+                }
+
+                Debug.Assert(min != -1, "Bad sorting");
+                newOrder[i] = _childNodes[min];
+                _childNodes[min] = null!;
+                newOrder[i]._index = i;
+                newOrder[i].SortChildren(parentTreeView);
+            }
+
+            _childNodes = newOrder;
         }
     }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeNode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeNode.cs
@@ -1200,33 +1200,16 @@ public partial class TreeNode : MarshalByRefObject, ICloneable, ISerializable
             List<TreeNode> newOrder = new(nodeCount);
             if (parentTreeView?.TreeViewNodeSorter is null)
             {
-                _childNodes.Sort((x, y) =>
-                {
-                    int result = Application.CurrentCulture.CompareInfo.Compare(x.Text, y.Text, CompareOptions.None);
-                    if (result == 1)
-                    {
-                        (x._index, y._index) = (y._index, x._index);
-                    }
-
-                    return result;
-                });
+                _childNodes.Sort((x, y) => Application.CurrentCulture.CompareInfo.Compare(x.Text, y.Text, CompareOptions.None));
             }
             else
             {
-                _childNodes.Sort((x, y) =>
-                {
-                    int result = parentTreeView.TreeViewNodeSorter.Compare(x, y);
-                    if (result == 1)
-                    {
-                        (x._index, y._index) = (y._index, x._index);
-                    }
-
-                    return result;
-                });
+                _childNodes.Sort(parentTreeView.TreeViewNodeSorter.Compare);
             }
 
             for (int i = 0; i < _childNodes.Count; i++)
             {
+                _childNodes[i]._index = i;
                 _childNodes[i].SortChildren(parentTreeView);
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeNode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeNode.cs
@@ -1196,12 +1196,14 @@ public partial class TreeNode : MarshalByRefObject, ICloneable, ISerializable
     {
         if (_childNodes.Count > 0)
         {
-            TreeNode[] newOrder = new TreeNode[_childNodes.Count];
+            List<TreeNode> newOrder = new(_childNodes.Count);
             if (parentTreeView is null || parentTreeView.TreeViewNodeSorter is null)
             {
                 CompareInfo compare = Application.CurrentCulture.CompareInfo;
                 for (int i = 0; i < _childNodes.Count; i++)
                 {
+                    newOrder.Add(_childNodes[i]);
+
                     int min = -1;
                     for (int j = 0; j < _childNodes.Count; j++)
                     {
@@ -1229,13 +1231,15 @@ public partial class TreeNode : MarshalByRefObject, ICloneable, ISerializable
                     newOrder[i].SortChildren(parentTreeView);
                 }
 
-                _childNodes = newOrder.ToList();
+                _childNodes = newOrder;
             }
             else
             {
                 IComparer sorter = parentTreeView.TreeViewNodeSorter;
                 for (int i = 0; i < _childNodes.Count; i++)
                 {
+                    newOrder.Add(_childNodes[i]);
+
                     int min = -1;
                     for (int j = 0; j < _childNodes.Count; j++)
                     {
@@ -1263,7 +1267,7 @@ public partial class TreeNode : MarshalByRefObject, ICloneable, ISerializable
                     newOrder[i].SortChildren(parentTreeView);
                 }
 
-                _childNodes = newOrder.ToList();
+                _childNodes = newOrder;
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeNode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeNode.cs
@@ -1200,11 +1200,29 @@ public partial class TreeNode : MarshalByRefObject, ICloneable, ISerializable
             List<TreeNode> newOrder = new(nodeCount);
             if (parentTreeView?.TreeViewNodeSorter is null)
             {
-                _childNodes.Sort((x, y) => Application.CurrentCulture.CompareInfo.Compare(x.Text, y.Text, CompareOptions.None));
+                _childNodes.Sort((x, y) =>
+                {
+                    int result = Application.CurrentCulture.CompareInfo.Compare(x.Text, y.Text, CompareOptions.None);
+                    if (result == 1)
+                    {
+                        (x._index, y._index) = (y._index, x._index);
+                    }
+
+                    return result;
+                });
             }
             else
             {
-                _childNodes.Sort(parentTreeView.TreeViewNodeSorter.Compare);
+                _childNodes.Sort((x, y) =>
+                {
+                    int result = parentTreeView.TreeViewNodeSorter.Compare(x, y);
+                    if (result == 1)
+                    {
+                        (x._index, y._index) = (y._index, x._index);
+                    }
+
+                    return result;
+                });
             }
 
             for (int i = 0; i < _childNodes.Count; i++)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeNode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeNode.cs
@@ -88,7 +88,7 @@ public partial class TreeNode : MarshalByRefObject, ICloneable, ISerializable
     }
 
     internal int _index;                  // our index into our parents child array
-    internal readonly List<TreeNode> _childNodes = new();
+    internal List<TreeNode> _childNodes = new();
     internal TreeNode? _parent;
     internal TreeView? _treeView;
     private bool _expandOnRealization;
@@ -1194,23 +1194,76 @@ public partial class TreeNode : MarshalByRefObject, ICloneable, ISerializable
 
     private void SortChildren(TreeView? parentTreeView)
     {
-        var nodeCount = _childNodes.Count;
-        if (nodeCount > 0)
+        if (_childNodes.Count > 0)
         {
-            List<TreeNode> newOrder = new(nodeCount);
-            if (parentTreeView?.TreeViewNodeSorter is null)
+            TreeNode[] newOrder = new TreeNode[_childNodes.Count];
+            if (parentTreeView is null || parentTreeView.TreeViewNodeSorter is null)
             {
-                _childNodes.Sort((x, y) => Application.CurrentCulture.CompareInfo.Compare(x.Text, y.Text, CompareOptions.None));
+                CompareInfo compare = Application.CurrentCulture.CompareInfo;
+                for (int i = 0; i < _childNodes.Count; i++)
+                {
+                    int min = -1;
+                    for (int j = 0; j < _childNodes.Count; j++)
+                    {
+                        if (_childNodes[j] is null)
+                        {
+                            continue;
+                        }
+
+                        if (min == -1)
+                        {
+                            min = j;
+                            continue;
+                        }
+
+                        if (compare.Compare(_childNodes[j].Text, _childNodes[min].Text) <= 0)
+                        {
+                            min = j;
+                        }
+                    }
+
+                    Debug.Assert(min != -1, "Bad sorting");
+                    newOrder[i] = _childNodes[min];
+                    _childNodes[min] = null!;
+                    newOrder[i]._index = i;
+                    newOrder[i].SortChildren(parentTreeView);
+                }
+
+                _childNodes = newOrder.ToList();
             }
             else
             {
-                _childNodes.Sort(parentTreeView.TreeViewNodeSorter.Compare);
-            }
+                IComparer sorter = parentTreeView.TreeViewNodeSorter;
+                for (int i = 0; i < _childNodes.Count; i++)
+                {
+                    int min = -1;
+                    for (int j = 0; j < _childNodes.Count; j++)
+                    {
+                        if (_childNodes[j] is null)
+                        {
+                            continue;
+                        }
 
-            for (int i = 0; i < _childNodes.Count; i++)
-            {
-                _childNodes[i]._index = i;
-                _childNodes[i].SortChildren(parentTreeView);
+                        if (min == -1)
+                        {
+                            min = j;
+                            continue;
+                        }
+
+                        if (sorter.Compare(_childNodes[j] /*previous*/, _childNodes[min] /*current*/) <= 0)
+                        {
+                            min = j;
+                        }
+                    }
+
+                    Debug.Assert(min != -1, "Bad sorting");
+                    newOrder[i] = _childNodes[min];
+                    _childNodes[min] = null!;
+                    newOrder[i]._index = i;
+                    newOrder[i].SortChildren(parentTreeView);
+                }
+
+                _childNodes = newOrder.ToList();
             }
         }
     }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
@@ -7113,6 +7113,53 @@ public class TreeViewTests
         treeView.TreeViewNodeSorter = treeSorter;
     }
 
+    [WinFormsTheory]
+    [InlineData("A", "B")]
+    [InlineData("A", "A")]
+    [InlineData("B", "A")]
+    public void Clear_AfterSort_ShouldNotGetStuck(string firstNodeText, string secondNodeText)
+    {
+        using TreeView treeView = new();
+        TreeNode parent = new("Parent");
+        treeView.Nodes.Add(parent);
+
+        TreeNode firstNode = new(firstNodeText);
+        parent.Nodes.Add(firstNode);
+        TreeNode secondNode = new(secondNodeText);
+        parent.Nodes.Add(secondNode);
+
+        treeView.Sort();
+
+        Action action = () => parent.Nodes.Clear();
+
+        action.ExecutionTime().Should().BeLessThanOrEqualTo(TimeSpan.FromMilliseconds(500));
+        action.Should().NotThrow();
+    }
+
+    [WinFormsTheory]
+    [InlineData("A", "B")]
+    [InlineData("A", "A")]
+    [InlineData("B", "A")]
+    public void Remove_AfterSort_ShouldNotThrowException(string firstNodeText, string secondNodeText)
+    {
+        using TreeView treeView = new();
+        TreeNode parent = new("Parent");
+        treeView.Nodes.Add(parent);
+
+        TreeNode firstNode = new(firstNodeText);
+        parent.Nodes.Add(firstNode);
+        TreeNode secondNode = new(secondNodeText);
+        parent.Nodes.Add(secondNode);
+
+        treeView.Sort();
+
+        parent.Nodes.Remove(firstNode);
+
+        Action action = () => parent.Nodes.Remove(secondNode);
+
+        action.Should().NotThrow();
+    }
+
     private class SubTreeView : TreeView
     {
         public new bool CanEnableIme => base.CanEnableIme;


### PR DESCRIPTION
Fixes #10376

## Proposed changes

- Fix Clear and Remove after Sort in TreeView. It looks like we broke this in https://github.com/dotnet/winforms/pull/9078 by following https://github.com/dotnet/winforms/pull/9078#discussion_r1187710943. Perhaps we should just bring back the old method instead of using the current approach?

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10377)