### PR TITLE
Fix `PrintDialog` to return `DialogResult.Cancel` when cancelled or closed

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.PrintDlg.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.PrintDlg.cs
@@ -9,9 +9,9 @@ namespace Windows.Win32;
 internal static partial class PInvoke
 {
     [DllImport("COMDLG32.dll", ExactSpelling = true, EntryPoint = "PrintDlgW")]
-    internal static extern unsafe HRESULT PrintDlg(PRINTDLGW_64* pPD);
+    internal static extern unsafe BOOL PrintDlg(PRINTDLGW_64* pPD);
 
-    internal static unsafe HRESULT PrintDlg(PRINTDLGW_32* pPD)
+    internal static unsafe BOOL PrintDlg(PRINTDLGW_32* pPD)
     {
         Debug.Assert(RuntimeInformation.ProcessArchitecture == Architecture.X86);
         return PrintDlg((PRINTDLGW_64*)pPD);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintDialog.cs
@@ -292,15 +292,18 @@ public sealed class PrintDialog : CommonDialog
                 dialogSettings->nMaxPage = (ushort)PrinterSettings.MaximumPage;
             }
 
-            HRESULT result = RuntimeInformation.ProcessArchitecture == Architecture.X86
+            BOOL result = RuntimeInformation.ProcessArchitecture == Architecture.X86
                 ? PInvoke.PrintDlg(&dialogSettings32)
                 : PInvoke.PrintDlg(&dialogSettings64);
 
-            if (result.Failed)
+            if (!result)
             {
 #if DEBUG
                 var extendedResult = PInvoke.CommDlgExtendedError();
-                Debug.Fail($"PrintDlg returned non zero error code: {extendedResult}");
+                if (extendedResult != COMMON_DLG_ERRORS.CDERR_GENERALCODES)
+                {
+                    Debug.Fail($"PrintDlg returned non zero error code: {extendedResult}");
+                }
 #endif
                 return false;
             }
@@ -331,7 +334,7 @@ public sealed class PrintDialog : CommonDialog
                 PrinterSettings.Collate = dialogSettings->Flags.HasFlag(PRINTDLGEX_FLAGS.PD_COLLATE);
             }
 
-            return true;
+            return result;
         }
         finally
         {

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/PrintDialogTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/PrintDialogTests.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit.Abstractions;
+
+namespace System.Windows.Forms.UITests;
+
+public class PrintDialogTests : ControlTestBase
+{
+    public PrintDialogTests(ITestOutputHelper testOutputHelper)
+        : base(testOutputHelper)
+    {
+    }
+
+    // Regression test for https://github.com/dotnet/winforms/issues/10920
+    [WinFormsFact]
+    public void PrintDialogTests_UseEXDialog_Cancel_Success()
+    {
+        using DialogHostForm dialogOwnerForm = new();
+        using PrintDialog dialog = new();
+        dialog.UseEXDialog = false;
+        Assert.Equal(DialogResult.Cancel, dialog.ShowDialog(dialogOwnerForm));
+    }
+
+    [WinFormsFact]
+    public void PrintDialogTests_UseEXDialog_Success()
+    {
+        using AcceptDialogForm dialogOwnerForm = new();
+        using PrintDialog dialog = new();
+        dialog.UseEXDialog = false;
+        Assert.Equal(DialogResult.OK, dialog.ShowDialog(dialogOwnerForm));
+    }
+
+    private class AcceptDialogForm : DialogHostForm
+    {
+        protected override void OnDialogIdle(HWND dialogHandle)
+        {
+            Accept(dialogHandle);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #10920
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/10928)