### PR TITLE
Enable nullability in MultiSelectRootGridEntry.PropertyMerger

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/MultiPropertyDescriptorGridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/MultiPropertyDescriptorGridEntry.cs
@@ -124,10 +124,10 @@ internal sealed class MultiPropertyDescriptorGridEntry : PropertyDescriptorGridE
             ChildCollection.Clear();
 
             var mergedProperties = MultiSelectRootGridEntry.PropertyMerger.GetMergedProperties(
-                _mergedDescriptor.GetValues(_objects),
+                _mergedDescriptor.GetValues(_objects)!,
                 this,
                 _propertySort,
-                OwnerTab);
+                OwnerTab!);
 
             Debug.WriteLineIf(
                 CompModSwitches.DebugGridView.TraceVerbose && mergedProperties is null,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/MultiPropertyDescriptorGridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/MultiPropertyDescriptorGridEntry.cs
@@ -124,10 +124,10 @@ internal sealed class MultiPropertyDescriptorGridEntry : PropertyDescriptorGridE
             ChildCollection.Clear();
 
             var mergedProperties = MultiSelectRootGridEntry.PropertyMerger.GetMergedProperties(
-                _mergedDescriptor.GetValues(_objects)!,
+                _mergedDescriptor.GetValues(_objects),
                 this,
                 _propertySort,
-                OwnerTab!);
+                OwnerTab);
 
             Debug.WriteLineIf(
                 CompModSwitches.DebugGridView.TraceVerbose && mergedProperties is null,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/MultiSelectRootGridEntry.PropertyMerger.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/MultiSelectRootGridEntry.PropertyMerger.cs
@@ -84,15 +84,11 @@ internal partial class MultiSelectRootGridEntry
             GridEntry parentEntry)
         {
             var objectProperties = new PropertyDescriptorCollection[objects.Length];
-            Attribute[]? attributes;
+            Attribute[]? attributes = null;
             if (parentEntry.BrowsableAttributes is not null)
             {
                 attributes = new Attribute[parentEntry.BrowsableAttributes.Count];
                 parentEntry.BrowsableAttributes.CopyTo(attributes, 0);
-            }
-            else
-            {
-                attributes = null;
             }
 
             for (int i = 0; i < objects.Length; i++)
@@ -106,7 +102,7 @@ internal partial class MultiSelectRootGridEntry
                 objectProperties[i] = properties;
             }
 
-            List<PropertyDescriptor[]> mergedList = new();
+            List<PropertyDescriptor[]> mergedList = [];
             var matchArray = new PropertyDescriptor[objects.Length];
 
             //


### PR DESCRIPTION
Hopefully this one doesn't step on your toes @gpetrou. Happy to close it if you prefer handling it yourself

## Proposed changes

- Enable nullability in `MultiSelectRootGridEntry.PropertyMerger`


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10420)