### PR TITLE
Refactor `IArrangedElement` to remove `PropertyStore` usage

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -303,7 +303,7 @@ public unsafe partial class Control :
 
     // IArrangedElement fields
     private BitVector32 _layoutState;
-    private Rectangle _specifiedBounds;
+    private Rectangle? _specifiedBounds;
     private Size _preferredSize;
     private Padding? _padding;
     private Padding? _margin;
@@ -13433,7 +13433,7 @@ public unsafe partial class Control :
     }
 
     BitVector32 IArrangedElement.LayoutState { get => _layoutState; set => _layoutState = value; }
-    Rectangle IArrangedElement.SpecifiedBounds { get => _specifiedBounds; set => _specifiedBounds = value; }
+    Rectangle? IArrangedElement.SpecifiedBounds { get => _specifiedBounds; set => _specifiedBounds = value; }
     Size IArrangedElement.PreferredSize { get => _preferredSize; set => _preferredSize = value; }
     Size IArrangedElement.LayoutBounds { get => _layoutBounds; set => _layoutBounds = value; }
     Padding? IArrangedElement.Padding { get => _padding; set => _padding = value; }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripDropDown.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripDropDown.cs
@@ -1455,7 +1455,7 @@ public partial class ToolStripDropDown : ToolStrip
                 bool closeOnHorizontalKey = false;
                 if (LayoutStyle == ToolStripLayoutStyle.Flow)
                 {
-                    closeOnHorizontalKey = FlowLayout.GetFlowDirection(this) == FlowDirection.TopDown && !FlowLayout.GetWrapContents(this);
+                    closeOnHorizontalKey = CommonProperties.GetFlowDirection(this) == FlowDirection.TopDown && !FlowLayout.GetWrapContents(this);
                 }
 
                 if (closeOnHorizontalKey)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripItem.cs
@@ -59,6 +59,21 @@ public abstract partial class ToolStripItem :
     private Input.ICommand? _command;
     private object? _commandParameter;
 
+    // IArrangedElement fields
+    private BitVector32 _layoutState;
+    private Rectangle _specifiedBounds;
+    private Size _preferredSize;
+    private Size _layoutBounds;
+    private Dictionary<string, string?>? _lastKnownState;
+    private Padding? _padding;
+    private Padding? _margin;
+    private Size? _minimumSize;
+    private Size? _maximumSize;
+    private DefaultLayout.AnchorInfo? _anchorInfo;
+    private readonly Dictionary<IArrangedElement, Rectangle> _cachedBounds = [];
+    private TableLayout.LayoutInfo? _layoutInfo;
+    private TableLayout.ContainerInfo? _containerInfo;
+
     private static readonly ArrangedElementCollection s_emptyChildCollection = new();
 
     internal static readonly object s_mouseDownEvent = new();
@@ -1009,8 +1024,6 @@ public abstract partial class ToolStripItem :
         }
     }
 
