### PR TITLE
Disable Removing Milestones from Closed Issues

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -919,7 +919,8 @@
             "parameters": {}
           }
         ]
-      }
+      },
+      "disabled": true
     },
     {
       "taskType": "trigger",


### PR DESCRIPTION
We want to stop the bot from removing milestones off of closed issues to better track what work has been done in different previews.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10625)