### PR TITLE
Add property "AllowThousandsSeparatorInput" to control whether thousands separator can be entered in NumericUpdown

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+System.Windows.Forms.NumericUpDown.AllowThousandsSeparatorInput.get -> bool
+System.Windows.Forms.NumericUpDown.AllowThousandsSeparatorInput.set -> void

--- a/src/System.Windows.Forms/src/Resources/SR.resx
+++ b/src/System.Windows.Forms/src/Resources/SR.resx
@@ -4317,6 +4317,9 @@ Stack trace where the illegal operation occurred was:
   <data name="NumericUpDownAccelerationCompareException" xml:space="preserve">
     <value>Argument is null or is not a NumericUpDownAcceleration object.</value>
   </data>
+  <data name="NumericUpDownAllowThousandsSeparatorInputDescr" xml:space="preserve">
+    <value>Indicates whether the numeric up-down should accept thousands separator input.</value>
+  </data>
   <data name="NumericUpDownDecimalPlacesDescr" xml:space="preserve">
     <value>Indicates the number of decimal places to display.</value>
   </data>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
@@ -7374,6 +7374,11 @@ Trasování zásobníku, kde došlo k neplatné operaci:
         <target state="translated">Argument má hodnotu Null nebo se nejedná o objekt NumericUpDownAcceleration.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NumericUpDownAllowThousandsSeparatorInputDescr">
+        <source>Indicates whether the numeric up-down should accept thousands separator input.</source>
+        <target state="new">Indicates whether the numeric up-down should accept thousands separator input.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NumericUpDownDecimalPlacesDescr">
         <source>Indicates the number of decimal places to display.</source>
         <target state="translated">Určuje počet zobrazovaných desetinných míst.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
@@ -7374,6 +7374,11 @@ Stapelüberwachung, in der der unzulässige Vorgang auftrat:
         <target state="translated">Das Argument ist NULL oder kein NumericUpDownAcceleration-Objekt.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NumericUpDownAllowThousandsSeparatorInputDescr">
+        <source>Indicates whether the numeric up-down should accept thousands separator input.</source>
+        <target state="new">Indicates whether the numeric up-down should accept thousands separator input.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NumericUpDownDecimalPlacesDescr">
         <source>Indicates the number of decimal places to display.</source>
         <target state="translated">Gibt die Anzahl der anzuzeigenden Dezimalstellen an.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
@@ -7374,6 +7374,11 @@ El seguimiento de la pila donde tuvo lugar la operación no válida fue:
         <target state="translated">El argumento es nulo o no es un objeto NumericUpDownAcceleration.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NumericUpDownAllowThousandsSeparatorInputDescr">
+        <source>Indicates whether the numeric up-down should accept thousands separator input.</source>
+        <target state="new">Indicates whether the numeric up-down should accept thousands separator input.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NumericUpDownDecimalPlacesDescr">
         <source>Indicates the number of decimal places to display.</source>
         <target state="translated">Indica el número de posiciones decimales que se muestran.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
@@ -7374,6 +7374,11 @@ Cette opération non conforme s'est produite sur la trace de la pile :
         <target state="translated">L'argument est null ou n'est pas un objet NumericUpDownAcceleration.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NumericUpDownAllowThousandsSeparatorInputDescr">
+        <source>Indicates whether the numeric up-down should accept thousands separator input.</source>
+        <target state="new">Indicates whether the numeric up-down should accept thousands separator input.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NumericUpDownDecimalPlacesDescr">
         <source>Indicates the number of decimal places to display.</source>
         <target state="translated">Indique le nombre de décimales à afficher.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
@@ -7374,6 +7374,11 @@ Traccia dello stack da cui si è verificata l'operazione non valida:
         <target state="translated">L'argomento è null o non è un oggetto NumericUpDownAcceleration.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NumericUpDownAllowThousandsSeparatorInputDescr">
+        <source>Indicates whether the numeric up-down should accept thousands separator input.</source>
+        <target state="new">Indicates whether the numeric up-down should accept thousands separator input.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NumericUpDownDecimalPlacesDescr">
         <source>Indicates the number of decimal places to display.</source>
         <target state="translated">Indica il numero di posizioni decimali da visualizzare.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
