### PR TITLE
Ignore System.Private.Windows.Core in FileClassification

### DIFF
--- a/pkg/Microsoft.Private.Winforms/sdk/dotnet-windowsdesktop/System.Windows.Forms.FileClassification.props
+++ b/pkg/Microsoft.Private.Winforms/sdk/dotnet-windowsdesktop/System.Windows.Forms.FileClassification.props
@@ -17,6 +17,9 @@
     <FrameworkListFileClass Include="System.Windows.Forms.dll" Profile="WindowsForms" />
     <FrameworkListFileClass Include="System.Windows.Forms.Primitives.dll" Profile="WindowsForms" />
   </ItemGroup>
+  <!--
+    Private assemblies should not be referenced.
+  -->
   <ItemGroup>
     <IgnoredReference Include="System.Private.Windows.Core" />
   </ItemGroup>

--- a/pkg/Microsoft.Private.Winforms/sdk/dotnet-windowsdesktop/System.Windows.Forms.FileClassification.props
+++ b/pkg/Microsoft.Private.Winforms/sdk/dotnet-windowsdesktop/System.Windows.Forms.FileClassification.props
@@ -16,6 +16,8 @@
     <FrameworkListFileClass Include="System.Windows.Forms.Design.Editors.dll" Profile="WindowsForms" />
     <FrameworkListFileClass Include="System.Windows.Forms.dll" Profile="WindowsForms" />
     <FrameworkListFileClass Include="System.Windows.Forms.Primitives.dll" Profile="WindowsForms" />
-    <FrameworkListFileClass Include="System.Private.Windows.Core.dll" Profile="WindowsForms" />
+  </ItemGroup>
+  <ItemGroup>
+    <IgnoredReference Include="System.Private.Windows.Core" />
   </ItemGroup>
 </Project>

--- a/pkg/Microsoft.Private.Winforms/sdk/dotnet-windowsdesktop/UpdateFileClassification.ps1
+++ b/pkg/Microsoft.Private.Winforms/sdk/dotnet-windowsdesktop/UpdateFileClassification.ps1
@@ -23,7 +23,8 @@ $assemblies = $xmlDoc.package.files.file | `
             ($_.target.StartsWith('lib\') -or $_.target.StartsWith('ref\') -or $_.target.StartsWith('sdk\analyzers\'))`
                 -and $_.target.EndsWith('.dll', [System.StringComparison]::OrdinalIgnoreCase) `
                 -and !$_.target.EndsWith('resources.dll', [System.StringComparison]::OrdinalIgnoreCase) `
-                -and !$_.target.EndsWith('\Accessibility.dll', [System.StringComparison]::OrdinalIgnoreCase)
+                -and !$_.target.EndsWith('\Accessibility.dll', [System.StringComparison]::OrdinalIgnoreCase) `
+                -and !$_.target.EndsWith('\System.Private.Windows.Core.dll', [System.StringComparison]::OrdinalIgnoreCase)
         } | `
     Select-Object -Unique @{Name="Path";Expression={Split-Path $_.target -Leaf}} | `
     Select-Object -ExpandProperty Path;
@@ -74,6 +75,12 @@ else {
             $output += "    <FrameworkListFileClass Include=`"$assembly`" Profile=`"WindowsForms`" />`r`n"
         }
     $output += "  </ItemGroup>
+  <!--
+    Private assemblies should not be referenced.
+  -->
+  <ItemGroup>
+    <IgnoredReference Include=`"System.Private.Windows.Core`" />
+  </ItemGroup>
 </Project>";
     $output | Out-File -FilePath $TargetFile -Encoding utf8 -Force;
 }


### PR DESCRIPTION
This helps with failures in https://github.com/dotnet/windowsdesktop/pull/4063. We want System.Private.Windows.Core to be in the runtime pack of the shared Framework, so this does not need to be omitted from FrameworkListFile 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10639)