### PR TITLE
Reduce the build verbosity for AxHosts.csproj

### DIFF
--- a/src/BuildAssist/BuildAssist.msbuildproj
+++ b/src/BuildAssist/BuildAssist.msbuildproj
@@ -14,13 +14,13 @@
 
   <Target Name="BuildAxHosts" BeforeTargets="AfterBuild" DependsOnTargets="FindFrameworkMsbuild">
     <Exec
-      Command="msbuild.exe $(_AxHostsPath) $(_ProjectArgs)"
+      Command="msbuild.exe $(_AxHostsPath) $(_ProjectArgs) /v:m"
       WorkingDirectory="$(_MSBuildCurrentPath)"/>
   </Target>
 
   <Target Name="CleanAxHosts" BeforeTargets="AfterClean" DependsOnTargets="FindFrameworkMsbuild">
     <Exec
-      Command="msbuild.exe $(_AxHostsPath) $(_ProjectArgs) /t:Clean"
+      Command="msbuild.exe $(_AxHostsPath) $(_ProjectArgs) /t:Clean /v:m"
       WorkingDirectory="$(_MSBuildCurrentPath)"/>
   </Target>
 


### PR DESCRIPTION
This reduces the amount of noise that appears in the build output window in Visual Studio.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10636)