### PR TITLE
fix [Accessibility] Narrator cannot announce the leaf node information(level 1) for nodes in TreeView

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeNode.TreeNodeAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeNode.TreeNodeAccessibleObject.cs
@@ -113,6 +113,7 @@ public partial class TreeNode
                 UIA_PROPERTY_ID.UIA_HasKeyboardFocusPropertyId => (VARIANT)State.HasFlag(AccessibleStates.Focused),
                 UIA_PROPERTY_ID.UIA_IsEnabledPropertyId => (VARIANT)_owningTreeView.Enabled,
                 UIA_PROPERTY_ID.UIA_IsKeyboardFocusablePropertyId => (VARIANT)State.HasFlag(AccessibleStates.Focusable),
+                UIA_PROPERTY_ID.UIA_LevelPropertyId => (VARIANT)(_owningTreeNode.Level + 1),
                 _ => base.GetPropertyValue(propertyID)
             };
 
@@ -123,7 +124,7 @@ public partial class TreeNode
         internal override bool IsPatternSupported(UIA_PATTERN_ID patternId)
             => patternId switch
             {
-                UIA_PATTERN_ID.UIA_ExpandCollapsePatternId => _owningTreeNode._childNodes.Count > 0,
+                UIA_PATTERN_ID.UIA_ExpandCollapsePatternId => true,
                 UIA_PATTERN_ID.UIA_LegacyIAccessiblePatternId => true,
                 UIA_PATTERN_ID.UIA_ScrollItemPatternId => true,
                 UIA_PATTERN_ID.UIA_SelectionItemPatternId => true,

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/TreeNode.TreeNodeAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/TreeNode.TreeNodeAccessibleObjectTests.cs
@@ -232,7 +232,7 @@ public class TreeNodeAccessibleObjectTests
     }
 
     [WinFormsTheory]
-    [InlineData((int)UIA_PATTERN_ID.UIA_ExpandCollapsePatternId, false)]
+    [InlineData((int)UIA_PATTERN_ID.UIA_ExpandCollapsePatternId, true)]
     [InlineData((int)UIA_PATTERN_ID.UIA_LegacyIAccessiblePatternId, true)]
     [InlineData((int)UIA_PATTERN_ID.UIA_ScrollItemPatternId, true)]
     [InlineData((int)UIA_PATTERN_ID.UIA_SelectionItemPatternId, true)]
@@ -246,7 +246,7 @@ public class TreeNodeAccessibleObjectTests
     }
 
     [WinFormsTheory]
-    [InlineData((int)UIA_PATTERN_ID.UIA_ExpandCollapsePatternId, false)]
+    [InlineData((int)UIA_PATTERN_ID.UIA_ExpandCollapsePatternId, true)]
     [InlineData((int)UIA_PATTERN_ID.UIA_LegacyIAccessiblePatternId, true)]
     [InlineData((int)UIA_PATTERN_ID.UIA_ScrollItemPatternId, true)]
     [InlineData((int)UIA_PATTERN_ID.UIA_SelectionItemPatternId, true)]
@@ -261,7 +261,7 @@ public class TreeNodeAccessibleObjectTests
     }
 
     [WinFormsTheory]
-    [InlineData((int)UIA_PATTERN_ID.UIA_ExpandCollapsePatternId, false)]
+    [InlineData((int)UIA_PATTERN_ID.UIA_ExpandCollapsePatternId, true)]
     [InlineData((int)UIA_PATTERN_ID.UIA_LegacyIAccessiblePatternId, true)]
     [InlineData((int)UIA_PATTERN_ID.UIA_ScrollItemPatternId, true)]
     [InlineData((int)UIA_PATTERN_ID.UIA_SelectionItemPatternId, true)]
@@ -279,7 +279,7 @@ public class TreeNodeAccessibleObjectTests
     public void TreeNodeAccessibleObject_Index_ReturnsExpected()
     {
         using TreeView control = new();
-        control.Nodes.AddRange(new TreeNode[] { new(), new(), new() });
+        control.Nodes.AddRange([new(), new(), new()]);
 
         TreeNodeAccessibleObject accessibleObject1 = control.Nodes[0].AccessibilityObject;
         TreeNodeAccessibleObject accessibleObject2 = control.Nodes[1].AccessibilityObject;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #10591

## Proposed changes

- 
- Add Level and ExpandCollapsePattern support
- 

<!-- 
## Customer Impact
- 
- 
 -->
## Regression? 

- Yes

## Risk

- minimal 

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Narrator:
![image](https://github.com/dotnet/winforms/assets/26474449/a76f3fe1-7ad7-4e8d-8c99-474541b02379)

Inspect:
![image](https://github.com/dotnet/winforms/assets/26474449/f494ed90-2144-43a1-8e50-b3981d8b7b0a)

### After

https://github.com/dotnet/winforms/assets/135201996/f327d45b-56f7-4b6a-90ba-d271d6285244

### .Net Framework behavior

https://github.com/dotnet/winforms/assets/135201996/8a83f270-d4e5-4c60-8730-2192d953cb78


## Test methodology <!-- How did you ensure quality? -->

- 
- manually 
- 
<!-- 
## Accessibility testing 
 -->

## Test environment(s) <!-- Remove any that don't apply -->

- 9.0.0-alpha.1.24066.33
