### PR TITLE
Fill out FORMATETC on MultilineStringEditor Paste

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/MultilineStringEditor.OleCallback.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/MultilineStringEditor.OleCallback.cs
@@ -103,12 +103,18 @@ public sealed partial class MultilineStringEditor
 
                 FORMATETC textFormat = new()
                 {
-                    cfFormat = (ushort)CLIPBOARD_FORMAT.CF_TEXT
+                    cfFormat = (ushort)CLIPBOARD_FORMAT.CF_TEXT,
+                    dwAspect = (uint)DVASPECT.DVASPECT_CONTENT,
+                    lindex = -1,
+                    tymed = (uint)(TYMED.TYMED_HGLOBAL | TYMED.TYMED_ISTREAM | TYMED.TYMED_GDI)
                 };
 
                 FORMATETC unicodeFormat = new()
                 {
-                    cfFormat = (ushort)CLIPBOARD_FORMAT.CF_UNICODETEXT
+                    cfFormat = (ushort)CLIPBOARD_FORMAT.CF_UNICODETEXT,
+                    dwAspect = (uint)DVASPECT.DVASPECT_CONTENT,
+                    lindex = -1,
+                    tymed = (uint)(TYMED.TYMED_HGLOBAL | TYMED.TYMED_ISTREAM | TYMED.TYMED_GDI)
                 };
 
                 return lpdataobj->QueryGetData(&textFormat).Succeeded || lpdataobj->QueryGetData(&unicodeFormat).Succeeded

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/MultilineStringEditor.OleCallback.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/MultilineStringEditor.OleCallback.cs
@@ -117,9 +117,9 @@ public sealed partial class MultilineStringEditor
                     tymed = (uint)(TYMED.TYMED_HGLOBAL | TYMED.TYMED_ISTREAM | TYMED.TYMED_GDI)
                 };
 
-                return lpdataobj->QueryGetData(&textFormat).Succeeded || lpdataobj->QueryGetData(&unicodeFormat).Succeeded
-                    ? HRESULT.S_OK
-                    : HRESULT.E_FAIL;
+                bool success = lpdataobj->QueryGetData(&textFormat).Succeeded || lpdataobj->QueryGetData(&unicodeFormat).Succeeded;
+                Debug.Assert(success);
+                return success ? HRESULT.S_OK : HRESULT.E_FAIL;
             }
 
             return HRESULT.E_NOTIMPL;


### PR DESCRIPTION
Fixes https://github.com/dotnet/winforms/issues/11084

When calling `QueryGetData` on the `IDataObject` given to us in `MultilineStringEditor.OleCallback.QueryAcceptData`, we were getting a failure due to invalid `FORMATETC` we were creating. Fixed to fill out `FORMATETC` completely using the same values we typically use when doing this same `QueryGetData` call in `DataObject` e.g. https://github.com/dotnet/winforms/blob/0e896ceec52ab5afea2731766bda744310df7995/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.ComposedDataObject.NativeDataObjectToWinFormsAdapter.cs#L472-L478

Since `MultilineStringEditor.OleCallback` is private and `MultilineStringEditor` is sealed, there doesn't seem to be a good way to add regression test so opted to do a debug assert to catch future regressions

Behavior after fix:
![multi](https://github.com/dotnet/winforms/assets/30007367/f5656001-deec-4645-b466-ca0987050cb3)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11104)