### PR TITLE
Clean up Image.Save

### DIFF
--- a/src/System.Drawing.Common/src/System/Drawing/Graphics.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Graphics.cs
@@ -142,7 +142,7 @@ public sealed unsafe partial class Graphics : MarshalByRefObject, IDisposable, I
             throw new ArgumentException(SR.GdiplusCannotCreateGraphicsFromIndexedPixelFormat, nameof(image));
 
         GpGraphics* nativeGraphics;
-        Gdip.CheckStatus(PInvoke.GdipGetImageGraphicsContext(image._nativeImage, &nativeGraphics));
+        Gdip.CheckStatus(PInvoke.GdipGetImageGraphicsContext(image.Pointer(), &nativeGraphics));
         GC.KeepAlive(image);
 
         return new Graphics(nativeGraphics) { _backingImage = image };
@@ -1813,7 +1813,7 @@ public sealed unsafe partial class Graphics : MarshalByRefObject, IDisposable, I
     public void DrawImage(Image image, float x, float y)
     {
         ArgumentNullException.ThrowIfNull(image);
-        Status status = PInvoke.GdipDrawImage(NativeGraphics, image._nativeImage, x, y);
+        Status status = PInvoke.GdipDrawImage(NativeGraphics, image.Pointer(), x, y);
         IgnoreMetafileErrors(image, ref status);
         CheckErrorStatus(status);
     }
@@ -1823,7 +1823,7 @@ public sealed unsafe partial class Graphics : MarshalByRefObject, IDisposable, I
     public void DrawImage(Image image, float x, float y, float width, float height)
     {
         ArgumentNullException.ThrowIfNull(image);
-        Status status = PInvoke.GdipDrawImageRect(NativeGraphics, image._nativeImage, x, y, width, height);
+        Status status = PInvoke.GdipDrawImageRect(NativeGraphics, image.Pointer(), x, y, width, height);
         IgnoreMetafileErrors(image, ref status);
         CheckErrorStatus(status);
     }
@@ -1878,7 +1878,7 @@ public sealed unsafe partial class Graphics : MarshalByRefObject, IDisposable, I
 
         fixed (PointF* p = destPoints)
         {
-            Status status = PInvoke.GdipDrawImagePoints(NativeGraphics, image._nativeImage, (GdiPlus.PointF*)p, count);
+            Status status = PInvoke.GdipDrawImagePoints(NativeGraphics, image.Pointer(), (GdiPlus.PointF*)p, count);
             IgnoreMetafileErrors(image, ref status);
             CheckErrorStatus(status);
         }
@@ -1895,7 +1895,7 @@ public sealed unsafe partial class Graphics : MarshalByRefObject, IDisposable, I
 
         fixed (Point* p = destPoints)
         {
-            Status status = PInvoke.GdipDrawImagePointsI(NativeGraphics, image._nativeImage, (GdiPlus.Point*)p, count);
+            Status status = PInvoke.GdipDrawImagePointsI(NativeGraphics, image.Pointer(), (GdiPlus.Point*)p, count);
             IgnoreMetafileErrors(image, ref status);
             CheckErrorStatus(status);
         }
@@ -1907,7 +1907,7 @@ public sealed unsafe partial class Graphics : MarshalByRefObject, IDisposable, I
 
         Status status = PInvoke.GdipDrawImagePointRect(
             NativeGraphics,
-            image._nativeImage,
+            image.Pointer(),
             x, y,
             srcRect.X, srcRect.Y, srcRect.Width, srcRect.Height,
             (Unit)srcUnit);