-    PropertyStore IArrangedElement.Properties => Properties;
-
     void IArrangedElement.SetBounds(Rectangle bounds, BoundsSpecified specified)
     {
         // in this case the parent is telling us to refresh our bounds - don't
@@ -1021,6 +1034,22 @@ public abstract partial class ToolStripItem :
     void IArrangedElement.PerformLayout(IArrangedElement container, string? propertyName)
     {
     }
+
+    BitVector32 IArrangedElement.LayoutState { get => _layoutState; set => _layoutState = value; }
+    Rectangle IArrangedElement.SpecifiedBounds { get => _specifiedBounds; set => _specifiedBounds = value; }
+    Size IArrangedElement.PreferredSize { get => _preferredSize; set => _preferredSize = value; }
+    Size IArrangedElement.LayoutBounds { get => _layoutBounds; set => _layoutBounds = value; }
+    Padding? IArrangedElement.Padding { get => _padding; set => _padding = value; }
+    Padding? IArrangedElement.Margin { get => _margin; set => _margin = value; }
+    Size? IArrangedElement.MinimumSize { get => _minimumSize; set => _minimumSize = value; }
+    Size? IArrangedElement.MaximumSize { get => _maximumSize; set => _maximumSize = value; }
+    DefaultLayout.AnchorInfo? IArrangedElement.AnchorInfo { get => _anchorInfo; set => _anchorInfo = value; }
+    Dictionary<IArrangedElement, Rectangle> IArrangedElement.CachedBounds => _cachedBounds;
+    TableLayout.LayoutInfo IArrangedElement.LayoutInfo { get => _layoutInfo ??= new(this); set => _layoutInfo = value; }
+    TableLayout.ContainerInfo IArrangedElement.ContainerInfo { get => _containerInfo ??= new(this); }
+#if DEBUG
+    Dictionary<string, string?>? IArrangedElement.LastKnownState { get => _lastKnownState; set => _lastKnownState = value; }
+#endif
 
     /// <summary>
     ///  Gets or sets the alignment of the image on the label control.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripItem.cs
@@ -64,7 +64,6 @@ public abstract partial class ToolStripItem :
     private Rectangle _specifiedBounds;
     private Size _preferredSize;
     private Size _layoutBounds;
-    private Dictionary<string, string?>? _lastKnownState;
     private Padding? _padding;
     private Padding? _margin;
     private Size? _minimumSize;
@@ -73,6 +72,9 @@ public abstract partial class ToolStripItem :
     private readonly Dictionary<IArrangedElement, Rectangle> _cachedBounds = [];
     private TableLayout.LayoutInfo? _layoutInfo;
     private TableLayout.ContainerInfo? _containerInfo;
+#if DEBUG
+    private Dictionary<string, string?>? _lastKnownState;
+#endif
 
     private static readonly ArrangedElementCollection s_emptyChildCollection = new();
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripItem.cs
@@ -61,7 +61,7 @@ public abstract partial class ToolStripItem :
 
     // IArrangedElement fields
     private BitVector32 _layoutState;
-    private Rectangle _specifiedBounds;
+    private Rectangle? _specifiedBounds;
     private Size _preferredSize;
     private Size _layoutBounds;
     private Padding? _padding;
@@ -1038,7 +1038,7 @@ public abstract partial class ToolStripItem :
     }
 
     BitVector32 IArrangedElement.LayoutState { get => _layoutState; set => _layoutState = value; }
-    Rectangle IArrangedElement.SpecifiedBounds { get => _specifiedBounds; set => _specifiedBounds = value; }
+    Rectangle? IArrangedElement.SpecifiedBounds { get => _specifiedBounds; set => _specifiedBounds = value; }
     Size IArrangedElement.PreferredSize { get => _preferredSize; set => _preferredSize = value; }
     Size IArrangedElement.LayoutBounds { get => _layoutBounds; set => _layoutBounds = value; }
     Padding? IArrangedElement.Padding { get => _padding; set => _padding = value; }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripOverflow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripOverflow.cs
@@ -74,11 +74,6 @@ public partial class ToolStripOverflow : ToolStripDropDown, IArrangedElement
         get { return GetState(States.Visible); }
     }
 
