### PR TITLE
Update initial function and add function GetStandardValuesByCulture i…

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -20,6 +20,7 @@ System.Windows.Forms.FolderBrowserDialog.Multiselect.get -> bool
 System.Windows.Forms.FolderBrowserDialog.Multiselect.set -> void
 System.Windows.Forms.FolderBrowserDialog.SelectedPaths.get -> string![]!
 System.Windows.Forms.ImageList.ImageCollection.AddRange(params System.Drawing.Image![]! images) -> void
+System.Windows.Forms.KeysConverter.GetStandardValuesByCulture() -> System.ComponentModel.TypeConverter.StandardValuesCollection!
 System.Windows.Forms.ListBox.IntegerCollection.AddRange(params int[]! items) -> void
 System.Windows.Forms.ListBox.ObjectCollection.AddRange(params object![]! items) -> void
 System.Windows.Forms.ListView.ListViewItemCollection.AddRange(params System.Windows.Forms.ListViewItem![]! items) -> void

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Input/KeysConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Input/KeysConverter.cs
@@ -24,7 +24,15 @@ public class KeysConverter : TypeConverter, IComparer
     {
         _cultureToDisplayOrder = new();
         _cultureToKeyName = new();
-        AddLocalizedKeyNames(CultureInfo.InvariantCulture);
+
+        if (CultureToKeyName.ContainsKey(CultureInfo.CurrentCulture))
+        {
+            AddLocalizedKeyNames(CultureInfo.CurrentCulture);
+        }
+        else
+        {
+            AddLocalizedKeyNames(CultureInfo.InvariantCulture);
+        }
     }
 
     private void AddLocalizedKeyNames(CultureInfo cultureInfo)
@@ -363,6 +371,21 @@ public class KeysConverter : TypeConverter, IComparer
     {
         if (_values is null)
         {
+            Keys[] list = CultureToKeyName[CultureInfo.InvariantCulture].Values.ToArray();
+            Array.Sort(list, this);
+            _values = new StandardValuesCollection(list);
+        }
+
+        return _values;
+    }
+
+    public StandardValuesCollection GetStandardValuesByCulture()
+    {
+        if (_values is null)
+        {
+            if (!CultureToKeyName.ContainsKey(CultureInfo.CurrentCulture))
+                AddLocalizedKeyNames(CultureInfo.CurrentCulture);
+
             Keys[] list = CultureToKeyName[CultureInfo.CurrentCulture].Values.ToArray();
             Array.Sort(list, this);
             _values = new StandardValuesCollection(list);


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #10610


## Proposed changes

- Update initial function and add function GetStandardValuesByCulture

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- The KeysConverter.GetStandardValues() can be used normally

## Regression? 

- Yes 

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Simply calling

`var test = new KeysConverter().GetStandardValues();`

throws the exception:

`System.Collections.Generic.KeyNotFoundException: 'The given key 'en-US' was not present in the dictionary.'`

### After

Call `var test = new KeysConverter().GetStandardValues();` to return standard key values
Call `var test = new KeysConverter().GetStandardValues();` to return key values matching current culture

## Test methodology <!-- How did you ensure quality? -->

- Manually

## Test environment(s) <!-- Remove any that don't apply -->

- .net 9.0.0-alpha.1.24058.11


<!-- Mention language, UI scaling, or anything else that might be relevant -->
