### PR TITLE
Clean doc analyzer messages

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -95,6 +95,17 @@ dotnet_style_prefer_collection_expression = true:suggestion
 # C# files
 [*.cs]
 
+# These two conflict with our usage of CsWin32
+
+# SYSLIB1054: Use 'LibraryImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+dotnet_diagnostic.SYSLIB1054.severity = none
+
+# SYSLIB1096: Convert to 'GeneratedComInterface'
+dotnet_diagnostic.SYSLIB1096.severity = none
+
+# DOC100: Place text in paragraphs
+dotnet_diagnostic.DOC100.severity = error
+
 # .NET diagnostic
 dotnet_diagnostic.RS0041.severity = none
 dotnet_diagnostic.IDE0005.severity = error
@@ -182,9 +193,6 @@ csharp_style_deconstructed_variable_declaration = true:suggestion
 
 # Visual Basic files
 
-# SYSLIB1054: Use 'LibraryImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
-dotnet_diagnostic.SYSLIB1054.severity = none
-
 [*.vb]
 # Modifier preferences
 visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public,Friend,NotOverridable,Overridable,MustOverride,Overloads,Overrides,MustInherit,NotInheritable,Static,Shared,Shadows,ReadOnly,WriteOnly,Dim,Const,WithEvents,Widening,Narrowing,Custom,Async:suggestion
@@ -222,3 +230,13 @@ end_of_line = lf
 
 [*.{cmd,bat}]
 end_of_line = crlf
+
+# Test specific
+[**/tests/**/*.cs]
+
+# CA1861: Avoid constant arrays as arguments - expected to be inline for test readability (4000 hits)
+dotnet_diagnostic.CA1861.severity = silent
+
+# This should be fixed https://github.com/dotnet/winforms/issues/11041
+# xUnit1042: The member referenced by the MemberData attribute returns untyped data rows
+dotnet_diagnostic.xUnit1042.severity = none

--- a/src/Common/src/UnconditionalSuppressMessageAttribute.cs
+++ b/src/Common/src/UnconditionalSuppressMessageAttribute.cs
@@ -1,16 +1,17 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace System.Diagnostics.CodeAnalysis;
 
 /// <summary>
-/// Suppresses reporting of a specific rule violation, allowing multiple suppressions on a
-/// single code artifact.
+///  Suppresses reporting of a specific rule violation, allowing multiple suppressions on a
+///  single code artifact.
 /// </summary>
 /// <remarks>
-/// <see cref="UnconditionalSuppressMessageAttribute"/> is different than
-/// <see cref="SuppressMessageAttribute"/> in that it doesn't have a
-/// <see cref="ConditionalAttribute"/>. So it is always preserved in the compiled assembly.
+///  <para>
+///   <see cref="UnconditionalSuppressMessageAttribute"/> is different than <see cref="SuppressMessageAttribute"/> in
+///   that it doesn't have a <see cref="ConditionalAttribute"/>. So it is always preserved in the compiled assembly.
+///  </para>
 /// </remarks>
 [AttributeUsage(AttributeTargets.All, Inherited = false, AllowMultiple = true)]
 #if SYSTEM_PRIVATE_CORELIB
@@ -21,8 +22,8 @@ internal
 sealed class UnconditionalSuppressMessageAttribute : Attribute
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="UnconditionalSuppressMessageAttribute"/>
-    /// class, specifying the category of the tool and the identifier for an analysis rule.
+    ///  Initializes a new instance of the <see cref="UnconditionalSuppressMessageAttribute"/>
+    ///  class, specifying the category of the tool and the identifier for an analysis rule.
     /// </summary>
     /// <param name="category">The category for the attribute.</param>
     /// <param name="checkId">The identifier of the analysis rule the attribute applies to.</param>
@@ -33,57 +34,67 @@ sealed class UnconditionalSuppressMessageAttribute : Attribute
     }
 
     /// <summary>
-    /// Gets the category identifying the classification of the attribute.
+    ///  Gets the category identifying the classification of the attribute.
     /// </summary>
     /// <remarks>
-    /// The <see cref="Category"/> property describes the tool or tool analysis category
-    /// for which a message suppression attribute applies.
+    ///  <para>
+    ///   The <see cref="Category"/> property describes the tool or tool analysis category
+    ///   for which a message suppression attribute applies.
+    ///  </para>
     /// </remarks>
     public string Category { get; }
 
     /// <summary>
-    /// Gets the identifier of the analysis tool rule to be suppressed.
+    ///  Gets the identifier of the analysis tool rule to be suppressed.
     /// </summary>
     /// <remarks>
-    /// Concatenated together, the <see cref="Category"/> and <see cref="CheckId"/>
-    /// properties form a unique check identifier.
+    ///  <para>
+    ///   Concatenated together, the <see cref="Category"/> and <see cref="CheckId"/>
+    ///   properties form a unique check identifier.
+    ///  </para>
     /// </remarks>
     public string CheckId { get; }
 
     /// <summary>
-    /// Gets or sets the scope of the code that is relevant for the attribute.
+    ///  Gets or sets the scope of the code that is relevant for the attribute.
     /// </summary>
     /// <remarks>
-    /// The Scope property is an optional argument that specifies the metadata scope for which
-    /// the attribute is relevant.
+    ///  <para>
+    ///   The Scope property is an optional argument that specifies the metadata scope for which
+    ///   the attribute is relevant.
+    ///  </para>
     /// </remarks>
     public string? Scope { get; set; }
 
     /// <summary>
-    /// Gets or sets a fully qualified path that represents the target of the attribute.
+    ///  Gets or sets a fully qualified path that represents the target of the attribute.
     /// </summary>
     /// <remarks>
-    /// The <see cref="Target"/> property is an optional argument identifying the analysis target
-    /// of the attribute. An example value is "System.IO.Stream.ctor():System.Void".
-    /// Because it is fully qualified, it can be long, particularly for targets such as parameters.
-    /// The analysis tool user interface should be capable of automatically formatting the parameter.
+    ///  <para>
+    ///   The <see cref="Target"/> property is an optional argument identifying the analysis target
+    ///   of the attribute. An example value is "System.IO.Stream.ctor():System.Void".
+    ///   Because it is fully qualified, it can be long, particularly for targets such as parameters.
+    ///   The analysis tool user interface should be capable of automatically formatting the parameter.
+    ///  </para>
     /// </remarks>
     public string? Target { get; set; }
 
     /// <summary>
-    /// Gets or sets an optional argument expanding on exclusion criteria.
+    ///  Gets or sets an optional argument expanding on exclusion criteria.
     /// </summary>
     /// <remarks>
-    /// The <see cref="MessageId "/> property is an optional argument that specifies additional
-    /// exclusion where the literal metadata target is not sufficiently precise. For example,
-    /// the <see cref="UnconditionalSuppressMessageAttribute"/> cannot be applied within a method,
-    /// and it may be desirable to suppress a violation against a statement in the method that will
-    /// give a rule violation, but not against all statements in the method.
+    ///  <para>
+    ///   The <see cref="MessageId "/> property is an optional argument that specifies additional
+    ///   exclusion where the literal metadata target is not sufficiently precise. For example,
+    ///   the <see cref="UnconditionalSuppressMessageAttribute"/> cannot be applied within a method,
+    ///   and it may be desirable to suppress a violation against a statement in the method that will
+    ///   give a rule violation, but not against all statements in the method.
+    ///  </para>
     /// </remarks>
     public string? MessageId { get; set; }
 
     /// <summary>
-    /// Gets or sets the justification for suppressing the code analysis message.
+    ///  Gets or sets the justification for suppressing the code analysis message.
     /// </summary>
     public string? Justification { get; set; }
 }

--- a/src/Common/tests/TestUtilities/TempFile.cs
+++ b/src/Common/tests/TestUtilities/TempFile.cs
@@ -10,7 +10,10 @@ namespace System.IO;
 /// and disposing the instance deletes the file.
 /// </summary>
 /// <remarks>
-/// This is copied verbatim from TempFile.cs in dotnet/runtime (https://github.com/dotnet/runtime/blob/master/src/libraries/Common/tests/System/IO/TempFile.cs)
+///  <para>
+///   This is copied verbatim from TempFile.cs in dotnet/runtime.
+///   (https://github.com/dotnet/runtime/blob/master/src/libraries/Common/tests/System/IO/TempFile.cs)
+///  </para>
 /// </remarks>
 public sealed class TempFile : IDisposable
 {

--- a/src/System.Private.Windows.Core/src/System/Drawing/ApplyGraphicsProperties.cs
+++ b/src/System.Private.Windows.Core/src/System/Drawing/ApplyGraphicsProperties.cs
@@ -3,6 +3,8 @@
 
 namespace System.Drawing;
 
+#pragma warning disable format
+
 /// <summary>
 ///  Enumeration defining the different Graphics properties to apply to an <see cref="HDC"/> when creating it
 ///  from a Graphics object.
@@ -27,3 +29,5 @@ internal enum ApplyGraphicsProperties
     /// </summary>
     All                 = Clipping | TranslateTransform
 }
