### PR TITLE
Add span overloads to ImageLayout

### DIFF
--- a/src/Common/tests/TestUtilities/TestAccessor.cs
+++ b/src/Common/tests/TestUtilities/TestAccessor.cs
@@ -23,9 +23,6 @@ namespace System;
 ///   Where internals access is more useful are testing building blocks of more
 ///   complicated objects, such as internal helper methods or classes.
 ///  </para>
-///  <para>
-///   This can be used to access private/internal objects as well via
-///  </para>
 /// </remarks>
 /// <example>
 ///  This class can also be derived from to create a strongly typed wrapper
@@ -66,7 +63,7 @@ public class TestAccessor<T> : ITestAccessor
     {
         Type type = typeof(TDelegate);
         MethodInfo? invokeMethodInfo = type.GetMethod("Invoke");
-        Type[] types = invokeMethodInfo is null ? Array.Empty<Type>() : invokeMethodInfo.GetParameters().Select(pi => pi.ParameterType).ToArray();
+        Type[] types = invokeMethodInfo is null ? [] : invokeMethodInfo.GetParameters().Select(pi => pi.ParameterType).ToArray();
 
         // To make it easier to write a class wrapper with a number of delegates,
         // we'll take the name from the delegate itself when unspecified.

--- a/src/Common/tests/TestUtilities/TestAccessors.cs
+++ b/src/Common/tests/TestUtilities/TestAccessors.cs
@@ -8,14 +8,14 @@ namespace System;
 ///  types being tested.
 /// </summary>
 /// <remarks>
-///  In the System namespace for implicit discovery.
+///  <para>In the System namespace for implicit discovery.</para>
 /// </remarks>
 public static partial class TestAccessors
 {
     // Need to pass a null parameter when constructing a static instance
     // of TestAccessor. As this is pretty common and never changes, caching
     // the array here.
-    private static object?[] s_nullObjectParam = { null };
+    private static object?[] s_nullObjectParam = [null];
 
     /// <summary>
     ///  Extension that creates a generic internals test accessor for a
@@ -24,23 +24,29 @@ public static partial class TestAccessors
     /// <param name="instanceOrType">
     ///  Instance or Type class (if only accessing statics).
     /// </param>
-    /// <example>
-    /// <![CDATA[
-    ///  Version version = new Version(4, 1);
-    ///  Assert.Equal(4, version.TestAccessor().Dynamic._Major));
-    ///
-    ///  // Or
-    ///
-    ///  dynamic accessor = version.TestAccessor().Dynamic;
-    ///  Assert.Equal(4, accessor._Major));
-    ///
-    /// // Or
-    ///
-    ///  Version version2 = new Version("4.1");
-    ///  dynamic accessor = typeof(Version).TestAccessor().Dynamic;
-    ///  Assert.Equal(version2, accessor.Parse("4.1")));
-    /// ]]>
-    /// </example>
+    /// <remarks>
+    ///  <para>
+    ///   Use <see cref="ITestAccessor.CreateDelegate">CreateDelegate</see> to deal with methods that take spans or
+    ///   other ref structs. For other members, use the dynamic accessor:
+    ///  </para>
+    ///  <code>
+    ///   <![CDATA[
+    ///   Version version = new Version(4, 1);
+    ///    Assert.Equal(4, version.TestAccessor().Dynamic._Major));
+    ///   
+    ///    // Or
+    ///   
+    ///    dynamic accessor = version.TestAccessor().Dynamic;
+    ///    Assert.Equal(4, accessor._Major));
+    ///   
+    ///    // Or
+    ///   
+    ///    Version version2 = new Version("4.1");
+    ///    dynamic accessor = typeof(Version).TestAccessor().Dynamic;
+    ///    Assert.Equal(version2, accessor.Parse("4.1")));
+    ///   ]]>
+    ///  </code>
+    /// </remarks>
     public static ITestAccessor TestAccessor(this object instanceOrType)
     {
         ITestAccessor? testAccessor = instanceOrType is Type type
@@ -51,11 +57,7 @@ public static partial class TestAccessors
                 typeof(TestAccessor<>).MakeGenericType(instanceOrType.GetType()),
                 instanceOrType);
 
-        if (testAccessor is null)
-        {
-            throw new ArgumentException("Cannot create TestAccessor for Nullable<T> instances with no value.");
-        }
-
-        return testAccessor;
+        return testAccessor
+            ?? throw new ArgumentException("Cannot create TestAccessor for Nullable<T> instances with no value.");
     }
 }

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/ValueColorMap.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/ValueColorMap.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Drawing.Imaging;
+#if NET9_0_OR_GREATER
+/// <summary>
+///  Defines a map for converting colors.
+/// </summary>
+/// <param name="OldColor">Specifies the existing <see cref='Color'/> to be converted.</param>
+/// <param name="NewColor">Specifies the new <see cref='Color'/> to which to convert.</param>
+public readonly record struct ValueColorMap(Color OldColor, Color NewColor);
+#endif

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.EditorPropertyLine.EditorButton.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.EditorPropertyLine.EditorButton.cs
@@ -68,106 +68,91 @@ internal sealed partial class DesignerActionPanel
                     }
 
                     ButtonRenderer.DrawButton(g, new Rectangle(-1, -1, Width + 2, Height + 2), "…", Font, Focused, buttonState);
