### PR TITLE
Add PrivateAsset tag to System.Drawing.Common

### DIFF
--- a/src/System.Drawing.Common/src/System.Drawing.Common.csproj
+++ b/src/System.Drawing.Common/src/System.Drawing.Common.csproj
@@ -59,6 +59,7 @@
     <ProjectReference Include="..\..\System.Private.Windows.Core\src\System.Private.Windows.Core.csproj">
       <SetTargetFramework>TargetFramework=$(TargetFramework)</SetTargetFramework>
       <Pack>true</Pack>
+      <PrivateAssets>all</PrivateAssets>
     </ProjectReference>
 
     <PackageReference Include="Microsoft.Win32.SystemEvents" Version="$(MicrosoftWin32SystemEventsPackageVersion)" />


### PR DESCRIPTION
Help fix build errors in https://github.com/dotnet/wpf/pull/8694
This is the same error as received in https://github.com/dotnet/wpf/pull/8635. This tag was removed recently, but it actually needs to be present to avoid this error.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10683)