@@ -7374,6 +7374,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">引数が null であるか、または NumericUpDownAcceleration オブジェクトではありません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="NumericUpDownAllowThousandsSeparatorInputDescr">
+        <source>Indicates whether the numeric up-down should accept thousands separator input.</source>
+        <target state="new">Indicates whether the numeric up-down should accept thousands separator input.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NumericUpDownDecimalPlacesDescr">
         <source>Indicates the number of decimal places to display.</source>
         <target state="translated">表示する小数点以下の桁数を示します。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
@@ -7374,6 +7374,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">인수가 null이거나 NumericUpDownAcceleration 개체가 아닙니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NumericUpDownAllowThousandsSeparatorInputDescr">
+        <source>Indicates whether the numeric up-down should accept thousands separator input.</source>
+        <target state="new">Indicates whether the numeric up-down should accept thousands separator input.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NumericUpDownDecimalPlacesDescr">
         <source>Indicates the number of decimal places to display.</source>
         <target state="translated">표시할 소수 자릿수를 나타냅니다.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
@@ -7374,6 +7374,11 @@ Stos śledzenia, w którym wystąpiła zabroniona operacja:
         <target state="translated">Argument jest zerowy lub nie jest obiektem NumericUpDownAcceleration.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NumericUpDownAllowThousandsSeparatorInputDescr">
+        <source>Indicates whether the numeric up-down should accept thousands separator input.</source>
+        <target state="new">Indicates whether the numeric up-down should accept thousands separator input.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NumericUpDownDecimalPlacesDescr">
         <source>Indicates the number of decimal places to display.</source>
         <target state="translated">Wskazuje liczbę miejsc dziesiętnych, które mają być wyświetlane.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
@@ -7374,6 +7374,11 @@ Rastreamento de pilha em que a operação ilegal ocorreu:
         <target state="translated">O argumento é nulo ou não é um objeto NumericUpDownAcceleration.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NumericUpDownAllowThousandsSeparatorInputDescr">
+        <source>Indicates whether the numeric up-down should accept thousands separator input.</source>
+        <target state="new">Indicates whether the numeric up-down should accept thousands separator input.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NumericUpDownDecimalPlacesDescr">
         <source>Indicates the number of decimal places to display.</source>
         <target state="translated">Indica o número de casas decimais a serem exibidas.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
@@ -7375,6 +7375,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">Аргумент пуст или не является объектом NumericUpDownAcceleration.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NumericUpDownAllowThousandsSeparatorInputDescr">
+        <source>Indicates whether the numeric up-down should accept thousands separator input.</source>
+        <target state="new">Indicates whether the numeric up-down should accept thousands separator input.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NumericUpDownDecimalPlacesDescr">
         <source>Indicates the number of decimal places to display.</source>
         <target state="translated">Указывает число отображаемых десятичных разрядов.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
@@ -7374,6 +7374,11 @@ Geçersiz işlemin gerçekleştiği yığın izi:
         <target state="translated">Bağımsız değişken null veya NumericUpDownAcceleration nesnesi değil.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NumericUpDownAllowThousandsSeparatorInputDescr">
+        <source>Indicates whether the numeric up-down should accept thousands separator input.</source>
+        <target state="new">Indicates whether the numeric up-down should accept thousands separator input.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NumericUpDownDecimalPlacesDescr">
         <source>Indicates the number of decimal places to display.</source>
         <target state="translated">Görüntülenecek ondalık basamak sayısını gösterir.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
@@ -7374,6 +7374,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">参数为空或不是 NumericUpDownAcceleration 对象。</target>
         <note />
       </trans-unit>
+      <trans-unit id="NumericUpDownAllowThousandsSeparatorInputDescr">
+        <source>Indicates whether the numeric up-down should accept thousands separator input.</source>
+        <target state="new">Indicates whether the numeric up-down should accept thousands separator input.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NumericUpDownDecimalPlacesDescr">
         <source>Indicates the number of decimal places to display.</source>
         <target state="translated">指示要显示的小数位数。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
@@ -7374,6 +7374,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">引數為 null，或者不是 NumericUpDownAcceleration 物件。</target>
         <note />
       </trans-unit>
+      <trans-unit id="NumericUpDownAllowThousandsSeparatorInputDescr">
+        <source>Indicates whether the numeric up-down should accept thousands separator input.</source>
+        <target state="new">Indicates whether the numeric up-down should accept thousands separator input.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NumericUpDownDecimalPlacesDescr">
         <source>Indicates the number of decimal places to display.</source>
         <target state="translated">表示要顯示的小數位數。</target>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/UpDown/NumericUpDown.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/UpDown/NumericUpDown.cs
