### PR TITLE
Enable nullability in DesignerActionUIService and DesignerActionUIStateChangeEventArgs

### DIFF
--- a/src/System.Windows.Forms.Design/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms.Design/src/PublicAPI.Shipped.txt
@@ -49,12 +49,12 @@
 ~System.ComponentModel.Design.DesignerActionMethodItem.DesignerActionMethodItem(System.ComponentModel.Design.DesignerActionList actionList, string memberName, string displayName, string category, string description, bool includeAsDesignerVerb) -> void
 ~System.ComponentModel.Design.DesignerActionMethodItem.RelatedComponent.get -> System.ComponentModel.IComponent
 ~System.ComponentModel.Design.DesignerActionMethodItem.RelatedComponent.set -> void
-~System.ComponentModel.Design.DesignerActionUIService.HideUI(System.ComponentModel.IComponent component) -> void
-~System.ComponentModel.Design.DesignerActionUIService.Refresh(System.ComponentModel.IComponent component) -> void
-~System.ComponentModel.Design.DesignerActionUIService.ShouldAutoShow(System.ComponentModel.IComponent component) -> bool
-~System.ComponentModel.Design.DesignerActionUIService.ShowUI(System.ComponentModel.IComponent component) -> void
-~System.ComponentModel.Design.DesignerActionUIStateChangeEventArgs.DesignerActionUIStateChangeEventArgs(object relatedObject, System.ComponentModel.Design.DesignerActionUIStateChangeType changeType) -> void
-~System.ComponentModel.Design.DesignerActionUIStateChangeEventArgs.RelatedObject.get -> object
+System.ComponentModel.Design.DesignerActionUIService.HideUI(System.ComponentModel.IComponent? component) -> void
+System.ComponentModel.Design.DesignerActionUIService.Refresh(System.ComponentModel.IComponent? component) -> void
+System.ComponentModel.Design.DesignerActionUIService.ShouldAutoShow(System.ComponentModel.IComponent! component) -> bool
+System.ComponentModel.Design.DesignerActionUIService.ShowUI(System.ComponentModel.IComponent? component) -> void
+System.ComponentModel.Design.DesignerActionUIStateChangeEventArgs.DesignerActionUIStateChangeEventArgs(object? relatedObject, System.ComponentModel.Design.DesignerActionUIStateChangeType changeType) -> void
+System.ComponentModel.Design.DesignerActionUIStateChangeEventArgs.RelatedObject.get -> object?
 ~System.Drawing.Design.IToolboxService.AddCreator(System.Drawing.Design.ToolboxItemCreatorCallback creator, string format) -> void
 ~System.Drawing.Design.IToolboxService.AddCreator(System.Drawing.Design.ToolboxItemCreatorCallback creator, string format, System.ComponentModel.Design.IDesignerHost host) -> void
 ~System.Drawing.Design.IToolboxService.AddLinkedToolboxItem(System.Drawing.Design.ToolboxItem toolboxItem, string category, System.ComponentModel.Design.IDesignerHost host) -> void
@@ -495,7 +495,7 @@ System.ComponentModel.Design.DesignerActionService.Remove(System.ComponentModel.
 System.ComponentModel.Design.DesignerActionTextItem
 System.ComponentModel.Design.DesignerActionTextItem.DesignerActionTextItem(string? displayName, string? category) -> void
 System.ComponentModel.Design.DesignerActionUIService
-System.ComponentModel.Design.DesignerActionUIService.DesignerActionUIStateChange -> System.ComponentModel.Design.DesignerActionUIStateChangeEventHandler
+System.ComponentModel.Design.DesignerActionUIService.DesignerActionUIStateChange -> System.ComponentModel.Design.DesignerActionUIStateChangeEventHandler?
 System.ComponentModel.Design.DesignerActionUIService.Dispose() -> void
 System.ComponentModel.Design.DesignerActionUIStateChangeEventArgs
 System.ComponentModel.Design.DesignerActionUIStateChangeEventArgs.ChangeType.get -> System.ComponentModel.Design.DesignerActionUIStateChangeType

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionUIService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionUIService.cs
@@ -45,31 +45,26 @@ public sealed class DesignerActionUIService : IDisposable
         remove => _designerActionUIStateChangedEventHandler -= value;
     }
 
