### PR TITLE
Fixes wrong tooltip when tabbing through PrintPreviewDialog's ToolStripButtons

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStrip.cs
@@ -4591,7 +4591,8 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
                 if (item != _currentlyActiveTooltipItem)
                 {
                     ToolTip.Hide(this);
-                    _currentlyActiveTooltipItem = item;
+                    if(!refresh)
+                        _currentlyActiveTooltipItem = item;
                 }
 
                 if (_currentlyActiveTooltipItem is not null && !GetToolStripState(STATE_DRAGGING))


### PR DESCRIPTION
Fixes #10970

## Proposed changes

- Stops updating the current Tooltip item while refreshing on the Toolstrip.

## Customer Impact

- Tabbing through the controls in the PrintPreviewDialog ToolStripButton's will show proper tooltip even after zoom is altered in the dropdown.

## Regression?

- Yes

## Risk

- Minimal

## Screenshots

### Before

![i10970-before](https://github.com/dotnet/winforms/assets/30190295/1b5437b0-82e7-4ad5-afe5-e000cf6d6ff4)

### After

![i10970-after](https://github.com/dotnet/winforms/assets/30190295/9db76a95-07c5-4d77-9d4a-0eb9f980f2fb)

## Test methodology

- Manual

## Accessibility testing

## Test environment(s)

- 9.0.100-preview.1.24101.2
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11089)