### PR TITLE
Improve NRT annotations for Control.Contains

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -4758,7 +4758,7 @@ public unsafe partial class Control :
     /// <summary>
     ///  Verifies if a control is a child of this control.
     /// </summary>
-    public bool Contains(Control? ctl)
+    public bool Contains([NotNullWhen(true)] Control? ctl)
     {
         while (ctl is not null)
         {
@@ -5896,7 +5896,7 @@ public unsafe partial class Control :
 
         if (forward)
         {
-            ControlCollection? controls = (ControlCollection?)ctl!.Properties.GetObject(s_controlsCollectionProperty);
+            ControlCollection? controls = (ControlCollection?)ctl.Properties.GetObject(s_controlsCollectionProperty);
 
             if (controls is not null && controls.Count > 0 && (ctl == this || !IsFocusManagingContainerControl(ctl)))
             {
@@ -5972,7 +5972,7 @@ public unsafe partial class Control :
         {
             if (ctl != this)
             {
-                int targetIndex = ctl!._tabIndex;
+                int targetIndex = ctl._tabIndex;
                 bool hitCtl = false;
                 Control? found = null;
                 Control? parent = ctl._parent;
@@ -10542,7 +10542,7 @@ public unsafe partial class Control :
 
     private Control? GetNextSelectableControl(Control? ctl, bool forward, bool tabStopOnly, bool nested, bool wrap)
     {
-        if (!Contains(ctl) || (!nested && ctl?._parent != this))
+        if (!Contains(ctl) || (!nested && ctl._parent != this))
         {
             ctl = null;
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/Containers/ContainerControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/Containers/ContainerControl.cs
@@ -653,13 +653,9 @@ public class ContainerControl : ScrollableControl, IContainerControl
     internal void FocusActiveControlInternal()
     {
         s_focusTracing.TraceVerbose($"ContainerControl::FocusActiveControlInternal() - {Name}");
-#if DEBUG
+
         // Things really get ugly if you try to pop up an assert dialog here
-        if (_activeControl is not null && !Contains(_activeControl))
-        {
-            Debug.WriteLine("ActiveControl is not a child of this ContainerControl");
-        }
-#endif
+        Debug.WriteLineIf(_activeControl is not null && !Contains(_activeControl), "ActiveControl is not a child of this ContainerControl");
 
         if (_activeControl is not null && _activeControl.Visible)
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/Containers/SplitContainer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/Containers/SplitContainer.cs
@@ -1838,7 +1838,7 @@ public partial class SplitContainer : ContainerControl, ISupportInitialize
                                   bool nested, bool wrap)
     {
         if (!Contains(ctl) ||
-            (!nested && ctl?.ParentInternal != this))
+            (!nested && ctl.ParentInternal != this))
         {
             ctl = null;
         }
@@ -1941,7 +1941,7 @@ public partial class SplitContainer : ContainerControl, ISupportInitialize
                                   bool nested, bool wrap)
     {
         if (!Contains(ctl) ||
-            (!nested && ctl?.ParentInternal != this))
+            (!nested && ctl.ParentInternal != this))
         {
             ctl = null;
         }


### PR DESCRIPTION
I noticed this while working on another PR. I updated all callsites accordingly.

## Proposed changes

- Use `NotNullWhenAttribute` on method `Contains` of class `Control`


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10419)