### PR TITLE
[release/8.0] Fix NRE in the keyboard-driven ToolTips when DataGridView control is re-created.

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
@@ -430,7 +430,7 @@ public abstract partial class DataGridViewCell : DataGridViewElement, ICloneable
 
     string IKeyboardToolTip.GetCaptionForTool(ToolTip toolTip)
     {
-        if (DataGridView.ShowCellErrors && !string.IsNullOrEmpty(ErrorText))
+        if (DataGridView is not null && DataGridView.ShowCellErrors && !string.IsNullOrEmpty(ErrorText))
         {
             return ErrorText;
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
@@ -414,7 +414,7 @@ public abstract partial class DataGridViewCell : DataGridViewElement, ICloneable
 
     bool IKeyboardToolTip.IsHoveredWithMouse() => false;
 
-    bool IKeyboardToolTip.HasRtlModeEnabled() => DataGridView.RightToLeft == RightToLeft.Yes;
+    bool IKeyboardToolTip.HasRtlModeEnabled() => DataGridView != null && DataGridView.RightToLeft == RightToLeft.Yes;
 
     bool IKeyboardToolTip.AllowsToolTip() => true;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
@@ -414,7 +414,7 @@ public abstract partial class DataGridViewCell : DataGridViewElement, ICloneable
 
     bool IKeyboardToolTip.IsHoveredWithMouse() => false;
 
-    bool IKeyboardToolTip.HasRtlModeEnabled() => DataGridView != null && DataGridView.RightToLeft == RightToLeft.Yes;
+    bool IKeyboardToolTip.HasRtlModeEnabled() => DataGridView is not null && DataGridView.RightToLeft == RightToLeft.Yes;
 
     bool IKeyboardToolTip.AllowsToolTip() => true;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
@@ -1571,7 +1571,7 @@ public partial class ToolTip : Component, IExtenderProvider, IHandle<HWND>
         HWND hwnd = GetCurrentToolHwnd();
         LRESULT result = default;
 
-        if (!hwnd.IsNull)
+        if (!hwnd.IsNull && tool.GetOwnerWindow() is not null)
         {
             ToolInfoWrapper<HandleRef<HWND>> info = new(Control.GetSafeHandle(tool.GetOwnerWindow()!));
             result = info.SendMessage(this, PInvoke.TTM_GETBUBBLESIZE);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
@@ -1520,7 +1520,10 @@ public partial class ToolTip : Component, IExtenderProvider, IHandle<HWND>
         int pointX = (toolRectangle.Left + toolRectangle.Right) / 2;
         int pointY = (toolRectangle.Top + toolRectangle.Bottom) / 2;
         var ownerWindow = tool.GetOwnerWindow();
-        Debug.Assert(ownerWindow is not null);
+        if (ownerWindow is null)
+        {
+            return;
+        }
 
         SetTool(ownerWindow, text, TipInfo.Type.Absolute, new Point(pointX, pointY));
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
@@ -1571,9 +1571,9 @@ public partial class ToolTip : Component, IExtenderProvider, IHandle<HWND>
         HWND hwnd = GetCurrentToolHwnd();
         LRESULT result = default;
 
-        if (!hwnd.IsNull && tool.GetOwnerWindow() is not null)
+        if (!hwnd.IsNull && tool.GetOwnerWindow() is IWin32Window ownerWindow)
         {
-            ToolInfoWrapper<HandleRef<HWND>> info = new(Control.GetSafeHandle(tool.GetOwnerWindow()!));
+            ToolInfoWrapper<HandleRef<HWND>> info = new(Control.GetSafeHandle(ownerWindow));
             result = info.SendMessage(this, PInvoke.TTM_GETBUBBLESIZE);
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
@@ -1530,7 +1530,7 @@ public partial class ToolTip : Component, IExtenderProvider, IHandle<HWND>
         SetTool(ownerWindow, text, TipInfo.Type.Absolute, new Point(pointX, pointY));
 
         // Then look for a better ToolTip location.
-        if (TryGetBubbleSize(tool, ownerWindow, out Size bubbleSize))
+        if (TryGetBubbleSize(ownerWindow, out Size bubbleSize))
         {
             Point optimalPoint = GetOptimalToolTipPosition(tool, toolRectangle, bubbleSize.Width, bubbleSize.Height);
 
@@ -1568,7 +1568,7 @@ public partial class ToolTip : Component, IExtenderProvider, IHandle<HWND>
         }
     }
 
-    private bool TryGetBubbleSize(IKeyboardToolTip tool, IWin32Window ownerWindow, out Size bubbleSize)
+    private bool TryGetBubbleSize(IWin32Window ownerWindow, out Size bubbleSize)
     {
         // Get bubble size to use it for optimal position calculation. Requesting the bubble
         // size will AV if there isn't a current tool window.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
@@ -1527,11 +1527,10 @@ public partial class ToolTip : Component, IExtenderProvider, IHandle<HWND>
         int pointX = (toolRectangle.Left + toolRectangle.Right) / 2;
         int pointY = (toolRectangle.Top + toolRectangle.Bottom) / 2;
 
- 
         SetTool(ownerWindow, text, TipInfo.Type.Absolute, new Point(pointX, pointY));
 
         // Then look for a better ToolTip location.
-        if (TryGetBubbleSize(tool, out Size bubbleSize))
+        if (TryGetBubbleSize(tool, ownerWindow, out Size bubbleSize))
         {
             Point optimalPoint = GetOptimalToolTipPosition(tool, toolRectangle, bubbleSize.Width, bubbleSize.Height);
 
@@ -1569,7 +1568,7 @@ public partial class ToolTip : Component, IExtenderProvider, IHandle<HWND>
         }
     }
 
-    private bool TryGetBubbleSize(IKeyboardToolTip tool, out Size bubbleSize)
+    private bool TryGetBubbleSize(IKeyboardToolTip tool, IWin32Window ownerWindow, out Size bubbleSize)
     {
         // Get bubble size to use it for optimal position calculation. Requesting the bubble
         // size will AV if there isn't a current tool window.
@@ -1577,7 +1576,7 @@ public partial class ToolTip : Component, IExtenderProvider, IHandle<HWND>
         HWND hwnd = GetCurrentToolHwnd();
         LRESULT result = default;
 
-        if (!hwnd.IsNull && tool.GetOwnerWindow() is IWin32Window ownerWindow)
+        if (!hwnd.IsNull)
         {
             ToolInfoWrapper<HandleRef<HWND>> info = new(Control.GetSafeHandle(ownerWindow));
             result = info.SendMessage(this, PInvoke.TTM_GETBUBBLESIZE);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
@@ -1514,17 +1514,20 @@ public partial class ToolTip : Component, IExtenderProvider, IHandle<HWND>
                 string.Format(SR.InvalidLowBoundArgumentEx, nameof(duration), (duration).ToString(CultureInfo.CurrentCulture), 0));
         }
 
-        Rectangle toolRectangle = tool.GetNativeScreenRectangle();
-
-        // At first, place the tooltip at the middle of the tool (default location).
-        int pointX = (toolRectangle.Left + toolRectangle.Right) / 2;
-        int pointY = (toolRectangle.Top + toolRectangle.Bottom) / 2;
         var ownerWindow = tool.GetOwnerWindow();
+
         if (ownerWindow is null)
         {
             return;
         }
 
+        Rectangle toolRectangle = tool.GetNativeScreenRectangle();
+
+        // At first, place the tooltip at the middle of the tool (default location).
+        int pointX = (toolRectangle.Left + toolRectangle.Right) / 2;
+        int pointY = (toolRectangle.Top + toolRectangle.Bottom) / 2;
+
+ 
         SetTool(ownerWindow, text, TipInfo.Type.Absolute, new Point(pointX, pointY));
 
         // Then look for a better ToolTip location.


### PR DESCRIPTION
Fixes https://github.com/dotnet/winforms/issues/11083
Fixes https://github.com/dotnet/winforms/issues/7262
<!-- Please read CONTRIBUTING.md before submitting a pull request -->


## Proposed changes

•	Added null-checks when accessing the owner DataGridView property from the DataGridView cell because this is a public property and could be set to null either by user code of when the owner control is re-created. Use default values when the owner DGV control is null.
•	Do not show the ToolTip when the owner window is null. This could happen when owner is available at the moment when the tool tip timer is started, but is destroyed by the end of the timer interval when the tooltip is ready to be shown. 


<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact
Fixes a rare application crash.


## Regression? 

•	Probably not a regression, the same code is present in the .NET Framework, where the keyboard tooltips were originally introduced. However, we don’t have customer reports about this issue in the framework. Most likely because .NET is faster.

## Risk
 Low – existing workarounds with  ThreadException handlers or UnhandledException handlers will not be affected, the application will end up showing an empty tooltip or will not show it at this time but will on the next `TAB`.

<!-- end TELL-MODE -->


## Test methodology <!-- How did you ensure quality? -->
* I provided my project the updated System.Windows.Forms.dll and it resolved the issue.
*  Unit test is hard to add because this is an intermittent timing issue.
 

## Test environment(s) <!-- Remove any that don't apply -->

- <!-- use `dotnet --info` -->
.NET SDK:
Version:           8.0.202
Commit:            25674bb2f4
Workload version:  8.0.200-manifests.8cf8de6d

Runtime Environment:
OS Name:     Windows
OS Version:  10.0.22631
OS Platform: Windows
RID:         win-x64
Base Path:   C:\Program Files\dotnet\sdk\8.0.202\

.NET workloads installed:
There are no installed workloads to display.

Host:
  Version:      8.0.3
  Architecture: x64
  Commit:       9f4b1f5d66

<!-- Mention language, UI scaling, or anything else that might be relevant -->
EN-US.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11092)