### PR TITLE
Update the return Type of the function GetDisplayOrder and GetKeyNames

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Input/KeysConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Input/KeysConverter.cs
@@ -157,7 +157,7 @@ public class KeysConverter : TypeConverter, IComparer
                 return null;
             }
 
-            IDictionary<string, Keys> keyNames = GetKeyNames(culture);
+            Dictionary<string, Keys> keyNames = GetKeyNames(culture);
 
             // Parse an array of key tokens.
             string[] tokens = text.Split('+', StringSplitOptions.TrimEntries);
@@ -236,8 +236,8 @@ public class KeysConverter : TypeConverter, IComparer
         {
             List<Enum> termKeys = new();
             Keys modifiers = key & Keys.Modifiers;
-            IDictionary<string, Keys> keyNames = GetKeyNames(culture);
-            IList<string> displayOrder = GetDisplayOrder(culture);
+            Dictionary<string, Keys> keyNames = GetKeyNames(culture);
+            List<string> displayOrder = GetDisplayOrder(culture);
 
             if (key != Keys.None)
             {
@@ -284,8 +284,8 @@ public class KeysConverter : TypeConverter, IComparer
         {
             StringBuilder termStrings = new(32);
             Keys modifiers = key & Keys.Modifiers;
-            IDictionary<string, Keys> keyNames = GetKeyNames(culture);
-            IList<string> displayOrder = GetDisplayOrder(culture);
+            Dictionary<string, Keys> keyNames = GetKeyNames(culture);
+            List<string> displayOrder = GetDisplayOrder(culture);
 
             if (key != Keys.None)
             {
@@ -329,7 +329,7 @@ public class KeysConverter : TypeConverter, IComparer
         }
     }
 
-    private IList<string> GetDisplayOrder(CultureInfo? culture)
+    private List<string> GetDisplayOrder(CultureInfo? culture)
     {
         // Use CurrentUICulture as default because we assume that this converter is primarily
         // used in user-facing applications (I.e. what key to press on the keyboard).
@@ -342,7 +342,7 @@ public class KeysConverter : TypeConverter, IComparer
         return CultureToDisplayOrder[culture];
     }
 
-    private IDictionary<string, Keys> GetKeyNames(CultureInfo? culture)
+    private Dictionary<string, Keys> GetKeyNames(CultureInfo? culture)
     {
         // Use CurrentUICulture as default because we assume that this converter is primarily
         // used in user-facing applications (I.e. what key to press on the keyboard).


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Related #10732

## Proposed changes

- Change return type of the GetDisplayOrder method from IList<> to List<>, the return type in GetKeyNames from IDictionary<> to Dictionary<>

<!-- We are in TELL-MODE the following section must be completed -->


## Risk

- Minimal

<!-- end TELL-MODE -->

## Test methodology <!-- How did you ensure quality? -->

- Manually


## Test environment(s) <!-- Remove any that don't apply -->

- .net 9.0.0-preview.2.24102.8


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10829)