### PR TITLE
Add support for binary formatting ImageListStreamer

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/BinaryFormatWriter.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/BinaryFormatWriter.cs
@@ -13,33 +13,25 @@ namespace System.Windows.Forms.BinaryFormat;
 /// </summary>
 internal static class BinaryFormatWriter
 {
-    private static string[]? s_hashtableMemberNames;
-    private static string[] HashtableMemberNames => s_hashtableMemberNames ??= new[]
-    {
+    private static readonly string[] s_hashtableMemberNames =
+    [
         "LoadFactor", "Version", "Comparer", "HashCodeProvider", "HashSize", "Keys", "Values"
-    };
+    ];
 
-    private static string[]? s_notSupportedExceptionMemberNames;
-    private static string[] NotSupportedExceptionMemberNames => s_notSupportedExceptionMemberNames ??= new[]
-    {
+    private static readonly string[] s_notSupportedExceptionMemberNames =
+    [
         "ClassName", "Message", "Data", "InnerException", "HelpURL", "StackTraceString", "RemoteStackTraceString",
         "RemoteStackIndex", "ExceptionMethod", "HResult", "Source", "WatsonBuckets"
-    };
+    ];
 
-    private static string[]? s_listMemberNames;
-    private static string[] ListMemberNames => s_listMemberNames ??= new[] { "_items", "_size", "_version" };
-
-    private static string[]? s_decimalMemberNames;
-    private static string[] DecimalMemberNames => s_decimalMemberNames ??= new[] { "flags", "hi", "lo", "mid" };
-
-    private static readonly string[] s_dateTimeMemberNames = new[] { "ticks", "dateData" };
-    private static readonly string[] s_primitiveMemberName = new[] { "m_value" };
-
-    private static string[]? s_pointMemberNames;
-    private static string[] PointMemberNames => s_pointMemberNames ??= new[] { "x", "y" };
-
-    private static string[]? s_rectangleMemberNames;
-    private static string[] RectangleMemberNames => s_rectangleMemberNames ??= new[] { "x", "y", "width", "height" };
+    private static readonly string[] s_listMemberNames = ["_items", "_size", "_version"];
+    private static readonly string[] s_decimalMemberNames = ["flags", "hi", "lo", "mid"];
+    private static readonly string[] s_dateTimeMemberNames = ["ticks", "dateData"];
+    private static readonly string[] s_primitiveMemberName = ["m_value"];
+    private static readonly string[] s_pointMemberNames = ["x", "y"];
+    private static readonly string[] s_rectangleMemberNames = ["x", "y", "width", "height"];
+    private static readonly string[] s_valueName = ["value"];
+    private static readonly string[] s_ticksName = ["_ticks"];
 
     /// <summary>
     ///  Writes a <see langword="string"/> in binary format.
@@ -61,7 +53,7 @@ internal static class BinaryFormatWriter
         using BinaryFormatWriterScope writer = new(stream);
 
         new SystemClassWithMembersAndTypes(
-            new ClassInfo(1, typeof(decimal).FullName!, DecimalMemberNames),
+            new ClassInfo(1, typeof(decimal).FullName!, s_decimalMemberNames),
             new MemberTypeInfo(
                 (BinaryType.Primitive, PrimitiveType.Int32),
                 (BinaryType.Primitive, PrimitiveType.Int32),
@@ -99,7 +91,7 @@ internal static class BinaryFormatWriter
     {
         using BinaryFormatWriterScope writer = new(stream);
         new SystemClassWithMembersAndTypes(
-            new ClassInfo(1, typeof(TimeSpan).FullName!, new string[] { "_ticks" }),
+            new ClassInfo(1, typeof(TimeSpan).FullName!, s_ticksName),
             new MemberTypeInfo((BinaryType.Primitive, PrimitiveType.Int64)),
             value.Ticks).Write(writer);
     }
@@ -111,7 +103,7 @@ internal static class BinaryFormatWriter
     {
         using BinaryFormatWriterScope writer = new(stream);
         new SystemClassWithMembersAndTypes(
-            new ClassInfo(1, typeof(nint).FullName!, new string[] { "value" }),
+            new ClassInfo(1, typeof(nint).FullName!, s_valueName),
             new MemberTypeInfo((BinaryType.Primitive, PrimitiveType.Int64)),
             (long)value).Write(writer);
     }
@@ -123,7 +115,7 @@ internal static class BinaryFormatWriter
     {
         using BinaryFormatWriterScope writer = new(stream);
         new SystemClassWithMembersAndTypes(
-            new ClassInfo(1, typeof(nuint).FullName!, new string[] { "value" }),
+            new ClassInfo(1, typeof(nuint).FullName!, s_valueName),
             new MemberTypeInfo((BinaryType.Primitive, PrimitiveType.UInt64)),
             (ulong)value).Write(writer);
     }
@@ -136,7 +128,7 @@ internal static class BinaryFormatWriter
         using BinaryFormatWriterScope writer = new(stream);
         new BinaryLibrary(2, TypeInfo.SystemDrawingAssemblyName).Write(writer);
         new ClassWithMembersAndTypes(
-            new ClassInfo(1, typeof(PointF).FullName!, PointMemberNames),
+            new ClassInfo(1, typeof(PointF).FullName!, s_pointMemberNames),
             libraryId: 2,
             new MemberTypeInfo(
                 (BinaryType.Primitive, PrimitiveType.Single),
@@ -153,7 +145,7 @@ internal static class BinaryFormatWriter
         using BinaryFormatWriterScope writer = new(stream);
         new BinaryLibrary(2, TypeInfo.SystemDrawingAssemblyName).Write(writer);
         new ClassWithMembersAndTypes(
-            new ClassInfo(1, typeof(RectangleF).FullName!, RectangleMemberNames),
+            new ClassInfo(1, typeof(RectangleF).FullName!, s_rectangleMemberNames),
             libraryId: 2,
             new MemberTypeInfo(
                 (BinaryType.Primitive, PrimitiveType.Single),
@@ -235,7 +227,7 @@ internal static class BinaryFormatWriter
             new ClassInfo(
                 1,
                 $"System.Collections.Generic.List`1[[{TypeInfo.StringType}, {TypeInfo.MscorlibAssemblyName}]]",
-                ListMemberNames),
+                s_listMemberNames),
             new MemberTypeInfo(
                 (BinaryType.StringArray, null),
                 (BinaryType.Primitive, PrimitiveType.Int32),
@@ -268,7 +260,7 @@ internal static class BinaryFormatWriter
             new ClassInfo(
                 1,
                 $"System.Collections.Generic.List`1[[{typeof(T).FullName}, {TypeInfo.MscorlibAssemblyName}]]",
-                ListMemberNames),
+                s_listMemberNames),
             new MemberTypeInfo(
                 (BinaryType.PrimitiveArray, primitiveType),
                 (BinaryType.Primitive, PrimitiveType.Int32),
@@ -360,7 +352,7 @@ internal static class BinaryFormatWriter
         {
             using BinaryFormatWriterScope writer = new(stream);
             new SystemClassWithMembersAndTypes(
-                new ClassInfo(1, typeof(ArrayList).FullName!, ListMemberNames),
+                new ClassInfo(1, typeof(ArrayList).FullName!, s_listMemberNames),
                 new MemberTypeInfo(
                     (BinaryType.ObjectArray, null),
                     (BinaryType.Primitive, PrimitiveType.Int32),
@@ -484,7 +476,7 @@ internal static class BinaryFormatWriter
         using BinaryFormatWriterScope writer = new(stream);
 
         new SystemClassWithMembersAndTypes(
-            new ClassInfo(1, TypeInfo.HashtableType, HashtableMemberNames),
+            new ClassInfo(1, TypeInfo.HashtableType, s_hashtableMemberNames),
             new MemberTypeInfo(
                 (BinaryType.Primitive, PrimitiveType.Single),
                 (BinaryType.Primitive, PrimitiveType.Int32),
@@ -519,7 +511,7 @@ internal static class BinaryFormatWriter
 
         // We only serialize the message to avoid binary serialization risks.
         new SystemClassWithMembersAndTypes(
-            new ClassInfo(1, TypeInfo.NotSupportedExceptionType, NotSupportedExceptionMemberNames),
+            new ClassInfo(1, TypeInfo.NotSupportedExceptionType, s_notSupportedExceptionMemberNames),
             new MemberTypeInfo(
                 (BinaryType.String, null),
                 (BinaryType.String, null),

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/BinaryFormattedObjectExtensions.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/BinaryFormattedObjectExtensions.cs
@@ -30,9 +30,9 @@ internal static class BinaryFormattedObjectExtensions
             _ => false,
         };
 
-    private delegate bool TryGetDelegate(BinaryFormattedObject format, [NotNullWhen(true)] out object? value);
+    internal delegate bool TryGetDelegate(BinaryFormattedObject format, [NotNullWhen(true)] out object? value);
 
-    private static bool TryGet(TryGetDelegate get, BinaryFormattedObject format, [NotNullWhen(true)] out object? value)
+    internal static bool TryGet(TryGetDelegate get, BinaryFormattedObject format, [NotNullWhen(true)] out object? value)
     {
         try
         {

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/Record.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/Record.cs
@@ -202,10 +202,18 @@ internal abstract class Record : IRecord
         where T : unmanaged
     {
         // Special casing byte[] for performance.
-        if (typeof(T) == typeof(byte) && values is byte[] byteArray)
+        if (typeof(T) == typeof(byte))
         {
-            writer.Write(byteArray);
-            return;
+            if (values is byte[] byteArray)
+            {
+                writer.Write(byteArray);
+                return;
+            }
+            else if (values is ArraySegment<byte> arraySegment)
+            {
+                writer.Write(arraySegment);
+                return;
+            }
         }
 
         for (int i = 0; i < values.Count; i++)

--- a/src/System.Windows.Forms/src/System/Resources/ResXDataNode.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResXDataNode.cs
@@ -303,7 +303,7 @@ public sealed class ResXDataNode : ISerializable
                 bool success = false;
                 try
                 {
-                    success = BinaryFormatWriter.TryWriteFrameworkObject(stream, value);
+                    success = WinFormsBinaryFormatWriter.TryWriteObject(stream, value);
                 }
                 catch (Exception ex) when (!ex.IsCriticalException())
                 {
@@ -433,7 +433,7 @@ public sealed class ResXDataNode : ISerializable
         try
         {
             BinaryFormattedObject format = new(stream, leaveOpen: true);
-            if (format.TryGetFrameworkObject(out object? value))
+            if (format.TryGetObject(out object? value))
             {
                 return value;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ActiveX/Control.ActiveXImpl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ActiveX/Control.ActiveXImpl.cs
@@ -1125,7 +1125,7 @@ public partial class Control
                     try
                     {
                         BinaryFormattedObject format = new(stream, leaveOpen: true);
-                        success = format.TryGetFrameworkObject(out deserialized);
+                        success = format.TryGetObject(out deserialized);
                     }
                     catch (Exception ex) when (!ex.IsCriticalException())
                     {
@@ -1492,7 +1492,7 @@ public partial class Control
 
                     try
                     {
-                        success = BinaryFormatWriter.TryWriteFrameworkObject(stream, sourceValue);
+                        success = WinFormsBinaryFormatWriter.TryWriteObject(stream, sourceValue);
                     }
                     catch (Exception ex) when (!ex.IsCriticalException())
                     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/BinaryFormat/WinFormsBinaryFormatWriter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/BinaryFormat/WinFormsBinaryFormatWriter.cs
@@ -1,0 +1,51 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Windows.Forms.BinaryFormat;
+
+/// <summary>
+///  Writer that writes Windows Forms specific types in binary format without using the BinaryFormatter.
+/// </summary>
+internal static class WinFormsBinaryFormatWriter
+{
+    private static readonly string[] s_dataMemberName = ["Data"];
+
+    private static readonly string s_currentWinFormsFullName = typeof(WinFormsBinaryFormatWriter).Assembly.FullName!;
+
+    public static void WriteImageListStreamer(Stream stream, ImageListStreamer streamer)
+    {
+        byte[] data = streamer.Serialize();
+
+        using BinaryFormatWriterScope writer = new(stream);
+
+        new BinaryLibrary(2, s_currentWinFormsFullName).Write(writer);
+        new ClassWithMembersAndTypes(
+            new ClassInfo(1, typeof(ImageListStreamer).FullName!, s_dataMemberName),
+            libraryId: 2,
+            new MemberTypeInfo((BinaryType.PrimitiveArray, PrimitiveType.Byte)),
+            new MemberReference(3)).Write(writer);
+
+        new ArraySinglePrimitive<byte>(3, data).Write(writer);
+    }
+
+    /// <summary>
+    ///  Writes the given <paramref name="value"/> if supported.
+    /// </summary>
+    public static bool TryWriteObject(Stream stream, object value)
+    {
+        // Framework types are more likely to be written, so check them first.
+        return BinaryFormatWriter.TryWriteFrameworkObject(stream, value)
+            || BinaryFormatWriter.TryWrite(Write, stream, value);
+
+        static bool Write(Stream stream, object value)
+        {
+            if (value is ImageListStreamer streamer)
+            {
+                WriteImageListStreamer(stream, streamer);
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/BinaryFormat/WinFormsBinaryFormattedObjectExtensions.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/BinaryFormat/WinFormsBinaryFormattedObjectExtensions.cs
@@ -1,0 +1,42 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Windows.Forms.BinaryFormat;
+
+internal static class WinFormsBinaryFormattedObjectExtensions
+{
+    /// <summary>
+    ///  Tries to get this object as a binary formatted <see cref="ImageListStreamer"/>.
+    /// </summary>
+    public static bool TryGetImageListStreamer(
+        this BinaryFormattedObject format,
+        out object? imageListStreamer)
+    {
+        return BinaryFormattedObjectExtensions.TryGet(Get, format, out imageListStreamer);
+
+        static bool Get(BinaryFormattedObject format, [NotNullWhen(true)] out object? imageListStreamer)
+        {
+            imageListStreamer = null;
+
+            if (format.RecordCount != 5
+                || format[1] is not BinaryLibrary library
+                || format[2] is not ClassWithMembersAndTypes types
+                || types.ClassInfo.Name != typeof(ImageListStreamer).FullName
+                || format[3] is not ArraySinglePrimitive<byte> data)
+            {
+                return false;
+            }
+
+            Debug.Assert(data.ArrayObjects is byte[]);
+            imageListStreamer = new ImageListStreamer((byte[])data.ArrayObjects);
+            return true;
+        }
+    }
+
+    /// <summary>
+    ///  Try to get a supported object.
+    /// </summary>
+    public static bool TryGetObject(this BinaryFormattedObject format, [NotNullWhen(true)] out object? value) =>
+        format.TryGetFrameworkObject(out value)
+        || format.TryGetImageListStreamer(out value);
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.ComDataObjectAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.ComDataObjectAdapter.cs
@@ -126,7 +126,7 @@ public partial class DataObject
                     long startPosition = stream.Position;
                     try
                     {
-                        if (new BinaryFormattedObject(stream, leaveOpen: true).TryGetFrameworkObject(out object? value))
+                        if (new BinaryFormattedObject(stream, leaveOpen: true).TryGetObject(out object? value))
                         {
                             return value;
                         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.cs
@@ -652,7 +652,7 @@ public unsafe partial class DataObject :
 
         try
         {
-            success = BinaryFormatWriter.TryWriteFrameworkObject(stream, data);
+            success = WinFormsBinaryFormatWriter.TryWriteObject(stream, data);
         }
         catch (Exception ex) when (!ex.IsCriticalException())
         {


### PR DESCRIPTION
Adds support for binary formatting ImageListStreamer without the BinaryFormatter.

Add another record writing optimization for ArraySegment<byte>.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10745)