### PR TITLE
avoid explicit calls to Dispose() in favor of 'using' statement

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.cs
@@ -3530,7 +3530,7 @@ public partial class ComboBox : ListControl
         else if (DrawMode == DrawMode.OwnerDrawVariable)
         {
             PInvoke.SendMessage(this, PInvoke.CB_SETITEMHEIGHT, (WPARAM)(-1), (LPARAM)ItemHeight);
-            Graphics graphics = CreateGraphicsInternal();
+            using Graphics graphics = CreateGraphicsInternal();
             for (int i = 0; i < Items.Count; i++)
             {
                 int original = (int)PInvoke.SendMessage(this, PInvoke.CB_GETITEMHEIGHT, (WPARAM)i);
@@ -3541,8 +3541,6 @@ public partial class ComboBox : ListControl
                     PInvoke.SendMessage(this, PInvoke.CB_SETITEMHEIGHT, (WPARAM)i, (LPARAM)mievent.ItemHeight);
                 }
             }
-
-            graphics.Dispose();
         }
     }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewLinkCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewLinkCell.cs
@@ -1038,13 +1038,13 @@ public partial class DataGridViewLinkCell : DataGridViewCell
             bool isActive = (LinkState & LinkState.Active) == LinkState.Active;
 
             LinkUtilities.EnsureLinkFonts(cellStyle.Font, LinkBehavior, ref getLinkFont, ref getHoverFont, isActive);
+            using Font linkFont = getLinkFont;
+            using Font hoverFont = getHoverFont;
+
             TextFormatFlags flags = DataGridViewUtilities.ComputeTextFormatFlagsForCellStyleAlignment(
                 DataGridView.RightToLeftInternal,
                 cellStyle.Alignment,
                 cellStyle.WrapMode);
-
-            using Font linkFont = getLinkFont;
-            using Font hoverFont = getHoverFont;
 
             // Paint the focus rectangle around the link
             if (!paint)
@@ -1129,9 +1129,6 @@ public partial class DataGridViewLinkCell : DataGridViewCell
                     ControlPaint.DrawFocusRectangle(g, errorBounds, Color.Empty, brushColor);
                 }
             }
-
-            linkFont.Dispose();
-            hoverFont.Dispose();
         }
         else if (paint || computeContentBounds)
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewRowHeaderCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewRowHeaderCell.cs
@@ -1042,7 +1042,7 @@ public partial class DataGridViewRowHeaderCell : DataGridViewHeaderCell
         s_colorMap[0].NewColor = foreColor;
         s_colorMap[0].OldColor = Color.Black;
 
-        ImageAttributes attr = new();
+        using ImageAttributes attr = new();
         attr.SetRemapTable(s_colorMap, ColorAdjustType.Bitmap);
 
         if (SystemInformation.HighContrast &&
@@ -1059,8 +1059,6 @@ public partial class DataGridViewRowHeaderCell : DataGridViewHeaderCell
         {
             g.DrawImage(bmp, bmpRect, 0, 0, s_iconsWidth, s_iconsHeight, GraphicsUnit.Pixel, attr);
         }
-
-        attr.Dispose();
     }
 
     protected override bool SetValue(int rowIndex, object? value)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ListBoxes/ListBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ListBoxes/ListBox.cs
