### PR TITLE
Fix drag and drop related spelling mistakes

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DragDropHelper.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DragDropHelper.cs
@@ -329,8 +329,8 @@ internal static class DragDropHelper
     /// <remarks>
     /// <para>
     /// Because InitializeFromBitmap always performs the RGB multiplication step in calculating the alpha value, you should
-    /// always pass a bitmap without premultiplied alpha blending. Note that no error will result from passing a bitmap
-    /// with premultiplied alpha blending, but this method will multiply it again, doubling the resulting alpha value.
+    /// always pass a bitmap without pre-multiplied alpha blending. Note that no error will result from passing a bitmap
+    /// with pre-multiplied alpha blending, but this method will multiply it again, doubling the resulting alpha value.
     /// </para>
     /// </remarks>
     public static void SetDragImage(IComDataObject dataObject, GiveFeedbackEventArgs e)
@@ -345,8 +345,8 @@ internal static class DragDropHelper
     /// <remarks>
     /// <para>
     /// Because InitializeFromBitmap always performs the RGB multiplication step in calculating the alpha value, you should
-    /// always pass a bitmap without premultiplied alpha blending. Note that no error will result from passing a bitmap
-    /// with premultiplied alpha blending, but this method will multiply it again, doubling the resulting alpha value.
+    /// always pass a bitmap without pre-multiplied alpha blending. Note that no error will result from passing a bitmap
+    /// with pre-multiplied alpha blending, but this method will multiply it again, doubling the resulting alpha value.
     /// </para>
     /// </remarks>
     public static void SetDragImage(IComDataObject dataObject, Bitmap? dragImage, Point cursorOffset, bool usingDefaultDragImage)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DropSource.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DropSource.cs
@@ -15,7 +15,7 @@ internal class DropSource : IDropSource.Interface, IDropSourceNotify.Interface, 
     private readonly IComDataObject _dataObject;
     private HWND _lastHwndTarget;
     private uint _lastHwndTargetThreadId;
-    private GiveFeedbackEventArgs? _lastGiveFeedbacEventArgs;
+    private GiveFeedbackEventArgs? _lastGiveFeedbackEventArgs;
 
     public DropSource(ISupportOleDropSource peer, IComDataObject dataObject, Bitmap? dragImage, Point cursorOffset, bool useDefaultDragImage)
     {
@@ -24,8 +24,8 @@ internal class DropSource : IDropSource.Interface, IDropSourceNotify.Interface, 
 
         if (dragImage is not null)
         {
-            _lastGiveFeedbacEventArgs = new(DragDropEffects.None, useDefaultCursors: false, dragImage, cursorOffset, useDefaultDragImage);
-            DragDropHelper.SetDragImage(_dataObject, _lastGiveFeedbacEventArgs);
+            _lastGiveFeedbackEventArgs = new(DragDropEffects.None, useDefaultCursors: false, dragImage, cursorOffset, useDefaultDragImage);
+            DragDropHelper.SetDragImage(_dataObject, _lastGiveFeedbackEventArgs);
         }
     }
 
@@ -57,21 +57,21 @@ internal class DropSource : IDropSource.Interface, IDropSourceNotify.Interface, 
 
     public HRESULT GiveFeedback(DROPEFFECT dwEffect)
     {
-        GiveFeedbackEventArgs gfbEvent = _lastGiveFeedbacEventArgs is null
+        GiveFeedbackEventArgs gfbEvent = _lastGiveFeedbackEventArgs is null
             ? new((DragDropEffects)dwEffect, useDefaultCursors: true)
             : new(
                 (DragDropEffects)dwEffect,
                 useDefaultCursors: false,
-                _lastGiveFeedbacEventArgs.DragImage,
-                _lastGiveFeedbacEventArgs.CursorOffset,
-                _lastGiveFeedbacEventArgs.UseDefaultDragImage);
+                _lastGiveFeedbackEventArgs.DragImage,
+                _lastGiveFeedbackEventArgs.CursorOffset,
+                _lastGiveFeedbackEventArgs.UseDefaultDragImage);
 
         _peer.OnGiveFeedback(gfbEvent);
 
-        if (IsDropTargetWindowInCurrentThread() && !gfbEvent.Equals(_lastGiveFeedbacEventArgs))
+        if (IsDropTargetWindowInCurrentThread() && !gfbEvent.Equals(_lastGiveFeedbackEventArgs))
         {
-            _lastGiveFeedbacEventArgs = gfbEvent.Clone();
-            UpdateDragImage(_lastGiveFeedbacEventArgs, _dataObject, _lastHwndTarget);
+            _lastGiveFeedbackEventArgs = gfbEvent.Clone();
+            UpdateDragImage(_lastGiveFeedbackEventArgs, _dataObject, _lastHwndTarget);
         }
 
         if (gfbEvent.UseDefaultCursors)

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/DragDropTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/DragDropTests.cs
@@ -339,7 +339,7 @@ public class DragDropTests : ControlTestBase
     }
 
     [WinFormsFact]
