### PR TITLE
fix bug [Accessibility]Inspect or AccessibilityInsights tool's rectangle can't focus on the entire Treeview with scrollBar

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeView.TreeViewAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeView.TreeViewAccessibleObject.cs
@@ -14,6 +14,9 @@ public partial class TreeView
     {
         public TreeViewAccessibleObject(TreeView owningTreeView) : base(owningTreeView) { }
 
+        internal override Rectangle BoundingRectangle => this.IsOwnerHandleCreated(out ListBox? owner) ?
+            owner.GetToolNativeScreenRectangle() : Rectangle.Empty;
+
         internal override IRawElementProviderFragment.Interface? ElementProviderFromPoint(double x, double y)
             => HitTest((int)x, (int)y) ?? base.ElementProviderFromPoint(x, y);
 


### PR DESCRIPTION
Fixes #10485


## Proposed changes

There is something wrong with the base method `BoundingRectangle`.
So override this method in the same manner that `TextBox` did
https://github.com/dotnet/winforms/blob/9e2fc95fca4e6d18444c819b35bb1338ac6ca63d/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ListBoxes/ListBox.AccessibleObject.cs#L31-L32C10

<!-- We are in TELL-MODE the following section must be completed -->
<!-- 
## Customer Impact

- 
- 
 -->
## Regression? 

- Yes.  It repro on .NET 8.0 & 7.0

## Risk

- minimal 



## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/dotnet/winforms/assets/130345015/659d0f27-1b6b-43cc-88dd-4976e63e9887)

### After

![image](https://github.com/dotnet/winforms/assets/135201996/b13347ee-1075-4a5d-91c2-508c135b3106)


## Test methodology <!-- How did you ensure quality? -->

- 
- manual 
- 

## Test environment(s) <!-- Remove any that don't apply -->

- 9.0.0-alpha.1.23623.1



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10532)