+                    return;
                 }
-                else
-                {
-                    if (ComboBoxRenderer.IsSupported)
-                    {
-                        ComboBoxState state = ComboBoxState.Normal;
-                        if (Enabled)
-                        {
-                            if (_mouseDown)
-                            {
-                                state = ComboBoxState.Pressed;
-                            }
-                            else if (_mouseOver)
-                            {
-                                state = ComboBoxState.Hot;
-                            }
-                        }
-                        else
-                        {
-                            state = ComboBoxState.Disabled;
-                        }
 
-                        ComboBoxRenderer.DrawDropDownButton(g, new Rectangle(0, 0, Width, Height), state);
+                if (ComboBoxRenderer.IsSupported)
+                {
+                    ComboBoxState state = ComboBoxState.Normal;
+                    if (Enabled)
+                    {
+                        if (_mouseDown)
+                        {
+                            state = ComboBoxState.Pressed;
+                        }
+                        else if (_mouseOver)
+                        {
+                            state = ComboBoxState.Hot;
+                        }
                     }
                     else
                     {
-                        PushButtonState buttonState = PushButtonState.Normal;
-                        if (Enabled)
-                        {
-                            if (_mouseDown)
-                            {
-                                buttonState = PushButtonState.Pressed;
-                            }
-                            else if (_mouseOver)
-                            {
-                                buttonState = PushButtonState.Hot;
-                            }
-                        }
-                        else
-                        {
-                            buttonState = PushButtonState.Disabled;
-                        }
-
-                        ButtonRenderer.DrawButton(g, new Rectangle(-1, -1, Width + 2, Height + 2), string.Empty, Font, Focused, buttonState);
-                        // Draw the arrow icon
-                        try
-                        {
-                            Icon icon = new(typeof(DesignerActionPanel), "Arrow.ico");
-                            try
-                            {
-                                Bitmap arrowBitmap = icon.ToBitmap();
-
-                                // Make sure we draw properly under high contrast by re-mapping
-                                // the arrow color to the WindowText color
-                                ImageAttributes attrs = new();
-                                try
-                                {
-                                    ColorMap cm = new ColorMap
-                                    {
-                                        OldColor = Color.Black,
-                                        NewColor = SystemColors.WindowText
-                                    };
-                                    attrs.SetRemapTable(new ColorMap[] { cm }, ColorAdjustType.Bitmap);
-                                    int imageWidth = arrowBitmap.Width;
-                                    int imageHeight = arrowBitmap.Height;
-                                    g.DrawImage(
-                                        arrowBitmap,
-                                        new Rectangle(
-                                            (Width - imageWidth + 1) / 2,
-                                            (Height - imageHeight + 1) / 2,
-                                            imageWidth,
-                                            imageHeight),
-                                        0,
-                                        0,
-                                        imageWidth,
-                                        imageWidth,
-                                        GraphicsUnit.Pixel,
-                                        attrs,
-                                        callback: null,
-                                        IntPtr.Zero);
-                                }
-                                finally
-                                {
-                                    attrs?.Dispose();
-                                }
-                            }
-                            finally
-                            {
-                                icon.Dispose();
-                            }
-                        }
-                        catch
-                        {
-                        }
+                        state = ComboBoxState.Disabled;
                     }
 
-                    if (Focused)
+                    ComboBoxRenderer.DrawDropDownButton(g, new Rectangle(0, 0, Width, Height), state);
+                }
+                else
+                {
+                    PushButtonState buttonState = PushButtonState.Normal;
+                    if (Enabled)
                     {
-                        ControlPaint.DrawFocusRectangle(g, new Rectangle(2, 2, Width - 5, Height - 5));
+                        if (_mouseDown)
+                        {
+                            buttonState = PushButtonState.Pressed;
+                        }
+                        else if (_mouseOver)
+                        {
+                            buttonState = PushButtonState.Hot;
+                        }
                     }
+                    else
+                    {
+                        buttonState = PushButtonState.Disabled;
+                    }
+
+                    ButtonRenderer.DrawButton(
+                        g,
+                        new Rectangle(-1, -1, Width + 2, Height + 2),
+                        string.Empty,
+                        Font,
+                        Focused,
+                        buttonState);
+
+                    // Draw the arrow icon
+                    try
+                    {
+                        using Icon icon = new(typeof(DesignerActionPanel), "Arrow.ico");
+                        using Bitmap arrowBitmap = icon.ToBitmap();
+
+                        // Make sure we draw properly under high contrast by re-mapping
+                        // the arrow color to the WindowText color
+                        using ImageAttributes attributes = new();
+                        ValueColorMap map = new(Color.Black, SystemColors.WindowText);
+                        attributes.SetRemapTable(ColorAdjustType.Bitmap, new ReadOnlySpan<ValueColorMap>(ref map));
+                        int imageWidth = arrowBitmap.Width;
+                        int imageHeight = arrowBitmap.Height;
+                        g.DrawImage(
+                            arrowBitmap,
+                            new Rectangle(
+                                (Width - imageWidth + 1) / 2,
+                                (Height - imageHeight + 1) / 2,
+                                imageWidth,
+                                imageHeight),
+                            0, 0, imageWidth, imageWidth,
+                            GraphicsUnit.Pixel,
+                            attributes,
+                            callback: null,
+                            0);
+                    }
+                    catch
+                    {
+                    }
+                }
+
+                if (Focused)
+                {
+                    ControlPaint.DrawFocusRectangle(g, new Rectangle(2, 2, Width - 5, Height - 5));
                 }
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewRowHeaderCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewRowHeaderCell.cs
@@ -13,9 +13,6 @@ public partial class DataGridViewRowHeaderCell : DataGridViewHeaderCell
 {
     private static readonly VisualStyleElement s_headerElement = VisualStyleElement.Header.Item.Normal;
 
-    // ColorMap used to map the black color of the resource bitmaps to the fore color in use in the row header cell
-    private static readonly ColorMap[] s_colorMap = [new()];
-
     private static Bitmap? s_rightArrowBmp;
     private static Bitmap? s_leftArrowBmp;
     private static Bitmap? s_rightArrowStarBmp;
@@ -1039,11 +1036,9 @@ public partial class DataGridViewRowHeaderCell : DataGridViewHeaderCell
         int height = bounds.Y + (bounds.Height - s_iconsHeight) / 2;
         Rectangle bmpRect = new(width, height, s_iconsWidth, s_iconsHeight);
 
-        s_colorMap[0].NewColor = foreColor;
-        s_colorMap[0].OldColor = Color.Black;
-
+        ValueColorMap map = new(Color.Black, foreColor);
         using ImageAttributes attr = new();
-        attr.SetRemapTable(s_colorMap, ColorAdjustType.Bitmap);
+        attr.SetRemapTable(ColorAdjustType.Bitmap, new ReadOnlySpan<ValueColorMap>(ref map));
 
         if (SystemInformation.HighContrast &&
             // We can't replace black with white and vice versa as in other cases due to the colors of images are not exactly black and white.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PictureBox/PictureBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PictureBox/PictureBox.cs
@@ -22,7 +22,9 @@ namespace System.Windows.Forms;
 [SRDescription(nameof(SR.DescriptionPictureBox))]
 public partial class PictureBox : Control, ISupportInitialize
 {
-    private static readonly bool s_useWebRequest = AppContext.TryGetSwitch("System.Windows.Forms.PictureBox.UseWebRequest", out bool useWebRequest) ? useWebRequest : true;
+    private static readonly bool s_useWebRequest =
+        !AppContext.TryGetSwitch("System.Windows.Forms.PictureBox.UseWebRequest", out bool useWebRequest)
+        || useWebRequest;
 
     /// <summary>
     ///  The type of border this control will have.
@@ -1147,8 +1149,7 @@ public partial class PictureBox : Control, ISupportInitialize
             ImageAnimator.UpdateFrames(Image);
 
             // Error and initial image are drawn centered, non-stretched.
-            Rectangle drawingRect =
-                (_imageInstallationType == ImageInstallationType.ErrorOrInitial)
+            Rectangle drawingRect = _imageInstallationType == ImageInstallationType.ErrorOrInitial
                 ? ImageRectangleFromSizeMode(PictureBoxSizeMode.CenterImage)
                 : ImageRectangle;
 
@@ -1177,7 +1178,10 @@ public partial class PictureBox : Control, ISupportInitialize
     protected override void OnResize(EventArgs e)
     {
         base.OnResize(e);
-        if (_sizeMode == PictureBoxSizeMode.Zoom || _sizeMode == PictureBoxSizeMode.StretchImage || _sizeMode == PictureBoxSizeMode.CenterImage || BackgroundImage is not null)
+        if (_sizeMode == PictureBoxSizeMode.Zoom
+            || _sizeMode == PictureBoxSizeMode.StretchImage
+            || _sizeMode == PictureBoxSizeMode.CenterImage
+            || BackgroundImage is not null)
         {
             Invalidate();
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripHighContrastRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripHighContrastRenderer.cs
@@ -492,20 +492,14 @@ internal class ToolStripHighContrastRenderer : ToolStripSystemRenderer
         if (IsHighContrastWhiteOnBlack() && !(FillWhenSelected && (item.Pressed || item.Selected)))
         {
             // Translate white, black and blue to colors visible in high contrast mode.
-            ColorMap cm1 = new();
-            ColorMap cm2 = new();
-            ColorMap cm3 = new();
+            Span<ValueColorMap> map =
+            [
+                new ValueColorMap(Color.Black, Color.White),
+                new ValueColorMap(Color.White, Color.Black),
+                new ValueColorMap(Color.FromArgb(0, 0, 128), Color.White)
+            ];
 
-            cm1.OldColor = Color.Black;
-            cm1.NewColor = Color.White;
-
-            cm2.OldColor = Color.White;
-            cm2.NewColor = Color.Black;
-
-            cm3.OldColor = Color.FromArgb(0, 0, 128);
-            cm3.NewColor = Color.White;
-
-            attrs.SetRemapTable(new ColorMap[3] { cm1, cm2, cm3 }, ColorAdjustType.Bitmap);
+            attrs.SetRemapTable(ColorAdjustType.Bitmap, map);
         }
 
         Graphics g = e.Graphics;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/ImageLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/ImageLayout.cs
@@ -9,12 +9,12 @@ namespace System.Windows.Forms;
 public enum ImageLayout
 {
     /// <summary>
-    ///  The image is aligned TOP - LEFT across the controls client rectangle.
+    ///  The image is left-aligned at the top across the control's client rectangle.
     /// </summary>
     None,
 
     /// <summary>
-    ///  The image is tiled across the controls client rectangle.
+    ///  The image is tiled across the control's client rectangle.
     /// </summary>
     Tile,
 
@@ -24,12 +24,12 @@ public enum ImageLayout
     Center,
 
     /// <summary>
-    ///  The image is stretched across the controls client rectangle.
+    ///  The image is stretched across the control's client rectangle.
     /// </summary>
     Stretch,
 
     /// <summary>
-    ///  The image is stretched across the controls client rectangle.
+    ///  The image is enlarged within the control's client rectangle.
     /// </summary>
-    Zoom,
+    Zoom
 }


### PR DESCRIPTION
Add span overloads to ImageLayout and a new struct ValueColorMap to avoid allocating a class for every map value.

- Remove all ColorMap usages
- Change ControlPaint.CalculateBackgroundImageRectangle to take the image size rather than the image
- Use ARGB span to access the bitmap scan in ControlPaint.CreateHBitmapTransparencyMask
- Use BufferScope in ControlPaint.DrawBorder
- Stack alloc the matrix array in DrawImageDisabled

Also add clarifying comments in TestAccessor and a few other random clean ups.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/10878)