### PR TITLE
Adds tests for AxSystemMonitor

### DIFF
--- a/src/System.Windows.Forms/tests/AxHosts/AxHosts.csproj
+++ b/src/System.Windows.Forms/tests/AxHosts/AxHosts.csproj
@@ -36,6 +36,24 @@
       <Isolated>false</Isolated>
       <EmbedInteropTypes>false</EmbedInteropTypes>
     </COMReference>
+    <COMReference Include="SystemMonitor">
+      <VersionMinor>7</VersionMinor>
+      <VersionMajor>3</VersionMajor>
+      <Guid>1b773e42-2509-11cf-942f-008029004347</Guid>
+      <Lcid>0</Lcid>
+      <WrapperTool>tlbimp</WrapperTool>
+      <Isolated>false</Isolated>
+      <EmbedInteropTypes>false</EmbedInteropTypes>
+    </COMReference>
+    <COMReference Include="AxSystemMonitor">
+      <WrapperTool>aximp</WrapperTool>
+      <VersionMinor>7</VersionMinor>
+      <VersionMajor>3</VersionMajor>
+      <Guid>1b773e42-2509-11cf-942f-008029004347</Guid>
+      <Lcid>0</Lcid>
+      <Isolated>false</Isolated>
+      <EmbedInteropTypes>false</EmbedInteropTypes>
+    </COMReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/System.Windows.Forms/tests/UnitTests/System.Windows.Forms.Tests.csproj
+++ b/src/System.Windows.Forms/tests/UnitTests/System.Windows.Forms.Tests.csproj
@@ -42,6 +42,15 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Reference Include="AxInterop.SystemMonitor">
+      <HintPath>$(ArtifactsBinDir)\AxHosts\$(Configuration)\net472\AxInterop.SystemMonitor.dll</HintPath>
+    </Reference>
+    <Reference Include="Interop.SystemMonitor">
+      <HintPath>$(ArtifactsBinDir)\AxHosts\$(Configuration)\net472\Interop.SystemMonitor.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
+  <ItemGroup>
     <Content Include="TestResources\Files\*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -67,14 +76,4 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="AxInterop.WMPLib">
-      <HintPath>$(ArtifactsBinDir)\AxHosts\$(Configuration)\net472\AxInterop.WMPLib.dll</HintPath>
-    </Reference>
-    <Reference Include="Interop.WMPLib">
-      <HintPath>$(ArtifactsBinDir)\AxHosts\$(Configuration)\net472\Interop.WMPLib.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-
 </Project>

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AxSystemMonitorTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AxSystemMonitorTests.cs
@@ -31,6 +31,7 @@ public class AxSystemMonitorTests : IDisposable
 
     public void Dispose()
     {
+        // This line was added due to https://github.com/dotnet/winforms/issues/10692
         using NoAssertContext context = new();
         _control.Dispose();
         _form.Dispose();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AxSystemMonitorTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AxSystemMonitorTests.cs
@@ -1,4 +1,6 @@
 ﻿using System.ComponentModel;
+using System.Reflection;
+using Castle.Core.Internal;
 
 namespace System.Windows.Forms.Tests;
 
@@ -27,6 +29,34 @@ public class AxSystemMonitorTests : IDisposable
 
         Assert.True(_control.Enabled);
         Assert.Equal(0, _control.Counters.Count);
+
+        // Finds out desired assembly properties
+        const string ClassName = "AxSystemMonitor.AxSystemMonitor";
+        Assembly assembly = Assembly.GetAssembly(typeof(AxSystemMonitor.AxSystemMonitor));
+        Type classType = assembly.GetType(ClassName);
+        TypeInfo classTypeInfo = classType.GetTypeInfo();
+        var assemblyClassProperties = classTypeInfo.DeclaredProperties;
+        List<string> assemblyClassPropertyNames = new();
+        assemblyClassPropertyNames = assemblyClassProperties.Select(p => p.Name).ToList();
+
+        // Finds out testing control properties that come from the right assembly
+        List<string> testingControlProps = new();
+        for (int i = 0; i < properties.Count; i++)
+        {
+            var property = properties[i];
+            string assemblyNameFromControl = property.ComponentType.AssemblyQualifiedName.Split(", ")[0];
+            if (!assemblyNameFromControl.IsNullOrEmpty() && assemblyNameFromControl == assembly.GetName().Name)
+            {
+                testingControlProps.Add(property.Name);
+            }
+        }
+
+        // Tests if the properties from control and assembly properly match
+        foreach (string testControlProp in testingControlProps)
+        {
+            string assemblyProp = assemblyClassPropertyNames.Where(p => p == testControlProp).First();
+            Assert.Contains(testControlProp, assemblyProp);
+        }
     }
 
     public void Dispose()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AxSystemMonitorTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AxSystemMonitorTests.cs
