### PR TITLE
replace a null-forgiving operator with a null-check in TreeNodeAccessibleObject 

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeNode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeNode.cs
@@ -1107,8 +1107,10 @@ public partial class TreeNode : MarshalByRefObject, ICloneable, ISerializable
         }
     }
 
-    internal TreeNodeAccessibleObject AccessibilityObject
-        => _accessibleObject ??= new TreeNodeAccessibleObject(this, TreeView!);
+    internal TreeNodeAccessibleObject? AccessibilityObject =>
+        _accessibleObject ??= TreeView is null
+            ? null
+            : new TreeNodeAccessibleObject(this, TreeView);
 
     /// <summary>
     ///  Adds a new child node at the appropriate sorted position

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeNode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeNode.cs
@@ -13,10 +13,10 @@ using System.Text;
 namespace System.Windows.Forms;
 
 /// <summary>
-///  Implements a node of a <see cref="Forms.TreeView"/>.
+///  Implements a node of a <see cref="TreeView"/>.
 /// </summary>
-[TypeConverterAttribute(typeof(TreeNodeConverter))]
-[Serializable]  // This class participates in resx serialization.
+[TypeConverter(typeof(TreeNodeConverter))]
+[Serializable]  // This class participates in ResX serialization.
 [DefaultProperty(nameof(Text))]
 [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 public partial class TreeNode : MarshalByRefObject, ICloneable, ISerializable
@@ -152,9 +152,9 @@ public partial class TreeNode : MarshalByRefObject, ICloneable, ISerializable
         Nodes.AddRange(children);
     }
 
