### PR TITLE
Add ToolStripMenuItem test UI in WinformsControlTests

### DIFF
--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ToolStripTests.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ToolStripTests.Designer.cs
@@ -53,6 +53,13 @@ partial class ToolStripTests
         this.toolStrip2_DropDownButton1_ChildButton2 = new System.Windows.Forms.ToolStripMenuItem();
         this.toolStrip2_SplitButton1_ChildButton1 = new System.Windows.Forms.ToolStripMenuItem();
         this.toolStrip2_SplitButton1_ChildButton2 = new System.Windows.Forms.ToolStripMenuItem();
+        this.toolStrip2_MenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
+        this.toolStrip2_MenuItem2 = new System.Windows.Forms.ToolStripMenuItem();
+        this.uncheckedCheckOnClickToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+        this.checkCheckOnClickToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+        this.checkedCheckOnClickFToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+        this.indeterminateToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+        this.indeterminateCheckOnClickFToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
         this.toolStrip2.SuspendLayout();
         this.toolStrip1.SuspendLayout();
         this.statusStrip1.SuspendLayout();
@@ -81,6 +88,8 @@ partial class ToolStripTests
         this.toolStrip2_Button4,
         this.toolStrip2_Button5,
         this.toolStrip2_Button6,
+        this.toolStrip2_MenuItem1,
+        this.toolStrip2_MenuItem2,
         this.toolStrip2_SplitButton1,
         this.toolStrip2_DropDownButton1,});
         this.toolStrip2.Location = new System.Drawing.Point(0, 22);
@@ -149,6 +158,63 @@ partial class ToolStripTests
         this.toolStrip2_SplitButton1_ChildButton2.Name = "toolStrip2_SplitButton1_ChildButton2";
         this.toolStrip2_SplitButton1_ChildButton2.Size = new System.Drawing.Size(180, 22);
         this.toolStrip2_SplitButton1_ChildButton2.Text = "toolStrip2_SplitButton1_ChildButton2";
