### PR TITLE
Remove another batch of tracing

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/OleDragDropHandler.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/OleDragDropHandler.cs
@@ -945,7 +945,6 @@ internal partial class OleDragDropHandler
 
     public void DoOleDragOver(DragEventArgs de)
     {
-        Debug.WriteLineIf(CompModSwitches.DragDrop.TraceInfo, $"\tOleDragDropHandler.OnDragOver: {de}");
         if (!Dragging && !_dragOk)
         {
             de.Effect = DragDropEffects.None;
@@ -976,8 +975,7 @@ internal partial class OleDragDropHandler
                 newOffset = new Point(de.X - _dragBase.X, de.Y - _dragBase.Y);
             }
 
-            // 96845 -- only allow drops on the client area
-            //
+            // Only allow drops on the client area.
             if (!Destination.GetDesignerControl().ClientRectangle.Contains(convertedPoint))
             {
                 copy = false;
@@ -987,7 +985,6 @@ internal partial class OleDragDropHandler
 
             if (newOffset != _localDragOffset)
             {
-                Debug.WriteLineIf(CompModSwitches.DragDrop.TraceInfo, $"\tParentControlDesigner.OnDragOver: {de}");
                 DrawDragFrames(_dragComps, _localDragOffset, _localDragEffect, newOffset, _forceDrawFrames);
                 _localDragOffset = newOffset;
                 _localDragEffect = de.Effect;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ParentControlDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ParentControlDesigner.cs
@@ -1659,10 +1659,7 @@ public partial class ParentControlDesigner : ControlDesigner, IOleDragClient
             de.Effect = (Control.ModifierKeys == Keys.Control) ? DragDropEffects.Copy : DragDropEffects.Move;
         }
 
-        Debug.WriteLineIf(CompModSwitches.DragDrop.TraceInfo, $"\tParentControlDesigner.OnDragOver: {de}");
-
-        // If tab order UI is being shown, then don't allow anything to be
-        // dropped here.
+        // If tab order UI is being shown, then don't allow anything to be dropped here.
         IMenuCommandService ms = (IMenuCommandService)GetService(typeof(IMenuCommandService));
         if (ms is not null)
         {
@@ -1691,8 +1688,6 @@ public partial class ParentControlDesigner : ControlDesigner, IOleDragClient
             de.Effect = DragDropEffects.Copy;
             return;
         }
-
-        Debug.WriteLineIf(CompModSwitches.DragDrop.TraceInfo, $"\tParentControlDesigner.OnDragOver: {de}");
     }
 
     /// <summary>

--- a/src/System.Windows.Forms.Primitives/src/System/ComponentModel/CompModSwitches.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/ComponentModel/CompModSwitches.cs
@@ -22,7 +22,6 @@ internal static class CompModSwitches
     private static TraceSwitch? s_dgRelationShpRowLayout;
     private static TraceSwitch? s_dgRelationShpRowPaint;
     private static TraceSwitch? s_dgRowPaint;
-    private static TraceSwitch? s_dragDrop;
     private static TraceSwitch? s_imeMode;
     private static TraceSwitch? s_msaa;
     private static TraceSwitch? s_layoutPerformance;
@@ -193,16 +192,6 @@ internal static class CompModSwitches
             s_dgRowPaint ??= new TraceSwitch("DGRowPaint", "DataGrid Simple Row painting stuff");
 
             return s_dgRowPaint;
-        }
-    }
-
-    public static TraceSwitch DragDrop
-    {
-        get
-        {
-            s_dragDrop ??= new TraceSwitch("DragDrop", "Debug OLEDragDrop support in Controls");
-
-            return s_dragDrop;
         }
     }
 

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Message.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Message.cs
@@ -10,10 +10,6 @@ namespace System.Windows.Forms;
 /// </summary>
 public struct Message : IEquatable<Message>, IHandle<HWND>
 {
-#if DEBUG
-    private static readonly TraceSwitch s_allWinMessages = new("AllWinMessages", "Output every received message");
-#endif
-
     // Keep HWND, WM, WPARAM, and LPARAM in this order so that they match the MSG struct.
     // This struct shouldn't be used as a direct mapping against MSG, but if someone does already do this
     // it will allow their code to continue to work.
@@ -112,12 +108,6 @@ public struct Message : IEquatable<Message>, IHandle<HWND>
             ResultInternal = (LRESULT)0
         };
 
