### PR TITLE
Issue 10735 error provider wrong icon multiple resolution

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider/ErrorProvider.IconRegion.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider/ErrorProvider.IconRegion.cs
@@ -17,7 +17,7 @@ public partial class ErrorProvider
 
         public IconRegion(Icon icon)
         {
-            _icon = icon;
+            _icon = new Icon(icon, ScaleHelper.LogicalSmallSystemIconSize);
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ErrorProviderTest.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ErrorProviderTest.Designer.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Drawing;
+
 namespace WinformsControlsTest;
 
 partial class ErrorProviderTest
@@ -32,16 +34,47 @@ partial class ErrorProviderTest
     private void InitializeComponent()
     {
         this.components = new System.ComponentModel.Container();
+
         this.textBox1 = new System.Windows.Forms.TextBox();
-        this.errorProvider1 = new System.Windows.Forms.ErrorProvider(this.components);
-        this.submitButton = new System.Windows.Forms.Button();
+        this.label1_2 = new System.Windows.Forms.Label();
         this.label1 = new System.Windows.Forms.Label();
+        this.errorProvider1 = new System.Windows.Forms.ErrorProvider(this.components);
+
+        this.textBox2 = new System.Windows.Forms.TextBox();
+        this.label2_1 = new System.Windows.Forms.Label();
+        this.label2 = new System.Windows.Forms.Label();
+        this.errorProvider2 = new System.Windows.Forms.ErrorProvider(this.components);
+        this.errorProvider2.Icon = SystemIcons.Shield;
+
+        this.submitButton = new System.Windows.Forms.Button();
+
         ((System.ComponentModel.ISupportInitialize)(this.errorProvider1)).BeginInit();
+        ((System.ComponentModel.ISupportInitialize)(this.errorProvider2)).BeginInit();
+
         this.SuspendLayout();
+        //
+        // label1
+        //
+        this.label1.AutoSize = true;
+        this.label1.Font = new System.Drawing.Font("Calibri", 12F, FontStyle.Bold);
+        this.label1.Location = new System.Drawing.Point(19, 26);
+        this.label1.Name = "label1";
+        this.label1.Size = new System.Drawing.Size(155, 15);
+        this.label1.TabIndex = 2;
+        this.label1.Text = "ErrorProvider with standard icon";
+        // 
+        // label1_2
+        // 
+        this.label1_2.AutoSize = true;
+        this.label1_2.Location = new System.Drawing.Point(19, 41);
+        this.label1_2.Name = "label1_2";
+        this.label1_2.Size = new System.Drawing.Size(155, 15);
+        this.label1_2.TabIndex = 2;
+        this.label1_2.Text = "Type from 5 to 10 characters";
         // 
         // textBox1
         // 
-        this.textBox1.Location = new System.Drawing.Point(35, 60);
+        this.textBox1.Location = new System.Drawing.Point(19, 60);
         this.textBox1.Name = "textBox1";
         this.textBox1.Size = new System.Drawing.Size(120, 23);
         this.textBox1.TabIndex = 0;
@@ -49,46 +82,76 @@ partial class ErrorProviderTest
         // errorProvider1
         // 
         this.errorProvider1.ContainerControl = this;
+        //
+        // label2
+        //
+        this.label2.AutoSize = true;
+        this.label2.Font = new System.Drawing.Font("Calibri", 12F, FontStyle.Bold);
+        this.label2.Location = new System.Drawing.Point(19, 100);
+        this.label2.Name = "label2";
+        this.label2.Size = new System.Drawing.Size(155, 15);
+        this.label2.TabIndex = 2;
+        this.label2.Text = "ErrorProvider with multi-resolution icon";
+        // 
+        // label2_1
+        // 
+        this.label2_1.AutoSize = true;
+        this.label2_1.Location = new System.Drawing.Point(19, 115);
+        this.label2_1.Name = "label2_1";
+        this.label2_1.Size = new System.Drawing.Size(155, 23);
+        this.label2_1.TabIndex = 2;
+        this.label2_1.Text = "Type from 5 to 20 characters";
+        // 
+        // textBox2
+        // 
+        this.textBox2.Location = new System.Drawing.Point(19, 135);
+        this.textBox2.Name = "textBox2";
+        this.textBox2.Size = new System.Drawing.Size(120, 23);
+        this.textBox2.TabIndex = 0;
+        // 
+        // errorProvider2
+        // 
+        this.errorProvider2.ContainerControl = this;
         // 
         // submitButton
         // 
-        this.submitButton.Location = new System.Drawing.Point(35, 109);
+        this.submitButton.Location = new System.Drawing.Point(19, 180);
         this.submitButton.Name = "submitButton";
         this.submitButton.Size = new System.Drawing.Size(120, 27);
         this.submitButton.TabIndex = 1;
-        this.submitButton.Text = "Submit";
+        this.submitButton.Text = "Validate";
         this.submitButton.UseVisualStyleBackColor = true;
         this.submitButton.Click += new System.EventHandler(this.submitButton_Click);
-        // 
-        // label1
-        // 
-        this.label1.AutoSize = true;
-        this.label1.Location = new System.Drawing.Point(19, 26);
-        this.label1.Name = "label1";
-        this.label1.Size = new System.Drawing.Size(155, 15);
-        this.label1.TabIndex = 2;
-        this.label1.Text = "Type from 5 to 10 characters";
         // 
         // Form1
         // 
         this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
         this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-        this.ClientSize = new System.Drawing.Size(194, 165);
+        this.ClientSize = new System.Drawing.Size(290, 230);
         this.Controls.Add(this.label1);
-        this.Controls.Add(this.submitButton);
+        this.Controls.Add(this.label1_2);
         this.Controls.Add(this.textBox1);
+        this.Controls.Add(this.label2);
+        this.Controls.Add(this.label2_1);
+        this.Controls.Add(this.textBox2);
+        this.Controls.Add(this.submitButton);
         this.Name = "Form1";
         this.Text = "Form1";
         ((System.ComponentModel.ISupportInitialize)(this.errorProvider1)).EndInit();
+        ((System.ComponentModel.ISupportInitialize)(this.errorProvider2)).EndInit();
         this.ResumeLayout(false);
         this.PerformLayout();
-
     }
 
     #endregion
 
     private System.Windows.Forms.TextBox textBox1;
+    private System.Windows.Forms.TextBox textBox2;
     private System.Windows.Forms.ErrorProvider errorProvider1;
+    private System.Windows.Forms.ErrorProvider errorProvider2;
     private System.Windows.Forms.Button submitButton;
+    private System.Windows.Forms.Label label1_2;
     private System.Windows.Forms.Label label1;
+    private System.Windows.Forms.Label label2_1;
+    private System.Windows.Forms.Label label2;
 }

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ErrorProviderTest.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ErrorProviderTest.cs
@@ -21,5 +21,15 @@ public partial class ErrorProviderTest : Form
             errorProvider1.Clear();
             MessageBox.Show("All right!", "OK", MessageBoxButtons.OK, MessageBoxIcon.Information);
         }
