### PR TITLE
Fix `StackOverflow` in `ControlDesigner`

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
@@ -358,7 +358,7 @@ public partial class ControlDesigner : ComponentDesigner
     /// </summary>
     public virtual IList SnapLines => EdgeAndMarginSnapLines().Unwrap();
 
-    internal IList<SnapLine> SnapLinesInternal => SnapLines.Adapt<SnapLine>();
+    internal IList<SnapLine> SnapLinesInternal => EdgeAndMarginSnapLines();
 
     internal IList<SnapLine> EdgeAndMarginSnapLines() => EdgeAndMarginSnapLines(Control.Margin);
 


### PR DESCRIPTION
Fixes #10580
Caused by #10279

![294309830-228b6d58-f9b8-44ac-be59-f73019024a3d](https://github.com/dotnet/winforms/assets/2433737/3da5c8e6-98f0-465c-bf8d-6768efabf274)
![294309898-978d4797-29b5-483f-8089-bbbd568ee69b](https://github.com/dotnet/winforms/assets/2433737/cb3e1976-a50e-4cbd-858c-da8e9a7082a9)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10584)