### PR TITLE
Type primitive arrays in BinaryFormattedObject

### DIFF
--- a/src/System.Private.Windows.Core/src/System/Collections/Generic/CollectionExtensions.cs
+++ b/src/System.Private.Windows.Core/src/System/Collections/Generic/CollectionExtensions.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Collections.Generic;
+
+internal static class CollectionExtensions
+{
+    /// <summary>
+    ///  Creates a list trimmed to the given count.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   This is an optimized implementation that avoids iterating over the entire list when possible.
+    ///  </para>
+    /// </remarks>
+    internal static List<T> CreateTrimmedList<T>(this IReadOnlyList<T> readOnlyList, int count)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(readOnlyList.Count, count, nameof(count));
+
+        // List<T> will use ICollection<T>.CopyTo if it's available, which is faster than iterating over the list.
+        // If we just have an array this can be done easily with ArraySegment<T>.
+        if (readOnlyList is T[] array)
+        {
+            return new List<T>(new ArraySegment<T>(array, 0, count));
+        }
+
+        // Fall back to just setting the count (by removing).
+        List<T> list = new(readOnlyList);
+        list.RemoveRange(count, list.Count - count);
+        return list;
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Collections/Generic/ListConverter.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Collections/Generic/ListConverter.cs
@@ -12,24 +12,24 @@ namespace System.Collections.Generic;
 ///   through the list this class should usually be avoided.
 ///  </para>
 /// </remarks>
-internal class ListConverter<TIn> : IReadOnlyList<object>
+internal class ListConverter<TIn, TOut> : IReadOnlyList<TOut>
 {
     private readonly IList _values;
-    private readonly Func<TIn, object> _converter;
+    private readonly Func<TIn, TOut> _converter;
 
-    public ListConverter(IList values, Func<TIn, object> converter)
+    public ListConverter(IList values, Func<TIn, TOut> converter)
     {
         _values = values;
         _converter = converter;
     }
 
-    public object this[int index] => _converter((TIn)_values[index]!);
+    public TOut this[int index] => _converter((TIn)_values[index]!);
 
     public int Count => _values.Count;
 
     // Saving a little bit of code by not writing an enumerator. It isn't huge, so this can be
     // added if needed.
 
-    IEnumerator<object> IEnumerable<object>.GetEnumerator() => throw new NotImplementedException();
+    IEnumerator<TOut> IEnumerable<TOut>.GetEnumerator() => throw new NotImplementedException();
     IEnumerator IEnumerable.GetEnumerator() => throw new NotImplementedException();
 }

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/ArrayInfo.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/ArrayInfo.cs
@@ -24,11 +24,11 @@ internal readonly struct ArrayInfo : IBinaryWriteable
         ObjectId = objectId;
     }
 
-    public static ArrayInfo Parse(BinaryReader reader, out Count length)
+    public static Id Parse(BinaryReader reader, out Count length)
     {
-        ArrayInfo arrayInfo = new(reader.ReadInt32(), reader.ReadInt32());
-        length = arrayInfo.Length;
-        return arrayInfo;
+        Id id = reader.ReadInt32();
+        length = reader.ReadInt32();
+        return id;
     }
 
     public readonly void Write(BinaryWriter writer)

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/ArrayRecord.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/ArrayRecord.cs
@@ -14,19 +14,9 @@ namespace System.Windows.Forms.BinaryFormat;
 ///  can be coalesced into an <see cref="NullRecord.ObjectNullMultiple"/> or <see cref="NullRecord.ObjectNullMultiple256"/>
 ///  record.
 /// </devdoc>
-internal abstract class ArrayRecord : Record, IEnumerable<object>
+internal abstract class ArrayRecord : Record, IEnumerable
 {
     public ArrayInfo ArrayInfo { get; }
-
-    /// <summary>
-    ///  The array items.
-    /// </summary>
-    /// <remarks>
-    ///  <para>
-    ///   Multi-null records are always expanded to individual <see cref="ObjectNull"/> entries when reading.
-    ///  </para>
-    /// </remarks>
-    public IReadOnlyList<object> ArrayObjects { get; }
 
     /// <summary>
     ///  Identifier for the array.
@@ -38,22 +28,44 @@ internal abstract class ArrayRecord : Record, IEnumerable<object>
     /// </summary>
     public Count Length => ArrayInfo.Length;
 
+    public ArrayRecord(ArrayInfo arrayInfo) => ArrayInfo = arrayInfo;
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    private protected abstract IEnumerator GetEnumerator();
+}
+
+/// <summary>
+///  Typed class for array records.
+/// </summary>
+internal abstract class ArrayRecord<T> : ArrayRecord, IEnumerable<T>
+{
+    /// <summary>
+    ///  The array items.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   Multi-null records are always expanded to individual <see cref="ObjectNull"/> entries when reading.
+    ///  </para>
+    /// </remarks>
+    public IReadOnlyList<T> ArrayObjects { get; }
+
     /// <summary>
     ///  Returns the item at the given index.
     /// </summary>
-    public object this[int index] => ArrayObjects[index];
+    public T this[int index] => ArrayObjects[index];
 
-    public ArrayRecord(ArrayInfo arrayInfo, IReadOnlyList<object> arrayObjects)
+    public ArrayRecord(ArrayInfo arrayInfo, IReadOnlyList<T> arrayObjects) : base(arrayInfo)
     {
         if (arrayInfo.Length != arrayObjects.Count)
         {
             throw new ArgumentException($"{nameof(arrayInfo)} doesn't match count of {nameof(arrayObjects)}");
         }
 
-        ArrayInfo = arrayInfo;
         ArrayObjects = arrayObjects;
     }
 
-    IEnumerator<object> IEnumerable<object>.GetEnumerator() => ArrayObjects.GetEnumerator();
+    IEnumerator<T> IEnumerable<T>.GetEnumerator() => ArrayObjects.GetEnumerator();
     IEnumerator IEnumerable.GetEnumerator() => ArrayObjects.GetEnumerator();
+    private protected override IEnumerator GetEnumerator() => ArrayObjects.GetEnumerator();
 }

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/ArraySingleObject.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/ArraySingleObject.cs
@@ -13,12 +13,12 @@ namespace System.Windows.Forms.BinaryFormat;
 ///   </see>
 ///  </para>
 /// </remarks>
