### PR TITLE
Make MsoComponent code trim friendly

### DIFF
--- a/src/System.Private.Windows.Core/src/Windows/Win32/System/Com/AgileComPointer.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/System/Com/AgileComPointer.cs
@@ -68,6 +68,14 @@ internal unsafe class AgileComPointer<TInterface> :
         return currentUnknown.Value == otherUnknown.Value;
     }
 
+    /// <inheritdoc cref="IsSameNativeObject(AgileComPointer{TInterface})"/>
+    public bool IsSameNativeObject(TInterface* other)
+    {
+        using var currentUnknown = GetInterface<IUnknown>();
+        using ComScope<IUnknown> otherUnknown = ComScope<IUnknown>.QueryFrom(other);
+        return currentUnknown.Value == otherUnknown.Value;
+    }
+
     /// <summary>
     ///  Gets the default interface. Throws if failed.
     /// </summary>

--- a/src/System.Private.Windows.Core/src/Windows/Win32/System/Com/ComHelpers.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/System/Com/ComHelpers.cs
@@ -199,10 +199,19 @@ internal static unsafe partial class ComHelpers
     }
 
     /// <summary>
-    ///  Returns <see langword="true"/> if the given <paramref name="object"/> is projected as the given <paramref name="unknown"/>.
+    ///  Returns <see langword="true"/> if the given <paramref name="object"/> is projected as the given <paramref name="comPointer"/>.
     /// </summary>
-    internal static bool WrapsManagedObject(object @object, IUnknown* unknown)
+    internal static bool WrapsManagedObject<T>(object @object, T* comPointer)
+        where T : unmanaged, IComIID
     {
+        if (comPointer is null)
+        {
+            return false;
+        }
+
+        using ComScope<IUnknown> unknown = new(null);
+        ((IUnknown*)comPointer)->QueryInterface(IID.Get<IUnknown>(), unknown).ThrowOnFailure();
+
         // If it is a ComWrappers object we need to simply pull out the original object to check.
         if (ComWrappers.TryGetObject((nint)unknown, out object? obj))
         {

--- a/src/System.Private.Windows.Core/src/Windows/Win32/System/Com/WinFormsComWrappers.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/System/Com/WinFormsComWrappers.cs
@@ -71,15 +71,28 @@ internal unsafe partial class WinFormsComWrappers : ComWrappers
         }
     }
 
+    internal static TReturnType UnwrapAndInvoke<TThis, TInterface, TReturnType>(TThis* @this, Func<TInterface, TReturnType> func)
+        where TThis : unmanaged
+        where TInterface : class
+        where TReturnType : unmanaged
+    {
+        try
+        {
+            TInterface? @object = ComInterfaceDispatch.GetInstance<TInterface>((ComInterfaceDispatch*)@this);
+            return @object is null ? default : func(@object);
+        }
+        catch (Exception ex)
+        {
+            Debug.Fail($"Exception thrown in UnwrapAndInvoke {ex.Message}.");
+            return default;
+        }
+    }
+
     /// <summary>
     ///  For the given <paramref name="this"/> pointer unwrap the associated managed object and use it to
     ///  invoke <paramref name="action"/>.
     /// </summary>
-    /// <remarks>
-    ///  <para>
-    ///   Handles exceptions and converts to <see cref="HRESULT"/>.
-    ///  </para>
-    /// </remarks>
+    /// <inheritdoc cref="UnwrapAndInvoke{TThis, TInterface}(TThis*, Func{TInterface, HRESULT})"/>
     internal static HRESULT UnwrapAndInvoke<TThis, TInterface>(TThis* @this, Action<TInterface> action)
         where TThis : unmanaged
         where TInterface : class

--- a/src/System.Windows.Forms.Primitives/src/Microsoft/Office/IMsoComponent.cs
+++ b/src/System.Windows.Forms.Primitives/src/Microsoft/Office/IMsoComponent.cs
@@ -1,282 +1,498 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Windows.Win32.System.Com;
+using static WinFormsComWrappers;
 
 namespace Microsoft.Office;
 
-/// <summary>
-///  Provides components that need idle time, such as packages that manage modeless top-level windows, with access to
-///  the message loop and other facilities. Register the interface with the component manager that implements the
-///  <see cref="IMsoComponentManager"/> interface.
-/// </summary>
-/// <remarks>
-///  <para>
-///   WM_MOUSEACTIVATE Note (for top level components and host)
-///  </para>
-///  <para>
-///   If the active (or tracking) comp's reg info indicates that it wants mouse messages, then no MA_xxxANDEAT value
-///   should be returned from WM_MOUSEACTIVATE, so that the active (or tracking) comp will be able to process the
-///   resulting mouse message. If one does not want to examine the reg info, no MA_xxxANDEAT value
-///   should be returned from WM_MOUSEACTIVATE if any comp is active (or tracking). One
-///   can query the reg info  of the active (or tracking) component at any time via
-///   <see cref="IMsoComponentManager.FGetActiveComponent"/>.
-///  </para>
-///  <para>
-///   <see href="https://learn.microsoft.com/previous-versions/office/developer/office-2007/ff518955(v=office.12)">Microsoft documentation</see>
-///  </para>
-/// </remarks>
-[ComImport]
-[Guid(MsoComponentIds.IID_IMsoComponent)]
-[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-internal unsafe interface IMsoComponent
+/// <inheritdoc cref="Interface"/>
+internal unsafe struct IMsoComponent : IComIID, IVTable<IMsoComponent, IMsoComponent.Vtbl>
 {
-    /// <summary>
-    ///  Standard <see cref="FDebugMessage"/> method.
-    /// </summary>
-    /// <remarks>
-    ///  <para>
-    ///   This method is reserved for internal use and is not intended to be used in your code.
-    ///  </para>
-    /// </remarks>
-    /// <returns><see cref="BOOL.TRUE"/></returns>
-    [PreserveSig]
-    BOOL FDebugMessage(
-        IntPtr hInst,
-        uint msg,
-        IntPtr wParam,
-        IntPtr lParam);
+    static void IVTable<IMsoComponent, Vtbl>.PopulateVTable(Vtbl* vtable)
+    {
+        vtable->FDebugMessage_4 = &FDebugMessage;
+        vtable->FPreTranslateMessage_5 = &FPreTranslateMessage;
+        vtable->OnEnterState_6 = &OnEnterState;
+        vtable->OnAppActivate_7 = &OnAppActivate;
+        vtable->OnLoseActivation_8 = &OnLoseActivation;
+        vtable->OnActivationChange_9 = &OnActivationChange;
+        vtable->FDoIdle_10 = &FDoIdle;
+        vtable->FContinueMessageLoop_11 = &FContinueMessageLoop;
+        vtable->FQueryTerminate_12 = &FQueryTerminate;
+        vtable->Terminate_13 = &Terminate;
+        vtable->HwndGetWindow_14 = &HwndGetWindow;
+    }
 
-    /// <summary>
-    ///  Give component a chance to process <paramref name="msg"/> before it is translated
-    ///  and dispatched. Component can modify <paramref name="msg"/>, call Win32 APIs such
-    ///  as TranslateAccelerator or IsDialogMessage, or take some other action.
-    /// </summary>
-    /// <returns>
-    ///  Return <see cref="BOOL.TRUE"/> if the message is consumed,
-    ///  <see cref="BOOL.FALSE"/> otherwise.
-    /// </returns>
-    [PreserveSig]
-    BOOL FPreTranslateMessage(MSG* msg);
+    internal struct Vtbl
+    {
+        internal delegate* unmanaged[Stdcall]<IMsoComponent*, Guid*, void**, HRESULT> QueryInterface_1;
+        internal delegate* unmanaged[Stdcall]<IMsoComponent*, uint> AddRef_2;
+        internal delegate* unmanaged[Stdcall]<IMsoComponent*, uint> Release_3;
+        internal delegate* unmanaged[Stdcall]<IMsoComponent*, nint, uint, WPARAM, LPARAM, BOOL> FDebugMessage_4;
+        internal delegate* unmanaged[Stdcall]<IMsoComponent*, MSG*, BOOL> FPreTranslateMessage_5;
+        internal delegate* unmanaged[Stdcall]<IMsoComponent*, msocstate, BOOL, void> OnEnterState_6;
+        internal delegate* unmanaged[Stdcall]<IMsoComponent*, BOOL, uint, void> OnAppActivate_7;
+        internal delegate* unmanaged[Stdcall]<IMsoComponent*, void> OnLoseActivation_8;
+        internal delegate* unmanaged[Stdcall]<IMsoComponent*, IMsoComponent*, BOOL, MSOCRINFO*, BOOL, nint, uint, void> OnActivationChange_9;
+        internal delegate* unmanaged[Stdcall]<IMsoComponent*, msoidlef, BOOL> FDoIdle_10;
+        internal delegate* unmanaged[Stdcall]<IMsoComponent*, msoloop, void*, MSG*, BOOL> FContinueMessageLoop_11;
+        internal delegate* unmanaged[Stdcall]<IMsoComponent*, BOOL, BOOL> FQueryTerminate_12;
+        internal delegate* unmanaged[Stdcall]<IMsoComponent*, void> Terminate_13;
+        internal delegate* unmanaged[Stdcall]<IMsoComponent*, msocWindow, uint, HWND> HwndGetWindow_14;
+    }
 
-    /// <summary>
-    ///  Notify component when app enters or exits (as indicated by <paramref name="fEnter"/>)
-    ///  the state identified by <paramref name="uStateID"/>. Component should take action
-    ///  depending on value of <paramref name="uStateID"/> (see olecstate comments, above).
-    /// </summary>
-    /// <remarks>
-    ///  <para>
-    ///   Note: If n calls are made with TRUE <paramref name="fEnter"/>, component should consider
-    ///   the state to be in effect until n calls are made with FALSE <paramref name="fEnter"/>.
-    ///  </para>
-    ///  <para>
-    ///   Note: Components should be aware that it is possible for this method to be called
-    ///   with FALSE <paramref name="fEnter"/> more times than it was called with TRUE
-    ///   <paramref name="fEnter"/> (so, for example, if component is maintaining a state counter
-    ///   incremented when this method is called with BOOL.TRUE <paramref name="fEnter"/>,
-    ///   decremented when called with FALSE <paramref name="fEnter"/>), the counter should not
-    ///   be decremented for FALSE <paramref name="fEnter"/> if it is already at zero.)
-    ///  </para>
-    /// </remarks>
-    [PreserveSig]
-    void OnEnterState(
-        msocstate uStateID,
-        BOOL fEnter);
+    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvStdcall)])]
+    private static BOOL FDebugMessage(IMsoComponent* @this, nint hInst, uint msg, WPARAM wParam, LPARAM lParam)
+        => UnwrapAndInvoke<IMsoComponent, Interface, BOOL>(@this, o => o.FDebugMessage(hInst, msg, wParam, lParam));
 
-    /// <summary>
-    ///  Notify component when the host application gains or loses activation.
-    /// </summary>
-    /// <remarks>
-    ///  <para>
-    ///   Note: this method is not called when both the window being activated and the one being
-    ///   deactivated belong to the host app.
-    ///  </para>
-    /// </remarks>
-    /// <param name="fActive">
-    ///  If <see cref="BOOL.TRUE"/>, the host app is being activated and <paramref name="dwOtherThreadID"/>
-    ///  is the ID of the thread owning the window being deactivated.
-    ///
-    ///  If <see cref="BOOL.FALSE"/>, the host app is being deactivated and <paramref name="dwOtherThreadID"/>
-    ///  is the ID of the thread owning the window being activated.
-    /// </param>
-    [PreserveSig]
-    void OnAppActivate(
-        BOOL fActive,
-        uint dwOtherThreadID);
+    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvStdcall)])]
+    private static BOOL FPreTranslateMessage(IMsoComponent* @this, MSG* msg)
+        => UnwrapAndInvoke<IMsoComponent, Interface, BOOL>(@this, o => o.FPreTranslateMessage(msg));
 
-    /// <summary>
-    ///  Notify the active component that it has lost its active status because the host or
-    ///  another component has become active.
-    /// </summary>
-    [PreserveSig]
-    void OnLoseActivation();
+    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvStdcall)])]
+    private static void OnEnterState(IMsoComponent* @this, msocstate uStateID, BOOL fEnter)
+        => UnwrapAndInvoke<IMsoComponent, Interface>(@this, o => o.OnEnterState(uStateID, fEnter));
 
