### PR TITLE
Fix calls to Component in ComponentDesigner.Dispose overrides

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ComboBoxDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ComboBoxDesigner.cs
@@ -19,6 +19,8 @@ internal class ComboBoxDesigner : ControlDesigner
 {
     private EventHandler propChanged; // Delegate used to dirty the selectionUIItem when needed.
 
+    public override ComboBox Control => (ComboBox)Component;
+
     /// <summary>
     ///  Adds a baseline SnapLine to the list of SnapLines related
     ///  to this control.
@@ -46,9 +48,9 @@ internal class ComboBoxDesigner : ControlDesigner
         if (disposing)
         {
             // Hook up the property change notification so that we can dirty the SelectionUIItem when needed.
-            if (propChanged is not null)
+            if (HasComponent && propChanged is not null)
             {
-                ((ComboBox)Control).StyleChanged -= propChanged;
+                Control.StyleChanged -= propChanged;
             }
         }
 
@@ -66,7 +68,7 @@ internal class ComboBoxDesigner : ControlDesigner
 
         // Hook up the property change notification so that we can dirty the SelectionUIItem when needed.
         propChanged = new EventHandler(OnControlPropertyChanged);
-        ((ComboBox)Control).StyleChanged += propChanged;
+        Control.StyleChanged += propChanged;
     }
 
     /// <summary>
@@ -77,7 +79,7 @@ internal class ComboBoxDesigner : ControlDesigner
         base.InitializeNewComponent(defaultValues);
 
         // in Whidbey, formattingEnabled is TRUE
-        ((ComboBox)Component).FormattingEnabled = true;
+        Control.FormattingEnabled = true;
 
         PropertyDescriptor textProp = TypeDescriptor.GetProperties(Component)["Text"];
         if (textProp is not null && textProp.PropertyType == typeof(string) && !textProp.IsReadOnly && textProp.IsBrowsable)

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ParentControlDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ParentControlDesigner.cs
@@ -678,7 +678,7 @@ public partial class ParentControlDesigner : ControlDesigner, IOleDragClient
 
             EnableDragDrop(false);
 
-            if (Control is ScrollableControl control)
+            if (HasComponent && Control is ScrollableControl control)
             {
                 control.Scroll -= new ScrollEventHandler(OnScroll);
             }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TabControlDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TabControlDesigner.cs
@@ -170,8 +170,7 @@ internal class TabControlDesigner : ParentControlDesigner
                 cs.ComponentChanged -= new ComponentChangedEventHandler(OnComponentChanged);
             }
 
-            TabControl tabControl = Control as TabControl;
-            if (tabControl is not null)
+            if (HasComponent && Control is TabControl tabControl)
             {
                 tabControl.SelectedIndexChanged -= new EventHandler(OnTabSelectedIndexChanged);
                 tabControl.GotFocus -= new EventHandler(OnGotFocus);

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripDesigner.cs
@@ -1143,7 +1143,11 @@ internal class ToolStripDesigner : ControlDesigner
                 _selectionService = null;
             }
 
-            EnableDragDrop(false);
+            if (HasComponent)
+            {
+                EnableDragDrop(false);
+            }
+
             // Dispose of the EditManager
             if (_editManager is not null)
             {
@@ -1181,11 +1185,14 @@ internal class ToolStripDesigner : ControlDesigner
             }
 
             // Always Remove all the glyphs we added
-            RemoveBodyGlyphsForOverflow();
-            // tear off the OverFlow if its being shown
-            if (ToolStrip.OverflowButton.DropDown.Visible)
+            if (HasComponent)
             {
-                ToolStrip.OverflowButton.HideDropDown();
+                RemoveBodyGlyphsForOverflow();
+                // tear off the OverFlow if its being shown
+                if (ToolStrip.OverflowButton.DropDown.Visible)
+                {
+                    ToolStrip.OverflowButton.HideDropDown();
+                }
             }
 
             if (_toolStripAdornerWindowService is not null)


### PR DESCRIPTION
In #9408, we forced the `ComponentDesigner.Component` property to be non-null. We noticed this had implications in the method `ControlDesigner.Dispose`. This PR addresses all other such cases that were broken by this PR but 2 instances that will be addressed in followup PRs.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10585)