-internal sealed class ArraySingleObject : ArrayRecord, IRecord<ArraySingleObject>
+internal sealed class ArraySingleObject : ArrayRecord<object>, IRecord<ArraySingleObject>
 {
     public static RecordType RecordType => RecordType.ArraySingleObject;
 
-    public ArraySingleObject(ArrayInfo arrayInfo, IReadOnlyList<object> arrayObjects)
-        : base(arrayInfo, arrayObjects)
+    public ArraySingleObject(Id objectId, IReadOnlyList<object> arrayObjects)
+        : base(new ArrayInfo(objectId, arrayObjects.Count), arrayObjects)
     { }
 
     static ArraySingleObject IBinaryFormatParseable<ArraySingleObject>.Parse(

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/ArraySingleString.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/ArraySingleString.cs
@@ -13,12 +13,12 @@ namespace System.Windows.Forms.BinaryFormat;
 ///   </see>
 ///  </para>
 /// </remarks>
-internal sealed class ArraySingleString : ArrayRecord, IRecord<ArraySingleString>
+internal sealed class ArraySingleString : ArrayRecord<object>, IRecord<ArraySingleString>
 {
     public static RecordType RecordType => RecordType.ArraySingleString;
 
-    public ArraySingleString(ArrayInfo arrayInfo, IReadOnlyList<object> arrayObjects)
-        : base(arrayInfo, arrayObjects)
+    public ArraySingleString(Id objectId, IReadOnlyList<object> arrayObjects)
+        : base(new ArrayInfo(objectId, arrayObjects.Count), arrayObjects)
     { }
 
     static ArraySingleString IBinaryFormatParseable<ArraySingleString>.Parse(

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/BinaryArray.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/BinaryArray.cs
@@ -13,7 +13,7 @@ namespace System.Windows.Forms.BinaryFormat;
 ///   </see>
 ///  </para>
 /// </remarks>
-internal sealed class BinaryArray : ArrayRecord, IRecord<BinaryArray>
+internal sealed class BinaryArray : ArrayRecord<object>, IRecord<BinaryArray>
 {
     public Count Rank { get; }
     public BinaryArrayType Type { get; }

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/BinaryFormatWriter.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/BinaryFormatWriter.cs
@@ -247,9 +247,7 @@ internal static class BinaryFormatWriter
 
         StringRecordsCollection strings = new(currentId: 3);
 
-        new ArraySingleString(
-            new ArrayInfo(2, list.Count),
-            new ListConverter<string>(list, strings.GetStringRecord)).Write(writer);
+        new ArraySingleString(2, new ListConverter<string, object?>(list, strings.GetStringRecord)).Write(writer);
     }
 
     /// <summary>
@@ -280,10 +278,7 @@ internal static class BinaryFormatWriter
             // _version doesn't matter
             0).Write(writer);
 
-        new ArraySinglePrimitive(
-            new ArrayInfo(2, list.Count),
-            primitiveType,
-            new ListConverter<T>(list, (T value) => value!)).Write(writer);
+        new ArraySinglePrimitive<T>(2, list).Write(writer);
     }
 
     /// <summary>
@@ -376,7 +371,7 @@ internal static class BinaryFormatWriter
                 0).Write(writer);
 
             new ArraySingleObject(
-                new ArrayInfo(2, list.Count),
+                2,
                 ListConverter.GetPrimitiveConverter(list, new StringRecordsCollection(currentId: 3))).Write(writer);
 
             return true;
@@ -403,16 +398,46 @@ internal static class BinaryFormatWriter
             if (primitiveType == PrimitiveType.String)
             {
                 StringRecordsCollection strings = new(currentId: 2);
-                new ArraySingleString(
-                    new ArrayInfo(1, array.Length),
-                    ListConverter.GetPrimitiveConverter(array, strings)).Write(writer);
+                new ArraySingleString(1, ListConverter.GetPrimitiveConverter(array, strings)).Write(writer);
                 return true;
             }
 
-            new ArraySinglePrimitive(
-                new ArrayInfo(1, array.Length),
-                primitiveType,
-                new ListConverter<object?>(array, o => o!)).Write(writer);
+            IRecord record = primitiveType switch
+            {
+                PrimitiveType.Boolean => new ArraySinglePrimitive<bool>(
+                    1, new ListConverter<object, bool>(array, o => (bool)o!)),
+                PrimitiveType.Char => new ArraySinglePrimitive<char>(
+                    1, new ListConverter<object, char>(array, o => (char)o!)),
+                PrimitiveType.Byte => new ArraySinglePrimitive<byte>(
+                    1, new ListConverter<object, byte>(array, o => (byte)o!)),
+                PrimitiveType.SByte => new ArraySinglePrimitive<sbyte>(
+                    1, new ListConverter<object, sbyte>(array, o => (sbyte)o!)),
+                PrimitiveType.Int16 => new ArraySinglePrimitive<short>(
+                    1, new ListConverter<object, short>(array, o => (short)o!)),
+                PrimitiveType.Int32 => new ArraySinglePrimitive<int>(
+                    1, new ListConverter<object, int>(array, o => (int)o!)),
+                PrimitiveType.Int64 => new ArraySinglePrimitive<long>(
+                    1, new ListConverter<object, long>(array, o => (long)o!)),
+                PrimitiveType.UInt16 => new ArraySinglePrimitive<ushort>(
+                    1, new ListConverter<object, ushort>(array, o => (ushort)o!)),
+                PrimitiveType.UInt32 => new ArraySinglePrimitive<uint>(
+                    1, new ListConverter<object, uint>(array, o => (uint)o!)),
+                PrimitiveType.UInt64 => new ArraySinglePrimitive<ulong>(
+                    1, new ListConverter<object, ulong>(array, o => (ulong)o!)),
+                PrimitiveType.Single => new ArraySinglePrimitive<float>(
+                    1, new ListConverter<object, float>(array, o => (float)o!)),
+                PrimitiveType.Double => new ArraySinglePrimitive<double>(
+                    1, new ListConverter<object, double>(array, o => (double)o!)),
+                PrimitiveType.Decimal => new ArraySinglePrimitive<decimal>(
+                    1, new ListConverter<object, decimal>(array, o => (decimal)o!)),
+                PrimitiveType.TimeSpan => new ArraySinglePrimitive<TimeSpan>(
+                    1, new ListConverter<object, TimeSpan>(array, o => (TimeSpan)o!)),
+                PrimitiveType.DateTime => new ArraySinglePrimitive<DateTime>(
+                    1, new ListConverter<object, DateTime>(array, o => (DateTime)o!)),
+                _ => throw new InvalidOperationException()
+            };
+
+            record.Write(writer);
 
             return true;
         }