-    /// <summary>
-    ///  Notify component when a new object is being activated.
-    /// </summary>
-    /// <remarks>
-    ///  <para>
-    ///   If <paramref name="pic"/> is being activated and <paramref name="pcrinfo"/>
-    ///   <see cref="MSOCRINFO.grfcrf"/> has the <see cref="msocrf.ExclusiveBorderSpace"/>
-    ///   bit set, component should hide its border space tools (toolbars, status bars, etc.);
-    ///   component should also do this if host is activating and <paramref name="pchostinfo"/>
-    ///   has the <see cref="msocrf.ExclusiveBorderSpace"/> bit set. In either of these cases,
-    ///   component should unhide its border space tools the next time it is activated.
-    ///  </para>
-    ///  <para>
-    ///   If <paramref name="pic"/> is being activated and <paramref name="pcrinfo"/>
-    ///   <see cref="MSOCRINFO.grfcrf"/> has the <see cref="msocrf.ExclusiveActivation"/>
-    ///   bit set, then <paramref name="pic"/> is being activated in "ExclusiveActive" mode.
-    ///   Component should retrieve the top frame window that is hosting <paramref name="pic"/>
-    ///   (via <see cref="HwndGetWindow"/> with <see cref="msocWindow.FrameToplevel"/>).
-    ///  </para>
-    ///  <para>
-    ///   If this window is different from component's own top frame window, component should
-    ///   disable its windows and do other things it would do when receiving
-    ///   <see cref="OnEnterState"/> with <see cref="msocstate.Modal" /> notification.
-    ///  </para>
-    ///  <para>
-    ///   Otherwise, if component is top-level, it should refuse to have its window activated
-    ///   by appropriately processing WM_MOUSEACTIVATE (but see WM_MOUSEACTIVATE NOTE, above).
-    ///   Component should remain in one of these states until the exclusive active mode ends,
-    ///   indicated by a future call to <see cref="OnActivationChange"/> with
-    ///   <see cref="msocrf.ExclusiveActivation" /> bit not set or with null
-    ///   <paramref name="pcrinfo"/>.
-    ///  </para>
-    /// </remarks>
-    /// <param name="pic">
-    ///  <para>
-    ///   If non-null, then it is the component that is being activated. In this case,
-    ///   <paramref name="fSameComponent"/> is TRUE if <paramref name="pic"/> is the same
-    ///   component as the callee of this method, and <paramref name="pcrinfo"/> is the
-    ///   reg info of <paramref name="pic"/>.
-    ///  </para>
-    ///  <para>
-    ///   If null and <paramref name="fHostIsActivating"/> is TRUE, then the host is the
-    ///   object being activated, and <paramref name="pchostinfo"/> is its host info.
-    ///  </para>
-    ///  <para>
-    ///   If null and <paramref name="fHostIsActivating"/> is FALSE, then there is no
-    ///   current active object.
-    ///  </para>
-    /// </param>
-    [PreserveSig]
-    void OnActivationChange(
-        IMsoComponent? pic,
+    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvStdcall)])]
+    private static void OnAppActivate(IMsoComponent* @this, BOOL fActive, uint dwOtherThreadID)
+        => UnwrapAndInvoke<IMsoComponent, Interface>(@this, o => o.OnAppActivate(fActive, dwOtherThreadID));
+
+    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvStdcall)])]
+    private static void OnLoseActivation(IMsoComponent* @this)
+        => UnwrapAndInvoke<IMsoComponent, Interface>(@this, o => o.OnLoseActivation());
+
+    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvStdcall)])]
+    private static void OnActivationChange(
+        IMsoComponent* @this,
+        IMsoComponent* pic,
         BOOL fSameComponent,
         MSOCRINFO* pcrinfo,
         BOOL fHostIsActivating,
         nint pchostinfo,
-        uint dwReserved);
+        uint dwReserved)
+        => UnwrapAndInvoke<IMsoComponent, Interface>(
+            @this,
+            o => o.OnActivationChange(pic, fSameComponent, pcrinfo, fHostIsActivating, pchostinfo, dwReserved));
+
+    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvStdcall)])]
+    private static BOOL FDoIdle(IMsoComponent* @this, msoidlef grfidlef)
+        => UnwrapAndInvoke<IMsoComponent, Interface, BOOL>(@this, o => o.FDoIdle(grfidlef));
+
+    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvStdcall)])]
+    private static BOOL FContinueMessageLoop(IMsoComponent* @this, msoloop uReason, void* pvLoopData, MSG* pMsgPeeked)
+        => UnwrapAndInvoke<IMsoComponent, Interface, BOOL>(@this, o => o.FContinueMessageLoop(uReason, pvLoopData, pMsgPeeked));
+
+    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvStdcall)])]
+    private static BOOL FQueryTerminate(IMsoComponent* @this, BOOL fPromptUser)
+        => UnwrapAndInvoke<IMsoComponent, Interface, BOOL>(@this, o => o.FQueryTerminate(fPromptUser));
+
+    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvStdcall)])]
+    private static void Terminate(IMsoComponent* @this)
+        => UnwrapAndInvoke<IMsoComponent, Interface>(@this, o => o.Terminate());
+
+    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvStdcall)])]
+    private static HWND HwndGetWindow(IMsoComponent* @this, msocWindow dwWhich, uint dwReserved)
+        => UnwrapAndInvoke<IMsoComponent, Interface, HWND>(@this, o => o.HwndGetWindow(dwWhich, dwReserved));
+
+    // 000C0600-0000-0000-C000-000000000046
+    internal static readonly Guid Guid = new(0x000C0600, 0x0000, 0x0000, 0xC0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46);
+
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0x00, 0x06, 0xc0, 0x00,
+                0x00, 0x00,
+                0x00, 0x00,
+                0xc0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46
+            ];
+
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
+
+    private readonly void** _lpVtbl;
+
+    /// <inheritdoc cref="IUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IMsoComponent* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IMsoComponent*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="IUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IMsoComponent* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IMsoComponent*, uint>)_lpVtbl[1])(pThis);
+    }
+
+    /// <inheritdoc cref="IUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IMsoComponent* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IMsoComponent*, uint>)_lpVtbl[2])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.FDebugMessage(nint, uint, WPARAM, LPARAM)"/>
+    public BOOL FDebugMessage(nint hInst, uint msg, WPARAM wParam, LPARAM lParam)
+    {
+        fixed (IMsoComponent* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IMsoComponent*, nint, uint, WPARAM, LPARAM, BOOL>)_lpVtbl[3])(
+                pThis, hInst, msg, wParam, lParam);
+    }
+
+    /// <inheritdoc cref="Interface.FPreTranslateMessage(MSG*)"/>
+    public BOOL FPreTranslateMessage(MSG* msg)
+    {
+        fixed (IMsoComponent* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IMsoComponent*, MSG*, BOOL>)_lpVtbl[4])(pThis, msg);
+    }
+
+    /// <inheritdoc cref="Interface.OnEnterState(msocstate, BOOL)"/>
+    public void OnEnterState(msocstate uStateID, BOOL fEnter)
+    {
+        fixed (IMsoComponent* pThis = &this)
+            ((delegate* unmanaged[Stdcall]<IMsoComponent*, msocstate, BOOL, void>)_lpVtbl[5])(pThis, uStateID, fEnter);
+    }
+
+    /// <inheritdoc cref="Interface.OnAppActivate(BOOL, uint)"/>
+    public void OnAppActivate(BOOL fActive, uint dwOtherThreadID)
+    {
+        fixed (IMsoComponent* pThis = &this)
+            ((delegate* unmanaged[Stdcall]<IMsoComponent*, BOOL, uint, void>)_lpVtbl[6])(pThis, fActive, dwOtherThreadID);
+    }
+
+    /// <inheritdoc cref="Interface.OnLoseActivation()"/>
+    public void OnLoseActivation()
+    {
+        fixed (IMsoComponent* pThis = &this)
+            ((delegate* unmanaged[Stdcall]<IMsoComponent*, void>)_lpVtbl[7])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.OnActivationChange(IMsoComponent*, BOOL, MSOCRINFO*, BOOL, nint, uint)"/>
+    public void OnActivationChange(IMsoComponent* pic, BOOL fSameComponent, MSOCRINFO* pcrinfo, BOOL fHostIsActivating, nint pchostinfo, uint dwReserved)
+    {
+        fixed (IMsoComponent* pThis = &this)
+            ((delegate* unmanaged[Stdcall]<IMsoComponent*, IMsoComponent*, BOOL, MSOCRINFO*, BOOL, nint, uint, void>)_lpVtbl[8])
+                (pThis, pic, fSameComponent, pcrinfo, fHostIsActivating, pchostinfo, dwReserved);
+    }
+
+    /// <inheritdoc cref="Interface.FDoIdle(msoidlef)"/>
+    public BOOL FDoIdle(msoidlef grfidlef)
+    {
+        fixed (IMsoComponent* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IMsoComponent*, msoidlef, BOOL>)_lpVtbl[9])(pThis, grfidlef);
+    }
+
+    /// <inheritdoc cref="Interface.FContinueMessageLoop(msoloop, void*, MSG*)"/>
+    public BOOL FContinueMessageLoop(msoloop uReason, void* pvLoopData, MSG* pMsgPeeked)
+    {
+        fixed (IMsoComponent* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IMsoComponent*, msoloop, void*, MSG*, BOOL>)_lpVtbl[10])
+                (pThis, uReason, pvLoopData, pMsgPeeked);
+    }
+
+    /// <inheritdoc cref="Interface.FQueryTerminate(BOOL)"/>
+    public BOOL FQueryTerminate(BOOL fPromptUser)
+    {
+        fixed (IMsoComponent* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IMsoComponent*, BOOL, BOOL>)_lpVtbl[11])(pThis, fPromptUser);
+    }
+
+    /// <inheritdoc cref="Interface.Terminate()"/>
+    public void Terminate()
+    {
+        fixed (IMsoComponent* pThis = &this)
+            ((delegate* unmanaged[Stdcall]<IMsoComponent*, void>)_lpVtbl[12])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.HwndGetWindow(msocWindow, uint)"/>
+    public HWND HwndGetWindow(msocWindow dwWhich, uint dwReserved)
+    {
+        fixed (IMsoComponent* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IMsoComponent*, msocWindow, uint, HWND>)_lpVtbl[13])(pThis, dwWhich, dwReserved);
+    }
 
     /// <summary>
-    ///  Give component a chance to do idle time tasks.  grfidlef is a group of
-    ///  bit flags taken from the enumeration of <see cref="msoidlef"/> values,
-    ///  indicating the type of idle tasks to perform.
+    ///  Provides components that need idle time, such as packages that manage modeless top-level windows, with access to
+    ///  the message loop and other facilities. Register the interface with the component manager that implements the
+    ///  <see cref="IMsoComponentManager"/> interface.
     /// </summary>
     /// <remarks>
     ///  <para>
-    ///   Component may periodically call <see cref="IMsoComponentManager.FContinueIdle"/>;
-    ///   if this method returns FALSE, component should terminate its idle time
-    ///   processing and return.
+    ///   WM_MOUSEACTIVATE Note (for top level components and host)
     ///  </para>
     ///  <para>
-    ///   Note: If a component reaches a point where it has no idle tasks and does not
-    ///   need <see cref="FDoIdle"/> calls, it should remove its idle task registration
-    ///   via <see cref="IMsoComponentManager.FUpdateComponentRegistration"/>.
+    ///   If the active (or tracking) comp's reg info indicates that it wants mouse messages, then no MA_xxxANDEAT value
+    ///   should be returned from WM_MOUSEACTIVATE, so that the active (or tracking) comp will be able to process the
+    ///   resulting mouse message. If one does not want to examine the reg info, no MA_xxxANDEAT value
+    ///   should be returned from WM_MOUSEACTIVATE if any comp is active (or tracking). One
+    ///   can query the reg info  of the active (or tracking) component at any time via
+    ///   <see cref="IMsoComponentManager.FGetActiveComponent"/>.
     ///  </para>
     ///  <para>
-    ///   Note: If this method is called on while component is performing a tracking
-    ///   operation, component should only perform idle time tasks that it deems are
-    ///   appropriate to perform during tracking.
+    ///   <see href="https://learn.microsoft.com/previous-versions/office/developer/office-2007/ff518955(v=office.12)">Microsoft documentation</see>
     ///  </para>
     /// </remarks>
