### PR TITLE
Match annotations for interface and overridden methods to reduce TrimTest warnings

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CollectionEditor.CollectionEditorCollectionForm.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CollectionEditor.CollectionEditorCollectionForm.cs
@@ -1244,6 +1244,7 @@ public partial class CollectionEditor
             /// <summary>
             ///  Retrieves the type converter for this object.
             /// </summary>
+            [RequiresUnreferencedCode("Generic TypeConverters may require the generic types to be annotated. For example, NullableConverter requires the underlying type to be DynamicallyAccessedMembers All.")]
             TypeConverter? ICustomTypeDescriptor.GetConverter() => null;
 
             /// <summary>
@@ -1259,6 +1260,7 @@ public partial class CollectionEditor
             /// <summary>
             ///  Retrieves the an editor for this object.
             /// </summary>
+            [RequiresUnreferencedCode("Design-time attributes are not preserved when trimming. Types referenced by attributes like EditorAttribute and DesignerAttribute may not be available after trimming.")]
             object? ICustomTypeDescriptor.GetEditor(Type editorBaseType) => null;
 
             /// <summary>
@@ -1284,6 +1286,7 @@ public partial class CollectionEditor
             ///  This may differ from the set of properties the class provides.
             ///  If the component is sited, the site may add or remove additional properties.
             /// </summary>
+            [RequiresUnreferencedCode("PropertyDescriptor's PropertyType cannot be statically discovered.")]
             PropertyDescriptorCollection ICustomTypeDescriptor.GetProperties() => _properties;
 
             /// <summary>
@@ -1292,6 +1295,7 @@ public partial class CollectionEditor
             ///  If the component is sited, the site may add or remove additional properties.
             ///  The returned array of properties will be filtered by the given set of attributes.
             /// </summary>
+            [RequiresUnreferencedCode("PropertyDescriptor's PropertyType cannot be statically discovered. The public parameterless constructor or the 'Default' static field may be trimmed from the Attribute's Type.")]
             PropertyDescriptorCollection ICustomTypeDescriptor.GetProperties(Attribute[]? attributes) => _properties;
 
             /// <summary>

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/EventBindingService.EventPropertyDescriptor.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/EventBindingService.EventPropertyDescriptor.cs
@@ -48,7 +48,11 @@ public abstract partial class EventBindingService
         /// <summary>
         ///  Retrieves the type converter for this property.
         /// </summary>
-        public override TypeConverter Converter => _converter ??= new EventConverter(Event);
+        public override TypeConverter Converter
+        {
+            [RequiresUnreferencedCode("PropertyDescriptor's PropertyType cannot be statically discovered.")]
+            get => _converter ??= new EventConverter(Event);
+        }
 
         /// <summary>
         ///  Retrieves the event descriptor we are representing.

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ResourceCodeDomSerializer.SerializationResourceManager.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ResourceCodeDomSerializer.SerializationResourceManager.cs
@@ -166,6 +166,7 @@ internal partial class ResourceCodeDomSerializer
         /// <summary>
         ///  This method examines all the resources for the provided culture. When it finds a resource with a key in the format of  "[objectName].[property name]"; it will apply that resources value to the corresponding property on the object.
         /// </summary>