@@ -16,6 +16,7 @@ namespace System.Windows.Forms;
 [SRDescription(nameof(SR.DescriptionNumericUpDown))]
 public partial class NumericUpDown : UpDownBase, ISupportInitialize
 {
+    private const bool DefaultAllowThousandsSeparator = true;
     private const decimal DefaultValue = decimal.Zero;
     private const decimal DefaultMinimum = decimal.Zero;
     private const decimal DefaultMaximum = (decimal)100.0;
@@ -29,6 +30,9 @@ public partial class NumericUpDown : UpDownBase, ISupportInitialize
     // Member variables
     //
     //////////////////////////////////////////////////////////////
+    // Allow thousands separator input?
+    private bool _allowThousandsSeparatorInput = DefaultAllowThousandsSeparator;
+
     /// <summary>
     ///  The number of decimal places to display.
     /// </summary>
@@ -271,6 +275,27 @@ public partial class NumericUpDown : UpDownBase, ISupportInitialize
     }
 
     /// <summary>
+    ///  Gets or sets a value indicating whether the up-down control accept a thousands separator to be entered.
+    /// </summary>
+    [SRCategory(nameof(SR.CatData))]
+    [DefaultValue(DefaultAllowThousandsSeparator)]
+    [Localizable(true)]
+    [SRDescription(nameof(SR.NumericUpDownAllowThousandsSeparatorInputDescr))]
+    public bool AllowThousandsSeparatorInput
+    {
+        get
+        {
+            return _allowThousandsSeparatorInput;
+        }
+
+        set
+        {
+            _allowThousandsSeparatorInput = value;
+            UpdateEditText();
+        }
+    }
+
+    /// <summary>
     ///  Gets or sets a value indicating whether a thousands
     ///  separator is displayed in the up-down control when appropriate.
     /// </summary>
@@ -462,7 +487,7 @@ public partial class NumericUpDown : UpDownBase, ISupportInitialize
         {
             // Digits are OK
         }
-        else if (keyInput.Equals(decimalSeparator) || keyInput.Equals(groupSeparator) || keyInput.Equals(negativeSign))
+        else if (keyInput.Equals(decimalSeparator) || (_allowThousandsSeparatorInput && keyInput.Equals(groupSeparator)) || keyInput.Equals(negativeSign))
         {
             // Decimal separator is OK
         }

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MultipleControls.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MultipleControls.Designer.cs
@@ -35,6 +35,7 @@ partial class MultipleControls
         this.backgroundWorker1 = new System.ComponentModel.BackgroundWorker();
         this.button1 = new System.Windows.Forms.Button();
         this.label1 = new System.Windows.Forms.Label();
+        this.label2 = new System.Windows.Forms.Label();
         this.maskedTextBox1 = new System.Windows.Forms.MaskedTextBox();
         this.richTextBox1 = new System.Windows.Forms.RichTextBox();
         this.textBox1 = new System.Windows.Forms.TextBox();
@@ -49,6 +50,7 @@ partial class MultipleControls
         this.groupBox1 = new System.Windows.Forms.GroupBox();
         this.checkedListBox1 = new System.Windows.Forms.CheckedListBox();
         this.numericUpDown1 = new System.Windows.Forms.NumericUpDown();
+        this.numericUpDown2 = new System.Windows.Forms.NumericUpDown();
         this.domainUpDown1 = new System.Windows.Forms.DomainUpDown();
         this.linkLabel1 = new System.Windows.Forms.LinkLabel();
         this.linkLabel2 = new System.Windows.Forms.LinkLabel();
@@ -58,6 +60,7 @@ partial class MultipleControls
         this.tabPage2.SuspendLayout();
         this.groupBox1.SuspendLayout();
         ((System.ComponentModel.ISupportInitialize)(this.numericUpDown1)).BeginInit();
+        ((System.ComponentModel.ISupportInitialize)(this.numericUpDown2)).BeginInit();
         this.SuspendLayout();
         // 
         // progressBar1