@@ -1925,7 +1925,7 @@ public sealed unsafe partial class Graphics : MarshalByRefObject, IDisposable, I
 
         Status status = PInvoke.GdipDrawImageRectRect(
             NativeGraphics,
-            image._nativeImage,
+            image.Pointer(),
             destRect.X, destRect.Y, destRect.Width, destRect.Height,
             srcRect.X, srcRect.Y, srcRect.Width, srcRect.Height,
             (Unit)srcUnit,
@@ -1953,7 +1953,7 @@ public sealed unsafe partial class Graphics : MarshalByRefObject, IDisposable, I
         {
             Status status = PInvoke.GdipDrawImagePointsRect(
                 NativeGraphics,
-                image._nativeImage,
+                image.Pointer(),
                 (GdiPlus.PointF*)p, destPoints.Length,
                 srcRect.X, srcRect.Y, srcRect.Width, srcRect.Height,
                 (Unit)srcUnit,
@@ -1998,7 +1998,7 @@ public sealed unsafe partial class Graphics : MarshalByRefObject, IDisposable, I
         {
             Status status = PInvoke.GdipDrawImagePointsRect(
                 NativeGraphics,
-                image._nativeImage,
+                image.Pointer(),
                 (GdiPlus.PointF*)p, destPoints.Length,
                 srcRect.X, srcRect.Y, srcRect.Width, srcRect.Height,
                 (Unit)srcUnit,
@@ -2051,7 +2051,7 @@ public sealed unsafe partial class Graphics : MarshalByRefObject, IDisposable, I
         {
             Status status = PInvoke.GdipDrawImagePointsRectI(
                 NativeGraphics,
-                image._nativeImage,
+                image.Pointer(),
                 (GdiPlus.Point*)p, destPoints.Length,
                 srcRect.X, srcRect.Y, srcRect.Width, srcRect.Height,
                 (Unit)srcUnit,
@@ -2113,7 +2113,7 @@ public sealed unsafe partial class Graphics : MarshalByRefObject, IDisposable, I
 
         Status status = PInvoke.GdipDrawImageRectRect(
             NativeGraphics,
-            image._nativeImage,
+            image.Pointer(),
             destRect.X, destRect.Y, destRect.Width, destRect.Height,
             srcX, srcY, srcWidth, srcHeight,
             (Unit)srcUnit,

--- a/src/System.Drawing.Common/src/System/Drawing/Image.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Image.cs
@@ -22,7 +22,7 @@ namespace System.Drawing;
 [Serializable]
 [Runtime.CompilerServices.TypeForwardedFrom(AssemblyRef.SystemDrawing)]
 [TypeConverter(typeof(ImageConverter))]
-public abstract unsafe class Image : MarshalByRefObject, IDisposable, ICloneable, ISerializable
+public abstract unsafe class Image : MarshalByRefObject, IImage, IDisposable, ICloneable, ISerializable
 {
 #if FINALIZATION_WATCH
     private string allocationSite = Graphics.GetAllocationStack();
@@ -38,12 +38,15 @@ public abstract unsafe class Image : MarshalByRefObject, IDisposable, ICloneable
     // However, as this delegate is not used in both GDI 1.0 and 1.1, we choose not
     // to modify it, in order to preserve compatibility.
     public delegate bool GetThumbnailImageAbort();
-    internal GpImage* _nativeImage;
+
+    GpImage* IPointer<GpImage>.Pointer => _nativeImage;
+    private GpImage* _nativeImage;
 
     private object? _userData;
 
-    // used to work around lack of animated gif encoder... rarely set...
-    private byte[]? _rawData;
+    // Used to work around lack of animated gif encoder.
+    private byte[]? _animatedGifRawData;
+    ReadOnlySpan<byte> IRawData.Data => _animatedGifRawData;
 
     [Localizable(false)]
     [DefaultValue(null)]
@@ -118,7 +121,7 @@ public abstract unsafe class Image : MarshalByRefObject, IDisposable, ICloneable
         ValidateImage(image);
 
         Image img = CreateImageObject(image);
-        EnsureSave(img, filename, null);
+        GetAnimatedGifRawData(img, filename, dataStream: null);
         return img;
     }
 
@@ -141,7 +144,7 @@ public abstract unsafe class Image : MarshalByRefObject, IDisposable, ICloneable
         }
 
         Image img = CreateImageObject(image);
-        EnsureSave(img, null, stream);
+        GetAnimatedGifRawData(img, filename: null, stream);
         return img;
     }
 
@@ -153,7 +156,7 @@ public abstract unsafe class Image : MarshalByRefObject, IDisposable, ICloneable
         _nativeImage = image;
         GdiPlus.ImageType type = default;
         PInvoke.GdipGetImageType(_nativeImage, &type).ThrowIfFailed();
-        EnsureSave(this, null, stream);
+        GetAnimatedGifRawData(this, filename: null, stream);
         return image;
     }
 
@@ -274,7 +277,7 @@ public abstract unsafe class Image : MarshalByRefObject, IDisposable, ICloneable
 
         if (encoderParams is not null)
         {
-            _rawData = null;
+            _animatedGifRawData = null;
             nativeParameters = encoderParams.ConvertToNative();
         }
 
@@ -283,10 +286,10 @@ public abstract unsafe class Image : MarshalByRefObject, IDisposable, ICloneable
             Guid guid = encoder.Clsid;
             bool saved = false;
 
-            if (_rawData is not null && RawFormat.FindEncoder() is { } rawEncoder && rawEncoder.Clsid == guid)
+            if (_animatedGifRawData is not null && RawFormat.FindEncoder() is { } rawEncoder && rawEncoder.Clsid == guid)
             {
                 using var fs = File.OpenWrite(filename);
-                fs.Write(_rawData, 0, _rawData.Length);
+                fs.Write(_animatedGifRawData, 0, _animatedGifRawData.Length);
                 saved = true;
             }
 
@@ -320,7 +323,7 @@ public abstract unsafe class Image : MarshalByRefObject, IDisposable, ICloneable
         // If we don't find an Encoder (for things like Icon), we just switch back to PNG...
         ImageCodecInfo codec = dest.FindEncoder() ?? ImageFormat.Png.FindEncoder()!;
 
-        Save(stream, codec, encoderParams: null);
+        Save(stream, codec);
     }
 
     /// <summary>
@@ -331,7 +334,28 @@ public abstract unsafe class Image : MarshalByRefObject, IDisposable, ICloneable
         ArgumentNullException.ThrowIfNull(format);
 
         ImageCodecInfo codec = format.FindEncoder()!;
-        Save(stream, codec, null);
+        Save(stream, codec);
+    }
+
+    internal void Save(Stream stream, ImageCodecInfo encoder) =>
+        Save(stream, encoder, encoderParameters: null);
+
+    internal void Save(Stream stream, ImageCodecInfo encoder, GdiPlus.EncoderParameters* encoderParameters) =>
+        Save(this, stream, encoder.Clsid, encoder.FormatID, encoderParameters);
+
+    internal static void Save(IImage image, Stream stream, Guid encoder, Guid format, GdiPlus.EncoderParameters* encoderParameters)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+        ArgumentNullException.ThrowIfNull(encoder);
+
+        if (format == ImageFormat.Gif.Guid && image.Data is { } rawData && rawData.Length > 0)
+        {
+            stream.Write(rawData);
+            return;
+        }
+
+        using var iStream = stream.ToIStream();
+        PInvoke.GdipSaveImageToStream(image.Pointer, iStream, &encoder, encoderParameters).ThrowIfFailed();
     }
 
     /// <summary>
@@ -346,26 +370,13 @@ public abstract unsafe class Image : MarshalByRefObject, IDisposable, ICloneable
 
         if (encoderParams is not null)
         {
-            _rawData = null;
+            _animatedGifRawData = null;
             nativeParameters = encoderParams.ConvertToNative();
         }
 
         try
         {
-            Guid guid = encoder.Clsid;
-            bool saved = false;
-
-            if (_rawData is not null && RawFormat.FindEncoder() is { } rawEncoder && rawEncoder.Clsid == guid)
-            {
-                stream.Write(_rawData, 0, _rawData.Length);
-                saved = true;
-            }
-
-            if (!saved)
-            {
-                using var iStream = stream.ToIStream();
-                PInvoke.GdipSaveImageToStream(_nativeImage, iStream, &guid, nativeParameters).ThrowIfFailed();
-            }
+            Save(stream, encoder, nativeParameters);
         }
         finally
         {
@@ -390,7 +401,7 @@ public abstract unsafe class Image : MarshalByRefObject, IDisposable, ICloneable
             nativeParameters = encoderParams.ConvertToNative();
         }
 
-        _rawData = null;
+        _animatedGifRawData = null;
 
         try
         {
@@ -422,7 +433,7 @@ public abstract unsafe class Image : MarshalByRefObject, IDisposable, ICloneable
             nativeParameters = encoderParams.ConvertToNative();
         }
 
-        _rawData = null;
+        _animatedGifRawData = null;
 
         try
         {
@@ -694,7 +705,7 @@ public abstract unsafe class Image : MarshalByRefObject, IDisposable, ICloneable
         // GDI+ had to ignore the callback as System.Drawing didn't define it correctly so it was eventually removed
         // completely in Windows 7. As such, we don't need to pass it to GDI+.
         PInvoke.GdipGetImageThumbnail(
-            _nativeImage,
+            this.Pointer(),
             (uint)thumbWidth,
             (uint)thumbHeight,
             &thumbImage,
@@ -925,85 +936,91 @@ public abstract unsafe class Image : MarshalByRefObject, IDisposable, ICloneable
         };
     }
 
-    internal static unsafe void EnsureSave(Image image, string? filename, Stream? dataStream)
+    /// <summary>
+    ///  If the image is an animated GIF, loads the raw data for the image into the _rawData field so we
+    ///  can work around the lack of an animated GIF encoder.
+    /// </summary>
+    internal static unsafe void GetAnimatedGifRawData(Image image, string? filename, Stream? dataStream)
     {
-        if (image.RawFormat.Equals(ImageFormat.Gif))
+        if (!image.RawFormat.Equals(ImageFormat.Gif))
         {
-            bool animatedGif = false;
+            return;
+        }
 
-            uint dimensions;
-            PInvoke.GdipImageGetFrameDimensionsCount(image._nativeImage, &dimensions).ThrowIfFailed();
-            if (dimensions <= 0)
+        bool animatedGif = false;
+
+        uint dimensions;
+        PInvoke.GdipImageGetFrameDimensionsCount(image._nativeImage, &dimensions).ThrowIfFailed();
+        if (dimensions <= 0)
+        {
+            return;
+        }
+
+        using BufferScope<Guid> guids = new(stackalloc Guid[16], (int)dimensions);
+
+        fixed (Guid* g = guids)
+        {
+            PInvoke.GdipImageGetFrameDimensionsList(image._nativeImage, g, dimensions).ThrowIfFailed();
+        }
+
+        Guid timeGuid = FrameDimension.Time.Guid;
+        for (int i = 0; i < dimensions; i++)
+        {
+            if (timeGuid == guids[i])
             {
-                return;
+                animatedGif = image.GetFrameCount(FrameDimension.Time) > 1;
+                break;
             }
+        }
 
-            using BufferScope<Guid> guids = new(stackalloc Guid[16], (int)dimensions);
+        if (!animatedGif)
+        {
+            return;
+        }
 
-            fixed (Guid* g = guids)
+        try
+        {
+            Stream? created = null;
+            long lastPos = 0;
+            if (dataStream is not null)
             {
-                PInvoke.GdipImageGetFrameDimensionsList(image._nativeImage, g, dimensions).ThrowIfFailed();
-            }
-
-            Guid timeGuid = FrameDimension.Time.Guid;
-            for (int i = 0; i < dimensions; i++)
-            {
-                if (timeGuid == guids[i])
-                {
-                    animatedGif = image.GetFrameCount(FrameDimension.Time) > 1;
-                    break;
-                }
-            }
-
-            if (!animatedGif)
-            {
-                return;
+                lastPos = dataStream.Position;
+                dataStream.Position = 0;
             }
 
             try
             {
-                Stream? created = null;
-                long lastPos = 0;
-                if (dataStream is not null)
+                if (dataStream is null)
                 {
-                    lastPos = dataStream.Position;
-                    dataStream.Position = 0;
+                    created = dataStream = File.OpenRead(filename ?? throw new InvalidOperationException());
                 }
 
-                try
-                {
-                    if (dataStream is null)
-                    {
-                        created = dataStream = File.OpenRead(filename!);
-                    }
-
-                    image._rawData = new byte[(int)dataStream.Length];
-                    dataStream.Read(image._rawData, 0, (int)dataStream.Length);
-                }
-                finally
-                {
-                    if (created is not null)
-                    {
-                        created.Close();
-                    }
-                    else
-                    {
-                        dataStream!.Position = lastPos;
-                    }
-                }
+                image._animatedGifRawData = new byte[(int)dataStream.Length];
+                dataStream.Read(image._animatedGifRawData, 0, (int)dataStream.Length);
             }
-            catch (Exception e) when (e
-                // possible exceptions for reading the filename
-                is UnauthorizedAccessException
-                or DirectoryNotFoundException
-                or IOException
-                // possible exceptions for setting/getting the position inside dataStream
-                or NotSupportedException
-                or ObjectDisposedException
-                // possible exception when reading stuff into dataStream
-                or ArgumentException)
+            finally
             {
+                if (created is not null)
+                {
+                    created.Close();
+                }
+                else
+                {
+                    dataStream!.Position = lastPos;
+                }
             }
+        }
+        catch (Exception e) when (e
+            // possible exceptions for reading the filename
+            is UnauthorizedAccessException
+            or DirectoryNotFoundException
+            or IOException
+            // possible exceptions for setting/getting the position inside dataStream
+            or NotSupportedException
+            or ObjectDisposedException
+            // possible exception when reading stuff into dataStream
+            or ArgumentException)
+        {
         }
     }
 }

--- a/src/System.Drawing.Common/src/System/Drawing/ImageConverter.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/ImageConverter.cs
@@ -73,7 +73,7 @@ public partial class ImageConverter : TypeConverter
                 // If we don't find an Encoder (for things like Icon), we
                 // just switch back to PNG.
                 ImageCodecInfo codec = FindEncoder(dest) ?? FindEncoder(ImageFormat.Png)!;
-                image.Save(ms, codec, null);
+                image.Save(ms, codec);
                 return ms.ToArray();
             }
         }

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/ImageFormat.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/ImageFormat.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel;
@@ -7,7 +7,7 @@ using System.Runtime.Versioning;
 namespace System.Drawing.Imaging;
 
 /// <summary>
