### PR TITLE
Issue 6514 sample renderer for winforms control test

### DIFF
--- a/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests.Common/MainFormControlsTabOrder.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests.Common/MainFormControlsTabOrder.cs
@@ -45,5 +45,6 @@ public enum MainFormControlsTabOrder
     ListBoxTestButton,
     PasswordButton,
     ChartControlButton,
-    ToolStripSeparatorPreferredSize
+    ToolStripSeparatorPreferredSize,
+    CustomComCtl32Button
 }

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/CustomComCtl32Button.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/CustomComCtl32Button.cs
@@ -1,0 +1,124 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Drawing;
+using System.Drawing.Drawing2D;
+
+namespace WinformsControlsTest;
+
+internal class CustomComCtl32Button : Form
+{
+    public CustomComCtl32Button()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        ClientSize = new Size(400, 100);
+
+        var controls = new Control[]
+        {
+            new CheckBox()
+            {
+                FlatStyle = FlatStyle.Standard,
+                CheckState = CheckState.Unchecked,
+                Appearance = Appearance.Button,
+
+                AutoSize = true,
+                Location = new Point(1, 0)
+            },
+
+            new CheckBox()
+            {
+                FlatStyle = FlatStyle.Standard,
+                Appearance = Appearance.Button,
+                CheckState = CheckState.Checked,
+
+                AutoSize = true,
+                Location = new Point(1, 30)
+            },
+
+            new Button()
+            {
+                FlatStyle = FlatStyle.Standard,
+                Text = $"Real Button Standard Not Pressed",
+
+                AutoSize = true,
+                Location = new Point(1, 60)
+            },
+       };
+
+        foreach (Control control in controls)
+        {
+            control.Paint += (sender, e) => DrawRoundBorder((Control)sender, e.Graphics);
+
+            if (control.GetType().Name == "Button")
+            {
+                var button = (Button)control;
+
+                button.MouseDown += (sender, e) =>
+                {
+                    button.Text = $"Real Button Standard Pressed";
+                };
+
+                button.MouseUp += (sender, e) =>
+                {
+                    button.Text = $"Real Button Standard Not Pressed";
+                };
+            }
+
+            Controls.Add(control);
+        }
+
+        void DrawRoundBorder(Control sender, Graphics g)
+        {
+            var isPressed = false;
+            if (sender.GetType().Name == "CheckBox")
+            {
+                var checkbox = (CheckBox)sender;
+                isPressed = checkbox.CheckState == CheckState.Checked;
+                checkbox.Text = $"CheckBox (Button appearance) Standard {(isPressed ? "Checked" : "Unchecked")}";
+            }
+
+            if (sender.GetType().Name == "Button")
+            {
+                if (sender.Text == "Real Button Standard Pressed")
+                    isPressed = true;
+            }
+
+            // Test possible approach to https://github.com/dotnet/winforms/issues/6514
+            if (Application.RenderWithVisualStyles && !isPressed)
+            {
+                GraphicsPath path = new GraphicsPath();
+                Pen pen = new Pen(SystemColors.ControlDarkDark, 1);
+
+                int x = sender.ClientRectangle.X + 1;
+                int y = sender.ClientRectangle.Y + 1;
+                int width = sender.ClientRectangle.Width - 10;
+                int height = sender.ClientRectangle.Height - 10;
+                const int radius = 8;
+
+                // Top-left corner
+                path.AddArc(new Rectangle(x, y, radius, radius), 180, 90);
+
+                // Top-right corner
+                path.AddArc(new Rectangle(width, y, radius, radius), 270, 90);
+
+                // Bottom-right corner
+                path.AddArc(new Rectangle(width, height, radius, radius), 0, 90);
+
+                // Bottom-left corner
+                path.AddArc(new Rectangle(x, height, radius, radius), 90, 90);
+
+                // Back to Top-left corner
+                path.AddArc(new Rectangle(x, y, radius, radius), 180, 90);
+
+                g.SmoothingMode = SmoothingMode.AntiAlias;
+                g.DrawPath(pen, path);
+            }
+        }
+
+    }
+}

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/CustomComCtl32Button.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/CustomComCtl32Button.cs
@@ -119,6 +119,5 @@ internal class CustomComCtl32Button : Form
                 g.DrawPath(pen, path);
             }
         }
-
     }
 }

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MainForm.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MainForm.cs
@@ -279,11 +279,12 @@ public partial class MainForm : Form
 
         overarchingFlowLayoutPanel.ResumeLayout(true);
 
-        // 4. Calculate the new form size showing all buttons in two vertical columns
+        // 4. Calculate the new form size showing all buttons in three vertical columns
         int padding = overarchingFlowLayoutPanel.Controls[0].Margin.All;
+
         ClientSize = new Size(
-            (biggestButton.Width + padding * 2) * 2 + padding * 2 + overarchingFlowLayoutPanel.Location.X * 2,
-            (overarchingFlowLayoutPanel.Controls.Count + 1) / 2 * (biggestButton.Height + padding * 2)
+            (biggestButton.Width + padding * 2) * 3 + padding * 2 + overarchingFlowLayoutPanel.Location.X * 2,
+            (overarchingFlowLayoutPanel.Controls.Count + 1) / 3 * (biggestButton.Height + padding * 2)
                 + padding * 2 + overarchingFlowLayoutPanel.Location.Y * 2);
         MinimumSize = Size;
         Debug.WriteLine($"Minimum form size: {MinimumSize}", nameof(MainForm));

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MainForm.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MainForm.cs
@@ -218,6 +218,11 @@ public partial class MainForm : Form
             // Test GetPreferredSize output https://github.com/dotnet/winforms/issues/2576
             MainFormControlsTabOrder.ToolStripSeparatorPreferredSize,
             new InitInfo("ToolStripSeparatorPreferredSize", (obj, e) => new ToolStripSeparatorPreferredSize().Show(this))
+        },
+        {
+            // Test possible approach to https://github.com/dotnet/winforms/issues/6514
+            MainFormControlsTabOrder.CustomComCtl32Button,
+            new InitInfo("ComCtl32 Button Custom Border", (obj, e) => new CustomComCtl32Button().Show(this))
         }
     };
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Related #6514 


## Proposed changes

As requested in [PR 10388](https://github.com/dotnet/winforms/pull/10388#discussion_r1408566765):

- Creates a sample on `WinformsControlsTest` for rendering a custom border on a button whose style is defined by the OS. The custom border is darker than the default one when visual styles is enabled;
- Makes the main view be rendered with a minimum of 3 columns of buttons.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- None

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->

![i-6514_before](https://github.com/dotnet/winforms/assets/30190295/077fc294-38e7-40bb-81e2-12b1c54f0bde)

### After

![i-6514_after](https://github.com/dotnet/winforms/assets/30190295/f9014ec0-dfd1-4d7c-8840-7afd01506528)

<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- Manual

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

- 9.0.100-alpha.1.23511.2<!-- use `dotnet --info` -->


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10404)