### PR TITLE
Issue 6514 button border contrast ratio too low

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Buttons/ButtonInternal/ButtonStandardAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Buttons/ButtonInternal/ButtonStandardAdapter.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Drawing;
+using System.Drawing.Drawing2D;
 using System.Windows.Forms.Layout;
 using System.Windows.Forms.VisualStyles;
 
@@ -191,6 +192,13 @@ internal class ButtonStandardAdapter : ButtonBaseAdapter
             PaintField(e, layout, colors, colors.WindowText, true);
         }
 
+        if (Application.RenderWithVisualStyles
+            && Control.FlatStyle == FlatStyle.Standard
+            && state == CheckState.Unchecked)
+        {
+            DrawRoundBorder(e);
+        }
+
         if (!Application.RenderWithVisualStyles)
         {
             Rectangle r = Control.ClientRectangle;
@@ -211,6 +219,37 @@ internal class ButtonStandardAdapter : ButtonBaseAdapter
                 ControlPaint.DrawBorderSimple(e, r, colors.ButtonShadow);
             }
         }
+    }
+
+    private void DrawRoundBorder(PaintEventArgs e)
+    {
+        GraphicsPath path = new GraphicsPath();
+        Pen pen = Color.Black.GetCachedPenScope();
+
+        int x = Control.ClientRectangle.X + 1;
+        int y = Control.ClientRectangle.Y + 1;
+        int width = Control.ClientRectangle.Width - 10;
+        int height = Control.ClientRectangle.Height - 10;
+        const int radius = 8;
+
+        // Top-left corner
+        path.AddArc(new Rectangle(x, y, radius, radius), 180, 90);
+
+        // Top-right corner
+        path.AddArc(new Rectangle(width, y, radius, radius), 270, 90);
+
+        // Bottom-right corner
+        path.AddArc(new Rectangle(width, height, radius, radius), 0, 90);
+
+        // Bottom-left corner
+        path.AddArc(new Rectangle(x, height, radius, radius), 90, 90);
+
+        // Back to Top-left corner
+        path.AddArc(new Rectangle(x, y, radius, radius), 180, 90);
+
+        var g = e.Graphics;
+        g.SmoothingMode = SmoothingMode.AntiAlias;
+        g.DrawPath(pen, path);
     }
 
     #region Layout

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Buttons/ButtonInternal/ButtonStandardAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Buttons/ButtonInternal/ButtonStandardAdapter.cs
@@ -192,6 +192,7 @@ internal class ButtonStandardAdapter : ButtonBaseAdapter
             PaintField(e, layout, colors, colors.WindowText, true);
         }
 
+        //Added for https://github.com/dotnet/winforms/issues/6514
         if (Application.RenderWithVisualStyles
             && Control.FlatStyle == FlatStyle.Standard
             && state == CheckState.Unchecked)
@@ -221,6 +222,7 @@ internal class ButtonStandardAdapter : ButtonBaseAdapter
         }
     }
 
+    //Added for https://github.com/dotnet/winforms/issues/6514
     private void DrawRoundBorder(PaintEventArgs e)
     {
         GraphicsPath path = new GraphicsPath();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Buttons/ButtonInternal/ButtonStandardAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Buttons/ButtonInternal/ButtonStandardAdapter.cs
@@ -224,7 +224,7 @@ internal class ButtonStandardAdapter : ButtonBaseAdapter
     private void DrawRoundBorder(PaintEventArgs e)
     {
         GraphicsPath path = new GraphicsPath();
-        Pen pen = Color.Black.GetCachedPenScope();
+        Pen pen = SystemColors.ControlDarkDark.GetCachedPenScope();
 
         int x = Control.ClientRectangle.X + 1;
         int y = Control.ClientRectangle.Y + 1;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Related #6514 


## Proposed changes

- Standard flat-style buttons with visual styles enabled will have dark borders with round corners

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- None 

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![UI. Unchecked borders with low contrast ratio](https://github.com/dotnet/winforms/assets/30190295/1558d75a-5f53-4a69-a2c5-d870d4be36a0)

![Accessibility insights manual test](https://github.com/dotnet/winforms/assets/30190295/bb9d761b-55f0-4d97-b369-e6c137efeb30)

### After

![UI. Unchecked borders with good contrast ratio](https://github.com/dotnet/winforms/assets/30190295/7005f678-9c93-4e19-b607-fb2e88f55a71)

![Accessibility insights manual test](https://github.com/dotnet/winforms/assets/30190295/1c67164d-737b-4673-a65a-5dcf5fabd7ca)

![Screenshot 2023-11-28 172808](https://github.com/dotnet/winforms/assets/30190295/38ac2873-4b97-4288-ba69-82dcad22b699)

![Screenshot 2023-11-28 172924](https://github.com/dotnet/winforms/assets/30190295/84352aff-5da0-4190-aee8-60cb53b43430)

![Screenshot 2023-11-28 172648](https://github.com/dotnet/winforms/assets/30190295/8cb364f7-6823-4544-b37c-d1c987f945b8)

![Screenshot 2023-11-28 173012](https://github.com/dotnet/winforms/assets/30190295/896aace4-33cb-42bb-9138-4900d48c02a7)

## Test methodology <!-- How did you ensure quality? -->

- Manual (Accessibility Insights for Windows)

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

- 9.0.100-alpha.1.23511.2

<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10388)