### PR TITLE
cleaned up implementations of RuntimeId in AccessibleObjects

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Accessibility/AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Accessibility/AccessibleObject.cs
@@ -596,7 +596,7 @@ public unsafe partial class AccessibleObject :
         => patternId == UIA_PATTERN_ID.UIA_InvokePatternId && IsInvokePatternAvailable;
 
     /// <summary>
-    ///  Gets the runtime ID.
+    ///  Gets the runtime identifier. This value must be unique within the parent window.
     /// </summary>
     internal virtual int[] RuntimeId
     {
@@ -604,7 +604,7 @@ public unsafe partial class AccessibleObject :
         {
             if (_isSystemWrapper)
             {
-                return new int[] { RuntimeIDFirstItem, GetHashCode() };
+                return [RuntimeIDFirstItem, GetHashCode()];
             }
 
             string message = string.Format(SR.AccessibleObjectRuntimeIdNotSupported, nameof(AccessibleObject), nameof(RuntimeId));

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Accessibility/Control.ControlAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Accessibility/Control.ControlAccessibleObject.cs
@@ -200,14 +200,20 @@ public partial class Control
 
         internal override bool CanGetDefaultActionInternal => IsInternal && Owner?.AccessibleDefaultActionDescription is null;
 
-        // This is used only if control supports IAccessibleEx. We need to provide a unique ID. Others are implementing this in the same manner.
-        // First item is static - 0x2a (RuntimeIDFirstItem). Second item can be anything, but it's good to supply HWND.
-        internal override int[] RuntimeId => new int[]
-        {
+        /// <remarks>
+        ///  <para>
+        ///    This is used only if control supports <see cref="IAccessibleEx" />.  We need to provide a unique ID.
+        ///    Others are implementing this in the same manner.  First item is static - <see cref="AccessibleObject.RuntimeIDFirstItem"/>).
+        ///    Second item can be anything unique, Win32 uses <see cref="HWND"/>, we copied that.
+        ///  </para>
+        /// </remarks>
+        /// <inheritdoc cref="AccessibleObject.RuntimeId" />
+        internal override int[] RuntimeId =>
+        [
             RuntimeIDFirstItem,
-            PARAM.ToInt(HandleInternal),
+            (int)HandleInternal,
             GetHashCode()
-        };
+        ];
 
         public override string? Description => Owner?.AccessibleDescription ?? base.Description;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Accessibility/LabelEditAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Accessibility/LabelEditAccessibleObject.cs
@@ -74,10 +74,10 @@ internal unsafe class LabelEditAccessibleObject : AccessibleObject
     internal override bool CanGetNameInternal => false;
 
     internal override int[] RuntimeId => _runtimeId ??=
-        [
-            RuntimeIDFirstItem,
-            _labelEdit.TryGetTarget(out var target) ? (int)target.HWND : (int)HWND.Null
-        ];
+    [
+        RuntimeIDFirstItem,
+        _labelEdit.TryGetTarget(out var target) ? (int)target.HWND : (int)HWND.Null
+    ];
 
     internal override ITextRangeProvider* DocumentRangeInternal
         => _textProvider.DocumentRange;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.ComboBoxChildDropDownButtonUiaProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.ComboBoxChildDropDownButtonUiaProvider.cs
@@ -99,15 +99,14 @@ public partial class ComboBox
 
         public override AccessibleRole Role => SystemIAccessible.TryGetRole(GetChildId());
 
-        internal override int[] RuntimeId
-            => new int[]
-            {
+        internal override int[] RuntimeId =>
+            [
                 RuntimeIDFirstItem,
-                PARAM.ToInt(_owner.InternalHandle),
+                (int)_owner.InternalHandle,
                 _owner.GetHashCode(),
                 GeneratedRuntimeId,
                 COMBOBOX_DROPDOWN_BUTTON_ACC_ITEM_INDEX
-            };
+            ];
 
         public override AccessibleStates State => SystemIAccessible.TryGetState(GetChildId());
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.ComboBoxChildEditUiaProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.ComboBoxChildEditUiaProvider.cs
@@ -100,10 +100,7 @@ public partial class ComboBox
                 _ => base.IsPatternSupported(patternId)
             };
 
-        /// <summary>
-        ///  Gets the runtime ID.
-        /// </summary>
-        internal override int[] RuntimeId => new int[] { RuntimeIDFirstItem, GetHashCode() };
+        internal override int[] RuntimeId => [RuntimeIDFirstItem, GetHashCode()];
 
         internal override unsafe ITextRangeProvider* DocumentRangeInternal
             => _textProvider.DocumentRange;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.ComboBoxChildListUiaProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.ComboBoxChildListUiaProvider.cs
@@ -190,13 +190,12 @@ public partial class ComboBox
             }
         }
 