-    PropertyStore IArrangedElement.Properties
-    {
-        get { return Properties; }
-    }
-
     void IArrangedElement.SetBounds(Rectangle bounds, BoundsSpecified specified)
     {
         SetBoundsCore(bounds.X, bounds.Y, bounds.Width, bounds.Height, specified);
@@ -107,26 +102,26 @@ public partial class ToolStripOverflow : ToolStripDropDown, IArrangedElement
     {
         if (ParentToolStrip is not null && ParentToolStrip.IsInDesignMode)
         {
-            if (FlowLayout.GetFlowDirection(this) != FlowDirection.TopDown)
+            if (CommonProperties.GetFlowDirection(this) != FlowDirection.TopDown)
             {
-                FlowLayout.SetFlowDirection(this, FlowDirection.TopDown);
+                CommonProperties.SetFlowDirection(this, FlowDirection.TopDown);
             }
 
-            if (FlowLayout.GetWrapContents(this))
+            if (CommonProperties.GetWrapContents(this))
             {
-                FlowLayout.SetWrapContents(this, false);
+                CommonProperties.SetWrapContents(this, false);
             }
         }
         else
         {
-            if (FlowLayout.GetFlowDirection(this) != FlowDirection.LeftToRight)
+            if (CommonProperties.GetFlowDirection(this) != FlowDirection.LeftToRight)
             {
-                FlowLayout.SetFlowDirection(this, FlowDirection.LeftToRight);
+                CommonProperties.SetFlowDirection(this, FlowDirection.LeftToRight);
             }
 
-            if (!FlowLayout.GetWrapContents(this))
+            if (!CommonProperties.GetWrapContents(this))
             {
-                FlowLayout.SetWrapContents(this, true);
+                CommonProperties.SetWrapContents(this, true);
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripPanelRow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripPanelRow.cs
@@ -44,7 +44,7 @@ public partial class ToolStripPanelRow : Component, IArrangedElement
 
     // IArrangedElement fields
     private BitVector32 _layoutState;
-    private Rectangle _specifiedBounds;
+    private Rectangle? _specifiedBounds;
     private Size _preferredSize;
     private Size _layoutBounds;
     private Padding? _padding;
@@ -735,7 +735,7 @@ public partial class ToolStripPanelRow : Component, IArrangedElement
     }
 
     BitVector32 IArrangedElement.LayoutState { get => _layoutState; set => _layoutState = value; }
-    Rectangle IArrangedElement.SpecifiedBounds { get => _specifiedBounds; set => _specifiedBounds = value; }
+    Rectangle? IArrangedElement.SpecifiedBounds { get => _specifiedBounds; set => _specifiedBounds = value; }
     Size IArrangedElement.PreferredSize { get => _preferredSize; set => _preferredSize = value; }
     Size IArrangedElement.LayoutBounds { get => _layoutBounds; set => _layoutBounds = value; }
     Padding? IArrangedElement.Padding { get => _padding; set => _padding = value; }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripPanelRow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripPanelRow.cs
@@ -47,7 +47,6 @@ public partial class ToolStripPanelRow : Component, IArrangedElement
     private Rectangle _specifiedBounds;
     private Size _preferredSize;
     private Size _layoutBounds;
-    private Dictionary<string, string?>? _lastKnownState;
     private Padding? _padding;
     private Padding? _margin;
     private Size? _minimumSize;
@@ -56,6 +55,9 @@ public partial class ToolStripPanelRow : Component, IArrangedElement
     private readonly Dictionary<IArrangedElement, Rectangle> _cachedBounds = [];
     private TableLayout.LayoutInfo? _layoutInfo;
     private TableLayout.ContainerInfo? _containerInfo;
+#if DEBUG
+    private Dictionary<string, string?>? _lastKnownState;
+#endif
 
     public ToolStripPanelRow(ToolStripPanel parent)
         : this(parent, true)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripPanelRow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripPanelRow.cs
@@ -4,6 +4,7 @@
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Drawing;
+
 #if DEBUG
 using System.Globalization;
 #endif
@@ -40,6 +41,21 @@ public partial class ToolStripPanelRow : Component, IArrangedElement
     private static int s_rowCreationCount;
     private readonly int _thisRowID;
 #endif
+
+    // IArrangedElement fields
+    private BitVector32 _layoutState;
+    private Rectangle _specifiedBounds;
+    private Size _preferredSize;
+    private Size _layoutBounds;
+    private Dictionary<string, string?>? _lastKnownState;
+    private Padding? _padding;
+    private Padding? _margin;
+    private Size? _minimumSize;
+    private Size? _maximumSize;
+    private DefaultLayout.AnchorInfo? _anchorInfo;
+    private readonly Dictionary<IArrangedElement, Rectangle> _cachedBounds = [];
+    private TableLayout.LayoutInfo? _layoutInfo;
+    private TableLayout.ContainerInfo? _containerInfo;
 
     public ToolStripPanelRow(ToolStripPanel parent)
         : this(parent, true)
@@ -684,14 +700,6 @@ public partial class ToolStripPanelRow : Component, IArrangedElement
         }
     }
 
-    PropertyStore IArrangedElement.Properties
-    {
-        get
-        {
-            return Properties;
-        }
-    }
-
     Size IArrangedElement.GetPreferredSize(Size constrainingSize)
     {
         Size preferredSize = LayoutEngine.GetPreferredSize(this, constrainingSize - Padding.Size) + Padding.Size;
@@ -724,7 +732,23 @@ public partial class ToolStripPanelRow : Component, IArrangedElement
         }
     }
 
