### PR TITLE
Supress remaining CodeQL warning on tests

### DIFF
--- a/src/Common/tests/TestUtilities/BinarySerialization.cs
+++ b/src/Common/tests/TestUtilities/BinarySerialization.cs
@@ -68,14 +68,17 @@ public static class BinarySerialization
             FormatterAssemblyStyle assemblyStyle = FormatterAssemblyStyle.Simple)
         {
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
-            BinaryFormatter binaryFormatter = new()
+            // cs/binary-formatter-without-binder
+            BinaryFormatter binaryFormatter = new()// CodeQL [SM04191] : Safe use because the deserialization process is performed on trusted data and the types are controlled and validated.
             {
                 AssemblyFormat = assemblyStyle
             };
 #pragma warning restore SYSLIB0011 // Type or member is obsolete
 
             using MemoryStream serializedStream = new(raw);
-            return binaryFormatter.Deserialize(serializedStream);
+
+            // cs/dangerous-binary-deserialization
+            return binaryFormatter.Deserialize(serializedStream);// CodeQL[SM03722] : This is a safe use of BinaryFormatter because the data is trusted and the types are controlled and validated.
         }
     }
 
@@ -89,7 +92,8 @@ public static class BinarySerialization
             FormatterAssemblyStyle assemblyStyle = FormatterAssemblyStyle.Simple)
         {
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
-            BinaryFormatter binaryFormatter = new()
+            // cs/binary-formatter-without-binder
+            BinaryFormatter binaryFormatter = new()// CodeQL [SM04191]: Safe use because the deserialization process is performed on trusted data and the types are controlled and validated.
             {
                 AssemblyFormat = assemblyStyle
             };

--- a/src/System.Drawing.Common/tests/DrawingTest.cs
+++ b/src/System.Drawing.Common/tests/DrawingTest.cs
@@ -7,7 +7,8 @@ namespace System.Drawing.Tests;
 
 public abstract class DrawingTest
 {
-    private static Security.Cryptography.MD5 s_md5 = Security.Cryptography.MD5.Create();
+    // cs/weak-crypto
+    private static Security.Cryptography.MD5 s_md5 = Security.Cryptography.MD5.Create();  // CodeQL [SM02196] This hash is used in test to compare two bitmaps.
 
     protected unsafe void ValidateBitmapContent(Bitmap bitmap, params byte[] expectedHash)
     {

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/BinaryFormatWriterTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/BinaryFormatWriterTests.cs
@@ -23,7 +23,9 @@ public class BinaryFormatWriterTests
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
         BinaryFormatter formatter = new();
 #pragma warning restore
-        object deserialized = formatter.Deserialize(stream);
+
+        // cs/dangerous-binary-deserialization
+        object deserialized = formatter.Deserialize(stream); // CodeQL [SM03722] : This is a safe use of BinaryFormatter because the data is trusted and the types are controlled and validated.
         deserialized.Should().Be(testString);
     }
 
@@ -38,9 +40,12 @@ public class BinaryFormatWriterTests
 
         using BinaryFormatterScope formatterScope = new(enable: true);
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
-        BinaryFormatter formatter = new();
+        // cs/binary-formatter-without-binder
+        BinaryFormatter formatter = new(); // CodeQL [SM04191] : Safe use because the deserialization process is performed on trusted data and the types are controlled and validated.
 #pragma warning restore SYSLIB0011 // Type or member is obsolete
-        object deserialized = formatter.Deserialize(stream);
+
+        // cs/dangerous-binary-deserialization
+        object deserialized = formatter.Deserialize(stream);// CodeQL [SM03722] : This is a safe use of BinaryFormatter because the data is trusted and the types are controlled and validated.
 
         if (value is Hashtable hashtable)
         {

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/HashTableTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/HashTableTests.cs
@@ -117,8 +117,11 @@ public class HashtableTests
 
         using BinaryFormatterScope formatterScope = new(enable: true);
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
-        BinaryFormatter formatter = new();
-        Hashtable deserialized = (Hashtable)formatter.Deserialize(stream);
+        // cs/binary-formatter-without-binder
+        BinaryFormatter formatter = new(); // CodeQL [SM04191] : Safe use because the deserialization process is performed on trusted data and the types are controlled and validated.
+
+        // cs/dangerous-binary-deserialization
+        Hashtable deserialized = (Hashtable)formatter.Deserialize(stream); // CodeQL [SM03722] : This is a safe use of BinaryFormatter because the data is trusted and the types are controlled and validated.
 #pragma warning restore SYSLIB0011
 
         deserialized.Count.Should().Be(hashtable.Count);

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/ListTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/ListTests.cs
@@ -172,8 +172,10 @@ public class ListTests
 
         using BinaryFormatterScope formatterScope = new(enable: true);
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
-        BinaryFormatter formatter = new();
-        IList deserialized = (IList)formatter.Deserialize(stream);
+        // cs/binary-formatter-without-binder
+        BinaryFormatter formatter = new(); // CodeQL [SM04191] : Safe use because the deserialization process is performed on trusted data and the types are controlled and validated.
+        // cs/dangerous-binary-deserialization
+        IList deserialized = (IList)formatter.Deserialize(stream); // CodeQL[SM02229] : This is a safe use of BinaryFormatter because the data is trusted and the types are controlled and validated.
 #pragma warning restore SYSLIB0011
 
         deserialized.Should().BeEquivalentTo(list);

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/PrimitiveTypeTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/PrimitiveTypeTests.cs
@@ -100,9 +100,14 @@ public class PrimitiveTypeTests
 
         using BinaryFormatterScope formatterScope = new(enable: true);
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
-        BinaryFormatter formatter = new();
+
+        // cs/binary-formatter-without-binder
+        BinaryFormatter formatter = new(); // CodeQL [SM04191] : Safe use because the deserialization process is performed on trusted data and the types are controlled and validated.
+
 #pragma warning restore SYSLIB0011 // Type or member is obsolete
-        object deserialized = formatter.Deserialize(stream);
+
+        // cs/dangerous-binary-deserialization
+        object deserialized = formatter.Deserialize(stream); // CodeQL [SM03722] : This is a safe use of BinaryFormatter because the data is trusted and the types are controlled and validated.
         deserialized.Should().Be(value);
     }
 

--- a/src/System.Windows.Forms/tests/InteropTests/NativeTests/testhelpers.h
+++ b/src/System.Windows.Forms/tests/InteropTests/NativeTests/testhelpers.h
@@ -32,7 +32,8 @@ std::wstring format(const wchar_t* format, Args... args)
     int length = std::swprintf(nullptr, 0, format, args...);
     // If this fails, let the program crash.
     wchar_t* buf = new wchar_t[length + 1];
-    std::swprintf(buf, length + 1, format, args...);
+    // cpp/non-constant-format
+    std::swprintf(buf, length + 1, format, args...); // CodeQL [SM01734] : This is a format string that is not a string literal. It could be a security vulnerability if it comes from an untrusted source.
 
     std::wstring str(buf);
     delete[] buf;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AxHost.PropertyBagStreamTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AxHost.PropertyBagStreamTests.cs
@@ -14,10 +14,12 @@ public unsafe class AxHost_PropertyBagStreamTests
     {
         using BinaryFormatterScope formatterScope = new(enable: true);
         AxHost.PropertyBagStream bag = new();
-        HRESULT hr = bag.Write("Integer", (VARIANT)42);
+        // cs/deserialization-unexpected-subtypes
+        HRESULT hr = bag.Write("Integer", (VARIANT)42); // CodeQL[SM02229] : This is a safe use of VARIANT because the data is trusted and the types are controlled and validated.
         Assert.True(hr.Succeeded);
         NameClass obj = new() { Name = "Hamlet" };
-        hr = bag.Write("Object", VARIANT.FromObject(obj));
+        // cs/deserialization-unexpected-subtypes
+        hr = bag.Write("Object", VARIANT.FromObject(obj)); // CodeQL[SM02229] : This is a safe use of VARIANT because the data is trusted and the types are controlled and validated.
         Assert.True(hr.Succeeded);
 
         using MemoryStream stream = new();
@@ -43,7 +45,9 @@ public unsafe class AxHost_PropertyBagStreamTests
     {
         using BinaryFormatterScope formatterScope = new(enable: false);
         AxHost.PropertyBagStream bag = new();
-        HRESULT hr = bag.Write("Integer", (VARIANT)42);
+
+        // cs/deserialization-unexpected-subtypes
+        HRESULT hr = bag.Write("Integer", (VARIANT)42); // CodeQL[SM02229] : This is a safe use of VARIANT because the data is trusted and the types are controlled and validated.
         Assert.True(hr.Succeeded);
         NameClass obj = new() { Name = "Hamlet" };
         hr = bag.Write("Object", VARIANT.FromObject(obj));
@@ -65,7 +69,8 @@ public unsafe class AxHost_PropertyBagStreamTests
         Marshal.GetNativeVariantForObject(value, (nint)(void*)&variant);
         string name = value.GetType().FullName!;
 
-        HRESULT hr = bag.Write(value.GetType().FullName!, variant);
+        // cs/deserialization-unexpected-subtypes
+        HRESULT hr = bag.Write(value.GetType().FullName!, variant); // CodeQL[SM02229] : This is a safe use of VARIANT because the data is trusted and the types are controlled and validated.
         Assert.True(hr.Succeeded);
 
         using MemoryStream stream = new();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/BinaryFormat/WinFormsBinaryFormattedObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/BinaryFormat/WinFormsBinaryFormattedObjectTests.cs
@@ -55,12 +55,14 @@ public class WinFormsBinaryFormattedObjectTests
 
         using BinaryFormatterScope formatterScope = new(enable: true);
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
-        BinaryFormatter binaryFormat = new();
+        // cs/binary-formatter-without-binder
+        BinaryFormatter binaryFormat = new(); // CodeQL [SM04191] : Safe use because the deserialization process is performed on trusted data and the types are controlled and validated.
 #pragma warning restore SYSLIB0011
 
-        using Bitmap deserialized = binaryFormat.Deserialize(stream).Should().BeOfType<Bitmap>().Which;
+        // cs/dangerous-binary-deserialization
+        using Bitmap deserialized = binaryFormat.Deserialize(stream).Should().BeOfType<Bitmap>().Which; // CodeQL [SM03722] : This is a safe use of BinaryFormatter because the data is trusted and the types are controlled and validated.
         deserialized.Size.Should().Be(bitmap.Size);
-    }   
+    }
 
     [Fact]
     public void BinaryFormattedObject_ImageListStreamer_FromBinaryFormatter()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataObject_BitmapBinderTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataObject_BitmapBinderTests.cs
@@ -42,7 +42,8 @@ public class DataObject_BitmapBinderTests
         {
             using MemoryStream stream = new();
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
-            BinaryFormatter formatter = new();
+            // cs/binary-formatter-without-binder
+            BinaryFormatter formatter = new(); // CodeQL [SM04191] : Safe use because the deserialization process is performed on trusted data and the types are controlled and validated.
 #pragma warning restore
             formatter.Serialize(stream, value);
             Assert.True(stream.Length > 0);
@@ -94,7 +95,8 @@ public class DataObject_BitmapBinderTests
         using BinaryFormatterScope formatterScope = new(enable: true);
         using MemoryStream stream = new();
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
-        BinaryFormatter formatter = new();
+        // cs/binary-formatter-without-binder
+        BinaryFormatter formatter = new(); // CodeQL [SM04191] : Safe use because the deserialization process is performed on trusted data and the types are controlled and validated.
 #pragma warning restore SYSLIB0011
         formatter.Serialize(stream, value);
         Assert.True(stream.Length > 0);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ImageListTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ImageListTests.cs
@@ -441,10 +441,12 @@ public class ImageListTests
         using BinaryFormatterScope formatterScope = new(enable: true);
         using MemoryStream stream = new();
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
-        BinaryFormatter formatter = new();
+        // cs/binary-formatter-without-binder
+        BinaryFormatter formatter = new();  // CodeQL [SM04191] : Safe use because the deserialization process is performed on trusted data and the types are controlled and validated.
         formatter.Serialize(stream, source);
         stream.Position = 0;
-        return (T)formatter.Deserialize(stream);
+        // cs/dangerous-binary-deserialization
+        return (T)formatter.Deserialize(stream); // CodeQL [SM03722] : This is a safe use of BinaryFormatter because the data is trusted and the types are controlled and validated.
 #pragma warning restore SYSLIB0011 // Type or member is obsolete
     }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Layout/TableLayoutSettingsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Layout/TableLayoutSettingsTests.cs
@@ -1785,11 +1785,13 @@ public class TableLayoutSettingsTests
         using (MemoryStream stream = new())
         {
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
-            BinaryFormatter formatter = new();
+            // cs/binary-formatter-without-binder
+            BinaryFormatter formatter = new(); // CodeQL [SM04191] : Safe use because the deserialization process is performed on trusted data and the types are controlled and validated.
             formatter.Serialize(stream, settings);
             stream.Seek(0, SeekOrigin.Begin);
 
-            TableLayoutSettings result = Assert.IsType<TableLayoutSettings>(formatter.Deserialize(stream));
+            // cs/dangerous-binary-deserialization
+            TableLayoutSettings result = Assert.IsType<TableLayoutSettings>(formatter.Deserialize(stream)); // CodeQL [SM03722] : This is a safe use of BinaryFormatter because the data is trusted and the types are controlled and validated.
 #pragma warning restore SYSLIB0011 // Type or member is obsolete
             Assert.Equal(columnStyle.SizeType, ((ColumnStyle)Assert.Single(result.ColumnStyles)).SizeType);
             Assert.Equal(columnStyle.Width, ((ColumnStyle)Assert.Single(result.ColumnStyles)).Width);
@@ -1815,11 +1817,13 @@ public class TableLayoutSettingsTests
         using (MemoryStream stream = new())
         {
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
-            BinaryFormatter formatter = new();
+            // cs/binary-formatter-without-binder
+            BinaryFormatter formatter = new(); // CodeQL [SM04191] : Safe use because the deserialization process is performed on trusted data and the types are controlled and validated.
             formatter.Serialize(stream, settings);
             stream.Seek(0, SeekOrigin.Begin);
 
-            Assert.Throws<SerializationException>(() => formatter.Deserialize(stream));
+            // cs/dangerous-binary-deserialization
+            Assert.Throws<SerializationException>(() => formatter.Deserialize(stream)); // CodeQL [SM03722] : This is a safe use of BinaryFormatter because the data is trusted and the types are controlled and validated.
 #pragma warning restore SYSLIB0011 // Type or member is obsolete
         }
     }
@@ -1836,12 +1840,14 @@ public class TableLayoutSettingsTests
         using (MemoryStream stream = new())
         {
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
-            BinaryFormatter formatter = new();
+            // cs/binary-formatter-without-binder
+            BinaryFormatter formatter = new(); // CodeQL [SM04191] : Safe use because the deserialization process is performed on trusted data and the types are controlled and validated. 
             formatter.Serialize(stream, settings);
 
             stream.Seek(0, SeekOrigin.Begin);
 
-            TableLayoutSettings result = Assert.IsType<TableLayoutSettings>(formatter.Deserialize(stream));
+            // cs/dangerous-binary-deserialization
+            TableLayoutSettings result = Assert.IsType<TableLayoutSettings>(formatter.Deserialize(stream)); // CodeQL [SM03722] : This is a safe use of BinaryFormatter because the data is trusted and the types are controlled and validated.
 #pragma warning restore SYSLIB0011 // Type or member is obsolete
             Assert.NotNull(result.LayoutEngine);
             Assert.Same(result.LayoutEngine, result.LayoutEngine);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroupTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroupTests.cs
@@ -1334,11 +1334,13 @@ public class ListViewGroupTests
         using BinaryFormatterScope formatterScope = new(enable: true);
         using MemoryStream stream = new();
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
-        BinaryFormatter formatter = new();
+        // cs/binary-formatter-without-binder 
+        BinaryFormatter formatter = new(); // CodeQL [SM04191] : Safe use because the deserialization process is performed on trusted data and the types are controlled and validated.
         formatter.Serialize(stream, group);
         stream.Seek(0, SeekOrigin.Begin);
 
-        ListViewGroup result = Assert.IsType<ListViewGroup>(formatter.Deserialize(stream));
+        // cs/dangerous-binary-deserialization 
+        ListViewGroup result = Assert.IsType<ListViewGroup>(formatter.Deserialize(stream)); // CodeQL [SM03722] : Deserialization is performed on trusted data and the types are controlled and validated.
 #pragma warning restore SYSLIB0011 // Type or member is obsolete
         Assert.Equal(group.Header, result.Header);
         Assert.Equal(group.HeaderAlignment, result.HeaderAlignment);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewSubItemTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewSubItemTests.cs
@@ -580,11 +580,13 @@ public class ListViewSubItemTests
         using BinaryFormatterScope formatterScope = new(enable: true);
         using MemoryStream stream = new();
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
-        BinaryFormatter formatter = new();
+        // cs/binary-formatter-without-binder
+        BinaryFormatter formatter = new(); // CodeQL [SM04191] : Safe use because the deserialization process is performed on trusted data and the types are controlled and validated.
         new BinaryFormatter().Serialize(stream, subItem);
         stream.Seek(0, SeekOrigin.Begin);
 
-        ListViewItem.ListViewSubItem result = Assert.IsType<ListViewItem.ListViewSubItem>(formatter.Deserialize(stream));
+        // cs/dangerous-binary-deserialization
+        ListViewItem.ListViewSubItem result = Assert.IsType<ListViewItem.ListViewSubItem>(formatter.Deserialize(stream)); // CodeQL[SM03722] : This is a safe use of BinaryFormatter because the data is trusted and the types are controlled and validated.
 #pragma warning restore SYSLIB0011 // Type or member is obsolete
         Assert.Equal(subItem.BackColor, result.BackColor);
         Assert.Equal(subItem.Font, result.Font);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/OwnerDrawPropertyBagTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/OwnerDrawPropertyBagTests.cs
@@ -114,11 +114,13 @@ public class OwnerDrawPropertyBagTests
         using (MemoryStream stream = new())
         {
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
-            BinaryFormatter formatter = new();
+            // cs/binary-formatter-without-binder
+            BinaryFormatter formatter = new(); // CodeQL [SM04191] : Safe use because the deserialization process is performed on trusted data and the types are controlled and validated.
             formatter.Serialize(stream, original);
 
             stream.Position = 0;
-            OwnerDrawPropertyBag bag = Assert.IsType<OwnerDrawPropertyBag>(formatter.Deserialize(stream));
+            // cs/dangerous-binary-deserialization
+            OwnerDrawPropertyBag bag = Assert.IsType<OwnerDrawPropertyBag>(formatter.Deserialize(stream)); // CodeQL[SM03722] : This is a safe use of BinaryFormatter because the data is trusted and the types are controlled and validated.
 #pragma warning restore SYSLIB0011 // Type or member is obsolete
             Assert.Equal(Color.Blue, bag.BackColor);
             Assert.Equal(SystemFonts.MenuFont.Name, bag.Font.Name);


### PR DESCRIPTION
Fixes #10871

## Proposed changes

- Adds comments based on PR [9431][pr_9431], in order to supress warnings unecessary on tests.

[pr_9431]: https://github.com/dotnet/winforms/pull/9431/files

## Customer Impact

- None

## Regression?

- No

## Risk

- Minimal

## Test environment(s)

- 9.0.100-alpha.1.23618.3