### PR TITLE
fix An exception popped up when click "Type Here" on ContextMenuStrip control in DemoConsole application

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripDesigner.cs
@@ -451,14 +451,7 @@ internal class ToolStripDesigner : ControlDesigner
         }
     }
 
-    private IComponentChangeService ComponentChangeService
-    {
-        get
-        {
-            _componentChangeService ??= GetService<IComponentChangeService>();
-            return _componentChangeService;
-        }
-    }
+    private IComponentChangeService ComponentChangeService => _componentChangeService ??= GetService<IComponentChangeService>();
 
     /// <summary>
     ///  This will add BodyGlyphs for the Items on the OverFlow. Since ToolStripItems are component we have to manage Adding and Deleting the glyphs ourSelves.
@@ -1425,7 +1418,7 @@ internal class ToolStripDesigner : ControlDesigner
         // initialize new Manager For Editing ToolStrips
         _editManager = new ToolStripEditorManager(component);
 
-        _host = GetService<IDesignerHost>();
+        _host = GetRequiredService<IDesignerHost>();
 
         // Setup the dropdown if our handle has been created.
         if (Control.IsHandleCreated)
@@ -1509,7 +1502,7 @@ internal class ToolStripDesigner : ControlDesigner
 
         if (parentPanel is not null)
         {
-            if (!(ToolStrip is MenuStrip))
+            if (ToolStrip is not MenuStrip)
             {
                 PropertyDescriptor controlsProp = TypeDescriptor.GetProperties(parentPanel)["Controls"];
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripDesigner.cs
@@ -1201,14 +1201,11 @@ internal class ToolStripDesigner : ControlDesigner
                 _toolStripAdornerWindowService = null;
             }
 
-            if (ComponentChangeService is not null)
-            {
-                ComponentChangeService.ComponentAdding -= ComponentChangeSvc_ComponentAdding;
-                ComponentChangeService.ComponentAdded -= ComponentChangeSvc_ComponentAdded;
-                ComponentChangeService.ComponentRemoving -= ComponentChangeSvc_ComponentRemoving;
-                ComponentChangeService.ComponentRemoved -= ComponentChangeSvc_ComponentRemoved;
-                ComponentChangeService.ComponentChanged -= ComponentChangeSvc_ComponentChanged;
-            }
+            ComponentChangeService.ComponentAdding -= ComponentChangeSvc_ComponentAdding;
+            ComponentChangeService.ComponentAdded -= ComponentChangeSvc_ComponentAdded;
+            ComponentChangeService.ComponentRemoving -= ComponentChangeSvc_ComponentRemoving;
+            ComponentChangeService.ComponentRemoved -= ComponentChangeSvc_ComponentRemoved;
+            ComponentChangeService.ComponentChanged -= ComponentChangeSvc_ComponentChanged;
         }
 
         base.Dispose(disposing);
@@ -1406,14 +1403,11 @@ internal class ToolStripDesigner : ControlDesigner
     {
         base.Initialize(component);
         AutoResizeHandles = true;
-        if (ComponentChangeService is not null)
-        {
-            ComponentChangeService.ComponentAdding += ComponentChangeSvc_ComponentAdding;
-            ComponentChangeService.ComponentAdded += ComponentChangeSvc_ComponentAdded;
-            ComponentChangeService.ComponentRemoving += ComponentChangeSvc_ComponentRemoving;
-            ComponentChangeService.ComponentRemoved += ComponentChangeSvc_ComponentRemoved;
-            ComponentChangeService.ComponentChanged += ComponentChangeSvc_ComponentChanged;
-        }
+        ComponentChangeService.ComponentAdding += ComponentChangeSvc_ComponentAdding;
+        ComponentChangeService.ComponentAdded += ComponentChangeSvc_ComponentAdded;
+        ComponentChangeService.ComponentRemoving += ComponentChangeSvc_ComponentRemoving;
+        ComponentChangeService.ComponentRemoved += ComponentChangeSvc_ComponentRemoved;
+        ComponentChangeService.ComponentChanged += ComponentChangeSvc_ComponentChanged;
 
         // initialize new Manager For Editing ToolStrips
         _editManager = new ToolStripEditorManager(component);
@@ -1506,19 +1500,16 @@ internal class ToolStripDesigner : ControlDesigner
             {
                 PropertyDescriptor controlsProp = TypeDescriptor.GetProperties(parentPanel)["Controls"];
 
-                ComponentChangeService?.OnComponentChanging(parentPanel, controlsProp);
+                ComponentChangeService.OnComponentChanging(parentPanel, controlsProp);
 
                 parentPanel.Join(ToolStrip, parentPanel.Rows.Length);
 
-                if (ComponentChangeService is not null)
-                {
-                    ComponentChangeService.OnComponentChanged(parentPanel, controlsProp, parentPanel.Controls, parentPanel.Controls);
+                ComponentChangeService.OnComponentChanged(parentPanel, controlsProp, parentPanel.Controls, parentPanel.Controls);
 
-                    // Try to fire ComponentChange on the Location Property for ToolStrip.
-                    PropertyDescriptor locationProp = TypeDescriptor.GetProperties(ToolStrip)["Location"];
-                    ComponentChangeService.OnComponentChanging(ToolStrip, locationProp);
-                    ComponentChangeService.OnComponentChanged(ToolStrip, locationProp);
-                }
+                // Try to fire ComponentChange on the Location Property for ToolStrip.
+                PropertyDescriptor locationProp = TypeDescriptor.GetProperties(ToolStrip)["Location"];
+                ComponentChangeService.OnComponentChanging(ToolStrip, locationProp);
+                ComponentChangeService.OnComponentChanged(ToolStrip, locationProp);
             }
         }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripDesigner.cs
