### PR TITLE
Delete UsingToolMicrosoftNetCompilers property

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -8,8 +8,6 @@
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>3</PreReleaseVersionIteration>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
-    <!-- Use the compiler in the CLI instead of in the sdk, since CLI is newer. -->
-    <UsingToolMicrosoftNetCompilers>false</UsingToolMicrosoftNetCompilers>
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
   </PropertyGroup>


### PR DESCRIPTION
False is already the default and winforms probably doesn't need to use a newer compiler than what's available in the SDK anytime soon. That was different in the past when the SDK wasn't updated every month.