+
+#pragma warning restore format

--- a/src/System.Private.Windows.Core/src/Windows/Win32/Foundation/HRESULT.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/Foundation/HRESULT.cs
@@ -16,6 +16,9 @@ internal readonly partial struct HRESULT
 
     public void AssertSuccess() => Debug.Assert(Succeeded, $"Result failed: {this}");
 
+#pragma warning disable format
+#pragma warning disable IDE1006 // Naming Styles
+
     // COR_* HRESULTs are .NET HRESULTs
     public static readonly HRESULT COR_E_ARGUMENT               = (HRESULT)unchecked((int)0x80070057);
     public static readonly HRESULT TLBX_E_LIBNOTREGISTERED      = (HRESULT)unchecked((int)0x80131165);
@@ -28,4 +31,7 @@ internal readonly partial struct HRESULT
     public static readonly HRESULT COR_E_SAFEARRAYTYPEMISMATCH  = (HRESULT)unchecked((int)0x80131533);
     public static readonly HRESULT COR_E_TARGETINVOCATION       = (HRESULT)unchecked((int)0x80131604);
     public static readonly HRESULT COR_E_OBJECTDISPOSED         = (HRESULT)unchecked((int)0x80131622);
+
+#pragma warning restore format
+#pragma warning restore IDE1006 // Naming Styles
 }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionListsChangedEventArgs.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionListsChangedEventArgs.cs
@@ -7,8 +7,10 @@ namespace System.ComponentModel.Design;
 ///  Provides data for the <see cref="DesignerActionService.DesignerActionListsChanged" /> event.
 /// </summary>
 /// <remarks>
