### PR TITLE
Fix TTTOOLINFOW Struct Size

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/UI/Controls/ToolInfoWrapper.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/UI/Controls/ToolInfoWrapper.cs
@@ -11,7 +11,7 @@ internal unsafe struct ToolInfoWrapper<T>
     private readonly T _handle;
 
     // The size of the TTTOOLINFOW struct in version 4.7. We use this version to maintain compatibility.
-    private const uint TTTOOLINFO_V2_Size = 44;
+    private static uint TTTOOLINFO_V2_Size => IntPtr.Size == 4 ? 44u : 64u;
 
     public ToolInfoWrapper(T handle, TOOLTIP_FLAGS flags = default, string? text = null)
         : this(handle, handle.Handle, flags | TOOLTIP_FLAGS.TTF_IDISHWND, text)

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/UI/Controls/ToolInfoWrapper.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/UI/Controls/ToolInfoWrapper.cs
@@ -8,37 +8,34 @@ internal unsafe struct ToolInfoWrapper<T>
 {
     public TTTOOLINFOW Info;
     public string? Text { get; set; }
-    [MaybeNull]
     private readonly T _handle;
 
+    // The size of the TTTOOLINFOW struct in version 4.7. We use this version to maintain compatibility.
+    private const uint TTTOOLINFO_V2_Size = 44;
+
     public ToolInfoWrapper(T handle, TOOLTIP_FLAGS flags = default, string? text = null)
+        : this(handle, handle.Handle, flags | TOOLTIP_FLAGS.TTF_IDISHWND, text)
     {
-        Info = new TTTOOLINFOW
-        {
-            hwnd = handle.Handle,
-            uId = (nuint)(IntPtr)handle.Handle,
-            uFlags = flags | TOOLTIP_FLAGS.TTF_IDISHWND
-        };
-        Text = text;
-        _handle = handle;
     }
 
-    public ToolInfoWrapper(T handle, IntPtr id, TOOLTIP_FLAGS flags = default, string? text = null, RECT rect = default)
+    public ToolInfoWrapper(T handle, nint id, TOOLTIP_FLAGS flags = default, string? text = null, RECT rect = default)
     {
         Info = new TTTOOLINFOW
         {
+            cbSize = TTTOOLINFO_V2_Size,
             hwnd = handle.Handle,
             uId = (nuint)id,
             uFlags = flags,
             rect = rect
         };
+
         Text = text;
         _handle = handle;
     }
 
     public LRESULT SendMessage(IHandle<HWND> sender, MessageId message, bool state = false)
     {
-        Info.cbSize = (uint)sizeof(TTTOOLINFOW);
+        Info.cbSize = TTTOOLINFO_V2_Size;
         fixed (char* c = Text)
         fixed (void* i = &Info)
         {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolTipTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolTipTests.cs
@@ -887,6 +887,15 @@ public class ToolTipTests
         Assert.Equal(tabControl.TabCount, (int)PInvoke.SendMessage(toolTip, PInvoke.TTM_GETTOOLCOUNT));
     }
 
+    [WinFormsFact]
+    public unsafe void ToolTip_TTTOOLINFOW_Struct_Size_IsExpected()
+    {
+        TTTOOLINFOW toolInfo = new();
+        int size = (int)&toolInfo.lParam - (int)&toolInfo + sizeof(LPARAM);
+        int expected = (int)new ToolInfoWrapper<Control>().TestAccessor().Dynamic.TTTOOLINFO_V2_Size;
+        size.Should().Be(expected);
+    }
+
     private class SubToolTip : ToolTip
     {
         public SubToolTip() : base()


### PR DESCRIPTION
Fixes #10614 

Cswin32 definition of `TTTOOLINFOW` has a different struct size than what we were using originally. Cswin32 has the additional member `lpReserved` while we did not in our old definition, which breaks compatibility.
https://learn.microsoft.com/en-us/windows/win32/controls/common-control-versions#structure-sizes-for-different-common-control-versions outlines some structs that have different sizes between versions, including `TTTOOLINFOW`. We had been previously using `TTTOOLINFO_V2_SIZE`. In order to maintain compatibility, we need to continue to use the struct size we had been using before, so explicitly set the `cbSize` to the "old" size when creating `TTTOOLINFOW`. This is unfortunately not exposed via Cswin32.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10800)