### PR TITLE
Add tests tree view after sorting

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
@@ -7202,27 +7202,43 @@ public class TreeViewTests
         TreeNode parent = new("Parent");
         treeView.Nodes.Add(parent);
 
-        TreeNode treeNode1 = new("Node1");
-        TreeNode treeNode2 = new("Node0");
-        TreeNode treeNode3 = new("Node2");
-        TreeNode treeNode4 = new("SubNode1-1-1-1", new[] { treeNode1, treeNode2, treeNode3 });
-        TreeNode treeNode5 = new("SubNode1-1-1", new[] { treeNode4 });
-        TreeNode treeNode6 = new("SubNode1-1", new[] { treeNode5 });
-        TreeNode treeNode7 = new("SubNode1", new[] { treeNode6 });
-        TreeNode treeNode8 = new("Parent", new[] { treeNode7 });
-        parent.Nodes.AddRange(new TreeNode[] { treeNode8 });
+        TreeNode lastSubNode1 = new("Node1");
+        TreeNode lastSubNode2 = new("Node2");
+        TreeNode lastSubNode3 = new("Node3");
+        TreeNode fifthSubNode1 = new("SubNode1-1-1-1", new[] { lastSubNode2, lastSubNode3, lastSubNode1 });
+        TreeNode fifthSubNode2 = new("SubNode1-1-1-2");
+        TreeNode fourthSubNode1 = new("SubNode1-1-1", new[] { fifthSubNode1, fifthSubNode2 });
+        TreeNode fourthSubNode2 = new("SubNode1-1-2");
+        TreeNode thirdSubNode1 = new("SubNode1-1", new[] { fourthSubNode2, fourthSubNode1 });
+        TreeNode thirdSubNode2 = new("SubNode1-2");
+        TreeNode secondSubNode1 = new("SubNode1", new[] { thirdSubNode2, thirdSubNode1 });
+        TreeNode secondSubNode2 = new("SubNode2");
+        TreeNode firstSubNode = new("Parent", new[] { secondSubNode1, secondSubNode2 });
+        parent.Nodes.AddRange(new TreeNode[] { firstSubNode });
+
+        // Make sure all nodes have been added as expected.
+        Assert.Equal(3, fifthSubNode1.Nodes.Count);
+        Assert.Equal(2, parent.Nodes[0].Nodes.Count);
+        Assert.Equal(1, parent.Nodes.Count);
+        Assert.Equal(fourthSubNode2, thirdSubNode1.Nodes[0]);
+        Assert.Equal(lastSubNode3, fifthSubNode1.Nodes[1]);
 
         treeView.Sort();
 
-        Assert.Equal(3, treeNode4.Nodes.Count);
-        Assert.Equal(1, parent.Nodes.Count);
+        // Verify that the sort is successful.
+        Assert.Equal(fourthSubNode2, thirdSubNode1.Nodes[1]);
+        Assert.Equal(lastSubNode3, fifthSubNode1.Nodes[2]);
 
-        // Clear the last node.
-        treeNode4.Nodes.Clear();
-        Assert.Equal(0, treeNode4.Nodes.Count);
+        // Clear the last non-leaf nodes.
+        fifthSubNode1.Nodes.Clear();
+        Assert.Equal(0, fifthSubNode1.Nodes.Count);
 
-        // Clear top-level node.
-        Action action = () => parent.Nodes.Clear();
+        // Clear the first-level child nodes.
+        firstSubNode.Nodes.Clear();
+        Assert.Equal(0, firstSubNode.Nodes.Count);
+
+        // Clear top-level nodes.
+        Action action = parent.Nodes.Clear;
         action.Should().NotThrow();
         Assert.Equal(0, parent.Nodes.Count);
     }
@@ -7236,17 +7252,25 @@ public class TreeViewTests
         TreeNode treeNode2 = new("Node2");
         TreeNode treeNode3 = new("Node3");
         TreeNode treeNode4 = new("Node3");
-        TreeNode parent = new("Parent", new[] { treeNode2, treeNode3, treeNode1, treeNode4 });
+        TreeNode parent = new("Parent", [treeNode2, treeNode3, treeNode1, treeNode4]);
+        parent.Nodes.Add("Node1", "Node1");
         treeView.Nodes.AddRange(parent);
 
         treeView.Sort();
 
-        // Remove node 3, which has the same value as node 4.
-        Assert.Equal(treeNode3, parent.Nodes[2]);
+        // Remove treeNode3, which has the same text as treeNode4.
+        Assert.Equal(treeNode3, parent.Nodes[3]);
 
         parent.Nodes.Remove(treeNode3);
-        Assert.Equal(3, parent.Nodes.Count);
-        Assert.Equal(treeNode4, parent.Nodes[2]);
+        Assert.Equal(4, parent.Nodes.Count);
+        Assert.Equal(treeNode4, parent.Nodes[3]);
+
+        // Remove node "Node1" by key, which has the same text as treeNode1.
+        Assert.True(parent.Nodes.ContainsKey("Node1"));
+
+        parent.Nodes.RemoveByKey("Node1");
+        Assert.False(parent.Nodes.ContainsKey("Node1"));
+        Assert.Equal(treeNode1, parent.Nodes[0]);
 
         // Remove the first child node.
         parent.Nodes.Remove(parent.Nodes[0]);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
@@ -6,7 +6,6 @@ using System.ComponentModel;
 using System.Drawing;
 using System.Windows.Forms.TestUtilities;
 using Moq;
-using static System.Windows.Forms.VisualStyles.VisualStyleElement;
 
 namespace System.Windows.Forms.Tests;
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #10397


## Proposed changes

- Add unit tests "Remove_MultipleLevelsNodes_AfterSort", "Clear_MultipleLevelsNodes_AfterSort" and "Verify_NodeValue_AfterSortAndRemove" to test TreeView after sorting

<!-- We are in TELL-MODE the following section must be completed -->

## Risk

- Minimal

<!-- end TELL-MODE -->


## Test methodology <!-- How did you ensure quality? -->

- Unit tests


## Test environment(s) <!-- Remove any that don't apply -->

- .net 9.0.0-alpha.1.23578.3


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10401)