### PR TITLE
Clean up ImageListStreamer

### DIFF
--- a/src/System.Private.Windows.Core/src/System/IO/Compression/RunLengthEncoder.cs
+++ b/src/System.Private.Windows.Core/src/System/IO/Compression/RunLengthEncoder.cs
@@ -1,0 +1,99 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.IO.Compression;
+
+/// <summary>
+///  Simple run length encoder (RLE) that works on spans.
+/// </summary>
+/// <remarks>
+///  <para>
+///   Format used is a byte for the count, followed by a byte for the value.
+///  </para>
+/// </remarks>
+internal static class RunLengthEncoder
+{
+    /// <summary>
+    ///  Get the encoded length, in bytes, of the given data.
+    /// </summary>
+    public static int GetEncodedLength(ReadOnlySpan<byte> data)
+    {
+        SpanReader<byte> reader = new(data);
+
+        int length = 0;
+        while (reader.TryRead(out byte value))
+        {
+            int count = reader.AdvancePast(value) + 1;
+            while (count > 0)
+            {
+                // 1 byte for the count, 1 byte for the value
+                length += 2;
+                count -= 0xFF;
+            }
+        }
+
+        return length;
+    }
+
+    /// <summary>
+    ///  Get the decoded length, in bytes, of the given encoded data.
+    /// </summary>
+    public static int GetDecodedLength(ReadOnlySpan<byte> encoded)
+    {
+        int length = 0;
+        for (int i = 0; i < encoded.Length; i += 2)
+        {
+            length += encoded[i];
+        }
+
+        return length;
+    }
+
+    /// <summary>
+    ///  Encode the given data into the given <paramref name="encoded"/> span.
+    /// </summary>
+    /// <returns>
+    ///  <see langword="false"/> if the <paramref name="encoded"/> span was not large enough to hold the encoded data.
+    /// </returns>
+    public static bool TryEncode(ReadOnlySpan<byte> data, Span<byte> encoded, out int written)
+    {
+        SpanReader<byte> reader = new(data);
+        SpanWriter<byte> writer = new(encoded);
+
+        while (reader.TryRead(out byte value))
+        {
+            int count = reader.AdvancePast(value) + 1;
+            while (count > 0)
+            {
+                if (!writer.TryWrite((byte)Math.Min(count, 0xFF)) || !writer.TryWrite(value))
+                {
+                    written = writer.Position;
+                    return false;
+                }
+
+                count -= 0xFF;
+            }
+        }
+
+        written = writer.Position;
+        return true;
+    }
+
+    public static bool TryDecode(ReadOnlySpan<byte> encoded, Span<byte> data, out int written)
+    {
+        SpanReader<byte> reader = new(encoded);
+        SpanWriter<byte> writer = new(data);
+
+        while (reader.TryRead(out byte count))
+        {
+            if (!reader.TryRead(out byte value) || !writer.TryWrite(count, value))
+            {
+                written = writer.Position;
+                return false;
+            }
+        }
+
+        written = writer.Position;
+        return true;
+    }
+}

