### PR TITLE
Enable nullability in ListControlStringCollectionEditor and StringArrayEditor

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ListControlStringCollectionEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ListControlStringCollectionEditor.cs
@@ -20,8 +20,7 @@ internal class ListControlStringCollectionEditor : StringCollectionEditor
     public override object? EditValue(ITypeDescriptorContext? context, IServiceProvider provider, object? value)
     {
         // If we're trying to edit the items in an object that has a DataSource set, throw an exception.
-        ListControl? control = context?.Instance as ListControl;
-        if (control?.DataSource is not null)
+        if (context?.Instance is ListControl control && control.DataSource is not null)
         {
             throw new ArgumentException(SR.DataSourceLocksItems);
         }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ListControlStringCollectionEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ListControlStringCollectionEditor.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.ComponentModel;
 
 namespace System.Windows.Forms.Design;
@@ -14,14 +12,15 @@ namespace System.Windows.Forms.Design;
 /// </summary>
 internal class ListControlStringCollectionEditor : StringCollectionEditor
 {
-    public ListControlStringCollectionEditor(Type type) : base(type)
+    public ListControlStringCollectionEditor(Type type)
+        : base(type)
     {
     }
 
-    public override object EditValue(ITypeDescriptorContext context, IServiceProvider provider, object value)
+    public override object? EditValue(ITypeDescriptorContext? context, IServiceProvider provider, object? value)
     {
         // If we're trying to edit the items in an object that has a DataSource set, throw an exception.
-        ListControl control = context.Instance as ListControl;
+        ListControl? control = context?.Instance as ListControl;
         if (control?.DataSource is not null)
         {
             throw new ArgumentException(SR.DataSourceLocksItems);

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/StringArrayEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/StringArrayEditor.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 namespace System.Windows.Forms.Design;
 
 /// <summary>
@@ -15,12 +13,12 @@ internal class StringArrayEditor : StringCollectionEditor
     {
     }
 
-    protected override Type CreateCollectionItemType() => CollectionType.GetElementType();
+    protected override Type CreateCollectionItemType() => CollectionType.GetElementType() ?? typeof(string[]);
 
     /// <summary>
     ///  We implement the getting and setting of items on this collection.
     /// </summary>
-    protected override object[] GetItems(object editValue)
+    protected override object[] GetItems(object? editValue)
     {
         if (editValue is not Array valueArray)
         {
@@ -37,9 +35,9 @@ internal class StringArrayEditor : StringCollectionEditor
     ///  It should return an instance to replace <paramref name="editValue"/> with, or
     ///  <paramref name="editValue"/> if there is no need to replace the instance.
     /// </summary>
-    protected override object SetItems(object editValue, object[] value)
+    protected override object? SetItems(object? editValue, object[]? value)
     {
-        if (editValue is Array or null)
+        if (editValue is Array or null && value is not null)
         {
             Array newArray = Array.CreateInstance(CollectionItemType, value.Length);
             Array.Copy(value, newArray, value.Length);


### PR DESCRIPTION
## Proposed changes

- Enable nullability in ListControlStringCollectionEditor and StringArrayEditor.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11144)