### PR TITLE
Fix `ListViewAccessibleObject` control type to be dependent on ListView View type

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ListView/ListView.ListViewAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ListView/ListView.ListViewAccessibleObject.cs
@@ -180,18 +180,6 @@ public partial class ListView
             };
         }
 
-        private UIA_CONTROLTYPE_ID GetControlType()
-        {
-            if (!this.IsOwnerHandleCreated(out ListView? owningListView))
-            {
-                return UIA_CONTROLTYPE_ID.UIA_ListControlTypeId;
-            }
-
-            return owningListView.View == View.Details
-                ? UIA_CONTROLTYPE_ID.UIA_TableControlTypeId
-                : UIA_CONTROLTYPE_ID.UIA_ListControlTypeId;
-        }
-
         internal override IRawElementProviderSimple.Interface[]? GetColumnHeaders()
         {
             if (!this.TryGetOwnerAs(out ListView? owningListView))
@@ -256,7 +244,9 @@ public partial class ListView
                 // And we don't have a 100% guarantee it will be correct, hence set it ourselves.
                 UIA_PROPERTY_ID.UIA_ControlTypePropertyId when
                     this.GetOwnerAccessibleRole() == AccessibleRole.Default
-                    => (VARIANT)(int)GetControlType(),
+                    => (VARIANT)(int)((this.TryGetOwnerAs(out ListView? owningListView) && owningListView.View == View.Details)
+                        ? UIA_CONTROLTYPE_ID.UIA_TableControlTypeId
+                        : UIA_CONTROLTYPE_ID.UIA_ListControlTypeId),
                 UIA_PROPERTY_ID.UIA_HasKeyboardFocusPropertyId => VARIANT.False,
                 UIA_PROPERTY_ID.UIA_IsKeyboardFocusablePropertyId => (VARIANT)State.HasFlag(AccessibleStates.Focusable),
                 UIA_PROPERTY_ID.UIA_ItemStatusPropertyId => (VARIANT)GetItemStatus(),

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ListView/ListView.ListViewAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ListView/ListView.ListViewAccessibleObject.cs
@@ -180,6 +180,18 @@ public partial class ListView
             };
         }
 
+        private UIA_CONTROLTYPE_ID GetControlType()
+        {
+            if (!this.IsOwnerHandleCreated(out ListView? owningListView))
+            {
+                return UIA_CONTROLTYPE_ID.UIA_ListControlTypeId;
+            }
+
+            return owningListView.View == View.Details
+                ? UIA_CONTROLTYPE_ID.UIA_TableControlTypeId
+                : UIA_CONTROLTYPE_ID.UIA_ListControlTypeId;
+        }
+
         internal override IRawElementProviderSimple.Interface[]? GetColumnHeaders()
         {
             if (!this.TryGetOwnerAs(out ListView? owningListView))
@@ -244,7 +256,7 @@ public partial class ListView
                 // And we don't have a 100% guarantee it will be correct, hence set it ourselves.
                 UIA_PROPERTY_ID.UIA_ControlTypePropertyId when
                     this.GetOwnerAccessibleRole() == AccessibleRole.Default
-                    => (VARIANT)(int)UIA_CONTROLTYPE_ID.UIA_ListControlTypeId,
+                    => (VARIANT)(int)GetControlType(),
                 UIA_PROPERTY_ID.UIA_HasKeyboardFocusPropertyId => VARIANT.False,
                 UIA_PROPERTY_ID.UIA_IsKeyboardFocusablePropertyId => (VARIANT)State.HasFlag(AccessibleStates.Focusable),
                 UIA_PROPERTY_ID.UIA_ItemStatusPropertyId => (VARIANT)GetItemStatus(),


### PR DESCRIPTION
Fixes #10546 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10560)