-    public async Task DragEnter_Set_DropImageType_Message_MessageReplacementToken_ReturnsExptected_Async()
+    public async Task DragEnter_Set_DropImageType_Message_MessageReplacementToken_ReturnsExpected_Async()
     {
         await RunFormWithoutControlAsync(() => new DragDropForm(TestOutputHelper), async (form) =>
         {
@@ -420,7 +420,7 @@ public class DragDropTests : ControlTestBase
     }
 
     [WinFormsFact]
-    public async Task PictureBox_SetData_DoDragDrop_RichTextBox_ReturnsExptected_Async()
+    public async Task PictureBox_SetData_DoDragDrop_RichTextBox_ReturnsExpected_Async()
     {
         await RunFormWithoutControlAsync(() => new DragImageDropDescriptionForm(TestOutputHelper), async (form) =>
         {
@@ -450,7 +450,7 @@ public class DragDropTests : ControlTestBase
     }
 
     [WinFormsFact]
-    public async Task ToolStripItem_SetData_DoDragDrop_RichTextBox_ReturnsExptected_Async()
+    public async Task ToolStripItem_SetData_DoDragDrop_RichTextBox_ReturnsExpected_Async()
     {
         await RunFormWithoutControlAsync(() => new DragImageDropDescriptionForm(TestOutputHelper), async (form) =>
         {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DragDropHelperTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DragDropHelperTests.cs
@@ -101,7 +101,7 @@ public class DragDropHelperTests
 
     [WinFormsTheory(Skip ="Causing issues with other tests on x86 from the command line")]
     [MemberData(nameof(DragImage_DataObject_Bitmap_Point_bool_TestData))]
-    public unsafe void SetDragImage_DataObject_Bitmap_Point_bool_ReturnsExptected(DataObject dataObject, Bitmap dragImage, Point cursorOffset, bool useDefaultDragImage)
+    public unsafe void SetDragImage_DataObject_Bitmap_Point_bool_ReturnsExpected(DataObject dataObject, Bitmap dragImage, Point cursorOffset, bool useDefaultDragImage)
     {
         try
         {
@@ -125,7 +125,7 @@ public class DragDropHelperTests
 
     [WinFormsTheory(Skip = "Causing issues with other tests on x86 from the command line")]
     [MemberData(nameof(DragImage_DataObject_GiveFeedbackEventArgs_TestData))]
-    public unsafe void SetDragImage_DataObject_GiveFeedbackEventArgs_ReturnsExptected(DataObject dataObject, GiveFeedbackEventArgs e)
+    public unsafe void SetDragImage_DataObject_GiveFeedbackEventArgs_ReturnsExpected(DataObject dataObject, GiveFeedbackEventArgs e)
     {
         try
         {
@@ -236,7 +236,7 @@ public class DragDropHelperTests
 
     [Theory]
     [MemberData(nameof(DropDescription_DataObject_DropImageType_string_string_TestData))]
-    public void SetDropDescription_ReleaseDragDropFormats_ReturnsExptected(DataObject dataObject, DropImageType dropImageType, string message, string messageReplacementToken)
+    public void SetDropDescription_ReleaseDragDropFormats_ReturnsExpected(DataObject dataObject, DropImageType dropImageType, string message, string messageReplacementToken)
     {
         DragDropHelper.SetDropDescription(dataObject, dropImageType, message, messageReplacementToken);
         DragDropHelper.ReleaseDragDropFormats(dataObject);
@@ -255,7 +255,7 @@ public class DragDropHelperTests
 
     [Theory]
     [MemberData(nameof(DropDescription_DragEventArgs_TestData))]
-    public unsafe void SetDropDescription_DragEventArgs_ReturnsExptected(DragEventArgs e)
+    public unsafe void SetDropDescription_DragEventArgs_ReturnsExpected(DragEventArgs e)
     {
         try
         {
@@ -282,7 +282,7 @@ public class DragDropHelperTests
 
     [Theory]
     [MemberData(nameof(DropDescription_DataObject_DropImageType_string_string_TestData))]
-    public unsafe void SetDropDescription_DataObject_DropImageType_string_string_ReturnsExptected(DataObject dataObject, DropImageType dropImageType, string message, string messageReplacementToken)
+    public unsafe void SetDropDescription_DataObject_DropImageType_string_string_ReturnsExpected(DataObject dataObject, DropImageType dropImageType, string message, string messageReplacementToken)
     {
         try
         {
@@ -313,7 +313,7 @@ public class DragDropHelperTests
 
     [Theory]
     [MemberData(nameof(InDragLoop_TestData))]
-    public unsafe void SetInDragLoop_ReturnsExptected(DataObject dataObject, bool inDragLoop)
+    public unsafe void SetInDragLoop_ReturnsExpected(DataObject dataObject, bool inDragLoop)
     {
         try
         {


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

- Fix drag and drop related spelling mistakes.
- Fix `_lastGiveFeedbakEventArgs` and rename to `_lastGiveFeedbackEventArgs`.
- Fix test method names like *`ReturnsExptected` and rename to *`ReturnsExpected`.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- None

## Regression? 

- No

## Risk

- None

<!-- end TELL-MODE -->

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10413)