### PR TITLE
Scale icon to Dpi when initializing icon in ThreadExceptionDialog

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/InheritanceUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/InheritanceUI.cs
@@ -16,6 +16,7 @@ internal class InheritanceUI
     private static Bitmap s_inheritanceGlyph;
     private static Rectangle s_inheritanceGlyphRect;
     private ToolTip _tooltip;
+    private const int IconSize = 16;
 
     /// <summary>
     ///  The bitmap we use to show inheritance.
@@ -23,7 +24,7 @@ internal class InheritanceUI
     public static Bitmap InheritanceGlyph => s_inheritanceGlyph ??= ScaleHelper.GetIconResourceAsBitmap(
         typeof(InheritanceUI),
         "InheritedGlyph",
-        ScaleHelper.InitialSystemDpi);
+        ScaleHelper.ScaleToDpi(new Size(IconSize, IconSize), ScaleHelper.InitialSystemDpi));
 
     /// <summary>
     ///  The rectangle surrounding the glyph.

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/InheritanceUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/InheritanceUI.cs
@@ -16,15 +16,14 @@ internal class InheritanceUI
     private static Bitmap s_inheritanceGlyph;
     private static Rectangle s_inheritanceGlyphRect;
     private ToolTip _tooltip;
-    private const int IconSize = 16;
 
     /// <summary>
     ///  The bitmap we use to show inheritance.
     /// </summary>
