### PR TITLE
Add RoundedRectangle methods to System.Drawing

### DIFF
--- a/src/System.Drawing.Common/src/System/Drawing/Bitmap.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Bitmap.cs
@@ -265,13 +265,11 @@ public sealed unsafe class Bitmap : Image
     {
         ArgumentNullException.ThrowIfNull(bitmapData);
 
-        Rect nativeRect = rect;
-
         fixed (void* data = &bitmapData.GetPinnableReference())
         {
             PInvoke.GdipBitmapLockBits(
                 NativeBitmap,
-                &nativeRect,
+                rect.IsEmpty ? null : (Rect*)&rect,
                 (uint)flags,
                 (int)format,
                 (GdiPlus.BitmapData*)data).ThrowIfFailed();

--- a/src/System.Drawing.Common/src/System/Drawing/Drawing2D/GraphicsPath.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Drawing2D/GraphicsPath.cs
@@ -492,6 +492,47 @@ public sealed unsafe class GraphicsPath : MarshalByRefObject, ICloneable, IDispo
         }
     }
 
+#if NET9_0_OR_GREATER
+    /// <inheritdoc cref="AddRoundedRectangle(RectangleF, SizeF)"/>
+    public void AddRoundedRectangle(Rectangle rect, Size corner) =>
+        AddRoundedRectangle((RectangleF)rect, corner);
+
+    /// <summary>
+    ///  Adds a rounded rectangle to this path.
+    /// </summary>
+    /// <param name="rect">The bounds of the rectangle to add.</param>
+    /// <param name="corner">The size of the ellipse used to round the corners of the rectangle.</param>
+    public void AddRoundedRectangle(RectangleF rect, SizeF corner)
+    {
+        StartFigure();
+        AddArc(
+            rect.Right - corner.Width,
+            rect.Top,
+            corner.Width,
+            corner.Height,
+            -90.0f, 90.0f);
+        AddArc(
+            rect.Right - corner.Width,
+            rect.Bottom - corner.Height,
+            corner.Width,
+            corner.Height,
+            0.0f, 90.0f);
+        AddArc(
+            rect.Left,
+            rect.Bottom - corner.Height,
+            corner.Width,
+            corner.Height,
+            90.0f, 90.0f);
+        AddArc(
+            rect.Left,
+            rect.Top,
+            corner.Width,
+            corner.Height,
+            180.0f, 90.0f);
+        CloseFigure();
+    }
+#endif
+
     public void AddEllipse(RectangleF rect) =>
         AddEllipse(rect.X, rect.Y, rect.Width, rect.Height);
 

--- a/src/System.Drawing.Common/src/System/Drawing/Graphics.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Graphics.cs
@@ -745,6 +745,24 @@ public sealed unsafe partial class Graphics : MarshalByRefObject, IDisposable, I
     /// </summary>
     public void DrawRectangle(Pen pen, Rectangle rect) => DrawRectangle(pen, rect.X, rect.Y, rect.Width, rect.Height);
 
+#if NET9_0_OR_GREATER
+    /// <inheritdoc cref="DrawRoundedRectangle(Pen, RectangleF, SizeF)"/>
+    public void DrawRoundedRectangle(Pen pen, Rectangle rect, Size corner) =>
+        DrawRoundedRectangle(pen, (RectangleF)rect, corner);
+
+    /// <summary>
+    ///  Draws the outline of the specified rounded rectangle.
+    /// </summary>
+    /// <param name="pen">The <see cref="Pen"/> to draw the outline with.</param>
+    /// <inheritdoc cref="FillRoundedRectangle(Brush, RectangleF, SizeF)"/>
+    public void DrawRoundedRectangle(Pen pen, RectangleF rect, SizeF corner)
+    {
+        using GraphicsPath path = new();
+        path.AddRoundedRectangle(rect, corner);
+        DrawPath(pen, path);
+    }
+#endif
+
     /// <summary>
     ///  Draws the outline of the specified rectangle.
     /// </summary>
@@ -1093,6 +1111,25 @@ public sealed unsafe partial class Graphics : MarshalByRefObject, IDisposable, I
     ///  Fills the entire drawing surface with the specified color.
     /// </summary>
     public void Clear(Color color) => CheckStatus(PInvoke.GdipGraphicsClear(NativeGraphics, (uint)color.ToArgb()));
+
+#if NET9_0_OR_GREATER
+    /// <inheritdoc cref="FillRoundedRectangle(Brush, RectangleF, SizeF)"/>/>
+    public void FillRoundedRectangle(Brush brush, Rectangle rect, Size corner) =>
+        FillRoundedRectangle(brush, (RectangleF)rect, corner);
+
+    /// <summary>
+    ///  Fills the interior of a rounded rectangle with a <see cref='Brush'/>.
+    /// </summary>
+    /// <param name="brush">The <see cref="Brush"/> to fill the rounded rectangle with.</param>
+    /// <param name="rect">The bounds of the rounded rectangle.</param>
+    /// <param name="corner">The size of the ellipse used to round the corners of the rectangle.</param>
+    public void FillRoundedRectangle(Brush brush, RectangleF rect, SizeF corner)
+    {
+        using GraphicsPath path = new();
+        path.AddRoundedRectangle(rect, corner);
+        FillPath(brush, path);
+    }
+#endif
 
     /// <summary>
     ///  Fills the interior of a rectangle with a <see cref='Brush'/>.

--- a/src/System.Drawing.Common/tests/Drawing2D/GraphicsPathTests.cs
+++ b/src/System.Drawing.Common/tests/Drawing2D/GraphicsPathTests.cs
@@ -2636,4 +2636,69 @@ public class GraphicsPathTests
             Assert.Equal(expectedTypes[i], reversedTypes[i]);
         }
     }