-    /**
-     * Constructor used in deserialization
-     */
+    /// <summary>
+    ///  Constructor used in deserialization from resources.
+    /// </summary>
     protected TreeNode(SerializationInfo serializationInfo, StreamingContext context)
         : this()
     {
@@ -1686,7 +1686,7 @@ public partial class TreeNode : MarshalByRefObject, ICloneable, ISerializable
 
     internal List<TreeNode> GetSelfAndChildNodes()
     {
-        List<TreeNode> nodes = new() { this };
+        List<TreeNode> nodes = [this];
         AggregateChildNodesToList(this);
         return nodes;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeView.cs
@@ -10,6 +10,7 @@ using System.Windows.Forms.Layout;
 using System.Windows.Forms.VisualStyles;
 using Windows.Win32.System.Variant;
 using Windows.Win32.UI.Accessibility;
+using static System.Windows.Forms.TreeNode;
 
 namespace System.Windows.Forms;
 
@@ -1830,12 +1831,10 @@ public partial class TreeView : Control
     }
 
     /// <summary>
-    ///  Fires the DrawNode event.
+    ///  Raises the DrawNode event.
     /// </summary>
-    protected virtual void OnDrawNode(DrawTreeNodeEventArgs e)
-    {
+    protected virtual void OnDrawNode(DrawTreeNodeEventArgs e) =>
         _onDrawNode?.Invoke(this, e);
-    }
 
     protected override void OnHandleCreated(EventArgs e)
     {
@@ -2080,15 +2079,13 @@ public partial class TreeView : Control
     }
 
     /// <summary>
-    ///  Fires the beforeLabelEdit event.
+    ///  Raises the beforeLabelEdit event.
     /// </summary>
-    protected virtual void OnBeforeLabelEdit(NodeLabelEditEventArgs e)
-    {
+    protected virtual void OnBeforeLabelEdit(NodeLabelEditEventArgs e) =>
         _onBeforeLabelEdit?.Invoke(this, e);
-    }
 
     /// <summary>
-    ///  Fires the afterLabelEdit event.
+    ///  Raises the afterLabelEdit event.
     /// </summary>
     protected virtual void OnAfterLabelEdit(NodeLabelEditEventArgs e)
     {
@@ -2103,15 +2100,13 @@ public partial class TreeView : Control
     }
 
     /// <summary>
-    ///  Fires the beforeCheck event.
+    ///  Raises the beforeCheck event.
     /// </summary>
-    protected virtual void OnBeforeCheck(TreeViewCancelEventArgs e)
-    {
+    protected virtual void OnBeforeCheck(TreeViewCancelEventArgs e) =>
         _onBeforeCheck?.Invoke(this, e);
-    }
 
     /// <summary>
-    ///  Fires the afterCheck event.
+    ///  Raises the afterCheck event.
     /// </summary>
     protected virtual void OnAfterCheck(TreeViewEventArgs e)
     {
@@ -2139,15 +2134,13 @@ public partial class TreeView : Control
     }
 
     /// <summary>
-    ///  Fires the beforeCollapse event.
+    ///  Raises the beforeCollapse event.
     /// </summary>
-    protected internal virtual void OnBeforeCollapse(TreeViewCancelEventArgs e)
-    {
+    protected internal virtual void OnBeforeCollapse(TreeViewCancelEventArgs e) =>
         _onBeforeCollapse?.Invoke(this, e);
-    }
 
     /// <summary>
-    ///  Fires the afterCollapse event.
+    ///  Raises the afterCollapse event.
     /// </summary>
     protected internal virtual void OnAfterCollapse(TreeViewEventArgs e)
     {
@@ -2164,15 +2157,13 @@ public partial class TreeView : Control
     }
 
     /// <summary>
-    ///  Fires the beforeExpand event.
+    ///  Raises the beforeExpand event.
     /// </summary>
-    protected virtual void OnBeforeExpand(TreeViewCancelEventArgs e)
-    {
+    protected virtual void OnBeforeExpand(TreeViewCancelEventArgs e) =>
         _onBeforeExpand?.Invoke(this, e);
-    }
 
     /// <summary>
-    ///  Fires the afterExpand event.
+    ///  Raises the afterExpand event.
     /// </summary>
     protected virtual void OnAfterExpand(TreeViewEventArgs e)
     {
@@ -2189,31 +2180,25 @@ public partial class TreeView : Control
     }
 
     /// <summary>
-    ///  Fires the ItemDrag event.
+    ///  Raises the ItemDrag event.
     /// </summary>
-    protected virtual void OnItemDrag(ItemDragEventArgs e)
-    {
+    protected virtual void OnItemDrag(ItemDragEventArgs e) =>
         _onItemDrag?.Invoke(this, e);
-    }
 
     /// <summary>
-    ///  Fires the NodeMouseHover event.
+    ///  Raises the NodeMouseHover event.
     /// </summary>
-    protected virtual void OnNodeMouseHover(TreeNodeMouseHoverEventArgs e)
-    {
+    protected virtual void OnNodeMouseHover(TreeNodeMouseHoverEventArgs e) =>
         _onNodeMouseHover?.Invoke(this, e);
-    }
 
     /// <summary>
-    ///  Fires the beforeSelect event.
+    ///  Raises the beforeSelect event.
     /// </summary>
-    protected virtual void OnBeforeSelect(TreeViewCancelEventArgs e)
-    {
+    protected virtual void OnBeforeSelect(TreeViewCancelEventArgs e) =>
         _onBeforeSelect?.Invoke(this, e);
-    }
 
     /// <summary>
-    ///  Fires the afterSelect event.
+    ///  Raises the afterSelect event.
     /// </summary>
     protected virtual void OnAfterSelect(TreeViewEventArgs e)
     {
@@ -2240,20 +2225,16 @@ public partial class TreeView : Control
     }
 
     /// <summary>
-    ///  Fires the onNodeMouseClick event.
+    ///  Raises the onNodeMouseClick event.
     /// </summary>
-    protected virtual void OnNodeMouseClick(TreeNodeMouseClickEventArgs e)
-    {
+    protected virtual void OnNodeMouseClick(TreeNodeMouseClickEventArgs e) =>
         _onNodeMouseClick?.Invoke(this, e);
-    }
 
     /// <summary>
-    ///  Fires the onNodeMouseDoubleClick event.
+    ///  Raises the onNodeMouseDoubleClick event.
     /// </summary>
-    protected virtual void OnNodeMouseDoubleClick(TreeNodeMouseClickEventArgs e)
-    {
+    protected virtual void OnNodeMouseDoubleClick(TreeNodeMouseClickEventArgs e) =>
         _onNodeMouseDoubleClick?.Invoke(this, e);
-    }
 
     /// <summary>
     ///  Handles the OnBeforeCheck / OnAfterCheck for keyboard clicks
@@ -2383,20 +2364,20 @@ public partial class TreeView : Control
     {
         if (_imageList is not null)
         {
-            return (SelectedImageIndex != 0);
+            return SelectedImageIndex != 0;
         }
 
-        return (SelectedImageIndex != ImageList.Indexer.DefaultIndex);
+        return SelectedImageIndex != ImageList.Indexer.DefaultIndex;
     }
 
     private bool ShouldSerializeImageIndex()
     {
         if (_imageList is not null)
         {
-            return (ImageIndex != 0);
+            return ImageIndex != 0;
         }
 
-        return (ImageIndex != ImageList.Indexer.DefaultIndex);
+        return ImageIndex != ImageList.Indexer.DefaultIndex;
     }
 
     /// <summary>
@@ -2443,14 +2424,14 @@ public partial class TreeView : Control
         OnItemDrag(new ItemDragEventArgs(buttons, node));
     }
 