-/// Specifies the format of the image.
+///  Specifies the format of the image.
 /// </summary>
 [TypeConverter(typeof(ImageFormatConverter))]
 public sealed class ImageFormat
@@ -30,128 +30,86 @@ public sealed class ImageFormat
     private readonly Guid _guid;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref='ImageFormat'/> class with the specified GUID.
+    ///  Initializes a new instance of the <see cref='ImageFormat'/> class with the specified GUID.
     /// </summary>
-    public ImageFormat(Guid guid)
-    {
-        _guid = guid;
-    }
+    public ImageFormat(Guid guid) => _guid = guid;
 
     /// <summary>
-    /// Specifies a global unique identifier (GUID) that represents this <see cref='ImageFormat'/>.
+    ///  Specifies a global unique identifier (GUID) that represents this <see cref='ImageFormat'/>.
     /// </summary>
-    public Guid Guid
-    {
-        get { return _guid; }
-    }
+    public Guid Guid => _guid;
 
     /// <summary>
-    /// Specifies a memory bitmap image format.
+    ///  Specifies a memory bitmap image format.
     /// </summary>
-    public static ImageFormat MemoryBmp
-    {
-        get { return s_memoryBMP; }
-    }
+    public static ImageFormat MemoryBmp => s_memoryBMP;
 
     /// <summary>
