### PR TITLE
Fix Few CodeQL Warnings

### DIFF
--- a/src/System.Drawing.Common/src/System/Drawing/Font.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Font.cs
@@ -18,6 +18,7 @@ namespace System.Drawing;
 [Runtime.CompilerServices.TypeForwardedFrom(AssemblyRef.SystemDrawing)]
 public sealed unsafe class Font : MarshalByRefObject, ICloneable, IDisposable, ISerializable
 {
+    [NonSerialized]
     private GpFont* _nativeFont;
     private float _fontSize;
     private FontStyle _fontStyle;

--- a/src/System.Drawing.Common/src/System/Drawing/Icon.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Icon.cs
@@ -31,6 +31,8 @@ public sealed unsafe partial class Icon : MarshalByRefObject, ICloneable, IDispo
     private uint _bestBytesInRes;
     private bool? _isBestImagePng;
     private Size _iconSize = Size.Empty;
+
+    [NonSerialized]
     private HICON _handle;
     private readonly bool _ownHandle = true;
 

--- a/src/System.Drawing.Common/src/System/Drawing/Image.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Image.cs
@@ -33,6 +33,8 @@ public abstract unsafe class Image : MarshalByRefObject, IImage, IDisposable, IC
     public delegate bool GetThumbnailImageAbort();
 
     GpImage* IPointer<GpImage>.Pointer => _nativeImage;
+
+    [NonSerialized]
     private GpImage* _nativeImage;
 
     private object? _userData;

--- a/src/System.Windows.Forms/src/System/Resources/ResXSerializationBinder.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResXSerializationBinder.cs
@@ -39,9 +39,7 @@ internal class ResXSerializationBinder : SerializationBinder
         if (_typeResolver is null)
         {
             // cs/deserialization/nullbindtotype
-            // CodeQL [SM04225] : This class is meant to redirect to .NET Framework type names.
-            // If this cannot be done, the default binder should be used.
-            return null;
+            return null; // CodeQL [SM04225] : This class is meant to redirect to .NET Framework type names. If this cannot be done, the default binder should be used.
         }
 
         // Try the fully-qualified name first.

--- a/src/System.Windows.Forms/src/System/Resources/ResXSerializationBinder.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResXSerializationBinder.cs
@@ -38,6 +38,9 @@ internal class ResXSerializationBinder : SerializationBinder
     {
         if (_typeResolver is null)
         {
+            // cs/deserialization/nullbindtotype
+            // CodeQL [SM04225] : This class is meant to redirect to .NET Framework type names.
+            // If this cannot be done, the default binder should be used.
             return null;
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ActiveX/AxHost.State.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ActiveX/AxHost.State.cs
@@ -14,7 +14,7 @@ public abstract partial class AxHost
 {
     /// <summary>
     ///  The class which encapsulates the persisted state of the underlying activeX control.
-    ///  An instance of this class my be obtained either by calling <see cref="OcxState"/> on an
+    ///  An instance of this class may be obtained either by calling <see cref="OcxState"/> on an
     ///  AxHost object, or by reading in from a stream.
     /// </summary>
     [TypeConverter(typeof(TypeConverter))]
@@ -25,8 +25,12 @@ public abstract partial class AxHost
         private int _length;
         private byte[]? _buffer;
         private MemoryStream? _memoryStream;
+
+        [NonSerialized]
         private AgileComPointer<IStorage>? _storage;
+        [NonSerialized]
         private AgileComPointer<ILockBytes>? _lockBytes;
+
         private readonly PropertyBagStream? _propertyBag;
         private const string PropertyBagSerializationName = "PropertyBagBinary";
         private const string DataSerializationName = "Data";

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.BitmapBinder.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.BitmapBinder.cs
@@ -32,7 +32,7 @@ public partial class DataObject
         public override Type? BindToType(string assemblyName, string typeName)
         {
             // Only safe to deserialize types are bypassing this callback. Strings and arrays of primitive types in
-            // particular. We are explicitly allowing the System.Drawing.Bitmap type to bind using the default binder.
+            // particular.
 
             if (AllowedTypeName.Equals(typeName, StringComparison.Ordinal))
             {
@@ -42,8 +42,7 @@ public partial class DataObject
                     if (AllowedAssemblyName.Equals(nameToBind.Name, StringComparison.Ordinal)
                         && AllowedToken.SequenceEqual(nameToBind.GetPublicKeyToken()))
                     {
-                        // Continue with the default binder.
-                        return null;
+                        return typeof(Bitmap);
                     }
                 }
                 catch (Exception ex) when (ex is ArgumentException or FileLoadException)


### PR DESCRIPTION
This PR fixes a few CodeQL warnings
- Add `NonSerializedAttribute` to explicitly indicate that pointers/handles are not being serialized ([ex](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1943327/?view=edit))
- Suppress [warning](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1845222/?view=edit) in `ResXSerializationBinder` as this is meant to redirect to .NET Framework type names, if we cannot do so we want to fall back to default binder
- Add more logic in BitmapBinderTest testing `BindToType` to ensure deserialized bitmap is equivalent to original
- Update `BitmapBinder` to avoid return null ([ex](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1931519/?view=edit))
- Change to use fluent assertions for `BitmapBinderTests`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11164)