### PR TITLE
Fix Close Stale Issue/PR Action

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -13,7 +13,6 @@ configuration:
       - hourly:
           hour: 12
       filters:
-      - isPullRequest
       - isOpen
       - hasLabel:
           label: ':mailbox_with_no_mail: waiting-author-feedback'
@@ -21,7 +20,6 @@ configuration:
           label: ':zzz: no-recent-activity'
       - noActivitySince:
           days: 7
-      - isIssue
       actions:
       - closeIssue
       - removeMilestone


### PR DESCRIPTION
Likely `isPullRequest` and `isIssue` is causing this action to always fail since both cannot be true. `isOpen = true` when item is an issues **or** PR
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11126)