-    /// Specifies the bitmap image format.
+    ///  Specifies the bitmap image format.
     /// </summary>
-    public static ImageFormat Bmp
-    {
-        get { return s_bmp; }
-    }
+    public static ImageFormat Bmp => s_bmp;
 
     /// <summary>
-    /// Specifies the enhanced Windows metafile image format.
+    ///  Specifies the enhanced Windows metafile image format.
     /// </summary>
-    public static ImageFormat Emf
-    {
-        get { return s_emf; }
-    }
+    public static ImageFormat Emf => s_emf;
 
     /// <summary>
-    /// Specifies the Windows metafile image format.
+    ///  Specifies the Windows metafile image format.
     /// </summary>
-    public static ImageFormat Wmf
-    {
-        get { return s_wmf; }
-    }
+    public static ImageFormat Wmf => s_wmf;
 
     /// <summary>
-    /// Specifies the GIF image format.
+    ///  Specifies the GIF image format.
     /// </summary>
-    public static ImageFormat Gif
-    {
-        get { return s_gif; }
-    }
+    public static ImageFormat Gif => s_gif;
 
     /// <summary>
-    /// Specifies the JPEG image format.
+    ///  Specifies the JPEG image format.
     /// </summary>
-    public static ImageFormat Jpeg
-    {
-        get { return s_jpeg; }
-    }
+    public static ImageFormat Jpeg => s_jpeg;
 
     /// <summary>
