### PR TITLE
Convert to 1ES Pipeline Template

### DIFF
--- a/azure-pipelines-PR.yml
+++ b/azure-pipelines-PR.yml
@@ -65,55 +65,24 @@ variables:
     value: ${{ contains(variables['Build.SourceBranch'], 'main') }}
   - name: NativeToolsOnMachine
     value: true
-  - name: isPublic
-    value: ${{ eq(variables['System.TeamProject'], 'public') }}
-  - name: isPR
-    value: ${{ eq(variables['Build.Reason'], 'PullRequest')}}
 
-  # used for post-build phases, internal builds only
-  - ${{ if and(ne(variables['isPublic'], 'true'), ne(variables['isPR'], 'true')) }}:
-    - group: DotNet-Winforms-SDLValidation-Params
-  - ${{ if ne(variables['System.TeamProject'], 'internal') }}:
-    - name: _InternalRuntimeDownloadArgs
-      value: ''
-  - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-    - group: DotNetBuilds storage account read tokens
-    - group: AzureDevOps-Artifact-Feeds-Pats
-    - name: _InternalRuntimeDownloadArgs
-      value: /p:DotNetRuntimeSourceFeed=https://dotnetbuilds.blob.core.windows.net/internal
-             /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
+  # used for post-build phases, no value for non-internal build
+  - name: _InternalRuntimeDownloadArgs
+    value: ''
 
   # Produce test-signed build for PR and Public builds
-  - ${{ if or(eq(variables['isPublic'], 'true'), eq(variables['isPR'], 'true')) }}:
-    # needed for darc (dependency flow) publishing
-    - name: _PublishArgs
-      value: ''
-    - name: _OfficialBuildIdArgs
-      value: ''
-    # needed for signing
-    - name: _SignType
-      value: test
-    - name: _SignArgs
-      value: ''
-    - name: _Sign
-      value: false
-
-  # Set up non-PR build from internal project
-  - ${{ if and(ne(variables['isPublic'], 'true'), ne(variables['isPR'], 'true')) }}:
-    # needed for darc (dependency flow) publishing
-    - name: _PublishArgs
-      value: >-
-            /p:DotNetPublishUsingPipelines=true
-    - name: _OfficialBuildIdArgs
-      value: /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
-    # needed for signing
-    - name: _SignType
-      value: real
-    - name: _SignArgs
-      value: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName) /p:Sign=$(_Sign)
-    - name: _Sign
-      value: true
-
+  # needed for darc (dependency flow) publishing
+  - name: _PublishArgs
+    value: ''
+  - name: _OfficialBuildIdArgs
+    value: ''
+  # needed for signing
+  - name: _SignType
+    value: test
+  - name: _SignArgs
+    value: ''
+  - name: _Sign
+    value: false
 
 stages:
 
@@ -140,57 +109,3 @@ stages:
       name: Windows_arm64
       targetArchitecture: arm64
       skipTests: $(SkipTests)
-
-
-- ${{ if and(eq(variables['EnableLoc'], 'true'), ne(variables['isPublic'], 'true'), ne(variables['isPR'], 'true')) }}:
-  - stage: OneLocBuild
-    displayName: Publish localizable content to OneLocBuild
-    jobs:
-    - template: /eng/common/templates/job/onelocbuild.yml
-      parameters:
-        MirrorRepo: winforms
-        UseCheckedInLocProjectJson: true
-        LclSource: lclFilesfromPackage
-        LclPackageId: 'LCL-JUNO-PROD-WINFORMS'
-
-
-- ${{ if and(ne(variables['isPublic'], 'true'), ne(variables['isPR'], 'true')) }}:
-  - stage: PublishAssetRegistry
-    displayName: Publish to Build Asset Registry
-    dependsOn: Build
-    variables:
-    - template: /eng/common/templates/variables/pool-providers.yml
-    jobs:
-    # Publish to Build Asset Registry in order to generate the ReleaseConfigs artifact.
-    - template: /eng/common/templates/job/publish-build-assets.yml
-      parameters:
-        publishUsingPipelines: true
-        pool:
-          name: $(DncEngInternalBuildPool)
-          demands: ImageOverride -equals windows.vs2022preview.amd64
-
-
-# Copied from the arcade repo and modified for winforms
-- ${{ if and(ne(variables['isPublic'], 'true'), ne(variables['isPR'], 'true')) }}:
-  - template: /eng/common/templates/post-build/post-build.yml
-    parameters:
-      validateDependsOn: PublishAssetRegistry
-      publishingInfraVersion: 3
-      enableSymbolValidation: false
-      enableSigningValidation: false
-      enableNugetValidation: false
-      enableSourceLinkValidation: false
-      # these param values come from the DotNet-Winforms-SDLValidation-Params azdo variable group
-      SDLValidationParameters:
-        enable: false
-        params: ' -SourceToolsList $(_TsaSourceToolsList)
-        -TsaInstanceURL $(_TsaInstanceURL)
-        -TsaProjectName $(_TsaProjectName)
-        -TsaNotificationEmail $(_TsaNotificationEmail)
-        -TsaCodebaseAdmin $(_TsaCodebaseAdmin)
-        -TsaBugAreaPath $(_TsaBugAreaPath)
-        -TsaIterationPath $(_TsaIterationPath)
-        -TsaRepositoryName $(_TsaRepositoryName)
-        -TsaCodebaseName $(_TsaCodebaseName)
-        -TsaOnboard $(_TsaOnboard)
-        -TsaPublish $(_TsaPublish)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,6 +2,11 @@
 # Please make sure to check all the converted content, it is your team's responsibility to make sure that the pipeline is still valid and functions as expected.
 # This pipeline will be extended to the OneESPT template
 # If you are not using the E+D shared hosted pool with windows-2022, replace the pool section with your hosted pool, os, and image name. If you are using a Linux image, you must specify an additional windows image for SDL: https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/sdlanalysis/overview#how-to-specify-a-windows-pool-for-the-sdl-source-analysis-stage
+
+# Parameters ARE available in template expressions, and parameters can have default values,
+# so they can be used to control yaml flow.
+
+# trigger ci builds for completed checkins into main and any release branches
 trigger:
   branches:
     include:
@@ -22,6 +27,8 @@ trigger:
     - README.md
     - SECURITY.md
     - THIRD-PARTY-NOTICES.TXT
+
+# trigger ci builds on pull requests into main and any release branches
 pr:
   autoCancel: true
   branches:
@@ -46,9 +53,11 @@ pr:
     - README.md
     - SECURITY.md
     - THIRD-PARTY-NOTICES.TXT
+
 variables:
 - name: TeamName
   value: DotNetCore
+# clean the local repo on the build agents
 - name: Build.Repository.Clean
   value: true
 - ${{ if or(startswith(variables['Build.SourceBranch'], 'refs/heads/release/'), startswith(variables['Build.SourceBranch'], 'refs/heads/internal/release/'), eq(variables['Build.Reason'], 'Manual')) }}:
@@ -65,6 +74,8 @@ variables:
   value: ${{ eq(variables['System.TeamProject'], 'public') }}
 - name: isPR
   value: ${{ eq(variables['Build.Reason'], 'PullRequest')}}
+
+# used for post-build phases, internal builds only
 - ${{ if and(ne(variables['isPublic'], 'true'), ne(variables['isPR'], 'true')) }}:
   - group: DotNet-Winforms-SDLValidation-Params
 - ${{ if ne(variables['System.TeamProject'], 'internal') }}:
@@ -74,24 +85,33 @@ variables:
   - group: DotNetBuilds storage account read tokens
   - group: AzureDevOps-Artifact-Feeds-Pats
   - name: _InternalRuntimeDownloadArgs
-    value: /p:DotNetRuntimeSourceFeed=https://dotnetbuilds.blob.core.windows.net/internal /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
+    value: /p:DotNetRuntimeSourceFeed=https://dotnetbuilds.blob.core.windows.net/internal
+           /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
+
+# Produce test-signed build for PR and Public builds
 - ${{ if or(eq(variables['isPublic'], 'true'), eq(variables['isPR'], 'true')) }}:
+  # needed for darc (dependency flow) publishing
   - name: _PublishArgs
     value: ''
   - name: _OfficialBuildIdArgs
     value: ''
+  # needed for signing
   - name: _SignType
     value: test
   - name: _SignArgs
     value: ''
   - name: _Sign
     value: false
+
+# Set up non-PR build from internal project
 - ${{ if and(ne(variables['isPublic'], 'true'), ne(variables['isPR'], 'true')) }}:
+  # needed for darc (dependency flow) publishing
   - name: _PublishArgs
     value: >-
       /p:DotNetPublishUsingPipelines=true
   - name: _OfficialBuildIdArgs
     value: /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+  # needed for signing
   - name: _SignType
     value: real
   - name: _SignArgs
@@ -116,23 +136,31 @@ extends:
     customBuildTags:
     - ES365AIMigrationTooling
     stages:
+
     - stage: Build
       jobs:
+
+      # Windows x64
       - template: /eng/pipelines/build.yml@self
         parameters:
           name: Windows_x64
           targetArchitecture: x64
           skipTests: $(SkipTests)
+
+      # Windows x86
       - template: /eng/pipelines/build.yml@self
         parameters:
           name: Windows_x86
           targetArchitecture: x86
           skipTests: $(SkipTests)
+
+      # Windows arm64
       - template: /eng/pipelines/build.yml@self
         parameters:
           name: Windows_arm64
           targetArchitecture: arm64
           skipTests: $(SkipTests)
+
     - ${{ if and(eq(variables['EnableLoc'], 'true'), ne(variables['isPublic'], 'true'), ne(variables['isPR'], 'true')) }}:
       - stage: OneLocBuild
         displayName: Publish localizable content to OneLocBuild
@@ -143,6 +171,7 @@ extends:
             UseCheckedInLocProjectJson: true
             LclSource: lclFilesfromPackage
             LclPackageId: 'LCL-JUNO-PROD-WINFORMS'
+
     - ${{ if and(ne(variables['isPublic'], 'true'), ne(variables['isPR'], 'true')) }}:
       - stage: PublishAssetRegistry
         displayName: Publish to Build Asset Registry