@@ -451,7 +451,7 @@ internal class ToolStripDesigner : ControlDesigner
         }
     }
 
-    private IComponentChangeService ComponentChangeService => _componentChangeService ??= GetService<IComponentChangeService>();
+    private IComponentChangeService ComponentChangeService => _componentChangeService ??= GetRequiredService<IComponentChangeService>();
 
     /// <summary>
     ///  This will add BodyGlyphs for the Items on the OverFlow. Since ToolStripItems are component we have to manage Adding and Deleting the glyphs ourSelves.
@@ -1510,12 +1510,12 @@ internal class ToolStripDesigner : ControlDesigner
 
                 parentPanel.Join(ToolStrip, parentPanel.Rows.Length);
 
-                ComponentChangeService?.OnComponentChanged(parentPanel, controlsProp, parentPanel.Controls, parentPanel.Controls);
-
-                // Try to fire ComponentChange on the Location Property for ToolStrip.
-                PropertyDescriptor locationProp = TypeDescriptor.GetProperties(ToolStrip)["Location"];
                 if (ComponentChangeService is not null)
                 {
+                    ComponentChangeService.OnComponentChanged(parentPanel, controlsProp, parentPanel.Controls, parentPanel.Controls);
+
+                    // Try to fire ComponentChange on the Location Property for ToolStrip.
+                    PropertyDescriptor locationProp = TypeDescriptor.GetProperties(ToolStrip)["Location"];
                     ComponentChangeService.OnComponentChanging(ToolStrip, locationProp);
                     ComponentChangeService.OnComponentChanged(ToolStrip, locationProp);
                 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripMenuItemDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripMenuItemDesigner.cs
@@ -18,7 +18,7 @@ namespace System.Windows.Forms.Design;
 internal class ToolStripMenuItemDesigner : ToolStripDropDownItemDesigner
 {
     private const int GLYPHINSET = 2;
-    // This is the typeHereNode that appears to the bottom and right  of each commited ToolStripDropDownItem
+    // This is the typeHereNode that appears to the bottom and right  of each committed ToolStripDropDownItem
     private DesignerToolStripControlHost typeHereNode;
     private ToolStripTemplateNode typeHereTemplateNode;
     // This is the TemplateNode.EditorToolStrip. The editor ToolStrip is encapsulated in a ToolStripControlHost and then added as a  ToolStripDropDownItem on the current ToolStripDropDownItems DropDown.
@@ -340,6 +340,8 @@ internal class ToolStripMenuItemDesigner : ToolStripDropDownItemDesigner
         }
     }
 
+    private IComponentChangeService ComponentChangeService => GetService(typeof(IComponentChangeService)) as IComponentChangeService;
+
     /// <summary>
     ///  Adds the dummy node for InSitu Edit.
     /// </summary>
