### PR TITLE
Remove test interop from System.Drawing

### DIFF
--- a/src/Common/tests/TestUtilities/FileCleanupTestBase.cs
+++ b/src/Common/tests/TestUtilities/FileCleanupTestBase.cs
@@ -5,22 +5,27 @@ namespace System;
 
 public abstract class FileCleanupTestBase : IDisposable
 {
-    public readonly string TestDirectory;
+    private string? _testDirectory;
 
-    protected FileCleanupTestBase()
+    public string TestDirectory
     {
-        TestDirectory = Path.Combine(Path.GetTempPath(), GetUniqueName());
-        Directory.CreateDirectory(TestDirectory);
+        get
+        {
+            if (_testDirectory is null)
+            {
+                _testDirectory = Path.Combine(Path.GetTempPath(), GetUniqueName());
+                Directory.CreateDirectory(_testDirectory);
+            }
+
+            return _testDirectory;
+        }
     }
 
-    ~FileCleanupTestBase()
-    {
-        Dispose(false);
-    }
+    ~FileCleanupTestBase() => Dispose(disposing: false);
 
     public void Dispose()
     {
-        Dispose(true);
+        Dispose(disposing: true);
         GC.SuppressFinalize(this);
     }
 

--- a/src/System.Drawing.Common/tests/System/Drawing/GdiPlusHandlesTests.cs
+++ b/src/System.Drawing.Common/tests/System/Drawing/GdiPlusHandlesTests.cs
@@ -24,7 +24,7 @@ public static class GdiPlusHandlesTests
             using Bitmap bmp = new(100, 100);
             using Icon ico = new(Helpers.GetTestBitmapPath("16x16_one_entry_4bit.ico"));
 
-            using var hdc = new GetDcScope(PInvokeCore.GetForegroundWindow());
+            using GetDcScope hdc = new(PInvokeCore.GetForegroundWindow());
             using Graphics graphicsFromHdc = Graphics.FromHdc(hdc);
 
             using Process currentProcess = Process.GetCurrentProcess();

--- a/src/System.Drawing.Common/tests/System/Drawing/GdiPlusHandlesTests.cs
+++ b/src/System.Drawing.Common/tests/System/Drawing/GdiPlusHandlesTests.cs
@@ -3,6 +3,10 @@
 
 using System.Runtime.InteropServices;
 using Microsoft.DotNet.RemoteExecutor;
+using Windows.Win32;
+using Windows.Win32.Foundation;
+using Windows.Win32.Graphics.Gdi;
+using Windows.Win32.System.Threading;
 using Xunit.Sdk;
 
 namespace System.Drawing.Tests;
@@ -16,17 +20,17 @@ public static class GdiPlusHandlesTests
     {
         RemoteExecutor.Invoke(() =>
         {
-            const int handleTreshold = 1;
+            const int HandleThreshold = 1;
             using Bitmap bmp = new(100, 100);
             using Icon ico = new(Helpers.GetTestBitmapPath("16x16_one_entry_4bit.ico"));
 
-            IntPtr hdc = Helpers.GetDC(Helpers.GetForegroundWindow());
+            using var hdc = new GetDcScope(PInvokeCore.GetForegroundWindow());
             using Graphics graphicsFromHdc = Graphics.FromHdc(hdc);
 
             using Process currentProcess = Process.GetCurrentProcess();
-            IntPtr processHandle = currentProcess.Handle;
+            HANDLE processHandle = new(currentProcess.Handle);
 
-            int initialHandles = Helpers.GetGuiResources(processHandle, 0);
+            uint initialHandles = PInvokeCore.GetGuiResources(processHandle, GET_GUI_RESOURCES_FLAGS.GR_GDIOBJECTS);
             ValidateNoWin32Error(initialHandles);
 
             for (int i = 0; i < 5000; i++)
@@ -34,14 +38,14 @@ public static class GdiPlusHandlesTests
                 graphicsFromHdc.DrawIcon(ico, 100, 100);
             }
 
-            int finalHandles = Helpers.GetGuiResources(processHandle, 0);
+            uint finalHandles = PInvokeCore.GetGuiResources(processHandle, GET_GUI_RESOURCES_FLAGS.GR_GDIOBJECTS);
             ValidateNoWin32Error(finalHandles);
 
-            Assert.InRange(finalHandles, initialHandles - handleTreshold, initialHandles + handleTreshold);
+            Assert.InRange(finalHandles, initialHandles - HandleThreshold, initialHandles + HandleThreshold);
         }).Dispose();
     }
 
