### PR TITLE
added hash algorithm value to the assembly table in metadata for Accessibility.dll

### DIFF
--- a/src/Accessibility/src/Accessibility.il
+++ b/src/Accessibility/src/Accessibility.il
@@ -50,6 +50,7 @@
   .custom instance void [INTEROP_ASSEMBLY]System.Runtime.InteropServices.GuidAttribute::.ctor(string) = ( 01 00 24 31 45 41 34 44 42 46 30 2D 33 43 33 42   // ..$1EA4DBF0-3C3B
                                                                                                   2D 31 31 43 46 2D 38 31 30 43 2D 30 30 41 41 30   // -11CF-810C-00AA0
                                                                                                   30 33 38 39 42 37 31 00 00 )                      // 0389B71..
+  .hash algorithm 0x00008004 // SHA1
   .ver 4:0:0:0
 }
 .module Accessibility.dll


### PR DESCRIPTION
Other .NET and .NET Framework assemblies have this value set to SHA1. And Accessibility.dll in .NET Framework has the same value. This issue is unlikely to cause any problems, it only looks inconsistent. Most likely we had overlooked this attribute when editing the IL when moving to Core.
Per @marklio this value is used for:
```
•	calculating the hashes for File table metadata. This is used in multi-file and multi-module assembly scenarios, which are rarer (multi-module basically only happens in System.EnterpriseServices and no where else, multi-file is more common, but isn't in play for Accessibility.dll)
•	Calculating the "strong name signature" data used in validating strong names. The content of the file is hashed with that algorithm and then signed with the private key and stored in these bytes, and can be validated using the public key that exists in the Assembly table. Without the algorithm, you can't validate the signature. I haven't validated whether the strong name signature is present and is a SHA1, but that is what I suspect (the strong name signature bytes are non-zero, which suggests that it is appropriately signed).
```

.NET9 before:
![image](https://github.com/dotnet/winforms/assets/15823268/e0def302-4181-40d6-b840-e1dc27621c79)

.NET Framework
![image](https://github.com/dotnet/winforms/assets/15823268/f0b47eeb-176d-41d9-b2c8-3f606c41daed)

.NET 9 after
![image](https://github.com/dotnet/winforms/assets/15823268/299da745-a075-4a45-9652-e6e58e43fa7b)
