### PR TITLE
Update the logic of the function GetIconResourceAsBitmap in class Sca…

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DesignerActionGlyph.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DesignerActionGlyph.cs
@@ -15,9 +15,8 @@ internal sealed class DesignerActionGlyph : Glyph
 {
     internal const int CONTROLOVERLAP_X = 5;                    // number of pixels the anchor should be offset to the left of the control's upper-right
     internal const int CONTROLOVERLAP_Y = 2;                    // number of pixels the anchor overlaps the control in the y-direction
-    private const byte IconsWidth = 10;
-    private const byte IconsHeight = 10;
 
+    private const byte IconSize = 10;
     private Rectangle _alternativeBounds = Rectangle.Empty;     // if !empty, this represents the bounds of the tray control this glyph is related to
     private Rectangle _bounds;                                  // the bounds of our glyph
     private readonly Adorner? _adorner;                         // A ptr back to our adorner - so when we decide to change state, we can invalidate
@@ -27,6 +26,8 @@ internal sealed class DesignerActionGlyph : Glyph
     private DockStyle _dockStyle;
     private Bitmap? _glyphImageClosed;
     private Bitmap? _glyphImageOpened;
+    private readonly byte _iconsWidth = IconSize;
+    private readonly byte _iconsHeight = IconSize;
 
     /// <summary>
     ///  Constructor that passes empty alternative bounds and parents.
@@ -49,6 +50,7 @@ internal sealed class DesignerActionGlyph : Glyph
     private DesignerActionGlyph(DesignerActionBehavior? behavior, Adorner? adorner, Rectangle alternativeBounds, Control? alternativeParent)
         : base(behavior)
     {
+        _iconsWidth = _iconsHeight = (byte)ScaleHelper.ScaleToInitialSystemDpi(IconSize);
         _adorner = adorner;
         _alternativeBounds = alternativeBounds;
         _alternativeParent = alternativeParent;
@@ -100,12 +102,12 @@ internal sealed class DesignerActionGlyph : Glyph
     private Image GlyphImageClosed => _glyphImageClosed ??= ScaleHelper.GetIconResourceAsBitmap(
         typeof(DesignerActionGlyph),
         "Close_left",
-        new Size(IconsWidth, IconsHeight));
+        new Size(_iconsWidth, _iconsHeight));
 
     private Image GlyphImageOpened => _glyphImageOpened ??= ScaleHelper.GetIconResourceAsBitmap(
         typeof(DesignerActionGlyph),
         "Open_left",
-        new Size(IconsWidth, IconsHeight));
+        new Size(_iconsWidth, _iconsHeight));
 
     internal void InvalidateOwnerLocation()
     {

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DesignerActionGlyph.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DesignerActionGlyph.cs
@@ -15,6 +15,8 @@ internal sealed class DesignerActionGlyph : Glyph
 {
     internal const int CONTROLOVERLAP_X = 5;                    // number of pixels the anchor should be offset to the left of the control's upper-right
     internal const int CONTROLOVERLAP_Y = 2;                    // number of pixels the anchor overlaps the control in the y-direction
+    private const byte IconsWidth = 10;
+    private const byte IconsHeight = 10;
 
     private Rectangle _alternativeBounds = Rectangle.Empty;     // if !empty, this represents the bounds of the tray control this glyph is related to
     private Rectangle _bounds;                                  // the bounds of our glyph
@@ -98,12 +100,12 @@ internal sealed class DesignerActionGlyph : Glyph
     private Image GlyphImageClosed => _glyphImageClosed ??= ScaleHelper.GetIconResourceAsBitmap(
         typeof(DesignerActionGlyph),
         "Close_left",
-        ScaleHelper.InitialSystemDpi);
+        new Size(IconsWidth, IconsHeight));
 
     private Image GlyphImageOpened => _glyphImageOpened ??= ScaleHelper.GetIconResourceAsBitmap(
         typeof(DesignerActionGlyph),
         "Open_left",
-        ScaleHelper.InitialSystemDpi);
+        new Size(IconsWidth, IconsHeight));
 
     internal void InvalidateOwnerLocation()
     {

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DesignerActionGlyph.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DesignerActionGlyph.cs
@@ -26,8 +26,6 @@ internal sealed class DesignerActionGlyph : Glyph
     private DockStyle _dockStyle;
     private Bitmap? _glyphImageClosed;
     private Bitmap? _glyphImageOpened;
-    private readonly byte _iconsWidth = IconSize;
-    private readonly byte _iconsHeight = IconSize;
 
     /// <summary>
     ///  Constructor that passes empty alternative bounds and parents.
@@ -50,7 +48,6 @@ internal sealed class DesignerActionGlyph : Glyph
     private DesignerActionGlyph(DesignerActionBehavior? behavior, Adorner? adorner, Rectangle alternativeBounds, Control? alternativeParent)
         : base(behavior)
     {
-        _iconsWidth = _iconsHeight = (byte)ScaleHelper.ScaleToInitialSystemDpi(IconSize);
         _adorner = adorner;
         _alternativeBounds = alternativeBounds;
         _alternativeParent = alternativeParent;
@@ -102,12 +99,12 @@ internal sealed class DesignerActionGlyph : Glyph
     private Image GlyphImageClosed => _glyphImageClosed ??= ScaleHelper.GetIconResourceAsBitmap(
         typeof(DesignerActionGlyph),
         "Close_left",
-        new Size(_iconsWidth, _iconsHeight));
+        ScaleHelper.ScaleToDpi(new Size(IconSize, IconSize), ScaleHelper.InitialSystemDpi));
 
     private Image GlyphImageOpened => _glyphImageOpened ??= ScaleHelper.GetIconResourceAsBitmap(
         typeof(DesignerActionGlyph),
         "Open_left",
-        new Size(_iconsWidth, _iconsHeight));
+        ScaleHelper.ScaleToDpi(new Size(IconSize, IconSize), ScaleHelper.InitialSystemDpi));
 
     internal void InvalidateOwnerLocation()
     {

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/ScaleHelper.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/ScaleHelper.cs
@@ -332,7 +332,7 @@ internal static partial class ScaleHelper
     ///  Gets the given icon resource as a <see cref="Bitmap"/> scaled to the specified dpi.
     /// </summary>
     internal static Bitmap GetIconResourceAsBitmap(Type type, string resource, int dpi)
-        => GetIconResourceAsBestMatchBitmap(type, resource, ScaleToDpi(SystemIconSize, dpi));
+        => GetIconResourceAsBitmap(type, resource, ScaleToDpi(SystemIconSize, dpi));
 
     /// <summary>
     ///  Gets the given icon resource as a <see cref="Bitmap"/> of the given size.

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/ScaleHelper.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/ScaleHelper.cs
@@ -332,7 +332,12 @@ internal static partial class ScaleHelper
     ///  Gets the given icon resource as a <see cref="Bitmap"/> scaled to the specified dpi.
     /// </summary>
     internal static Bitmap GetIconResourceAsBitmap(Type type, string resource, int dpi)
-        => GetIconResourceAsBitmap(type, resource, ScaleToDpi(SystemIconSize, dpi));
+    {
+        Size size = ScaleToDpi(SystemIconSize, dpi);
+        return dpi == OneHundredPercentLogicalDpi
+            ? GetIconResourceAsBestMatchBitmap(type, resource, size)
+            : GetIconResourceAsBitmap(type, resource, size);
+    }
 
     /// <summary>
     ///  Gets the given icon resource as a <see cref="Bitmap"/> of the given size.

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/ScaleHelper.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/ScaleHelper.cs
@@ -332,12 +332,7 @@ internal static partial class ScaleHelper
     ///  Gets the given icon resource as a <see cref="Bitmap"/> scaled to the specified dpi.
     /// </summary>
     internal static Bitmap GetIconResourceAsBitmap(Type type, string resource, int dpi)
-    {
-        Size size = ScaleToDpi(SystemIconSize, dpi);
-        return dpi == OneHundredPercentLogicalDpi
-            ? GetIconResourceAsBestMatchBitmap(type, resource, size)
-            : GetIconResourceAsBitmap(type, resource, size);
-    }
+        => GetIconResourceAsBestMatchBitmap(type, resource, ScaleToDpi(SystemIconSize, dpi));
 
     /// <summary>
     ///  Gets the given icon resource as a <see cref="Bitmap"/> of the given size.


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #10444

## Cause of this issue:
- Since the icon` Close_left` and` Open_left` are not standard logical sizes (16X16), after calling `GetIconResourceAsBitmap(Type type, string resource, int dpi)`, thay are scaled from the standard logical size 16x16 to 200% size - 32X32

## Proposed changes

- Specify custom icon size in code for the non-standard icons (glyphs in the designer)
- Using  `GetIconResourceAsBitmap(Type type, string resource, Size size)` instead of "GetIconResourceAsBitmap(Type type, string resource, int dpi)" when initial Image "GlyphImageClosed" and "GlyphImageOpened"


<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- The smart tag icon can be show normally

## Regression? 

- Yes (From PR#[10434](https://github.com/dotnet/winforms/pull/10434))

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
Smart tag icons getting very large

![image](https://github.com/dotnet/winforms/assets/86937911/dfdb07ad-a73b-4117-8948-cd7f2dabc929)


### After
The size of the Smart tag icon is normal

![image](https://github.com/dotnet/winforms/assets/132890443/f57053e5-2dbe-4b82-a664-ffc275ec07ac)


## Test methodology <!-- How did you ensure quality? -->

- Manually


## Test environment(s) <!-- Remove any that don't apply -->

- .net 9.0.0-alpha.1.23609.5


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10459)