### PR TITLE
dispose graphics in TabControl.WmReflectDrawItem()

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TabControl/TabControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TabControl/TabControl.cs
@@ -1933,11 +1933,13 @@ public partial class TabControl : Control
         DRAWITEMSTRUCT* dis = (DRAWITEMSTRUCT*)(nint)m.LParamInternal;
 
         using DrawItemEventArgs e = new(
-            dis->hDC.CreateGraphics(),
+            dis->hDC,
             Font,
             dis->rcItem,
-            (int)dis->itemID,
-            (DrawItemState)(int)dis->itemState);
+            dis->itemID,
+            dis->itemState,
+            ForeColor,
+            BackColor);
 
         OnDrawItem(e);
 


### PR DESCRIPTION
fixes #10534


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10536)