+
+        if (textBox2.TextLength < 5 || textBox2.TextLength > 20)
+        {
+            errorProvider2.SetError(textBox2, "The length of the testbox is invalid!");
+        }
+        else
+        {
+            errorProvider2.Clear();
+            MessageBox.Show("All right!", "OK", MessageBoxButtons.OK, MessageBoxIcon.Information);
+        }
     }
 }


### PR DESCRIPTION
Fixes #10735

## Proposed changes

- Apply @elachlan 's [suggestion][elachlan-suggestion] on sizing the icon using `ScaleHelper.LogicalSmallSystemIconSize`.

## Customer Impact

- Multi-resolution icons should now display on correct size on the ErrorProvider component.

## Regression?

- Yes

## Risk

- Minimal

## Screenshots

### Before

![Screenshot_2024-02-07_160514](https://github.com/dotnet/winforms/assets/30190295/4b3e2d2e-c42d-4529-a43a-542fdf72301a)

### After

![Screenshot_2024-02-08_061021](https://github.com/dotnet/winforms/assets/30190295/280fe91b-0be6-4693-a31c-23d2d12ac12b)

## Test methodology

- Interaction test on WinformsControlsTest, ErrorProvider component test.

## Test environment(s)

- 9.0.100-alpha.1.23618.3

[elachlan-suggestion]: https://github.com/dotnet/winforms/issues/10735#issuecomment-1917911767
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/10850)