### PR TITLE
Fix ListView CancelEdit

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ListView/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ListView/ListView.cs
@@ -6536,7 +6536,7 @@ public partial class ListView : Control
                     string? text = dispInfo->item.pszText.ToString();
                     LabelEditEventArgs e = new(dispInfo->item.iItem, text);
                     OnAfterLabelEdit(e);
-                    m.ResultInternal = (LRESULT)(nint)(BOOL)e.CancelEdit;
+                    m.ResultInternal = (LRESULT)(nint)(BOOL)!e.CancelEdit;
 
                     // from msdn:
                     //   "If the user cancels editing, the pszText member of the LVITEM structure is NULL"


### PR DESCRIPTION
The state got inverted in https://github.com/dotnet/winforms/commit/7e0115d442c26dfce4ad49231e446b8bdd172cab. I don't think there is a good way to get an automated test for this, but I'll look into it.

We need to get this serviced as it always flips what you try to do.

Fixes #10746

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10768)