-#region MouseStuff
+    BitVector32 IArrangedElement.LayoutState { get => _layoutState; set => _layoutState = value; }
+    Rectangle IArrangedElement.SpecifiedBounds { get => _specifiedBounds; set => _specifiedBounds = value; }
+    Size IArrangedElement.PreferredSize { get => _preferredSize; set => _preferredSize = value; }
+    Size IArrangedElement.LayoutBounds { get => _layoutBounds; set => _layoutBounds = value; }
+    Padding? IArrangedElement.Padding { get => _padding; set => _padding = value; }
+    Padding? IArrangedElement.Margin { get => _margin; set => _margin = value; }
+    Size? IArrangedElement.MinimumSize { get => _minimumSize; set => _minimumSize = value; }
+    Size? IArrangedElement.MaximumSize { get => _maximumSize; set => _maximumSize = value; }
+    DefaultLayout.AnchorInfo? IArrangedElement.AnchorInfo { get => _anchorInfo; set => _anchorInfo = value; }
+    Dictionary<IArrangedElement, Rectangle> IArrangedElement.CachedBounds => _cachedBounds;
+    TableLayout.LayoutInfo IArrangedElement.LayoutInfo { get => _layoutInfo ??= new(this); set => _layoutInfo = value; }
+    TableLayout.ContainerInfo IArrangedElement.ContainerInfo { get => _containerInfo ??= new(this); }
+#if DEBUG
+    Dictionary<string, string?>? IArrangedElement.LastKnownState { get => _lastKnownState; set => _lastKnownState = value; }
+#endif
+
+    #region MouseStuff
 
 #if DEBUG
     internal static readonly TraceSwitch ToolStripPanelMouseDebug = new("ToolStripPanelMouse", "Debug ToolStrip WM_MOUSEACTIVATE code");

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/ArrangedElement.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/ArrangedElement.cs
@@ -16,7 +16,7 @@ internal abstract class ArrangedElement : Component, IArrangedElement
 
     // IArrangedElement fields
     private BitVector32 _layoutState;
-    private Rectangle _specifiedBounds;
+    private Rectangle? _specifiedBounds;
     private Size _preferredSize;
     private Size _layoutBounds;
     private Padding? _padding;
@@ -200,7 +200,7 @@ internal abstract class ArrangedElement : Component, IArrangedElement
     }
 
     BitVector32 IArrangedElement.LayoutState { get => _layoutState; set => _layoutState = value; }
-    Rectangle IArrangedElement.SpecifiedBounds { get => _specifiedBounds; set => _specifiedBounds = value; }
+    Rectangle? IArrangedElement.SpecifiedBounds { get => _specifiedBounds; set => _specifiedBounds = value; }
     Size IArrangedElement.PreferredSize { get => _preferredSize; set => _preferredSize = value; }
     Size IArrangedElement.LayoutBounds { get => _layoutBounds; set => _layoutBounds = value; }
     Padding? IArrangedElement.Padding { get => _padding; set => _padding = value; }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/ArrangedElement.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/ArrangedElement.cs
@@ -19,7 +19,6 @@ internal abstract class ArrangedElement : Component, IArrangedElement
     private Rectangle _specifiedBounds;
     private Size _preferredSize;
     private Size _layoutBounds;
-    private Dictionary<string, string?>? _lastKnownState;
     private Padding? _padding;
     private Padding? _margin;
     private Size? _minimumSize;
@@ -28,6 +27,9 @@ internal abstract class ArrangedElement : Component, IArrangedElement
     private readonly Dictionary<IArrangedElement, Rectangle> _cachedBounds = [];
     private TableLayout.LayoutInfo? _layoutInfo;
     private TableLayout.ContainerInfo? _containerInfo;
