### PR TITLE
[release/8.0] [Accessibility]Inspect or AccessibilityInsights tool's rectangle can't focus on the entire FlowLayoutPanel/Panel/SplitContainer/TableLayoutPanel/TabControl/TextBox with scrollBar

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Panel.PanelAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Panel.PanelAccessibleObject.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Drawing;
 using static Interop;
 
 namespace System.Windows.Forms;
@@ -12,6 +13,9 @@ public partial class Panel
         public PanelAccessibleObject(Panel owner) : base(owner)
         {
         }
+
+        internal override Rectangle BoundingRectangle => this.IsOwnerHandleCreated(out Panel? owner) ?
+            owner.GetToolNativeScreenRectangle() : Rectangle.Empty;
 
         internal override UiaCore.IRawElementProviderFragmentRoot FragmentRoot => this;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.TabPageAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.TabPageAccessibleObject.cs
@@ -12,20 +12,8 @@ public partial class TabPage
     {
         public TabPageAccessibleObject(TabPage owningTabPage) : base(owningTabPage) { }
 
-        public override Rectangle Bounds
-        {
-            get
-            {
-                if (!this.IsOwnerHandleCreated(out TabPage? _))
-                {
-                    return Rectangle.Empty;
-                }
-
-                // The CHILDID_SELF constant returns to the id of the TabPage, which allows to use the native
-                // "accLocation" method to get the "Bounds" property
-                return SystemIAccessible.TryGetLocation(CHILDID_SELF);
-            }
-        }
+        internal override Rectangle BoundingRectangle => this.IsOwnerHandleCreated(out TabPage? owner) ?
+            owner.GetPageRectangle() : Rectangle.Empty;
 
         public override AccessibleStates State => SystemIAccessible.TryGetState(GetChildId());
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.cs
@@ -506,6 +506,8 @@ public partial class TabPage : Panel
         return (TabPage?)c;
     }
 
+    internal Rectangle GetPageRectangle() => base.GetToolNativeScreenRectangle();
+
     internal override Rectangle GetToolNativeScreenRectangle()
     {
         // Check SelectedIndex of the parental TabControl instead of SelectedTab

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.TextBoxBaseAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.TextBoxBaseAccessibleObject.cs
@@ -18,6 +18,9 @@ public abstract partial class TextBoxBase
             _textProvider = new TextBoxBaseUiaTextProvider(owner);
         }
 
+        internal override Rectangle BoundingRectangle => this.IsOwnerHandleCreated(out TextBoxBase? owner) ?
+            owner.GetToolNativeScreenRectangle() : Rectangle.Empty;
+
         internal void ClearObjects()
         {
             _textProvider = null;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Panel.PanelAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Panel.PanelAccessibleObjectTests.cs
@@ -244,4 +244,35 @@ public class Panel_PanelAccessibleObjectTests
         Assert.Equal(buttonFirst.AccessibilityObject, panel.AccessibilityObject.Navigate(AccessibleNavigation.FirstChild));
         Assert.Equal(buttonLast.AccessibilityObject, panel.AccessibilityObject.Navigate(AccessibleNavigation.LastChild));
     }
+
+    [WinFormsFact]
+    public void PanelAccessibleObject_BoundingRectangle_IsCorrect()
+    {
+        using Form form = new();
+        using Panel panel1 = new();
+        using Button button1 = new();
+
+        panel1.AutoScroll = true;
+        panel1.Controls.Add(button1);
+        panel1.Location = new Point(50, 50);
+        panel1.Size = new Size(200, 140);
+
+        button1.Location = new Point(17, 16);
+        button1.Size = new Size(237, 153);
+
+        form.ClientSize = new Size(300, 200);
+        form.Controls.Add(panel1);
+
+        form.Show();
+
+        Rectangle boundingRectangle = panel1.AccessibilityObject.BoundingRectangle;
+
+        int horizontalScrollBarHeight = SystemInformation.HorizontalScrollBarHeight;
+        int verticalScrollBarWidth = SystemInformation.VerticalScrollBarWidth;
+
+        Rectangle expected = panel1.RectangleToScreen(panel1.ClientRectangle);
+
+        Assert.Equal(boundingRectangle.Width, expected.Width + verticalScrollBarWidth);
+        Assert.Equal(boundingRectangle.Height, expected.Height + horizontalScrollBarHeight);
+    }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabPage.TabPageAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabPage.TabPageAccessibleObjectTests.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Drawing;
 using static Interop.UiaCore;
 using static System.Windows.Forms.TabControl;
 using static System.Windows.Forms.TabPage;
