### PR TITLE
Remove offset calculation from method "PaintValue" of IconEditor

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/IconEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/IconEditor.cs
@@ -116,10 +116,6 @@ public class IconEditor : UITypeEditor
 
         // If icon is smaller than rectangle, just center it unscaled in the rectangle.
         Rectangle rectangle = e.Bounds;
-        Graphics g = e.Graphics;
-        using var transform = g.Transform;
-        rectangle.X -= (int)transform.OffsetX;
-        rectangle.Y -= (int)transform.OffsetY;
 
         if (icon.Width < rectangle.Width)
         {


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #10830 


## Proposed changes

- Remove offset calculation from method "PaintValue" of IconEditor

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- When using "Choose Icon... " command line to add an icon, the icon can be displayed in correct position

## Regression? 

- Yes  

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

The icon is displayed in the upper left corner of the properties window
![image](https://github.com/dotnet/winforms/assets/108860782/9e29e74e-8d6e-402a-8691-e0b4f71a09e7)


### After

The icon display in correct position
![image](https://github.com/dotnet/winforms/assets/132890443/9abad9b7-1e6f-4348-89bc-8e83363d176a)



## Test methodology <!-- How did you ensure quality? -->

- Manual


## Test environment(s) <!-- Remove any that don't apply -->

- .net 9.0.0-preview.2.24105.1


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10833)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/10833)