### PR TITLE
fix bug: No text for new tabpage item that added by TabPages property in the properties window in the DemoConsole application

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CollectionEditor.CollectionEditorCollectionForm.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CollectionEditor.CollectionEditorCollectionForm.cs
@@ -301,6 +301,12 @@ public partial class CollectionEditor
                 {
                     AddItems(multipleInstance);
                 }
+
+                if (instance is IComponent component &&
+                    (Context?.Instance as Control)?.Site?.GetService<IDesignerHost>()?.GetDesigner(component) is IComponentInitializer initializer)
+                {
+                    initializer.InitializeNewComponent(defaultValues: null);
+                }
             }
             catch (Exception e)
             {
@@ -374,10 +380,10 @@ public partial class CollectionEditor
 
         private void HookEvents()
         {
-            _listbox.KeyDown += Listbox_keyDown;
-            _listbox.DrawItem += Listbox_drawItem;
-            _listbox.SelectedIndexChanged += Listbox_SelectedIndexChanged;
-            _listbox.HandleCreated += Listbox_HandleCreated;
+            _listbox.KeyDown += ListBox_keyDown;
+            _listbox.DrawItem += ListBox_drawItem;
+            _listbox.SelectedIndexChanged += ListBox_SelectedIndexChanged;
+            _listbox.HandleCreated += ListBox_HandleCreated;
             _upButton.Click += UpButton_Click;
             _downButton.Click += DownButton_click;
             _propertyGrid.PropertyValueChanged += PropertyGrid_propertyValueChanged;
@@ -552,9 +558,9 @@ public partial class CollectionEditor
         }
 
         /// <summary>
-        ///  This draws a row of the listbox.
+        ///  This draws a row of the listBox.
         /// </summary>
-        private void Listbox_drawItem(object? sender, DrawItemEventArgs e)
+        private void ListBox_drawItem(object? sender, DrawItemEventArgs e)
         {
             if (e.Index != -1)
             {
@@ -621,7 +627,7 @@ public partial class CollectionEditor
                         e.Bounds with { X = e.Bounds.X + offset, Width = e.Bounds.Width - offset });
                 }
 
-                // Check to see if we need to change the horizontal extent of the listbox
+                // Check to see if we need to change the horizontal extent of the listBox
                 int width = offset + (int)g.MeasureString(itemText, Font).Width;
                 if (width > e.Bounds.Width && _listbox.HorizontalExtent < width)
                 {
@@ -633,9 +639,9 @@ public partial class CollectionEditor
         /// <summary>
         ///  Handles keypress events for the list box.
         /// </summary>
-        private void Listbox_keyDown(object? sender, KeyEventArgs kevent)
+        private void ListBox_keyDown(object? sender, KeyEventArgs keyEvent)
         {
-            switch (kevent.KeyData)
+            switch (keyEvent.KeyData)
             {
                 case Keys.Delete:
                     PerformRemove();
@@ -649,7 +655,7 @@ public partial class CollectionEditor
         /// <summary>
         ///  Event that fires when the selected list box index changes.
         /// </summary>
-        private void Listbox_SelectedIndexChanged(object? sender, EventArgs e)
+        private void ListBox_SelectedIndexChanged(object? sender, EventArgs e)
         {
             UpdateEnabled();
         }
@@ -657,7 +663,7 @@ public partial class CollectionEditor
         /// <summary>
         ///  Event that fires when the list box's window handle is created.
         /// </summary>
-        private void Listbox_HandleCreated(object? sender, EventArgs e)
+        private void ListBox_HandleCreated(object? sender, EventArgs e)
         {
             UpdateItemWidths(null);
         }
@@ -845,7 +851,7 @@ public partial class CollectionEditor
         {
             _dirty = true;
 
-            // Refresh selected listbox item so that it picks up any name change
+            // Refresh selected listBox item so that it picks up any name change
             SuspendEnabledUpdates();
             try
             {
@@ -1063,7 +1069,7 @@ public partial class CollectionEditor
                 int selectedItemCount = _listbox.SelectedItems.Count;
                 if (selectedItemCount is 1 or -1)
                 {
-                    // handle both single select listboxes and a single item selected in a multi-select listbox
+                    // handle both single select listBoxes and a single item selected in a multi-select listBox
                     _propertiesLabel.Text = string.Format(SR.CollectionEditorProperties, GetDisplayText((ListItem)_listbox.SelectedItem));
                 }
                 else

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CollectionEditor.CollectionEditorCollectionForm.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CollectionEditor.CollectionEditorCollectionForm.cs
@@ -28,7 +28,7 @@ public partial class CollectionEditor
 
         private readonly CollectionEditor _editor;
 
-        private FilterListBox _listbox;
+        private FilterListBox _listBox;
         private SplitButton _addButton;
         private Button _removeButton;
         private Button _cancelButton;
@@ -80,7 +80,7 @@ public partial class CollectionEditor
         {
             get
             {
-                foreach (ListItem item in _listbox.SelectedItems)
+                foreach (ListItem item in _listBox.SelectedItems)
                 {
                     Type type = item.Value.GetType();
 
@@ -128,7 +128,7 @@ public partial class CollectionEditor
         {
             _createdItems ??= new List<object>();
 
-            _listbox.BeginUpdate();
+            _listBox.BeginUpdate();
             try
             {
                 foreach (object? instance in instances)
@@ -138,19 +138,19 @@ public partial class CollectionEditor
                         _dirty = true;
                         _createdItems.Add(instance);
                         ListItem created = new(_editor, instance);
-                        _listbox.Items.Add(created);
+                        _listBox.Items.Add(created);
                     }
                 }
             }
             finally
             {
-                _listbox.EndUpdate();
+                _listBox.EndUpdate();
             }
 
             if (instances.Count == 1)
             {
                 // optimize for the case where we just added one thing...
-                UpdateItemWidths(_listbox.Items[_listbox.Items.Count - 1] as ListItem);
+                UpdateItemWidths(_listBox.Items[_listBox.Items.Count - 1] as ListItem);
             }
             else
             {
@@ -160,23 +160,23 @@ public partial class CollectionEditor
             SuspendEnabledUpdates();
             try
             {
-                _listbox.ClearSelected();
-                _listbox.SelectedIndex = _listbox.Items.Count - 1;
+                _listBox.ClearSelected();
+                _listBox.SelectedIndex = _listBox.Items.Count - 1;
 
-                object[] items = new object[_listbox.Items.Count];
+                object[] items = new object[_listBox.Items.Count];
                 for (int i = 0; i < items.Length; i++)
                 {
-                    items[i] = ((ListItem)_listbox.Items[i]).Value;
+                    items[i] = ((ListItem)_listBox.Items[i]).Value;
                 }
 
                 Items = items;
 
                 // If someone changes the edit value which resets the selindex, we
                 // should keep the new index.
-                if (_listbox.Items.Count > 0 && _listbox.SelectedIndex != _listbox.Items.Count - 1)
+                if (_listBox.Items.Count > 0 && _listBox.SelectedIndex != _listBox.Items.Count - 1)
                 {
-                    _listbox.ClearSelected();
-                    _listbox.SelectedIndex = _listbox.Items.Count - 1;
+                    _listBox.ClearSelected();
+                    _listBox.SelectedIndex = _listBox.Items.Count - 1;
                 }
             }
             finally
@@ -187,7 +187,7 @@ public partial class CollectionEditor
 
         private void AdjustListBoxItemHeight()
         {
-            _listbox.ItemHeight = Font.Height + SystemInformation.BorderSize.Width * 2;
+            _listBox.ItemHeight = Font.Height + SystemInformation.BorderSize.Width * 2;
         }
 
         /// <summary>
@@ -208,8 +208,8 @@ public partial class CollectionEditor
 
         private int CalcItemWidth(Graphics g, ListItem item)
         {
-            int c = Math.Max(2, _listbox.Items.Count);
-            SizeF sizeW = g.MeasureString(c.ToString(CultureInfo.CurrentCulture), _listbox.Font);
+            int c = Math.Max(2, _listBox.Items.Count);
+            SizeF sizeW = g.MeasureString(c.ToString(CultureInfo.CurrentCulture), _listBox.Font);
 
             int charactersInNumber = ((int)(Math.Log(c - 1) / s_log10) + 1);
             int w = 4 + charactersInNumber * (Font.Height / 2);
@@ -217,7 +217,7 @@ public partial class CollectionEditor
             w = Math.Max(w, (int)Math.Ceiling(sizeW.Width));
             w += SystemInformation.BorderSize.Width * 4;
 
-            SizeF size = g.MeasureString(GetDisplayText(item), _listbox.Font);
+            SizeF size = g.MeasureString(GetDisplayText(item), _listBox.Font);
             int pic = 0;
             if (item.Editor is not null && item.Editor.GetPaintValueSupported())
             {
@@ -242,7 +242,7 @@ public partial class CollectionEditor
                 }
 
                 _dirty = false;
-                _listbox.Items.Clear();
+                _listBox.Items.Clear();
 
                 if (_createdItems is not null)
                 {
@@ -301,12 +301,6 @@ public partial class CollectionEditor
                 {
                     AddItems(multipleInstance);
                 }
-
-                if (instance is IComponent component &&
-                    (Context?.Instance as Control)?.Site?.GetService<IDesignerHost>()?.GetDesigner(component) is IComponentInitializer initializer)
-                {
-                    initializer.InitializeNewComponent(defaultValues: null);
-                }
             }
             catch (Exception e)
             {
@@ -323,24 +317,24 @@ public partial class CollectionEditor
             {
                 SuspendEnabledUpdates();
                 _dirty = true;
-                int index = _listbox.SelectedIndex;
-                if (index == _listbox.Items.Count - 1)
+                int index = _listBox.SelectedIndex;
+                if (index == _listBox.Items.Count - 1)
                 {
                     return;
                 }
 
-                int ti = _listbox.TopIndex;
-                object itemMove = _listbox.Items[index];
-                _listbox.Items[index] = _listbox.Items[index + 1];
-                _listbox.Items[index + 1] = itemMove;
+                int ti = _listBox.TopIndex;
+                object itemMove = _listBox.Items[index];
+                _listBox.Items[index] = _listBox.Items[index + 1];
+                _listBox.Items[index + 1] = itemMove;
 
-                if (ti < _listbox.Items.Count - 1)
+                if (ti < _listBox.Items.Count - 1)
                 {
-                    _listbox.TopIndex = ti + 1;
+                    _listBox.TopIndex = ti + 1;
                 }
 
-                _listbox.ClearSelected();
-                _listbox.SelectedIndex = index + 1;
+                _listBox.ClearSelected();
+                _listBox.SelectedIndex = index + 1;
 
                 // enabling/disabling the buttons has moved the focus to the OK button, move it back to the sender
                 Control ctrlSender = (Control)sender!;
@@ -380,10 +374,10 @@ public partial class CollectionEditor
 
         private void HookEvents()
         {
-            _listbox.KeyDown += ListBox_keyDown;
-            _listbox.DrawItem += ListBox_drawItem;
-            _listbox.SelectedIndexChanged += ListBox_SelectedIndexChanged;
-            _listbox.HandleCreated += ListBox_HandleCreated;
+            _listBox.KeyDown += ListBox_keyDown;
+            _listBox.DrawItem += ListBox_drawItem;
+            _listBox.SelectedIndexChanged += ListBox_SelectedIndexChanged;
+            _listBox.HandleCreated += ListBox_HandleCreated;
             _upButton.Click += UpButton_Click;
             _downButton.Click += DownButton_click;
             _propertyGrid.PropertyValueChanged += PropertyGrid_propertyValueChanged;
@@ -397,7 +391,7 @@ public partial class CollectionEditor
         }
 
         [MemberNotNull(nameof(_membersLabel))]
-        [MemberNotNull(nameof(_listbox))]
+        [MemberNotNull(nameof(_listBox))]
         [MemberNotNull(nameof(_upButton))]
         [MemberNotNull(nameof(_downButton))]
         [MemberNotNull(nameof(_propertiesLabel))]
@@ -413,7 +407,7 @@ public partial class CollectionEditor
         {
             ComponentResourceManager resources = new(typeof(CollectionEditor));
             _membersLabel = new Label();
-            _listbox = new FilterListBox();
+            _listBox = new FilterListBox();
             _upButton = new Button();
             _downButton = new Button();
             _propertiesLabel = new Label();
@@ -434,13 +428,13 @@ public partial class CollectionEditor
             _membersLabel.Margin = new Padding(0, 0, 3, 3);
             _membersLabel.Name = "membersLabel";
 
-            resources.ApplyResources(_listbox, "listbox");
-            _listbox.SelectionMode = (CanSelectMultipleInstances() ? SelectionMode.MultiExtended : SelectionMode.One);
-            _listbox.DrawMode = DrawMode.OwnerDrawFixed;
-            _listbox.FormattingEnabled = true;
-            _listbox.Margin = new Padding(0, 3, 3, 3);
-            _listbox.Name = "listbox";
-            _overArchingTableLayoutPanel.SetRowSpan(_listbox, 2);
+            resources.ApplyResources(_listBox, "listbox");
+            _listBox.SelectionMode = (CanSelectMultipleInstances() ? SelectionMode.MultiExtended : SelectionMode.One);
+            _listBox.DrawMode = DrawMode.OwnerDrawFixed;
+            _listBox.FormattingEnabled = true;
+            _listBox.Margin = new Padding(0, 3, 3, 3);
+            _listBox.Name = "listbox";
+            _overArchingTableLayoutPanel.SetRowSpan(_listBox, 2);
 
             resources.ApplyResources(_upButton, "upButton");
             _upButton.Name = "upButton";
@@ -489,7 +483,7 @@ public partial class CollectionEditor
             _overArchingTableLayoutPanel.Controls.Add(_addRemoveTableLayoutPanel, 0, 3);
             _overArchingTableLayoutPanel.Controls.Add(_propertiesLabel, 2, 0);
             _overArchingTableLayoutPanel.Controls.Add(_membersLabel, 0, 0);
-            _overArchingTableLayoutPanel.Controls.Add(_listbox, 0, 1);
+            _overArchingTableLayoutPanel.Controls.Add(_listBox, 0, 1);
             _overArchingTableLayoutPanel.Controls.Add(_propertyGrid, 2, 1);
             _overArchingTableLayoutPanel.Controls.Add(_okCancelTableLayoutPanel, 0, 4);
             _overArchingTableLayoutPanel.Controls.Add(_upButton, 1, 1);
@@ -523,27 +517,27 @@ public partial class CollectionEditor
 
         private void UpdateItemWidths(ListItem? item)
         {
-            if (!_listbox.IsHandleCreated)
+            if (!_listBox.IsHandleCreated)
             {
                 return;
             }
 
-            using (Graphics g = _listbox.CreateGraphics())
+            using (Graphics g = _listBox.CreateGraphics())
             {
-                int old = _listbox.HorizontalExtent;
+                int old = _listBox.HorizontalExtent;
 
                 if (item is not null)
                 {
                     int w = CalcItemWidth(g, item);
                     if (w > old)
                     {
-                        _listbox.HorizontalExtent = w;
+                        _listBox.HorizontalExtent = w;
                     }
                 }
                 else
                 {
                     int max = 0;
-                    foreach (ListItem i in _listbox.Items)
+                    foreach (ListItem i in _listBox.Items)
                     {
                         int w = CalcItemWidth(g, i);
                         if (w > max)
@@ -552,7 +546,7 @@ public partial class CollectionEditor
                         }
                     }
 
-                    _listbox.HorizontalExtent = max;
+                    _listBox.HorizontalExtent = max;
                 }
             }
         }
@@ -564,14 +558,14 @@ public partial class CollectionEditor
         {
             if (e.Index != -1)
             {
-                ListItem item = (ListItem)_listbox.Items[e.Index];
+                ListItem item = (ListItem)_listBox.Items[e.Index];
 
                 Graphics g = e.Graphics;
 
-                int c = _listbox.Items.Count;
+                int c = _listBox.Items.Count;
                 int maxC = (c > 1) ? c - 1 : c;
                 // We add the +4 is a fudge factor...
-                SizeF sizeW = g.MeasureString(maxC.ToString(CultureInfo.CurrentCulture), _listbox.Font);
+                SizeF sizeW = g.MeasureString(maxC.ToString(CultureInfo.CurrentCulture), _listBox.Font);
 
                 int charactersInNumber = ((int)(Math.Log(maxC) / s_log10) + 1); // Luckily, this is never called if count = 0
                 int w = 4 + charactersInNumber * (Font.Height / 2);
@@ -629,9 +623,9 @@ public partial class CollectionEditor
 
                 // Check to see if we need to change the horizontal extent of the listBox
                 int width = offset + (int)g.MeasureString(itemText, Font).Width;
-                if (width > e.Bounds.Width && _listbox.HorizontalExtent < width)
+                if (width > e.Bounds.Width && _listBox.HorizontalExtent < width)
                 {
-                    _listbox.HorizontalExtent = width;
+                    _listBox.HorizontalExtent = width;
                 }
             }
         }
@@ -639,9 +633,9 @@ public partial class CollectionEditor
         /// <summary>
         ///  Handles keypress events for the list box.
         /// </summary>
-        private void ListBox_keyDown(object? sender, KeyEventArgs keyEvent)
+        private void ListBox_keyDown(object? sender, KeyEventArgs e)
         {
-            switch (keyEvent.KeyData)
+            switch (e.KeyData)
             {
                 case Keys.Delete:
                     PerformRemove();
@@ -684,10 +678,10 @@ public partial class CollectionEditor
 
                 if (_dirty)
                 {
-                    object[] items = new object[_listbox.Items.Count];
+                    object[] items = new object[_listBox.Items.Count];
                     for (int i = 0; i < items.Length; i++)
                     {
-                        items[i] = ((ListItem)_listbox.Items[i]).Value;
+                        items[i] = ((ListItem)_listBox.Items[i]).Value;
                     }
 
                     Items = items;
@@ -708,7 +702,7 @@ public partial class CollectionEditor
                 _createdItems?.Clear();
                 _originalItems?.Clear();
 
-                _listbox.Items.Clear();
+                _listBox.Items.Clear();
                 _dirty = false;
             }
             catch (Exception ex)
@@ -754,7 +748,7 @@ public partial class CollectionEditor
             _originalItems.Clear();
 
             // Now update the list box.
-            _listbox.Items.Clear();
+            _listBox.Items.Clear();
             _propertyGrid.Site = new PropertyGridSite(Context, _propertyGrid);
             if (EditValue is not null)
             {
@@ -764,13 +758,13 @@ public partial class CollectionEditor
                     object[] items = Items;
                     for (int i = 0; i < items.Length; i++)
                     {
-                        _listbox.Items.Add(new ListItem(_editor, items[i]));
+                        _listBox.Items.Add(new ListItem(_editor, items[i]));
                         _originalItems.Add(items[i]);
                     }
 
-                    if (_listbox.Items.Count > 0)
+                    if (_listBox.Items.Count > 0)
                     {
-                        _listbox.SelectedIndex = 0;
+                        _listBox.SelectedIndex = 0;
                     }
                 }
                 finally
@@ -808,16 +802,16 @@ public partial class CollectionEditor
         /// </summary>
         private void PerformRemove()
         {
-            int index = _listbox.SelectedIndex;
+            int index = _listBox.SelectedIndex;
 
             if (index != -1)
             {
                 SuspendEnabledUpdates();
                 try
                 {
-                    if (_listbox.SelectedItems.Count > 1)
+                    if (_listBox.SelectedItems.Count > 1)
                     {
-                        List<ListItem> toBeDeleted = _listbox.SelectedItems.Cast<ListItem>().ToList();
+                        List<ListItem> toBeDeleted = _listBox.SelectedItems.Cast<ListItem>().ToList();
                         foreach (ListItem item in toBeDeleted)
                         {
                             RemoveInternal(item);
@@ -825,16 +819,16 @@ public partial class CollectionEditor
                     }
                     else
                     {
-                        RemoveInternal((ListItem?)_listbox.SelectedItem);
+                        RemoveInternal((ListItem?)_listBox.SelectedItem);
                     }
 
-                    if (index < _listbox.Items.Count)
+                    if (index < _listBox.Items.Count)
                     {
-                        _listbox.SelectedIndex = index;
+                        _listBox.SelectedIndex = index;
                     }
-                    else if (_listbox.Items.Count > 0)
+                    else if (_listBox.Items.Count > 0)
                     {
-                        _listbox.SelectedIndex = _listbox.Items.Count - 1;
+                        _listBox.SelectedIndex = _listBox.Items.Count - 1;
                     }
                 }
                 finally
@@ -855,10 +849,10 @@ public partial class CollectionEditor
             SuspendEnabledUpdates();
             try
             {
-                int selectedItem = _listbox.SelectedIndex;
+                int selectedItem = _listBox.SelectedIndex;
                 if (selectedItem >= 0)
                 {
-                    _listbox.RefreshItem(_listbox.SelectedIndex);
+                    _listBox.RefreshItem(_listBox.SelectedIndex);
                 }
             }
             finally
@@ -868,10 +862,10 @@ public partial class CollectionEditor
 
             // if a property changes, invalidate the grid in case it affects the item's name.
             UpdateItemWidths(null);
-            _listbox.Invalidate();
+            _listBox.Invalidate();
 
             // also update the string above the grid.
-            _propertiesLabel.Text = string.Format(SR.CollectionEditorProperties, GetDisplayText((ListItem?)_listbox.SelectedItem));
+            _propertiesLabel.Text = string.Format(SR.CollectionEditorProperties, GetDisplayText((ListItem?)_listBox.SelectedItem));
         }
 
         /// <summary>
@@ -889,7 +883,7 @@ public partial class CollectionEditor
                 {
                     DestroyInstance(item.Value);
                     _createdItems.Remove(item.Value);
-                    _listbox.Items.Remove(item);
+                    _listBox.Items.Remove(item);
                 }
                 else
                 {
@@ -900,7 +894,7 @@ public partial class CollectionEditor
                             _removedItems ??= new List<object>();
 
                             _removedItems.Add(item.Value);
-                            _listbox.Items.Remove(item);
+                            _listBox.Items.Remove(item);
                         }
                         else
                         {
@@ -973,7 +967,7 @@ public partial class CollectionEditor
                 }
 
                 // This is cached across requests, so reset the initial focus.
-                ActiveControl = _listbox;
+                ActiveControl = _listBox;
                 result = base.ShowEditorDialog(edSvc);
             }
             finally
@@ -992,7 +986,7 @@ public partial class CollectionEditor
         /// </summary>
         private void UpButton_Click(object? sender, EventArgs e)
         {
-            int index = _listbox.SelectedIndex;
+            int index = _listBox.SelectedIndex;
             if (index == 0)
             {
                 return;
@@ -1002,18 +996,18 @@ public partial class CollectionEditor
             try
             {
                 SuspendEnabledUpdates();
-                int ti = _listbox.TopIndex;
-                object itemMove = _listbox.Items[index];
-                _listbox.Items[index] = _listbox.Items[index - 1];
-                _listbox.Items[index - 1] = itemMove;
+                int ti = _listBox.TopIndex;
+                object itemMove = _listBox.Items[index];
+                _listBox.Items[index] = _listBox.Items[index - 1];
+                _listBox.Items[index - 1] = itemMove;
 
                 if (ti > 0)
                 {
-                    _listbox.TopIndex = ti - 1;
+                    _listBox.TopIndex = ti - 1;
                 }
 
-                _listbox.ClearSelected();
-                _listbox.SelectedIndex = index - 1;
+                _listBox.ClearSelected();
+                _listBox.SelectedIndex = index - 1;
 
                 // enabling/disabling the buttons has moved the focus to the OK button, move it back to the sender
                 Control ctrlSender = (Control)sender!;
@@ -1040,14 +1034,14 @@ public partial class CollectionEditor
                 return;
             }
 
-            bool editEnabled = (_listbox.SelectedItem is not null) && CollectionEditable;
-            _removeButton.Enabled = editEnabled && AllowRemoveInstance(((ListItem)_listbox.SelectedItem!).Value);
-            _upButton.Enabled = editEnabled && _listbox.Items.Count > 1;
-            _downButton.Enabled = editEnabled && _listbox.Items.Count > 1;
+            bool editEnabled = (_listBox.SelectedItem is not null) && CollectionEditable;
+            _removeButton.Enabled = editEnabled && AllowRemoveInstance(((ListItem)_listBox.SelectedItem!).Value);
+            _upButton.Enabled = editEnabled && _listBox.Items.Count > 1;
+            _downButton.Enabled = editEnabled && _listBox.Items.Count > 1;
             _propertyGrid.Enabled = editEnabled;
             _addButton.Enabled = CollectionEditable;
 
-            if (_listbox.SelectedItem is not null)
+            if (_listBox.SelectedItem is not null)
             {
                 object[] items;
 
@@ -1055,22 +1049,22 @@ public partial class CollectionEditor
                 // otherwise, the user will be presented with a batch of read only properties, which isn't terribly useful.
                 if (IsImmutable)
                 {
-                    items = new object[] { new SelectionWrapper(CollectionType, CollectionItemType, _listbox, _listbox.SelectedItems) };
+                    items = new object[] { new SelectionWrapper(CollectionType, CollectionItemType, _listBox, _listBox.SelectedItems) };
                 }
                 else
                 {
-                    items = new object[_listbox.SelectedItems.Count];
+                    items = new object[_listBox.SelectedItems.Count];
                     for (int i = 0; i < items.Length; i++)
                     {
-                        items[i] = ((ListItem)_listbox.SelectedItems[i]!).Value;
+                        items[i] = ((ListItem)_listBox.SelectedItems[i]!).Value;
                     }
                 }
 
-                int selectedItemCount = _listbox.SelectedItems.Count;
+                int selectedItemCount = _listBox.SelectedItems.Count;
                 if (selectedItemCount is 1 or -1)
                 {
                     // handle both single select listBoxes and a single item selected in a multi-select listBox
-                    _propertiesLabel.Text = string.Format(SR.CollectionEditorProperties, GetDisplayText((ListItem)_listbox.SelectedItem));
+                    _propertiesLabel.Text = string.Format(SR.CollectionEditorProperties, GetDisplayText((ListItem)_listBox.SelectedItem));
                 }
                 else
                 {

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CollectionEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CollectionEditor.cs
@@ -92,7 +92,10 @@ public partial class CollectionEditor : UITypeEditor
     {
         ArgumentNullException.ThrowIfNull(itemType);
 
-        if (Context.TryGetService(out IDesignerHost? host) && typeof(IComponent).IsAssignableFrom(itemType))
+        Context.TryGetService(out IDesignerHost? host);
+        host ??= (Context?.Instance as Control)?.Site?.GetService<IDesignerHost>();
+
+        if (host is not null && typeof(IComponent).IsAssignableFrom(itemType))
         {
             IComponent instance = host.CreateComponent(itemType);
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CollectionEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CollectionEditor.cs
@@ -92,10 +92,7 @@ public partial class CollectionEditor : UITypeEditor
     {
         ArgumentNullException.ThrowIfNull(itemType);
 
-        Context.TryGetService(out IDesignerHost? host);
-        host ??= (Context?.Instance as Control)?.Site?.GetService<IDesignerHost>();
-
-        if (host is not null && typeof(IComponent).IsAssignableFrom(itemType))
+        if (Context.TryGetService(out IDesignerHost? host) && typeof(IComponent).IsAssignableFrom(itemType))
         {
             IComponent instance = host.CreateComponent(itemType);
 

--- a/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/MainForm.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/MainForm.Designer.cs
@@ -1,168 +1,172 @@
 ﻿namespace TestConsole;
 
-partial class MainForm {
-/// <summary>
-/// Required designer variable.
-/// </summary>
-private System.ComponentModel.IContainer components = null;
+partial class MainForm
+{
+    /// <summary>
+    /// Required designer variable.
+    /// </summary>
+    private System.ComponentModel.IContainer components = null;
 
-/// <summary>
-/// Clean up any resources being used.
-/// </summary>
-/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
-protected override void Dispose ( bool disposing ) {
-    if ( disposing && ( components != null ) ) {
-        components.Dispose();
+    /// <summary>
+    /// Clean up any resources being used.
+    /// </summary>
+    /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing && (components != null))
+        {
+            components.Dispose();
+        }
+        base.Dispose(disposing);
     }
-    base.Dispose ( disposing );
-}
 
-#region Windows Form Designer generated code
+    #region Windows Form Designer generated code
 
-/// <summary>
-/// Required method for Designer support - do not modify
-/// the contents of this method with the code editor.
-/// </summary>
-private void InitializeComponent() {
-    System.ComponentModel.ComponentResourceManager resources = new( typeof( MainForm ) );
-    this.splitContainer = new System.Windows.Forms.SplitContainer();
-    this.tabControl1 = new System.Windows.Forms.TabControl();
-    this.tabPage1 = new System.Windows.Forms.TabPage();
-    this.tabPage2 = new System.Windows.Forms.TabPage();
-    this.tabPage3 = new System.Windows.Forms.TabPage();
-    this.tabPage4 = new System.Windows.Forms.TabPage();
-    this.tabPage5 = new System.Windows.Forms.TabPage();
-    this.propertyGrid = new System.Windows.Forms.PropertyGrid();
-    this.menuStrip1 = new System.Windows.Forms.MenuStrip();
-    this.editToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-    this.ToolStripMenuItemUnDo = new System.Windows.Forms.ToolStripMenuItem();
-    this.ToolStripMenuItemReDo = new System.Windows.Forms.ToolStripMenuItem();
-    this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
-    this.ToolStripMenuItemCut = new System.Windows.Forms.ToolStripMenuItem();
-    this.ToolStripMenuItemCopy = new System.Windows.Forms.ToolStripMenuItem();
-    this.ToolStripMenuItemPaste = new System.Windows.Forms.ToolStripMenuItem();
-    this.ToolStripMenuItemDelete = new System.Windows.Forms.ToolStripMenuItem();
-    this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
-    this.toolStripMenuItemTools = new System.Windows.Forms.ToolStripMenuItem();
-    this.toolStripMenuItemTabOrder = new System.Windows.Forms.ToolStripMenuItem();
-    this.helpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-    this.ToolStripMenuItemAbout = new System.Windows.Forms.ToolStripMenuItem();
-    this.splitContainer.Panel1.SuspendLayout();
-    this.splitContainer.Panel2.SuspendLayout();
-    this.splitContainer.SuspendLayout();
-    this.tabControl1.SuspendLayout();
-    this.menuStrip1.SuspendLayout();
-    this.SuspendLayout();
-    // 
-    // splitContainer
-    // 
-    this.splitContainer.Dock = System.Windows.Forms.DockStyle.Fill;
-    this.splitContainer.Location = new System.Drawing.Point( 0, 28 );
-    this.splitContainer.Margin = new System.Windows.Forms.Padding( 4 );
-    this.splitContainer.Name = "splitContainer";
-    // 
-    // splitContainer.Panel1
-    // 
-    this.splitContainer.Panel1.BackColor = System.Drawing.SystemColors.Window;
-    this.splitContainer.Panel1.Controls.Add( this.tabControl1 );
-    // 
-    // splitContainer.Panel2
-    // 
-    this.splitContainer.Panel2.Controls.Add( this.propertyGrid );
-    this.splitContainer.Size = new System.Drawing.Size( 824, 502 );
-    this.splitContainer.SplitterDistance = 593;
-    this.splitContainer.SplitterWidth = 5;
-    this.splitContainer.TabIndex = 0;
-    // 
-    // tabControl1
-    // 
-    this.tabControl1.Controls.Add( this.tabPage1 );
-    this.tabControl1.Controls.Add( this.tabPage2 );
-    this.tabControl1.Controls.Add( this.tabPage3 );
-    this.tabControl1.Controls.Add( this.tabPage4 );
-    this.tabControl1.Controls.Add( this.tabPage5 );
-    this.tabControl1.Dock = System.Windows.Forms.DockStyle.Fill;
-    this.tabControl1.Location = new System.Drawing.Point( 0, 0 );
-    this.tabControl1.Name = "tabControl1";
-    this.tabControl1.SelectedIndex = 0;
-    this.tabControl1.Size = new System.Drawing.Size( 593, 502 );
-    this.tabControl1.TabIndex = 0;
-    // 
-    // tabPage1
-    // 
-    this.tabPage1.Location = new System.Drawing.Point( 4, 25 );
-    this.tabPage1.Name = "tabPage1";
-    this.tabPage1.Padding = new System.Windows.Forms.Padding( 3 );
-    this.tabPage1.Size = new System.Drawing.Size( 585, 473 );
-    this.tabPage1.TabIndex = 0;
-    this.tabPage1.Text = "tabPage1";
-    this.tabPage1.UseVisualStyleBackColor = true;
-    // 
-    // tabPage2
-    // 
-    this.tabPage2.Location = new System.Drawing.Point( 4, 25 );
-    this.tabPage2.Name = "tabPage2";
-    this.tabPage2.Padding = new System.Windows.Forms.Padding( 3 );
-    this.tabPage2.Size = new System.Drawing.Size( 585, 473 );
-    this.tabPage2.TabIndex = 1;
-    this.tabPage2.Text = "tabPage2";
-    this.tabPage2.UseVisualStyleBackColor = true;
-    // 
-    // tabPage3
-    // 
-    this.tabPage3.Location = new System.Drawing.Point( 4, 25 );
-    this.tabPage3.Name = "tabPage3";
-    this.tabPage3.Padding = new System.Windows.Forms.Padding( 3 );
-    this.tabPage3.Size = new System.Drawing.Size( 585, 473 );
-    this.tabPage3.TabIndex = 2;
-    this.tabPage3.Text = "tabPage3";
-    this.tabPage3.UseVisualStyleBackColor = true;
-    // 
-    // tabPage4
-    // 
-    this.tabPage4.Location = new System.Drawing.Point( 4, 25 );
-    this.tabPage4.Name = "tabPage4";
-    this.tabPage4.Padding = new System.Windows.Forms.Padding( 3 );
-    this.tabPage4.Size = new System.Drawing.Size( 585, 473 );
-    this.tabPage4.TabIndex = 3;
-    this.tabPage4.Text = "tabPage4";
-    this.tabPage4.UseVisualStyleBackColor = true;
-    // 
-    // tabPage5
-    // 
-    this.tabPage5.Location = new System.Drawing.Point(4, 25);
-    this.tabPage5.Name = "tabPage5";
-    this.tabPage5.Padding = new System.Windows.Forms.Padding(3);
-    this.tabPage5.Size = new System.Drawing.Size(585, 473);
-    this.tabPage5.TabIndex = 3;
-    this.tabPage5.Text = "tabPage5";
-    this.tabPage5.UseVisualStyleBackColor = true;
-    // 
-    // propertyGrid
-    // 
-    this.propertyGrid.Dock = System.Windows.Forms.DockStyle.Fill;
-    this.propertyGrid.Location = new System.Drawing.Point( 0, 0 );
-    this.propertyGrid.Margin = new System.Windows.Forms.Padding( 4 );
-    this.propertyGrid.Name = "propertyGrid";
-    this.propertyGrid.Size = new System.Drawing.Size( 226, 502 );
-    this.propertyGrid.TabIndex = 0;
-    // 
-    // menuStrip1
-    // 
-    this.menuStrip1.Items.AddRange( new System.Windows.Forms.ToolStripItem[] {
+    /// <summary>
+    /// Required method for Designer support - do not modify
+    /// the contents of this method with the code editor.
+    /// </summary>
+    private void InitializeComponent()
+    {
+        System.ComponentModel.ComponentResourceManager resources = new(typeof(MainForm));
+        this.splitContainer = new System.Windows.Forms.SplitContainer();
+        this.tabControl1 = new System.Windows.Forms.TabControl();
+        this.tabPage1 = new System.Windows.Forms.TabPage();
+        this.tabPage2 = new System.Windows.Forms.TabPage();
+        this.tabPage3 = new System.Windows.Forms.TabPage();
+        this.tabPage4 = new System.Windows.Forms.TabPage();
+        this.tabPage5 = new System.Windows.Forms.TabPage();
+        this.propertyGrid = new System.Windows.Forms.PropertyGrid();
+        this.menuStrip1 = new System.Windows.Forms.MenuStrip();
+        this.editToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+        this.ToolStripMenuItemUnDo = new System.Windows.Forms.ToolStripMenuItem();
+        this.ToolStripMenuItemReDo = new System.Windows.Forms.ToolStripMenuItem();
+        this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
+        this.ToolStripMenuItemCut = new System.Windows.Forms.ToolStripMenuItem();
+        this.ToolStripMenuItemCopy = new System.Windows.Forms.ToolStripMenuItem();
+        this.ToolStripMenuItemPaste = new System.Windows.Forms.ToolStripMenuItem();
+        this.ToolStripMenuItemDelete = new System.Windows.Forms.ToolStripMenuItem();
+        this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
+        this.toolStripMenuItemTools = new System.Windows.Forms.ToolStripMenuItem();
+        this.toolStripMenuItemTabOrder = new System.Windows.Forms.ToolStripMenuItem();
+        this.helpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+        this.ToolStripMenuItemAbout = new System.Windows.Forms.ToolStripMenuItem();
+        this.splitContainer.Panel1.SuspendLayout();
+        this.splitContainer.Panel2.SuspendLayout();
+        this.splitContainer.SuspendLayout();
+        this.tabControl1.SuspendLayout();
+        this.menuStrip1.SuspendLayout();
+        this.SuspendLayout();
+        // 
+        // splitContainer
+        // 
+        this.splitContainer.Dock = System.Windows.Forms.DockStyle.Fill;
+        this.splitContainer.Location = new System.Drawing.Point(0, 28);
+        this.splitContainer.Margin = new System.Windows.Forms.Padding(4);
+        this.splitContainer.Name = "splitContainer";
+        // 
+        // splitContainer.Panel1
+        // 
+        this.splitContainer.Panel1.BackColor = System.Drawing.SystemColors.Window;
+        this.splitContainer.Panel1.Controls.Add(this.tabControl1);
+        // 
+        // splitContainer.Panel2
+        // 
+        this.splitContainer.Panel2.Controls.Add(this.propertyGrid);
+        this.splitContainer.Size = new System.Drawing.Size(824, 502);
+        this.splitContainer.SplitterDistance = 593;
+        this.splitContainer.SplitterWidth = 5;
+        this.splitContainer.TabIndex = 0;
+        // 
+        // tabControl1
+        // 
+        this.tabControl1.Controls.Add(this.tabPage1);
+        this.tabControl1.Controls.Add(this.tabPage2);
+        this.tabControl1.Controls.Add(this.tabPage3);
+        this.tabControl1.Controls.Add(this.tabPage4);
+        this.tabControl1.Controls.Add(this.tabPage5);
+        this.tabControl1.Dock = System.Windows.Forms.DockStyle.Fill;
+        this.tabControl1.Location = new System.Drawing.Point(0, 0);
+        this.tabControl1.Name = "tabControl1";
+        this.tabControl1.SelectedIndex = 0;
+        this.tabControl1.Size = new System.Drawing.Size(593, 502);
+        this.tabControl1.TabIndex = 0;
+        // 
+        // tabPage1
+        // 
+        this.tabPage1.Location = new System.Drawing.Point(4, 25);
+        this.tabPage1.Name = "tabPage1";
+        this.tabPage1.Padding = new System.Windows.Forms.Padding(3);
+        this.tabPage1.Size = new System.Drawing.Size(585, 473);
+        this.tabPage1.TabIndex = 0;
+        this.tabPage1.Text = "tabPage1";
+        this.tabPage1.UseVisualStyleBackColor = true;
+        // 
+        // tabPage2
+        // 
+        this.tabPage2.Location = new System.Drawing.Point(4, 25);
+        this.tabPage2.Name = "tabPage2";
+        this.tabPage2.Padding = new System.Windows.Forms.Padding(3);
+        this.tabPage2.Size = new System.Drawing.Size(585, 473);
+        this.tabPage2.TabIndex = 1;
+        this.tabPage2.Text = "tabPage2";
+        this.tabPage2.UseVisualStyleBackColor = true;
+        // 
+        // tabPage3
+        // 
+        this.tabPage3.Location = new System.Drawing.Point(4, 25);
+        this.tabPage3.Name = "tabPage3";
+        this.tabPage3.Padding = new System.Windows.Forms.Padding(3);
+        this.tabPage3.Size = new System.Drawing.Size(585, 473);
+        this.tabPage3.TabIndex = 2;
+        this.tabPage3.Text = "tabPage3";
+        this.tabPage3.UseVisualStyleBackColor = true;
+        // 
+        // tabPage4
+        // 
+        this.tabPage4.Location = new System.Drawing.Point(4, 25);
+        this.tabPage4.Name = "tabPage4";
+        this.tabPage4.Padding = new System.Windows.Forms.Padding(3);
+        this.tabPage4.Size = new System.Drawing.Size(585, 473);
+        this.tabPage4.TabIndex = 3;
+        this.tabPage4.Text = "tabPage4";
+        this.tabPage4.UseVisualStyleBackColor = true;
+        // 
+        // tabPage5
+        // 
+        this.tabPage5.Location = new System.Drawing.Point(4, 25);
+        this.tabPage5.Name = "tabPage5";
+        this.tabPage5.Padding = new System.Windows.Forms.Padding(3);
+        this.tabPage5.Size = new System.Drawing.Size(585, 473);
+        this.tabPage5.TabIndex = 3;
+        this.tabPage5.Text = "tabPage5";
+        this.tabPage5.UseVisualStyleBackColor = true;
+        // 
+        // propertyGrid
+        // 
+        this.propertyGrid.Dock = System.Windows.Forms.DockStyle.Fill;
+        this.propertyGrid.Location = new System.Drawing.Point(0, 0);
+        this.propertyGrid.Margin = new System.Windows.Forms.Padding(4);
+        this.propertyGrid.Name = "propertyGrid";
+        this.propertyGrid.Size = new System.Drawing.Size(226, 502);
+        this.propertyGrid.TabIndex = 0;
+        // 
+        // menuStrip1
+        // 
+        this.menuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
         this.editToolStripMenuItem,
         this.toolStripMenuItemTools,
-        this.helpToolStripMenuItem} );
-    this.menuStrip1.Location = new System.Drawing.Point( 0, 0 );
-    this.menuStrip1.Name = "menuStrip1";
-    this.menuStrip1.Padding = new System.Windows.Forms.Padding( 8, 2, 0, 2 );
-    this.menuStrip1.Size = new System.Drawing.Size( 824, 28 );
-    this.menuStrip1.TabIndex = 1;
-    this.menuStrip1.Text = "menuStrip1";
-    // 
-    // editToolStripMenuItem
-    // 
-    this.editToolStripMenuItem.DropDownItems.AddRange( new System.Windows.Forms.ToolStripItem[] {
+        this.helpToolStripMenuItem});
+        this.menuStrip1.Location = new System.Drawing.Point(0, 0);
+        this.menuStrip1.Name = "menuStrip1";
+        this.menuStrip1.Padding = new System.Windows.Forms.Padding(8, 2, 0, 2);
+        this.menuStrip1.Size = new System.Drawing.Size(824, 28);
+        this.menuStrip1.TabIndex = 1;
+        this.menuStrip1.Text = "menuStrip1";
+        // 
+        // editToolStripMenuItem
+        // 
+        this.editToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
         this.ToolStripMenuItemUnDo,
         this.ToolStripMenuItemReDo,
         this.toolStripSeparator3,
@@ -170,153 +174,152 @@ private void InitializeComponent() {
         this.ToolStripMenuItemCopy,
         this.ToolStripMenuItemPaste,
         this.ToolStripMenuItemDelete,
-        this.toolStripSeparator4} );
-    this.editToolStripMenuItem.Name = "editToolStripMenuItem";
-    this.editToolStripMenuItem.Size = new System.Drawing.Size( 47, 24 );
-    this.editToolStripMenuItem.Text = "&Edit";
-    // 
-    // ToolStripMenuItemUnDo
-    // 
-    this.ToolStripMenuItemUnDo.Name = "ToolStripMenuItemUnDo";
-    this.ToolStripMenuItemUnDo.ShortcutKeys = ((System.Windows.Forms.Keys) ((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Z)));
-    this.ToolStripMenuItemUnDo.Size = new System.Drawing.Size( 165, 24 );
-    this.ToolStripMenuItemUnDo.Text = "Undo";
-    this.ToolStripMenuItemUnDo.Click += new System.EventHandler( this.undoToolStripMenuItem_Click );
-    // 
-    // ToolStripMenuItemReDo
-    // 
-    this.ToolStripMenuItemReDo.Name = "ToolStripMenuItemReDo";
-    this.ToolStripMenuItemReDo.ShortcutKeys = ((System.Windows.Forms.Keys) ((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Y)));
-    this.ToolStripMenuItemReDo.Size = new System.Drawing.Size( 165, 24 );
-    this.ToolStripMenuItemReDo.Text = "Redo";
-    this.ToolStripMenuItemReDo.Click += new System.EventHandler( this.redoToolStripMenuItem_Click );
-    // 
-    // toolStripSeparator3
-    // 
-    this.toolStripSeparator3.Name = "toolStripSeparator3";
-    this.toolStripSeparator3.Size = new System.Drawing.Size( 162, 6 );
-    // 
-    // ToolStripMenuItemCut
-    // 
-    this.ToolStripMenuItemCut.Image = ((System.Drawing.Image) (resources.GetObject( "ToolStripMenuItemCut.Image" )));
-    this.ToolStripMenuItemCut.ImageTransparentColor = System.Drawing.Color.Magenta;
-    this.ToolStripMenuItemCut.Name = "ToolStripMenuItemCut";
-    this.ToolStripMenuItemCut.ShortcutKeys = ((System.Windows.Forms.Keys) ((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.X)));
-    this.ToolStripMenuItemCut.Size = new System.Drawing.Size( 165, 24 );
-    this.ToolStripMenuItemCut.Text = "Cut";
-    this.ToolStripMenuItemCut.Click += new System.EventHandler( this.OnMenuClick );
-    // 
-    // ToolStripMenuItemCopy
-    // 
-    this.ToolStripMenuItemCopy.Image = ((System.Drawing.Image) (resources.GetObject( "ToolStripMenuItemCopy.Image" )));
-    this.ToolStripMenuItemCopy.ImageTransparentColor = System.Drawing.Color.Magenta;
-    this.ToolStripMenuItemCopy.Name = "ToolStripMenuItemCopy";
-    this.ToolStripMenuItemCopy.ShortcutKeys = ((System.Windows.Forms.Keys) ((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.C)));
-    this.ToolStripMenuItemCopy.Size = new System.Drawing.Size( 165, 24 );
-    this.ToolStripMenuItemCopy.Text = "Copy";
-    this.ToolStripMenuItemCopy.Click += new System.EventHandler( this.OnMenuClick );
-    // 
-    // ToolStripMenuItemPaste
-    // 
-    this.ToolStripMenuItemPaste.Image = ((System.Drawing.Image) (resources.GetObject( "ToolStripMenuItemPaste.Image" )));
-    this.ToolStripMenuItemPaste.ImageTransparentColor = System.Drawing.Color.Magenta;
-    this.ToolStripMenuItemPaste.Name = "ToolStripMenuItemPaste";
-    this.ToolStripMenuItemPaste.ShortcutKeys = ((System.Windows.Forms.Keys) ((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.V)));
-    this.ToolStripMenuItemPaste.Size = new System.Drawing.Size( 165, 24 );
-    this.ToolStripMenuItemPaste.Text = "Paste";
-    this.ToolStripMenuItemPaste.Click += new System.EventHandler( this.OnMenuClick );
-    // 
-    // ToolStripMenuItemDelete
-    // 
-    this.ToolStripMenuItemDelete.Name = "ToolStripMenuItemDelete";
-    this.ToolStripMenuItemDelete.ShortcutKeys = System.Windows.Forms.Keys.Delete;
-    this.ToolStripMenuItemDelete.Size = new System.Drawing.Size( 165, 24 );
-    this.ToolStripMenuItemDelete.Text = "Delete";
-    this.ToolStripMenuItemDelete.Click += new System.EventHandler( this.OnMenuClick );
-    // 
-    // toolStripSeparator4
-    // 
-    this.toolStripSeparator4.Name = "toolStripSeparator4";
-    this.toolStripSeparator4.Size = new System.Drawing.Size( 162, 6 );
-    // 
-    // toolStripMenuItemTools
-    // 
-    this.toolStripMenuItemTools.DropDownItems.AddRange( new System.Windows.Forms.ToolStripItem[] {
-        this.toolStripMenuItemTabOrder} );
-    this.toolStripMenuItemTools.Name = "toolStripMenuItemTools";
-    this.toolStripMenuItemTools.Size = new System.Drawing.Size( 57, 24 );
-    this.toolStripMenuItemTools.Text = "&Tools";
-    // 
-    // toolStripMenuItemTabOrder
-    // 
-    this.toolStripMenuItemTabOrder.Name = "toolStripMenuItemTabOrder";
-    this.toolStripMenuItemTabOrder.Size = new System.Drawing.Size( 145, 24 );
-    this.toolStripMenuItemTabOrder.Text = "Tab Order";
-    this.toolStripMenuItemTabOrder.Click += new System.EventHandler( this.toolStripMenuItemTabOrder_Click );
-    // 
-    // helpToolStripMenuItem
-    // 
-    this.helpToolStripMenuItem.DropDownItems.AddRange( new System.Windows.Forms.ToolStripItem[] {
-        this.ToolStripMenuItemAbout} );
-    this.helpToolStripMenuItem.Name = "helpToolStripMenuItem";
-    this.helpToolStripMenuItem.Size = new System.Drawing.Size( 53, 24 );
-    this.helpToolStripMenuItem.Text = "&Help";
-    // 
-    // ToolStripMenuItemAbout
-    // 
-    this.ToolStripMenuItemAbout.Name = "ToolStripMenuItemAbout";
-    this.ToolStripMenuItemAbout.Size = new System.Drawing.Size( 128, 24 );
-    this.ToolStripMenuItemAbout.Text = "About...";
-    this.ToolStripMenuItemAbout.Click += new System.EventHandler( this.OnAbout );
-    // 
-    // MainForm
-    // 
-    this.AutoScaleDimensions = new System.Drawing.SizeF( 8F, 16F );
-    this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-    this.ClientSize = new System.Drawing.Size( 824, 530 );
-    this.Controls.Add( this.splitContainer );
-    this.Controls.Add( this.menuStrip1 );
-    this.Icon = ((System.Drawing.Icon) (resources.GetObject( "$this.Icon" )));
-    this.MainMenuStrip = this.menuStrip1;
-    this.Margin = new System.Windows.Forms.Padding( 4 );
-    this.Name = "MainForm";
-    this.Text = "Tiny Form Designer";
-    this.Load += new System.EventHandler( this.MainForm_Load );
-    this.splitContainer.Panel1.ResumeLayout( false );
-    this.splitContainer.Panel2.ResumeLayout( false );
-    this.splitContainer.ResumeLayout( false );
-    this.tabControl1.ResumeLayout( false );
-    this.menuStrip1.ResumeLayout( false );
-    this.menuStrip1.PerformLayout();
-    this.ResumeLayout( false );
-    this.PerformLayout();
+        this.toolStripSeparator4});
+        this.editToolStripMenuItem.Name = "editToolStripMenuItem";
+        this.editToolStripMenuItem.Size = new System.Drawing.Size(47, 24);
+        this.editToolStripMenuItem.Text = "&Edit";
+        // 
+        // ToolStripMenuItemUnDo
+        // 
+        this.ToolStripMenuItemUnDo.Name = "ToolStripMenuItemUnDo";
+        this.ToolStripMenuItemUnDo.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Z)));
+        this.ToolStripMenuItemUnDo.Size = new System.Drawing.Size(165, 24);
+        this.ToolStripMenuItemUnDo.Text = "Undo";
+        this.ToolStripMenuItemUnDo.Click += new System.EventHandler(this.undoToolStripMenuItem_Click);
+        // 
+        // ToolStripMenuItemReDo
+        // 
+        this.ToolStripMenuItemReDo.Name = "ToolStripMenuItemReDo";
+        this.ToolStripMenuItemReDo.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Y)));
+        this.ToolStripMenuItemReDo.Size = new System.Drawing.Size(165, 24);
+        this.ToolStripMenuItemReDo.Text = "Redo";
+        this.ToolStripMenuItemReDo.Click += new System.EventHandler(this.redoToolStripMenuItem_Click);
+        // 
+        // toolStripSeparator3
+        // 
+        this.toolStripSeparator3.Name = "toolStripSeparator3";
+        this.toolStripSeparator3.Size = new System.Drawing.Size(162, 6);
+        // 
+        // ToolStripMenuItemCut
+        // 
+        this.ToolStripMenuItemCut.Image = ((System.Drawing.Image)(resources.GetObject("ToolStripMenuItemCut.Image")));
+        this.ToolStripMenuItemCut.ImageTransparentColor = System.Drawing.Color.Magenta;
+        this.ToolStripMenuItemCut.Name = "ToolStripMenuItemCut";
+        this.ToolStripMenuItemCut.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.X)));
+        this.ToolStripMenuItemCut.Size = new System.Drawing.Size(165, 24);
+        this.ToolStripMenuItemCut.Text = "Cut";
+        this.ToolStripMenuItemCut.Click += new System.EventHandler(this.OnMenuClick);
+        // 
+        // ToolStripMenuItemCopy
+        // 
+        this.ToolStripMenuItemCopy.Image = ((System.Drawing.Image)(resources.GetObject("ToolStripMenuItemCopy.Image")));
+        this.ToolStripMenuItemCopy.ImageTransparentColor = System.Drawing.Color.Magenta;
+        this.ToolStripMenuItemCopy.Name = "ToolStripMenuItemCopy";
+        this.ToolStripMenuItemCopy.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.C)));
+        this.ToolStripMenuItemCopy.Size = new System.Drawing.Size(165, 24);
+        this.ToolStripMenuItemCopy.Text = "Copy";
+        this.ToolStripMenuItemCopy.Click += new System.EventHandler(this.OnMenuClick);
+        // 
+        // ToolStripMenuItemPaste
+        // 
+        this.ToolStripMenuItemPaste.Image = ((System.Drawing.Image)(resources.GetObject("ToolStripMenuItemPaste.Image")));
+        this.ToolStripMenuItemPaste.ImageTransparentColor = System.Drawing.Color.Magenta;
+        this.ToolStripMenuItemPaste.Name = "ToolStripMenuItemPaste";
+        this.ToolStripMenuItemPaste.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.V)));
+        this.ToolStripMenuItemPaste.Size = new System.Drawing.Size(165, 24);
+        this.ToolStripMenuItemPaste.Text = "Paste";
+        this.ToolStripMenuItemPaste.Click += new System.EventHandler(this.OnMenuClick);
+        // 
+        // ToolStripMenuItemDelete
+        // 
+        this.ToolStripMenuItemDelete.Name = "ToolStripMenuItemDelete";
+        this.ToolStripMenuItemDelete.ShortcutKeys = System.Windows.Forms.Keys.Delete;
+        this.ToolStripMenuItemDelete.Size = new System.Drawing.Size(165, 24);
+        this.ToolStripMenuItemDelete.Text = "Delete";
+        this.ToolStripMenuItemDelete.Click += new System.EventHandler(this.OnMenuClick);
+        // 
+        // toolStripSeparator4
+        // 
+        this.toolStripSeparator4.Name = "toolStripSeparator4";
+        this.toolStripSeparator4.Size = new System.Drawing.Size(162, 6);
+        // 
+        // toolStripMenuItemTools
+        // 
+        this.toolStripMenuItemTools.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+        this.toolStripMenuItemTabOrder});
+        this.toolStripMenuItemTools.Name = "toolStripMenuItemTools";
+        this.toolStripMenuItemTools.Size = new System.Drawing.Size(57, 24);
+        this.toolStripMenuItemTools.Text = "&Tools";
+        // 
+        // toolStripMenuItemTabOrder
+        // 
+        this.toolStripMenuItemTabOrder.Name = "toolStripMenuItemTabOrder";
+        this.toolStripMenuItemTabOrder.Size = new System.Drawing.Size(145, 24);
+        this.toolStripMenuItemTabOrder.Text = "Tab Order";
+        this.toolStripMenuItemTabOrder.Click += new System.EventHandler(this.toolStripMenuItemTabOrder_Click);
+        // 
+        // helpToolStripMenuItem
+        // 
+        this.helpToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+        this.ToolStripMenuItemAbout});
+        this.helpToolStripMenuItem.Name = "helpToolStripMenuItem";
+        this.helpToolStripMenuItem.Size = new System.Drawing.Size(53, 24);
+        this.helpToolStripMenuItem.Text = "&Help";
+        // 
+        // ToolStripMenuItemAbout
+        // 
+        this.ToolStripMenuItemAbout.Name = "ToolStripMenuItemAbout";
+        this.ToolStripMenuItemAbout.Size = new System.Drawing.Size(128, 24);
+        this.ToolStripMenuItemAbout.Text = "About...";
+        this.ToolStripMenuItemAbout.Click += new System.EventHandler(this.OnAbout);
+        // 
+        // MainForm
+        // 
+        this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+        this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+        this.ClientSize = new System.Drawing.Size(824, 530);
+        this.Controls.Add(this.splitContainer);
+        this.Controls.Add(this.menuStrip1);
+        this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+        this.MainMenuStrip = this.menuStrip1;
+        this.Margin = new System.Windows.Forms.Padding(4);
+        this.Name = "MainForm";
+        this.Text = "Tiny Form Designer";
+        this.Load += new System.EventHandler(this.MainForm_Load);
+        this.splitContainer.Panel1.ResumeLayout(false);
+        this.splitContainer.Panel2.ResumeLayout(false);
+        this.splitContainer.ResumeLayout(false);
+        this.tabControl1.ResumeLayout(false);
+        this.menuStrip1.ResumeLayout(false);
+        this.menuStrip1.PerformLayout();
+        this.ResumeLayout(false);
+        this.PerformLayout();
+
+    }
+
+    #endregion
+
+    private System.Windows.Forms.SplitContainer splitContainer;
+    private System.Windows.Forms.PropertyGrid propertyGrid;
+    private System.Windows.Forms.MenuStrip menuStrip1;
+    private System.Windows.Forms.ToolStripMenuItem editToolStripMenuItem;
+    private System.Windows.Forms.ToolStripMenuItem ToolStripMenuItemUnDo;
+    private System.Windows.Forms.ToolStripMenuItem ToolStripMenuItemReDo;
+    private System.Windows.Forms.ToolStripSeparator toolStripSeparator3;
+    private System.Windows.Forms.ToolStripMenuItem ToolStripMenuItemCut;
+    private System.Windows.Forms.ToolStripMenuItem ToolStripMenuItemCopy;
+    private System.Windows.Forms.ToolStripMenuItem ToolStripMenuItemPaste;
+    private System.Windows.Forms.ToolStripSeparator toolStripSeparator4;
+    private System.Windows.Forms.ToolStripMenuItem ToolStripMenuItemDelete;
+    private System.Windows.Forms.ToolStripMenuItem helpToolStripMenuItem;
+    private System.Windows.Forms.ToolStripMenuItem ToolStripMenuItemAbout;
+    private System.Windows.Forms.TabControl tabControl1;
+    private System.Windows.Forms.TabPage tabPage1;
+    private System.Windows.Forms.TabPage tabPage2;
+    private System.Windows.Forms.TabPage tabPage3;
+    private System.Windows.Forms.TabPage tabPage4;
+    private System.Windows.Forms.TabPage tabPage5;
+    private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemTools;
+    private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemTabOrder;
 
 }
-
-#endregion
-
-private System.Windows.Forms.SplitContainer splitContainer;
-private System.Windows.Forms.PropertyGrid propertyGrid;
-private System.Windows.Forms.MenuStrip menuStrip1;
-private System.Windows.Forms.ToolStripMenuItem editToolStripMenuItem;
-private System.Windows.Forms.ToolStripMenuItem ToolStripMenuItemUnDo;
-private System.Windows.Forms.ToolStripMenuItem ToolStripMenuItemReDo;
-private System.Windows.Forms.ToolStripSeparator toolStripSeparator3;
-private System.Windows.Forms.ToolStripMenuItem ToolStripMenuItemCut;
-private System.Windows.Forms.ToolStripMenuItem ToolStripMenuItemCopy;
-private System.Windows.Forms.ToolStripMenuItem ToolStripMenuItemPaste;
-private System.Windows.Forms.ToolStripSeparator toolStripSeparator4;
-private System.Windows.Forms.ToolStripMenuItem ToolStripMenuItemDelete;
-private System.Windows.Forms.ToolStripMenuItem helpToolStripMenuItem;
-private System.Windows.Forms.ToolStripMenuItem ToolStripMenuItemAbout;
-private System.Windows.Forms.TabControl tabControl1;
-private System.Windows.Forms.TabPage tabPage1;
-private System.Windows.Forms.TabPage tabPage2;
-private System.Windows.Forms.TabPage tabPage3;
-private System.Windows.Forms.TabPage tabPage4;
-private System.Windows.Forms.TabPage tabPage5;
-private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemTools;
-private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemTabOrder;
-
-}
-

--- a/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/MainForm.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/MainForm.Designer.cs
@@ -1,4 +1,6 @@
-﻿namespace TestConsole;
+﻿using DesignSurfaceExt;
+
+namespace TestConsole;
 
 partial class MainForm
 {
@@ -36,7 +38,7 @@ partial class MainForm
         this.tabPage3 = new System.Windows.Forms.TabPage();
         this.tabPage4 = new System.Windows.Forms.TabPage();
         this.tabPage5 = new System.Windows.Forms.TabPage();
-        this.propertyGrid = new System.Windows.Forms.PropertyGrid();
+        this.propertyGrid = new PropertyGridExt();
         this.menuStrip1 = new System.Windows.Forms.MenuStrip();
         this.editToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
         this.ToolStripMenuItemUnDo = new System.Windows.Forms.ToolStripMenuItem();
@@ -141,15 +143,7 @@ partial class MainForm
         this.tabPage5.TabIndex = 3;
         this.tabPage5.Text = "tabPage5";
         this.tabPage5.UseVisualStyleBackColor = true;
-        // 
-        // propertyGrid
-        // 
-        this.propertyGrid.Dock = System.Windows.Forms.DockStyle.Fill;
-        this.propertyGrid.Location = new System.Drawing.Point(0, 0);
-        this.propertyGrid.Margin = new System.Windows.Forms.Padding(4);
-        this.propertyGrid.Name = "propertyGrid";
-        this.propertyGrid.Size = new System.Drawing.Size(226, 502);
-        this.propertyGrid.TabIndex = 0;
+
         // 
         // menuStrip1
         // 
@@ -300,7 +294,7 @@ partial class MainForm
     #endregion
 
     private System.Windows.Forms.SplitContainer splitContainer;
-    private System.Windows.Forms.PropertyGrid propertyGrid;
+    private PropertyGridExt propertyGrid;
     private System.Windows.Forms.MenuStrip menuStrip1;
     private System.Windows.Forms.ToolStripMenuItem editToolStripMenuItem;
     private System.Windows.Forms.ToolStripMenuItem ToolStripMenuItemUnDo;

--- a/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/MainForm.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/MainForm.cs
@@ -315,7 +315,10 @@ public partial class MainForm : Form
         // - find out the DesignSurfaceExt control hosted by the TabPage
         IDesignSurfaceExt isurf = _listOfDesignSurface[tabControl1.SelectedIndex];
         if (isurf is not null)
+        {
             propertyGrid.SelectedObject = isurf.GetIDesignerHost().RootComponent;
+            propertyGrid.Site = isurf.GetIDesignerHost().RootComponent.Site;
+        }
     }
 
     private void undoToolStripMenuItem_Click(object sender, EventArgs e)

--- a/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/MainForm.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/MainForm.cs
@@ -316,8 +316,20 @@ public partial class MainForm : Form
         IDesignSurfaceExt isurf = _listOfDesignSurface[tabControl1.SelectedIndex];
         if (isurf is not null)
         {
-            propertyGrid.SelectedObject = isurf.GetIDesignerHost().RootComponent;
-            propertyGrid.Site = isurf.GetIDesignerHost().RootComponent.Site;
+            splitContainer.Panel2.Controls.Remove(propertyGrid);
+            propertyGrid = new()
+            {
+                DesignerHost = isurf.GetIDesignerHost(),
+                Dock = DockStyle.Fill,
+                Location = new Point(0, 0),
+                Margin = new Padding(4),
+                Name = "propertyGrid",
+                Size = new Size(226, 502),
+                TabIndex = 0,
+                SelectedObject = isurf.GetIDesignerHost().RootComponent
+            };
+
+            splitContainer.Panel2.Controls.Add(propertyGrid);
         }
     }
 

