### PR TITLE
Suppress codeQL warnings in tests "BitmapTests" and "ImageListTests"

### DIFF
--- a/src/System.Drawing.Common/tests/mono/System.Drawing/BitmapTests.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing/BitmapTests.cs
@@ -390,7 +390,7 @@ public class BitmapTests
         }
 
         // cs/weak-crypto
-        hash = MD5.Create().ComputeHash(pixels);// CodeQL [SM02196] Using MD5 for this specific scenario is acceptable.
+        hash = MD5.Create().ComputeHash(pixels); // CodeQL [SM02196] This hash is used in test to compare two bitmaps.
         return ByteArrayToString(hash);
     }
 

--- a/src/System.Drawing.Common/tests/mono/System.Drawing/BitmapTests.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing/BitmapTests.cs
@@ -389,7 +389,8 @@ public class BitmapTests
             }
         }
 
-        hash = MD5.Create().ComputeHash(pixels);
+        // cs/weak-crypto
+        hash = MD5.Create().ComputeHash(pixels);// CodeQL [SM02196] Using MD5 for this specific scenario is acceptable.
         return ByteArrayToString(hash);
     }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ImageListTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ImageListTests.cs
@@ -444,7 +444,8 @@ public class ImageListTests
         BinaryFormatter formatter = new();
         formatter.Serialize(stream, source);
         stream.Position = 0;
-        return (T)formatter.Deserialize(stream);
+        // cs/deserialization-unexpected-subtypes
+        return (T)formatter.Deserialize(stream);// CodeQL [SM02229] Deserialization is handled correctly here.
 #pragma warning restore SYSLIB0011 // Type or member is obsolete
     }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ImageListTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ImageListTests.cs
@@ -445,7 +445,7 @@ public class ImageListTests
         formatter.Serialize(stream, source);
         stream.Position = 0;
         // cs/deserialization-unexpected-subtypes
-        return (T)formatter.Deserialize(stream);// CodeQL [SM02229] Deserialization is handled correctly here.
+        return (T)formatter.Deserialize(stream); // CodeQL [SM02229] Testing legacy features: we are deserializing stream with controlled content.
 #pragma warning restore SYSLIB0011 // Type or member is obsolete
     }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Related #10871

Suppress codeQL warnings in BitmapTests and ImageListTests 

## Related bug:
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1666874/?view=edit
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1775936/?view=edit

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/10922)