### PR TITLE
Get rid of CA1822 in UiaTextProvider

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Automation/UiaTextProvider.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Automation/UiaTextProvider.cs
@@ -116,9 +116,9 @@ internal abstract unsafe class UiaTextProvider : ITextProvider.Interface, ITextP
     internal static VARIANT BoundingRectangleAsVariant(Rectangle bounds)
         => (VARIANT)BoundingRectangleAsArray(bounds);
 
-    public int SendInput(int inputs, ref INPUT input, int size) => (int)PInvoke.SendInput([input], size);
+    public static int SendInput(int inputs, ref INPUT input, int size) => (int)PInvoke.SendInput([input], size);
 
-    public unsafe int SendKeyboardInputVK(VIRTUAL_KEY vk, bool press)
+    public static unsafe int SendKeyboardInputVK(VIRTUAL_KEY vk, bool press)
     {
         INPUT keyboardInput = default;
 

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Automation/UiaTextRange.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Automation/UiaTextRange.cs
@@ -608,7 +608,7 @@ internal sealed unsafe class UiaTextRange : ITextRangeProvider.Interface, IManag
             {
                 if (Start > visibleStart || Start < visibleEnd)
                 {
-                    _provider.SendKeyboardInputVK(key, true);
+                    UiaTextProvider.SendKeyboardInputVK(key, true);
                     _provider.GetVisibleRangePoints(out visibleStart, out visibleEnd);
                 }
 
@@ -617,7 +617,7 @@ internal sealed unsafe class UiaTextRange : ITextRangeProvider.Interface, IManag
 
             if (Start < visibleStart || Start > visibleEnd)
             {
-                _provider.SendKeyboardInputVK(key, true);
+                UiaTextProvider.SendKeyboardInputVK(key, true);
                 _provider.GetVisibleRangePoints(out visibleStart, out visibleEnd);
             }
         }

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/Automation/UiaTextProviderTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/Automation/UiaTextProviderTests.cs
@@ -106,19 +106,16 @@ public unsafe class UiaTextProviderTests
     [StaFact]
     public unsafe void UiaTextProvider_SendInput_SendsOneInput()
     {
-        Mock<UiaTextProvider> providerMock = new Mock<UiaTextProvider>(MockBehavior.Strict);
         INPUT keyboardInput = new INPUT();
 
-        int actual = providerMock.Object.SendInput(1, ref keyboardInput, sizeof(INPUT));
+        int actual = UiaTextProvider.SendInput(1, ref keyboardInput, sizeof(INPUT));
         Assert.Equal(1, actual);
     }
 
     [StaFact]
     public void UiaTextProvider_SendKeyboardInputVK_SendsOneInput()
     {
-        Mock<UiaTextProvider> providerMock = new Mock<UiaTextProvider>(MockBehavior.Strict);
-
-        int actual = providerMock.Object.SendKeyboardInputVK(VIRTUAL_KEY.VK_LEFT, true);
+        int actual = UiaTextProvider.SendKeyboardInputVK(VIRTUAL_KEY.VK_LEFT, true);
         Assert.Equal(1, actual);
     }
 }


### PR DESCRIPTION
Visual Studio shows CA1822 warning that a method could be made static

<img width="778" alt="image" src="https://github.com/dotnet/winforms/assets/15823268/6f51245b-8dbd-466e-8f58-78d7ec9441be">


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10465)