-        internal override int[] RuntimeId
-            => new int[]
-            {
+        internal override int[] RuntimeId =>
+            [
                 RuntimeIDFirstItem,
-                PARAM.ToInt(_owningComboBox.InternalHandle),
+                (int)_owningComboBox.InternalHandle,
                 _owningComboBox.GetListNativeWindowRuntimeIdPart()
-            };
+            ];
 
         public override AccessibleStates State
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.ComboBoxChildTextUiaProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.ComboBoxChildTextUiaProvider.cs
@@ -107,18 +107,14 @@ public partial class ComboBox
                 _ => base.GetPropertyValue(propertyID)
             };
 
-        /// <summary>
-        ///  Gets the runtime ID.
-        /// </summary>
-        internal override int[] RuntimeId
-            => new int[]
-            {
+        internal override int[] RuntimeId =>
+            [
                 RuntimeIDFirstItem,
-                PARAM.ToInt(_owner.InternalHandle),
+                (int)_owner.InternalHandle,
                 _owner.GetHashCode(),
                 GetHashCode(),
                 GetChildId()
-            };
+            ];
 
         /// <summary>
         ///  Gets the accessible state.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.ComboBoxItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.ComboBoxItemAccessibleObject.cs
@@ -147,14 +147,13 @@ public partial class ComboBox
         public override AccessibleRole Role
             => _owningComboBox.ChildListAccessibleObject.SystemIAccessible.TryGetRole(GetChildId());
 
-        internal override int[] RuntimeId
-            => new int[]
-            {
-                RuntimeIDFirstItem,
-                PARAM.ToInt(_owningComboBox.InternalHandle),
-                _owningComboBox.GetListNativeWindowRuntimeIdPart(),
-                _owningItem.GetHashCode()
-            };
+        internal override int[] RuntimeId =>
+        [
+            RuntimeIDFirstItem,
+            (int)_owningComboBox.InternalHandle,
+            _owningComboBox.GetListNativeWindowRuntimeIdPart(),
+            _owningItem.GetHashCode()
+        ];
 
         public override AccessibleStates State
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridView.AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridView.AccessibleObject.cs
@@ -11,7 +11,7 @@ public partial class DataGridView
 {
     protected class DataGridViewAccessibleObject : ControlAccessibleObject
     {
-        private int[]? runtimeId; // Used by UIAutomation
+        private int[]? _runtimeId;
         private bool? _isModal;
 
         private DataGridViewTopRowAccessibleObject? _topRowAccessibilityObject;
@@ -217,21 +217,11 @@ public partial class DataGridView
             }
         }
 
-        /* Microsoft: why is this method defined and not used?
-        // this method is called when the accessible object needs to be reset
-        // Example: when the user changes the display index on a column or when the user modifies the column collection
-        internal void Reset()
-        {
-            this.NotifyClients(AccessibleEvents.Reorder);
-        }
-        */
-
-        internal override int[] RuntimeId
-            => runtimeId ??= new int[]
-            {
-                RuntimeIDFirstItem, // first item is static - 0x2a
-                GetHashCode()
-            };
+        internal override int[] RuntimeId => _runtimeId ??=
+        [
+            RuntimeIDFirstItem,
+            GetHashCode()
+        ];
 
         internal override bool IsIAccessibleExSupported() => true;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridView.DataGridViewEditingPanelAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridView.DataGridViewEditingPanelAccessibleObject.cs
@@ -28,8 +28,9 @@ public partial class DataGridView
                 ? owner.AccessibilityObject
                 : UiaCore.StubFragmentRoot.Instance;
 
-        internal override int[] RuntimeId
-            => _runtimeId ??= this.TryGetOwnerAs(out Panel? owner) ? owner.AccessibilityObject.RuntimeId : base.RuntimeId;
+        internal override int[] RuntimeId => _runtimeId ??= this.TryGetOwnerAs(out Panel? owner)
+            ? owner.AccessibilityObject.RuntimeId
+            : base.RuntimeId;
 
         internal override IRawElementProviderFragment.Interface? FragmentNavigate(NavigateDirection direction)
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridView.SelectedCellsAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridView.SelectedCellsAccessibleObject.cs
@@ -30,7 +30,7 @@ public partial class DataGridView
 
         internal override bool CanGetValueInternal => false;
 
-        internal override int[] RuntimeId => new int[] { RuntimeIDFirstItem, Parent.GetHashCode(), GetHashCode() };
+        internal override int[] RuntimeId => [RuntimeIDFirstItem, Parent.GetHashCode(), GetHashCode()];
 
         public override AccessibleObject? GetChild(int index) =>
             _parentAccessibleObject.TryGetOwnerAs(out DataGridView? owner) && index >= 0 && index < owner.GetCellCount(DataGridViewElementStates.Selected)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridView.TopRowAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridView.TopRowAccessibleObject.cs
