### PR TITLE
Use CurrentUICulture in KeysConverter.cs when converting to name in d…

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Input/KeysConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Input/KeysConverter.cs
@@ -331,7 +331,8 @@ public class KeysConverter : TypeConverter, IComparer
 
     private IList<string> GetDisplayOrder(CultureInfo? culture)
     {
-        // Use CurrentUICulture as default to match other TypeConverters.
+        // Use CurrentUICulture as default because we assume that this converter is primarily
+        // used in user-facing applications (I.e. what key to press on the keyboard).
         culture ??= CultureInfo.CurrentUICulture;
         if (!CultureToDisplayOrder.ContainsKey(culture))
         {
@@ -343,7 +344,8 @@ public class KeysConverter : TypeConverter, IComparer
 
     private IDictionary<string, Keys> GetKeyNames(CultureInfo? culture)
     {
-        // Use CurrentUICulture as default to match other TypeConverters.
+        // Use CurrentUICulture as default because we assume that this converter is primarily
+        // used in user-facing applications (I.e. what key to press on the keyboard).
         culture ??= CultureInfo.CurrentUICulture;
         if (!CultureToKeyName.ContainsKey(culture))
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Input/KeysConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Input/KeysConverter.cs
@@ -331,8 +331,8 @@ public class KeysConverter : TypeConverter, IComparer
 
     private IList<string> GetDisplayOrder(CultureInfo? culture)
     {
-        // Use CurrentCulture as default to match other TypeConverters.
-        culture ??= CultureInfo.CurrentCulture;
+        // Use CurrentUICulture as default to match other TypeConverters.
+        culture ??= CultureInfo.CurrentUICulture;
         if (!CultureToDisplayOrder.ContainsKey(culture))
         {
             AddLocalizedKeyNames(culture);
@@ -343,8 +343,8 @@ public class KeysConverter : TypeConverter, IComparer
 
     private IDictionary<string, Keys> GetKeyNames(CultureInfo? culture)
     {
-        // Use CurrentCulture as default to match other TypeConverters.
-        culture ??= CultureInfo.CurrentCulture;
+        // Use CurrentUICulture as default to match other TypeConverters.
+        culture ??= CultureInfo.CurrentUICulture;
         if (!CultureToKeyName.ContainsKey(culture))
         {
             AddLocalizedKeyNames(culture);


### PR DESCRIPTION

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #10687 


## Proposed changes

- Use CurrentUICulture instead of CurrentCulture in function ConvertTo and ConvertFrom 

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Key values and order will be displayed according to CurrentUICulture

## Regression? 

- Yes 

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

- Key values and order are displayed according to CurrentCulture

### After

 - Key values and order are displayed according to CurrentUICulture


## Test methodology <!-- How did you ensure quality? -->

- Unit test

## Test environment(s) <!-- Remove any that don't apply -->

- .net 9.0.0-alpha.1.24066.33


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10732)