### PR TITLE
Add Fallback to CursorConverter.ConvertTo

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Input/CursorConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Input/CursorConverter.cs
@@ -91,6 +91,32 @@ public class CursorConverter : TypeConverter
                     return propertyName;
                 }
 
+                PropertyInfo[] props = GetProperties();
+                int bestMatch = -1;
+
+                for (int i = 0; i < props.Length; i++)
+                {
+                    PropertyInfo prop = props[i];
+                    object[]? tempIndex = null;
+                    Cursor? c = (Cursor?)prop.GetValue(null, tempIndex);
+                    if (c == cursor)
+                    {
+                        if (ReferenceEquals(c, value))
+                        {
+                            return prop.Name;
+                        }
+                        else
+                        {
+                            bestMatch = i;
+                        }
+                    }
+                }
+
+                if (bestMatch != -1)
+                {
+                    return props[bestMatch].Name;
+                }
+
                 // We throw here because we cannot meaningfully convert a custom
                 // cursor into a string. In fact, the ResXResourceWriter will use
                 // this exception to indicate to itself that this object should

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Input/CursorConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Input/CursorConverter.cs
@@ -97,10 +97,10 @@ public class CursorConverter : TypeConverter
                 for (int i = 0; i < props.Length; i++)
                 {
                     PropertyInfo prop = props[i];
-                    Cursor? c = (Cursor?)prop.GetValue(obj: null, index: null);
-                    if (c == cursor)
+                    Cursor? knownCursor = (Cursor?)prop.GetValue(obj: null, index: null);
+                    if (knownCursor == cursor)
                     {
-                        if (ReferenceEquals(c, value))
+                        if (ReferenceEquals(knownCursor, value))
                         {
                             return prop.Name;
                         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Input/CursorConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Input/CursorConverter.cs
@@ -97,8 +97,7 @@ public class CursorConverter : TypeConverter
                 for (int i = 0; i < props.Length; i++)
                 {
                     PropertyInfo prop = props[i];
-                    object[]? tempIndex = null;
-                    Cursor? c = (Cursor?)prop.GetValue(null, tempIndex);
+                    Cursor? c = (Cursor?)prop.GetValue(obj: null, index: null);
                     if (c == cursor)
                     {
                         if (ReferenceEquals(c, value))

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Input/CursorConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Input/CursorConverter.cs
@@ -90,30 +90,24 @@ public class CursorConverter : TypeConverter
                 {
                     return propertyName;
                 }
+                else if (cursor.Handle == Cursors.Arrow.Handle)
+                {
+                    // Arrow and Default cursors share the same HCURSOR.
+                    // Always return "Default" in this case.
+                    return nameof(Cursors.Default);
+                }
 
+                // We have a cursor that only has handle information. This can happen if other processes set the cursor.
+                // Try to find an exact instance match to a known cursor from Cursors properties using HCURSOR equality (==).
                 PropertyInfo[] props = GetProperties();
-                int bestMatch = -1;
-
                 for (int i = 0; i < props.Length; i++)
                 {
                     PropertyInfo prop = props[i];
                     Cursor? knownCursor = (Cursor?)prop.GetValue(obj: null, index: null);
                     if (knownCursor == cursor)
                     {
-                        if (ReferenceEquals(knownCursor, value))
-                        {
-                            return prop.Name;
-                        }
-                        else
-                        {
-                            bestMatch = i;
-                        }
+                        return prop.Name;
                     }
-                }
-
-                if (bestMatch != -1)
-                {
-                    return props[bestMatch].Name;
                 }
 
                 // We throw here because we cannot meaningfully convert a custom

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Input/CursorConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Input/CursorConverter.cs
@@ -97,7 +97,7 @@ public class CursorConverter : TypeConverter
                     return nameof(Cursors.Default);
                 }
 
-                // We have a cursor that only has handle information. This can happen if other processes set the cursor.
+                // We have a cursor that only has handle information. This can happen when the cursor was read via PInvoke.
                 // Try to find an exact instance match to a known cursor from Cursors properties using HCURSOR equality (==).
                 PropertyInfo[] props = GetProperties();
                 for (int i = 0; i < props.Length; i++)

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CursorConverterTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CursorConverterTests.cs
@@ -231,4 +231,12 @@ public class CursorConverterTests
         CursorConverter converter = new();
         Assert.True(converter.GetStandardValuesSupported());
     }
+
+    [Fact]
+    public void CursorConverter_ConvertTo_FromKnownCursorHandle()
+    {
+        CursorConverter converter = new();
+        string converted = (string)converter.ConvertTo(new Cursor(Cursors.Default.Handle), typeof(string));
+        converted.Should().Be(nameof(Cursors.Default));
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/winforms/issues/10185

We had previously removed this code in https://github.com/dotnet/winforms/pull/10005 in an attempt to avoid using reflection when converting Cursor->string. We had tried to avoid reflection by adding property `CursorsProperty` to `Cursor` to track the "string version" of the Cursor. This will work as expected when we are setting the cursor, however there are times when other processes set the cursor, in which we only have the handle available to us i.e. we cannot utilize `CursorsProperty` to properly convert Cursor->string since we will not have that information. To handle this case, we should fall back to our old code to convert the cursor properly.

Manually testing results:
![cursor](https://github.com/dotnet/winforms/assets/30007367/2e81532f-a4c9-43d6-9bdc-16dc7b987e53)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10814)