+#if DEBUG
+    private Dictionary<string, string?>? _lastKnownState;
+#endif
 
     private readonly PropertyStore _propertyStore = new();  // Contains all properties that are not always set.
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/CommonProperties.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/CommonProperties.cs
@@ -65,12 +65,7 @@ internal partial class CommonProperties
     ///  property and not calling base.  If CommonProperties.GetAutoSize(element) is false,
     ///  a layout engine will treat it as AutoSize = false and not size the element to its
     ///  preferred size.
-    internal static bool GetAutoSize(IArrangedElement element)
-    {
-        BitVector32 state = element.LayoutState;
-        int value = state[s_autoSizeSection];
-        return value != 0;
-    }
+    internal static bool GetAutoSize(IArrangedElement element) => element.LayoutState[s_autoSizeSection] != 0;
 
     ///  GetMargin
     ///  Returns the Margin (exterior space) for an item
@@ -101,8 +96,7 @@ internal partial class CommonProperties
     ///  Returns the last size manually set into the element.  See UpdateSpecifiedBounds.
     internal static Rectangle GetSpecifiedBounds(IArrangedElement element)
     {
-        Rectangle rectangle = element.SpecifiedBounds;
-        if (rectangle != LayoutUtils.s_maxRectangle)
+        if (element.SpecifiedBounds is Rectangle rectangle && rectangle != LayoutUtils.s_maxRectangle)
         {
             return rectangle;
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/FlowLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/FlowLayout.cs
@@ -12,9 +12,6 @@ internal partial class FlowLayout : LayoutEngine
 {
     internal static readonly FlowLayout Instance = new();
 
-    private static readonly int s_wrapContentsProperty = PropertyStore.CreateKey();
-    private static readonly int s_flowDirectionProperty = PropertyStore.CreateKey();
-
     private protected override bool LayoutCore(IArrangedElement container, LayoutEventArgs args)
     {
 #if DEBUG
@@ -304,27 +301,11 @@ internal partial class FlowLayout : LayoutEngine
         return rowSize;
     }
 
-    public static bool GetWrapContents(IArrangedElement container) =>
-        container.Properties.GetInteger(s_wrapContentsProperty) == 0;
+    public static bool GetWrapContents(IArrangedElement container) => CommonProperties.GetWrapContents(container);
 
-    public static void SetWrapContents(IArrangedElement container, bool value)
-    {
-        container.Properties.SetInteger(s_wrapContentsProperty, value ? 0 : 1);
-        LayoutTransaction.DoLayout(container, container, PropertyNames.WrapContents);
-        Debug.Assert(GetWrapContents(container) == value, "GetWrapContents should return the same value as we set");
-    }
-
-    public static FlowDirection GetFlowDirection(IArrangedElement container) =>
-        (FlowDirection)container.Properties.GetInteger(s_flowDirectionProperty);
-
-    public static void SetFlowDirection(IArrangedElement container, FlowDirection value)
-    {
-        SourceGenerated.EnumValidator.Validate(value);
-
-        container.Properties.SetInteger(s_flowDirectionProperty, (int)value);
-        LayoutTransaction.DoLayout(container, container, PropertyNames.FlowDirection);
-        Debug.Assert(GetFlowDirection(container) == value, "GetFlowDirection should return the same value as we set");
-    }
+    public static void SetWrapContents(IArrangedElement container, bool value) => CommonProperties.SetWrapContents(container, value);
+public static FlowDirection GetFlowDirection(IArrangedElement container) => CommonProperties.GetFlowDirection(container);
+    public static void SetFlowDirection(IArrangedElement container, FlowDirection value) => CommonProperties.SetFlowDirection(container, value);
 
     [Conditional("DEBUG_VERIFY_ALIGNMENT")]
     private static void Debug_VerifyAlignment(IArrangedElement container, FlowDirection flowDirection)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/IArrangedElement.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/IArrangedElement.cs
@@ -67,7 +67,7 @@ internal interface IArrangedElement : IComponent
     /// </summary>
     BitVector32 LayoutState { get; set; }
 
-    Rectangle SpecifiedBounds { get; set; }
+    Rectangle? SpecifiedBounds { get; set; }
 
     Size PreferredSize { get; set; }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/IArrangedElement.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/IArrangedElement.cs
@@ -1,8 +1,11 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Drawing;
+using static System.Windows.Forms.Layout.DefaultLayout;
+using static System.Windows.Forms.Layout.TableLayout;
 
 namespace System.Windows.Forms.Layout;
 
@@ -41,13 +44,6 @@ internal interface IArrangedElement : IComponent
     bool ParticipatesInLayout { get; }
 
     /// <summary>
-    ///  Internally, layout engines will get properties from the
-    ///  property store on this interface.  In Orcas, this will be
-    ///  replaced with a global PropertyManager for DPs.
-    /// </summary>
-    PropertyStore Properties { get; }
-
-    /// <summary>
     ///  When an extender provided property is changed, we call this
     ///  method to update the layout on the element. In Orcas, we
     ///  will sync the DPs changed event.
@@ -63,4 +59,37 @@ internal interface IArrangedElement : IComponent
     ///  Returns the element's children (on a control, this forwards to Controls)
     /// </summary>
     ArrangedElementCollection Children { get; }
+
+    /// <summary>
+    ///  Returns the layout state bit vector.
+    ///  CAREFUL: this is a copy of the state.
+    ///  You need to pass the value back to the property to save your changes.
+    /// </summary>
+    BitVector32 LayoutState { get; set; }
+
+    Rectangle SpecifiedBounds { get; set; }
+
+    Size PreferredSize { get; set; }
+
+    Padding? Padding { get; set; }
+
+    Padding? Margin { get; set; }
+
+    Size? MinimumSize { get; set; }
+
+    Size? MaximumSize { get; set; }
+
+    Size LayoutBounds { get; set; }
+
+    AnchorInfo? AnchorInfo { get; set; }
+
+    Dictionary<IArrangedElement, Rectangle> CachedBounds { get; }
+
+    LayoutInfo LayoutInfo { get; set; }
+
+    ContainerInfo ContainerInfo { get; }
+
+#if DEBUG
+    Dictionary<string, string?>? LastKnownState { get; set; }
+#endif
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/TableLayout.ContainerInfo.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/TableLayout.ContainerInfo.cs
@@ -248,7 +248,7 @@ internal partial class TableLayout
                             continue;
                         }
 
-                        LayoutInfo layoutInfo = GetLayoutInfo(element);
+                        LayoutInfo layoutInfo = element.LayoutInfo;
                         if (layoutInfo.IsAbsolutelyPositioned)
                         {
                             _countFixedChildren++;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Panels/TableLayoutPanel/TableLayoutSettings.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Panels/TableLayoutPanel/TableLayoutSettings.cs
@@ -243,7 +243,7 @@ public sealed partial class TableLayoutSettings : LayoutSettings, ISerializable
         else
         {
             IArrangedElement element = LayoutEngine.CastToArrangedElement(control);
-            return TableLayout.GetLayoutInfo(element).ColumnSpan;
+            return element.LayoutInfo.ColumnSpan;
         }
     }
 
@@ -264,7 +264,7 @@ public sealed partial class TableLayoutSettings : LayoutSettings, ISerializable
                 TableLayout.ClearCachedAssignments(TableLayout.GetContainerInfo(element.Container));
             }
 
-            TableLayout.GetLayoutInfo(element).ColumnSpan = value;
+            element.LayoutInfo.ColumnSpan = value;
             LayoutTransaction.DoLayout(element.Container, element, PropertyNames.ColumnSpan);
             Debug.Assert(GetColumnSpan(element) == value, "column span should equal to the value we set");
         }
