### PR TITLE
opt-in for AnchorLayoutV2 in .Net 8.0

### DIFF
--- a/docs/design/anchor-layout-changes-in-net80.md
+++ b/docs/design/anchor-layout-changes-in-net80.md
@@ -110,14 +110,14 @@ private static void ComputeAnchorInfo(IArrangedElement element)
 
 ## Risk mitigation
 
-The layout engine, in general, is quite complex, and any changes in it carry a very high risk. In order to reduce the risks and to provide backward compatibility, the new anchor calculations are put behind a feature switch `System.Windows.Forms.AnchorLayoutV2`. The switch is disabled by default for Windows Forms applications.
+The layout engine, in general, is quite complex, and any changes in it carry a very high risk. In order to reduce the risks and to provide backward compatibility, the new anchor calculations are put behind a feature switch `System.Windows.Forms.AnchorLayoutV2`. The switch is enabled by default for Windows Forms applications targeting .NET 8.
 
-Developers need to opt-in to get this new feature by setting the switch value to `true` in the [runtimeconfig.json](https://learn.microsoft.com/dotnet/core/runtime-config/#runtimeconfigjson).
+It is possible to retain the original anchor calculations by setting the swtich to `false` in the [runtimeconfig.json](https://learn.microsoft.com/dotnet/core/runtime-config/#runtimeconfigjson).
 Snippet for runtimeconfig.template.json:
 ```JSON
 {
   "configProperties": {
-    "System.Windows.Forms.AnchorLayoutV2": true
+    "System.Windows.Forms.AnchorLayoutV2": false
   }
 }
 ```

--- a/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
@@ -100,6 +100,11 @@ internal static partial class LocalAppContextSwitches
                     return true;
                 }
 
+                if (switchName == AnchorLayoutV2SwitchName)
+                {
+                    return true;
+                }
+
                 if (switchName == TrackBarModernRenderingSwitchName)
                 {
                     return true;
@@ -119,7 +124,7 @@ internal static partial class LocalAppContextSwitches
     ///  Indicates whether AnchorLayoutV2 feature is enabled.
     /// </summary>
     /// <devdoc>
-    ///  Returns AnchorLayoutV2 switch value from runtimeconfig.json. Defaults to false.
+    ///  Returns AnchorLayoutV2 switch value from runtimeconfig.json. Defaults to true if application is targeting .NET 8.0 and beyond.
     ///  Refer to
     ///  https://github.com/dotnet/winforms/blob/tree/main/docs/design/anchor-layout-changes-in-net80.md for more details.
     /// </devdoc>

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/LocalAppContextSwitchesTest.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/LocalAppContextSwitchesTest.cs
@@ -31,6 +31,7 @@ public class LocalAppContextSwitchesTest
             testAccessor.s_targetFrameworkName = new FrameworkName(targetFrameworkName);
 
             Assert.Equal(expected, LocalAppContextSwitches.TrackBarModernRendering);
+            Assert.Equal(expected, LocalAppContextSwitches.AnchorLayoutV2);
             Assert.Equal(expected, LocalAppContextSwitches.ScaleTopLevelFormMinMaxSizeForDpi);
             Assert.Equal(expected, LocalAppContextSwitches.ServicePointManagerCheckCrl);
         }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #10382 


## Proposed changes

- Revert the PR #9942 to change default opt-in to true for AnchorLayoutV2 in .Net 8.0, due to the related issue  [9740](https://github.com/dotnet/winforms/issues/9740) and [5136](https://github.com/microsoft/winforms-designer/issues/5136) have been resolved in [PR #5489](https://github.com/microsoft/winforms-designer/pull/5489)

<!-- We are in TELL-MODE the following section must be completed -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
Open application in 125% resolution
![image](https://github.com/dotnet/winforms/assets/132890443/ec57a200-b879-4ac0-8136-dfb7e46a623f)


### After
Open application in 100% resolution and change resolution 100 to 125% 
![image](https://github.com/dotnet/winforms/assets/132890443/ba2057bb-174c-47f3-8eac-58f9a2660bac)


## Test methodology <!-- How did you ensure quality? -->

- Manually


## Test environment(s) <!-- Remove any that don't apply -->

- .net 8.0.100


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10477)