-    /// <returns>
-    ///  <see cref="BOOL.TRUE"/> if more time is needed to perform the idle time tasks,
-    ///  <see cref="BOOL.FALSE"/> otherwise.
-    /// </returns>
-    [PreserveSig]
-    BOOL FDoIdle(
-        msoidlef grfidlef);
+    [ComImport]
+    [Guid(MsoComponentIds.IID_IMsoComponent)]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    internal unsafe interface Interface
+    {
+        /// <summary>
+        ///  Standard <see cref="FDebugMessage"/> method.
+        /// </summary>
+        /// <remarks>
+        ///  <para>
+        ///   This method is reserved for internal use and is not intended to be used in your code.
+        ///  </para>
+        /// </remarks>
+        /// <returns><see cref="BOOL.TRUE"/></returns>
+        [PreserveSig]
+        BOOL FDebugMessage(
+            nint hInst,
+            uint msg,
+            WPARAM wParam,
+            LPARAM lParam);
 
-    /// <summary>
-    ///  Called during each iteration of a message loop that the component pushed.
-    /// </summary>
-    /// <remarks>
-    ///  <para>
-    ///   This method is called after peeking the next message in the queue (via PeekMessage)
-    ///   but before the message is removed from the queue. The peeked message is passed in
-    ///   the <paramref name="pMsgPeeked"/> param (null if no message is in the queue).
-    ///  </para>
-    ///  <para>
-    ///   This method may be additionally called when the next message has already been removed
-    ///   from the queue, in which case <paramref name="pMsgPeeked"/> is passed as null.
-    ///  </para>
-    /// </remarks>
-    /// <param name="uReason">
-    ///  Reason that was passed to <see cref="IMsoComponentManager.FPushMessageLoop"/>.
-    /// </param>
-    /// <param name="pvLoopData">
-    ///  Component private data passed to <see cref="IMsoComponentManager.FPushMessageLoop"/>.
-    /// </param>
-    /// <returns>
-    ///  <para>
-    ///   <see cref="BOOL.TRUE"/> if the message loop should continue, <see cref="BOOL.FALSE"/> otherwise.
-    ///  </para>
-    ///  <para>
-    ///   If <see cref="BOOL.FALSE"/> is returned, the component manager terminates the
-    ///   loop without removing <paramref name="pMsgPeeked"/> from the queue.
-    ///  </para>
-    /// </returns>
-    [PreserveSig]
-    BOOL FContinueMessageLoop(
-        msoloop uReason,
-        void* pvLoopData,
-        MSG* pMsgPeeked);
+        /// <summary>
+        ///  Give component a chance to process <paramref name="msg"/> before it is translated
+        ///  and dispatched. Component can modify <paramref name="msg"/>, call Win32 APIs such
+        ///  as TranslateAccelerator or IsDialogMessage, or take some other action.
+        /// </summary>
+        /// <returns>
+        ///  Return <see cref="BOOL.TRUE"/> if the message is consumed,
+        ///  <see cref="BOOL.FALSE"/> otherwise.
+        /// </returns>
+        [PreserveSig]
+        BOOL FPreTranslateMessage(MSG* msg);
 
-    /// <summary>
-    ///  Called when component manager wishes to know if the component is in a
-    ///  state in which it can terminate.
-    /// </summary>
-    /// <remarks>
-    ///  <para>
-    ///   If <paramref name="fPromptUser"/> is FALSE, component should simply return
-    ///   TRUE if it can terminate, FALSE otherwise.
-    ///  </para>
-    ///  <para>
-    ///   If <paramref name="fPromptUser"/> is TRUE, component should return TRUE if
-    ///   it can terminate without prompting the user; otherwise it should prompt the
-    ///   user, either 1.) asking user if it can terminate and returning TRUE or FALSE
-    ///   appropriately, or 2.) giving an indication as to why it cannot terminate and
-    ///   returning FALSE.
-    ///  </para>
-    /// </remarks>
-    [PreserveSig]
-    BOOL FQueryTerminate(
-        BOOL fPromptUser);
+        /// <summary>
+        ///  Notify component when app enters or exits (as indicated by <paramref name="fEnter"/>)
+        ///  the state identified by <paramref name="uStateID"/>. Component should take action
+        ///  depending on value of <paramref name="uStateID"/> (see olecstate comments, above).
+        /// </summary>
+        /// <remarks>
+        ///  <para>
+        ///   Note: If n calls are made with TRUE <paramref name="fEnter"/>, component should consider
+        ///   the state to be in effect until n calls are made with FALSE <paramref name="fEnter"/>.
+        ///  </para>
+        ///  <para>
+        ///   Note: Components should be aware that it is possible for this method to be called
+        ///   with FALSE <paramref name="fEnter"/> more times than it was called with TRUE
+        ///   <paramref name="fEnter"/> (so, for example, if component is maintaining a state counter
+        ///   incremented when this method is called with BOOL.TRUE <paramref name="fEnter"/>,
+        ///   decremented when called with FALSE <paramref name="fEnter"/>), the counter should not
+        ///   be decremented for FALSE <paramref name="fEnter"/> if it is already at zero.)
+        ///  </para>
+        /// </remarks>
+        [PreserveSig]
+        void OnEnterState(
+            msocstate uStateID,
+            BOOL fEnter);
 
-    /// <summary>
-    ///  Called when component manager wishes to terminate the component's registration.
-    /// </summary>
-    /// <remarks>
-    ///  <para>
-    ///   Component should revoke its registration with component manager, release
-    ///   references to component manager and perform any necessary cleanup.
-    ///  </para>
-    /// </remarks>
-    [PreserveSig]
-    void Terminate();
+        /// <summary>
+        ///  Notify component when the host application gains or loses activation.
+        /// </summary>
+        /// <remarks>
+        ///  <para>
+        ///   Note: this method is not called when both the window being activated and the one being
+        ///   deactivated belong to the host app.
+        ///  </para>
+        /// </remarks>
+        /// <param name="fActive">
+        ///  If <see cref="BOOL.TRUE"/>, the host app is being activated and <paramref name="dwOtherThreadID"/>
+        ///  is the ID of the thread owning the window being deactivated.
+        ///
+        ///  If <see cref="BOOL.FALSE"/>, the host app is being deactivated and <paramref name="dwOtherThreadID"/>
+        ///  is the ID of the thread owning the window being activated.
+        /// </param>
+        [PreserveSig]
+        void OnAppActivate(
+            BOOL fActive,
+            uint dwOtherThreadID);
 
-    /// <summary>
-    ///  Called to retrieve a window associated with the component, as specified
-    ///  by <paramref name="dwWhich"/>.
-    /// </summary>
-    /// <returns>
-    ///  Desired window or null if no such window exists.
-    /// </returns>
-    /// <param name="dwReserved">Reserved for future use and should be zero.</param>
-    [PreserveSig]
-    IntPtr HwndGetWindow(
-        msocWindow dwWhich,
-        uint dwReserved);
+        /// <summary>
+        ///  Notify the active component that it has lost its active status because the host or
+        ///  another component has become active.
+        /// </summary>
+        [PreserveSig]
+        void OnLoseActivation();
+
+        /// <summary>
+        ///  Notify component when a new object is being activated.
+        /// </summary>
+        /// <remarks>
+        ///  <para>
+        ///   If <paramref name="pic"/> is being activated and <paramref name="pcrinfo"/>
+        ///   <see cref="MSOCRINFO.grfcrf"/> has the <see cref="msocrf.ExclusiveBorderSpace"/>
+        ///   bit set, component should hide its border space tools (toolbars, status bars, etc.);
+        ///   component should also do this if host is activating and <paramref name="pchostinfo"/>
+        ///   has the <see cref="msocrf.ExclusiveBorderSpace"/> bit set. In either of these cases,
+        ///   component should unhide its border space tools the next time it is activated.
+        ///  </para>
+        ///  <para>
+        ///   If <paramref name="pic"/> is being activated and <paramref name="pcrinfo"/>
+        ///   <see cref="MSOCRINFO.grfcrf"/> has the <see cref="msocrf.ExclusiveActivation"/>
+        ///   bit set, then <paramref name="pic"/> is being activated in "ExclusiveActive" mode.
+        ///   Component should retrieve the top frame window that is hosting <paramref name="pic"/>
+        ///   (via <see cref="HwndGetWindow"/> with <see cref="msocWindow.FrameToplevel"/>).
+        ///  </para>
+        ///  <para>
+        ///   If this window is different from component's own top frame window, component should
+        ///   disable its windows and do other things it would do when receiving
+        ///   <see cref="OnEnterState"/> with <see cref="msocstate.Modal" /> notification.
+        ///  </para>
+        ///  <para>
+        ///   Otherwise, if component is top-level, it should refuse to have its window activated
+        ///   by appropriately processing WM_MOUSEACTIVATE (but see WM_MOUSEACTIVATE NOTE, above).
+        ///   Component should remain in one of these states until the exclusive active mode ends,
+        ///   indicated by a future call to <see cref="OnActivationChange"/> with
+        ///   <see cref="msocrf.ExclusiveActivation" /> bit not set or with null
+        ///   <paramref name="pcrinfo"/>.
+        ///  </para>
+        /// </remarks>
+        /// <param name="pic">
+        ///  <para>
+        ///   If non-null, then it is the component that is being activated. In this case,
+        ///   <paramref name="fSameComponent"/> is TRUE if <paramref name="pic"/> is the same
+        ///   component as the callee of this method, and <paramref name="pcrinfo"/> is the
+        ///   reg info of <paramref name="pic"/>.
+        ///  </para>
+        ///  <para>
+        ///   If null and <paramref name="fHostIsActivating"/> is TRUE, then the host is the
+        ///   object being activated, and <paramref name="pchostinfo"/> is its host info.
+        ///  </para>
+        ///  <para>
+        ///   If null and <paramref name="fHostIsActivating"/> is FALSE, then there is no
+        ///   current active object.
+        ///  </para>
+        /// </param>
+        [PreserveSig]
+        void OnActivationChange(
+            IMsoComponent* pic,
+            BOOL fSameComponent,
+            MSOCRINFO* pcrinfo,
+            BOOL fHostIsActivating,
+            nint pchostinfo,
+            uint dwReserved);
+
+        /// <summary>
+        ///  Give component a chance to do idle time tasks.  grfidlef is a group of
+        ///  bit flags taken from the enumeration of <see cref="msoidlef"/> values,
+        ///  indicating the type of idle tasks to perform.
+        /// </summary>
+        /// <remarks>
+        ///  <para>
+        ///   Component may periodically call <see cref="IMsoComponentManager.FContinueIdle"/>;
+        ///   if this method returns FALSE, component should terminate its idle time
+        ///   processing and return.
+        ///  </para>
+        ///  <para>
+        ///   Note: If a component reaches a point where it has no idle tasks and does not
+        ///   need <see cref="FDoIdle"/> calls, it should remove its idle task registration
+        ///   via <see cref="IMsoComponentManager.FUpdateComponentRegistration"/>.
+        ///  </para>
+        ///  <para>
+        ///   Note: If this method is called on while component is performing a tracking
+        ///   operation, component should only perform idle time tasks that it deems are
+        ///   appropriate to perform during tracking.
+        ///  </para>
+        /// </remarks>
+        /// <returns>
+        ///  <see cref="BOOL.TRUE"/> if more time is needed to perform the idle time tasks,
+        ///  <see cref="BOOL.FALSE"/> otherwise.
+        /// </returns>
+        [PreserveSig]
+        BOOL FDoIdle(
+            msoidlef grfidlef);
+
+        /// <summary>
+        ///  Called during each iteration of a message loop that the component pushed.
+        /// </summary>
+        /// <remarks>
+        ///  <para>
+        ///   This method is called after peeking the next message in the queue (via PeekMessage)
+        ///   but before the message is removed from the queue. The peeked message is passed in
+        ///   the <paramref name="pMsgPeeked"/> param (null if no message is in the queue).
+        ///  </para>
+        ///  <para>
+        ///   This method may be additionally called when the next message has already been removed
+        ///   from the queue, in which case <paramref name="pMsgPeeked"/> is passed as null.
+        ///  </para>
+        /// </remarks>
+        /// <param name="uReason">
+        ///  Reason that was passed to <see cref="IMsoComponentManager.FPushMessageLoop"/>.
+        /// </param>
+        /// <param name="pvLoopData">
+        ///  Component private data passed to <see cref="IMsoComponentManager.FPushMessageLoop"/>.
+        /// </param>
+        /// <returns>
+        ///  <para>
+        ///   <see cref="BOOL.TRUE"/> if the message loop should continue, <see cref="BOOL.FALSE"/> otherwise.
+        ///  </para>
+        ///  <para>
+        ///   If <see cref="BOOL.FALSE"/> is returned, the component manager terminates the
+        ///   loop without removing <paramref name="pMsgPeeked"/> from the queue.
+        ///  </para>
+        /// </returns>
+        [PreserveSig]
+        BOOL FContinueMessageLoop(
+            msoloop uReason,
+            void* pvLoopData,
+            MSG* pMsgPeeked);
+
+        /// <summary>
+        ///  Called when component manager wishes to know if the component is in a
+        ///  state in which it can terminate.
+        /// </summary>
+        /// <remarks>
+        ///  <para>
+        ///   If <paramref name="fPromptUser"/> is FALSE, component should simply return
+        ///   TRUE if it can terminate, FALSE otherwise.
+        ///  </para>
+        ///  <para>
+        ///   If <paramref name="fPromptUser"/> is TRUE, component should return TRUE if
+        ///   it can terminate without prompting the user; otherwise it should prompt the
+        ///   user, either 1.) asking user if it can terminate and returning TRUE or FALSE
+        ///   appropriately, or 2.) giving an indication as to why it cannot terminate and
+        ///   returning FALSE.
+        ///  </para>
+        /// </remarks>
+        [PreserveSig]
+        BOOL FQueryTerminate(
+            BOOL fPromptUser);
+
+        /// <summary>
+        ///  Called when component manager wishes to terminate the component's registration.
+        /// </summary>
+        /// <remarks>
+        ///  <para>
+        ///   Component should revoke its registration with component manager, release
+        ///   references to component manager and perform any necessary cleanup.
+        ///  </para>
+        /// </remarks>
+        [PreserveSig]
+        void Terminate();
+
+        /// <summary>
+        ///  Called to retrieve a window associated with the component, as specified
+        ///  by <paramref name="dwWhich"/>.
+        /// </summary>
+        /// <returns>
+        ///  Desired window or null if no such window exists.
+        /// </returns>
+        /// <param name="dwReserved">Reserved for future use and should be zero.</param>
+        [PreserveSig]
+        HWND HwndGetWindow(
+            msocWindow dwWhich,
+            uint dwReserved);
+    }
 }

