### PR TITLE
Revert "fix isssue 10516 [Accessibility] CheckBox control should support ValuePattern property (#10533)"

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -13,7 +13,6 @@
 *REMOVED*virtual System.Windows.Forms.Control.ControlCollection.AddRange(System.Windows.Forms.Control![]! controls) -> void
 *REMOVED*virtual System.Windows.Forms.ListView.ColumnHeaderCollection.AddRange(System.Windows.Forms.ColumnHeader![]! values) -> void
 *REMOVED*virtual System.Windows.Forms.TreeNodeCollection.AddRange(System.Windows.Forms.TreeNode![]! nodes) -> void
-override System.Windows.Forms.CheckBox.CheckBoxAccessibleObject.Value.get -> string!
 override System.Windows.Forms.LinkLabel.Dispose(bool disposing) -> void
 System.Windows.Forms.AutoCompleteStringCollection.AddRange(params string![]! value) -> void
 System.Windows.Forms.ComboBox.ObjectCollection.AddRange(params object![]! items) -> void

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/Buttons/CheckBox.CheckBoxAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/Buttons/CheckBox.CheckBoxAccessibleObject.cs
@@ -41,7 +41,6 @@ public partial class CheckBox
         internal override bool IsPatternSupported(UIA_PATTERN_ID patternId) => patternId switch
         {
             var p when p == UIA_PATTERN_ID.UIA_TogglePatternId => true,
-            UIA_PATTERN_ID.UIA_ValuePatternId => true,
             _ => base.IsPatternSupported(patternId)
         };
 
@@ -92,50 +91,5 @@ public partial class CheckBox
                 }
             }
         }
-
-        internal override void SetValue(string? newValue)
-        {
-            if (!this.TryGetOwnerAs(out CheckBox? owner))
-            {
-                return;
-            }
-
-            if (owner.ThreeState)
-            {
-                if (CheckState.Checked.ToString().Equals(newValue, StringComparison.InvariantCultureIgnoreCase))
-                {
-                    owner.CheckState = CheckState.Checked;
-                    return;
-                }
-                else if (CheckState.Unchecked.ToString().Equals(newValue, StringComparison.InvariantCultureIgnoreCase))
-                {
-                    owner.CheckState = CheckState.Unchecked;
-                    return;
-                }
-                else if (CheckState.Indeterminate.ToString().Equals(newValue, StringComparison.InvariantCultureIgnoreCase))
-                {
-                    owner.CheckState = CheckState.Indeterminate;
-                    return;
-                }
-
-                throw new ArgumentException($"'{newValue}' does not specify a {nameof(CheckBox)} {nameof(CheckState)}.");
-            }
-            else if ("true".Equals(newValue, StringComparison.InvariantCultureIgnoreCase))
-            {
-                owner.Checked = true;
-                return;
-            }
-            else if ("false".Equals(newValue, StringComparison.InvariantCultureIgnoreCase))
-            {
-                owner.Checked = false;
-                return;
-            }
-
-            throw new ArgumentException($"'{newValue}' does not specify a {nameof(CheckBox)} {nameof(CheckState)}.");
-        }
-
-        public override string Value => this.TryGetOwnerAs(out CheckBox? owner)
-            ? owner.ThreeState ? owner.CheckState.ToString() : owner.Checked.ToString()
-            : string.Empty;
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/CheckBox.CheckBoxAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/CheckBox.CheckBoxAccessibleObjectTests.cs
@@ -287,49 +287,4 @@ public class CheckBox_CheckBoxAccessibleObjectTests
         Assert.Equal(checkBox.AccessibilityObject.DefaultAction, ((BSTR)checkBox.AccessibilityObject.GetPropertyValue(UIA_PROPERTY_ID.UIA_LegacyIAccessibleDefaultActionPropertyId)).ToStringAndFree());
         Assert.False(checkBox.IsHandleCreated);
     }
-
-    // Unit test for https://github.com/dotnet/winforms/issues/10516.
-    [WinFormsFact]
-    public void CheckBoxAccessibleObject_Value_Pattern_Success()
-    {
-        using CheckBox checkBox = new();
-        CheckBoxAccessibleObject checkBoxAccessibleObject = new(checkBox);
-        Assert.False(checkBox.Checked);
-        Assert.False(checkBox.ThreeState);
-
-        Assert.True(checkBoxAccessibleObject.IsPatternSupported(UIA_PATTERN_ID.UIA_ValuePatternId));
-        Assert.Equal("False", checkBoxAccessibleObject.Value);
-
-        checkBox.Checked = true;
-        Assert.Equal("True", checkBoxAccessibleObject.Value);
-
-        checkBox.ThreeState = true;
-
-        Assert.Equal("Checked", checkBoxAccessibleObject.Value);
-
-        checkBox.CheckState = CheckState.Unchecked;
-        Assert.Equal("Unchecked", checkBoxAccessibleObject.Value);
-
-        checkBox.CheckState = CheckState.Indeterminate;
-        Assert.Equal("Indeterminate", checkBoxAccessibleObject.Value);
-
-        checkBoxAccessibleObject.SetValue(CheckState.Indeterminate.ToString());
-        Assert.Equal(CheckState.Indeterminate, checkBox.CheckState);
-
-        checkBoxAccessibleObject.SetValue(CheckState.Unchecked.ToString());
-        Assert.Equal(CheckState.Unchecked, checkBox.CheckState);
-
-        checkBoxAccessibleObject.SetValue(CheckState.Checked.ToString());
-        Assert.Equal(CheckState.Checked, checkBox.CheckState);
-
-        checkBox.ThreeState = false;
-        Assert.True(checkBox.Checked);
-
-        checkBoxAccessibleObject.SetValue(false.ToString());
-        Assert.False(checkBox.Checked);
-
-        Assert.Throws<ArgumentException>(() => checkBoxAccessibleObject.SetValue("Microsoft"));
-
-        Assert.False(checkBox.IsHandleCreated);
-    }
 }


### PR DESCRIPTION
revert [PR 10533](https://github.com/dotnet/winforms/pull/10533), since it is not a bug.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10569)