### PR TITLE
Use inbox throw helpers in System.Drawing.Common

### DIFF
--- a/src/System.Drawing.Common/src/Resources/Strings.resx
+++ b/src/System.Drawing.Common/src/Resources/Strings.resx
@@ -287,12 +287,6 @@
   <data name="InvalidPrinterHandle" xml:space="preserve">
     <value>Handle {0} is not valid.</value>
   </data>
-  <data name="ValidRangeX" xml:space="preserve">
-    <value>Parameter must be positive and &lt; Width.</value>
-  </data>
-  <data name="ValidRangeY" xml:space="preserve">
-    <value>Parameter must be positive and &lt; Height.</value>
-  </data>
   <data name="NativeHandle0" xml:space="preserve">
     <value>Native handle is 0.</value>
   </data>

--- a/src/System.Drawing.Common/src/System/Drawing/Bitmap.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Bitmap.cs
@@ -299,15 +299,10 @@ public unsafe sealed class Bitmap : Image
 
     public Color GetPixel(int x, int y)
     {
-        if (x < 0 || x >= Width)
-        {
-            throw new ArgumentOutOfRangeException(nameof(x), SR.ValidRangeX);
-        }
-
-        if (y < 0 || y >= Height)
-        {
-            throw new ArgumentOutOfRangeException(nameof(y), SR.ValidRangeY);
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(x);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(x, Width);
+        ArgumentOutOfRangeException.ThrowIfNegative(y);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(y, Height);
 
         int color;
         int status = Gdip.GdipBitmapGetPixel(new HandleRef(this, _nativeImage), x, y, out color);
@@ -323,15 +318,10 @@ public unsafe sealed class Bitmap : Image
             throw new InvalidOperationException(SR.GdiplusCannotSetPixelFromIndexedPixelFormat);
         }
 
-        if (x < 0 || x >= Width)
-        {
-            throw new ArgumentOutOfRangeException(nameof(x), SR.ValidRangeX);
-        }
-
-        if (y < 0 || y >= Height)
-        {
-            throw new ArgumentOutOfRangeException(nameof(y), SR.ValidRangeY);
-        }
+        ArgumentOutOfRangeException.ThrowIfNegative(x);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(x, Width);
+        ArgumentOutOfRangeException.ThrowIfNegative(y);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(y, Height);
 
         int status = Gdip.GdipBitmapSetPixel(new HandleRef(this, _nativeImage), x, y, color.ToArgb());
         Gdip.CheckStatus(status);

--- a/src/System.Drawing.Common/src/System/Drawing/Drawing2D/LinearGradientBrush.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Drawing2D/LinearGradientBrush.cs
@@ -464,8 +464,7 @@ public sealed class LinearGradientBrush : Brush
         }
         set
         {
-            if (value is null)
-                throw new ArgumentNullException(nameof(value));
+            ArgumentNullException.ThrowIfNull(value);
 
             Gdip.CheckStatus(Gdip.GdipSetLineTransform(new HandleRef(this, NativeBrush), new HandleRef(value, value.NativeMatrix)));
         }

--- a/src/System.Drawing.Common/src/System/Drawing/Drawing2D/PathGradientBrush.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Drawing2D/PathGradientBrush.cs
@@ -322,8 +322,7 @@ public sealed class PathGradientBrush : Brush
         }
         set
         {
-            if (value is null)
-                throw new ArgumentNullException(nameof(value));
+            ArgumentNullException.ThrowIfNull(value);
 
             Gdip.CheckStatus(Gdip.GdipSetPathGradientTransform(new HandleRef(this, NativeBrush), new HandleRef(value, value.NativeMatrix)));
         }

--- a/src/System.Drawing.Common/src/System/Drawing/Icon.ComWrappers.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Icon.ComWrappers.cs
@@ -18,8 +18,7 @@ public sealed partial class Icon : MarshalByRefObject, ICloneable, IDisposable, 
         }
         else
         {
-            if (outputStream is null)
-                throw new ArgumentNullException(nameof(outputStream));
+            ArgumentNullException.ThrowIfNull(outputStream);
 
             // Ideally, we would pick apart the icon using
             // GetIconInfo, and then pull the individual bitmaps out,

--- a/src/System.Drawing.Common/src/System/Drawing/Icon.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Icon.cs
@@ -204,7 +204,14 @@ public sealed partial class Icon : MarshalByRefObject, ICloneable, IDisposable, 
     }
 
     [Browsable(false)]
-    public IntPtr Handle => _handle.IsNull ? throw new ObjectDisposedException(GetType().Name) : (nint)_handle;
+    public IntPtr Handle
+    {
+        get
+        {
+            ObjectDisposedException.ThrowIf(_handle.IsNull, this);
+            return (nint)_handle;
+        }
+    }
 
     HICON IHandle<HICON>.Handle => (HICON)Handle;
 

--- a/src/System.Drawing.Common/src/System/Drawing/Icon.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Icon.cs
@@ -881,9 +881,11 @@ public sealed partial class Icon : MarshalByRefObject, ICloneable, IDisposable, 
     ///  <paramref name="filePath"/> is null.
     /// </exception>
     public static unsafe Icon? ExtractIcon(string filePath, int id, int size)
