### PR TITLE
fix ToolStripItem SelectedChanged event is invoked twice

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripItem.cs
@@ -2587,15 +2587,9 @@ public abstract partial class ToolStripItem :
     {
         if (_state[s_stateMouseDownAndNoDrag] || _state[s_statePressed] || _state[s_stateSelected])
         {
-            bool wasSelected = _state[s_stateSelected];
             _state[s_stateMouseDownAndNoDrag | s_statePressed | s_stateSelected] = false;
 
             KeyboardToolTipStateMachine.Instance.NotifyAboutLostFocus(this);
-
-            if (wasSelected)
-            {
-                OnSelectedChanged(EventArgs.Empty);
-            }
 
             Invalidate();
         }
@@ -3651,8 +3645,6 @@ public abstract partial class ToolStripItem :
 
                 KeyboardToolTipStateMachine.Instance.NotifyAboutLostFocus(this);
             }
-
-            OnSelectedChanged(EventArgs.Empty);
         }
     }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripItemTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripItemTests.cs
@@ -15400,23 +15400,23 @@ public class ToolStripItemTests
 
     // Unit test for https://github.com/dotnet/winforms/issues/8548
     [WinFormsFact]
-    public void ToolStripItem_OnItemSelected()
+    public void ToolStripItem_OnItemSelectedChanged()
     {
         using MyMenuStrip menuStrip1 = new();
         using ToolStripMenuItem toolStripMenuItem1 = new();
         using ToolStripMenuItem toolStripMenuItem2 = new();
         using ToolStripMenuItem toolStripMenuItem3 = new();
 
-        menuStrip1.Size = new Size(50, 100);
-        toolStripMenuItem1.Size = new Size(15, 30);
+        menuStrip1.Size = new Size(100, 50);
+        toolStripMenuItem1.Size = new Size(10, 30);
         toolStripMenuItem2.Size = new Size(15, 30);
         toolStripMenuItem3.Size = new Size(15, 30);
 
-        bool callBackInvoked = false;
+        int callBackInvokedCount = 0;
 
         toolStripMenuItem2.SelectedChanged += (e, s) =>
         {
-            callBackInvoked = true;
+            callBackInvokedCount++;
         };
 
         menuStrip1.Items.AddRange(new ToolStripMenuItem[] { toolStripMenuItem1, toolStripMenuItem2, toolStripMenuItem3 });
@@ -15429,14 +15429,16 @@ public class ToolStripItemTests
             menuStrip1.MoveMouse(new MouseEventArgs(MouseButtons.None, 0, new Point(i, 5)));
         }
 
-        Assert.False(callBackInvoked);
+        Assert.Equal(0, callBackInvokedCount);
 
-        for (int i = 10; i < 50; i++)
+        for (int i = 10; i < 100; i++)
         {
             menuStrip1.MoveMouse(new MouseEventArgs(MouseButtons.None, 0, new Point(i, 5)));
         }
 
-        Assert.True(callBackInvoked);
+        // SelectedChanged event should be fired once in one round.
+
+        Assert.Equal(1, callBackInvokedCount);
     }
 
     private class MyMenuStrip: MenuStrip


### PR DESCRIPTION
After PR [10321 add ToolStripItem.SelectedChanged event](https://github.com/dotnet/winforms/pull/10321), tester raised a question: whether it is reasonable to fire SelectedChanged event **twice** when selection status turns from unselected to selected **and** from selected to unselected. After discussion we reached an agreement: the newly added API(ToolStripItem.SelectedChanged) should be consistent with framework's , i.e. when selection status turns from unselected to selected we will fire ToolStripItem.SelectedChanged event. but when selection status turns from selected to unselected we will **not**.

See the discussion [here](https://github.com/dotnet/winforms/issues/8548#issuecomment-1862431770)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10514)