@@ -481,12 +506,8 @@ internal static class BinaryFormatWriter
         // 1, 2 and 3 are used for the class id and array ids.
         StringRecordsCollection strings = new(currentId: 4);
 
-        new ArraySingleObject(
-            new ArrayInfo(2, keys.Length),
-            ListConverter.GetPrimitiveConverter(keys, strings)).Write(writer);
-        new ArraySingleObject(
-            new ArrayInfo(3, values.Length),
-            ListConverter.GetPrimitiveConverter(values, strings)).Write(writer);
+        new ArraySingleObject(2, ListConverter.GetPrimitiveConverter(keys, strings)).Write(writer);
+        new ArraySingleObject(3, ListConverter.GetPrimitiveConverter(values, strings)).Write(writer);
     }
 
     /// <summary>
@@ -605,7 +626,7 @@ internal static class BinaryFormatWriter
         catch (Exception ex) when (!ex.IsCriticalException())
         {
             Debug.WriteLine($"Failed to binary format: {ex.Message}");
-            Debug.Assert(ex is ArgumentException, "We should only be getting ArgumentExceptions on write.");
+            Debug.Assert(ex is ArgumentException or SerializationException, "Unexpected write exception.");
             success = false;
         }
 

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/BinaryFormatWriter.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/BinaryFormatWriter.cs
@@ -247,7 +247,7 @@ internal static class BinaryFormatWriter
 
         StringRecordsCollection strings = new(currentId: 3);
 
-        new ArraySingleString(2, new ListConverter<string, object?>(list, strings.GetStringRecord)).Write(writer);
+        new ArraySingleString(2, new ListConverter<string, object>(list, strings.GetStringRecord)).Write(writer);
     }
 
     /// <summary>

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/BinaryFormattedObjectExtensions.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/BinaryFormattedObjectExtensions.cs
@@ -178,7 +178,7 @@ internal static class BinaryFormattedObjectExtensions
     }
 
     /// <summary>
-    ///  Trys to get this object as a <see cref="List{T}"/> of <see cref="PrimitiveType"/>.
+    ///  Tries to get this object as a <see cref="List{T}"/> of <see cref="PrimitiveType"/>.
     /// </summary>
     public static bool TryGetPrimitiveList(this BinaryFormattedObject format, [NotNullWhen(true)] out object? list)
     {
@@ -237,37 +237,32 @@ internal static class BinaryFormattedObjectExtensions
                     return false;
             }
 
-            if (array is not ArraySinglePrimitive primitiveArray || primitiveArray.PrimitiveType != primitiveType)
+            if (array is not IPrimitiveTypeRecord primitiveArray || primitiveArray.PrimitiveType != primitiveType)
             {
                 return false;
             }
 
