### PR TITLE
Add convenience / perf methods to ListViewItem/ControlCollection

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+System.Windows.Forms.ListView.ListViewItemCollection.AddRange(System.Collections.Generic.IEnumerable<System.Windows.Forms.ListViewItem!>! collection) -> void
+System.Windows.Forms.ListView.ListViewItemCollection.CopyTo(System.Windows.Forms.ListViewItem![]! array, int arrayIndex) -> void

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -4695,20 +4695,14 @@ public unsafe partial class Control :
     ///  should not call base.CreateAccessibilityObject.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Advanced)]
-    protected virtual AccessibleObject CreateAccessibilityInstance()
-    {
-        return new ControlAccessibleObject(this);
-    }
+    protected virtual AccessibleObject CreateAccessibilityInstance() => new ControlAccessibleObject(this);
 
     /// <summary>
     ///  Constructs the new instance of the Controls collection objects. Subclasses
     ///  should not call base.CreateControlsInstance.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Advanced)]
-    protected virtual ControlCollection CreateControlsInstance()
-    {
-        return new ControlCollection(this);
-    }
+    protected virtual ControlCollection CreateControlsInstance() => new ControlCollection(this);
 
     /// <summary>
     ///  Creates a Graphics for this control. The control's brush, font, foreground

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ListView/ListView.ListViewItemCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ListView/ListView.ListViewItemCollection.cs
@@ -12,7 +12,7 @@ public partial class ListView
     ///  Represents the collection of items in a ListView or ListViewGroup
     /// </summary>
     [ListBindable(false)]
