### PR TITLE
Small refactor of `ToolStripDesignerUtils` to remove `ArrayList` usage

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripDesignerUtils.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripDesignerUtils.cs
@@ -254,7 +254,7 @@ internal sealed class ToolStripDesignerUtils
             Type[] stockItemTypeList = GetStandardItemTypes(component);
             if (currentToolStripVisibility != ToolStripItemDesignerAvailability.None)
             {
-                ArrayList creatableTypes = new ArrayList(itemTypes.Count);
+                List<Type> creatableTypes = new(itemTypes.Count);
                 foreach (Type t in itemTypes)
                 {
                     if (t.IsAbstract)
@@ -303,10 +303,8 @@ internal sealed class ToolStripDesignerUtils
 
                 if (creatableTypes.Count > 0)
                 {
-                    Type[] creatableTypesArray = new Type[creatableTypes.Count];
-                    creatableTypes.CopyTo(creatableTypesArray, 0);
                     s_customToolStripItemCount = creatableTypes.Count;
-                    return creatableTypesArray;
+                    return [.. creatableTypes];
                 }
             }
         }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripDesignerUtils.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripDesignerUtils.cs
@@ -301,11 +301,8 @@ internal sealed class ToolStripDesignerUtils
                     }
                 }
 
-                if (creatableTypes.Count > 0)
-                {
-                    s_customToolStripItemCount = creatableTypes.Count;
-                    return [.. creatableTypes];
-                }
+                s_customToolStripItemCount = creatableTypes.Count;
+                return [.. creatableTypes];
             }
         }
 


### PR DESCRIPTION
Related: #8140

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10400)