### PR TITLE
Fix dynamic invocation of InitializeStatics

### DIFF
--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Dpi/FormDpiTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Dpi/FormDpiTests.cs
@@ -25,7 +25,7 @@ public class FormDpiTests : ControlTestBase
         }
 
         DPI_AWARENESS_CONTEXT originalAwarenessContext = PInvoke.SetThreadDpiAwarenessContextInternal(DPI_AWARENESS_CONTEXT.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
-        typeof(ScaleHelper).TestAccessor().Dynamic.Initialize();
+        typeof(ScaleHelper).TestAccessor().Dynamic.InitializeStatics();
         try
         {
             using Form form = new();
@@ -62,7 +62,7 @@ public class FormDpiTests : ControlTestBase
         }
 
         DPI_AWARENESS_CONTEXT originalAwarenessContext = PInvoke.SetThreadDpiAwarenessContext(DPI_AWARENESS_CONTEXT.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
-        typeof(ScaleHelper).TestAccessor().Dynamic.Initialize();
+        typeof(ScaleHelper).TestAccessor().Dynamic.InitializeStatics();
         try
         {
             var minSize = new Drawing.Size(100, 100);
@@ -96,7 +96,7 @@ public class FormDpiTests : ControlTestBase
         }
 
         DPI_AWARENESS_CONTEXT originalAwarenessContext = PInvoke.SetThreadDpiAwarenessContext(DPI_AWARENESS_CONTEXT.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
-        typeof(ScaleHelper).TestAccessor().Dynamic.Initialize();
+        typeof(ScaleHelper).TestAccessor().Dynamic.InitializeStatics();
         try
         {
             var minSize = new Drawing.Size(100, 100);
@@ -138,7 +138,7 @@ public class FormDpiTests : ControlTestBase
         }
 
         DPI_AWARENESS_CONTEXT originalAwarenessContext = PInvoke.SetThreadDpiAwarenessContext(DPI_AWARENESS_CONTEXT.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
-        typeof(ScaleHelper).TestAccessor().Dynamic.Initialize();
+        typeof(ScaleHelper).TestAccessor().Dynamic.InitializeStatics();
         try
         {
             using Form form = new();
@@ -174,7 +174,7 @@ public class FormDpiTests : ControlTestBase
         }
 
         DPI_AWARENESS_CONTEXT originalAwarenessContext = PInvoke.SetThreadDpiAwarenessContext(DPI_AWARENESS_CONTEXT.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
-        typeof(ScaleHelper).TestAccessor().Dynamic.Initialize();
+        typeof(ScaleHelper).TestAccessor().Dynamic.InitializeStatics();
         try
         {
             using Form form = new();
@@ -206,7 +206,7 @@ public class FormDpiTests : ControlTestBase
         }
 
         DPI_AWARENESS_CONTEXT originalAwarenessContext = PInvoke.SetThreadDpiAwarenessContext(DPI_AWARENESS_CONTEXT.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
-        typeof(ScaleHelper).TestAccessor().Dynamic.Initialize();
+        typeof(ScaleHelper).TestAccessor().Dynamic.InitializeStatics();
         try
         {
             using Form form = new();
@@ -234,7 +234,7 @@ public class FormDpiTests : ControlTestBase
         }
 
         DPI_AWARENESS_CONTEXT originalAwarenessContext = PInvoke.SetThreadDpiAwarenessContext(DPI_AWARENESS_CONTEXT.DPI_AWARENESS_CONTEXT_SYSTEM_AWARE);
-        typeof(ScaleHelper).TestAccessor().Dynamic.Initialize();
+        typeof(ScaleHelper).TestAccessor().Dynamic.InitializeStatics();
         try
         {
             using Form form = new();

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Dpi/SplitContainerTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Dpi/SplitContainerTests.cs
@@ -39,7 +39,7 @@ public class SplitContainerTests : ControlTestBase
 
         DPI_AWARENESS_CONTEXT originalAwarenessContext = PInvoke.SetThreadDpiAwarenessContextInternal(DPI_AWARENESS_CONTEXT.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
 
-        typeof(ScaleHelper).TestAccessor().Dynamic.Initialize();
+        typeof(ScaleHelper).TestAccessor().Dynamic.InitializeStatics();
         try
         {
             using Form form = new();

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Dpi/ToolStripItemTests.Dpi.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Dpi/ToolStripItemTests.Dpi.cs
@@ -27,7 +27,7 @@ public class ToolStripItemDpiTests : ControlTestBase
 
         // Set thread awareness context to PermonitorV2(PMv2).
         DPI_AWARENESS_CONTEXT originalAwarenessContext = PInvoke.SetThreadDpiAwarenessContextInternal(DPI_AWARENESS_CONTEXT.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
-        typeof(ScaleHelper).TestAccessor().Dynamic.Initialize();
+        typeof(ScaleHelper).TestAccessor().Dynamic.InitializeStatics();
         try
         {
             int clientWidth = 800;


### PR DESCRIPTION
The `Initialize` method was renamed while integration tests were disabled, so this error was not caught by CI.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10556)