@@ -281,7 +281,7 @@ public sealed partial class TableLayoutSettings : LayoutSettings, ISerializable
         else
         {
             IArrangedElement element = LayoutEngine.CastToArrangedElement(control);
-            return TableLayout.GetLayoutInfo(element).RowSpan;
+            return element.LayoutInfo.RowSpan;
         }
     }
 
@@ -302,7 +302,7 @@ public sealed partial class TableLayoutSettings : LayoutSettings, ISerializable
                 TableLayout.ClearCachedAssignments(TableLayout.GetContainerInfo(element.Container));
             }
 
-            TableLayout.GetLayoutInfo(element).RowSpan = value;
+            element.LayoutInfo.RowSpan = value;
             LayoutTransaction.DoLayout(element.Container, element, PropertyNames.RowSpan);
             Debug.Assert(GetRowSpan(element) == value, "row span should equal to the value we set");
         }
@@ -325,8 +325,7 @@ public sealed partial class TableLayoutSettings : LayoutSettings, ISerializable
         else
         {
             IArrangedElement element = LayoutEngine.CastToArrangedElement(control);
-            TableLayout.LayoutInfo layoutInfo = TableLayout.GetLayoutInfo(element);
-            return layoutInfo.RowPosition;
+            return element.LayoutInfo.RowPosition;
         }
     }
 