+        // 
+        // toolStrip2_MenuItem1
+        //
+        this.toolStrip2_MenuItem1.CheckState = System.Windows.Forms.CheckState.Checked;
+        this.toolStrip2_MenuItem1.Name = "toolStripMenuItem_checked";
+        this.toolStrip2_MenuItem1.Size = new System.Drawing.Size(180, 40);
+        this.toolStrip2_MenuItem1.Text = "toolStripMenuItem_checked";
+        this.toolStrip2_MenuItem1.ToolTipText = "toolStripMenuItem_checked";
+        // 
+        // toolStrip2_MenuItem2
+        // 
+        this.toolStrip2_MenuItem2.DropDownItems.AddRange(new ToolStripItem[] { uncheckedCheckOnClickToolStripMenuItem, checkCheckOnClickToolStripMenuItem, checkedCheckOnClickFToolStripMenuItem, indeterminateToolStripMenuItem, indeterminateCheckOnClickFToolStripMenuItem });
+        this.toolStrip2_MenuItem2.Name = "toolStripMenuItemWithDropDownItem";
+        this.toolStrip2_MenuItem2.Size = new System.Drawing.Size(180, 40);
+        this.toolStrip2_MenuItem2.Text = "toolStripMenuItemWithDropDownItem_unchecked";
+        this.toolStrip2_MenuItem2.ToolTipText = "toolStripMenuItemWithDropDownItem";
+        // 
+        // uncheckedCheckOnClickToolStripMenuItem
+        // 
+        this.uncheckedCheckOnClickToolStripMenuItem.CheckOnClick = true;
+        this.uncheckedCheckOnClickToolStripMenuItem.Name = "uncheckedCheckOnClickToolStripMenuItem";
+        this.uncheckedCheckOnClickToolStripMenuItem.Size = new System.Drawing.Size(481, 44);
+        this.uncheckedCheckOnClickToolStripMenuItem.Text = "Unchecked_CheckOnClick(T)";
+        // 
+        // checkCheckOnClickToolStripMenuItem
+        // 
+        this.checkCheckOnClickToolStripMenuItem.Checked = true;
+        this.checkCheckOnClickToolStripMenuItem.CheckOnClick = true;
+        this.checkCheckOnClickToolStripMenuItem.CheckState = CheckState.Checked;
+        this.checkCheckOnClickToolStripMenuItem.Name = "checkCheckOnClickToolStripMenuItem";
+        this.checkCheckOnClickToolStripMenuItem.Size = new System.Drawing.Size(481, 44);
+        this.checkCheckOnClickToolStripMenuItem.Text = "Checked_CheckOnClick(T)";
+        // 
+        // checkedCheckOnClickFToolStripMenuItem
+        // 
+        this.checkedCheckOnClickFToolStripMenuItem.Checked = true;
+        this.checkedCheckOnClickFToolStripMenuItem.CheckState = CheckState.Checked;
+        this.checkedCheckOnClickFToolStripMenuItem.Name = "checkedCheckOnClickFToolStripMenuItem";
+        this.checkedCheckOnClickFToolStripMenuItem.Size = new System.Drawing.Size(481, 44);
+        this.checkedCheckOnClickFToolStripMenuItem.Text = "Checked_CheckOnClick(F)";
+        // 
+        // indeterminateToolStripMenuItem
+        // 
+        this.indeterminateToolStripMenuItem.Checked = true;
+        this.indeterminateToolStripMenuItem.CheckOnClick = true;
+        this.indeterminateToolStripMenuItem.CheckState = CheckState.Indeterminate;
+        this.indeterminateToolStripMenuItem.Name = "indeterminateToolStripMenuItem";
+        this.indeterminateToolStripMenuItem.Size = new System.Drawing.Size(481, 44);
+        this.indeterminateToolStripMenuItem.Text = "Indeterminate_CheckOnClick(T)";
+        // 
+        // indeterminateCheckOnClickFToolStripMenuItem
+        // 
+        this.indeterminateCheckOnClickFToolStripMenuItem.Checked = true;
+        this.indeterminateCheckOnClickFToolStripMenuItem.CheckState = CheckState.Indeterminate;
+        this.indeterminateCheckOnClickFToolStripMenuItem.Name = "indeterminateCheckOnClickFToolStripMenuItem";
+        this.indeterminateCheckOnClickFToolStripMenuItem.Size = new System.Drawing.Size(481, 44);
+        this.indeterminateCheckOnClickFToolStripMenuItem.Text = "Indeterminate_CheckOnClick(F)";
         // 
         // toolStrip2_SplitButton1
         //
@@ -286,4 +352,11 @@ partial class ToolStripTests
     private System.Windows.Forms.ToolStripMenuItem toolStrip2_DropDownButton1_ChildButton2;
     private System.Windows.Forms.ToolStripMenuItem toolStrip2_SplitButton1_ChildButton1;
     private System.Windows.Forms.ToolStripMenuItem toolStrip2_SplitButton1_ChildButton2;
+    private System.Windows.Forms.ToolStripMenuItem toolStrip2_MenuItem1;
+    private System.Windows.Forms.ToolStripMenuItem toolStrip2_MenuItem2;
+    private System.Windows.Forms.ToolStripMenuItem uncheckedCheckOnClickToolStripMenuItem;
+    private System.Windows.Forms.ToolStripMenuItem checkCheckOnClickToolStripMenuItem;
+    private System.Windows.Forms.ToolStripMenuItem checkedCheckOnClickFToolStripMenuItem;
+    private System.Windows.Forms.ToolStripMenuItem indeterminateToolStripMenuItem;
+    private System.Windows.Forms.ToolStripMenuItem indeterminateCheckOnClickFToolStripMenuItem;
 }

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ToolStripTests.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ToolStripTests.Designer.cs
@@ -53,8 +53,9 @@ partial class ToolStripTests
         this.toolStrip2_DropDownButton1_ChildButton2 = new System.Windows.Forms.ToolStripMenuItem();
         this.toolStrip2_SplitButton1_ChildButton1 = new System.Windows.Forms.ToolStripMenuItem();
         this.toolStrip2_SplitButton1_ChildButton2 = new System.Windows.Forms.ToolStripMenuItem();
