### PR TITLE
Release Pointer when Index Setting ComSafeArrayScope

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Com/ComSafeArrayScope.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Com/ComSafeArrayScope.cs
@@ -61,7 +61,8 @@ internal readonly unsafe ref struct ComSafeArrayScope<T> where T : unmanaged, IC
         ComSafeArrayScope<T> scope = new(length);
         for (int i = 0; i < length; i++)
         {
-            scope[i] = ComHelpers.GetComPointer<T>(array[i]);
+            using var pointer = ComHelpers.GetComScope<T>(array[i]);
+            scope[i] = pointer;
         }
 
         return scope;

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Com/ComSafeArrayScope.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Com/ComSafeArrayScope.cs
@@ -61,6 +61,8 @@ internal readonly unsafe ref struct ComSafeArrayScope<T> where T : unmanaged, IC
         ComSafeArrayScope<T> scope = new(length);
         for (int i = 0; i < length; i++)
         {
+            // SAFEARRAY will add ref, a using is needed to
+            // release to maintain the correct ref count.
             using var pointer = ComHelpers.GetComScope<T>(array[i]);
             scope[i] = pointer;
         }

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/Windows/Win32/System/Com/ComSafeArrayScopeTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/Windows/Win32/System/Com/ComSafeArrayScopeTests.cs
@@ -36,6 +36,17 @@ public unsafe class ComSafeArrayScopeTests
     }
 
     [Fact]