+
+#if NET9_0_OR_GREATER
+    [Fact]
+    public void GraphicsPath_AddRoundedRectangle_Integer()
+    {
+        using GraphicsPath path = new();
+        path.AddRoundedRectangle(new Rectangle(10, 10, 20, 20), new(5, 5));
+        path.PathPoints.Should().BeApproximatelyEquivalentTo(
+            new PointF[]
+            {
+                new(27.499994f, 10),
+                new(28.880707f, 9.999997f),
+                new(29.999996f, 11.119284f),
+                new(29.999998f, 12.499999f),
+                new(29.999998f, 12.499999f),
+                new(29.999998f, 12.5f),
+                new(29.999998f, 12.5f),
+                new(29.999998f, 27.499998f),
+                new(29.999998f, 28.88071f),
+                new(28.88071f, 29.999998f),
+                new(27.5f, 29.999998f),
+                new(12.500001f, 29.999998f),
+                new(11.119289f, 30),
+                new(10.000001f, 28.880713f),
+                new(10f, 27.5f),
+                new(9.999999f, 12.500001f),
+                new(9.999998f, 11.119289f),
+                new(11.119286f, 10.000001f),
+                new(12.499997f, 9.999999f),
+            },
+            0.000001f);
+    }
+
+    [Fact]
+    public void GraphicsPath_AddRoundedRectangle_Float()
+    {
+        using GraphicsPath path = new();
+        path.AddRoundedRectangle(new RectangleF(10, 10, 20, 20), new(5, 5));
+        path.PathPoints.Should().BeApproximatelyEquivalentTo(
+            new PointF[]
+            {
+                new(27.499994f, 10),
+                new(28.880707f, 9.999997f),
+                new(29.999996f, 11.119284f),
+                new(29.999998f, 12.499999f),
+                new(29.999998f, 12.499999f),
+                new(29.999998f, 12.5f),
+                new(29.999998f, 12.5f),
+                new(29.999998f, 27.499998f),
+                new(29.999998f, 28.88071f),
+                new(28.88071f, 29.999998f),
+                new(27.5f, 29.999998f),
+                new(12.500001f, 29.999998f),
+                new(11.119289f, 30),
+                new(10.000001f, 28.880713f),
+                new(10f, 27.5f),
+                new(9.999999f, 12.500001f),
+                new(9.999998f, 11.119289f),
+                new(11.119286f, 10.000001f),
+                new(12.499997f, 9.999999f),
+            },
+            0.000001f);
+    }
+
+#endif
 }

--- a/src/System.Drawing.Common/tests/GraphicsTests.cs
+++ b/src/System.Drawing.Common/tests/GraphicsTests.cs
@@ -3274,4 +3274,70 @@ public partial class GraphicsTests
         }
     }
 #endif
+
+    internal unsafe static void VerifyBitmapEmpty(Bitmap bitmap)
+    {
+        BitmapData data = bitmap.LockBits(default, ImageLockMode.ReadOnly, PixelFormat.Format32bppArgb);
+        try
+        {
+            ReadOnlySpan<byte> bytes = new((byte*)data.Scan0, data.Stride * data.Height);
+            bytes.IndexOfAnyExcept((byte)0).Should().Be(-1);
+        }
+        finally
+        {
+            bitmap.UnlockBits(data);
+        }
+    }
+
+    internal unsafe static void VerifyBitmapNotEmpty(Bitmap bitmap)
+    {
+        BitmapData data = bitmap.LockBits(default, ImageLockMode.ReadOnly, PixelFormat.Format32bppArgb);
+        try
+        {
+            ReadOnlySpan<byte> bytes = new((byte*)data.Scan0, data.Stride * data.Height);
+            bytes.IndexOfAnyExcept((byte)0).Should().NotBe(-1);
+        }
+        finally
+        {
+            bitmap.UnlockBits(data);
+        }
+    }
+
+#if NET9_0_OR_GREATER
+    [Fact]
+    public void Graphics_DrawRoundedRectangle_Integer()
+    {
+        using Bitmap bitmap = new(10, 10);
+        using Graphics graphics = Graphics.FromImage(bitmap);
+        graphics.DrawRoundedRectangle(Pens.Red, new(0, 0, 10, 10), new(2, 2));
+        VerifyBitmapNotEmpty(bitmap);
+    }
+
+    [Fact]
+    public void Graphics_DrawRoundedRectangle_Float()
+    {
+        using Bitmap bitmap = new(10, 10);
+        using Graphics graphics = Graphics.FromImage(bitmap);
+        graphics.DrawRoundedRectangle(Pens.Red, new RectangleF(0, 0, 10, 10), new(2, 2));
+        VerifyBitmapNotEmpty(bitmap);
+    }
+
+    [Fact]
+    public void Graphics_FillRoundedRectangle_Integer()
+    {
+        using Bitmap bitmap = new(10, 10);
+        using Graphics graphics = Graphics.FromImage(bitmap);
+        graphics.FillRoundedRectangle(Brushes.Green, new(0, 0, 10, 10), new(2, 2));
+        VerifyBitmapNotEmpty(bitmap);
+    }
+
+    [Fact]
+    public void Graphics_FillRoundedRectangle_Float()
+    {
+        using Bitmap bitmap = new(10, 10);
+        using Graphics graphics = Graphics.FromImage(bitmap);
+        graphics.FillRoundedRectangle(Brushes.Green, new RectangleF(0, 0, 10, 10), new(2, 2));
+        VerifyBitmapNotEmpty(bitmap);
+    }
+#endif
 }


### PR DESCRIPTION
This adds simple methods for drawing rounded rectangles.

Also changes behavior of LockBits to allow passing in an empty rectangle to mean "the whole bitmap".

I'll move the bitmap validation helper somewhere centralized.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10764)