### PR TITLE
Fix `ErrorProvider.HasErrors` so maintains correct value

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ErrorProviderTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ErrorProviderTests.cs
@@ -1231,15 +1231,80 @@ public class ErrorProviderTests
     }
 
     [WinFormsFact]
-    public void ErrorProvider_HasErrors_ControlErrorReset()
+    public void ErrorProvider_HasErrors_Cleared()
     {
         using var provider = new ErrorProvider();
         using var control1 = new Control();
 
-        provider.SetError(control1, String.Empty);
+        provider.SetError(control1, "Some error");
         Assert.True(provider.HasErrors);
 
         provider.Clear();
+        Assert.False(provider.HasErrors);
+    }
+
+    [WinFormsFact]
+    public void ErrorProvider_HasErrors_After_ErrorSetNull()
+    {
+        using var provider = new ErrorProvider();
+        using var control1 = new Control();
+
+        provider.SetError(control1, "Some error");
+        Assert.True(provider.HasErrors);
+
+        provider.SetError(control1, null);
+        Assert.False(provider.HasErrors);
+    }
+
+    [WinFormsFact]
+    public void ErrorProvider_HasErrors_After_ErrorSetEmptyString()
+    {
+        using var provider = new ErrorProvider();
+        using var control1 = new Control();
+
+        provider.SetError(control1, "Some error");
+        Assert.True(provider.HasErrors);
+
+        provider.SetError(control1, string.Empty);
+        Assert.False(provider.HasErrors);
+    }
+
+    [WinFormsFact]
+    public void ErrorProvider_HasErrors_After_ErrorSetEmptyStringMultiple()
+    {
+        using var provider = new ErrorProvider();
+        using var control1 = new Control();
+
+        provider.SetError(control1, "Some error");
+        Assert.True(provider.HasErrors);
+
+        provider.SetError(control1, string.Empty);
+        provider.SetError(control1, string.Empty);
+        provider.SetError(control1, string.Empty);
+        provider.SetError(control1, string.Empty);
+        Assert.False(provider.HasErrors);
+    }
+
+    [WinFormsFact]
+    public void ErrorProvider_HasErrors_SetErrorMultiple()
+    {
+        using var provider = new ErrorProvider();
+        using var control1 = new Control();
+
+        provider.SetError(control1, "Some error");
+        provider.SetError(control1, "Some error");
+        provider.SetError(control1, "Some error");
+        provider.SetError(control1, "Some error");
+        Assert.True(provider.HasErrors);
+    }
+
+    [WinFormsFact]
+    public void ErrorProvider_HasErrors_After_GetError()
+    {
+        using var provider = new ErrorProvider();
+        using var control1 = new Control();
+
+        _ = provider.GetError(control1);
         Assert.False(provider.HasErrors);
     }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ErrorProviderTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ErrorProviderTests.cs
@@ -1214,7 +1214,7 @@ public class ErrorProviderTests
     [WinFormsFact]
     public void ErrorProvider_HasErrors_NoControl_Set()
     {
-        using var provider = new ErrorProvider();
+        using ErrorProvider provider = new();
 
         Assert.False(provider.HasErrors);
     }
@@ -1222,8 +1222,8 @@ public class ErrorProviderTests
     [WinFormsFact]
     public void ErrorProvider_HasErrors_SomeControlsSet()
     {
-        using var provider = new ErrorProvider();
-        using var control1 = new Control();
+        using ErrorProvider provider = new();
+        using Control control1 = new();
 
         provider.SetError(control1, "error");
 
@@ -1233,8 +1233,8 @@ public class ErrorProviderTests
     [WinFormsFact]
     public void ErrorProvider_HasErrors_Cleared()
     {
-        using var provider = new ErrorProvider();
-        using var control1 = new Control();
+        using ErrorProvider provider = new();
+        using Control control1 = new();
 
         provider.SetError(control1, "Some error");
         Assert.True(provider.HasErrors);
@@ -1246,8 +1246,8 @@ public class ErrorProviderTests
     [WinFormsFact]
     public void ErrorProvider_HasErrors_After_ErrorSetNull()
     {
-        using var provider = new ErrorProvider();
-        using var control1 = new Control();
+        using ErrorProvider provider = new();
+        using Control control1 = new();
 
         provider.SetError(control1, "Some error");
         Assert.True(provider.HasErrors);
@@ -1259,8 +1259,8 @@ public class ErrorProviderTests
     [WinFormsFact]
     public void ErrorProvider_HasErrors_After_ErrorSetEmptyString()
     {
-        using var provider = new ErrorProvider();
-        using var control1 = new Control();
+        using ErrorProvider provider = new();
+        using Control control1 = new();
 
         provider.SetError(control1, "Some error");
         Assert.True(provider.HasErrors);
@@ -1272,8 +1272,8 @@ public class ErrorProviderTests
     [WinFormsFact]
     public void ErrorProvider_HasErrors_After_ErrorSetEmptyStringMultiple()
     {
-        using var provider = new ErrorProvider();
-        using var control1 = new Control();
+        using ErrorProvider provider = new();
+        using Control control1 = new();
 
         provider.SetError(control1, "Some error");
         Assert.True(provider.HasErrors);
@@ -1288,8 +1288,8 @@ public class ErrorProviderTests
     [WinFormsFact]
     public void ErrorProvider_HasErrors_SetErrorMultiple()
     {
-        using var provider = new ErrorProvider();
-        using var control1 = new Control();
+        using ErrorProvider provider = new();
+        using Control control1 = new();
 
         provider.SetError(control1, "Some error");
         provider.SetError(control1, "Some error");
@@ -1301,8 +1301,8 @@ public class ErrorProviderTests
     [WinFormsFact]
     public void ErrorProvider_HasErrors_After_GetError()
     {
-        using var provider = new ErrorProvider();
-        using var control1 = new Control();
+        using ErrorProvider provider = new();
+        using Control control1 = new();
 
         _ = provider.GetError(control1);
         Assert.False(provider.HasErrors);


### PR DESCRIPTION
Fixes #10424

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10440)