### PR TITLE
Refactoring `DesignerActionMethodItem` usage to use nameof instead of inline string

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewDesigner.cs
@@ -940,15 +940,17 @@ internal class DataGridViewDesigner : ControlDesigner
 
         public override DesignerActionItemCollection GetSortedActionItems()
         {
-            DesignerActionItemCollection items = new();
-            items.Add(new DesignerActionMethodItem(this,
-                        "EditColumns",                      // method name
-                        SR.DataGridViewEditColumnsVerb,   // display name
-                        true));                             // promoteToDesignerVerb
-            items.Add(new DesignerActionMethodItem(this,
-                        "AddColumn",                        // method name
-                        SR.DataGridViewAddColumnVerb,     // display name
-                        true));                             // promoteToDesignerVerb
+            DesignerActionItemCollection items =
+            [
+                new DesignerActionMethodItem(this,
+                            nameof(EditColumns),              // method name
+                            SR.DataGridViewEditColumnsVerb,   // display name
+                            true),                            // promoteToDesignerVerb
+                new DesignerActionMethodItem(this,
+                            nameof(AddColumn),                // method name
+                            SR.DataGridViewAddColumnVerb,     // display name
+                            true),                            // promoteToDesignerVerb
+            ];
 
             return items;
         }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewDesigner.cs
@@ -943,13 +943,13 @@ internal class DataGridViewDesigner : ControlDesigner
             DesignerActionItemCollection items =
             [
                 new DesignerActionMethodItem(this,
-                            nameof(EditColumns),              // method name
-                            SR.DataGridViewEditColumnsVerb,   // display name
-                            true),                            // promoteToDesignerVerb
+                    memberName: nameof(EditColumns),
+                    displayName: SR.DataGridViewEditColumnsVerb,
+                    includeAsDesignerVerb:true),
                 new DesignerActionMethodItem(this,
-                            nameof(AddColumn),                // method name
-                            SR.DataGridViewAddColumnVerb,     // display name
-                            true),                            // promoteToDesignerVerb
+                    memberName: nameof(AddColumn),
+                    displayName: SR.DataGridViewAddColumnVerb,
+                    includeAsDesignerVerb: true),
             ];
 
             return items;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/NotifyIconDesignerActionList.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/NotifyIconDesignerActionList.cs
@@ -20,10 +20,10 @@ namespace System.Windows.Forms.Design
 
         public override DesignerActionItemCollection GetSortedActionItems()
         {
-            DesignerActionItemCollection items = new()
-            {
-                new DesignerActionMethodItem(this, "ChooseIcon", SR.ChooseIconDisplayName, true)
-            };
+            DesignerActionItemCollection items =
+            [
+                new DesignerActionMethodItem(this, nameof(ChooseIcon), SR.ChooseIconDisplayName, true)
+            ];
             return items;
         }
     }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/NotifyIconDesignerActionList.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/NotifyIconDesignerActionList.cs
@@ -22,7 +22,10 @@ namespace System.Windows.Forms.Design
         {
             DesignerActionItemCollection items =
             [
-                new DesignerActionMethodItem(this, nameof(ChooseIcon), SR.ChooseIconDisplayName, true)
+                new DesignerActionMethodItem(this,
+                    memberName: nameof(ChooseIcon),
+                    displayName: SR.ChooseIconDisplayName,
+                    includeAsDesignerVerb: true)
             ];
             return items;
         }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TableLayoutPanelDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TableLayoutPanelDesigner.cs
