### PR TITLE
Fix coding style link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,5 +57,5 @@ There are lots of thoughts and [approaches](https://github.com/antlr/antlr4-cpp/
 [api-review-process]: https://github.com/dotnet/runtime/blob/master/docs/project/api-review-process.md
 [breaking-changes]: https://github.com/dotnet/runtime/blob/master/docs/coding-guidelines/breaking-changes.md#bucket-1-public-contract
 [breaking-changes-public-contract]: https://github.com/dotnet/runtime/blob/master/docs/coding-guidelines/breaking-changes.md#bucket-1-public-contract
-[coding-style]: coding-style.md
+[coding-style]: docs/coding-style.md
 [net-contributing]: https://github.com/dotnet/runtime/blob/master/CONTRIBUTING.md


### PR DESCRIPTION
## Proposed changes

- Fix coding style link in CONTRIBUTING.md


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10450)