### PR TITLE
Update Padding.cs

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Padding.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Padding.cs
@@ -44,7 +44,7 @@ public struct Padding : IEquatable<Padding>
         readonly get => _all ? _top : -1;
         set
         {
-            if (_all != true || _top != value)
+            if (!_all || _top != value)
             {
                 _all = true;
                 _top = _left = _right = _bottom = value;


### PR DESCRIPTION
Fixes:

D:\a\_work\1\vmr\src\winforms\src\System.Windows.Forms.Primitives\src\System\Windows\Forms\Padding.cs(47,22): error IDE0100: Remove redundant equality (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0100) [D:\a\_work\1\vmr\src\winforms\src\System.Windows.Forms.Primitives\src\System.Windows.Forms.Primitives.csproj]

from https://dev.azure.com/dnceng-public/public/_build/results?buildId=614433&view=logs&jobId=9050e078-31bf-5111-d8ec-8b6fa95caf9c&j=9050e078-31bf-5111-d8ec-8b6fa95caf9c&t=7c4aad8e-3f00-5c65-8153-2dae8a34a4c9
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11122)