### PR TITLE
removing an override that is identical to the base class implementation

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/UpDown/UpDownBase.UpDownButtons.UpDownButtonsAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/UpDown/UpDownBase.UpDownButtons.UpDownButtonsAccessibleObject.cs
@@ -72,20 +72,6 @@ public abstract partial class UpDownBase
                 return null;
             }
 
-            internal override unsafe IRawElementProviderSimple* HostRawElementProvider
-            {
-                get
-                {
-                    if (HandleInternal.IsNull)
-                    {
-                        return null;
-                    }
-
-                    PInvoke.UiaHostProviderFromHwnd(new HandleRef<HWND>(this, HandleInternal), out IRawElementProviderSimple* provider);
-                    return provider;
-                }
-            }
-
             [AllowNull]
             public override string Name
             {


### PR DESCRIPTION
Implementation in the ControlAccessibleObject class - 
https://github.com/dotnet/winforms/blob/d5528f6ce1d65d9f3694d679ee745690cb2e1675/src/System.Windows.Forms/src/System/Windows/Forms/Accessibility/Control.ControlAccessibleObject.cs#L535-L547