### PR TITLE
Mimic Marshal Behavior on Clipboard when Built-in Com is Off

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -5198,7 +5198,7 @@ public unsafe partial class Control :
     ///   value.
     ///  </para>
     /// </remarks>
-    public unsafe DragDropEffects DoDragDrop(
+    public DragDropEffects DoDragDrop(
         object data,
         DragDropEffects allowedEffects,
         Bitmap? dragImage,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/RichTextBox/RichTextBox.OleCallback.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/RichTextBox/RichTextBox.OleCallback.cs
@@ -13,7 +13,7 @@ namespace System.Windows.Forms;
 public partial class RichTextBox
 {
     // I used the visual basic 6 RichText (REOleCB.CPP) as a guide for this
-    private unsafe class OleCallback : IRichEditOleCallback.Interface
+    private unsafe class OleCallback : IRichEditOleCallback.Interface, IManagedWrapper<IRichEditOleCallback>
     {
         private readonly RichTextBox _owner;
         private IDataObject? _lastDataObject;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/Clipboard.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/Clipboard.cs
@@ -100,9 +100,9 @@ public static class Clipboard
         }
 
         // OleGetClipboard always returns a proxy. The proxy forwards all IDataObject method calls to the real data object,
-        // without giving out the real data object. If the data placed on the clipboard is not one of our CCWs or the data
+        // without giving out the real data object. If the data placed on the clipboard is not one of our CCWs or the clipboard
         // has been flushed, marshal will create a wrapper around the proxy for us to use. However, if the data placed on
-        // the clipboard is one of our own and the data has not been flushed, we need to retrieve the real data object
+        // the clipboard is one of our own and the clipboard has not been flushed, we need to retrieve the real data object
         // pointer in order to retrieve the original managed object via ComWrappers. To do this, we must query for an
         // interface that is not known to the proxy e.g. IComCallableWrapper. If we are able to query for IComCallableWrapper
         // it means that the real data object is one of our CCWs and we've retrieved it successfully,
@@ -129,8 +129,8 @@ public static class Clipboard
         {
             // If we do not have a IComDataObject, built-in com support is turned off and
             // we have a proxy where there is no way to retrieve the original data object
-            // pointer from it as the clipboard has likely been flushed.
-            // We need to mimic built-in com behavior and wrap the proxy ourselves.
+            // pointer from it likely because either the clipboard was flushed or the data on the
+            // clipboard is from another process. We need to mimic built-in com behavior and wrap the proxy ourselves.
             return new DataObject(proxyDataObject, managedDataObject);
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/Clipboard.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/Clipboard.cs
@@ -100,12 +100,13 @@ public static class Clipboard
         }
 
         // OleGetClipboard always returns a proxy. The proxy forwards all IDataObject method calls to the real data object,
-        // without giving out the real data object. If the real data object is not one of our CCWs, marshal will know how to
-        // retrieve the original object using the proxy. However, if the original object is one of our own, we need the real
-        // data object in order to retrieve the original object via ComWrappers. In order to retrieve the real data object,
-        // we must query for an interface that is not known to the proxy e.g. IComCallableWrapper. If we are able to query
-        // for IComCallableWrapper it means that the real data object is one of our CCWs and we've retrieved it successfully,
-        // otherwise it is not ours and we will be able to retrieve the original object with the proxy.
+        // without giving out the real data object. If the data placed on the clipboard is not one of our CCWs or the data
+        // has been flushed, marshal will create a wrapper around the proxy for us to use. However, if the data placed on
+        // the clipboard is one of our own and the data has not been flushed, we need to retrieve the real data object
+        // pointer in order to retrieve the original managed object via ComWrappers. To do this, we must query for an
+        // interface that is not known to the proxy e.g. IComCallableWrapper. If we are able to query for IComCallableWrapper
+        // it means that the real data object is one of our CCWs and we've retrieved it successfully,
+        // otherwise it is not ours and we will use the wrapped proxy.
         IUnknown* target = default;
         var realDataObject = proxyDataObject.TryQuery<IComCallableWrapper>(out hr);
         if (hr.Succeeded)
@@ -118,10 +119,19 @@ public static class Clipboard
             target = proxyDataObject.AsUnknown;
         }
 
-        if (!ComHelpers.TryGetObjectForIUnknown(target, out IComDataObject? dataObject))
+        if (!ComHelpers.TryGetObjectForIUnknown(target, out object? managedDataObject))
         {
             target->Release();
             return null;
+        }
+
+        if (managedDataObject is not IComDataObject dataObject)
+        {
+            // If we do not have a IComDataObject, built-in com support is turned off and
+            // we have a proxy where there is no way to retrieve the original data object
+            // pointer from it as the clipboard has likely been flushed.
+            // We need to mimic built-in com behavior and wrap the proxy ourselves.
+            return new DataObject(proxyDataObject, managedDataObject);
         }
 
         if (dataObject is DataObject { IsWrappedForClipboard: true } wrappedData)

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ClipboardTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ClipboardTests.cs
@@ -438,14 +438,6 @@ public class ClipboardTests
         }
     }
 