-    /// Specifies the W3C PNG image format.
+    ///  Specifies the W3C PNG image format.
     /// </summary>
-    public static ImageFormat Png
-    {
-        get { return s_png; }
-    }
+    public static ImageFormat Png => s_png;
 
     /// <summary>
-    /// Specifies the Tag Image File Format (TIFF) image format.
+    ///  Specifies the Tag Image File Format (TIFF) image format.
     /// </summary>
-    public static ImageFormat Tiff
-    {
-        get { return s_tiff; }
-    }
+    public static ImageFormat Tiff => s_tiff;
 
     /// <summary>
-    /// Specifies the Exchangeable Image Format (EXIF).
+    ///  Specifies the Exchangeable Image Format (EXIF).
     /// </summary>
-    public static ImageFormat Exif
-    {
-        get { return s_exif; }
-    }
+    public static ImageFormat Exif => s_exif;
 
     /// <summary>
-    /// Specifies the Windows icon image format.
+    ///  Specifies the Windows icon image format.
     /// </summary>
-    public static ImageFormat Icon
-    {
-        get { return s_icon; }
-    }
+    public static ImageFormat Icon => s_icon;
 
     /// <summary>
-    /// Specifies the High Efficiency Image Format (HEIF).
+    ///  Specifies the High Efficiency Image Format (HEIF).
     /// </summary>
     /// <remarks>
