### PR TITLE
fix [Accessibility] Accessibility Insights tool keeps loading when mouse-over DataGridView #10343

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+*REMOVED*override System.Windows.Forms.DataGridViewTextBoxEditingControl.OnHandleCreated(System.EventArgs! e) -> void
+*REMOVED*override System.Windows.Forms.DataGridViewComboBoxEditingControl.OnHandleCreated(System.EventArgs! e) -> void

--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -1,2 +1,0 @@
-*REMOVED*override System.Windows.Forms.DataGridViewTextBoxEditingControl.OnHandleCreated(System.EventArgs! e) -> void
-*REMOVED*override System.Windows.Forms.DataGridViewComboBoxEditingControl.OnHandleCreated(System.EventArgs! e) -> void

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxEditingControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxEditingControl.cs
@@ -17,10 +17,12 @@ public partial class DataGridViewComboBoxEditingControl : ComboBox, IDataGridVie
         TabStop = false;
     }
 
-    protected override AccessibleObject CreateAccessibilityInstance() =>
-        new DataGridViewComboBoxEditingControlAccessibleObject(this);
-
-    // IDataGridViewEditingControl interface implementation
+    protected override AccessibleObject CreateAccessibilityInstance()
+    {
+        var controlAccessibleObject = new DataGridViewComboBoxEditingControlAccessibleObject(this);
+        _dataGridView?.SetAccessibleObjectParent(controlAccessibleObject);
+        return controlAccessibleObject;
+    }
 
     public virtual DataGridView? EditingControlDataGridView
     {
@@ -120,17 +122,6 @@ public partial class DataGridViewComboBoxEditingControl : ComboBox, IDataGridVie
         if (SelectedIndex != -1)
         {
             NotifyDataGridViewOfValueChange();
-        }
-    }
-
-    protected override void OnHandleCreated(EventArgs e)
-    {
-        base.OnHandleCreated(e);
-
-        // The null-check was added as a fix for a https://github.com/dotnet/winforms/issues/2138
-        if (_dataGridView?.IsAccessibilityObjectCreated == true)
-        {
-            _dataGridView.SetAccessibleObjectParent(AccessibilityObject);
         }
     }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxEditingControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxEditingControl.cs
@@ -125,6 +125,11 @@ public partial class DataGridViewComboBoxEditingControl : ComboBox, IDataGridVie
         }
     }
 
+    protected override void OnHandleCreated(EventArgs e)
+    {
+        base.OnHandleCreated(e);
+    }
+
     internal override void ReleaseUiaProvider(HWND handle)
     {
         if (TryGetAccessibilityObject(out AccessibleObject? accessibleObject))

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxEditingControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxEditingControl.cs
@@ -312,4 +312,9 @@ public partial class DataGridViewTextBoxEditingControl : TextBox, IDataGridViewE
             return HorizontalAlignment.Left;
         }
     }
+
+    protected override void OnHandleCreated(EventArgs e)
+    {
+        base.OnHandleCreated(e);
+    }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxEditingControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxEditingControl.cs
@@ -22,7 +22,11 @@ public partial class DataGridViewTextBoxEditingControl : TextBox, IDataGridViewE
     }
 
     protected override AccessibleObject CreateAccessibilityInstance()
-        => new DataGridViewTextBoxEditingControlAccessibleObject(this);
+    {
+        var controlAccessibleObject = new DataGridViewTextBoxEditingControlAccessibleObject(this);
+        _dataGridView?.SetAccessibleObjectParent(controlAccessibleObject);
+        return controlAccessibleObject;
+    }
 
     public virtual DataGridView? EditingControlDataGridView
     {
@@ -306,17 +310,6 @@ public partial class DataGridViewTextBoxEditingControl : TextBox, IDataGridViewE
         else
         {
             return HorizontalAlignment.Left;
-        }
-    }
-
-    protected override void OnHandleCreated(EventArgs e)
-    {
-        base.OnHandleCreated(e);
-
-        // The null-check was added as a fix for a https://github.com/dotnet/winforms/issues/2138
-        if (IsHandleCreated && _dataGridView?.IsAccessibilityObjectCreated == true)
-        {
-            _dataGridView.SetAccessibleObjectParent(AccessibilityObject);
         }
     }
 }


### PR DESCRIPTION
Fix #10343


Same change from [PR_10372](https://github.com/dotnet/winforms/pull/10372)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10472)