-    public static Bitmap InheritanceGlyph => s_inheritanceGlyph ??= ScaleHelper.GetIconResourceAsBitmap(
+    public static Bitmap InheritanceGlyph => s_inheritanceGlyph ??= ScaleHelper.GetSmallIconResourceAsBitmap(
         typeof(InheritanceUI),
         "InheritedGlyph",
-        ScaleHelper.ScaleToDpi(new Size(IconSize, IconSize), ScaleHelper.InitialSystemDpi));
+        ScaleHelper.InitialSystemDpi);
 
     /// <summary>
     ///  The rectangle surrounding the glyph.

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripTemplateNode.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripTemplateNode.cs
@@ -1389,7 +1389,7 @@ internal class ToolStripTemplateNode : IMenuStatusHandler
             {
                 ItemTypeToolStripMenuItem firstItem = (ItemTypeToolStripMenuItem)_addItemButton.DropDownItems[0];
                 _addItemButton.ImageTransparentColor = Color.Lime;
-                _addItemButton.Image = ScaleHelper.GetIconResourceAsBitmap(
+                _addItemButton.Image = ScaleHelper.GetSmallIconResourceAsBitmap(
                     typeof(ToolStripTemplateNode),
                     "ToolStripTemplateNode",
                     ScaleHelper.InitialSystemDpi);

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/ScaleHelper.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/ScaleHelper.cs
@@ -26,6 +26,7 @@ internal static partial class ScaleHelper
 
     // Backing field, indicating that we will need to send a PerMonitorV2 query in due course.
     private static bool s_processPerMonitorAware;
+    private static Size? _logicalSystemIconSize;
 
     /// <summary>
     ///  The initial primary monitor DPI (logical pixels per inch) for the process.
@@ -322,20 +323,28 @@ internal static partial class ScaleHelper
         PInvoke.GetSystemMetrics(SYSTEM_METRICS_INDEX.SM_CXICON),
         PInvoke.GetSystemMetrics(SYSTEM_METRICS_INDEX.SM_CYICON));
 
-    internal static Size LogicalSystemIconSize
+    [NotNull]
+    internal static Size? LogicalSystemIconSize
     {
         get
         {
-            Size logicalSystemIconSize = new(16, 16);
+            if (_logicalSystemIconSize is not null)
+            {
+                return _logicalSystemIconSize;
+            }
 
             if (OsVersion.IsWindows10_1607OrGreater())
             {
-                logicalSystemIconSize = new(
+                _logicalSystemIconSize = new(
                     PInvoke.GetSystemMetricsForDpi(SYSTEM_METRICS_INDEX.SM_CXICON, OneHundredPercentLogicalDpi),
                     PInvoke.GetSystemMetricsForDpi(SYSTEM_METRICS_INDEX.SM_CYICON, OneHundredPercentLogicalDpi));
             }
+            else
+            {
+                _logicalSystemIconSize = new Size(16, 16);
+            }
 
-            return logicalSystemIconSize;
+            return _logicalSystemIconSize;
         }
     }
 
@@ -349,7 +358,7 @@ internal static partial class ScaleHelper
     ///  Gets the given icon resource as a <see cref="Bitmap"/> scaled to the specified dpi.
     /// </summary>
     internal static Bitmap GetIconResourceAsBitmap(Type type, string resource, int dpi)
-        => GetIconResourceAsBitmap(type, resource, ScaleToDpi(LogicalSystemIconSize, dpi));
+        => GetIconResourceAsBitmap(type, resource, ScaleToDpi((Size)LogicalSystemIconSize, dpi));
 
     /// <summary>
     ///  Gets the given icon resource as a <see cref="Bitmap"/> of the given size.

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/ScaleHelper.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/ScaleHelper.cs
@@ -324,35 +324,23 @@ internal static partial class ScaleHelper
         PInvoke.GetSystemMetrics(SYSTEM_METRICS_INDEX.SM_CXICON),
         PInvoke.GetSystemMetrics(SYSTEM_METRICS_INDEX.SM_CYICON));
 
-    internal static Size LogicalLargeSystemIconSize => s_logicalLargeSystemIconSize ??= OsVersion.IsWindows10_1607OrGreater()
-      ? new(
-          PInvoke.GetSystemMetricsForDpi(SYSTEM_METRICS_INDEX.SM_CXICON, OneHundredPercentLogicalDpi),
-          PInvoke.GetSystemMetricsForDpi(SYSTEM_METRICS_INDEX.SM_CYICON, OneHundredPercentLogicalDpi))
-      : new(32, 32);
-
     internal static Size LogicalSmallSystemIconSize => s_logicalSmallSystemIconSize ??= OsVersion.IsWindows10_1607OrGreater()
-     ? new(
-         PInvoke.GetSystemMetricsForDpi(SYSTEM_METRICS_INDEX.SM_CXSMICON, OneHundredPercentLogicalDpi),
-         PInvoke.GetSystemMetricsForDpi(SYSTEM_METRICS_INDEX.SM_CXSMICON, OneHundredPercentLogicalDpi))
-     : new(16, 16);
+        ? new(
+            PInvoke.GetSystemMetricsForDpi(SYSTEM_METRICS_INDEX.SM_CXSMICON, OneHundredPercentLogicalDpi),
+            PInvoke.GetSystemMetricsForDpi(SYSTEM_METRICS_INDEX.SM_CXSMICON, OneHundredPercentLogicalDpi))
+        : new(16, 16);
 
     /// <summary>
     ///  Gets the given icon resource as a <see cref="Bitmap"/> at the default icon size.
     /// </summary>
-    internal static Bitmap GetIconResourceAsDefaultSizeBitmap(Type type, string resource)
-        => GetIconResourceAsBestMatchBitmap(type, resource, Size.Empty);
-
-    /// <summary>
-    ///  Gets the given large icon (usually 32x32) resource as a <see cref="Bitmap"/> scaled to the specified dpi.
-    /// </summary>
-    internal static Bitmap GetLargeIconResourceAsBitmap(Type type, string resource, int dpi)
-        => GetIconResourceAsBitmap(type, resource, ScaleToDpi(LogicalLargeSystemIconSize, dpi));
+    internal static Bitmap GetIconResourceAsDefaultSizeBitmap(Type type, string resource) =>
+        GetIconResourceAsBestMatchBitmap(type, resource, Size.Empty);
 
     /// <summary>
     ///  Gets the given small icon (usually 16x16) resource as a <see cref="Bitmap"/> scaled to the specified dpi.
     /// </summary>
-    internal static Bitmap GetSmallIconResourceAsBitmap(Type type, string resource, int dpi)
-        => GetIconResourceAsBitmap(type, resource, ScaleToDpi(LogicalSmallSystemIconSize, dpi));
+    internal static Bitmap GetSmallIconResourceAsBitmap(Type type, string resource, int dpi) =>
+        GetIconResourceAsBitmap(type, resource, ScaleToDpi(LogicalSmallSystemIconSize, dpi));
 
     /// <summary>
     ///  Gets the given icon resource as a <see cref="Bitmap"/> of the given size.

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/ScaleHelper.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/ScaleHelper.cs
@@ -322,6 +322,23 @@ internal static partial class ScaleHelper
         PInvoke.GetSystemMetrics(SYSTEM_METRICS_INDEX.SM_CXICON),
         PInvoke.GetSystemMetrics(SYSTEM_METRICS_INDEX.SM_CYICON));
 
