### PR TITLE
Using CurrentUICulture to localize instead of using the CurrentCulture

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripMenuItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripMenuItem.cs
@@ -4,6 +4,7 @@
 using System.ComponentModel;
 using System.ComponentModel.Design.Serialization;
 using System.Drawing;
+using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Windows.Forms.Design;
 using System.Windows.Forms.Layout;
@@ -1239,7 +1240,7 @@ public partial class ToolStripMenuItem : ToolStripDropDownItem
             return string.Empty;
         }
 
-        return TypeDescriptor.GetConverter(typeof(Keys)).ConvertToString(shortcutKeys);
+        return TypeDescriptor.GetConverter(typeof(Keys)).ConvertToString(context: null, CultureInfo.CurrentUICulture, shortcutKeys);
     }
 
     internal override bool IsBeingTabbedTo()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripMenuItemTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripMenuItemTests.cs
@@ -147,11 +147,17 @@ public class ToolStripMenuItemTests
     [MemberData(nameof(CultureInfo_Shortcut_TestData))]
     public void ToolStripMenuItem_SetShortcutKeys_ReturnExpectedShortcutText(CultureInfo cultureInfo, CultureInfo cultureUIInfo, string shortCutText)
     {
+        CultureInfo _uiCulture = Thread.CurrentThread.CurrentUICulture;
+        CultureInfo _curCulture = Thread.CurrentThread.CurrentCulture;
+
         Thread.CurrentThread.CurrentUICulture = cultureUIInfo;
         Thread.CurrentThread.CurrentCulture = cultureInfo;
         using SubToolStripMenuItem item = new();
         item.ShortcutKeys = Keys.Control | Keys.Shift | Keys.K;
         Assert.Equal(item.GetShortcutText(), shortCutText);
+
+        Thread.CurrentThread.CurrentUICulture = _uiCulture;
+        Thread.CurrentThread.CurrentCulture = _curCulture;
     }
 
     public static IEnumerable<object[]> CultureInfo_Shortcut_TestData()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripMenuItemTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripMenuItemTests.cs
