### PR TITLE
Remove more tracing

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/UndoEngine.UndoUnit.AddRemoveUndoEvent.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/UndoEngine.UndoUnit.AddRemoveUndoEvent.cs
@@ -26,7 +26,6 @@ public abstract partial class UndoEngine
                 NextUndoAdds = !add;
                 OpenComponent = component;
 
-                Debug.WriteLineIf(s_traceUndo.TraceVerbose, $"UndoEngine: ---> Creating {(add ? "Add" : "Remove")} undo event for '{_componentName}'");
                 using (_serializedData = engine._serializationService.CreateStore())
                 {
                     engine._serializationService.Serialize(_serializedData, component);
@@ -58,7 +57,6 @@ public abstract partial class UndoEngine
             {
                 if (!Committed)
                 {
-                    Debug.WriteLineIf(s_traceUndo.TraceVerbose, $"UndoEngine: ---> Committing remove of '{_componentName}'");
                     Committed = true;
                 }
             }
@@ -70,7 +68,6 @@ public abstract partial class UndoEngine
             {
                 if (NextUndoAdds)
                 {
-                    Debug.WriteLineIf(s_traceUndo.TraceVerbose, $"UndoEngine: ---> Adding '{_componentName}'");
                     // We need to add this component.  To add it, we deserialize it and then we add it to the designer host's container.
                     IDesignerHost host = engine.GetRequiredService<IDesignerHost>();
 
@@ -78,7 +75,6 @@ public abstract partial class UndoEngine
                 }
                 else
                 {
-                    Debug.WriteLineIf(s_traceUndo.TraceVerbose, $"UndoEngine: ---> Removing '{_componentName}'");
                     // We need to remove this component.  Take the name and match it to an object, and then ask that object to delete itself.
                     IDesignerHost host = engine.GetRequiredService<IDesignerHost>();
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/UndoEngine.UndoUnit.ChangeUndoEvent.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/UndoEngine.UndoUnit.ChangeUndoEvent.cs
@@ -28,10 +28,8 @@ public abstract partial class UndoEngine
                 OpenComponent = e.Component;
                 _member = e.Member;
 
-                Debug.WriteLineIf(s_traceUndo.TraceVerbose, $"UndoEngine: ---> Creating change undo event for '{_componentName}'");
                 if (serializeBeforeState)
                 {
-                    Debug.WriteLineIf(s_traceUndo.TraceVerbose, $"UndoEngine: ---> Saving before snapshot for change to '{_componentName}'");
                     _before = Serialize(engine, OpenComponent!, _member);
                 }
             }
@@ -93,7 +91,6 @@ public abstract partial class UndoEngine
             {
                 if (!Committed)
                 {
-                    Debug.WriteLineIf(s_traceUndo.TraceVerbose, $"UndoEngine: ---> Committing change to '{_componentName}'");
                     OpenComponent = null;
                 }
             }
@@ -101,7 +98,6 @@ public abstract partial class UndoEngine
             private void SaveAfterState(UndoEngine engine)
             {
                 Debug.Assert(_after is null, "Change undo saving state twice.");
-                Debug.WriteLineIf(s_traceUndo.TraceVerbose, $"UndoEngine: ---> Saving after snapshot for change to '{_componentName}'");
                 object? component = null;
 
                 if (engine.TryGetService(out IReferenceService? rs))
@@ -143,7 +139,6 @@ public abstract partial class UndoEngine
             /// </summary>
             public override void Undo(UndoEngine engine)
             {
-                Debug.WriteLineIf(s_traceUndo.TraceVerbose, $"UndoEngine: ---> Applying changes to '{_componentName}'");
                 Debug.Assert(_savedAfterState, "After state not saved.  BeforeUndo was not called?");
 
                 if (_before is not null)

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/UndoEngine.UndoUnit.RenameUndoEvent.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/UndoEngine.UndoUnit.RenameUndoEvent.cs
@@ -19,7 +19,6 @@ public abstract partial class UndoEngine
             {
                 _before = before;
                 _after = after;
-                Debug.WriteLineIf(s_traceUndo.TraceVerbose, $"UndoEngine: ---> Creating rename undo event for '{_before}'->'{_after}'");
             }
 
             /// <summary>
@@ -27,7 +26,6 @@ public abstract partial class UndoEngine
             /// </summary>
             public override void Undo(UndoEngine engine)
             {
-                Debug.WriteLineIf(s_traceUndo.TraceVerbose, $"UndoEngine: ---> Renaming '{_after}'->'{_before}'");
                 IComponent? comp = engine._host.Container.Components[_after];
                 if (comp is not null)
                 {

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/UndoEngine.UndoUnit.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/UndoEngine.UndoUnit.cs
@@ -25,8 +25,6 @@ public abstract partial class UndoEngine
         {
             Name = name ?? string.Empty;
 
-            Debug.WriteLineIf(s_traceUndo.TraceVerbose, $"UndoEngine: Creating undo unit '{Name}'");
-
             UndoEngine = engine.OrThrowIfNull();
             _reverse = true;
             if (UndoEngine.TryGetService(out ISelectionService? ss))
@@ -224,7 +222,6 @@ public abstract partial class UndoEngine
                     if (name is not null)
                     {
                         string memberName = e.Member?.Name ?? "(none)";
-                        Debug.WriteLineIf(s_traceUndo.TraceVerbose && hasChange, $"Adding second ChangeEvent for {name} Member: {memberName}");
                     }
                     else
                     {
@@ -357,7 +354,6 @@ public abstract partial class UndoEngine
         /// </summary>
         public void Undo()
         {
-            Debug.WriteLineIf(s_traceUndo.TraceVerbose, $"UndoEngine: Performing undo '{Name}'");
             UndoUnit? savedUnit = UndoEngine._executingUnit;
             UndoEngine._executingUnit = this;
             DesignerTransaction? transaction = null;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/UndoEngine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/UndoEngine.cs
@@ -16,8 +16,6 @@ namespace System.ComponentModel.Design;
 /// </summary>
 public abstract partial class UndoEngine : IDisposable
 {
-    private static readonly TraceSwitch s_traceUndo = new("UndoEngine", "Trace UndoRedo");
-
     private IServiceProvider _provider;
     private readonly Stack<UndoUnit> _unitStack; // the stack of active (non-committed) units.
     private UndoUnit? _executingUnit; // the unit currently executing an undo.
@@ -122,7 +120,6 @@ public abstract partial class UndoEngine : IDisposable
         if (reason != PopUnitReason.Normal || !_host.InTransaction)
         {
             UndoUnit unit = _unitStack.Pop();
-            Debug.WriteLineIf(s_traceUndo.TraceVerbose, $"UndoEngine: Popping unit {unit}.  Reason: {reason}");
 
             if (!unit.IsEmpty)
             {
@@ -187,8 +184,6 @@ public abstract partial class UndoEngine : IDisposable
     {
         if (disposing)
         {
-            Debug.WriteLineIf(s_traceUndo.TraceVerbose, "UndoEngine: Disposing undo engine");
-
             _host.TransactionOpening -= new EventHandler(OnTransactionOpening);
             _host.TransactionClosed -= new DesignerTransactionCloseEventHandler(OnTransactionClosed);
 
@@ -422,7 +417,7 @@ public abstract partial class UndoEngine : IDisposable
                             continue;
                         }
 
-                        if (obj is not null && object.ReferenceEquals(obj, e.Component))
+                        if (obj is not null && ReferenceEquals(obj, e.Component))
                         {
                             if (propsToUpdate is null)
                             {

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/ToolboxItem.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/ToolboxItem.cs
@@ -15,8 +15,6 @@ namespace System.Drawing.Design;
 /// </summary>
 public class ToolboxItem : ISerializable
 {
-    private static readonly TraceSwitch s_toolboxItemPersist = new("ToolboxPersisting", "ToolboxItem: write data");
-
     private static bool s_isScalingInitialized;
     private const int ICON_DIMENSION = 16;
     private static int s_iconWidth = ICON_DIMENSION;
@@ -698,15 +696,10 @@ public class ToolboxItem : ISerializable
     }
 
     /// <summary>
-    ///Saves the state of this ToolboxItem to the specified serialization info
+    ///  Saves the state of this ToolboxItem to the specified serialization info
     /// </summary>
     protected virtual void Serialize(SerializationInfo info, StreamingContext context)
     {
-        Debug.WriteLineIf(s_toolboxItemPersist.TraceVerbose, $"""
-                Persisting: {GetType().Name}
-                    Display Name: {DisplayName}
-                """);
-
         info.AddValue(nameof(Locked), Locked);
         List<string> propertyNames = new(Properties.Count);
         foreach (DictionaryEntry de in Properties)

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.cs
@@ -46,8 +46,6 @@ public sealed partial class BehaviorService : IDisposable
     private bool _useSnapLines;                                     // indicates if this designer session is using snaplines or snapping to a grid
     private bool _queriedSnapLines;                                 // only query for this once since we require the user restart design sessions when this changes
     private readonly HashSet<Glyph> _dragEnterReplies;              // we keep track of whether glyph has already responded to a DragEnter this D&D.
-    private static readonly TraceSwitch s_dragDropSwitch
-        = new("BSDRAGDROP", "Behavior service drag & drop messages");
 
     // test hooks for SnapLines
     private static MessageId WM_GETALLSNAPLINES { get; } = PInvoke.RegisterWindowMessage("WM_GETALLSNAPLINES");
@@ -628,8 +626,6 @@ public sealed partial class BehaviorService : IDisposable
 
     private void OnDragEnter(Glyph? g, DragEventArgs e)
     {
-        Debug.WriteLineIf(s_dragDropSwitch.TraceVerbose, "BS::OnDragEnter");
-
         // If the AdornerWindow receives a drag message, this method will be called without
         // a glyph - assign the last hit tested one
         g ??= _hitTestedGlyph;
@@ -637,24 +633,19 @@ public sealed partial class BehaviorService : IDisposable
         Behavior? behavior = GetAppropriateBehavior(g);
         if (behavior is null)
         {
-            Debug.WriteLineIf(s_dragDropSwitch.TraceVerbose, "\tNo behavior, returning");
             return;
         }
 
-        Debug.WriteLineIf(s_dragDropSwitch.TraceVerbose, "\tForwarding to behavior");
         behavior.OnDragEnter(g, e);
 
         if (g is ControlBodyGlyph && e.Effect == DragDropEffects.None)
         {
             _dragEnterReplies.Add(g);
-            Debug.WriteLineIf(s_dragDropSwitch.TraceVerbose, "\tCalled DragEnter on this glyph. Caching");
         }
     }
 
     private void OnDragLeave(Glyph? g, EventArgs e)
     {
-        Debug.WriteLineIf(s_dragDropSwitch.TraceVerbose, "BS::DragLeave");
-
         // This is normally cleared on OnMouseUp, but we might not get an OnMouseUp to clear it. VSWhidbey #474259
         // So let's make sure it is really cleared when we start the drag.
         _dragEnterReplies.Clear();
@@ -666,11 +657,9 @@ public sealed partial class BehaviorService : IDisposable
         Behavior? behavior = GetAppropriateBehavior(g);
         if (behavior is null)
         {
-            Debug.WriteLineIf(s_dragDropSwitch.TraceVerbose, "\t No behavior returning ");
             return;
         }
 
-        Debug.WriteLineIf(s_dragDropSwitch.TraceVerbose, "\tBehavior found calling OnDragLeave");
         behavior.OnDragLeave(g, e);
     }
 
@@ -727,17 +716,14 @@ public sealed partial class BehaviorService : IDisposable
 
     private void OnDragDrop(DragEventArgs e)
     {
-        Debug.WriteLineIf(s_dragDropSwitch.TraceVerbose, "BS::OnDragDrop");
         _validDragArgs = null;
 
         Behavior? behavior = GetAppropriateBehavior(_hitTestedGlyph);
         if (behavior is null)
         {
-            Debug.WriteLineIf(s_dragDropSwitch.TraceVerbose, "\tNo behavior. returning");
             return;
         }
 
-        Debug.WriteLineIf(s_dragDropSwitch.TraceVerbose, "\tForwarding to behavior");
         behavior.OnDragDrop(_hitTestedGlyph, e);
     }
 
@@ -827,12 +813,10 @@ public sealed partial class BehaviorService : IDisposable
     {
         // cache off our validDragArgs so we can re-fabricate enter/leave drag events
         _validDragArgs = e;
-        Debug.WriteLineIf(s_dragDropSwitch.TraceVerbose, "BS::DragOver");
         Behavior? behavior = GetAppropriateBehavior(_hitTestedGlyph);
 
         if (behavior is null)
         {
-            Debug.WriteLineIf(s_dragDropSwitch.TraceVerbose, "\tNo behavior, exiting with DragDropEffects.None");
             e.Effect = DragDropEffects.None;
             return;
         }
@@ -840,12 +824,10 @@ public sealed partial class BehaviorService : IDisposable
         if (_hitTestedGlyph is null ||
            (_hitTestedGlyph is not null && !_dragEnterReplies.Contains(_hitTestedGlyph)))
         {
-            Debug.WriteLineIf(s_dragDropSwitch.TraceVerbose, "\tFound glyph, forwarding to behavior");
             behavior.OnDragOver(_hitTestedGlyph, e);
         }
         else
         {
-            Debug.WriteLineIf(s_dragDropSwitch.TraceVerbose, "\tFell through");
             e.Effect = DragDropEffects.None;
         }
     }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DocumentDesigner.AxToolboxItem.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DocumentDesigner.AxToolboxItem.cs
@@ -101,13 +101,7 @@ public partial class DocumentDesigner
                 }
                 catch (TargetInvocationException tie)
                 {
-                    Debug.WriteLineIf(AxToolSwitch.TraceVerbose, $"Generating Ax References failed: {tie.InnerException}");
                     throw tie.InnerException!;
-                }
-                catch (Exception e)
-                {
-                    Debug.WriteLineIf(AxToolSwitch.TraceVerbose, $"Generating Ax References failed: {e}");
-                    throw;
                 }
             }
 
@@ -177,7 +171,6 @@ public partial class DocumentDesigner
 
             FileInfo file = new(path);
             string fullPath = file.FullName;
-            Debug.WriteLineIf(AxToolSwitch.TraceVerbose, $"Checking: {fullPath}");
 
             ITypeResolutionService? trs = host.GetService<ITypeResolutionService>();
             Debug.Assert(trs is not null, "No type resolution service found.");
@@ -257,13 +250,8 @@ public partial class DocumentDesigner
         private unsafe TLIBATTR GetTypeLibAttr()
         {
             string controlKey = $"CLSID\\{_clsid}";
-            using RegistryKey? key = Registry.ClassesRoot.OpenSubKey(controlKey);
-            if (key is null)
-            {
-                if (AxToolSwitch.TraceVerbose)
-                    Debug.WriteLine($"No registry key found for: {controlKey}");
-                throw new ArgumentException(string.Format(SR.AXNotRegistered, controlKey));
-            }
+            using RegistryKey? key = Registry.ClassesRoot.OpenSubKey(controlKey)
+                ?? throw new ArgumentException(string.Format(SR.AXNotRegistered, controlKey));
 
             // Load the typelib into memory.
             ITypeLib* pTLB = null;
@@ -354,12 +342,10 @@ public partial class DocumentDesigner
         }
 
         /// <summary>
-        /// <para>Saves the state of this 'AxToolboxItem' to
-        ///  the specified serialization info.</para>
+        ///  Saves the state of this <see cref="AxToolboxItem"/> to the specified serialization info.
         /// </summary>
         protected override void Serialize(SerializationInfo info, StreamingContext context)
         {
-            Debug.WriteLineIf(AxToolSwitch.TraceVerbose, $"Serializing AxToolboxItem:{_clsid}");
             base.Serialize(info, context);
             info.AddValue("Clsid", _clsid);
         }

--- a/src/System.Windows.Forms.Primitives/src/System/ComponentModel/CompModSwitches.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/ComponentModel/CompModSwitches.cs
@@ -17,7 +17,6 @@ internal static class CompModSwitches
     private static TraceSwitch? s_dataGridSelection;
     private static TraceSwitch? s_dataObject;
     private static TraceSwitch? s_dataView;
-    private static TraceSwitch? s_debugGridView;
     private static TraceSwitch? s_dgCaptionPaint;
     private static TraceSwitch? s_dgEditColumnEditing;
     private static TraceSwitch? s_dgRelationShpRowLayout;
@@ -144,16 +143,6 @@ internal static class CompModSwitches
             s_dataView ??= new TraceSwitch("DataView", "DataView");
 
             return s_dataView;
-        }
-    }
-
-    public static TraceSwitch DebugGridView
-    {
-        get
-        {
-            s_debugGridView ??= new TraceSwitch("PSDEBUGGRIDVIEW", "Debug PropertyGridView");
-
-            return s_debugGridView;
         }
     }
 

--- a/src/System.Windows.Forms/src/GlobalSuppressions.cs
+++ b/src/System.Windows.Forms/src/GlobalSuppressions.cs
@@ -141,6 +141,13 @@
 [assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Public API", Scope = "member", Target = "~F:System.Windows.Forms.DataFormats.Serializable")]
 [assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Public API", Scope = "member", Target = "~F:System.Windows.Forms.OSFeature.LayeredWindows")]
 [assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Public API", Scope = "member", Target = "~F:System.Windows.Forms.OSFeature.Themes")]
+[assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Public API", Scope = "member", Target = "~F:System.Resources.ResXResourceWriter.BinSerializedObjectMimeType")]
+[assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Public API", Scope = "member", Target = "~F:System.Resources.ResXResourceWriter.SoapSerializedObjectMimeType")]
+[assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Public API", Scope = "member", Target = "~F:System.Resources.ResXResourceWriter.DefaultSerializedObjectMimeType")]
+[assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Public API", Scope = "member", Target = "~F:System.Resources.ResXResourceWriter.ByteArraySerializedObjectMimeType")]
+[assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Public API", Scope = "member", Target = "~F:System.Resources.ResXResourceWriter.ResMimeType")]
+[assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Public API", Scope = "member", Target = "~F:System.Resources.ResXResourceWriter.Version")]
+[assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Public API", Scope = "member", Target = "~F:System.Resources.ResXResourceWriter.ResourceSchema")]
 [assembly: SuppressMessage("Performance", "CA1815:Override equals and operator equals on value types", Justification = "Public API", Scope = "type", Target = "~T:System.Windows.Forms.ImeModeConversion")]
 
 // Thread locals (there is no way to configure this style yet)

--- a/src/System.Windows.Forms/src/System/Resources/ResXResourceWriter.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResXResourceWriter.cs
@@ -29,9 +29,6 @@ public class ResXResourceWriter : IResourceWriter
 
     private Dictionary<string, string?>? _cachedAliases;
 
-    private static readonly TraceSwitch s_resValueProviderSwitch = new("ResX", "Debug the resource value provider");
-
-#pragma warning disable IDE1006 // Naming Styles (Shipped public API)
     public static readonly string BinSerializedObjectMimeType = "application/x-microsoft.net.object.binary.base64";
     public static readonly string SoapSerializedObjectMimeType = "application/x-microsoft.net.object.soap.base64";
     public static readonly string DefaultSerializedObjectMimeType = BinSerializedObjectMimeType;
@@ -87,7 +84,6 @@ public class ResXResourceWriter : IResourceWriter
                 </xsd:element>
             </xsd:schema>
             """;
-#pragma warning restore IDE1006 // Naming Styles
 
     private readonly string? _fileName;
     private Stream? _stream;
@@ -341,7 +337,6 @@ public class ResXResourceWriter : IResourceWriter
     /// </summary>
     private void AddDataRow(string elementName, string name, object? value)
     {
-        s_resValueProviderSwitch.TraceVerbose($"  resx: adding resource {name}");
         switch (value)
         {
             case string str:
@@ -590,11 +585,8 @@ public class ResXResourceWriter : IResourceWriter
         }
 
         _hasBeenSaved = true;
-        s_resValueProviderSwitch.TraceVerbose("writing XML");
 
         Writer.WriteEndElement();
         Writer.Flush();
-
-        s_resValueProviderSwitch.TraceVerbose("done");
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2Properties.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2Properties.cs
@@ -11,11 +11,6 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop;
 /// </summary>
 internal sealed class Com2Properties
 {
-#if DEBUG
-    private static readonly TraceSwitch s_dbgCom2PropertiesSwitch
-        = new("DbgCom2Properties", "Com2Properties: debug Com2 properties manager");
-#endif
-
     // This is the interval that we'll hold properties for. If someone doesn't touch an object for this amount of time,
     // we'll dump the properties from our cache. 5 minutes -- ticks are 1/10,000,000th of a second
     private const long AgeThreshold = 10000000L * 60L * 5L;
@@ -43,13 +38,6 @@ internal sealed class Com2Properties
     {
         ArgumentNullException.ThrowIfNull(comObject);
         ArgumentNullException.ThrowIfNull(properties);
-
-#if DEBUG
-        if (s_dbgCom2PropertiesSwitch.TraceVerbose)
-        {
-            Debug.WriteLine($"Creating Com2Properties for object {comObject.GetType().FullName ?? "(null)"}.");
-        }
-#endif
 
         // Set up our variables.
         _properties = properties;
@@ -117,12 +105,6 @@ internal sealed class Com2Properties
         {
             if (CheckAndGetTarget(checkVersions: false, callDispose: true) is not { } target || _touchedTime == 0)
             {
-#if DEBUG
-                if (s_dbgCom2PropertiesSwitch.TraceVerbose)
-                {
-                    Debug.WriteLine("CheckValid called on dead object!");
-                }
-#endif
                 return null;
             }
 
@@ -153,12 +135,6 @@ internal sealed class Com2Properties
                 _properties[i].SetNeedsRefresh(Com2PropertyDescriptorRefresh.All, true);
             }
 
-#if DEBUG
-            if (s_dbgCom2PropertiesSwitch.TraceVerbose)
-            {
-                Debug.WriteLine("Returning property array for object.");
-            }
-#endif
             return _properties;
         }
     }
@@ -198,13 +174,6 @@ internal sealed class Com2Properties
 
     public void Dispose()
     {
-#if DEBUG
-        if (s_dbgCom2PropertiesSwitch.TraceVerbose)
-        {
-            Debug.WriteLine("Disposing property manager.");
-        }
-#endif
-
         if (_properties is not null)
         {
             Disposed?.Invoke(this, EventArgs.Empty);
@@ -290,13 +259,6 @@ internal sealed class Com2Properties
         if (!valid && callDispose)
         {
             // Weak reference has died, so remove this from the hash table
-#if DEBUG
-            if (s_dbgCom2PropertiesSwitch.TraceVerbose)
-            {
-                Debug.WriteLine($"Disposing reference to object (weakRef {(_weakObjectReference is null ? "null" : "dead")})");
-            }
-#endif
-
             Dispose();
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/Menus/MenuStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/Menus/MenuStrip.cs
@@ -201,7 +201,6 @@ public partial class MenuStrip : ToolStrip
     {
         if (!(Focused || ContainsFocus))
         {
-            s_snapFocusDebug.TraceVerbose("[ProcessMenuKey] set focus to menustrip");
             ToolStripManager.ModalMenuFilter.SetActiveToolStrip(this, menuKeyPressed: true);
 
             if (DisplayedItems.Count > 0)
@@ -230,13 +229,11 @@ public partial class MenuStrip : ToolStrip
             // ALT, then space should dismiss the menu and activate the system menu.
             if (keyData == Keys.Space)
             {
-                // if we're focused it's ok to activate system menu
-                // if we're not focused - we should not activate if we contain focus - this means a text box or something
-                // has focus.
+                // If we're focused it's ok to activate system menu. If we're not focused - we should not activate if
+                // we contain focus - this means a text box or something has focus.
                 if (Focused || !ContainsFocus)
                 {
                     NotifySelectionChange(item: null);
-                    s_snapFocusDebug.TraceVerbose("[MenuStrip.ProcessCmdKey] Rolling up the menu and invoking the system menu");
                     ToolStripManager.ModalMenuFilter.ExitMenuMode();
 
                     // Send a WM_SYSCOMMAND SC_KEYMENU + Space to activate the system menu.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/Menus/MenuTimer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/Menus/MenuTimer.cs
@@ -6,9 +6,6 @@ namespace System.Windows.Forms;
 internal class MenuTimer
 {
     private readonly Timer _autoMenuExpandTimer = new();
-
-    // consider - weak reference?
-    private ToolStripMenuItem? _currentItem;
     private ToolStripMenuItem? _fromItem;
     private bool _inTransition;
 
@@ -26,19 +23,8 @@ internal class MenuTimer
         _slowShow = Math.Max(_quickShow, SystemInformation.MenuShowDelay);
     }
 
-    // the current item to autoexpand.
-    private ToolStripMenuItem? CurrentItem
-    {
-        get
-        {
-            return _currentItem;
-        }
-        set
-        {
-            Debug.WriteLineIf(ToolStrip.s_menuAutoExpandDebug!.TraceVerbose && _currentItem != value, $"[MenuTimer.CurrentItem] changed: {(value is null ? "null" : value.ToString())}");
-            _currentItem = value;
-        }
-    }
+    // The current item to autoexpand.
+    private ToolStripMenuItem? CurrentItem { get; set; }
 
     public bool InTransition
     {
@@ -74,14 +60,11 @@ internal class MenuTimer
 
     public void Transition(ToolStripMenuItem fromItem, ToolStripMenuItem? toItem)
     {
-        ToolStrip.s_menuAutoExpandDebug.TraceVerbose($"[MenuTimer.Transition] transitioning items {fromItem} {toItem?.ToString()}");
-
         if (toItem is null && InTransition)
         {
             Cancel();
 
-            // in this case we're likely to have hit an item that's not a menu item
-            // or nothing is selected.
+            // In this case we're likely to have hit an item that's not a menu item or nothing is selected.
             EndTransition(forceClose: true);
             return;
         }
@@ -93,7 +76,7 @@ internal class MenuTimer
             StartCore(toItem);
         }
 
-        // set up the current item to be the toItem so it will be auto expanded when complete.
+        // Set up the current item to be the toItem so it will be auto expanded when complete.
         CurrentItem = toItem;
         InTransition = true;
     }
@@ -184,7 +167,6 @@ internal class MenuTimer
         EndTransition(forceClose: false);
         if (CurrentItem is not null && !CurrentItem.IsDisposed && CurrentItem.Selected && CurrentItem.Enabled && ToolStripManager.ModalMenuFilter.InMenuMode)
         {
-            ToolStrip.s_menuAutoExpandDebug.TraceVerbose("[MenuTimer.OnTick] calling OnMenuAutoExpand");
             CurrentItem.OnMenuAutoExpand();
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/MultiPropertyDescriptorGridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/MultiPropertyDescriptorGridEntry.cs
@@ -129,10 +129,6 @@ internal sealed class MultiPropertyDescriptorGridEntry : PropertyDescriptorGridE
                 _propertySort,
                 OwnerTab);
 
-            Debug.WriteLineIf(
-                CompModSwitches.DebugGridView.TraceVerbose && mergedProperties is null,
-                "PropertyGridView: MergedProps returned null!");
-
             if (mergedProperties is not null)
             {
                 ChildCollection.AddRange(mergedProperties);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/MultiSelectRootGridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/MultiSelectRootGridEntry.cs
@@ -66,8 +66,6 @@ internal sealed partial class MultiSelectRootGridEntry : SingleSelectRootGridEnt
 
             var mergedProperties = PropertyMerger.GetMergedProperties(targets, this, _propertySort, OwnerTab);
 
-            Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose && mergedProperties is null, "PropertyGridView: MergedProps returned null!");
-
             if (mergedProperties is not null)
             {
                 ChildCollection.AddRange(mergedProperties);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.DropDownHolder.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.DropDownHolder.cs
@@ -249,7 +249,6 @@ internal partial class PropertyGridView
 
         public void FocusComponent()
         {
-            CompModSwitches.DebugGridView.TraceVerbose("DropDownHolder:FocusComponent()");
             if (_currentControl is not null && Visible)
             {
                 _currentControl.Focus();
@@ -582,9 +581,6 @@ internal partial class PropertyGridView
             }
 
             _currentControl = control;
-            CompModSwitches.DebugGridView.TraceVerbose(
-                $"DropDownHolder:SetComponent({control.GetType().Name})");
-
             DockPadding.All = 0;
 
             // First handle the control. If it's a listbox, make sure it's got some height to it.
@@ -668,7 +664,6 @@ internal partial class PropertyGridView
             if (m.MsgInternal == PInvoke.WM_ACTIVATE)
             {
                 SetState(States.Modal, true);
-                CompModSwitches.DebugGridView.TraceVerbose("DropDownHolder:WM_ACTIVATE()");
                 HWND activatedWindow = (HWND)m.LParamInternal;
                 if (Visible && m.WParamInternal.LOWORD == PInvoke.WA_INACTIVE && !OwnsWindow(activatedWindow))
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.GridViewTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.GridViewTextBox.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.ComponentModel;
 using System.Drawing;
 using Windows.Win32.UI.Accessibility;
 
@@ -274,8 +273,6 @@ internal partial class PropertyGridView
 
         protected override void SetVisibleCore(bool value)
         {
-            CompModSwitches.DebugGridView.TraceVerbose($"DropDownHolder:Visible({value})");
-
             // Make sure we don't have the mouse captured if we're going invisible.
             if (value == false && HookMouseDown)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.MouseHook.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.MouseHook.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.ComponentModel;
 using System.Runtime.InteropServices;
 
 namespace System.Windows.Forms.PropertyGridInternal;
@@ -97,8 +96,8 @@ internal partial class PropertyGridView
                     (delegate* unmanaged[Stdcall]<int, WPARAM, LPARAM, LRESULT>)hook,
                     (HINSTANCE)0,
                     PInvoke.GetCurrentThreadId());
+
                 Debug.Assert(!_mouseHookHandle.IsNull, "Failed to install mouse hook");
-                CompModSwitches.DebugGridView.TraceVerbose("DropDownHolder:HookMouse()");
             }
         }
 
@@ -146,7 +145,6 @@ internal partial class PropertyGridView
                 {
                     PInvoke.UnhookWindowsHookEx(_mouseHookHandle);
                     _mouseHookHandle = default;
-                    CompModSwitches.DebugGridView.TraceVerbose("DropDownHolder:UnhookMouse()");
                 }
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.cs
@@ -22,8 +22,6 @@ internal sealed partial class PropertyGridView :
 {
     private static Point InvalidPoint { get; } = new(int.MinValue, int.MinValue);
 
-    private static readonly TraceSwitch s_gridViewDebugPaint = new("GridViewDebugPaint", "PropertyGridView: Debug property painting");
-
     // Constants
     private const int EditIndent = 0;
     private const int OutlineIndent = 10;
@@ -676,9 +674,6 @@ internal sealed partial class PropertyGridView :
 
     private static void AdjustOrigin(Graphics g, Point newOrigin, ref Rectangle r)
     {
-        s_gridViewDebugPaint.TraceVerbose(
-            $"Adjusting paint origin to ({newOrigin.X},{newOrigin.Y})");
-
         g.ResetTransform();
         g.TranslateTransform(newOrigin.X, newOrigin.Y);
         r.Offset(-newOrigin.X, -newOrigin.Y);
@@ -686,7 +681,6 @@ internal sealed partial class PropertyGridView :
 
     private void CancelSplitterMove()
     {
-        CompModSwitches.DebugGridView.TraceVerbose("PropertyGridView:CancelSplitterMove");
         if (_flags.HasFlag(Flags.IsSplitterMove))
         {
             SetFlag(Flags.IsSplitterMove, false);
@@ -703,7 +697,6 @@ internal sealed partial class PropertyGridView :
 
     private void ClearGridEntryEvents(GridEntryCollection? entries, int startIndex, int count)
     {
-        CompModSwitches.DebugGridView.TraceVerbose("PropertyGridView:ClearGridEntryEvents");
         if (entries is null)
         {
             return;
@@ -729,8 +722,6 @@ internal sealed partial class PropertyGridView :
 
     public void ClearGridEntries()
     {
-        CompModSwitches.DebugGridView.TraceVerbose("PropertyGridView:ClearGridEntries");
-
         if (!HasEntries)
         {
             return;
@@ -751,8 +742,6 @@ internal sealed partial class PropertyGridView :
 
     private void CloseDropDownInternal(bool resetFocus)
     {
-        CompModSwitches.DebugGridView.TraceVerbose("PropertyGridView:CloseDropDown");
-
         // The activation code in the DropDownHolder can cause this to recurse.
 
         if (_flags.HasFlag(Flags.DropDownClosing) || _dropDownHolder is null || !_dropDownHolder.Visible)
@@ -822,8 +811,6 @@ internal sealed partial class PropertyGridView :
 
     private void CommonEditorHide(bool always = false)
     {
-        CompModSwitches.DebugGridView.TraceVerbose("PropertyGridView:CommonEditorHide");
-
         if (!always && !HasEntries)
         {
             return;
@@ -882,16 +869,12 @@ internal sealed partial class PropertyGridView :
 
     private void CommonEditorSetup(Control control)
     {
-        CompModSwitches.DebugGridView.TraceVerbose("PropertyGridView:CommonEditorSetup");
         control.Visible = false;
         Controls.Add(control);
     }
 
     private void CommonEditorUse(Control control, Rectangle targetRectangle)
     {
-        CompModSwitches.DebugGridView.TraceVerbose("PropertyGridView:CommonEditorUse");
-        s_gridViewDebugPaint.TraceVerbose("Showing common editors");
-
         Debug.Assert(control is not null, "Null control passed to CommonEditorUse");
 
         Rectangle rectCur = control.Bounds;
@@ -930,7 +913,6 @@ internal sealed partial class PropertyGridView :
 
     private static int CountPropertiesFromOutline(GridEntryCollection? entries)
     {
-        CompModSwitches.DebugGridView.TraceVerbose("PropertyGridView:CountPropertiesFromOutline");
         if (entries is null)
         {
             return 0;
@@ -976,7 +958,6 @@ internal sealed partial class PropertyGridView :
     {
         if (disposing)
         {
-            CompModSwitches.DebugGridView.TraceVerbose("PropertyGridView:Dispose");
             _scrollBar?.Dispose();
             _listBox?.Dispose();
             _dropDownHolder?.Dispose();
@@ -1112,8 +1093,6 @@ internal sealed partial class PropertyGridView :
             return;
         }
 
-        s_gridViewDebugPaint.TraceVerbose($"Drawing label for property {gridEntry.PropertyLabel}");
-
         Point newOrigin = new(rect.X, rect.Y);
         clipRect = Rectangle.Intersect(rect, clipRect);
 
@@ -1162,8 +1141,6 @@ internal sealed partial class PropertyGridView :
         {
             return;
         }
-
-        s_gridViewDebugPaint.TraceVerbose($"Drawing value for property {gridEntry.PropertyLabel}");
 
         Rectangle rect = GetRectangle(row, RowValue);
         Point newOrigin = new(rect.X, rect.Y);
@@ -1246,14 +1223,11 @@ internal sealed partial class PropertyGridView :
 
     public void DoubleClickRow(int row, bool toggleExpand, int type)
     {
-        CompModSwitches.DebugGridView.TraceVerbose("PropertyGridView:DoubleClickRow");
         GridEntry? gridEntry = GetGridEntryFromRow(row);
         if (gridEntry is null)
         {
             return;
         }
-
-        s_gridViewDebugPaint.TraceVerbose($"Property {gridEntry.PropertyLabel} double clicked");
 
         if (!toggleExpand || type == RowValue)
         {
@@ -1420,14 +1394,10 @@ internal sealed partial class PropertyGridView :
 
     public void DropDownControl(Control control)
     {
-        CompModSwitches.DebugGridView.TraceVerbose("PropertyGridView:DropDownControl");
-
         if (control is null)
         {
             return;
         }
-
-        s_gridViewDebugPaint.TraceVerbose($"DropDownControl(ctl = {control.GetType().Name})");
 
         _dropDownHolder ??= new(this);
         _dropDownHolder.Visible = false;
@@ -1496,7 +1466,6 @@ internal sealed partial class PropertyGridView :
 
     public void DropDownUpdate()
     {
-        CompModSwitches.DebugGridView.TraceVerbose("DropDownHolder:DropDownUpdate");
         if (_dropDownHolder is not null && _dropDownHolder.GetUsed())
         {
             int row = _selectedRow;
@@ -1595,8 +1564,6 @@ internal sealed partial class PropertyGridView :
         {
             return;
         }
-
-        CompModSwitches.DebugGridView.TraceVerbose("PropertyGridView:FilterKeyPress()");
 
         EditTextBox.FilterKeyPress(keyChar);
     }
@@ -1839,7 +1806,6 @@ internal sealed partial class PropertyGridView :
 
     private static int GetGridEntriesFromOutline(GridEntryCollection? entries, int current, int target, GridEntry[] targetEntries)
     {
-        CompModSwitches.DebugGridView.TraceVerbose("PropertyGridView:GetGridEntriesFromOutline");
         if (entries is null || entries.Count == 0)
         {
             return current;
@@ -2020,9 +1986,6 @@ internal sealed partial class PropertyGridView :
 
     private void InvalidateRows(int startRow, int endRow, int type)
     {
-        CompModSwitches.DebugGridView.TraceVerbose("PropertyGridView:InvalidateRows");
-
-        s_gridViewDebugPaint.TraceVerbose($"Invalidating rows {startRow} through {endRow}");
         Rectangle rect;
 
         // Invalidate from the start row down.
@@ -2091,12 +2054,11 @@ internal sealed partial class PropertyGridView :
     private bool IsScrollValueValid(int newValue)
     {
         // Is this move valid?
-        if (newValue == ScrollBar.Value ||
-            newValue < 0 ||
-            newValue > ScrollBar.Maximum ||
-            (newValue + (ScrollBar.LargeChange - 1) >= TotalProperties))
+        if (newValue == ScrollBar.Value
+            || newValue < 0
+            || newValue > ScrollBar.Maximum
+            || (newValue + (ScrollBar.LargeChange - 1) >= TotalProperties))
         {
-            CompModSwitches.DebugGridView.TraceVerbose("PropertyGridView: move not needed, returning");
             return false;
         }
 
@@ -2190,7 +2152,6 @@ internal sealed partial class PropertyGridView :
 
     private void OnChildLostFocus(object? sender, EventArgs e)
     {
-        CompModSwitches.DebugGridView.TraceVerbose("PropertyGridView:OnChildLostFocus");
         InvokeLostFocus(this, e);
     }
 
@@ -2204,8 +2165,6 @@ internal sealed partial class PropertyGridView :
 
     protected override void OnGotFocus(EventArgs e)
     {
-        CompModSwitches.DebugGridView.TraceVerbose("PropertyGridView:OnGotFocus");
-
         base.OnGotFocus(e);
 
         if (e is not null && !InPropertySet)
@@ -2267,7 +2226,6 @@ internal sealed partial class PropertyGridView :
 
     private void OnListChange(object? sender, EventArgs e)
     {
-        CompModSwitches.DebugGridView.TraceVerbose("PropertyGridView:OnListChange");
         if (!DropDownListBox.InSetSelectedIndex())
         {
             GridEntry? gridEntry = GetGridEntryFromRow(_selectedRow);
@@ -2286,7 +2244,6 @@ internal sealed partial class PropertyGridView :
 
     private void OnListClick(object? sender, EventArgs? e)
     {
-        CompModSwitches.DebugGridView.TraceVerbose("PropertyGridView:OnListClick");
         _ = GetGridEntryFromRow(_selectedRow);
 
         if (DropDownListBox.Items.Count == 0)
@@ -2321,7 +2278,6 @@ internal sealed partial class PropertyGridView :
 
         string text = (string)DropDownListBox.Items[e.Index];
 
-        s_gridViewDebugPaint.TraceVerbose($"Drawing list item, value='{text}'");
         e.DrawBackground();
         e.DrawFocusRectangle();
 
@@ -2363,9 +2319,6 @@ internal sealed partial class PropertyGridView :
 
     protected override void OnLostFocus(EventArgs e)
     {
-        CompModSwitches.DebugGridView.TraceVerbose("PropertyGridView:OnLostFocus");
-        s_gridViewDebugPaint.TraceVerbose("PropertyGridView lost focus");
-
         if (e is not null)
         {
             base.OnLostFocus(e);
@@ -2381,7 +2334,6 @@ internal sealed partial class PropertyGridView :
         GridEntry? gridEntry = GetGridEntryFromRow(_selectedRow);
         if (gridEntry is not null)
         {
-            s_gridViewDebugPaint.TraceVerbose("removing gridEntry focus");
             gridEntry.HasFocus = false;
             CommonEditorHide();
             InvalidateRow(_selectedRow);
@@ -2394,7 +2346,6 @@ internal sealed partial class PropertyGridView :
         if (TotalProperties <= 0)
         {
             Rectangle clearRect = new(1, 1, Size.Width - 2, Size.Height - 2);
-            s_gridViewDebugPaint.TraceVerbose($"Filling empty gridview rect={clearRect}");
 
             Color color = BackColor;
             if (color.HasTransparency())
@@ -2414,7 +2365,6 @@ internal sealed partial class PropertyGridView :
 
     private void OnEditChange(object? sender, EventArgs e)
     {
-        CompModSwitches.DebugGridView.TraceVerbose("PropertyGridView:OnEditChange");
         SetCommitError(ErrorState.None, EditTextBox.Focused);
 
         ToolTip.ToolTip = string.Empty;
@@ -2423,8 +2373,6 @@ internal sealed partial class PropertyGridView :
 
     private void OnEditGotFocus(object? sender, EventArgs e)
     {
-        CompModSwitches.DebugGridView.TraceVerbose("PropertyGridView:OnEditGotFocus");
-
         if (!EditTextBox.Visible)
         {
             Focus();
@@ -2453,7 +2401,6 @@ internal sealed partial class PropertyGridView :
 
         if (_selectedGridEntry is not null && GetRowFromGridEntry(_selectedGridEntry) != -1)
         {
-            s_gridViewDebugPaint.TraceVerbose("adding gridEntry focus");
             _selectedGridEntry.HasFocus = true;
             InvalidateRow(_selectedRow);
 
@@ -2526,7 +2473,6 @@ internal sealed partial class PropertyGridView :
 
     private void OnEditKeyDown(object? sender, KeyEventArgs e)
     {
-        CompModSwitches.DebugGridView.TraceVerbose("PropertyGridView:OnEditKeyDown");
         if (!e.Alt && (e.KeyCode == Keys.Up || e.KeyCode == Keys.Down))
         {
             GridEntry gridEntry = GetGridEntryFromRow(_selectedRow)!;
@@ -2554,7 +2500,6 @@ internal sealed partial class PropertyGridView :
 
     private void OnEditKeyPress(object? sender, KeyPressEventArgs e)
     {
-        CompModSwitches.DebugGridView.TraceVerbose("PropertyGridView:OnEditKeyPress");
         GridEntry? gridEntry = GetGridEntryFromRow(_selectedRow);
         if (gridEntry is null)
         {
@@ -2569,8 +2514,6 @@ internal sealed partial class PropertyGridView :
 
     private void OnEditLostFocus(object? sender, EventArgs e)
     {
-        CompModSwitches.DebugGridView.TraceVerbose("PropertyGridView:OnEditLostFocus");
-
         // Believe it or not this can actually happen.
         if (EditTextBox.Focused || (_errorState == ErrorState.MessageBoxUp) || (_errorState == ErrorState.Thrown) || InPropertySet)
         {
@@ -2613,8 +2556,6 @@ internal sealed partial class PropertyGridView :
 
     private void OnEditMouseDown(object? sender, MouseEventArgs e)
     {
-        CompModSwitches.DebugGridView.TraceVerbose("PropertyGridView:OnEditMouseDown");
-
         if (!FocusInside)
         {
             SelectGridEntry(_selectedGridEntry, pageIn: false);
@@ -2656,7 +2597,6 @@ internal sealed partial class PropertyGridView :
 
     private bool OnEscape(Control sender)
     {
-        CompModSwitches.DebugGridView.TraceVerbose("PropertyGridView:OnEscape");
         if ((ModifierKeys & (Keys.Alt | Keys.Control)) != 0)
         {
             return false;
@@ -3306,8 +3246,6 @@ internal sealed partial class PropertyGridView :
 
     protected override void OnPaint(PaintEventArgs e)
     {
-        CompModSwitches.DebugGridView.TraceVerbose("PropertyGridView:OnPaint");
-        s_gridViewDebugPaint.TraceVerbose($"On paint called.  Rect={e.ClipRectangle}");
         Graphics g = e.Graphics;
 
         int yPosition = 0;
@@ -3338,13 +3276,6 @@ internal sealed partial class PropertyGridView :
 
             int visibleCount = Math.Min(TotalProperties - GetScrollOffset(), 1 + _visibleRows);
 
-#if DEBUG
-            GridEntry? debugEntryStart = GetGridEntryFromRow(startRow);
-            GridEntry? debugEntryEnd = GetGridEntryFromRow(endRow);
-            string startName = debugEntryStart?.PropertyLabel ?? "(null)";
-            string endName = debugEntryEnd?.PropertyLabel ?? "(null)";
-#endif
-
             SetFlag(Flags.NeedsRefresh, false);
 
             Size size = GetOurSize();
@@ -3361,12 +3292,10 @@ internal sealed partial class PropertyGridView :
                 // Draw splitter.
                 visibleCount = Math.Min(visibleCount, endRow + 1);
 
-                s_gridViewDebugPaint.TraceVerbose("Drawing splitter");
                 using var splitterPen = OwnerGrid.LineColor.GetCachedPenScope(SplitterWidth);
                 g.DrawLine(splitterPen, _labelWidth, location.Y, _labelWidth, visibleCount * (RowHeight + 1) + location.Y);
 
                 // Draw lines.
-                s_gridViewDebugPaint.TraceVerbose("Drawing lines");
                 using var linePen = g.FindNearestColor(OwnerGrid.LineColor).GetCachedPenScope();
 
                 int currentRowHeight = 0;
@@ -3397,10 +3326,9 @@ internal sealed partial class PropertyGridView :
                             EditTextBox.Invalidate();
                         }
                     }
-                    catch
+                    catch (Exception ex) when (!ex.IsCriticalException())
                     {
-                        s_gridViewDebugPaint.TraceVerbose(
-                            $"Exception thrown during painting property {GetGridEntryFromRow(i)!.PropertyLabel}");
+                        Debug.Fail(ex.Message);
                     }
                 }
 
@@ -3414,7 +3342,6 @@ internal sealed partial class PropertyGridView :
             {
                 yPosition++;
                 Rectangle clearRect = new(1, yPosition, Size.Width - 2, Size.Height - yPosition - 1);
-                s_gridViewDebugPaint.TraceVerbose($"Filling remaining area rect={clearRect}");
 
                 using var backBrush = BackColor.GetCachedSolidBrushScope();
                 g.FillRectangle(backBrush, clearRect);
@@ -3426,15 +3353,15 @@ internal sealed partial class PropertyGridView :
 
             _boldFont = null;
         }
-        catch
+        catch (Exception ex) when (!ex.IsCriticalException())
         {
-            Debug.Fail("Caught exception in OnPaint");
+            Debug.Fail(ex.Message);
         }
     }
 
     private void OnGridEntryLabelDoubleClick(object? s, EventArgs e)
     {
-        var gridEntry = (GridEntry)s!;
+        GridEntry gridEntry = (GridEntry)s!;
 
         // If we've changed since the click (probably because we moved a row into view), bail.
         if (gridEntry != _lastClickedEntry)
@@ -3448,7 +3375,7 @@ internal sealed partial class PropertyGridView :
 
     private void OnGridEntryValueDoubleClick(object? s, EventArgs e)
     {
-        var gridEntry = (GridEntry)s!;
+        GridEntry gridEntry = (GridEntry)s!;
 
         // If we've changed since the click (probably because we moved a row into view), bail.
         if (gridEntry != _lastClickedEntry)
@@ -3640,8 +3567,6 @@ internal sealed partial class PropertyGridView :
 
     protected override void OnResize(EventArgs e)
     {
-        CompModSwitches.DebugGridView.TraceVerbose("PropertyGridView:OnResize");
-
         Rectangle newRect = ClientRectangle;
         int yDelta = _lastClientRect == Rectangle.Empty ? 0 : newRect.Height - _lastClientRect.Height;
 
@@ -3682,9 +3607,6 @@ internal sealed partial class PropertyGridView :
 
     private void OnScroll(object? sender, ScrollEventArgs e)
     {
-        CompModSwitches.DebugGridView.TraceVerbose(
-            $"PropertyGridView:OnScroll({ScrollBar.Value} -> {e.NewValue})");
-
         if (!CommitEditTextBox() || !IsScrollValueValid(e.NewValue))
         {
             // Cancel the move
@@ -3697,7 +3619,6 @@ internal sealed partial class PropertyGridView :
         if (_selectedGridEntry is not null)
         {
             oldRow = GetRowFromGridEntry(oldGridEntry);
-            CompModSwitches.DebugGridView.TraceVerbose($"OnScroll: SelectedGridEntry={oldGridEntry!.PropertyLabel}");
         }
 
         ScrollBar.Value = e.NewValue;
@@ -3731,7 +3652,6 @@ internal sealed partial class PropertyGridView :
     /// </summary>
     public unsafe void PopupEditor(int row)
     {
-        CompModSwitches.DebugGridView.TraceVerbose("PropertyGridView:PopupEditor");
         GridEntry? gridEntry = GetGridEntryFromRow(row);
         if (gridEntry is null)
         {
@@ -3875,7 +3795,6 @@ internal sealed partial class PropertyGridView :
 
     protected override bool ProcessDialogKey(Keys keyData)
     {
-        CompModSwitches.DebugGridView.TraceVerbose("PropertyGridView:ProcessDialogKey");
         if (HasEntries)
         {
             Keys keyCode = keyData & Keys.KeyCode;
@@ -3884,7 +3803,6 @@ internal sealed partial class PropertyGridView :
                 case Keys.F4:
                     if (FocusInside)
                     {
-                        CompModSwitches.DebugGridView.TraceVerbose("PropertyGridView:OnF4");
                         if (ModifierKeys != 0)
                         {
                             return false;
@@ -3992,7 +3910,6 @@ internal sealed partial class PropertyGridView :
 
     private void RecalculateProperties()
     {
-        CompModSwitches.DebugGridView.TraceVerbose("PropertyGridView:RecalculateProperties");
         int propertyCount = CountPropertiesFromOutline(TopLevelGridEntries);
         if (TotalProperties != propertyCount)
         {
@@ -4054,9 +3971,6 @@ internal sealed partial class PropertyGridView :
 
     private void Refresh(bool fullRefresh, int startRow, int endRow)
     {
-        CompModSwitches.DebugGridView.TraceVerbose("PropertyGridView:Refresh");
-        s_gridViewDebugPaint.TraceVerbose(
-            $"Refresh called for rows {startRow} through {endRow}");
         SetFlag(Flags.NeedsRefresh, true);
         GridEntry? gridEntry = null;
 
@@ -4178,7 +4092,6 @@ internal sealed partial class PropertyGridView :
 
     public void Reset()
     {
-        CompModSwitches.DebugGridView.TraceVerbose("PropertyGridView:Reset");
         GridEntry? gridEntry = GetGridEntryFromRow(_selectedRow);
         if (gridEntry is null)
         {
@@ -4277,8 +4190,6 @@ internal sealed partial class PropertyGridView :
             return;
         }
 
-        CompModSwitches.DebugGridView.TraceVerbose($"PropertyGridView:SelectGridEntry({entry.PropertyLabel})");
-
         int row = GetRowFromGridEntry(entry);
         if (row + GetScrollOffset() < 0)
         {
@@ -4324,8 +4235,6 @@ internal sealed partial class PropertyGridView :
 
     private void SelectRow(int row)
     {
-        CompModSwitches.DebugGridView.TraceVerbose($"PropertyGridView:SelectRow({row})");
-
         if (!_flags.HasFlag(Flags.IsNewSelection))
         {
             if (FocusInside)
@@ -4507,7 +4416,6 @@ internal sealed partial class PropertyGridView :
 
     public void SetConstants()
     {
-        CompModSwitches.DebugGridView.TraceVerbose("PropertyGridView:SetConstants");
         Size size = GetOurSize();
 
         _visibleRows = (int)Math.Ceiling(((double)size.Height) / (1 + RowHeight));
@@ -4537,23 +4445,6 @@ internal sealed partial class PropertyGridView :
         {
             _labelRatio = GetOurSize().Width / (double)(oldWidth - _location.X);
         }
-
-        CompModSwitches.DebugGridView.TraceVerbose($"\tsize       :{size}");
-        CompModSwitches.DebugGridView.TraceVerbose($"\tlocation   :{_location}");
-        CompModSwitches.DebugGridView.TraceVerbose($"\tvisibleRows:{_visibleRows}");
-        CompModSwitches.DebugGridView.TraceVerbose($"\tlabelWidth :{_labelWidth}");
-        CompModSwitches.DebugGridView.TraceVerbose($"\tlabelRatio :{_labelRatio}");
-        CompModSwitches.DebugGridView.TraceVerbose($"\trowHeight  :{RowHeight}");
-#if DEBUG
-        if (rgipesAll is null)
-        {
-            CompModSwitches.DebugGridView.TraceVerbose("\tIPE Count  :(null)");
-        }
-        else
-        {
-            CompModSwitches.DebugGridView.TraceVerbose($"\tIPE Count  :{rgipesAll.Count}");
-        }
-#endif
     }
 
     private void SetCommitError(ErrorState error)
@@ -4563,26 +4454,6 @@ internal sealed partial class PropertyGridView :
 
     private void SetCommitError(ErrorState error, bool capture)
     {
-#if DEBUG
-        if (CompModSwitches.DebugGridView.TraceVerbose)
-        {
-            string err = "UNKNOWN!";
-            switch (error)
-            {
-                case ErrorState.None:
-                    err = "ERROR_NONE";
-                    break;
-                case ErrorState.Thrown:
-                    err = "ERROR_THROWN";
-                    break;
-                case ErrorState.MessageBoxUp:
-                    err = "ERROR_MSGBOX_UP";
-                    break;
-            }
-
-            Debug.WriteLine($"PropertyGridView:SetCommitError(error={err}, capture={capture})");
-        }
-#endif
         _errorState = error;
         if (error != ErrorState.None)
         {
@@ -4673,7 +4544,6 @@ internal sealed partial class PropertyGridView :
 
     public void SetScrollOffset(int offset)
     {
-        CompModSwitches.DebugGridView.TraceVerbose($"PropertyGridView:SetScrollOffset({offset})");
         int newPosition = Math.Max(0, Math.Min(TotalProperties - _visibleRows + 1, offset));
         int oldPosition = ScrollBar.Value;
         if (newPosition != oldPosition && IsScrollValueValid(newPosition) && _visibleRows > 0)
@@ -4690,20 +4560,14 @@ internal sealed partial class PropertyGridView :
     /// </summary>
     internal bool CommitEditTextBox()
     {
-        CompModSwitches.DebugGridView.TraceVerbose("PropertyGridView:Commit()");
-
         if (_errorState == ErrorState.MessageBoxUp)
         {
-            CompModSwitches.DebugGridView.TraceVerbose(
-                "PropertyGridView:Commit() returning false because an error has been thrown or we are in a property set");
             return false;
         }
 
         if (!EditTextBoxNeedsCommit)
         {
             SetCommitError(ErrorState.None);
-            CompModSwitches.DebugGridView.TraceVerbose(
-                "PropertyGridView:Commit() returning true because no change has been made");
             return true;
         }
 
@@ -4758,8 +4622,6 @@ internal sealed partial class PropertyGridView :
 
     internal bool CommitValue(GridEntry entry, object? value, bool closeDropDown = true)
     {
-        CompModSwitches.DebugGridView.TraceVerbose($"PropertyGridView:CommitValue({value?.ToString() ?? "null"})");
-
         int propCount = entry.ChildCount;
         bool capture = EditTextBox.HookMouseDown;
         object? originalValue = null;
@@ -4854,8 +4716,6 @@ internal sealed partial class PropertyGridView :
 
     private bool CommitText(string text)
     {
-        CompModSwitches.DebugGridView.TraceVerbose($"PropertyGridView:CommitValue({text ?? "null"})");
-
         GridEntry? currentEntry = _selectedGridEntry;
 
         if (_selectedGridEntry is null && _selectedRow != -1)
@@ -4934,8 +4794,6 @@ internal sealed partial class PropertyGridView :
 
     private bool SetScrollbarLength()
     {
-        CompModSwitches.DebugGridView.TraceVerbose("PropertyGridView:SetScrollBarLength");
-
         if (TotalProperties == -1)
         {
             return false;
@@ -5032,8 +4890,6 @@ internal sealed partial class PropertyGridView :
     {
         propertyName ??= "(unknown)";
 
-        CompModSwitches.DebugGridView.TraceVerbose($"PropertyGridView:ShowFormatExceptionMessage(prop={propertyName})");
-
         // We have to uninstall our hook so the user can push the button!
         bool hooked = EditTextBox.HookMouseDown;
         EditTextBox.DisableMouseHook = true;
@@ -5107,8 +4963,6 @@ internal sealed partial class PropertyGridView :
     internal unsafe void ShowInvalidMessage(string propertyName, Exception? ex)
     {
         propertyName ??= "(unknown)";
-
-        CompModSwitches.DebugGridView.TraceVerbose($"PropertyGridView:ShowInvalidMessage(prop={propertyName})");
 
         // We have to uninstall our hook so the user can push the button.
         bool hooked = EditTextBox.HookMouseDown;
@@ -5314,7 +5168,6 @@ internal sealed partial class PropertyGridView :
 
     private bool UnfocusSelection()
     {
-        CompModSwitches.DebugGridView.TraceVerbose("PropertyGridView:UnfocusSelection()");
         GridEntry? gridEntry = GetGridEntryFromRow(_selectedRow);
         if (gridEntry is null)
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/RichTextBox/RichTextBox.OleCallback.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/RichTextBox/RichTextBox.OleCallback.cs
@@ -30,7 +30,6 @@ public partial class RichTextBox
 
         public HRESULT GetNewStorage(IStorage** lplpstg)
         {
-            RichTextDbg.TraceVerbose("IRichEditOleCallback::GetNewStorage");
             if (lplpstg is null)
             {
                 return HRESULT.E_POINTER;
@@ -63,35 +62,17 @@ public partial class RichTextBox
         public HRESULT GetInPlaceContext(
             IOleInPlaceFrame** lplpFrame,
             IOleInPlaceUIWindow** lplpDoc,
-            OLEINPLACEFRAMEINFO* lpFrameInfo)
-        {
-            RichTextDbg.TraceVerbose("IRichEditOleCallback::GetInPlaceContext");
-            return HRESULT.E_NOTIMPL;
-        }
+            OLEINPLACEFRAMEINFO* lpFrameInfo) => HRESULT.E_NOTIMPL;
 
-        public HRESULT ShowContainerUI(BOOL fShow)
-        {
-            RichTextDbg.TraceVerbose("IRichEditOleCallback::ShowContainerUI");
-            return HRESULT.S_OK;
-        }
+        public HRESULT ShowContainerUI(BOOL fShow) => HRESULT.S_OK;
 
-        public HRESULT QueryInsertObject(Guid* lpclsid, IStorage* lpstg, int cp)
-        {
-            RichTextDbg.TraceVerbose($"IRichEditOleCallback::QueryInsertObject({(lpclsid is null ? "null" : lpclsid->ToString())})");
-            return HRESULT.S_OK;
-        }
+        public HRESULT QueryInsertObject(Guid* lpclsid, IStorage* lpstg, int cp) => HRESULT.S_OK;
 
-        public HRESULT DeleteObject(IOleObject* lpoleobj)
-        {
-            RichTextDbg.TraceVerbose("IRichEditOleCallback::DeleteObject");
-            return HRESULT.S_OK;
-        }
+        public HRESULT DeleteObject(IOleObject* lpoleobj) => HRESULT.S_OK;
 
         /// <inheritdoc cref="IRichEditOleCallback.QueryAcceptData(Com.IDataObject*, ushort*, RECO_FLAGS, BOOL, HGLOBAL)"/>
         public HRESULT QueryAcceptData(Com.IDataObject* lpdataobj, ushort* lpcfFormat, RECO_FLAGS reco, BOOL fReally, HGLOBAL hMetaPict)
         {
-            RichTextDbg.TraceVerbose($"IRichEditOleCallback::QueryAcceptData(reco={reco})");
-
             if (reco != RECO_FLAGS.RECO_DROP)
             {
                 return HRESULT.E_NOTIMPL;
@@ -99,7 +80,6 @@ public partial class RichTextBox
 
             if (!_owner.AllowDrop && !_owner.EnableAutoDragDrop)
             {
-                RichTextDbg.TraceVerbose("\tCancel data, allowdrop == false");
                 _lastDataObject = null;
                 return HRESULT.E_FAIL;
             }
@@ -201,29 +181,12 @@ public partial class RichTextBox
             }
 
             _lastEffect = e.Effect;
-            if (e.Effect == DragDropEffects.None)
-            {
-                RichTextDbg.TraceVerbose("\tCancel data");
-                return HRESULT.E_FAIL;
-            }
-            else
-            {
-                RichTextDbg.TraceVerbose("\tAccept data");
-                return HRESULT.S_OK;
-            }
+            return e.Effect == DragDropEffects.None ? HRESULT.E_FAIL : HRESULT.S_OK;
         }
 
-        public HRESULT ContextSensitiveHelp(BOOL fEnterMode)
-        {
-            RichTextDbg.TraceVerbose("IRichEditOleCallback::ContextSensitiveHelp");
-            return HRESULT.E_NOTIMPL;
-        }
+        public HRESULT ContextSensitiveHelp(BOOL fEnterMode) => HRESULT.E_NOTIMPL;
 
-        public HRESULT GetClipboardData(CHARRANGE* lpchrg, uint reco, Com.IDataObject** lplpdataobj)
-        {
-            RichTextDbg.TraceVerbose("IRichEditOleCallback::GetClipboardData");
-            return HRESULT.E_NOTIMPL;
-        }
+        public HRESULT GetClipboardData(CHARRANGE* lpchrg, uint reco, Com.IDataObject** lplpdataobj) => HRESULT.E_NOTIMPL;
 
         public unsafe HRESULT GetDragDropEffect(BOOL fDrag, MODIFIERKEYS_FLAGS grfKeyState, DROPEFFECT* pdwEffect)
         {
@@ -231,8 +194,6 @@ public partial class RichTextBox
             {
                 return HRESULT.E_POINTER;
             }
-
-            RichTextDbg.TraceVerbose("IRichEditOleCallback::GetDragDropEffect");
 
             if (!_owner.AllowDrop && !_owner.EnableAutoDragDrop)
             {
@@ -314,8 +275,6 @@ public partial class RichTextBox
             CHARRANGE* lpchrg,
             HMENU* hmenu)
         {
-            RichTextDbg.TraceVerbose("IRichEditOleCallback::GetContextMenu");
-
             // Do nothing, we don't have ContextMenu any longer
             if (hmenu is not null)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/RichTextBox/RichTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/RichTextBox/RichTextBox.cs
@@ -23,18 +23,6 @@ namespace System.Windows.Forms;
 [SRDescription(nameof(SR.DescriptionRichTextBox))]
 public partial class RichTextBox : TextBoxBase
 {
-    private static TraceSwitch? s_richTextDbg;
-
-    private static TraceSwitch RichTextDbg
-    {
-        get
-        {
-            s_richTextDbg ??= new TraceSwitch("RichTextDbg", "Debug info about RichTextBox");
-
-            return s_richTextDbg;
-        }
-    }
-
     /// <summary>
     ///  Paste special flags.
     /// </summary>
@@ -3097,7 +3085,6 @@ public partial class RichTextBox : TextBoxBase
 
     private void UpdateOleCallback()
     {
-        RichTextDbg.TraceVerbose($"update ole callback ({AllowDrop})");
         if (!IsHandleCreated)
         {
             return;
@@ -3105,8 +3092,6 @@ public partial class RichTextBox : TextBoxBase
 
         if (_oleCallback is null)
         {
-            RichTextDbg.TraceVerbose("binding ole callback");
-
             AllowOleObjects = true;
 
             _oleCallback = CreateRichEditOleCallback();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStrip.RestoreFocusMessageFilter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStrip.RestoreFocusMessageFilter.cs
@@ -54,12 +54,7 @@ public partial class ToolStrip
 
         private void RestoreFocusInternal()
         {
-            s_snapFocusDebug.TraceVerbose("[ToolStrip.RestoreFocusFilter] Detected a click, restoring focus.");
-
             _ownerToolStrip.BeginInvoke(new BooleanMethodInvoker(_ownerToolStrip.RestoreFocusInternal), [ToolStripManager.ModalMenuFilter.InMenuMode]);
-
-            // PERF
-
             Application.ThreadContext.FromCurrent().RemoveMessageFilter(this);
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStrip.cs
@@ -106,32 +106,6 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
     internal const int STATE_LASTMOUSEDOWNEDITEMCAPTURE = 0x00004000;
     internal const int STATE_MENUACTIVE = 0x00008000;
 
-#if DEBUG
-    internal static readonly TraceSwitch s_selectionDebug = new("SelectionDebug", "Debug ToolStrip Selection code");
-    internal static readonly TraceSwitch s_dropTargetDebug = new("DropTargetDebug", "Debug ToolStrip Drop code");
-    internal static readonly TraceSwitch s_layoutDebugSwitch = new("Layout debug", "Debug ToolStrip layout code");
-    internal static readonly TraceSwitch s_mouseActivateDebug = new("ToolStripMouseActivate", "Debug ToolStrip WM_MOUSEACTIVATE code");
-    internal static readonly TraceSwitch s_mergeDebug = new("ToolStripMergeDebug", "Debug toolstrip merging");
-    internal static readonly TraceSwitch s_snapFocusDebug = new("SnapFocus", "Debug snapping/restoration of focus");
-    internal static readonly TraceSwitch s_flickerDebug = new("FlickerDebug", "Debug excessive calls to Invalidate()");
-    internal static readonly TraceSwitch s_itemReorderDebug = new("ItemReorderDebug", "Debug excessive calls to Invalidate()");
-    internal static readonly TraceSwitch s_mdiMergeDebug = new("MDIMergeDebug", "Debug toolstrip MDI merging");
-    internal static readonly TraceSwitch s_menuAutoExpandDebug = new("MenuAutoExpand", "Debug menu auto expand");
-    internal static readonly TraceSwitch s_controlTabDebug = new("ControlTab", "Debug ToolStrip Control+Tab selection");
-#else
-    internal static readonly TraceSwitch? s_selectionDebug;
-    internal static readonly TraceSwitch? s_dropTargetDebug;
-    internal static readonly TraceSwitch? s_layoutDebugSwitch;
-    internal static readonly TraceSwitch? s_mouseActivateDebug;
-    internal static readonly TraceSwitch? s_mergeDebug;
-    internal static readonly TraceSwitch? s_snapFocusDebug;
-    internal static readonly TraceSwitch? s_flickerDebug;
-    internal static readonly TraceSwitch? s_itemReorderDebug;
-    internal static readonly TraceSwitch? s_mdiMergeDebug;
-    internal static readonly TraceSwitch? s_menuAutoExpandDebug;
-    internal static readonly TraceSwitch? s_controlTabDebug;
-#endif
-
     private delegate void BooleanMethodInvoker(bool arg);
     internal Action<int, int>? _rescaleConstsCallbackDelegate;
 
@@ -1908,7 +1882,6 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
                 if (displayedItems[i].Selected)
                 {
                     displayedItems[i].Unselect();
-                    s_selectionDebug.TraceVerbose($"[SelectDBG ClearAllSelectionsExcept] Unselecting {displayedItems[i].Text}");
                     invalidate = true;
                 }
 
@@ -2039,7 +2012,6 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
                 // if we were the last toolstrip in the queue, exit menu mode.
                 if (exitMenuMode && ToolStripManager.ModalMenuFilter.GetActiveToolStrip() is null)
                 {
-                    s_snapFocusDebug.TraceVerbose("Exiting menu mode because we're the last toolstrip in the queue, and we've disposed.");
                     ToolStripManager.ModalMenuFilter.ExitMenuMode();
                 }
 
@@ -2183,12 +2155,8 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
         int current = DisplayedItems.IndexOf(start);
         if (current == -1)
         {
-            s_selectionDebug.TraceVerbose("Started from a visible = false item");
             return null;
         }
-
-        Debug.WriteLineIf(s_selectionDebug!.TraceVerbose && (current != -1), $"[SelectDBG GetNextToolStripItem] Last selected item was {DisplayedItems[current].Text}");
-        Debug.WriteLineIf(s_selectionDebug!.TraceVerbose && (current == -1), "[SelectDBG GetNextToolStripItem] Last selected item was null");
 
         int count = DisplayedItems.Count;
 
@@ -2211,8 +2179,6 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
 
             if (DisplayedItems[current].CanKeyboardSelect)
             {
-                s_selectionDebug.TraceVerbose($"[SelectDBG GetNextToolStripItem] selecting {DisplayedItems[current].Text}");
-                // ClearAllSelectionsExcept(Items[current]);
                 return DisplayedItems[current];
             }
         }
@@ -2277,12 +2243,13 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
             double hypotenuse = Math.Sqrt(adjacentSide * adjacentSide + oppositeSide * oppositeSide);
 
             if (adjacentSide != 0)
-            { // avoid divide by zero - we don't do layered controls
-              //    _[o]
-              //    |/
-              //   [s]
-              //   get the angle between s and o by taking the arctan.
-              //   PERF consider using approximation instead
+            {
+                // avoid divide by zero - we don't do layered controls
+                //    _[o]
+                //    |/
+                //   [s]
+                //   get the angle between s and o by taking the arctan.
+                //   PERF consider using approximation instead
                 double tan = Math.Abs(Math.Atan(oppositeSide / adjacentSide));
 
                 // we want the thing with the smallest angle and smallest distance between midpoints
@@ -2540,8 +2507,7 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
 
     private void HandleMouseLeave()
     {
-        // If we had a particular item that was "entered"
-        // notify it that we have left.
+        // If we had a particular item that was "entered" notify it that we have left.
         if (_lastMouseActiveItem is not null)
         {
             if (!DesignMode)
@@ -2551,12 +2517,10 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
 
             try
             {
-                ToolStripItem.s_mouseDebugging.TraceVerbose($"firing mouse leave on {_lastMouseActiveItem}");
                 _lastMouseActiveItem.FireEvent(EventArgs.Empty, ToolStripItemEventType.MouseLeave);
             }
             finally
             {
-                ToolStripItem.s_mouseDebugging.TraceVerbose("setting last active item to null");
                 _lastMouseActiveItem = null;
             }
         }
@@ -2803,7 +2767,6 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
             {
                 ClearAllSelections();
                 ToolStripManager.ModalMenuFilter.MenuKeyToggle = true;
-                s_snapFocusDebug.TraceVerbose("[ToolStrip.ProcessCmdKey] Detected a second ALT keypress while in Menu Mode.");
                 ToolStripManager.ModalMenuFilter.ExitMenuMode();
             }
         }
@@ -2939,21 +2902,19 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
             return retVal;
         }
 
-        s_selectionDebug.TraceVerbose("[SelectDBG ProcessDialogKey] calling base");
         return base.ProcessDialogKey(keyData);
     }
 
     internal virtual void ProcessDuplicateMnemonic(ToolStripItem item, char charCode)
     {
         if (!CanProcessMnemonic())
-        {  // Checking again for security...
+        {
+            // Checking again for security.
             return;
         }
 
-        //
         if (item is not null)
         {
-            //
             SetFocusUnsafe();
             item.Select();
         }
@@ -3003,7 +2964,8 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
     private bool ProcessMnemonicInternal(char charCode)
     {
         if (!CanProcessMnemonic())
-        {  // Checking again for security...
+        {
+            // Checking again for security.
             return false;
         }
 
@@ -3175,7 +3137,6 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
     internal virtual bool ProcessArrowKey(Keys keyCode)
     {
         bool retVal = false;
-        s_menuAutoExpandDebug.TraceVerbose("[ToolStrip.ProcessArrowKey] MenuTimer.Cancel called");
         ToolStripMenuItem.MenuTimer.Cancel();
 
         switch (keyCode)
@@ -3229,12 +3190,10 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
     {
         if (item is null)
         {
-            s_selectionDebug.TraceVerbose("[SelectDBG NotifySelectionChange] none should be selected");
             ClearAllSelections();
         }
         else if (item.Selected)
         {
-            s_selectionDebug.TraceVerbose($"[SelectDBG NotifySelectionChange] Notify selection change: {item}: {item.Selected}");
             ClearAllSelectionsExcept(item);
         }
     }
@@ -3311,39 +3270,6 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
             Items[i].OnOwnerFontChanged(e);
         }
     }
-
-#if DEBUG
-#pragma warning disable RS0016 // Add public types and members to the declared API
-    protected override void OnInvalidated(InvalidateEventArgs e)
-    {
-        base.OnInvalidated(e);
-        // Debug code which is helpful for FlickerFest debugging.
-        if (s_flickerDebug.TraceVerbose)
-        {
-            string name = Name;
-            if (string.IsNullOrEmpty(name))
-            {
-                if (IsDropDown)
-                {
-                    ToolStripItem? item = ((ToolStripDropDown)this).OwnerItem;
-                    if (item is not null && item.Name is not null)
-                    {
-                        name = item.Name = ".DropDown";
-                    }
-                }
-
-                if (string.IsNullOrEmpty(name))
-                {
-                    name = GetType().Name;
-                }
-            }
-
-            // for debugging VS we want to filter out the propgrid toolstrip
-            Debug.WriteLineIf(ParentInternal is not PropertyGrid, $"Invalidate called on: {name}{new StackTrace()}");
-        }
-    }
-#pragma warning restore RS0016 // Add public types and members to the declared API
-#endif
 
     protected override void OnHandleCreated(EventArgs e)
     {
@@ -3466,10 +3392,6 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
         base.OnLeave(e);
         if (!IsDropDown)
         {
-            s_snapFocusDebug.TraceVerbose("uninstalling RestoreFocusFilter");
-
-            // PERF,
-
             Application.ThreadContext.FromCurrent().RemoveMessageFilter(RestoreFocusFilter);
         }
     }
@@ -3522,8 +3444,6 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
     /// </summary>
     protected override void OnMouseMove(MouseEventArgs mea)
     {
-        ToolStripItem.s_mouseDebugging.TraceVerbose("OnMouseMove called");
-
         ToolStripItem? item = GetItemAt(mea.X, mea.Y);
 
         if (!Grip.MovingToolStrip)
@@ -3534,20 +3454,16 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
             // control's WM_MOUSEMOVE. Waiting until this event gives us
             // the actual coordinates.
 
-            ToolStripItem.s_mouseDebugging.TraceVerbose($"Item to get mouse move: {(item is null ? "null" : item.ToString())}");
             if (item != _lastMouseActiveItem)
             {
-                ToolStripItem.s_mouseDebugging.TraceVerbose($"This is a new item - last item to get was {(_lastMouseActiveItem is null ? "null" : _lastMouseActiveItem.ToString())}");
-
-                // notify the item that we've moved on
+                // Notify the item that we've moved on.
                 HandleMouseLeave();
 
-                // track only items that don't get mouse events themselves.
+                // Track only items that don't get mouse events themselves.
                 _lastMouseActiveItem = (item is ToolStripControlHost) ? null : item;
 
                 if (_lastMouseActiveItem is not null)
                 {
-                    ToolStripItem.s_mouseDebugging.TraceVerbose($"Firing MouseEnter on: {_lastMouseActiveItem}");
                     item!.FireEvent(EventArgs.Empty, ToolStripItemEventType.MouseEnter);
                 }
 
@@ -3564,8 +3480,6 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
 
         if (item is not null)
         {
-            ToolStripItem.s_mouseDebugging.TraceVerbose($"Firing MouseMove on: {item}");
-
             // Fire mouse move on the item
             // Transpose this to "client coordinates" of the ToolStripItem.
             Point itemRelativePoint = item!.TranslatePoint(new Point(mea.X, mea.Y), ToolStripPointType.ToolStripCoords, ToolStripPointType.ToolStripItemCoords);
@@ -3574,8 +3488,6 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
         }
         else
         {
-            ToolStripItem.s_mouseDebugging.TraceVerbose($"Firing MouseMove on: {(this is null ? "null" : ToString())}");
-
             base.OnMouseMove(mea);
         }
     }
@@ -4152,19 +4064,12 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
         ClearAllSelections();
         _lastMouseDownedItem = null;
 
-        s_snapFocusDebug.TraceVerbose("[ToolStrip.RestoreFocus] Someone has called RestoreFocus, exiting MenuMode.");
         ToolStripManager.ModalMenuFilter.ExitMenuMode();
 
         if (!IsDropDown)
         {
-            // reset menu auto expansion.
-            s_snapFocusDebug.TraceVerbose("[ToolStrip.RestoreFocus] Setting menu auto expand to false");
-            s_snapFocusDebug.TraceVerbose("[ToolStrip.RestoreFocus] uninstalling RestoreFocusFilter");
-
-            // PERF,
-
+            // Reset menu auto expansion.
             Application.ThreadContext.FromCurrent().RemoveMessageFilter(RestoreFocusFilter);
-
             MenuAutoExpand = false;
 
             if (!DesignMode && !TabStop && (Focused || ContainsFocus))
@@ -4191,10 +4096,6 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
         if (!_hwndThatLostFocus.IsNull && (_hwndThatLostFocus != Handle))
         {
             Control? control = FromHandle(_hwndThatLostFocus);
-
-            s_snapFocusDebug.TraceVerbose(
-                $"[ToolStrip RestoreFocus]: Will Restore Focus to: {WindowsFormsUtils.GetControlInformation(_hwndThatLostFocus)}");
-
             _hwndThatLostFocus = default;
 
             if ((control is not null) && control.Visible)
@@ -4309,19 +4210,15 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
         // which could accidentally change selection.
         if (_mouseEnterWhenShown == s_invalidMouseEnter)
         {
-            ToolStripItem.s_mouseDebugging.TraceVerbose("[TS: ShouldSelectItem] MouseEnter already reset.");
             return true;
         }
 
         Point mousePosition = WindowsFormsUtils.LastCursorPoint;
         if (_mouseEnterWhenShown != mousePosition)
         {
-            ToolStripItem.s_mouseDebugging.TraceVerbose("[TS: ShouldSelectItem] Mouse position has changed - call Select().");
             _mouseEnterWhenShown = s_invalidMouseEnter;
             return true;
         }
-
-        ToolStripItem.s_mouseDebugging.TraceVerbose("[TS: ShouldSelectItem] Mouse hasnt actually moved yet.");
 
         return false;
     }
@@ -4357,13 +4254,11 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
     {
         if (TabStop)
         {
-            s_snapFocusDebug.TraceVerbose("[ToolStrip.SetFocus] Focusing toolstrip.");
             Focus();
         }
         else
         {
-            s_snapFocusDebug.TraceVerbose("[ToolStrip.SetFocus] Entering menu mode.");
-            ToolStripManager.ModalMenuFilter.SetActiveToolStrip(this, /*menuKeyPressed=*/false);
+            ToolStripManager.ModalMenuFilter.SetActiveToolStrip(this, menuKeyPressed: false);
         }
     }
 
@@ -4528,7 +4423,6 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
         {
             // NOT a SplitStack layout.  We don't change the order of the displayed items collection
             // for custom keyboard handling override GetNextItem.
-            s_layoutDebugSwitch.TraceVerbose($"Setting Displayed Items: Current bounds: {Bounds}");
             Rectangle clientBounds = ClientRectangle;
 
             // for all other layout managers, we ignore overflow placement
@@ -4543,8 +4437,9 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
                     bool boundsCheck = !IsDropDown;
                     bool intersects = item.Bounds.IntersectsWith(clientBounds);
 
-                    bool verticallyContained = clientBounds.Contains(clientBounds.X, item.Bounds.Top) &&
-                                            clientBounds.Contains(clientBounds.X, item.Bounds.Bottom);
+                    bool verticallyContained = clientBounds.Contains(clientBounds.X, item.Bounds.Top)
+                        && clientBounds.Contains(clientBounds.X, item.Bounds.Bottom);
+
                     if (!verticallyContained)
                     {
                         allContained = false;
@@ -4562,8 +4457,6 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
                 {
                     item.SetPlacement(ToolStripItemPlacement.None);
                 }
-
-                s_layoutDebugSwitch.TraceVerbose($"{item}{item.Bounds}");
             }
 
             // For performance we calculate this here, since we're already iterating over the items.
@@ -4603,9 +4496,6 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
     /// </summary>
     private void SnapFocus(HWND otherHwnd)
     {
-#if DEBUG
-        Debug.WriteLineIf(s_snapFocusDebug.TraceVerbose, $"{!Environment.StackTrace.Contains("FocusInternal")}", "who is setting focus to us?");
-#endif
         // we need to know who sent us focus so we know who to send it back to later.
 
         if (!TabStop && !IsDropDown)
@@ -4638,9 +4528,6 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
 
                     if (thisHwndRoot == otherHwndRoot && !thisHwndRoot.IsNull)
                     {
-                        s_snapFocusDebug.TraceVerbose(
-                            $"[ToolStrip SnapFocus]: Caching for return focus:{WindowsFormsUtils.GetControlInformation(otherHwnd)}");
-
                         // We know we're in the same window heirarchy.
                         _hwndThatLostFocus = otherHwnd;
                     }
@@ -4837,8 +4724,6 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
                 SnapFocus(PInvoke.GetFocus());
                 if (!IsDropDown && !TabStop)
                 {
-                    s_snapFocusDebug.TraceVerbose("Installing restoreFocusFilter");
-                    // PERF
                     Application.ThreadContext.FromCurrent().AddMessageFilter(RestoreFocusFilter);
                 }
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripDropDownItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripDropDownItem.cs
@@ -573,35 +573,31 @@ public abstract class ToolStripDropDownItem : ToolStripItem
         {
             if (isTopLevel && (keyCode == Keys.Down || keyCode == Keys.Up || keyCode == Keys.Enter || (SupportsSpaceKey && keyCode == Keys.Space)))
             {
-                ToolStrip.s_selectionDebug.TraceVerbose("[SelectDBG ProcessDialogKey] open submenu from toplevel item");
-
                 if (Enabled || DesignMode)
                 {
                     // |__[ * File ]_____|  * is where you are.  Up or down arrow hit should expand menu.
                     ShowDropDown();
                     KeyboardToolTipStateMachine.Instance.NotifyAboutLostFocus(this);
                     DropDown.SelectNextToolStripItem(start: null, forward: true);
-                }// else eat the key
+                }
 
                 return true;
             }
             else if (!isTopLevel)
             {
-                // if we're on a DropDown - then cascade out.
+                // If we're on a DropDown - then cascade out.
                 bool menusCascadeRight = (((int)DropDownDirection & 0x0001) == 0);
                 bool forward = ((keyCode == Keys.Enter) || (SupportsSpaceKey && keyCode == Keys.Space));
                 forward = (forward || (menusCascadeRight && keyCode == Keys.Left) || (!menusCascadeRight && keyCode == Keys.Right));
 
                 if (forward)
                 {
-                    ToolStrip.s_selectionDebug.TraceVerbose("[SelectDBG ProcessDialogKey] open submenu from NON-toplevel item");
-
                     if (Enabled || DesignMode)
                     {
                         ShowDropDown();
                         KeyboardToolTipStateMachine.Instance.NotifyAboutLostFocus(this);
                         DropDown.SelectNextToolStripItem(start: null, forward: true);
-                    } // else eat the key
+                    }
 
                     return true;
                 }
@@ -623,27 +619,20 @@ public abstract class ToolStripDropDownItem : ToolStripItem
 
             if (backward)
             {
-                ToolStrip.s_selectionDebug.TraceVerbose("[SelectDBG ProcessDialogKey] close submenu from NON-toplevel item");
-
-                // we're on a drop down but we're heading back up the chain.
-                // remember to select the item that displayed this dropdown.
+                // We're on a drop down but we're heading back up the chain.
+                // Remember to select the item that displayed this dropdown.
                 ToolStripDropDown? parent = GetCurrentParentDropDown();
                 if (parent is not null && !parent.IsFirstDropDown)
                 {
-                    // we're walking back up the dropdown chain.
+                    // We're walking back up the dropdown chain.
                     parent.SetCloseReason(ToolStripDropDownCloseReason.Keyboard);
                     KeyboardToolTipStateMachine.Instance.NotifyAboutLostFocus(this);
                     parent.SelectPreviousToolStrip();
                     return true;
                 }
-
-                // else if (parent.IsFirstDropDown)
-                //    the base handling (ToolStripDropDown.ProcessArrowKey) will perform auto-expansion of
-                //    the previous item in the menu.
             }
         }
 
-        ToolStrip.s_selectionDebug.TraceVerbose("[SelectDBG ProcessDialogKey] ddi calling base");
         return base.ProcessDialogKey(keyData);
     }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripDropTargetManager.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripDropTargetManager.cs
@@ -21,16 +21,7 @@ internal class ToolStripDropTargetManager : IDropTarget
     private bool _dropTargetIsEntered;
 #endif
 
-#if DEBUG
-    internal static TraceSwitch DragDropDebug { get; } = new("DragDropDebug", "Debug ToolStrip DragDrop code");
-#else
-    internal static TraceSwitch? DragDropDebug { get; }
-#endif
-
-    public ToolStrip Owner
-    {
-        get => _owner;
-    }
+    public ToolStrip Owner => _owner;
 
     public ToolStripDropTargetManager(ToolStrip owner)
     {
@@ -39,26 +30,24 @@ internal class ToolStripDropTargetManager : IDropTarget
 
     public void EnsureRegistered()
     {
-        DragDropDebug.TraceVerbose("Ensuring drop target registered");
         SetAcceptDrops(true);
     }
 
     public void EnsureUnRegistered()
     {
-        DragDropDebug.TraceVerbose("Attempting to unregister droptarget");
         for (int i = 0; i < _owner.Items.Count; i++)
         {
             if (_owner.Items[i].AllowDrop)
             {
-                DragDropDebug.TraceVerbose("An item still has allowdrop set to true - can't unregister");
-                return; // can't unregister this as a drop target unless everyone is done.
+                // Can't unregister this as a drop target unless everyone is done.
+                return;
             }
         }
 
         if (_owner.AllowDrop || _owner.AllowItemReorder)
         {
-            DragDropDebug.TraceVerbose("The ToolStrip has AllowDrop or AllowItemReorder set to true - can't unregister");
-            return;  // can't unregister this as a drop target if ToolStrip is still accepting drops
+            // Can't unregister this as a drop target if ToolStrip is still accepting drops.
+            return;
         }
 
         SetAcceptDrops(false);
@@ -75,13 +64,10 @@ internal class ToolStripDropTargetManager : IDropTarget
 
     public void OnDragEnter(DragEventArgs e)
     {
-        DragDropDebug.TraceVerbose("[DRAG ENTER] ==============");
-
         // If we are supporting Item Reordering
         // and this is a ToolStripItem - snitch it.
         if (_owner.AllowItemReorder && e.Data is not null && e.Data.GetDataPresent(typeof(ToolStripItem)))
         {
-            DragDropDebug.TraceVerbose("ItemReorderTarget taking this...");
             _lastDropTarget = _owner.ItemReorderDropTarget;
         }
         else
@@ -90,28 +76,23 @@ internal class ToolStripDropTargetManager : IDropTarget
 
             if ((item is not null) && (item.AllowDrop))
             {
-                // the item wants this event
-                DragDropDebug.TraceVerbose($"ToolStripItem taking this: {item}");
-
+                // The item wants this event.
                 _lastDropTarget = item;
             }
             else if (_owner.AllowDrop)
             {
-                // the ToolStrip wants this event
-                DragDropDebug.TraceVerbose("ToolStrip taking this because AllowDrop set to true.");
+                // The ToolStrip wants this event.
                 _lastDropTarget = _owner;
             }
             else
             {
                 // There could be one item that says "AllowDrop == true" which would turn
-                // on this drop target manager.  If we're not over that particular item - then
+                // on this drop target manager. If we're not over that particular item - then
                 // just null out the last drop target manager.
 
-                // the other valid reason for being here is that we've done an AllowItemReorder
+                // The other valid reason for being here is that we've done an AllowItemReorder
                 // and we don't have a ToolStripItem contain within the data (say someone drags a link
-                // from IE over the ToolStrip)
-
-                DragDropDebug.TraceVerbose("No one wanted it.");
+                // from IE over the ToolStrip).
 
                 _lastDropTarget = null;
             }
@@ -119,7 +100,6 @@ internal class ToolStripDropTargetManager : IDropTarget
 
         if (_lastDropTarget is not null)
         {
-            DragDropDebug.TraceVerbose("Calling OnDragEnter on target...");
 #if DEBUG
             _dropTargetIsEntered = true;
 #endif
@@ -129,15 +109,12 @@ internal class ToolStripDropTargetManager : IDropTarget
 
     public void OnDragOver(DragEventArgs e)
     {
-        DragDropDebug.TraceVerbose("[DRAG OVER] ==============");
-
         IDropTarget? newDropTarget = null;
 
         // If we are supporting Item Reordering
         // and this is a ToolStripItem - snitch it.
         if (_owner.AllowItemReorder && e.Data is not null && e.Data.GetDataPresent(typeof(ToolStripItem)))
         {
-            DragDropDebug.TraceVerbose("ItemReorderTarget taking this...");
             newDropTarget = _owner.ItemReorderDropTarget;
         }
         else
@@ -146,46 +123,33 @@ internal class ToolStripDropTargetManager : IDropTarget
 
             if ((item is not null) && (item.AllowDrop))
             {
-                // the item wants this event
-                DragDropDebug.TraceVerbose($"ToolStripItem taking this: {item}");
+                // The item wants this event.
                 newDropTarget = item;
             }
             else if (_owner.AllowDrop)
             {
-                // the ToolStrip wants this event
-                DragDropDebug.TraceVerbose("ToolStrip taking this because AllowDrop set to true.");
+                // The ToolStrip wants this event.
                 newDropTarget = _owner;
             }
             else
             {
-                DragDropDebug.TraceVerbose("No one wanted it.");
                 newDropTarget = null;
             }
         }
 
-        // if we've switched drop targets - then
-        // we need to create drag enter and leave events
+        // If we've switched drop targets then we need to create drag enter and leave events.
         if (newDropTarget != _lastDropTarget)
         {
-            DragDropDebug.TraceVerbose("NEW DROP TARGET!");
             UpdateDropTarget(newDropTarget, e);
         }
 
-        // now call drag over
-        if (_lastDropTarget is not null)
-        {
-            DragDropDebug.TraceVerbose("Calling OnDragOver on target...");
-            _lastDropTarget.OnDragOver(e);
-        }
+        _lastDropTarget?.OnDragOver(e);
     }
 
     public void OnDragLeave(EventArgs e)
     {
-        DragDropDebug.TraceVerbose("[DRAG LEAVE] ==============");
-
         if (_lastDropTarget is not null)
         {
-            DragDropDebug.TraceVerbose("Calling OnDragLeave on current target...");
 #if DEBUG
             _dropTargetIsEntered = false;
 #endif
@@ -202,12 +166,8 @@ internal class ToolStripDropTargetManager : IDropTarget
 
     public void OnDragDrop(DragEventArgs e)
     {
-        DragDropDebug.TraceVerbose("[DRAG DROP] ==============");
-
         if (_lastDropTarget is not null)
         {
-            DragDropDebug.TraceVerbose("Calling OnDragDrop on current target...");
-
             _lastDropTarget.OnDragDrop(e);
         }
         else

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripDropTargetManager.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripDropTargetManager.cs
@@ -17,10 +17,6 @@ internal class ToolStripDropTargetManager : IDropTarget
     private IDropTarget? _lastDropTarget;
     private readonly ToolStrip _owner;
 
-#if DEBUG
-    private bool _dropTargetIsEntered;
-#endif
-
     public ToolStrip Owner => _owner;
 
     public ToolStripDropTargetManager(ToolStrip owner)
@@ -98,13 +94,7 @@ internal class ToolStripDropTargetManager : IDropTarget
             }
         }
 
-        if (_lastDropTarget is not null)
-        {
-#if DEBUG
-            _dropTargetIsEntered = true;
-#endif
-            _lastDropTarget.OnDragEnter(e);
-        }
+        _lastDropTarget?.OnDragEnter(e);
     }
 
     public void OnDragOver(DragEventArgs e)
@@ -148,19 +138,7 @@ internal class ToolStripDropTargetManager : IDropTarget
 
     public void OnDragLeave(EventArgs e)
     {
-        if (_lastDropTarget is not null)
-        {
-#if DEBUG
-            _dropTargetIsEntered = false;
-#endif
-            _lastDropTarget.OnDragLeave(e);
-        }
-#if DEBUG
-        else
-        {
-            Debug.Assert(!_dropTargetIsEntered, "Why do we have an entered droptarget and NO lastDropTarget?");
-        }
-#endif
+        _lastDropTarget?.OnDragLeave(e);
         _lastDropTarget = null;
     }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripManager.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripManager.cs
@@ -348,7 +348,7 @@ public static partial class ToolStripManager
             }
 
             int nextControlTabIndex = toolStrip.TabIndex;
-            ToolStrip.s_controlTabDebug.TraceVerbose($"SELECTNEXTTOOLSTRIP: start: {startTabIndex} {start.Name}");
+
             // since CanChangeSelection can iterate through all the items in a toolstrip,
             // defer the checking until we think we've got a viable TabIndex candidate.
             // this brings it to O(n+m) instead of O(n*m) where n is # toolstrips & m is avg number
@@ -357,7 +357,6 @@ public static partial class ToolStripManager
             {
                 if (nextControlTabIndex >= startTabIndex && CanChangeSelection(start, toolStrip))
                 {
-                    ToolStrip.s_controlTabDebug.TraceVerbose($"FORWARD considering selection {toolStrip.Name} {toolStrip.TabIndex}");
                     if (nextControl is null)
                     {
                         nextControl = toolStrip;
@@ -373,7 +372,6 @@ public static partial class ToolStripManager
                           && CanChangeSelection(start, toolStrip))
                 {
                     // We've found a candidate for wrapping (the one with the smallest tab index in the collection)
-                    ToolStrip.s_controlTabDebug.TraceVerbose($"\tFORWARD new wrap candidate {toolStrip.Name}");
                     wrappedControl = toolStrip;
                 }
             }
@@ -381,7 +379,6 @@ public static partial class ToolStripManager
             {
                 if (nextControlTabIndex <= startTabIndex && CanChangeSelection(start, toolStrip))
                 {
-                    ToolStrip.s_controlTabDebug.TraceVerbose($"\tREVERSE selecting {toolStrip.Name}");
                     if (nextControl is null)
                     {
                         nextControl = toolStrip;
@@ -394,21 +391,14 @@ public static partial class ToolStripManager
                     }
                 }
                 else if (((wrappedControl is null) || (toolStrip.TabIndex > wrappedControl.TabIndex))
-                           && CanChangeSelection(start, toolStrip))
+                    && CanChangeSelection(start, toolStrip))
                 {
                     // We've found a candidate for wrapping (the one with the largest tab index in the collection)
-                    ToolStrip.s_controlTabDebug.TraceVerbose($"\tREVERSE new wrap candidate {toolStrip.Name}");
-
                     wrappedControl = toolStrip;
-                }
-                else
-                {
-                    ToolStrip.s_controlTabDebug.TraceVerbose($"\tREVERSE skipping wrap candidate {toolStrip.Name}{toolStrip.TabIndex}");
                 }
             }
 
-            if (nextControl is not null
-                && Math.Abs(nextControl.TabIndex - startTabIndex) <= 1)
+            if (nextControl is not null && Math.Abs(nextControl.TabIndex - startTabIndex) <= 1)
             {
                 // If we've found a valid candidate and it's within 1
                 // then bail, we've found something close enough.
@@ -418,13 +408,10 @@ public static partial class ToolStripManager
 
         if (nextControl is not null)
         {
-            ToolStrip.s_controlTabDebug.TraceVerbose($"SELECTING {nextControl.Name}");
             return ChangeSelection(start, nextControl);
         }
         else if (wrappedControl is not null)
         {
-            ToolStrip.s_controlTabDebug.TraceVerbose($"WRAPPING {wrappedControl.Name}");
-
             return ChangeSelection(start, wrappedControl);
         }
 
@@ -911,8 +898,6 @@ public static partial class ToolStripManager
             return false;
         }
 
-        ToolStrip.s_snapFocusDebug.TraceVerbose("[ProcessMenuKey] Determining whether we should send focus to MenuStrip");
-
         Keys keyData = (Keys)(nint)m.LParamInternal;
 
         // Search for our menu to work with
@@ -932,8 +917,6 @@ public static partial class ToolStripManager
                     // Only activate the menu if there's no win32 menu. Win32 menus trump menustrips.
                     menuStripToActivate = GetMainMenuStrip(toplevelControl);
                 }
-
-                ToolStrip.s_snapFocusDebug.TraceVerbose($"[ProcessMenuKey] MenuStripToActivate is: {menuStripToActivate}");
             }
         }
 
@@ -962,28 +945,23 @@ public static partial class ToolStripManager
             {
                 // If it's Shift+F10 and we're already InMenuMode, then we
                 // need to cancel this message, otherwise we'll enter the native modal menu loop.
-                ToolStrip.s_snapFocusDebug.TraceVerbose($"[ProcessMenuKey] DETECTED SHIFT+F10{keyData}");
                 return ModalMenuFilter.InMenuMode;
             }
             else
             {
                 if (menuStripToActivate is not null && !ModalMenuFilter.MenuKeyToggle)
                 {
-                    ToolStrip.s_snapFocusDebug.TraceVerbose("[ProcessMenuKey] attempting to set focus to menustrip");
-
                     // If we've alt-tabbed away don't snap/restore focus.
                     HWND topmostParentOfMenu = PInvoke.GetAncestor(menuStripToActivate, GET_ANCESTOR_FLAGS.GA_ROOT);
                     HWND foregroundWindow = PInvokeCore.GetForegroundWindow();
 
                     if (topmostParentOfMenu == foregroundWindow)
                     {
-                        ToolStrip.s_snapFocusDebug.TraceVerbose("[ProcessMenuKey] ToolStripManager call MenuStrip.OnMenuKey");
                         return menuStripToActivate.OnMenuKey();
                     }
                 }
                 else if (menuStripToActivate is not null)
                 {
-                    ToolStrip.s_snapFocusDebug.TraceVerbose("[ProcessMenuKey] Resetting MenuKeyToggle");
                     ModalMenuFilter.MenuKeyToggle = false;
                     return true;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripMenuItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripMenuItem.cs
@@ -801,8 +801,7 @@ public partial class ToolStripMenuItem : ToolStripDropDownItem
     }
 
     /// <summary>
-    ///  Raises the <see cref="CheckedChanged"/>
-    ///  event.
+    ///  Raises the <see cref="CheckedChanged"/> event.
     /// </summary>
     protected virtual void OnCheckedChanged(EventArgs e)
     {
@@ -820,16 +819,13 @@ public partial class ToolStripMenuItem : ToolStripDropDownItem
 
     protected override void OnDropDownHide(EventArgs e)
     {
-        ToolStrip.s_menuAutoExpandDebug.TraceVerbose("[ToolStripMenuItem.OnDropDownHide] MenuTimer.Cancel called");
         MenuTimer.Cancel(this);
         base.OnDropDownHide(e);
     }
 
     protected override void OnDropDownShow(EventArgs e)
     {
-        // if someone has beaten us to the punch by arrowing around
-        // cancel the current menu timer.
-        ToolStrip.s_menuAutoExpandDebug.TraceVerbose("[ToolStripMenuItem.OnDropDownShow] MenuTimer.Cancel called");
+        // If someone has beaten us to the punch by arrowing around, cancel the current menu timer.
         MenuTimer.Cancel(this);
         if (ParentInternal is not null)
         {
@@ -852,17 +848,13 @@ public partial class ToolStripMenuItem : ToolStripDropDownItem
 
     protected override void OnMouseDown(MouseEventArgs e)
     {
-        // Opening should happen on mouse down
-        // we use a mouse down ID to ensure that the reshow
-
-        ToolStrip.s_menuAutoExpandDebug.TraceVerbose("[ToolStripMenuItem.OnMouseDown] MenuTimer.Cancel called");
         MenuTimer.Cancel(this);
-        OnMouseButtonStateChange(e, /*isMouseDown=*/true);
+        OnMouseButtonStateChange(e, isMouseDown: true);
     }
 
     protected override void OnMouseUp(MouseEventArgs e)
     {
-        OnMouseButtonStateChange(e, /*isMouseDown=*/false);
+        OnMouseButtonStateChange(e, isMouseDown: false);
         base.OnMouseUp(e);
     }
 
@@ -917,10 +909,6 @@ public partial class ToolStripMenuItem : ToolStripDropDownItem
         // If we are in a submenu pop down the submenu.
         if (ParentInternal is not null && ParentInternal.MenuAutoExpand && Selected)
         {
-            s_mouseDebugging.TraceVerbose("received mouse enter - calling drop down");
-
-            ToolStrip.s_menuAutoExpandDebug.TraceVerbose("[ToolStripMenuItem.OnMouseEnter] MenuTimer.Cancel / MenuTimer.Start called");
-
             MenuTimer.Cancel(this);
             MenuTimer.Start(this);
         }
@@ -930,7 +918,6 @@ public partial class ToolStripMenuItem : ToolStripDropDownItem
 
     protected override void OnMouseLeave(EventArgs e)
     {
-        ToolStrip.s_menuAutoExpandDebug.TraceVerbose("[ToolStripMenuItem.OnMouseLeave] MenuTimer.Cancel called");
         MenuTimer.Cancel(this);
         base.OnMouseLeave(e);
     }
@@ -1052,9 +1039,6 @@ public partial class ToolStripMenuItem : ToolStripDropDownItem
         }
     }
 
-    /// <summary>
-    ///  handle shortcut keys here.
-    /// </summary>
     protected internal override bool ProcessCmdKey(ref Message m, Keys keyData)
     {
         if (Enabled && ShortcutKeys == keyData && !HasDropDownItems)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripOverflow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripOverflow.cs
@@ -8,19 +8,12 @@ namespace System.Windows.Forms;
 
 public partial class ToolStripOverflow : ToolStripDropDown, IArrangedElement
 {
-#if DEBUG
-    internal static TraceSwitch PopupLayoutDebug { get; } = new("PopupLayoutDebug", "Debug ToolStripPopup Layout code");
-#else
-    internal static TraceSwitch? PopupLayoutDebug { get; }
-#endif
-
     private readonly ToolStripOverflowButton? _ownerItem;
 
     public ToolStripOverflow(ToolStripItem parentItem)
         : base(parentItem)
     {
         ArgumentNullException.ThrowIfNull(parentItem);
-
         _ownerItem = parentItem as ToolStripOverflowButton;
     }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripPanel.ToolStripPanelRowCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripPanel.ToolStripPanelRowCollection.cs
@@ -145,29 +145,9 @@ public partial class ToolStripPanel
             }
         }
 
-        /// <summary>
-        ///  Do proper cleanup of ownership, etc.
-        /// </summary>
-        private static void OnAfterRemove(ToolStripPanelRow? row)
-        {
-#if DEBUG
-            if (s_toolStripPanelMissingRowDebug.TraceVerbose)
-            {
-                if (row is not null)
-                {
-                    Debug.Write("Removing row: ");
-                    row.Debug_PrintRowID();
-                    Debug.WriteLine(new StackTrace().ToString());
-                }
-            }
-#endif
-
-        }
-
         public void Remove(ToolStripPanelRow value)
         {
             InnerList.Remove(value);
-            OnAfterRemove(value);
         }
 
         public void RemoveAt(int index)
@@ -179,7 +159,6 @@ public partial class ToolStripPanel
             }
 
             InnerList.RemoveAt(index);
-            OnAfterRemove(item);
         }
 
         public void CopyTo(ToolStripPanelRow[] array, int index)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripPanelRow.HorizontalRowManager.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripPanelRow.HorizontalRowManager.cs
@@ -92,7 +92,6 @@ public partial class ToolStripPanelRow
                 return totalSize.Width < DisplayRectangle.Width;
             }
 
-            s_toolStripPanelRowCreationDebug.TraceVerbose("HorizontalRM.CanMove returns false - not enough room");
             return false;
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripPanelRow.ToolStripPanelRowManager.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripPanelRow.ToolStripPanelRowManager.cs
@@ -18,25 +18,16 @@ public partial class ToolStripPanelRow
 
         public virtual bool CanMove(ToolStrip toolStripToDrag)
         {
-            if (toolStripToDrag is ISupportToolStripPanel toolStripToDragAsRaftingControl)
+            if (toolStripToDrag is ISupportToolStripPanel toolStripToDragAsRaftingControl && toolStripToDragAsRaftingControl.Stretch)
             {
-                if (toolStripToDragAsRaftingControl.Stretch)
-                {
-                    s_toolStripPanelRowCreationDebug.TraceVerbose("TSP RM CanMove returns false - the item moving is stretched.");
-                    return false;
-                }
+                return false;
             }
 
             foreach (Control control in Row.ControlsInternal)
             {
-                var controlAsRaftingControl = control as ISupportToolStripPanel;
-                if (controlAsRaftingControl is not null)
+                if (control is ISupportToolStripPanel controlAsRaftingControl && controlAsRaftingControl.Stretch)
                 {
-                    if (controlAsRaftingControl.Stretch)
-                    {
-                        s_toolStripPanelRowCreationDebug.TraceVerbose("TSP RM CanMove returns false - the row already contains a stretched item.");
-                        return false;
-                    }
+                    return false;
                 }
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripPanelRow.VerticalRowManager.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripPanelRow.VerticalRowManager.cs
@@ -94,7 +94,6 @@ public partial class ToolStripPanelRow
                 return totalSize.Height < DisplayRectangle.Height;
             }
 
-            s_toolStripPanelRowCreationDebug.TraceVerbose("VerticalRM.CanMove returns false - not enough room");
             return false;
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripPanelRow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripPanelRow.cs
@@ -31,12 +31,6 @@ public partial class ToolStripPanelRow : Component, IArrangedElement
     private static readonly int s_propControlsCollection = PropertyStore.CreateKey();
 
 #if DEBUG
-    internal static TraceSwitch s_toolStripPanelRowCreationDebug = new("ToolStripPanelRowCreationDebug", "Debug code for rafting row creation");
-#else
-    internal static TraceSwitch? s_toolStripPanelRowCreationDebug;
-#endif
-
-#if DEBUG
     private static int s_rowCreationCount;
     private readonly int _thisRowID;
 #endif
@@ -58,8 +52,6 @@ public partial class ToolStripPanelRow : Component, IArrangedElement
         ToolStripPanel = parent;
         _state[s_stateVisible] = visible;
         _state[s_stateDisposing | s_stateLocked | s_stateInitialized] = false;
-
-        s_toolStripPanelRowCreationDebug.TraceVerbose("Created new ToolStripPanelRow");
 
         using LayoutTransaction lt = new(parent, this, null);
         Margin = DefaultMargin;
@@ -301,7 +293,6 @@ public partial class ToolStripPanelRow : Component, IArrangedElement
         {
             if (disposing)
             {
-                s_toolStripPanelRowCreationDebug.TraceVerbose("Disposed ToolStripPanelRow");
                 _state[s_stateDisposing] = true;
                 ControlsInternal.Clear();
             }
@@ -315,7 +306,7 @@ public partial class ToolStripPanelRow : Component, IArrangedElement
 
     protected internal virtual void OnControlAdded(Control control, int index)
     {
-        // if previously added - remove.
+        // If previously added - remove.
 
         if (control is ISupportToolStripPanel controlToBeDragged)
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripSplitStackDragDropHandler.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripSplitStackDragDropHandler.cs
@@ -20,7 +20,6 @@ internal sealed partial class ToolStripSplitStackDragDropHandler : IDropTarget, 
 
     public void OnDragEnter(DragEventArgs e)
     {
-        ToolStrip.s_itemReorderDebug.TraceVerbose($"OnDragEnter: {e}");
         if (e.Data is not null && e.Data.GetDataPresent(typeof(ToolStripItem)))
         {
             e.Effect = DragDropEffects.Move;
@@ -30,14 +29,11 @@ internal sealed partial class ToolStripSplitStackDragDropHandler : IDropTarget, 
 
     public void OnDragLeave(EventArgs e)
     {
-        ToolStrip.s_itemReorderDebug.TraceVerbose($"OnDragLeave: {e}");
         _owner.ClearInsertionMark();
     }
 
     public void OnDragDrop(DragEventArgs e)
     {
-        ToolStrip.s_itemReorderDebug.TraceVerbose($"OnDragDrop: {e}");
-
         if (e.Data is not null && e.Data.GetDataPresent(typeof(ToolStripItem)))
         {
             ToolStripItem item = (ToolStripItem)e.Data.GetData(typeof(ToolStripItem))!;
@@ -47,8 +43,6 @@ internal sealed partial class ToolStripSplitStackDragDropHandler : IDropTarget, 
 
     public void OnDragOver(DragEventArgs e)
     {
-        ToolStrip.s_itemReorderDebug.TraceVerbose($"OnDragOver: {e}");
-
         if (e.Data is not null && e.Data.GetDataPresent(typeof(ToolStripItem)))
         {
             if (ShowItemDropPoint(_owner.PointToClient(new Point(e.X, e.Y))))
@@ -142,9 +136,6 @@ internal sealed partial class ToolStripSplitStackDragDropHandler : IDropTarget, 
             ToolStripItem item = _owner.Items[i];
             RelativeLocation relativeLocation = ComparePositions(item.Bounds, ownerClientAreaRelativeDropPoint);
 
-            ToolStrip.s_itemReorderDebug.TraceVerbose($"Drop relative loc {relativeLocation}");
-            ToolStrip.s_itemReorderDebug.TraceVerbose($"Index {i}");
-
             Rectangle insertionRect = Rectangle.Empty;
             switch (relativeLocation)
             {
@@ -184,8 +175,6 @@ internal sealed partial class ToolStripSplitStackDragDropHandler : IDropTarget, 
             bounds.Inflate(_owner.DisplayedItems[i].Margin.Size);
             if (bounds.Contains(ownerClientAreaRelativeDropPoint))
             {
-                ToolStrip.s_dropTargetDebug.TraceVerbose($"MATCH {_owner.DisplayedItems[i].Text} Bounds: {_owner.DisplayedItems[i].Bounds}");
-
                 // consider what to do about items not in the display
                 return _owner.Items.IndexOf(_owner.DisplayedItems[i]);
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripSplitStackLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripSplitStackLayout.cs
@@ -11,11 +11,6 @@ internal class ToolStripSplitStackLayout : LayoutEngine
     private Point _noMansLand;
     private Rectangle _displayRectangle = Rectangle.Empty;
 
-#if DEBUG
-    internal static TraceSwitch DebugLayoutTraceSwitch { get; } = new("DebugLayout", "Debug ToolStrip Layout code");
-#else
-    internal static TraceSwitch? DebugLayoutTraceSwitch { get; }
-#endif
     internal ToolStripSplitStackLayout(ToolStrip owner)
     {
         ToolStrip = owner;
@@ -82,7 +77,6 @@ internal class ToolStripSplitStackLayout : LayoutEngine
                 // if we have something set to overflow always we need to show an overflow button
                 if (item.Overflow == ToolStripItemOverflow.Always)
                 {
-                    DebugLayoutTraceSwitch.TraceVerbose($"OverflowRequired - item set to always overflow: {item} ");
                     OverflowRequired = true;
                 }
 
@@ -97,9 +91,7 @@ internal class ToolStripSplitStackLayout : LayoutEngine
 
                     if (currentWidth > _displayRectangle.Width - overflowWidth)
                     {
-                        DebugLayoutTraceSwitch.TraceVerbose($"SendNextItemToOverflow to free space for {item}");
                         int spaceRecovered = SendNextItemToOverflow((currentWidth + overflowWidth) - _displayRectangle.Width, true);
-
                         currentWidth -= spaceRecovered;
                     }
                 }
@@ -136,7 +128,6 @@ internal class ToolStripSplitStackLayout : LayoutEngine
                 if (item.Overflow == ToolStripItemOverflow.Always)
                 {
                     OverflowRequired = true;
-                    DebugLayoutTraceSwitch.TraceVerbose($"OverflowRequired - item set to always overflow: {item} ");
                 }
 
                 if (item.Overflow != ToolStripItemOverflow.Always && item.Placement == ToolStripItemPlacement.None)
@@ -146,12 +137,10 @@ internal class ToolStripSplitStackLayout : LayoutEngine
                     int overflowWidth = (OverflowRequired) ? OverflowButtonSize.Height : 0;
 
                     currentHeight += itemSize.Height + item.Margin.Vertical;
-                    DebugLayoutTraceSwitch.TraceVerbose($"Adding {item} Size {itemSize} to currentHeight = {currentHeight}");
+
                     if (currentHeight > _displayRectangle.Height - overflowWidth)
                     {
-                        DebugLayoutTraceSwitch.TraceVerbose($"Got to {item} and realized that currentHeight = {currentHeight} is larger than displayRect {_displayRectangle} minus overflow {overflowWidth}");
                         int spaceRecovered = SendNextItemToOverflow(currentHeight - _displayRectangle.Height, false);
-
                         currentHeight -= spaceRecovered;
                     }
                 }
@@ -221,11 +210,6 @@ internal class ToolStripSplitStackLayout : LayoutEngine
         ToolStrip toolStrip = ToolStrip;
         Rectangle clientRectangle = toolStrip.ClientRectangle;
 
-        DebugLayoutTraceSwitch.TraceVerbose($"""
-                _________________________
-                Horizontal Layout:{toolStrip}{_displayRectangle}
-                """);
-
         int lastRight = _displayRectangle.Right;
         int lastLeft = _displayRectangle.Left;
         bool needsMoreSpace = false;
@@ -291,7 +275,6 @@ internal class ToolStripSplitStackLayout : LayoutEngine
             // main.
             if (!needOverflow && (item.Overflow == ToolStripItemOverflow.AsNeeded && item.Placement == ToolStripItemPlacement.Overflow))
             {
-                DebugLayoutTraceSwitch.TraceVerbose($"Resetting {item} to Main - we don't need it to overflow");
                 item.SetPlacement(ToolStripItemPlacement.Main);
             }
 
@@ -363,8 +346,6 @@ internal class ToolStripSplitStackLayout : LayoutEngine
             {
                 item.ParentInternal = (item.Placement == ToolStripItemPlacement.Overflow) ? toolStrip.OverflowButton.DropDown : null;
             }
-
-            DebugLayoutTraceSwitch.TraceVerbose($"Item {item} Placement {item.Placement} Bounds {item.Bounds} Parent {(item.ParentInternal is null ? "null" : item.ParentInternal.ToString())}");
         }
 
         return needsMoreSpace;
@@ -372,11 +353,6 @@ internal class ToolStripSplitStackLayout : LayoutEngine
 
     private bool LayoutVertical()
     {
-        DebugLayoutTraceSwitch.TraceVerbose($"""
-            _________________________
-            Vertical Layout{_displayRectangle}
-            """);
-
         ToolStrip toolStrip = ToolStrip;
         Rectangle clientRectangle = toolStrip.ClientRectangle;
         int lastBottom = _displayRectangle.Bottom;
@@ -441,7 +417,6 @@ internal class ToolStripSplitStackLayout : LayoutEngine
             // main.
             if (!needOverflow && (item.Overflow == ToolStripItemOverflow.AsNeeded && item.Placement == ToolStripItemPlacement.Overflow))
             {
-                DebugLayoutTraceSwitch.TraceVerbose($"Resetting {item} to Main - we don't need it to overflow");
                 item.SetPlacement(ToolStripItemPlacement.Main);
             }
 
@@ -504,8 +479,6 @@ internal class ToolStripSplitStackLayout : LayoutEngine
             {
                 item.ParentInternal = (item.Placement == ToolStripItemPlacement.Overflow) ? toolStrip.OverflowButton.DropDown : null;
             }
-
-            DebugLayoutTraceSwitch.TraceVerbose($"Item {item} Placement {item.Placement} Bounds {item.Bounds} Parent {(item.ParentInternal is null ? "null" : item.ParentInternal.ToString())}");
         }
 
         return needsMoreSpace;
@@ -527,7 +500,6 @@ internal class ToolStripSplitStackLayout : LayoutEngine
             {
                 if ((itemBounds.Right > _displayRectangle.Right) || (itemBounds.Left < _displayRectangle.Left))
                 {
-                    DebugLayoutTraceSwitch.TraceVerbose($"[SplitStack.SetItemLocation] Sending Item {item} to NoMansLand as it doesn't fit horizontally within the DRect");
                     itemLocation = _noMansLand;
                     item.SetPlacement(ToolStripItemPlacement.None);
                 }
@@ -536,8 +508,6 @@ internal class ToolStripSplitStackLayout : LayoutEngine
             {
                 if ((itemBounds.Bottom > _displayRectangle.Bottom) || (itemBounds.Top < _displayRectangle.Top))
                 {
-                    DebugLayoutTraceSwitch.TraceVerbose($"[SplitStack.SetItemLocation] Sending Item {item} to NoMansLand as it doesn't fit vertically within the DRect");
-
                     itemLocation = _noMansLand;
                     item.SetPlacement(ToolStripItemPlacement.None);
                 }
@@ -591,9 +561,6 @@ internal class ToolStripSplitStackLayout : LayoutEngine
     /// </summary>²
     private int SendNextItemToOverflow(int spaceNeeded, bool horizontal)
     {
-        DebugLayoutTraceSwitch.TraceVerbose($"SendNextItemToOverflow attempting to free {spaceNeeded}");
-        Debug.Indent();
-
         int freedSpace = 0;
         int backIndex = BackwardsWalkingIndex;
 
@@ -613,8 +580,6 @@ internal class ToolStripSplitStackLayout : LayoutEngine
             // not looking at ones that Always overflow - as the forward walker already skips these.
             if (item.Overflow == ToolStripItemOverflow.AsNeeded && item.Placement != ToolStripItemPlacement.Overflow)
             {
-                DebugLayoutTraceSwitch.TraceVerbose($"Found candidate for sending to overflow {item}");
-
                 // since we haven't parented the item yet - the auto size won't have reset the size yet.
                 Size itemSize = item.AutoSize ? item.GetPreferredSize(_displayRectangle.Size) : item.Size;
 
@@ -624,7 +589,6 @@ internal class ToolStripSplitStackLayout : LayoutEngine
                     // we need to let him know how much space we're freeing by sending this guy over
                     // to the overflow.
                     freedSpace += (horizontal) ? itemSize.Width + itemMargin.Horizontal : itemSize.Height + itemMargin.Vertical;
-                    DebugLayoutTraceSwitch.TraceVerbose($"Sweet! {itemSize} FreedSpace - which is now {freedSpace}");
                 }
 
                 // send the item to the overflow.
@@ -634,7 +598,6 @@ internal class ToolStripSplitStackLayout : LayoutEngine
                     // this is the first item we're sending down.
                     // we now need to account for the width or height of the overflow button
                     spaceNeeded += (horizontal) ? OverflowButtonSize.Width : OverflowButtonSize.Height;
-                    DebugLayoutTraceSwitch.TraceVerbose($"Turns out we now need an overflow button, space needed now: {spaceNeeded}");
                     OverflowRequired = true;
                 }
 
@@ -647,7 +610,6 @@ internal class ToolStripSplitStackLayout : LayoutEngine
             }
         }
 
-        Debug.Unindent();
         return freedSpace;
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -5797,27 +5797,19 @@ public partial class Form : ContainerControl
                 MdiControlStrip = null;
             }
 
-            if (ActiveMdiChildInternal is not null && maximized)
+            if (ActiveMdiChildInternal is not null && maximized && ActiveMdiChildInternal.ControlBox)
             {
-                if (ActiveMdiChildInternal.ControlBox)
+                // Determine if we need to add control gadgets into the MenuStrip.
+                // Double check GetMenu incase someone is using interop.
+                HMENU hMenu = PInvoke.GetMenu(this);
+                if (hMenu == HMENU.Null)
                 {
-                    ToolStrip.s_mdiMergeDebug.TraceVerbose("UpdateMdiControlStrip: Detected ControlBox on ActiveMDI child, adding in MDIControlStrip.");
-
-                    // determine if we need to add control gadgets into the MenuStrip
-                    // double check GetMenu incase someone is using interop
-                    HMENU hMenu = PInvoke.GetMenu(this);
-                    if (hMenu == HMENU.Null)
+                    MenuStrip? sourceMenuStrip = ToolStripManager.GetMainMenuStrip(this);
+                    if (sourceMenuStrip is not null)
                     {
-                        MenuStrip? sourceMenuStrip = ToolStripManager.GetMainMenuStrip(this);
-                        if (sourceMenuStrip is not null)
-                        {
-                            MdiControlStrip = new MdiControlStrip(ActiveMdiChildInternal);
-                            ToolStrip.s_mdiMergeDebug.TraceVerbose($"UpdateMdiControlStrip: built up an MDI control strip for {ActiveMdiChildInternal.Text} with {MdiControlStrip.Items.Count} items.");
-                            ToolStrip.s_mdiMergeDebug.TraceVerbose($"UpdateMdiControlStrip: merging MDI control strip into source menustrip - items before: {sourceMenuStrip.Items.Count}");
-                            ToolStripManager.Merge(MdiControlStrip, sourceMenuStrip);
-                            ToolStrip.s_mdiMergeDebug.TraceVerbose($"UpdateMdiControlStrip: merging MDI control strip into source menustrip - items after: {sourceMenuStrip.Items.Count}");
-                            MdiControlStrip.MergedMenu = sourceMenuStrip;
-                        }
+                        MdiControlStrip = new MdiControlStrip(ActiveMdiChildInternal);
+                        ToolStripManager.Merge(MdiControlStrip, sourceMenuStrip);
+                        MdiControlStrip.MergedMenu = sourceMenuStrip;
                     }
                 }
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Help/Help.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Help/Help.cs
@@ -13,18 +13,11 @@ namespace System.Windows.Forms;
 /// </summary>
 public static class Help
 {
-#if DEBUG
-    internal static readonly TraceSwitch s_windowsFormsHelpTrace = new("WindowsFormsHelpTrace", "Debug help system");
-#else
-    internal static readonly TraceSwitch? s_windowsFormsHelpTrace;
-#endif
-
     private const int HTML10HELP = 2;
     private const int HTMLFILE = 3;
 
     /// <summary>
-    ///  Displays
-    ///  the contents of the Help file at located at a specified Url.
+    ///  Displays the contents of the Help file at located at a specified Url.
     /// </summary>
     public static void ShowHelp(Control? parent, string? url)
     {
@@ -32,9 +25,7 @@ public static class Help
     }
 
     /// <summary>
-    ///  Displays the contents of
-    ///  the Help
-    ///  file for a specific topic found at the specified Url.
+    ///  Displays the contents of the Help file for a specific topic found at the specified Url.
     /// </summary>
     public static void ShowHelp(Control? parent, string? url, HelpNavigator navigator)
     {
@@ -42,9 +33,7 @@ public static class Help
     }
 
     /// <summary>
-    ///  Displays the contents of
-    ///  the Help
-    ///  file for a specific topic found at the specified Url.
+    ///  Displays the contents of the Help file for a specific topic found at the specified Url.
     /// </summary>
     public static void ShowHelp(Control? parent, string? url, string? keyword)
     {
@@ -59,15 +48,10 @@ public static class Help
     }
 
     /// <summary>
-    ///  Displays the contents of the Help file located at
-    ///  the Url
-    ///  supplied by the
-    ///  user.
+    ///  Displays the contents of the Help file located at the Url supplied by the user.
     /// </summary>
     public static void ShowHelp(Control? parent, string? url, HelpNavigator command, object? parameter)
     {
-        s_windowsFormsHelpTrace.TraceVerbose("Help:: ShowHelp");
-
         switch (GetHelpFileType(url))
         {
             case HTML10HELP:
@@ -84,8 +68,6 @@ public static class Help
     /// </summary>
     public static void ShowHelpIndex(Control? parent, string? url)
     {
-        s_windowsFormsHelpTrace.TraceVerbose("Help:: ShowHelpIndex");
-
         ShowHelp(parent, url, HelpNavigator.Index, null);
     }
 
@@ -94,8 +76,6 @@ public static class Help
     /// </summary>
     public static unsafe void ShowPopup(Control? parent, string caption, Point location)
     {
-        s_windowsFormsHelpTrace.TraceVerbose("Help:: ShowPopup");
-
         HH_POPUP pop = new()
         {
             cbStruct = sizeof(HH_POPUP),
@@ -117,12 +97,10 @@ public static class Help
     }
 
     /// <summary>
-    ///  Displays HTML 1.0 Help with the specified parameters
+    ///  Displays HTML 1.0 Help with the specified parameters.
     /// </summary>
     private static unsafe void ShowHTML10Help(Control? parent, string? url, HelpNavigator command, object? param)
     {
-        s_windowsFormsHelpTrace.TraceVerbose($"Help:: ShowHTML10Help:: {url}, {command:G}, {param}");
-
         // See if we can get a full path and file name and if that will
         // resolve the out of memory condition with file names that include spaces.
         // If we can't, though, we can't assume that the path's no good: it might be in
@@ -215,8 +193,6 @@ public static class Help
     /// </summary>
     private static void ShowHTMLFile(Control? parent, string? url, HelpNavigator command, object? param)
     {
-        s_windowsFormsHelpTrace.TraceVerbose($"Help:: ShowHTMLHelp:: {url}, {command:G}, {param}");
-
         Uri? file = Resolve(url) ?? throw new ArgumentException(string.Format(SR.HelpInvalidURL, url), nameof(url));
 
         switch (command)
@@ -224,8 +200,7 @@ public static class Help
             case HelpNavigator.TableOfContents:
             case HelpNavigator.Find:
             case HelpNavigator.Index:
-                // nothing needed...
-                //
+                // Nothing needed.
                 break;
             case HelpNavigator.Topic:
                 if (param is string stringParam)
@@ -237,7 +212,6 @@ public static class Help
         }
 
         HandleRef<HWND> handle = parent is not null ? new(parent) : Control.GetHandleRef(PInvoke.GetActiveWindow());
-        s_windowsFormsHelpTrace.TraceVerbose($"\tExecuting '{file}'");
         string fileName = file.ToString();
         string? executable = file.IsFile ? FindExecutableInternal(file.LocalPath.ToString()) : null;
         PInvoke.ShellExecute(handle.Handle, lpOperation: null, executable ?? fileName, executable is not null ? fileName : null, lpDirectory: null, SHOW_WINDOW_CMD.SW_NORMAL);
@@ -261,9 +235,6 @@ public static class Help
 
     private static Uri? Resolve(string? partialUri)
     {
-        s_windowsFormsHelpTrace.TraceVerbose($"Help:: Resolve {partialUri}");
-        Debug.Indent();
-
         Uri? file = null;
 
         if (!string.IsNullOrEmpty(partialUri))
@@ -281,21 +252,19 @@ public static class Help
         if (file is not null && file.Scheme == "file")
         {
             string localPath = file.LocalPath + file.Fragment;
-            s_windowsFormsHelpTrace.TraceVerbose("file, check for existence");
 
             if (!File.Exists(localPath))
             {
-                // clear, and try relative to AppBase...
+                // Clear, and try relative to AppBase.
                 file = null;
             }
         }
 
         if (file is null)
         {
-            s_windowsFormsHelpTrace.TraceVerbose("try AppBase relative");
             try
             {
-                // try relative to AppBase...
+                // Try relative to AppBase.
                 file = new Uri(new Uri(AppContext.BaseDirectory),
                                partialUri);
             }
@@ -307,26 +276,21 @@ public static class Help
             if (file is not null && file.Scheme == "file")
             {
                 string localPath = file.LocalPath + file.Fragment;
-                s_windowsFormsHelpTrace.TraceVerbose("file, check for existence");
                 if (!File.Exists(localPath))
                 {
-                    // clear - file isn't there...
+                    // Clear - file isn't there.
                     file = null;
                 }
             }
         }
 
-        Debug.Unindent();
         return file;
     }
 
     private static int GetHelpFileType(string? url)
     {
-        s_windowsFormsHelpTrace.TraceVerbose("Help:: GetHelpFileType {url}");
-
         if (url is null)
         {
-            s_windowsFormsHelpTrace.TraceVerbose("\tnull, must be Html File");
             return HTMLFILE;
         }
 
@@ -334,17 +298,13 @@ public static class Help
 
         if (file is null || file.Scheme == "file")
         {
-            s_windowsFormsHelpTrace.TraceVerbose("\tfile");
-
             string ext = Path.GetExtension(file is null ? url : file.LocalPath + file.Fragment).ToLower(CultureInfo.InvariantCulture);
             if (ext is ".chm" or ".col")
             {
-                s_windowsFormsHelpTrace.TraceVerbose("\tchm or col, HtmlHelp 1.0 file");
                 return HTML10HELP;
             }
         }
 
-        s_windowsFormsHelpTrace.TraceVerbose("\tnot file, or odd extension, but be HTML");
         return HTMLFILE;
     }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Help/HelpProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Help/HelpProvider.cs
@@ -122,7 +122,6 @@ public class HelpProvider : Component, IExtenderProvider
 
         if (Control.MouseButtons != MouseButtons.None && !string.IsNullOrEmpty(helpString))
         {
-            Help.s_windowsFormsHelpTrace.TraceVerbose("HelpProvider:: Mouse down w/ helpstring");
             Help.ShowPopup(ctl, helpString, hevent.MousePos);
             hevent.Handled = true;
             return;
@@ -131,7 +130,6 @@ public class HelpProvider : Component, IExtenderProvider
         // If we have a help file, and help keyword we try F1 help next
         if (HelpNamespace is not null)
         {
-            Help.s_windowsFormsHelpTrace.TraceVerbose("HelpProvider:: F1 help");
             if (!string.IsNullOrEmpty(keyword))
             {
                 Help.ShowHelp(ctl, HelpNamespace, navigator, keyword);
@@ -148,7 +146,6 @@ public class HelpProvider : Component, IExtenderProvider
         // So at this point we don't have a help keyword, so try to display the whats this help
         if (!string.IsNullOrEmpty(helpString))
         {
-            Help.s_windowsFormsHelpTrace.TraceVerbose("HelpProvider:: back to helpstring");
             Help.ShowPopup(ctl, helpString, hevent.MousePos);
             hevent.Handled = true;
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MDI/MdiWindowListStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MDI/MdiWindowListStrip.cs
@@ -116,30 +116,32 @@ internal class MdiWindowListStrip : MenuStrip
                                 MergeAction = MergeAction.Append,
                                 MergeIndex = accel
                             };
-                            windowListItem.Click += new EventHandler(OnWindowListItemClick);
+
+                            windowListItem.Click += OnWindowListItemClick;
+
                             if (forms[i].Equals(activeMdiChild))
-                            {  // if this the active one, check it off.
+                            {
+                                // If this the active one, check it off.
                                 windowListItem.Checked = true;
                                 activeFormAdded = true;
                             }
 
                             accel++;
                             formsAddedToMenu++;
-                            s_mdiMergeDebug.TraceVerbose($"\tPopulateItems: Added {windowListItem.Text}");
                             mergeItem.DropDownItems.Add(windowListItem);
                         }
                     }
                 }
 
-                // show the More Windows... item if necessary.
+                // Show the "More Windows..." item if necessary.
                 if (visibleChildren > maxMenuForms)
                 {
                     ToolStripMenuItem moreWindowsMenuItem = new ToolStripMenuItem
                     {
                         Text = SR.MDIMenuMoreWindows
                     };
-                    s_mdiMergeDebug.TraceVerbose($"\tPopulateItems: Added {moreWindowsMenuItem.Text}");
-                    moreWindowsMenuItem.Click += new EventHandler(OnMoreWindowsMenuItemClick);
+
+                    moreWindowsMenuItem.Click += OnMoreWindowsMenuItemClick;
                     moreWindowsMenuItem.MergeAction = MergeAction.Append;
                     mergeItem.DropDownItems.Add(moreWindowsMenuItem);
                 }
@@ -147,7 +149,7 @@ internal class MdiWindowListStrip : MenuStrip
         }
         finally
         {
-            // this is an invisible toolstrip don't even bother doing layout.
+            // This is an invisible toolstrip don't even bother doing layout.
             ResumeLayout(false);
             MergeItem.DropDown.ResumeLayout(false);
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Scrolling/ScrollableControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Scrolling/ScrollableControl.cs
@@ -13,20 +13,10 @@ namespace System.Windows.Forms;
 [Designer($"System.Windows.Forms.Design.ScrollableControlDesigner, {AssemblyRef.SystemDesign}")]
 public partial class ScrollableControl : Control, IArrangedElement
 {
-#if DEBUG
-    internal static readonly TraceSwitch s_autoScrolling = new("AutoScrolling", "Debug autoscrolling logic");
-#else
-    internal static readonly TraceSwitch? s_autoScrolling;
-#endif
-
     protected const int ScrollStateAutoScrolling = 0x0001;
-
     protected const int ScrollStateHScrollVisible = 0x0002;
-
     protected const int ScrollStateVScrollVisible = 0x0004;
-
     protected const int ScrollStateUserHasScrolled = 0x0008;
-
     protected const int ScrollStateFullDrag = 0x0010;
 
     private Size _userAutoScrollMinSize = Size.Empty;
@@ -844,9 +834,6 @@ public partial class ScrollableControl : Control, IArrangedElement
             return;
         }
 
-        s_autoScrolling.TraceVerbose($"ScrollControlIntoView({activeControl.GetType().FullName})");
-        Debug.Indent();
-
         Rectangle client = ClientRectangle;
 
         if (IsDescendant(activeControl)
@@ -854,18 +841,15 @@ public partial class ScrollableControl : Control, IArrangedElement
             && (HScroll || VScroll)
             && (client.Width > 0 && client.Height > 0))
         {
-            s_autoScrolling.TraceVerbose("Calculating...");
-
             Point scrollLocation = ScrollToControl(activeControl);
             SetScrollState(ScrollStateUserHasScrolled, false);
             SetDisplayRectLocation(scrollLocation.X, scrollLocation.Y);
             SyncScrollbars(true);
         }
-
-        Debug.Unindent();
     }
 
-    /// <summary> Allow containers to tweak autoscrolling. when you tab between controls contained in the scrollable control
+    /// <summary>
+    ///  Allow containers to tweak autoscrolling. when you tab between controls contained in the scrollable control
     ///  this allows you to set the scroll location. This would allow you to scroll to the middle of a control, where as the default is
     ///  the top of the control.
     ///  Additionally there is a new AutoScrollOffset property on the child controls themselves. This lets them control where they want to
@@ -883,8 +867,6 @@ public partial class ScrollableControl : Control, IArrangedElement
         Rectangle bounds = activeControl.Bounds;
         if (activeControl.ParentInternal != this)
         {
-            s_autoScrolling.TraceVerbose($"not direct child, original bounds: {bounds}");
-
             if (activeControl.ParentInternal is null)
             {
                 throw new InvalidOperationException(SR.ScrollableControlActiveControlParentNull);
@@ -892,8 +874,6 @@ public partial class ScrollableControl : Control, IArrangedElement
 
             bounds = RectangleToClient(activeControl.ParentInternal.RectangleToScreen(bounds));
         }
-
-        s_autoScrolling.TraceVerbose($"adjusted bounds: {bounds}");
 
         if (bounds.X < xMargin)
         {


### PR DESCRIPTION
This change removes another chunk of trace statements from the code. ToolStrip, UndoEngine, PropertyGrid, etc.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11068)