-    public void HideUI(IComponent? component)
-    {
-        OnDesignerActionUIStateChange(new DesignerActionUIStateChangeEventArgs(component, DesignerActionUIStateChangeType.Hide));
-    }
+    public void HideUI(IComponent? component) =>
+        OnDesignerActionUIStateChange(
+            new DesignerActionUIStateChangeEventArgs(component, DesignerActionUIStateChangeType.Hide));
 
-    public void ShowUI(IComponent? component)
-    {
-        OnDesignerActionUIStateChange(new DesignerActionUIStateChangeEventArgs(component, DesignerActionUIStateChangeType.Show));
-    }
+    public void ShowUI(IComponent? component) =>
+        OnDesignerActionUIStateChange(
+            new DesignerActionUIStateChangeEventArgs(component, DesignerActionUIStateChangeType.Show));
 
     /// <summary>
     ///  Refreshes the <see cref="DesignerActionGlyph">designer action glyph</see> as well as <see cref="DesignerActionPanel">designer action panels</see>.
     /// </summary>
-    public void Refresh(IComponent? component)
-    {
-        OnDesignerActionUIStateChange(new DesignerActionUIStateChangeEventArgs(component, DesignerActionUIStateChangeType.Refresh));
-    }
+    public void Refresh(IComponent? component) =>
+        OnDesignerActionUIStateChange(
+            new DesignerActionUIStateChangeEventArgs(component, DesignerActionUIStateChangeType.Refresh));
 
     /// <summary>
     ///  This fires our DesignerActionsChanged event.
     /// </summary>