--- a/src/System.Windows.Forms.Primitives/src/Microsoft/Office/IMsoComponentManager.NativeAdapter.cs
+++ b/src/System.Windows.Forms.Primitives/src/Microsoft/Office/IMsoComponentManager.NativeAdapter.cs
@@ -1,0 +1,123 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Windows.Win32.System.Com;
+
+namespace Microsoft.Office;
+
+internal unsafe partial struct IMsoComponentManager
+{
+    internal unsafe class NativeAdapter : Interface, IDisposable
+    {
+        private AgileComPointer<IMsoComponentManager>? _manager;
+        public NativeAdapter(IMsoComponentManager* manager) => _manager =
+#if DEBUG
+            new(manager, takeOwnership: true, trackDisposal: false);
+#else
+            new(manager, takeOwnership: true);
+#endif
+
+        public void Dispose() => DisposeHelper.NullAndDispose(ref _manager);
+
+        HRESULT Interface.QueryService(Guid* guidService, Guid* iid, void** ppvObj)
+        {
+            using var manager = _manager!.GetInterface();
+            return manager.Value->QueryService(guidService, iid, ppvObj);
+        }
+
+        BOOL Interface.FDebugMessage(nint dwReserved, uint msg, WPARAM wParam, LPARAM lParam)
+        {
+            using var manager = _manager!.GetInterface();
+            return manager.Value->FDebugMessage(dwReserved, msg, wParam, lParam);
+        }
+
+        BOOL Interface.FRegisterComponent(IMsoComponent* piComponent, MSOCRINFO* pcrinfo, nuint* dwComponentID)
+        {
+            using var manager = _manager!.GetInterface();
+            return manager.Value->FRegisterComponent(piComponent, pcrinfo, dwComponentID);
+        }
+
+        BOOL Interface.FRevokeComponent(nuint dwComponentID)
+        {
+            using var manager = _manager!.GetInterface();
+            return manager.Value->FRevokeComponent(dwComponentID);
+        }
+
+        BOOL Interface.FUpdateComponentRegistration(nuint dwComponentID, MSOCRINFO* pcrinfo)
+        {
+            using var manager = _manager!.GetInterface();
+            return manager.Value->FUpdateComponentRegistration(dwComponentID, pcrinfo);
+        }
+
+        BOOL Interface.FOnComponentActivate(nuint dwComponentID)
+        {
+            using var manager = _manager!.GetInterface();
+            return manager.Value->FOnComponentActivate(dwComponentID);
+        }
+
+        BOOL Interface.FSetTrackingComponent(nuint dwComponentID, BOOL fTrack)
+        {
+            using var manager = _manager!.GetInterface();
+            return manager.Value->FSetTrackingComponent(dwComponentID, fTrack);
+        }
+
+        void Interface.OnComponentEnterState(
+            nuint dwComponentID,
+            msocstate uStateID,
+            msoccontext uContext,
+            uint cpicmExclude,
+            IMsoComponentManager** rgpicmExclude,
+            uint dwReserved)
+        {
+            using var manager = _manager!.GetInterface();
+            manager.Value->OnComponentEnterState(dwComponentID, uStateID, uContext, cpicmExclude, rgpicmExclude, dwReserved);
+        }
+
+        BOOL Interface.FOnComponentExitState(
+            nuint dwComponentID,
+            msocstate uStateID,
+            msoccontext uContext,
+            uint cpicmExclude,
+            IMsoComponentManager** rgpicmExclude)
+        {
+            using var manager = _manager!.GetInterface();
+            return manager.Value->FOnComponentExitState(dwComponentID, uStateID, uContext, cpicmExclude, rgpicmExclude);
+        }
+
+        BOOL Interface.FInState(msocstate uStateID, void* pvoid)
+        {
+            using var manager = _manager!.GetInterface();
+            return manager.Value->FInState(uStateID, pvoid);
+        }
+
+        BOOL Interface.FContinueIdle()
+        {
+            using var manager = _manager!.GetInterface();
+            return manager.Value->FContinueIdle();
+        }
+
+        BOOL Interface.FPushMessageLoop(nuint dwComponentID, msoloop uReason, void* pvLoopData)
+        {
+            using var manager = _manager!.GetInterface();
+            return manager.Value->FPushMessageLoop(dwComponentID, uReason, pvLoopData);
+        }
+
+        BOOL Interface.FCreateSubComponentManager(IUnknown* punkOuter, IUnknown* punkServProv, Guid* riid, void** ppvObj)
+        {
+            using var manager = _manager!.GetInterface();
+            return manager.Value->FCreateSubComponentManager(punkOuter, punkServProv, riid, ppvObj);
+        }
+
+        BOOL Interface.FGetParentComponentManager(IMsoComponentManager** ppicm)
+        {
+            using var manager = _manager!.GetInterface();
+            return manager.Value->FGetParentComponentManager(ppicm);
+        }
+
+        BOOL Interface.FGetActiveComponent(msogac dwgac, IMsoComponent** ppic, MSOCRINFO* pcrinfo, uint dwReserved)
+        {
+            using var manager = _manager!.GetInterface();
+            return manager.Value->FGetActiveComponent(dwgac, ppic, pcrinfo, dwReserved);
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/Microsoft/Office/IMsoComponentManager.cs
+++ b/src/System.Windows.Forms.Primitives/src/Microsoft/Office/IMsoComponentManager.cs
@@ -1,354 +1,533 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Windows.Win32.System.Ole;
+using Windows.Win32.System.Com;
 
 namespace Microsoft.Office;
 
-/// <summary>
-///  Defines a component manager, which is an object that coordinates other components by using its message loop for
-///  message processing and allocation of idle time.
-/// </summary>
-/// <remarks>
-///  <para>
-///   ** Comments on State Contexts **
-///  </para>
-///  <para>
-///   <see cref="FCreateSubComponentManager"/> allows one to create a hierarchical tree of component managers.
-///   This tree is used to maintain multiple contexts with regard to <see cref="msocstate"/> states. These
-///   contexts are referred to as 'state contexts'. Each component manager in the tree defines a state context.
-///   The components registered with a particular component manager or any of its descendents live within that
-///   component manager's state context.
-///  </para>
-///  <para>
-///   Calls to <see cref="OnComponentEnterState"/> and <see cref="FOnComponentExitState"/> can be used to affect
-///   all components, only components within the component manager's state context, or only those components
-///   that are outside of the component manager's state context. <see cref="FInState"/> is used to query the
-///   state of the component manager's state context at its root.
-///  </para>
-///  <para>
-///   <see href="https://learn.microsoft.com/previous-versions/office/developer/office-2007/ff518963(v=office.12)">Microsoft documentation</see>
-///  </para>
-/// </remarks>
-[ComImport]
-[Guid(MsoComponentIds.IID_IMsoComponentManager)]
-[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-internal unsafe interface IMsoComponentManager
+/// <inheritdoc cref="Interface"/>
+internal unsafe partial struct IMsoComponentManager : IComIID
 {
-    /// <summary>
-    ///  Returns in <paramref name="ppvObj"/> an implementation of interface <paramref name="iid"/>
-    ///  for service <paramref name="guidService"/> (same as IServiceProvider::QueryService).
-    /// </summary>
-    /// <param name="ppvObj">The queried interface or null if failed.</param>
-    /// <returns>
-    ///  NOERROR if the requested service is supported, otherwise appropriate error such
-    ///  as E_FAIL, E_NOINTERFACE.
-    /// </returns>
-    [PreserveSig]
-    HRESULT QueryService(
-        Guid* guidService,
-        Guid* iid,
-        void** ppvObj);
+    // 000C0601-0000-0000-C000-000000000046
+    internal static readonly Guid Guid = new(0x000C0601, 0x0000, 0x0000, 0xC0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46);
 
-    /// <summary>
-    ///  Standard <see cref="FDebugMessage"/> method.
-    /// </summary>
-    /// <remarks>
-    ///  <para>
-    ///   This method is reserved for internal use and is not intended to be used in your code.
-    ///  </para>
-    /// </remarks>
-    /// <returns><see cref="BOOL.TRUE"/></returns>
-    [PreserveSig]
-    BOOL FDebugMessage(
-        nint dwReserved,
-        uint msg,
-        WPARAM wParam,
-        LPARAM lParam);
+    static ref readonly Guid IComIID.Guid
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            ReadOnlySpan<byte> data =
+            [
+                0x01, 0x06, 0xc0, 0x00,
+                0x00, 0x00,
+                0x00, 0x00,
+                0xc0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46
+            ];
 
-    /// <summary>
-    ///  Register component <paramref name="piComponent"/> and its registration info
-    ///  <paramref name="pcrinfo"/> with this component manager.
-    /// </summary>
-    /// <param name="dwComponentID">
-    ///  Returns a cookie which will identify the component when it calls other
-    ///  <see cref="IMsoComponentManager"/> methods.
-    /// </param>
-    /// <returns><see cref="BOOL.TRUE"/> if successful.</returns>
-    [PreserveSig]
-    BOOL FRegisterComponent(
-        IMsoComponent piComponent,
-        MSOCRINFO* pcrinfo,
-        nuint* dwComponentID);
+            return ref Unsafe.As<byte, Guid>(ref MemoryMarshal.GetReference(data));
+        }
+    }
 
-    /// <summary>
-    ///  Undo the registration of the component identified by <paramref name="dwComponentID"/>
-    ///  (the cookie returned from the <see cref="FRegisterComponent"/> method).
-    /// </summary>
-    /// <returns><see cref="BOOL.TRUE"/> if successful.</returns>
-    [PreserveSig]
-    BOOL FRevokeComponent(nuint dwComponentID);
+    private readonly void** _lpVtbl;
 
-    /// <summary>
-    ///  Update the registration info of the component identified by <paramref name="dwComponentID"/>
-    ///  (the cookie returned from <see cref="FRegisterComponent"/>) with the new registration
-    ///  information <paramref name="pcrinfo"/>.
-    /// </summary>
-    /// <remarks>
-    ///  <para>
-    ///   Typically this is used to update the idle time registration data, but it can be used to
-    ///   update other registration data as well.
-    ///  </para>
-    /// </remarks>
-    /// <returns><see cref="BOOL.TRUE"/> if successful.</returns>
-    [PreserveSig]
-    BOOL FUpdateComponentRegistration(
-        nuint dwComponentID,
-        MSOCRINFO* pcrinfo);
+    /// <inheritdoc cref="IUnknown.QueryInterface(Guid*, void**)"/>
+    public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+    {
+        fixed (IMsoComponentManager* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IMsoComponentManager*, Guid*, void**, HRESULT>)_lpVtbl[0])(pThis, riid, ppvObject);
+    }
 
-    /// <summary>
-    ///  Notify component manager that component identified by <paramref name="dwComponentID"/>
-    ///  (cookie returned from <see cref="FRegisterComponent"/>) has been activated.
-    /// </summary>
-    /// <remarks>
-    ///  <para>
-    ///   The active component gets the chance to process messages before they are dispatched
-    ///   (via <see cref="IMsoComponent.FPreTranslateMessage"/> and typically gets first chance
-    ///   at idle time after the host.
-    ///  </para>
-    ///  <para>
-    ///   This method fails if another component is already exclusively active. In this case,
-    ///   <see cref="BOOL.FALSE"/> is returned and SetLastError is set to msoerrACompIsXActive
-    ///   (comp usually need not take any special action in this case).
-    ///  </para>
-    /// </remarks>
-    /// <returns><see cref="BOOL.TRUE"/> if successful.</returns>
-    [PreserveSig]
-    BOOL FOnComponentActivate(nuint dwComponentID);
+    /// <inheritdoc cref="IUnknown.AddRef"/>
+    public uint AddRef()
+    {
+        fixed (IMsoComponentManager* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IMsoComponentManager*, uint>)_lpVtbl[1])(pThis);
+    }
 
-    /// <summary>
-    ///  Called to inform component manager that component identified by <paramref name="dwComponentID"/>
-    ///  (cookie returned from <see cref="FRegisterComponent"/>) wishes to perform a tracking operation
-    ///  (such as mouse tracking).
-    /// </summary>
-    /// <remarks>
-    ///  <para>
-    ///   During the tracking operation the component manager routes messages to the tracking component
-    ///   (via <see cref="IMsoComponent.FPreTranslateMessage"/>) rather than to the active component.
-    ///   When the tracking operation ends, the component manager should resume routing messages to the active
-    ///   component.
-    ///  </para>
-    ///  <para>
-    ///   Note: component manager should perform no idle time processing during a tracking operation other
-    ///   than give the tracking component idle time via <see cref="IMsoComponent.FDoIdle"/>.
-    ///  </para>
-    ///  <para>
-    ///   Note: there can only be one tracking component at a time.
-    ///  </para>
-    /// </remarks>
-    /// <param name="fTrack">
-    ///  <see cref="BOOL.TRUE"/> to begin tracking operation. <see cref="BOOL.FALSE"/>
-    ///  to end the operation.
-    /// </param>
-    /// <returns><see cref="BOOL.TRUE"/> if successful.</returns>
-    [PreserveSig]
-    BOOL FSetTrackingComponent(
-        nuint dwComponentID,
-        BOOL fTrack);
+    /// <inheritdoc cref="IUnknown.Release"/>
+    public uint Release()
+    {
+        fixed (IMsoComponentManager* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IMsoComponentManager*, uint>)_lpVtbl[2])(pThis);
+    }
 
