### PR TITLE
Add inheritdoc to PInvoke overloads

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.ChildWindowFromPointEx.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.ChildWindowFromPointEx.cs
@@ -7,6 +7,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="ChildWindowFromPointEx(HWND, Point, CWP_FLAGS)"/>
     public static HWND ChildWindowFromPointEx<T>(T hwndParent, Point pt, CWP_FLAGS uFlags)
         where T : IHandle<HWND>
     {

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.ClientToScreen.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.ClientToScreen.cs
@@ -7,6 +7,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="ClientToScreen(HWND, ref Point)"/>
     public static BOOL ClientToScreen<T>(T hWnd, ref Point lpPoint)
         where T : IHandle<HWND>
     {

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.CloseHandle.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.CloseHandle.cs
@@ -5,6 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="CloseHandle(HANDLE)"/>
     public static BOOL CloseHandle<T>(T handle) where T : IHandle<HANDLE>
     {
         BOOL result = CloseHandle(handle.Handle);

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.CreateWindowEx.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.CreateWindowEx.cs
@@ -8,6 +8,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="CreateWindowEx(WINDOW_EX_STYLE, string, string, WINDOW_STYLE, int, int, int, int, HWND, HMENU, HINSTANCE, void*)"/>
     public static unsafe HWND CreateWindowEx(
         WINDOW_EX_STYLE dwExStyle,
         string? lpClassName,

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.DestroyAcceleratorTable.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.DestroyAcceleratorTable.cs
@@ -5,6 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="DestroyAcceleratorTable(HACCEL)"/>
     public static BOOL DestroyAcceleratorTable<T>(T hAccel)
          where T : IHandle<HACCEL>
     {

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.DragAcceptFiles.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.DragAcceptFiles.cs
@@ -5,6 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="DragAcceptFiles(HWND, BOOL)"/>
     public static void DragAcceptFiles<T>(T hWnd, BOOL fAccept) where T : IHandle<HWND>
     {
         DragAcceptFiles(hWnd.Handle, fAccept);

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.DrawMenuBar.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.DrawMenuBar.cs
@@ -5,6 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="DrawMenuBar(HWND)"/>
     public static BOOL DrawMenuBar<T>(T hWnd)
         where T : IHandle<HWND>
     {

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.DrawTextEx.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.DrawTextEx.cs
@@ -5,6 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="DrawTextEx(HDC, PWSTR, int, RECT*, DRAW_TEXT_FORMAT, DRAWTEXTPARAMS*)"/>
     public static unsafe int DrawTextEx(
         HDC hdc,
         ReadOnlySpan<char> lpchText,

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.EnableMenuItem.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.EnableMenuItem.cs
@@ -5,6 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="EnableMenuItem(HMENU, uint, MENU_ITEM_FLAGS)"/>
     public static BOOL EnableMenuItem<T>(T hMenu, uint uIDEnableItem, MENU_ITEM_FLAGS uEnable)
         where T : IHandle<HMENU>
     {

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.EnableScrollBar.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.EnableScrollBar.cs
@@ -5,6 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="EnableScrollBar(HWND, uint, ENABLE_SCROLL_BAR_ARROWS)"/>
     public static BOOL EnableScrollBar<T>(T hWnd, SCROLLBAR_CONSTANTS wSBflags, ENABLE_SCROLL_BAR_ARROWS wArrows)
         where T : IHandle<HWND>
     {

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.EnableWindow.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.EnableWindow.cs
@@ -5,6 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="EnableWindow(HWND, BOOL)"/>
     public static BOOL EnableWindow<T>(T hWnd, BOOL bEnable)
         where T : IHandle<HWND>
     {

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.EndDialog.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.EndDialog.cs
@@ -5,6 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="EndDialog(HWND, nint)"/>
     public static BOOL EndDialog<T>(T hDlg, IntPtr nResult)
         where T : IHandle<HWND>
     {

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.FillRect.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.FillRect.cs
@@ -5,6 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="FillRect(HDC, in RECT, HBRUSH)"/>
     public static int FillRect<T>(T hDC, ref RECT lprc, HBRUSH hbr)
         where T : IHandle<HDC>
     {

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetAncestor.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetAncestor.cs
@@ -5,6 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="GetAncestor(HWND, GET_ANCESTOR_FLAGS)"/>
     public static HWND GetAncestor<T>(T hwnd, GET_ANCESTOR_FLAGS flags) where T : IHandle<HWND>
     {
         HWND result = GetAncestor(hwnd.Handle, flags);

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetClientRect.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetClientRect.cs
@@ -5,6 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="GetClientRect(HWND, out RECT)"/>
     public static BOOL GetClientRect<T>(T hWnd, out RECT lpRect)
         where T : IHandle<HWND>
     {

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetDlgItem.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetDlgItem.cs
@@ -5,6 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="GetDlgItem(HWND, int)"/>
     public static HWND GetDlgItem<T>(T hDlg, int nIDDlgItem)
         where T : IHandle<HWND>
     {

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetDpiForWindow.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetDpiForWindow.cs
@@ -5,6 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="GetDpiForWindow(HWND)"/>
     public static uint GetDpiForWindow<T>(T hwnd) where T : IHandle<HWND>
     {
         if (OsVersion.IsWindows10_1607OrGreater())

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetMenu.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetMenu.cs
@@ -5,6 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="GetMenu(HWND)"/>
     public static HMENU GetMenu<T>(T hWnd)
         where T : IHandle<HWND>
     {

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetMenuItemCount.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetMenuItemCount.cs
@@ -5,6 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="GetMenuItemCount(HMENU)"/>
     public static int GetMenuItemCount<T>(T hMenu)
         where T : IHandle<HMENU>
     {

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetParent.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetParent.cs
@@ -5,6 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="GetParent(HWND)"/>
     public static HWND GetParent<T>(T hwnd) where T : IHandle<HWND>
     {
         HWND result = GetParent(hwnd.Handle);

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetScrollInfo.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetScrollInfo.cs
@@ -5,6 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="GetScrollInfo(HWND, SCROLLBAR_CONSTANTS, ref SCROLLINFO)"/>
     public static BOOL GetScrollInfo<T>(T hwnd, SCROLLBAR_CONSTANTS nBar, ref SCROLLINFO lpsi)
         where T : IHandle<HWND>
     {

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetSysColorBrush.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetSysColorBrush.cs
@@ -7,6 +7,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="GetSysColorBrush(SYS_COLOR_INDEX)"/>
     public static HBRUSH GetSysColorBrush(Color systemColor)
     {
         Debug.Assert(systemColor.IsSystemColor);

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetSystemMenu.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetSystemMenu.cs
@@ -5,6 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="GetSystemMenu(HWND, BOOL)"/>
     public static HMENU GetSystemMenu<T>(T hwnd, BOOL bRevert) where T : IHandle<HWND>
     {
         HMENU result = GetSystemMenu(hwnd.Handle, bRevert);

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetTextExtentPoint32.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetTextExtentPoint32.cs
@@ -7,6 +7,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="GetTextExtentPoint32W(HDC, PCWSTR, int, SIZE*)"/>
     public static unsafe BOOL GetTextExtentPoint32W<T>(T hdc, string lpString, int c, Size size) where T : IHandle<HDC>
     {
         fixed (char* pString = lpString)

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetThemeFont.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetThemeFont.cs
@@ -7,6 +7,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="GetThemeFont(HTHEME, HDC, int, int, int, LOGFONTW*)"/>
     public static unsafe HRESULT GetThemeFont<T>(T hTheme, HDC hdc, int iPartId, int iStateId, int iPropId, out LOGFONT pFont)
         where T : IHandle<HTHEME>
     {

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetWindow.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetWindow.cs
@@ -5,6 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="GetWindow(HWND, GET_WINDOW_CMD)"/>
     public static HWND GetWindow<T>(T hWnd, GET_WINDOW_CMD uCmd) where T : IHandle<HWND>
     {
         HWND result = GetWindow(hWnd.Handle, uCmd);

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetWindowRect.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetWindowRect.cs
@@ -5,6 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="GetWindowRect(HWND, out RECT)"/>
     public static BOOL GetWindowRect<T>(T hWnd, out RECT lpRect) where T : IHandle<HWND>
     {
         BOOL result = GetWindowRect(hWnd.Handle, out lpRect);

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetWindowTextLength.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetWindowTextLength.cs
@@ -5,6 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="GetWindowTextLength(HWND)"/>
     public static int GetWindowTextLength<T>(T hWnd) where T : IHandle<HWND>
     {
         int result = GetWindowTextLength(hWnd.Handle);

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetWindowThreadProcessId.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetWindowThreadProcessId.cs
@@ -5,6 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="GetWindowThreadProcessId(HWND, uint*)"/>
     public static unsafe uint GetWindowThreadProcessId<T>(T hWnd, out uint lpdwProcessId)
         where T : IHandle<HWND>
     {

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.ImmGetContext.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.ImmGetContext.cs
@@ -7,6 +7,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="ImmGetContext(HWND)"/>
     public static HIMC ImmGetContext<T>(T hWnd) where T : IHandle<HWND>
     {
         HIMC result = ImmGetContext(hWnd.Handle);

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.ImmReleaseContext.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.ImmReleaseContext.cs
@@ -7,6 +7,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="ImmReleaseContext(HWND, HIMC)"/>
     public static BOOL ImmReleaseContext<T>(T hWnd, HIMC hIMC) where T : IHandle<HWND>
     {
         BOOL result = ImmReleaseContext(hWnd.Handle, hIMC);

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.IntersectClipRect.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.IntersectClipRect.cs
@@ -5,6 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="IntersectClipRect(HDC, int, int, int, int)"/>
     public static GDI_REGION_TYPE IntersectClipRect<T>(T hdc, int left, int top, int right, int bottom) where T : IHandle<HDC>
     {
         GDI_REGION_TYPE result = IntersectClipRect(hdc.Handle, left, top, right, bottom);

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.InvalidateRect.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.InvalidateRect.cs
@@ -5,6 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="InvalidateRect(HWND, RECT*, BOOL)"/>
     public static unsafe BOOL InvalidateRect<T>(T hWnd, RECT* lpRect, BOOL bErase)
         where T : IHandle<HWND>
     {

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.InvalidateRgn.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.InvalidateRgn.cs
@@ -5,6 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="InvalidateRgn(HWND, HRGN, BOOL)"/>
     public static BOOL InvalidateRgn<T>(T hWnd, HRGN hrgn, BOOL erase)
         where T : IHandle<HWND>
     {

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.IsAccelerator.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.IsAccelerator.cs
@@ -5,6 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="IsAccelerator(HACCEL, int, MSG*, ushort*)"/>
     public static unsafe bool IsAccelerator<T>(T hAccel, int cAccelEntries, MSG* lpMsg, ushort* lpwCmd)
         where T : IHandle<HACCEL>
     {

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.IsChild.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.IsChild.cs
@@ -5,6 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="IsChild(HWND, HWND)"/>
     public static BOOL IsChild<TParent, TChild>(TParent hWndParent, TChild hWnd)
         where TParent : IHandle<HWND>
         where TChild : IHandle<HWND>

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.IsWindow.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.IsWindow.cs
@@ -5,6 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="IsWindow(HWND)"/>
     public static BOOL IsWindow<T>(T hWnd) where T : IHandle<HWND>
     {
         BOOL result = IsWindow(hWnd.Handle);

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.IsWindowEnabled.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.IsWindowEnabled.cs
@@ -5,6 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="IsWindowEnabled(HWND)"/>
     public static BOOL IsWindowEnabled<T>(T hWnd) where T : IHandle<HWND>
     {
         BOOL result = IsWindowEnabled(hWnd.Handle);

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.IsWindowVisible.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.IsWindowVisible.cs
@@ -5,6 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="IsWindowVisible(HWND)"/>
     public static BOOL IsWindowVisible<T>(T hWnd) where T : IHandle<HWND>
     {
         BOOL result = IsWindowVisible(hWnd.Handle);

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.KillTimer.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.KillTimer.cs
@@ -5,6 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="KillTimer(HWND, nuint)"/>
     public static BOOL KillTimer<T>(T hWnd, IntPtr uIDEvent)
         where T : IHandle<HWND>
     {

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.MapWindowPoints.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.MapWindowPoints.cs
@@ -7,6 +7,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="MapWindowPoints(HWND, HWND, Point*, uint)"/>
     public static unsafe int MapWindowPoints<TFrom, TTo>(TFrom hWndFrom, TTo hWndTo, ref RECT lpRect)
         where TFrom : IHandle<HWND>
         where TTo : IHandle<HWND>
@@ -20,6 +21,7 @@ internal static partial class PInvoke
         }
     }
 
+    /// <inheritdoc cref="MapWindowPoints(HWND, HWND, Point*, uint)"/>
     public static unsafe int MapWindowPoints<TFrom, TTo>(TFrom hWndFrom, TTo hWndTo, ref Point lpPoint)
         where TFrom : IHandle<HWND>
         where TTo : IHandle<HWND>

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.NotifyWinEvent.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.NotifyWinEvent.cs
@@ -5,6 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="NotifyWinEvent(uint, HWND, int, int)"/>
     public static void NotifyWinEvent<T>(uint @event, T hwnd, int idObject, int idChild)
         where T : IHandle<HWND>
     {

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.RedrawWindow.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.RedrawWindow.cs
@@ -5,6 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="RedrawWindow(HWND, RECT*, HRGN, REDRAW_WINDOW_FLAGS)"/>
     public static unsafe BOOL RedrawWindow<T>(T hWnd, RECT* lprcUpdate, HRGN hrgnUpdate, REDRAW_WINDOW_FLAGS flags)
         where T : IHandle<HWND>
     {

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.RegisterDragDrop.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.RegisterDragDrop.cs
@@ -7,6 +7,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="RegisterDragDrop(HWND, IDropTarget*)"/>
     public static unsafe HRESULT RegisterDragDrop<T>(T hwnd, IDropTarget.Interface pDropTarget)
         where T : IHandle<HWND>
     {

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.RevokeDragDrop.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.RevokeDragDrop.cs
@@ -5,6 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="RevokeDragDrop(HWND)"/>
     public static HRESULT RevokeDragDrop<T>(T hwnd) where T : IHandle<HWND>
     {
         HRESULT result = RevokeDragDrop(hwnd.Handle);

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SHAutoComplete.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SHAutoComplete.cs
@@ -5,6 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="SHAutoComplete(HWND, SHELL_AUTOCOMPLETE_FLAGS)"/>
     public static HRESULT SHAutoComplete<T>(T hwndEdit, SHELL_AUTOCOMPLETE_FLAGS flags) where T : IHandle<HWND>
     {
         HRESULT result = SHAutoComplete(hwndEdit.Handle, flags);

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SHCreateItemFromParsingName.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SHCreateItemFromParsingName.cs
@@ -7,6 +7,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="SHCreateItemFromParsingName(string, System.Com.IBindCtx*, in Guid, out void*)"/>
     public static unsafe IShellItem* SHCreateItemFromParsingName(string path)
     {
         HRESULT hr = SHCreateItemFromParsingName(path, pbc: null, in IID.GetRef<IShellItem>(), out void* ppv);

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.ScreenToClient.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.ScreenToClient.cs
@@ -7,6 +7,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="ScreenToClient(HWND, ref Point)"/>
     public static BOOL ScreenToClient<T>(T hWnd, ref Point lpPoint)
         where T : IHandle<HWND>
     {

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.ScrollWindow.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.ScrollWindow.cs
@@ -5,6 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="ScrollWindow(HWND, int, int, RECT*, RECT*)"/>
     public static unsafe BOOL ScrollWindow<T>(T hWnd, int XAmount, int YAmount, RECT* lpRect, RECT* rectClip)
         where T : IHandle<HWND>
     {

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.ScrollWindowEx.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.ScrollWindowEx.cs
@@ -5,6 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="ScrollWindowEx(HWND, int, int, RECT*, RECT*, HRGN, RECT*, SCROLL_WINDOW_FLAGS)"/>
     public static unsafe int ScrollWindowEx<T>(
         T hWnd,
         int dx,

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SendMessage.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SendMessage.cs
@@ -5,6 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="SendMessage(HWND, uint, WPARAM, LPARAM)"/>
     public static LRESULT SendMessage<T>(
         T hWnd,
         MessageId Msg,
@@ -16,6 +17,7 @@ internal static partial class PInvoke
         return result;
     }
 
+    /// <inheritdoc cref="SendMessage(HWND, uint, WPARAM, LPARAM)"/>
     public static LRESULT SendMessage<THwnd, TWParam>(
         THwnd hWnd,
         MessageId Msg,
@@ -27,6 +29,7 @@ internal static partial class PInvoke
         return result;
     }
 
+    /// <inheritdoc cref="SendMessage(HWND, uint, WPARAM, LPARAM)"/>
     public static unsafe LRESULT SendMessage<T>(
         T hWnd,
         MessageId Msg,
@@ -39,6 +42,7 @@ internal static partial class PInvoke
         }
     }
 
+    /// <inheritdoc cref="SendMessage(HWND, uint, WPARAM, LPARAM)"/>
     public static unsafe nint SendMessage<THwnd, TLParam>(
         THwnd hWnd,
         MessageId Msg,
@@ -53,6 +57,7 @@ internal static partial class PInvoke
         }
     }
 
+    /// <inheritdoc cref="SendMessage(HWND, uint, WPARAM, LPARAM)"/>
     public static unsafe nint SendMessage<THwnd, TWParam, TLParam>(
         THwnd hWnd,
         MessageId Msg,

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SetActiveWindow.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SetActiveWindow.cs
@@ -5,6 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="SetActiveWindow(HWND)"/>
     public static HWND SetActiveWindow<T>(T hWnd) where T : IHandle<HWND>
     {
         HWND result = SetActiveWindow(hWnd.Handle);

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SetCapture.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SetCapture.cs
@@ -5,6 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="SetCapture(HWND)"/>
     public static IntPtr SetCapture<T>(T hWnd) where T : IHandle<HWND>
     {
         IntPtr result = SetCapture(hWnd.Handle);

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SetFocus.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SetFocus.cs
@@ -5,6 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="SetFocus(HWND)"/>
     public static HWND SetFocus<T>(T hWnd) where T : IHandle<HWND>
     {
         HWND result = SetFocus(hWnd.Handle);

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SetForegroundWindow.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SetForegroundWindow.cs
@@ -5,6 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="SetForegroundWindow(HWND)"/>
     public static BOOL SetForegroundWindow<T>(T hWnd) where T : IHandle<HWND>
     {
         BOOL result = SetForegroundWindow(hWnd.Handle);

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SetLayeredWindowAttributes.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SetLayeredWindowAttributes.cs
@@ -5,6 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="SetLayeredWindowAttributes(HWND, COLORREF, byte, LAYERED_WINDOW_ATTRIBUTES_FLAGS)"/>
     public static BOOL SetLayeredWindowAttributes<T>(T hwnd, COLORREF crKey, byte bAlpha, LAYERED_WINDOW_ATTRIBUTES_FLAGS dwFlags)
         where T : IHandle<HWND>
     {

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SetMenu.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SetMenu.cs
@@ -5,6 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="SetMenu(HWND, HMENU)"/>
     public static BOOL SetMenu<T>(T hWnd, HMENU hMenu)
         where T : IHandle<HWND>
     {
@@ -13,6 +14,7 @@ internal static partial class PInvoke
         return result;
     }
 
+    /// <inheritdoc cref="SetMenu(HWND, HMENU)"/>
     public static BOOL SetMenu<T1, T2>(T1 hWnd, T2 hMenu)
         where T1 : IHandle<HWND>
         where T2: IHandle<HMENU>

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SetParent.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SetParent.cs
@@ -5,6 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="SetParent(HWND, HWND)"/>
     public static HWND SetParent<TChild, TParent>(TChild hWndChild, TParent hWndNewParent)
         where TChild : IHandle<HWND>
         where TParent : IHandle<HWND>

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SetScrollInfo.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SetScrollInfo.cs
@@ -5,6 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="SetScrollInfo(HWND, SCROLLBAR_CONSTANTS, in SCROLLINFO, BOOL)"/>
     public static int SetScrollInfo<T>(T hWnd, SCROLLBAR_CONSTANTS nBar, ref SCROLLINFO lpsi, BOOL redraw)
         where T : IHandle<HWND>
     {

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SetScrollPos.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SetScrollPos.cs
@@ -5,6 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="SetScrollPos(HWND, SCROLLBAR_CONSTANTS, int, BOOL)"/>
     public static int SetScrollPos<T>(T hWnd, SCROLLBAR_CONSTANTS nBar, int nPos, BOOL bRedraw)
         where T : IHandle<HWND>
     {

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SetWindowPos.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SetWindowPos.cs
@@ -5,6 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="SetWindowPos(HWND, HWND, int, int, int, int, SET_WINDOW_POS_FLAGS)"/>
     public static BOOL SetWindowPos<T1, T2>(T1 hWnd, T2 hWndInsertAfter, int X, int Y, int cx, int cy, SET_WINDOW_POS_FLAGS uFlags)
         where T1 : IHandle<HWND>
         where T2 : IHandle<HWND>

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SetWindowRgn.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SetWindowRgn.cs
@@ -5,6 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="SetWindowRgn(HWND, HRGN, BOOL)"/>
     public static int SetWindowRgn<T>(T hwnd, HRGN hrgn, BOOL fRedraw)
         where T : IHandle<HWND>
     {

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SetWindowText.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SetWindowText.cs
@@ -5,6 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="SetWindowText(HWND, string)"/>
     public static BOOL SetWindowText<T>(T hWnd, string text) where T : IHandle<HWND>
     {
         BOOL result = SetWindowText(hWnd.Handle, text);

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.ShowWindow.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.ShowWindow.cs
@@ -5,6 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="ShowWindow(HWND, SHOW_WINDOW_CMD)"/>
     public static BOOL ShowWindow<T>(T hWnd, SHOW_WINDOW_CMD nCmdShow) where T : IHandle<HWND>
     {
         BOOL result = ShowWindow(hWnd.Handle, nCmdShow);

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.UiaDisconnectProvider.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.UiaDisconnectProvider.cs
@@ -7,6 +7,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="UiaDisconnectProvider(IRawElementProviderSimple*)"/>
     public static unsafe void UiaDisconnectProvider(IRawElementProviderSimple.Interface? provider, bool skipOSCheck = false)
     {
         if (provider is not null && (skipOSCheck || OsVersion.IsWindows8OrGreater()))

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.UiaHostProviderFromHwnd.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.UiaHostProviderFromHwnd.cs
@@ -7,6 +7,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="UiaHostProviderFromHwnd(HWND, IRawElementProviderSimple**)"/>
     public static unsafe HRESULT UiaHostProviderFromHwnd<T>(T hwnd, out IRawElementProviderSimple* ppProvider) where T : IHandle<HWND>
     {
         IRawElementProviderSimple* provider;

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.UiaRaiseNotificationEvent.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.UiaRaiseNotificationEvent.cs
@@ -8,6 +8,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="UiaRaiseNotificationEvent(IRawElementProviderSimple*, NotificationKind, NotificationProcessing, BSTR, BSTR)"/>
     public static unsafe HRESULT UiaRaiseNotificationEvent(
         IRawElementProviderSimple.Interface provider,
         AutomationNotificationKind notificationKind,

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.UiaReturnRawElementProvider.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.UiaReturnRawElementProvider.cs
@@ -7,6 +7,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="UiaReturnRawElementProvider(HWND, WPARAM, LPARAM, IRawElementProviderSimple*)"/>
     public static unsafe LRESULT UiaReturnRawElementProvider<T>(
         T hwnd,
         WPARAM wParam,

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.UpdateWindow.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.UpdateWindow.cs
@@ -5,6 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="UpdateWindow(HWND)"/>
     public static BOOL UpdateWindow<T>(T hWnd) where T : IHandle<HWND>
     {
         BOOL result = UpdateWindow(hWnd.Handle);

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.ValidateRect.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.ValidateRect.cs
@@ -5,6 +5,7 @@ namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
+    /// <inheritdoc cref="ValidateRect(HWND, RECT*)"/>
     public static unsafe BOOL ValidateRect<T>(T hWnd, RECT* lpRect)
         where T : IHandle<HWND>
     {


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #10695

## Proposed changes

- Add `<ineritdoc>` to PInvoke overloads to get links to the docs from CsWin32.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Improve the developer experience.

## Regression? 

- No

## Risk

- None.

<!-- end TELL-MODE -->

## Test methodology <!-- How did you ensure quality? -->

- Manual.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10699)