-    private unsafe IntPtr TvnExpanding(NMTREEVIEWW* nmtv)
+    private unsafe nint TvnExpanding(NMTREEVIEWW* nmtv)
     {
         TVITEMW item = nmtv->itemNew;
 
         // Check for invalid node handle
         if (item.hItem == IntPtr.Zero)
         {
-            return IntPtr.Zero;
+            return 0;
         }
 
         TreeViewCancelEventArgs? e = null;
@@ -2465,7 +2446,7 @@ public partial class TreeView : Control
             OnBeforeCollapse(e);
         }
 
-        return (IntPtr)(e.Cancel ? 1 : 0);
+        return e.Cancel ? 1 : 0;
     }
 
     private unsafe void TvnExpanded(NMTREEVIEWW* nmtv)
@@ -2494,17 +2475,17 @@ public partial class TreeView : Control
         }
     }
 
-    private unsafe IntPtr TvnSelecting(NMTREEVIEWW* nmtv)
+    private unsafe nint TvnSelecting(NMTREEVIEWW* nmtv)
     {
         if (_treeViewState[TREEVIEWSTATE_ignoreSelects])
         {
-            return (IntPtr)1;
+            return 1;
         }
 
         // Check for invalid node handle
         if (nmtv->itemNew.hItem == IntPtr.Zero)
         {
-            return IntPtr.Zero;
+            return 0;
         }
 
         TreeNode? node = NodeFromHandle(nmtv->itemNew.hItem);
@@ -2524,7 +2505,7 @@ public partial class TreeView : Control
         TreeViewCancelEventArgs e = new(node, false, action);
         OnBeforeSelect(e);
 
-        return (IntPtr)(e.Cancel ? 1 : 0);
+        return e.Cancel ? 1 : 0;
     }
 
     private unsafe void TvnSelected(NMTREEVIEWW* nmtv)
@@ -3115,7 +3096,7 @@ public partial class TreeView : Control
     }
 
     /// <summary>
-    ///  Shows the context menu for the Treenode.
+    ///  Shows the context menu for the <see cref="TreeNode"/>.
     /// </summary>
     private void ShowContextMenu(TreeNode treeNode)
     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeView.cs
@@ -2098,7 +2098,7 @@ public partial class TreeView : Control
         // if editing hasn't been canceled.
         if (IsAccessibilityObjectCreated && !e.CancelEdit)
         {
-            e.Node!.AccessibilityObject.RaiseAutomationEvent(UIA_EVENT_ID.UIA_AutomationFocusChangedEventId);
+            e.Node!.AccessibilityObject?.RaiseAutomationEvent(UIA_EVENT_ID.UIA_AutomationFocusChangedEventId);
         }
     }
 
