### PR TITLE
[release/8.0] [Accessibility]Inspect or AccessibilityInsights tool's rectangle can't focus on the entire Treeview with scrollBar

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.TreeViewAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.TreeViewAccessibleObject.cs
@@ -14,6 +14,9 @@ public partial class TreeView
     {
         public TreeViewAccessibleObject(TreeView owningTreeView) : base(owningTreeView) { }
 
+        internal override Rectangle BoundingRectangle => this.IsOwnerHandleCreated(out TreeView? owner) ?
+            owner.GetToolNativeScreenRectangle() : Rectangle.Empty;
+
         internal override IRawElementProviderFragment? ElementProviderFromPoint(double x, double y)
             => HitTest((int)x, (int)y) ?? base.ElementProviderFromPoint(x, y);
 


### PR DESCRIPTION
related to [PR_10532](https://github.com/dotnet/winforms/pull/10532)

Fix #10485

## Proposed changes
Do not use BoundingRectangle method defined on the AccessibleObject class, instead use Win32 API GetWindowRect

## Customer Impact
Accessibility tools do not have access to the control scroll bars if TreeView shows them.

## Regression?
 - [X] Yes 
 - [ ] No
 
## Risk
- [ ] High
- [ ] Medium
- [X] Low – because the change made in this pr does not affect TreeView control itself. It only change TreeViews' rectangle when accessibility client is open.

## Before

![image](https://github.com/dotnet/winforms/assets/130345015/659d0f27-1b6b-43cc-88dd-4976e63e9887)

## After

![image](https://github.com/dotnet/winforms/assets/135201996/b13347ee-1075-4a5d-91c2-508c135b3106)

## Verification
- [x] Manual 
- [ ] Automated
 
## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [X] N/A

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10570)