### PR TITLE
Always Wrap Incoming Clipboard Data

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/Clipboard.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/Clipboard.cs
@@ -129,9 +129,7 @@ public static class Clipboard
             // There is a DataObject on the clipboard that we placed there. If the real data object
             // implements IDataObject, we want to unwrap it and return it. Otherwise return
             // the DataObject as is.
-            return wrappedData.UnwrapInnerIDataObject() is { } innerData
-                ? innerData
-                : wrappedData;
+            return wrappedData.TryUnwrapInnerIDataObject();
         }
 
         // We did not place the data on the clipboard. Fall back to old behavior.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/Clipboard.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/Clipboard.cs
@@ -41,7 +41,11 @@ public static class Clipboard
         ArgumentOutOfRangeException.ThrowIfNegative(retryTimes);
         ArgumentOutOfRangeException.ThrowIfNegative(retryDelay);
 
-        using var dataObject = ComHelpers.GetComScope<Com.IDataObject>(data is IComDataObject ? data : new DataObject(data));
+        // Always wrap the data in our DataObject since we know how to retrieve our DataObject from the proxy OleGetClipboard returns.
+        DataObject wrappedData = data is DataObject { IsWrappedForClipboard: true } alreadyWrapped
+            ? alreadyWrapped
+            : new DataObject(data) { IsWrappedForClipboard = true };
+        using var dataObject = ComHelpers.GetComScope<Com.IDataObject>(wrappedData);
 
         HRESULT hr;
         int retry = retryTimes;
@@ -120,6 +124,17 @@ public static class Clipboard
             return null;
         }
 
+        if (dataObject is DataObject { IsWrappedForClipboard: true } wrappedData)
+        {
+            // There is a DataObject on the clipboard that we placed there. If the real data object
+            // implements IDataObject, we want to unwrap it and return it. Otherwise return
+            // the DataObject as is.
+            return wrappedData.UnwrapInnerIDataObject() is { } innerData
+                ? innerData
+                : wrappedData;
+        }
+
+        // We did not place the data on the clipboard. Fall back to old behavior.
         return dataObject is IDataObject ido && !Marshal.IsComObject(dataObject)
                 ? ido
                 : new DataObject(dataObject);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.cs
@@ -130,7 +130,7 @@ public unsafe partial class DataObject :
     /// <summary>
     ///  Flags that the original data was wrapped for clipboard purposes.
     /// </summary>
-    internal bool IsWrappedForClipboard { get; set; }
+    internal bool IsWrappedForClipboard { get; init; }
 
     /// <summary>
     ///  Returns the inner data that the <see cref="DataObject"/> was created with if the original data implemented

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.cs
@@ -134,18 +134,15 @@ public unsafe partial class DataObject :
 
     /// <summary>
     ///  Returns the inner data that the <see cref="DataObject"/> was created with if the original data implemented
-    ///  <see cref="IDataObject"/>. Otherwise, returns null.
+    ///  <see cref="IDataObject"/>. Otherwise, returns this.
     ///  This method should only be used if the <see cref="DataObject"/> was created for clipboard purposes.
     /// </summary>
-    internal IDataObject? UnwrapInnerIDataObject()
+    internal IDataObject TryUnwrapInnerIDataObject()
     {
-        if (!IsWrappedForClipboard)
-        {
-            throw new InvalidOperationException("This method should only be used for clipboard purposes.");
-        }
+        Debug.Assert(IsWrappedForClipboard, "This method should only be used for clipboard purposes.");
 
         return _innerData is DataStore or ComDataObjectAdapter
-            ? null
+            ? this
             : _innerData;
     }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.cs
@@ -128,6 +128,28 @@ public unsafe partial class DataObject :
     internal DataObject(string format, bool autoConvert, object data) : this() => SetData(format, autoConvert, data);
 
     /// <summary>
+    ///  Flags that the original data was wrapped for clipboard purposes.
+    /// </summary>
+    internal bool IsWrappedForClipboard { get; set; }
+
+    /// <summary>
+    ///  Returns the inner data that the <see cref="DataObject"/> was created with if the original data implemented
+    ///  <see cref="IDataObject"/>. Otherwise, returns null.
+    ///  This method should only be used if the <see cref="DataObject"/> was created for clipboard purposes.
+    /// </summary>
+    internal IDataObject? UnwrapInnerIDataObject()
+    {
+        if (!IsWrappedForClipboard)
+        {
+            throw new InvalidOperationException("This method should only be used for clipboard purposes.");
+        }
+
+        return _innerData is DataStore or ComDataObjectAdapter
+            ? null
+            : _innerData;
+    }
+
+    /// <summary>
     ///  Retrieves the data associated with the specified data format, using an automated conversion parameter to
     ///  determine whether to convert the data to the format.
     /// </summary>


