### PR TITLE
Enable the xUnit1004 refactoring

### DIFF
--- a/eng/CodeAnalysis.test.globalconfig
+++ b/eng/CodeAnalysis.test.globalconfig
@@ -318,7 +318,7 @@ dotnet_diagnostic.xUnit1002.severity = warning
 dotnet_diagnostic.xUnit1003.severity = warning
 
 # xUnit1004: Test methods should not be skipped
-dotnet_diagnostic.xUnit1004.severity = none # TODO: warning
+dotnet_diagnostic.xUnit1004.severity = silent # TODO: warning
 
 # xUnit1005: Fact methods should not have test data
 dotnet_diagnostic.xUnit1005.severity = warning


### PR DESCRIPTION
xUnit1004 comes with a code fix that allows users to remove the `Skip` attribute from a test method using the light bulb. This code fix only works when the diagnostic is enabled. This pull request enables the diagnostic at `silent` severity, which means it applies to the IDE experience but still does not report any diagnostics during a build.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10554)