### PR TITLE
[release/8.0] Fix ImageList rendering of transparent images

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/Foundation/COLORREF.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/Foundation/COLORREF.cs
@@ -5,6 +5,14 @@ using System.Drawing;
 
 namespace Windows.Win32.Foundation;
 
+/// <remarks>
+///  <para>
+///   Never convert native constants (such as <see cref="PInvoke.CLR_NONE"/> to <see cref="Color"/> or pass them through
+///   any conversion in <see cref="Color"/>, <see cref="ColorTranslator"/>, etc. as they can change the value.
+///   <see cref="COLORREF"/> is a DWORD- passing constants in native code would just pass the value as is.
+///  </para>
+///  <para><see href="https://learn.microsoft.com/windows/win32/gdi/colorref#">Read more on learn.microsoft.com</see>.</para>
+/// </remarks>
 internal readonly partial struct COLORREF
 {
     public static implicit operator COLORREF(Color color) => new((uint)ColorTranslator.ToWin32(color));

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.ImageList.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.ImageList.cs
@@ -31,6 +31,7 @@ internal partial class PInvoke
             return result;
         }
 
+        /// <inheritdoc cref="ImageList_DrawEx(HIMAGELIST, int, HDC, int, int, int, int, COLORREF, COLORREF, IMAGE_LIST_DRAW_STYLE)"/>
         public static bool DrawEx<THIML, THDC>(
             THIML himl,
             int i,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.cs
@@ -446,7 +446,7 @@ public sealed partial class ImageList : Component, IHandle<HIMAGELIST>
             _nativeImageList = new NativeImageList(_imageSize, flags);
         }
 
-        PInvoke.ImageList.SetBkColor(this, Color.FromArgb(PInvoke.CLR_NONE));
+        PInvoke.ImageList.SetBkColor(this, (COLORREF)PInvoke.CLR_NONE);
 
         Debug.Assert(_originals is not null, "Handle not yet created, yet original images are gone");
         for (int i = 0; i < _originals.Count; i++)
@@ -553,8 +553,8 @@ public sealed partial class ImageList : Component, IHandle<HIMAGELIST>
                 y,
                 width,
                 height,
-                Color.FromArgb(PInvoke.CLR_NONE),
-                Color.FromArgb(PInvoke.CLR_NONE),
+                (COLORREF)PInvoke.CLR_NONE,
+                (COLORREF)PInvoke.CLR_NONE,
                 (IMAGE_LIST_DRAW_STYLE)ComCtl32.ILD.TRANSPARENT);
         }
         finally
@@ -691,8 +691,8 @@ public sealed partial class ImageList : Component, IHandle<HIMAGELIST>
                         0,
                         _imageSize.Width,
                         _imageSize.Height,
-                        Color.FromArgb(PInvoke.CLR_NONE),
-                        Color.FromArgb(PInvoke.CLR_NONE),
+                        (COLORREF)PInvoke.CLR_NONE,
+                        (COLORREF)PInvoke.CLR_NONE,
                         (IMAGE_LIST_DRAW_STYLE)ComCtl32.ILD.TRANSPARENT);
                 }
                 finally


### PR DESCRIPTION
backport of https://github.com/dotnet/winforms/pull/10696

We were modifying the CLR_NONE constant when passing it to Win32 APIs that accept it.

- Don't pass PInvoke.CLR_NONE through Color.FromArgb, just cast to COLORREF
- Add comments to COLORREF
- Added Inheritdoc for a few methods in PInvoke.ImageList

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10725)