@@ -411,7 +413,7 @@ internal class ToolStripMenuItemDesigner : ToolStripDropDownItemDesigner
     internal override void CommitEdit(Type type, string text, bool commit, bool enterKeyPressed, bool tabKeyPressed)
     {
         IsEditorActive = false;
-        if (!(MenuItem.Owner is ToolStripDropDown) && base.Editor is not null) // we are on Base Menustrip !!
+        if (!(MenuItem.Owner is ToolStripDropDown) && base.Editor is not null) // we are on Base MenuStrip !!
         {
             base.CommitEdit(type, text, commit, enterKeyPressed, tabKeyPressed);
         }
@@ -487,7 +489,7 @@ internal class ToolStripMenuItemDesigner : ToolStripDropDownItemDesigner
                             dummyItemAdded = true;
                             CreateNewItem(type, index, text);
                             _designerHost.DestroyComponent(editedItem);
-                            // One place where we need to call this explicitly since the selection doesnt change.
+                            // One place where we need to call this explicitly since the selection doesn't change.
                             if (enterKeyPressed)
                             {
                                 typeHereNode.SelectControl();
@@ -551,7 +553,7 @@ internal class ToolStripMenuItemDesigner : ToolStripDropDownItemDesigner
                     }
                 }
             }
-            else // if commitedEditorNode is null and we are in commitEdit then just add the new Item, since this item is added through dropDown.
+            else // if committedEditorNode is null and we are in commitEdit then just add the new Item, since this item is added through dropDown.
             {
                 // if no editorNode then we are committing a NEW NODE...
                 index = MenuItem.DropDownItems.IndexOf(typeHereNode);
@@ -565,7 +567,7 @@ internal class ToolStripMenuItemDesigner : ToolStripDropDownItemDesigner
                     dummyItemAdded = false;
                 }
 
-                // One place where we need to call this explicitly since the selection doesnt change.
+                // One place where we need to call this explicitly since the selection doesn't change.
                 typeHereNode.SelectControl();
             }
 
@@ -574,7 +576,7 @@ internal class ToolStripMenuItemDesigner : ToolStripDropDownItemDesigner
             MenuItem.DropDown.PerformLayout();
             // Reset the Glyphs after Item addition...
             ResetGlyphs(MenuItem);
