### PR TITLE
Update WinformsControlsTest.csproj for easy testing with no VisualStyles

### DIFF
--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/WinformsControlsTest.csproj
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/WinformsControlsTest.csproj
@@ -19,6 +19,8 @@
   <PropertyGroup>
     <ApplicationDefaultFont>Calibri, 11pt, style=regular</ApplicationDefaultFont>
     <ApplicationHighDpiMode>SystemAware</ApplicationHighDpiMode>
+    <ApplicationVisualStyles>true</ApplicationVisualStyles>
+    <ApplicationUseCompatibleTextRendering>false</ApplicationUseCompatibleTextRendering>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Added properties hidden in the application bootstrap explicitly to the project file for easy testing. I'm setting them to the default values.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/10841)