-            IList primitiveList = primitiveType switch
+            // BinaryFormatter serializes the entire backing array, so we need to trim it down to the size of the list.
+            list = primitiveType switch
             {
-                PrimitiveType.Boolean => new List<bool>(size),
-                PrimitiveType.Byte => new List<byte>(size),
-                PrimitiveType.Char => new List<char>(size),
-                PrimitiveType.Decimal => new List<decimal>(size),
-                PrimitiveType.Double => new List<double>(size),
-                PrimitiveType.Int16 => new List<short>(size),
-                PrimitiveType.Int32 => new List<int>(size),
-                PrimitiveType.Int64 => new List<long>(size),
-                PrimitiveType.SByte => new List<sbyte>(size),
-                PrimitiveType.Single => new List<float>(size),
-                PrimitiveType.TimeSpan => new List<TimeSpan>(size),
-                PrimitiveType.DateTime => new List<DateTime>(size),
-                PrimitiveType.UInt16 => new List<ushort>(size),
-                PrimitiveType.UInt32 => new List<uint>(size),
-                PrimitiveType.UInt64 => new List<ulong>(size),
+                PrimitiveType.Boolean => ((ArrayRecord<bool>)array).ArrayObjects.CreateTrimmedList(size),
+                PrimitiveType.Byte => ((ArrayRecord<byte>)array).ArrayObjects.CreateTrimmedList(size),
+                PrimitiveType.Char => ((ArrayRecord<char>)array).ArrayObjects.CreateTrimmedList(size),
+                PrimitiveType.Decimal => ((ArrayRecord<decimal>)array).ArrayObjects.CreateTrimmedList(size),
+                PrimitiveType.Double => ((ArrayRecord<double>)array).ArrayObjects.CreateTrimmedList(size),
+                PrimitiveType.Int16 => ((ArrayRecord<short>)array).ArrayObjects.CreateTrimmedList(size),
+                PrimitiveType.Int32 => ((ArrayRecord<int>)array).ArrayObjects.CreateTrimmedList(size),
+                PrimitiveType.Int64 => ((ArrayRecord<long>)array).ArrayObjects.CreateTrimmedList(size),
+                PrimitiveType.SByte => ((ArrayRecord<sbyte>)array).ArrayObjects.CreateTrimmedList(size),
+                PrimitiveType.Single => ((ArrayRecord<float>)array).ArrayObjects.CreateTrimmedList(size),
+                PrimitiveType.TimeSpan => ((ArrayRecord<TimeSpan>)array).ArrayObjects.CreateTrimmedList(size),
+                PrimitiveType.DateTime => ((ArrayRecord<DateTime>)array).ArrayObjects.CreateTrimmedList(size),
+                PrimitiveType.UInt16 => ((ArrayRecord<ushort>)array).ArrayObjects.CreateTrimmedList(size),
+                PrimitiveType.UInt32 => ((ArrayRecord<uint>)array).ArrayObjects.CreateTrimmedList(size),
+                PrimitiveType.UInt64 => ((ArrayRecord<ulong>)array).ArrayObjects.CreateTrimmedList(size),
                 _ => throw new InvalidOperationException()
             };
 
-            foreach (object item in array.Take(size))
-            {
-                primitiveList.Add(item);
-            }
-
-            list = primitiveList;
             return true;
         }
     }
@@ -331,7 +326,7 @@ internal static class BinaryFormattedObjectExtensions
         static bool Get(BinaryFormattedObject format, [NotNullWhen(true)] out object? value)
         {
             value = null;
-            if (format.RecordCount != 3)
+            if (format.RecordCount != 3 || format[1] is not ArrayRecord)
             {
                 return false;
             }
@@ -342,28 +337,28 @@ internal static class BinaryFormattedObjectExtensions
                 return true;
             }
 
-            if (format[1] is not ArraySinglePrimitive primitiveArray)
+            if (format[1] is not IPrimitiveTypeRecord primitiveArray)
             {
                 return false;
             }
 
             value = primitiveArray.PrimitiveType switch
             {
-                PrimitiveType.Boolean => primitiveArray.ArrayObjects.Cast<bool>().ToArray(),
-                PrimitiveType.Byte => primitiveArray.ArrayObjects.Cast<byte>().ToArray(),
-                PrimitiveType.Char => primitiveArray.ArrayObjects.Cast<char>().ToArray(),
-                PrimitiveType.Decimal => primitiveArray.ArrayObjects.Cast<decimal>().ToArray(),
-                PrimitiveType.Double => primitiveArray.ArrayObjects.Cast<double>().ToArray(),
-                PrimitiveType.Int16 => primitiveArray.ArrayObjects.Cast<short>().ToArray(),
-                PrimitiveType.Int32 => primitiveArray.ArrayObjects.Cast<int>().ToArray(),
-                PrimitiveType.Int64 => primitiveArray.ArrayObjects.Cast<long>().ToArray(),
-                PrimitiveType.SByte => primitiveArray.ArrayObjects.Cast<sbyte>().ToArray(),
-                PrimitiveType.Single => primitiveArray.ArrayObjects.Cast<float>().ToArray(),
-                PrimitiveType.TimeSpan => primitiveArray.ArrayObjects.Cast<TimeSpan>().ToArray(),
-                PrimitiveType.DateTime => primitiveArray.ArrayObjects.Cast<DateTime>().ToArray(),
-                PrimitiveType.UInt16 => primitiveArray.ArrayObjects.Cast<ushort>().ToArray(),
-                PrimitiveType.UInt32 => primitiveArray.ArrayObjects.Cast<uint>().ToArray(),
-                PrimitiveType.UInt64 => primitiveArray.ArrayObjects.Cast<ulong>().ToArray(),
+                PrimitiveType.Boolean => ((ArrayRecord<bool>)primitiveArray).ArrayObjects,
+                PrimitiveType.Byte => ((ArrayRecord<byte>)primitiveArray).ArrayObjects,
+                PrimitiveType.Char => ((ArrayRecord<char>)primitiveArray).ArrayObjects,
+                PrimitiveType.Decimal => ((ArrayRecord<decimal>)primitiveArray).ArrayObjects,
+                PrimitiveType.Double => ((ArrayRecord<double>)primitiveArray).ArrayObjects,
+                PrimitiveType.Int16 => ((ArrayRecord<short>)primitiveArray).ArrayObjects,
+                PrimitiveType.Int32 => ((ArrayRecord<int>)primitiveArray).ArrayObjects,
+                PrimitiveType.Int64 => ((ArrayRecord<long>)primitiveArray).ArrayObjects,
+                PrimitiveType.SByte => ((ArrayRecord<sbyte>)primitiveArray).ArrayObjects,
+                PrimitiveType.Single => ((ArrayRecord<float>)primitiveArray).ArrayObjects,
+                PrimitiveType.TimeSpan => ((ArrayRecord<TimeSpan>)primitiveArray).ArrayObjects,
+                PrimitiveType.DateTime => ((ArrayRecord<DateTime>)primitiveArray).ArrayObjects,
+                PrimitiveType.UInt16 => ((ArrayRecord<ushort>)primitiveArray).ArrayObjects,
+                PrimitiveType.UInt32 => ((ArrayRecord<uint>)primitiveArray).ArrayObjects,
+                PrimitiveType.UInt64 => ((ArrayRecord<ulong>)primitiveArray).ArrayObjects,
                 _ => null
             };
 
