### PR TITLE
Add test coverage for Label 

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/LabelTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/LabelTests.cs
@@ -3,6 +3,7 @@
 
 using System.ComponentModel;
 using System.Drawing;
+using System.Windows.Forms.Automation;
 using Point = System.Drawing.Point;
 using Size = System.Drawing.Size;
 
@@ -437,24 +438,19 @@ public class LabelTests
         label.AutoSizeChanged -= handler;
         Assert.Equal(0, callCount);
 
-        // The event handler should not be invoked.
         label.AutoSizeChanged += handler;
         label.AutoSize = label.AutoSize;
         Assert.Equal(0, callCount);
 
-        // The event handler should be invoked.
         label.AutoSize = !label.AutoSize;
         Assert.Equal(1, callCount);
 
-        // The event handler should not be invoked.
         label.AutoSize = label.AutoSize;
         Assert.Equal(1, callCount);
 
-        // The event handler should be invoked.
         label.AutoSize = !label.AutoSize;
         Assert.Equal(2, callCount);
 
-        // The event handler should not be invoked.
         label.AutoSizeChanged -= handler;
         label.AutoSize = !label.AutoSize;
         Assert.Equal(2, callCount);
@@ -522,7 +518,6 @@ public class LabelTests
         Assert.Null(label.BackgroundImage);
     }
 
-
     [WinFormsFact]
     public void Label_BackgroundImageChangedEvent_AddRemove_Success()
     {
@@ -539,25 +534,20 @@ public class LabelTests
         label.BackgroundImageChanged -= handler;
         Assert.Equal(0, callCount);
 
-        // The event handler should not be invoked.
         label.BackgroundImageChanged += handler;
         label.BackgroundImage = label.BackgroundImage;
         Assert.Equal(0, callCount);
 
-        // The event handler should be invoked.
         var image = new Bitmap(10, 10);
         label.BackgroundImage = image;
         Assert.Equal(1, callCount);
 
-        // The event handler should not be invoked.
         label.BackgroundImage = label.BackgroundImage;
         Assert.Equal(1, callCount);
 
-        // The event handler should be invoked.
         label.BackgroundImage = null;
         Assert.Equal(2, callCount);
 
-        // The event handler should not be invoked.
         label.BackgroundImageChanged -= handler;
         label.BackgroundImage = image;
         Assert.Equal(2, callCount);
@@ -598,24 +588,19 @@ public class LabelTests
         label.BackgroundImageLayoutChanged -= handler;
         Assert.Equal(0, callCount);
 
-        // The event handler should not be invoked.
         label.BackgroundImageLayoutChanged += handler;
         label.BackgroundImageLayout = label.BackgroundImageLayout;
         Assert.Equal(0, callCount);
 
-        // The event handler should be invoked.
         label.BackgroundImageLayout = ImageLayout.Center;
         Assert.Equal(1, callCount);
 
-        // The event handler should not be invoked.
         label.BackgroundImageLayout = label.BackgroundImageLayout;
         Assert.Equal(1, callCount);
 
-        // The event handler should be invoked.
         label.BackgroundImageLayout = ImageLayout.Stretch;
         Assert.Equal(2, callCount);
 
-        // The event handler should not be invoked.
         label.BackgroundImageLayoutChanged -= handler;
         label.BackgroundImageLayout = ImageLayout.Zoom;
         Assert.Equal(2, callCount);
@@ -723,6 +708,159 @@ public class LabelTests
         Assert.True(label.IsHandleCreated);
     }
 