@@ -242,6 +245,32 @@ partial class MultipleControls
         this.numericUpDown1.Name = "numericUpDown1";
         this.numericUpDown1.Size = new System.Drawing.Size(140, 23);
         this.numericUpDown1.TabIndex = 11;
+        this.numericUpDown1.ThousandsSeparator = true;
+        // 
+        // label2
+        // 
+        this.label2.AutoSize = true;
+        this.label2.FlatStyle = System.Windows.Forms.FlatStyle.System;
+        this.label2.Location = new System.Drawing.Point(378, 164);
+        this.label2.Name = "label2";
+        this.label2.Size = new System.Drawing.Size(38, 15);
+        this.label2.TabIndex = 2;
+        this.label2.Text = "AllowThousandsSeparatorInput = false";
+        // 
+        // numericUpDown2
+        // 
+        this.numericUpDown2.Location = new System.Drawing.Point(600, 164);
+        this.numericUpDown2.Name = "numericUpDown2";
+        this.numericUpDown2.Size = new System.Drawing.Size(140, 23);
+        this.numericUpDown2.TabIndex = 11;
+        this.numericUpDown2.Maximum = new decimal(new int[] {
+        10000,
+        0,
+        0,
+        0});
+        this.numericUpDown2.AllowThousandsSeparatorInput = false;
+        this.numericUpDown2.ThousandsSeparator = false;
+        this.numericUpDown2.DecimalPlaces = 2;
         // 
         // domainUpDown1
         // 
@@ -302,6 +331,7 @@ partial class MultipleControls
         this.Controls.Add(this.checkedListBox2);
         this.Controls.Add(this.domainUpDown1);
         this.Controls.Add(this.numericUpDown1);
+        this.Controls.Add(this.numericUpDown2);
         this.Controls.Add(this.checkedListBox1);
         this.Controls.Add(this.groupBox1);
         this.Controls.Add(this.tabControl1);
@@ -309,6 +339,7 @@ partial class MultipleControls
         this.Controls.Add(this.richTextBox1);
         this.Controls.Add(this.maskedTextBox1);
         this.Controls.Add(this.label1);
+        this.Controls.Add(this.label2);
         this.Controls.Add(this.button1);
         this.Controls.Add(this.progressBar1);
         this.Controls.Add(this.linkLabel1);
@@ -322,6 +353,7 @@ partial class MultipleControls
         this.tabPage2.PerformLayout();
         this.groupBox1.ResumeLayout(false);
         ((System.ComponentModel.ISupportInitialize)(this.numericUpDown1)).EndInit();
+        ((System.ComponentModel.ISupportInitialize)(this.numericUpDown2)).EndInit();
         this.ResumeLayout(false);
         this.PerformLayout();
 
@@ -333,6 +365,7 @@ partial class MultipleControls
     private System.ComponentModel.BackgroundWorker backgroundWorker1;
     private System.Windows.Forms.Button button1;
     private System.Windows.Forms.Label label1;
+    private System.Windows.Forms.Label label2;
     private System.Windows.Forms.MaskedTextBox maskedTextBox1;
     private System.Windows.Forms.RichTextBox richTextBox1;
     private System.Windows.Forms.TextBox textBox1;
@@ -347,6 +380,7 @@ partial class MultipleControls
     private System.Windows.Forms.GroupBox groupBox1;
     private System.Windows.Forms.CheckedListBox checkedListBox1;
     private System.Windows.Forms.NumericUpDown numericUpDown1;
+    private System.Windows.Forms.NumericUpDown numericUpDown2;
     private System.Windows.Forms.DomainUpDown domainUpDown1;
     private System.Windows.Forms.LinkLabel linkLabel1;
     private System.Windows.Forms.LinkLabel linkLabel2;


### PR DESCRIPTION
Fixes #10908


## Proposed changes

- Add property "AllowThousandsSeparatorInput" to control NumericUpdown

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Whether Thousands Separator can be typed can be set through properties

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

The thousands separator "," can be entered in control "NumericUpdown" even if ThousandsSeparator is false

### After

Whether Thousands Separator can be entered can be set through properties
![AfterChange](https://github.com/dotnet/winforms/assets/132890443/e01194ba-f0e6-428b-9c41-4244540abce9)


## Test methodology <!-- How did you ensure quality? -->

- Manually (interactive test)

## Test environment(s) <!-- Remove any that don't apply -->

- .net 9.0.0-preview.3.24154.1


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/10995)