@@ -372,7 +367,7 @@ internal static class BinaryFormattedObjectExtensions
     }
 
     /// <summary>
-    ///  Trys to get this object as a binary formatted <see cref="Hashtable"/> of <see cref="PrimitiveType"/> keys and values.
+    ///  Tries to get this object as a binary formatted <see cref="Hashtable"/> of <see cref="PrimitiveType"/> keys and values.
     /// </summary>
     public static bool TryGetPrimitiveHashtable(this BinaryFormattedObject format, [NotNullWhen(true)] out Hashtable? hashtable)
     {
@@ -382,7 +377,7 @@ internal static class BinaryFormattedObjectExtensions
     }
 
     /// <summary>
-    ///  Trys to get this object as a binary formatted <see cref="Hashtable"/> of <see cref="PrimitiveType"/> keys and values.
+    ///  Tries to get this object as a binary formatted <see cref="Hashtable"/> of <see cref="PrimitiveType"/> keys and values.
     /// </summary>
     public static bool TryGetPrimitiveHashtable(this BinaryFormattedObject format, [NotNullWhen(true)] out object? hashtable)
     {
@@ -459,7 +454,7 @@ internal static class BinaryFormattedObjectExtensions
     }
 
     /// <summary>
-    ///  Trys to get this object as a binary formatted <see cref="NotSupportedException"/>.
+    ///  Tries to get this object as a binary formatted <see cref="NotSupportedException"/>.
     /// </summary>
     public static bool TryGetNotSupportedException(
         this BinaryFormattedObject format,

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/IPrimitiveTypeRecord.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/IPrimitiveTypeRecord.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Windows.Forms.BinaryFormat;
+
+/// <summary>
+///  Record that represents a primitive type or an array of primitive types.
+/// </summary>
+internal interface IPrimitiveTypeRecord : IRecord
+{
+    PrimitiveType PrimitiveType { get; }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/MemberPrimitiveTyped.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/MemberPrimitiveTyped.cs
@@ -13,7 +13,7 @@ namespace System.Windows.Forms.BinaryFormat;
 ///   </see>
 ///  </para>
 /// </remarks>
-internal sealed class MemberPrimitiveTyped : Record, IRecord<MemberPrimitiveTyped>
+internal sealed class MemberPrimitiveTyped : Record, IRecord<MemberPrimitiveTyped>, IPrimitiveTypeRecord
 {
     public PrimitiveType PrimitiveType { get; }
     public object Value { get; }

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/Record.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/Record.cs
@@ -32,7 +32,7 @@ internal abstract class Record : IRecord
         PrimitiveType.DateTime => reader.ReadDateTime(),
         PrimitiveType.TimeSpan => new TimeSpan(reader.ReadInt64()),
         // String is handled with a record, never on it's own
-        _ => throw new SerializationException($"Failure trying to read primitve '{primitiveType}'"),
+        _ => throw new SerializationException($"Failure trying to read primitive '{primitiveType}'"),
     };
 
     /// <summary>
@@ -44,6 +44,84 @@ internal abstract class Record : IRecord
         for (int i = 0; i < count; i++)
         {
             values.Add(ReadPrimitiveType(reader, primitiveType));
+        }
+
+        return values;
+    }
+
+    private protected static IReadOnlyList<T> ReadPrimitiveTypes<T>(BinaryReader reader, int count)
+        where T : unmanaged
+    {
+        // Special casing byte for performance.
+        if (typeof(T) == typeof(byte))
+        {
+            byte[] bytes = reader.ReadBytes(count);
+            return (IReadOnlyList<T>)(object)bytes;
+        }
+
+        List<T> values = new(Math.Min(count, BinaryFormattedObject.MaxNewCollectionSize));
+        for (int i = 0; i < count; i++)
+        {
+            if (typeof(T) == typeof(bool))
+            {
+                values.Add((T)(object)reader.ReadBoolean());
+            }
+            else if (typeof(T) == typeof(sbyte))
+            {
+                values.Add((T)(object)reader.ReadSByte());
+            }
+            else if (typeof(T) == typeof(char))
+            {
+                values.Add((T)(object)reader.ReadChar());
+            }
+            else if (typeof(T) == typeof(short))
+            {
+                values.Add((T)(object)reader.ReadInt16());
+            }
+            else if (typeof(T) == typeof(ushort))
+            {
+                values.Add((T)(object)reader.ReadUInt16());
+            }
+            else if (typeof(T) == typeof(int))
+            {
+                values.Add((T)(object)reader.ReadInt32());
+            }
+            else if (typeof(T) == typeof(uint))
+            {
+                values.Add((T)(object)reader.ReadUInt32());
+            }
+            else if (typeof(T) == typeof(long))
+            {
+                values.Add((T)(object)reader.ReadInt64());
+            }
+            else if (typeof(T) == typeof(ulong))
+            {
+                values.Add((T)(object)reader.ReadUInt64());
+            }
+            else if (typeof(T) == typeof(float))
+            {
+                values.Add((T)(object)reader.ReadSingle());
+            }
+            else if (typeof(T) == typeof(double))
+            {
+                values.Add((T)(object)reader.ReadDouble());
+            }
+            else if (typeof(T) == typeof(decimal))
+            {
+                values.Add((T)(object)decimal.Parse(reader.ReadString(), CultureInfo.InvariantCulture));
+            }
+            else if (typeof(T) == typeof(DateTime))
+            {
+                values.Add((T)(object)reader.ReadDateTime());
+            }
+            else if (typeof(T) == typeof(TimeSpan))
+            {
+                values.Add((T)(object)new TimeSpan(reader.ReadInt64()));
+            }
+            else
+            {
+                throw new SerializationException($"Failure trying to read primitive '{typeof(T)}'");
+            }
         }
 
         return values;
@@ -120,10 +198,89 @@ internal abstract class Record : IRecord
         }
     }
 
