### PR TITLE
Support partial code coverage when integration tests are not running

### DIFF
--- a/eng/CodeCoverage.proj
+++ b/eng/CodeCoverage.proj
@@ -10,7 +10,7 @@
     <PackageReference Include="ReportGenerator" Version="$(ReportGeneratorVersion)" GeneratePathProperty="true" />
   </ItemGroup>
 
-  <Target Name="Codecov">
+  <Target Name="GatherCoverageInputs">
     <PropertyGroup>
       <_CodecovPath>$(PkgCodecov)\tools\Codecov.exe</_CodecovPath>
       <_ReportGeneratorPath>$(PkgReportGenerator)\tools\net47\ReportGenerator.exe</_ReportGeneratorPath>
@@ -22,21 +22,26 @@
       <_UnitCoverageReports Include="@(_CoverageReports)" Condition="!$([System.String]::Copy('%(Identity)').EndsWith('.IntegrationTests.coverage'))" />
       <_IntegrationCoverageReports Include="@(_CoverageReports)" Condition="$([System.String]::Copy('%(Identity)').EndsWith('.IntegrationTests.coverage'))" />
     </ItemGroup>
+  </Target>
 
+  <Target Name="MergeCoverage" DependsOnTargets="GatherCoverageInputs">
     <!-- Merge multiple coverlet reports into a single Cobertura report before uploading to codecov.io, in order to
       reduce upload size and load on the codecov.io processing servers. -->
     <Message Importance="high" Text="&quot;$(_ReportGeneratorPath)&quot; &quot;-reports:@(_CoverageReports)&quot; -targetdir:$(BaseOutputPath)coverage/full -reporttypes:Cobertura -filefilters:-*.g.cs" />
-    <Exec Command="&quot;$(_ReportGeneratorPath)&quot; &quot;-reports:@(_CoverageReports)&quot; -targetdir:$(BaseOutputPath)coverage/full -reporttypes:Cobertura -filefilters:-*.g.cs" />
+    <Exec Condition="'@(_CoverageReports)' != ''" Command="&quot;$(_ReportGeneratorPath)&quot; &quot;-reports:@(_CoverageReports)&quot; -targetdir:$(BaseOutputPath)coverage/full -reporttypes:Cobertura -filefilters:-*.g.cs" />
 
     <!-- Merge multiple coverlet reports into a single Cobertura report before uploading to codecov.io, in order to
       reduce upload size and load on the codecov.io processing servers. -->
     <Message Importance="high" Text="&quot;$(_ReportGeneratorPath)&quot; &quot;-reports:@(_UnitCoverageReports)&quot; -targetdir:$(BaseOutputPath)coverage/unit -reporttypes:Cobertura -filefilters:-*.g.cs" />
-    <Exec Command="&quot;$(_ReportGeneratorPath)&quot; &quot;-reports:@(_UnitCoverageReports)&quot; -targetdir:$(BaseOutputPath)coverage/unit -reporttypes:Cobertura -filefilters:-*.g.cs" />
+    <Exec Condition="'@(_UnitCoverageReports)' != ''" Command="&quot;$(_ReportGeneratorPath)&quot; &quot;-reports:@(_UnitCoverageReports)&quot; -targetdir:$(BaseOutputPath)coverage/unit -reporttypes:Cobertura -filefilters:-*.g.cs" />
 
     <!-- Merge multiple coverlet reports into a single Cobertura report before uploading to codecov.io, in order to
       reduce upload size and load on the codecov.io processing servers. -->
     <Message Importance="high" Text="&quot;$(_ReportGeneratorPath)&quot; &quot;-reports:@(_IntegrationCoverageReports)&quot; -targetdir:$(BaseOutputPath)coverage/integration -reporttypes:Cobertura -filefilters:-*.g.cs" />