+    [WinFormsTheory]
+    [InlineData(AutomationLiveSetting.Off)]
+    [InlineData(AutomationLiveSetting.Polite)]
+    [InlineData(AutomationLiveSetting.Assertive)]
+    public void Label_LiveSetting_Set_GetReturnsExpected(AutomationLiveSetting value)
+    {
+        using Label label = new();
+        label.LiveSetting = value;
+        Assert.Equal(value, label.LiveSetting);
+    }
+
+    [WinFormsFact]
+    public void Label_LiveSetting_SetInvalidValue_ThrowsInvalidEnumArgumentException()
+    {
+        using Label label = new();
+        Assert.Throws<InvalidEnumArgumentException>(() => label.LiveSetting = (AutomationLiveSetting)999);
+    }
+
+    [WinFormsFact]
+    public void Label_KeyUp_AddRemove_Success()
+    {
+        using SubLabel label = new();
+        int callCount = 0;
+        KeyEventHandler handler = (sender, e) =>
+        {
+            Assert.Same(label, sender);
+            callCount++;
+        };
+
+        label.KeyUp += handler;
+        label.OnKeyUp(new KeyEventArgs(Keys.A));
+        Assert.Equal(1, callCount);
+
+        label.KeyUp -= handler;
+        label.OnKeyUp(new KeyEventArgs(Keys.A));
+        Assert.Equal(1, callCount);
+    }
+
+    [WinFormsFact]
+    public void Label_KeyDown_AddRemove_Success()
+    {
+        using SubLabel label = new();
+        int callCount = 0;
+        KeyEventHandler handler = (sender, e) =>
+        {
+            Assert.Same(label, sender);
+            callCount++;
+        };
+
+        label.KeyDown += handler;
+        label.OnKeyDown(new KeyEventArgs(Keys.A));
+        Assert.Equal(1, callCount);
+
+        label.KeyDown -= handler;
+        label.OnKeyDown(new KeyEventArgs(Keys.A));
+        Assert.Equal(1, callCount);
+    }
+
+    [WinFormsFact]
+    public void Label_KeyPress_AddRemove_Success()
+    {
+        using SubLabel label = new();
+        int callCount = 0;
+        KeyPressEventHandler handler = (sender, e) =>
+        {
+            Assert.Same(label, sender);
+            callCount++;
+        };
+
+        label.KeyPress += handler;
+        label.OnKeyPress(new KeyPressEventArgs('A'));
+        Assert.Equal(1, callCount);
+
+        label.KeyPress -= handler;
+        label.OnKeyPress(new KeyPressEventArgs('A'));
+        Assert.Equal(1, callCount);
+    }
+
+    [WinFormsFact]
+    public void Label_TabStopChanged_AddRemove_Success()
+    {
+        using Label label = new();
+        int callCount = 0;
+        EventHandler handler = (sender, e) =>
+        {
+            Assert.Same(label, sender);
+            Assert.Same(EventArgs.Empty, e);
+            callCount++;
+        };
+
+        label.TabStopChanged += handler;
+        label.TabStop = !label.TabStop;
+        Assert.Equal(1, callCount);
+
+        label.TabStopChanged -= handler;
+        label.TabStop = !label.TabStop;
+        Assert.Equal(1, callCount);
+    }
+
+    [WinFormsFact]
+    public void Label_TextAlignChanged_AddRemove_Success()
+    {
+        using Label label = new();
+        int callCount = 0;
+        EventHandler handler = (sender, e) =>
+        {
+            Assert.Same(label, sender);
+            Assert.Same(EventArgs.Empty, e);
+            callCount++;
+        };
+
+        label.TextAlignChanged += handler;
+        label.TextAlign = ContentAlignment.BottomCenter;
+        Assert.Equal(1, callCount);
+
+        label.TextAlignChanged -= handler;
+        label.TextAlign = ContentAlignment.BottomLeft;
+        Assert.Equal(1, callCount);
+    }
+
+    [WinFormsFact]
+    public void Label_UseCompatibleTextRendering_GetSet_ReturnsExpected()
+    {
+        using Label label = new();
+        bool defaultValue = label.UseCompatibleTextRendering;
+
+        // Set true.
+        label.UseCompatibleTextRendering = true;
+        Assert.True(label.UseCompatibleTextRendering);
+
+        // Set false.
+        label.UseCompatibleTextRendering = false;
+        Assert.False(label.UseCompatibleTextRendering);
+
+        // Set default.
+        label.UseCompatibleTextRendering = defaultValue;
+        Assert.Equal(defaultValue, label.UseCompatibleTextRendering);
+    }
+
+    [WinFormsFact]
+    public void Label_UseCompatibleTextRendering_SetWithAutoSize_UpdatesPreferredSize()
+    {
+        using Label label = new()
+        {
+            AutoSize = true,
+            Text = "Some text"
+        };
+        Size defaultSize = label.PreferredSize;
+
+        label.UseCompatibleTextRendering = !label.UseCompatibleTextRendering;
+        Assert.NotEqual(defaultSize, label.PreferredSize);
+    }
+
     public class SubLabel : Label
     {
         public new bool CanEnableIme => base.CanEnableIme;
@@ -791,6 +929,12 @@ public class LabelTests
 
         public new bool GetTopLevel() => base.GetTopLevel();
 
-        public void RecreateHandle() => base.RecreateHandle();
+        public new void RecreateHandle() => base.RecreateHandle();
+
+        public new void OnKeyUp(KeyEventArgs e) => base.OnKeyUp(e);
+
+        public new void OnKeyDown(KeyEventArgs e) => base.OnKeyDown(e);
+
+        public new void OnKeyPress(KeyPressEventArgs e) => base.OnKeyPress(e);
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/LabelTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/LabelTests.cs
@@ -421,6 +421,308 @@ public class LabelTests
         Assert.True(label.IsHandleCreated);
     }
 