@@ -84,13 +84,12 @@ public partial class DataGridView
             }
         }
 
-        internal override int[] RuntimeId
-            => runtimeId ??= new int[]
-            {
-                RuntimeIDFirstItem, // first item is static - 0x2a
-                Parent.GetHashCode(),
-                GetHashCode()
-            };
+        internal override int[] RuntimeId => runtimeId ??=
+        [
+            RuntimeIDFirstItem,
+            Parent.GetHashCode(),
+            GetHashCode()
+        ];
 
         public override string Value => Name;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewCell.DataGridViewCellAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewCell.DataGridViewCellAccessibleObject.cs
@@ -619,12 +619,11 @@ public abstract partial class DataGridViewCell
             RaiseAutomationEvent(UIA_EVENT_ID.UIA_AutomationFocusChangedEventId);
         }
 
-        internal override int[] RuntimeId
-            => _runtimeId ??= new int[]
-            {
-                RuntimeIDFirstItem, // first item is static - 0x2a
-                GetHashCode()
-            };
+        internal override int[] RuntimeId => _runtimeId ??=
+        [
+            RuntimeIDFirstItem,
+            GetHashCode()
+        ];
 
         private protected override string AutomationId
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewCheckBoxCell.DataGridViewCheckBoxCellAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewCheckBoxCell.DataGridViewCheckBoxCellAccessibleObject.cs
@@ -136,7 +136,7 @@ public partial class DataGridViewCheckBoxCell
 
         internal override bool IsIAccessibleExSupported() => true;
 
-        internal override int[] RuntimeId => runtimeId ??= new int[] { RuntimeIDFirstItem, GetHashCode() };
+        internal override int[] RuntimeId => runtimeId ??= [RuntimeIDFirstItem, GetHashCode()];
 
         internal override VARIANT GetPropertyValue(UIA_PROPERTY_ID propertyID)
             => propertyID switch

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewRow.DataGridViewRowAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewRow.DataGridViewRowAccessibleObject.cs
@@ -138,13 +138,12 @@ public partial class DataGridViewRow
 
         private static int RowStartIndex => LocalAppContextSwitches.DataGridViewUIAStartRowCountAtZero ? 0 : 1;
 
-        internal override int[] RuntimeId
-            => _runtimeId ??= new int[]
-            {
-                RuntimeIDFirstItem, // first item is static - 0x2a
-                Parent?.GetHashCode() ?? 0,
-                GetHashCode()
-            };
+        internal override int[] RuntimeId => _runtimeId ??=
+        [
+            RuntimeIDFirstItem,
+            Parent?.GetHashCode() ?? 0,
+            GetHashCode()
+        ];
 
         private AccessibleObject SelectedCellsAccessibilityObject
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewRow.DataGridViewSelectedRowCellsAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewRow.DataGridViewSelectedRowCellsAccessibleObject.cs
@@ -34,8 +34,7 @@ public partial class DataGridViewRow
 
         internal override bool CanGetValueInternal => false;
 
-        internal override int[] RuntimeId
-            => _runtimeId ??= new int[] { RuntimeIDFirstItem, Parent.GetHashCode(), GetHashCode() };
+        internal override int[] RuntimeId => _runtimeId ??= [RuntimeIDFirstItem, Parent.GetHashCode(), GetHashCode()];
 
         public override AccessibleObject? GetChild(int index)
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/Labels/LinkLabel.Link.LinkAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/Labels/LinkLabel.Link.LinkAccessibleObject.cs
@@ -130,13 +130,12 @@ public partial class LinkLabel
 
             public override AccessibleRole Role => AccessibleRole.Link;
 
-            internal override int[] RuntimeId
-                => new int[]
-                {
-                    RuntimeIDFirstItem,
-                    PARAM.ToInt(_owningLinkLabel.InternalHandle),
-                    _owningLink.GetHashCode()
-                };
+            internal override int[] RuntimeId =>
+            [
+                RuntimeIDFirstItem,
+                (int)_owningLinkLabel.InternalHandle,
+                _owningLink.GetHashCode()
+            ];
 
             public override AccessibleStates State
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ListBoxes/ListBox.AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ListBoxes/ListBox.AccessibleObject.cs
@@ -41,9 +41,6 @@ public partial class ListBox
                 && owner.SelectionMode != SelectionMode.One
                 && owner.SelectionMode != SelectionMode.None;
 