@@ -416,35 +416,35 @@ internal class TableLayoutPanelDesigner : FlowPanelDesigner
                 // to disable/enable the Remove entries, based on the number of Rows/Cols.
                 // Unfortunately, you cannot do that via the DesignerAction stuff.
                 new DesignerActionMethodItem(this,
-                                             nameof(AddColumn), // method name
-                                             SR.TableLayoutPanelDesignerAddColumn, // display name
-                                             false), // promoteToDesignerVerb
+                    memberName: nameof(AddColumn),
+                    displayName: SR.TableLayoutPanelDesignerAddColumn,
+                    includeAsDesignerVerb: false),
                 new DesignerActionMethodItem(this,
-                                             nameof(AddRow), // method name
-                                             SR.TableLayoutPanelDesignerAddRow,  // display name
-                                             false), // promoteToDesignerVerb
+                    memberName: nameof(AddRow),
+                    displayName: SR.TableLayoutPanelDesignerAddRow,
+                    includeAsDesignerVerb: false),
             ];
 
             if (owner.Table.ColumnCount > 1)
             {
                 items.Add(new DesignerActionMethodItem(this,
-                                                       nameof(RemoveColumn), // method name
-                                                       SR.TableLayoutPanelDesignerRemoveColumn, // display name
-                                                       false)); // promoteToDesignerVerb
+                    memberName: nameof(RemoveColumn),
+                    displayName: SR.TableLayoutPanelDesignerRemoveColumn,
+                    includeAsDesignerVerb: false));
             }
 
             if (owner.Table.RowCount > 1)
             {
                 items.Add(new DesignerActionMethodItem(this,
-                                                       nameof(RemoveRow), // method name
-                                                       SR.TableLayoutPanelDesignerRemoveRow,  // display name
-                                                       false)); // promoteToDesignerVerb
+                    memberName: nameof(RemoveRow),
+                    displayName: SR.TableLayoutPanelDesignerRemoveRow,
+                    includeAsDesignerVerb: false));
             }
 
             items.Add(new DesignerActionMethodItem(this,
-                                                   nameof(EditRowAndCol), // method name
-                                                   SR.TableLayoutPanelDesignerEditRowAndCol,  // display name
-                                                   false)); // promoteToDesignerVerb
+                memberName: nameof(EditRowAndCol),
+                displayName: SR.TableLayoutPanelDesignerEditRowAndCol,
+                includeAsDesignerVerb: false));
 
             return items;
         }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TableLayoutPanelDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TableLayoutPanelDesigner.cs
@@ -410,40 +410,41 @@ internal class TableLayoutPanelDesigner : FlowPanelDesigner
 
         public override DesignerActionItemCollection GetSortedActionItems()
         {
-            DesignerActionItemCollection items = new();
-
-            // We don't promote these Items to DesignerVerbs, since we need to be able
-            // to disable/enable the Remove entries, based on the number of Rows/Cols.
-            // Unfortunately, you cannot do that via the DesignerAction stuff.
-            items.Add(new DesignerActionMethodItem(this,
-                                                     "AddColumn", // method name
-                                                      SR.TableLayoutPanelDesignerAddColumn, // display name
-                                                      false)); // promoteToDesignerVerb
-            items.Add(new DesignerActionMethodItem(this,
-                                                     "AddRow", // method name
-                                                      SR.TableLayoutPanelDesignerAddRow,  // display name
-                                                      false)); // promoteToDesignerVerb
+            DesignerActionItemCollection items =
+            [
+                // We don't promote these Items to DesignerVerbs, since we need to be able
+                // to disable/enable the Remove entries, based on the number of Rows/Cols.
+                // Unfortunately, you cannot do that via the DesignerAction stuff.
+                new DesignerActionMethodItem(this,
+                                             nameof(AddColumn), // method name
+                                             SR.TableLayoutPanelDesignerAddColumn, // display name
+                                             false), // promoteToDesignerVerb
+                new DesignerActionMethodItem(this,
+                                             nameof(AddRow), // method name
+                                             SR.TableLayoutPanelDesignerAddRow,  // display name
+                                             false), // promoteToDesignerVerb
+            ];
 
             if (owner.Table.ColumnCount > 1)
             {
                 items.Add(new DesignerActionMethodItem(this,
-                                                     "RemoveColumn", // method name
-                                                      SR.TableLayoutPanelDesignerRemoveColumn, // display name
-                                                      false)); // promoteToDesignerVerb
+                                                       nameof(RemoveColumn), // method name
+                                                       SR.TableLayoutPanelDesignerRemoveColumn, // display name
+                                                       false)); // promoteToDesignerVerb
             }
 
             if (owner.Table.RowCount > 1)
             {
                 items.Add(new DesignerActionMethodItem(this,
-                                                     "RemoveRow", // method name
-                                                      SR.TableLayoutPanelDesignerRemoveRow,  // display name
-                                                      false)); // promoteToDesignerVerb
+                                                       nameof(RemoveRow), // method name
+                                                       SR.TableLayoutPanelDesignerRemoveRow,  // display name
+                                                       false)); // promoteToDesignerVerb
             }
 
             items.Add(new DesignerActionMethodItem(this,
-                                                     "EditRowAndCol", // method name
-                                                      SR.TableLayoutPanelDesignerEditRowAndCol,  // display name
-                                                      false)); // promoteToDesignerVerb
+                                                   nameof(EditRowAndCol), // method name
+                                                   SR.TableLayoutPanelDesignerEditRowAndCol,  // display name
+                                                   false)); // promoteToDesignerVerb
 
             return items;
         }


### PR DESCRIPTION
Stumbled onto this when investigating #10579

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10588)