### PR TITLE
Add ScratchProject with Access to Internals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -379,3 +379,4 @@ InteropTests/NativeTests/out
 # Normally do not want to pick up changes in the scratch project, this will ignore files that aren't already tracked.
 # 'git update-index --assume-unchanged <filename>' will allow ignoring changes for tracked files.
 **/ScratchProject/
+**/ScratchProjectWithInternals/

--- a/Winforms.sln
+++ b/Winforms.sln
@@ -169,6 +169,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "eng", "eng", "{8B4B1E09-B3C
 		eng\Versions.props = eng\Versions.props
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ScratchProjectWithInternals", "src\System.Windows.Forms\tests\IntegrationTests\ScratchProjectWithInternals\ScratchProjectWithInternals.csproj", "{522EBAB3-E4D2-45F3-ACBD-B25FC457BF78}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -925,6 +927,22 @@ Global
 		{61376D2A-4AD5-48F4-BF99-2BB630E21945}.Release|x64.Build.0 = Release|Any CPU
 		{61376D2A-4AD5-48F4-BF99-2BB630E21945}.Release|x86.ActiveCfg = Release|Any CPU
 		{61376D2A-4AD5-48F4-BF99-2BB630E21945}.Release|x86.Build.0 = Release|Any CPU
+		{522EBAB3-E4D2-45F3-ACBD-B25FC457BF78}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{522EBAB3-E4D2-45F3-ACBD-B25FC457BF78}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{522EBAB3-E4D2-45F3-ACBD-B25FC457BF78}.Debug|arm64.ActiveCfg = Debug|Any CPU
+		{522EBAB3-E4D2-45F3-ACBD-B25FC457BF78}.Debug|arm64.Build.0 = Debug|Any CPU
+		{522EBAB3-E4D2-45F3-ACBD-B25FC457BF78}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{522EBAB3-E4D2-45F3-ACBD-B25FC457BF78}.Debug|x64.Build.0 = Debug|Any CPU
+		{522EBAB3-E4D2-45F3-ACBD-B25FC457BF78}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{522EBAB3-E4D2-45F3-ACBD-B25FC457BF78}.Debug|x86.Build.0 = Debug|Any CPU
+		{522EBAB3-E4D2-45F3-ACBD-B25FC457BF78}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{522EBAB3-E4D2-45F3-ACBD-B25FC457BF78}.Release|Any CPU.Build.0 = Release|Any CPU
+		{522EBAB3-E4D2-45F3-ACBD-B25FC457BF78}.Release|arm64.ActiveCfg = Release|Any CPU
+		{522EBAB3-E4D2-45F3-ACBD-B25FC457BF78}.Release|arm64.Build.0 = Release|Any CPU
+		{522EBAB3-E4D2-45F3-ACBD-B25FC457BF78}.Release|x64.ActiveCfg = Release|Any CPU
+		{522EBAB3-E4D2-45F3-ACBD-B25FC457BF78}.Release|x64.Build.0 = Release|Any CPU
+		{522EBAB3-E4D2-45F3-ACBD-B25FC457BF78}.Release|x86.ActiveCfg = Release|Any CPU
+		{522EBAB3-E4D2-45F3-ACBD-B25FC457BF78}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/System.Private.Windows.Core/src/Properties/AssemblyInfo.cs
+++ b/src/System.Private.Windows.Core/src/Properties/AssemblyInfo.cs
@@ -29,6 +29,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("MauiTabControlTests, PublicKey=00000000000000000400000000000000")]
 [assembly: InternalsVisibleTo("NativeHost.ManagedControl, PublicKey=00000000000000000400000000000000")]
 [assembly: InternalsVisibleTo("MauiToolStripTests, PublicKey=00000000000000000400000000000000")]
+[assembly: InternalsVisibleTo("ScratchProjectWithInternals, PublicKey=00000000000000000400000000000000")]
 
 // This is needed in order to Moq internal interfaces for testing
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")]

--- a/src/System.Windows.Forms.Design/src/Properties/AssemblyInfo.cs
+++ b/src/System.Windows.Forms.Design/src/Properties/AssemblyInfo.cs
@@ -10,3 +10,4 @@ using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("System.Windows.Forms.Design.Tests, PublicKey=00000000000000000400000000000000")]
 [assembly: InternalsVisibleTo("System.Windows.Forms.UI.IntegrationTests, PublicKey=00000000000000000400000000000000")]
+[assembly: InternalsVisibleTo("ScratchProjectWithInternals, PublicKey=00000000000000000400000000000000")]

--- a/src/System.Windows.Forms.Primitives/src/Properties/AssemblyInfo.cs
+++ b/src/System.Windows.Forms.Primitives/src/Properties/AssemblyInfo.cs
@@ -27,6 +27,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("MauiTabControlTests, PublicKey=00000000000000000400000000000000")]
 [assembly: InternalsVisibleTo("NativeHost.ManagedControl, PublicKey=00000000000000000400000000000000")]
 [assembly: InternalsVisibleTo("MauiToolStripTests, PublicKey=00000000000000000400000000000000")]