+    internal static Size LogicalSystemIconSize
+    {
+        get
+        {
+            Size logicalSystemIconSize = new(16, 16);
+
+            if (OsVersion.IsWindows10_1607OrGreater())
+            {
+                logicalSystemIconSize = new(
+                    PInvoke.GetSystemMetricsForDpi(SYSTEM_METRICS_INDEX.SM_CXICON, OneHundredPercentLogicalDpi),
+                    PInvoke.GetSystemMetricsForDpi(SYSTEM_METRICS_INDEX.SM_CYICON, OneHundredPercentLogicalDpi));
+            }
+
+            return logicalSystemIconSize;
+        }
+    }
+
     /// <summary>
     ///  Gets the given icon resource as a <see cref="Bitmap"/> at the default icon size.
     /// </summary>
@@ -332,7 +349,7 @@ internal static partial class ScaleHelper
     ///  Gets the given icon resource as a <see cref="Bitmap"/> scaled to the specified dpi.
     /// </summary>
     internal static Bitmap GetIconResourceAsBitmap(Type type, string resource, int dpi)
-        => GetIconResourceAsBitmap(type, resource, ScaleToDpi(SystemIconSize, dpi));
+        => GetIconResourceAsBitmap(type, resource, ScaleToDpi(LogicalSystemIconSize, dpi));
 
     /// <summary>
     ///  Gets the given icon resource as a <see cref="Bitmap"/> of the given size.

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/ScaleHelper.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/ScaleHelper.cs
@@ -26,7 +26,6 @@ internal static partial class ScaleHelper
 
     // Backing field, indicating that we will need to send a PerMonitorV2 query in due course.
     private static bool s_processPerMonitorAware;
