### PR TITLE
[release/8.0] Fix empty `OpenFileDialog.FileNames` when `AutoUpgradeEnabled=false` and `Multiselect = true`

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.cs
@@ -457,13 +457,16 @@ public abstract partial class FileDialog : CommonDialog
     private static string[] GetMultiselectFiles(ReadOnlySpan<char> fileBuffer)
     {
         var directory = fileBuffer.SliceAtFirstNull();
-        var fileNames = fileBuffer[directory.Length..];
-        if (fileNames.Length == 0)
+        var fileNames = fileBuffer[(directory.Length + 1)..];
+
+        // When a single file is returned, the directory is not null delimited.
+        // So we check here to see if the filename starts with a null.
+        if (fileNames.Length == 0 || fileNames[0] == '\0')
         {
             return new string[] { directory.ToString() };
         }
 
-        List<string> names = new List<string>();
+        List<string> names = [];
         var fileName = fileNames.SliceAtFirstNull();
         while (fileName.Length > 0)
         {
@@ -471,7 +474,7 @@ public abstract partial class FileDialog : CommonDialog
                 ? fileName.ToString()
                 : Path.Join(directory, fileName));
 
-            fileNames = fileNames[fileName.Length..];
+            fileNames = fileNames[(fileName.Length + 1)..];
             fileName = fileNames.SliceAtFirstNull();
         }
 

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/Dialogs.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/Dialogs.cs
@@ -31,6 +31,13 @@ public partial class Dialogs : Form
 
         _btnOpen.Click += (s, e) =>
         {
+            if (propertyGrid1.SelectedObject is OpenFileDialog openFileDialog)
+            {
+                openFileDialog.ShowDialog(this);
+                MessageBox.Show(string.Join(',', openFileDialog.FileNames), "File Names");
+                return;
+            }
+
             if (propertyGrid1.SelectedObject is CommonDialog dialog)
             {
                 dialog.ShowDialog(this);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FileDialogTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FileDialogTests.cs
@@ -788,6 +788,37 @@ public class FileDialogTests
         Assert.Equal(expected, dialog.ToString());
     }
 
+    [WinFormsFact]
+    public void FileDialog_GetMultiselectFiles_ReturnsExpected()
+    {
+        // Test with directory
+        var accessor = typeof(FileDialog).TestAccessor();
+        string buffer = "C:\\test\0testfile.txt\0testfile2.txt\0";
+        string[] expected = ["C:\\test\\testfile.txt", "C:\\test\\testfile2.txt"];
+        string[] result = accessor.CreateDelegate<GetMultiselectFiles>()(buffer);
+        Assert.Equal(expected, result);
+
+        // Test without directory
+        buffer = "C:\\\0testfile.txt\0testfile2.txt\0";
+        expected = ["C:\\testfile.txt", "C:\\testfile2.txt"];
+        result = accessor.CreateDelegate<GetMultiselectFiles>()(buffer);
+        Assert.Equal(expected, result);
+
+        // Test single file with directory
+        buffer = "C:\\test\\testfile.txt\0";
+        expected = ["C:\\test\\testfile.txt"];
+        result = accessor.CreateDelegate<GetMultiselectFiles>()(buffer);
+        Assert.Equal(expected, result);
+
+        // Test single file without directory
+        buffer = "C:\\testfile.txt\0";
+        expected = ["C:\\testfile.txt"];
+        result = accessor.CreateDelegate<GetMultiselectFiles>()(buffer);
+        Assert.Equal(expected, result);
+    }
+
+    private delegate string[] GetMultiselectFiles(ReadOnlySpan<char> fileBuffer);
+
     private unsafe class SubFileDialog : FileDialog
     {
         public static new readonly object EventFileOk = FileDialog.EventFileOk;


### PR DESCRIPTION
Backport of https://github.com/dotnet/winforms/pull/10849

 Fix the parsing logic for `GetMultiselectFiles`. When using `OpenFileDialog`​ that has properties `AutoUpgradeEnabled = false`​  and  `Multiselect = true​` , selecting a single file or mutiple files will result in no file names being returned, causing this to be unusable.​ The logic has been updated to include the null delimiter from the directory path when selecting multiple files and to check if we have single file case before proceeding with rest of parse.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/10867)