@@ -517,5 +518,42 @@ public class TabPage_TabPageAccessibilityObjectTests
 
         Assert.Equal(expected, accessibleObject.GetPropertyValue((UIA)propertyId) ?? false);
         Assert.False(tabPage.IsHandleCreated);
+    }
+
+    [WinFormsFact]
+    public void TabPageAccessibleObject_BoundingRectangle_IsCorrect()
+    {
+        using Form form = new();
+        using TabControl tabControl = new();
+        using Button button = new Button();
+        using TabPage tabPage = new TabPage();
+
+        tabControl.Controls.Add(tabPage);
+        tabControl.Location = new Point(22, 25);
+        tabControl.Size = new Size(151, 104);
+
+        button.Location = new Point(16, 12);
+        button.Size = new Size(198, 86);
+
+        tabPage.AutoScroll = true;
+        tabPage.Controls.Add(button);
+        tabPage.Location = new Point(4, 24);
+        tabPage.Padding = new Padding(3);
+        tabPage.Size = new Size(143, 76);
+
+        form.ClientSize = new Size(520, 305);
+        form.Controls.Add(tabControl);
+
+        form.Show();
+
+        Rectangle boundingRectangle = tabPage.AccessibilityObject.BoundingRectangle;
+
+        int horizontalScrollBarHeight = SystemInformation.HorizontalScrollBarHeight;
+        int verticalScrollBarWidth = SystemInformation.VerticalScrollBarWidth;
+
+        Rectangle expected = tabPage.RectangleToScreen(tabPage.ClientRectangle);
+
+        Assert.Equal(boundingRectangle.Width, expected.Width + verticalScrollBarWidth);
+        Assert.Equal(boundingRectangle.Height, expected.Height + horizontalScrollBarHeight);
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TextBoxBaseAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TextBoxBaseAccessibleObjectTests.cs
@@ -105,9 +105,10 @@ public class TextBoxBaseAccessibleObjectTests
         using TextBoxBase textBoxBase = new SubTextBoxBase { Size = new Size(width, height) };
         textBoxBase.CreateControl();
         AccessibleObject accessibleObject = textBoxBase.AccessibilityObject;
-        Rectangle expected = textBoxBase.RectangleToScreen(textBoxBase.ClientRectangle); // Forces Handle creating
+        Rectangle expected = textBoxBase.RectangleToScreen(textBoxBase.ClientRectangle);
         Rectangle actual = accessibleObject.BoundingRectangle;
-        Assert.Equal(expected, actual);
+
+        Assert.True(actual.Contains(expected));
         Assert.True(textBoxBase.IsHandleCreated);
     }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #10540


## Proposed changes

- 
-  There is something wrong with the base method `BoundingRectangle`.
So override this method in the same manner that `ListBox` did
https://github.com/dotnet/winforms/blob/9e2fc95fca4e6d18444c819b35bb1338ac6ca63d/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ListBoxes/ListBox.AccessibleObject.cs#L31-L32C10
- 

<!-- We are in TELL-MODE the following section must be completed -->


## Regression? 

- Yes 

## Risk

- minimal 

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/dotnet/winforms/assets/38325459/5a6b8c79-ce62-418c-a953-718e156e5e4d)
![image](https://github.com/dotnet/winforms/assets/38325459/80b9973c-21a2-4ab5-bdd4-aafe5adf448b)
![image](https://github.com/dotnet/winforms/assets/38325459/2f10ef12-224a-4613-bd46-3345bd379d95)



### After



![image](https://github.com/dotnet/winforms/assets/38325459/3db13ec7-ee3c-44bf-9f4d-0e71d896116b)
![image](https://github.com/dotnet/winforms/assets/38325459/2d0c015a-60ec-4ae7-a0bc-86160f85f191)
![image](https://github.com/dotnet/winforms/assets/38325459/24c15fa2-d2f9-45d1-ac18-442b5380c3d4)


## Test methodology <!-- How did you ensure quality? -->

- 
- manual 
- 


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10669)