-    /// <summary>
-    ///  Notify component manager that component identified by <paramref name="dwComponentID"/>
-    ///  (cookie returned from <see cref="FRegisterComponent"/>) is entering the state identified
-    ///  by <paramref name="uStateID"/>. (For convenience when dealing with sub CompMgrs, the host
-    ///  can call this method passing 0 for <paramref name="dwComponentID"/>.
-    /// </summary>
-    /// <remarks>
-    ///  <para>
-    ///   Component manager should notify all other interested components within the state context
-    ///   indicated by <paramref name="uContext"/>, excluding those within the state context of a
-    ///   component manager in <paramref name="rgpicmExclude"/>, via
-    ///   <see cref="IMsoComponent.OnEnterState"/> (see "Comments on State Contexts" in
-    ///   <see cref="IMsoComponentManager"/> remarks).
-    ///  </para>
-    ///  <para>
-    ///   Component Manager should also take appropriate action depending on the value of
-    ///   <paramref name="uStateID"/>.
-    ///  </para>
-    ///  <para>
-    ///   Note: Calls to this method are symmetric with calls to <see cref="FOnComponentExitState" />
-    ///   That is, if n <see cref="OnComponentEnterState"/> calls are made, the component is
-    ///   considered to be in the state until n <see cref="FOnComponentExitState" /> calls are
-    ///   made.  Before revoking its registration a component must make a sufficient number of
-    ///   <see cref="FOnComponentExitState" /> calls to offset any outstanding
-    ///   <see cref="OnComponentEnterState"/> calls it has made.
-    ///  </para>
-    ///  <para>
-    ///   Note: inplace objects should not call this method with <paramref name="uStateID" />
-    ///   of <see cref="msocstate.Modal"/> when entering modal state. Such objects should call
-    ///   <see cref="IOleInPlaceFrame.EnableModeless(BOOL)"/> instead.
-    ///  </para>
-    /// </remarks>
-    /// <param name="dwReserved">Reserved for future use. Should be zero.</param>
-    /// <param name="cpicmExclude">Count of items in <paramref name="rgpicmExclude"/>.</param>
-    /// <param name="rgpicmExclude">
-    ///  Can be null. An array of component managers (can include root component manager and/or
-    ///  sub component managers). Components within the state context of a component manager
-    ///  appearing in this array should NOT be notified of the state change (note: if
-    ///  <paramref name="uContext"/> is <see cref="msoccontext.Mine"/>, the only component
-    ///  managers in <paramref name="rgpicmExclude"/> that are checked for exclusion are those that
-    ///  are sub component managers of this component manager, since all other component
-    ///  managers are outside of this component manager's state context anyway.)
-    /// </param>
-    [PreserveSig]
-    void OnComponentEnterState(
+    /// <inheritdoc cref="Interface.QueryService(Guid*, Guid*, void**)"/>
+    public HRESULT QueryService(Guid* guidService, Guid* iid, void** ppvObj)
+    {
+        fixed (IMsoComponentManager* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IMsoComponentManager*, Guid*, Guid*, void**, HRESULT>)_lpVtbl[3])
+                (pThis, guidService, iid, ppvObj);
+    }
+
+    /// <inheritdoc cref="Interface.FDebugMessage(nint, uint, WPARAM, LPARAM)"/>
+    public BOOL FDebugMessage(nint dwReserved, uint msg, WPARAM wParam, LPARAM lParam)
+    {
+        fixed (IMsoComponentManager* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IMsoComponentManager*, nint, uint, WPARAM, LPARAM, BOOL>)_lpVtbl[4])
+                (pThis, dwReserved, msg, wParam, lParam);
+    }
+
+    /// <inheritdoc cref="Interface.FRegisterComponent(IMsoComponent*, MSOCRINFO*, nuint*)"/>
+    public BOOL FRegisterComponent(IMsoComponent* piComponent, MSOCRINFO* pcrinfo, nuint* dwComponentID)
+    {
+        fixed (IMsoComponentManager* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IMsoComponentManager*, IMsoComponent*, MSOCRINFO*, nuint*, BOOL>)_lpVtbl[5])
+                (pThis, piComponent, pcrinfo, dwComponentID);
+    }
+
+    /// <inheritdoc cref="Interface.FRevokeComponent(nuint)"/>
+    public BOOL FRevokeComponent(nuint dwComponentID)
+    {
+        fixed (IMsoComponentManager* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IMsoComponentManager*, nuint, BOOL>)_lpVtbl[6])
+                (pThis, dwComponentID);
+    }
+
+    /// <inheritdoc cref="Interface.FUpdateComponentRegistration(nuint, MSOCRINFO*)"/>
+    public BOOL FUpdateComponentRegistration(nuint dwComponentID, MSOCRINFO* pcrinfo)
+    {
+        fixed (IMsoComponentManager* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IMsoComponentManager*, nuint, MSOCRINFO*, BOOL>)_lpVtbl[7])
+                (pThis, dwComponentID, pcrinfo);
+    }
+
+    /// <inheritdoc cref="Interface.FOnComponentActivate(nuint)"/>
+    public BOOL FOnComponentActivate(nuint dwComponentID)
+    {
+        fixed (IMsoComponentManager* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IMsoComponentManager*, nuint, BOOL>)_lpVtbl[8])
+                (pThis, dwComponentID);
+    }
+
+    /// <inheritdoc cref="Interface.FSetTrackingComponent(nuint, BOOL)"/>
+    public BOOL FSetTrackingComponent(nuint dwComponentID, BOOL fTrack)
+    {
+        fixed (IMsoComponentManager* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IMsoComponentManager*, nuint, BOOL, BOOL>)_lpVtbl[9])
+                (pThis, dwComponentID, fTrack);
+    }
+
+    /// <inheritdoc cref="Interface.OnComponentEnterState(nuint, msocstate, msoccontext, uint, IMsoComponentManager**, uint)"/>
+    public void OnComponentEnterState(
         nuint dwComponentID,
         msocstate uStateID,
         msoccontext uContext,
         uint cpicmExclude,
-        /* IMsoComponentManager */ void** rgpicmExclude,
-        uint dwReserved);
+        IMsoComponentManager** rgpicmExclude,
+        uint dwReserved)
+    {
+        fixed (IMsoComponentManager* pThis = &this)
+            ((delegate* unmanaged[Stdcall]<IMsoComponentManager*, nuint, msocstate, msoccontext, uint, IMsoComponentManager**, uint, void>)_lpVtbl[10])
+                (pThis, dwComponentID, uStateID, uContext, cpicmExclude, rgpicmExclude, dwReserved);
+    }
 
-    /// <summary>
-    ///  Notify component manager that component identified by <paramref name="dwComponentID"/>
-    ///  (cookie returned from <see cref="FRegisterComponent"/>) is exiting the state identified by
-    ///  <paramref name="uStateID"/>. For convenience when dealing with sub component managers, the
-    ///  host can call this method passing 0 for <paramref name="dwComponentID"/>.
-    /// </summary>
-    /// <remarks>
-    ///  <para>
-    ///   <paramref name="uContext"/>, <paramref name="cpicmExclude"/>, and <paramref name="rgpicmExclude"/>
-    ///   are as they are in <see cref="OnComponentEnterState"/>.
-    ///  </para>
-    ///  <para>
-    ///   Component manager should notify all appropriate interested components (taking into account
-    ///   <paramref name="uContext"/>, <paramref name="cpicmExclude"/>, <paramref name="rgpicmExclude"/>)
-    ///   via <see cref="IMsoComponent.OnEnterState"/> (see "Comments on State Contexts", above).
-    ///  </para>
-    ///  <para>
-    ///   Component manager should also take appropriate action depending on the value of <paramref name="uStateID"/>.
-    ///  </para>
-    ///  <para>
-    ///   Note: n calls to this method are symmetric with n calls to <see cref="OnComponentEnterState"/>.
-    ///  </para>
-    /// </remarks>
-    /// <returns>
-    ///  <para>
-    ///   <see cref="BOOL.TRUE"/> if, at the end of this call, the state is still in effect at the root
-    ///   of this component manager's state context (because the host or some other component is still in the state),
-    ///   otherwise return <see cref="BOOL.FALSE"/> (ie. return what <see cref="FInState"/> would return).
-    ///  </para>
-    ///  <para>
-    ///   Callers can normally ignore the return value.
-    ///  </para>
-    /// </returns>
-    [PreserveSig]
-    BOOL FOnComponentExitState(
+    /// <inheritdoc cref="Interface.FOnComponentExitState(nuint, msocstate, msoccontext, uint, IMsoComponentManager**)"/>
+    public BOOL FOnComponentExitState(
         nuint dwComponentID,
         msocstate uStateID,
         msoccontext uContext,
         uint cpicmExclude,
-        /* IMsoComponentManager */ void** rgpicmExclude);
+        IMsoComponentManager** rgpicmExclude)
+    {
+        fixed (IMsoComponentManager* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IMsoComponentManager*, nuint, msocstate, msoccontext, uint, IMsoComponentManager**, BOOL>)_lpVtbl[11])
+                (pThis, dwComponentID, uStateID, uContext, cpicmExclude, rgpicmExclude);
+    }
+
+    /// <inheritdoc cref="Interface.FInState(msocstate, void*)"/>
+    public BOOL FInState(msocstate uStateID, void* pvoid)
+    {
+        fixed (IMsoComponentManager* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IMsoComponentManager*, msocstate, void*, BOOL>)_lpVtbl[12])
+                (pThis, uStateID, pvoid);
+    }
+
+    /// <inheritdoc cref="Interface.FContinueIdle"/>
+    public BOOL FContinueIdle()
+    {
+        fixed (IMsoComponentManager* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IMsoComponentManager*, BOOL>)_lpVtbl[13])(pThis);
+    }
+
+    /// <inheritdoc cref="Interface.FPushMessageLoop(nuint, msoloop, void*)"/>
+    public BOOL FPushMessageLoop(nuint dwComponentID, msoloop uReason, void* pvLoopData)
+    {
+        fixed (IMsoComponentManager* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IMsoComponentManager*, nuint, msoloop, void*, BOOL>)_lpVtbl[14])
+                (pThis, dwComponentID, uReason, pvLoopData);
+    }
+
+    /// <inheritdoc cref="Interface.FCreateSubComponentManager(IUnknown*, IUnknown*, Guid*, void**)"/>
+    public BOOL FCreateSubComponentManager(IUnknown* punkOuter, IUnknown* punkServProv, Guid* riid, void** ppvObj)
+    {
+        fixed (IMsoComponentManager* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IMsoComponentManager*, IUnknown*, IUnknown*, Guid*, void**, BOOL>)_lpVtbl[15])
+                (pThis, punkOuter, punkServProv, riid, ppvObj);
+    }
+
+    /// <inheritdoc cref="Interface.FGetParentComponentManager(IMsoComponentManager**)"/>
+    public BOOL FGetParentComponentManager(IMsoComponentManager** ppicm)
+    {
+        fixed (IMsoComponentManager* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IMsoComponentManager*, IMsoComponentManager**, BOOL>)_lpVtbl[16])
+                (pThis, ppicm);
+    }
+
+    /// <inheritdoc cref="Interface.FGetActiveComponent(msogac, IMsoComponent**, MSOCRINFO*, uint)"/>
+    public BOOL FGetActiveComponent(msogac dwgac, IMsoComponent** ppic, MSOCRINFO* pcrinfo, uint dwReserved)
+    {
+        fixed (IMsoComponentManager* pThis = &this)
+            return ((delegate* unmanaged[Stdcall]<IMsoComponentManager*, msogac, IMsoComponent**, MSOCRINFO*, uint, BOOL>)_lpVtbl[17])
+                (pThis, dwgac, ppic, pcrinfo, dwReserved);
+    }
 
     /// <summary>