-    private static void ValidateNoWin32Error(int handleCount)
+    private static void ValidateNoWin32Error(uint handleCount)
     {
         if (handleCount == 0)
         {

--- a/src/System.Drawing.Common/tests/System/Drawing/Printing/PageSettingsTests.cs
+++ b/src/System.Drawing.Common/tests/System/Drawing/Printing/PageSettingsTests.cs
@@ -31,7 +31,7 @@ namespace System.Drawing.Printing.Tests;
 
 public class PageSettingsTests
 {
-    [ConditionalFact(Helpers.AnyInstalledPrinters, Helpers.WindowsRS3OrEarlier)] // RS4 failures: https://github.com/dotnet/winforms/issues/8816
+    [ConditionalFact(Helpers.AnyInstalledPrinters)]
     public void Clone_Success()
     {
         PageSettings ps = new();

--- a/src/System.Drawing.Common/tests/System/Drawing/Printing/PrintDocumentTests.cs
+++ b/src/System.Drawing.Common/tests/System/Drawing/Printing/PrintDocumentTests.cs
@@ -35,7 +35,7 @@ public class PrintDocumentTests : FileCleanupTestBase
         }
     };
 
-    [ConditionalFact(Helpers.WindowsRS3OrEarlier)] // RS4 failures: https://github.com/dotnet/winforms/issues/8816
+    [Fact]
     public void Ctor_Default_Success()
     {
         using PrintDocument document = new();
@@ -44,7 +44,7 @@ public class PrintDocumentTests : FileCleanupTestBase
         AssertDefaultPageSettings(document.DefaultPageSettings);
     }
 
-    [ConditionalFact(Helpers.WindowsRS3OrEarlier)] // RS4 failures: https://github.com/dotnet/winforms/issues/8816
+    [Fact]
     public void DefaultPageSettings_SetValue_ReturnsExpected()
     {
         using PrintDocument document = new();
@@ -56,7 +56,6 @@ public class PrintDocumentTests : FileCleanupTestBase
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/winforms/issues/8812")]
     public void DefaultPageSettings_Null_ReturnsExpected()
     {
         using PrintDocument document = new();
@@ -104,7 +103,7 @@ public class PrintDocumentTests : FileCleanupTestBase
         Assert.Same(printController, document.PrintController);
     }
 
-    [ConditionalFact(Helpers.AnyInstalledPrinters, Helpers.WindowsRS3OrEarlier)] // RS4 failures: https://github.com/dotnet/winforms/issues/8816
+    [ConditionalFact(Helpers.AnyInstalledPrinters)]
     public void PrinterSettings_SetValue_ReturnsExpected()
     {
         using PrintDocument document = new();
@@ -125,7 +124,7 @@ public class PrintDocumentTests : FileCleanupTestBase
             document.DefaultPageSettings.PaperSize.Kind);
     }
 
-    [ConditionalFact(Helpers.AnyInstalledPrinters, Helpers.WindowsRS3OrEarlier)] // RS4 failures: https://github.com/dotnet/winforms/issues/8816
+    [ConditionalFact(Helpers.AnyInstalledPrinters)]
     public void BeginPrint_SetValue_ReturnsExpected()
     {
         bool flag = false;
@@ -143,7 +142,6 @@ public class PrintDocumentTests : FileCleanupTestBase
         Assert.False(flag);
     }
 
-    [ActiveIssue("https://github.com/dotnet/winforms/issues/8815")]
     [ConditionalFact(Helpers.AnyInstalledPrinters)]
     public void EndPrint_SetValue_ReturnsExpected()
     {
@@ -187,7 +185,6 @@ public class PrintDocumentTests : FileCleanupTestBase
         Assert.True(endPrintCalled);
     }
 
-    [ActiveIssue("https://github.com/dotnet/winforms/issues/8815")]
     [ConditionalFact(Helpers.AnyInstalledPrinters)]
     public void PrintPage_SetValue_ReturnsExpected()
     {
@@ -206,7 +203,7 @@ public class PrintDocumentTests : FileCleanupTestBase
         Assert.False(flag);
     }
 
-    [ConditionalFact(Helpers.AnyInstalledPrinters, Helpers.WindowsRS3OrEarlier)] // RS4 failures: https://github.com/dotnet/winforms/issues/8816
+    [ConditionalFact(Helpers.AnyInstalledPrinters)] 
     public void QueryPageSettings_SetValue_ReturnsExpected()
     {
         bool flag = false;
@@ -253,9 +250,9 @@ public class PrintDocumentTests : FileCleanupTestBase
     private const string PrintToPdfPrinterName = "Microsoft Print to PDF";
     private static bool CanPrintToPdf()
     {
-        foreach (string name in PrinterSettings.InstalledPrinters)
+        foreach (string name in Helpers.InstalledPrinters)
         {
-            if (name.StartsWith(PrintToPdfPrinterName))
+            if (name.StartsWith(PrintToPdfPrinterName, StringComparison.Ordinal))
             {
                 return true;
             }
@@ -266,9 +263,9 @@ public class PrintDocumentTests : FileCleanupTestBase
 
     private static string GetPdfPrinterName()
     {
-        foreach (string name in PrinterSettings.InstalledPrinters)
+        foreach (string name in Helpers.InstalledPrinters)
         {
-            if (name.StartsWith(PrintToPdfPrinterName))
+            if (name.StartsWith(PrintToPdfPrinterName, StringComparison.Ordinal))
             {
                 return name;
             }

--- a/src/System.Drawing.Common/tests/System/Drawing/Printing/PrinterSettingsTests.cs
+++ b/src/System.Drawing.Common/tests/System/Drawing/Printing/PrinterSettingsTests.cs
@@ -158,7 +158,7 @@ public class PrinterSettingsTests
     [ConditionalFact(Helpers.AnyInstalledPrinters)]
     public void Static_InstalledPrinters_ReturnsExpected()
     {
-        Assert.NotNull(PrinterSettings.InstalledPrinters);
+        Assert.NotNull(Helpers.InstalledPrinters);
     }
 
     [Fact]
@@ -168,7 +168,7 @@ public class PrinterSettingsTests
         Assert.True(printerSettings.IsDefaultPrinter);
     }
 
-    [ConditionalFact(Helpers.AnyInstalledPrinters, Helpers.WindowsRS3OrEarlier)] // RS4 failures: https://github.com/dotnet/winforms/issues/8816
+    [ConditionalFact(Helpers.AnyInstalledPrinters)]
     public void IsPlotter_ReturnsExpected()
     {
         PrinterSettings printerSettings = new();
@@ -442,7 +442,7 @@ public class PrinterSettingsTests
         AssertExtensions.Throws<ArgumentException>(null, () => printerSettings.ToPage = toPage);
     }
 
-    [ConditionalFact(Helpers.AnyInstalledPrinters, Helpers.WindowsRS3OrEarlier)] // RS4 failures: https://github.com/dotnet/winforms/issues/8816
+    [ConditionalFact(Helpers.AnyInstalledPrinters)]
     public void Clone_Success()
     {
         PrinterSettings printerSettings = new();
@@ -450,7 +450,7 @@ public class PrinterSettingsTests
         Assert.False(ReferenceEquals(clone, printerSettings));
     }
 
-    [ConditionalFact(Helpers.AnyInstalledPrinters, Helpers.WindowsRS3OrEarlier)] // RS4 failures: https://github.com/dotnet/winforms/issues/8816
+    [ConditionalFact(Helpers.AnyInstalledPrinters)]
     public void CreateMeasurementGraphics_Default_ReturnsExpected()
     {
         PrinterSettings printerSettings = new();
@@ -462,7 +462,7 @@ public class PrinterSettingsTests
         Assert.Equal((double)printerSettings.DefaultPageSettings.PrintableArea.Width, graphic.VisibleClipBounds.Width, 0);
     }
 
-    [ConditionalFact(Helpers.AnyInstalledPrinters, Helpers.WindowsRS3OrEarlier)] // RS4 failures: https://github.com/dotnet/winforms/issues/8816
+    [ConditionalFact(Helpers.AnyInstalledPrinters)]
     public void CreateMeasurementGraphics_Bool_ReturnsExpected()
     {
         PrinterSettings printerSettings = new();
@@ -472,7 +472,7 @@ public class PrinterSettingsTests
         Assert.Equal((double)printerSettings.DefaultPageSettings.PrintableArea.Width, graphic.VisibleClipBounds.Width, 0);
     }
 
-    [ConditionalFact(Helpers.AnyInstalledPrinters, Helpers.WindowsRS3OrEarlier)] // RS4 failures: https://github.com/dotnet/winforms/issues/8816
+    [ConditionalFact(Helpers.AnyInstalledPrinters)]
     public void CreateMeasurementGraphics_PageSettings_ReturnsExpected()
     {
         PrinterSettings printerSettings = new();
@@ -485,7 +485,7 @@ public class PrinterSettingsTests
         Assert.Equal((double)printerSettings.DefaultPageSettings.PrintableArea.Width, graphic.VisibleClipBounds.Width, 0);
     }
 
-    [ConditionalFact(Helpers.AnyInstalledPrinters, Helpers.WindowsRS3OrEarlier)] // RS4 failures: https://github.com/dotnet/winforms/issues/8816
+    [ConditionalFact(Helpers.AnyInstalledPrinters)]
     public void CreateMeasurementGraphics_PageSettingsBool_ReturnsExpected()
     {
         PrinterSettings printerSettings = new();
@@ -496,7 +496,7 @@ public class PrinterSettingsTests
         Assert.Equal((double)printerSettings.DefaultPageSettings.PrintableArea.Width, graphic.VisibleClipBounds.Width, 0);
     }
 
-    [ConditionalFact(Helpers.WindowsRS3OrEarlier)] // RS4 failures: https://github.com/dotnet/winforms/issues/8816
+    [Fact]
     public void CreateMeasurementGraphics_Null_ThrowsNullReferenceException()
     {
         PrinterSettings printerSettings = new();
@@ -618,7 +618,7 @@ public class PrinterSettingsTests
     [Fact]
     public void PrinterSettings_GetInstalledPrinters_Success()
     {
-        var installedPrinters = PrinterSettings.InstalledPrinters;
+        var installedPrinters = Helpers.InstalledPrinters;
         installedPrinters.Should().NotBeNull();
         foreach (string printer in installedPrinters)
         {

--- a/src/System.Private.Windows.Core/src/NativeMethods.txt
+++ b/src/System.Private.Windows.Core/src/NativeMethods.txt
@@ -67,13 +67,17 @@ GdipGetImageEncodersSize
 GdipGetImageRawFormat
 GdipGetRegionHRgn
 GdipIsInfiniteRegion
+GetClientRect
 GdipSaveImageToStream
 GetClipRgn
 GetDC
 GetDCEx
 GetDesktopWindow
 GetDeviceCaps
+GetForegroundWindow
+GetGuiResources
 GetIconInfo
+GetMonitorInfo
 GetObject
 GetObjectType
 GetPaletteEntries
@@ -122,6 +126,11 @@ LoadIcon
 LoadRegTypeLib
 LPARAM
 MAX_PATH
+MonitorFromPoint
+MonitorFromRect
+MonitorFromWindow
+MONITORINFOEXW
+MONITORINFOF_*
 NONCLIENTMETRICSW
 OBJ_TYPE
 OffsetViewportOrgEx
@@ -133,8 +142,8 @@ POINTS
 PRINTDLGEX_FLAGS
 PropVariantClear
 PWSTR
-RECT
 Rect
+RECT
 RectF
 REGDB_E_CLASSNOTREG
 ReleaseDC
@@ -168,4 +177,5 @@ SystemParametersInfoForDpi
 TYPE_E_BADMODULEKIND
 VIEW_E_DRAW
 WIN32_ERROR
+WindowFromDC
 WPARAM

--- a/src/System.Private.Windows.Core/src/Properties/AssemblyInfo.cs
+++ b/src/System.Private.Windows.Core/src/Properties/AssemblyInfo.cs
@@ -18,6 +18,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("System.Windows.Forms.TestUtilities, PublicKey=00000000000000000400000000000000")]
 [assembly: InternalsVisibleTo("System.Windows.Forms.UI.IntegrationTests, PublicKey=00000000000000000400000000000000")]
 [assembly: InternalsVisibleTo("System.Windows.Forms.Interop.Tests, PublicKey=00000000000000000400000000000000")]
+[assembly: InternalsVisibleTo("System.Drawing.Common.Tests, PublicKey=00240000048000009400000006020000002400005253413100040000010001004b86c4cb78549b34bab61a3b1800e23bfeb5b3ec390074041536a7e3cbd97f5f04cf0f857155a8928eaa29ebfd11cfbbad3ba70efea7bda3226c6a8d370a4cd303f714486b6ebc225985a638471e6ef571cc92a4613c00b8fa65d61ccee0cbe5f36330c9a01f4183559f1bef24cc2917c6d913e3a541333a1d05d9bed22b38cb")]
 [assembly: InternalsVisibleTo("WinformsControlsTest, PublicKey=00000000000000000400000000000000")]
 [assembly: InternalsVisibleTo("MauiListViewTests, PublicKey=00000000000000000400000000000000")]
 [assembly: InternalsVisibleTo("System.Windows.Forms.IntegrationTests.Common, PublicKey=00000000000000000400000000000000")]

--- a/src/System.Private.Windows.Core/src/Windows/Win32/PInvoke.GetClientRect.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/PInvoke.GetClientRect.cs
@@ -3,7 +3,7 @@
 
 namespace Windows.Win32;
 
-internal static partial class PInvoke
+internal static partial class PInvokeCore
 {
     /// <inheritdoc cref="GetClientRect(HWND, out RECT)"/>
     public static BOOL GetClientRect<T>(T hWnd, out RECT lpRect)

--- a/src/System.Windows.Forms.Primitives/src/NativeMethods.txt
+++ b/src/System.Windows.Forms.Primitives/src/NativeMethods.txt
@@ -160,7 +160,6 @@ GetCaretBlinkTime
 GetCaretPos
 GetClassInfo
 GetClassName
-GetClientRect
 GetClipboardFormatName
 GetClipBox
 GetClipCursor
@@ -183,8 +182,6 @@ GetDpiForWindow
 GetErrorInfo
 GetExitCodeThread
 GetFocus
-GetForegroundWindow
-GetGuiResources
 GetHGlobalFromILockBytes
 GetKeyboardLayout
 GetKeyboardLayoutList
@@ -200,7 +197,6 @@ GetMessagePos
 GetMessageTime
 GetModuleFileName
 GetModuleHandle
-GetMonitorInfo
 GetNearestColor
 GetParent
 GetPhysicalCursorPos
@@ -494,11 +490,6 @@ MESSAGEBOX_RESULT
 MINIMIZEDMETRICS
 MINMAXINFO
 MODIFY_WORLD_TRANSFORM_MODE
-MonitorFromPoint
-MonitorFromRect
-MonitorFromWindow
-MONITORINFOEXW
-MONITORINFOF_*
 MONTH_CALDENDAR_MESSAGES_VIEW
 MONTHCAL_CLASS
 MOUSEHOOKSTRUCT
@@ -769,7 +760,6 @@ WC_TREEVIEW
 WHEEL_DELTA
 WideCharToMultiByte
 WINDOW_LONG_PTR_INDEX
-WindowFromDC
 WindowFromPoint
 WINDOWPOS
 WINEVENT_INCONTEXT

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -8408,7 +8408,7 @@ public unsafe partial class Control :
     protected virtual void OnPaintBackground(PaintEventArgs pevent)
     {
         // We need the true client rectangle as clip rectangle causes problems on "Windows Classic" theme.
-        PInvoke.GetClientRect(new HandleRef<HWND>(_window, InternalHandle), out RECT rect);
+        PInvokeCore.GetClientRect(new HandleRef<HWND>(_window, InternalHandle), out RECT rect);
         PaintBackground(pevent, rect);
     }
 
@@ -11422,7 +11422,7 @@ public unsafe partial class Control :
 
         if (IsHandleCreated)
         {
-            PInvoke.GetClientRect(this, out rect);
+            PInvokeCore.GetClientRect(this, out rect);
             clientWidth = rect.right;
             clientHeight = rect.bottom;
             PInvoke.GetWindowRect(this, out rect);
@@ -11889,7 +11889,7 @@ public unsafe partial class Control :
                     return;
                 }
 
-                PInvoke.GetClientRect(this, out RECT rc);
+                PInvokeCore.GetClientRect(this, out RECT rc);
                 using PaintEventArgs pevent = new(dc, rc);
                 PaintWithErrorHandling(pevent, PaintLayerBackground);
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.cs
@@ -3588,7 +3588,7 @@ public partial class ComboBox : ListControl
     {
         if ((DropDownStyle == ComboBoxStyle.Simple) && ParentInternal is not null)
         {
-            PInvoke.GetClientRect(this, out RECT rect);
+            PInvokeCore.GetClientRect(this, out RECT rect);
             HDC hdc = (HDC)m.WParamInternal;
             using var hbrush = new CreateBrushScope(ParentInternal?.BackColor ?? SystemColors.Control);
             hdc.FillRectangle(rect, hbrush);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/GroupBox/GroupBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/GroupBox/GroupBox.cs
@@ -657,7 +657,7 @@ public partial class GroupBox : Control
             return;
         }
 
-        PInvoke.GetClientRect(this, out RECT rect);
+        PInvokeCore.GetClientRect(this, out RECT rect);
         Color backColor = BackColor;
 
         if (backColor.HasTransparency())

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ListBoxes/ListBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ListBoxes/ListBox.cs
@@ -1508,7 +1508,7 @@ public partial class ListBox : ListControl
     {
         // NT4 SP6A : SendMessage Fails. So First check whether the point is in Client Co-ordinates and then
         // call SendMessage.
-        PInvoke.GetClientRect(this, out RECT r);
+        PInvokeCore.GetClientRect(this, out RECT r);
         if (r.left <= x && x < r.right && r.top <= y && y < r.bottom)
         {
             int index = (int)PInvoke.SendMessage(this, PInvoke.LB_ITEMFROMPOINT, 0, PARAM.FromLowHigh(x, y));

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ListView/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ListView/ListView.cs
@@ -4976,7 +4976,7 @@ public partial class ListView : Control
         if (!headerWindow.IsNull)
         {
             WINDOWPOS position = default;
-            PInvoke.GetClientRect(this, out RECT clientRect);
+            PInvokeCore.GetClientRect(this, out RECT clientRect);
             HDLAYOUT hd = new()
             {
                 prc = &clientRect,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.cs
@@ -2581,7 +2581,7 @@ internal sealed partial class PropertyGridView :
         if (_dropDownHolder is not null && _dropDownHolder.Visible)
         {
             bool found = false;
-            for (HWND hwnd = PInvoke.GetForegroundWindow(); !hwnd.IsNull; hwnd = PInvoke.GetParent(hwnd))
+            for (HWND hwnd = PInvokeCore.GetForegroundWindow(); !hwnd.IsNull; hwnd = PInvoke.GetParent(hwnd))
             {
                 if (hwnd == _dropDownHolder.Handle)
                 {
@@ -3126,8 +3126,8 @@ internal sealed partial class PropertyGridView :
 
             // Ensure that tooltips don't display when host application is not foreground app.
             // Assume that we don't want to display the tooltips
-            HWND foregroundWindow = PInvoke.GetForegroundWindow();
-            if (PInvoke.IsChild(PInvoke.GetForegroundWindow(), this))
+            HWND foregroundWindow = PInvokeCore.GetForegroundWindow();
+            if (PInvoke.IsChild(PInvokeCore.GetForegroundWindow(), this))
             {
                 // Don't show the tips if a dropdown is showing
                 if (_dropDownHolder is null || _dropDownHolder.Component is null || rowMoveCurrent == _selectedRow)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/StatusStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/StatusStrip.cs
@@ -581,7 +581,7 @@ public partial class StatusStrip : ToolStrip
                 {
                     // get the client area of the topmost window.  If we're next to the edge then
                     // the sizing grip is valid.
-                    PInvoke.GetClientRect(rootHwnd, out RECT rootHwndClientArea);
+                    PInvokeCore.GetClientRect(rootHwnd, out RECT rootHwndClientArea);
 
                     // map the size grip FROM statusStrip coords TO the toplevel window coords.
                     Point gripLocation;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripDropDown.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripDropDown.cs
@@ -1746,7 +1746,7 @@ public partial class ToolStripDropDown : ToolStrip
                     // Snap the foreground window BEFORE calling any user events so they
                     // don't have a chance to activate something else. This covers the case
                     // where someone handles the opening event and throws up a messagebox.
-                    HWND foregroundWindow = PInvoke.GetForegroundWindow();
+                    HWND foregroundWindow = PInvokeCore.GetForegroundWindow();
 
                     // Fire Opening event
                     // Cancellable event in which default value of e.Cancel depends on

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripManager.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripManager.cs
@@ -965,7 +965,7 @@ public static partial class ToolStripManager
 
                     // If we've alt-tabbed away don't snap/restore focus.
                     HWND topmostParentOfMenu = PInvoke.GetAncestor(menuStripToActivate, GET_ANCESTOR_FLAGS.GA_ROOT);
-                    HWND foregroundWindow = PInvoke.GetForegroundWindow();
+                    HWND foregroundWindow = PInvokeCore.GetForegroundWindow();
 
                     if (topmostParentOfMenu == foregroundWindow)
                     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripTextBox.ToolStripTextBoxControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripTextBox.ToolStripTextBoxControl.cs
@@ -37,7 +37,7 @@ public partial class ToolStripTextBox
                 int offsetY = -rect.top;
 
                 // fetch the client rect, then apply the offset.
-                PInvoke.GetClientRect(this, out var clientRect);
+                PInvokeCore.GetClientRect(this, out var clientRect);
 
                 clientRect.left += offsetX;
                 clientRect.right += offsetX;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -2907,7 +2907,7 @@ public partial class Form : ContainerControl
             }
         }
 
-        PInvoke.GetClientRect(this, out RECT currentClient);
+        PInvokeCore.GetClientRect(this, out RECT currentClient);
         Rectangle bounds = Bounds;
 
         // If the width is incorrect, compute the correct size with
@@ -2934,7 +2934,7 @@ public partial class Form : ContainerControl
             bounds.Width = correct.Width;
             bounds.Height = correct.Height;
             Bounds = bounds;
-            PInvoke.GetClientRect(this, out currentClient);
+            PInvokeCore.GetClientRect(this, out currentClient);
         }
 
         // If it still isn't correct, then we assume that the problem is

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -278,7 +278,7 @@ public partial class Form : ContainerControl
     /// <summary>
     ///  Gets the currently active form for this application.
     /// </summary>
-    public static Form? ActiveForm => FromHandle(PInvoke.GetForegroundWindow()) as Form;
+    public static Form? ActiveForm => FromHandle(PInvokeCore.GetForegroundWindow()) as Form;
 
     /// <summary>
     ///

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/Containers/ContainerControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/Containers/ContainerControl.cs
@@ -720,7 +720,7 @@ public class ContainerControl : ScrollableControl, IContainerControl
         if (GetTopLevel())
         {
             // Get window's client rectangle (i.e. without chrome) expressed in screen coordinates
-            PInvoke.GetClientRect(this, out RECT clientRectangle);
+            PInvokeCore.GetClientRect(this, out RECT clientRectangle);
             Point topLeftPoint = default;
             PInvoke.ClientToScreen(this, ref topLeftPoint);
             return new Rectangle(topLeftPoint.X, topLeftPoint.Y, clientRectangle.right, clientRectangle.bottom);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Screen.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Screen.cs
@@ -71,9 +71,9 @@ public partial class Screen
             };
 
             // API takes EX, determines which one you pass by size.
-            PInvoke.GetMonitorInfo(monitor, (MONITORINFO*)&info);
+            PInvokeCore.GetMonitorInfo(monitor, (MONITORINFO*)&info);
             _bounds = info.monitorInfo.rcMonitor;
-            _primary = ((info.monitorInfo.dwFlags & PInvoke.MONITORINFOF_PRIMARY) != 0);
+            _primary = ((info.monitorInfo.dwFlags & PInvokeCore.MONITORINFOF_PRIMARY) != 0);
 
             _deviceName = new string(info.szDevice.ToString());
 
@@ -202,7 +202,7 @@ public partial class Screen
                     };
 
                     // API takes EX, determines which one you pass by size.
-                    PInvoke.GetMonitorInfo(_hmonitor, (MONITORINFO*)&info);
+                    PInvokeCore.GetMonitorInfo(_hmonitor, (MONITORINFO*)&info);
                     _workingArea = info.monitorInfo.rcWork;
                 }
             }
@@ -248,7 +248,7 @@ public partial class Screen
     /// </summary>
     public static Screen FromPoint(Point point)
         => SystemInformation.MultiMonitorSupport
-        ? new Screen(PInvoke.MonitorFromPoint(point, MONITOR_FROM_FLAGS.MONITOR_DEFAULTTONEAREST))
+        ? new Screen(PInvokeCore.MonitorFromPoint(point, MONITOR_FROM_FLAGS.MONITOR_DEFAULTTONEAREST))
         : new Screen(PRIMARY_MONITOR);
 
     /// <summary>
@@ -256,7 +256,7 @@ public partial class Screen
     /// </summary>
     public static Screen FromRectangle(Rectangle rect)
         => SystemInformation.MultiMonitorSupport
-        ? new Screen(PInvoke.MonitorFromRect(rect, MONITOR_FROM_FLAGS.MONITOR_DEFAULTTONEAREST))
+        ? new Screen(PInvokeCore.MonitorFromRect(rect, MONITOR_FROM_FLAGS.MONITOR_DEFAULTTONEAREST))
         : new Screen(PRIMARY_MONITOR, default);
 
     /// <summary>
@@ -274,7 +274,7 @@ public partial class Screen
     /// </summary>
     public static Screen FromHandle(IntPtr hwnd)
         => SystemInformation.MultiMonitorSupport
-        ? new Screen(PInvoke.MonitorFromWindow((HWND)hwnd, MONITOR_FROM_FLAGS.MONITOR_DEFAULTTONEAREST))
+        ? new Screen(PInvokeCore.MonitorFromWindow((HWND)hwnd, MONITOR_FROM_FLAGS.MONITOR_DEFAULTTONEAREST))
         : new Screen(PRIMARY_MONITOR, default);
 
     /// <summary>

--- a/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests.Common/TestHelpers.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests.Common/TestHelpers.cs
@@ -434,7 +434,7 @@ public static class TestHelpers
             PInvoke.SetForegroundWindow(mainWindowHandle);
         }
 
-        HWND foregroundWindow = PInvoke.GetForegroundWindow();
+        HWND foregroundWindow = PInvokeCore.GetForegroundWindow();
 
         string windowTitle = PInvoke.GetWindowText(foregroundWindow);
 

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/ImageListTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/ImageListTests.cs
@@ -71,8 +71,10 @@ public class ImageListTests : ControlTestBase
         {
             GC.GetTotalMemory(true);
 
-            uint result = PInvoke.GetGuiResources((HANDLE)Process.GetCurrentProcess().Handle,
+            uint result = PInvokeCore.GetGuiResources(
+                (HANDLE)Process.GetCurrentProcess().Handle,
                 GET_GUI_RESOURCES_FLAGS.GR_GDIOBJECTS);
+
             if (result == 0)
             {
                 int lastWin32Error = Marshal.GetLastWin32Error();


### PR DESCRIPTION
Remove some hand spun interop from System.Drawing tests.  Also:

- Unskip RS4 related issue tests (seem to all work fine now)
- Only create the directory for FileCleanupTestBase on demand
- Cache the installed printer names for tests

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10799)