### PR DESCRIPTION
Fixes #4555 

**Background:**
WinForms original clipboard behavior is that:
- The original data coming in must implement `System.Runtime.InteropServices.ComTypes.IDataObject` to be taken as is. If it does not, we will wrap the data in a `DataObject`.
- The original data going out must implement `System.Windows.Forms.IDataObject` to be passed out as is. If it does not, we will wrap the data in a `DataObject` before passing it out

Native call to `OleGetClipboard` will always return a proxy that will forward all IDataObject method calls to the real data object, without giving out the real data object. The only time that the proxy ever gives back the real object is when we query for an interface it does not know about. WinForms `DataObject` class also implements `IComCallableWrapper` which is an internal interface meant to help indicate to us that this object is one of our CCWs. The proxy does not know about `IComCallableWrapper` meaning that when we query for it on the proxy, the proxy will give us back the real data object. This is how we have been able to give the user back the original object they placed on the clipboard (if the original object meets the 2 requirements outlined above) when they ask for it.

**Issue:**
When users create a custom data object that implements both `System.Runtime.InteropServices.ComTypes.IDataObject` and `System.Windows.Forms.IDataObject`, the expectation is that the user will be able to set their custom data object onto the clipboard and get the data object back out as is i.e. not wrapped. 
This is not the case with today's code since:
1. The custom data object coming in will not be wrapped due to it implementing 
    `System.Runtime.InteropServices.ComTypes.IDataObject`
2. `OleGetClipboard` will continue to return a proxy. Since the user's custom data object does not implement an interface that WinForms knows about and the proxy does not, e.g. `IComCallableWrapper`, WinForms cannot retrieve the real data object from the proxy and will just return the proxy wrapped in a `DataObject`

**Proposed Solution:**
WinForms new clipboard behavior:
- The original data coming will always be wrapped in a `DataObject`.
- The original data must implement `System.Windows.Forms.IDataObject` to be passed out as is. If it does not, we will leave the data wrapped in a `DataObject` when passing it out

How it works:
1. Always wrap the incoming data to the clipboard in a `DataObject` and flag that we've wrapped it for clipboard purposes using new property `IsWrappedForClipboard`
2. When passing the data out from the clipboard, try to query for `IComCallableWrapper` per usual. If we were able to query for `IComCallableWrapper` successfully, this means that we a pointer to the data object we placed onto the clipboard, not the proxy
3. Get the managed object from the pointer received from querying for `IComCallableWrapper` successfully and check if the managed object is a `DataObject` that has `IsWrappedForClipboard = true`. If so, we know we have the `DataObject` that we created in step 1 that wraps the real data object. We can now utilize new internal method `DataObject.UnwrapInnerIDataObject` to retrieve the real data object we wrapped if the real data object had implemented `System.Windows.Forms.IDataObject` and return it. 
Implementation for this new method is the opposite of the wrapping behavior we have in place for `DataObject` construction where we only track the real data object as is via `_innerData` if it implements `System.Windows.Forms.IDataObject`:
https://github.com/dotnet/winforms/blob/47131cd723c596d567cd2d80480f6f64272f41aa/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.cs#L104-L120
Note: We must only unwrap the real data object from the `DataObject` if the real data object implements `System.Windows.Forms.IDataObject` to maintain our original heuristic. If the real data object does not implement `System.Windows.Forms.IDataObject`, we return `DataObject`, which is still inline with our original heuristic as the data is wrapped when passing it out.
4. If we were not able to successfully query for `IComCallableWrapper` in step 2 or the `DataObject` on the clipboard has `IsWrappedForClipboard = false`, we did not place that data on the clipboard so we should not unwrap it. Fallback to old behavior.

Other thoughts:
- Looking through windows sources, native DragDrop operation does not have this same odd behavior of returning a proxy so we do not need do something similar for that scenario
- Getting data via WinForms clipboard and setting clipboard data by other means should still work as expected since we fall back to old behavior if WinForms did not set the data on the clipboard
- Setting the data via WinForms clipboard and getting the clipboard data by other means should also still work as expected since native call `OleGetClipboard` will continue to return a proxy that forwards `IDataObject` method calls to the underlying data, which would now be our `DataObject` and our `DataObject` forwards calls to the real data object we wrap.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10759)