+[assembly: InternalsVisibleTo("ScratchProjectWithInternals, PublicKey=00000000000000000400000000000000")]
 
 // This is needed in order to Moq internal interfaces for testing
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")]

--- a/src/System.Windows.Forms/src/Properties/AssemblyInfo.cs
+++ b/src/System.Windows.Forms/src/Properties/AssemblyInfo.cs
@@ -17,6 +17,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("MauiTabControlTests, PublicKey=00000000000000000400000000000000")]
 [assembly: InternalsVisibleTo("MauiScrollBarTests, PublicKey=00000000000000000400000000000000")]
 [assembly: InternalsVisibleTo("MauiToolStripTests, PublicKey=00000000000000000400000000000000")]
+[assembly: InternalsVisibleTo("ScratchProjectWithInternals, PublicKey=00000000000000000400000000000000")]
 
 // This is needed in order to Moq internal interfaces for testing
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")]

--- a/src/System.Windows.Forms/tests/IntegrationTests/ScratchProjectWithInternals/Form1.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/ScratchProjectWithInternals/Form1.Designer.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace ScratchProjectWithInternals;
+
+partial class Form1
+{
+    /// <summary>
+    ///  Required designer variable.
+    /// </summary>
+    private System.ComponentModel.IContainer components = null;
+
+    /// <summary>
+    ///  Clean up any resources being used.
+    /// </summary>
+    /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing && (components != null))
+        {
+            components.Dispose();
+        }
+        base.Dispose(disposing);
+    }
+
+    #region Windows Form Designer generated code
+
+    /// <summary>
+    ///  Required method for Designer support - do not modify
+    ///  the contents of this method with the code editor.
+    /// </summary>
+    private void InitializeComponent()
+    {
+        this.components = new System.ComponentModel.Container();
+        this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+        this.ClientSize = new System.Drawing.Size(800, 450);
+        this.Text = "Form1";
+    }
+
+    #endregion
+}

--- a/src/System.Windows.Forms/tests/IntegrationTests/ScratchProjectWithInternals/Form1.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/ScratchProjectWithInternals/Form1.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel;
+
+namespace ScratchProjectWithInternals;
+
+// As we can't currently design in VS in the runtime solution, mark as "Default" so this opens in code view by default.
+[DesignerCategory("Default")]
+public partial class Form1 : Form
+{
+    public Form1()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/System.Windows.Forms/tests/IntegrationTests/ScratchProjectWithInternals/Form1.resx
+++ b/src/System.Windows.Forms/tests/IntegrationTests/ScratchProjectWithInternals/Form1.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/src/System.Windows.Forms/tests/IntegrationTests/ScratchProjectWithInternals/Program.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/ScratchProjectWithInternals/Program.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace ScratchProjectWithInternals;
+
+// This project is meant for temporary testing and experimenting with access to internals and should be kept as simple as possible.
+
+internal static class Program
+{
+    [STAThread]
+    public unsafe static void Main()
+    {
+        Application.EnableVisualStyles();
+        Application.SetHighDpiMode(HighDpiMode.PerMonitorV2);
+        Application.Run(new Form1());
+    }
+}

--- a/src/System.Windows.Forms/tests/IntegrationTests/ScratchProjectWithInternals/ScratchProjectWithInternals.csproj
+++ b/src/System.Windows.Forms/tests/IntegrationTests/ScratchProjectWithInternals/ScratchProjectWithInternals.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <Nullable>enable</Nullable>
+    <OutputType>WinExe</OutputType>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- These are needed to suppress the localization step picked up from Arcade targets -->
+    <EnableXlfLocalization>false</EnableXlfLocalization>
+    <UpdateXlfOnBuild>false</UpdateXlfOnBuild>
+  </PropertyGroup>
+
+  <!-- These normally come from $(UseWindowsForms) when $(ImplicitUsings) is enabled -->
+  <ItemGroup>
+    <Using Include="System.Drawing" />
+    <Using Include="System.Windows.Forms" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\System.Drawing.Common\src\System.Drawing.Common.csproj" />
+    <ProjectReference Include="..\..\..\src\System.Windows.Forms.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/System.Windows.Forms/tests/IntegrationTests/ScratchProjectWithInternals/readme.txt
+++ b/src/System.Windows.Forms/tests/IntegrationTests/ScratchProjectWithInternals/readme.txt
@@ -1,0 +1,1 @@
+This project is meant for doing temporary testing with access to internals and should be left as simple and basic as possible.


### PR DESCRIPTION
Adds another test project similar to `ScratchProject` , which has access to our internals for experimenting.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10685)