### PR TITLE
make it easier to experiment with single file deployments

### DIFF
--- a/src/System.Windows.Forms/tests/IntegrationTests/ScratchProject/ScratchProject.csproj
+++ b/src/System.Windows.Forms/tests/IntegrationTests/ScratchProject/ScratchProject.csproj
@@ -12,6 +12,14 @@
     <UpdateXlfOnBuild>false</UpdateXlfOnBuild>
   </PropertyGroup>
 
+  <!-- Experiment with single file deployments
+  https://learn.microsoft.com/dotnet/core/deploying/single-file/overview?tabs=cli#sample-project-file -->
+  <PropertyGroup>
+    <PublishSingleFile>false</PublishSingleFile>
+    <SelfContained>false</SelfContained>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+  </PropertyGroup>
+
   <!-- These normally come from $(UseWindowsForms) when $(ImplicitUsings) is enabled -->
   <ItemGroup>
     <Using Include="System.Drawing" />


### PR DESCRIPTION
To convert scratch project to a single file, change appropriate property values to true and run `dotnet publish` or build in VisualStudio
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/10877)