### PR TITLE
7027 : fix treeview sorter issue when treeviewnodesorter is null set …

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeView.cs
@@ -1256,6 +1256,11 @@ public partial class TreeView : Control
                 {
                     Sort();
                 }
+                else
+                {
+                    Sorted = false;
+                    RefreshNodes();
+                }
             }
         }
     }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
@@ -4723,6 +4723,19 @@ public class TreeViewTests
     }
 
     [WinFormsFact]
+    public void TreeViewNodeSorter_Set_SortedFalseIfNull()
+    {
+        using var treeView = new TreeView
+        {
+            TreeViewNodeSorter = StringComparer.CurrentCulture
+        };
+        Assert.True(treeView.Sorted);
+
+        treeView.TreeViewNodeSorter = null;
+        Assert.False(treeView.Sorted);
+    }
+
+    [WinFormsFact]
     public void AddExistingNodeAsChild_ThrowsArgumentException()
     {
         using TreeView treeView = new();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
@@ -4711,7 +4711,7 @@ public class TreeViewTests
     [MemberData(nameof(TreeViewNodeSorter_TestData))]
     public void TreeViewNodeSorter_Set_GetReturnsExpected(IComparer value)
     {
-        using TreeView treeView = new()
+        using TreeView treeView = new ()
         {
             TreeViewNodeSorter = value
         };

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
@@ -4725,7 +4725,7 @@ public class TreeViewTests
     [WinFormsFact]
     public void TreeViewNodeSorter_Set_SortedFalseIfNull()
     {
-        using var treeView = new ()
+        using TreeView treeView = new ()
         {
             TreeViewNodeSorter = StringComparer.CurrentCulture
         };

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
@@ -4725,7 +4725,7 @@ public class TreeViewTests
     [WinFormsFact]
     public void TreeViewNodeSorter_Set_SortedFalseIfNull()
     {
-        using var treeView = new TreeView
+        using var treeView = new ()
         {
             TreeViewNodeSorter = StringComparer.CurrentCulture
         };

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
@@ -4711,7 +4711,7 @@ public class TreeViewTests
     [MemberData(nameof(TreeViewNodeSorter_TestData))]
     public void TreeViewNodeSorter_Set_GetReturnsExpected(IComparer value)
     {
-        using TreeView treeView = new ()
+        using TreeView treeView = new()
         {
             TreeViewNodeSorter = value
         };
@@ -4725,7 +4725,7 @@ public class TreeViewTests
     [WinFormsFact]
     public void TreeViewNodeSorter_Set_SortedFalseIfNull()
     {
-        using TreeView treeView = new ()
+        using TreeView treeView = new()
         {
             TreeViewNodeSorter = StringComparer.CurrentCulture
         };


### PR DESCRIPTION
Fixes #7027
If you have a TreeView control, and you set TreeView.TreeViewNodeSorter = new TreeNodeComparer().
Then .net will set TreeView.Sorted=true.

## Proposed changes
- when we set TreeViewNodeSorter null system will update Sorted = false

## Customer Impact

- No
- 

## Regression? 

- Yes

## Risk

- No

### Before

- When we set TreeViewNodeSorter to null after previously assigning a value to it, it still appears to be sorted as true even after updating TreeViewNodeSorter with null.

### After

- When we set TreeViewNodeSorter to null after previously assigning a value to it, it is set sorted as false.

## Test methodology 

- Added testcase 

## Test environment(s) 

- tested with .net core 8.0


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10707)