### PR TITLE
Restore handling of a null name in CreateComponent and CreateSite

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerHost.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerHost.cs
@@ -373,7 +373,7 @@ internal sealed partial class DesignerHost : Container, IDesignerLoaderHost2, ID
         // We need to handle the case where a component's ctor adds itself to the container.  We don't want to do the
         // work of creating a name, and then immediately renaming.  So, DesignerHost's CreateComponent will set
         // _newComponentName to the newly created name before creating the component.
-        if (!string.IsNullOrEmpty(_newComponentName))
+        if (_newComponentName is not null)
         {
             name = _newComponentName;
             _newComponentName = null;
@@ -383,7 +383,7 @@ internal sealed partial class DesignerHost : Container, IDesignerLoaderHost2, ID
 
         // Fabricate a name if one wasn't provided.  We try to use the name creation service, but if it is not available
         // we will just use an empty string.
-        if (string.IsNullOrEmpty(name))
+        if (name is null)
         {
             if (nameCreate is not null)
             {
@@ -918,8 +918,10 @@ internal sealed partial class DesignerHost : Container, IDesignerLoaderHost2, ID
 
     void IDesignerHost.Activate() => _surface?.OnViewActivate();
 
+    // The CreateComponent implementation has special handling of null and string.Empty,
+    // and we want to preserve this distinction.
     IComponent IDesignerHost.CreateComponent(Type componentType) =>
-        ((IDesignerHost)this).CreateComponent(componentType, string.Empty);
+        ((IDesignerHost)this).CreateComponent(componentType, null!);
 
     IComponent IDesignerHost.CreateComponent(Type componentType, string name)
     {

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerHost.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerHost.cs
@@ -379,11 +379,11 @@ internal sealed partial class DesignerHost : Container, IDesignerLoaderHost2, ID
             _newComponentName = null;
         }
 
-        INameCreationService? nameCreate = GetService(typeof(INameCreationService)) as INameCreationService;
+        this.TryGetService(out INameCreationService? nameCreate);
 
         // Fabricate a name if one wasn't provided.  We try to use the name creation service, but if it is not available
         // we will just use an empty string.
-        if (name is null)
+        if (string.IsNullOrEmpty(name))
         {
             if (nameCreate is not null)
             {

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignerHostTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignerHostTests.cs
@@ -724,25 +724,17 @@ public class DesignerHostTests
         SubDesignSurface surface = new(mockServiceProvider.Object);
         IDesignerLoaderHost2 host = surface.Host;
         using RootDesignerComponent component1 = new();
+        host.Container.Add(component1, name);
+        Assert.Same(name, component1.Site.Name);
+        mockNameCreationService.Verify(s => s.ValidateName(name), Times.Once());
+        mockServiceProvider.Verify(p => p.GetService(typeof(INameCreationService)), Times.Once());
 
-        if (string.IsNullOrEmpty(name))
-        {
-            Assert.Throws<MockException>(() => host.Container.Add(component1, name));
-        }
-        else
-        {
-            host.Container.Add(component1, name);
-            Assert.Same(name, component1.Site.Name);
-            mockNameCreationService.Verify(s => s.ValidateName(name), Times.Once());
-            mockServiceProvider.Verify(p => p.GetService(typeof(INameCreationService)), Times.Once());
-
-            // Add another.
-            using DesignerComponent component2 = new();
-            host.Container.Add(component2, "name2");
-            Assert.Equal("name2", component2.Site.Name);
-            mockNameCreationService.Verify(s => s.ValidateName("name2"), Times.Once());
-            mockServiceProvider.Verify(p => p.GetService(typeof(INameCreationService)), Times.Exactly(2));
-        }
+        // Add another.
+        using DesignerComponent component2 = new();
+        host.Container.Add(component2, "name2");
+        Assert.Equal("name2", component2.Site.Name);
+        mockNameCreationService.Verify(s => s.ValidateName("name2"), Times.Once());
+        mockServiceProvider.Verify(p => p.GetService(typeof(INameCreationService)), Times.Exactly(2));
     }
 
     [WinFormsFact]

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignerHostTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignerHostTests.cs
@@ -4,8 +4,6 @@
 using System.Collections;
 using System.ComponentModel.Design.Serialization;
 using System.Reflection;
-using System.Windows.Forms.Design;
-using System.Xml.Linq;
 using Moq;
 
 namespace System.ComponentModel.Design.Tests;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #11095


## Proposed changes

- Add `string.Empty` judgement in function `CreateSite `of the file `DesignerHost`

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- The DemoConsole app can be run normally

## Regression? 

- Yes 

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://github.com/dotnet/winforms/assets/132890443/a9f70392-474f-47b6-83f8-79b6a1c8116d)


### After

![image](https://github.com/dotnet/winforms/assets/132890443/78ee7c05-34f3-435c-88e0-b1062b31434d)


## Test methodology <!-- How did you ensure quality? -->

- Run DemoConsole App

## Test environment(s) <!-- Remove any that don't apply -->

- .net 9.0.0-preview.4.24169.16


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11097)