-    ///  Return <see cref="BOOL.TRUE"/> if the state identified by <paramref name="uStateID"/>
-    ///  is in effect at the root of this component manager's state context, <see cref="BOOL.FALSE"/>
-    ///  otherwise (see "Comments on State Contexts" in <see cref="IMsoComponentManager"/> remarks).
-    /// </summary>
-    /// <param name="pvoid">Reserved for future use and should be <see langword="null" />.</param>
-    [PreserveSig]
-    BOOL FInState(
-        msocstate uStateID,
-        void* pvoid);
-
-    /// <summary>
-    ///  Called periodically by a component during <see cref="IMsoComponent.FDoIdle"/>.
-    /// </summary>
-    /// <returns>
-    ///  <see cref="BOOL.TRUE"/> if component can continue its idle time processing,
-    ///  <see cref="BOOL.FALSE"/> if not (in which case component returns from FDoIdle.)
-    /// </returns>
-    [PreserveSig]
-    BOOL FContinueIdle();
-
-    /// <summary>
-    ///  Component identified by <paramref name="dwComponentID"/> (cookie returned from <see cref="FRegisterComponent"/>)
-    ///  wishes to push a message loop for reason <paramref name="uReason"/>.
-    /// </summary>
-    /// <remarks>
-    ///  <para>
-    ///   The component manager should push its message loop, calling <see cref="IMsoComponent.FContinueMessageLoop"/>
-    ///   during each loop iteration. When <see cref="IMsoComponent.FContinueMessageLoop"/> returns <see cref="BOOL.FALSE"/>,
-    ///   the component manager terminates the loop.
-    ///  </para>
-    /// </remarks>
-    /// <param name="pvLoopData">Data private to the component.</param>
-    /// <returns>
-    ///  <see cref="BOOL.TRUE"/> if component manager terminates loop because component told it
-    ///  to (by returning <see cref="BOOL.FALSE"/> from <see cref="IMsoComponent.FContinueMessageLoop"/>),
-    ///  <see cref="BOOL.FALSE"/> if it had to terminate the loop for some other reason.  In the
-    ///  latter case, component should perform any necessary action (such as cleanup).
-    /// </returns>
-    [PreserveSig]
-    BOOL FPushMessageLoop(
-        nuint dwComponentID,
-        msoloop uReason,
-        void* pvLoopData);
-
-    /// <summary>
-    ///  Cause the component manager to create a "sub" component manager, which  will be one of its
-    ///  children in the hierarchical tree of component managers used to maintain state contexts
-    ///  (see "Comments on State Contexts" in <see cref="IMsoComponentManager"/> remarks).
-    /// </summary>
-    /// <param name="punkOuter">The controlling unknown. Can be null.</param>
-    /// <param name="riid">Desired interface identifier (IID).</param>
-    /// <param name="ppvObj">The created sub-component manager.</param>
-    /// <param name="punkServProv">
-    ///  IUnknown object that supports IServiceProvider that the sub component manager should
-    ///  delegate <see cref="QueryService" /> calls to. Can be null.
-    /// </param>
-    /// <returns><see cref="BOOL.TRUE"/> if successful.</returns>
-    [PreserveSig]
-    BOOL FCreateSubComponentManager(
-        IntPtr punkOuter,
-        IntPtr punkServProv,
-        Guid* riid,
-        void** ppvObj);
-
-    /// <summary>
-    ///  Return in <paramref name="ppicm"/> an AddRef'ed ptr to this component manager's parent
-    ///  in the hierarchical tree of component managers used to maintain state contexts (see
-    ///  "Comments on State Contexts" in <see cref="IMsoComponentManager"/> remarks).
-    /// </summary>
-    /// <returns>
-    ///  <see cref="BOOL.TRUE"/> if the parent is returned, <see cref="BOOL.FALSE"/>
-    ///  if no parent exists or some error occurred.
-    /// </returns>
-    [PreserveSig]
-    BOOL FGetParentComponentManager(
-        /* IMsoComponentManager */ void** ppicm);
-
-    /// <summary>
-    ///  Return in <paramref name="ppic"/> an AddRef'ed ptr to the current active
-    ///  or tracking component (as indicated by <paramref name="dwgac"/>, and its
-    ///  registration information in <paramref name="pcrinfo"/>.
+    ///  Defines a component manager, which is an object that coordinates other components by using its message loop for
+    ///  message processing and allocation of idle time.
     /// </summary>
     /// <remarks>
     ///  <para>
-    ///   <paramref name="ppic"/> and/or <paramref name="pcrinfo"/> can be NULL if caller is not interested these values.
-    ///   If <paramref name="pcrinfo"/> is not <see langword="null" /> caller should set <see cref="MSOCRINFO.cbSize"/>
-    ///   before calling this method.
+    ///   ** Comments on State Contexts **
+    ///  </para>
+    ///  <para>
+    ///   <see cref="FCreateSubComponentManager"/> allows one to create a hierarchical tree of component managers.
+    ///   This tree is used to maintain multiple contexts with regard to <see cref="msocstate"/> states. These
+    ///   contexts are referred to as 'state contexts'. Each component manager in the tree defines a state context.
+    ///   The components registered with a particular component manager or any of its descendents live within that
+    ///   component manager's state context.
+    ///  </para>
+    ///  <para>
+    ///   Calls to <see cref="OnComponentEnterState"/> and <see cref="FOnComponentExitState"/> can be used to affect
+    ///   all components, only components within the component manager's state context, or only those components
+    ///   that are outside of the component manager's state context. <see cref="FInState"/> is used to query the
+    ///   state of the component manager's state context at its root.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/previous-versions/office/developer/office-2007/ff518963(v=office.12)">Microsoft documentation</see>
     ///  </para>
     /// </remarks>
