### PR TITLE
Fix GH issue 10499 by layout current form's controls

### DIFF
--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/DragDrop.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/DragDrop.Designer.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Drawing;
+
 namespace WinformsControlsTest;
 
 partial class DragDrop
@@ -31,183 +33,182 @@ partial class DragDrop
     /// </summary>
     private void InitializeComponent()
     {
-        this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
-        this.textBox = new System.Windows.Forms.TextBox();
-        this.richTextBox = new System.Windows.Forms.RichTextBox();
-        this.pictureBox1 = new System.Windows.Forms.PictureBox();
-        this.pictureBox2 = new System.Windows.Forms.PictureBox();
-        this.pictureBox3 = new System.Windows.Forms.PictureBox();
-        this.pictureBox4 = new System.Windows.Forms.PictureBox();
-        this.pictureBox5 = new System.Windows.Forms.PictureBox();
-        this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
-        this.buttonOpenCats = new System.Windows.Forms.Button();
-        this.buttonClear = new System.Windows.Forms.Button();
-        this.tableLayoutPanel1.SuspendLayout();
-        ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
-        ((System.ComponentModel.ISupportInitialize)(this.pictureBox2)).BeginInit();
-        ((System.ComponentModel.ISupportInitialize)(this.pictureBox3)).BeginInit();
-        ((System.ComponentModel.ISupportInitialize)(this.pictureBox4)).BeginInit();
-        ((System.ComponentModel.ISupportInitialize)(this.pictureBox5)).BeginInit();
-        this.tableLayoutPanel2.SuspendLayout();
-        this.SuspendLayout();
+        tableLayoutPanel1 = new TableLayoutPanel();
+        textBox = new TextBox();
+        richTextBox = new RichTextBox();
+        pictureBox1 = new PictureBox();
+        pictureBox2 = new PictureBox();
+        pictureBox3 = new PictureBox();
+        pictureBox4 = new PictureBox();
+        pictureBox5 = new PictureBox();
+        tableLayoutPanel2 = new TableLayoutPanel();
+        buttonOpenCats = new Button();
+        buttonClear = new Button();
+        tableLayoutPanel1.SuspendLayout();
+        ((System.ComponentModel.ISupportInitialize)pictureBox1).BeginInit();
+        ((System.ComponentModel.ISupportInitialize)pictureBox2).BeginInit();
+        ((System.ComponentModel.ISupportInitialize)pictureBox3).BeginInit();
+        ((System.ComponentModel.ISupportInitialize)pictureBox4).BeginInit();
+        ((System.ComponentModel.ISupportInitialize)pictureBox5).BeginInit();
+        tableLayoutPanel2.SuspendLayout();
+        SuspendLayout();
         // 
         // tableLayoutPanel1
         // 
-        this.tableLayoutPanel1.ColumnCount = 3;
-        this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 115F));
-        this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 55.55556F));
-        this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 44.44445F));
-        this.tableLayoutPanel1.Controls.Add(this.textBox, 2, 0);
-        this.tableLayoutPanel1.Controls.Add(this.richTextBox, 1, 0);
-        this.tableLayoutPanel1.Controls.Add(this.pictureBox1, 0, 0);
-        this.tableLayoutPanel1.Controls.Add(this.pictureBox2, 0, 1);
-        this.tableLayoutPanel1.Controls.Add(this.pictureBox3, 0, 2);
-        this.tableLayoutPanel1.Controls.Add(this.pictureBox4, 0, 3);
-        this.tableLayoutPanel1.Controls.Add(this.pictureBox5, 0, 4);
-        this.tableLayoutPanel1.Controls.Add(this.tableLayoutPanel2, 2, 5);
-        this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-        this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 0);
-        this.tableLayoutPanel1.Name = "tableLayoutPanel1";
-        this.tableLayoutPanel1.RowCount = 6;
-        this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 112F));
-        this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 112F));
-        this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 112F));
-        this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 112F));
-        this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 112F));
-        this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-        this.tableLayoutPanel1.Size = new System.Drawing.Size(1226, 674);
-        this.tableLayoutPanel1.TabIndex = 0;
+        tableLayoutPanel1.ColumnCount = 3;
+        tableLayoutPanel1.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 115F));
+        tableLayoutPanel1.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 55.55556F));
+        tableLayoutPanel1.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 44.44445F));
+        tableLayoutPanel1.Controls.Add(textBox, 2, 0);
+        tableLayoutPanel1.Controls.Add(richTextBox, 1, 0);
+        tableLayoutPanel1.Controls.Add(pictureBox1, 0, 0);
+        tableLayoutPanel1.Controls.Add(pictureBox2, 0, 1);
+        tableLayoutPanel1.Controls.Add(pictureBox3, 0, 2);
+        tableLayoutPanel1.Controls.Add(pictureBox4, 0, 3);
+        tableLayoutPanel1.Controls.Add(pictureBox5, 0, 4);
+        tableLayoutPanel1.Controls.Add(tableLayoutPanel2, 2, 5);
+        tableLayoutPanel1.Dock = DockStyle.Fill;
+        tableLayoutPanel1.Location = new Point(0, 0);
+        tableLayoutPanel1.Name = "tableLayoutPanel1";
+        tableLayoutPanel1.RowCount = 6;
+        tableLayoutPanel1.RowStyles.Add(new RowStyle(SizeType.Absolute, 112F));
+        tableLayoutPanel1.RowStyles.Add(new RowStyle(SizeType.Absolute, 112F));
+        tableLayoutPanel1.RowStyles.Add(new RowStyle(SizeType.Absolute, 112F));
+        tableLayoutPanel1.RowStyles.Add(new RowStyle(SizeType.Absolute, 112F));
+        tableLayoutPanel1.RowStyles.Add(new RowStyle(SizeType.Absolute, 112F));
+        tableLayoutPanel1.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
+        tableLayoutPanel1.Size = new Size(1226, 625);
+        tableLayoutPanel1.TabIndex = 0;
         // 
         // textBox
         // 