-        this.toolStrip2_MenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
-        this.toolStrip2_MenuItem2 = new System.Windows.Forms.ToolStripMenuItem();
+        this.toolStrip3 = new System.Windows.Forms.ToolStrip();
+        this.toolStrip3_MenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
+        this.toolStrip3_MenuItem2 = new System.Windows.Forms.ToolStripMenuItem();
         this.uncheckedCheckOnClickToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
         this.checkCheckOnClickToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
         this.checkedCheckOnClickFToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -88,8 +89,8 @@ partial class ToolStripTests
         this.toolStrip2_Button4,
         this.toolStrip2_Button5,
         this.toolStrip2_Button6,
-        this.toolStrip2_MenuItem1,
-        this.toolStrip2_MenuItem2,
+        this.toolStrip3_MenuItem1,
+        this.toolStrip3_MenuItem2,
         this.toolStrip2_SplitButton1,
         this.toolStrip2_DropDownButton1,});
         this.toolStrip2.Location = new System.Drawing.Point(0, 22);
@@ -98,6 +99,18 @@ partial class ToolStripTests
         this.toolStrip2.TabIndex = 1;
         this.toolStrip2.Text = "toolStrip2";
         this.toolStrip2.TabStop = true;
+        // 
+        // toolStrip3
+        // 
+        this.toolStrip3.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+        this.toolStrip3_MenuItem1,
+        this.toolStrip3_MenuItem2,});
+        this.toolStrip3.Location = new System.Drawing.Point(0, 45);
+        this.toolStrip3.Name = "toolStrip3";
+        this.toolStrip3.Size = new System.Drawing.Size(481, 22);
+        this.toolStrip3.TabIndex = 1;
+        this.toolStrip3.Text = "toolStrip3";
+        this.toolStrip3.TabStop = true;
         // 
         // toolStrip2_Button1
         //
@@ -159,21 +172,21 @@ partial class ToolStripTests
         this.toolStrip2_SplitButton1_ChildButton2.Size = new System.Drawing.Size(180, 22);
         this.toolStrip2_SplitButton1_ChildButton2.Text = "toolStrip2_SplitButton1_ChildButton2";
         // 
-        // toolStrip2_MenuItem1
+        // toolStrip3_MenuItem1
         //
-        this.toolStrip2_MenuItem1.CheckState = System.Windows.Forms.CheckState.Checked;
-        this.toolStrip2_MenuItem1.Name = "toolStripMenuItem_checked";
-        this.toolStrip2_MenuItem1.Size = new System.Drawing.Size(180, 40);
-        this.toolStrip2_MenuItem1.Text = "toolStripMenuItem_checked";
-        this.toolStrip2_MenuItem1.ToolTipText = "toolStripMenuItem_checked";
+        this.toolStrip3_MenuItem1.CheckState = System.Windows.Forms.CheckState.Checked;
+        this.toolStrip3_MenuItem1.Name = "toolStripMenuItem_checked";
+        this.toolStrip3_MenuItem1.Size = new System.Drawing.Size(180, 40);
+        this.toolStrip3_MenuItem1.Text = "toolStripMenuItem_checked";
+        this.toolStrip3_MenuItem1.ToolTipText = "toolStripMenuItem_checked";
         // 
-        // toolStrip2_MenuItem2
+        // toolStrip3_MenuItem2
         // 
-        this.toolStrip2_MenuItem2.DropDownItems.AddRange(new ToolStripItem[] { uncheckedCheckOnClickToolStripMenuItem, checkCheckOnClickToolStripMenuItem, checkedCheckOnClickFToolStripMenuItem, indeterminateToolStripMenuItem, indeterminateCheckOnClickFToolStripMenuItem });
-        this.toolStrip2_MenuItem2.Name = "toolStripMenuItemWithDropDownItem";
-        this.toolStrip2_MenuItem2.Size = new System.Drawing.Size(180, 40);
-        this.toolStrip2_MenuItem2.Text = "toolStripMenuItemWithDropDownItem_unchecked";
-        this.toolStrip2_MenuItem2.ToolTipText = "toolStripMenuItemWithDropDownItem";
+        this.toolStrip3_MenuItem2.DropDownItems.AddRange(new ToolStripItem[] { uncheckedCheckOnClickToolStripMenuItem, checkCheckOnClickToolStripMenuItem, checkedCheckOnClickFToolStripMenuItem, indeterminateToolStripMenuItem, indeterminateCheckOnClickFToolStripMenuItem });
+        this.toolStrip3_MenuItem2.Name = "toolStripMenuItemWithDropDownItem";
+        this.toolStrip3_MenuItem2.Size = new System.Drawing.Size(180, 40);
+        this.toolStrip3_MenuItem2.Text = "toolStripMenuItemWithDropDownItem_unchecked";
+        this.toolStrip3_MenuItem2.ToolTipText = "toolStripMenuItemWithDropDownItem";
         // 
         // uncheckedCheckOnClickToolStripMenuItem
         // 
