### PR TITLE
Add missing Stream overloads in DataStreamFromComStream

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ActiveX/DataStreamFromComStream.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ActiveX/DataStreamFromComStream.cs
@@ -82,6 +82,13 @@ internal unsafe class DataStreamFromComStream : Stream
         return (int)bytesRead;
     }
 
+    public override int ReadByte()
+    {
+        Span<byte> oneByteArray = stackalloc byte[1];
+        int r = Read(oneByteArray);
+        return r == 0 ? -1 : oneByteArray[0];
+    }
+
     public override void SetLength(long value)
     {
         _comStream->SetSize((ulong)value);
@@ -139,6 +146,8 @@ internal unsafe class DataStreamFromComStream : Stream
             throw new IOException(SR.DataStreamWrite);
         }
     }
+
+    public override void WriteByte(byte value) => Write([value]);
 
     protected override void Dispose(bool disposing)
     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ActiveX/DataStreamFromComStream.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ActiveX/DataStreamFromComStream.cs
@@ -84,9 +84,9 @@ internal unsafe class DataStreamFromComStream : Stream
 
     public override int ReadByte()
     {
-        Span<byte> oneByteArray = stackalloc byte[1];
-        int r = Read(oneByteArray);
-        return r == 0 ? -1 : oneByteArray[0];
+        byte data = default;
+        int r = Read(new Span<byte>(ref data));
+        return r == 0 ? -1 : data;
     }
 
     public override void SetLength(long value)


### PR DESCRIPTION
## Proposed changes

- Add optimised overloads to methods `DataStreamFromComStream.ReadByte` and `WriteByte`

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- remove some small arrays allocations

## Risk

- low

## Test methodology <!-- How did you ensure quality? -->

- CI

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/10857)