-    /// <param name="dwReserved">Reserved for future use and should be zero.</param>
-    /// <returns>
-    ///  <see cref="BOOL.TRUE"/> if the component indicated by <paramref name="dwgac"/>
-    ///  exists, <see cref="BOOL.FALSE"/> if no such component exists or some error occurred.
-    /// </returns>
-    [PreserveSig]
-    BOOL FGetActiveComponent(
-        msogac dwgac,
-        /* IMsoComponent */ void** ppic,
-        MSOCRINFO* pcrinfo,
-        uint dwReserved);
+    [ComImport]
+    [Guid(MsoComponentIds.IID_IMsoComponentManager)]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    internal unsafe interface Interface
+    {
+        /// <summary>
+        ///  Returns in <paramref name="ppvObj"/> an implementation of interface <paramref name="iid"/>
+        ///  for service <paramref name="guidService"/> (same as IServiceProvider::QueryService).
+        /// </summary>
+        /// <param name="ppvObj">The queried interface or null if failed.</param>
+        /// <returns>
+        ///  NOERROR if the requested service is supported, otherwise appropriate error such
+        ///  as E_FAIL, E_NOINTERFACE.
+        /// </returns>
+        [PreserveSig]
+        HRESULT QueryService(
+            Guid* guidService,
+            Guid* iid,
+            void** ppvObj);
+
+        /// <summary>
+        ///  Standard <see cref="FDebugMessage"/> method.
+        /// </summary>
+        /// <remarks>
+        ///  <para>
+        ///   This method is reserved for internal use and is not intended to be used in your code.
+        ///  </para>
+        /// </remarks>
+        /// <returns><see cref="BOOL.TRUE"/></returns>
+        [PreserveSig]
+        BOOL FDebugMessage(
+            nint dwReserved,
+            uint msg,
+            WPARAM wParam,
+            LPARAM lParam);
+
+        /// <summary>
+        ///  Register component <paramref name="piComponent"/> and its registration info
+        ///  <paramref name="pcrinfo"/> with this component manager.
+        /// </summary>
+        /// <param name="dwComponentID">
+        ///  Returns a cookie which will identify the component when it calls other
+        ///  <see cref="IMsoComponentManager"/> methods.
+        /// </param>
+        /// <returns><see cref="BOOL.TRUE"/> if successful.</returns>
+        [PreserveSig]
+        BOOL FRegisterComponent(
+            IMsoComponent* piComponent,
+            MSOCRINFO* pcrinfo,
+            nuint* dwComponentID);
+
+        /// <summary>
+        ///  Undo the registration of the component identified by <paramref name="dwComponentID"/>
+        ///  (the cookie returned from the <see cref="FRegisterComponent"/> method).
+        /// </summary>
+        /// <returns><see cref="BOOL.TRUE"/> if successful.</returns>
+        [PreserveSig]
+        BOOL FRevokeComponent(nuint dwComponentID);
+
+        /// <summary>
+        ///  Update the registration info of the component identified by <paramref name="dwComponentID"/>
+        ///  (the cookie returned from <see cref="FRegisterComponent"/>) with the new registration
+        ///  information <paramref name="pcrinfo"/>.
+        /// </summary>
+        /// <remarks>
+        ///  <para>
+        ///   Typically this is used to update the idle time registration data, but it can be used to
+        ///   update other registration data as well.
+        ///  </para>
+        /// </remarks>
+        /// <returns><see cref="BOOL.TRUE"/> if successful.</returns>
+        [PreserveSig]
+        BOOL FUpdateComponentRegistration(
+            nuint dwComponentID,
+            MSOCRINFO* pcrinfo);
+
+        /// <summary>
+        ///  Notify component manager that component identified by <paramref name="dwComponentID"/>
+        ///  (cookie returned from <see cref="FRegisterComponent"/>) has been activated.
+        /// </summary>
+        /// <remarks>
+        ///  <para>
+        ///   The active component gets the chance to process messages before they are dispatched
+        ///   (via <see cref="IMsoComponent.FPreTranslateMessage(MSG*)"/> and typically gets first chance
+        ///   at idle time after the host.
+        ///  </para>
+        ///  <para>
+        ///   This method fails if another component is already exclusively active. In this case,
+        ///   <see cref="BOOL.FALSE"/> is returned and SetLastError is set to msoerrACompIsXActive
+        ///   (comp usually need not take any special action in this case).
+        ///  </para>
+        /// </remarks>
+        /// <returns><see cref="BOOL.TRUE"/> if successful.</returns>
+        [PreserveSig]
+        BOOL FOnComponentActivate(nuint dwComponentID);
+
+        /// <summary>
+        ///  Called to inform component manager that component identified by <paramref name="dwComponentID"/>
+        ///  (cookie returned from <see cref="FRegisterComponent"/>) wishes to perform a tracking operation
+        ///  (such as mouse tracking).
+        /// </summary>
+        /// <remarks>
+        ///  <para>
+        ///   During the tracking operation the component manager routes messages to the tracking component
+        ///   (via <see cref="IMsoComponent.FPreTranslateMessage(MSG*)"/>) rather than to the active component.
+        ///   When the tracking operation ends, the component manager should resume routing messages to the active
+        ///   component.
+        ///  </para>
+        ///  <para>
+        ///   Note: component manager should perform no idle time processing during a tracking operation other
+        ///   than give the tracking component idle time via <see cref="IMsoComponent.FDoIdle(msoidlef)"/>.
+        ///  </para>
+        ///  <para>
+        ///   Note: there can only be one tracking component at a time.
+        ///  </para>
+        /// </remarks>
+        /// <param name="fTrack">
+        ///  <see cref="BOOL.TRUE"/> to begin tracking operation. <see cref="BOOL.FALSE"/>
+        ///  to end the operation.
+        /// </param>
+        /// <returns><see cref="BOOL.TRUE"/> if successful.</returns>
+        [PreserveSig]
+        BOOL FSetTrackingComponent(
+            nuint dwComponentID,
+            BOOL fTrack);
+
+        /// <summary>
+        ///  Notify component manager that component identified by <paramref name="dwComponentID"/>
+        ///  (cookie returned from <see cref="FRegisterComponent"/>) is entering the state identified
+        ///  by <paramref name="uStateID"/>. (For convenience when dealing with sub CompMgrs, the host
+        ///  can call this method passing 0 for <paramref name="dwComponentID"/>.
+        /// </summary>
+        /// <remarks>
+        ///  <para>
+        ///   Component manager should notify all other interested components within the state context
+        ///   indicated by <paramref name="uContext"/>, excluding those within the state context of a
+        ///   component manager in <paramref name="rgpicmExclude"/>, via
+        ///   <see cref="IMsoComponent.OnEnterState(msocstate, BOOL)"/> (see "Comments on State Contexts" in
+        ///   <see cref="IMsoComponentManager"/> remarks).
+        ///  </para>
+        ///  <para>
+        ///   Component Manager should also take appropriate action depending on the value of
+        ///   <paramref name="uStateID"/>.
+        ///  </para>
+        ///  <para>
+        ///   Note: Calls to this method are symmetric with calls to <see cref="FOnComponentExitState" />
+        ///   That is, if n <see cref="OnComponentEnterState"/> calls are made, the component is
+        ///   considered to be in the state until n <see cref="FOnComponentExitState" /> calls are
+        ///   made.  Before revoking its registration a component must make a sufficient number of
+        ///   <see cref="FOnComponentExitState" /> calls to offset any outstanding
+        ///   <see cref="OnComponentEnterState"/> calls it has made.
+        ///  </para>
+        ///  <para>
+        ///   Note: in place objects should not call this method with <paramref name="uStateID" />
+        ///   of <see cref="msocstate.Modal"/> when entering modal state. Such objects should call
+        ///   <see cref="IOleInPlaceFrame.EnableModeless(BOOL)"/> instead.
+        ///  </para>
+        /// </remarks>
+        /// <param name="dwReserved">Reserved for future use. Should be zero.</param>
+        /// <param name="cpicmExclude">Count of items in <paramref name="rgpicmExclude"/>.</param>
+        /// <param name="rgpicmExclude">
+        ///  Can be null. An array of component managers (can include root component manager and/or
+        ///  sub component managers). Components within the state context of a component manager
+        ///  appearing in this array should NOT be notified of the state change (note: if
+        ///  <paramref name="uContext"/> is <see cref="msoccontext.Mine"/>, the only component
+        ///  managers in <paramref name="rgpicmExclude"/> that are checked for exclusion are those that
+        ///  are sub component managers of this component manager, since all other component
+        ///  managers are outside of this component manager's state context anyway.)
+        /// </param>
+        [PreserveSig]
+        void OnComponentEnterState(
+            nuint dwComponentID,
+            msocstate uStateID,
+            msoccontext uContext,
+            uint cpicmExclude,
+            IMsoComponentManager** rgpicmExclude,
+            uint dwReserved);
+
+        /// <summary>
+        ///  Notify component manager that component identified by <paramref name="dwComponentID"/>
+        ///  (cookie returned from <see cref="FRegisterComponent"/>) is exiting the state identified by
+        ///  <paramref name="uStateID"/>. For convenience when dealing with sub component managers, the
+        ///  host can call this method passing 0 for <paramref name="dwComponentID"/>.
+        /// </summary>
+        /// <remarks>
+        ///  <para>
+        ///   <paramref name="uContext"/>, <paramref name="cpicmExclude"/>, and <paramref name="rgpicmExclude"/>
+        ///   are as they are in <see cref="OnComponentEnterState"/>.
+        ///  </para>
+        ///  <para>
+        ///   Component manager should notify all appropriate interested components (taking into account
+        ///   <paramref name="uContext"/>, <paramref name="cpicmExclude"/>, <paramref name="rgpicmExclude"/>)
+        ///   via <see cref="IMsoComponent.OnEnterState(msocstate, BOOL)"/> (see "Comments on State Contexts", above).
+        ///  </para>
+        ///  <para>
+        ///   Component manager should also take appropriate action depending on the value of <paramref name="uStateID"/>.
+        ///  </para>
+        ///  <para>
+        ///   Note: n calls to this method are symmetric with n calls to <see cref="OnComponentEnterState"/>.
+        ///  </para>
+        /// </remarks>
+        /// <returns>
+        ///  <para>
+        ///   <see cref="BOOL.TRUE"/> if, at the end of this call, the state is still in effect at the root
+        ///   of this component manager's state context (because the host or some other component is still in the state),
+        ///   otherwise return <see cref="BOOL.FALSE"/> (ie. return what <see cref="FInState"/> would return).
+        ///  </para>
+        ///  <para>
+        ///   Callers can normally ignore the return value.
+        ///  </para>
+        /// </returns>
+        [PreserveSig]
+        BOOL FOnComponentExitState(
+            nuint dwComponentID,
+            msocstate uStateID,
+            msoccontext uContext,
+            uint cpicmExclude,
+            IMsoComponentManager** rgpicmExclude);
+
+        /// <summary>
+        ///  Return <see cref="BOOL.TRUE"/> if the state identified by <paramref name="uStateID"/>
+        ///  is in effect at the root of this component manager's state context, <see cref="BOOL.FALSE"/>
+        ///  otherwise (see "Comments on State Contexts" in <see cref="IMsoComponentManager"/> remarks).
+        /// </summary>
+        /// <param name="pvoid">Reserved for future use and should be <see langword="null" />.</param>
+        [PreserveSig]
+        BOOL FInState(
+            msocstate uStateID,
+            void* pvoid);
+
+        /// <summary>
+        ///  Called periodically by a component during <see cref="IMsoComponent.FDoIdle(msoidlef)"/>.
+        /// </summary>
+        /// <returns>
+        ///  <see cref="BOOL.TRUE"/> if component can continue its idle time processing,
+        ///  <see cref="BOOL.FALSE"/> if not (in which case component returns from FDoIdle.)
+        /// </returns>
+        [PreserveSig]
+        BOOL FContinueIdle();
+
+        /// <summary>
+        ///  Component identified by <paramref name="dwComponentID"/> (cookie returned from <see cref="FRegisterComponent"/>)
+        ///  wishes to push a message loop for reason <paramref name="uReason"/>.
+        /// </summary>
+        /// <remarks>
+        ///  <para>
+        ///   The component manager should push its message loop, calling <see cref="IMsoComponent.FContinueMessageLoop(msoloop, void*, MSG*)"/>
+        ///   during each loop iteration. When <see cref="IMsoComponent.FContinueMessageLoop(msoloop, void*, MSG*)"/> returns <see cref="BOOL.FALSE"/>,
+        ///   the component manager terminates the loop.
+        ///  </para>
+        /// </remarks>
+        /// <param name="pvLoopData">Data private to the component.</param>
+        /// <returns>
+        ///  <see cref="BOOL.TRUE"/> if component manager terminates loop because component told it
+        ///  to (by returning <see cref="BOOL.FALSE"/> from <see cref="IMsoComponent.FContinueMessageLoop(msoloop, void*, MSG*)"/>),
+        ///  <see cref="BOOL.FALSE"/> if it had to terminate the loop for some other reason.  In the
+        ///  latter case, component should perform any necessary action (such as cleanup).
+        /// </returns>
+        [PreserveSig]
+        BOOL FPushMessageLoop(
+            nuint dwComponentID,
+            msoloop uReason,
+            void* pvLoopData);
+
+        /// <summary>
+        ///  Cause the component manager to create a "sub" component manager, which  will be one of its
+        ///  children in the hierarchical tree of component managers used to maintain state contexts
+        ///  (see "Comments on State Contexts" in <see cref="IMsoComponentManager"/> remarks).
+        /// </summary>
+        /// <param name="punkOuter">The controlling unknown. Can be null.</param>
+        /// <param name="riid">Desired interface identifier (IID).</param>
+        /// <param name="ppvObj">The created sub-component manager.</param>
+        /// <param name="punkServProv">
+        ///  IUnknown object that supports IServiceProvider that the sub component manager should
+        ///  delegate <see cref="QueryService" /> calls to. Can be null.
+        /// </param>
+        /// <returns><see cref="BOOL.TRUE"/> if successful.</returns>
+        [PreserveSig]
+        BOOL FCreateSubComponentManager(
+            IUnknown* punkOuter,
+            IUnknown* punkServProv,
+            Guid* riid,
+            void** ppvObj);
+
+        /// <summary>
+        ///  Return in <paramref name="ppicm"/> an AddRef'ed ptr to this component manager's parent
+        ///  in the hierarchical tree of component managers used to maintain state contexts (see
+        ///  "Comments on State Contexts" in <see cref="IMsoComponentManager"/> remarks).
+        /// </summary>
+        /// <returns>
+        ///  <see cref="BOOL.TRUE"/> if the parent is returned, <see cref="BOOL.FALSE"/>
+        ///  if no parent exists or some error occurred.
+        /// </returns>
+        [PreserveSig]
+        BOOL FGetParentComponentManager(
+            IMsoComponentManager** ppicm);
+
+        /// <summary>
+        ///  Return in <paramref name="ppic"/> an AddRef'ed ptr to the current active
+        ///  or tracking component (as indicated by <paramref name="dwgac"/>, and its
+        ///  registration information in <paramref name="pcrinfo"/>.
+        /// </summary>
+        /// <remarks>
+        ///  <para>
+        ///   <paramref name="ppic"/> and/or <paramref name="pcrinfo"/> can be NULL if caller is not interested these values.
+        ///   If <paramref name="pcrinfo"/> is not <see langword="null" /> caller should set <see cref="MSOCRINFO.cbSize"/>
+        ///   before calling this method.
+        ///  </para>
+        /// </remarks>
+        /// <param name="dwReserved">Reserved for future use and should be zero.</param>
+        /// <returns>
+        ///  <see cref="BOOL.TRUE"/> if the component indicated by <paramref name="dwgac"/>
+        ///  exists, <see cref="BOOL.FALSE"/> if no such component exists or some error occurred.
+        /// </returns>
+        [PreserveSig]
+        BOOL FGetActiveComponent(
+            msogac dwgac,
+            IMsoComponent** ppic,
+            MSOCRINFO* pcrinfo,
+            uint dwReserved);
+    }
 }

--- a/src/System.Windows.Forms.Primitives/src/Microsoft/Office/msocstate.cs
+++ b/src/System.Windows.Forms.Primitives/src/Microsoft/Office/msocstate.cs
@@ -4,7 +4,7 @@
 namespace Microsoft.Office;
 
 /// <summary>
-///  State IDs passed to <see cref="IMsoComponent.OnEnterState" /> and
+///  State IDs passed to <see cref="IMsoComponent.OnEnterState(msocstate, BOOL)" /> and
 ///  <see cref="IMsoComponentManager.OnComponentEnterState" />
 ///
 ///  When the host or a component is notified through one of these methods that another

--- a/src/System.Windows.Forms.Primitives/src/Microsoft/Office/msoloop.cs
+++ b/src/System.Windows.Forms.Primitives/src/Microsoft/Office/msoloop.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Office;
 
 /// <summary>
 ///  Reasons for pushing a message loop as passed to <see cref="IMsoComponentManager.FPushMessageLoop" />.
-///  The host should remain in message loop until <see cref="IMsoComponent.FContinueMessageLoop" />
+///  The host should remain in message loop until <see cref="IMsoComponent.FContinueMessageLoop(msoloop, void*, MSG*)" />
 ///  returns <see cref="BOOL.FALSE" />
 /// </summary>
 internal enum msoloop : uint

--- a/src/System.Windows.Forms.Primitives/src/System/ComponentModel/CompModSwitches.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/ComponentModel/CompModSwitches.cs
@@ -26,7 +26,6 @@ internal static class CompModSwitches
     private static TraceSwitch? dragDrop;
     private static TraceSwitch? imeMode;
     private static TraceSwitch? msaa;
-    private static TraceSwitch? msoComponentManager;
     private static TraceSwitch? layoutPerformance;
     private static TraceSwitch? layoutSuspendResume;
     private static TraceSwitch? richLayout;
@@ -275,16 +274,6 @@ internal static class CompModSwitches
             msaa ??= new TraceSwitch("MSAA", "Debug Microsoft Active Accessibility");
 
             return msaa;
-        }
-    }
-
-    public static TraceSwitch MSOComponentManager
-    {
-        get
-        {
-            msoComponentManager ??= new TraceSwitch("MSOComponentManager", "Debug MSO Component Manager support");
-
-            return msoComponentManager;
         }
     }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.ThreadWindows.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.ThreadWindows.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.ComponentModel;
-
 namespace System.Windows.Forms;
 
 public sealed partial class Application
