### PR TITLE
Fix PropertyGrid.RemoveTabType method

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGrid.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGrid.cs
@@ -3564,7 +3564,7 @@ public partial class PropertyGrid : ContainerControl, IComPropertyBrowser, IProp
         int tabIndex = -1;
         for (int i = 0; i < _tabs.Count; i++)
         {
-            if (tabType == _tabs[i].GetType())
+            if (tabType == _tabs[i].Tab.GetType())
             {
                 tabIndex = i;
                 break;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridTests.cs
@@ -11,6 +11,7 @@ using System.Windows.Forms.TestUtilities;
 using System.Runtime.CompilerServices;
 using Point = System.Drawing.Point;
 using Size = System.Drawing.Size;
+using System.Windows.Forms.Design;
 
 namespace System.Windows.Forms.Tests;
 
@@ -2355,6 +2356,28 @@ public partial class PropertyGridTests
         Assert.Equal(2, invalidatedCallCount);
         Assert.Equal(0, styleChangedCallCount);
         Assert.Equal(0, createdCallCount);
+    }
+
+    [WinFormsFact]
+    public void PropertyGrid_PropertyTabCollection_AddAndRemoveTabType_Success()
+    {
+        using PropertyGrid grid = new();
+        Assert.Equal(1, grid.PropertyTabs.Count);
+
+        grid.PropertyTabs.AddTabType(typeof(TestPropertyTab));
+        Assert.Equal(2, grid.PropertyTabs.Count);
+
+        grid.PropertyTabs.RemoveTabType(typeof(TestPropertyTab));
+        Assert.Equal(1, grid.PropertyTabs.Count);
+    }
+
+    private class TestPropertyTab : PropertyTab
+    {
+        public override string TabName => "TestTabName";
+
+        public override Bitmap Bitmap => new(10, 10);
+
+        public override PropertyDescriptorCollection GetProperties(object component, Attribute[] attributes) => throw new NotImplementedException();
     }
 
     [WinFormsFact]


### PR DESCRIPTION
Tab removal wasn't matching the tab type so it wouldn't remove tabs.

Fixes #10574