### PR TITLE
Set ProducesDotNetReleaseShippingAssets property in Publishing.props

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -2,5 +2,6 @@
 <Project>
    <PropertyGroup>
       <PublishingVersion>3</PublishingVersion>
+      <ProducesDotNetReleaseShippingAssets>true</ProducesDotNetReleaseShippingAssets>
    </PropertyGroup>
 </Project>


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

Add a boolean property named `ProducesDotNetReleaseShippingAssets` in Publishing.props for repos that produce .NET shipping packages (packages that we ship with the release infra)
Based on this property we will select which packages to ship as part of .NET on release day.

**This is a infrastructure only change.** It will add extra metadata to the MergedManifest.xml produced during CI build.

Issue: https://github.com/dotnet/release/issues/822

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

No

## Regression? 

No

## Risk

No

<!-- end TELL-MODE -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/10923)