### PR TITLE
Fix `WinformsControlsTest` MessageBox to avoid exception

### DIFF
--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MessageBoxes.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MessageBoxes.cs
@@ -35,7 +35,7 @@ public partial class MessageBoxes : Form
                     _messgageBoxProxy.Buttons, _messgageBoxProxy.Icon,
                     _messgageBoxProxy.DefaultButton, _messgageBoxProxy.Options);
             }
-            };
+        };
 
         ToolStrip toolbar = GetToolbar();
         toolbar.Items.Add(new ToolStripSeparator { Visible = true });

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MessageBoxes.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MessageBoxes.cs
@@ -27,7 +27,7 @@ public partial class MessageBoxes : Form
                 MessageBox.Show(this, _messgageBoxProxy.Text, _messgageBoxProxy.Caption,
                     _messgageBoxProxy.Buttons, _messgageBoxProxy.Icon,
                     _messgageBoxProxy.DefaultButton, _messgageBoxProxy.Options,
-                    "mspaint.chm", HelpNavigator.KeywordIndex, "ovals");
+                    "mmc.chm", HelpNavigator.KeywordIndex, "ovals");
             }
             else
             {

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MessageBoxes.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MessageBoxes.cs
@@ -22,11 +22,20 @@ public partial class MessageBoxes : Form
 
         _btnOpen.Click += (s, e) =>
         {
-            MessageBox.Show(this, _messgageBoxProxy.Text, _messgageBoxProxy.Caption,
-                _messgageBoxProxy.Buttons, _messgageBoxProxy.Icon,
-                _messgageBoxProxy.DefaultButton, _messgageBoxProxy.Options,
-                "mspaint.chm", HelpNavigator.KeywordIndex, "ovals");
-        };
+            if ((_messgageBoxProxy.Options & (MessageBoxOptions.ServiceNotification | MessageBoxOptions.DefaultDesktopOnly)) == 0)
+            {
+                MessageBox.Show(this, _messgageBoxProxy.Text, _messgageBoxProxy.Caption,
+                    _messgageBoxProxy.Buttons, _messgageBoxProxy.Icon,
+                    _messgageBoxProxy.DefaultButton, _messgageBoxProxy.Options,
+                    "mspaint.chm", HelpNavigator.KeywordIndex, "ovals");
+            }
+            else
+            {
+                MessageBox.Show(_messgageBoxProxy.Text, _messgageBoxProxy.Caption,
+                    _messgageBoxProxy.Buttons, _messgageBoxProxy.Icon,
+                    _messgageBoxProxy.DefaultButton, _messgageBoxProxy.Options);
+            }
+            };
 
         ToolStrip toolbar = GetToolbar();
         toolbar.Items.Add(new ToolStripSeparator { Visible = true });


### PR DESCRIPTION
Fixes #10513

- Don't pass owner when `MessageBoxOptions.ServiceNotification | MessageBoxOptions.DefaultDesktopOnly` is specified. 
- Changed help file name as the old one was missing.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10612)