+    private protected static void WritePrimitiveTypes<T>(BinaryWriter writer, IReadOnlyList<T> values)
+        where T : unmanaged
+    {
+        // Special casing byte[] for performance.
+        if (typeof(T) == typeof(byte) && values is byte[] byteArray)
+        {
+            writer.Write(byteArray);
+            return;
+        }
+
+        for (int i = 0; i < values.Count; i++)
+        {
+            if (typeof(T) == typeof(bool))
+            {
+                writer.Write((bool)(object)values[i]);
+            }
+            else if (typeof(T) == typeof(byte))
+            {
+                writer.Write((byte)(object)values[i]);
+            }
+            else if (typeof(T) == typeof(sbyte))
+            {
+                writer.Write((sbyte)(object)values[i]);
+            }
+            else if (typeof(T) == typeof(char))
+            {
+                writer.Write((char)(object)values[i]);
+            }
+            else if (typeof(T) == typeof(short))
+            {
+                writer.Write((short)(object)values[i]);
+            }
+            else if (typeof(T) == typeof(ushort))
+            {
+                writer.Write((ushort)(object)values[i]);
+            }
+            else if (typeof(T) == typeof(int))
+            {
+                writer.Write((int)(object)values[i]);
+            }
+            else if (typeof(T) == typeof(uint))
+            {
+                writer.Write((uint)(object)values[i]);
+            }
+            else if (typeof(T) == typeof(long))
+            {
+                writer.Write((long)(object)values[i]);
+            }
+            else if (typeof(T) == typeof(ulong))
+            {
+                writer.Write((ulong)(object)values[i]);
+            }
+            else if (typeof(T) == typeof(float))
+            {
+                writer.Write((float)(object)values[i]);
+            }
+            else if (typeof(T) == typeof(double))
+            {
+                writer.Write((double)(object)values[i]);
+            }
+            else if (typeof(T) == typeof(decimal))
+            {
+                writer.Write(((decimal)(object)values[i]).ToString(CultureInfo.InvariantCulture));
+            }
+            else if (typeof(T) == typeof(DateTime))
+            {
+                writer.Write((DateTime)(object)values[i]);
+            }
+            else if (typeof(T) == typeof(TimeSpan))
+            {
+                writer.Write(((TimeSpan)(object)values[i]).Ticks);
+            }
+            else
+            {
+                throw new SerializationException($"Failure trying to write primitive '{typeof(T)}'");
+            }
+        }
+    }
+
     /// <summary>
     ///  Reads the next record from the given <paramref name="reader"/>.
     /// </summary>
-    /// <exception cref="NotImplementedException">Found a mulitdimensional array.</exception>
+    /// <exception cref="NotImplementedException">Found a multidimensional array.</exception>
     /// <exception cref="NotSupportedException">Found a remote method invocation record.</exception>
     /// <exception cref="SerializationException">Unknown or corrupted data.</exception>
     internal static IRecord ReadBinaryFormatRecord(BinaryReader reader, RecordMap recordMap)
@@ -148,13 +305,43 @@ internal abstract class Record : IRecord
             RecordType.BinaryLibrary => ReadSpecificRecord<BinaryLibrary>(recordMap),
             RecordType.ObjectNullMultiple256 => ReadSpecificRecord<NullRecord.ObjectNullMultiple256>(recordMap),
             RecordType.ObjectNullMultiple => ReadSpecificRecord<NullRecord.ObjectNullMultiple>(recordMap),
-            RecordType.ArraySinglePrimitive => ReadSpecificRecord<ArraySinglePrimitive>(recordMap),
+            RecordType.ArraySinglePrimitive => ReadArraySinglePrimitive(recordMap),
             RecordType.ArraySingleObject => ReadSpecificRecord<ArraySingleObject>(recordMap),
             RecordType.ArraySingleString => ReadSpecificRecord<ArraySingleString>(recordMap),
             RecordType.MethodCall => throw new NotSupportedException(),
             RecordType.MethodReturn => throw new NotSupportedException(),
             _ => throw new SerializationException("Invalid record type."),
         };