-#if DEBUG
-        if (s_allWinMessages.TraceVerbose)
-        {
-            Debug.WriteLine(m.ToString());
-        }
-#endif
         return m;
     }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -48,72 +48,6 @@ public unsafe partial class Control :
     IHandle<HWND>
 {
 #if DEBUG
-    internal static readonly TraceSwitch s_paletteTracing = new(
-        "PaletteTracing",
-        "Debug Palette code");
-    internal static readonly TraceSwitch s_controlKeyboardRouting = new(
-        "ControlKeyboardRouting",
-        "Debug Keyboard routing for controls");
-    private protected static readonly TraceSwitch s_focusTracing = new(
-        "FocusTracing",
-        "Debug focus/active control/enter/leave");
-
-    private static readonly BooleanSwitch s_assertOnControlCreateSwitch = new(
-        "AssertOnControlCreate",
-        "Assert when anything directly deriving from control is created.");
-    private protected static readonly BooleanSwitch s_traceMnemonicProcessing = new(
-        "TraceCanProcessMnemonic",
-        "Trace mnemonic processing calls to assure right child-parent call ordering.");
-
-    private protected void TraceCanProcessMnemonic()
-    {
-        if (s_traceMnemonicProcessing.Enabled)
-        {
-            string str;
-            try
-            {
-                str = $"{GetType().Name}<{Text}>";
-                int maxFrameCount = new StackTrace().FrameCount;
-                if (maxFrameCount > 5)
-                {
-                    maxFrameCount = 5;
-                }
-
-                int frameIndex = 1;
-                while (frameIndex < maxFrameCount)
-                {
-                    StackFrame sf = new(frameIndex);
-                    if (frameIndex == 2 && sf.GetMethod()!.Name.Equals("CanProcessMnemonic"))
-                    {
-                        // log immediate call if in a virtual/recursive call.
-                        break;
-                    }
-
-                    str += new StackTrace(sf).ToString().TrimEnd();
-                    frameIndex++;
-                }
-
-                if (frameIndex > 2)
-                {
-                    // new CanProcessMnemonic virtual/recursive call stack.
-                    str = "\r\n" + str;
-                }
-            }
-            catch (Exception ex)
-            {
-                str = ex.ToString();
-            }
-
-            Debug.WriteLine(str);
-        }
-    }
-#else
-    internal static readonly TraceSwitch? s_paletteTracing;
-    internal static readonly TraceSwitch? s_controlKeyboardRouting;
-    private protected readonly TraceSwitch? s_focusTracing;
-#endif
-
-#if DEBUG
     private static readonly BooleanSwitch s_bufferPinkRect = new(
         "BufferPinkRect",
         "Renders a pink rectangle with painting double buffered controls");
@@ -344,13 +278,6 @@ public unsafe partial class Control :
 
     internal Control(bool autoInstallSyncContext) : base()
     {
-#if DEBUG
-        if (s_assertOnControlCreateSwitch.Enabled)
-        {
-            Debug.Assert(GetType().BaseType != typeof(Control), $"Direct derivative of Control Created: {GetType().FullName}");
-            Debug.Assert(GetType() != typeof(Control), "Control Created!");
-        }
-#endif
         Properties = new PropertyStore();
 
         // Initialize Dpi to the value on the primary screen, we will have the correct value when the Handle is created.
@@ -4656,9 +4583,6 @@ public unsafe partial class Control :
     /// </summary>
     internal virtual bool CanProcessMnemonic()
     {
-#if DEBUG
-        TraceCanProcessMnemonic();
-#endif
         if (!Enabled || !Visible)
         {
             return false;
@@ -5405,8 +5329,6 @@ public unsafe partial class Control :
     [EditorBrowsable(EditorBrowsableState.Advanced)]
     public bool Focus()
     {
-        s_focusTracing.TraceVerbose($"Control::Focus - {Name}");
-
         // Call the internal method (which form overrides)
         return FocusInternal();
     }
@@ -5418,7 +5340,6 @@ public unsafe partial class Control :
     /// </summary>
     private protected virtual bool FocusInternal()
     {
-        s_focusTracing.TraceVerbose($"Control::FocusInternal - {Name}");
         if (CanFocus)
         {
             PInvoke.SetFocus(this);
@@ -6617,8 +6538,6 @@ public unsafe partial class Control :
     /// </returns>
     protected virtual bool IsInputChar(char charCode)
     {
-        s_controlKeyboardRouting.TraceVerbose($"Control.IsInputChar 0x{((int)charCode):X}");
-
         int mask;
         if (charCode == (char)(int)Keys.Tab)
         {
@@ -6647,8 +6566,6 @@ public unsafe partial class Control :
     /// </returns>
     protected virtual bool IsInputKey(Keys keyData)
     {
-        s_controlKeyboardRouting.TraceVerbose($"Control.IsInputKey {keyData}");
-
         if ((keyData & Keys.Alt) == Keys.Alt)
         {
             return false;
@@ -6679,12 +6596,9 @@ public unsafe partial class Control :
     /// </summary>
     public static bool IsMnemonic(char charCode, string? text)
     {
-        s_controlKeyboardRouting.TraceVerbose($"Control.IsMnemonic({charCode}, {(text is not null ? text : "null")})");
-
         // Special case handling:
         if (charCode == '&')
         {
-            s_controlKeyboardRouting.TraceVerbose("   ...returning false");
             return false;
         }
 
@@ -6706,18 +6620,14 @@ public unsafe partial class Control :
                 }
 
                 char c1 = char.ToUpper(text[pos], CultureInfo.CurrentCulture);
-                s_controlKeyboardRouting.TraceVerbose($"   ...& found... char={c1}");
+
                 if (c1 == c2 || char.ToLower(c1, CultureInfo.CurrentCulture) == char.ToLower(c2, CultureInfo.CurrentCulture))
                 {
-                    s_controlKeyboardRouting.TraceVerbose("   ...returning true");
                     return true;
                 }
             }
-
-            Debug.WriteLineIf(s_controlKeyboardRouting!.TraceVerbose && pos == 0, "   ...no & found");
         }
 
-        s_controlKeyboardRouting.TraceVerbose("   ...returning false");
         return false;
     }
 
@@ -6902,20 +6812,6 @@ public unsafe partial class Control :
         Marshal.Copy(nullBytes, 0, m.LParamInternal + (nint)bytes.Length, nullBytes.Length);
 
         m.ResultInternal = (LRESULT)((bytes.Length + nullBytes.Length) / sizeof(char));
-    }
-
-    // Used by form to notify the control that it has been "entered"
-    internal void NotifyEnter()
-    {
-        s_focusTracing.TraceVerbose($"Control::NotifyEnter() - {Name}");
-        OnEnter(EventArgs.Empty);
-    }
-
-    // Used by form to notify the control that it has been "left"
-    internal void NotifyLeave()
-    {
-        s_focusTracing.TraceVerbose($"Control::NotifyLeave() - {Name}");
-        OnLeave(EventArgs.Empty);
     }
 
     /// <summary>
@@ -7974,7 +7870,7 @@ public unsafe partial class Control :
     }
 
     [EditorBrowsable(EditorBrowsableState.Advanced)]
-    protected virtual void OnEnter(EventArgs e)
+    protected internal virtual void OnEnter(EventArgs e)
     {
         ((EventHandler?)Events[s_enterEvent])?.Invoke(this, e);
     }
@@ -8142,7 +8038,7 @@ public unsafe partial class Control :
     ///  Raises the <see cref="Leave"/> event.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Advanced)]
-    protected virtual void OnLeave(EventArgs e)
+    protected internal virtual void OnLeave(EventArgs e)
     {
         ((EventHandler?)Events[s_leaveEvent])?.Invoke(this, e);
     }
@@ -9071,8 +8967,6 @@ public unsafe partial class Control :
         target.SetExtendedState(ExtendedStates.InputChar, false);
         target.SetExtendedState(ExtendedStates.UiCues, true);
 
-        s_controlKeyboardRouting.TraceVerbose($"Control.PreProcessControlMessageInternal {message}");
-
         try
         {
             Keys keyData = (Keys)(nint)message.WParamInternal | ModifierKeys;
@@ -9087,8 +8981,6 @@ public unsafe partial class Control :
 
                 if (args.IsInputKey)
                 {
-                    s_controlKeyboardRouting.TraceVerbose("PreviewKeyDown indicated this is an input key.");
-
                     // Control wants this message - indicate it should be dispatched.
                     return PreProcessControlState.MessageNeeded;
                 }
@@ -9104,7 +8996,6 @@ public unsafe partial class Control :
                     // or if it is safe to call - we only want it to be called once.
                     if (target.GetExtendedState(ExtendedStates.InputKey) || target.IsInputKey(keyData))
                     {
-                        s_controlKeyboardRouting.TraceVerbose("Control didn't preprocess this message but it needs to be dispatched");
                         state = PreProcessControlState.MessageNeeded;
                     }
                 }
@@ -9114,7 +9005,6 @@ public unsafe partial class Control :
                     // or if it is safe to call - we only want it to be called once.
                     if (target.GetExtendedState(ExtendedStates.InputChar) || target.IsInputChar((char)(nint)message.WParamInternal))
                     {
-                        s_controlKeyboardRouting.TraceVerbose("Control didn't preprocess this message but it needs to be dispatched");
                         state = PreProcessControlState.MessageNeeded;
                     }
                 }
@@ -9133,33 +9023,24 @@ public unsafe partial class Control :
     }
 
     /// <summary>
-    ///  Processes a command key. This method is called during message
-    ///  pre-processing to handle command keys. Command keys are keys that always
-    ///  take precedence over regular input keys. Examples of command keys
-    ///  include accelerators and menu shortcuts. The method must return true to
-    ///  indicate that it has processed the command key, or false to indicate
-    ///  that the key is not a command key.
-    ///  processCmdKey() first checks if the control has a context menu, and if
-    ///  so calls the menu's processCmdKey() to check for menu shortcuts. If the
-    ///  command key isn't a menu shortcut, and if the control has a parent, the
-    ///  key is passed to the parent's processCmdKey() method. The net effect is
-    ///  that command keys are "bubbled" up the control hierarchy.
-    ///  When overriding processCmdKey(), a control should return true to
-    ///  indicate that it has processed the key. For keys that aren't processed by
-    ///  the control, the result of "base.processCmdKey()" should be returned.
-    ///  Controls will seldom, if ever, need to override this method.
+    ///  Processes a command key.
     /// </summary>
-    protected virtual bool ProcessCmdKey(ref Message msg, Keys keyData)
-    {
-        s_controlKeyboardRouting.TraceVerbose($"Control.ProcessCmdKey {msg}");
-
-        if (_parent is not null)
-        {
-            return _parent.ProcessCmdKey(ref msg, keyData);
-        }
-
-        return false;
-    }
+    /// <remarks>
+    ///  <para>
+    ///   This method is called during message pre-processing to handle command keys. Command keys are keys that always
+    ///   take precedence over regular input keys. Examples of command keys include accelerators and menu shortcuts. The
+    ///   method must return <see langword="true"/> to indicate that it has  processed the command key, or
+    ///   <see langword="false"/> to indicate that the key is not a command key.
+    ///  </para>
+    ///  <para>
+    ///   If the control has a parent, the key is passed to the parent's <see cref="ProcessCmdKey(ref Message, Keys)"/>
+    ///   method. The net effect is that command keys are "bubbled" up the control hierarchy. In addition to the key the
+    ///   user pressed, the key data also indicates which, if any, modifier keys were pressed at the same time as the
+    ///   key. Modifier keys include the SHIFT, CTRL, and ALT keys.
+    ///  </para>
+    /// </remarks>
+    protected virtual bool ProcessCmdKey(ref Message msg, Keys keyData) =>
+        _parent?.ProcessCmdKey(ref msg, keyData) ?? false;
 
     private unsafe void PrintToMetaFile(HDC hDC, IntPtr lParam)
     {
@@ -9254,63 +9135,47 @@ public unsafe partial class Control :
     }
 
     /// <summary>
-    ///  Processes a dialog character. This method is called during message
-    ///  pre-processing to handle dialog characters, such as control mnemonics.
-    ///  This method is called only if the isInputChar() method indicates that
-    ///  the control isn't interested in the character.
-    ///  processDialogChar() simply sends the character to the parent's
-    ///  processDialogChar() method, or returns false if the control has no
-    ///  parent. The Form class overrides this method to perform actual
-    ///  processing of dialog characters.
-    ///  When overriding processDialogChar(), a control should return true to
-    ///  indicate that it has processed the character. For characters that aren't
-    ///  processed by the control, the result of "base.processDialogChar()"
-    ///  should be returned.
-    ///  Controls will seldom, if ever, need to override this method.
+    ///  Processes a dialog character.
     /// </summary>
-    protected virtual bool ProcessDialogChar(char charCode)
-    {
-        s_controlKeyboardRouting.TraceVerbose($"Control.ProcessDialogChar [{charCode}]");
-        return _parent is not null && _parent.ProcessDialogChar(charCode);
-    }
+    /// <remarks>
+    ///  <para>
+    ///   This method is called during message preprocessing to handle dialog characters, such as control mnemonics.
+    ///   This method is called only if the <see cref="IsInputChar(char)"/> method indicates that the control is not
+    ///   processing the character. The <see cref="ProcessDialogChar(char)"/> method simply sends the character to the
+    ///   parent's <see cref="ProcessDialogChar(char)"/> method, or returns <see langword="false"/> if the control has no
+    ///   parent. The <see cref="Form"/> class overrides this method to perform actual processing of dialog characters.
+    ///  </para>
+    /// </remarks>
+    protected virtual bool ProcessDialogChar(char charCode) => _parent?.ProcessDialogChar(charCode) ?? false;
 
     /// <summary>
-    ///  Processes a dialog key. This method is called during message
-    ///  pre-processing to handle dialog characters, such as TAB, RETURN, ESCAPE,
-    ///  and arrow keys. This method is called only if the isInputKey() method
-    ///  indicates that the control isn't interested in the key.
-    ///  processDialogKey() simply sends the character to the parent's
-    ///  processDialogKey() method, or returns false if the control has no
-    ///  parent. The Form class overrides this method to perform actual
-    ///  processing of dialog keys.
-    ///  When overriding processDialogKey(), a control should return true to
-    ///  indicate that it has processed the key. For keys that aren't processed
-    ///  by the control, the result of "base.processDialogKey(...)" should be
-    ///  returned.
-    ///  Controls will seldom, if ever, need to override this method.
+    ///  Processes a dialog key.
     /// </summary>
-    protected virtual bool ProcessDialogKey(Keys keyData)
-    {
-        s_controlKeyboardRouting.TraceVerbose($"Control.ProcessDialogKey {keyData}");
-        return _parent is not null && _parent.ProcessDialogKey(keyData);
-    }
+    /// <remarks>
+    ///  <para>
+    ///   This method is called during message preprocessing to handle dialog characters, such as TAB, RETURN, ESC, and
+    ///   arrow keys. This method is called only if the <see cref="IsInputKey(Keys)"/> method indicates that the control
+    ///   is not processing the key. The <see cref="ProcessDialogKey(Keys)"/> simply sends the character to the parent's
+    ///   <see cref="ProcessDialogKey(Keys)"/> method, or returns <see langword="false"/> if the control has no parent.
+    ///   The <see cref="Form"/> class overrides this method to perform actual processing of dialog keys.
+    ///  </para>
+    /// </remarks>
+    protected virtual bool ProcessDialogKey(Keys keyData) => _parent?.ProcessDialogKey(keyData) ?? false;
 
     /// <summary>
-    ///  Processes a key message. This method is called when a control receives a
-    ///  keyboard message. The method is responsible for generating the appropriate
-    ///  key events for the message by calling OnKeyPress(), onKeyDown(), or
-    ///  onKeyUp(). The m parameter contains the window message that must
-    ///  be processed. Possible values for the m.msg field are WM_CHAR,
-    ///  WM_KEYDOWN, WM_SYSKEYDOWN, WM_KEYUP, WM_SYSKEYUP, and WM_IMECHAR.
-    ///  When overriding processKeyEventArgs(), a control should return true to
-    ///  indicate that it has processed the key. For keys that aren't processed
-    ///  by the control, the result of "base.processKeyEventArgs()" should be
-    ///  returned.
-    ///  Controls will seldom, if ever, need to override this method.
+    ///  Processes a key message and generates the appropriate control events.
     /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   This method is called when a control receives a keyboard message. The method is responsible for generating the
+    ///   appropriate key events for the message by calling the <see cref="OnKeyPress(KeyPressEventArgs)"/>,
+    ///   <see cref="OnKeyDown(KeyEventArgs)"/>, or <see cref="OnKeyUp(KeyEventArgs)"/>. The <paramref name="m"/>
+    ///   parameter contains the window message that must be processed. Possible values for the <see cref="Message.Msg"/>
+    ///   property are WM_CHAR, WM_KEYDOWN, WM_SYSKEYDOWN, WM_KEYUP, WM_SYSKEYUP, and WM_IME_CHAR.
+    ///  </para>
+    /// </remarks>
     protected virtual bool ProcessKeyEventArgs(ref Message m)
     {
-        s_controlKeyboardRouting.TraceVerbose($"Control.ProcessKeyEventArgs {m}");
         KeyEventArgs? ke = null;
         KeyPressEventArgs? kpe = null;
         WPARAM newWParam = 0;
@@ -9373,13 +9238,11 @@ public unsafe partial class Control :
 
         if (kpe is not null)
         {
-            s_controlKeyboardRouting.TraceVerbose($"    processkeyeventarg returning: {kpe.Handled}");
             m.WParamInternal = newWParam;
             return kpe.Handled;
         }
         else
         {
-            s_controlKeyboardRouting.TraceVerbose($"    processkeyeventarg returning: {ke!.Handled}");
             if (ke!.SuppressKeyPress)
             {
                 RemovePendingMessages(PInvoke.WM_CHAR, PInvoke.WM_CHAR);
@@ -9392,23 +9255,20 @@ public unsafe partial class Control :
     }
 
     /// <summary>
-    ///  Processes a key message. This method is called when a control receives a
-    ///  keyboard message. The method first checks if the control has a parent,
-    ///  and if so calls the parent's processKeyPreview() method. If the parent's
-    ///  processKeyPreview() method doesn't consume the message then
-    ///  processKeyEventArgs() is called to generate the appropriate keyboard events.
-    ///  The m parameter contains the window message that must be
-    ///  processed. Possible values for the m.msg field are WM_CHAR,
-    ///  WM_KEYDOWN, WM_SYSKEYDOWN, WM_KEYUP, and WM_SYSKEYUP.
-    ///  When overriding processKeyMessage(), a control should return true to
-    ///  indicate that it has processed the key. For keys that aren't processed
-    ///  by the control, the result of "base.processKeyMessage()" should be
-    ///  returned.
-    ///  Controls will seldom, if ever, need to override this method.
+    ///  Processes a key message.
     /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   This method is called when a control receives a keyboard message. The method first determines whether the
+    ///   control has a parent; if so, it calls the parent's <see cref="ProcessKeyPreview(ref Message)"/> method. If the
+    ///   parent's <see cref="ProcessKeyPreview(ref Message)"/> method does not process the message then the
+    ///   <see cref="ProcessKeyEventArgs(ref Message)"/> is called to generate the appropriate keyboard events. The
+    ///   <paramref name="m"/> parameter contains the window message that must be processed. Possible values for the
+    ///   <see cref="Message.Msg"/> property are WM_CHAR, WM_KEYDOWN, WM_SYSKEYDOWN, WM_KEYUP, and WM_SYSKEYUP.
+    ///  </para>
+    /// </remarks>
     protected internal virtual bool ProcessKeyMessage(ref Message m)
     {
-        s_controlKeyboardRouting.TraceVerbose($"Control.ProcessKeyMessage {m}");
         if (_parent is not null && _parent.ProcessKeyPreview(ref m))
         {
             return true;
@@ -9418,57 +9278,36 @@ public unsafe partial class Control :
     }
 
     /// <summary>
-    ///  Previews a keyboard message. This method is called by a child control
-    ///  when the child control receives a keyboard message. The child control
-    ///  calls this method before generating any keyboard events for the message.
-    ///  If this method returns true, the child control considers the message
-    ///  consumed and does not generate any keyboard events. The m
-    ///  parameter contains the window message to preview. Possible values for
-    ///  the m.msg field are WM_CHAR, WM_KEYDOWN, WM_SYSKEYDOWN, WM_KEYUP,
-    ///  and WM_SYSKEYUP.
-    ///  processKeyPreview() simply sends the character to the parent's
-    ///  processKeyPreview() method, or returns false if the control has no
-    ///  parent. The Form class overrides this method to perform actual
-    ///  processing of dialog keys.
-    ///  When overriding processKeyPreview(), a control should return true to
-    ///  indicate that it has processed the key. For keys that aren't processed
-    ///  by the control, the result of "base.ProcessKeyPreview(...)" should be
-    ///  returned.
+    ///  Previews a keyboard message.
     /// </summary>
-    protected virtual bool ProcessKeyPreview(ref Message m)
-    {
-        s_controlKeyboardRouting.TraceVerbose($"Control.ProcessKeyPreview {m}");
-        return _parent is not null && _parent.ProcessKeyPreview(ref m);
-    }
+    /// <remarks>
+    ///  <para>
+    ///   This method is called by a child control when the child control receives a keyboard message. The child control
+    ///   calls this method before generating any keyboard events for the message. If this method returns <see langword="true"/>,
+    ///   the child control considers the message processed and does not generate any keyboard events. The
+    ///   <paramref name="m"/> parameter contains the window message to preview. Possible values for the
+    ///   <see cref="Message.Msg"/> property are WM_CHAR, WM_KEYDOWN, WM_SYSKEYDOWN, WM_KEYUP, and WM_SYSKEYUP. The
+    ///   <see cref="ProcessKeyPreview(ref Message)"/> method simply sends the character to the parent's
+    ///   <see cref="ProcessKeyPreview(ref Message)"/> method, or returns <see langword="false"/> if the control has no
+    ///   parent. The <see cref="Form"/> class overrides this method to perform actual processing of dialog keys.
+    ///  </para>
+    /// </remarks>
+    protected virtual bool ProcessKeyPreview(ref Message m) => _parent?.ProcessKeyPreview(ref m) ?? false;
 
     /// <summary>
-    ///  <para>
-    ///   Processes a mnemonic character. This method is called to give a control
-    ///   the opportunity to process a mnemonic character. The method should check
-    ///   if the control is in a state to process mnemonics and if the given
-    ///   character represents a mnemonic. If so, the method should perform the
-    ///   action associated with the mnemonic and return <see langword="true"/>.
-    ///   If not, the method should return <see langword="false"/>.
-    ///  </para>
-    ///  <para>
-    ///   Implementations of this method often use the isMnemonic() method to
-    ///   check if the given character matches a mnemonic in the control's text,
-    ///   for example:
-    ///  </para>
-    ///  <code>
-    ///   if (CanSelect() &amp;&amp; IsMnemonic(charCode, GetText())
-    ///   {
-    ///       // Perform action associated with mnemonic...
-    ///   }
-    ///  </code>
+    ///  Processes a mnemonic character.
     /// </summary>
-    protected internal virtual bool ProcessMnemonic(char charCode)
-    {
-#if DEBUG
-        s_controlKeyboardRouting.TraceVerbose($"Control.ProcessMnemonic [0x{((int)charCode):X}]");
-#endif
-        return false;
-    }
+    /// <remarks>
+    ///  <para>
+    ///   This method is called to give a control the opportunity to process a mnemonic character. The method should
+    ///   check if the control is in a state to process mnemonics and if the given  character represents a mnemonic. If
+    ///   so, the method should perform the action associated with the mnemonic and return <see langword="true"/>.
+    ///   If not, the method should return <see langword="false"/>. Implementations of this method often use the
+    ///   <see cref="IsMnemonic(char, string?)"/> method to determine whether the given character matches a mnemonic
+    ///   in the control's text.
+    ///  </para>
+    /// </remarks>
+    protected internal virtual bool ProcessMnemonic(char charCode) => false;
 
     /// <summary>
     ///  Preprocess keys which affect focus indicators and keyboard cues.
@@ -9997,11 +9836,8 @@ public unsafe partial class Control :
 
             if (accept)
             {
-                Debug.WriteLineIf(CompModSwitches.DragDrop.TraceInfo, $"Registering as drop target: {Handle}");
-
                 // Register
                 HRESULT hr = PInvoke.RegisterDragDrop(this, new DropTarget(this));
-                Debug.WriteLineIf(CompModSwitches.DragDrop.TraceInfo, $"   ret:{hr}");
                 if (hr != HRESULT.S_OK && hr != HRESULT.DRAGDROP_E_ALREADYREGISTERED)
                 {
                     throw Marshal.GetExceptionForHR((int)hr)!;
@@ -10009,11 +9845,8 @@ public unsafe partial class Control :
             }
             else
             {
-                Debug.WriteLineIf(CompModSwitches.DragDrop.TraceInfo, $"Revoking drop target: {Handle}");
-
                 // Revoke
                 HRESULT hr = PInvoke.RevokeDragDrop(this);
-                Debug.WriteLineIf(CompModSwitches.DragDrop.TraceInfo, $"   ret:{hr}");
                 if (hr != HRESULT.S_OK && hr != HRESULT.DRAGDROP_E_NOTREGISTERED)
                 {
                     throw Marshal.GetExceptionForHR((int)hr)!;
@@ -11974,7 +11807,6 @@ public unsafe partial class Control :
     /// </summary>
     private void WmKillFocus(ref Message m)
     {
-        s_focusTracing.TraceVerbose($"Control::WmKillFocus - {Name}");
         WmImeKillFocus();
         DefWndProc(ref m);
         InvokeLostFocus(this, EventArgs.Empty);
@@ -11985,19 +11817,18 @@ public unsafe partial class Control :
     /// </summary>
     private void WmMouseDown(ref Message m, MouseButtons button, int clicks)
     {
-        // If this is a "real" mouse event (not just WM_LBUTTONDOWN, etc) then
-        // we need to see if something happens during processing of
-        // user code that changed the state of the buttons (i.e. bringing up
-        // a dialog) to keep the control in a consistent state...
+        // If this is a "real" mouse event (not just WM_LBUTTONDOWN, etc) then we need to see if something happens
+        // during processing of user code that changed the state of the buttons (i.e. bringing up a dialog) to keep
+        // the control in a consistent state.
         MouseButtons realState = MouseButtons;
         SetState(States.MousePressed, true);
 
-        // If the UserMouse style is set, the control does its own processing
-        // of mouse messages
+        // If the UserMouse style is set, the control does its own processing of mouse messages.
         if (!GetStyle(ControlStyles.UserMouse))
         {
             DefWndProc(ref m);
-            // we might had re-entered the message loop and processed a WM_CLOSE message
+
+            // We might have re-entered the message loop and processed a WM_CLOSE message.
             if (IsDisposed)
             {
                 return;
@@ -12460,11 +12291,9 @@ public unsafe partial class Control :
 
     private void WmQueryNewPalette(ref Message m)
     {
-        s_paletteTracing.TraceVerbose($"{Handle}: WM_QUERYNEWPALETTE");
-
         using GetDcScope dc = new(HWND);
 
-        // We don't want to unset the palette in this case so we don't do this in a using
+        // We don't want to unset the palette in this case so we don't do this in a using.
         var paletteScope = SelectPaletteScope.HalftonePalette(
             dc,
             forceBackground: true,
@@ -12555,7 +12384,6 @@ public unsafe partial class Control :
     /// </summary>
     private void WmSetFocus(ref Message m)
     {
-        s_focusTracing.TraceVerbose($"Control::WmSetFocus - {Name}");
         WmImeSetFocus();
 
         if (!HostedInWin32DialogManager)
@@ -12595,57 +12423,57 @@ public unsafe partial class Control :
 
         DefWndProc(ref m);
 
-        if ((_state & States.Recreate) == 0)
+        if (_state.HasFlag(States.Recreate))
         {
-            bool visible = m.WParamInternal != 0u;
-            bool oldVisibleProperty = Visible;
+            return;
+        }
 
-            if (visible)
+        bool visible = m.WParamInternal != 0u;
+        bool oldVisibleProperty = Visible;
+
+        if (visible)
+        {
+            bool oldVisibleBit = GetState(States.Visible);
+            SetState(States.Visible, true);
+            bool executedOk = false;
+            try
             {
-                bool oldVisibleBit = GetState(States.Visible);
-                SetState(States.Visible, true);
-                bool executedOk = false;
-                try
-                {
-                    CreateControl();
-                    executedOk = true;
-                }
-
-                finally
-                {
-                    if (!executedOk)
-                    {
-                        // We do it this way instead of a try/catch because catching and rethrowing
-                        // an exception loses call stack information
-                        SetState(States.Visible, oldVisibleBit);
-                    }
-                }
-            }
-            else
-            {
-                // not visible
-                // If Windows tells us it's visible, that's pretty unambiguous.
-                // But if it tells us it's not visible, there's more than one explanation --
-                // maybe the container control became invisible.  So we look at the parent
-                // and take a guess at the reason.
-
-                // We do not want to update state if we are on the parking window.
-                bool parentVisible = GetTopLevel();
-                if (ParentInternal is not null)
-                {
-                    parentVisible = ParentInternal.Visible;
-                }
-
-                if (parentVisible)
-                {
-                    SetState(States.Visible, false);
-                }
+                CreateControl();
+                executedOk = true;
             }
 
-            if (!GetState(States.ParentRecreating) && (oldVisibleProperty != visible))
+            finally
             {
-                OnVisibleChanged(EventArgs.Empty);
+                if (!executedOk)
+                {
+                    // We do it this way instead of a try/catch because catching and rethrowing
+                    // an exception loses call stack information
+                    SetState(States.Visible, oldVisibleBit);
+                }
             }
+        }
+        else
+        {
+            // Not visible. If Windows tells us it's visible, that's pretty unambiguous. But if it tells us it's
+            // not visible, there's more than one explanation -- maybe the container control became invisible. So
+            // we look at the parent and take a guess at the reason.
+
+            // We do not want to update state if we are on the parking window.
+            bool parentVisible = GetTopLevel();
+            if (ParentInternal is not null)
+            {
+                parentVisible = ParentInternal.Visible;
+            }
+
+            if (parentVisible)
+            {
+                SetState(States.Visible, false);
+            }
+        }
+
+        if (!GetState(States.ParentRecreating) && (oldVisibleProperty != visible))
+        {
+            OnVisibleChanged(EventArgs.Empty);
         }
     }
 
@@ -12862,17 +12690,10 @@ public unsafe partial class Control :
                 break;
 
             case PInvoke.WM_SYSCOMMAND:
-                if ((m.WParamInternal & 0xFFF0) == PInvoke.SC_KEYMENU)
+                if ((m.WParamInternal & 0xFFF0) == PInvoke.SC_KEYMENU && ToolStripManager.ProcessMenuKey(ref m))
                 {
-                    s_controlKeyboardRouting.TraceVerbose($"Control.WndProc processing {m}");
-
-                    if (ToolStripManager.ProcessMenuKey(ref m))
-                    {
-                        s_controlKeyboardRouting.TraceVerbose(
-                            $"Control.WndProc ToolStripManager.ProcessMenuKey returned true{m}");
-                        m.ResultInternal = (LRESULT)0;
-                        return;
-                    }
+                    m.ResultInternal = (LRESULT)0;
+                    return;
                 }
 
                 DefWndProc(ref m);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/Buttons/RadioButton.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/Buttons/RadioButton.cs
@@ -363,7 +363,7 @@ public partial class RadioButton : ButtonBase
         base.OnClick(e);
     }
 
-    protected override void OnEnter(EventArgs e)
+    protected internal override void OnEnter(EventArgs e)
     {
         // Just like the Win32 RadioButton, fire a click if the user arrows onto the control.
         if (MouseButtons == MouseButtons.None)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridView.Methods.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridView.Methods.cs
@@ -15390,7 +15390,7 @@ public partial class DataGridView
         }
     }
 
-    protected override void OnEnter(EventArgs e)
+    protected internal override void OnEnter(EventArgs e)
     {
         if (EditingControl is not null && EditingControl.ContainsFocus)
         {
@@ -16201,7 +16201,7 @@ public partial class DataGridView
         }
     }
 
-    protected override void OnLeave(EventArgs e)
+    protected internal override void OnLeave(EventArgs e)
     {
         if (_ptCurrentCell.X > -1 && !_dataGridViewState1[State1_LeavingWithTabKey])
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TabControl/TabControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TabControl/TabControl.cs
@@ -1330,7 +1330,7 @@ public partial class TabControl : Control
     ///  Focus. To be Backward compatible we have added new bool which can be set to true
     ///  to the get the NEW SANE ENTER-LEAVE EVENTS ON THE TABPAGE.
     /// </summary>
-    protected override void OnEnter(EventArgs e)
+    protected internal override void OnEnter(EventArgs e)
     {
         base.OnEnter(e);
         SelectedTab?.FireEnter(e);
@@ -1350,7 +1350,7 @@ public partial class TabControl : Control
     ///  Focus. To be Backward compatible we have added new bool which can be set to true
     ///  to the get the NEW SANE ENTER-LEAVE EVENTS ON THE TABPAGE.
     /// </summary>
-    protected override void OnLeave(EventArgs e)
+    protected internal override void OnLeave(EventArgs e)
     {
         SelectedTab?.FireLeave(e);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TabControl/TabPage.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TabControl/TabPage.cs
@@ -546,7 +546,7 @@ public partial class TabPage : Panel
     ///  TabPage should fire enter when the focus is on the TabPage and not when the control
     ///  within the TabPage gets Focused.
     /// </summary>
-    protected override void OnEnter(EventArgs e)
+    protected internal override void OnEnter(EventArgs e)
     {
         if (ParentInternal is TabControl)
         {
@@ -569,7 +569,7 @@ public partial class TabPage : Panel
     ///  the TabPage gets Focused.
     ///  Similary the Leave should fire when the TabControl (and hence the TabPage) loses focus.
     /// </summary>
-    protected override void OnLeave(EventArgs e)
+    protected internal override void OnLeave(EventArgs e)
     {
         if (ParentInternal is TabControl)
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TextBox/TextBoxBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TextBox/TextBoxBase.cs
@@ -1429,7 +1429,6 @@ public abstract partial class TextBoxBase : Control
 
     protected override bool ProcessDialogKey(Keys keyData)
     {
-        s_controlKeyboardRouting.TraceVerbose($"TextBoxBase.ProcessDialogKey [{keyData}]");
         Keys keyCode = keyData & Keys.KeyCode;
 
         if (keyCode == Keys.Tab && AcceptsTab && (keyData & Keys.Control) != 0)
@@ -2052,16 +2051,9 @@ public abstract partial class TextBoxBase : Control
     private void WmGetDlgCode(ref Message m)
     {
         base.WndProc(ref m);
-        if (AcceptsTab)
-        {
-            s_controlKeyboardRouting.TraceVerbose("TextBox wants tabs");
-            m.ResultInternal = (LRESULT)(m.ResultInternal | (int)PInvoke.DLGC_WANTTAB);
-        }
-        else
-        {
-            s_controlKeyboardRouting.TraceVerbose("TextBox doesn't want tabs");
-            m.ResultInternal = (LRESULT)(m.ResultInternal & ~(int)(PInvoke.DLGC_WANTTAB | PInvoke.DLGC_WANTALLKEYS));
-        }
+        m.ResultInternal = AcceptsTab
+            ? (LRESULT)(m.ResultInternal | (int)PInvoke.DLGC_WANTTAB)
+            : (LRESULT)(m.ResultInternal & ~(int)(PInvoke.DLGC_WANTTAB | PInvoke.DLGC_WANTALLKEYS));
     }
 
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStrip.cs
@@ -3387,7 +3387,7 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
         ClearAllSelections();
     }
 
-    protected override void OnLeave(EventArgs e)
+    protected internal override void OnLeave(EventArgs e)
     {
         base.OnLeave(e);
         if (!IsDropDown)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripDropDown.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripDropDown.cs
@@ -1503,8 +1503,6 @@ public partial class ToolStripDropDown : ToolStrip
     [EditorBrowsable(EditorBrowsableState.Advanced)]
     protected override bool ProcessDialogChar(char charCode)
     {
-        s_controlKeyboardRouting.TraceVerbose($"ToolStripDropDown.ProcessDialogChar [{charCode}]");
-
         // Since we're toplevel and aren't a container control, we've got to do our own mnemonic handling.
         if ((OwnerItem is null || OwnerItem.Pressed) && charCode != ' ' && ProcessMnemonic(charCode))
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripDropTargetManager.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripDropTargetManager.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.ComponentModel;
 using System.Drawing;
 using System.Runtime.InteropServices;
 
@@ -173,11 +172,8 @@ internal class ToolStripDropTargetManager : IDropTarget
                 throw new ThreadStateException(SR.ThreadMustBeSTA);
             }
 
-            Debug.WriteLineIf(CompModSwitches.DragDrop.TraceInfo, $"Registering as drop target: {_owner.Handle}");
-
             // Register
             HRESULT hr = PInvoke.RegisterDragDrop(_owner, new DropTarget(this));
-            Debug.WriteLineIf(CompModSwitches.DragDrop.TraceInfo, $"   ret:{hr}");
             if (hr.Failed && hr != HRESULT.DRAGDROP_E_ALREADYREGISTERED)
             {
                 throw Marshal.GetExceptionForHR((int)hr)!;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripPanelCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripPanelCell.cs
@@ -325,7 +325,6 @@ internal sealed class ToolStripPanelCell : ArrangedElement
                     }
                 }
 
-                ToolStripPanelRow.ToolStripPanelMouseDebug.TraceVerbose($"[CELL] DRAGGING calling SetBounds {bounds}");
                 base.SetBoundsCore(bounds, specified);
                 InnerElement.SetBounds(bounds, specified);
             }
@@ -333,7 +332,6 @@ internal sealed class ToolStripPanelCell : ArrangedElement
             {
                 if (!ToolStripPanelRow.CachedBoundsMode)
                 {
-                    ToolStripPanelRow.ToolStripPanelMouseDebug.TraceVerbose($"[CELL] NOT DRAGGING calling SetBounds {bounds}");
                     base.SetBoundsCore(bounds, specified);
                     InnerElement.SetBounds(bounds, specified);
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripPanelRow.HorizontalRowManager.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripPanelRow.HorizontalRowManager.cs
@@ -166,7 +166,6 @@ public partial class ToolStripPanelRow
 
         private int MoveLeft(int index, int spaceToFree)
         {
-            ToolStripPanelMouseDebug.TraceVerbose($"MoveLeft: {spaceToFree}");
             int freedSpace = 0;
 
             Row.SuspendLayout();
@@ -174,7 +173,6 @@ public partial class ToolStripPanelRow
             {
                 if (spaceToFree == 0 || index < 0)
                 {
-                    ToolStripPanelMouseDebug.TraceVerbose("MoveLeft Early EXIT - 0 ");
                     return 0;
                 }
 
@@ -221,7 +219,6 @@ public partial class ToolStripPanelRow
                             }
                         }
 
-                        ToolStripPanelMouseDebug.TraceVerbose($"MoveLeft Recovered (Margin only): {spaceToFree}");
                         return spaceToFree;
                     }
                 }
@@ -231,20 +228,17 @@ public partial class ToolStripPanelRow
                 Row.ResumeLayout(true);
             }
 
-            ToolStripPanelMouseDebug.TraceVerbose($"MoveLeft Recovered Partial (Shrink): {freedSpace}");
             return freedSpace;
         }
 
         private int MoveRight(int index, int spaceToFree)
         {
-            ToolStripPanelMouseDebug.TraceVerbose($"MoveRight: {spaceToFree}");
             int freedSpace = 0;
             Row.SuspendLayout();
             try
             {
                 if (spaceToFree == 0 || index < 0 || index >= Row.ControlsInternal.Count)
                 {
-                    ToolStripPanelMouseDebug.TraceVerbose("MoveRight Early EXIT - 0 ");
                     return 0;
                 }
 
@@ -313,7 +307,6 @@ public partial class ToolStripPanelRow
                         cell.Margin = cellMargin;
                     }
 
-                    ToolStripPanelMouseDebug.TraceVerbose($"MoveRight Recovered (Margin only): {spaceToFree}");
                     return spaceToFree;
                 }
 
@@ -330,7 +323,6 @@ public partial class ToolStripPanelRow
 
                     if (spaceToFree >= freedSpace)
                     {
-                        ToolStripPanelMouseDebug.TraceVerbose($"MoveRight Recovered (Shrink): {spaceToFree}");
                         Row.ResumeLayout(true);
                         return spaceToFree;
                     }
@@ -351,8 +343,6 @@ public partial class ToolStripPanelRow
             {
                 Row.ResumeLayout(true);
             }
-
-            ToolStripPanelMouseDebug.TraceVerbose($"MoveRight Recovered Partial (Shrink): {freedSpace}");
 
             return freedSpace;
         }
@@ -400,7 +390,6 @@ public partial class ToolStripPanelRow
 
         public override void JoinRow(ToolStrip toolStripToDrag, Point locationToDrag)
         {
-            ToolStripPanelMouseDebug.TraceVerbose("Horizontal JoinRow called ");
             int index;
 
             if (!Row.ControlsInternal.Contains(toolStripToDrag))

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripPanelRow.VerticalRowManager.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripPanelRow.VerticalRowManager.cs
@@ -168,7 +168,6 @@ public partial class ToolStripPanelRow
 
         private int MoveUp(int index, int spaceToFree)
         {
-            ToolStripPanelMouseDebug.TraceVerbose($"MoveUp: {spaceToFree}");
             int freedSpace = 0;
 
             Row.SuspendLayout();
@@ -176,7 +175,6 @@ public partial class ToolStripPanelRow
             {
                 if (spaceToFree == 0 || index < 0)
                 {
-                    ToolStripPanelMouseDebug.TraceVerbose("MoveUp Early EXIT - 0 ");
                     return 0;
                 }
 
@@ -223,7 +221,6 @@ public partial class ToolStripPanelRow
                             }
                         }
 
-                        ToolStripPanelMouseDebug.TraceVerbose($"MoveUp Recovered (Margin only): {spaceToFree}");
                         return spaceToFree;
                     }
                 }
@@ -233,21 +230,17 @@ public partial class ToolStripPanelRow
                 Row.ResumeLayout(true);
             }
 
-            ToolStripPanelMouseDebug.TraceVerbose($"MoveLeft Recovered Partial (Shrink): {freedSpace}");
-
             return freedSpace;
         }
 
         private int MoveDown(int index, int spaceToFree)
         {
-            ToolStripPanelMouseDebug.TraceVerbose($"MoveDown: {spaceToFree}");
             int freedSpace = 0;
             Row.SuspendLayout();
             try
             {
                 if (spaceToFree == 0 || index < 0 || index >= Row.ControlsInternal.Count)
                 {
-                    ToolStripPanelMouseDebug.TraceVerbose("MoveDown Early EXIT - 0 ");
                     return 0;
                 }
 
@@ -309,7 +302,6 @@ public partial class ToolStripPanelRow
                     cellMargin.Top += spaceToFree;
                     cell.Margin = cellMargin;
 
-                    ToolStripPanelMouseDebug.TraceVerbose($"MoveDown Recovered (Margin only): {spaceToFree}");
                     return spaceToFree;
                 }
 
@@ -326,7 +318,6 @@ public partial class ToolStripPanelRow
 
                     if (spaceToFree >= freedSpace)
                     {
-                        ToolStripPanelMouseDebug.TraceVerbose($"MoveDown Recovered (Shrink): {spaceToFree}");
                         Row.ResumeLayout(true);
                         return spaceToFree;
                     }
@@ -349,8 +340,6 @@ public partial class ToolStripPanelRow
             }
 
             int recoveredSpace = spaceToFree - freedSpace;
-            ToolStripPanelMouseDebug.TraceVerbose($"MoveDown Recovered Partial (Shrink): {recoveredSpace}");
-
             return recoveredSpace;
         }
 
@@ -408,7 +397,6 @@ public partial class ToolStripPanelRow
 
         public override void JoinRow(ToolStrip toolStripToDrag, Point locationToDrag)
         {
-            ToolStripPanelMouseDebug.TraceVerbose("Vertical JoinRow called ");
             int index;
 
             if (!Row.ControlsInternal.Contains(toolStripToDrag))

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripPanelRow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripPanelRow.cs
@@ -700,8 +700,7 @@ public partial class ToolStripPanelRow : Component, IArrangedElement
     // Sets the bounds for an element.
     void IArrangedElement.SetBounds(Rectangle bounds, BoundsSpecified specified)
     {
-        // in this case the parent is telling us to refresh our bounds - don't
-        // call PerformLayout
+        // In this case the parent is telling us to refresh our bounds - don't call PerformLayout.
         SetBounds(bounds);
     }
 
@@ -713,28 +712,12 @@ public partial class ToolStripPanelRow : Component, IArrangedElement
         }
     }
 
-    #region MouseStuff
-
-#if DEBUG
-    internal static TraceSwitch ToolStripPanelMouseDebug { get; } = new("ToolStripPanelMouse", "Debug ToolStrip WM_MOUSEACTIVATE code");
-#else
-    internal static TraceSwitch? ToolStripPanelMouseDebug { get; }
-#endif
-
-    internal Rectangle DragBounds
-    {
-        get
-        {
-            return RowManager.DragBounds;
-        }
-    }
+    internal Rectangle DragBounds => RowManager.DragBounds;
 
     internal void MoveControl(ToolStrip movingControl, Point startClientLocation, Point endClientLocation)
     {
         RowManager.MoveControl(movingControl, startClientLocation, endClientLocation);
     }
-
-    //
 
     internal void JoinRow(ToolStrip toolStripToDrag, Point locationToDrag)
     {
@@ -750,6 +733,4 @@ public partial class ToolStripPanelRow : Component, IArrangedElement
             Dispose();
         }
     }
-
-    #endregion
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/WebBrowser/WebBrowserBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/WebBrowser/WebBrowserBase.cs
@@ -254,7 +254,6 @@ public unsafe partial class WebBrowserBase : Control
             HRESULT hr = _axOleInPlaceActiveObject!.TranslateAccelerator(&win32Message);
             if (hr == HRESULT.S_OK)
             {
-                s_controlKeyboardRouting.TraceVerbose($"\t Message translated to {win32Message}");
                 return true;
             }
             else
@@ -285,14 +284,10 @@ public unsafe partial class WebBrowserBase : Control
                 }
                 else if (GetAXHostState(WebBrowserHelper.s_siteProcessedInputKey))
                 {
-                    s_controlKeyboardRouting.TraceVerbose(
-                        $"\t Message processed by site. Calling base.PreProcessMessage() {msg}");
                     return base.PreProcessMessage(ref msg);
                 }
                 else
                 {
-                    s_controlKeyboardRouting.TraceVerbose(
-                        $"\t Message not processed by site. Returning false. {msg}");
                     return false;
                 }
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -235,7 +235,6 @@ public partial class Form : ContainerControl
         }
         set
         {
-            s_focusTracing.TraceVerbose($"Form::set_Active - {Name}");
             if ((_formState[s_formStateIsActive] != 0) != value)
             {
                 if (value)
@@ -2215,8 +2214,6 @@ public partial class Form : ContainerControl
     [EditorBrowsable(EditorBrowsableState.Advanced)]
     protected override void SetVisibleCore(bool value)
     {
-        s_focusTracing.TraceVerbose($"Form::SetVisibleCore({value}) - {Name}");
-
         // If DialogResult.OK and the value == Visible then this code has been called either through
         // ShowDialog( ) or explicit Hide( ) by the user. So don't go through this function again.
         // This will avoid flashing during closing the dialog;
@@ -3636,11 +3633,11 @@ public partial class Form : ContainerControl
     /// </summary>
     internal override bool CanProcessMnemonic()
     {
-#if DEBUG
-        TraceCanProcessMnemonic();
-#endif
         // If this is a Mdi child form, child controls should process mnemonics only if this is the active mdi child.
-        if (IsMdiChild && (_formStateEx[s_formStateExMnemonicProcessed] == 1 || this != MdiParentInternal.ActiveMdiChildInternal || WindowState == FormWindowState.Minimized))
+        if (IsMdiChild &&
+            (_formStateEx[s_formStateExMnemonicProcessed] == 1
+                || this != MdiParentInternal.ActiveMdiChildInternal
+                || WindowState == FormWindowState.Minimized))
         {
             return false;
         }
@@ -3917,7 +3914,7 @@ public partial class Form : ContainerControl
     }
 
     [EditorBrowsable(EditorBrowsableState.Advanced)]
-    protected override void OnEnter(EventArgs e)
+    protected internal override void OnEnter(EventArgs e)
     {
         base.OnEnter(e);
 
@@ -4533,11 +4530,7 @@ public partial class Form : ContainerControl
     [EditorBrowsable(EditorBrowsableState.Advanced)]
     protected override bool ProcessDialogChar(char charCode)
     {
-#if DEBUG
-        s_controlKeyboardRouting.TraceVerbose($"Form.ProcessDialogChar [{charCode}]");
-#endif
-        // If we're the top-level form or control, we need to do the mnemonic handling
-        //
+        // If we're the top-level form or control, we need to do the mnemonic handling.
         if (IsMdiChild && charCode != ' ')
         {
             if (ProcessMnemonic(charCode))

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/Containers/SplitContainer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/Containers/SplitContainer.cs
@@ -2293,20 +2293,8 @@ public partial class SplitContainer : ContainerControl, ISupportInitialize
         }
     }
 
-    /// <summary>
-    ///  Processes a dialog key. Overrides Control.processDialogKey(). This
-    ///  method implements handling of the TAB, LEFT, RIGHT, UP, and DOWN
-    ///  keys in dialogs.
-    ///  The method performs no processing on keys that include the ALT or
-    ///  CONTROL modifiers. For the TAB key, the method selects the next control
-    ///  on the form. For the arrow keys,
-    ///  !!!
-    /// </summary>
     protected override bool ProcessDialogKey(Keys keyData)
     {
-#if DEBUG
-        s_controlKeyboardRouting.TraceVerbose($"ContainerControl.ProcessDialogKey [{keyData}]");
-#endif
         if ((keyData & (Keys.Alt | Keys.Control)) == Keys.None)
         {
             Keys keyCode = keyData & Keys.KeyCode;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DropTarget.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DropTarget.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.ComponentModel;
 using System.Runtime.InteropServices;
 using Windows.Win32.System.Com;
 using Windows.Win32.System.SystemServices;
@@ -20,7 +19,6 @@ internal unsafe class DropTarget : Ole.IDropTarget.Interface, IManagedWrapper<Ol
 
     public DropTarget(IDropTarget owner)
     {
-        Debug.WriteLineIf(CompModSwitches.DragDrop.TraceInfo, "DropTarget created");
         _owner = owner.OrThrowIfNull();
 
         if (_owner is Control control && control.IsHandleCreated)
@@ -34,13 +32,6 @@ internal unsafe class DropTarget : Ole.IDropTarget.Interface, IManagedWrapper<Ol
             _hwndTarget = toolStrip.HWND;
         }
     }
-
-#if DEBUG
-    ~DropTarget()
-    {
-        Debug.WriteLineIf(CompModSwitches.DragDrop.TraceInfo, "DropTarget destroyed");
-    }
-#endif
 
     private void ClearDropDescription()
     {
@@ -103,8 +94,6 @@ internal unsafe class DropTarget : Ole.IDropTarget.Interface, IManagedWrapper<Ol
 
     HRESULT Ole.IDropTarget.Interface.DragEnter(Com.IDataObject* pDataObj, MODIFIERKEYS_FLAGS grfKeyState, POINTL pt, Ole.DROPEFFECT* pdwEffect)
     {
-        Debug.WriteLineIf(CompModSwitches.DragDrop.TraceInfo, "OleDragEnter received");
-        Debug.WriteLineIf(CompModSwitches.DragDrop.TraceInfo, $"\t{pt.x},{pt.y}");
         Debug.Assert(pDataObj is not null, "OleDragEnter didn't give us a valid data object.");
 
         if (pdwEffect is null)
@@ -134,9 +123,6 @@ internal unsafe class DropTarget : Ole.IDropTarget.Interface, IManagedWrapper<Ol
 
     HRESULT Ole.IDropTarget.Interface.DragOver(MODIFIERKEYS_FLAGS grfKeyState, POINTL pt, Ole.DROPEFFECT* pdwEffect)
     {
-        Debug.WriteLineIf(CompModSwitches.DragDrop.TraceInfo, "OleDragOver received");
-        Debug.WriteLineIf(CompModSwitches.DragDrop.TraceInfo, $"\t{pt.x},{pt.y}");
-
         if (pdwEffect is null)
         {
             return HRESULT.E_INVALIDARG;
@@ -164,7 +150,6 @@ internal unsafe class DropTarget : Ole.IDropTarget.Interface, IManagedWrapper<Ol
 
     HRESULT Ole.IDropTarget.Interface.DragLeave()
     {
-        Debug.WriteLineIf(CompModSwitches.DragDrop.TraceInfo, "OleDragLeave received");
         _owner.OnDragLeave(EventArgs.Empty);
 
         if (_lastDragEventArgs?.DropImageType > DropImageType.Invalid)
@@ -178,9 +163,6 @@ internal unsafe class DropTarget : Ole.IDropTarget.Interface, IManagedWrapper<Ol
 
     HRESULT Ole.IDropTarget.Interface.Drop(Com.IDataObject* pDataObj, MODIFIERKEYS_FLAGS grfKeyState, POINTL pt, Ole.DROPEFFECT* pdwEffect)
     {
-        Debug.WriteLineIf(CompModSwitches.DragDrop.TraceInfo, "OleDrop received");
-        Debug.WriteLineIf(CompModSwitches.DragDrop.TraceInfo, $"\t{pt.x},{pt.y}");
-
         if (pdwEffect is null)
         {
             return HRESULT.E_INVALIDARG;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.Internals.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.Internals.cs
@@ -401,30 +401,6 @@ public partial class ControlTests
     }
 
     [WinFormsFact]
-    public void Control_NotifyEnter()
-    {
-        bool wasChanged = false;
-        using Control control = new();
-        control.Enter += (sender, args) => wasChanged = true;
-
-        control.NotifyEnter();
-
-        Assert.True(wasChanged);
-    }
-
-    [WinFormsFact]
-    public void Control_NotifyLeave()
-    {
-        bool wasChanged = false;
-        using Control control = new();
-        control.Leave += (sender, args) => wasChanged = true;
-
-        control.NotifyLeave();
-
-        Assert.True(wasChanged);
-    }
-
-    [WinFormsFact]
     public void Control_ReflectParentDoesNotRootParent()
     {
         using Control control = new();


### PR DESCRIPTION
Removes another set of trace statements.

Reduce nesting on a few impacted methods.

Make OnEnter/Leave protected internal to avoid a separate method just to make internal access possible.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11071)