-        this.textBox.Dock = System.Windows.Forms.DockStyle.Fill;
-        this.textBox.Font = new System.Drawing.Font("Segoe UI", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
-        this.textBox.Location = new System.Drawing.Point(742, 3);
-        this.textBox.Multiline = true;
-        this.textBox.Name = "textBox";
-        this.tableLayoutPanel1.SetRowSpan(this.textBox, 5);
-        this.textBox.Size = new System.Drawing.Size(481, 619);
-        this.textBox.TabIndex = 18;
+        textBox.Dock = DockStyle.Fill;
+        textBox.Font = new Font("Segoe UI", 14.25F);
+        textBox.Location = new Point(735, 3);
+        textBox.Multiline = true;
+        textBox.Name = "textBox";
+        tableLayoutPanel1.SetRowSpan(textBox, 5);
+        textBox.Size = new Size(488, 554);
+        textBox.TabIndex = 18;
         // 
         // richTextBox
         // 
-        this.richTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
-        this.richTextBox.Font = new System.Drawing.Font("Segoe UI", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
-        this.richTextBox.Location = new System.Drawing.Point(134, 3);
-        this.richTextBox.Name = "richTextBox";
-        this.tableLayoutPanel1.SetRowSpan(this.richTextBox, 5);
-        this.richTextBox.Size = new System.Drawing.Size(602, 619);
-        this.richTextBox.TabIndex = 22;
-        this.richTextBox.Text = "";
+        richTextBox.Dock = DockStyle.Fill;
+        richTextBox.Font = new Font("Segoe UI", 14.25F);
+        richTextBox.Location = new Point(118, 3);
+        richTextBox.Name = "richTextBox";
+        tableLayoutPanel1.SetRowSpan(richTextBox, 5);
+        richTextBox.Size = new Size(611, 554);
+        richTextBox.TabIndex = 22;
+        richTextBox.Text = "";
         // 
         // pictureBox1
         // 
-        this.pictureBox1.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-        this.pictureBox1.Dock = System.Windows.Forms.DockStyle.Fill;
-        this.pictureBox1.InitialImage = null;
-        this.pictureBox1.Location = new System.Drawing.Point(3, 3);
-        this.pictureBox1.Name = "pictureBox1";
-        this.pictureBox1.Size = new System.Drawing.Size(125, 119);
-        this.pictureBox1.TabIndex = 13;
-        this.pictureBox1.TabStop = false;
+        pictureBox1.BorderStyle = BorderStyle.FixedSingle;
+        pictureBox1.Dock = DockStyle.Fill;
+        pictureBox1.InitialImage = null;
+        pictureBox1.Location = new Point(3, 3);
+        pictureBox1.Name = "pictureBox1";
+        pictureBox1.Size = new Size(109, 106);
+        pictureBox1.TabIndex = 13;
+        pictureBox1.TabStop = false;
         // 
         // pictureBox2
         // 
-        this.pictureBox2.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-        this.pictureBox2.Dock = System.Windows.Forms.DockStyle.Fill;
-        this.pictureBox2.InitialImage = null;
-        this.pictureBox2.Location = new System.Drawing.Point(3, 128);
-        this.pictureBox2.Name = "pictureBox2";
-        this.pictureBox2.Size = new System.Drawing.Size(125, 119);
-        this.pictureBox2.TabIndex = 13;
-        this.pictureBox2.TabStop = false;
+        pictureBox2.BorderStyle = BorderStyle.FixedSingle;
+        pictureBox2.Dock = DockStyle.Fill;
+        pictureBox2.InitialImage = null;
+        pictureBox2.Location = new Point(3, 115);
+        pictureBox2.Name = "pictureBox2";
+        pictureBox2.Size = new Size(109, 106);
+        pictureBox2.TabIndex = 13;
+        pictureBox2.TabStop = false;
         // 
         // pictureBox3
         // 
-        this.pictureBox3.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-        this.pictureBox3.Dock = System.Windows.Forms.DockStyle.Fill;
-        this.pictureBox3.InitialImage = null;
-        this.pictureBox3.Location = new System.Drawing.Point(3, 253);
-        this.pictureBox3.Name = "pictureBox3";
-        this.pictureBox3.Size = new System.Drawing.Size(125, 119);
-        this.pictureBox3.TabIndex = 13;
-        this.pictureBox3.TabStop = false;
+        pictureBox3.BorderStyle = BorderStyle.FixedSingle;
+        pictureBox3.Dock = DockStyle.Fill;
+        pictureBox3.InitialImage = null;
+        pictureBox3.Location = new Point(3, 227);
+        pictureBox3.Name = "pictureBox3";
+        pictureBox3.Size = new Size(109, 106);
+        pictureBox3.TabIndex = 13;
+        pictureBox3.TabStop = false;
         // 
         // pictureBox4
         // 
-        this.pictureBox4.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-        this.pictureBox4.Dock = System.Windows.Forms.DockStyle.Fill;
-        this.pictureBox4.InitialImage = null;
-        this.pictureBox4.Location = new System.Drawing.Point(3, 378);
-        this.pictureBox4.Name = "pictureBox4";
-        this.pictureBox4.Size = new System.Drawing.Size(125, 119);
-        this.pictureBox4.TabIndex = 13;
-        this.pictureBox4.TabStop = false;
+        pictureBox4.BorderStyle = BorderStyle.FixedSingle;
+        pictureBox4.Dock = DockStyle.Fill;
+        pictureBox4.InitialImage = null;
+        pictureBox4.Location = new Point(3, 339);
+        pictureBox4.Name = "pictureBox4";
+        pictureBox4.Size = new Size(109, 106);
+        pictureBox4.TabIndex = 13;
+        pictureBox4.TabStop = false;
         // 
         // pictureBox5
         // 
-        this.pictureBox5.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-        this.pictureBox5.Dock = System.Windows.Forms.DockStyle.Fill;
-        this.pictureBox5.InitialImage = null;
-        this.pictureBox5.Location = new System.Drawing.Point(3, 503);
-        this.pictureBox5.Name = "pictureBox5";
-        this.pictureBox5.Size = new System.Drawing.Size(125, 119);
-        this.pictureBox5.TabIndex = 13;
-        this.pictureBox5.TabStop = false;
+        pictureBox5.BorderStyle = BorderStyle.FixedSingle;
+        pictureBox5.Dock = DockStyle.Fill;
+        pictureBox5.InitialImage = null;
+        pictureBox5.Location = new Point(3, 451);
+        pictureBox5.Name = "pictureBox5";
+        pictureBox5.Size = new Size(109, 106);
+        pictureBox5.TabIndex = 13;
+        pictureBox5.TabStop = false;
         // 
         // tableLayoutPanel2
         // 
-        this.tableLayoutPanel2.ColumnCount = 2;
-        this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
-        this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
-        this.tableLayoutPanel2.Controls.Add(this.buttonOpenCats, 0, 0);
-        this.tableLayoutPanel2.Controls.Add(this.buttonClear, 1, 0);
-        this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Right;
-        this.tableLayoutPanel2.Location = new System.Drawing.Point(1046, 628);
-        this.tableLayoutPanel2.Name = "tableLayoutPanel2";
-        this.tableLayoutPanel2.RowCount = 1;
-        this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
-        this.tableLayoutPanel2.Size = new System.Drawing.Size(177, 43);
-        this.tableLayoutPanel2.TabIndex = 23;
+        tableLayoutPanel2.ColumnCount = 2;
+        tableLayoutPanel2.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
+        tableLayoutPanel2.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
+        tableLayoutPanel2.Controls.Add(buttonOpenCats, 0, 0);
+        tableLayoutPanel2.Controls.Add(buttonClear, 1, 0);
+        tableLayoutPanel2.Dock = DockStyle.Right;
+        tableLayoutPanel2.Location = new Point(1046, 563);
+        tableLayoutPanel2.Name = "tableLayoutPanel2";
+        tableLayoutPanel2.RowCount = 1;
+        tableLayoutPanel2.RowStyles.Add(new RowStyle(SizeType.Percent, 50F));
+        tableLayoutPanel2.Size = new Size(177, 59);
+        tableLayoutPanel2.TabIndex = 23;
         // 
         // buttonOpenCats
         // 
-        this.buttonOpenCats.Dock = System.Windows.Forms.DockStyle.Right;
-        this.buttonOpenCats.Location = new System.Drawing.Point(3, 3);
-        this.buttonOpenCats.Name = "buttonOpenCats";
-        this.buttonOpenCats.Size = new System.Drawing.Size(82, 37);
-        this.buttonOpenCats.TabIndex = 21;
-        this.buttonOpenCats.Text = "Open Cats";
-        this.buttonOpenCats.UseVisualStyleBackColor = true;
+        buttonOpenCats.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
+        buttonOpenCats.Location = new Point(3, 3);
+        buttonOpenCats.Name = "buttonOpenCats";
+        buttonOpenCats.Size = new Size(82, 53);
+        buttonOpenCats.TabIndex = 21;
+        buttonOpenCats.Text = "Open Cats";
+        buttonOpenCats.UseVisualStyleBackColor = true;
         // 
         // buttonClear
         // 
-        this.buttonClear.Dock = System.Windows.Forms.DockStyle.Right;
-        this.buttonClear.Location = new System.Drawing.Point(92, 3);
-        this.buttonClear.Name = "buttonClear";
-        this.buttonClear.Size = new System.Drawing.Size(82, 37);
-        this.buttonClear.TabIndex = 20;
-        this.buttonClear.Text = "Clear";
-        this.buttonClear.UseVisualStyleBackColor = true;
+        buttonClear.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
+        buttonClear.Location = new Point(92, 3);
+        buttonClear.Name = "buttonClear";
+        buttonClear.Size = new Size(82, 53);
+        buttonClear.TabIndex = 20;
+        buttonClear.Text = "Clear";
+        buttonClear.UseVisualStyleBackColor = true;
         // 
         // Form1
         // 
-        this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
-        this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-        this.ClientSize = new System.Drawing.Size(1226, 625);
-        this.Controls.Add(this.tableLayoutPanel1);
-        this.Name = "Form1";
-        this.Text = "Form1";
-        this.tableLayoutPanel1.ResumeLayout(false);
-        this.tableLayoutPanel1.PerformLayout();
-        ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
-        ((System.ComponentModel.ISupportInitialize)(this.pictureBox2)).EndInit();
-        ((System.ComponentModel.ISupportInitialize)(this.pictureBox3)).EndInit();
-        ((System.ComponentModel.ISupportInitialize)(this.pictureBox4)).EndInit();
-        ((System.ComponentModel.ISupportInitialize)(this.pictureBox5)).EndInit();
-        this.tableLayoutPanel2.ResumeLayout(false);
-        this.ResumeLayout(false);
-
+        AutoScaleDimensions = new SizeF(7F, 15F);
+        AutoScaleMode = AutoScaleMode.Font;
+        ClientSize = new Size(1226, 625);
+        Controls.Add(tableLayoutPanel1);
+        Name = "Form1";
+        Text = "Form1";
+        tableLayoutPanel1.ResumeLayout(false);
+        tableLayoutPanel1.PerformLayout();
+        ((System.ComponentModel.ISupportInitialize)pictureBox1).EndInit();
+        ((System.ComponentModel.ISupportInitialize)pictureBox2).EndInit();
+        ((System.ComponentModel.ISupportInitialize)pictureBox3).EndInit();
+        ((System.ComponentModel.ISupportInitialize)pictureBox4).EndInit();
+        ((System.ComponentModel.ISupportInitialize)pictureBox5).EndInit();
+        tableLayoutPanel2.ResumeLayout(false);
+        ResumeLayout(false);
     }
 
     #endregion


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes https://github.com/dotnet/winforms/issues/10449


## Proposed changes
Re-layout OpenCats and Clear buttons by setting Anchor property

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact
N/A
## Regression? 

No

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

When resizing form, the size of OpenCats and Clear buttons will be increased or decreased.

https://github.com/dotnet/winforms/assets/26474449/8540b1ae-538e-4c37-a2a4-44adeddcbbd6



### After
When decreasing or increasing the size of the current window, as long as buttons are in the current tablelayout cell, they are visible and their size are fixed.

https://github.com/dotnet/winforms/assets/26474449/c2ca4192-0eae-4fbd-9071-14f981878a83




###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10517)