@@ -1,0 +1,40 @@
+﻿using System.ComponentModel;
+
+namespace System.Windows.Forms.Tests;
+
+public class AxSystemMonitorTests
+{
+    private readonly Form form;
+    private readonly AxSystemMonitor.AxSystemMonitor control;
+
+    public AxSystemMonitorTests()
+    {
+        form = new Form();
+        control = new AxSystemMonitor.AxSystemMonitor();
+        ((ISupportInitialize)control).BeginInit();
+        form.Controls.Add(control);
+        ((ISupportInitialize)control).EndInit();
+    }
+
+    [WinFormsFact]
+    public void AxSystemMonitor_WhenInitialized_ExpectsProperties()
+    {
+        var properties = TypeDescriptor.GetProperties(control);
+        Assert.NotEmpty(properties);
+
+        var events = TypeDescriptor.GetEvents(control);
+        Assert.NotEmpty(events);
+    }
+
+    [WinFormsFact]
+    public void AxSystemMonitor_WhenInitialized_IsEnabled()
+    {
+        Assert.True(control.Enabled);
+    }
+
+    [WinFormsFact]
+    public void AxSystemMonitor_Counter_ReturnsDefaultCounter()
+    {
+        Assert.Equal(0, control.Counters.Count);
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AxSystemMonitorTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AxSystemMonitorTests.cs
@@ -30,32 +30,55 @@ public class AxSystemMonitorTests : IDisposable
         Assert.True(_control.Enabled);
         Assert.Equal(0, _control.Counters.Count);
 
-        // Finds out desired assembly properties
-        const string ClassName = "AxSystemMonitor.AxSystemMonitor";
-        Assembly assembly = Assembly.GetAssembly(typeof(AxSystemMonitor.AxSystemMonitor));
-        Type classType = assembly.GetType(ClassName);
+        // Finds out the class's assembly properties and events
+        Type type = typeof(AxSystemMonitor.AxSystemMonitor);
+        Assembly assembly = Assembly.GetAssembly(type);
+        Type classType = assembly.GetType(type.FullName);
         TypeInfo classTypeInfo = classType.GetTypeInfo();
-        var assemblyClassProperties = classTypeInfo.DeclaredProperties;
+
+        IEnumerable<PropertyInfo> assemblyClassProperties = classTypeInfo.DeclaredProperties;
         List<string> assemblyClassPropertyNames = new();
         assemblyClassPropertyNames = assemblyClassProperties.Select(p => p.Name).ToList();
 
-        // Finds out testing control properties that come from the right assembly
+        IEnumerable<EventInfo> assemblyClassEvents = classTypeInfo.DeclaredEvents;
+        List<string> assemblyClassEventNames = new();
+        assemblyClassEventNames = assemblyClassEvents.Select(p => p.Name).ToList();
+
+        // Finds out testing control properties and events that come from the right assembly
+        string assemblyNameFromClass = assembly.GetName().Name;
         List<string> testingControlProps = new();
         for (int i = 0; i < properties.Count; i++)
         {
             var property = properties[i];
-            string assemblyNameFromControl = property.ComponentType.AssemblyQualifiedName.Split(", ")[0];
-            if (!assemblyNameFromControl.IsNullOrEmpty() && assemblyNameFromControl == assembly.GetName().Name)
+            string assemblyNameFromProperty = property.ComponentType.Assembly.GetName().Name;
+            if (!assemblyNameFromProperty.IsNullOrEmpty() && assemblyNameFromProperty == assemblyNameFromClass)
             {
                 testingControlProps.Add(property.Name);
             }
         }
 
-        // Tests if the properties from control and assembly properly match
+        List<string> testingControlEvents = new();
+        for (int i = 0; i < events.Count; i++)
+        {
+            var singleEvent = events[i];
+            string assemblyNameFromProperty = singleEvent.ComponentType.Assembly.GetName().Name;
+            if (!assemblyNameFromProperty.IsNullOrEmpty() && assemblyNameFromProperty == assemblyNameFromClass)
+            {
+                testingControlEvents.Add(singleEvent.Name);
+            }
+        }
+
+        // Tests if the properties and events from control and assembly properly match
         foreach (string testControlProp in testingControlProps)
         {
             string assemblyProp = assemblyClassPropertyNames.Where(p => p == testControlProp).First();
             Assert.Contains(testControlProp, assemblyProp);
+        }
+
+        foreach (string testControlEvent in testingControlEvents)
+        {
+            string assemblyEvent = assemblyClassEventNames.Where(p => p == testControlEvent).First();
+            Assert.Contains(testControlEvent, assemblyEvent);
         }
     }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AxSystemMonitorTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AxSystemMonitorTests.cs
@@ -4,37 +4,28 @@ namespace System.Windows.Forms.Tests;
 
 public class AxSystemMonitorTests
 {
-    private readonly Form form;
-    private readonly AxSystemMonitor.AxSystemMonitor control;
+    private readonly Form _form;
+    private readonly AxSystemMonitor.AxSystemMonitor _control;
 
     public AxSystemMonitorTests()
     {
-        form = new Form();
-        control = new AxSystemMonitor.AxSystemMonitor();
-        ((ISupportInitialize)control).BeginInit();
-        form.Controls.Add(control);
-        ((ISupportInitialize)control).EndInit();
+        _form = new Form();
+        _control = new AxSystemMonitor.AxSystemMonitor();
+        ((ISupportInitialize)_control).BeginInit();
+        _form.Controls.Add(_control);
+        ((ISupportInitialize)_control).EndInit();
     }
 
     [WinFormsFact]
     public void AxSystemMonitor_WhenInitialized_ExpectsProperties()
     {
-        var properties = TypeDescriptor.GetProperties(control);
+        var properties = TypeDescriptor.GetProperties(_control);
         Assert.NotEmpty(properties);
 
-        var events = TypeDescriptor.GetEvents(control);
+        var events = TypeDescriptor.GetEvents(_control);
         Assert.NotEmpty(events);
-    }
 
-    [WinFormsFact]
-    public void AxSystemMonitor_WhenInitialized_IsEnabled()
-    {
-        Assert.True(control.Enabled);
-    }
-
-    [WinFormsFact]
-    public void AxSystemMonitor_Counter_ReturnsDefaultCounter()
-    {
-        Assert.Equal(0, control.Counters.Count);
+        Assert.True(_control.Enabled);
+        Assert.Equal(0, _control.Counters.Count);
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AxSystemMonitorTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AxSystemMonitorTests.cs
@@ -2,7 +2,7 @@
 
 namespace System.Windows.Forms.Tests;
 
-public class AxSystemMonitorTests
+public class AxSystemMonitorTests : IDisposable
 {
     private readonly Form _form;
     private readonly AxSystemMonitor.AxSystemMonitor _control;
@@ -27,5 +27,12 @@ public class AxSystemMonitorTests
 
         Assert.True(_control.Enabled);
         Assert.Equal(0, _control.Counters.Count);
+    }
+
+    public void Dispose()
+    {
+        using NoAssertContext context = new();
+        _control.Dispose();
+        _form.Dispose();
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Related #8302 


## Proposed changes

- Instead of consolidating multiple controls into a single pull request, opted for separate PRs for each control for better organization.
- Followed [Lonitra's instructions](https://github.com/dotnet/winforms/issues/8294#issuecomment-1331026574) on related issue #[8294](https://github.com/dotnet/winforms/issues/8294) by adding Ax control references to both the AxHosts project and the WinForms test project. Additionally, added corresponding tests.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- None

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->

## Test methodology <!-- How did you ensure quality? -->

- Unit tests

## Test environment(s) <!-- Remove any that don't apply -->

- 9.0.100-alpha.1.23618.3<!-- use `dotnet --info` -->

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10675)