@@ -98,9 +96,6 @@ public sealed partial class Application
             for (int i = 0; i < _windowCount; i++)
             {
                 HWND hWnd = _windows[i];
-                Debug.WriteLineIf(
-                    CompModSwitches.MSOComponentManager.TraceInfo,
-                    $"ComponentManager : Changing enabled on window: {hWnd} : {state}");
 
                 if (PInvoke.IsWindow(hWnd))
                 {

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/Properties/launchSettings.json
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "WinformsControlsTest": {
       "commandName": "Project",
-      "nativeDebugging": false
+      "nativeDebugging": true
     }
   }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Application.ComponentManagerTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Application.ComponentManagerTests.cs
@@ -1,16 +1,16 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Runtime.InteropServices;
 using Moq;
 using Microsoft.Office;
+using Windows.Win32.System.Com;
 
 namespace System.Windows.Forms.Tests.Interop_Mso;
 
 public unsafe class IMsoComponentManagerTests
 {
-    private IMsoComponentManager CreateComponentManager()
-        => (IMsoComponentManager)Activator.CreateInstance(
+    private IMsoComponentManager.Interface CreateComponentManager()
+        => (IMsoComponentManager.Interface)Activator.CreateInstance(
             typeof(Application).Assembly.GetType("System.Windows.Forms.Application+ComponentManager")!,
             nonPublic: true)!;
 
@@ -39,12 +39,13 @@ public unsafe class IMsoComponentManagerTests
     public void FRegisterComponent_HandlesNull()
     {
         var manager = CreateComponentManager();
-        Mock<IMsoComponent> mock = new(MockBehavior.Strict);
+        Mock<IMsoComponent.Interface> mock = new(MockBehavior.Strict);
+        using var component = ComHelpers.GetComScope<IMsoComponent>(new MockWrapper(mock.Object));
         MSOCRINFO info = default;
         UIntPtr id = default;
 
-        Assert.False(manager.FRegisterComponent(mock.Object, &info, null));
-        Assert.False(manager.FRegisterComponent(mock.Object, null, &id));
+        Assert.False(manager.FRegisterComponent(component, &info, null));
+        Assert.False(manager.FRegisterComponent(component, null, &id));
         Assert.Equal(UIntPtr.Zero, id);
     }
 
@@ -52,11 +53,12 @@ public unsafe class IMsoComponentManagerTests
     public void FRegisterComponent_RejectsUnsized()
     {
         var manager = CreateComponentManager();
-        Mock<IMsoComponent> mock = new(MockBehavior.Strict);
+        Mock<IMsoComponent.Interface> mock = new(MockBehavior.Strict);
+        using var component = ComHelpers.GetComScope<IMsoComponent>(new MockWrapper(mock.Object));
         MSOCRINFO info = default;
         UIntPtr id = default;
 
-        Assert.False(manager.FRegisterComponent(mock.Object, &info, &id));
+        Assert.False(manager.FRegisterComponent(component, &info, &id));
         Assert.Equal(UIntPtr.Zero, id);
     }
 
@@ -64,15 +66,17 @@ public unsafe class IMsoComponentManagerTests
     public void FRegisterComponent_Cookies()
     {
         var manager = CreateComponentManager();
-        Mock<IMsoComponent> mock = new(MockBehavior.Strict);
+        Mock<IMsoComponent.Interface> mock = new(MockBehavior.Strict);
+        using var component = ComHelpers.GetComScope<IMsoComponent>(new MockWrapper(mock.Object));
+
         MSOCRINFO info = new MSOCRINFO { cbSize = (uint)sizeof(MSOCRINFO) };
         UIntPtr id = default;
 
-        Assert.True(manager.FRegisterComponent(mock.Object, &info, &id));
+        Assert.True(manager.FRegisterComponent(component, &info, &id));
         Assert.NotEqual(UIntPtr.Zero, id);
 
         UIntPtr newId = default;
-        Assert.True(manager.FRegisterComponent(mock.Object, &info, &newId));
+        Assert.True(manager.FRegisterComponent(component, &info, &newId));
         Assert.NotEqual(UIntPtr.Zero, newId);
 
         Assert.NotEqual(id, newId);
@@ -82,12 +86,14 @@ public unsafe class IMsoComponentManagerTests
     public void FRevokeComponent()
     {
         var manager = CreateComponentManager();
-        Mock<IMsoComponent> mock = new(MockBehavior.Strict);
+        Mock<IMsoComponent.Interface> mock = new(MockBehavior.Strict);
+        using var component = ComHelpers.GetComScope<IMsoComponent>(new MockWrapper(mock.Object));
+
         MSOCRINFO info = new MSOCRINFO { cbSize = (uint)sizeof(MSOCRINFO) };
         UIntPtr id = default;
 
         Assert.False(manager.FRevokeComponent(UIntPtr.Zero));
-        Assert.True(manager.FRegisterComponent(mock.Object, &info, &id));
+        Assert.True(manager.FRegisterComponent(component, &info, &id));
         Assert.True(manager.FRevokeComponent(id));
         Assert.False(manager.FRevokeComponent(id));
     }
@@ -96,11 +102,13 @@ public unsafe class IMsoComponentManagerTests
     public void FUpdateComponentRegistration_HandlesNull()
     {
         var manager = CreateComponentManager();
-        Mock<IMsoComponent> mock = new(MockBehavior.Strict);
+        Mock<IMsoComponent.Interface> mock = new(MockBehavior.Strict);
+        using var component = ComHelpers.GetComScope<IMsoComponent>(new MockWrapper(mock.Object));
+
         MSOCRINFO info = new MSOCRINFO { cbSize = (uint)sizeof(MSOCRINFO) };
         UIntPtr id = default;
 
-        Assert.True(manager.FRegisterComponent(mock.Object, &info, &id));
+        Assert.True(manager.FRegisterComponent(component, &info, &id));
         Assert.False(manager.FUpdateComponentRegistration(id, null));
     }
 
@@ -108,12 +116,14 @@ public unsafe class IMsoComponentManagerTests
     public void FUpdateComponentRegistration()
     {
         var manager = CreateComponentManager();
-        Mock<IMsoComponent> mock = new(MockBehavior.Strict);
+        Mock<IMsoComponent.Interface> mock = new(MockBehavior.Strict);
+        using var component = ComHelpers.GetComScope<IMsoComponent>(new MockWrapper(mock.Object));
+
         MSOCRINFO info = new MSOCRINFO { cbSize = (uint)sizeof(MSOCRINFO) };
         UIntPtr id = default;
 
         Assert.False(manager.FUpdateComponentRegistration(id, &info));
-        Assert.True(manager.FRegisterComponent(mock.Object, &info, &id));
+        Assert.True(manager.FRegisterComponent(component, &info, &id));
         Assert.True(manager.FUpdateComponentRegistration(id, &info));
     }
 
@@ -137,11 +147,13 @@ public unsafe class IMsoComponentManagerTests
     {
         var manager = CreateComponentManager();
 
-        Mock<IMsoComponent> mock = new(MockBehavior.Strict);
+        Mock<IMsoComponent.Interface> mock = new(MockBehavior.Strict);
+        using var component = ComHelpers.GetComScope<IMsoComponent>(new MockWrapper(mock.Object));
+
         MSOCRINFO info = new MSOCRINFO { cbSize = (uint)sizeof(MSOCRINFO) };
         UIntPtr id = default;
 
-        Assert.True(manager.FRegisterComponent(mock.Object, &info, &id));
+        Assert.True(manager.FRegisterComponent(component, &info, &id));
 
         Assert.True(manager.FSetTrackingComponent(id, true));
 
@@ -166,12 +178,14 @@ public unsafe class IMsoComponentManagerTests
     public void OnComponentEnterState_Notification()
     {
         var manager = CreateComponentManager();
-        Mock<IMsoComponent> mock = new(MockBehavior.Strict);
+        Mock<IMsoComponent.Interface> mock = new(MockBehavior.Strict);
+        using var component = ComHelpers.GetComScope<IMsoComponent>(new MockWrapper(new MockWrapper(mock.Object)));
+
         mock.Setup(m => m.OnEnterState(msocstate.Modal, true));
 
         MSOCRINFO info = new MSOCRINFO { cbSize = (uint)sizeof(MSOCRINFO) };
         UIntPtr id = default;
-        Assert.True(manager.FRegisterComponent(mock.Object, &info, &id));
+        Assert.True(manager.FRegisterComponent(component, &info, &id));
 
         // No call on "Others"
         manager.OnComponentEnterState(default, msocstate.Modal, msoccontext.Others, 0, null, 0);
@@ -195,12 +209,14 @@ public unsafe class IMsoComponentManagerTests
     public void FOnComponentExitState_Notification()
     {
         var manager = CreateComponentManager();
-        Mock<IMsoComponent> mock = new(MockBehavior.Strict);
+        Mock<IMsoComponent.Interface> mock = new(MockBehavior.Strict);
+        using var component = ComHelpers.GetComScope<IMsoComponent>(new MockWrapper(mock.Object));
+
         mock.Setup(m => m.OnEnterState(msocstate.Modal, false));
 
         MSOCRINFO info = new MSOCRINFO { cbSize = (uint)sizeof(MSOCRINFO) };
         UIntPtr id = default;
-        Assert.True(manager.FRegisterComponent(mock.Object, &info, &id));
+        Assert.True(manager.FRegisterComponent(component, &info, &id));
 
         // No call on "Others"
         manager.FOnComponentExitState(default, msocstate.Modal, msoccontext.Others, 0, null);
@@ -266,7 +282,7 @@ public unsafe class IMsoComponentManagerTests
 
         // Should null out obj pointer
         void* obj = (void*)0xDEADBEEF;
-        Assert.False(manager.FGetParentComponentManager(&obj));
+        Assert.False(manager.FGetParentComponentManager((IMsoComponentManager**)&obj));
         Assert.True(obj is null);
     }
 
@@ -276,8 +292,11 @@ public unsafe class IMsoComponentManagerTests
         var manager = CreateComponentManager();
         Assert.False(manager.FGetActiveComponent(msogac.Active, null, null, 0));
 
-        Mock<IMsoComponent> mock1 = new(MockBehavior.Strict);
-        Mock<IMsoComponent> mock2 = new(MockBehavior.Strict);
+        Mock<IMsoComponent.Interface> mock1 = new(MockBehavior.Strict);
+        using var component1 = ComHelpers.GetComScope<IMsoComponent>(new MockWrapper(mock1.Object));
+
+        Mock<IMsoComponent.Interface> mock2 = new(MockBehavior.Strict);
+        using var component2 = ComHelpers.GetComScope<IMsoComponent>(new MockWrapper(mock2.Object));
 
         MSOCRINFO info = new MSOCRINFO
         {
@@ -286,10 +305,10 @@ public unsafe class IMsoComponentManagerTests
         };
 
         UIntPtr firstId = default;
-        Assert.True(manager.FRegisterComponent(mock1.Object, &info, &firstId));
+        Assert.True(manager.FRegisterComponent(component1, &info, &firstId));
         info.uIdleTimeInterval = 2;
         UIntPtr secondId = default;
-        Assert.True(manager.FRegisterComponent(mock2.Object, &info, &secondId));
+        Assert.True(manager.FRegisterComponent(component2, &info, &secondId));
 
         Assert.False(manager.FGetActiveComponent(msogac.Active, null, null, 0));
 
@@ -312,17 +331,51 @@ public unsafe class IMsoComponentManagerTests
 
         // Now check that we can get the object out
         mock2.Setup(m => m.FQueryTerminate(true)).Returns(true);
-        void* pUnk = default;
-        Assert.True(manager.FGetActiveComponent(msogac.Tracking, &pUnk, &info, 0));
-        Assert.True(pUnk != null);
-        try
-        {
-            var component = (IMsoComponent)Marshal.GetObjectForIUnknown((IntPtr)pUnk);
-            Assert.True(component.FQueryTerminate(true));
-        }
-        finally
-        {
-            Marshal.Release((IntPtr)pUnk);
-        }
+        using ComScope<IMsoComponent> component = new(null);
+        Assert.True(manager.FGetActiveComponent(msogac.Tracking, component, &info, 0));
+        Assert.False(component.IsNull);
+        Assert.True(component.Value->FQueryTerminate(true));
+    }
+
+    private class MockWrapper : IMsoComponent.Interface, IManagedWrapper<IMsoComponent>
+    {
+        private IMsoComponent.Interface _mock;
+        public MockWrapper(IMsoComponent.Interface mock) => _mock = mock;
+
+        BOOL IMsoComponent.Interface.FDebugMessage(nint hInst, uint msg, WPARAM wParam, LPARAM lParam)
+            => _mock.FDebugMessage(hInst, msg, wParam, lParam);
+
+        BOOL IMsoComponent.Interface.FPreTranslateMessage(MSG* msg)
+            => _mock.FPreTranslateMessage(msg);
+
+        void IMsoComponent.Interface.OnEnterState(msocstate uStateID, BOOL fEnter)
+            => _mock.OnEnterState(uStateID, fEnter);
+
+        void IMsoComponent.Interface.OnAppActivate(BOOL fActive, uint dwOtherThreadID)
+            => _mock.OnAppActivate(fActive, dwOtherThreadID);
+
+        void IMsoComponent.Interface.OnLoseActivation() => _mock.OnLoseActivation();
+
+        void IMsoComponent.Interface.OnActivationChange(
+            IMsoComponent* pic,
+            BOOL fSameComponent,
+            MSOCRINFO* pcrinfo,
+            BOOL fHostIsActivating,
+            nint pchostinfo,
+            uint dwReserved) => _mock.OnActivationChange(pic, fSameComponent, pcrinfo, fHostIsActivating, pchostinfo, dwReserved);
+
+        BOOL IMsoComponent.Interface.FDoIdle(msoidlef grfidlef) => _mock.FDoIdle(grfidlef);
+
+        BOOL IMsoComponent.Interface.FContinueMessageLoop(
+            msoloop uReason,
+            void* pvLoopData,
+            MSG* pMsgPeeked) => _mock.FContinueMessageLoop(uReason, pvLoopData, pMsgPeeked);
+
+        BOOL IMsoComponent.Interface.FQueryTerminate(BOOL fPromptUser) => _mock.FQueryTerminate(fPromptUser);
+
+        void IMsoComponent.Interface.Terminate() => _mock.Terminate();
+
+        HWND IMsoComponent.Interface.HwndGetWindow(msocWindow uWhich, uint dwReserved)
+            => _mock.HwndGetWindow(uWhich, dwReserved);
     }
 }


### PR DESCRIPTION
This change converts the interfaces to match the same patterns we're using with other Com interfaces. Also yanks the trace statements for these.

I'm probably going to try and factor this stuff out into an opt-in feature.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/10881)