+    [WinFormsFact]
+    public void Label_AutoSizeChangedEvent_AddRemove_Success()
+    {
+        using Label label = new();
+        int callCount = 0;
+        EventHandler handler = (sender, e) =>
+        {
+            Assert.Same(label, sender);
+            Assert.Same(EventArgs.Empty, e);
+            callCount++;
+        };
+
+        label.AutoSizeChanged += handler;
+        label.AutoSizeChanged -= handler;
+        Assert.Equal(0, callCount);
+
+        // The event handler should not be invoked.
+        label.AutoSizeChanged += handler;
+        label.AutoSize = label.AutoSize;
+        Assert.Equal(0, callCount);
+
+        // The event handler should be invoked.
+        label.AutoSize = !label.AutoSize;
+        Assert.Equal(1, callCount);
+
+        // The event handler should not be invoked.
+        label.AutoSize = label.AutoSize;
+        Assert.Equal(1, callCount);
+
+        // The event handler should be invoked.
+        label.AutoSize = !label.AutoSize;
+        Assert.Equal(2, callCount);
+
+        // The event handler should not be invoked.
+        label.AutoSizeChanged -= handler;
+        label.AutoSize = !label.AutoSize;
+        Assert.Equal(2, callCount);
+    }
+
+    [WinFormsFact]
+    public void Label_AutoEllipsis_SetWithHandle_GetReturnsExpected()
+    {
+        using Label label = new();
+        Assert.NotEqual(0, label.Handle);
+        int invalidatedCallCount = 0;
+        label.Invalidated += (sender, e) => invalidatedCallCount++;
+        int styleChangedCallCount = 0;
+        label.StyleChanged += (sender, e) => styleChangedCallCount++;
+        int createdCallCount = 0;
+        label.HandleCreated += (sender, e) => createdCallCount++;
+
+        // Set true.
+        label.AutoEllipsis = true;
+        Assert.True(label.AutoEllipsis);
+        Assert.True(label.IsHandleCreated);
+        Assert.Equal(1, invalidatedCallCount);
+        Assert.Equal(0, styleChangedCallCount);
+        Assert.Equal(0, createdCallCount);
+
+        // Set same.
+        label.AutoEllipsis = true;
+        Assert.True(label.AutoEllipsis);
+        Assert.True(label.IsHandleCreated);
+        Assert.Equal(1, invalidatedCallCount);
+        Assert.Equal(0, styleChangedCallCount);
+        Assert.Equal(0, createdCallCount);
+
+        // Set different.
+        label.AutoEllipsis = false;
+        Assert.False(label.AutoEllipsis);
+        Assert.True(label.IsHandleCreated);
+        Assert.Equal(2, invalidatedCallCount);
+        Assert.Equal(0, styleChangedCallCount);
+        Assert.Equal(0, createdCallCount);
+    }
+
+    [WinFormsFact]
+    public void Label_BackgroundImageGetSet()
+    {
+        using Label label = new();
+        Assert.Null(label.BackgroundImage);  // Default value
+
+        // Set null.
+        var image1 = new Bitmap(10, 10);
+        label.BackgroundImage = image1;
+        Assert.Same(image1, label.BackgroundImage);
+
+        // Set same.
+        label.BackgroundImage = image1;
+        Assert.Same(image1, label.BackgroundImage);
+
+        // Set different.
+        var image2 = new Bitmap(10, 10);
+        label.BackgroundImage = image2;
+        Assert.Same(image2, label.BackgroundImage);
+
+        // Set null.
+        label.BackgroundImage = null;
+        Assert.Null(label.BackgroundImage);
+    }
+
+
+    [WinFormsFact]
+    public void Label_BackgroundImageChangedEvent_AddRemove_Success()
+    {
+        using Label label = new();
+        int callCount = 0;
+        EventHandler handler = (sender, e) =>
+        {
+            Assert.Same(label, sender);
+            Assert.Same(EventArgs.Empty, e);
+            callCount++;
+        };
+
+        label.BackgroundImageChanged += handler;
+        label.BackgroundImageChanged -= handler;
+        Assert.Equal(0, callCount);
+
+        // The event handler should not be invoked.
+        label.BackgroundImageChanged += handler;
+        label.BackgroundImage = label.BackgroundImage;
+        Assert.Equal(0, callCount);
+
+        // The event handler should be invoked.
+        var image = new Bitmap(10, 10);
+        label.BackgroundImage = image;
+        Assert.Equal(1, callCount);
+
+        // The event handler should not be invoked.
+        label.BackgroundImage = label.BackgroundImage;
+        Assert.Equal(1, callCount);
+
+        // The event handler should be invoked.
+        label.BackgroundImage = null;
+        Assert.Equal(2, callCount);
+
+        // The event handler should not be invoked.
+        label.BackgroundImageChanged -= handler;
+        label.BackgroundImage = image;
+        Assert.Equal(2, callCount);
+    }
+
+    [WinFormsFact]
+    public void Label_BackgroundImageLayoutGetSet()
+    {
+        using Label label = new();
+        Assert.Equal(ImageLayout.Tile, label.BackgroundImageLayout);  // Default value
+
+        // Set valid value.
+        label.BackgroundImageLayout = ImageLayout.Center;
+        Assert.Equal(ImageLayout.Center, label.BackgroundImageLayout);
+
+        // Set same.
+        label.BackgroundImageLayout = ImageLayout.Center;
+        Assert.Equal(ImageLayout.Center, label.BackgroundImageLayout);
+
+        // Set different.
+        label.BackgroundImageLayout = ImageLayout.Stretch;
+        Assert.Equal(ImageLayout.Stretch, label.BackgroundImageLayout);
+    }
+
+    [WinFormsFact]
+    public void Label_BackgroundImageLayoutChangedEvent_AddRemove_Success()
+    {
+        using Label label = new();
+        int callCount = 0;
+        EventHandler handler = (sender, e) =>
+        {
+            Assert.Same(label, sender);
+            Assert.Same(EventArgs.Empty, e);
+            callCount++;
+        };
+
+        label.BackgroundImageLayoutChanged += handler;
+        label.BackgroundImageLayoutChanged -= handler;
+        Assert.Equal(0, callCount);
+
+        // The event handler should not be invoked.
+        label.BackgroundImageLayoutChanged += handler;
+        label.BackgroundImageLayout = label.BackgroundImageLayout;
+        Assert.Equal(0, callCount);
+
+        // The event handler should be invoked.
+        label.BackgroundImageLayout = ImageLayout.Center;
+        Assert.Equal(1, callCount);
+
+        // The event handler should not be invoked.
+        label.BackgroundImageLayout = label.BackgroundImageLayout;
+        Assert.Equal(1, callCount);
+
+        // The event handler should be invoked.
+        label.BackgroundImageLayout = ImageLayout.Stretch;
+        Assert.Equal(2, callCount);
+
+        // The event handler should not be invoked.
+        label.BackgroundImageLayoutChanged -= handler;
+        label.BackgroundImageLayout = ImageLayout.Zoom;
+        Assert.Equal(2, callCount);
+    }
+
+    [WinFormsFact]
+    public void Label_ImageIndex_GetSet_ImageList()
+    {
+        using ImageList imageList = new();
+        imageList.Images.Add(new Bitmap(10, 10));
+        imageList.Images.Add(new Bitmap(10, 10));
+
+        using Label label = new();
+        label.ImageList = imageList;
+
+        // Set valid value.
+        label.ImageIndex = 0;
+        Assert.Equal(0, label.ImageIndex);
+
+        // Set same.
+        label.ImageIndex = 0;
+        Assert.Equal(0, label.ImageIndex);
+
+        // Set different.
+        label.ImageIndex = 1;
+        Assert.Equal(1, label.ImageIndex);
+
+        // Set invalid value.
+        Assert.Throws<ArgumentOutOfRangeException>(() => label.ImageIndex = -2);
+        Assert.Equal(1, label.ImageIndex);  // Value should not have changed.
+
+        // Set to default value.
+        label.ImageIndex = -1;
+        Assert.Equal(-1, label.ImageIndex);
+    }
+
+    [WinFormsFact]
+    public void Label_ImageKey_GetSet_ImageList()
+    {
+        using ImageList imageList = new();
+        imageList.Images.Add("key1", new Bitmap(10, 10));
+        imageList.Images.Add("key2", new Bitmap(10, 10));
+
+        using Label label = new();
+        label.ImageList = imageList;
+
+        // Set valid value exists in the ImageList.
+        label.ImageKey = "key1";
+        Assert.Equal("key1", label.ImageKey);
+
+        // Set different value exists in the ImageList.
+        label.ImageKey = "key2";
+        Assert.Equal("key2", label.ImageKey);
+
+        // Set value does not exist in the ImageList.
+        label.ImageKey = "nonexistent";
+        Assert.Equal("nonexistent", label.ImageKey);
+
+        // Set null.
+        label.ImageKey = null;
+        Assert.Equal(ImageList.Indexer.DefaultKey, label.ImageKey);  // Should reset to default value.
+
+        // Set empty.
+        label.ImageKey = string.Empty;
+        Assert.Equal(ImageList.Indexer.DefaultKey, label.ImageKey);  // Should reset to default value.
+    }
+
+    [WinFormsFact]
+    public void Label_ImageList_GetSet_Image()
+    {
+        using Label label = new();
+        using var image = new Bitmap(10, 10);
+        label.Image = image;
+
+        // Set valid value.
+        using ImageList imageList = new();
+        label.ImageList = imageList;
+        Assert.Same(imageList, label.ImageList);
+        Assert.Null(label.Image);  // Image should be reset.
+    }
+
+    [WinFormsFact]
+    public void Label_ImageList_Disposing_UnsetsImageList()
+    {
+        using Label label = new();
+        using ImageList imageList = new();
+        label.ImageList = imageList;
+
+        imageList.Dispose();
+        Assert.Null(label.ImageList);
+    }
+
+    [WinFormsFact]
+    public void Label_ImageList_RecreateHandleRefreshesControl()
+    {
+        using SubLabel label = new();
+        using ImageList imageList = new();
+        label.ImageList = imageList;
+
+        imageList.Images.Add(new Bitmap(10, 10));
+        label.CreateControl();
+        Assert.True(label.IsHandleCreated);
+
+        label.RecreateHandle();
+        Assert.True(label.IsHandleCreated);
+    }
+
     public class SubLabel : Label
     {
         public new bool CanEnableIme => base.CanEnableIme;
@@ -488,5 +790,7 @@ public class LabelTests
         public new bool GetStyle(ControlStyles flag) => base.GetStyle(flag);
 
         public new bool GetTopLevel() => base.GetTopLevel();
+
+        public void RecreateHandle() => base.RecreateHandle();
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/LabelTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/LabelTests.cs
@@ -501,7 +501,7 @@ public class LabelTests
         Assert.Null(label.BackgroundImage);  // Default value
 
         // Set image.
-        using Bitmap image1 = new Bitmap(10, 10);
+        using Bitmap image1 = new(10, 10);
         label.BackgroundImage = image1;
         Assert.Same(image1, label.BackgroundImage);
 
@@ -510,7 +510,7 @@ public class LabelTests
         Assert.Same(image1, label.BackgroundImage);
 
         // Set different.
-        using Bitmap image2 = new Bitmap(50, 10);
+        using Bitmap image2 = new(50, 10);
         label.BackgroundImage = image2;
         Assert.Same(image2, label.BackgroundImage);
 
@@ -539,7 +539,7 @@ public class LabelTests
         label.BackgroundImage = label.BackgroundImage;
         Assert.Equal(0, callCount);
 
-        var image = new Bitmap(10, 10);
+        using Bitmap image = new(10, 10);
         label.BackgroundImage = image;
         Assert.Equal(1, callCount);
 
@@ -611,8 +611,8 @@ public class LabelTests
     public void Label_ImageIndex_GetSet_ImageList()
     {
         using ImageList imageList = new();
-        using Bitmap bitmap1 = new Bitmap(10, 10);
-        using Bitmap bitmap2 = new Bitmap(10, 10);
+        using Bitmap bitmap1 = new(10, 10);
+        using Bitmap bitmap2 = new(10, 10);
 
         imageList.Images.Add(bitmap1);
         imageList.Images.Add(bitmap2);
@@ -645,8 +645,8 @@ public class LabelTests
     public void Label_ImageKey_GetSet_ImageList()
     {
         using ImageList imageList = new();
-        using Bitmap bitmap1 = new Bitmap(10, 10);
-        using Bitmap bitmap2 = new Bitmap(10, 10);
+        using Bitmap bitmap1 = new(10, 10);
+        using Bitmap bitmap2 = new(10, 10);
 
         imageList.Images.Add("key1", bitmap1);
         imageList.Images.Add("key2", bitmap2);
@@ -679,7 +679,7 @@ public class LabelTests
     public void Label_ImageList_GetSet_Image()
     {
         using Label label = new();
-        using Bitmap image = new Bitmap(10, 10);
+        using Bitmap image = new(10, 10);
         label.Image = image;
 
         // Set valid value.
@@ -705,7 +705,7 @@ public class LabelTests
     {
         using SubLabel label = new();
         using ImageList imageList = new();
-        using Bitmap bitmap = new Bitmap(10, 10);
+        using Bitmap bitmap = new(10, 10);
 
         label.ImageList = imageList;
         imageList.Images.Add(bitmap);
@@ -746,12 +746,14 @@ public class LabelTests
             callCount++;
         };
 
+        KeyEventArgs keyEventArgs = new KeyEventArgs(Keys.A);
+
         label.KeyUp += handler;
-        label.OnKeyUp(new KeyEventArgs(Keys.A));
+        label.OnKeyUp(keyEventArgs);
         Assert.Equal(1, callCount);
 
         label.KeyUp -= handler;
-        label.OnKeyUp(new KeyEventArgs(Keys.A));
+        label.OnKeyUp(keyEventArgs);
         Assert.Equal(1, callCount);
     }
 
@@ -766,12 +768,14 @@ public class LabelTests
             callCount++;
         };
 
+        KeyEventArgs keyEventArgs = new KeyEventArgs(Keys.A);
+
         label.KeyDown += handler;
-        label.OnKeyDown(new KeyEventArgs(Keys.A));
+        label.OnKeyDown(keyEventArgs);
         Assert.Equal(1, callCount);
 
         label.KeyDown -= handler;
-        label.OnKeyDown(new KeyEventArgs(Keys.A));
+        label.OnKeyDown(keyEventArgs);
         Assert.Equal(1, callCount);
     }
 
@@ -786,12 +790,14 @@ public class LabelTests
             callCount++;
         };
 
