### PR TITLE
Update System.Private.Windows.Core.csproj

### DIFF
--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -4,6 +4,5 @@
   <PropertyGroup>
     <GitHubRepositoryName>winforms</GitHubRepositoryName>
     <SourceBuildManagedOnly>true</SourceBuildManagedOnly>
-    <InnerBuildArgs>$(InnerBuildArgs) -warnNotAsError:MSB3026</InnerBuildArgs>
   </PropertyGroup>
 </Project>

--- a/src/System.Drawing.Common/src/System.Drawing.Common.csproj
+++ b/src/System.Drawing.Common/src/System.Drawing.Common.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(NetCurrent);$(NetPrevious);$(NetMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
+    <!-- Unset TargetFramework as this property gets set in Directory.Build.props. This is necessary to avoid over-building. -->
     <TargetFramework />
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <WarningsNotAsErrors>CS0618</WarningsNotAsErrors>

--- a/src/System.Private.Windows.Core/src/System.Private.Windows.Core.csproj
+++ b/src/System.Private.Windows.Core/src/System.Private.Windows.Core.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <AssemblyName>System.Private.Windows.Core</AssemblyName>
     <TargetFrameworks>$(NetCurrent);$(NetPrevious);$(NetMinimum)</TargetFrameworks>
+    <TargetFramework />
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
     <!--

--- a/src/System.Private.Windows.Core/src/System.Private.Windows.Core.csproj
+++ b/src/System.Private.Windows.Core/src/System.Private.Windows.Core.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <AssemblyName>System.Private.Windows.Core</AssemblyName>
     <TargetFrameworks>$(NetCurrent);$(NetPrevious);$(NetMinimum)</TargetFrameworks>
+    <!-- Unset TargetFramework as this property gets set in Directory.Build.props. This is necessary to avoid over-building. -->
     <TargetFramework />
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
https://github.com/dotnet/winforms/pull/10525 introduced System.Private.Windows.Core.csproj which multi-targets. Unfortunately that project was declared incorrectly as the `<TargetFramework>` property needs to be unset as it's defined in the root of the repo.

This caused overbuilds of System.Private.Windows.Core.csproj which ultimately manifested in build race conditions.

The binlog shows that the `Csc` task is invoked twice for the same TFM and hence the race condition:

### Global properties for CSC 1 project evaluation
![image](https://github.com/dotnet/winforms/assets/7412651/f13dfdfc-8cb7-4ca6-ba8a-7998271b6f17)

### Global properties for CSC 2 project evaluation
![image](https://github.com/dotnet/winforms/assets/7412651/c5906e57-6195-48b7-a4aa-da8c8c4c62bc)

Notice that the only difference between those two is the `TargetFramework` global property. The first evaluation also builds for the same TFM as that property is defined in the root repo.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/10864)