### PR TITLE
Make it possible to not import CMake Sdk when excluding project

### DIFF
--- a/src/System.Windows.Forms/tests/InteropTests/Directory.Build.targets
+++ b/src/System.Windows.Forms/tests/InteropTests/Directory.Build.targets
@@ -1,0 +1,6 @@
+<Project>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)..\'))" />
+  <Import Project="ProjectReference.targets" Sdk="Microsoft.DotNet.CMake.Sdk" Condition="'$(_SuppressAllTargets )' != 'true'" />
+
+</Project>

--- a/src/System.Windows.Forms/tests/InteropTests/Directory.Build.targets
+++ b/src/System.Windows.Forms/tests/InteropTests/Directory.Build.targets
@@ -1,6 +1,6 @@
 <Project>
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)..\'))" />
-  <Import Project="ProjectReference.targets" Sdk="Microsoft.DotNet.CMake.Sdk" Condition="'$(_SuppressAllTargets )' != 'true'" />
+  <Import Project="ProjectReference.targets" Sdk="Microsoft.DotNet.CMake.Sdk" Condition="'$(_SuppressAllTargets)' != 'true'" />
 
 </Project>

--- a/src/System.Windows.Forms/tests/InteropTests/System.Windows.Forms.Interop.Tests.csproj
+++ b/src/System.Windows.Forms/tests/InteropTests/System.Windows.Forms.Interop.Tests.csproj
@@ -8,8 +8,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
-  <Import Project="ProjectReference.targets" Sdk="Microsoft.DotNet.CMake.Sdk" />
-
   <ItemGroup>
     <ProjectReference Include="..\..\src\System.Windows.Forms.csproj" />
     <ProjectReference Include="..\TestUtilities\System.Windows.Forms.TestUtilities.csproj" />


### PR DESCRIPTION
More context in https://github.com/dotnet/arcade/issues/14295

This allows to not exclude the CMake.Sdk targets when the project should be excluded (i.e. in source-build or a VMR vertical build).

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10672)