-    private void OnDesignerActionUIStateChange(DesignerActionUIStateChangeEventArgs e)
-    {
+    private void OnDesignerActionUIStateChange(DesignerActionUIStateChangeEventArgs e) =>
         _designerActionUIStateChangedEventHandler?.Invoke(this, e);
-    }
 
     public bool ShouldAutoShow(IComponent component)
     {

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionUIService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionUIService.cs
@@ -31,7 +31,7 @@ public sealed class DesignerActionUIService : IDisposable
     {
         if (_serviceProvider is not null)
         {
-            IDesignerHost? host = (IDesignerHost?)_serviceProvider.GetService(typeof(IDesignerHost));
+            IDesignerHost? host = _serviceProvider.GetService<IDesignerHost>();
             host?.RemoveService<DesignerActionUIService>();
         }
     }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionUIService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionUIService.cs
@@ -1,25 +1,23 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.Windows.Forms.Design.Behavior;
 
 namespace System.ComponentModel.Design;
 
 public sealed class DesignerActionUIService : IDisposable
 {
-    private DesignerActionUIStateChangeEventHandler _designerActionUIStateChangedEventHandler;
-    private readonly IServiceProvider _serviceProvider; // standard service provider
-    private readonly DesignerActionService _designerActionService;
+    private DesignerActionUIStateChangeEventHandler? _designerActionUIStateChangedEventHandler;
+    private readonly IServiceProvider? _serviceProvider; // standard service provider
+    private readonly DesignerActionService? _designerActionService;
 
-    internal DesignerActionUIService(IServiceProvider serviceProvider)
+    internal DesignerActionUIService(IServiceProvider? serviceProvider)
     {
         _serviceProvider = serviceProvider;
         if (serviceProvider is not null)
         {
             _serviceProvider = serviceProvider;
-            IDesignerHost host = (IDesignerHost)serviceProvider.GetService(typeof(IDesignerHost));
+            IDesignerHost host = serviceProvider.GetRequiredService<IDesignerHost>();
             host.AddService(this);
             _designerActionService = serviceProvider.GetService(typeof(DesignerActionService)) as DesignerActionService;
             Debug.Assert(_designerActionService is not null, "we should have created and registered the DAService first");
@@ -33,7 +31,7 @@ public sealed class DesignerActionUIService : IDisposable
     {
         if (_serviceProvider is not null)
         {
-            IDesignerHost host = (IDesignerHost)_serviceProvider.GetService(typeof(IDesignerHost));
+            IDesignerHost? host = (IDesignerHost?)_serviceProvider.GetService(typeof(IDesignerHost));
             host?.RemoveService<DesignerActionUIService>();
         }
     }
@@ -41,18 +39,18 @@ public sealed class DesignerActionUIService : IDisposable
     /// <summary>
     ///  This event is thrown whenever a request is made to show/hide the UI.
     /// </summary>
-    public event DesignerActionUIStateChangeEventHandler DesignerActionUIStateChange
+    public event DesignerActionUIStateChangeEventHandler? DesignerActionUIStateChange
     {
         add => _designerActionUIStateChangedEventHandler += value;
         remove => _designerActionUIStateChangedEventHandler -= value;
     }
 
-    public void HideUI(IComponent component)
+    public void HideUI(IComponent? component)
     {
         OnDesignerActionUIStateChange(new DesignerActionUIStateChangeEventArgs(component, DesignerActionUIStateChangeType.Hide));
     }
 
-    public void ShowUI(IComponent component)
+    public void ShowUI(IComponent? component)
     {
         OnDesignerActionUIStateChange(new DesignerActionUIStateChangeEventArgs(component, DesignerActionUIStateChangeType.Show));
     }
@@ -60,7 +58,7 @@ public sealed class DesignerActionUIService : IDisposable
     /// <summary>
     ///  Refreshes the <see cref="DesignerActionGlyph">designer action glyph</see> as well as <see cref="DesignerActionPanel">designer action panels</see>.
     /// </summary>
-    public void Refresh(IComponent component)
+    public void Refresh(IComponent? component)
     {
         OnDesignerActionUIStateChange(new DesignerActionUIStateChangeEventArgs(component, DesignerActionUIStateChangeType.Refresh));
     }
@@ -80,8 +78,8 @@ public sealed class DesignerActionUIService : IDisposable
         {
             if (_serviceProvider.GetService(typeof(DesignerOptionService)) is DesignerOptionService opts)
             {
-                PropertyDescriptor p = opts.Options.Properties["ObjectBoundSmartTagAutoShow"];
-                if (p is not null && p.PropertyType == typeof(bool) && !(bool)p.GetValue(null))
+                PropertyDescriptor? p = opts.Options.Properties["ObjectBoundSmartTagAutoShow"];
+                if (p is not null && p.PropertyType == typeof(bool) && !(bool)p.GetValue(null)!)
                 {
                     return false;
                 }
@@ -95,7 +93,7 @@ public sealed class DesignerActionUIService : IDisposable
             {
                 for (int i = 0; i < coll.Count; i++)
                 {
-                    if (coll[i].AutoShow)
+                    if (coll[i]?.AutoShow == true)
                     {
                         return true;
                     }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionUIStateChangeEventArgs.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionUIStateChangeEventArgs.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 namespace System.ComponentModel.Design;
 
 /// <summary>
@@ -13,7 +11,7 @@ public class DesignerActionUIStateChangeEventArgs : EventArgs
     /// <summary>
     ///  Constructor that requires the object in question, the type of change and the remaining actionlists left for the object on the related object.
     /// </summary>
-    public DesignerActionUIStateChangeEventArgs(object relatedObject, DesignerActionUIStateChangeType changeType)
+    public DesignerActionUIStateChangeEventArgs(object? relatedObject, DesignerActionUIStateChangeType changeType)
     {
         RelatedObject = relatedObject;
         ChangeType = changeType;
@@ -22,7 +20,7 @@ public class DesignerActionUIStateChangeEventArgs : EventArgs
     /// <summary>
     ///  The object this change is related to.
     /// </summary>
-    public object RelatedObject { get; }
+    public object? RelatedObject { get; }
 
     /// <summary>
     ///  The type of changed that caused the related event to be thrown.

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DesignerActionKeyboardBehavior.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DesignerActionKeyboardBehavior.cs
@@ -47,7 +47,7 @@ internal sealed class DesignerActionKeyboardBehavior : Behavior
             // in case of a ctrl-tab we need to close the DAP
             if (_daUISvc is not null && commandId.Guid == s_vSStandardCommandSet97 && commandId.ID == 1124)
             {
-                _daUISvc.HideUI(null);
+                _daUISvc.HideUI(component: null);
             }
         }
 


### PR DESCRIPTION
## Proposed changes

- Enable nullability in DesignerActionUIService and DesignerActionUIStateChangeEventArgs.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11121)