### PR TITLE
Fix SafeArray type in HtmlDocument.Write

### DIFF
--- a/src/System.Private.Windows.Core/src/Windows/Win32/System/Com/SafeArrayScope.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/System/Com/SafeArrayScope.cs
@@ -66,6 +66,13 @@ internal readonly unsafe ref struct SafeArrayScope<T>
         {
             throw new ArgumentException("Use ComSafeArrayScope instead");
         }
+        else if (typeof(T) == typeof(object))
+        {
+            if (value->VarType is not VARENUM.VT_VARIANT)
+            {
+                throw new ArgumentException($"Wanted SafeArrayScope<{typeof(T)}> but got SAFEARRAY with VarType={value->VarType}");
+            }
+        }
         else
         {
             // The type has not been accounted for yet in the SafeArrayScope
@@ -95,6 +102,10 @@ internal readonly unsafe ref struct SafeArrayScope<T>
         else if (typeof(T) == typeof(nint) || typeof(T).IsAssignableTo(typeof(IComIID)))
         {
             throw new ArgumentException("Use ComSafeArrayScope instead");
+        }
+        else if (typeof(T) == typeof(object))
+        {
+            vt = VARENUM.VT_VARIANT;
         }
         else
         {
@@ -153,6 +164,13 @@ internal readonly unsafe ref struct SafeArrayScope<T>
             {
                 return (T)(object)GetElement<nint>(i);
             }
+            else if (typeof(T) == typeof(object))
+            {
+                // This may need to change if we have a case where
+                // the VARIANT should not be disposed.
+                using VARIANT result = GetElement<VARIANT>(i);
+                return (T?)result.ToObject();
+            }
 
             // Noop. This is an unknown type. We should fill this method out to to do the right
             // thing as we run into new types.
@@ -160,7 +178,12 @@ internal readonly unsafe ref struct SafeArrayScope<T>
         }
         set
         {
-            if (value is string s)
+            if (Value->VarType == VARENUM.VT_VARIANT)
+            {
+                using VARIANT variant = VARIANT.FromObject(value);
+                PutElement(i, &variant);
+            }
+            else if (value is string s)
             {
                 using BSTR bstrText = new(s);
                 PutElement(i, bstrText);

--- a/src/System.Private.Windows.Core/src/Windows/Win32/System/Com/SafeArrayScope.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/System/Com/SafeArrayScope.cs
@@ -139,8 +139,9 @@ internal readonly unsafe ref struct SafeArrayScope<T>
     /// <remarks>
     ///  <para>
     ///   A copy will be made of anything that is put into the <see cref="SAFEARRAY"/>
-    ///   and anything the <see cref="SAFEARRAY"/> gives out. Be sure to dispose of the
-    ///   items that are given to/from the <see cref="SAFEARRAY"/> if necessary.
+    ///   and anything the <see cref="SAFEARRAY"/> gives out is a copy and has been add ref appropriately if applicable.
+    ///   Be sure to dispose of items that are given to the <see cref="SAFEARRAY"/> if necessary. All
+    ///   items given out by the <see cref="SAFEARRAY"/> should be disposed.
     ///  </para>
     /// </remarks>
     public T? this[int i]
@@ -166,8 +167,6 @@ internal readonly unsafe ref struct SafeArrayScope<T>
             }
             else if (typeof(T) == typeof(object))
             {
-                // This may need to change if we have a case where
-                // the VARIANT should not be disposed.
                 using VARIANT result = GetElement<VARIANT>(i);
                 return (T?)result.ToObject();
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/WebBrowser/HtmlDocument.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/WebBrowser/HtmlDocument.cs
@@ -413,7 +413,7 @@ public sealed unsafe partial class HtmlDocument
 
     public void Write(string text)
     {
-        using SafeArrayScope<string> scope = new(1);
+        using SafeArrayScope<object> scope = new(1);
         if (scope.IsNull)
         {
             return;
@@ -422,7 +422,7 @@ public sealed unsafe partial class HtmlDocument
         scope[0] = text;
 
         using var htmlDoc2 = NativeHtmlDocument2.GetInterface();
-        htmlDoc2.Value->write(scope.Value).ThrowOnFailure();
+        htmlDoc2.Value->write(scope);
     }
 
     /// <summary>

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/HtmlDocumentTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/HtmlDocumentTests.cs
@@ -1895,7 +1895,7 @@ public class HtmlDocumentTests
         yield return new object[] { "<p>Hi</p>", "<P>Hi</P>" };
     }
 
-/*    [WinFormsTheory]
+    [WinFormsTheory]
     [MemberData(nameof(Write_TestData))]
     public async Task HtmlDocument_Write_InvokeEmpty_Success(string text, string expectedInnerHtml)
     {
@@ -1927,7 +1927,7 @@ public class HtmlDocumentTests
 
         document.Write(text);
         Assert.Equal(expectedInnerHtml, document.Body?.InnerHtml);
-    }*/
+    }
 
     [WinFormsTheory]
     [BoolData]


### PR DESCRIPTION
Fixes https://github.com/dotnet/winforms/issues/10615 , regression from https://github.com/dotnet/winforms/pull/9972
- Avoid throwing on failure in `IHtmlDocument2.Write` as original code did not throw on failure 
- While making changes in the regression PR, I had accidentally commented out some tests covering this scenario 🤦‍♀️ , I re-enabled those tests which covers scenario outlined by issue
- The SafeArray type passed to `IHtmlDocument2.Write` needs to be `VT_VARIANT` so I've added to `SafeArrayScope` to be able to handle this.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10674)