### PR TITLE
Make AxHost work without classic COM interop.

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ActiveX/AxHost.ConnectionPointCookie.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ActiveX/AxHost.ConnectionPointCookie.cs
@@ -22,7 +22,7 @@ public abstract partial class AxHost
 
         internal ConnectionPointCookie(object? source, object sink, Type eventInterface, bool throwException)
         {
-            if (source is not IConnectionPointContainer.Interface cpc)
+            if (!ComHelpers.SupportsInterface<IConnectionPointContainer>(source))
             {
                 if (throwException)
                 {
@@ -45,8 +45,10 @@ public abstract partial class AxHost
             IConnectionPoint* connectionPoint = null;
             try
             {
+                using var cpc = ComHelpers.GetComScope<IConnectionPointContainer>(source);
+
                 Guid riid = eventInterface.GUID;
-                HRESULT hr = cpc.FindConnectionPoint(&riid, &connectionPoint);
+                HRESULT hr = cpc.Value->FindConnectionPoint(&riid, &connectionPoint);
             }
             catch (Exception ex)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ActiveX/AxHost.OleInterfaces.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ActiveX/AxHost.OleInterfaces.cs
@@ -5,6 +5,7 @@ using System.ComponentModel;
 using System.ComponentModel.Design;
 using System.Drawing;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Windows.Win32.System.Com;
 using Windows.Win32.System.Ole;
 using Windows.Win32.System.Variant;
@@ -129,7 +130,15 @@ public abstract partial class AxHost
             object? ambient = _host.GetAmbientProperty(dispId);
             if (ambient is not null)
             {
-                Marshal.GetNativeVariantForObject(ambient, (nint)result);
+                if (ComHelpers.BuiltInComSupported)
+                {
+                    Marshal.GetNativeVariantForObject(ambient, (nint)result);
+                }
+                else
+                {
+                    *(ComVariant*)result = ComVariantMarshaller.ConvertToUnmanaged(ambient);
+                }
+
                 return HRESULT.S_OK;
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ActiveX/AxHost.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ActiveX/AxHost.cs
@@ -9,6 +9,7 @@ using System.Globalization;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using Microsoft.VisualStudio.Shell;
 using Windows.Win32.System.Com;
 using Windows.Win32.System.Com.StructuredStorage;
@@ -3464,7 +3465,15 @@ public abstract unsafe partial class AxHost : Control, ISupportInitialize, ICust
         {
             if (_instance is not null)
             {
-                Marshal.ReleaseComObject(_instance);
+                if (_instance is ComObject)
+                {
+                    // TODO: how to release a ComWrappers ComObject?
+                }
+                else
+                {
+                    Marshal.ReleaseComObject(_instance);
+                }
+
                 _instance = null;
                 DisposeHelper.NullAndDispose(ref _iOleInPlaceActiveObjectExternal);
             }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #10583

## Proposed changes

- Adjust COM interop in WinForms to have AxHost usable together with classic COM interop disabled (`<BuiltInComInteropSupport>false</BuiltInComInteropSupport>`), which is a requirement for AOT.

## Customer Impact

- Allows using ActiveX controls in AOT builds.

## Regression? 

- No

## Risk

- I may have gotten some of the interop wrong, the PR requires review
- I have no unit test coverage. Test coverage can be added but requires #10754 to have a simple control. Since it has to be handwritten and cannot be generated yet it can't be one of the more complex Windows-provided ActiveX controls.

### Before

- Application fails with exceptions if an ActiveX control is used while having configured  `<BuiltInComInteropSupport>false</BuiltInComInteropSupport>` in the project file.

### After

- Application can support a simple ActiveX while having configured  `<BuiltInComInteropSupport>false</BuiltInComInteropSupport>` in the project file.

## Test methodology <!-- How did you ensure quality? -->

- so far only manual testing in the scratch project, not part of the PR since it depends on the ActiveX control of #10754 which is part of a separate PR

## Test environment(s) <!-- Remove any that don't apply -->

- 9.0.0-preview.2.24116.2
- `<BuiltInComInteropSupport>false</BuiltInComInteropSupport>` in the project file
- I've also used `[assembly: DisableRuntimeMarshalling]` in my test, in case its relevant

<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/10927)