@@ -386,8 +385,7 @@ public sealed partial class TableLayoutSettings : LayoutSettings, ISerializable
         else
         {
             IArrangedElement element = LayoutEngine.CastToArrangedElement(control);
-            TableLayout.LayoutInfo layoutInfo = TableLayout.GetLayoutInfo(element);
-            return layoutInfo.ColumnPosition;
+            return element.LayoutInfo.ColumnPosition;
         }
     }
 
@@ -433,15 +431,14 @@ public sealed partial class TableLayoutSettings : LayoutSettings, ISerializable
                 TableLayout.ClearCachedAssignments(TableLayout.GetContainerInfo(element.Container));
             }
 
-            TableLayout.LayoutInfo layoutInfo = TableLayout.GetLayoutInfo(element);
             if (colSpecified)
             {
-                layoutInfo.ColumnPosition = column;
+                element.LayoutInfo.ColumnPosition = column;
             }
 
             if (rowSpecified)
             {
-                layoutInfo.RowPosition = row;
+                element.LayoutInfo.RowPosition = row;
             }
 
             LayoutTransaction.DoLayout(element.Container, element, PropertyNames.TableIndex);

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/AnchorLayoutTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/AnchorLayoutTests.cs
@@ -65,14 +65,14 @@ public class AnchorLayoutTests : ControlTestBase
 
         try
         {
-            DefaultLayout.AnchorInfo? anchorInfo = DefaultLayout.GetAnchorInfo(button);
+            DefaultLayout.AnchorInfo? anchorInfo = ((IArrangedElement)button).AnchorInfo;
             Assert.Null(anchorInfo);
 
             // Unparent button and resume layout.
             form.Controls.Remove(button);
             form.ResumeLayout(performLayout: false);
 
-            anchorInfo = DefaultLayout.GetAnchorInfo(button);
+            anchorInfo = ((IArrangedElement)button).AnchorInfo;
             Assert.Null(anchorInfo);
         }
         finally
@@ -91,11 +91,11 @@ public class AnchorLayoutTests : ControlTestBase
 
         try
         {
-            DefaultLayout.AnchorInfo? anchorInfo = DefaultLayout.GetAnchorInfo(button);
+            DefaultLayout.AnchorInfo? anchorInfo = ((IArrangedElement)button).AnchorInfo;
             Assert.Null(anchorInfo);
 
             form.Controls.Add(button);
-            anchorInfo = DefaultLayout.GetAnchorInfo(button);
+            anchorInfo = ((IArrangedElement)button).AnchorInfo;
             Assert.Null(anchorInfo);
         }
         finally
@@ -114,15 +114,15 @@ public class AnchorLayoutTests : ControlTestBase
 
         try
         {
-            DefaultLayout.AnchorInfo? anchorInfo = DefaultLayout.GetAnchorInfo(button);
+            DefaultLayout.AnchorInfo? anchorInfo = ((IArrangedElement)button).AnchorInfo;
             Assert.Null(anchorInfo);
 
             form.Controls.Add(button);
-            anchorInfo = DefaultLayout.GetAnchorInfo(button);
+            anchorInfo = ((IArrangedElement)button).AnchorInfo;
             Assert.Null(anchorInfo);
 
             form.ResumeLayout(performLayout: false);
-            anchorInfo = DefaultLayout.GetAnchorInfo(button);
+            anchorInfo = ((IArrangedElement)button).AnchorInfo;
             Assert.NotNull(anchorInfo);
         }
         finally
