### PR TITLE
Fix RichTextBox drag and drop

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.cs
@@ -66,7 +66,7 @@ public unsafe partial class DataObject :
         // Get the RCW for the pointer and continue.
         bool success = ComHelpers.TryGetObjectForIUnknown(
             (Com.IUnknown*)data,
-            takeOwnership: true,
+            takeOwnership: false,
             out ComTypes.IDataObject? comTypesData);
 
         Debug.Assert(success && comTypesData is not null);


### PR DESCRIPTION
When receiving dropped data the COM IDataObject was not adding a ref count as appropriately. (The RCW adds a ref, but we were also releasing it.)

This causes random memory corruption, and crashes .NET.

Fixes #10470

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10475)