@@ -12,7 +12,7 @@ public class ToolStripMenuItemTests
     [WinFormsFact]
     public void ToolStripMenuItem_Ctor_Default()
     {
-        using var item = new SubToolStripMenuItem();
+        using SubToolStripMenuItem item = new();
         Assert.NotNull(item.AccessibilityObject);
         Assert.Same(item.AccessibilityObject, item.AccessibilityObject);
         Assert.Null(item.AccessibleDefaultActionDescription);
@@ -127,7 +127,7 @@ public class ToolStripMenuItemTests
     [InlineData(Keys.Control | Keys.Alt | Keys.Shift | Keys.F1)]
     public void ToolStripMenuItem_SetShortcutKeys(Keys keys)
     {
-        using var item = new SubToolStripMenuItem();
+        using SubToolStripMenuItem item = new();
         item.ShortcutKeys = keys;
         Assert.Equal(keys, item.ShortcutKeys);
     }
@@ -139,7 +139,7 @@ public class ToolStripMenuItemTests
     [InlineData(Keys.Control | Keys.Alt | Keys.Shift)]
     public void ToolStripMenuItem_SetShortcutKeys_ThrowsInvalidEnumArgumentException(Keys keys)
     {
-        using var item = new SubToolStripMenuItem();
+        using SubToolStripMenuItem item = new();
         Assert.Throws<InvalidEnumArgumentException>(() => item.ShortcutKeys = keys);
     }
 
@@ -149,7 +149,7 @@ public class ToolStripMenuItemTests
     {
         Thread.CurrentThread.CurrentUICulture = cultureUIInfo;
         Thread.CurrentThread.CurrentCulture = cultureInfo;
-        using var item = new SubToolStripMenuItem();
+        using SubToolStripMenuItem item = new();
         item.ShortcutKeys = Keys.Control | Keys.Shift | Keys.K;
         Assert.Equal(item.GetShortcutText(), shortCutText);
     }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripMenuItemTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripMenuItemTests.cs
@@ -3,6 +3,7 @@
 
 using System.ComponentModel;
 using System.Drawing;
+using System.Globalization;
 
 namespace System.Windows.Forms.Tests;
 
@@ -140,6 +141,40 @@ public class ToolStripMenuItemTests
     {
         using var item = new SubToolStripMenuItem();
         Assert.Throws<InvalidEnumArgumentException>(() => item.ShortcutKeys = keys);
+    }
+
+    [WinFormsTheory]
+    [MemberData(nameof(CultureInfo_Shortcut_TestData))]
+    public void ToolStripMenuItem_SetShortcutKeys_ReturnExpectedShortcutText(CultureInfo cultureInfo, CultureInfo cultureUIInfo, string shortCutText)
+    {
+        Thread.CurrentThread.CurrentUICulture = cultureUIInfo;
+        Thread.CurrentThread.CurrentCulture = cultureInfo;
+        using var item = new SubToolStripMenuItem();
+        item.ShortcutKeys = Keys.Control | Keys.Shift | Keys.K;
+        Assert.Equal(item.GetShortcutText(), shortCutText);
+    }
+
+    public static IEnumerable<object[]> CultureInfo_Shortcut_TestData()
+    {
+        yield return new object[] { new CultureInfo("en-US"), new CultureInfo("en-US"), "Ctrl+Shift+K" };
+        yield return new object[] { new CultureInfo("fr-FR"), new CultureInfo("en-US"), "Ctrl+Shift+K" };
+        yield return new object[] { new CultureInfo("zh-CN"), new CultureInfo("en-US"), "Ctrl+Shift+K" };
+        yield return new object[] { new CultureInfo("de-DE"), new CultureInfo("en-US"), "Ctrl+Shift+K" };
+
+        yield return new object[] { new CultureInfo("en-US"), new CultureInfo("zh-CN"), "Ctrl+Shift+K" };
+        yield return new object[] { new CultureInfo("fr-FR"), new CultureInfo("zh-CN"), "Ctrl+Shift+K" };
+        yield return new object[] { new CultureInfo("zh-CN"), new CultureInfo("zh-CN"), "Ctrl+Shift+K" };
+        yield return new object[] { new CultureInfo("de-DE"), new CultureInfo("zh-CN"), "Ctrl+Shift+K" };
+
+        yield return new object[] { new CultureInfo("en-US"), new CultureInfo("fr-FR"), "Ctrl+Majuscule+K" };
+        yield return new object[] { new CultureInfo("fr-FR"), new CultureInfo("fr-FR"), "Ctrl+Majuscule+K" };
+        yield return new object[] { new CultureInfo("zh-CN"), new CultureInfo("fr-FR"), "Ctrl+Majuscule+K" };
+        yield return new object[] { new CultureInfo("de-DE"), new CultureInfo("fr-FR"), "Ctrl+Majuscule+K" };
+
+        yield return new object[] { new CultureInfo("en-US"), new CultureInfo("de-DE"), "Strg+Umschalttaste+K" };
+        yield return new object[] { new CultureInfo("fr-FR"), new CultureInfo("de-DE"), "Strg+Umschalttaste+K" };
+        yield return new object[] { new CultureInfo("zh-CN"), new CultureInfo("de-DE"), "Strg+Umschalttaste+K" };
+        yield return new object[] { new CultureInfo("de-DE"), new CultureInfo("de-DE"), "Strg+Umschalttaste+K" };
     }
 
     private class SubToolStripMenuItem : ToolStripMenuItem

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripMenuItemTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripMenuItemTests.cs
@@ -145,19 +145,19 @@ public class ToolStripMenuItemTests
 
     [WinFormsTheory]
     [MemberData(nameof(CultureInfo_Shortcut_TestData))]
-    public void ToolStripMenuItem_SetShortcutKeys_ReturnExpectedShortcutText(CultureInfo cultureInfo, CultureInfo cultureUIInfo, string shortCutText)
+    public void ToolStripMenuItem_SetShortcutKeys_ReturnExpectedShortcutText(CultureInfo threadCulture, CultureInfo threadUICulture, string expectedShortcutText)
     {
-        CultureInfo _uiCulture = Thread.CurrentThread.CurrentUICulture;
-        CultureInfo _curCulture = Thread.CurrentThread.CurrentCulture;
+        CultureInfo uiCulture = Thread.CurrentThread.CurrentUICulture;
+        CultureInfo curCulture = Thread.CurrentThread.CurrentCulture;
 
-        Thread.CurrentThread.CurrentUICulture = cultureUIInfo;
-        Thread.CurrentThread.CurrentCulture = cultureInfo;
+        Thread.CurrentThread.CurrentUICulture = threadUICulture;
+        Thread.CurrentThread.CurrentCulture = threadCulture;
         using SubToolStripMenuItem item = new();
         item.ShortcutKeys = Keys.Control | Keys.Shift | Keys.K;
-        Assert.Equal(item.GetShortcutText(), shortCutText);
+        Assert.Equal(expectedShortcutText, item.GetShortcutText());
 
-        Thread.CurrentThread.CurrentUICulture = _uiCulture;
-        Thread.CurrentThread.CurrentCulture = _curCulture;
+        Thread.CurrentThread.CurrentUICulture = uiCulture;
+        Thread.CurrentThread.CurrentCulture = curCulture;
     }
 
     public static IEnumerable<object[]> CultureInfo_Shortcut_TestData()


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #10384


## Proposed changes

- Localizing Keyboard Shortcuts with the CurrentUICulture.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- The shortcuts will be display in windows display language.

## Regression? 

- Yes

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
![image](https://github.com/dotnet/winforms/assets/133954995/218132b9-d60a-4b6f-b6a2-e5026a69b26e)

### After
![image](https://github.com/dotnet/winforms/assets/133954995/79ad9a0f-4ba6-4c65-a690-b18625b4e1fe)


## Test methodology <!-- How did you ensure quality? -->

- Manual 

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

- 9.0.100-alpha.1.23504.14


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10426)