### PR TITLE
fix Issue "ColumnType is disabled for Columns in EditColumns dialog"

### DIFF
--- a/src/System.Design/src/System.Design.Forwards.cs
+++ b/src/System.Design/src/System.Design.Forwards.cs
@@ -9,6 +9,7 @@ using System.Runtime.CompilerServices;
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.ColumnHeaderCollectionEditor))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.DataMemberFieldConverter))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.DataGridViewCellStyleEditor))]
+[assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.DataGridViewColumnTypeEditor))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.DataSourceListEditor))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.FormatStringEditor))]
 [assembly: TypeForwardedTo(typeof(System.Windows.Forms.Design.HelpNamespaceEditor))]

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewColumnCollectionDialog.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewColumnCollectionDialog.cs
@@ -1348,7 +1348,7 @@ internal class DataGridViewColumnCollectionDialog : Form
         {
             get
             {
-                EditorAttribute editorAttr = new("System.Windows.Forms.Design.DataGridViewColumnTypeEditor, " + AssemblyRef.SystemDesign, typeof(System.Drawing.Design.UITypeEditor));
+                EditorAttribute editorAttr = new($"System.Windows.Forms.Design.DataGridViewColumnTypeEditor, {AssemblyRef.SystemDesign}", typeof(System.Drawing.Design.UITypeEditor));
                 DescriptionAttribute descriptionAttr = new(SR.DataGridViewColumnTypePropertyDescription);
                 CategoryAttribute categoryAttr = CategoryAttribute.Design;
                 // add the description attribute and the categories attribute

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewColumnCollectionDialog.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewColumnCollectionDialog.cs
@@ -1348,7 +1348,7 @@ internal class DataGridViewColumnCollectionDialog : Form
         {
             get
             {
-                EditorAttribute editorAttr = new("Design.DataGridViewColumnTypeEditor, " + AssemblyRef.SystemDesign, typeof(System.Drawing.Design.UITypeEditor));
+                EditorAttribute editorAttr = new("System.Windows.Forms.Design.DataGridViewColumnTypeEditor, " + AssemblyRef.SystemDesign, typeof(System.Drawing.Design.UITypeEditor));
                 DescriptionAttribute descriptionAttr = new(SR.DataGridViewColumnTypePropertyDescription);
                 CategoryAttribute categoryAttr = CategoryAttribute.Design;
                 // add the description attribute and the categories attribute

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewColumnTypeEditor.Picker.ListBoxItem.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewColumnTypeEditor.Picker.ListBoxItem.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Windows.Forms.Design;
+
+internal partial class DataGridViewColumnTypePicker : ContainerControl
+{
+    private class ListBoxItem
+    {
+        private Type _columnType;
+        public ListBoxItem(Type columnType)
+        {
+            _columnType = columnType;
+        }
+
+        public override string ToString() => _columnType.Name;
+
+        public Type ColumnType => _columnType;
+    }
+}

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewColumnTypeEditor.Picker.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewColumnTypeEditor.Picker.cs
@@ -1,0 +1,171 @@
+﻿using System.Collections;
+using System.ComponentModel;
+using System.ComponentModel.Design;
+using System.Drawing;
+
+namespace System.Windows.Forms.Design;
+[
+ToolboxItem(false),
+DesignTimeVisible(false)
+]
+internal class DataGridViewColumnTypePicker : ContainerControl
+{
+    private ListBox _typesListBox;
+    private Type? _selectedType;
+
+    private IWindowsFormsEditorService? _edSvc;        // the current editor service that we need to close the drop down.
+    private static Type _dataGridViewColumnType = typeof(DataGridViewColumn);
+
+    private const int MinimumHeight = 90;
+    private const int MinimumWidth = 100;
+
+    public DataGridViewColumnTypePicker()
+    {
+        _typesListBox = new ListBox();
+        Size = _typesListBox.Size;
+        _typesListBox.Dock = DockStyle.Fill;
+        _typesListBox.Sorted = true;
+        _typesListBox.HorizontalScrollbar = true;
+        _typesListBox.SelectedIndexChanged += new EventHandler(typesListBox_SelectedIndexChanged);
+        Controls.Add(_typesListBox);
+        BackColor = SystemColors.Control;
+        ActiveControl = _typesListBox;
+    }
+
+    public Type? SelectedType => _selectedType;
+
+    private int PreferredWidth
+    {
+        get
+        {
+            int width = 0;
+            Graphics g = _typesListBox.CreateGraphics();
+            try
+            {
+                for (int i = 0; i < _typesListBox.Items.Count; i++)
+                {
+                    ListBoxItem item = (ListBoxItem)_typesListBox.Items[i];
+                    width = Math.Max(width, Size.Ceiling(g.MeasureString(item.ToString(), _typesListBox.Font)).Width);
+                }
+            }
+            finally
+            {
+                g.Dispose();
+            }
+
+            return width;
+        }
+    }
+
+    private void CloseDropDown()
+    {
+        if (_edSvc is not null)
+        {
+            _edSvc.CloseDropDown();
+        }
+    }
+
+    protected override void SetBoundsCore(int x, int y, int width, int height, BoundsSpecified specified)
+    {
+        if ((BoundsSpecified.Width & specified) == BoundsSpecified.Width)
+        {
+            width = Math.Max(width, MinimumWidth);
+        }
+
+        if ((BoundsSpecified.Height & specified) == BoundsSpecified.Height)
+        {
+            height = Math.Max(height, MinimumHeight);
+        }
+
+        base.SetBoundsCore(x, y, width, height, specified);
+    }
+
+    /// <devdoc>
+    /// Setup the picker, and fill it with type information
+    /// </devdoc>
+    public void Start(IWindowsFormsEditorService edSvc, ITypeDiscoveryService discoveryService, Type defaultType)
+    {
+        _edSvc = edSvc;
+
+        _typesListBox.Items.Clear();
+
+        ICollection columnTypes = DesignerUtils.FilterGenericTypes(discoveryService.GetTypes(_dataGridViewColumnType, false /*excludeGlobalTypes*/));
+
+        foreach (Type t in columnTypes)
+        {
+            if (t == _dataGridViewColumnType)
+            {
+                continue;
+            }
+
+            if (t.IsAbstract)
+            {
+                continue;
+            }
+
+            if (!t.IsPublic && !t.IsNestedPublic)
+            {
+                continue;
+            }
+
+            DataGridViewColumnDesignTimeVisibleAttribute? attr = TypeDescriptor.GetAttributes(t)[typeof(DataGridViewColumnDesignTimeVisibleAttribute)] as DataGridViewColumnDesignTimeVisibleAttribute;
+            if (attr is not null && !attr.Visible)
+            {
+                continue;
+            }
+
+            _typesListBox.Items.Add(new ListBoxItem(t));
+        }
+
+        _typesListBox.SelectedIndex = TypeToSelectedIndex(defaultType);
+
+        _selectedType = null;
+
+        // set our default width.
+        //
+        Width = Math.Max(Width, PreferredWidth + (SystemInformation.VerticalScrollBarWidth * 2));
+    }
+
+    private void typesListBox_SelectedIndexChanged(object? sender, EventArgs e)
+    {
+        _selectedType = _typesListBox.SelectedItem is ListBoxItem selectedItem ? selectedItem.ColumnType : null;
+        _edSvc?.CloseDropDown();
+    }
+
+    private int TypeToSelectedIndex(Type type)
+    {
+        for (int i = 0; i < _typesListBox.Items.Count; i++)
+        {
+            if (type == ((ListBoxItem)_typesListBox.Items[i]).ColumnType)
+            {
+                return i;
+            }
+        }
+
+        Debug.Assert(false, "we should have found a type by now");
+
+        return -1;
+    }
+
+    private class ListBoxItem
+    {
+        private Type _columnType;
+        public ListBoxItem(Type columnType)
+        {
+            _columnType = columnType;
+        }
+
+        public override string ToString()
+        {
+            return _columnType.Name;
+        }
+
+        public Type ColumnType
+        {
+            get
+            {
+                return _columnType;
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewColumnTypeEditor.Picker.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewColumnTypeEditor.Picker.cs
@@ -54,10 +54,7 @@ internal partial class DataGridViewColumnTypePicker : ContainerControl
         }
     }
 
-    private void CloseDropDown()
-    {
-        _windowsFormsEditorService?.CloseDropDown();
-    }
+    private void CloseDropDown() => _windowsFormsEditorService?.CloseDropDown();
 
     protected override void SetBoundsCore(int x, int y, int width, int height, BoundsSpecified specified)
     {

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewColumnTypeEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewColumnTypeEditor.cs
@@ -12,21 +12,15 @@ internal class DataGridViewColumnTypeEditor : UITypeEditor
 
     private DataGridViewColumnTypePicker? _columnTypePicker;
 
-    public override bool IsDropDownResizable
-    {
-        get
-        {
-            return true;
-        }
-    }
+    public override bool IsDropDownResizable => true;
 
-    public override object EditValue(ITypeDescriptorContext? context, IServiceProvider provider, object? value)
+    public override object? EditValue(ITypeDescriptorContext? context, IServiceProvider provider, object? value)
     {
         if (provider is not null)
         {
-            IWindowsFormsEditorService? edSvc = provider.GetService(typeof(IWindowsFormsEditorService)) as IWindowsFormsEditorService;
+            IWindowsFormsEditorService? windowsFormsEditorService = provider.GetService(typeof(IWindowsFormsEditorService)) as IWindowsFormsEditorService;
 
-            if (edSvc is not null && context?.Instance is not null)
+            if (windowsFormsEditorService is not null && context?.Instance is not null)
             {
                 _columnTypePicker ??= new DataGridViewColumnTypePicker();
 
@@ -39,8 +33,8 @@ internal class DataGridViewColumnTypeEditor : UITypeEditor
                     discoveryService = host.GetService(typeof(ITypeDiscoveryService)) as ITypeDiscoveryService;
                 }
 
-                _columnTypePicker.Start(edSvc, discoveryService!, item.DataGridViewColumn.GetType());
-                edSvc.DropDownControl(_columnTypePicker);
+                _columnTypePicker.Start(windowsFormsEditorService, discoveryService!, item.DataGridViewColumn.GetType());
+                windowsFormsEditorService.DropDownControl(_columnTypePicker);
                 if (_columnTypePicker.SelectedType is not null)
                 {
                     value = _columnTypePicker.SelectedType;
@@ -48,11 +42,8 @@ internal class DataGridViewColumnTypeEditor : UITypeEditor
             }
         }
 
-        return value!;
+        return value;
     }
 
-    public override UITypeEditorEditStyle GetEditStyle(ITypeDescriptorContext? context)
-    {
-        return UITypeEditorEditStyle.DropDown;
-    }
+    public override UITypeEditorEditStyle GetEditStyle(ITypeDescriptorContext? context) => UITypeEditorEditStyle.DropDown;
 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewColumnTypeEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewColumnTypeEditor.cs
@@ -1,0 +1,58 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel;
+using System.ComponentModel.Design;
+using System.Drawing.Design;
+
+namespace System.Windows.Forms.Design;
+internal class DataGridViewColumnTypeEditor : UITypeEditor
+{
+    public DataGridViewColumnTypeEditor() : base() { }
+
+    private DataGridViewColumnTypePicker? _columnTypePicker;
+
+    public override bool IsDropDownResizable
+    {
+        get
+        {
+            return true;
+        }
+    }
+
+    public override object EditValue(ITypeDescriptorContext? context, IServiceProvider provider, object? value)
+    {
+        if (provider is not null)
+        {
+            IWindowsFormsEditorService? edSvc = provider.GetService(typeof(IWindowsFormsEditorService)) as IWindowsFormsEditorService;
+
+            if (edSvc is not null && context?.Instance is not null)
+            {
+                _columnTypePicker ??= new DataGridViewColumnTypePicker();
+
+                DataGridViewColumnCollectionDialog.ListBoxItem item = (DataGridViewColumnCollectionDialog.ListBoxItem)context.Instance;
+
+                IDesignerHost? host = provider.GetService(typeof(IDesignerHost)) as IDesignerHost;
+                ITypeDiscoveryService? discoveryService = null;
+                if (host is not null)
+                {
+                    discoveryService = host.GetService(typeof(ITypeDiscoveryService)) as ITypeDiscoveryService;
+                }
+
+                _columnTypePicker.Start(edSvc, discoveryService!, item.DataGridViewColumn.GetType());
+                edSvc.DropDownControl(_columnTypePicker);
+                if (_columnTypePicker.SelectedType is not null)
+                {
+                    value = _columnTypePicker.SelectedType;
+                }
+            }
+        }
+
+        return value!;
+    }
+
+    public override UITypeEditorEditStyle GetEditStyle(ITypeDescriptorContext? context)
+    {
+        return UITypeEditorEditStyle.DropDown;
+    }
+}


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #10364 


## Proposed changes

- 
- Add DataGridViewColumnTypeEditor
- 

<!-- We are in TELL-MODE the following section must be completed -->
<!-- 
## Customer Impact

- 
- 

## Regression? 

- Yes / No
 -->
## Risk

- low



## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/dotnet/winforms/assets/26474449/3c335ca9-ccec-4595-b93a-dfa2c25f2da3)




### After

![image](https://github.com/dotnet/winforms/assets/26474449/55875bfa-0655-43d7-9c6d-efcb5571572e)


## Test methodology <!-- How did you ensure quality? -->

- 
- manually
- 
<!--
## Accessibility testing  <!-- Remove this section if PR does not change UI 


     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

9.0.0-preview.2.24116.2




 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/10907)