### PR TITLE
[release/8.0.x] Fix expandable property grid entries

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MultiPropertyDescriptorGridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MultiPropertyDescriptorGridEntry.cs
@@ -231,7 +231,7 @@ internal sealed class MultiPropertyDescriptorGridEntry : PropertyDescriptorGridE
             {
                 for (int i = 0; i < ownerArray.Length; i++)
                 {
-                    PropertyDescriptor propertyInfo = propertyEntry.PropertyDescriptor;
+                    PropertyDescriptor propertyInfo = entry.PropertyDescriptor;
 
                     if (propertyInfo is MergePropertyDescriptor descriptor)
                     {
@@ -248,8 +248,8 @@ internal sealed class MultiPropertyDescriptorGridEntry : PropertyDescriptorGridE
             }
             else
             {
-                changeService.OnComponentChanging(owner, propertyEntry.PropertyDescriptor);
-                changeService.OnComponentChanged(owner, propertyEntry.PropertyDescriptor);
+                changeService.OnComponentChanging(owner, entry.PropertyDescriptor);
+                changeService.OnComponentChanged(owner, entry.PropertyDescriptor);
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntry.cs
@@ -392,16 +392,16 @@ internal partial class PropertyDescriptorGridEntry : GridEntry
             }
 
             // Fire the change on the owner.
-            if (entry is not null)
+            if (entry is PropertyDescriptorGridEntry property)
             {
-                owner = entry.GetValueOwner();
+                owner = property.GetValueOwner();
 
-                ComponentChangeService?.OnComponentChanging(owner, propertyEntry._propertyDescriptor);
-                ComponentChangeService?.OnComponentChanged(owner, propertyEntry._propertyDescriptor);
+                ComponentChangeService?.OnComponentChanging(owner, property._propertyDescriptor);
+                ComponentChangeService?.OnComponentChanged(owner, property._propertyDescriptor);
 
                 // Clear the value so it paints correctly next time.
-                entry.ClearCachedValues(clearChildren: false);
-                OwnerGridView?.InvalidateGridEntryValue(entry);
+                property.ClearCachedValues(clearChildren: false);
+                OwnerGridView?.InvalidateGridEntryValue(property);
             }
         }
     }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridTests.cs
@@ -5,10 +5,10 @@ using System.ComponentModel;
 using System.ComponentModel.Design;
 using System.Drawing;
 using System.Drawing.Design;
-using System.Windows.Forms.PropertyGridInternal;
-using Moq;
-using System.Windows.Forms.TestUtilities;
 using System.Runtime.CompilerServices;
+using System.Windows.Forms.PropertyGridInternal;
+using System.Windows.Forms.TestUtilities;
+using Moq;
 using Point = System.Drawing.Point;
 using Size = System.Drawing.Size;
 
@@ -4063,5 +4063,71 @@ public partial class PropertyGridTests
         public new void OnSystemColorsChanged(EventArgs e) => base.OnSystemColorsChanged(e);
 
         public new void WndProc(ref Message m) => base.WndProc(ref m);
+    }
+
+    [WinFormsFact]
+    public void PropertyGrid_NotifyParentChange()
+    {
+        // Regression test for https://github.com/dotnet/winforms/issues/10427
+        using PropertyGrid propertyGrid = new();
+        propertyGrid.Site = new MySite();
+        MyClass myClass = new();
+        propertyGrid.SelectedObject = myClass;
+        PropertyGridView propertyGridView = (PropertyGridView)propertyGrid.Controls[2];
+        GridEntry entry = propertyGridView.SelectedGridEntry;
+        var descriptor = entry.GridItems[0] as PropertyDescriptorGridEntry;
+
+        descriptor.SetPropertyTextValue("123");
+        Assert.Equal("123", myClass.ParentGridEntry.NestedGridEntry);
+    }
+
+    private class MyClass
+    {
+        [TypeConverter(typeof(ExpandableObjectConverter))]
+        public virtual MyExpandableClass ParentGridEntry { get; set; } = new() { };
+
+        public class MyExpandableClass
+        {
+            [NotifyParentProperty(true)]
+            [TypeConverter(typeof(StringConverter))]
+            public string NestedGridEntry { get; set; }
+        }
+    }
+
+    private class MySite : ISite
+    {
+        private IComponentChangeService _componentChangeService = new ComponentChangeService();
+        public IComponent Component => null;
+        public IContainer Container => null;
+        public bool DesignMode => false;
+        public string Name { get; set; }
+
+        public object GetService(Type serviceType)
+            => serviceType == typeof(IComponentChangeService) ? _componentChangeService : null;
+
+        public class ComponentChangeService : IComponentChangeService
+        {
+#pragma warning disable CS0067 // Required by Interface
+            public event ComponentEventHandler ComponentAdded;
+            public event ComponentEventHandler ComponentAdding;
+            public event ComponentChangedEventHandler ComponentChanged;
+            public event ComponentChangingEventHandler ComponentChanging;
+            public event ComponentEventHandler ComponentRemoved;
+            public event ComponentEventHandler ComponentRemoving;
+            public event ComponentRenameEventHandler ComponentRename;
+#pragma warning restore
+
+            public void OnComponentChanged(object component, MemberDescriptor member, object oldValue, object newValue)
+            {
+            }
+
+            public void OnComponentChanging(object component, MemberDescriptor member)
+            {
+                if (member is null)
+                    return;
+                Reflection.MemberInfo[] properties = component.GetType().GetMembers();
+                Assert.False(properties.All(p => p.Name != member.Name), "Property not found!");
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #https://github.com/dotnet/winforms/issues/10427
Port of a .NET9 fix - https://github.com/dotnet/winforms/pull/10433

## Proposed changes
Fixed a typo where we were not referencing the right local variable.

## Customer Impact
DevExpress can't use expandable property grid entries, i.e. entries where a child value is displayed on the parent line.

## Regression? 

- Yes 

## Risk

-low, this is a very specific scenario

## Test methodology 
Manual and unit test.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10507)