+        [RequiresUnreferencedCode("The Type of value cannot be statically discovered.")]
         public override void ApplyResources(object value, string objectName, CultureInfo? culture)
         {
             culture ??= ReadCulture;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewColumnCollectionDialog.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DataGridViewColumnCollectionDialog.cs
@@ -1244,20 +1244,24 @@ internal class DataGridViewColumnCollectionDialog : Form
 
         string? ICustomTypeDescriptor.GetComponentName() => TypeDescriptor.GetComponentName(DataGridViewColumn);
 
+        [RequiresUnreferencedCode("Generic TypeConverters may require the generic types to be annotated. For example, NullableConverter requires the underlying type to be DynamicallyAccessedMembers All.")]
         TypeConverter ICustomTypeDescriptor.GetConverter() => TypeDescriptor.GetConverter(DataGridViewColumn);
 
         EventDescriptor? ICustomTypeDescriptor.GetDefaultEvent() => TypeDescriptor.GetDefaultEvent(DataGridViewColumn);
 
         PropertyDescriptor? ICustomTypeDescriptor.GetDefaultProperty() => TypeDescriptor.GetDefaultProperty(DataGridViewColumn);
 
+        [RequiresUnreferencedCode("Design-time attributes are not preserved when trimming. Types referenced by attributes like EditorAttribute and DesignerAttribute may not be available after trimming.")]
         object? ICustomTypeDescriptor.GetEditor(Type type) => TypeDescriptor.GetEditor(DataGridViewColumn, type);
 
         EventDescriptorCollection ICustomTypeDescriptor.GetEvents() => TypeDescriptor.GetEvents(DataGridViewColumn);
 
         EventDescriptorCollection ICustomTypeDescriptor.GetEvents(Attribute[]? attrs) => TypeDescriptor.GetEvents(DataGridViewColumn, attrs!);
 
+        [RequiresUnreferencedCode("PropertyDescriptor's PropertyType cannot be statically discovered.")]
         PropertyDescriptorCollection ICustomTypeDescriptor.GetProperties() => ((ICustomTypeDescriptor)this).GetProperties(null);
 
+        [RequiresUnreferencedCode("PropertyDescriptor's PropertyType cannot be statically discovered. The public parameterless constructor or the 'Default' static field may be trimmed from the Attribute's Type.")]
         PropertyDescriptorCollection ICustomTypeDescriptor.GetProperties(Attribute[]? attrs)
         {
             PropertyDescriptorCollection props = TypeDescriptor.GetProperties(DataGridViewColumn);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyDescriptor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyDescriptor.cs
@@ -673,7 +673,7 @@ internal unsafe partial class Com2PropertyDescriptor : PropertyDescriptor, IClon
     ///   the parameter will be passed in.
     ///  </para>
     /// </remarks>
-    public void GetTypeConverterAndTypeEditor([NotNull] ref TypeConverter? typeConverter, Type editorBaseType, ref object? typeEditor)
+    public void GetTypeConverterAndTypeEditor([NotNull] ref TypeConverter? typeConverter, [DynamicallyAccessedMembers((DynamicallyAccessedMemberTypes.All))] Type editorBaseType, ref object? typeEditor)
     {
         // Get the base editor and converter, attributes first.
         TypeConverter? localConverter = typeConverter;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyDescriptor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyDescriptor.cs
@@ -673,7 +673,7 @@ internal unsafe partial class Com2PropertyDescriptor : PropertyDescriptor, IClon
     ///   the parameter will be passed in.
     ///  </para>
     /// </remarks>
-    public void GetTypeConverterAndTypeEditor([NotNull] ref TypeConverter? typeConverter, [DynamicallyAccessedMembers((DynamicallyAccessedMemberTypes.All))] Type editorBaseType, ref object? typeEditor)
+    public void GetTypeConverterAndTypeEditor([NotNull] ref TypeConverter? typeConverter, Type editorBaseType, ref object? typeEditor)
     {
         // Get the base editor and converter, attributes first.
         TypeConverter? localConverter = typeConverter;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/ComNativeDescriptor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/ComNativeDescriptor.cs
@@ -96,6 +96,7 @@ internal sealed unsafe partial class ComNativeDescriptor : TypeDescriptionProvid
 
     internal static TypeConverter GetIComponentConverter() => TypeDescriptor.GetConverter(typeof(IComponent));
 
+    [RequiresUnreferencedCode("Design-time attributes are not preserved when trimming. Types referenced by attributes like EditorAttribute and DesignerAttribute may not be available after trimming.")]
     internal static object? GetEditor(object component, Type baseEditorType)
         => TypeDescriptor.GetEditor(component.GetType(), baseEditorType);
 
@@ -328,7 +329,7 @@ internal sealed unsafe partial class ComNativeDescriptor : TypeDescriptionProvid
     internal static void ResolveVariantTypeConverterAndTypeEditor(
         object? propertyValue,
         ref TypeConverter currentConverter,
-        Type editorType,
+        [DynamicallyAccessedMembers((DynamicallyAccessedMemberTypes.All))] Type editorType,
         ref object? currentEditor)
     {
         if (propertyValue is not null && !Convert.IsDBNull(propertyValue))

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/ComNativeDescriptor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/ComNativeDescriptor.cs
@@ -329,7 +329,7 @@ internal sealed unsafe partial class ComNativeDescriptor : TypeDescriptionProvid
     internal static void ResolveVariantTypeConverterAndTypeEditor(
         object? propertyValue,
         ref TypeConverter currentConverter,
-        [DynamicallyAccessedMembers((DynamicallyAccessedMemberTypes.All))] Type editorType,
+        Type editorType,
         ref object? currentEditor)
     {
         if (propertyValue is not null && !Convert.IsDBNull(propertyValue))


### PR DESCRIPTION
Reducing [TrimTest](https://github.com/dotnet/winforms/blob/main/src/System.Windows.Forms/tests/IntegrationTests/TrimTest/TrimTest.csproj) project warnings by mostly addressing [IL2046](https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trim-warnings/il2046) warnings that the test project encounters (should be reduced by 12 warnings to 72 now, with some fixes coming from other repos)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11087)