+        KeyPressEventArgs keyPressEventArgs = new KeyPressEventArgs('A');
+
         label.KeyPress += handler;
-        label.OnKeyPress(new KeyPressEventArgs('A'));
+        label.OnKeyPress(keyPressEventArgs);
         Assert.Equal(1, callCount);
 
         label.KeyPress -= handler;
-        label.OnKeyPress(new KeyPressEventArgs('A'));
+        label.OnKeyPress(keyPressEventArgs);
         Assert.Equal(1, callCount);
     }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/LabelTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/LabelTests.cs
@@ -461,6 +461,7 @@ public class LabelTests
     {
         using Label label = new();
         Assert.NotEqual(0, label.Handle);
+
         int invalidatedCallCount = 0;
         label.Invalidated += (sender, e) => invalidatedCallCount++;
         int styleChangedCallCount = 0;
@@ -499,8 +500,8 @@ public class LabelTests
         using Label label = new();
         Assert.Null(label.BackgroundImage);  // Default value
 
-        // Set null.
-        var image1 = new Bitmap(10, 10);
+        // Set image.
+        using Bitmap image1 = new Bitmap(10, 10);
         label.BackgroundImage = image1;
         Assert.Same(image1, label.BackgroundImage);
 
@@ -509,7 +510,7 @@ public class LabelTests
         Assert.Same(image1, label.BackgroundImage);
 
         // Set different.
-        var image2 = new Bitmap(10, 10);
+        using Bitmap image2 = new Bitmap(50, 10);
         label.BackgroundImage = image2;
         Assert.Same(image2, label.BackgroundImage);
 
@@ -610,8 +611,11 @@ public class LabelTests
     public void Label_ImageIndex_GetSet_ImageList()
     {
         using ImageList imageList = new();
-        imageList.Images.Add(new Bitmap(10, 10));
-        imageList.Images.Add(new Bitmap(10, 10));
+        using Bitmap bitmap1 = new Bitmap(10, 10);
+        using Bitmap bitmap2 = new Bitmap(10, 10);
+
+        imageList.Images.Add(bitmap1);
+        imageList.Images.Add(bitmap2);
 
         using Label label = new();
         label.ImageList = imageList;
@@ -641,8 +645,11 @@ public class LabelTests
     public void Label_ImageKey_GetSet_ImageList()
     {
         using ImageList imageList = new();
-        imageList.Images.Add("key1", new Bitmap(10, 10));
-        imageList.Images.Add("key2", new Bitmap(10, 10));
+        using Bitmap bitmap1 = new Bitmap(10, 10);
+        using Bitmap bitmap2 = new Bitmap(10, 10);
+
+        imageList.Images.Add("key1", bitmap1);
+        imageList.Images.Add("key2", bitmap2);
 
         using Label label = new();
         label.ImageList = imageList;
@@ -672,7 +679,7 @@ public class LabelTests
     public void Label_ImageList_GetSet_Image()
     {
         using Label label = new();
-        using var image = new Bitmap(10, 10);
+        using Bitmap image = new Bitmap(10, 10);
         label.Image = image;
 
         // Set valid value.
@@ -698,9 +705,11 @@ public class LabelTests
     {
         using SubLabel label = new();
         using ImageList imageList = new();
-        label.ImageList = imageList;
+        using Bitmap bitmap = new Bitmap(10, 10);
 
-        imageList.Images.Add(new Bitmap(10, 10));
+        label.ImageList = imageList;
+        imageList.Images.Add(bitmap);
+
         label.CreateControl();
         Assert.True(label.IsHandleCreated);
 


### PR DESCRIPTION
Related https://github.com/dotnet/winforms/issues/10453

## Proposed changes

- Add unit tests for Label to test its properties: AutoEllipsis, BackgroundImage, BackgroundImageLayout, ImageIndex, ImageKey, ImageList, LiveSetting, UseCompatibleTextRendering
- Add unit tests for Label to test its events: AutoSizeChanged, BackgroundImageChanged, BackgroundImageLayoutChanged, KeyUp, KeyDown, KeyPress, TabStopChanged, TextAlignChanged

## Customer Impact

- None

## Regression? 

- No

## Risk

- Minimal


## Test methodology 

- Unit tests


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/10976)