@@ -1947,19 +1947,12 @@ public partial class ListBox : ListControl
         {
             // Fire MeasureItem for Each Item in the ListBox...
             int cnt = Items.Count;
-            Graphics graphics = CreateGraphicsInternal();
+            using Graphics graphics = CreateGraphicsInternal();
 
-            try
+            for (int i = 0; i < cnt; i++)
             {
-                for (int i = 0; i < cnt; i++)
-                {
-                    MeasureItemEventArgs mie = new(graphics, i, ItemHeight);
-                    OnMeasureItem(mie);
-                }
-            }
-            finally
-            {
-                graphics.Dispose();
+                MeasureItemEventArgs mie = new(graphics, i, ItemHeight);
+                OnMeasureItem(mie);
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TextBox/MaskedTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TextBox/MaskedTextBox.cs
@@ -1118,14 +1118,10 @@ public partial class MaskedTextBox : TextBoxBase
                 // the default one so we can get it; this would change the text displayed in the box (even for a short time)
                 // opening a sec hole.
 
-                TextBox txtBox = new TextBox
-                {
-                    UseSystemPasswordChar = true // this forces the creation of the control handle.
-                };
+                using TextBox txtBox = new();
+                txtBox.UseSystemPasswordChar = true; // this forces the creation of the control handle.
 
                 MaskedTextBox.systemPwdChar = txtBox.PasswordChar;
-
-                txtBox.Dispose();
             }
 
             return MaskedTextBox.systemPwdChar;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStrip.cs
@@ -2751,17 +2751,13 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
         {
             if (IsCurrentlyDragging)
             {
-                Region? transparentRegion = Renderer.GetTransparentRegion(this);
-                if (transparentRegion is not null && (location.X != x || location.Y != y))
+                if (location.X != x || location.Y != y)
                 {
-                    try
+                    using Region? transparentRegion = Renderer.GetTransparentRegion(this);
+                    if (transparentRegion is not null)
                     {
                         Invalidate(transparentRegion);
                         Update();
-                    }
-                    finally
-                    {
-                        transparentRegion.Dispose();
                     }
                 }
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeView.cs
@@ -2736,11 +2736,8 @@ public partial class TreeView : Control
                 }
                 else if (_drawMode == TreeViewDrawMode.OwnerDrawAll)
                 {
-                    Graphics g = nmtvcd->nmcd.hdc.CreateGraphics();
-
                     DrawTreeNodeEventArgs e;
-
-                    try
+                    using (Graphics g = nmtvcd->nmcd.hdc.CreateGraphics())
                     {
                         Rectangle bounds = node.RowBounds;
 
@@ -2764,10 +2761,6 @@ public partial class TreeView : Control
 
                         e = new DrawTreeNodeEventArgs(g, node, bounds, (TreeNodeStates)(state));
                         OnDrawNode(e);
-                    }
-                    finally
-                    {
-                        g.Dispose();
                     }
 
                     if (!e.DrawDefault)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Design/ComponentEditorForm.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Design/ComponentEditorForm.cs
@@ -200,7 +200,7 @@ public partial class ComponentEditorForm : Form
 
         int selectorWidth = MIN_SELECTOR_WIDTH;
 
-        if (_pageSites is not null)
+        if (_pageSites is not null && _pageSites.Length != 0)
         {
             using Graphics graphics = CreateGraphicsInternal();
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Design/ComponentEditorForm.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Design/ComponentEditorForm.cs
@@ -202,15 +202,15 @@ public partial class ComponentEditorForm : Form
 
         if (_pageSites is not null)
         {
+            using Graphics graphics = CreateGraphicsInternal();
+
             // Add the nodes corresponding to the pages
             for (int n = 0; n < _pageSites.Length; n++)
             {
                 ComponentEditorPage page = _pageSites[n].GetPageControl();
 
                 string title = page.Title;
-                Graphics graphics = CreateGraphicsInternal();
                 int titleWidth = (int)graphics.MeasureString(title, Font).Width;
-                graphics.Dispose();
                 _selectorImageList.Images.Add(page.Icon.ToBitmap());
 
                 _selector.Nodes.Add(new TreeNode(title, n, n));

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Dialogs/ThreadExceptionDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Dialogs/ThreadExceptionDialog.cs
@@ -197,8 +197,6 @@ public class ThreadExceptionDialog : Form
 
         string detailsText = detailsTextBuilder.ToString();
 
-        Graphics g = _message.CreateGraphicsInternal();
-
         Size textSize = new(_scaledMaxWidth - _scaledPaddingWidth, int.MaxValue);
 
         if (ScaleHelper.IsScalingRequirementMet && !UseCompatibleTextRenderingDefault)
@@ -208,13 +206,12 @@ public class ThreadExceptionDialog : Form
         }
         else
         {
+            using Graphics g = _message.CreateGraphicsInternal();
             // if HighDpi improvements are not enabled, or rendering mode is GDI+, use Graphics.MeasureString
             textSize = Size.Ceiling(g.MeasureString(messageText, Font, textSize.Width));
         }
 
         textSize.Height += _scaledExceptionMessageVerticalPadding;
-        g.Dispose();
-
         if (textSize.Width < _scaledMaxTextWidth)
         {
             textSize.Width = _scaledMaxTextWidth;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/Containers/SplitContainer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/Containers/SplitContainer.cs
@@ -1550,7 +1550,7 @@ public partial class SplitContainer : ContainerControl, ISupportInitialize
     {
         if (IsHandleCreated)
         {
-            Graphics g = CreateGraphicsInternal();
+            using Graphics g = CreateGraphicsInternal();
             if (BackgroundImage is not null)
             {
                 using TextureBrush textureBrush = new(BackgroundImage, WrapMode.Tile);
@@ -1561,8 +1561,6 @@ public partial class SplitContainer : ContainerControl, ISupportInitialize
                 using var solidBrush = BackColor.GetCachedSolidBrushScope();
                 g.FillRectangle(solidBrush, _splitterRect);
             }
-
-            g.Dispose();
         }
     }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MDI/MDIControlStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MDI/MDIControlStrip.cs
@@ -94,12 +94,8 @@ internal partial class MdiControlStrip : MenuStrip
     {
         HICON hIcon = (HICON)PInvoke.SendMessage(GetSafeHandle(_target), PInvoke.WM_GETICON, (WPARAM)PInvoke.ICON_SMALL);
         Icon icon = !hIcon.IsNull ? Icon.FromHandle(hIcon) : Form.DefaultIcon;
-        Icon smallIcon = new(icon, SystemInformation.SmallIconSize);
-
-        Image systemIcon = smallIcon.ToBitmap();
-        smallIcon.Dispose();
-
-        return systemIcon;
+        using Icon smallIcon = new(icon, SystemInformation.SmallIconSize);
+        return smallIcon.ToBitmap();
     }
 
     private bool GetTargetWindowIconVisibility() => _target is not Form formTarget || formTarget.ShowIcon;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Rendering/ControlPaint.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Rendering/ControlPaint.cs
@@ -509,7 +509,7 @@ public static partial class ControlPaint
             }
             else
             {
-                ImageAttributes imageAttrib = new();
+                using ImageAttributes imageAttrib = new();
                 imageAttrib.SetWrapMode(WrapMode.TileFlipXY);
                 g.DrawImage(
                     backgroundImage,
@@ -520,8 +520,6 @@ public static partial class ControlPaint
                     backgroundImage.Height,
                     GraphicsUnit.Pixel,
                     imageAttrib);
-
-                imageAttrib.Dispose();
             }
         }
     }
@@ -1617,7 +1615,7 @@ public static partial class ControlPaint
     // the supplied Graphics object.
     internal static void DrawImageReplaceColor(Graphics g, Image image, Rectangle dest, Color oldColor, Color newColor)
     {
-        ImageAttributes attrs = new();
+        using ImageAttributes attrs = new();
 
         ColorMap cm = new()
         {
@@ -1628,7 +1626,6 @@ public static partial class ControlPaint
         attrs.SetRemapTable(new ColorMap[] { cm }, ColorAdjustType.Bitmap);
 
         g.DrawImage(image, dest, 0, 0, image.Width, image.Height, GraphicsUnit.Pixel, attrs, null, IntPtr.Zero);
-        attrs.Dispose();
     }
 
     /// <summary>
@@ -2136,7 +2133,7 @@ public static partial class ControlPaint
 
             int patternSize = 8;
 
-            Bitmap bitmap = new(patternSize, patternSize);
+            using Bitmap bitmap = new(patternSize, patternSize);
 
             // Bitmap does not initialize itself to be zero?
 
@@ -2160,7 +2157,6 @@ public static partial class ControlPaint
             }
 
             t_frameBrushActive = new TextureBrush(bitmap);
-            bitmap.Dispose();
         }
 
         return t_frameBrushActive;
@@ -2267,7 +2263,7 @@ public static partial class ControlPaint
 
             int patternSize = 8;
 
-            Bitmap bitmap = new(patternSize, patternSize);
+            using Bitmap bitmap = new(patternSize, patternSize);
 
             // Bitmap does not initialize itself to be zero?
 
@@ -2292,7 +2288,6 @@ public static partial class ControlPaint
             }
 
             t_frameBrushSelected = new TextureBrush(bitmap);
-            bitmap.Dispose();
         }
 
         return t_frameBrushSelected;


### PR DESCRIPTION
avoid explicit calls to Dispose() in favor of 'using' statement.  this ensures Dispose() is called in the event of an exception and improves code readability.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10694)