-    /// This format is supported since Windows 10 1809.
+    ///  This format is supported since Windows 10 1809.
     /// </remarks>
     [SupportedOSPlatform("windows10.0.17763.0")]
-    public static ImageFormat Heif
-    {
-        get { return s_heif; }
-    }
+    public static ImageFormat Heif => s_heif;
 
     /// <summary>
     /// Specifies the WebP image format.
     /// </summary>
     /// <remarks>
-    /// This format is supported since Windows 10 1809.
+    ///  This format is supported since Windows 10 1809.
     /// </remarks>
     [SupportedOSPlatform("windows10.0.17763.0")]
-    public static ImageFormat Webp
-    {
-        get { return s_webp; }
-    }
+    public static ImageFormat Webp => s_webp;
 
     /// <summary>
-    /// Returns a value indicating whether the specified object is an <see cref='ImageFormat'/> equivalent to this
-    /// <see cref='ImageFormat'/>.
+    ///  Returns a value indicating whether the specified object is an <see cref='ImageFormat'/> equivalent to this
+    ///  <see cref='ImageFormat'/>.
     /// </summary>
     public override bool Equals([NotNullWhen(true)] object? o)
     {
@@ -162,7 +120,7 @@ public sealed class ImageFormat
     }
 
     /// <summary>
