### PR TITLE
Replace `ArrayList` usage in `ToolStripItemDataObject` with `List`

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerUtils.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerUtils.cs
@@ -744,7 +744,7 @@ internal static class DesignerUtils
     /// <summary>
     ///  Used to create copies of the objects that we are dragging in a drag operation
     /// </summary>
-    public static List<IComponent>? CopyDragObjects(ICollection objects, IServiceProvider svcProvider)
+    public static List<IComponent>? CopyDragObjects(IReadOnlyList<IComponent> objects, IServiceProvider svcProvider)
     {
         if (objects is null || svcProvider is null)
         {
@@ -803,7 +803,7 @@ internal static class DesignerUtils
         return null;
     }
 
-    private static List<IComponent> GetCopySelection(ICollection objects, IDesignerHost host)
+    private static List<IComponent> GetCopySelection(IReadOnlyList<IComponent> objects, IDesignerHost host)
     {
         List<IComponent> copySelection = new();
         foreach (IComponent comp in objects)

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripDesigner.cs
@@ -1816,24 +1816,24 @@ internal class ToolStripDesigner : ControlDesigner
         }
 
         string transDesc;
-        IList components = data.DragComponents;
+        List<ToolStripItem> dragComponents = data.DragComponents;
         ToolStripItem primaryItem = data.PrimarySelection;
         int primaryIndex = -1;
         bool copy = (de.Effect == DragDropEffects.Copy);
 
-        if (components.Count == 1)
+        if (dragComponents.Count == 1)
         {
-            string name = TypeDescriptor.GetComponentName(components[0]);
+            string name = TypeDescriptor.GetComponentName(dragComponents[0]);
             if (name is null || name.Length == 0)
             {
-                name = components[0].GetType().Name;
+                name = dragComponents[0].GetType().Name;
             }
 
             transDesc = string.Format(copy ? SR.BehaviorServiceCopyControl : SR.BehaviorServiceMoveControl, name);
         }
         else
         {
-            transDesc = string.Format(copy ? SR.BehaviorServiceCopyControls : SR.BehaviorServiceMoveControls, components.Count);
+            transDesc = string.Format(copy ? SR.BehaviorServiceCopyControls : SR.BehaviorServiceMoveControls, dragComponents.Count);
         }
 
         // create a transaction so this happens as an atomic unit.
@@ -1845,13 +1845,15 @@ internal class ToolStripDesigner : ControlDesigner
                 changeService.OnComponentChanging(parentToolStrip, TypeDescriptor.GetProperties(parentToolStrip)["Items"]);
             }
 
+            IReadOnlyList<IComponent> components;
+
             // If we are copying, then we want to make a copy of the components we are dragging
             if (copy)
             {
                 // Remember the primary selection if we had one
                 if (primaryItem is not null)
                 {
-                    primaryIndex = components.IndexOf(primaryItem);
+                    primaryIndex = dragComponents.IndexOf(primaryItem);
                 }
 
                 if (KeyboardHandlingService is not null)
@@ -1859,7 +1861,7 @@ internal class ToolStripDesigner : ControlDesigner
                     KeyboardHandlingService.CopyInProgress = true;
                 }
 