@@ -143,7 +143,7 @@ public class AnchorLayoutTests : ControlTestBase
         {
             form.Controls.Add(button);
 
-            DefaultLayout.AnchorInfo? anchorInfo = DefaultLayout.GetAnchorInfo(button);
+            DefaultLayout.AnchorInfo? anchorInfo = ((IArrangedElement)button).AnchorInfo;
             Assert.NotNull(anchorInfo);
         }
         finally
@@ -166,7 +166,7 @@ public class AnchorLayoutTests : ControlTestBase
             container.SuspendLayout();
             container.Controls.Add(button);
 
-            DefaultLayout.AnchorInfo? anchorInfo = DefaultLayout.GetAnchorInfo(button);
+            DefaultLayout.AnchorInfo? anchorInfo = ((IArrangedElement)button).AnchorInfo;
             Assert.Null(anchorInfo);
 
             form.Controls.Add(container);
@@ -174,7 +174,7 @@ public class AnchorLayoutTests : ControlTestBase
 
             container.ResumeLayout(false);
             form.ResumeLayout(false);
-            anchorInfo = DefaultLayout.GetAnchorInfo(button);
+            anchorInfo = ((IArrangedElement)button).AnchorInfo;
             Assert.NotNull(anchorInfo);
         }
         finally
@@ -197,7 +197,7 @@ public class AnchorLayoutTests : ControlTestBase
             container.SuspendLayout();
             container.Controls.Add(button);
 
-            DefaultLayout.AnchorInfo? anchorInfo = DefaultLayout.GetAnchorInfo(button);
+            DefaultLayout.AnchorInfo? anchorInfo = ((IArrangedElement)button).AnchorInfo;
             Assert.Null(anchorInfo);
 
             form.Controls.Add(container);
@@ -206,7 +206,7 @@ public class AnchorLayoutTests : ControlTestBase
             container.ResumeLayout(false);
             form.ResumeLayout(false);
 
-            anchorInfo = DefaultLayout.GetAnchorInfo(button);
+            anchorInfo = ((IArrangedElement)button).AnchorInfo;
             Assert.NotNull(anchorInfo);
 
             container.Controls.Remove(button);
@@ -233,12 +233,12 @@ public class AnchorLayoutTests : ControlTestBase
         {
             form.Controls.Add(button);
 
-            DefaultLayout.AnchorInfo? anchorInfo = DefaultLayout.GetAnchorInfo(button);
+            DefaultLayout.AnchorInfo? anchorInfo = ((IArrangedElement)button).AnchorInfo;
             Assert.Null(anchorInfo);
 
             form.ResumeLayout(false);
 
-            anchorInfo = DefaultLayout.GetAnchorInfo(button);
+            anchorInfo = ((IArrangedElement)button).AnchorInfo;
             Assert.NotNull(anchorInfo);
 
             var bounds = button.Bounds;
@@ -307,7 +307,7 @@ public class AnchorLayoutTests : ControlTestBase
             Anchor = buttonAnchors
         };
 
-        DefaultLayout.AnchorInfo? anchorInfo = DefaultLayout.GetAnchorInfo(button);
+        DefaultLayout.AnchorInfo? anchorInfo = ((IArrangedElement)button).AnchorInfo;
         Assert.Null(anchorInfo);
 
         return (form, button);


### PR DESCRIPTION
This is part of the effort to refactor winforms to remove `PropertyStore` and move to fields.

Related: #9508

I reviewed the layout classes (`DefaultLayout`/`FlowLayout`/`TableLayout`) as well as `CommonProperties` and moved any of the `PropertyStore` usages to properties on `IArrangedElement`. For the values that made use of the `BitVector32 LayoutState`, I did not expose individual properties, as the logic was able to be centralized in `CommonProperties`.

The properties from `FlowLayout` were merged into the `BitVector32 LayoutState` to reduce memory usage.

Using winforms test the memory usage was:
| Before | After |
|--------|--------|
| 573.41Kb | 574.42Kb |

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10788)