### PR TITLE
Intermittent exception when creating a ListViewGroupAccessibleObject

### DIFF
--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ListView/ListView.ListViewAccessibleObject.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ListView/ListView.ListViewAccessibleObject.cs
@@ -296,7 +296,7 @@ public partial class ListView
                 IReadOnlyList<ListViewGroup> visibleGroups = GetVisibleGroups();
                 for (int i = 0; i < visibleGroups.Count; i++)
                 {
-                    if (visibleGroups[i].AccessibilityObject.Bounds.Contains(hitTestPoint))
+                    if (visibleGroups[i].AccessibilityObject?.Bounds.Contains(hitTestPoint) == true)
                     {
                         return visibleGroups[i].AccessibilityObject;
                     }

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ListView/ListViewGroup.ListViewGroupAccessibleObject.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ListView/ListViewGroup.ListViewGroupAccessibleObject.cs
@@ -17,15 +17,10 @@ public partial class ListViewGroup
         private readonly ListViewGroup _owningGroup;
         private readonly bool _owningGroupIsDefault;
 
-        public ListViewGroupAccessibleObject(ListViewGroup owningGroup, bool owningGroupIsDefault)
+        public ListViewGroupAccessibleObject(ListViewGroup owningGroup, ListView listView, bool owningGroupIsDefault)
         {
             _owningGroup = owningGroup.OrThrowIfNull();
-
-            // Using item from group for getting of ListView is a workaround for https://github.com/dotnet/winforms/issues/4019
-            _owningListView = owningGroup.ListView
-                ?? (owningGroup.Items.Count > 0 && _owningGroup.Items[0].ListView is ListView listView
-                    ? listView
-                    : throw new InvalidOperationException(nameof(owningGroup.ListView)));
+            _owningListView = listView.OrThrowIfNull();
 
             _owningListViewAccessibilityObject = _owningListView.AccessibilityObject as ListViewAccessibleObject
                 ?? throw new InvalidOperationException(nameof(_owningListView.AccessibilityObject));

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ListView/ListViewGroup.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ListView/ListViewGroup.cs
@@ -83,7 +83,8 @@ public sealed partial class ListViewGroup : ISerializable
                 return _accessibilityObject;
             }
 
-            // Get ListView from the group item as a workaround for https://github.com/dotnet/winforms/issues/4019
+            // Using an item from the group to obtain the ListView because the group might not yet be associated
+            // with the ListView. See https://github.com/dotnet/winforms/issues/4019.
             var listView = ListView ?? (Items.Count > 0 ? Items[0].ListView : null);
             if (listView is not null)
             {

--- a/src/System.Windows.Forms/System/Windows/Forms/Controls/ListView/ListViewGroup.cs
+++ b/src/System.Windows.Forms/System/Windows/Forms/Controls/ListView/ListViewGroup.cs
@@ -74,8 +74,25 @@ public sealed partial class ListViewGroup : ISerializable
         _headerAlignment = headerAlignment;
     }
 
-    internal AccessibleObject AccessibilityObject
-        => _accessibilityObject ??= new ListViewGroupAccessibleObject(this, ListView?.Groups.Contains(this) == false);
+    internal AccessibleObject? AccessibilityObject
+    {
+        get
+        {
+            if (_accessibilityObject is not null)
+            {
+                return _accessibilityObject;
+            }
+
+            // Get ListView from the group item as a workaround for https://github.com/dotnet/winforms/issues/4019
+            var listView = ListView ?? (Items.Count > 0 ? Items[0].ListView : null);
+            if (listView is not null)
+            {
+                _accessibilityObject = new ListViewGroupAccessibleObject(this, listView, owningGroupIsDefault: !listView.Groups.Contains(this));
+            }
+
+            return _accessibilityObject;
+        }
+    }
 
     /// <summary>
     ///  The text displayed in the group header.


### PR DESCRIPTION
This fix is based on this call stack, I'm eliminating the top frame by creating this Accessibility object only when the parent control is available.
```
System.InvalidOperationException: ListView

   at System.Windows.Forms.ListViewGroup.ListViewGroupAccessibleObject..ctor(ListViewGroup owningGroup, Boolean owningGroupIsDefault)
   at System.Windows.Forms.ListViewGroup.get_AccessibilityObject()
   at System.Windows.Forms.ListView.OnGotFocus(EventArgs e)
```
This is a follow up on https://github.com/dotnet/winforms/pull/10910#issuecomment-1958261561
Related to https://github.com/dotnet/winforms/issues/4019

I couldn't reproduce the issue, but the call stack is clear enough to understand the problem. There are situations when AccessibilityObject is not available, for example when the corresponding control is not displayed or not parented, thus changing nullability on this property. We were already guarding against accessing objects for "invisible" groups in the parent ListViewAccessibleObject when enumerating children.
We should not attempt to create accessible object for unparented ListView groups, for example when a group is removed from the control.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/10934)