-    <Exec Command="&quot;$(_ReportGeneratorPath)&quot; &quot;-reports:@(_IntegrationCoverageReports)&quot; -targetdir:$(BaseOutputPath)coverage/integration -reporttypes:Cobertura -filefilters:-*.g.cs" />
+    <Exec Condition="'@(_IntegrationCoverageReports)' != ''" Command="&quot;$(_ReportGeneratorPath)&quot; &quot;-reports:@(_IntegrationCoverageReports)&quot; -targetdir:$(BaseOutputPath)coverage/integration -reporttypes:Cobertura -filefilters:-*.g.cs" />
+  </Target>
+
+  <Target Name="Codecov" DependsOnTargets="MergeCoverage">
 
     <ItemGroup>
       <_CodecovFullArgs Include="-f;$(BaseOutputPath)coverage\full\Cobertura.xml" />
@@ -65,16 +70,16 @@
 
     <!-- Upload the unit test coverage file with a 'production' flag, which will be filtered by codecov.io to production code -->
     <Message Importance="high" Text="&quot;$(_CodecovPath)&quot; @(_CodecovUnitArgs, ' ') @(_CodecovArgs, ' ') --flag @(_CodecovProductionUnitFlags, ',')" />
-    <Exec Command="&quot;$(_CodecovPath)&quot; @(_CodecovUnitArgs, ' ') @(_CodecovArgs, ' ') --flag @(_CodecovProductionUnitFlags, ',')" />
+    <Exec Condition="'@(_UnitCoverageReports)' != ''" Command="&quot;$(_CodecovPath)&quot; @(_CodecovUnitArgs, ' ') @(_CodecovArgs, ' ') --flag @(_CodecovProductionUnitFlags, ',')" />
 
     <!-- Upload the integration test coverage file with a 'production' flag, which will be filtered by codecov.io to production code -->
     <Message Importance="high" Text="&quot;$(_CodecovPath)&quot; @(_CodecovIntegrationArgs, ' ') @(_CodecovArgs, ' ') --flag @(_CodecovProductionIntegrationFlags, ',')" />
-    <Exec Command="&quot;$(_CodecovPath)&quot; @(_CodecovIntegrationArgs, ' ') @(_CodecovArgs, ' ') --flag @(_CodecovProductionIntegrationFlags, ',')" />
+    <Exec Condition="'@(_IntegrationCoverageReports)' != ''" Command="&quot;$(_CodecovPath)&quot; @(_CodecovIntegrationArgs, ' ') @(_CodecovArgs, ' ') --flag @(_CodecovProductionIntegrationFlags, ',')" />
 
     <!-- Upload the full test coverage file with a 'test' flag, which will be filtered by codecov.io to test code. We
     don't further separate this by integration vs. unit tests because the answer is clear from the file path. -->
     <Message Importance="high" Text="&quot;$(_CodecovPath)&quot; @(_CodecovFullArgs, ' ') @(_CodecovArgs, ' ') --flag @(_CodecovTestFlags, ',')" />
-    <Exec Command="&quot;$(_CodecovPath)&quot; @(_CodecovFullArgs, ' ') @(_CodecovArgs, ' ') --flag @(_CodecovTestFlags, ',')" />
+    <Exec Condition="'@(_CoverageReports)' != ''" Command="&quot;$(_CodecovPath)&quot; @(_CodecovFullArgs, ' ') @(_CodecovArgs, ' ') --flag @(_CodecovTestFlags, ',')" />
   </Target>
 
 </Project>

--- a/eng/pipelines/build.yml
+++ b/eng/pipelines/build.yml
@@ -122,7 +122,7 @@ jobs:
       env:
         XUNIT_LOGS: $(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)
       displayName: Run Integration Tests
-      condition: and(eq(variables['System.TeamProject'], 'public'), ne('${{ parameters.targetArchitecture }}', 'arm64'), contains(variables['System.PullRequest.TargetBranch'], 'main'))
+      condition: and(eq(variables['System.TeamProject'], 'public'), ne('${{ parameters.targetArchitecture }}', 'arm64'))
 
     # Create Nuget package, sign, and publish
     - script: eng\cibuild.cmd


### PR DESCRIPTION
Also enable integration tests for main branch builds so reference code coverage data is available.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/10837)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/10837)