### PR TITLE
Modify the accessibility of ToolStripItem's "Renderer" to enable subclasses to set custom renderers and reuse OnPaint logic

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -1696,6 +1696,7 @@ override System.Windows.Forms.ToolStrip.ToString() -> string!
 override System.Windows.Forms.ToolStrip.WndProc(ref System.Windows.Forms.Message m) -> void
 override System.Windows.Forms.ToolStripButton.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject!
 override System.Windows.Forms.ToolStripButton.DefaultAutoToolTip.get -> bool
+override System.Windows.Forms.ToolStripButton.Renderer.get -> System.Windows.Forms.ToolStripRenderer?
 override System.Windows.Forms.ToolStripButton.GetPreferredSize(System.Drawing.Size constrainingSize) -> System.Drawing.Size
 override System.Windows.Forms.ToolStripButton.OnClick(System.EventArgs! e) -> void
 override System.Windows.Forms.ToolStripButton.OnPaint(System.Windows.Forms.PaintEventArgs! e) -> void

--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -1696,7 +1696,6 @@ override System.Windows.Forms.ToolStrip.ToString() -> string!
 override System.Windows.Forms.ToolStrip.WndProc(ref System.Windows.Forms.Message m) -> void
 override System.Windows.Forms.ToolStripButton.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject!
 override System.Windows.Forms.ToolStripButton.DefaultAutoToolTip.get -> bool
-override System.Windows.Forms.ToolStripButton.Renderer.get -> System.Windows.Forms.ToolStripRenderer?
 override System.Windows.Forms.ToolStripButton.GetPreferredSize(System.Drawing.Size constrainingSize) -> System.Drawing.Size
 override System.Windows.Forms.ToolStripButton.OnClick(System.EventArgs! e) -> void
 override System.Windows.Forms.ToolStripButton.OnPaint(System.Windows.Forms.PaintEventArgs! e) -> void
@@ -13387,6 +13386,7 @@ virtual System.Windows.Forms.ToolStripItem.Pressed.get -> bool
 virtual System.Windows.Forms.ToolStripItem.ProcessCmdKey(ref System.Windows.Forms.Message m, System.Windows.Forms.Keys keyData) -> bool
 virtual System.Windows.Forms.ToolStripItem.ProcessDialogKey(System.Windows.Forms.Keys keyData) -> bool
 virtual System.Windows.Forms.ToolStripItem.ProcessMnemonic(char charCode) -> bool
+virtual System.Windows.Forms.ToolStripItem.Renderer.get -> System.Windows.Forms.ToolStripRenderer?
 virtual System.Windows.Forms.ToolStripItem.ResetBackColor() -> void
 virtual System.Windows.Forms.ToolStripItem.ResetDisplayStyle() -> void
 virtual System.Windows.Forms.ToolStripItem.ResetFont() -> void

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripItem.cs
@@ -1660,7 +1660,7 @@ public abstract partial class ToolStripItem :
     /// </summary>
     internal Color RawBackColor => Properties.GetColor(s_backColorProperty);
 
-    internal ToolStripRenderer? Renderer
+    protected virtual ToolStripRenderer? Renderer
     {
         get
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripItem.cs
@@ -1661,7 +1661,7 @@ public abstract partial class ToolStripItem :
     internal Color RawBackColor => Properties.GetColor(s_backColorProperty);
 
     /// <summary>
-    ///  Returns the parent <see="ToolStrip"/>'s renderer
+    ///  Returns the parent <see cref="ToolStrip"/>'s renderer
     /// </summary>
     protected internal virtual ToolStripRenderer? Renderer
     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripItem.cs
@@ -1660,6 +1660,9 @@ public abstract partial class ToolStripItem :
     /// </summary>
     internal Color RawBackColor => Properties.GetColor(s_backColorProperty);
 
+    /// <summary>
+    /// Returns tool strip item's renderer
+    /// </summary>
     protected internal virtual ToolStripRenderer? Renderer
     {
         get

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripItem.cs
@@ -1661,7 +1661,7 @@ public abstract partial class ToolStripItem :
     internal Color RawBackColor => Properties.GetColor(s_backColorProperty);
 
     /// <summary>
-    /// Returns tool strip item's renderer
+    ///  Returns the parent <see="ToolStrip"/>'s renderer
     /// </summary>
     protected internal virtual ToolStripRenderer? Renderer
     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripItem.cs
@@ -1660,7 +1660,7 @@ public abstract partial class ToolStripItem :
     /// </summary>
     internal Color RawBackColor => Properties.GetColor(s_backColorProperty);
 
-    protected virtual ToolStripRenderer? Renderer
+    protected internal virtual ToolStripRenderer? Renderer
     {
         get
         {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripItemTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripItemTests.cs
@@ -388,6 +388,16 @@ public class ToolStripItemTests
         Assert.Equal(value, item.Alignment);
     }
 
+    [WinFormsFact]
+    public void ToolStripItem_Renderer_GetReturnsExpected()
+    {
+        using ToolStrip toolStrip = new();
+        using SubToolStripItem item = new();
+        toolStrip.Items.Add(item);
+
+        Assert.Same(toolStrip.Renderer, item.Renderer);
+    }
+
     [WinFormsTheory]
     [EnumData<ToolStripItemAlignment>]
     public void ToolStripItem_Alignment_SetWithParent_GetReturnsExpected(ToolStripItemAlignment value)
@@ -15441,7 +15451,7 @@ public class ToolStripItemTests
         Assert.Equal(1, callBackInvokedCount);
     }
 
-    private class MyMenuStrip: MenuStrip
+    private class MyMenuStrip : MenuStrip
     {
         public void MoveMouse(MouseEventArgs mea)
         {
@@ -15617,7 +15627,7 @@ public class ToolStripItemTests
         public new void SetVisibleCore(bool visible) => base.SetVisibleCore(visible);
     }
 
-    private class  ToolStripWithDisconnectCount : ToolStrip
+    private class ToolStripWithDisconnectCount : ToolStrip
     {
         public ToolStripWithDisconnectCount() : base() { }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #10592 


## Proposed changes

- Enhance ToolStripItem to make Renderer accessable

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- ToolStripItem's Renderer accessable

## Regression? 

- No

## Risk

- No

<!-- end TELL-MODE -->

## Test methodology <!-- How did you ensure quality? -->

- This modification is very tiny, and doesn't change default behavior.

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10593)