### PR TITLE
Fix `null` values in `AutoCompleteCustomSource` 

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/AutoCompleteStringCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AutoCompleteStringCollection.cs
@@ -59,7 +59,11 @@ public class AutoCompleteStringCollection : IList
     /// </summary>
     public int Add(string value)
     {
-        ArgumentNullException.ThrowIfNull(value);
+        if (value is null)
+        {
+            return -1;
+        }
+
         int index = ((IList)_data).Add(value);
         OnCollectionChanged(new CollectionChangeEventArgs(CollectionChangeAction.Add, value));
         return index;
@@ -72,15 +76,16 @@ public class AutoCompleteStringCollection : IList
     {
         ArgumentNullException.ThrowIfNull(value);
 
+        List<string> nonNullItems = [];
         foreach (string item in value)
         {
-            if (item is null)
+            if (item is not null)
             {
-                throw new InvalidOperationException(SR.InvalidNullItemInCollection);
+                nonNullItems.Add(item);
             }
         }
 
-        _data.AddRange(value);
+        _data.AddRange(nonNullItems);
         OnCollectionChanged(new CollectionChangeEventArgs(CollectionChangeAction.Refresh, null));
     }
 
@@ -121,9 +126,12 @@ public class AutoCompleteStringCollection : IList
     {
         ArgumentOutOfRangeException.ThrowIfNegative(index);
         ArgumentOutOfRangeException.ThrowIfGreaterThan(index, _data.Count);
-        ArgumentNullException.ThrowIfNull(value);
-        _data.Insert(index, value);
-        OnCollectionChanged(new CollectionChangeEventArgs(CollectionChangeAction.Add, value));
+
+        if (value is not null)
+        {
+            _data.Insert(index, value);
+            OnCollectionChanged(new CollectionChangeEventArgs(CollectionChangeAction.Add, value));
+        }
     }
 
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AutoCompleteStringCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AutoCompleteStringCollection.cs
@@ -12,7 +12,7 @@ namespace System.Windows.Forms;
 public class AutoCompleteStringCollection : IList
 {
     private CollectionChangeEventHandler? _onCollectionChanged;
-    private readonly List<string> _data = new();
+    private readonly List<string> _data = [];
 
     public AutoCompleteStringCollection()
     {
@@ -59,6 +59,7 @@ public class AutoCompleteStringCollection : IList
     /// </summary>
     public int Add(string value)
     {
+        ArgumentNullException.ThrowIfNull(value);
         int index = ((IList)_data).Add(value);
         OnCollectionChanged(new CollectionChangeEventArgs(CollectionChangeAction.Add, value));
         return index;
@@ -70,6 +71,14 @@ public class AutoCompleteStringCollection : IList
     public void AddRange(params string[] value)
     {
         ArgumentNullException.ThrowIfNull(value);
+
+        foreach (string item in value)
+        {
+            if (item is null)
+            {
+                throw new InvalidOperationException(SR.InvalidNullItemInCollection);
+            }
+        }
 
         _data.AddRange(value);
         OnCollectionChanged(new CollectionChangeEventArgs(CollectionChangeAction.Refresh, null));
@@ -110,6 +119,7 @@ public class AutoCompleteStringCollection : IList
     /// </summary>
     public void Insert(int index, string value)
     {
+        ArgumentNullException.ThrowIfNull(value);
         _data.Insert(index, value);
         OnCollectionChanged(new CollectionChangeEventArgs(CollectionChangeAction.Add, value));
     }
@@ -168,4 +178,6 @@ public class AutoCompleteStringCollection : IList
     void ICollection.CopyTo(Array array, int index) => ((ICollection)_data).CopyTo(array, index);
 
     public IEnumerator GetEnumerator() => _data.GetEnumerator();
+
+    internal string[] ToArray() => [.. _data];
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AutoCompleteStringCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AutoCompleteStringCollection.cs
@@ -119,6 +119,8 @@ public class AutoCompleteStringCollection : IList
     /// </summary>
     public void Insert(int index, string value)
     {
+        ArgumentOutOfRangeException.ThrowIfNegative(index);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(index, _data.Count);
         ArgumentNullException.ThrowIfNull(value);
         _data.Insert(index, value);
         OnCollectionChanged(new CollectionChangeEventArgs(CollectionChangeAction.Add, value));

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AutoCompleteStringCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AutoCompleteStringCollection.cs
@@ -57,6 +57,10 @@ public class AutoCompleteStringCollection : IList
     ///  Adds a string with the specified value to the
     ///  <see cref="AutoCompleteStringCollection"/> .
     /// </summary>
+    /// <returns>
+    ///  The position into which the new element was inserted, or -1 to indicate that
+    ///  the item was not inserted into the collection.
+    /// </returns>
     public int Add(string value)
     {
         if (value is null)
@@ -83,6 +87,11 @@ public class AutoCompleteStringCollection : IList
             {
                 nonNullItems.Add(item);
             }
+        }
+
+        if (nonNullItems.Count <= 0)
+        {
+            return;
         }
 
         _data.AddRange(nonNullItems);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.cs
@@ -917,12 +917,12 @@ public partial class ComboBox : ListControl
 
     private string[] GetStringsForAutoComplete()
     {
-        if (_itemsCollection is not null)
+        if (Items is not null)
         {
-            string[] strings = new string[_itemsCollection.Count];
-            for (int i = 0; i < _itemsCollection.Count; i++)
+            string[] strings = new string[Items.Count];
+            for (int i = 0; i < Items.Count; i++)
             {
-                strings[i] = GetItemText(_itemsCollection[i])!;
+                strings[i] = GetItemText(Items[i])!;
             }
 
             return strings;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.cs
@@ -915,19 +915,9 @@ public partial class ComboBox : ListControl
         return cyCombo;
     }
 
-    private string[] GetStringsForAutoComplete(IList collection)
+    private string[] GetStringsForAutoComplete()
     {
-        if (collection is AutoCompleteStringCollection)
-        {
-            string[] strings = new string[AutoCompleteCustomSource.Count];
-            for (int i = 0; i < AutoCompleteCustomSource.Count; i++)
-            {
-                strings[i] = AutoCompleteCustomSource[i];
-            }
-
-            return strings;
-        }
-        else if (collection is ObjectCollection && _itemsCollection is not null)
+        if (_itemsCollection is not null)
         {
             string[] strings = new string[_itemsCollection.Count];
             for (int i = 0; i < _itemsCollection.Count; i++)
@@ -938,7 +928,7 @@ public partial class ComboBox : ListControl
             return strings;
         }
 
-        return Array.Empty<string>();
+        return [];
     }
 
     /// <summary>
@@ -3283,7 +3273,7 @@ public partial class ComboBox : ListControl
 
             if (_stringSource is null)
             {
-                _stringSource = new StringSource(GetStringsForAutoComplete(AutoCompleteCustomSource));
+                _stringSource = new StringSource(AutoCompleteCustomSource.ToArray());
                 if (!_stringSource.Bind(_childEdit, (AUTOCOMPLETEOPTIONS)AutoCompleteMode))
                 {
                     throw new ArgumentException(SR.AutoCompleteFailure);
@@ -3291,7 +3281,7 @@ public partial class ComboBox : ListControl
             }
             else
             {
-                _stringSource.RefreshList(GetStringsForAutoComplete(AutoCompleteCustomSource));
+                _stringSource.RefreshList(AutoCompleteCustomSource.ToArray());
             }
 
             return;
@@ -3326,7 +3316,7 @@ public partial class ComboBox : ListControl
 
             if (_stringSource is null)
             {
-                _stringSource = new StringSource(GetStringsForAutoComplete(Items));
+                _stringSource = new StringSource(GetStringsForAutoComplete());
                 if (!_stringSource.Bind(_childEdit, (AUTOCOMPLETEOPTIONS)AutoCompleteMode))
                 {
                     throw new ArgumentException(SR.AutoCompleteFailureListItems);
@@ -3334,7 +3324,7 @@ public partial class ComboBox : ListControl
             }
             else
             {
-                _stringSource.RefreshList(GetStringsForAutoComplete(Items));
+                _stringSource.RefreshList(GetStringsForAutoComplete());
             }
 
             return;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TextBox/TextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TextBox/TextBox.cs
@@ -721,17 +721,6 @@ public partial class TextBox : TextBoxBase
         base.SelectInternal(start, length, textLen);
     }
 
-    private string[] GetStringsForAutoComplete()
-    {
-        string[] strings = new string[AutoCompleteCustomSource.Count];
-        for (int i = 0; i < AutoCompleteCustomSource.Count; i++)
-        {
-            strings[i] = AutoCompleteCustomSource[i];
-        }
-
-        return strings;
-    }
-
     /// <summary>
     ///  Sets the AutoComplete mode in TextBox.
     /// </summary>
@@ -767,7 +756,7 @@ public partial class TextBox : TextBoxBase
                     {
                         if (_stringSource is null)
                         {
-                            _stringSource = new StringSource(GetStringsForAutoComplete());
+                            _stringSource = new StringSource(AutoCompleteCustomSource.ToArray());
                             if (!_stringSource.Bind(this, (AUTOCOMPLETEOPTIONS)AutoCompleteMode))
                             {
                                 throw new ArgumentException(SR.AutoCompleteFailure);
@@ -775,7 +764,7 @@ public partial class TextBox : TextBoxBase
                         }
                         else
                         {
-                            _stringSource.RefreshList(GetStringsForAutoComplete());
+                            _stringSource.RefreshList(AutoCompleteCustomSource.ToArray());
                         }
                     }
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/StringSource.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/StringSource.cs
@@ -13,9 +13,9 @@ namespace System.Windows.Forms;
 /// </summary>
 internal unsafe class StringSource : IEnumString.Interface, IManagedWrapper<IEnumString>
 {
-    private string[] strings;
-    private int current;
-    private int size;
+    private string[] _strings;
+    private int _current;
+    private int _size;
     private IAutoComplete2* _autoComplete2;
 
     /// <summary>
@@ -23,11 +23,8 @@ internal unsafe class StringSource : IEnumString.Interface, IManagedWrapper<IEnu
     /// </summary>
     public StringSource(string[] strings)
     {
-        Array.Clear(strings, 0, size);
-        this.strings = strings;
-
-        current = 0;
-        size = strings.Length;
+        _strings = strings;
+        _size = strings.Length;
 
         PInvokeCore.CoCreateInstance(
             in CLSID.AutoComplete,
@@ -68,10 +65,10 @@ internal unsafe class StringSource : IEnumString.Interface, IManagedWrapper<IEnu
 
     public void RefreshList(string[] newSource)
     {
-        Array.Clear(strings, 0, size);
-        strings = newSource;
-        current = 0;
-        size = strings.Length;
+        Array.Clear(_strings, 0, _size);
+        _strings = newSource;
+        _current = 0;
+        _size = _strings.Length;
     }
 
     public unsafe HRESULT Clone(IEnumString** ppenum)
@@ -81,7 +78,7 @@ internal unsafe class StringSource : IEnumString.Interface, IManagedWrapper<IEnu
             return HRESULT.E_POINTER;
         }
 
-        *ppenum = ComHelpers.GetComPointer<IEnumString>(new StringSource(strings) { current = current });
+        *ppenum = ComHelpers.GetComPointer<IEnumString>(new StringSource(_strings) { _current = _current });
         return HRESULT.S_OK;
     }
 
@@ -94,10 +91,10 @@ internal unsafe class StringSource : IEnumString.Interface, IManagedWrapper<IEnu
 
         uint fetched = 0;
 
-        while (current < size && celt > 0)
+        while (_current < _size && celt > 0)
         {
-            rgelt[fetched] = (char*)Marshal.StringToCoTaskMemUni(strings[current]);
-            current++;
+            rgelt[fetched] = (char*)Marshal.StringToCoTaskMemUni(_strings[_current]);
+            _current++;
             fetched++;
             celt--;
         }
@@ -112,19 +109,19 @@ internal unsafe class StringSource : IEnumString.Interface, IManagedWrapper<IEnu
 
     public HRESULT Skip(uint celt)
     {
-        int newCurrent = current + (int)celt;
-        if (newCurrent >= size)
+        int newCurrent = _current + (int)celt;
+        if (newCurrent >= _size)
         {
             return HRESULT.S_FALSE;
         }
 
-        current = newCurrent;
+        _current = newCurrent;
         return HRESULT.S_OK;
     }
 
     public HRESULT Reset()
     {
-        current = 0;
+        _current = 0;
         return HRESULT.S_OK;
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AutoCompleteStringCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AutoCompleteStringCollectionTests.cs
@@ -35,21 +35,24 @@ public class AutoCompleteStringCollectionTests
         Assert.Throws<ArgumentNullException>("value", () => collection.AddRange(null));
     }
 
+#nullable enable
     [WinFormsFact]
-    public void AutoCompleteStringCollection_AddRange_NullValues_ThrowsInvalidOperationException()
+    public void AutoCompleteStringCollection_AddRange_NullValues_Nop()
     {
         AutoCompleteStringCollection collection = new();
-        Assert.Throws<InvalidOperationException>(() => collection.AddRange([null]));
+        collection.AddRange([null!]);
+        Assert.Empty(collection);
     }
 
     [WinFormsFact]
     public void AutoCompleteStringCollection_Add_NullValue_ThrowsArgumentNullException()
     {
         AutoCompleteStringCollection collection = new();
-        Assert.Throws<ArgumentNullException>("value", () => collection.AddRange(null));
+        Assert.Throws<ArgumentNullException>("value", () => collection.AddRange(null!));
     }
+#nullable disable
 
-        [WinFormsFact]
+    [WinFormsFact]
     public void AutoCompleteStringCollection_Contains_Invoke_ReturnsExpected()
     {
         AutoCompleteStringCollection collection = new();
@@ -186,14 +189,6 @@ public class AutoCompleteStringCollectionTests
         Assert.Empty(collection);
     }
 
-    [WinFormsFact]
-    public void AutoCompleteStringCollection_IListInsert_NullItem_ThrowsArgumentNullException()
-    {
-        IList collection = new AutoCompleteStringCollection();
-        Assert.Throws<ArgumentNullException>("value", () => collection.Insert(0, null));
-        Assert.Empty(collection);
-    }
-
     [WinFormsTheory]
     [InlineData(-1)]
     [InlineData(1)]
@@ -202,6 +197,16 @@ public class AutoCompleteStringCollectionTests
         IList collection = new AutoCompleteStringCollection();
         Assert.Throws<ArgumentOutOfRangeException>("index", () => collection.Insert(index, "value"));
     }
+
+#nullable enable
+    [WinFormsFact]
+    public void AutoCompleteStringCollection_IListInsert_NullItem_Nop()
+    {
+        IList collection = new AutoCompleteStringCollection();
+        collection.Insert(0, null);
+        Assert.Empty(collection);
+    }
+#nullable disable
 
     [WinFormsFact]
     public void AutoCompleteStringCollection_Remove_String_Success()
@@ -236,6 +241,7 @@ public class AutoCompleteStringCollectionTests
     }
 
     [WinFormsTheory]
+    [InlineData(null)]
     [InlineData("text")]
     public void AutoCompleteStringCollection_IListRemove_InvalidItem_Nop(object value)
     {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AutoCompleteStringCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AutoCompleteStringCollectionTests.cs
@@ -36,6 +36,20 @@ public class AutoCompleteStringCollectionTests
     }
 
     [WinFormsFact]
+    public void AutoCompleteStringCollection_AddRange_NullValues_ThrowsInvalidOperationException()
+    {
+        AutoCompleteStringCollection collection = new();
+        Assert.Throws<InvalidOperationException>(() => collection.AddRange([null]));
+    }
+
+    [WinFormsFact]
+    public void AutoCompleteStringCollection_Add_NullValue_ThrowsArgumentNullException()
+    {
+        AutoCompleteStringCollection collection = new();
+        Assert.Throws<ArgumentNullException>("value", () => collection.AddRange(null));
+    }
+
+        [WinFormsFact]
     public void AutoCompleteStringCollection_Contains_Invoke_ReturnsExpected()
     {
         AutoCompleteStringCollection collection = new();
@@ -172,6 +186,14 @@ public class AutoCompleteStringCollectionTests
         Assert.Empty(collection);
     }
 
+    [WinFormsFact]
+    public void AutoCompleteStringCollection_IListInsert_NullItem_ThrowsArgumentNullException()
+    {
+        IList collection = new AutoCompleteStringCollection();
+        Assert.Throws<ArgumentNullException>("value", () => collection.Insert(0, null));
+        Assert.Empty(collection);
+    }
+
     [WinFormsTheory]
     [InlineData(-1)]
     [InlineData(1)]
@@ -214,7 +236,6 @@ public class AutoCompleteStringCollectionTests
     }
 
     [WinFormsTheory]
-    [InlineData(null)]
     [InlineData("text")]
     public void AutoCompleteStringCollection_IListRemove_InvalidItem_Nop(object value)
     {

--- a/src/System.Windows.Forms/tests/UnitTests/TextBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/TextBoxTests.cs
@@ -637,6 +637,19 @@ public partial class TextBoxTests
         Assert.Equal(0, createdCallCount);
     }
 
+    [WinFormsFact]
+    public void TextBox_AutoCompleteCustomSource_ThrowsOnNull()
+    {
+        using TextBox tb = new();
+        tb.AutoCompleteMode = AutoCompleteMode.Suggest;
+        tb.AutoCompleteSource = AutoCompleteSource.CustomSource;
+        tb.AutoCompleteCustomSource.Clear();
+        Assert.Throws<ArgumentNullException>(() => tb.AutoCompleteCustomSource.Add(null));
+        Assert.Throws<ArgumentNullException>(() => tb.AutoCompleteCustomSource.AddRange(null));
+        Assert.Throws<ArgumentNullException>(() => tb.AutoCompleteCustomSource.Insert(0, null));
+        Assert.Throws<InvalidOperationException>(() => tb.AutoCompleteCustomSource.AddRange([null]));
+    }
+
     private class SubTextBox : TextBox
     {
         public int TextCount;

--- a/src/System.Windows.Forms/tests/UnitTests/TextBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/TextBoxTests.cs
@@ -637,19 +637,6 @@ public partial class TextBoxTests
         Assert.Equal(0, createdCallCount);
     }
 
-    [WinFormsFact]
-    public void TextBox_AutoCompleteCustomSource_ThrowsOnNull()
-    {
-        using TextBox tb = new();
-        tb.AutoCompleteMode = AutoCompleteMode.Suggest;
-        tb.AutoCompleteSource = AutoCompleteSource.CustomSource;
-        tb.AutoCompleteCustomSource.Clear();
-        Assert.Throws<ArgumentNullException>(() => tb.AutoCompleteCustomSource.Add(null));
-        Assert.Throws<ArgumentNullException>(() => tb.AutoCompleteCustomSource.AddRange(null));
-        Assert.Throws<ArgumentNullException>(() => tb.AutoCompleteCustomSource.Insert(0, null));
-        Assert.Throws<InvalidOperationException>(() => tb.AutoCompleteCustomSource.AddRange([null]));
-    }
-
     private class SubTextBox : TextBox
     {
         public int TextCount;


### PR DESCRIPTION
- Refactoring to add `ArgumentNullException`/`InvalidOperationException` to `AutoCompleteCustomSource`
- add tests to verify
- Cleanup/Refactor of `StringSource`

I think this is an API change, so it might need to be documented. Since the APIs now throw exceptions.

#Fixes #10904
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/10905)