### PR TITLE
Hide the RichTextBox drag image and drop description if the Effect is set to None

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/RichTextBox/RichTextBox.OleCallback.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/RichTextBox/RichTextBox.OleCallback.cs
@@ -180,7 +180,7 @@ public partial class RichTextBox
                 e.Effect = keyState.HasFlag(MODIFIERKEYS_FLAGS.MK_CONTROL) ? DragDropEffects.Copy : DragDropEffects.Move;
                 _owner.OnDragEnter(e);
 
-                if ((e.Effect != DragDropEffects.None && e.DropImageType > DropImageType.Invalid) && _owner.IsHandleCreated)
+                if (CanShowImage(e))
                 {
                     UpdateDropDescription(e);
                     DragDropHelper.DragEnter(_owner.Handle, e);
@@ -295,7 +295,7 @@ public partial class RichTextBox
                     _owner.OnDragOver(e);
                     _lastEffect = e.Effect;
 
-                    if (e.Effect != DragDropEffects.None && e.DropImageType > DropImageType.Invalid)
+                    if (CanShowImage(e))
                     {
                         UpdateDropDescription(e);
                         DragDropHelper.DragOver(e);
@@ -324,6 +324,9 @@ public partial class RichTextBox
 
             return HRESULT.S_OK;
         }
+
+        private bool CanShowImage(DragEventArgs e)
+            => e.Effect != DragDropEffects.None && e.DropImageType > DropImageType.Invalid && _owner.IsHandleCreated;
 
         private void UpdateDropDescription(DragEventArgs e)
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/RichTextBox/RichTextBox.OleCallback.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/RichTextBox/RichTextBox.OleCallback.cs
@@ -180,7 +180,7 @@ public partial class RichTextBox
                 e.Effect = keyState.HasFlag(MODIFIERKEYS_FLAGS.MK_CONTROL) ? DragDropEffects.Copy : DragDropEffects.Move;
                 _owner.OnDragEnter(e);
 
-                if ((e.DropImageType > DropImageType.Invalid) && _owner.IsHandleCreated)
+                if ((e.Effect != DragDropEffects.None && e.DropImageType > DropImageType.Invalid) && _owner.IsHandleCreated)
                 {
                     UpdateDropDescription(e);
                     DragDropHelper.DragEnter(_owner.Handle, e);
@@ -295,7 +295,7 @@ public partial class RichTextBox
                     _owner.OnDragOver(e);
                     _lastEffect = e.Effect;
 
-                    if (e.DropImageType > DropImageType.Invalid)
+                    if (e.Effect != DragDropEffects.None && e.DropImageType > DropImageType.Invalid)
                     {
                         UpdateDropDescription(e);
                         DragDropHelper.DragOver(e);


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #8903 

## Proposed changes

- The RichTextBox behaves differently in the cross-process scenario and the drag image manager doesn't automatically synthesize a call to DragLeave on drop when the Effect is set to None, like it does in the in-process scenario, leaving a drag image artefact.
- Hide the RichTextBox drag image and drop description if the application sets the Effect to None.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Fixes a drag image artefact that occurs when dropping onto the RichTextBox cross-process with an Effect of None.

## Regression? 

- No

## Risk

-

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Cross-process behavior on drop when the Effect is set to None.

https://github.com/dotnet/winforms/assets/5017479/784fa0a4-bf5e-44c4-807c-a2ecc1152b7b

In-process behavior on drop when the Effect is set to None. Note how the drag image manager automatically synthesizes a drag leave on drop. I'm very interested in learning why there is a difference since obviously this is the preferred behavior.

https://github.com/dotnet/winforms/assets/5017479/2ace6804-8994-4e41-96d8-4268b265d763

### After

This after video also includes the change made in #10475 for a complete demonstration.

https://github.com/dotnet/winforms/assets/5017479/bd47839c-179f-4631-b215-91661c09a735

One more video demonstrating a workaround for this minor annoyance by setting the RichTextBox Effect to something other than None in DragEnter in order to display the drag image and drop description, and more importantly, not leave an artefact.

https://github.com/dotnet/winforms/assets/5017479/cad6f4bb-1c00-4e65-990f-7cc1c890ff97

## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- 8.0.0

<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10478)