### PR TITLE
Add code coverage for MonthCalendar

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MonthCalendar.DateBoldEventArgsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MonthCalendar.DateBoldEventArgsTests.cs
@@ -1,0 +1,42 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Windows.Forms.Tests;
+
+public class MonthCalendar_DateBoldEventArgsTests
+{
+    public static readonly TheoryData<DateTime, int> s_dateBoldEventArgs_Constructor_InitializesPropertiesCorrectly_Data = new()
+    {
+        { DateTime.UtcNow, 5 },
+        { DateTime.UtcNow.AddDays(-1), 10 },
+        { DateTime.UtcNow.AddDays(1), 0 }
+    };
+
+    [WinFormsTheory]
+    [MemberData(nameof(s_dateBoldEventArgs_Constructor_InitializesPropertiesCorrectly_Data))]
+    public void DateBoldEventArgs_Constructor_InitializesPropertiesCorrectly(DateTime startDate, int size)
+    {
+        var eventArgs = new DateBoldEventArgs(startDate, size);
+
+        eventArgs.StartDate.Should().Be(startDate);
+        eventArgs.Size.Should().Be(size);
+    }
+
+    public static readonly TheoryData<int[]> s_daysToBold_GetSetWorksCorrectly_Data = new()
+    {
+        { new int[] {1, 2, 3, 4, 5} },
+        { null }
+    };
+
+    [WinFormsTheory]
+    [MemberData(nameof(s_daysToBold_GetSetWorksCorrectly_Data))]
+    public void DateBoldEventArgs_DaysToBold_GetSetWorksCorrectly(int[] value)
+    {
+        var eventArgs = new DateBoldEventArgs(DateTime.UtcNow, 5)
+        {
+            DaysToBold = value
+        };
+
+        eventArgs.DaysToBold.Should().Equal(value);
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MonthCalendar.SelectionRangeConverterTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MonthCalendar.SelectionRangeConverterTests.cs
@@ -7,6 +7,7 @@ using System.ComponentModel.Design.Serialization;
 using System.Globalization;
 
 namespace System.Windows.Forms.Tests;
+
 public class MonthCalendar_SelectionRangeConverterTests
 {
     [WinFormsTheory]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MonthCalendar.SelectionRangeConverterTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MonthCalendar.SelectionRangeConverterTests.cs
@@ -1,0 +1,177 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections;
+using System.ComponentModel;
+using System.ComponentModel.Design.Serialization;
+using System.Globalization;
+
+namespace System.Windows.Forms.Tests;
+public class MonthCalendar_SelectionRangeConverterTests
+{
+    [WinFormsTheory]
+    [InlineData(typeof(string), true)]
+    [InlineData(typeof(DateTime), true)]
+    [InlineData(typeof(int), false)]
+    public void CanConvertFrom_ReturnsExpected(Type type, bool expected)
+    {
+        _converter.CanConvertFrom(null, type).Should().Be(expected);
+    }
+
+    [WinFormsTheory]
+    [InlineData(typeof(InstanceDescriptor), true)]
+    [InlineData(typeof(DateTime), true)]
+    [InlineData(typeof(int), false)]
+    public void CanConvertTo_ReturnsExpected(Type type, bool expected)
+    {
+        _converter.CanConvertTo(null, type).Should().Be(expected);
+    }
+
+    [WinFormsTheory]
+    [InlineData("2022-01-01, 2022-12-31", "2022-01-01", "2022-12-31")]
+    [InlineData("2022-01-01", "2022-01-01", "2022-01-01")]
+    public void ConvertFromString_ReturnsCorrectSelectionRange(string value, string expectedStart, string expectedEnd)
+    {
+        if (!value.Contains(','))
+        {
+            // If not, append a comma and the same date to make it a range
+            value += $", {value}";
+        }
+
+        SelectionRange range = (SelectionRange)_converter.ConvertFrom(null, CultureInfo.InvariantCulture, value);
+
+        range.Start.Should().Be(DateTime.Parse(expectedStart));
+        range.End.Should().Be(DateTime.Parse(expectedEnd));
+    }
+
+    [WinFormsFact]
+    public void ConvertFromDateTime_ReturnsSelectionRangeWithSameStartAndEnd()
+    {
+        DateTime value = new(2022, 1, 1);
+        SelectionRange range = (SelectionRange)_converter.ConvertFrom(null, CultureInfo.InvariantCulture, value);
+
+        range.Start.Should().Be(value);
+        range.End.Should().Be(value);
+    }
+
+    [WinFormsFact]
+    public void ConvertFromInvalidString_ThrowsArgumentException()
+    {
+        string value = "invalid";
+        Action act = () => _converter.ConvertFrom(null, CultureInfo.InvariantCulture, value);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [WinFormsTheory]
+    [InlineData("2022-01-01, 2022-12-31")]
+    public void ConvertTo_String_ReturnsCorrectString(string expected)
+    {
+        string result = (string)_converter.ConvertTo(null, CultureInfo.InvariantCulture, _range, typeof(string));
+
+        result.Should().Be(expected);
+    }
+
+    [WinFormsTheory]
+    [InlineData("2022-01-01")]
+    public void ConvertTo_DateTime_ReturnsStartOfRange(string dateValue)
+    {
+        DateTime expected = DateTime.Parse(dateValue);
+        DateTime result = (DateTime)_converter.ConvertTo(null, CultureInfo.InvariantCulture, _range, typeof(DateTime));
+
+        result.Should().Be(expected);
+    }
+
+    [WinFormsFact]
+    public void ConvertTo_InstanceDescriptor_ReturnsCorrectInstanceDescriptor()
+    {     
+        InstanceDescriptor descriptor = (InstanceDescriptor)_converter.ConvertTo(null, CultureInfo.InvariantCulture, _range, typeof(InstanceDescriptor));
+        SelectionRange result = (SelectionRange)descriptor.Invoke();
+
+        result.Start.Should().Be(new DateTime(2022, 1, 1));
+        result.End.Should().Be(new DateTime(2022, 12, 31));
+    }
+
+    [WinFormsFact]
+    public void ConvertTo_UnsupportedType_ThrowsNotSupportedException()
+    {
+        Action act = () => _converter.ConvertTo(null, CultureInfo.InvariantCulture, _range, typeof(int));
+
+        act.Should().Throw<NotSupportedException>();
+    }
+
+    [WinFormsFact]
+    public void CreateInstance_ValidPropertyValues_ReturnsCorrectSelectionRange()
+    {
+        IDictionary propertyValues = CreatePropertyValues(new DateTime(2022, 1, 1), new DateTime(2022, 12, 31));
+        SelectionRange range = (SelectionRange)_converter.CreateInstance(null, propertyValues);
+
+        range.Start.Should().Be(new DateTime(2022, 1, 1));
+        range.End.Should().Be(new DateTime(2022, 12, 31));
+    }
+
+    [WinFormsFact]
+    public void CreateInstance_InvalidStart_ThrowsArgumentException()
+    {
+        IDictionary propertyValues = CreatePropertyValues("invalid", new DateTime(2022, 12, 31));
+        Action act = () => _converter.CreateInstance(null, propertyValues);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [WinFormsFact]
+    public void CreateInstance_InvalidEnd_ThrowsArgumentException()
+    {
+        IDictionary propertyValues = CreatePropertyValues(new DateTime(2022, 1, 1), "invalid");
+        Action act = () => _converter.CreateInstance(null, propertyValues);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [WinFormsFact]
+    public void CreateInstance_MissingEnd_ThrowsArgumentException()
+    {
+        IDictionary propertyValues = CreatePropertyValues(new DateTime(2022, 1, 1), null);
+        Action act = () => _converter.CreateInstance(null, propertyValues);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [WinFormsFact]
+    public void GetCreateInstanceSupported_ReturnsTrue()
+    {
+        _converter.GetCreateInstanceSupported(null).Should().BeTrue();
+    }
+
+    [WinFormsFact]
+    public void GetProperties_ReturnsCorrectProperties()
+    {
+        SelectionRange range = new SelectionRange(DateTime.Now, DateTime.Now.AddDays(1));
+        PropertyDescriptorCollection props = _converter.GetProperties(null, range, null);
+
+        props.Count.Should().Be(2);
+        props[0].Name.Should().Be("Start");
+        props[1].Name.Should().Be("End");
+    }
+
+    [WinFormsFact]
+    public void GetPropertiesSupported_ReturnsTrue()
+    {
+        _converter.GetPropertiesSupported(null).Should().BeTrue();
+    }
+
+    private readonly SelectionRange _range = new(new DateTime(2022, 1, 1), new DateTime(2022, 12, 31));
+
+    private readonly SelectionRangeConverter _converter;
+
+    public MonthCalendar_SelectionRangeConverterTests()
+    {
+        _converter = new SelectionRangeConverter();
+    }
+
+    private static IDictionary CreatePropertyValues(object start, object end) => new Dictionary<string, object>
+    {
+        { "Start", start },
+        { "End", end }
+    };
+}

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MonthCalendarTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MonthCalendarTests.cs
@@ -4241,6 +4241,18 @@ public class MonthCalendarTests
         Assert.Equal(expectedIndex, actualIndex);
     }
 
+    [WinFormsFact]
+    public void SelectionRange_CopyConstructor_CopiesStartAndEndDatesCorrectly()
+    {
+        DateTime startDate = new(2023, 1, 1);
+        DateTime endDate = new(2023, 12, 31);
+        SelectionRange originalRange = new(startDate, endDate);
+        SelectionRange copiedRange = new(originalRange);
+
+        copiedRange.Start.Should().Be(startDate);
+        copiedRange.End.Should().Be(endDate);
+    }
+
     private class SubMonthCalendar : MonthCalendar
     {
         public new bool CanEnableIme => base.CanEnableIme;


### PR DESCRIPTION
related https://github.com/dotnet/winforms/issues/10453

## Proposed changes

- Add unit tests for MonthCalendar to test its properties: SelectionRange, CanConvertTo, CanConvertFrom, DateTime, Size, DaysToBold 
- Add unit tests for MonthCalendar to test its methods: GetProperties, GetPropertiesSupported, GetCreateInstanceSupported, ConvertTo, CreateInstance, ConvertFrom, 

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact
- None

## Regression? 
-  No

## Risk
- Minimal

## Test methodology <!-- How did you ensure quality? -->
- Unit tests