+
+        IRecord ReadArraySinglePrimitive(RecordMap recordMap)
+        {
+            // Special casing to avoid excessive boxing/unboxing.
+            Id id = ArrayInfo.Parse(reader, out Count length);
+            PrimitiveType primitiveType = (PrimitiveType)reader.ReadByte();
+
+            IRecord record = primitiveType switch
+            {
+                PrimitiveType.Boolean => new ArraySinglePrimitive<bool>(id, ReadPrimitiveTypes<bool>(reader, length)),
+                PrimitiveType.Byte => new ArraySinglePrimitive<byte>(id, ReadPrimitiveTypes<byte>(reader, length)),
+                PrimitiveType.SByte => new ArraySinglePrimitive<sbyte>(id, ReadPrimitiveTypes<sbyte>(reader, length)),
+                PrimitiveType.Char => new ArraySinglePrimitive<char>(id, ReadPrimitiveTypes<char>(reader, length)),
+                PrimitiveType.Int16 => new ArraySinglePrimitive<short>(id, ReadPrimitiveTypes<short>(reader, length)),
+                PrimitiveType.UInt16 => new ArraySinglePrimitive<ushort>(id, ReadPrimitiveTypes<ushort>(reader, length)),
+                PrimitiveType.Int32 => new ArraySinglePrimitive<int>(id, ReadPrimitiveTypes<int>(reader, length)),
+                PrimitiveType.UInt32 => new ArraySinglePrimitive<uint>(id, ReadPrimitiveTypes<uint>(reader, length)),
+                PrimitiveType.Int64 => new ArraySinglePrimitive<long>(id, ReadPrimitiveTypes<long>(reader, length)),
+                PrimitiveType.UInt64 => new ArraySinglePrimitive<ulong>(id, ReadPrimitiveTypes<ulong>(reader, length)),
+                PrimitiveType.Single => new ArraySinglePrimitive<float>(id, ReadPrimitiveTypes<float>(reader, length)),
+                PrimitiveType.Double => new ArraySinglePrimitive<double>(id, ReadPrimitiveTypes<double>(reader, length)),
+                PrimitiveType.Decimal => new ArraySinglePrimitive<decimal>(id, ReadPrimitiveTypes<decimal>(reader, length)),
+                PrimitiveType.DateTime => new ArraySinglePrimitive<DateTime>(id, ReadPrimitiveTypes<DateTime>(reader, length)),
+                PrimitiveType.TimeSpan => new ArraySinglePrimitive<TimeSpan>(id, ReadPrimitiveTypes<TimeSpan>(reader, length)),
+                _ => throw new SerializationException($"Failure trying to read primitive '{primitiveType}'"),
+            };
+
+            recordMap[id] = record;
+            return record;
+        }
 
         unsafe TRecord ReadSpecificRecord<TRecord>(RecordMap recordMap) where TRecord : class, IRecord<TRecord>
         {

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/Support/ListConverter.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/Support/ListConverter.cs
@@ -7,7 +7,7 @@ namespace System.Windows.Forms.BinaryFormat;
 
 internal static class ListConverter
 {
-    public static ListConverter<object?> GetPrimitiveConverter(
+    public static ListConverter<object?, object> GetPrimitiveConverter(
         IList values,
         StringRecordsCollection strings) => new(
             values,

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/Support/TypeInfo.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/Support/TypeInfo.cs
@@ -84,4 +84,28 @@ internal static class TypeInfo
         // TypeCode.DBNull => 0,
         _ => type == typeof(TimeSpan) ? PrimitiveType.TimeSpan : default,
     };
+
+    /// <summary>
+    ///  Returns the <see cref="Type"/> for the given <paramref name="primitiveType"/>.
+    /// </summary>
+    internal static Type GetPrimitiveTypeType(this PrimitiveType primitiveType) => primitiveType switch
+    {
+        PrimitiveType.Boolean => typeof(bool),
+        PrimitiveType.Char => typeof(char),
+        PrimitiveType.SByte => typeof(sbyte),
+        PrimitiveType.Byte => typeof(byte),
+        PrimitiveType.Int16 => typeof(short),
+        PrimitiveType.UInt16 => typeof(ushort),
+        PrimitiveType.Int32 => typeof(int),
+        PrimitiveType.UInt32 => typeof(uint),
+        PrimitiveType.Int64 => typeof(long),
+        PrimitiveType.UInt64 => typeof(ulong),
+        PrimitiveType.Single => typeof(float),
+        PrimitiveType.Double => typeof(double),
+        PrimitiveType.Decimal => typeof(decimal),
+        PrimitiveType.DateTime => typeof(DateTime),
+        PrimitiveType.String => typeof(string),
+        PrimitiveType.TimeSpan => typeof(TimeSpan),
+        _ => throw new NotSupportedException(),
+    };
 }

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/ArrayTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/ArrayTests.cs
@@ -13,18 +13,18 @@ public class ArrayTests
     public void ArrayInfo_Parse_Success(Stream stream, int expectedId, int expectedLength)
     {
         using BinaryReader reader = new(stream);
-        ArrayInfo info = ArrayInfo.Parse(reader, out Count length);
-        info.ObjectId.Should().Be(expectedId);
-        info.Length.Should().Be(expectedLength);
+        Id id = ArrayInfo.Parse(reader, out Count length);
+        id.Should().Be((Id)expectedId);
+        length.Should().Be(expectedLength);
         length.Should().Be(expectedLength);
     }
 
     public static TheoryData<Stream, int, int> ArrayInfo_ParseSuccessData => new()
     {
-        { new MemoryStream(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }), 0, 0 },
-        { new MemoryStream(new byte[] { 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00 }), 1, 1 },
-        { new MemoryStream(new byte[] { 0x02, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00 }), 2, 1 },
-        { new MemoryStream(new byte[] { 0xFF, 0xFF, 0xFF, 0x7F, 0xFF, 0xFF, 0xFF, 0x7F }), int.MaxValue, int.MaxValue }
+        { new MemoryStream([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]), 0, 0 },
+        { new MemoryStream([0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00]), 1, 1 },
+        { new MemoryStream([0x02, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00]), 2, 1 },
+        { new MemoryStream([0xFF, 0xFF, 0xFF, 0x7F, 0xFF, 0xFF, 0xFF, 0x7F]), int.MaxValue, int.MaxValue }
     };
 
     [Theory]
@@ -38,10 +38,10 @@ public class ArrayTests
     public static TheoryData<Stream, Type> ArrayInfo_ParseNegativeData => new()
     {
         // Not enough data
-        { new MemoryStream(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }), typeof(EndOfStreamException) },
-        { new MemoryStream(new byte[] { 0x00, 0x00, 0x00 }), typeof(EndOfStreamException) },
+        { new MemoryStream([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]), typeof(EndOfStreamException) },
+        { new MemoryStream([0x00, 0x00, 0x00]), typeof(EndOfStreamException) },
         // Negative numbers
-        { new MemoryStream(new byte[] { 0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF }), typeof(ArgumentOutOfRangeException) }
+        { new MemoryStream([0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF]), typeof(ArgumentOutOfRangeException) }
     };
 
     [Theory]
