### PR TITLE
[release/8.0] Fix regression in KeysConverter.GetStandardValues 

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/KeysConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/KeysConverter.cs
@@ -369,9 +369,9 @@ public class KeysConverter : TypeConverter, IComparer
     {
         if (_values is null)
         {
-            Keys[] list = CultureToKeyName[CultureInfo.CurrentCulture].Values.ToArray();
-            Array.Sort(list, this);
-            _values = new StandardValuesCollection(list);
+            Keys[] values = CultureToKeyName[CultureInfo.InvariantCulture].Values.ToArray();
+            Array.Sort(values, this);
+            _values = new StandardValuesCollection(values);
         }
 
         return _values;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/KeysConverterTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/KeysConverterTests.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections;
 using System.Globalization;
 
 namespace System.Windows.Forms.Tests;
@@ -82,5 +83,55 @@ public class KeysConverterTests
         KeysConverter converter = new();
         var result = converter.ConvertTo(keys, typeof(Enum[]));
         Assert.Equal(expectedResult, result);
+    }
+
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData("de-DE", null)]
+    [InlineData(null, "de-DE")]
+    [InlineData("fr-FR", "en-US")]
+    [InlineData("en-US", "fr-FR")]
+    [InlineData("zh-CN", "it-IT")]
+    [InlineData("it-IT", "zh-CN")]
+    [InlineData("ko-KR", "ru-RU")]
+    [InlineData("ru-RU", "ko-KR")]
+    [InlineData("zh-TW", "cs-CZ")]
+    [InlineData("cs-CZ", "zh-TW")]
+    [InlineData("ja-JP", "en-US")]
+    public void GetStandardValues(string cultureName, string uiCultureName)
+    {
+        // Record original culture
+        CultureInfo originalCulture = Thread.CurrentThread.CurrentCulture;
+        CultureInfo originalUICulture = Thread.CurrentThread.CurrentUICulture;
+
+        // Update CurrentCulture
+        Thread.CurrentThread.CurrentCulture = cultureName is not null ? CultureInfo.GetCultureInfo(cultureName) : originalCulture;
+        Thread.CurrentThread.CurrentUICulture = uiCultureName is not null ? CultureInfo.GetCultureInfo(uiCultureName) : originalUICulture;
+
+        Keys[] expectedValues =
+        [
+            Keys.None, Keys.D0, Keys.D1, Keys.D2, Keys.D3, Keys.D4, Keys.D5, Keys.D6, Keys.D7, Keys.D8, Keys.D9, Keys.Alt, Keys.Back, Keys.Control,
+            Keys.Delete, Keys.End, Keys.Enter, Keys.F1, Keys.F10, Keys.F11, Keys.F12, Keys.F2, Keys.F3, Keys.F4, Keys.F5, Keys.F6, Keys.F7, Keys.F8,
+            Keys.F9, Keys.Home, Keys.Insert, Keys.Next, Keys.PageUp, Keys.Shift
+        ];
+
+        try
+        {
+            var standardValuesCollection = new KeysConverter().GetStandardValues();
+            object[] actualValues = new ArrayList(standardValuesCollection).ToArray();
+
+            Assert.Equal(expectedValues.Length, standardValuesCollection.Count);
+
+            foreach (object key in expectedValues)
+            {
+                Assert.Contains(key, actualValues);
+            }
+        }
+        finally
+        {
+            // Restore original Culture
+            Thread.CurrentThread.CurrentCulture = originalCulture;
+            Thread.CurrentThread.CurrentUICulture = originalUICulture;
+        }
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Backport of https://github.com/dotnet/winforms/pull/10647 to release/8.0


## Proposed changes

- Update GetStandardValues to get the standard values by CultureInfo.InvariantCulture

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- The KeysConverter.GetStandardValues() can be used normally

## Regression? 

- Yes 

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Simply calling

`var test = new KeysConverter().GetStandardValues();`

throws the exception:

`System.Collections.Generic.KeyNotFoundException: 'The given key 'en-US' was not present in the dictionary.'`

### After

Call `var test = new KeysConverter().GetStandardValues();` to return standard key values

## Test methodology <!-- How did you ensure quality? -->

- Manually

## Test environment(s) <!-- Remove any that don't apply -->

- .net 9.0.0-alpha.1.24058.11


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10647)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10697)