### PR TITLE
[release/8.0] WinForms TreeView null reference exception 'owningTreeView'

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeNode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeNode.cs
@@ -1169,7 +1169,7 @@ public partial class TreeNode : MarshalByRefObject, ICloneable, ISerializable
     }
 
     internal TreeNodeAccessibleObject AccessibilityObject
-        => _accessibleObject ??= new TreeNodeAccessibleObject(this, TreeView);
+        => _accessibleObject ??= TreeView is null ? null : new TreeNodeAccessibleObject(this, TreeView);
 
     /// <summary>
     ///  Adds a new child node at the appropriate sorted position

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
@@ -2208,7 +2208,7 @@ public partial class TreeView : Control
         // if editing hasn't been canceled.
         if (IsAccessibilityObjectCreated && !e.CancelEdit)
         {
-            e.Node.AccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
+            e.Node.AccessibilityObject?.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
         }
     }
 
@@ -2230,7 +2230,12 @@ public partial class TreeView : Control
         // Raise an event to announce a toggle state change.
         if (IsAccessibilityObjectCreated)
         {
-            AccessibleObject nodeAccessibleObject = e.Node.AccessibilityObject;
+            TreeNode.TreeNodeAccessibleObject nodeAccessibleObject = e.Node.AccessibilityObject;
+            if (nodeAccessibleObject is null)
+            {
+                return;
+            }
+
             UiaCore.ToggleState newState = nodeAccessibleObject.ToggleState;
             UiaCore.ToggleState oldState = newState == UiaCore.ToggleState.On
                 ? UiaCore.ToggleState.Off
@@ -2261,7 +2266,7 @@ public partial class TreeView : Control
         // Raise an event to announce the expand-collapse state change.
         if (IsAccessibilityObjectCreated)
         {
-            e.Node.AccessibilityObject.RaiseAutomationPropertyChangedEvent(
+            e.Node.AccessibilityObject?.RaiseAutomationPropertyChangedEvent(
                 UiaCore.UIA.ExpandCollapseExpandCollapseStatePropertyId,
                 oldValue: UiaCore.ExpandCollapseState.Expanded,
                 newValue: UiaCore.ExpandCollapseState.Collapsed);
@@ -2286,7 +2291,7 @@ public partial class TreeView : Control
         // Raise anevent to announce the expand-collapse state change.
         if (IsAccessibilityObjectCreated)
         {
-            e.Node.AccessibilityObject.RaiseAutomationPropertyChangedEvent(
+            e.Node.AccessibilityObject?.RaiseAutomationPropertyChangedEvent(
                 UiaCore.UIA.ExpandCollapseExpandCollapseStatePropertyId,
                 oldValue: UiaCore.ExpandCollapseState.Collapsed,
                 newValue: UiaCore.ExpandCollapseState.Expanded);
@@ -2327,7 +2332,12 @@ public partial class TreeView : Control
         // Raise an event to highlight & announce the selected node.
         if (IsAccessibilityObjectCreated)
         {
-            AccessibleObject nodeAccessibleObject = e.Node.AccessibilityObject;
+            TreeNode.TreeNodeAccessibleObject nodeAccessibleObject = e.Node.AccessibilityObject;
+            if (nodeAccessibleObject is null)
+            {
+                return;
+            }
+
             nodeAccessibleObject.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
             nodeAccessibleObject.RaiseAutomationEvent(UiaCore.UIA.SelectionItem_ElementSelectedEventId);
 
@@ -3194,7 +3204,7 @@ public partial class TreeView : Control
         // Raise an event to highlight & announce the selected node.
         if (IsAccessibilityObjectCreated)
         {
-            SelectedNode?.AccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
+            SelectedNode?.AccessibilityObject?.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
         }
     }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
@@ -2206,7 +2206,7 @@ public partial class TreeView : Control
 
         // Raise an event to highlight & announce the edited node
         // if editing hasn't been canceled.
-        if (IsAccessibilityObjectCreated && !e.CancelEdit)
+        if (IsAccessibilityObjectCreated && !e.CancelEdit && e.Node is not null)
         {
             e.Node.AccessibilityObject?.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
         }
@@ -2228,7 +2228,7 @@ public partial class TreeView : Control
         onAfterCheck?.Invoke(this, e);
 
         // Raise an event to announce a toggle state change.
-        if (IsAccessibilityObjectCreated)
+        if (IsAccessibilityObjectCreated && e.Node is not null)
         {
             TreeNode.TreeNodeAccessibleObject nodeAccessibleObject = e.Node.AccessibilityObject;
             if (nodeAccessibleObject is null)
@@ -2264,7 +2264,7 @@ public partial class TreeView : Control
         onAfterCollapse?.Invoke(this, e);
 
         // Raise an event to announce the expand-collapse state change.
-        if (IsAccessibilityObjectCreated)
+        if (IsAccessibilityObjectCreated && e.Node is not null)
         {
             e.Node.AccessibilityObject?.RaiseAutomationPropertyChangedEvent(
                 UiaCore.UIA.ExpandCollapseExpandCollapseStatePropertyId,
@@ -2288,8 +2288,8 @@ public partial class TreeView : Control
     {
         onAfterExpand?.Invoke(this, e);
 
-        // Raise anevent to announce the expand-collapse state change.
-        if (IsAccessibilityObjectCreated)
+        // Raise an event to announce the expand-collapse state change.
+        if (IsAccessibilityObjectCreated && e.Node is not null)
         {
             e.Node.AccessibilityObject?.RaiseAutomationPropertyChangedEvent(
                 UiaCore.UIA.ExpandCollapseExpandCollapseStatePropertyId,
@@ -2330,7 +2330,7 @@ public partial class TreeView : Control
         onAfterSelect?.Invoke(this, e);
 
         // Raise an event to highlight & announce the selected node.
-        if (IsAccessibilityObjectCreated)
+        if (IsAccessibilityObjectCreated && e.Node is not null)
         {
             TreeNode.TreeNodeAccessibleObject nodeAccessibleObject = e.Node.AccessibilityObject;
             if (nodeAccessibleObject is null)
@@ -2958,14 +2958,14 @@ public partial class TreeView : Control
                             {
                                 g.FillRectangle(SystemBrushes.Highlight, bounds);
                                 ControlPaint.DrawFocusRectangle(g, bounds, color, SystemColors.Highlight);
-                                TextRenderer.DrawText(g, e.Node.Text, font, bounds, color, TextFormatFlags.Default);
+                                TextRenderer.DrawText(g, node.Text, font, bounds, color, TextFormatFlags.Default);
                             }
                             else
                             {
                                 using var brush = BackColor.GetCachedSolidBrushScope();
                                 g.FillRectangle(brush, bounds);
 
-                                TextRenderer.DrawText(g, e.Node.Text, font, bounds, color, TextFormatFlags.Default);
+                                TextRenderer.DrawText(g, node.Text, font, bounds, color, TextFormatFlags.Default);
                             }
                         }
                     }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
@@ -5402,9 +5402,9 @@ public class TreeViewTests
 
     public static IEnumerable<object[]> TreeViewEventArgs_TestData()
     {
-        yield return new object[] { null };
         yield return new object[] { new TreeViewEventArgs(null) };
         yield return new object[] { new TreeViewEventArgs(new TreeNode()) };
+        yield return new object[] { new TreeViewEventArgs(new TreeNode(), TreeViewAction.ByMouse) };
     }
 
     [WinFormsTheory]
@@ -5419,6 +5419,8 @@ public class TreeViewTests
             Assert.Same(eventArgs, e);
             callCount++;
         };
+
+        Assert.NotNull(control.AccessibilityObject);
 
         // Call with handler.
         control.AfterCheck += handler;
@@ -5444,6 +5446,8 @@ public class TreeViewTests
             callCount++;
         };
 
+        Assert.NotNull(control.AccessibilityObject);
+
         // Call with handler.
         control.AfterCollapse += handler;
         control.OnAfterCollapse(eventArgs);
@@ -5468,6 +5472,8 @@ public class TreeViewTests
             callCount++;
         };
 
+        Assert.NotNull(control.AccessibilityObject);
+
         // Call with handler.
         control.AfterExpand += handler;
         control.OnAfterExpand(eventArgs);
@@ -5481,7 +5487,6 @@ public class TreeViewTests
 
     public static IEnumerable<object[]> NodeLabelEditEventArgs_TestData()
     {
-        yield return new object[] { null };
         yield return new object[] { new NodeLabelEditEventArgs(null) };
         yield return new object[] { new NodeLabelEditEventArgs(new TreeNode()) };
         yield return new object[] { new NodeLabelEditEventArgs(new TreeNode(), "label") };
@@ -5499,6 +5504,8 @@ public class TreeViewTests
             Assert.Same(eventArgs, e);
             callCount++;
         };
+
+        Assert.NotNull(control.AccessibilityObject);
 
         // Call with handler.
         control.AfterLabelEdit += handler;
@@ -5523,6 +5530,8 @@ public class TreeViewTests
             Assert.Same(eventArgs, e);
             callCount++;
         };
+
+        Assert.NotNull(control.AccessibilityObject);
 
         // Call with handler.
         control.AfterSelect += handler;


### PR DESCRIPTION
Fixes #10876
Port of https://github.com/dotnet/winforms/pull/10880
(PR was created by cherry-picking commits one-by-one)

## Proposed changes
TreeNodeAccessibleObject can't be created when the parent TreeView is not found. This could happen when a node is being added or deleted from the Nodes collection. If AccessibleObject is not created on this attempt, it will be created on the next access. If TreeView is not available, we skip object creation. This fix was implemented based on the exception call stack from the customer.

## Customer Impact
Customer observes random crashes in their application when dragging TreeView items and clicking on TreeView subtrees with the mouse.
No workaround is available, 

## Regression? 
- Yes from NET7, introduced while enabling accessibility events to TreeNode operations.

## Risk
 - Low, we are exiting if accessible object can't be created. AccessibleObject will be created after the node is parented properly.

## Test 
- added unit tests
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/10910)