--- a/src/System.Private.Windows.Core/src/System/SpanWriter.cs
+++ b/src/System.Private.Windows.Core/src/System/SpanWriter.cs
@@ -1,0 +1,112 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace System;
+
+/// <summary>
+///  Fast stack based <see cref="Span{T}"/> writer.
+/// </summary>
+internal unsafe ref struct SpanWriter<T>(Span<T> span) where T : unmanaged, IEquatable<T>
+{
+    private Span<T> _unwritten = span;
+    public Span<T> Span { get; } = span;
+
+    public int Position
+    {
+        readonly get => Span.Length - _unwritten.Length;
+        set => _unwritten = Span[value..];
+    }
+
+    public readonly int Length => Span.Length;
+
+    /// <summary>
+    ///  Try to write the given value.
+    /// </summary>
+    public bool TryWrite(T value)
+    {
+        bool success = false;
+
+        if (!_unwritten.IsEmpty)
+        {
+            success = true;
+            _unwritten[0] = value;
+            UnsafeAdvance(1);
+        }
+
+        return success;
+    }
+
+    /// <summary>
+    ///  Try to write the given value.
+    /// </summary>
+    public bool TryWrite(ReadOnlySpan<T> values)
+    {
+        bool success = false;
+
+        if (_unwritten.Length >= values.Length)
+        {
+            success = true;
+            values.CopyTo(_unwritten);
+            UnsafeAdvance(values.Length);
+        }
+
+        return success;
+    }
+
+    /// <summary>
+    ///  Try to write the given value <paramref name="count"/> times.
+    /// </summary>
+    public bool TryWrite(int count, T value)
+    {
+        bool success = false;
+
+        if (_unwritten.Length >= count)
+        {
+            success = true;
+            _unwritten[..count].Fill(value);
+            UnsafeAdvance(count);
+        }
+
+        return success;
+    }
+
+    /// <summary>
+    ///  Advance the writer by the given <paramref name="count"/>.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Advance(int count) => _unwritten = _unwritten[count..];
+
+    /// <summary>
+    ///  Rewind the writer by the given <paramref name="count"/>.
+    /// </summary>
+    public void Rewind(int count) => _unwritten = Span[(Span.Length - _unwritten.Length - count)..];
+
+    /// <summary>
+    ///  Reset the reader to the beginning of the span.
+    /// </summary>
+    public void Reset() => _unwritten = Span;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void UnsafeAdvance(int count)
+    {
+        Debug.Assert((uint)count <= (uint)_unwritten.Length);
+        UncheckedSlice(ref _unwritten, count, _unwritten.Length - count);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void UncheckedSliceTo(ref Span<T> span, int length)
+    {
+        Debug.Assert((uint)length <= (uint)span.Length);
+        span = MemoryMarshal.CreateSpan(ref MemoryMarshal.GetReference(span), length);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void UncheckedSlice(ref Span<T> span, int start, int length)
+    {
+        Debug.Assert((uint)start <= (uint)span.Length && (uint)length <= (uint)(span.Length - start));
+        span = MemoryMarshal.CreateSpan(ref Unsafe.Add(ref MemoryMarshal.GetReference(span), (nint)(uint)start), length);
+    }
+}

--- a/src/System.Private.Windows.Core/src/Windows/Win32/System/Com/Interop.GPStream.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/System/Com/Interop.GPStream.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 
 namespace Windows.Win32.System.Com;
 
-public sealed unsafe class ComManagedStream : IStream.Interface, IManagedWrapper<IStream, ISequentialStream>
+internal sealed unsafe class ComManagedStream : IStream.Interface, IManagedWrapper<IStream, ISequentialStream>
 {
     private readonly Stream _dataStream;
 

--- a/src/System.Private.Windows.Core/src/Windows/Win32/UI/Controls/Dialogs/DEVNAMES.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/UI/Controls/Dialogs/DEVNAMES.cs
@@ -21,7 +21,7 @@ namespace Windows.Win32.UI.Controls.Dialogs;
 ///
 ///  https://github.com/microsoft/CsWin32/issues/882
 /// </devdoc>
-public partial struct DEVNAMES
+internal partial struct DEVNAMES
 {
     /// <summary>
     /// <para>Type: <b>WORD</b> The offset, in characters, from the beginning of this structure to a null-terminated string that contains the file name (without the extension) of the device driver. On input, this string is used to determine the printer to display initially in the dialog box.</para>

--- a/src/System.Private.Windows.Core/src/Windows/Win32/UI/WindowsAndMessaging/ICONDIR.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/UI/WindowsAndMessaging/ICONDIR.cs
@@ -7,7 +7,7 @@ namespace Windows.Win32.UI.WindowsAndMessaging;
 
 // Needs to be packed to 2 to get ICONDIRENTRY to follow immediately after idCount.
 [StructLayout(LayoutKind.Sequential, Pack = 2)]
-public struct ICONDIR
+internal struct ICONDIR
 {
     // Must be 0
     public ushort idReserved;

--- a/src/System.Private.Windows.Core/src/Windows/Win32/UI/WindowsAndMessaging/ICONDIRENTRY.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/UI/WindowsAndMessaging/ICONDIRENTRY.cs
@@ -9,7 +9,7 @@ namespace Windows.Win32.UI.WindowsAndMessaging;
 // https://devblogs.microsoft.com/oldnewthing/20120720-00/?p=7083
 
 [StructLayout(LayoutKind.Sequential)]
-public struct ICONDIRENTRY
+internal struct ICONDIRENTRY
 {
     // Width and height are 1 - 255 or 0 for 256
     public byte bWidth;

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.ImageList.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.ImageList.cs
@@ -7,8 +7,9 @@ namespace Windows.Win32;
 
 internal partial class PInvoke
 {
-    public static class ImageList
+    public static unsafe class ImageList
     {
+        /// <inheritdoc cref="ImageList_Add(HIMAGELIST, HBITMAP, HBITMAP)"/>
         public static int Add<T>(T himl, HBITMAP hbmImage, HBITMAP hbmMask) where T : IHandle<HIMAGELIST>
         {
             int result = ImageList_Add(himl.Handle, hbmImage, hbmMask);
@@ -16,6 +17,7 @@ internal partial class PInvoke
             return result;
         }
 
+        /// <inheritdoc cref="ImageList_Destroy(HIMAGELIST)"/>
         public static bool Destroy<T>(T himl) where T: IHandle<HIMAGELIST>
         {
             bool result = ImageList_Destroy(himl.Handle);
@@ -23,6 +25,7 @@ internal partial class PInvoke
             return result;
         }
 
+        /// <inheritdoc cref="ImageList_Draw(HIMAGELIST, int, HDC, int, int, IMAGE_LIST_DRAW_STYLE)"/>
         public static bool Draw<T>(T himl, int i, HDC hdcDst, int x, int y, IMAGE_LIST_DRAW_STYLE fStyle)
             where T : IHandle<HIMAGELIST>
         {
@@ -50,7 +53,8 @@ internal partial class PInvoke
             return result;
         }
 
-        public static unsafe bool GetIconSize<T>(T himl, out int x, out int y) where T : IHandle<HIMAGELIST>
+        /// <inheritdoc cref="ImageList_GetIconSize(HIMAGELIST, int*, int*)"/>
+        public static bool GetIconSize<T>(T himl, out int x, out int y) where T : IHandle<HIMAGELIST>
         {
             fixed (int* px = &x)
             fixed (int* py = &y)
@@ -61,6 +65,7 @@ internal partial class PInvoke
             }
         }
 
+        /// <inheritdoc cref="ImageList_GetImageCount(HIMAGELIST)"/>
         public static int GetImageCount<T>(T himl) where T : IHandle<HIMAGELIST>
         {
             int result = ImageList_GetImageCount(himl.Handle);
@@ -68,6 +73,7 @@ internal partial class PInvoke
             return result;
         }
 
+        /// <inheritdoc cref="ImageList_GetImageInfo(HIMAGELIST, int, IMAGEINFO*)"/>
         public static bool GetImageInfo<T>(T himl, int i, out IMAGEINFO pImageInfo) where T : IHandle<HIMAGELIST>
         {
             bool result = ImageList_GetImageInfo(himl.Handle, i, out pImageInfo);
@@ -75,6 +81,7 @@ internal partial class PInvoke
             return result;
         }
 
+        /// <inheritdoc cref="ImageList_Remove(HIMAGELIST, int)"/>
         public static bool Remove<T>(T himl, int i) where T : IHandle<HIMAGELIST>
         {
             bool result = ImageList_Remove(himl.Handle, i);
@@ -82,6 +89,7 @@ internal partial class PInvoke
             return result;
         }
 
+        /// <inheritdoc cref="ImageList_Replace(HIMAGELIST, int, HBITMAP, HBITMAP)"/>
         public static bool Replace<T>(T himl, int i, HBITMAP hbmImage, HBITMAP hbmMask) where T : IHandle<HIMAGELIST>
         {
             bool result = ImageList_Replace(himl.Handle, i, hbmImage, hbmMask);
@@ -89,6 +97,7 @@ internal partial class PInvoke
             return result;
         }
 
+        /// <inheritdoc cref="ImageList_ReplaceIcon(HIMAGELIST, int, HICON)"/>
         public static int ReplaceIcon<THIML, THICON>(
             THIML himl,
             int i,
@@ -100,6 +109,7 @@ internal partial class PInvoke
             return result;
         }
 
+        /// <inheritdoc cref="ImageList_SetBkColor(HIMAGELIST, COLORREF)"/>
         public static COLORREF SetBkColor<T>(T himl, COLORREF clrBk) where T : IHandle<HIMAGELIST>
         {
             COLORREF result = ImageList_SetBkColor(himl.Handle, clrBk);
@@ -107,22 +117,22 @@ internal partial class PInvoke
             return result;
         }
 
-        public static unsafe BOOL Write<T>(T himl, IStream.Interface pstm) where T : IHandle<HIMAGELIST>
+        /// <inheritdoc cref="ImageList_Write(HIMAGELIST, IStream*)"/>
+        public static BOOL Write<T>(T himl, Stream pstm) where T : IHandle<HIMAGELIST>
         {
-            using var stream = ComHelpers.TryGetComScope<IStream>(pstm, out HRESULT hr);
-            Debug.Assert(hr.Succeeded);
+            using var stream = pstm.ToIStream();
             BOOL result = ImageList_Write(himl.Handle, stream);
             GC.KeepAlive(himl.Wrapper);
             return result;
         }
 
-        public static unsafe HRESULT WriteEx<T>(
+        /// <inheritdoc cref="ImageList_WriteEx(HIMAGELIST, IMAGE_LIST_WRITE_STREAM_FLAGS, IStream*)"/>
+        public static HRESULT WriteEx<T>(
             T himl,
             IMAGE_LIST_WRITE_STREAM_FLAGS dwFlags,
-            IStream.Interface pstm) where T : IHandle<HIMAGELIST>
+            Stream pstm) where T : IHandle<HIMAGELIST>
         {
-            using var stream = ComHelpers.TryGetComScope<IStream>(pstm, out HRESULT hr);
-            Debug.Assert(hr.Succeeded);
+            using var stream = pstm.ToIStream();
             HRESULT result = ImageList_WriteEx(himl.Handle, dwFlags, stream);
             GC.KeepAlive(himl.Wrapper);
             return result;

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/IO/Compression/RunLengthEncoderTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/IO/Compression/RunLengthEncoderTests.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.IO.Compression;
+
+public class RunLengthEncoderTests
+{
+    [Fact]
+    public void RunLengthEncoder_TryEncode()
+    {
+        ReadOnlySpan<byte> data = [1, 1, 1, 2, 2, 3, 3, 3, 3];
+        Span<byte> encoded = new byte[RunLengthEncoder.GetEncodedLength(data)];
+        RunLengthEncoder.TryEncode(data, encoded, out int written).Should().BeTrue();
+        written.Should().Be(6);
+        encoded.ToArray().Should().BeEquivalentTo([3, 1, 2, 2, 4, 3]);
+    }
+
+    [Theory]
+    [InlineData(0, 0)]
+    [InlineData(1, 2)]
+    [InlineData(255, 2)]
+    [InlineData(256, 4)]
+    public void RunLengthEncoder_GetEncodedLength(int count, int expectedLength)
+    {
+        Span<byte> data = new byte[count];
+        Span<byte> encoded = new byte[RunLengthEncoder.GetEncodedLength(data)];
+        RunLengthEncoder.TryEncode(data, encoded, out int written).Should().BeTrue();
+        written.Should().Be(expectedLength);
+        encoded.Length.Should().Be(expectedLength);
+    }
+
+    [Fact]
+    public void RunLengthEncoder_RoundTrip()
+    {
+        ReadOnlySpan<byte> data = [1, 1, 1, 2, 2, 3, 3, 3, 3];
+        Span<byte> encoded = new byte[RunLengthEncoder.GetEncodedLength(data)];
+        RunLengthEncoder.TryEncode(data, encoded, out int written).Should().BeTrue();
+        written.Should().Be(6);
+
+        Span<byte> decoded = new byte[RunLengthEncoder.GetDecodedLength(encoded)];
+        RunLengthEncoder.TryDecode(encoded, decoded, out written).Should().BeTrue();
+        written.Should().Be(data.Length);
+        decoded.ToArray().Should().BeEquivalentTo(data.ToArray());
+    }
+}

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Private/Windows/Core/PrivateCoreTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Private/Windows/Core/PrivateCoreTests.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Private.Windows.Core;
+
+public class PrivateCoreTests
+{
+    [Fact]
+    public void PrivateCore_HasNoPublicTypes()
+    {
+        // There should be no public types in this assembly.
+        typeof(BufferScope<>).Assembly.GetExportedTypes().Should().BeEmpty();
+    }
+}

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/SpanReaderTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/SpanReaderTests.cs
@@ -3,58 +3,58 @@
 
 using System.Drawing;
 
-namespace System.Tests;
+namespace System;
 
 public class SpanReaderTests
 {
     [Fact]
     public void SpanReader_TryReadTo_SkipDelimiter()
     {
-        ReadOnlySpan<byte> span = new byte[] { 1, 2, 3, 4, 5 };
+        ReadOnlySpan<byte> span = [1, 2, 3, 4, 5];
         SpanReader<byte> reader = new(span);
 
         reader.TryReadTo(3, out var read).Should().BeTrue();
         read.ToArray().Should().BeEquivalentTo([1, 2]);
-        reader.UnreadSpan.ToArray().Should().BeEquivalentTo([4, 5]);
+        reader.Position.Should().Be(3);
 
         reader.TryReadTo(5, out read).Should().BeTrue();
         read.ToArray().Should().BeEquivalentTo([4]);
-        reader.UnreadSpan.ToArray().Should().BeEmpty();
+        reader.Position.Should().Be(5);
     }
 
     [Fact]
-    public void SpanReader_TryReadTo_DontSkipDelimiter()
+    public void SpanReader_TryReadTo_DoNotSkipDelimiter()
     {
-        ReadOnlySpan<byte> span = new byte[] { 1, 2, 3, 4, 5 };
+        ReadOnlySpan<byte> span = [1, 2, 3, 4, 5];
         SpanReader<byte> reader = new(span);
 
         reader.TryReadTo(3, advancePastDelimiter: false, out var read).Should().BeTrue();
         read.ToArray().Should().BeEquivalentTo([1, 2]);
-        reader.UnreadSpan.ToArray().Should().BeEquivalentTo([3, 4, 5]);
+        reader.Position.Should().Be(2);
 
         reader.TryReadTo(5, advancePastDelimiter: false, out read).Should().BeTrue();
         read.ToArray().Should().BeEquivalentTo([3, 4]);
-        reader.UnreadSpan.ToArray().Should().BeEquivalentTo([5]);
+        reader.Position.Should().Be(4);
 
         reader.TryReadTo(5, advancePastDelimiter: false, out read).Should().BeTrue();
         read.ToArray().Should().BeEmpty();
-        reader.UnreadSpan.ToArray().Should().BeEquivalentTo([5]);
+        reader.Position.Should().Be(4);
     }
 
     [Fact]
     public void SpanReader_Advance()
     {
-        ReadOnlySpan<byte> span = new byte[] { 1, 2, 3, 4, 5 };
+        ReadOnlySpan<byte> span = [1, 2, 3, 4, 5];
         SpanReader<byte> reader = new(span);
 
         reader.Advance(2);
-        reader.UnreadSpan.ToArray().Should().BeEquivalentTo([3, 4, 5]);
+        reader.Position.Should().Be(2);
 
         reader.Advance(2);
-        reader.UnreadSpan.ToArray().Should().BeEquivalentTo([5]);
+        reader.Position.Should().Be(4);
 
         reader.Advance(1);
-        reader.UnreadSpan.ToArray().Should().BeEmpty();
+        reader.Position.Should().Be(5);
 
         try
         {
@@ -70,14 +70,14 @@ public class SpanReaderTests
     [Fact]
     public void SpanReader_Rewind()
     {
-        ReadOnlySpan<byte> span = new byte[] { 1, 2, 3, 4, 5 };
+        ReadOnlySpan<byte> span = [1, 2, 3, 4, 5];
         SpanReader<byte> reader = new(span);
 
         reader.Advance(2);
-        reader.UnreadSpan.ToArray().Should().BeEquivalentTo([3, 4, 5]);
+        reader.Position.Should().Be(2);
 
         reader.Rewind(1);
-        reader.UnreadSpan.ToArray().Should().BeEquivalentTo([2, 3, 4, 5]);
+        reader.Position.Should().Be(1);
 
         try
         {
@@ -90,13 +90,13 @@ public class SpanReaderTests
         }
 
         reader.Rewind(1);
-        reader.UnreadSpan.ToArray().Should().BeEquivalentTo([1, 2, 3, 4, 5]);
+        reader.Position.Should().Be(0);
     }
 
     [Fact]
     public void SpanReader_TryRead_ReadPoints()
     {
-        ReadOnlySpan<uint> span = new uint[] { 1, 2, 3, 4, 5 };
+        ReadOnlySpan<uint> span = [1, 2, 3, 4, 5];
         SpanReader<uint> reader = new(span);
 
         reader.TryRead(out Point value).Should().BeTrue();
@@ -106,13 +106,14 @@ public class SpanReaderTests
         value.Should().Be(new Point(3, 4));
 
         reader.TryRead(out value).Should().BeFalse();
-        reader.UnreadSpan.ToArray().Should().BeEquivalentTo([5]);
+        value.Should().Be(default(Point));
+        reader.Position.Should().Be(4);
     }
 
     [Fact]
     public void SpanReader_TryRead_ReadPointCounts()
     {
-        ReadOnlySpan<uint> span = new uint[] { 1, 2, 3, 4, 5 };
+        ReadOnlySpan<uint> span = [1, 2, 3, 4, 5];
         SpanReader<uint> reader = new(span);
 
         reader.TryRead(2, out ReadOnlySpan<Point> value).Should().BeTrue();
@@ -141,18 +142,18 @@ public class SpanReaderTests
     [Fact]
     public void SpanReader_TryRead_Count()
     {
-        ReadOnlySpan<uint> span = new uint[] { 1, 2, 3, 4, 5 };
+        ReadOnlySpan<uint> span = [1, 2, 3, 4, 5];
         SpanReader<uint> reader = new(span);
 
         reader.TryRead(2, out var read).Should().BeTrue();
         read.ToArray().Should().BeEquivalentTo([1, 2]);
-        reader.UnreadSpan.ToArray().Should().BeEquivalentTo([3, 4, 5]);
+        reader.Position.Should().Be(2);
 
         reader.TryRead(2, out read).Should().BeTrue();
         read.ToArray().Should().BeEquivalentTo([3, 4]);
-        reader.UnreadSpan.ToArray().Should().BeEquivalentTo([5]);
+        reader.Position.Should().Be(4);
 
-        reader.TryRead(2, out read).Should().BeFalse();
-        reader.UnreadSpan.ToArray().Should().BeEquivalentTo([5]);
+        reader.TryRead(2, out _).Should().BeFalse();
+        reader.Position.Should().Be(4);
     }
 }

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/SpanWriterTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/SpanWriterTests.cs
@@ -1,0 +1,87 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Drawing;
+
+namespace System;
+
+public class SpanWriterTests
+{
+    [Fact]
+    public void SpanWriter_TryWrite()
+    {
+        Span<byte> span = new byte[5];
+        SpanWriter<byte> writer = new(span);
+
+        writer.TryWrite(1).Should().BeTrue();
+        span.ToArray().Should().BeEquivalentTo([1, 0, 0, 0, 0]);
+
+        writer.TryWrite(2).Should().BeTrue();
+        span.ToArray().Should().BeEquivalentTo([1, 2, 0, 0, 0]);
+
+        writer.TryWrite(3).Should().BeTrue();
+        span.ToArray().Should().BeEquivalentTo([1, 2, 3, 0, 0]);
+
+        writer.TryWrite(4).Should().BeTrue();
+        span.ToArray().Should().BeEquivalentTo([1, 2, 3, 4, 0]);
+
+        writer.TryWrite(5).Should().BeTrue();
+        span.ToArray().Should().BeEquivalentTo([1, 2, 3, 4, 5]);
+
+        writer.TryWrite(6).Should().BeFalse();
+    }
+
+    [Fact]
+    public void SpanWriter_TryWrite_Spans()
+    {
+        Span<byte> span = new byte[5];
+        SpanWriter<byte> writer = new(span);
+
+        writer.TryWrite([1, 2]).Should().BeTrue();
+        span.ToArray().Should().BeEquivalentTo([1, 2, 0, 0, 0]);
+
+        writer.TryWrite([3, 4]).Should().BeTrue();
+        span.ToArray().Should().BeEquivalentTo([1, 2, 3, 4, 0]);
+
+        writer.TryWrite([5]).Should().BeTrue();
+        span.ToArray().Should().BeEquivalentTo([1, 2, 3, 4, 5]);
+
+        writer.TryWrite([6]).Should().BeFalse();
+    }
+
+    [Fact]
+    public void SpanWriter_TryWrite_Count()
+    {
+        Span<int> span = new int[5];
+        SpanWriter<int> writer = new(span);
+
+        writer.TryWrite(2, 1).Should().BeTrue();
+        span.ToArray().Should().BeEquivalentTo([1, 1, 0, 0, 0]);
+
+        writer.TryWrite(2, 2).Should().BeTrue();
+        span.ToArray().Should().BeEquivalentTo([1, 1, 2, 2, 0]);
+
+        writer.TryWrite(1, 3).Should().BeTrue();
+        span.ToArray().Should().BeEquivalentTo([1, 1, 2, 2, 3]);
+
+        writer.TryWrite(1, 4).Should().BeFalse();
+    }
+
+    [Fact]
+    public void SpanWriter_TryWrite_CountPoints()
+    {
+        Span<Point> span = new Point[5];
+        SpanWriter<Point> writer = new(span);
+
+        writer.TryWrite(2, new Point(1, 2)).Should().BeTrue();
+        span.ToArray().Should().BeEquivalentTo([new Point(1, 2), new Point(1, 2), default, default, default]);
+
+        writer.TryWrite(2, new Point(3, 4)).Should().BeTrue();
+        span.ToArray().Should().BeEquivalentTo([new Point(1, 2), new Point(1, 2), new Point(3, 4), new Point(3, 4), default]);
+
+        writer.TryWrite(1, new Point(5, 6)).Should().BeTrue();
+        span.ToArray().Should().BeEquivalentTo([new Point(1, 2), new Point(1, 2), new Point(3, 4), new Point(3, 4), new Point(5, 6)]);
+
+        writer.TryWrite(1, new Point(7, 8)).Should().BeFalse();
+    }
+}

--- a/src/System.Windows.Forms/src/GlobalSuppressions.cs
+++ b/src/System.Windows.Forms/src/GlobalSuppressions.cs
@@ -16,6 +16,7 @@
 [assembly: SuppressMessage("Naming", "CA1725:Parameter names should match base declaration", Justification = "Public API", Scope = "member", Target = "~M:System.Windows.Forms.PrintPreviewControl.OnPaintBackground(System.Windows.Forms.PaintEventArgs)")]
 [assembly: SuppressMessage("Naming", "CA1725:Parameter names should match base declaration", Justification = "Public API", Scope = "member", Target = "~M:System.Windows.Forms.PrintPreviewControl.OnPaint(System.Windows.Forms.PaintEventArgs)")]
 [assembly: SuppressMessage("Naming", "CA1725:Parameter names should match base declaration", Justification = "Public API", Scope = "member", Target = "~M:System.Windows.Forms.FontDialog.RunDialog(System.IntPtr)~System.Boolean")]
+[assembly: SuppressMessage("Naming", "CA1725:Parameter names should match base declaration", Justification = "Public API", Scope = "member", Target = "~M:System.Windows.Forms.ImageListStreamer.GetObjectData(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)")]
 [assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Public API", Scope = "member", Target = "~F:System.Windows.Forms.FontDialog.EventApply")]
 [assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Public API", Scope = "member", Target = "~F:System.Windows.Forms.FileDialog.EventFileOk")]
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ImageList/ImageList.NativeImageList.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ImageList/ImageList.NativeImageList.cs
@@ -93,7 +93,7 @@ public sealed partial class ImageList
             //      resources.ApplyResources(this.listView1, "listView1");
             //
             // In those cases the loose instances will be collected by the GC.
-            Dispose(false);
+            Dispose(disposing: false);
         }
 
         internal NativeImageList Duplicate()

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/ImageListTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/ImageListTests.cs
@@ -120,7 +120,6 @@ public class ImageListTests : ControlTestBase
     private static ImageListStreamer DeserializeStreamer(string base64String)
     {
         byte[] bytes = Convert.FromBase64String(base64String);
-        using MemoryStream ms = new(bytes);
-        return new ImageListStreamer(ms);
+        return new ImageListStreamer(bytes);
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ImageListStreamerTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ImageListStreamerTests.cs
@@ -24,7 +24,7 @@ public class ImageListStreamerTests
 
         // Create a new ImageListStreamer from the stream
         ms.Position = 0;
-        using ImageListStreamer streamerFromMs = new(ms);
+        using ImageListStreamer streamerFromMs = new(ms.GetBuffer());
         using NativeImageList nativeImageListMs = streamerFromMs.GetNativeImageList();
         Assert.NotEqual(HIMAGELIST.Null, nativeImageListMs.HIMAGELIST);
 
@@ -46,8 +46,7 @@ public class ImageListStreamerTests
 
         // Create a new ImageListStreamer from the stream
         byte[] bytes = Convert.FromBase64String(DevMsImageListStreamer);
-        using MemoryStream ms = new(bytes);
-        using ImageListStreamer streamerFromMs = new(ms);
+        using ImageListStreamer streamerFromMs = new(bytes);
         using NativeImageList nativeImageListMs = streamerFromMs.GetNativeImageList();
         Assert.NotEqual(HIMAGELIST.Null, nativeImageListMs.HIMAGELIST);
 


### PR DESCRIPTION
Clean up the code in ImageListStreamer. It should be more efficient now as it uses vector optimized reading and writing from the .NET libraries (through the SpanReader/Writer) .

- Factor out RLE encoding into RunLengthEncoder
- Add a SpanWriter to go with SpanReader
- Tweak SpanReader to have Position property and add IsNext, TryAdvancePast, and AdvancePast
- Add inherit doc to ImageList P/Invoke overloads

Also add a test to catch public types in System.Private.Windows.Core and fix the prior misses.