-    /// Returns a hash code.
+    ///  Returns a hash code.
     /// </summary>
     public override int GetHashCode()
     {
@@ -183,22 +141,22 @@ public sealed class ImageFormat
     }
 
     /// <summary>
-    /// Converts this <see cref='ImageFormat'/> to a human-readable string.
+    ///  Converts this <see cref='ImageFormat'/> to a human-readable string.
     /// </summary>
     public override string ToString()
     {
-        if (this.Guid == s_memoryBMP.Guid) return "MemoryBMP";
-        if (this.Guid == s_bmp.Guid) return "Bmp";
-        if (this.Guid == s_emf.Guid) return "Emf";
-        if (this.Guid == s_wmf.Guid) return "Wmf";
-        if (this.Guid == s_gif.Guid) return "Gif";
-        if (this.Guid == s_jpeg.Guid) return "Jpeg";
-        if (this.Guid == s_png.Guid) return "Png";
-        if (this.Guid == s_tiff.Guid) return "Tiff";
-        if (this.Guid == s_exif.Guid) return "Exif";
-        if (this.Guid == s_icon.Guid) return "Icon";
-        if (this.Guid == s_heif.Guid) return "Heif";
-        if (this.Guid == s_webp.Guid) return "Webp";
+        if (Guid == s_memoryBMP.Guid) return "MemoryBMP";
+        if (Guid == s_bmp.Guid) return "Bmp";
+        if (Guid == s_emf.Guid) return "Emf";
+        if (Guid == s_wmf.Guid) return "Wmf";
+        if (Guid == s_gif.Guid) return "Gif";
+        if (Guid == s_jpeg.Guid) return "Jpeg";
+        if (Guid == s_png.Guid) return "Png";
+        if (Guid == s_tiff.Guid) return "Tiff";
+        if (Guid == s_exif.Guid) return "Exif";
+        if (Guid == s_icon.Guid) return "Icon";
+        if (Guid == s_heif.Guid) return "Heif";
+        if (Guid == s_webp.Guid) return "Webp";
         return $"[ImageFormat: {_guid}]";
     }
 }

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/Metafile.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/Metafile.cs
@@ -537,7 +537,7 @@ public sealed unsafe class Metafile : Image
         fixed (byte* d = data)
         {
             PInvoke.GdipPlayMetafileRecord(
-                (GpMetafile*)_nativeImage,
+                this.Pointer(),
                 (GdiPlus.EmfPlusRecordType)recordType,
                 (uint)flags,
                 (uint)dataSize,
@@ -619,7 +619,7 @@ public sealed unsafe class Metafile : Image
 
         fixed (GdiPlus.MetafileHeader* mf = &header._header)
         {
-            PInvoke.GdipGetMetafileHeaderFromMetafile((GpMetafile*)_nativeImage, mf).ThrowIfFailed();
+            PInvoke.GdipGetMetafileHeaderFromMetafile(this.Pointer(), mf).ThrowIfFailed();
             GC.KeepAlive(this);
             return header;
         }
@@ -631,7 +631,7 @@ public sealed unsafe class Metafile : Image
     public IntPtr GetHenhmetafile()
     {
         HENHMETAFILE hemf;
-        PInvoke.GdipGetHemfFromMetafile((GpMetafile*)_nativeImage, &hemf).ThrowIfFailed();
+        PInvoke.GdipGetHemfFromMetafile(this.Pointer(), &hemf).ThrowIfFailed();
         GC.KeepAlive(this);
         return hemf;
     }

--- a/src/System.Drawing.Common/src/System/Drawing/PointerExtensions.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/PointerExtensions.cs
@@ -20,9 +20,9 @@ internal static unsafe class PointerExtensions
     public static GpImageAttributes* Pointer(this ImageAttributes? imageAttr) => imageAttr is null ? null : imageAttr._nativeImageAttributes;
     public static GpGraphics* Pointer(this Graphics? graphics) => graphics is null ? null : graphics.NativeGraphics;
     public static GpFont* Pointer(this Font? font) => font is null ? null : font.NativeFont;
-    public static GpBitmap* Pointer(this Bitmap? bitmap) => bitmap is null ? null : bitmap.NativeBitmap;
-    public static GpMetafile* Pointer(this Metafile? metafile) => metafile is null ? null : (GpMetafile*)metafile._nativeImage;
-    public static GpImage* Pointer(this Image? image) => image is null ? null : image._nativeImage;
+    public static GpBitmap* Pointer(this Bitmap? bitmap) => bitmap is null ? null : ((IPointer<GpBitmap>)bitmap).Pointer;
+    public static GpMetafile* Pointer(this Metafile? metafile) => metafile is null ? null : (GpMetafile*)((Image)metafile).Pointer();
+    public static GpImage* Pointer(this Image? image) => image is null ? null : ((IPointer<GpImage>)image).Pointer;
 #if NET9_0_OR_GREATER
     [RequiresPreviewFeatures]
     public static CGpEffect* Pointer(this Effect? effect) => effect is null ? null : effect.NativeEffect;

--- a/src/System.Drawing.Common/src/System/Drawing/TextureBrush.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/TextureBrush.cs
@@ -28,7 +28,7 @@ public sealed unsafe class TextureBrush : Brush
         }
 
         GpTexture* brush;
-        PInvoke.GdipCreateTexture(image._nativeImage, (WrapMode)wrapMode, &brush).ThrowIfFailed();
+        PInvoke.GdipCreateTexture(image.Pointer(), (WrapMode)wrapMode, &brush).ThrowIfFailed();
         GC.KeepAlive(image);
         SetNativeBrushInternal((GpBrush*)brush);
     }
