### PR TITLE
Add System.Private.Windows.Core to ref

### DIFF
--- a/eng/packageContent.targets
+++ b/eng/packageContent.targets
@@ -44,7 +44,7 @@
       <PackagePath Condition="'$(IsAnalyzerProject)' == 'true'">sdk/analyzers/dotnet$(AnalyzerTargetLanguage)</PackagePath>
     </PropertyGroup>
 
-    <PropertyGroup>
+    <PropertyGroup Condition="'$(HasNoPublicIntellisense)' != 'true'">
       <!-- The intellisense provided by the Docs system -->
       <IntellisenseXmlFileSource>$([MSBuild]::NormalizePath('$(_DotnetApiDocsFilesRoot)', '$(AssemblyName).xml'))</IntellisenseXmlFileSource>
 

--- a/pkg/Microsoft.Private.Winforms/sdk/dotnet-windowsdesktop/System.Windows.Forms.FileClassification.props
+++ b/pkg/Microsoft.Private.Winforms/sdk/dotnet-windowsdesktop/System.Windows.Forms.FileClassification.props
@@ -1,7 +1,7 @@
 ﻿<!--
     This props file comes from dotnet/winforms. It gets ingested by dotnet/windowsdesktop and processed by
     pkg\windowsdesktop\sfx\Microsoft.WindowsDesktop.App.Ref.sfxproj.
-   -->
+-->
 <Project>
   <ItemGroup Condition="'$(PackageTargetRuntime)' == ''">
     <FrameworkListFileClass Include="Microsoft.VisualBasic.dll" Profile="WindowsForms" />
@@ -16,5 +16,6 @@
     <FrameworkListFileClass Include="System.Windows.Forms.Design.Editors.dll" Profile="WindowsForms" />
     <FrameworkListFileClass Include="System.Windows.Forms.dll" Profile="WindowsForms" />
     <FrameworkListFileClass Include="System.Windows.Forms.Primitives.dll" Profile="WindowsForms" />
+    <FrameworkListFileClass Include="System.Private.Windows.Core.dll" Profile="WindowsForms" />
   </ItemGroup>
 </Project>

--- a/pkg/Microsoft.Private.Winforms/sdk/dotnet-windowsdesktop/System.Windows.Forms.IgnoredReferences.props
+++ b/pkg/Microsoft.Private.Winforms/sdk/dotnet-windowsdesktop/System.Windows.Forms.IgnoredReferences.props
@@ -1,9 +1,0 @@
-<!--
-    This props file comes from dotnet/winforms. It gets ingested by dotnet/windowsdesktop and processed by
-    pkg\windowsdesktop\sfx\Microsoft.WindowsDesktop.App.Ref.sfxproj.
-   -->
-<Project>
-  <ItemGroup Condition="'$(PackageTargetRuntime)' == ''">
-    <IgnoredReference Include="System.Private.Windows.Core" />
-  </ItemGroup>
-</Project>

--- a/pkg/Microsoft.Private.Winforms/sdk/dotnet-windowsdesktop/UpdateFileClassification.ps1
+++ b/pkg/Microsoft.Private.Winforms/sdk/dotnet-windowsdesktop/UpdateFileClassification.ps1
@@ -23,8 +23,7 @@ $assemblies = $xmlDoc.package.files.file | `
             ($_.target.StartsWith('lib\') -or $_.target.StartsWith('ref\') -or $_.target.StartsWith('sdk\analyzers\'))`
                 -and $_.target.EndsWith('.dll', [System.StringComparison]::OrdinalIgnoreCase) `
                 -and !$_.target.EndsWith('resources.dll', [System.StringComparison]::OrdinalIgnoreCase) `
-                -and !$_.target.EndsWith('\Accessibility.dll', [System.StringComparison]::OrdinalIgnoreCase) `
-                -and !$_.target.EndsWith('\System.Private.Windows.Core.dll', [System.StringComparison]::OrdinalIgnoreCase)
+                -and !$_.target.EndsWith('\Accessibility.dll', [System.StringComparison]::OrdinalIgnoreCase)
         } | `
     Select-Object -Unique @{Name="Path";Expression={Split-Path $_.target -Leaf}} | `
     Select-Object -ExpandProperty Path;
@@ -65,7 +64,7 @@ else {
     $output = "<!--
     This props file comes from dotnet/winforms. It gets ingested by dotnet/windowsdesktop and processed by
     pkg\windowsdesktop\sfx\Microsoft.WindowsDesktop.App.Ref.sfxproj.
-   -->
+-->
 <Project>
   <ItemGroup Condition=`"'`$(PackageTargetRuntime)' == ''`">`r`n";
     $assemblies | `

--- a/src/System.Drawing.Common/src/System.Drawing.Common.csproj
+++ b/src/System.Drawing.Common/src/System.Drawing.Common.csproj
@@ -59,7 +59,6 @@
     <ProjectReference Include="..\..\System.Private.Windows.Core\src\System.Private.Windows.Core.csproj">
       <SetTargetFramework>TargetFramework=$(TargetFramework)</SetTargetFramework>
       <Pack>true</Pack>
-      <PrivateAssets>all</PrivateAssets>
     </ProjectReference>
 
     <PackageReference Include="Microsoft.Win32.SystemEvents" Version="$(MicrosoftWin32SystemEventsPackageVersion)" />

--- a/src/System.Private.Windows.Core/src/System.Private.Windows.Core.csproj
+++ b/src/System.Private.Windows.Core/src/System.Private.Windows.Core.csproj
@@ -16,13 +16,8 @@
       We don't care about CLS compliance since everything here is internal and we want to match native types.
     -->
     <NoWarn>$(NoWarn);CS3016</NoWarn>
-    <!--
-      Libraries code has changed a number of APIs from `ref` to `in`. CSWin32 generates code that passes by `ref`
-      to some of these. Disabling for now until we can get https://github.com/microsoft/CsWin32/issues/1014 resolved.
-    <NoWarn>$(NoWarn);CS9195</NoWarn>
-    -->
     <Deterministic>true</Deterministic>
-    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <UsePublicApiAnalyzers>false</UsePublicApiAnalyzers>
     <RootNamespace />
     <HasNoPublicIntellisense>true</HasNoPublicIntellisense>


### PR DESCRIPTION
As nothing is actually visible in this assembly we were trying to leave it out of the ref package. C# needs the types to be there when it compiles interface casts. This adds the assembly to the ref and excludes looking for IntelliSense files.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10673)