@@ -150,12 +179,15 @@ extends:
         variables:
         - template: /eng/common/templates-official/variables/pool-providers.yml@self
         jobs:
+        # Publish to Build Asset Registry in order to generate the ReleaseConfigs artifact.
         - template: /eng/common/templates-official/job/publish-build-assets.yml@self
           parameters:
             publishUsingPipelines: true
             pool:
               name: $(DncEngInternalBuildPool)
               demands: ImageOverride -equals windows.vs2022preview.amd64
+
+    # Copied from the arcade repo and modified for winforms
     - ${{ if and(ne(variables['isPublic'], 'true'), ne(variables['isPR'], 'true')) }}:
       - template: /eng/common/templates-official/post-build/post-build.yml@self
         parameters:
@@ -165,6 +197,17 @@ extends:
           enableSigningValidation: false
           enableNugetValidation: false
           enableSourceLinkValidation: false
+          # these param values come from the DotNet-Winforms-SDLValidation-Params azdo variable group
           SDLValidationParameters:
             enable: false
-            params: ' -SourceToolsList $(_TsaSourceToolsList) -TsaInstanceURL $(_TsaInstanceURL) -TsaProjectName $(_TsaProjectName) -TsaNotificationEmail $(_TsaNotificationEmail) -TsaCodebaseAdmin $(_TsaCodebaseAdmin) -TsaBugAreaPath $(_TsaBugAreaPath) -TsaIterationPath $(_TsaIterationPath) -TsaRepositoryName $(_TsaRepositoryName) -TsaCodebaseName $(_TsaCodebaseName) -TsaOnboard $(_TsaOnboard) -TsaPublish $(_TsaPublish)'
+            params: ' -SourceToolsList $(_TsaSourceToolsList)
+            -TsaInstanceURL $(_TsaInstanceURL)
+            -TsaProjectName $(_TsaProjectName)
+            -TsaNotificationEmail $(_TsaNotificationEmail)
+            -TsaCodebaseAdmin $(_TsaCodebaseAdmin)
+            -TsaBugAreaPath $(_TsaBugAreaPath)
+            -TsaIterationPath $(_TsaIterationPath)
+            -TsaRepositoryName $(_TsaRepositoryName)
+            -TsaCodebaseName $(_TsaCodebaseName)
+            -TsaOnboard $(_TsaOnboard)
+            -TsaPublish $(_TsaPublish)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,196 +1,168 @@
-# Parameters ARE available in template expressions, and parameters can have default values,
-# so they can be used to control yaml flow.
-
-# trigger ci builds for completed checkins into main and any release branches
+# This Yaml Document has been converted by ESAI Yaml Pipeline Conversion Tool.
+# Please make sure to check all the converted content, it is your team's responsibility to make sure that the pipeline is still valid and functions as expected.
+# This pipeline will be extended to the OneESPT template
+# If you are not using the E+D shared hosted pool with windows-2022, replace the pool section with your hosted pool, os, and image name. If you are using a Linux image, you must specify an additional windows image for SDL: https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/sdlanalysis/overview#how-to-specify-a-windows-pool-for-the-sdl-source-analysis-stage
 trigger:
   branches:
     include:
-      - main
-      - release/*
-      - internal/release/*
-      - internal/experimental/*
+    - main
+    - release/*
+    - internal/release/*
+    - internal/experimental/*
   paths:
     include:
-      - '*'
+    - '*'
     exclude:
-      - .github/*
-      - docs/*
-      - CODE-OF-CONDUCT.md
-      - CONTRIBUTING.md
-      - LICENSE.TXT
-      - PATENTS.TXT
-      - README.md
-      - SECURITY.md
-      - THIRD-PARTY-NOTICES.TXT
-
-# trigger ci builds on pull requests into main and any release branches
+    - .github/*
+    - docs/*
+    - CODE-OF-CONDUCT.md
+    - CONTRIBUTING.md
+    - LICENSE.TXT
+    - PATENTS.TXT
+    - README.md
+    - SECURITY.md
+    - THIRD-PARTY-NOTICES.TXT
 pr:
   autoCancel: true
   branches:
     include:
-      - main
-      - vnext
-      - release/*
-      - internal/release/*
-      - internal/experimental/*
-      - feature/win32
-      - feature/9.0
+    - main
+    - vnext
+    - release/*
+    - internal/release/*
+    - internal/experimental/*
+    - feature/win32
+    - feature/9.0
   paths:
     include:
-      - '*'
+    - '*'
     exclude:
-      - .github/*
-      - docs/*
-      - CODE-OF-CONDUCT.md
-      - CONTRIBUTING.md
-      - LICENSE.TXT
-      - PATENTS.TXT
-      - README.md
-      - SECURITY.md
-      - THIRD-PARTY-NOTICES.TXT
-
+    - .github/*
+    - docs/*
+    - CODE-OF-CONDUCT.md
+    - CONTRIBUTING.md
+    - LICENSE.TXT
+    - PATENTS.TXT
+    - README.md
+    - SECURITY.md
+    - THIRD-PARTY-NOTICES.TXT
 variables:
-  - name: TeamName
-    value: DotNetCore
-  # clean the local repo on the build agents
-  - name: Build.Repository.Clean
+- name: TeamName
+  value: DotNetCore
+- name: Build.Repository.Clean
+  value: true
+- ${{ if or(startswith(variables['Build.SourceBranch'], 'refs/heads/release/'), startswith(variables['Build.SourceBranch'], 'refs/heads/internal/release/'), eq(variables['Build.Reason'], 'Manual')) }}:
+  - name: PostBuildSign
+    value: false
+- ${{ else }}:
+  - name: PostBuildSign
     value: true
-  - ${{ if or(startswith(variables['Build.SourceBranch'], 'refs/heads/release/'), startswith(variables['Build.SourceBranch'], 'refs/heads/internal/release/'), eq(variables['Build.Reason'], 'Manual')) }}:
-    - name: PostBuildSign
-      value: false
-  - ${{ else }}:
-    - name: PostBuildSign
-      value: true
-  - name: EnableLoc
-    value: ${{ contains(variables['Build.SourceBranch'], 'main') }}
-  - name: NativeToolsOnMachine
+- name: EnableLoc
+  value: ${{ contains(variables['Build.SourceBranch'], 'main') }}
+- name: NativeToolsOnMachine
+  value: true
+- name: isPublic
+  value: ${{ eq(variables['System.TeamProject'], 'public') }}
+- name: isPR
+  value: ${{ eq(variables['Build.Reason'], 'PullRequest')}}
+- ${{ if and(ne(variables['isPublic'], 'true'), ne(variables['isPR'], 'true')) }}:
+  - group: DotNet-Winforms-SDLValidation-Params
+- ${{ if ne(variables['System.TeamProject'], 'internal') }}:
+  - name: _InternalRuntimeDownloadArgs
+    value: ''
+- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+  - group: DotNetBuilds storage account read tokens
+  - group: AzureDevOps-Artifact-Feeds-Pats
+  - name: _InternalRuntimeDownloadArgs
+    value: /p:DotNetRuntimeSourceFeed=https://dotnetbuilds.blob.core.windows.net/internal /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
+- ${{ if or(eq(variables['isPublic'], 'true'), eq(variables['isPR'], 'true')) }}:
+  - name: _PublishArgs
+    value: ''
+  - name: _OfficialBuildIdArgs
+    value: ''
+  - name: _SignType
+    value: test
+  - name: _SignArgs
+    value: ''
+  - name: _Sign
+    value: false
+- ${{ if and(ne(variables['isPublic'], 'true'), ne(variables['isPR'], 'true')) }}:
+  - name: _PublishArgs
+    value: >-
+      /p:DotNetPublishUsingPipelines=true
+  - name: _OfficialBuildIdArgs
+    value: /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+  - name: _SignType
+    value: real
+  - name: _SignArgs
+    value: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName) /p:Sign=$(_Sign)
+  - name: _Sign
     value: true
-  - name: isPublic
-    value: ${{ eq(variables['System.TeamProject'], 'public') }}
-  - name: isPR
-    value: ${{ eq(variables['Build.Reason'], 'PullRequest')}}
-
-  # used for post-build phases, internal builds only
-  - ${{ if and(ne(variables['isPublic'], 'true'), ne(variables['isPR'], 'true')) }}:
-    - group: DotNet-Winforms-SDLValidation-Params
-  - ${{ if ne(variables['System.TeamProject'], 'internal') }}:
-    - name: _InternalRuntimeDownloadArgs
-      value: ''
-  - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-    - group: DotNetBuilds storage account read tokens
-    - group: AzureDevOps-Artifact-Feeds-Pats
-    - name: _InternalRuntimeDownloadArgs
-      value: /p:DotNetRuntimeSourceFeed=https://dotnetbuilds.blob.core.windows.net/internal
-             /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
-
-  # Produce test-signed build for PR and Public builds
-  - ${{ if or(eq(variables['isPublic'], 'true'), eq(variables['isPR'], 'true')) }}:
-    # needed for darc (dependency flow) publishing
-    - name: _PublishArgs
-      value: ''
-    - name: _OfficialBuildIdArgs
-      value: ''
-    # needed for signing
-    - name: _SignType
-      value: test
-    - name: _SignArgs
-      value: ''
-    - name: _Sign
-      value: false
-
-  # Set up non-PR build from internal project
-  - ${{ if and(ne(variables['isPublic'], 'true'), ne(variables['isPR'], 'true')) }}:
-    # needed for darc (dependency flow) publishing
-    - name: _PublishArgs
-      value: >-
-            /p:DotNetPublishUsingPipelines=true
-    - name: _OfficialBuildIdArgs
-      value: /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
-    # needed for signing
-    - name: _SignType
-      value: real
-    - name: _SignArgs
-      value: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName) /p:Sign=$(_Sign)
-    - name: _Sign
-      value: true
-
-
-stages:
-
-- stage: Build
-  jobs:
-
-  # Windows x64
-  - template: /eng/pipelines/build.yml
-    parameters:
-      name: Windows_x64
-      targetArchitecture: x64
-      skipTests: $(SkipTests)
-
-  # Windows x86
-  - template: /eng/pipelines/build.yml
-    parameters:
-      name: Windows_x86
-      targetArchitecture: x86
-      skipTests: $(SkipTests)
-
-  # Windows arm64
-  - template: /eng/pipelines/build.yml
-    parameters:
-      name: Windows_arm64
-      targetArchitecture: arm64
-      skipTests: $(SkipTests)
-
-
-- ${{ if and(eq(variables['EnableLoc'], 'true'), ne(variables['isPublic'], 'true'), ne(variables['isPR'], 'true')) }}:
-  - stage: OneLocBuild
-    displayName: Publish localizable content to OneLocBuild
-    jobs:
-    - template: /eng/common/templates/job/onelocbuild.yml
-      parameters:
-        MirrorRepo: winforms
-        UseCheckedInLocProjectJson: true
-        LclSource: lclFilesfromPackage
-        LclPackageId: 'LCL-JUNO-PROD-WINFORMS'
-
-
-- ${{ if and(ne(variables['isPublic'], 'true'), ne(variables['isPR'], 'true')) }}:
-  - stage: PublishAssetRegistry
-    displayName: Publish to Build Asset Registry
-    dependsOn: Build
-    variables:
-    - template: /eng/common/templates/variables/pool-providers.yml
-    jobs:
-    # Publish to Build Asset Registry in order to generate the ReleaseConfigs artifact.
-    - template: /eng/common/templates/job/publish-build-assets.yml
-      parameters:
-        publishUsingPipelines: true
-        pool:
-          name: $(DncEngInternalBuildPool)
-          demands: ImageOverride -equals windows.vs2022preview.amd64
-
-
-# Copied from the arcade repo and modified for winforms
-- ${{ if and(ne(variables['isPublic'], 'true'), ne(variables['isPR'], 'true')) }}:
-  - template: /eng/common/templates/post-build/post-build.yml
-    parameters:
-      validateDependsOn: PublishAssetRegistry
-      publishingInfraVersion: 3
-      enableSymbolValidation: false
-      enableSigningValidation: false
-      enableNugetValidation: false
-      enableSourceLinkValidation: false
-      # these param values come from the DotNet-Winforms-SDLValidation-Params azdo variable group
-      SDLValidationParameters:
-        enable: false
-        params: ' -SourceToolsList $(_TsaSourceToolsList)
-        -TsaInstanceURL $(_TsaInstanceURL)
-        -TsaProjectName $(_TsaProjectName)
-        -TsaNotificationEmail $(_TsaNotificationEmail)
-        -TsaCodebaseAdmin $(_TsaCodebaseAdmin)
-        -TsaBugAreaPath $(_TsaBugAreaPath)
-        -TsaIterationPath $(_TsaIterationPath)
-        -TsaRepositoryName $(_TsaRepositoryName)
-        -TsaCodebaseName $(_TsaCodebaseName)
-        -TsaOnboard $(_TsaOnboard)
-        -TsaPublish $(_TsaPublish)'
+resources:
+  repositories:
+  - repository: 1ESPipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    pool:
+      name: Azure-Pipelines-1ESPT-ExDShared
+      image: windows-2022
+      os: windows
+    customBuildTags:
+    - ES365AIMigrationTooling
+    stages:
+    - stage: Build
+      jobs:
+      - template: /eng/pipelines/build.yml@self
+        parameters:
+          name: Windows_x64
+          targetArchitecture: x64
+          skipTests: $(SkipTests)
+      - template: /eng/pipelines/build.yml@self
+        parameters:
+          name: Windows_x86
+          targetArchitecture: x86
+          skipTests: $(SkipTests)
+      - template: /eng/pipelines/build.yml@self
+        parameters:
+          name: Windows_arm64
+          targetArchitecture: arm64
+          skipTests: $(SkipTests)
+    - ${{ if and(eq(variables['EnableLoc'], 'true'), ne(variables['isPublic'], 'true'), ne(variables['isPR'], 'true')) }}:
+      - stage: OneLocBuild
+        displayName: Publish localizable content to OneLocBuild
+        jobs:
+        - template: /eng/common/templates/job/onelocbuild.yml@self
+          parameters:
+            MirrorRepo: winforms
+            UseCheckedInLocProjectJson: true
+            LclSource: lclFilesfromPackage
+            LclPackageId: 'LCL-JUNO-PROD-WINFORMS'
+    - ${{ if and(ne(variables['isPublic'], 'true'), ne(variables['isPR'], 'true')) }}:
+      - stage: PublishAssetRegistry
+        displayName: Publish to Build Asset Registry
+        dependsOn: Build
+        variables:
+        - template: /eng/common/templates/variables/pool-providers.yml@self
+        jobs:
+        - template: /eng/common/templates/job/publish-build-assets.yml@self
+          parameters:
+            publishUsingPipelines: true
+            pool:
+              name: $(DncEngInternalBuildPool)
+              demands: ImageOverride -equals windows.vs2022preview.amd64
+    - ${{ if and(ne(variables['isPublic'], 'true'), ne(variables['isPR'], 'true')) }}:
+      - template: /eng/common/templates/post-build/post-build.yml@self
+        parameters:
+          validateDependsOn: PublishAssetRegistry
+          publishingInfraVersion: 3
+          enableSymbolValidation: false
+          enableSigningValidation: false
+          enableNugetValidation: false
+          enableSourceLinkValidation: false
+          SDLValidationParameters:
+            enable: false
+            params: ' -SourceToolsList $(_TsaSourceToolsList) -TsaInstanceURL $(_TsaInstanceURL) -TsaProjectName $(_TsaProjectName) -TsaNotificationEmail $(_TsaNotificationEmail) -TsaCodebaseAdmin $(_TsaCodebaseAdmin) -TsaBugAreaPath $(_TsaBugAreaPath) -TsaIterationPath $(_TsaIterationPath) -TsaRepositoryName $(_TsaRepositoryName) -TsaCodebaseName $(_TsaCodebaseName) -TsaOnboard $(_TsaOnboard) -TsaPublish $(_TsaPublish)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,8 +1,3 @@
-# This Yaml Document has been converted by ESAI Yaml Pipeline Conversion Tool.
-# Please make sure to check all the converted content, it is your team's responsibility to make sure that the pipeline is still valid and functions as expected.
-# This pipeline will be extended to the OneESPT template
-# If you are not using the E+D shared hosted pool with windows-2022, replace the pool section with your hosted pool, os, and image name. If you are using a Linux image, you must specify an additional windows image for SDL: https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/sdlanalysis/overview#how-to-specify-a-windows-pool-for-the-sdl-source-analysis-stage
-
 # Parameters ARE available in template expressions, and parameters can have default values,
 # so they can be used to control yaml flow.
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -108,8 +108,8 @@ extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
     pool:
-      name: Azure-Pipelines-1ESPT-ExDShared
-      image: windows-2022
+      name: NetCore1ESPool-Internal
+      image: 1es-windows-2022-pt
       os: windows
     customBuildTags:
     - ES365AIMigrationTooling

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -107,6 +107,8 @@ resources:
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
+    featureFlags:
+      autoBaseline: true
     pool:
       name: NetCore1ESPool-Internal
       image: 1es-windows-2022-pt

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,32 +23,6 @@ trigger:
     - SECURITY.md
     - THIRD-PARTY-NOTICES.TXT
 
-# trigger ci builds on pull requests into main and any release branches
-pr:
-  autoCancel: true
-  branches:
-    include:
-    - main
-    - vnext
-    - release/*
-    - internal/release/*
-    - internal/experimental/*
-    - feature/win32
-    - feature/9.0
-  paths:
-    include:
-    - '*'
-    exclude:
-    - .github/*
-    - docs/*
-    - CODE-OF-CONDUCT.md
-    - CONTRIBUTING.md
-    - LICENSE.TXT
-    - PATENTS.TXT
-    - README.md
-    - SECURITY.md
-    - THIRD-PARTY-NOTICES.TXT
-
 variables:
 - name: TeamName
   value: DotNetCore
@@ -65,54 +39,29 @@ variables:
   value: ${{ contains(variables['Build.SourceBranch'], 'main') }}
 - name: NativeToolsOnMachine
   value: true
-- name: isPublic
-  value: ${{ eq(variables['System.TeamProject'], 'public') }}
-- name: isPR
-  value: ${{ eq(variables['Build.Reason'], 'PullRequest')}}
 
-# used for post-build phases, internal builds only
-- ${{ if and(ne(variables['isPublic'], 'true'), ne(variables['isPR'], 'true')) }}:
-  - group: DotNet-Winforms-SDLValidation-Params
-- ${{ if ne(variables['System.TeamProject'], 'internal') }}:
-  - name: _InternalRuntimeDownloadArgs
-    value: ''
-- ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-  - group: DotNetBuilds storage account read tokens
-  - group: AzureDevOps-Artifact-Feeds-Pats
-  - name: _InternalRuntimeDownloadArgs
-    value: /p:DotNetRuntimeSourceFeed=https://dotnetbuilds.blob.core.windows.net/internal
-           /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
-
-# Produce test-signed build for PR and Public builds
-- ${{ if or(eq(variables['isPublic'], 'true'), eq(variables['isPR'], 'true')) }}:
-  # needed for darc (dependency flow) publishing
-  - name: _PublishArgs
-    value: ''
-  - name: _OfficialBuildIdArgs
-    value: ''
-  # needed for signing
-  - name: _SignType
-    value: test
-  - name: _SignArgs
-    value: ''
-  - name: _Sign
-    value: false
+# used for post-build phases
+- group: DotNet-Winforms-SDLValidation-Params
+- group: DotNetBuilds storage account read tokens
+- group: AzureDevOps-Artifact-Feeds-Pats
+- name: _InternalRuntimeDownloadArgs
+  value: /p:DotNetRuntimeSourceFeed=https://dotnetbuilds.blob.core.windows.net/internal
+          /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
 
 # Set up non-PR build from internal project
-- ${{ if and(ne(variables['isPublic'], 'true'), ne(variables['isPR'], 'true')) }}:
-  # needed for darc (dependency flow) publishing
-  - name: _PublishArgs
-    value: >-
-      /p:DotNetPublishUsingPipelines=true
-  - name: _OfficialBuildIdArgs
-    value: /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
-  # needed for signing
-  - name: _SignType
-    value: real
-  - name: _SignArgs
-    value: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName) /p:Sign=$(_Sign)
-  - name: _Sign
-    value: true
+# needed for darc (dependency flow) publishing
+- name: _PublishArgs
+  value: >-
+    /p:DotNetPublishUsingPipelines=true
+- name: _OfficialBuildIdArgs
+  value: /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+# needed for signing
+- name: _SignType
+  value: real
+- name: _SignArgs
+  value: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName) /p:Sign=$(_Sign)
+- name: _Sign
+  value: true
 resources:
   repositories:
   - repository: 1ESPipelineTemplates
@@ -156,7 +105,7 @@ extends:
           targetArchitecture: arm64
           skipTests: $(SkipTests)
 
-    - ${{ if and(eq(variables['EnableLoc'], 'true'), ne(variables['isPublic'], 'true'), ne(variables['isPR'], 'true')) }}:
+    - ${{ if eq(variables['EnableLoc'], 'true') }}:
       - stage: OneLocBuild
         displayName: Publish localizable content to OneLocBuild
         jobs:
@@ -167,42 +116,40 @@ extends:
             LclSource: lclFilesfromPackage
             LclPackageId: 'LCL-JUNO-PROD-WINFORMS'
 
-    - ${{ if and(ne(variables['isPublic'], 'true'), ne(variables['isPR'], 'true')) }}:
-      - stage: PublishAssetRegistry
-        displayName: Publish to Build Asset Registry
-        dependsOn: Build
-        variables:
-        - template: /eng/common/templates-official/variables/pool-providers.yml@self
-        jobs:
-        # Publish to Build Asset Registry in order to generate the ReleaseConfigs artifact.
-        - template: /eng/common/templates-official/job/publish-build-assets.yml@self
-          parameters:
-            publishUsingPipelines: true
-            pool:
-              name: $(DncEngInternalBuildPool)
-              demands: ImageOverride -equals windows.vs2022preview.amd64
+    - stage: PublishAssetRegistry
+      displayName: Publish to Build Asset Registry
+      dependsOn: Build
+      variables:
+      - template: /eng/common/templates-official/variables/pool-providers.yml@self
+      jobs:
+      # Publish to Build Asset Registry in order to generate the ReleaseConfigs artifact.
+      - template: /eng/common/templates-official/job/publish-build-assets.yml@self
+        parameters:
+          publishUsingPipelines: true
+          pool:
+            name: $(DncEngInternalBuildPool)
+            demands: ImageOverride -equals windows.vs2022preview.amd64
 
     # Copied from the arcade repo and modified for winforms
-    - ${{ if and(ne(variables['isPublic'], 'true'), ne(variables['isPR'], 'true')) }}:
-      - template: /eng/common/templates-official/post-build/post-build.yml@self
-        parameters:
-          validateDependsOn: PublishAssetRegistry
-          publishingInfraVersion: 3
-          enableSymbolValidation: false
-          enableSigningValidation: false
-          enableNugetValidation: false
-          enableSourceLinkValidation: false
-          # these param values come from the DotNet-Winforms-SDLValidation-Params azdo variable group
-          SDLValidationParameters:
-            enable: false
-            params: ' -SourceToolsList $(_TsaSourceToolsList)
-            -TsaInstanceURL $(_TsaInstanceURL)
-            -TsaProjectName $(_TsaProjectName)
-            -TsaNotificationEmail $(_TsaNotificationEmail)
-            -TsaCodebaseAdmin $(_TsaCodebaseAdmin)
-            -TsaBugAreaPath $(_TsaBugAreaPath)
-            -TsaIterationPath $(_TsaIterationPath)
-            -TsaRepositoryName $(_TsaRepositoryName)
-            -TsaCodebaseName $(_TsaCodebaseName)
-            -TsaOnboard $(_TsaOnboard)
-            -TsaPublish $(_TsaPublish)'
+    - template: /eng/common/templates-official/post-build/post-build.yml@self
+      parameters:
+        validateDependsOn: PublishAssetRegistry
+        publishingInfraVersion: 3
+        enableSymbolValidation: false
+        enableSigningValidation: false
+        enableNugetValidation: false
+        enableSourceLinkValidation: false
+        # these param values come from the DotNet-Winforms-SDLValidation-Params azdo variable group
+        SDLValidationParameters:
+          enable: false
+          params: ' -SourceToolsList $(_TsaSourceToolsList)
+          -TsaInstanceURL $(_TsaInstanceURL)
+          -TsaProjectName $(_TsaProjectName)
+          -TsaNotificationEmail $(_TsaNotificationEmail)
+          -TsaCodebaseAdmin $(_TsaCodebaseAdmin)
+          -TsaBugAreaPath $(_TsaBugAreaPath)
+          -TsaIterationPath $(_TsaIterationPath)
+          -TsaRepositoryName $(_TsaRepositoryName)
+          -TsaCodebaseName $(_TsaCodebaseName)
+          -TsaOnboard $(_TsaOnboard)
+          -TsaPublish $(_TsaPublish)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -135,7 +135,7 @@ extends:
       - stage: OneLocBuild
         displayName: Publish localizable content to OneLocBuild
         jobs:
-        - template: /eng/common/templates/job/onelocbuild.yml@self
+        - template: /eng/common/templates-official/job/onelocbuild.yml@self
           parameters:
             MirrorRepo: winforms
             UseCheckedInLocProjectJson: true
@@ -146,16 +146,16 @@ extends:
         displayName: Publish to Build Asset Registry
         dependsOn: Build
         variables:
-        - template: /eng/common/templates/variables/pool-providers.yml@self
+        - template: /eng/common/templates-official/variables/pool-providers.yml@self
         jobs:
-        - template: /eng/common/templates/job/publish-build-assets.yml@self
+        - template: /eng/common/templates-official/job/publish-build-assets.yml@self
           parameters:
             publishUsingPipelines: true
             pool:
               name: $(DncEngInternalBuildPool)
               demands: ImageOverride -equals windows.vs2022preview.amd64
     - ${{ if and(ne(variables['isPublic'], 'true'), ne(variables['isPR'], 'true')) }}:
-      - template: /eng/common/templates/post-build/post-build.yml@self
+      - template: /eng/common/templates-official/post-build/post-build.yml@self
         parameters:
           validateDependsOn: PublishAssetRegistry
           publishingInfraVersion: 3

--- a/eng/pipelines/build-PR.yml
+++ b/eng/pipelines/build-PR.yml
@@ -15,25 +15,20 @@ jobs:
     variables:
     - template: /eng/common/templates/variables/pool-providers.yml
     pool:
-      ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        name: $(DncEngPublicBuildPool)
-        demands: ImageOverride -equals windows.vs2022preview.amd64.open
-      ${{ if ne(variables['System.TeamProject'], 'public') }}:
-        name: $(DncEngInternalBuildPool)
-        demands: ImageOverride -equals windows.vs2022preview.amd64
+      name: $(DncEngPublicBuildPool)
+      demands: ImageOverride -equals windows.vs2022preview.amd64.open
     strategy:
       matrix:
-        ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-          Debug:
-            _BuildConfig: Debug
-            # override some variables for debug
-            _SignType: test
-            # Only collect coverage for external Debug-x64 builds. Uploads fail on internal builds, and coverage
-            # collection on additional legs produces unnecessary performance overhead.
-            ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(parameters.targetArchitecture, 'x64')) }}:
-              _Coverage: true
-            ${{ else }}:
-              _Coverage: false
+        Debug:
+          _BuildConfig: Debug
+          # override some variables for debug
+          _SignType: test
+          # Only collect coverage for external Debug-x64 builds. Uploads fail on internal builds, and coverage
+          # collection on additional legs produces unnecessary performance overhead.
+          ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(parameters.targetArchitecture, 'x64')) }}:
+            _Coverage: true
+          ${{ else }}:
+            _Coverage: false
         Release:
           _BuildConfig: Release
           _Coverage: false
@@ -44,24 +39,6 @@ jobs:
     - checkout: self
       clean: true
 
-    - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-      - task: PowerShell@2
-        displayName: Setup Private Feeds Credentials
-        inputs:
-          filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-          arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
-        env:
-          Token: $(dn-bot-dnceng-artifact-feeds-rw)
-
-      - task: MicroBuildSigningPlugin@2
-        displayName: Install MicroBuild plugin for Signing
-        inputs:
-          signType: $(_SignType)
-          zipSources: false
-          feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
-        continueOnError: false
-        condition: and(succeeded(), 
-                       in(variables['_SignType'], 'real', 'test'))
     # NuGet's http cache lasts 30 minutes. If we're on a static machine, this may interfere with
     # auto-update PRs by preventing the CI build from fetching the new version. Delete the cache.
     - powershell: Remove-Item -Recurse -ErrorAction Ignore "$env:LocalAppData\NuGet\v3-cache"
@@ -154,12 +131,6 @@ jobs:
         reportDirectory: '$(Build.SourcesDirectory)\artifacts\bin\CodeCoverage\coverage\full'
       displayName: PublishCodeCoverageResults
       condition: and(eq(variables['_BuildConfig'], 'Debug'), eq('${{ parameters.targetArchitecture }}', 'x64'))
-
-    # Generate SBOM for the internal leg only
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-      - template: ..\common\templates\steps\generate-sbom.yml
-        parameters:
-          name: Generate_SBOM_${{ parameters.name }}
 
     - template: post-build-PR.yml
       parameters:

--- a/eng/pipelines/build.yml
+++ b/eng/pipelines/build.yml
@@ -1,3 +1,10 @@
+# This Yaml Document has been converted by ESAI Yaml Pipeline Conversion Tool.
+# Please make sure to check all the converted content, it is your team's responsibility to make sure that the pipeline is still valid and functions as expected.
+# Outputs were added with YAML Conditional expressions generated using AI in a best attempt to preserve the boolean logic that would have lead to the tasks producing outputs executing before conversion. You may need to review the generated expressions for correctness of the execution logic, and you will need to manually translate any cross-template parameters.
+# Output from "eng\pipelines\post-build.yml" added to job "${{ parameters.name }}" with conditionals extracted using AI from the following files: "eng\pipelines\post-build.yml".
+# Output from "eng\pipelines\post-build.yml" added to job "${{ parameters.name }}" with conditionals extracted using AI from the following files: "eng\pipelines\post-build.yml".
+# Output from "eng\pipelines\post-build.yml" added to job "${{ parameters.name }}" with conditionals extracted using AI from the following files: "eng\pipelines\post-build.yml".
+
 parameters:
   name: ''
   targetArchitecture: null
@@ -7,160 +14,101 @@ parameters:
   enablePublishTestResults: true
   enablePublishBuildAssets: true
   enablePublishUsingPipelines: true
-
 jobs:
-  - job: ${{ parameters.name }}
-    displayName: ${{ parameters.name }}
-    timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
-    variables:
-    - template: /eng/common/templates/variables/pool-providers.yml
-    pool:
-      ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        name: $(DncEngPublicBuildPool)
-        demands: ImageOverride -equals windows.vs2022preview.amd64.open
-      ${{ if ne(variables['System.TeamProject'], 'public') }}:
-        name: $(DncEngInternalBuildPool)
-        demands: ImageOverride -equals windows.vs2022preview.amd64
-    strategy:
-      matrix:
-        ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-          Debug:
-            _BuildConfig: Debug
-            # override some variables for debug
-            _SignType: test
-            # Only collect coverage for external Debug-x64 builds. Uploads fail on internal builds, and coverage
-            # collection on additional legs produces unnecessary performance overhead.
-            ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(parameters.targetArchitecture, 'x64')) }}:
-              _Coverage: true
-            ${{ else }}:
-              _Coverage: false
-        Release:
-          _BuildConfig: Release
-          _Coverage: false
-    workspace:
-      clean: all
-
-    steps:
-    - checkout: self
-      clean: true
-
-    - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-      - task: PowerShell@2
-        displayName: Setup Private Feeds Credentials
-        inputs:
-          filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-          arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
-        env:
-          Token: $(dn-bot-dnceng-artifact-feeds-rw)
-
-      - task: MicroBuildSigningPlugin@2
-        displayName: Install MicroBuild plugin for Signing
-        inputs:
-          signType: $(_SignType)
-          zipSources: false
-          feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
-        continueOnError: false
-        condition: and(succeeded(), 
-                       in(variables['_SignType'], 'real', 'test'))
-    # NuGet's http cache lasts 30 minutes. If we're on a static machine, this may interfere with
-    # auto-update PRs by preventing the CI build from fetching the new version. Delete the cache.
-    - powershell: Remove-Item -Recurse -ErrorAction Ignore "$env:LocalAppData\NuGet\v3-cache"
-      displayName: Clear NuGet http cache (if exists)
-
-    - script: C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe queue pause
-      displayName: Pause NGEN x86
-
-    - script: C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe queue pause
-      displayName: Pause NGEN x64
-
-    # Build and rename binlog
-    # The /p:Coverage argument is passed here since some build properties change to accommodate running with
-    # coverage. This is part of the workarounds for https://github.com/tonerdo/coverlet/issues/362 and
-    # https://github.com/tonerdo/coverlet/issues/363.
-    - script: eng\cibuild.cmd
-        -restore
-        -build
-        -configuration $(_BuildConfig)
-        /p:Platform=${{ parameters.targetArchitecture }}
-        /p:TargetArchitecture=${{ parameters.targetArchitecture }}
-        $(_OfficialBuildIdArgs)
-        $(_InternalRuntimeDownloadArgs)
-        /p:Coverage=$(_Coverage)
-        /bl:$(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)\BuildSrc-${{ parameters.targetArchitecture }}.binlog
-      displayName: Build
-
-    # Run Unit Tests
-    # Tests are run with /m:1 to work around https://github.com/tonerdo/coverlet/issues/364
-    - script: eng\cibuild.cmd
-        -test
-        -configuration $(_BuildConfig)
-        /p:Platform=${{ parameters.targetArchitecture }}
-        /p:TargetArchitecture=${{ parameters.targetArchitecture }}
-        $(_OfficialBuildIdArgs)
-        $(_InternalRuntimeDownloadArgs)
-        /p:Coverage=$(_Coverage)
-        /p:TestRunnerAdditionalArguments='-notrait Category=IgnoreForCI -notrait Category=failing'
-        /bl:$(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)\Test-${{ parameters.targetArchitecture }}.binlog
-        /m:1
-      displayName: Run Unit Tests
-      condition: and(eq(variables['System.TeamProject'], 'public'), ne('${{ parameters.targetArchitecture }}', 'arm64'))
-
-    # Run Integration Tests
-    # Tests are run with /m:1 to avoid parallelism across different assemblies which can lead to
-    # UI race conditions
-    - script: eng\cibuild.cmd
-        -integrationTest
-        -configuration $(_BuildConfig)
-        /p:Platform=${{ parameters.targetArchitecture }}
-        /p:TargetArchitecture=${{ parameters.targetArchitecture }}
-        $(_OfficialBuildIdArgs)
-        $(_InternalRuntimeDownloadArgs)
-        /p:Coverage=$(_Coverage)
-        /p:TestRunnerAdditionalArguments='-notrait Category=IgnoreForCI -notrait Category=failing'
-        /bl:$(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)\IntegrationTest-${{ parameters.targetArchitecture }}.binlog
-        /m:1
-      env:
-        XUNIT_LOGS: $(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)
-      displayName: Run Integration Tests
-      condition: and(eq(variables['System.TeamProject'], 'public'), ne('${{ parameters.targetArchitecture }}', 'arm64'))
-
-    # Create Nuget package, sign, and publish
-    - script: eng\cibuild.cmd
-        -restore
-        -pack
-        -sign $(_SignArgs)
-        -publish $(_PublishArgs)
-        -configuration $(_BuildConfig)
-        $(_OfficialBuildIdArgs)
-        $(_InternalRuntimeDownloadArgs)
-        /bl:$(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)\PackSignPublish-${{ parameters.targetArchitecture }}.binlog
-      displayName: Pack, Sign, and Publish
-
-    # Upload code coverage data
-    - script: $(Build.SourcesDirectory)/.dotnet/dotnet msbuild -restore
-        eng/CodeCoverage.proj
-        /p:Configuration=$(_BuildConfig)
-        $(_InternalRuntimeDownloadArgs)
-        /bl:$(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)\CodeCoverage-${{ parameters.targetArchitecture }}.binlog
-      displayName: Upload coverage to codecov.io
-      condition: and(succeeded(), eq(variables._Coverage, 'true'), eq('${{ parameters.targetArchitecture }}', 'x64'))
-
-    #Publish code coverage results
-    - task: PublishCodeCoverageResults@1
+- job: ${{ parameters.name }}
+  displayName: ${{ parameters.name }}
+  timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
+  variables:
+  - template: /eng/common/templates/variables/pool-providers.yml@self
+  strategy:
+    matrix:
+      ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+        Debug:
+          _BuildConfig: Debug
+          _SignType: test
+          ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(parameters.targetArchitecture, 'x64')) }}:
+            _Coverage: true
+          ${{ else }}:
+            _Coverage: false
+      Release:
+        _BuildConfig: Release
+        _Coverage: false
+  workspace:
+    clean: all
+  templateContext:
+    outputs:
+    - ${{ if and(ne(parameters.artifacts.publish, ''), or(eq(parameters.artifacts.publish.artifacts, 'true'), ne(parameters.artifacts.publish.artifacts, ''))) }}:
+      - output: pipelineArtifact
+        displayName: 'Publish pipeline artifacts'
+        condition: always()
+        targetPath: '$(Build.ArtifactStagingDirectory)/artifacts'
+        publishLocation: Container
+        artifactName: ${{ coalesce(parameters.artifacts.publish.artifacts.name , 'Artifacts_$(Agent.Os)_$(_BuildConfig)') }}
+    - ${{ if and(ne(parameters.artifacts.publish, ''), or(eq(parameters.artifacts.publish.logs, 'true'), ne(parameters.artifacts.publish.logs, ''))) }}:
+      - output: pipelineArtifact
+        displayName: 'Publish logs'
+        condition: always()
+        targetPath: artifacts/log
+        artifactName: ${{ coalesce(parameters.artifacts.publish.logs.name, 'Logs_Build_$(Agent.Os)_$(_BuildConfig)') }}
+    - ${{ if ne(parameters.enablePublishBuildArtifacts, 'false') }}:
+      - output: pipelineArtifact
+        displayName: 'Publish Logs'
+        condition: always()
+        targetPath: '$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)'
+        publishLocation: Container
+        artifactName: ${{ coalesce(parameters.enablePublishBuildArtifacts.artifactName, '$(Agent.Os)_$(Agent.JobName)' ) }}
+  steps:
+  - checkout: self
+    clean: true
+  - ${{ if ne(variables['System.TeamProject'], 'public') }}:
+    - task: PowerShell@2
+      displayName: Setup Private Feeds Credentials
       inputs:
-        codeCoverageTool: 'cobertura'
-        summaryFileLocation: '$(Build.SourcesDirectory)\artifacts\bin\CodeCoverage\coverage\full\Cobertura.xml'
-        pathToSources: '$(Build.SourcesDirectory)'
-        reportDirectory: '$(Build.SourcesDirectory)\artifacts\bin\CodeCoverage\coverage\full'
-      displayName: PublishCodeCoverageResults
-      condition: and(eq(variables['_BuildConfig'], 'Debug'), eq('${{ parameters.targetArchitecture }}', 'x64'))
-
-    # Generate SBOM for the internal leg only
-    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-      - template: ..\common\templates\steps\generate-sbom.yml
-        parameters:
-          name: Generate_SBOM_${{ parameters.name }}
-
-    - template: post-build.yml
+        filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
+        arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
+      env:
+        Token: $(dn-bot-dnceng-artifact-feeds-rw)
+    - task: MicroBuildSigningPlugin@2
+      displayName: Install MicroBuild plugin for Signing
+      inputs:
+        signType: $(_SignType)
+        zipSources: false
+        feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
+      continueOnError: false
+      condition: and(succeeded(), in(variables['_SignType'], 'real', 'test'))
+  - powershell: Remove-Item -Recurse -ErrorAction Ignore "$env:LocalAppData\NuGet\v3-cache"
+    displayName: Clear NuGet http cache (if exists)
+  - script: C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe queue pause
+    displayName: Pause NGEN x86
+  - script: C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe queue pause
+    displayName: Pause NGEN x64
+  - script: eng\cibuild.cmd -restore -build -configuration $(_BuildConfig) /p:Platform=${{ parameters.targetArchitecture }} /p:TargetArchitecture=${{ parameters.targetArchitecture }} $(_OfficialBuildIdArgs) $(_InternalRuntimeDownloadArgs) /p:Coverage=$(_Coverage) /bl:$(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)\BuildSrc-${{ parameters.targetArchitecture }}.binlog
+    displayName: Build
+  - script: eng\cibuild.cmd -test -configuration $(_BuildConfig) /p:Platform=${{ parameters.targetArchitecture }} /p:TargetArchitecture=${{ parameters.targetArchitecture }} $(_OfficialBuildIdArgs) $(_InternalRuntimeDownloadArgs) /p:Coverage=$(_Coverage) /p:TestRunnerAdditionalArguments='-notrait Category=IgnoreForCI -notrait Category=failing' /bl:$(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)\Test-${{ parameters.targetArchitecture }}.binlog /m:1
+    displayName: Run Unit Tests
+    condition: and(eq(variables['System.TeamProject'], 'public'), ne('${{ parameters.targetArchitecture }}', 'arm64'))
+  - script: eng\cibuild.cmd -integrationTest -configuration $(_BuildConfig) /p:Platform=${{ parameters.targetArchitecture }} /p:TargetArchitecture=${{ parameters.targetArchitecture }} $(_OfficialBuildIdArgs) $(_InternalRuntimeDownloadArgs) /p:Coverage=$(_Coverage) /p:TestRunnerAdditionalArguments='-notrait Category=IgnoreForCI -notrait Category=failing' /bl:$(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)\IntegrationTest-${{ parameters.targetArchitecture }}.binlog /m:1
+    env:
+      XUNIT_LOGS: $(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)
+    displayName: Run Integration Tests
+    condition: and(eq(variables['System.TeamProject'], 'public'), ne('${{ parameters.targetArchitecture }}', 'arm64'))
+  - script: eng\cibuild.cmd -restore -pack -sign $(_SignArgs) -publish $(_PublishArgs) -configuration $(_BuildConfig) $(_OfficialBuildIdArgs) $(_InternalRuntimeDownloadArgs) /bl:$(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)\PackSignPublish-${{ parameters.targetArchitecture }}.binlog
+    displayName: Pack, Sign, and Publish
+  - script: $(Build.SourcesDirectory)/.dotnet/dotnet msbuild -restore eng/CodeCoverage.proj /p:Configuration=$(_BuildConfig) $(_InternalRuntimeDownloadArgs) /bl:$(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)\CodeCoverage-${{ parameters.targetArchitecture }}.binlog
+    displayName: Upload coverage to codecov.io
+    condition: and(succeeded(), eq(variables._Coverage, 'true'), eq('${{ parameters.targetArchitecture }}', 'x64'))
+  - task: PublishCodeCoverageResults@1
+    inputs:
+      codeCoverageTool: 'cobertura'
+      summaryFileLocation: '$(Build.SourcesDirectory)\artifacts\bin\CodeCoverage\coverage\full\Cobertura.xml'
+      pathToSources: '$(Build.SourcesDirectory)'
+      reportDirectory: '$(Build.SourcesDirectory)\artifacts\bin\CodeCoverage\coverage\full'
+    displayName: PublishCodeCoverageResults
+    condition: and(eq(variables['_BuildConfig'], 'Debug'), eq('${{ parameters.targetArchitecture }}', 'x64'))
+  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    - template: /eng/common/templates/steps/generate-sbom.yml@self
       parameters:
-        name: ${{ parameters.name }}
+        name: Generate_SBOM_${{ parameters.name }}
+  - template: /eng/pipelines/post-build.yml@self
+    parameters:
+      name: ${{ parameters.name }}

--- a/eng/pipelines/build.yml
+++ b/eng/pipelines/build.yml
@@ -16,17 +16,6 @@ jobs:
   - template: /eng/common/templates-official/variables/pool-providers.yml@self
   strategy:
     matrix:
-      ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-        Debug:
-          _BuildConfig: Debug
-          # override some variables for debug
-          _SignType: test
-          # Only collect coverage for external Debug-x64 builds. Uploads fail on internal builds, and coverage
-          # collection on additional legs produces unnecessary performance overhead.
-          ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(parameters.targetArchitecture, 'x64')) }}:
-            _Coverage: true
-          ${{ else }}:
-            _Coverage: false
       Release:
         _BuildConfig: Release
         _Coverage: false
@@ -59,23 +48,22 @@ jobs:
   - checkout: self
     clean: true
 
-  - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-    - task: PowerShell@2
-      displayName: Setup Private Feeds Credentials
-      inputs:
-        filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-        arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
-      env:
-        Token: $(dn-bot-dnceng-artifact-feeds-rw)
+  - task: PowerShell@2
+    displayName: Setup Private Feeds Credentials
+    inputs:
+      filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
+      arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
+    env:
+      Token: $(dn-bot-dnceng-artifact-feeds-rw)
 
-    - task: MicroBuildSigningPlugin@2
-      displayName: Install MicroBuild plugin for Signing
-      inputs:
-        signType: $(_SignType)
-        zipSources: false
-        feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
-      continueOnError: false
-      condition: and(succeeded(), in(variables['_SignType'], 'real', 'test'))
+  - task: MicroBuildSigningPlugin@2
+    displayName: Install MicroBuild plugin for Signing
+    inputs:
+      signType: $(_SignType)
+      zipSources: false
+      feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
+    continueOnError: false
+    condition: and(succeeded(), in(variables['_SignType'], 'real', 'test'))
   # NuGet's http cache lasts 30 minutes. If we're on a static machine, this may interfere with
   # auto-update PRs by preventing the CI build from fetching the new version. Delete the cache.
   - powershell: Remove-Item -Recurse -ErrorAction Ignore "$env:LocalAppData\NuGet\v3-cache"
@@ -169,11 +157,10 @@ jobs:
     displayName: PublishCodeCoverageResults
     condition: and(eq(variables['_BuildConfig'], 'Debug'), eq('${{ parameters.targetArchitecture }}', 'x64'))
 
-  # Generate SBOM for the internal leg only
-  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - template: /eng/common/templates-official/steps/generate-sbom.yml@self
-      parameters:
-        name: Generate_SBOM_${{ parameters.name }}
+  # Generate SBOM
+  - template: /eng/common/templates-official/steps/generate-sbom.yml@self
+    parameters:
+      name: Generate_SBOM_${{ parameters.name }}
 
   - template: /eng/pipelines/post-build.yml@self
     parameters:

--- a/eng/pipelines/build.yml
+++ b/eng/pipelines/build.yml
@@ -14,6 +14,7 @@ parameters:
   enablePublishTestResults: true
   enablePublishBuildAssets: true
   enablePublishUsingPipelines: true
+
 jobs:
 - job: ${{ parameters.name }}
   displayName: ${{ parameters.name }}
@@ -25,7 +26,10 @@ jobs:
       ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
         Debug:
           _BuildConfig: Debug
+          # override some variables for debug
           _SignType: test
+          # Only collect coverage for external Debug-x64 builds. Uploads fail on internal builds, and coverage
+          # collection on additional legs produces unnecessary performance overhead.
           ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(parameters.targetArchitecture, 'x64')) }}:
             _Coverage: true
           ${{ else }}:
@@ -35,6 +39,7 @@ jobs:
         _Coverage: false
   workspace:
     clean: all
+
   templateContext:
     outputs:
     - ${{ if and(ne(parameters.artifacts.publish, ''), or(eq(parameters.artifacts.publish.artifacts, 'true'), ne(parameters.artifacts.publish.artifacts, ''))) }}:
@@ -60,6 +65,7 @@ jobs:
   steps:
   - checkout: self
     clean: true
+
   - ${{ if ne(variables['System.TeamProject'], 'public') }}:
     - task: PowerShell@2
       displayName: Setup Private Feeds Credentials
@@ -68,6 +74,7 @@ jobs:
         arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
       env:
         Token: $(dn-bot-dnceng-artifact-feeds-rw)
+
     - task: MicroBuildSigningPlugin@2
       displayName: Install MicroBuild plugin for Signing
       inputs:
@@ -76,27 +83,90 @@ jobs:
         feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
       continueOnError: false
       condition: and(succeeded(), in(variables['_SignType'], 'real', 'test'))
+  # NuGet's http cache lasts 30 minutes. If we're on a static machine, this may interfere with
+  # auto-update PRs by preventing the CI build from fetching the new version. Delete the cache.
   - powershell: Remove-Item -Recurse -ErrorAction Ignore "$env:LocalAppData\NuGet\v3-cache"
     displayName: Clear NuGet http cache (if exists)
+
   - script: C:\Windows\Microsoft.NET\Framework\v4.0.30319\ngen.exe queue pause
     displayName: Pause NGEN x86
+
   - script: C:\Windows\Microsoft.NET\Framework64\v4.0.30319\ngen.exe queue pause
     displayName: Pause NGEN x64
-  - script: eng\cibuild.cmd -restore -build -configuration $(_BuildConfig) /p:Platform=${{ parameters.targetArchitecture }} /p:TargetArchitecture=${{ parameters.targetArchitecture }} $(_OfficialBuildIdArgs) $(_InternalRuntimeDownloadArgs) /p:Coverage=$(_Coverage) /bl:$(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)\BuildSrc-${{ parameters.targetArchitecture }}.binlog
+
+  # Build and rename binlog
+  # The /p:Coverage argument is passed here since some build properties change to accommodate running with
+  # coverage. This is part of the workarounds for https://github.com/tonerdo/coverlet/issues/362 and
+  # https://github.com/tonerdo/coverlet/issues/363.
+  - script: eng\cibuild.cmd
+      -restore
+      -build
+      -configuration $(_BuildConfig)
+      /p:Platform=${{ parameters.targetArchitecture }}
+      /p:TargetArchitecture=${{ parameters.targetArchitecture }}
+      $(_OfficialBuildIdArgs)
+      $(_InternalRuntimeDownloadArgs)
+      /p:Coverage=$(_Coverage)
+      /bl:$(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)\BuildSrc-${{ parameters.targetArchitecture }}.binlog
     displayName: Build
-  - script: eng\cibuild.cmd -test -configuration $(_BuildConfig) /p:Platform=${{ parameters.targetArchitecture }} /p:TargetArchitecture=${{ parameters.targetArchitecture }} $(_OfficialBuildIdArgs) $(_InternalRuntimeDownloadArgs) /p:Coverage=$(_Coverage) /p:TestRunnerAdditionalArguments='-notrait Category=IgnoreForCI -notrait Category=failing' /bl:$(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)\Test-${{ parameters.targetArchitecture }}.binlog /m:1
+
+  # Run Unit Tests
+  # Tests are run with /m:1 to work around https://github.com/tonerdo/coverlet/issues/364
+  - script: eng\cibuild.cmd
+      -test
+      -configuration $(_BuildConfig)
+      /p:Platform=${{ parameters.targetArchitecture }}
+      /p:TargetArchitecture=${{ parameters.targetArchitecture }}
+      $(_OfficialBuildIdArgs)
+      $(_InternalRuntimeDownloadArgs)
+      /p:Coverage=$(_Coverage)
+      /p:TestRunnerAdditionalArguments='-notrait Category=IgnoreForCI -notrait Category=failing'
+      /bl:$(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)\Test-${{ parameters.targetArchitecture }}.binlog
+      /m:1
     displayName: Run Unit Tests
     condition: and(eq(variables['System.TeamProject'], 'public'), ne('${{ parameters.targetArchitecture }}', 'arm64'))
-  - script: eng\cibuild.cmd -integrationTest -configuration $(_BuildConfig) /p:Platform=${{ parameters.targetArchitecture }} /p:TargetArchitecture=${{ parameters.targetArchitecture }} $(_OfficialBuildIdArgs) $(_InternalRuntimeDownloadArgs) /p:Coverage=$(_Coverage) /p:TestRunnerAdditionalArguments='-notrait Category=IgnoreForCI -notrait Category=failing' /bl:$(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)\IntegrationTest-${{ parameters.targetArchitecture }}.binlog /m:1
+
+  # Run Integration Tests
+  # Tests are run with /m:1 to avoid parallelism across different assemblies which can lead to
+  # UI race conditions
+  - script: eng\cibuild.cmd
+      -integrationTest
+      -configuration $(_BuildConfig)
+      /p:Platform=${{ parameters.targetArchitecture }}
+      /p:TargetArchitecture=${{ parameters.targetArchitecture }}
+      $(_OfficialBuildIdArgs)
+      $(_InternalRuntimeDownloadArgs)
+      /p:Coverage=$(_Coverage)
+      /p:TestRunnerAdditionalArguments='-notrait Category=IgnoreForCI -notrait Category=failing'
+      /bl:$(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)\IntegrationTest-${{ parameters.targetArchitecture }}.binlog
+      /m:1
     env:
       XUNIT_LOGS: $(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)
     displayName: Run Integration Tests
     condition: and(eq(variables['System.TeamProject'], 'public'), ne('${{ parameters.targetArchitecture }}', 'arm64'))
-  - script: eng\cibuild.cmd -restore -pack -sign $(_SignArgs) -publish $(_PublishArgs) -configuration $(_BuildConfig) $(_OfficialBuildIdArgs) $(_InternalRuntimeDownloadArgs) /bl:$(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)\PackSignPublish-${{ parameters.targetArchitecture }}.binlog
+
+  # Create Nuget package, sign, and publish
+  - script: eng\cibuild.cmd
+      -restore
+      -pack
+      -sign $(_SignArgs)
+      -publish $(_PublishArgs)
+      -configuration $(_BuildConfig)
+      $(_OfficialBuildIdArgs)
+      $(_InternalRuntimeDownloadArgs)
+      /bl:$(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)\PackSignPublish-${{ parameters.targetArchitecture }}.binlog
     displayName: Pack, Sign, and Publish
-  - script: $(Build.SourcesDirectory)/.dotnet/dotnet msbuild -restore eng/CodeCoverage.proj /p:Configuration=$(_BuildConfig) $(_InternalRuntimeDownloadArgs) /bl:$(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)\CodeCoverage-${{ parameters.targetArchitecture }}.binlog
+
+  # Upload code coverage data
+  - script: $(Build.SourcesDirectory)/.dotnet/dotnet msbuild -restore
+      eng/CodeCoverage.proj
+      /p:Configuration=$(_BuildConfig)
+      $(_InternalRuntimeDownloadArgs)
+      /bl:$(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)\CodeCoverage-${{ parameters.targetArchitecture }}.binlog
     displayName: Upload coverage to codecov.io
     condition: and(succeeded(), eq(variables._Coverage, 'true'), eq('${{ parameters.targetArchitecture }}', 'x64'))
+
+  #Publish code coverage results
   - task: PublishCodeCoverageResults@1
     inputs:
       codeCoverageTool: 'cobertura'
@@ -105,10 +175,13 @@ jobs:
       reportDirectory: '$(Build.SourcesDirectory)\artifacts\bin\CodeCoverage\coverage\full'
     displayName: PublishCodeCoverageResults
     condition: and(eq(variables['_BuildConfig'], 'Debug'), eq('${{ parameters.targetArchitecture }}', 'x64'))
+
+  # Generate SBOM for the internal leg only
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - template: /eng/common/templates-official/steps/generate-sbom.yml@self
       parameters:
         name: Generate_SBOM_${{ parameters.name }}
+
   - template: /eng/pipelines/post-build.yml@self
     parameters:
       name: ${{ parameters.name }}

--- a/eng/pipelines/build.yml
+++ b/eng/pipelines/build.yml
@@ -19,7 +19,7 @@ jobs:
   displayName: ${{ parameters.name }}
   timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
   variables:
-  - template: /eng/common/templates/variables/pool-providers.yml@self
+  - template: /eng/common/templates-official/variables/pool-providers.yml@self
   strategy:
     matrix:
       ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
@@ -106,7 +106,7 @@ jobs:
     displayName: PublishCodeCoverageResults
     condition: and(eq(variables['_BuildConfig'], 'Debug'), eq('${{ parameters.targetArchitecture }}', 'x64'))
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - template: /eng/common/templates/steps/generate-sbom.yml@self
+    - template: /eng/common/templates-official/steps/generate-sbom.yml@self
       parameters:
         name: Generate_SBOM_${{ parameters.name }}
   - template: /eng/pipelines/post-build.yml@self

--- a/eng/pipelines/build.yml
+++ b/eng/pipelines/build.yml
@@ -1,10 +1,3 @@
-# This Yaml Document has been converted by ESAI Yaml Pipeline Conversion Tool.
-# Please make sure to check all the converted content, it is your team's responsibility to make sure that the pipeline is still valid and functions as expected.
-# Outputs were added with YAML Conditional expressions generated using AI in a best attempt to preserve the boolean logic that would have lead to the tasks producing outputs executing before conversion. You may need to review the generated expressions for correctness of the execution logic, and you will need to manually translate any cross-template parameters.
-# Output from "eng\pipelines\post-build.yml" added to job "${{ parameters.name }}" with conditionals extracted using AI from the following files: "eng\pipelines\post-build.yml".
-# Output from "eng\pipelines\post-build.yml" added to job "${{ parameters.name }}" with conditionals extracted using AI from the following files: "eng\pipelines\post-build.yml".
-# Output from "eng\pipelines\post-build.yml" added to job "${{ parameters.name }}" with conditionals extracted using AI from the following files: "eng\pipelines\post-build.yml".
-
 parameters:
   name: ''
   targetArchitecture: null

--- a/eng/pipelines/post-build-PR.yml
+++ b/eng/pipelines/post-build-PR.yml
@@ -9,16 +9,6 @@ parameters:
   testResultsFormat: 'xunit'
 
 steps:
-
-  - ${{ if eq(parameters.enableMicrobuild, 'true') }}:
-    - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-      - task: MicroBuildCleanup@1
-        displayName: Execute Microbuild cleanup tasks  
-        condition: and(always(), in(variables['_SignType'], 'real', 'test'), eq(variables['Agent.Os'], 'Windows_NT'))
-        continueOnError: ${{ parameters.continueOnError }}
-        env:
-          TeamName: $(_TeamName)
-
   - ${{ if ne(parameters.artifacts.publish, '') }}:
     - ${{ if or(eq(parameters.artifacts.publish.artifacts, 'true'), ne(parameters.artifacts.publish.artifacts, '')) }}:
       - task: CopyFiles@2

--- a/eng/pipelines/post-build.yml
+++ b/eng/pipelines/post-build.yml
@@ -1,8 +1,3 @@
-# This Yaml Document has been converted by ESAI Yaml Pipeline Conversion Tool.
-# Please make sure to check all the converted content, it is your team's responsibility to make sure that the pipeline is still valid and functions as expected.
-# The Task 'PublishBuildArtifacts@1' has been converted to an output named 'Publish pipeline artifacts' in the templateContext section.
-# The Task 'PublishPipelineArtifact@1' has been converted to an output named 'Publish logs' in the templateContext section.
-# The Task 'PublishBuildArtifacts@1' has been converted to an output named 'Publish Logs' in the templateContext section.
 parameters:
   name: ''
   enableMicrobuild: true

--- a/eng/pipelines/post-build.yml
+++ b/eng/pipelines/post-build.yml
@@ -1,4 +1,8 @@
-
+# This Yaml Document has been converted by ESAI Yaml Pipeline Conversion Tool.
+# Please make sure to check all the converted content, it is your team's responsibility to make sure that the pipeline is still valid and functions as expected.
+# The Task 'PublishBuildArtifacts@1' has been converted to an output named 'Publish pipeline artifacts' in the templateContext section.
+# The Task 'PublishPipelineArtifact@1' has been converted to an output named 'Publish logs' in the templateContext section.
+# The Task 'PublishBuildArtifacts@1' has been converted to an output named 'Publish Logs' in the templateContext section.
 parameters:
   name: ''
   enableMicrobuild: true
@@ -7,78 +11,50 @@ parameters:
   enablePublishBuildAssets: true
   enablePublishUsingPipelines: true
   testResultsFormat: 'xunit'
-
 steps:
-
-  - ${{ if eq(parameters.enableMicrobuild, 'true') }}:
-    - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-      - task: MicroBuildCleanup@1
-        displayName: Execute Microbuild cleanup tasks  
-        condition: and(always(), in(variables['_SignType'], 'real', 'test'), eq(variables['Agent.Os'], 'Windows_NT'))
-        continueOnError: ${{ parameters.continueOnError }}
-        env:
-          TeamName: $(_TeamName)
-
-  - ${{ if ne(parameters.artifacts.publish, '') }}:
-    - ${{ if or(eq(parameters.artifacts.publish.artifacts, 'true'), ne(parameters.artifacts.publish.artifacts, '')) }}:
-      - task: CopyFiles@2
-        displayName: Gather binaries for publish to artifacts
-        inputs:
-          SourceFolder: 'artifacts/bin'
-          Contents: '**'
-          TargetFolder: '$(Build.ArtifactStagingDirectory)/artifacts/bin'
-      - task: CopyFiles@2
-        displayName: Gather packages for publish to artifacts
-        inputs:
-          SourceFolder: 'artifacts/packages'
-          Contents: '**'
-          TargetFolder: '$(Build.ArtifactStagingDirectory)/artifacts/packages'
-      - task: PublishBuildArtifacts@1
-        displayName: Publish pipeline artifacts
-        inputs:
-          PathtoPublish: '$(Build.ArtifactStagingDirectory)/artifacts'
-          PublishLocation: Container
-          ArtifactName: ${{ coalesce(parameters.artifacts.publish.artifacts.name , 'Artifacts_$(Agent.Os)_$(_BuildConfig)') }}
-        continueOnError: true
-        condition: always()
-    - ${{ if or(eq(parameters.artifacts.publish.logs, 'true'), ne(parameters.artifacts.publish.logs, '')) }}:
-      - publish: artifacts/log
-        artifact: ${{ coalesce(parameters.artifacts.publish.logs.name, 'Logs_Build_$(Agent.Os)_$(_BuildConfig)') }}
-        displayName: Publish logs
-        continueOnError: true
-        condition: always()
-
-  - ${{ if ne(parameters.enablePublishBuildArtifacts, 'false') }}:
-    - task: PublishBuildArtifacts@1
-      displayName: Publish Logs
+- ${{ if eq(parameters.enableMicrobuild, 'true') }}:
+  - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+    - task: MicroBuildCleanup@1
+      displayName: Execute Microbuild cleanup tasks
+      condition: and(always(), in(variables['_SignType'], 'real', 'test'), eq(variables['Agent.Os'], 'Windows_NT'))
+      continueOnError: ${{ parameters.continueOnError }}
+      env:
+        TeamName: $(_TeamName)
+- ${{ if ne(parameters.artifacts.publish, '') }}:
+  - ${{ if or(eq(parameters.artifacts.publish.artifacts, 'true'), ne(parameters.artifacts.publish.artifacts, '')) }}:
+    - task: CopyFiles@2
+      displayName: Gather binaries for publish to artifacts
       inputs:
-        PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)'
-        PublishLocation: Container
-        ArtifactName: ${{ coalesce(parameters.enablePublishBuildArtifacts.artifactName, '$(Agent.Os)_$(Agent.JobName)' ) }}
-      continueOnError: true
-      condition: always()
-
-  - ${{ if or(and(eq(parameters.enablePublishTestResults, 'true'), eq(parameters.testResultsFormat, '')), eq(parameters.testResultsFormat, 'xunit')) }}:
-    - task: PublishTestResults@2
-      displayName: Publish XUnit Test Results
+        SourceFolder: 'artifacts/bin'
+        Contents: '**'
+        TargetFolder: '$(Build.ArtifactStagingDirectory)/artifacts/bin'
+    - task: CopyFiles@2
+      displayName: Gather packages for publish to artifacts
       inputs:
-        testResultsFormat: 'xUnit'
-        testResultsFiles: '*.xml' 
-        searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
-        testRunTitle: ${{ coalesce(parameters.testRunTitle, parameters.name, '$(System.JobName)') }}-xunit
-        mergeTestResults: ${{ parameters.mergeTestResults }}
-      continueOnError: true
-      condition: and(eq(variables['System.TeamProject'], 'public'), ne('${{ parameters.targetArchitecture }}', 'arm64'))
-
-  - ${{ if or(and(eq(parameters.enablePublishTestResults, 'true'), eq(parameters.testResultsFormat, '')), eq(parameters.testResultsFormat, 'vstest')) }}:
-    - task: PublishTestResults@2
-      displayName: Publish TRX Test Results
-      inputs:
-        testResultsFormat: 'VSTest'
-        testResultsFiles: '*.trx' 
-        searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
-        testRunTitle: ${{ coalesce(parameters.testRunTitle, parameters.name, '$(System.JobName)') }}-trx
-        mergeTestResults: ${{ parameters.mergeTestResults }}
-      continueOnError: true
-      condition: and(eq(variables['System.TeamProject'], 'public'), ne('${{ parameters.targetArchitecture }}', 'arm64'))
-
+        SourceFolder: 'artifacts/packages'
+        Contents: '**'
+        TargetFolder: '$(Build.ArtifactStagingDirectory)/artifacts/packages'
+  - ${{ if or(eq(parameters.artifacts.publish.logs, 'true'), ne(parameters.artifacts.publish.logs, '')) }}: []
+- ${{ if ne(parameters.enablePublishBuildArtifacts, 'false') }}: []
+- ${{ if or(and(eq(parameters.enablePublishTestResults, 'true'), eq(parameters.testResultsFormat, '')), eq(parameters.testResultsFormat, 'xunit')) }}:
+  - task: PublishTestResults@2
+    displayName: Publish XUnit Test Results
+    inputs:
+      testResultsFormat: 'xUnit'
+      testResultsFiles: '*.xml'
+      searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
+      testRunTitle: ${{ coalesce(parameters.testRunTitle, parameters.name, '$(System.JobName)') }}-xunit
+      mergeTestResults: ${{ parameters.mergeTestResults }}
+    continueOnError: true
+    condition: and(eq(variables['System.TeamProject'], 'public'), ne('${{ parameters.targetArchitecture }}', 'arm64'))
+- ${{ if or(and(eq(parameters.enablePublishTestResults, 'true'), eq(parameters.testResultsFormat, '')), eq(parameters.testResultsFormat, 'vstest')) }}:
+  - task: PublishTestResults@2
+    displayName: Publish TRX Test Results
+    inputs:
+      testResultsFormat: 'VSTest'
+      testResultsFiles: '*.trx'
+      searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
+      testRunTitle: ${{ coalesce(parameters.testRunTitle, parameters.name, '$(System.JobName)') }}-trx
+      mergeTestResults: ${{ parameters.mergeTestResults }}
+    continueOnError: true
+    condition: and(eq(variables['System.TeamProject'], 'public'), ne('${{ parameters.targetArchitecture }}', 'arm64'))

--- a/eng/pipelines/post-build.yml
+++ b/eng/pipelines/post-build.yml
@@ -11,7 +11,9 @@ parameters:
   enablePublishBuildAssets: true
   enablePublishUsingPipelines: true
   testResultsFormat: 'xunit'
+
 steps:
+
 - ${{ if eq(parameters.enableMicrobuild, 'true') }}:
   - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - task: MicroBuildCleanup@1
@@ -20,6 +22,7 @@ steps:
       continueOnError: ${{ parameters.continueOnError }}
       env:
         TeamName: $(_TeamName)
+
 - ${{ if ne(parameters.artifacts.publish, '') }}:
   - ${{ if or(eq(parameters.artifacts.publish.artifacts, 'true'), ne(parameters.artifacts.publish.artifacts, '')) }}:
     - task: CopyFiles@2
@@ -47,6 +50,7 @@ steps:
       mergeTestResults: ${{ parameters.mergeTestResults }}
     continueOnError: true
     condition: and(eq(variables['System.TeamProject'], 'public'), ne('${{ parameters.targetArchitecture }}', 'arm64'))
+
 - ${{ if or(and(eq(parameters.enablePublishTestResults, 'true'), eq(parameters.testResultsFormat, '')), eq(parameters.testResultsFormat, 'vstest')) }}:
   - task: PublishTestResults@2
     displayName: Publish TRX Test Results

--- a/eng/pipelines/post-build.yml
+++ b/eng/pipelines/post-build.yml
@@ -10,7 +10,7 @@ parameters:
 steps:
 
 - ${{ if eq(parameters.enableMicrobuild, 'true') }}:
-  - ${{ if and(eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+  - ${{ if eq(parameters.runAsPublic, 'false') }}:
     - task: MicroBuildCleanup@1
       displayName: Execute Microbuild cleanup tasks
       condition: and(always(), in(variables['_SignType'], 'real', 'test'), eq(variables['Agent.Os'], 'Windows_NT'))


### PR DESCRIPTION
Best to review without whitespace since the conversion tool removed any unnecessary indents
test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2400049&view=results
The error in the test run is being tracked by https://github.com/dotnet/arcade/issues/14560 but it does not block successful build

note- the PR validation does not use this new yml file, it uses `azure-pipelines-pr.yml` which is a dupe of the original azure-pipelines.yml definition
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11025)