### PR TITLE
Don't build DesignSurface tests in .NET product build

### DIFF
--- a/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/DemoConsole.csproj
+++ b/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/DemoConsole.csproj
@@ -16,6 +16,10 @@
     <PackageProjectUrl>https://www.codeproject.com/Articles/24385/Have-a-Great-DesignTime-Experience-with-a-Powerful</PackageProjectUrl>
     <SuppressLicenseValidation>true</SuppressLicenseValidation>
     <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
+
+    <!-- Do not build this project when doing a .NET product build. -->
+    <!-- The files for this project have been removed from the .NET product due to licensing issues. -->
+    <ExcludeFromDotNetBuild>true</ExcludeFromDotNetBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DesignSurfaceExt/DesignSurfaceExt.csproj
+++ b/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DesignSurfaceExt/DesignSurfaceExt.csproj
@@ -16,6 +16,10 @@
     <PackageProjectUrl>https://www.codeproject.com/Articles/24385/Have-a-Great-DesignTime-Experience-with-a-Powerful</PackageProjectUrl>
 
     <SuppressLicenseValidation>true</SuppressLicenseValidation>
+
+    <!-- Do not build this project when doing a .NET product build. -->
+    <!-- The files for this project have been removed from the .NET product due to licensing issues. -->
+    <ExcludeFromDotNetBuild>true</ExcludeFromDotNetBuild>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Related to https://github.com/dotnet/winforms/issues/10779
Related to https://github.com/dotnet/dotnet/pull/86
Related to https://github.com/dotnet/installer/pull/19218

All files in `src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/**`, except for the project files, are under a non-OSS license and [cannot be in the dotnet product](https://github.com/dotnet/arcade/blob/main/Documentation/UnifiedBuild/VMR-Permissible-Sources.md#policy-1). This means that the files must be removed from the .NET product via cloaking (originally completed in https://github.com/dotnet/installer/pull/19218).

Since these tests will not be buildable in the .NET product due to the cloaking, we must add `<ExcludeFromDotNetBuild>true</ExcludeFromDotNetBuild>` to the project files.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11140)