--- a/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DesignSurfaceExt/PropertyGridExt.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DesignSurfaceExt/PropertyGridExt.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel.Design;
+using System.Windows.Forms;
+
+namespace DesignSurfaceExt;
+public class PropertyGridExt : PropertyGrid
+{
+    public IDesignerHost DesignerHost { get; set; }
+
+    protected override void OnSelectedObjectsChanged(EventArgs e) => base.OnSelectedObjectsChanged(e);
+
+    protected override object GetService(Type serviceType)
+    {
+        object service = DesignerHost?.GetService(serviceType);
+        return service ?? base.GetService(serviceType);
+    }
+}


### PR DESCRIPTION

Fixes #10545


## Root cause.

- 
-  `PropertyGrid` requires `DesignerHost` to perform some functions . in our case it is to CreateNewObject
- 

https://github.com/dotnet/winforms/blob/a05dd925fe03e64ee026ad2fda65638b75d08998/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CollectionEditor.cs#L91-L114

please see line 95. if the `host` here is not null, then our existing code can create target object **and set `Text` property(line 102)**

if the `host` is null, some properties would not be initialized inclining `Text`, which is the cause of this issue.


<!-- We are in TELL-MODE the following section must be completed

## Customer Impact

- 
-  -->
<!--
## Regression? 

- Yes / No-->

## Risk

- low

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![TabControl](https://github.com/dotnet/winforms/assets/38325459/e1788125-2832-45b1-8148-1640a410b094)

### After

https://github.com/dotnet/winforms/assets/135201996/c6e1f5bf-d614-41e2-ba07-ca82902a53e1


## Test methodology <!-- How did you ensure quality? -->

- 
- manual
- 

<!--## Accessibility testing   Remove this section if PR does not change UI -->


## Test environment(s) <!-- Remove any that don't apply -->

9.0.0-alpha.1.24066.33


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10720)