-        => size is <= 0 or > ushort.MaxValue
-            ? throw new ArgumentOutOfRangeException(nameof(size))
-            : ExtractIcon(filePath, id, size, smallIcon: false);
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(size);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(size, ushort.MaxValue);
+        return ExtractIcon(filePath, id, size, smallIcon: false);
+    }
 
     /// <param name="smallIcon">
     ///  If <see langword="true"/>, gets the <see cref="Icon"/> at the current system small icon size setting. If

--- a/src/System.Drawing.Common/src/System/Drawing/Pen.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Pen.cs
@@ -482,10 +482,7 @@ public sealed class Pen : MarshalByRefObject, ICloneable, IDisposable, ISystemCo
                 throw new ArgumentException(SR.Format(SR.CantChangeImmutableObjects, nameof(Pen)));
             }
 
-            if (value is null)
-            {
-                throw new ArgumentNullException(nameof(value));
-            }
+            ArgumentNullException.ThrowIfNull(value);
 
             int status = Gdip.GdipSetPenTransform(new HandleRef(this, NativePen), new HandleRef(value, value.NativeMatrix));
             Gdip.CheckStatus(status);
@@ -686,10 +683,7 @@ public sealed class Pen : MarshalByRefObject, ICloneable, IDisposable, ISystemCo
                 throw new ArgumentException(SR.Format(SR.CantChangeImmutableObjects, nameof(Pen)));
             }
 
-            if (value is null)
-            {
-                throw new ArgumentNullException(nameof(value));
-            }
+            ArgumentNullException.ThrowIfNull(value);
 
             int status = Gdip.GdipSetPenBrushFill(new HandleRef(this, NativePen),
                 new HandleRef(value, value.NativeBrush));

--- a/src/System.Drawing.Common/src/System/Drawing/Printing/Margins.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/Margins.cs
@@ -41,10 +41,10 @@ public partial class Margins : ICloneable
     /// </summary>
     public Margins(int left, int right, int top, int bottom)
     {
-        CheckMargin(left, nameof(left));
-        CheckMargin(right, nameof(right));
-        CheckMargin(top, nameof(top));
-        CheckMargin(bottom, nameof(bottom));
+        ArgumentOutOfRangeException.ThrowIfNegative(left);
+        ArgumentOutOfRangeException.ThrowIfNegative(right);
+        ArgumentOutOfRangeException.ThrowIfNegative(top);
+        ArgumentOutOfRangeException.ThrowIfNegative(bottom);
 
         _left = left;
         _right = right;
@@ -65,7 +65,7 @@ public partial class Margins : ICloneable
         get => _left;
         set
         {
-            CheckMargin(value, nameof(value));
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
             _left = value;
             _doubleLeft = value;
         }
@@ -79,7 +79,7 @@ public partial class Margins : ICloneable
         get => _right;
         set
         {
-            CheckMargin(value, nameof(value));
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
             _right = value;
             _doubleRight = value;
         }
@@ -93,7 +93,7 @@ public partial class Margins : ICloneable
         get => _top;
         set
         {
-            CheckMargin(value, nameof(value));
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
             _top = value;
             _doubleTop = value;
         }
@@ -107,7 +107,7 @@ public partial class Margins : ICloneable
         get => _bottom;
         set
         {
-            CheckMargin(value, nameof(value));
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
             _bottom = value;
             _doubleBottom = value;
         }
@@ -162,14 +162,6 @@ public partial class Margins : ICloneable
         {
             Bottom = (int)Math.Round(value);
             _doubleBottom = value;
-        }
-    }
-
-    private static void CheckMargin(int margin, string name)
-    {
-        if (margin < 0)
-        {
-            throw new ArgumentOutOfRangeException(name, margin, SR.Format(SR.InvalidLowBoundArgumentEx, name, margin, 0));
         }
     }
 

--- a/src/System.Drawing.Common/src/System/Drawing/Text/PrivateFontCollection.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Text/PrivateFontCollection.cs
@@ -64,10 +64,7 @@ public sealed class PrivateFontCollection : FontCollection
 #pragma warning restore CA2208
         }
 
-        if (filename is null)
-        {
-            throw new ArgumentNullException(nameof(filename));
-        }
+        ArgumentNullException.ThrowIfNull(filename);
 
         // this ensure the filename is valid (or throw the correct exception)
         string fullPath = Path.GetFullPath(filename);

--- a/src/System.Drawing.Common/src/System/Drawing/TextureBrush.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/TextureBrush.cs
@@ -150,10 +150,7 @@ public sealed class TextureBrush : Brush
         }
         set
         {
-            if (value is null)
-            {
-                throw new ArgumentNullException(nameof(value));
-            }
+            ArgumentNullException.ThrowIfNull(value);
 
             int status = Gdip.GdipSetTextureTransform(new HandleRef(this, NativeBrush), new HandleRef(value, value.NativeMatrix));
             Gdip.CheckStatus(status);


### PR DESCRIPTION
Now that System.Drawing.Common dropped support for .Net Framework, we can take advantage of throw helpers.

## Proposed changes

- Use ArgumentOutOfRangeException.ThrowIf* across System.Drawing.Common and remove some custom error messages
- Use ArgumentNullException.ThrowIfNull across System.Drawing.Common
- Use ObjectDisposedException.ThrowIf across System.Drawing.Common

## Customer Impact

- Slightly better perf

## Risk

- minimal

## Test methodology <!-- How did you ensure quality? -->

CI



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10655)