-        // We need to provide a unique ID. Others are implementing this in the same manner. First item is static - 0x2a (RuntimeIDFirstItem).
-        // Second item can be anything, but it's good to supply HWND.
-
         public override AccessibleStates State
         {
             get

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ListBoxes/ListBox.ItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ListBoxes/ListBox.ItemAccessibleObject.cs
@@ -42,17 +42,11 @@ public partial class ListBox
         {
             get
             {
-                int[] parentRuntimeId = _owningAccessibleObject.RuntimeId;
+                int[] id = _owningAccessibleObject.RuntimeId;
 
-                Debug.Assert(parentRuntimeId.Length >= 3);
+                Debug.Assert(id.Length >= 3);
 
-                return new int[]
-                {
-                    parentRuntimeId[0],
-                    parentRuntimeId[1],
-                    parentRuntimeId[2],
-                    _itemEntry.GetHashCode()
-                };
+                return [id[0], id[1], id[2], _itemEntry.GetHashCode()];
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ListView/ColumnHeader.ListViewColumnHeaderAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ListView/ColumnHeader.ListViewColumnHeaderAccessibleObject.cs
@@ -23,7 +23,7 @@ public partial class ColumnHeader
 
         internal override bool CanGetNameInternal => false;
 
-        internal override int[] RuntimeId => new int[] { RuntimeIDFirstItem, _owningColumnHeader.GetHashCode() };
+        internal override int[] RuntimeId => [RuntimeIDFirstItem, _owningColumnHeader.GetHashCode()];
 
         internal override VARIANT GetPropertyValue(UIA_PROPERTY_ID propertyID)
             => propertyID switch

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ListView/ListViewGroup.ListViewGroupAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ListView/ListViewGroup.ListViewGroupAccessibleObject.cs
@@ -111,17 +111,18 @@ public partial class ListViewGroup
         {
             get
             {
-                int[] owningListViewRuntimeId = _owningListViewAccessibilityObject.RuntimeId;
+                int[] id = _owningListViewAccessibilityObject.RuntimeId;
 
-                Debug.Assert(owningListViewRuntimeId.Length >= 2);
+                Debug.Assert(id.Length >= 2);
 
-                return new int[]
-                {
-                    owningListViewRuntimeId[0],
-                    owningListViewRuntimeId[1],
-                    4, // Win32-control specific RuntimeID constant, is used in similar Win32 controls and is used in WinForms controls for consistency.
+                return
+                [
+                    id[0],
+                    id[1],
+                    // Win32 control specific RuntimeID constant, is used in similar Win32 controls and is used in WinForms controls for consistency.
+                    4,
                     GetHashCode()
-                };
+                ];
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ListView/ListViewItem.ListViewItemBaseAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ListView/ListViewItem.ListViewItemBaseAccessibleObject.cs
@@ -198,14 +198,14 @@ public partial class ListViewItem
         {
             get
             {
-                int[] owningListViewRuntimeId = _owningListView.AccessibilityObject.RuntimeId;
+                int[] id = _owningListView.AccessibilityObject.RuntimeId;
 
-                Debug.Assert(owningListViewRuntimeId.Length >= 2);
+                Debug.Assert(id.Length >= 2);
 
-                return new int[]
-                {
-                    owningListViewRuntimeId[0],
-                    owningListViewRuntimeId[1],
+                return
+                [
+                    id[0],
+                    id[1],
                     // Win32-control specific RuntimeID constant.
                     4,
                     // RuntimeId uses hash code instead of item's index. When items are removed,
@@ -215,7 +215,7 @@ public partial class ListViewItem
                     // Similar applies for items within a group, where adding the group's index
                     // was preventing from correct disconnection of items on removal.
                     _owningItem.GetHashCode()
-                };
+                ];
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ListView/ListViewItem.ListViewItemImageAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ListView/ListViewItem.ListViewItemImageAccessibleObject.cs
@@ -41,18 +41,11 @@ public partial class ListViewItem
         {
             get
             {
-                int[] owningItemRuntimeId = Parent.RuntimeId;
+                int[] id = Parent.RuntimeId;
 
-                Debug.Assert(owningItemRuntimeId.Length >= 4);
+                Debug.Assert(id.Length >= 4);
 
-                return new[]
-                {
-                    owningItemRuntimeId[0],
-                    owningItemRuntimeId[1],
-                    owningItemRuntimeId[2],
-                    owningItemRuntimeId[3],
-                    GetHashCode()
-                };
+                return [id[0], id[1], id[2], id[3], GetHashCode()];
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ListView/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ListView/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObject.cs
@@ -104,18 +104,11 @@ public partial class ListViewItem
             {
                 get
                 {
-                    int[] owningItemRuntimeId = Parent.RuntimeId;
+                    int[] id = Parent.RuntimeId;
 
-                    Debug.Assert(owningItemRuntimeId.Length >= 4);
+                    Debug.Assert(id.Length >= 4);
 
-                    return new int[]
-                    {
-                        owningItemRuntimeId[0],
-                        owningItemRuntimeId[1],
-                        owningItemRuntimeId[2],
-                        owningItemRuntimeId[3],
-                        GetHashCode()
-                    };
+                    return [id[0], id[1], id[2], id[3], GetHashCode()];
                 }
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/MonthCalendar/MonthCalendar.CalendarBodyAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/MonthCalendar/MonthCalendar.CalendarBodyAccessibleObject.cs
@@ -22,7 +22,7 @@ public partial class MonthCalendar
         private readonly MonthCalendarAccessibleObject _monthCalendarAccessibleObject;
         private readonly int _calendarIndex;
         private readonly string _initName;
-        private readonly int[] _initRuntimeId;
+        private readonly int[] _runtimeId;
         private LinkedList<CalendarRowAccessibleObject>? _rowsAccessibleObjects;
 
         public CalendarBodyAccessibleObject(CalendarAccessibleObject calendarAccessibleObject,
@@ -37,13 +37,9 @@ public partial class MonthCalendar
             // So save these values one time to avoid sending messages to Windows every time
             // or recreating new structures and making extra calculations.
             _initName = _monthCalendarAccessibleObject.GetCalendarPartText(MCGRIDINFO_PART.MCGIP_CALENDARHEADER, _calendarIndex);
-            _initRuntimeId = new int[]
-            {
-                _calendarAccessibleObject.RuntimeId[0],
-                _calendarAccessibleObject.RuntimeId[1],
-                _calendarAccessibleObject.RuntimeId[2],
-                GetChildId()
-            };
+
+            int[] id = _calendarAccessibleObject.RuntimeId;
+            _runtimeId = [id[0], id[1], id[2], GetChildId()];
         }
 
         public override Rectangle Bounds
@@ -248,7 +244,7 @@ public partial class MonthCalendar
             }
         }
 
-        internal override int[] RuntimeId => _initRuntimeId;
+        internal override int[] RuntimeId => _runtimeId;
 
         internal override void SetFocus()
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/MonthCalendar/MonthCalendar.CalendarCellAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/MonthCalendar/MonthCalendar.CalendarCellAccessibleObject.cs
@@ -41,18 +41,12 @@ public partial class MonthCalendar
             _calendarIndex = calendarIndex;
             _rowIndex = rowIndex;
             _columnIndex = columnIndex;
+
             // RuntimeId don't change if the calendar date range is not changed,
             // otherwise the calendar accessibility tree will be rebuilt.
             // So save this value one time to avoid recreating new structures and making extra calculations.
-            _initRuntimeId = new int[]
-            {
-                _calendarRowAccessibleObject.RuntimeId[0],
-                _calendarRowAccessibleObject.RuntimeId[1],
-                _calendarRowAccessibleObject.RuntimeId[2],
-                _calendarRowAccessibleObject.RuntimeId[3],
-                _calendarRowAccessibleObject.RuntimeId[4],
-                GetChildId()
-            };
+            int[] id = _calendarRowAccessibleObject.RuntimeId;
+            _initRuntimeId = [id[0], id[1], id[2], id[3], id[4], GetChildId()];
         }
 
         public override Rectangle Bounds

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/MonthCalendar/MonthCalendar.CalendarHeaderAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/MonthCalendar/MonthCalendar.CalendarHeaderAccessibleObject.cs
@@ -30,18 +30,14 @@ public partial class MonthCalendar
             _calendarAccessibleObject = calendarAccessibleObject;
             _monthCalendarAccessibleObject = monthCalendarAccessibleObject;
             _calendarIndex = calendarIndex;
+
             // Name and RuntimeId don't change if the calendar date range is not changed,
             // otherwise the calendar accessibility tree will be rebuilt.
             // So save these values one time to avoid sending messages to Windows every time
             // or recreating new structures and making extra calculations.
             _initName = _monthCalendarAccessibleObject.GetCalendarPartText(MCGRIDINFO_PART.MCGIP_CALENDARHEADER, _calendarIndex);
-            _initRuntimeId = new int[]
-            {
-                _calendarAccessibleObject.RuntimeId[0],
-                _calendarAccessibleObject.RuntimeId[1],
-                _calendarAccessibleObject.RuntimeId[2],
-                GetChildId()
-            };
+            int[] id = _calendarAccessibleObject.RuntimeId;
+            _initRuntimeId = [id[0], id[1], id[2], GetChildId()];
         }
 
         public override Rectangle Bounds

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/MonthCalendar/MonthCalendar.CalendarRowAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/MonthCalendar/MonthCalendar.CalendarRowAccessibleObject.cs
@@ -24,7 +24,7 @@ public partial class MonthCalendar
         private readonly MonthCalendarAccessibleObject _monthCalendarAccessibleObject;
         private readonly int _calendarIndex;
         private readonly int _rowIndex;
-        private readonly int[] _initRuntimeId;
+        private readonly int[] _runtimeId;
         private LinkedList<CalendarCellAccessibleObject>? _cellsAccessibleObjects;
         private CalendarWeekNumberCellAccessibleObject? _weekNumberCellAccessibleObject;
 
@@ -36,18 +36,13 @@ public partial class MonthCalendar
             _monthCalendarAccessibleObject = monthCalendarAccessibleObject;
             _calendarIndex = calendarIndex;
             _rowIndex = rowIndex;
+
             // RuntimeId doesn't change if the calendar date range is not changed,
             // otherwise the calendar accessibility tree will be rebuilt.
             // So save this value one time to avoid recreating new structures
             // and making extra calculations every time.
-            _initRuntimeId = new int[]
-            {
-                _calendarBodyAccessibleObject.RuntimeId[0],
-                _calendarBodyAccessibleObject.RuntimeId[1],
-                _calendarBodyAccessibleObject.RuntimeId[2],
-                _calendarBodyAccessibleObject.RuntimeId[3],
-                GetChildId()
-            };
+            int[] id = _calendarBodyAccessibleObject.RuntimeId;
+            _runtimeId = [id[0], id[1], id[2], id[3], GetChildId()];
         }
 
         public override Rectangle Bounds
@@ -199,7 +194,7 @@ public partial class MonthCalendar
 
         internal override int Row => _rowIndex;
 
-        internal override int[] RuntimeId => _initRuntimeId;
+        internal override int[] RuntimeId => _runtimeId;
 
         internal override void SetFocus()
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/MonthCalendar/MonthCalendar.MonthCalendarChildAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/MonthCalendar/MonthCalendar.MonthCalendarChildAccessibleObject.cs
@@ -49,16 +49,18 @@ public partial class MonthCalendar
                 _ => base.FragmentNavigate(direction)
             };
 
-        // This value wasn't saved to _initRuntimeId as in the rest calendar accessible objects
-        // because GetChildId requires _monthCalendarAccessibleObject existing
-        // but it will be null because an inherited constructor is not called yet.
-        internal override int[] RuntimeId
-            => !_monthCalendarAccessibleObject.TryGetOwnerAs(out Control? owner) ? base.RuntimeId : new int[]
-            {
-                RuntimeIDFirstItem,
-                (int)(nint)owner.InternalHandle,
-                GetChildId()
-            };
+        /// <remarks>
+        ///  <para>
+        ///    This value wasn't saved to a field as in the rest calendar accessible objects
+        ///    because GetChildId requires <see cref="_monthCalendarAccessibleObject" /> existing
+        ///    but it will be <see langword="null"/> because an inherited constructor is not called yet.
+        ///  </para>
+        /// </remarks>
+        /// <inheritdoc cref="AccessibleObject.RuntimeId" />
+        internal override int[] RuntimeId =>
+            !_monthCalendarAccessibleObject.TryGetOwnerAs(out Control? owner)
+                ? base.RuntimeId
+                : [RuntimeIDFirstItem, (int)owner.InternalHandle, GetChildId()];
 
         public override AccessibleStates State => AccessibleStates.None;
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/GridEntry.GridEntryAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/GridEntry.GridEntryAccessibleObject.cs
@@ -195,18 +195,22 @@ internal abstract partial class GridEntry
             }
         }
 
-        internal override int[] RuntimeId => _runtimeId ??= new[]
-        {
-            // We need to provide a unique ID. Others are implementing this in the same manner. First item is static - 0x2a.
-            // Second item can be anything, but it's good to supply HWND. Third and others are optional, but in case of
-            // GridItem we need it, to make it unique. Grid items are not controls, they don't have hwnd - we use hwnd
-            // of PropertyGridView.
+        /// <remarks>
+        ///  <para>
+        ///    For <see cref="GridEntry" /> the item hash code to make the ID unique. Grid items are not controls,
+        ///    they don't have windows - we use <see cref="HWND" /> of <see cref="PropertyGridView" />.
+        ///  </para>
+        /// </remarks>
+        /// <inheritdoc cref="AccessibleObject.RuntimeId" />
+        internal override int[] RuntimeId => _runtimeId ??=
+        [
+
             RuntimeIDFirstItem,
             this.TryGetOwnerAs(out GridEntry? owner)
                 ? (int)(owner?.OwnerGridView?.InternalHandle ?? HWND.Null)
                 : (int)HWND.Null,
             GetHashCode()
-        };
+        ];
 
         private PropertyGridView? PropertyGridView
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.GridViewListBoxItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.GridViewListBoxItemAccessibleObject.cs
@@ -42,13 +42,11 @@ internal partial class PropertyGridView
 
         private protected override bool IsInternal => true;
 
-        /// <inheritdoc />
-        internal override int[] RuntimeId
-            => new int[]
-            {
-                RuntimeIDFirstItem,
-                PARAM.ToInt(_owningGridViewListBox.InternalHandle),
-                _owningItem.GetHashCode()
-            };
+        internal override int[] RuntimeId =>
+        [
+            RuntimeIDFirstItem,
+            (int)_owningGridViewListBox.InternalHandle,
+            _owningItem.GetHashCode()
+        ];
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TabControl/TabPage.TabAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TabControl/TabPage.TabAccessibleObject.cs
@@ -64,15 +64,14 @@ public partial class TabPage
 
         internal override IRawElementProviderSimple.Interface? ItemSelectionContainer => OwningTabControl?.AccessibilityObject;
 
-        internal override int[] RuntimeId
-            => new int[]
-            {
-                RuntimeIDFirstItem,
-                OwningTabControl is null
-                    ? PARAM.ToInt(IntPtr.Zero)
-                    : PARAM.ToInt(OwningTabControl.InternalHandle),
-                GetHashCode()
-            };
+        internal override int[] RuntimeId =>
+        [
+            RuntimeIDFirstItem,
+            OwningTabControl is null
+                ? (int)IntPtr.Zero
+                : (int)OwningTabControl.InternalHandle,
+            GetHashCode()
+        ];
 
         private int CurrentIndex => OwningTabControl?.TabPages.IndexOf(_owningTabPage) ?? -1;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripItem.ToolStripItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripItem.ToolStripItemAccessibleObject.cs
@@ -85,15 +85,20 @@ public abstract partial class ToolStripItem
 
         internal override bool CanGetKeyboardShortcutInternal => false;
 
-        // We need to provide a unique ID. Others are implementing this in the same manner. First item should be UiaAppendRuntimeId
-        // since this is not a top-level element of the fragment. Second item can be anything, but here it is a hash.
-        // For toolstrip hash is unique even with child controls. Hwnd  is not.
-        internal override int[] RuntimeId
-            => _runtimeId ??= new int[]
-            {
-                (int)PInvoke.UiaAppendRuntimeId,
-                _ownerItem.GetHashCode()
-            };
+        /// <remarks>
+        ///  <para>
+        ///    First item should be <see cref="PInvoke.UiaAppendRuntimeId" /> since this is not a top-level
+        ///    element of the fragment. Second item can be anything, but here it is the owner hash code.
+        ///    For <see cref="ToolStrip" /> hash code is unique even with child controls.
+        ///    <see cref="ToolStrip.Handle" /> is not.
+        ///  </para>
+        /// </remarks>
+        /// <inheritdoc cref="AccessibleObject.RuntimeId" />
+        internal override int[] RuntimeId => _runtimeId ??=
+        [
+            (int)PInvoke.UiaAppendRuntimeId,
+            _ownerItem.GetHashCode()
+        ];
 
         internal override VARIANT GetPropertyValue(UIA_PROPERTY_ID propertyID) =>
             propertyID switch

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TrackBar/TrackBar.TrackBarChildAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TrackBar/TrackBar.TrackBarChildAccessibleObject.cs
@@ -55,13 +55,12 @@ public partial class TrackBar
             ? owner.AccessibilityObject as TrackBarAccessibleObject
             : null;
 
-        internal override int[] RuntimeId
-            => _runtimeId ??= new int[]
-            {
-                RuntimeIDFirstItem,
-                (int)(this.TryGetOwnerAs(out TrackBar? owner) ? owner.InternalHandle : HWND.Null),
-                GetChildId()
-            };
+        internal override int[] RuntimeId => _runtimeId ??=
+        [
+            RuntimeIDFirstItem,
+            (int)(this.TryGetOwnerAs(out TrackBar? owner) ? owner.InternalHandle : HWND.Null),
+            GetChildId()
+        ];
 
         internal override IRawElementProviderFragment.Interface? FragmentNavigate(NavigateDirection direction)
             => direction switch

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeNode.TreeNodeAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeNode.TreeNodeAccessibleObject.cs
@@ -146,13 +146,12 @@ public partial class TreeNode
                 ? AccessibleRole.CheckButton
                 : AccessibleRole.OutlineItem;
 
-        internal override int[] RuntimeId
-            => new int[]
-            {
-                RuntimeIDFirstItem,
-                PARAM.ToInt(_owningTreeView.InternalHandle),
-                _owningTreeNode.GetHashCode()
-            };
+        internal override int[] RuntimeId =>
+        [
+            RuntimeIDFirstItem,
+            (int)_owningTreeView.InternalHandle,
+            _owningTreeNode.GetHashCode()
+        ];
 
         public override AccessibleStates State
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/UpDown/DomainUpDown.DomainItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/UpDown/DomainUpDown.DomainItemAccessibleObject.cs
@@ -42,6 +42,6 @@ public partial class DomainUpDown
 
         internal override bool CanGetValueInternal => false;
 
-        internal override int[] RuntimeId => new int[] { RuntimeIDFirstItem, GetHashCode() };
+        internal override int[] RuntimeId => [RuntimeIDFirstItem, GetHashCode()];
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/UpDown/UpDownBase.UpDownButtons.UpDownButtonsAccessibleObject.DirectionButtonAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/UpDown/UpDownBase.UpDownButtons.UpDownButtonsAccessibleObject.DirectionButtonAccessibleObject.cs
@@ -103,17 +103,14 @@ public abstract partial class UpDownBase
 
                 public override AccessibleRole Role => AccessibleRole.PushButton;
 
-                /// <summary>
-                ///  Gets the runtime ID.
-                /// </summary>
                 internal override int[] RuntimeId
-                    => new int[]
+                {
+                    get
                     {
-                        _parent.RuntimeId[0],
-                        _parent.RuntimeId[1],
-                        _parent.RuntimeId[2],
-                        _up ? 1 : 0
-                    };
+                        int[] id = _parent.RuntimeId;
+                        return [id[0], id[1], id[2], _up ? 1 : 0];
+                    }
+                }
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider/ErrorProvider.ControlItem.ControlItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider/ErrorProvider.ControlItem.ControlItemAccessibleObject.cs
@@ -125,21 +125,13 @@ public partial class ErrorProvider
                 {
                     if (_window is null)
                     {
-                        return new int[]
-                        {
-                            _controlItem.GetHashCode()
-                        };
+                        return [_controlItem.GetHashCode()];
                     }
 
-                    Debug.Assert(_window.AccessibilityObject.RuntimeId.Length >= 3);
+                    int[] id = _window.AccessibilityObject.RuntimeId;
+                    Debug.Assert(id.Length >= 3);
 
-                    return new int[]
-                    {
-                        _window.AccessibilityObject.RuntimeId[0],
-                        _window.AccessibilityObject.RuntimeId[1],
-                        _window.AccessibilityObject.RuntimeId[2],
-                        _controlItem.GetHashCode()
-                    };
+                    return [id[0], id[1], id[2], _controlItem.GetHashCode()];
                 }
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider/ErrorProvider.ErrorWindow.ErrorWindowAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider/ErrorProvider.ErrorWindow.ErrorWindowAccessibleObject.cs
@@ -113,15 +113,12 @@ public partial class ErrorProvider
 
             public override AccessibleRole Role => AccessibleRole.Grouping;
 
-            // We need to provide a unique ID. Others are implementing this in the same manner. First item is static - 0x2a (RuntimeIDFirstItem).
-            // Second item can be anything, but it's good to supply HWND.
-            internal override int[] RuntimeId
-                => new int[]
-                {
-                    RuntimeIDFirstItem,
-                    PARAM.ToInt(_owner.Handle),
-                    _owner.GetHashCode()
-                };
+            internal override int[] RuntimeId =>
+            [
+                RuntimeIDFirstItem,
+                (int)_owner.Handle,
+                _owner.GetHashCode()
+            ];
 
             public override AccessibleStates State => AccessibleStates.ReadOnly;
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Scrolling/ScrollBar.ScrollBarChildAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Scrolling/ScrollBar.ScrollBarChildAccessibleObject.cs
@@ -62,13 +62,12 @@ public partial class ScrollBar
 
         internal ScrollBarAccessibleObject ParentInternal => (ScrollBarAccessibleObject)OwningScrollBar.AccessibilityObject;
 
-        internal override int[] RuntimeId
-            => new int[]
-            {
-                RuntimeIDFirstItem,
-                PARAM.ToInt(OwningScrollBar.InternalHandle),
-                GetChildId()
-            };
+        internal override int[] RuntimeId =>
+        [
+            RuntimeIDFirstItem,
+            (int)OwningScrollBar.InternalHandle,
+            GetChildId()
+        ];
 
         internal override IRawElementProviderFragment.Interface? FragmentNavigate(NavigateDirection direction)
             => direction switch


### PR DESCRIPTION
1  fixed style
2. replaced PARAM.ToInt with a cast (int) because InpPtr is now implemented as a nint
3. fixed xml-doc comments


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10730)