### PR TITLE
Change default opt-in to false for AnchorLayoutV2 (#9942)

### DIFF
--- a/docs/design/anchor-layout-changes-in-net80.md
+++ b/docs/design/anchor-layout-changes-in-net80.md
@@ -110,14 +110,14 @@ private static void ComputeAnchorInfo(IArrangedElement element)
 
 ## Risk mitigation
 
-The layout engine, in general, is quite complex, and any changes in it carry a very high risk. In order to reduce the risks and to provide backward compatibility, the new anchor calculations are put behind a feature switch `System.Windows.Forms.AnchorLayoutV2`. The switch is enabled by default for Windows Forms applications targeting .NET 8.
+The layout engine, in general, is quite complex, and any changes in it carry a very high risk. In order to reduce the risks and to provide backward compatibility, the new anchor calculations are put behind a feature switch `System.Windows.Forms.AnchorLayoutV2`. The switch is disabled by default for Windows Forms applications.
 
-It is possible to retain the original anchor calculations by setting the swtich to `false` in the [runtimeconfig.json](https://learn.microsoft.com/dotnet/core/runtime-config/#runtimeconfigjson).
+Developers need to opt-in to get this new feature by setting the switch value to `true` in the [runtimeconfig.json](https://learn.microsoft.com/dotnet/core/runtime-config/#runtimeconfigjson).
 Snippet for runtimeconfig.template.json:
 ```JSON
 {
   "configProperties": {
-    "System.Windows.Forms.AnchorLayoutV2": false
+    "System.Windows.Forms.AnchorLayoutV2": true
   }
 }
 ```

--- a/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
@@ -102,11 +102,6 @@ internal static partial class LocalAppContextSwitches
                     return true;
                 }
 
-                if (switchName == AnchorLayoutV2SwitchName)
-                {
-                    return true;
-                }
-
                 if (switchName == TrackBarModernRenderingSwitchName)
                 {
                     return true;
@@ -126,7 +121,7 @@ internal static partial class LocalAppContextSwitches
     ///  Indicates whether AnchorLayoutV2 feature is enabled.
     /// </summary>
     /// <devdoc>
-    ///  Returns AnchorLayoutV2 switch value from runtimeconfig.json. Defaults to true if application is targeting .NET 8.0 and beyond.
+    ///  Returns AnchorLayoutV2 switch value from runtimeconfig.json. Defaults to false.
     ///  Refer to
     ///  https://github.com/dotnet/winforms/blob/tree/main/docs/design/anchor-layout-changes-in-net80.md for more details.
     /// </devdoc>

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/LocalAppContextSwitchesTest.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/LocalAppContextSwitchesTest.cs
@@ -31,7 +31,6 @@ public class LocalAppContextSwitchesTest
             testAccessor.s_targetFrameworkName = new FrameworkName(targetFrameworkName);
 
             Assert.Equal(expected, LocalAppContextSwitches.TrackBarModernRendering);
-            Assert.Equal(expected, LocalAppContextSwitches.AnchorLayoutV2);
             Assert.Equal(expected, LocalAppContextSwitches.ScaleTopLevelFormMinMaxSizeForDpi);
             Assert.Equal(expected, LocalAppContextSwitches.ServicePointManagerCheckCrl);
         }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #10382 


## Proposed changes

-  Update the switch `System.Windows.Forms.AnchorLayoutV2` to be disabled by default

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Developers need to opt-in to get the new feature by setting the switch  `System.Windows.Forms.AnchorLayoutV2` value to `true` in the [runtimeconfig.json]

## Risk

- Minimal

<!-- end TELL-MODE -->


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10484)