### PR TITLE
Makes UIA consider starting row as 1 (new default) for new lines in DataGridView

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridView.Methods.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridView.Methods.cs
@@ -9,6 +9,7 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.Windows.Forms.Automation;
 using System.Windows.Forms.Layout;
+using System.Windows.Forms.Primitives;
 using System.Windows.Forms.VisualStyles;
 using Microsoft.Win32;
 using Windows.Win32.UI.Accessibility;
@@ -85,7 +86,7 @@ public partial class DataGridView
                 AccessibilityObject.InternalRaiseAutomationNotification(
                     AutomationNotificationKind.ItemAdded,
                     AutomationNotificationProcessing.ImportantMostRecent,
-                    string.Format(SR.DataGridView_RowAddedNotification, NewRowIndex));
+                    string.Format(SR.DataGridView_RowAddedNotification, NewRowIndex + (LocalAppContextSwitches.DataGridViewUIAStartRowCountAtZero ? 0 : 1)));
             }
         }
     }


### PR DESCRIPTION
Fixes #10428


## Proposed changes

- Makes UIA consider DataGridView starting row as 1 by default when adding a new row, unless the `LocalAppContextSwitches.DataGridViewUIAStartRowCountAtZero` switch is set to true.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- None

## Regression? 

- Yes

## Risk

- Minimal

<!-- end TELL-MODE -->

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->

### After

<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- Manual (Narrator)

## Test environment(s) <!-- Remove any that don't apply -->

- 9.0.100-alpha.1.23511.2


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10464)