@@ -67,8 +67,8 @@ public class ArrayTests
     {
         BinaryFormattedObject format = array.SerializeAndParse();
         format.RecordCount.Should().BeGreaterThanOrEqualTo(3);
-        ArraySinglePrimitive arrayRecord = (ArraySinglePrimitive)format[1];
-        ((IEnumerable)arrayRecord.ArrayObjects).Should().BeEquivalentTo((IEnumerable)array);
+        ArrayRecord arrayRecord = (ArrayRecord)format[1];
+        arrayRecord.Should().BeEquivalentTo((IEnumerable)array);
     }
 
     public static TheoryData<Array> PrimitiveArray_Parse_Data => new()

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/BinaryFormatWriterTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/BinaryFormatWriterTests.cs
@@ -32,10 +32,11 @@ public class BinaryFormatWriterTests
     public void BinaryFormatWriter_TryWriteObject_SupportedObjects_BinaryFormatterRead(object value)
     {
         using MemoryStream stream = new();
-        BinaryFormatWriter.TryWriteFrameworkObject(stream, value).Should().BeTrue();
+        bool success = BinaryFormatWriter.TryWriteFrameworkObject(stream, value);
+        success.Should().BeTrue();
         stream.Position = 0;
 
-        using BinaryFormatterScope formaterScope = new(enable: true);
+        using BinaryFormatterScope formatterScope = new(enable: true);
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
         BinaryFormatter formatter = new();
 #pragma warning restore SYSLIB0011 // Type or member is obsolete

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/BinaryFormattedObjectTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/BinaryFormattedObjectTests.cs
@@ -169,7 +169,7 @@ public class BinaryFormattedObjectTests
             new MemberReference(3)
         });
 
-        ArrayRecord array = (ArrayRecord)format[(MemberReference)systemClass.MemberValues[5]];
+        ArrayRecord<object> array = (ArrayRecord<object>)format[(MemberReference)systemClass.MemberValues[5]];
 
         array.ArrayInfo.ObjectId.Should().Be(2);
         array.ArrayInfo.Length.Should().Be(3);
@@ -177,7 +177,7 @@ public class BinaryFormattedObjectTests
         value.ObjectId.Should().Be(4);
         value.Value.Should().BeOneOf("Yowza", "Youza", "Meeza");
 
-        array = (ArrayRecord)format[(MemberReference)systemClass["Values"]];
+        array = (ArrayRecord<object>)format[(MemberReference)systemClass["Values"]];
         array.ArrayInfo.ObjectId.Should().Be(3);
         array.ArrayInfo.Length.Should().Be(3);
         array.ArrayObjects[0].Should().BeOfType<ObjectNull>();
@@ -296,7 +296,7 @@ public class BinaryFormattedObjectTests
     {
         BinaryFormattedObject format = new int[] { 10, 9, 8, 7 }.SerializeAndParse();
 
-        ArraySinglePrimitive array = (ArraySinglePrimitive)format[1];
+        ArraySinglePrimitive<int> array = (ArraySinglePrimitive<int>)format[1];
         array.ArrayInfo.Length.Should().Be(4);
         array.PrimitiveType.Should().Be(PrimitiveType.Int32);
         array.ArrayObjects.Should().BeEquivalentTo(new object[] { 10, 9, 8, 7 });

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/ListTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/ListTests.cs
@@ -145,7 +145,7 @@ public class ListTests
         classInfo["_size"].Should().Be(0);
         classInfo["_version"].Should().Be(0);
 
-        ArraySinglePrimitive array = (ArraySinglePrimitive)format[2];
+        ArraySinglePrimitive<int> array = (ArraySinglePrimitive<int>)format[2];
         array.Length.Should().Be(0);
     }
 


### PR DESCRIPTION
`ArraySinglePrimitive` was taking `IReadOnlyList<object>` which necessitated boxing all items. This converts `ArrayRecord` to be typed so we can avoid this and adds special optimizations for `byte[]`. This is important for performance of the types we're supporting or intending to support (such as `ImageListStreamer`).

It may be possible to further improve this. If the array data is always aligned in the input then we can just read/write the data directly as byte arrays. `DateTime`, `TimeSpan`, and `decimal` need individually parsed.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10738)