-                components = DesignerUtils.CopyDragObjects(components, Component.Site);
+                components = DesignerUtils.CopyDragObjects(dragComponents, Component.Site);
                 if (KeyboardHandlingService is not null)
                 {
                     KeyboardHandlingService.CopyInProgress = false;
@@ -1869,6 +1871,10 @@ internal class ToolStripDesigner : ControlDesigner
                 {
                     primaryItem = components[primaryIndex] as ToolStripItem;
                 }
+            }
+            else
+            {
+                components = dragComponents;
             }
 
             if (de.Effect == DragDropEffects.Move || copy)

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripItemBehavior.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripItemBehavior.cs
@@ -653,7 +653,7 @@ internal class ToolStripItemBehavior : Behavior.Behavior
                 }
                 else
                 {
-                    transDesc = string.Format(copy ? SR.BehaviorServiceCopyControls : SR.BehaviorServiceMoveControls, components.Count);
+                    transDesc = string.Format(copy ? SR.BehaviorServiceCopyControls : SR.BehaviorServiceMoveControls, dragComponents.Count);
                 }
 
                 DesignerTransaction designerTransaction = designerHost.CreateTransaction(transDesc);

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripItemBehavior.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripItemBehavior.cs
@@ -567,7 +567,7 @@ internal class ToolStripItemBehavior : Behavior.Behavior
                 // Proceed with the drag and drop, passing in the list item.
                 try
                 {
-                    ArrayList dragItems = new();
+                    List<ToolStripItem> dragItems = new();
                     ICollection selComps = selSvc.GetSelectedComponents();
                     // create our list of controls-to-drag
                     foreach (IComponent comp in selComps)
@@ -636,17 +636,17 @@ internal class ToolStripItemBehavior : Behavior.Behavior
             // Do DragDrop only if currentDropItem has changed.
             if (currentDropItem != selectedItem && designerHost is not null)
             {
-                IList components = data.DragComponents;
+                List<ToolStripItem> dragComponents = data.DragComponents;
                 ToolStrip parentToolStrip = currentDropItem.GetCurrentParent();
                 int primaryIndex = -1;
                 string transDesc;
                 bool copy = (e.Effect == DragDropEffects.Copy);
-                if (components.Count == 1)
+                if (dragComponents.Count == 1)
                 {
-                    string name = TypeDescriptor.GetComponentName(components[0]);
+                    string name = TypeDescriptor.GetComponentName(dragComponents[0]);
                     if (name is null || name.Length == 0)
                     {
-                        name = components[0].GetType().Name;
+                        name = dragComponents[0].GetType().Name;
                     }
 
                     transDesc = string.Format(copy ? SR.BehaviorServiceCopyControl : SR.BehaviorServiceMoveControl, name);
@@ -672,13 +672,15 @@ internal class ToolStripItemBehavior : Behavior.Behavior
                         }
                     }
 
+                    IReadOnlyList<IComponent> components;
+
                     // If we are copying, then we want to make a copy of the components we are dragging
                     if (copy)
                     {
                         // Remember the primary selection if we had one
                         if (selectedItem is not null)
                         {
-                            primaryIndex = components.IndexOf(selectedItem);
+                            primaryIndex = dragComponents.IndexOf(selectedItem);
                         }
 
                         ToolStripKeyboardHandlingService keyboardHandlingService = GetKeyBoardHandlingService(selectedItem);
@@ -687,7 +689,7 @@ internal class ToolStripItemBehavior : Behavior.Behavior
                             keyboardHandlingService.CopyInProgress = true;
                         }
 
-                        components = DesignerUtils.CopyDragObjects(components, currentDropItem.Site);
+                        components = DesignerUtils.CopyDragObjects(dragComponents, currentDropItem.Site);
                         if (keyboardHandlingService is not null)
                         {
                             keyboardHandlingService.CopyInProgress = false;
@@ -697,6 +699,10 @@ internal class ToolStripItemBehavior : Behavior.Behavior
                         {
                             selectedItem = components[primaryIndex] as ToolStripItem;
                         }
+                    }
+                    else
+                    {
+                        components = dragComponents;
                     }
 
                     if (e.Effect == DragDropEffects.Move || copy)

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripItemDataObject.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripItemDataObject.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections;
-
 namespace System.Windows.Forms.Design;
 
 /// <summary>
@@ -10,28 +8,16 @@ namespace System.Windows.Forms.Design;
 /// </summary>
 internal class ToolStripItemDataObject : DataObject
 {
-    private readonly ArrayList _dragComponents;
-    private readonly ToolStrip _owner;
-    private readonly ToolStripItem _primarySelection;
-    internal ToolStripItemDataObject(ArrayList dragComponents, ToolStripItem primarySelection, ToolStrip owner) : base()
+    internal ToolStripItemDataObject(List<ToolStripItem> dragComponents, ToolStripItem primarySelection, ToolStrip owner) : base()
     {
-        _dragComponents = dragComponents;
-        _owner = owner;
-        _primarySelection = primarySelection;
+        DragComponents = dragComponents;
+        Owner = owner;
+        PrimarySelection = primarySelection;
     }
 
-    internal ArrayList DragComponents
-    {
-        get => _dragComponents;
-    }
+    internal List<ToolStripItem> DragComponents { get; }
 
-    internal ToolStrip Owner
-    {
-        get => _owner;
-    }
+    internal ToolStrip Owner { get; }
 
-    internal ToolStripItem PrimarySelection
-    {
-        get => _primarySelection;
-    }
+    internal ToolStripItem PrimarySelection { get; }
 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripMenuItemDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripMenuItemDesigner.cs
@@ -2658,19 +2658,19 @@ internal class ToolStripMenuItemDesigner : ToolStripDropDownItemDesigner
                     List<ToolStripItem> dragComponents = data.DragComponents;
                     int primaryIndex = -1;
                     bool copy = (e.Effect == DragDropEffects.Copy);
-                    if (components.Count == 1)
+                    if (dragComponents.Count == 1)
                     {
-                        string name = TypeDescriptor.GetComponentName(components[0]);
+                        string name = TypeDescriptor.GetComponentName(dragComponents[0]);
                         if (name is null || name.Length == 0)
                         {
-                            name = components[0].GetType().Name;
+                            name = dragComponents[0].GetType().Name;
                         }
 
                         transDesc = string.Format(copy ? SR.BehaviorServiceCopyControl : SR.BehaviorServiceMoveControl, name);
                     }
                     else
                     {
-                        transDesc = string.Format(copy ? SR.BehaviorServiceCopyControls : SR.BehaviorServiceMoveControls, components.Count);
+                        transDesc = string.Format(copy ? SR.BehaviorServiceCopyControls : SR.BehaviorServiceMoveControls, dragComponents.Count);
                     }
 
                     // create a transaction so this happens as an atomic unit.

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripMenuItemDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripMenuItemDesigner.cs
@@ -2655,7 +2655,7 @@ internal class ToolStripMenuItemDesigner : ToolStripDropDownItemDesigner
                 if (ownerItem is not null && host is not null)
                 {
                     string transDesc;
-                    IList components = data.DragComponents;
+                    List<ToolStripItem> dragComponents = data.DragComponents;
                     int primaryIndex = -1;
                     bool copy = (e.Effect == DragDropEffects.Copy);
                     if (components.Count == 1)
@@ -2680,13 +2680,15 @@ internal class ToolStripMenuItemDesigner : ToolStripDropDownItemDesigner
                         var changeService = primaryItem.Site.GetService<IComponentChangeService>();
                         changeService?.OnComponentChanging(ownerItem, TypeDescriptor.GetProperties(ownerItem)["DropDownItems"]);
 
+                        IReadOnlyList<IComponent> components;
+
                         // If we are copying, then we want to make a copy of the components we are dragging
                         if (copy)
                         {
                             // Remember the primary selection if we had one
                             if (primaryItem is not null)
                             {
-                                primaryIndex = components.IndexOf(primaryItem);
+                                primaryIndex = dragComponents.IndexOf(primaryItem);
                             }
 
                             ToolStripKeyboardHandlingService keyboardHandlingService = (ToolStripKeyboardHandlingService)primaryItem.Site.GetService(typeof(ToolStripKeyboardHandlingService));
@@ -2695,7 +2697,7 @@ internal class ToolStripMenuItemDesigner : ToolStripDropDownItemDesigner
                                 keyboardHandlingService.CopyInProgress = true;
                             }
 
-                            components = DesignerUtils.CopyDragObjects(components, primaryItem.Site);
+                            components = DesignerUtils.CopyDragObjects(dragComponents, primaryItem.Site);
 
                             if (keyboardHandlingService is not null)
                             {
@@ -2706,6 +2708,10 @@ internal class ToolStripMenuItemDesigner : ToolStripDropDownItemDesigner
                             {
                                 primaryItem = components[primaryIndex] as ToolStripItem;
                             }
+                        }
+                        else
+                        {
+                            components = dragComponents;
                         }
 
                         if (e.Effect == DragDropEffects.Move || copy)


### PR DESCRIPTION
Contributes to #8140


## Proposed changes

- Replace `ArrayList` usage in `ToolStripItemDataObject` with `List`
- Update relevant call sites to move off `IList` and `ICollection` interfaces


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10626)