### PR TITLE
Avoid System.Private.Windows.Core Package Reference in System.Drawing.Common

### DIFF
--- a/src/System.Drawing.Common/src/System.Drawing.Common.csproj
+++ b/src/System.Drawing.Common/src/System.Drawing.Common.csproj
@@ -323,6 +323,7 @@ Since .NET 7, non-Windows platforms are not supported, even with the runtime con
     <ProjectReference Include="..\..\System.Private.Windows.Core\src\System.Private.Windows.Core.csproj">
       <SetTargetFramework>TargetFramework=$(TargetFramework)</SetTargetFramework>
       <Pack>true</Pack>
+      <PrivateAssets>all</PrivateAssets>
     </ProjectReference>
 
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="$(MicrosoftWindowsCsWin32PackageVersion)">


### PR DESCRIPTION
Helps fix build errors in https://github.com/dotnet/wpf/pull/8635

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10609)