### PR TITLE
Update EnsureRun to return null when _textRegion is null

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/Labels/LinkLabel.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/Labels/LinkLabel.cs
@@ -34,6 +34,7 @@ public partial class LinkLabel : Label, IButtonControl
     private Font? _linkFont;
     private Font? _hoverLinkFont;
 
+    private bool _textLayoutValid;
     private bool _receivedDoubleClick;
     private readonly List<Link> _links = new(2);
 
@@ -509,7 +510,7 @@ public partial class LinkLabel : Label, IButtonControl
     {
         Debug.Assert(g is not null);
 
-        if (_textRegion is not null)
+        if (_textLayoutValid)
         {
             return _textRegion;
         }
@@ -520,6 +521,7 @@ public partial class LinkLabel : Label, IButtonControl
         {
             Links.Clear();
             Links.Add(new Link(0, -1));   // default 'magic' link.
+            _textLayoutValid = true;
             return null;
         }
 
@@ -592,6 +594,7 @@ public partial class LinkLabel : Label, IButtonControl
             _textRegion = visualRegion;
         }
 
+        _textLayoutValid = true;
         return _textRegion;
     }
 
@@ -719,6 +722,7 @@ public partial class LinkLabel : Label, IButtonControl
 
     private void InvalidateTextLayout()
     {
+        _textLayoutValid = false;
         _textRegion?.Dispose();
         _textRegion = null;
     }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #10630 , fixes #10555


## Proposed changes

- Update function `EnsureRun ` to return null when _textRegion is null

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- UI can be show normally when scrolling

## Regression? 

- Yes 

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

The content on Window is messed up.
![ReproSteps](https://github.com/dotnet/winforms/assets/83067197/e7c6d4da-05b6-46c6-b984-63f48d69f108)

### After
![AfterChange (2)](https://github.com/dotnet/winforms/assets/132890443/f1e89409-eb68-497a-bbad-9d857fa1e870)


## Test methodology <!-- How did you ensure quality? -->

- Manually


## Test environment(s) <!-- Remove any that don't apply -->

- .net 9.0.0-alpha.1.24060.2


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10642)