### PR TITLE
[VMR] Don't error out on non-fatal file locking warnings

### DIFF
--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -4,5 +4,6 @@
   <PropertyGroup>
     <GitHubRepositoryName>winforms</GitHubRepositoryName>
     <SourceBuildManagedOnly>true</SourceBuildManagedOnly>
+    <InnerBuildArgs>$(InnerBuildArgs) -warnNotAsError:MSB3026</InnerBuildArgs>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Don't error out on MSB3026 in the VMR build.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/10858)