-///  The <c>DesignerActionListsChangedEventArgs</c> class is used by the <see cref="DesignerActionService"/> class
-///  to signify that a <see cref="DesignerActionList"/> was added or removed from the related object.
+///  <para>
+///   The <c>DesignerActionListsChangedEventArgs</c> class is used by the <see cref="DesignerActionService"/> class
+///   to signify that a <see cref="DesignerActionList"/> was added or removed from the related object.
+///  </para>
 /// </remarks>
 public class DesignerActionListsChangedEventArgs : EventArgs
 {

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializerBase.TraceIfInterpolatedStringHandler.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializerBase.TraceIfInterpolatedStringHandler.cs
@@ -38,8 +38,10 @@ public abstract partial class CodeDomSerializerBase
         /// <param name="level">The trace level of the message.</param>
         /// <param name="shouldAppend">A value indicating whether formatting should proceed.</param>
         /// <remarks>
-        ///  This is intended to be called only by compiler-generated code. Arguments are not validated as they'd
-        ///  otherwise be for members intended to be used directly.
+        ///  <para>
+        ///   This is intended to be called only by compiler-generated code. Arguments are not validated as they'd
+        ///   otherwise be for members intended to be used directly.
+        ///  </para>
         /// </remarks>
         public TraceIfInterpolatedStringHandler(int literalLength, int formattedCount, bool condition, TraceLevel level, out bool shouldAppend)
         {

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializerBase.TraceInterpolatedStringHandler.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializerBase.TraceInterpolatedStringHandler.cs
@@ -36,8 +36,10 @@ public abstract partial class CodeDomSerializerBase
         /// <param name="level">The trace level of the message.</param>
         /// <param name="shouldAppend">A value indicating whether formatting should proceed.</param>
         /// <remarks>
-        ///  This is intended to be called only by compiler-generated code. Arguments are not validated as they'd
-        ///  otherwise be for members intended to be used directly.
+        ///  <para>
+        ///   This is intended to be called only by compiler-generated code. Arguments are not validated as they'd
+        ///   otherwise be for members intended to be used directly.
+        ///  </para>
         /// </remarks>
         public TraceInterpolatedStringHandler(int literalLength, int formattedCount, TraceLevel level, out bool shouldAppend)
         {

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
@@ -1565,14 +1565,29 @@ public partial class ControlDesigner : ComponentDesigner
     ///  Called each time the cursor needs to be set.
     /// </summary>
     /// <remarks>
-    /// The ControlDesigner behavior here will set the cursor to one of three things:
-    ///
-    ///  1.  If the toolbox service has a tool selected, it will allow the toolbox service to set the cursor.
-    ///  2.  If the selection UI service shows a locked selection, or if there is no location property on the
-    ///  control, then the default arrow will be set.
-    ///  3.  Otherwise, the four headed arrow will be set to indicate that the component can be clicked and moved.
-    ///  4.  If the user is currently dragging a component, the crosshair cursor will be used instead of the four
-    ///  headed arrow.
+    ///  <para>
+    ///   The ControlDesigner behavior here will set the cursor to one of three things:
+    ///  </para>
+    ///  <list type="number">
+    ///   <item>
+    ///    <description>
+    ///     If the toolbox service has a tool selected, it will allow the toolbox service to set the cursor.
+    ///    </description>
+    ///   </item>
+    ///   <item>
+    ///    <description>
+    ///     If the selection UI service shows a locked selection, or if there is no location property on the
+    ///     control, then the default arrow will be set. Otherwise, the four headed arrow will be set to indicate that
+    ///     the component can be clicked and moved.
+    ///    </description>
+    ///   </item>
+    ///   <item>
+    ///    <description>
+    ///     If the user is currently dragging a component, the crosshair cursor will be used instead of the four
+    ///     headed arrow.
+    ///    </description>
+    ///   </item>
+    ///  </list>
     /// </remarks>
     protected virtual void OnSetCursor()
     {

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/FileDialogCustomPlace.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/FileDialogCustomPlace.cs
@@ -4,11 +4,15 @@
 namespace System.Windows.Forms;
 
 /// <remarks>
-///  Sample Guids
-///  ComputerFolder: "0AC0837C-BBF8-452A-850D-79D08E667CA7"
-///  Favorites: "1777F761-68AD-4D8A-87BD-30B759FA33DD"
-///  Documents: "FDD39AD0-238F-46AF-ADB4-6C85480369C7"
-///  Profile: "5E6C858F-0E22-4760-9AFE-EA3317B67173"
+///  <para>
+///   Sample Guids
+///  </para>
+///  <list type="bullet">
+///   <item><description>ComputerFolder: "0AC0837C-BBF8-452A-850D-79D08E667CA7"</description></item>
+///   <item><description>Favorites: "1777F761-68AD-4D8A-87BD-30B759FA33DD"</description></item>
+///   <item><description>Documents: "FDD39AD0-238F-46AF-ADB4-6C85480369C7"</description></item>
+///   <item><description>Profile: "5E6C858F-0E22-4760-9AFE-EA3317B67173"</description></item>
+///  </list>
 /// </remarks>
 public class FileDialogCustomPlace
 {

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/GdiPlus/GdiPlusCache.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/GdiPlus/GdiPlusCache.cs
@@ -62,32 +62,21 @@ internal static class GdiPlusCache
     ///  Returns a cached <see cref="Pen"/>. Use in a using and assign to var.
     /// </summary>
     /// <remarks>
-    ///  Correct: using var pen = GdiPlusCache.GetCachedPen(Color.Blue);
-    ///  Incorrect (LEAKS): using Pen pen = GdiPlusCache.GetCachedPen(Color.Blue);
+    ///  <para>
+    ///   Correct: using var pen = GdiPlusCache.GetCachedPen(Color.Blue);
+    ///   Incorrect (LEAKS): using Pen pen = GdiPlusCache.GetCachedPen(Color.Blue);
+    ///  </para>
+    ///  <para>
+    ///   Debug builds track proper disposal.
+    ///  </para>
     /// </remarks>
     internal static PenCache.Scope GetCachedPenScope(this Color color) => GetPenScope(color);
 
-    /// <summary>
-    ///  Returns a cached <see cref="Pen"/>. Use in a using and assign to var.
-    /// </summary>
-    /// <remarks>
-    ///  Correct: using var pen = GdiPlusCache.GetCachedPen(Color.Blue);
-    ///  Incorrect (LEAKS): using Pen pen = GdiPlusCache.GetCachedPen(Color.Blue);
-    ///
-    ///  Debug builds track proper disposal.
-    /// </remarks>
+    /// <inheritdoc cref="GetCachedPenScope(Color)"/>
     internal static PenCache.Scope GetCachedPenScope(this Color color, int width)
         => width == 1 ? GetPenScope(color) : new PenCache.Scope(new Pen(color, width));
 
-    /// <summary>
-    ///  Returns a cached <see cref="SolidBrush"/>. Use in a using and assign to var.
-    /// </summary>
-    /// <remarks>
-    ///  Correct: using var pen = GdiPlusCache.GetCachedSolidBrush(Color.Blue);
-    ///  Incorrect (LEAKS): using Pen pen = GdiPlusCache.GetCachedSolidBrush(Color.Blue);
-    ///
-    ///  Debug builds track proper disposal.
-    /// </remarks>
+    /// <inheritdoc cref="GetCachedPenScope(Color)"/>
     internal static SolidBrushCache.Scope GetCachedSolidBrushScope(this Color color) => GetSolidBrushScope(color);
 
     private static Brush? BrushFromKnownColor(KnownColor color) => color switch

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/RefCountedCache.Scope.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/RefCountedCache.Scope.cs
@@ -21,11 +21,13 @@ internal abstract partial class RefCountedCache<TObject, TCacheEntryData, TKey>
         ///  Constructor to hold an uncached object. Used to wrap something not coming from the cache in a scope
         ///  so it can be abstracted for the end users of a given API.
         ///
-        ///  <see cref="GdiPlusCache.GetSolidBrushScope(Drawing.Color)"/> for an example.
+        ///  See <see cref="GdiPlusCache.GetSolidBrushScope(Drawing.Color)"/> for an example.
         /// </summary>
         /// <remarks>
-        ///  Currently we don't dispose the <paramref name="object"/> as we don't need to in our usages. If this
-        ///  becomes necessary we can add a bool to track whether or not we should dispose it.
+        ///  <para>
+        ///   Currently we don't dispose the <paramref name="object"/> as we don't need to in our usages. If this
+        ///   becomes necessary we can add a bool to track whether or not we should dispose it.
+        ///  </para>
         /// </remarks>
         public Scope(TObject @object)
         {
@@ -50,8 +52,10 @@ internal abstract partial class RefCountedCache<TObject, TCacheEntryData, TKey>
         ///  Implicit conversion to the "target" type, i.e. <typeparamref name="TObject"/>.
         /// </summary>
         /// <remarks>
-        ///  This is somewhat dangerous as implicit casting in the using statement will leak the scope. Not doing
-        ///  this, however, makes usage with APIs difficult. We track in DEBUG to catch misuse as a mitigation.
+        ///  <para>
+        ///   This is somewhat dangerous as implicit casting in the using statement will leak the scope. Not doing
+        ///   this, however, makes usage with APIs difficult. We track in DEBUG to catch misuse as a mitigation.
+        ///  </para>
         /// </remarks>
         public static implicit operator TObject(in Scope scope)
         {

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/SystemDrawingExtensions.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/SystemDrawingExtensions.cs
@@ -18,13 +18,16 @@ internal static class SystemDrawingExtensions
     ///  didn't actually change. This retains the state of the color.
     /// </summary>
     /// <remarks>
-    ///  This is important as the color only changes if <paramref name="graphics"/> has a very low color depth. This
-    ///  is extremely rare for the normal case of HDC backed Graphics objects. Keeping the original color keeps the
-    ///  state that would otherwise be stripped, notably things like <see cref="Color.IsKnownColor"/> which allows
-    ///  us to later pull from a the various caches that <see cref="Drawing"/> maintains (saving allocations).
-    ///
-    ///  Ideally we'd drop checking at all and just support full color drawing to improve performance for the
-    ///  expected normal case (more than 8 BITSPIXEL for the HDC).
+    ///  <para>
+    ///   This is important as the color only changes if <paramref name="graphics"/> has a very low color depth. This
+    ///   is extremely rare for the normal case of HDC backed Graphics objects. Keeping the original color keeps the
+    ///   state that would otherwise be stripped, notably things like <see cref="Color.IsKnownColor"/> which allows
+    ///   us to later pull from a the various caches that <see cref="Drawing"/> maintains (saving allocations).
+    ///  </para>
+    ///  <para>
+    ///   Ideally we'd drop checking at all and just support full color drawing to improve performance for the
+    ///   expected normal case (more than 8 BITSPIXEL for the HDC).
+    ///  </para>
     /// </remarks>
     internal static Color FindNearestColor(this Graphics graphics, Color color)
     {

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/RecordTypes/EMRENUMRECORD.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/RecordTypes/EMRENUMRECORD.cs
@@ -10,7 +10,7 @@ namespace System.Windows.Forms.Metafiles;
 /// <summary>
 ///  Record that has just a single enum value.
 /// </summary>
-/// <remarks>
+/// <devdoc>
 ///   Not an actual Win32 define, encapsulates:
 ///
 ///   - EMRSELECTCLIPPATH
@@ -21,7 +21,7 @@ namespace System.Windows.Forms.Metafiles;
 ///   - EMRSETROP2
 ///   - EMRSETSTRETCHBLTMODE
 ///   - EMRSETTEXTALIGN
-/// </remarks>
+/// </devdoc>
 [StructLayout(LayoutKind.Sequential)]
 internal struct EMRENUMRECORD<T> where T : Enum
 {

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/RecordTypes/EMRINDEXRECORD.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/RecordTypes/EMRINDEXRECORD.cs
@@ -10,13 +10,13 @@ namespace System.Windows.Forms.Metafiles;
 /// <summary>
 ///  Record that represents an index.
 /// </summary>
-/// <remarks>
+/// <devdoc>
 ///   Not an actual Win32 define, encapsulates:
 ///
 ///   - EMRSELECTOBJECT
 ///   - EMRDELETEOBJECT
 ///   - EMRSELECTPALETTE
-/// </remarks>
+/// </devdoc>
 [StructLayout(LayoutKind.Sequential)]
 internal struct EMRINDEXRECORD
 {

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/RecordTypes/EMRPOINTRECORD.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/RecordTypes/EMRPOINTRECORD.cs
@@ -11,7 +11,7 @@ namespace System.Windows.Forms.Metafiles;
 /// <summary>
 ///  Record that just has a single point value.
 /// </summary>
-/// <remarks>
+/// <devdoc>
 ///   Not an actual Win32 define, encapsulates:
 ///
 ///    - EMRLINETO
@@ -20,7 +20,7 @@ namespace System.Windows.Forms.Metafiles;
 ///    - EMRSETVIEWPORTORGEX
 ///    - EMRSETWINDOWORGEX
 ///    - EMRSETBRUSHORGEX
-/// </remarks>
+/// </devdoc>
 [StructLayout(LayoutKind.Sequential)]
 internal struct EMRPOINTRECORD
 {

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/RecordTypes/EMRPOLY16.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/RecordTypes/EMRPOLY16.cs
@@ -11,7 +11,7 @@ namespace System.Windows.Forms.Metafiles;
 /// <summary>
 ///  Record that represents a 16 bit Poly record.
 /// </summary>
-/// <remarks>
+/// <devdoc>
 ///   Not an actual Win32 define, encapsulates:
 ///
 ///  - EMRPOLYLINE16
@@ -19,7 +19,7 @@ namespace System.Windows.Forms.Metafiles;
 ///  - EMRPOLYGON16
 ///  - EMRPOLYBEZIERTO16
 ///  - EMRPOLYLINETO16
-/// </remarks>
+/// </devdoc>
 [StructLayout(LayoutKind.Sequential)]
 internal struct EMRPOLY16
 {

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/RecordTypes/EMRPOLYPOLY16.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/RecordTypes/EMRPOLYPOLY16.cs
@@ -11,14 +11,14 @@ namespace System.Windows.Forms.Metafiles;
 /// <summary>
 ///  Record that represents a 16 bit Poly record.
 /// </summary>
-/// <remarks>
+/// <devdoc>
 ///   Not an actual Win32 define, encapsulates:
 ///
 ///  - EMRPOLYPOLYLINE16
 ///  - EMRPOLYPOLYBEZIER16
 ///  - EMRPOLYPOLYGON16
 ///  - EMRPOLYPOLYLINETO16
-/// </remarks>
+/// </devdoc>
 [StructLayout(LayoutKind.Sequential)]
 internal struct EMRPOLYPOLY16
 {

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/RecordTypes/EMRRECTRECORD.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/RecordTypes/EMRRECTRECORD.cs
@@ -10,7 +10,7 @@ namespace System.Windows.Forms.Metafiles;
 /// <summary>
 ///  Record that just has a single <see cref="RECT"/> value.
 /// </summary>
-/// <remarks>
+/// <devdoc>
 ///   Not an actual Win32 define, encapsulates:
 ///
 ///    - EMRFILLPATH
@@ -20,7 +20,7 @@ namespace System.Windows.Forms.Metafiles;
 ///    - EMRINTERSECTCLIPRECT
 ///    - EMRELLIPSE
 ///    - EMRRECTANGLE
-/// </remarks>
+/// </devdoc>
 [StructLayout(LayoutKind.Sequential)]
 internal struct EMRRECTRECORD
 {

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/RecordTypes/EMRSETCOLOR.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/RecordTypes/EMRSETCOLOR.cs
@@ -10,12 +10,12 @@ namespace System.Windows.Forms.Metafiles;
 /// <summary>
 ///  Record that represents a 16 bit Poly record.
 /// </summary>
-/// <remarks>
+/// <devdoc>
 ///   Not an actual Win32 define, encapsulates:
 ///
 ///   - EMRSETTEXTCOLOR
 ///   - EMRSETBKCOLOR
-/// </remarks>
+/// </devdoc>
 [StructLayout(LayoutKind.Sequential)]
 internal struct EMRSETCOLOR
 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Accessibility/AccessibleEvents.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Accessibility/AccessibleEvents.cs
@@ -9,7 +9,7 @@ namespace System.Windows.Forms;
 public enum AccessibleEvents
 {
     /// <summary>
-    /// <c>EVENT_SYSTEM_SOUND</c>
+    ///  <c>EVENT_SYSTEM_SOUND</c>
     ///  Sent when a sound is played. Currently nothing is generating this, we
     ///  are going to be cleaning up the SOUNDSENTRY feature in the control panel
     ///  and will use this at that time. Applications implementing WinEvents
@@ -19,85 +19,94 @@ public enum AccessibleEvents
     SystemSound = 0x0001,
 
     /// <summary>
-    /// <c>EVENT_SYSTEM_ALERT</c>
+    ///  <c>EVENT_SYSTEM_ALERT</c>
     ///  Sent when an alert needs to be given to the user. MessageBoxes generate
     ///  alerts for example.
     /// </summary>
     SystemAlert = 0x0002,
 
     /// <summary>
-    /// <c>EVENT_SYSTEM_FOREGROUND</c>
+    ///  <c>EVENT_SYSTEM_FOREGROUND</c>
     ///  Sent when the foreground (active) window changes, even if it is changing
     ///  to another window in the same thread as the previous one.
     /// </summary>
     SystemForeground = 0x0003,
 
     /// <summary>
-    /// <c>EVENT_SYSTEM_MENUSTART</c>
+    ///  <c>EVENT_SYSTEM_MENUSTART</c>
     ///  Sent when entering into menu mode (system, app bar, and track popups).
     /// </summary>
     /// <seealso cref="SystemMenuEnd"/>.
     SystemMenuStart = 0x0004,
 
     /// <summary>
-    /// <c>EVENT_SYSTEM_MENUEND</c>
+    ///  <c>EVENT_SYSTEM_MENUEND</c>
     ///  Sent when leaving from menu mode (system, app bar, and track popups).
     /// </summary>
     /// <seealso cref="SystemMenuStart"/>.
     SystemMenuEnd = 0x0005,
 
     /// <summary>
-    /// <c>EVENT_SYSTEM_MENUPOPUPSTART</c>
+    ///  <c>EVENT_SYSTEM_MENUPOPUPSTART</c>
     ///  Sent when a menu popup comes up.
     /// </summary>
     /// <remarks>
-    ///  For a call to TrackPopupMenu(), a client will see <c>EVENT_SYSTEM_MENUSTART</c>
-    ///  followed almost immediately by <c>EVENT_SYSTEM_MENUPOPUPSTART</c> for the popup being shown.
+    ///  <para>
+    ///   <seealso cref="SystemMenuPopupEnd"/> is the matching end event.
+    ///  </para>
+    ///  <para>
+    ///   For a call to TrackPopupMenu(), a client will see <c>EVENT_SYSTEM_MENUSTART</c>
+    ///   followed almost immediately by <c>EVENT_SYSTEM_MENUPOPUPSTART</c> for the popup being shown.
+    ///  </para>
     /// </remarks>
     /// <seealso cref="SystemMenuPopupEnd"/>.
     SystemMenuPopupStart = 0x0006,
 
     /// <summary>
-    /// <c>EVENT_SYSTEM_MENUPOPUPEND</c>
+    ///  <c>EVENT_SYSTEM_MENUPOPUPEND</c>
     ///  Sent when a menu popup just before it is taken down.
     /// </summary>
     /// <remarks>
-    ///  For a call to TrackPopupMenu(), a client will see <c>EVENT_SYSTEM_MENUSTART</c>
-    ///  followed almost immediately by <c>EVENT_SYSTEM_MENUPOPUPSTART</c> for the popup being shown.
+    ///  <para>
+    ///   <seealso cref="SystemMenuPopupStart"/> is the matching start event.
+    ///  </para>
+    ///  <para>
+    ///   For a call to TrackPopupMenu(), a client will see <c>EVENT_SYSTEM_MENUSTART</c>
+    ///   followed almost immediately by <c>EVENT_SYSTEM_MENUPOPUPSTART</c> for the popup being shown.
+    ///  </para>
     /// </remarks>
-    /// <seealso cref="SystemMenuPopupStart"/>.
     SystemMenuPopupEnd = 0x0007,
 
     /// <summary>
-    /// <c>EVENT_SYSTEM_CAPTURESTART</c>
+    ///  <c>EVENT_SYSTEM_CAPTURESTART</c>
     ///  Sent when a window takes the capture.
     /// </summary>
     /// <seealso cref="SystemCaptureEnd"/>.
     SystemCaptureStart = 0x0008,
 
     /// <summary>
-    /// <c>EVENT_SYSTEM_CAPTUREEND</c>
+    ///  <c>EVENT_SYSTEM_CAPTUREEND</c>
     ///  Sent when a window releases the capture.
     /// </summary>
     /// <seealso cref="SystemCaptureStart"/>.
     SystemCaptureEnd = 0x0009,
 
     /// <summary>
-    /// <c>EVENT_SYSTEM_MOVESIZESTART</c>
+    ///  <c>EVENT_SYSTEM_MOVESIZESTART</c>
     ///  Sent when a window enters move-size dragging mode.
     /// </summary>
     /// <seealso cref="SystemMoveSizeEnd"/>.
     SystemMoveSizeStart = 0x000A,
 
     /// <summary>
-    /// <c>EVENT_SYSTEM_MOVESIZEEND</c>
+    ///  <c>EVENT_SYSTEM_MOVESIZEEND</c>
     ///  Sent when a window leaves move-size dragging mode.
     /// </summary>
     /// <seealso cref="SystemMoveSizeStart"/>.
     SystemMoveSizeEnd = 0x000B,
 
     /// <summary>
-    /// <c>EVENT_SYSTEM_CONTEXTHELPSTART</c>
+    ///  <c>EVENT_SYSTEM_CONTEXTHELPSTART</c>
     ///  Sent when a window enters context sensitive help mode.
     /// </summary>
     /// <seealso cref="SystemContextHelpEnd"/>.
@@ -114,18 +123,31 @@ public enum AccessibleEvents
     ///  <c>EVENT_SYSTEM_DRAGDROPSTART</c>
     ///  Sent when a window enters drag drop mode.
     /// </summary>
-    /// <seealso cref="SystemDragDropEnd"/>.
-    // It is up to apps and OLE to generate this, since the system doesn't know.
-    //  Like <c>EVENT_SYSTEM_SOUND</c>, it will be a while before this is prevalent.
+    /// <remarks>
+    ///  <para>
+    ///   <seealso cref="SystemDragDropEnd"/> is the matching end event.
+    ///  </para>
+    ///  <para>
+    ///   It is up to apps and OLE to generate this, since the system doesn't know.
+    ///   Like <c>EVENT_SYSTEM_SOUND</c>, it will be a while before this is prevalent.
+    ///  </para>
+    /// </remarks>
     SystemDragDropStart = 0x000E,
 
     /// <summary>
     ///  <c>EVENT_SYSTEM_DRAGDROPEND</c>
     ///  Sent when a window leaves drag drop mode.
     /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <seealso cref="SystemDragDropStart"/> is the matching start event.
+    ///  </para>
+    ///  <para>
+    ///   It is up to apps and OLE to generate this, since the system doesn't know.
+    ///   Like <c>EVENT_SYSTEM_SOUND</c>, it will be a while before this is prevalent.
+    ///  </para>
+    /// </remarks>
     /// <seealso cref="SystemDragDropStart"/>.
-    // It is up to apps and OLE to generate this, since the system doesn't know.
-    //  Like <c>EVENT_SYSTEM_SOUND</c>, it will be a while before this is prevalent.
     SystemDragDropEnd = 0x000F,
 
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Accessibility/AccessibleRoles.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Accessibility/AccessibleRoles.cs
@@ -6,10 +6,10 @@ namespace System.Windows.Forms;
 /// <summary>
 ///  Specifies values representing possible roles for an accessible object.
 /// </summary>
-/// <remarks>
-///  if adding to this enumeration please update Control and ToolStripItem
-///  AccessibleRole to ensure the new member is valid.
-/// </remarks>
+/// <devdoc>
+///  If adding to this enumeration please update <see cref="Control.AccessibleRole"/> and
+///  <see cref="ToolStripItem.AccessibleRole"/> to ensure the new member is valid.
+/// </devdoc>
 public enum AccessibleRole
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
@@ -137,8 +137,10 @@ public sealed partial class Application
     ///  Gets the path for the application data that is shared among all users.
     /// </summary>
     /// <remarks>
-    ///  Don't obsolete these. GetDataPath isn't on SystemInformation, and it provides
-    ///  the Windows logo required adornments to the directory (Company\Product\Version)
+    ///  <para>
+    ///   Don't obsolete these. GetDataPath isn't on SystemInformation, and it provides
+    ///   the Windows logo required adornments to the directory (Company\Product\Version).
+    ///  </para>
     /// </remarks>
     public static string CommonAppDataPath
         => GetDataPath(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData));
@@ -250,8 +252,8 @@ public sealed partial class Application
     ///  Gets the path for the application data specific to a local, non-roaming user.
     /// </summary>
     /// <remarks>
-    ///  Don't obsolete these. GetDataPath isn't on SystemInformation, and it provides
-    ///  the Windows logo required adornments to the directory (Company\Product\Version)
+    ///  <para>Don't obsolete these. GetDataPath isn't on SystemInformation, and it provides
+    ///  the Windows logo required adornments to the directory (Company\Product\Version)</para>
     /// </remarks>
     public static string LocalUserAppDataPath
         => GetDataPath(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData));
@@ -458,8 +460,8 @@ public sealed partial class Application
     ///  Gets the path for the application data specific to the roaming user.
     /// </summary>
     /// <remarks>
-    ///  Don't obsolete these. GetDataPath isn't on SystemInformation, and it provides
-    ///  the Windows logo required adornments to the directory (Company\Product\Version)
+    ///  <para>Don't obsolete these. GetDataPath isn't on SystemInformation, and it provides
+    ///  the Windows logo required adornments to the directory (Company\Product\Version)</para>
     /// </remarks>
     public static string UserAppDataPath
         => GetDataPath(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData));
@@ -476,15 +478,19 @@ public sealed partial class Application
     /// </summary>
     /// <value><see langword="true" /> if visual styles are enabled; otherwise, <see langword="false" />.</value>
     /// <remarks>
-    ///  The visual styles can be enabled by calling <see cref="EnableVisualStyles"/>.
-    ///  The visual styles will not be enabled if the OS does not support them, or theming is disabled at the OS level.
+    ///  <para>
+    ///   The visual styles can be enabled by calling <see cref="EnableVisualStyles"/>.
+    ///   The visual styles will not be enabled if the OS does not support them, or theming is disabled at the OS level.
+    ///  </para>
     /// </remarks>
     public static bool UseVisualStyles { get; private set; }
 
     /// <remarks>
-    ///  Don't never ever change this name, since the window class and partner teams
-    ///  dependent on this. Changing this will introduce breaking changes.
-    ///  If there is some reason need to change this, notify any partner teams affected.
+    ///  <para>
+    ///   Don't never ever change this name, since the window class and partner teams
+    ///   dependent on this. Changing this will introduce breaking changes.
+    ///   If there is some reason need to change this, notify any partner teams affected.
+    ///  </para>
     /// </remarks>
     internal static string WindowsFormsVersion => "WindowsForms10";
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ProgressBar/ProgressBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ProgressBar/ProgressBar.cs
@@ -666,8 +666,10 @@ public partial class ProgressBar : Control
     }
 
     /// <remarks>
-    ///  Note: <see cref="ProgressBar"/> doesn't work like other controls as far as setting ForeColor/BackColor.
-    ///  You need to send messages to update the colors.
+    ///  <para>
+    ///   Note: <see cref="ProgressBar"/> doesn't work like other controls as far as setting ForeColor/BackColor.
+    ///   You need to send messages to update the colors.
+    ///  </para>
     /// </remarks>
     private void UserPreferenceChangedHandler(object o, UserPreferenceChangedEventArgs e)
     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripControlHost.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripControlHost.cs
@@ -797,7 +797,7 @@ public partial class ToolStripControlHost : ToolStripItem
         => (ReadOnlyControlCollection?)toolStrip?.Controls;
 
     /// <remarks>
-    ///  Ensures the hosted Control is parented to the ToolStrip hosting this ToolStripItem.
+    ///  <para>Ensures the hosted Control is parented to the ToolStrip hosting this ToolStripItem.</para>
     /// </remarks>
     private void SyncControlParent()
     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripManager.ModalMenuFilter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripManager.ModalMenuFilter.cs
@@ -8,20 +8,20 @@ namespace System.Windows.Forms;
 public static partial class ToolStripManager
 {
     ///  <remarks>
-    ///  - this installs a message filter when a dropdown becomes active.
-    ///  - the message filter
-    ///  a. eats WM_MOUSEMOVEs so that the window that's underneath
-    ///  doesnt get highlight processing/tooltips
-    ///  b. detects mouse clicks. if the click is outside the dropdown, it
-    ///  dismisses it.
-    ///  c. detects when the active window has changed. If the active window
-    ///  is unexpected, it dismisses all dropdowns.
-    ///  d. detects keyboard messages, and redirects them to the active dropdown.
-    ///
-    ///  - There should be 1 Message Filter per thread and it should be uninstalled once
-    ///  the last dropdown has gone away
-    ///  This is not part of ToolStripManager because it's DropDown specific and
-    ///  we don't want to publicly expose this message filter.
+    ///   <para>
+    ///    This installs a message filter when a dropdown becomes active. The filter:
+    ///   </para>
+    ///   <list type="bullet">
+    ///    <item><description>Eats WM_MOUSEMOVEs so that the window underneath doesnt get highlight processing/tooltips.</description></item>
+    ///    <item><description>Dismisses the menu if clicked outside the dropdown.</description></item>
+    ///    <item><description>Dismisses all dropdowns if the active window changes.</description></item>
+    ///    <item><description>Redirects keyboard messages to the active dropdown.</description></item>
+    ///   </list>
+    ///   <para>
+    ///    There should be one Message Filter per thread and it should be uninstalled once the last dropdown has gone away.
+    ///    This is not part of <see cref="ToolStripManager"/> because it is DropDown specific and
+    ///    we don't want to publicly expose this message filter.
+    ///   </para>
     ///  </remarks>
     internal partial class ModalMenuFilter : IMessageModifyAndFilter
     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeView.cs
@@ -2646,7 +2646,7 @@ public partial class TreeView : Control
     }
 
     /// <remarks>
-    ///  Setting the PInvoke.TVS_CHECKBOXES style clears the checked state
+    ///  <para>Setting the PInvoke.TVS_CHECKBOXES style clears the checked state</para>
     /// </remarks>
     private static void UpdateCheckedState(TreeNode node, bool update)
     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/UpDown/UpDownBase.UpDownButtons.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/UpDown/UpDownBase.UpDownButtons.cs
@@ -48,7 +48,7 @@ public abstract partial class UpDownBase
         }
 
         /// <remarks>
-        ///  Called when the mouse button is pressed - we need to start spinning the value of the updown.
+        ///  <para>Called when the mouse button is pressed - we need to start spinning the value of the updown.</para>
         /// </remarks>
         private void BeginButtonPress(MouseEventArgs e)
         {
@@ -81,7 +81,7 @@ public abstract partial class UpDownBase
             => new UpDownButtonsAccessibleObject(this);
 
         /// <remarks>
-        ///  Called when the mouse button is released - we need to stop spinning the value of the updown.
+        ///  <para>Called when the mouse button is released - we need to stop spinning the value of the updown.</para>
         /// </remarks>
         private void EndButtonPress()
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/WebBrowser/WebBrowserBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/WebBrowser/WebBrowserBase.cs
@@ -187,7 +187,7 @@ public unsafe partial class WebBrowserBase : Control
     }
 
     /// <remarks>
-    /// We have to resize the ActiveX control when our size changes.
+    ///  <para>We have to resize the ActiveX control when our size changes.</para>
     /// </remarks>
     internal override unsafe void OnBoundsUpdate(int x, int y, int width, int height)
     {
@@ -361,8 +361,10 @@ public unsafe partial class WebBrowserBase : Control
     }
 
     /// <remarks>
-    /// Certain messages are forwarder directly to the ActiveX control,
-    /// others are first processed by the wndproc of Control
+    ///  <para>
+    ///   Certain messages are forwardef directly to the ActiveX control, others are first processed by the wndproc of
+    ///   <see cref="Control"/>.
+    ///  </para>
     /// </remarks>
     protected override unsafe void WndProc(ref Message m)
     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/WebBrowser/WebBrowserHelper.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/WebBrowser/WebBrowserHelper.cs
@@ -104,10 +104,7 @@ internal static partial class WebBrowserHelper
     }
 
     /// <remarks>
-    ///  Returns a big clip RECT.
+    ///  <para>Returns a big clip RECT.</para>
     /// </remarks>
-    internal static RECT GetClipRect()
-    {
-        return new Rectangle(0, 0, 32000, 32000);
-    }
+    internal static RECT GetClipRect() => new Rectangle(0, 0, 32000, 32000);
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataBinding/BindingContext.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataBinding/BindingContext.cs
@@ -92,7 +92,7 @@ public partial class BindingContext : ICollection
     ///  Fires the CollectionChangedEvent.
     /// </summary>
     /// <remarks>
-    ///  This method is obsolete and unused.
+    ///  <para>This method is obsolete and unused.</para>
     /// </remarks>
     protected internal void Add(object dataSource, BindingManagerBase listManager)
     {
@@ -101,7 +101,7 @@ public partial class BindingContext : ICollection
     }
 
     /// <remarks>
-    ///  This method is obsolete and unused.
+    ///  <para>This method is obsolete and unused.</para>
     /// </remarks>
     protected virtual void AddCore(object dataSource, BindingManagerBase listManager)
     {
@@ -115,7 +115,7 @@ public partial class BindingContext : ICollection
     ///  Occurs when the collection has changed.
     /// </summary>
     /// <remarks>
-    ///  This method is obsolete and unused.
+    ///  <para>This method is obsolete and unused.</para>
     /// </remarks>
     [SRDescription(nameof(SR.collectionChangedEventDescr))]
     [EditorBrowsable(EditorBrowsableState.Never)]
@@ -136,7 +136,7 @@ public partial class BindingContext : ICollection
     ///  Fires the CollectionChangedEvent.
     /// </summary>
     /// <remarks>
-    ///  This method is obsolete and unused.
+    ///  <para>This method is obsolete and unused.</para>
     /// </remarks>
     protected internal void Clear()
     {
@@ -148,7 +148,7 @@ public partial class BindingContext : ICollection
     ///  Clears the collection.
     /// </summary>
     /// <remarks>
-    ///  This method is obsolete and unused.
+    ///  <para>This method is obsolete and unused.</para>
     /// </remarks>
     protected virtual void ClearCore() => _listManagers.Clear();
 
@@ -187,7 +187,7 @@ public partial class BindingContext : ICollection
     ///  The CollectionChanged event is fired if it succeeds.
     /// </summary>
     /// <remarks>
-    ///  This method is obsolete and unused.
+    ///  <para>This method is obsolete and unused.</para>
     /// </remarks>
     protected internal void Remove(object dataSource)
     {
@@ -196,7 +196,7 @@ public partial class BindingContext : ICollection
     }
 
     /// <remarks>
-    ///  This method is obsolete and unused.
+    ///  <para>This method is obsolete and unused.</para>
     /// </remarks>
     protected virtual void RemoveCore(object dataSource)
     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataBinding/BindingSource.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataBinding/BindingSource.cs
@@ -778,8 +778,10 @@ public partial class BindingSource : Component,
     public void MovePrevious() => Position--;
 
     /// <remarks>
-    ///  This method is used to fire ListChanged events when the inner list
-    ///  is not an IBindingList (and therefore cannot fire them itself).
+    ///  <para>
+    ///   This method is used to fire ListChanged events when the inner list is not an <see cref="IBindingList"/>
+    ///   (and therefore cannot fire them itself).
+    ///  </para>
     /// </remarks>
     private void OnSimpleListChanged(ListChangedType listChangedType, int newIndex)
     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataBinding/ICommandBindingTargetProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataBinding/ICommandBindingTargetProvider.cs
@@ -72,10 +72,12 @@ internal interface ICommandBindingTargetProvider
     /// <see cref="Command"/> should be executed.
     /// </summary>
     /// <remarks>
-    /// As an example, a <see cref="Button"/> should call this method inside the method which
-    /// also raises the <see cref="Control.Click"/> Event of that Button, which
-    /// would be the <see cref="Button.OnClick(EventArgs)"/> OnClick method.
-    /// See <see cref="ButtonBase"/> for an exmaple implementation.
+    ///  <para>
+    ///   As an example, a <see cref="Button"/> should call this method inside the method which
+    ///   also raises the <see cref="Control.Click"/> Event of that Button, which
+    ///   would be the <see cref="Button.OnClick(EventArgs)"/> OnClick method.
+    ///   See <see cref="ButtonBase"/> for an example implementation.
+    ///  </para>
     /// </remarks>
     /// <param name="commandComponent"></param>
     protected static void RequestCommandExecute(ICommandBindingTargetProvider commandComponent)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Dialogs/TaskDialog/TaskDialogButton.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Dialogs/TaskDialog/TaskDialogButton.cs
@@ -90,12 +90,12 @@ public class TaskDialogButton : TaskDialogControl
     // Static factory properties that return a new instance of the button.
 
     /// <summary>
-    ///  Gets a standard <see cref="TaskDialogButton"/> instance representing the <c>OK</c> button.
+    ///  Gets a standard <see cref="TaskDialogButton"/> instance representing the "OK" button.
     /// </summary>
     public static TaskDialogButton OK => new(TaskDialogResult.OK);
 
     /// <summary>
-    ///  Gets a standard <see cref="TaskDialogButton"/> instance representing the <c>Cancel</c> button.
+    ///  Gets a standard <see cref="TaskDialogButton"/> instance representing the "Cancel" button.
     /// </summary>
     /// <remarks>
     /// <para>
@@ -108,37 +108,37 @@ public class TaskDialogButton : TaskDialogControl
     public static TaskDialogButton Cancel => new(TaskDialogResult.Cancel);
 
     /// <summary>
-    ///  Gets a standard <see cref="TaskDialogButton"/> instance representing the <c>Abort</c> button.
+    ///  Gets a standard <see cref="TaskDialogButton"/> instance representing the "Abort" button.
     /// </summary>
     public static TaskDialogButton Abort => new(TaskDialogResult.Abort);
 
     /// <summary>
-    ///  Gets a standard <see cref="TaskDialogButton"/> instance representing the <c>Retry</c> button.
+    ///  Gets a standard <see cref="TaskDialogButton"/> instance representing the "Retry" button.
     /// </summary>
     public static TaskDialogButton Retry => new(TaskDialogResult.Retry);
 
     /// <summary>
-    ///  Gets a standard <see cref="TaskDialogButton"/> instance representing the <c>Ignore</c> button.
+    ///  Gets a standard <see cref="TaskDialogButton"/> instance representing the "Ignore" button.
     /// </summary>
     public static TaskDialogButton Ignore => new(TaskDialogResult.Ignore);
 
     /// <summary>
-    ///  Gets a standard <see cref="TaskDialogButton"/> instance representing the <c>Yes</c> button.
+    ///  Gets a standard <see cref="TaskDialogButton"/> instance representing the "Yes" button.
     /// </summary>
     public static TaskDialogButton Yes => new(TaskDialogResult.Yes);
 
     /// <summary>
-    ///  Gets a standard <see cref="TaskDialogButton"/> instance representing the <c>No</c> button.
+    ///  Gets a standard <see cref="TaskDialogButton"/> instance representing the "No" button.
     /// </summary>
     public static TaskDialogButton No => new(TaskDialogResult.No);
 
     /// <summary>
-    ///  Gets a standard <see cref="TaskDialogButton"/> instance representing the <c>Close</c> button.
+    ///  Gets a standard <see cref="TaskDialogButton"/> instance representing the "Close" button.
     /// </summary>
     public static TaskDialogButton Close => new(TaskDialogResult.Close);
 
     /// <summary>
-    ///  Gets a standard <see cref="TaskDialogButton"/> instance representing the <c>Help</c> button.
+    ///  Gets a standard <see cref="TaskDialogButton"/> instance representing the "Help" button.
     /// </summary>
     /// <remarks>
     /// <para>
@@ -149,12 +149,12 @@ public class TaskDialogButton : TaskDialogControl
     public static TaskDialogButton Help => new(TaskDialogResult.Help);
 
     /// <summary>
-    ///  Gets a standard <see cref="TaskDialogButton"/> instance representing the <c>Try Again</c> button.
+    ///  Gets a standard <see cref="TaskDialogButton"/> instance representing the "Try Again" button.
     /// </summary>
     public static TaskDialogButton TryAgain => new(TaskDialogResult.TryAgain);
 
     /// <summary>
-    ///  Gets a standard <see cref="TaskDialogButton"/> instance representing the <c>Continue</c> button.
+    ///  Gets a standard <see cref="TaskDialogButton"/> instance representing the "Continue" button.
     /// </summary>
     public static TaskDialogButton Continue => new(TaskDialogResult.Continue);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Dialogs/TaskDialog/TaskDialogLinkClickedEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Dialogs/TaskDialog/TaskDialogLinkClickedEventArgs.cs
@@ -20,9 +20,11 @@ public class TaskDialogLinkClickedEventArgs : EventArgs
     /// Gets the value of the <c>href</c> attribute of the link that the user clicked.
     /// </summary>
     /// <remarks>
-    /// Note: In order to avoid possible security vulnerabilities when showing content
-    /// from unsafe sources in a task dialog, you should always verify the value of this
-    /// property before actually opening the link.
+    ///  <para>
+    ///   Note: In order to avoid possible security vulnerabilities when showing content
+    ///   from unsafe sources in a task dialog, you should always verify the value of this
+    ///   property before actually opening the link.
+    ///  </para>
     /// </remarks>
     public string LinkHref { get; }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Dialogs/TaskDialog/TaskDialogResult.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Dialogs/TaskDialog/TaskDialogResult.cs
@@ -4,7 +4,7 @@
 namespace System.Windows.Forms;
 
 /// <summary>
-/// Specifies identifiers to indicate the return value of a task dialog.
+///  Specifies identifiers to indicate the return value of a task dialog.
 /// </summary>
 internal enum TaskDialogResult : int
 {
@@ -14,57 +14,57 @@ internal enum TaskDialogResult : int
     None = 0,
 
     /// <summary>
-    ///  The <c>OK</c> button was selected.
+    ///  The "OK" button was selected.
     /// </summary>
     OK = MESSAGEBOX_RESULT.IDOK,
 
     /// <summary>
-    ///  The <c>Cancel</c> button was selected.
+    ///  The "Cancel" button was selected.
     /// </summary>
     Cancel = MESSAGEBOX_RESULT.IDCANCEL,
 
     /// <summary>
-    ///  The <c>Abort</c> button was selected.
+    ///  The "Abort" button was selected.
     /// </summary>
     Abort = MESSAGEBOX_RESULT.IDABORT,
 
     /// <summary>
-    ///  The <c>Retry</c> button was selected.
+    ///  The "Retry" button was selected.
     /// </summary>
     Retry = MESSAGEBOX_RESULT.IDRETRY,
 
     /// <summary>
-    ///  The <c>Ignore</c> button was selected.
+    ///  The "Ignore" button was selected.
     /// </summary>
     Ignore = MESSAGEBOX_RESULT.IDIGNORE,
 
     /// <summary>
-    ///  The <c>Yes</c> button was selected.
+    ///  The "Yes" button was selected.
     /// </summary>
     Yes = MESSAGEBOX_RESULT.IDYES,
 
     /// <summary>
-    ///  The <c>No</c> button was selected.
+    ///  The "No" button was selected.
     /// </summary>
     No = MESSAGEBOX_RESULT.IDNO,
 
     /// <summary>
-    ///  The <c>Close</c> button was selected.
+    ///  The "Close" button was selected.
     /// </summary>
     Close = MESSAGEBOX_RESULT.IDCLOSE,
 
     /// <summary>
-    ///  The <c>Help</c> button was selected.
+    ///  The "Help" button was selected.
     /// </summary>
     Help = MESSAGEBOX_RESULT.IDHELP,
 
     /// <summary>
-    ///  The <c>Try Again</c> button was selected.
+    ///  The "Try Again" button was selected.
     /// </summary>
     TryAgain = MESSAGEBOX_RESULT.IDTRYAGAIN,
 
     /// <summary>
-    ///  The <c>Continue</c> button was selected.
+    ///  The "Continue" button was selected.
     /// </summary>
     Continue = MESSAGEBOX_RESULT.IDCONTINUE
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ImageIndexConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ImageIndexConverter.cs
@@ -21,16 +21,12 @@ public class ImageIndexConverter : Int32Converter
     ///  isn't valid in the standard values collection.
     /// </value>
     /// <remarks>
-    ///  <c>none</c> is the display name that is used when standard values are presented
-    ///  in the control UI and corresponds to a <c>null</c> value.
+    ///  <para>
+    ///   <c>none</c> is the display name that is used when standard values are presented
+    ///   in the control UI and corresponds to a <see langword="null"/> value.
+    ///  </para>
     /// </remarks>
-    protected virtual bool IncludeNoneAsStandardValue
-    {
-        get
-        {
-            return true;
-        }
-    }
+    protected virtual bool IncludeNoneAsStandardValue => true;
 
     /// <summary>
     ///  this is the property to look at when there is no ImageList property

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Internal/WinFormsUtils.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Internal/WinFormsUtils.cs
@@ -234,9 +234,11 @@ internal sealed partial class WindowsFormsUtils
     ///  Strips all keyboard mnemonic prefixes from a given string, eg. turning "He&amp;lp" into "Help".
     /// </summary>
     /// <remarks>
-    ///  Note: Be careful not to call this multiple times on the same string, otherwise you'll turn
-    ///  something like "Fi&amp;sh &amp;&amp; Chips" into "Fish &amp; Chips" on the first call, and then "Fish Chips"
-    ///  on the second call.
+    ///  <para>
+    ///   Note: Be careful not to call this multiple times on the same string, otherwise you'll turn
+    ///   something like "Fi&amp;sh &amp;&amp; Chips" into "Fish &amp; Chips" on the first call, and then "Fish Chips"
+    ///   on the second call.
+    ///  </para>
     /// </remarks>
     [return: NotNullIfNotNull(nameof(text))]
     public static string? TextWithoutMnemonics(string? text)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Rendering/GdiCache.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Rendering/GdiCache.cs
@@ -19,12 +19,16 @@ internal static partial class GdiCache
     ///  Gets an <see cref="HDC"/> based off of the primary display.
     /// </summary>
     /// <remarks>
-    ///  Use in a using statement for proper cleanup.
-    ///
-    ///  When disposed the <see cref="HDC"/> will be returned to the cache. Do NOT change the state of the
-    ///  DC (clipping, selecting objects into it) without restoring the state. If you must pass the scope to
-    ///  another method it must be passed by reference or you risk accidentally returning extra copies to the
-    ///  cache.
+    ///  <para>
+    ///   Use in a using statement for proper cleanup.
+    ///  </para>
+    ///  <para>
+    ///   When disposed the <see cref="HDC"/> will be returned to the cache. Do NOT change the state of the
+    ///   DC (clipping, selecting objects int
+    ///   o it) without restoring the state. If you must pass the scope to
+    ///   another method it must be passed by reference or you risk accidentally returning extra copies to the
+    ///   cache.
+    ///  </para>
     /// </remarks>
     public static ScreenDcCache.ScreenDcScope GetScreenHdc() => (s_dcCache ??= new ScreenDcCache()).Acquire();
 
@@ -32,12 +36,15 @@ internal static partial class GdiCache
     ///  Gets an <see cref="Graphics"/> based off of the primary display.
     /// </summary>
     /// <remarks>
-    ///  Use in a using statement for proper cleanup.
-    ///
-    ///  When disposed the <see cref="Graphics"/> object will be disposed and the underlying <see cref="HDC"/>
-    ///  will be returned to the cache. Do NOT change the state of the underlying DC (clipping, selecting objects
-    ///  into it) without restoring the state. If you must pass the scope to another method it must be passed by
-    ///  reference or you risk double disposal and accidentally returning extra copies to the cache.
+    ///  <para>
+    ///   Use in a using statement for proper cleanup.
+    ///  </para>
+    ///  <para>
+    ///   When disposed the <see cref="Graphics"/> object will be disposed and the underlying <see cref="HDC"/>
+    ///   will be returned to the cache. Do NOT change the state of the underlying DC (clipping, selecting objects
+    ///   into it) without restoring the state. If you must pass the scope to another method it must be passed by
+    ///   reference or you risk double disposal and accidentally returning extra copies to the cache.
+    ///  </para>
     /// </remarks>
     public static ScreenGraphicsScope GetScreenDCGraphics()
     {
@@ -72,11 +79,14 @@ internal static partial class GdiCache
     ///  <paramref name="quality"/>.
     /// </summary>
     /// <remarks>
-    ///  Use in a using statement for proper cleanup.
-    ///
-    ///  When disposed the <see cref="HFONT"/> will be returned to the cache.  If you must pass the scope to
-    ///  another method it must be passed by reference or you risk double disposal and accidentally returning extra
-    ///  copies to the cache.
+    ///  <para>
+    ///   Use in a using statement for proper cleanup.
+    ///  </para>
+    ///  <para>
+    ///   When disposed the <see cref="HFONT"/> will be returned to the cache.  If you must pass the scope to
+    ///   another method it must be passed by reference or you risk double disposal and accidentally returning extra
+    ///   copies to the cache.
+    ///  </para>
     /// </remarks>
     public static FontCache.Scope GetHFONT(Font? font, FONT_QUALITY quality = FONT_QUALITY.DEFAULT_QUALITY)
     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Rendering/PaintEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Rendering/PaintEventArgs.cs
@@ -20,13 +20,17 @@ public partial class PaintEventArgs : EventArgs, IDisposable, IDeviceContext, IG
     private readonly DrawingEventArgs _event;
 
     /// <remarks>
-    ///  This is only needed for <see cref="ResetGraphics"/> callers and applies in the following places:
-    ///
-    ///    1. In <see cref="Control.WmPaint(ref Message)"/> when we are painting the background.
-    ///    2. In <see cref="Control.WmPrintClient(ref Message)"/>.
-    ///
-    ///  We can potentially optimize further by skipping the save when we only use <see cref="GraphicsInternal"/>
-    ///  as we shouldn't have messed with the clipping there.
+    ///  <para>
+    ///   This is only needed for <see cref="ResetGraphics"/> callers and applies in the following places:
+    ///  </para>
+    ///  <list type="number">
+    ///   <item><description>In <see cref="Control.WmPaint(ref Message)"/> when we are painting the background.</description></item>
+    ///   <item><description>In <see cref="Control.WmPrintClient(ref Message)"/>.</description></item>
+    ///  </list>
+    ///  <para>
+    ///   We can potentially optimize further by skipping the save when we only use <see cref="GraphicsInternal"/>
+    ///   as we shouldn't have messed with the clipping there.
+    ///  </para>
     /// </remarks>
     private GraphicsState? _savedGraphicsState;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Rendering/TextFormatFlags.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Rendering/TextFormatFlags.cs
@@ -3,6 +3,8 @@
 
 namespace System.Windows.Forms;
 
+#pragma warning disable format
+
 /// <summary>
 ///  Specifies the display and layout information for text strings.
 /// </summary>
@@ -19,7 +21,7 @@ public enum TextFormatFlags
     Internal                            = (int)DRAW_TEXT_FORMAT.DT_INTERNAL,
 
     /// <remarks>
-    ///  This is the default.
+    ///  <para>This is the default.</para>
     /// </remarks>
     Left                                = (int)DRAW_TEXT_FORMAT.DT_LEFT,
 
@@ -36,7 +38,7 @@ public enum TextFormatFlags
     TextBoxControl                      = (int)DRAW_TEXT_FORMAT.DT_EDITCONTROL,
 
     /// <remarks>
-    ///  This is the default.
+    ///  <para>This is the default.</para>
     /// </remarks>
     Top                                 = (int)DRAW_TEXT_FORMAT.DT_TOP,
 
@@ -63,3 +65,5 @@ public enum TextFormatFlags
     NoPadding                           = 0x1000_0000,
     LeftAndRightPadding                 = 0x2000_0000
 }
+
+#pragma warning restore format

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SendKeys/SendKeys.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SendKeys/SendKeys.cs
@@ -975,8 +975,10 @@ public partial class SendKeys
     ///  Sends the given keys to the active application, and then waits for the messages to be processed.
     /// </summary>
     /// <remarks>
-    ///  WARNING: this method will never work if control is not null, because while Windows journaling *looks* like it
-    ///  can be directed to a specific HWND, it can't.
+    ///  <para>
+    ///   WARNING: this method will never work if control is not null, because while Windows journaling *looks* like it
+    ///   can be directed to a specific HWND, it can't.
+    ///  </para>
     /// </remarks>
     private static void SendWait(string keys, Control? control)
     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip/KeyboardToolTipStateMachine.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip/KeyboardToolTipStateMachine.cs
@@ -10,13 +10,17 @@ namespace System.Windows.Forms;
 ///  This state machine attempts to simulate the mouse ToolTip behavior.
 /// </summary>
 /// <remarks>
-///  The control should be focused with keyboard for an amount of time specified with TTDT_INITIAL flag to make
-///  the keyboard ToolTip appear. <see href="https://docs.microsoft.com/windows/win32/controls/ttm-getdelaytime">TTM_GETDELAYTIME message (Microsoft Docs)</see>
-///
-///  Once visible, the keyboard ToolTip will be demonstrated for an amount of time specified with TTDT_AUTOPOP
-///  flag. The ToolTip will disappear afterwards. If the keyboard ToolTip is visible and the focus moves from
-///  one ToolTip-enabled control to another, the keyboard ToolTip will be shown after a time interval specified
-///  with TTDT_RESHOW flag has passed.
+///  <para>
+///   The control should be focused with keyboard for an amount of time specified with TTDT_INITIAL flag to make
+///   the keyboard ToolTip appear. <see href="https://docs.microsoft.com/windows/win32/controls/ttm-getdelaytime">
+///   TTM_GETDELAYTIME message (Microsoft Docs)</see>
+///  </para>
+///  <para>
+///   Once visible, the keyboard ToolTip will be demonstrated for an amount of time specified with TTDT_AUTOPOP
+///   flag. The ToolTip will disappear afterwards. If the keyboard ToolTip is visible and the focus moves from
+///   one ToolTip-enabled control to another, the keyboard ToolTip will be shown after a time interval specified
+///   with TTDT_RESHOW flag has passed.
+///  </para>
 /// </remarks>
 internal sealed partial class KeyboardToolTipStateMachine
 {

--- a/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests.Common/TestHelpers.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests.Common/TestHelpers.cs
@@ -343,7 +343,6 @@ public static class TestHelpers
     /// </summary>
     /// <param name="process">The process to send the Tab key(s) to</param>
     /// <param name="times">The number of times to press tab in a row</param>
-    /// <remarks>Throws an ArgumentException if number of times is zero; this is unlikely to be intended.</remarks>
     /// <returns>Whether or not the Tab key(s) were pressed on the process</returns>
     /// <seealso cref="SendKeysToProcess(Process, string, bool)"/>
     public static bool SendTabKeysToProcess(Process process, MainFormControlsTabOrder times, bool switchToMainWindow = true)

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Infra/ScreenRecordService.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Infra/ScreenRecordService.cs
@@ -16,11 +16,11 @@ internal class ScreenRecordService : IDisposable
     private static readonly Stopwatch s_timer = Stopwatch.StartNew();
 
     /// <summary>
-    /// Frames captured for the current test. The elapsed time field is a timestamp relative to a fixed but unspecified
-    /// point in time.
+    ///  Frames captured for the current test. The elapsed time field is a timestamp relative to a fixed but unspecified
+    ///  point in time.
     /// </summary>
     /// <remarks>
-    /// Lock on this object before accessing to prevent concurrent accesses.
+    ///  <para>Lock on this object before accessing to prevent concurrent accesses.</para>
     /// </remarks>
     private static readonly List<(TimeSpan elapsed, Bitmap image)> s_frames = new();
     private static readonly ArrayPool<byte> s_pool = ArrayPool<byte>.Shared;


### PR DESCRIPTION
This cleans up doc analyzer messages and turns the <para> message into a failure.

It also suppresses CA1861 in tests, which accounts for over 4000 hits.

Lastly it suppresses the TheoryData message and opens an issue to track fixing these.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11042)