-    [WinFormsFact]
-    public void Clipboard_SetText_InvokeString_GetReturnsExpected()
-    {
-        Clipboard.SetText("text");
-        Assert.Equal("text", Clipboard.GetText());
-        Assert.True(Clipboard.ContainsText());
-    }
-
     [WinFormsTheory]
     [EnumData<TextDataFormat>]
     public void Clipboard_SetText_InvokeStringTextDataFormat_GetReturnsExpected(TextDataFormat format)
@@ -603,5 +595,31 @@ public class ClipboardTests
         void IDataObject.SetData(Type format, object data) => throw new NotImplementedException();
         void IDataObject.SetData(object data) => throw new NotImplementedException();
         void ComTypes.IDataObject.SetData(ref ComTypes.FORMATETC formatIn, ref ComTypes.STGMEDIUM medium, bool release) => throw new NotImplementedException();
+    }
+
+    [Collection("Sequential")]
+    public class ClipboardSequentialTests()
+    {
+        [WinFormsTheory]
+        [BoolData]
+        public void Clipboard_SetText_InvokeString_GetReturnsExpected(bool builtInComSupported)
+        {
+            string builtInComInteropSwitch = "System.Runtime.InteropServices.BuiltInComInterop.IsSupported";
+            AppContext.TryGetSwitch(builtInComInteropSwitch, out bool original);
+            try
+            {
+                AppContext.SetSwitch(builtInComInteropSwitch, builtInComSupported);
+                AppContext.TryGetSwitch(builtInComInteropSwitch, out bool isEnabled).Should().BeTrue();
+                isEnabled.Should().Be(builtInComSupported);
+
+                Clipboard.SetText("text");
+                Assert.Equal("text", Clipboard.GetText());
+                Assert.True(Clipboard.ContainsText());
+            }
+            finally
+            {
+                AppContext.SetSwitch(builtInComInteropSwitch, original);
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR fixes some issues found when running our test suite with `BuiltInComSupport = false` (mimic trimming).

When there is data on the clipboard that is from another process or when the clipboard has been flushed ([OleFlushClipboard](https://learn.microsoft.com/en-us/windows/win32/api/ole2/nf-ole2-oleflushclipboard) was called), we are no longer able to retrieve the real `IDataObject` pointer from the proxy that is returned by `OleGetClipboard` if we had placed something on the clipboard. In this case, when built in COM is turned on, marshal will simply return the proxy in a wrapper that implements `System.Runtime.InteropServices.ComTypes.IDataObject` via `Marshal.GetObjectForIUnknown`. When built in COM is turned off, we need to mimic this behavior ourselves.

Also added `IManagedWrapper` onto our `RichTextBox.OleCallback` as part of fixing failing tests when ` BuiltInComSupport = false`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/10879)