### PR TITLE
Do not use fixed index in the `TreeNode.PrevNode` if the `TreeView` is sorted 

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
@@ -21,6 +21,7 @@ internal static partial class LocalAppContextSwitches
     internal const string TrackBarModernRenderingSwitchName = "System.Windows.Forms.TrackBarModernRendering";
     private const string DoNotCatchUnhandledExceptionsSwitchName = "System.Windows.Forms.DoNotCatchUnhandledExceptions";
     internal const string DataGridViewUIAStartRowCountAtZeroSwitchName = "System.Windows.Forms.DataGridViewUIAStartRowCountAtZero";
+    internal const string TreeNodePrevNodeDoNotUseFixedIndexWithSortedTreeViewSwitchName = "System.Windows.Forms.TreeNodeDoNotUseFixedIndexWithSortedTreeView";
 
     private static int s_scaleTopLevelFormMinMaxSizeForDpi;
     private static int s_anchorLayoutV2;
@@ -28,6 +29,7 @@ internal static partial class LocalAppContextSwitches
     private static int s_trackBarModernRendering;
     private static int s_doNotCatchUnhandledExceptions;
     private static int s_dataGridViewUIAStartRowCountAtZero;
+    private static int s_treeNodePrevNodeDoNotUseFixedIndexWithSortedTreeView;
 
     private static FrameworkName? s_targetFrameworkName;
 
@@ -158,6 +160,16 @@ internal static partial class LocalAppContextSwitches
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get => GetCachedSwitchValue(DataGridViewUIAStartRowCountAtZeroSwitchName, ref s_dataGridViewUIAStartRowCountAtZero);
+    }
+
+    /// <summary>
+    ///  Indicates whether TreeNode.PrevNode uses a fixed index to return its value.
+    ///  Thus mirroring the behaviour of the TreeNodeCollection.
+    /// </summary>
+    public static bool TreeNodePrevNodeDoNotUseFixedIndexWithSortedTreeView
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => GetCachedSwitchValue(TreeNodePrevNodeDoNotUseFixedIndexWithSortedTreeViewSwitchName, ref s_treeNodePrevNodeDoNotUseFixedIndexWithSortedTreeView);
     }
 
     internal static void SetDataGridViewUIAStartRowCountAtZero(bool value) => s_dataGridViewUIAStartRowCountAtZero = value ? 1 : 0;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeNode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeNode.cs
@@ -9,6 +9,7 @@ using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
 using System.Text;
+using System.Windows.Forms.Primitives;
 
 namespace System.Windows.Forms;
 
@@ -812,17 +813,20 @@ public partial class TreeNode : MarshalByRefObject, ICloneable, ISerializable
             }
 
             // fixedIndex is used for perf. optimization in case of adding big ranges of nodes
-            int currentInd = _index;
-            int fixedInd = _parent.Nodes.FixedIndex;
+            int currentIndex = _index;
+            int fixedIndex = _parent.Nodes.FixedIndex;
 
-            if (fixedInd > 0)
+            if (fixedIndex > 0)
             {
-                currentInd = fixedInd;
+                if (!LocalAppContextSwitches.TreeNodePrevNodeDoNotUseFixedIndexWithSortedTreeView || TreeView is null || !TreeView.Sorted)
+                {
+                    currentIndex = fixedIndex;
+                }
             }
 
-            if (currentInd > 0 && currentInd <= _parent.Nodes.Count)
+            if (currentIndex > 0 && currentIndex <= _parent.Nodes.Count)
             {
-                return _parent.Nodes[currentInd - 1];
+                return _parent.Nodes[currentIndex - 1];
             }
             else
             {


### PR DESCRIPTION
Fixes #8768

This is a re-roll of the PR in #8774, but with the switch added.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10493)