-            // set the selection to our new item only if item was commited via ENTER KEY in the Insitu Mode.
+            // set the selection to our new item only if item was committed via ENTER KEY in the Insitu Mode.
             if (_selectionService is not null)
             {
                 if (enterKeyPressed)
@@ -683,7 +685,7 @@ internal class ToolStripMenuItemDesigner : ToolStripDropDownItemDesigner
                 if (dummyItem)
                 {
                     // Since the operation is cancelled and there is no change of glyphs,
-                    // set SelectionManager.NeedRefresh to false so that it doesnt refresh,
+                    // set SelectionManager.NeedRefresh to false so that it doesn't refresh,
                     // when the transaction is cancelled.
                     GetService<SelectionManager>().NeedRefresh = false;
                     if (newMenuItemTransaction is not null)
@@ -897,7 +899,7 @@ internal class ToolStripMenuItemDesigner : ToolStripDropDownItemDesigner
         }
         catch
         {
-            // There might be scenarios where the ComponentAdding is fired but the Added doesnt get fired. Is such cases the InsertTransaction might be still active...  So we need to cancel that too here.
+            // There might be scenarios where the ComponentAdding is fired but the Added doesn't get fired. Is such cases the InsertTransaction might be still active...  So we need to cancel that too here.
             CommitInsertTransaction(false);
             if (outerTransaction is not null)
             {
@@ -941,7 +943,7 @@ internal class ToolStripMenuItemDesigner : ToolStripDropDownItemDesigner
     {
         if (commitedTemplateNode is not null && commitedTemplateNode.Active)
         {
-            // Get Index of the CommitedItem..
+            // Get Index of the CommittedItem..
             int index = MenuItem.DropDownItems.IndexOf(commitedEditorNode);
             commitedTemplateNode.Commit(false, false);
             if (index != -1 && MenuItem.DropDownItems.Count > index)
@@ -994,6 +996,12 @@ internal class ToolStripMenuItemDesigner : ToolStripDropDownItemDesigner
                 MenuItem.DropDown.Hide();
                 // Unhook the events...
                 UnHookEvents();
+            }
+
+            if (ComponentChangeService is not null)
+            {
+                ComponentChangeService.ComponentAdding -= ComponentChangeSvc_ComponentAdding;
+                ComponentChangeService.ComponentAdded -= ComponentChangeSvc_ComponentAdded;
             }
 
             if (_toolStripAdornerWindowService is not null)
@@ -1068,7 +1076,7 @@ internal class ToolStripMenuItemDesigner : ToolStripDropDownItemDesigner
                     }
                 }
 
-                // When you alt-tab from VS to any other application and come back  and if the dropDown is open; then the templateNode doesnt paint. This happens when you have another control below the dropDown which paints over the controlhost so we need to refresh the TemplateNode in this case.
+                // When you alt-tab from VS to any other application and come back  and if the dropDown is open; then the templateNode doesn't paint. This happens when you have another control below the dropDown which paints over the controlhost so we need to refresh the TemplateNode in this case.
                 if (item is DesignerToolStripControlHost controlHost)
                 {
                     controlHost.Control.Refresh();
@@ -1080,7 +1088,7 @@ internal class ToolStripMenuItemDesigner : ToolStripDropDownItemDesigner
     // Invalidate the BehaviorService if the location changed.
     private void DropDownLocationChanged(object sender, EventArgs e)
     {
-        // this shouldn't get fired manytimes.. only in certain case... but in those cases its needed to REFRESH THE ENTIRE adornerWindow.
+        // this shouldn't get fired many times.. only in certain case... but in those cases its needed to REFRESH THE ENTIRE adornerWindow.
         ToolStripDropDown dropDown = sender as ToolStripDropDown;
         if (dropDown.Visible)
         {
@@ -1264,7 +1272,7 @@ internal class ToolStripMenuItemDesigner : ToolStripDropDownItemDesigner
         {
             if (checkoutException.Equals(CheckoutException.Canceled))
             {
-                CommitInsertTransaction(/*commit=*/ false);
+                CommitInsertTransaction(commit: false);
 
                 if (newMenuItemTransaction is not null)
                 {
@@ -1502,6 +1510,12 @@ internal class ToolStripMenuItemDesigner : ToolStripDropDownItemDesigner
 
         // Set the DoubleClickEnabled
         MenuItem.DoubleClickEnabled = true;
+
+        if (ComponentChangeService is not null)
+        {
+            ComponentChangeService.ComponentAdding += ComponentChangeSvc_ComponentAdding;
+            ComponentChangeService.ComponentAdded += ComponentChangeSvc_ComponentAdded;
+        }
 
         if (_undoEngine is null && TryGetService(out _undoEngine))
         {
@@ -1746,7 +1760,7 @@ internal class ToolStripMenuItemDesigner : ToolStripDropDownItemDesigner
             }
             catch
             {
-                CommitInsertTransaction(/*commit=*/false);
+                CommitInsertTransaction(commit: false);
             }
             finally
             {
@@ -2092,7 +2106,7 @@ internal class ToolStripMenuItemDesigner : ToolStripDropDownItemDesigner
     }
 
     /// <summary>
-    ///  Once a menuitem designer has selection - be sure to expand and collapse all necessary child/parent items Implements the Selection Paint Logic by adding Text to Tag property. Also Hides Unnecessary DropDowns.
+    ///  Once a menuItem designer has selection - be sure to expand and collapse all necessary child/parent items Implements the Selection Paint Logic by adding Text to Tag property. Also Hides Unnecessary DropDowns.
     /// </summary>
     private void OnSelectionChanged(object sender, EventArgs e)
     {

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripMenuItemDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripMenuItemDesigner.cs
@@ -35,6 +35,8 @@ internal class ToolStripMenuItemDesigner : ToolStripDropDownItemDesigner
     // Make Selection service a class level member.. used a lot.
     private ISelectionService _selectionService;
 
+    private IComponentChangeService _componentChangeService;
+
     // DesignerTransaction used for removing Items
     private DesignerTransaction _pendingTransaction;
     private bool fireComponentChanged;
@@ -340,7 +342,14 @@ internal class ToolStripMenuItemDesigner : ToolStripDropDownItemDesigner
         }
     }
 
-    private IComponentChangeService ComponentChangeService => GetService(typeof(IComponentChangeService)) as IComponentChangeService;
+    private IComponentChangeService ComponentChangeService
+    {
+        get
+        {
+            _componentChangeService ??= GetService<IComponentChangeService>();
+            return _componentChangeService;
+        }
+    }
 
     /// <summary>
     ///  Adds the dummy node for InSitu Edit.
@@ -1002,6 +1011,9 @@ internal class ToolStripMenuItemDesigner : ToolStripDropDownItemDesigner
             {
                 ComponentChangeService.ComponentAdding -= ComponentChangeSvc_ComponentAdding;
                 ComponentChangeService.ComponentAdded -= ComponentChangeSvc_ComponentAdded;
+
+                ComponentChangeService.ComponentRemoving -= ComponentChangeSvc_ComponentRemoving;
+                ComponentChangeService.ComponentRemoved -= ComponentChangeSvc_ComponentRemoved;
             }
 
             if (_toolStripAdornerWindowService is not null)
@@ -1515,6 +1527,9 @@ internal class ToolStripMenuItemDesigner : ToolStripDropDownItemDesigner
         {
             ComponentChangeService.ComponentAdding += ComponentChangeSvc_ComponentAdding;
             ComponentChangeService.ComponentAdded += ComponentChangeSvc_ComponentAdded;
+
+            ComponentChangeService.ComponentRemoving += ComponentChangeSvc_ComponentRemoving;
+            ComponentChangeService.ComponentRemoved += ComponentChangeSvc_ComponentRemoved;
         }
 
         if (_undoEngine is null && TryGetService(out _undoEngine))

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripMenuItemDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripMenuItemDesigner.cs
@@ -342,14 +342,7 @@ internal class ToolStripMenuItemDesigner : ToolStripDropDownItemDesigner
         }
     }
 
-    private IComponentChangeService ComponentChangeService
-    {
-        get
-        {
-            _componentChangeService ??= GetService<IComponentChangeService>();
-            return _componentChangeService;
-        }
-    }
+    private IComponentChangeService ComponentChangeService => _componentChangeService ??= GetService<IComponentChangeService>();
 
     /// <summary>
     ///  Adds the dummy node for InSitu Edit.
@@ -562,8 +555,9 @@ internal class ToolStripMenuItemDesigner : ToolStripDropDownItemDesigner
                     }
                 }
             }
-            else // if committedEditorNode is null and we are in commitEdit then just add the new Item, since this item is added through dropDown.
+            else
             {
+                // if committedEditorNode is null and we are in commitEdit then just add the new Item, since this item is added through dropDown.
                 // if no editorNode then we are committing a NEW NODE...
                 index = MenuItem.DropDownItems.IndexOf(typeHereNode);
                 try

--- a/src/System.Windows.Forms.Design/tests/UnitTests/ToolStripDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/ToolStripDesignerTests.cs
@@ -31,6 +31,10 @@ public class ToolStripDesignerTests
         var mockSite = MockSite.CreateMockSiteWithDesignerHost(mockDesignerHost.Object);
         mockSite.Setup(s => s.GetService(typeof(BehaviorService))).Returns(null);
         mockSite.Setup(s => s.GetService(typeof(ToolStripAdornerWindowService))).Returns(null);
+
+        Mock<IComponentChangeService> mockComponentChangeService = new(MockBehavior.Strict);
+        mockSite.Setup(s => s.GetService(typeof(IComponentChangeService))).Returns(mockComponentChangeService.Object);
+
         toolStrip.Site = mockSite.Object;
 
         toolStripDesigner.Initialize(toolStrip);


### PR DESCRIPTION
Fixes #9413 

## Root cause

The error is thrown in line 1585. MenuItem.Owner is null here.


https://github.com/dotnet/winforms/blob/bd97476fa596ac2063153181daa6a46251dc755d/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripMenuItemDesigner.cs#L1579-L1586

Actually , MenuItem.Owner is set in the method.

https://github.com/dotnet/winforms/blob/bd97476fa596ac2063153181daa6a46251dc755d/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripMenuItemDesigner.cs#L1640

We didn't bind this method to `ComponentChangeService`. It looks like a careless omission.

## Proposed changes

- 
- bind methods to `ComponentChangeService`
- 



## Screenshots 

### Before

https://github.com/dotnet/winforms/assets/94418985/4ae6cb77-9592-41ae-96df-65fe24d9241b

![menu-1](https://github.com/dotnet/winforms/assets/94418985/d9a6ef8a-76fc-4638-9ddd-8fa88128324f)

### After



https://github.com/dotnet/winforms/assets/135201996/eb8502a2-5bc0-4526-833c-ff8b2e8b2a02



## Test methodology <!-- How did you ensure quality? -->

- 
- manually 
- 



 

## Test environment(s) <!-- Remove any that don't apply -->
9.0.0-preview.3.24128.10


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/10979)