@@ -44,7 +44,7 @@ public sealed unsafe class TextureBrush : Brush
 
         GpTexture* brush;
         PInvoke.GdipCreateTexture2(
-            image._nativeImage,
+            image.Pointer(),
             (WrapMode)wrapMode,
             dstRect.X, dstRect.Y, dstRect.Width, dstRect.Height, &brush).ThrowIfFailed();
 
@@ -65,7 +65,7 @@ public sealed unsafe class TextureBrush : Brush
 
         GpTexture* brush;
         PInvoke.GdipCreateTextureIA(
-            image._nativeImage,
+            image.Pointer(),
             imageAttr is null ? null : imageAttr._nativeImageAttributes,
             dstRect.X,
             dstRect.Y,

--- a/src/System.Private.Windows.Core/src/NativeMethods.txt
+++ b/src/System.Private.Windows.Core/src/NativeMethods.txt
@@ -86,6 +86,7 @@ GlobalReAlloc
 GlobalSize
 GlobalUnlock
 GpGraphics
+GpImage
 GpRegion
 HBITMAP
 HBMMENU_*

--- a/src/System.Private.Windows.Core/src/System/Drawing/IImage.cs
+++ b/src/System.Private.Windows.Core/src/System/Drawing/IImage.cs
@@ -1,0 +1,10 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Windows.Win32.Graphics.GdiPlus;
+
+namespace System.Drawing;
+
+internal interface IImage : IRawData, IPointer<GpImage>
+{
+}

--- a/src/System.Private.Windows.Core/src/System/IO/IRawData.cs
+++ b/src/System.Private.Windows.Core/src/System/IO/IRawData.cs
@@ -1,0 +1,9 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.IO;
+
+internal interface IRawData
+{
+    ReadOnlySpan<byte> Data { get; }
+}


### PR DESCRIPTION
Do a little cleanup on Image.Save.

- Improve terminology
- Factor code to allow moving some logic to Core


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10783)