@@ -264,7 +277,7 @@ partial class ToolStripTests
         // label1
         // 
         this.label1.AutoSize = true;
-        this.label1.Location = new System.Drawing.Point(12, 56);
+        this.label1.Location = new System.Drawing.Point(12, 78);
         this.label1.Name = "label1";
         this.label1.Size = new System.Drawing.Size(78, 13);
         this.label1.TabIndex = 2;
@@ -313,6 +326,7 @@ partial class ToolStripTests
         this.ClientSize = new System.Drawing.Size(881, 123);
         this.Controls.Add(this.label1);
         this.Controls.Add(this.statusStrip1);
+        this.Controls.Add(this.toolStrip3);
         this.Controls.Add(this.toolStrip2);
         this.Controls.Add(this.toolStrip1);
         this.Name = "ToolStripTests";
@@ -323,6 +337,8 @@ partial class ToolStripTests
         this.statusStrip1.PerformLayout();
         this.toolStrip2.ResumeLayout(false);
         this.toolStrip2.PerformLayout();
+        this.toolStrip3.ResumeLayout(false);
+        this.toolStrip3.PerformLayout();
         this.ResumeLayout(false);
         this.PerformLayout();
 
@@ -340,6 +356,7 @@ partial class ToolStripTests
     private System.Windows.Forms.ToolStripProgressBar toolStripProgressBar2;
     private System.Windows.Forms.Label label1;
     private System.Windows.Forms.ToolStrip toolStrip2;
+    private System.Windows.Forms.ToolStrip toolStrip3;
     private System.Windows.Forms.ToolStripButton toolStrip2_Button1;
     private System.Windows.Forms.ToolStripButton toolStrip2_Button2;
     private System.Windows.Forms.ToolStripButton toolStrip2_Button3;
@@ -352,8 +369,8 @@ partial class ToolStripTests
     private System.Windows.Forms.ToolStripMenuItem toolStrip2_DropDownButton1_ChildButton2;
     private System.Windows.Forms.ToolStripMenuItem toolStrip2_SplitButton1_ChildButton1;
     private System.Windows.Forms.ToolStripMenuItem toolStrip2_SplitButton1_ChildButton2;
-    private System.Windows.Forms.ToolStripMenuItem toolStrip2_MenuItem1;
-    private System.Windows.Forms.ToolStripMenuItem toolStrip2_MenuItem2;
+    private System.Windows.Forms.ToolStripMenuItem toolStrip3_MenuItem1;
+    private System.Windows.Forms.ToolStripMenuItem toolStrip3_MenuItem2;
     private System.Windows.Forms.ToolStripMenuItem uncheckedCheckOnClickToolStripMenuItem;
     private System.Windows.Forms.ToolStripMenuItem checkCheckOnClickToolStripMenuItem;
     private System.Windows.Forms.ToolStripMenuItem checkedCheckOnClickFToolStripMenuItem;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Related #10834 


## Proposed changes

- Add ToolStripMenuItem test in WinformsControlTests

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- ToolStripMenuItem can be tested in project WinformsControlTests

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/dotnet/winforms/assets/132890443/f68a7403-082f-4a11-baee-c76bd6c5fd69)


### After
![image](https://github.com/dotnet/winforms/assets/132890443/ccbc72ed-7982-44c7-98d7-c18d17a9d7cc)



## Test methodology <!-- How did you ensure quality? -->

- Manually

## Test environment(s) <!-- Remove any that don't apply -->

- .net 9.0.0-preview.2.24116.2


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/10914)