### PR TITLE
Fix empty `OpenFileDialog.FileNames` when `AutoUpgradeEnabled=false` and `Multiselect = true`

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Dialogs/CommonDialogs/FileDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Dialogs/CommonDialogs/FileDialog.cs
@@ -457,6 +457,9 @@ public abstract partial class FileDialog : CommonDialog
     {
         var directory = fileBuffer.SliceAtFirstNull();
         var fileNames = fileBuffer[(directory.Length + 1)..];
+
+        // When a single file is returned, the directory is not null delimited.
+        // So we check here to see if the filename starts with a null.
         if (fileNames[0] == '\0')
         {
             return [directory.ToString()];

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Dialogs/CommonDialogs/FileDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Dialogs/CommonDialogs/FileDialog.cs
@@ -456,7 +456,7 @@ public abstract partial class FileDialog : CommonDialog
     private static string[] GetMultiselectFiles(ReadOnlySpan<char> fileBuffer)
     {
         var directory = fileBuffer.SliceAtFirstNull();
-        var fileNames = fileBuffer[directory.Length..];
+        var fileNames = fileBuffer[(directory.Length + 1)..];
         if (fileNames.Length == 0)
         {
             return [directory.ToString()];
@@ -470,7 +470,7 @@ public abstract partial class FileDialog : CommonDialog
                 ? fileName.ToString()
                 : Path.Join(directory, fileName));
 
-            fileNames = fileNames[fileName.Length..];
+            fileNames = fileNames[(fileName.Length + 1)..];
             fileName = fileNames.SliceAtFirstNull();
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Dialogs/CommonDialogs/FileDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Dialogs/CommonDialogs/FileDialog.cs
@@ -457,12 +457,12 @@ public abstract partial class FileDialog : CommonDialog
     {
         var directory = fileBuffer.SliceAtFirstNull();
         var fileNames = fileBuffer[(directory.Length + 1)..];
-        if (fileNames.Length == 0)
+        if (fileNames[0] == '\0')
         {
             return [directory.ToString()];
         }
 
-        List<string> names = new();
+        List<string> names = [];
         var fileName = fileNames.SliceAtFirstNull();
         while (fileName.Length > 0)
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Dialogs/CommonDialogs/FileDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Dialogs/CommonDialogs/FileDialog.cs
@@ -460,7 +460,7 @@ public abstract partial class FileDialog : CommonDialog
 
         // When a single file is returned, the directory is not null delimited.
         // So we check here to see if the filename starts with a null.
-        if (fileNames[0] == '\0')
+        if (fileNames.Length == 0 || fileNames[0] == '\0')
         {
             return [directory.ToString()];
         }

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/Dialogs.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/Dialogs.cs
@@ -34,7 +34,7 @@ public partial class Dialogs : Form
             if (propertyGrid1.SelectedObject is OpenFileDialog openFileDialog)
             {
                 openFileDialog.ShowDialog(this);
-                MessageBox.Show(string.Join(',', openFileDialog.FileNames),"File Names");
+                MessageBox.Show(string.Join(',', openFileDialog.FileNames), "File Names");
                 return;
             }
 

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/Dialogs.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/Dialogs.cs
@@ -31,6 +31,13 @@ public partial class Dialogs : Form
 
         _btnOpen.Click += (s, e) =>
         {
+            if (propertyGrid1.SelectedObject is OpenFileDialog openFileDialog)
+            {
+                openFileDialog.ShowDialog(this);
+                MessageBox.Show(string.Join(',', openFileDialog.FileNames),"File Names");
+                return;
+            }
+
             if (propertyGrid1.SelectedObject is CommonDialog dialog)
             {
                 dialog.ShowDialog(this);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FileDialogTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FileDialogTests.cs
@@ -805,13 +805,13 @@ public class FileDialogTests
         Assert.Equal(expected, result);
 
         // Test single file with directory
-        buffer = "C:\\test\testfile.txt\0";
+        buffer = "C:\\test\\testfile.txt\0";
         expected = ["C:\\test\\testfile.txt"];
         result = accessor.CreateDelegate<GetMultiselectFiles>()(buffer);
         Assert.Equal(expected, result);
 
         // Test single file without directory
-        buffer = "C:\\\testfile.txt\0";
+        buffer = "C:\\testfile.txt\0";
         expected = ["C:\\testfile.txt"];
         result = accessor.CreateDelegate<GetMultiselectFiles>()(buffer);
         Assert.Equal(expected, result);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FileDialogTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FileDialogTests.cs
@@ -788,6 +788,37 @@ public class FileDialogTests
         Assert.Equal(expected, dialog.ToString());
     }
 
+    [WinFormsFact]
+    public void FileDialog_GetMultiselectFiles_ReturnsExpected()
+    {
+        // Test with directory
+        var accessor = typeof(FileDialog).TestAccessor();
+        string buffer = "C:\\test\0testfile.txt\0testfile2.txt\0";
+        string[] expected = ["C:\\test\\testfile.txt", "C:\\test\\testfile2.txt"];
+        string[] result = accessor.CreateDelegate<GetMultiselectFiles>()(buffer);
+        Assert.Equal(expected, result);
+
+        // Test without directory
+        buffer = "C:\\\0testfile.txt\0testfile2.txt\0";
+        expected = ["C:\\testfile.txt", "C:\\testfile2.txt"];
+        result = accessor.CreateDelegate<GetMultiselectFiles>()(buffer);
+        Assert.Equal(expected, result);
+
+        // Test single file with directory
+        buffer = "C:\\test\testfile.txt\0";
+        expected = ["C:\\test\\testfile.txt"];
+        result = accessor.CreateDelegate<GetMultiselectFiles>()(buffer);
+        Assert.Equal(expected, result);
+
+        // Test single file without directory
+        buffer = "C:\\\testfile.txt\0";
+        expected = ["C:\\testfile.txt"];
+        result = accessor.CreateDelegate<GetMultiselectFiles>()(buffer);
+        Assert.Equal(expected, result);
+    }
+
+    private delegate string[] GetMultiselectFiles(ReadOnlySpan<char> fileBuffer);
+
     private unsafe class SubFileDialog : FileDialog
     {
         public static new readonly object EventFileOk = FileDialog.EventFileOk;


### PR DESCRIPTION
Fixes #10846
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/10849)