+    public void ComSafeArrayScope_IndexSet_AddsRef()
+    {
+        MyStream stream = new();
+        using ComScope<IStream> streamScope = ComHelpers.GetComScope<IStream>(stream);
+        using ComSafeArrayScope<IStream> scope = new(1);
+        scope[0] = streamScope;
+        streamScope.Value->AddRef();
+        Assert.Equal((uint)2, streamScope.Value->Release());
+    }
+
+    [Fact]
     public void ComSafeArrayScope_CreateFromInterfaceArray_ThrowsArgumentException()
     {
         IStream.Interface[] streams = [new MyStream()];

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Accessibility/LabelEditUiaTextProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Accessibility/LabelEditUiaTextProvider.cs
@@ -164,6 +164,7 @@ internal sealed unsafe class LabelEditUiaTextProvider : UiaTextProvider
         PInvoke.SendMessage(_owningChildEdit, PInvoke.EM_GETSEL, ref start, ref end);
 
         ComSafeArrayScope<ITextRangeProvider> result = new(1);
+        // Adding to the SAFEARRAY adds a reference
         using var selection = ComHelpers.GetComScope<ITextRangeProvider>(new UiaTextRange(_owningChildEditAccessibilityObject, this, start, end));
         result[0] = selection;
         *pRetVal = result;
@@ -211,6 +212,7 @@ internal sealed unsafe class LabelEditUiaTextProvider : UiaTextProvider
         GetVisibleRangePoints(out int start, out int end);
 
         ComSafeArrayScope<ITextRangeProvider> result = new(1);
+        // Adding to the SAFEARRAY adds a reference
         using var ranges = ComHelpers.GetComScope<ITextRangeProvider>(new UiaTextRange(_owningChildEditAccessibilityObject, this, start, end));
         result[0] = ranges;
         *pRetVal = result;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Accessibility/LabelEditUiaTextProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Accessibility/LabelEditUiaTextProvider.cs
@@ -164,7 +164,8 @@ internal sealed unsafe class LabelEditUiaTextProvider : UiaTextProvider
         PInvoke.SendMessage(_owningChildEdit, PInvoke.EM_GETSEL, ref start, ref end);
 
         ComSafeArrayScope<ITextRangeProvider> result = new(1);
-        result[0] = ComHelpers.GetComPointer<ITextRangeProvider>(new UiaTextRange(_owningChildEditAccessibilityObject, this, start, end));
+        using var selection = ComHelpers.GetComScope<ITextRangeProvider>(new UiaTextRange(_owningChildEditAccessibilityObject, this, start, end));
+        result[0] = selection;
         *pRetVal = result;
 
         return HRESULT.S_OK;
@@ -210,7 +211,8 @@ internal sealed unsafe class LabelEditUiaTextProvider : UiaTextProvider
         GetVisibleRangePoints(out int start, out int end);
 
         ComSafeArrayScope<ITextRangeProvider> result = new(1);
-        result[0] = ComHelpers.GetComPointer<ITextRangeProvider>(new UiaTextRange(_owningChildEditAccessibilityObject, this, start, end));
+        using var ranges = ComHelpers.GetComScope<ITextRangeProvider>(new UiaTextRange(_owningChildEditAccessibilityObject, this, start, end));
+        result[0] = ranges;
         *pRetVal = result;
 
         return HRESULT.S_OK;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.ComboBoxUiaTextProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.ComboBoxUiaTextProvider.cs
@@ -225,7 +225,8 @@ public partial class ComboBox
             PInvoke.SendMessage(_owningChildEdit, PInvoke.EM_GETSEL, ref start, ref end);
 
             ComSafeArrayScope<ITextRangeProvider> result = new(1);
-            result[0] = ComHelpers.GetComPointer<ITextRangeProvider>(new UiaTextRange(_owningComboBox.ChildEditAccessibleObject, this, start, end));
+            using var selection = ComHelpers.GetComScope<ITextRangeProvider>(new UiaTextRange(_owningComboBox.ChildEditAccessibleObject, this, start, end));
+            result[0] = selection;
 
             *pRetVal = result;
             return HRESULT.S_OK;
@@ -277,7 +278,8 @@ public partial class ComboBox
             GetVisibleRangePoints(out int start, out int end);
 
             ComSafeArrayScope<ITextRangeProvider> result = new(1);
-            result[0] = ComHelpers.GetComPointer<ITextRangeProvider>(new UiaTextRange(_owningComboBox.ChildEditAccessibleObject, this, start, end));
+            using var ranges = ComHelpers.GetComScope<ITextRangeProvider>(new UiaTextRange(_owningComboBox.ChildEditAccessibleObject, this, start, end));
+            result[0] = ranges;
 
             *pRetVal = result;
             return HRESULT.S_OK;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.ComboBoxUiaTextProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.ComboBoxUiaTextProvider.cs
@@ -225,6 +225,7 @@ public partial class ComboBox
             PInvoke.SendMessage(_owningChildEdit, PInvoke.EM_GETSEL, ref start, ref end);
 
             ComSafeArrayScope<ITextRangeProvider> result = new(1);
+            // Adding to the SAFEARRAY adds a reference
             using var selection = ComHelpers.GetComScope<ITextRangeProvider>(new UiaTextRange(_owningComboBox.ChildEditAccessibleObject, this, start, end));
             result[0] = selection;
 
@@ -278,6 +279,7 @@ public partial class ComboBox
             GetVisibleRangePoints(out int start, out int end);
 
             ComSafeArrayScope<ITextRangeProvider> result = new(1);
+            // Adding to the SAFEARRAY adds a reference
             using var ranges = ComHelpers.GetComScope<ITextRangeProvider>(new UiaTextRange(_owningComboBox.ChildEditAccessibleObject, this, start, end));
             result[0] = ranges;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TextBox/TextBoxBase.TextBoxBaseUiaTextProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TextBox/TextBoxBase.TextBoxBaseUiaTextProvider.cs
@@ -45,6 +45,7 @@ public abstract partial class TextBoxBase
             PInvoke.SendMessage(Owner, PInvoke.EM_GETSEL, ref start, ref end);
 
             ComSafeArrayScope<ITextRangeProvider> result = new(1);
+            // Adding to the SAFEARRAY adds a reference
             using var selection = ComHelpers.GetComScope<ITextRangeProvider>(new UiaTextRange(Owner.AccessibilityObject, this, start, end));
             result[0] = selection;
 
@@ -68,6 +69,7 @@ public abstract partial class TextBoxBase
             GetVisibleRangePoints(out int start, out int end);
 
             ComSafeArrayScope<ITextRangeProvider> result = new(1);
+            // Adding to the SAFEARRAY adds a reference
             using var ranges = ComHelpers.GetComScope<ITextRangeProvider>(new UiaTextRange(Owner.AccessibilityObject, this, start, end));
             result[0] = ranges;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TextBox/TextBoxBase.TextBoxBaseUiaTextProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TextBox/TextBoxBase.TextBoxBaseUiaTextProvider.cs
@@ -45,7 +45,8 @@ public abstract partial class TextBoxBase
             PInvoke.SendMessage(Owner, PInvoke.EM_GETSEL, ref start, ref end);
 
             ComSafeArrayScope<ITextRangeProvider> result = new(1);
-            result[0] = ComHelpers.GetComPointer<ITextRangeProvider>(new UiaTextRange(Owner.AccessibilityObject, this, start, end));
+            using var selection = ComHelpers.GetComScope<ITextRangeProvider>(new UiaTextRange(Owner.AccessibilityObject, this, start, end));
+            result[0] = selection;
 
             *pRetVal = result;
             return HRESULT.S_OK;
@@ -67,7 +68,8 @@ public abstract partial class TextBoxBase
             GetVisibleRangePoints(out int start, out int end);
 
             ComSafeArrayScope<ITextRangeProvider> result = new(1);
-            result[0] = ComHelpers.GetComPointer<ITextRangeProvider>(new UiaTextRange(Owner.AccessibilityObject, this, start, end));
+            using var ranges = ComHelpers.GetComScope<ITextRangeProvider>(new UiaTextRange(Owner.AccessibilityObject, this, start, end));
+            result[0] = ranges;
 
             *pRetVal = result;
             return HRESULT.S_OK;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes https://github.com/dotnet/winforms/issues/10443

If the object being placed into a SafeArray is a IDispatch or IUnknown, SafeArray does an `AddRef` on the object (https://learn.microsoft.com/en-us/windows/win32/api/oleauto/nf-oleauto-safearrayputelement#remarks). This means to maintain the correct ref count, we should be releasing the object that we put into the SafeArray. This was missed in `ComSafeArrayScope.CreateFromInterfaceArray`

Before:
![image](https://github.com/dotnet/winforms/assets/30007367/1bcccb0d-ca2e-441e-86e8-52a531a23dc4)

After: No AccessibleObject leaks
![image](https://github.com/dotnet/winforms/assets/30007367/c7ede670-e738-41ba-8de2-de04dbc67d78)

Note:
This should also fix other AccessibleObject memory leaks that have been noted as .NET 9 regressions.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10501)