### PR TITLE
Mark ComNativeDescriptor-related code as RequiresUnreferencedCode

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2AboutBoxPropertyDescriptor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2AboutBoxPropertyDescriptor.cs
@@ -7,6 +7,7 @@ using System.Runtime.InteropServices;
 
 namespace System.Windows.Forms.ComponentModel.Com2Interop;
 
+[RequiresUnreferencedCode(ComNativeDescriptor.ComTypeDescriptorsMessage + " Uses Com2PropertyDescriptor which is not trim-compatible.")]
 internal sealed partial class Com2AboutBoxPropertyDescriptor : Com2PropertyDescriptor
 {
     private TypeConverter? _converter;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2IDispatchConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2IDispatchConverter.cs
@@ -7,6 +7,7 @@ using Windows.Win32.System.Com;
 
 namespace System.Windows.Forms.ComponentModel.Com2Interop;
 
+[RequiresUnreferencedCode(ComNativeDescriptor.ComTypeDescriptorsMessage + " Uses ComNativeDescriptor which is not trim-compatible.")]
 internal unsafe class Com2IDispatchConverter : Com2ExtendedTypeConverter
 {
     private readonly bool _allowExpand;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2IManagedPerPropertyBrowsingHandler.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2IManagedPerPropertyBrowsingHandler.cs
@@ -11,6 +11,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop;
 /// <summary>
 ///  Browsing handler for <see cref="IVSMDPerPropertyBrowsing"/>.
 /// </summary>
+[RequiresUnreferencedCode(ComNativeDescriptor.ComTypeDescriptorsMessage + " Uses reflection to inspect types whose names are not statically known.")]
 internal sealed unsafe class Com2IManagedPerPropertyBrowsingHandler : Com2ExtendedBrowsingHandler<IVSMDPerPropertyBrowsing>
 {
     public override void RegisterEvents(Com2PropertyDescriptor[]? properties)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2IPerPropertyBrowsingHandler.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2IPerPropertyBrowsingHandler.cs
@@ -10,6 +10,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop;
 /// <summary>
 ///  Browsing handler for <see cref="IPerPropertyBrowsing"/>.
 /// </summary>
+[RequiresUnreferencedCode(ComNativeDescriptor.ComTypeDescriptorsMessage + " Uses COM2PropertyDescriptor which is not trim-compatible.")]
 internal sealed unsafe partial class Com2IPerPropertyBrowsingHandler : Com2ExtendedBrowsingHandler<IPerPropertyBrowsing>
 {
     public override void RegisterEvents(Com2PropertyDescriptor[]? properties)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2IVsPerPropertyBrowsingHandler.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2IVsPerPropertyBrowsingHandler.cs
@@ -10,6 +10,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop;
 /// <summary>
 ///  Browsing handler for <see cref="IVsPerPropertyBrowsing"/>.
 /// </summary>
+[RequiresUnreferencedCode(ComNativeDescriptor.ComTypeDescriptorsMessage + " Uses Com2IDispatchConverter which is not trim-compatible.")]
 internal sealed unsafe class Com2IVsPerPropertyBrowsingHandler : Com2ExtendedBrowsingHandler<IVsPerPropertyBrowsing>
 {
     public static unsafe bool AllowChildProperties(Com2PropertyDescriptor property)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2Properties.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2Properties.cs
@@ -9,6 +9,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop;
 ///  This class is responsible for managing a set of properties for a native object. It determines
 ///  when the properties need to be refreshed, and owns the extended handlers for those properties.
 /// </summary>
+[RequiresUnreferencedCode(ComNativeDescriptor.ComTypeDescriptorsMessage + " Uses Com2TypeInfoProcessor which is not trim-compatible.")]
 internal sealed class Com2Properties
 {
     // This is the interval that we'll hold properties for. If someone doesn't touch an object for this amount of time,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyDescriptor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyDescriptor.cs
@@ -23,6 +23,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop;
 ///   of <see cref="TypeConverter"/>s.
 ///  </para>
 /// </summary>
+[RequiresUnreferencedCode(ComNativeDescriptor.ComTypeDescriptorsMessage + " Uses ComNativeDescriptor which is not trim-compatible.")]
 internal unsafe partial class Com2PropertyDescriptor : PropertyDescriptor, ICloneable
 {
     private EventHandlerList? _events;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2TypeInfoProcessor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2TypeInfoProcessor.cs
@@ -26,6 +26,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop;
 ///   information such as IPerPropertyBrowsing is handled elsewhere.
 ///  </para>
 /// </summary>
+[RequiresUnreferencedCode(ComNativeDescriptor.ComTypeDescriptorsMessage + " Uses ComNativeDescriptor which is not trim-compatible.")]
 internal static unsafe partial class Com2TypeInfoProcessor
 {
     private static ModuleBuilder? s_moduleBuilder;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/Com2IPerPropertyBrowsingHandler.Com2IPerPropertyBrowsingEnum.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/Com2IPerPropertyBrowsingHandler.Com2IPerPropertyBrowsingEnum.cs
@@ -10,6 +10,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop;
 internal partial class Com2IPerPropertyBrowsingHandler
 {
     // This exists for perf reasons. We delay doing this until we are actually asked for the array of values.
+    [RequiresUnreferencedCode(ComNativeDescriptor.ComTypeDescriptorsMessage + " Uses Com2IPerPropertyBrowsingHandler which is not trim-compatible.")]
     private unsafe class Com2IPerPropertyBrowsingEnum : Com2Enum
     {
         private readonly string?[] _names;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/Com2IPerPropertyBrowsingHandler.Com2IPerPropertyEnumConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/Com2IPerPropertyBrowsingHandler.Com2IPerPropertyEnumConverter.cs
@@ -12,6 +12,7 @@ internal partial class Com2IPerPropertyBrowsingHandler
     /// <summary>
     ///  Used to identify the enums that we added.
     /// </summary>
+    [RequiresUnreferencedCode(ComNativeDescriptor.ComTypeDescriptorsMessage + " Uses Com2IPerPropertyBrowsingHandler which is not trim-compatible.")]
     private unsafe class Com2IPerPropertyEnumConverter : Com2EnumConverter
     {
         private readonly Com2IPerPropertyBrowsingEnum _itemsEnum;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/ComNativeDescriptor.ComTypeDescriptor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/ComNativeDescriptor.ComTypeDescriptor.cs
@@ -12,6 +12,7 @@ internal partial class ComNativeDescriptor
     /// <summary>
     ///  The <see cref="ICustomTypeDescriptor"/> given by <see cref="ComNativeDescriptor"/> for a given type instance.
     /// </summary>
+    [RequiresUnreferencedCode(ComNativeDescriptor.ComTypeDescriptorsMessage + " Uses ComNativeDescriptor which is not trim-compatible.")]
     private sealed unsafe class ComTypeDescriptor : ICustomTypeDescriptor
     {
         private readonly ComNativeDescriptor _handler;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/ComNativeDescriptor.NullTypeDescriptor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/ComNativeDescriptor.NullTypeDescriptor.cs
@@ -12,6 +12,7 @@ internal partial class ComNativeDescriptor
     ///  Stub descriptor for when we're passed a null to <see cref="ComNativeDescriptor"/>. This used to be
     ///  contained in <see cref="ComTypeDescriptor"/>.
     /// </summary>
+    [RequiresUnreferencedCode(ComTypeDescriptorsMessage + " Uses ComNativeDescriptor which is not trim-compatible.")]
     private sealed class NullTypeDescriptor : ICustomTypeDescriptor
     {
         AttributeCollection ICustomTypeDescriptor.GetAttributes() => new(s_staticAttributes);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/ComNativeDescriptor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/ComNativeDescriptor.cs
@@ -22,8 +22,11 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop;
 ///   <see cref="TypeDescriptor.ComObjectType"/>.
 ///  </para>
 /// </remarks>
+[RequiresUnreferencedCode(ComNativeDescriptor.ComTypeDescriptorsMessage + " Uses Com2IManagedPerPropertyBrowsingHandler which is not trim-compatible.")]
 internal sealed unsafe partial class ComNativeDescriptor : TypeDescriptionProvider
 {
+    internal const string ComTypeDescriptorsMessage = "COM type descriptors are not trim-compatible.";
+
     private static readonly Attribute[] s_staticAttributes = [BrowsableAttribute.Yes, DesignTimeVisibleAttribute.No];
 
     // Our collection of Object managers (Com2Properties) for native properties


### PR DESCRIPTION
Addresses some warnings in a winforms app by propagating RUC to code related to ComNativeDescriptor.
The app still produces one related warning for dotnet/runtime's reference (by name) to ComNativeDescriptor, which I plan to address with a feature switch. The code path is not needed in the trimmed test app.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11165)