@@ -2120,7 +2120,12 @@ public partial class TreeView : Control
         // Raise an event to announce a toggle state change.
         if (IsAccessibilityObjectCreated)
         {
-            AccessibleObject nodeAccessibleObject = e.Node!.AccessibilityObject;
+            AccessibleObject? nodeAccessibleObject = e.Node!.AccessibilityObject;
+            if (nodeAccessibleObject is null)
+            {
+                return;
+            }
+
             ToggleState newState = nodeAccessibleObject.ToggleState;
             ToggleState oldState = newState == ToggleState.ToggleState_On
                 ? ToggleState.ToggleState_Off
@@ -2151,7 +2156,7 @@ public partial class TreeView : Control
         // Raise an event to announce the expand-collapse state change.
         if (IsAccessibilityObjectCreated)
         {
-            e.Node!.AccessibilityObject.RaiseAutomationPropertyChangedEvent(
+            e.Node!.AccessibilityObject?.RaiseAutomationPropertyChangedEvent(
                 UIA_PROPERTY_ID.UIA_ExpandCollapseExpandCollapseStatePropertyId,
                 oldValue: (VARIANT)(int)ExpandCollapseState.ExpandCollapseState_Expanded,
                 newValue: (VARIANT)(int)ExpandCollapseState.ExpandCollapseState_Collapsed);
@@ -2176,7 +2181,7 @@ public partial class TreeView : Control
         // Raise an event to announce the expand-collapse state change.
         if (IsAccessibilityObjectCreated)
         {
-            e.Node!.AccessibilityObject.RaiseAutomationPropertyChangedEvent(
+            e.Node!.AccessibilityObject?.RaiseAutomationPropertyChangedEvent(
                 UIA_PROPERTY_ID.UIA_ExpandCollapseExpandCollapseStatePropertyId,
                 oldValue: (VARIANT)(int)ExpandCollapseState.ExpandCollapseState_Collapsed,
                 newValue: (VARIANT)(int)ExpandCollapseState.ExpandCollapseState_Expanded);
@@ -2217,7 +2222,12 @@ public partial class TreeView : Control
         // Raise an event to highlight & announce the selected node.
         if (IsAccessibilityObjectCreated)
         {
-            AccessibleObject nodeAccessibleObject = e.Node!.AccessibilityObject;
+            AccessibleObject? nodeAccessibleObject = e.Node!.AccessibilityObject;
+            if (nodeAccessibleObject is null)
+            {
+                return;
+            }
+
             nodeAccessibleObject.RaiseAutomationEvent(UIA_EVENT_ID.UIA_AutomationFocusChangedEventId);
             nodeAccessibleObject.RaiseAutomationEvent(UIA_EVENT_ID.UIA_SelectionItem_ElementSelectedEventId);
 
@@ -3094,7 +3104,7 @@ public partial class TreeView : Control
         // Raise an event to highlight & announce the selected node.
         if (IsAccessibilityObjectCreated)
         {
-            SelectedNode?.AccessibilityObject.RaiseAutomationEvent(UIA_EVENT_ID.UIA_AutomationFocusChangedEventId);
+            SelectedNode?.AccessibilityObject?.RaiseAutomationEvent(UIA_EVENT_ID.UIA_AutomationFocusChangedEventId);
         }
     }
 
@@ -3452,7 +3462,7 @@ public partial class TreeView : Control
                 if (m.LParamInternal == PInvoke.UiaRootObjectId && SupportsUiaProviders && !IsAccessibilityObjectCreated && Focused)
                 {
                     base.WndProc(ref m);
-                    SelectedNode?.AccessibilityObject.RaiseAutomationEvent(UIA_EVENT_ID.UIA_AutomationFocusChangedEventId);
+                    SelectedNode?.AccessibilityObject?.RaiseAutomationEvent(UIA_EVENT_ID.UIA_AutomationFocusChangedEventId);
                 }
                 else
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeView.cs
@@ -2096,9 +2096,9 @@ public partial class TreeView : Control
 
         // Raise an event to highlight & announce the edited node
         // if editing hasn't been canceled.
-        if (IsAccessibilityObjectCreated && !e.CancelEdit)
+        if (IsAccessibilityObjectCreated && !e.CancelEdit && e.Node is not null)
         {
-            e.Node!.AccessibilityObject?.RaiseAutomationEvent(UIA_EVENT_ID.UIA_AutomationFocusChangedEventId);
+            e.Node.AccessibilityObject?.RaiseAutomationEvent(UIA_EVENT_ID.UIA_AutomationFocusChangedEventId);
         }
     }
 
@@ -2118,9 +2118,9 @@ public partial class TreeView : Control
         _onAfterCheck?.Invoke(this, e);
 
         // Raise an event to announce a toggle state change.
-        if (IsAccessibilityObjectCreated)
+        if (IsAccessibilityObjectCreated && e.Node is not null)
         {
-            AccessibleObject? nodeAccessibleObject = e.Node!.AccessibilityObject;
+            TreeNodeAccessibleObject? nodeAccessibleObject = e.Node.AccessibilityObject;
             if (nodeAccessibleObject is null)
             {
                 return;
@@ -2154,9 +2154,9 @@ public partial class TreeView : Control
         _onAfterCollapse?.Invoke(this, e);
 
         // Raise an event to announce the expand-collapse state change.
-        if (IsAccessibilityObjectCreated)
+        if (IsAccessibilityObjectCreated && e.Node is not null)
         {
-            e.Node!.AccessibilityObject?.RaiseAutomationPropertyChangedEvent(
+            e.Node.AccessibilityObject?.RaiseAutomationPropertyChangedEvent(
                 UIA_PROPERTY_ID.UIA_ExpandCollapseExpandCollapseStatePropertyId,
                 oldValue: (VARIANT)(int)ExpandCollapseState.ExpandCollapseState_Expanded,
                 newValue: (VARIANT)(int)ExpandCollapseState.ExpandCollapseState_Collapsed);
@@ -2179,9 +2179,9 @@ public partial class TreeView : Control
         _onAfterExpand?.Invoke(this, e);
 
         // Raise an event to announce the expand-collapse state change.
-        if (IsAccessibilityObjectCreated)
+        if (IsAccessibilityObjectCreated && e.Node is not null)
         {
-            e.Node!.AccessibilityObject?.RaiseAutomationPropertyChangedEvent(
+            e.Node.AccessibilityObject?.RaiseAutomationPropertyChangedEvent(
                 UIA_PROPERTY_ID.UIA_ExpandCollapseExpandCollapseStatePropertyId,
                 oldValue: (VARIANT)(int)ExpandCollapseState.ExpandCollapseState_Collapsed,
                 newValue: (VARIANT)(int)ExpandCollapseState.ExpandCollapseState_Expanded);
@@ -2220,9 +2220,9 @@ public partial class TreeView : Control
         _onAfterSelect?.Invoke(this, e);
 
         // Raise an event to highlight & announce the selected node.
-        if (IsAccessibilityObjectCreated)
+        if (IsAccessibilityObjectCreated && e.Node is not null)
         {
-            AccessibleObject? nodeAccessibleObject = e.Node!.AccessibilityObject;
+            TreeNodeAccessibleObject? nodeAccessibleObject = e.Node.AccessibilityObject;
             if (nodeAccessibleObject is null)
             {
                 return;
@@ -2856,14 +2856,14 @@ public partial class TreeView : Control
                             {
                                 g.FillRectangle(SystemBrushes.Highlight, bounds);
                                 ControlPaint.DrawFocusRectangle(g, bounds, color, SystemColors.Highlight);
-                                TextRenderer.DrawText(g, e.Node!.Text, font, bounds, color, TextFormatFlags.Default);
+                                TextRenderer.DrawText(g, node.Text, font, bounds, color, TextFormatFlags.Default);
                             }
                             else
                             {
                                 using var brush = BackColor.GetCachedSolidBrushScope();
                                 g.FillRectangle(brush, bounds);
 
-                                TextRenderer.DrawText(g, e.Node!.Text, font, bounds, color, TextFormatFlags.Default);
+                                TextRenderer.DrawText(g, node.Text, font, bounds, color, TextFormatFlags.Default);
                             }
                         }
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeViewLabelEditAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeViewLabelEditAccessibleObject.cs
@@ -20,7 +20,7 @@ internal sealed unsafe class TreeViewLabelEditAccessibleObject : LabelEditAccess
 
     private protected override string? AutomationId =>
         _owningTreeView.TryGetTarget(out TreeView? target)
-            ? target._editNode?.AccessibilityObject.Name
+            ? target._editNode?.AccessibilityObject?.Name
             : null;
 
     internal override IRawElementProviderFragmentRoot.Interface? FragmentRoot =>

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
@@ -5414,9 +5414,9 @@ public class TreeViewTests
 
     public static IEnumerable<object[]> TreeViewEventArgs_TestData()
     {
-        yield return new object[] { null };
         yield return new object[] { new TreeViewEventArgs(null) };
         yield return new object[] { new TreeViewEventArgs(new TreeNode()) };
+        yield return new object[] { new TreeViewEventArgs(new TreeNode(), TreeViewAction.ByMouse) };
     }
 
     [WinFormsTheory]
@@ -5431,6 +5431,8 @@ public class TreeViewTests
             Assert.Same(eventArgs, e);
             callCount++;
         };
+
+        Assert.NotNull(control.AccessibilityObject);
 
         // Call with handler.
         control.AfterCheck += handler;
@@ -5456,6 +5458,8 @@ public class TreeViewTests
             callCount++;
         };
 
+        Assert.NotNull(control.AccessibilityObject);
+
         // Call with handler.
         control.AfterCollapse += handler;
         control.OnAfterCollapse(eventArgs);
@@ -5480,6 +5484,8 @@ public class TreeViewTests
             callCount++;
         };
 
+        Assert.NotNull(control.AccessibilityObject);
+
         // Call with handler.
         control.AfterExpand += handler;
         control.OnAfterExpand(eventArgs);
@@ -5493,7 +5499,6 @@ public class TreeViewTests
 
     public static IEnumerable<object[]> NodeLabelEditEventArgs_TestData()
     {
-        yield return new object[] { null };
         yield return new object[] { new NodeLabelEditEventArgs(null) };
         yield return new object[] { new NodeLabelEditEventArgs(new TreeNode()) };
         yield return new object[] { new NodeLabelEditEventArgs(new TreeNode(), "label") };
@@ -5511,6 +5516,8 @@ public class TreeViewTests
             Assert.Same(eventArgs, e);
             callCount++;
         };
+
+        Assert.NotNull(control.AccessibilityObject);
 
         // Call with handler.
         control.AfterLabelEdit += handler;
@@ -5535,6 +5542,8 @@ public class TreeViewTests
             Assert.Same(eventArgs, e);
             callCount++;
         };
+
+        Assert.NotNull(control.AccessibilityObject);
 
         // Call with handler.
         control.AfterSelect += handler;


### PR DESCRIPTION
Fixes #10876

## Proposed changes
TreeNodeAccessibleObject can't be created when the parent TreeView is not found. This could happen when a node is being added or deleted from the Nodes collection. If AccessibleObject is not created on this attempt, it will be created on the next access. If TreeView is not available, we skip object creation.

## Regression? 

- Yes  from NET7

## Risk

Low - adding a null-check

## Testing
Fix is based on the exception callstack, I couldn't reproduce this crash

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/10880)