-    public partial class ListViewItemCollection : IList
+    public partial class ListViewItemCollection : IList, IList<ListViewItem>
     {
         ///  A caching mechanism for key accessor
         ///  We use an index here rather than control so that we don't have lifetime
@@ -75,10 +75,7 @@ public partial class ListView
 
         object? IList.this[int index]
         {
-            get
-            {
-                return this[index];
-            }
+            get => this[index];
             set
             {
                 this[index] = value is ListViewItem item
@@ -116,10 +113,7 @@ public partial class ListView
         ///  the correct sorted position, or, if no sorting is set, at the end
         ///  of the list.
         /// </summary>
-        public virtual ListViewItem Add(string? text)
-        {
-            return Add(text, -1);
-        }
+        public virtual ListViewItem Add(string? text) => Add(text, -1);
 
         int IList.Add(object? item)
         {
@@ -158,8 +152,6 @@ public partial class ListView
             InnerList.Add(value);
             return value;
         }
-
-        // <-- NEW ADD OVERLOADS IN WHIDBEY
 
         /// <summary>
         ///  Add an item to the ListView.  The item will be inserted either in
@@ -203,8 +195,6 @@ public partial class ListView
             return item;
         }
 
-        // END - NEW ADD OVERLOADS IN WHIDBEY  -->
-
         public void AddRange(params ListViewItem[] items)
         {
             ArgumentNullException.ThrowIfNull(items);
@@ -224,10 +214,7 @@ public partial class ListView
         /// <summary>
         ///  Removes all items from the list view.
         /// </summary>
-        public virtual void Clear()
-        {
-            InnerList.Clear();
-        }
+        public virtual void Clear() => InnerList.Clear();
 
         public bool Contains(ListViewItem item)
         {
@@ -335,7 +322,7 @@ public partial class ListView
             // step 1 - check the last cached item
             if (IsValidIndex(_lastAccessedIndex))
             {
-                if (WindowsFormsUtils.SafeCompareStrings(this[_lastAccessedIndex].Name, key, /* ignoreCase = */ true))
+                if (WindowsFormsUtils.SafeCompareStrings(this[_lastAccessedIndex].Name, key, ignoreCase: true))
                 {
                     return _lastAccessedIndex;
                 }
@@ -344,7 +331,7 @@ public partial class ListView
             // step 2 - search for the item
             for (int i = 0; i < Count; i++)
             {
-                if (WindowsFormsUtils.SafeCompareStrings(this[i].Name, key, /* ignoreCase = */ true))
+                if (WindowsFormsUtils.SafeCompareStrings(this[i].Name, key, ignoreCase: true))
                 {
                     _lastAccessedIndex = i;
                     return i;
@@ -395,8 +382,6 @@ public partial class ListView
             }
         }
 
-        // <-- NEW INSERT OVERLOADS IN WHIDBEY
-
         public ListViewItem Insert(int index, string? text, string? imageKey)
             => Insert(index, new ListViewItem(text, imageKey));
 
@@ -411,8 +396,6 @@ public partial class ListView
             {
                 Name = key
             });
-
-        // END - NEW INSERT OVERLOADS IN WHIDBEY -->
 
         /// <summary>
         ///  Removes an item from the ListView
@@ -450,6 +433,43 @@ public partial class ListView
             if (item is ListViewItem listViewItem)
             {
                 Remove(listViewItem);
+            }
+        }
+
+        void IList<ListViewItem>.Insert(int index, ListViewItem item) => Insert(index, item);
+
+        void ICollection<ListViewItem>.Add(ListViewItem item) => Add(item);
+
+        public void CopyTo(ListViewItem[] array, int arrayIndex) => CopyTo((Array)array, arrayIndex);
+
+        bool ICollection<ListViewItem>.Remove(ListViewItem item)
+        {
+            if (Contains(item))
+            {
+                Remove(item);
+                return true;
+            }
+
+            return false;
+        }
+
+        IEnumerator<ListViewItem> IEnumerable<ListViewItem>.GetEnumerator()
+        {
+            var enumerator = GetEnumerator();
+            while (enumerator.MoveNext())
+            {
+                if (enumerator.Current is ListViewItem item)
+                {
+                    yield return item;
+                }
+            }
+        }
+
+        public void AddRange(IEnumerable<ListViewItem> collection)
+        {
+            foreach (ListViewItem item in collection)
+            {
+                Add(item);
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripPanel.ToolStripPanelControlCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripPanel.ToolStripPanelControlCollection.cs
@@ -34,14 +34,13 @@ public partial class ToolStripPanel
 
         internal void Sort()
         {
-            if (_owner.Orientation == Orientation.Horizontal)
+            if (InnerList is not List<IArrangedElement> list)
             {
-                InnerList.Sort(new YXComparer());
+                Debug.Fail("InnerList is not a List<IArrangedElement>?");
+                return;
             }
-            else
-            {
-                InnerList.Sort(new XYComparer());
-            }
+
+            list.Sort(_owner.Orientation == Orientation.Horizontal ? new YXComparer() : new XYComparer());
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/ArrangedElementCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/ArrangedElementCollection.cs
@@ -7,17 +7,17 @@ namespace System.Windows.Forms.Layout;
 
 public class ArrangedElementCollection : IList
 {
-    internal static ArrangedElementCollection Empty { get; } = new(0);
+    internal static ArrangedElementCollection Empty { get; } = new(new List<IArrangedElement>().AsReadOnly());
 
     internal ArrangedElementCollection() : this(4)
     {
     }
 
-    internal ArrangedElementCollection(List<IArrangedElement> innerList) => InnerList = innerList;
+    internal ArrangedElementCollection(IList<IArrangedElement> innerList) => InnerList = innerList;
 
     private ArrangedElementCollection(int size) => InnerList = new List<IArrangedElement>(size);
 
-    private protected List<IArrangedElement> InnerList { get; }
+    private protected IList<IArrangedElement> InnerList { get; }
 
     internal virtual IArrangedElement this[int index] => InnerList[index];
 
@@ -93,7 +93,12 @@ public class ArrangedElementCollection : IList
         InnerList[toIndex] = element;
     }
 
-    private static void Copy(ArrangedElementCollection sourceList, int sourceIndex, ArrangedElementCollection destinationList, int destinationIndex, int length)
+    private static void Copy(
+        ArrangedElementCollection sourceList,
+        int sourceIndex,
+        ArrangedElementCollection destinationList,
+        int destinationIndex,
+        int length)
     {
         if (sourceIndex < destinationIndex)
         {

--- a/src/System.Windows.Forms/tests/UnitTests/SerializableTypesTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/SerializableTypesTests.cs
@@ -146,7 +146,7 @@ public class SerializableTypesTests
             Assert.Equal(HorizontalAlignment.Center, result.HeaderAlignment);
             Assert.Equal("Tag", result.Tag);
             Assert.Equal("GroupName", result.Name);
-            var item = Assert.Single(result.Items) as ListViewItem;
+            var item = Assert.Single(result.Items);
             Assert.NotNull(item);
             Assert.Equal("Item", item.Text);
         }


### PR DESCRIPTION
`ListViewItemCollection` doesn't have an `AddRange` that takes an `IEnumerable<ListViewItem>`, which necessitates unnecessary array allocations when adding from a collection.

It also doesn't implement a generic `IList<T>` which makes typed usage and LINQ usage difficult. This adds that.

Also add `IEnumerable<Control>` to `ControlCollection` to address the LINQ scenario. Control has `IList`, but indexed setting throws. I don't want to add `IList<Control>` until we've had time to evaluate the implications of implicitly doing the public steps with the collection that replicate what those setters should be doing.

Also tweak `ArrangedElementCollection` so the static empty collection can't be written to.

This doesn't fix the ambiguity of `AddRange([..])` with `ListViewItemCollection`, but it does avoid the need for it in some cases.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/10944)