### PR TITLE
Move IgnoredReferences to Own Props File

### DIFF
--- a/pkg/Microsoft.Private.Winforms/sdk/dotnet-windowsdesktop/System.Windows.Forms.FileClassification.props
+++ b/pkg/Microsoft.Private.Winforms/sdk/dotnet-windowsdesktop/System.Windows.Forms.FileClassification.props
@@ -17,10 +17,4 @@
     <FrameworkListFileClass Include="System.Windows.Forms.dll" Profile="WindowsForms" />
     <FrameworkListFileClass Include="System.Windows.Forms.Primitives.dll" Profile="WindowsForms" />
   </ItemGroup>
-  <!--
-    Private assemblies should not be referenced.
-  -->
-  <ItemGroup>
-    <IgnoredReference Include="System.Private.Windows.Core" />
-  </ItemGroup>
 </Project>

--- a/pkg/Microsoft.Private.Winforms/sdk/dotnet-windowsdesktop/System.Windows.Forms.IgnoredReferences.props
+++ b/pkg/Microsoft.Private.Winforms/sdk/dotnet-windowsdesktop/System.Windows.Forms.IgnoredReferences.props
@@ -3,7 +3,7 @@
     pkg\windowsdesktop\sfx\Microsoft.WindowsDesktop.App.Ref.sfxproj.
    -->
 <Project>
-  <ItemGroup>
+  <ItemGroup Condition="'$(PackageTargetRuntime)' == ''">
     <IgnoredReference Include="System.Private.Windows.Core" />
   </ItemGroup>
 </Project>

--- a/pkg/Microsoft.Private.Winforms/sdk/dotnet-windowsdesktop/System.Windows.Forms.IgnoredReferences.props
+++ b/pkg/Microsoft.Private.Winforms/sdk/dotnet-windowsdesktop/System.Windows.Forms.IgnoredReferences.props
@@ -1,0 +1,9 @@
+<!--
+    This props file comes from dotnet/winforms. It gets ingested by dotnet/windowsdesktop and processed by
+    pkg\windowsdesktop\sfx\Microsoft.WindowsDesktop.App.Ref.sfxproj.
+   -->
+<Project>
+  <ItemGroup>
+    <IgnoredReference Include="System.Private.Windows.Core" />
+  </ItemGroup>
+</Project>

--- a/pkg/Microsoft.Private.Winforms/sdk/dotnet-windowsdesktop/UpdateFileClassification.ps1
+++ b/pkg/Microsoft.Private.Winforms/sdk/dotnet-windowsdesktop/UpdateFileClassification.ps1
@@ -75,12 +75,6 @@ else {
             $output += "    <FrameworkListFileClass Include=`"$assembly`" Profile=`"WindowsForms`" />`r`n"
         }
     $output += "  </ItemGroup>
-  <!--
-    Private assemblies should not be referenced.
-  -->
-  <ItemGroup>
-    <IgnoredReference Include=`"System.Private.Windows.Core`" />
-  </ItemGroup>
 </Project>";
     $output | Out-File -FilePath $TargetFile -Encoding utf8 -Force;
 }


### PR DESCRIPTION
Place `IgnoredReferences` tag added in https://github.com/dotnet/winforms/pull/10639 in its own props file for windowsdesktop to consume to avoid tight coupling.

cc: @ericstj 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10649)