-    private static Size? s_logicalLargeSystemIconSize;
     private static Size? s_logicalSmallSystemIconSize;
 
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/GridErrorDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/GridErrorDialog.cs
@@ -42,8 +42,8 @@ internal partial class GridErrorDialog : Form
     public GridErrorDialog(PropertyGrid owner)
     {
         _ownerGrid = owner;
-        _expandImage = ScaleHelper.GetIconResourceAsBitmap(typeof(ThreadExceptionDialog), "down", ScaleHelper.InitialSystemDpi);
-        _collapseImage = ScaleHelper.GetIconResourceAsBitmap(typeof(ThreadExceptionDialog), "up", ScaleHelper.InitialSystemDpi);
+        _expandImage = ScaleHelper.GetSmallIconResourceAsBitmap(typeof(ThreadExceptionDialog), "down", ScaleHelper.InitialSystemDpi);
+        _collapseImage = ScaleHelper.GetSmallIconResourceAsBitmap(typeof(ThreadExceptionDialog), "up", ScaleHelper.InitialSystemDpi);
 
         InitializeComponent();
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Dialogs/ThreadExceptionDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Dialogs/ThreadExceptionDialog.cs
@@ -36,6 +36,7 @@ public class ThreadExceptionDialog : Form
     private const int PICTUREWIDTH = 64;
     private const int PICTUREHEIGHT = 64;
     private const int EXCEPTIONMESSAGEVERTICALPADDING = 4;
+    private const int IconSize = 16;
 
     private readonly int _scaledMaxWidth = MAXWIDTH;
     private readonly int _scaledMaxHeight = MAXHEIGHT;
@@ -278,20 +279,26 @@ public class ThreadExceptionDialog : Form
         _detailsButton.FlatStyle = FlatStyle.Standard;
         _detailsButton.Click += new EventHandler(DetailsClick);
 
-        Button? b = null;
+        Button? button = null;
         int startIndex = 0;
 
         if (detailAnchor)
         {
-            b = _detailsButton;
+            button = _detailsButton;
 
-            _expandImage = ScaleHelper.GetIconResourceAsBitmap(GetType(), DownBitmapName, DeviceDpi);
-            _collapseImage = ScaleHelper.GetIconResourceAsBitmap(GetType(), UpBitmapName, DeviceDpi);
+            _expandImage = ScaleHelper.GetIconResourceAsBitmap(
+                GetType(),
+                DownBitmapName,
+                ScaleHelper.ScaleToDpi(new Size(IconSize, IconSize), ScaleHelper.InitialSystemDpi));
+            _collapseImage = ScaleHelper.GetIconResourceAsBitmap(
+                GetType(),
+                UpBitmapName,
+                ScaleHelper.ScaleToDpi(new Size(IconSize, IconSize), ScaleHelper.InitialSystemDpi));
 
-            b.SetBounds(_scaledButtonDetailsLeftPadding, buttonTop, _scaledButtonWidth, _scaledButtonHeight);
-            b.Image = _expandImage;
-            b.ImageAlign = ContentAlignment.MiddleLeft;
-            Controls.Add(b);
+            button.SetBounds(_scaledButtonDetailsLeftPadding, buttonTop, _scaledButtonWidth, _scaledButtonHeight);
+            button.Image = _expandImage;
+            button.ImageAlign = ContentAlignment.MiddleLeft;
+            Controls.Add(button);
             startIndex = 1;
         }
 
@@ -300,9 +307,9 @@ public class ThreadExceptionDialog : Form
 
         for (int i = startIndex; i < buttons.Length; i++)
         {
-            b = buttons[i];
-            b.SetBounds(buttonLeft, buttonTop, _scaledButtonWidth, _scaledButtonHeight);
-            Controls.Add(b);
+            button = buttons[i];
+            button.SetBounds(buttonLeft, buttonTop, _scaledButtonWidth, _scaledButtonHeight);
+            Controls.Add(button);
             buttonLeft += _scaledButtonAlignmentWidth;
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Dialogs/ThreadExceptionDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Dialogs/ThreadExceptionDialog.cs
@@ -36,7 +36,6 @@ public class ThreadExceptionDialog : Form
     private const int PICTUREWIDTH = 64;
     private const int PICTUREHEIGHT = 64;
     private const int EXCEPTIONMESSAGEVERTICALPADDING = 4;
-    private const int IconSize = 16;
 
     private readonly int _scaledMaxWidth = MAXWIDTH;
     private readonly int _scaledMaxHeight = MAXHEIGHT;
@@ -286,14 +285,14 @@ public class ThreadExceptionDialog : Form
         {
             button = _detailsButton;
 
-            _expandImage = ScaleHelper.GetIconResourceAsBitmap(
+            _expandImage = ScaleHelper.GetSmallIconResourceAsBitmap(
                 GetType(),
                 DownBitmapName,
-                ScaleHelper.ScaleToDpi(new Size(IconSize, IconSize), ScaleHelper.InitialSystemDpi));
-            _collapseImage = ScaleHelper.GetIconResourceAsBitmap(
+                DeviceDpi);
+            _collapseImage = ScaleHelper.GetSmallIconResourceAsBitmap(
                 GetType(),
                 UpBitmapName,
-                ScaleHelper.ScaleToDpi(new Size(IconSize, IconSize), ScaleHelper.InitialSystemDpi));
+                DeviceDpi);
 
             button.SetBounds(_scaledButtonDetailsLeftPadding, buttonTop, _scaledButtonWidth, _scaledButtonHeight);
             button.Image = _expandImage;
@@ -336,8 +335,8 @@ public class ThreadExceptionDialog : Form
     private void ThreadExceptionDialog_DpiChanged(object? sender, DpiChangedEventArgs e)
     {
         _expandImage?.Dispose();
-        _expandImage = ScaleHelper.GetIconResourceAsBitmap(GetType(), DownBitmapName, DeviceDpi);
-        _collapseImage = ScaleHelper.GetIconResourceAsBitmap(GetType(), UpBitmapName, DeviceDpi);
+        _expandImage = ScaleHelper.GetSmallIconResourceAsBitmap(GetType(), DownBitmapName, DeviceDpi);
+        _collapseImage = ScaleHelper.GetSmallIconResourceAsBitmap(GetType(), UpBitmapName, DeviceDpi);
         _detailsButton.Image = _detailsVisible ? _collapseImage : _expandImage;
 
         if (e.DeviceDpiNew != e.DeviceDpiOld)


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #10512 


## Proposed changes

-   Adding methods `GetLargeIconResourceAsBitmap `and `GetSmallIconResourceAsBitmap `to ScaleHelper.cs to 100% scaling the icon resource.

<!-- We are in TELL-MODE the following section must be completed -->

## The cause of this issue
-  In the original logic, the resource was scaled once when calling `GetSystemMetrics(SM_CXICON)` (this is not expected), and was scaled again when calling `ScaleToDpi`. The two scalings resulted in abnormal icon display.

## Customer Impact

- The down arrow icon align with Details in Thread exception dialog can be show normally

## Regression? 

- Yes 

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

In 200% screen:
![image](https://github.com/dotnet/winforms/assets/132890443/a754fa12-264a-405f-ae71-d6abb4dca9c9)


### After
![image](https://github.com/dotnet/winforms/assets/132890443/fcce8b3e-0285-443a-87e5-8129c1deb71a)


## Test methodology <!-- How did you ensure quality? -->

- Manually
 

## Test environment(s) <!-- Remove any that don't apply -->

- .net 9.0.0-alpha.1.23623.1


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10529)