### PR TITLE
Tests should use theory data

### DIFF
--- a/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/ApplicationConfigurationGeneratorTests.cs
+++ b/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/ApplicationConfigurationGeneratorTests.cs
@@ -37,16 +37,20 @@ namespace MyProject
     }
 }";
 
-    public static IEnumerable<object[]> UnsupportedProjectTypes_TestData()
+    public static TheoryData<OutputKind> UnsupportedProjectTypes_TestData()
     {
+        var testData = new TheoryData<OutputKind>();
+
         foreach (OutputKind projectType in Enum.GetValues(typeof(OutputKind)))
         {
             if (projectType is not OutputKind.ConsoleApplication
                 and not OutputKind.WindowsApplication)
             {
-                yield return new object[] { projectType };
+                testData.Add(projectType);
             }
         }
+
+        return testData;
     }
 
     [Theory]

--- a/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/ApplicationConfigurationInitializeBuilderTests.cs
+++ b/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/ApplicationConfigurationInitializeBuilderTests.cs
@@ -46,15 +46,17 @@ public partial class ApplicationConfigurationInitializeBuilderTests
         Assert.Equal(expected, output);
     }
 
-    public static IEnumerable<object[]> GenerateInitializeData()
+    public static TheoryData<CultureInfo, object, string> GenerateInitializeData()
     {
+        var testData = new TheoryData<CultureInfo, object, string>();
+
         foreach (string cultureName in s_locales)
         {
             CultureInfo culture = new(cultureName);
 
             // EnableVisualStyles: false, true
-            yield return new object[]
-            {
+            testData.Add
+            (
                 culture,
                 new ApplicationConfig(
                     EnableVisualStyles: false,
@@ -63,9 +65,10 @@ public partial class ApplicationConfigurationInitializeBuilderTests
                     UseCompatibleTextRendering: PropertyDefaultValue.UseCompatibleTextRendering
                 ),
                 "EnableVisualStyles=false"
-            };
-            yield return new object[]
-            {
+            );
+
+            testData.Add
+            (
                 culture,
                 new ApplicationConfig(
                     EnableVisualStyles: true,
@@ -74,11 +77,11 @@ public partial class ApplicationConfigurationInitializeBuilderTests
                     UseCompatibleTextRendering: PropertyDefaultValue.UseCompatibleTextRendering
                 ),
                 "EnableVisualStyles=true"
-            };
+            );
 
             // UseCompatibleTextRendering: false, true
-            yield return new object[]
-            {
+            testData.Add
+            (
                 culture,
                 new ApplicationConfig(
                     EnableVisualStyles: PropertyDefaultValue.EnableVisualStyles,
@@ -87,9 +90,10 @@ public partial class ApplicationConfigurationInitializeBuilderTests
                     UseCompatibleTextRendering: false
                 ),
                 "UseCompTextRendering=false"
-            };
-            yield return new object[]
-            {
+            );
+            
+            testData.Add
+            (
                 culture,
                 new ApplicationConfig(
                     EnableVisualStyles: PropertyDefaultValue.EnableVisualStyles,
@@ -98,11 +102,11 @@ public partial class ApplicationConfigurationInitializeBuilderTests
                     UseCompatibleTextRendering: true
                 ),
                 "UseCompTextRendering=true"
-            };
+            );
 
             // DefaultFont: null, FontDescriptor
-            yield return new object[]
-            {
+            testData.Add
+            (
                 culture,
                 new ApplicationConfig(
                     EnableVisualStyles: PropertyDefaultValue.EnableVisualStyles,
@@ -111,9 +115,10 @@ public partial class ApplicationConfigurationInitializeBuilderTests
                     UseCompatibleTextRendering: false
                 ),
                 "DefaultFont=null"
-            };
-            yield return new object[]
-            {
+            );
+
+            testData.Add
+            (
                 culture,
                 new ApplicationConfig(
                     EnableVisualStyles: PropertyDefaultValue.EnableVisualStyles,
@@ -122,9 +127,10 @@ public partial class ApplicationConfigurationInitializeBuilderTests
                     UseCompatibleTextRendering: true
                 ),
                 "DefaultFont=default"
-            };
-            yield return new object[]
-            {
+            );
+
+            testData.Add
+            (
                 culture,
                 new ApplicationConfig(
                     EnableVisualStyles: PropertyDefaultValue.EnableVisualStyles,
@@ -133,9 +139,10 @@ public partial class ApplicationConfigurationInitializeBuilderTests
                     UseCompatibleTextRendering: true
                 ),
                 "DefaultFont=Tahoma"
-            };
-            yield return new object[]
-            {
+            );
+
+            testData.Add
+            (
                 culture,
                 new ApplicationConfig(
                     EnableVisualStyles: PropertyDefaultValue.EnableVisualStyles,
@@ -144,8 +151,10 @@ public partial class ApplicationConfigurationInitializeBuilderTests
                     UseCompatibleTextRendering: true
                 ),
                 "DefaultFont=SansSerif"
-            };
+            );
         }
+
+        return testData;
     }
 
     [Theory]

--- a/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/ProjectFileReaderTests.FontConverter.cs
+++ b/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/ProjectFileReaderTests.FontConverter.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+﻿﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel;
@@ -26,216 +26,40 @@ public partial class ProjectFileReaderTests
             "zh-CN"
         ];
 
-        public static TheoryData<CultureInfo, string, string, float, GraphicsUnit, FontStyle> TestConvertFormData()
+        public static IEnumerable<object[]> TestConvertFormData()
         {
-            var testData = new TheoryData<CultureInfo,
-                                          string,
-                                          string,
-                                          float,
-                                          GraphicsUnit,
-                                          FontStyle>();
-
             foreach (string cultureName in s_locales)
             {
                 CultureInfo culture = new(cultureName);
 
-                testData.Add
-                (
-                    culture,
-                    $"Courier New",
-                    "Courier New",
-                    PropertyDefaultValue.FontSize,
-                    (int)GraphicsUnit.Point,
-                    (int)FontStyle.Regular
-                );
-
-                testData.Add
-                (   
-                    culture,
-                    $"Courier New{s_separator} 11", 
-                    "Courier New", 
-                    11f, 
-                    (int)GraphicsUnit.Point, 
-                    (int)FontStyle.Regular
-                );
-
-                testData.Add
-                (
-                    culture,
-                    $"Arial{s_separator} 11px",
-                    "Arial", 
-                    11f,
-                    (int)GraphicsUnit.Pixel, 
-                    (int)FontStyle.Regular
-                );
-
-                testData.Add
-                (
-                    culture,
-                    $"Courier New{s_separator} 11 px", 
-                    "Courier New", 
-                    11f, 
-                    (int)GraphicsUnit.Pixel, 
-                    (int)FontStyle.Regular
-                );
-
-                testData.Add
-                (
-                    culture,
-                    $"Courier New{s_separator} 11 px{s_separator} style=Regular", 
-                    "Courier New", 
-                    11f, 
-                    (int)GraphicsUnit.Pixel, 
-                    (int)FontStyle.Regular
-                );
-
-                testData.Add
-                (
-                    culture,
-                    $"Courier New{s_separator} style=Bold", 
-                    "Courier New", 
-                    PropertyDefaultValue.FontSize, 
-                    (int)GraphicsUnit.Point, 
-                    (int)FontStyle.Bold
-                );
-
-                testData.Add
-                (
-                    culture,
-                    $"Courier New{s_separator} 11 px{s_separator} style=Bold{s_separator} Italic",
-                    "Courier New", 
-                    11f,
-                    (int)GraphicsUnit.Pixel,
-                    (int)(FontStyle.Bold | FontStyle.Italic)
-                );
-
-                testData.Add
-                (   
-                    culture,
-                    $"Courier New{s_separator} 11 px{s_separator} style=Regular, Italic",
-                    "Courier New",
-                    11f,
-                    (int)GraphicsUnit.Pixel,
-                    (int)(FontStyle.Regular | FontStyle.Italic)
-                );
-
-                testData.Add
-                (
-                    culture,
-                    $"Courier New{s_separator} 11 px{s_separator} style=Bold{s_separator} Italic{s_separator} Strikeout",
-                    "Courier New",
-                    11f, 
-                    (int)GraphicsUnit.Pixel, 
-                    (int)(FontStyle.Bold | FontStyle.Italic | FontStyle.Strikeout)
-                );
-
-                testData.Add
-                (
-                    culture,
-                    $"Arial{s_separator} 11 px{s_separator} style=Bold, Italic, Strikeout",
-                    "Arial", 
-                    11f, 
-                    (int)GraphicsUnit.Pixel, 
-                    (int)(FontStyle.Bold | FontStyle.Italic | FontStyle.Strikeout)
-                );
-
-                testData.Add
-                (
-                    culture,
-                    $"arIAL{s_separator} 10{s_separator} style=bold", 
-                    "arIAL", 
-                    10f, 
-                    (int)GraphicsUnit.Point, 
-                    (int)FontStyle.Bold
-                );
-
-                testData.Add
-                (
-                    culture,
-                    $"Arial{s_separator} 10{s_separator}", 
-                    "Arial", 
-                    10f, 
-                    (int)GraphicsUnit.Point, 
-                    (int)FontStyle.Regular
-                );
-
-                testData.Add
-                (
-                    culture,
-                    $"Arial{s_separator}",
-                    "Arial", 
-                    PropertyDefaultValue.FontSize, 
-                    (int)GraphicsUnit.Point, 
-                    (int)FontStyle.Regular
-                );
-
-                testData.Add
-                (
-                    culture,
-                    $"Arial{s_separator} 10{s_separator} style=12",
-                    "Arial", 
-                    10f, 
-                    (int)GraphicsUnit.Point, 
-                    (int)(FontStyle.Underline | FontStyle.Strikeout)
-                );
-
-                testData.Add
-                (
-                    culture,
-                    $"Courier New{s_separator} Style=Bold", 
-                    "Courier New", 
-                    PropertyDefaultValue.FontSize, 
-                    (int)GraphicsUnit.Point, 
-                    (int)FontStyle.Bold
-                ); // FullFramework style keyword is case sensitive.
-
-                testData.Add
-                (
-                    culture,
-                    $"{s_separator} 10{s_separator} style=bold", 
-                    "",
-                    10f, 
-                    (int)GraphicsUnit.Point, 
-                    (int)FontStyle.Bold
-                );
+                yield return new object[] { culture, $"Courier New", "Courier New", PropertyDefaultValue.FontSize, (int)GraphicsUnit.Point, (int)FontStyle.Regular };
+                yield return new object[] { culture, $"Courier New{s_separator} 11", "Courier New", 11f, (int)GraphicsUnit.Point, (int)FontStyle.Regular };
+                yield return new object[] { culture, $"Arial{s_separator} 11px", "Arial", 11f, (int)GraphicsUnit.Pixel, (int)FontStyle.Regular };
+                yield return new object[] { culture, $"Courier New{s_separator} 11 px", "Courier New", 11f, (int)GraphicsUnit.Pixel, (int)FontStyle.Regular };
+                yield return new object[] { culture, $"Courier New{s_separator} 11 px{s_separator} style=Regular", "Courier New", 11f, (int)GraphicsUnit.Pixel, (int)FontStyle.Regular };
+                yield return new object[] { culture, $"Courier New{s_separator} style=Bold", "Courier New", PropertyDefaultValue.FontSize, (int)GraphicsUnit.Point, (int)FontStyle.Bold };
+                yield return new object[] { culture, $"Courier New{s_separator} 11 px{s_separator} style=Bold{s_separator} Italic", "Courier New", 11f, (int)GraphicsUnit.Pixel, (int)(FontStyle.Bold | FontStyle.Italic) };
+                yield return new object[] { culture, $"Courier New{s_separator} 11 px{s_separator} style=Regular, Italic", "Courier New", 11f, (int)GraphicsUnit.Pixel, (int)(FontStyle.Regular | FontStyle.Italic) };
+                yield return new object[] { culture, $"Courier New{s_separator} 11 px{s_separator} style=Bold{s_separator} Italic{s_separator} Strikeout", "Courier New", 11f, (int)GraphicsUnit.Pixel, (int)(FontStyle.Bold | FontStyle.Italic | FontStyle.Strikeout) };
+                yield return new object[] { culture, $"Arial{s_separator} 11 px{s_separator} style=Bold, Italic, Strikeout", "Arial", 11f, (int)GraphicsUnit.Pixel, (int)(FontStyle.Bold | FontStyle.Italic | FontStyle.Strikeout) };
+                yield return new object[] { culture, $"arIAL{s_separator} 10{s_separator} style=bold", "arIAL", 10f, (int)GraphicsUnit.Point, (int)FontStyle.Bold };
+                yield return new object[] { culture, $"Arial{s_separator} 10{s_separator}", "Arial", 10f, (int)GraphicsUnit.Point, (int)FontStyle.Regular };
+                yield return new object[] { culture, $"Arial{s_separator}", "Arial", PropertyDefaultValue.FontSize, (int)GraphicsUnit.Point, (int)FontStyle.Regular };
+                yield return new object[] { culture, $"Arial{s_separator} 10{s_separator} style=12", "Arial", 10f, (int)GraphicsUnit.Point, (int)(FontStyle.Underline | FontStyle.Strikeout) };
+                yield return new object[] { culture, $"Courier New{s_separator} Style=Bold", "Courier New", PropertyDefaultValue.FontSize, (int)GraphicsUnit.Point, (int)FontStyle.Bold }; // FullFramework style keyword is case sensitive.
+                yield return new object[] { culture, $"{s_separator} 10{s_separator} style=bold", "", 10f, (int)GraphicsUnit.Point, (int)FontStyle.Bold };
 
                 // NOTE: in .NET runtime these tests will result in FontName='', but the implementation relies on GDI+, which we don't have...
-                testData.Add
-                (
-                    culture, 
-                    $"11px{s_separator} Style=Bold",
-                    $"11px", 
-                    PropertyDefaultValue.FontSize,
-                    (int)GraphicsUnit.Point,
-                    (int)FontStyle.Bold
-                );
-
-                testData.Add
-                (
-                    culture, 
-                    $"11px", 
-                    "11px", 
-                    PropertyDefaultValue.FontSize, 
-                    (int)GraphicsUnit.Point, 
-                    (int)FontStyle.Regular
-                );
-
-                testData.Add
-                (
-                    culture, 
-                    $"Style=Bold", 
-                    "Style=Bold", 
-                    PropertyDefaultValue.FontSize, 
-                    (int)GraphicsUnit.Point, 
-                    (int)FontStyle.Regular
-                );
+                yield return new object[] { culture, $"11px{s_separator} Style=Bold", $"11px", PropertyDefaultValue.FontSize, (int)GraphicsUnit.Point, (int)FontStyle.Bold };
+                yield return new object[] { culture, $"11px", "11px", PropertyDefaultValue.FontSize, (int)GraphicsUnit.Point, (int)FontStyle.Regular };
+                yield return new object[] { culture, $"Style=Bold", "Style=Bold", PropertyDefaultValue.FontSize, (int)GraphicsUnit.Point, (int)FontStyle.Regular };
             }
-
-            return testData;
         }
 
         [Theory]
+        #pragma warning disable xUnit1042 // The member referenced by the MemberData attribute returns untyped data rows
         [MemberData(nameof(TestConvertFormData))]
+        #pragma warning restore xUnit1042 // The member referenced by the MemberData attribute returns untyped data rows
         internal void TestConvertFrom(CultureInfo culture, string input, string expectedName, float expectedSize, GraphicsUnit expectedUnits, FontStyle expectedFontStyle)
         {
             Thread.CurrentThread.CurrentCulture = culture;

--- a/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/ProjectFileReaderTests.FontConverter.cs
+++ b/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/ProjectFileReaderTests.FontConverter.cs
@@ -26,24 +26,24 @@ public partial class ProjectFileReaderTests
             "zh-CN"
         ];
 
-        public static TheoryData<CultureInfo, string, string, PropertyValue.FontSize, int, int> TestConvertFormData()
+        public static TheoryData<CultureInfo, string, string, float, GraphicsUnit, FontStyle> TestConvertFormData()
         {
             var testData = new TheoryData<CultureInfo,
-                                          string, 
-                                          string, 
-                                          PropertyValue.FontSize,
-                                          int,
-                                          int>();
+                                          string,
+                                          string,
+                                          float,
+                                          GraphicsUnit,
+                                          FontStyle>();
 
             foreach (string cultureName in s_locales)
             {
                 CultureInfo culture = new(cultureName);
 
                 testData.Add(culture,
-                             $"Courier New", 
-                             "Courier New", 
-                             PropertyDefaultValue.FontSize, 
-                             (int)GraphicsUnit.Point, 
+                             $"Courier New",
+                             "Courier New",
+                             PropertyDefaultValue.FontSize,
+                             (int)GraphicsUnit.Point,
                              (int)FontStyle.Regular);
 
                 testData.Add(culture,

--- a/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/ProjectFileReaderTests.FontConverter.cs
+++ b/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/ProjectFileReaderTests.FontConverter.cs
@@ -26,34 +26,154 @@ public partial class ProjectFileReaderTests
             "zh-CN"
         ];
 
-        public static IEnumerable<object[]> TestConvertFormData()
+        public static TheoryData<string, string, PropertyValue.FontSize, int, int> TestConvertFormData()
         {
+            var testData = new TheoryData<string, 
+                                          string, 
+                                          PropertyValue.FontSize,
+                                          int,
+                                          int>();
+
             foreach (string cultureName in s_locales)
             {
                 CultureInfo culture = new(cultureName);
 
-                yield return new object[] { culture, $"Courier New", "Courier New", PropertyDefaultValue.FontSize, (int)GraphicsUnit.Point, (int)FontStyle.Regular };
-                yield return new object[] { culture, $"Courier New{s_separator} 11", "Courier New", 11f, (int)GraphicsUnit.Point, (int)FontStyle.Regular };
-                yield return new object[] { culture, $"Arial{s_separator} 11px", "Arial", 11f, (int)GraphicsUnit.Pixel, (int)FontStyle.Regular };
-                yield return new object[] { culture, $"Courier New{s_separator} 11 px", "Courier New", 11f, (int)GraphicsUnit.Pixel, (int)FontStyle.Regular };
-                yield return new object[] { culture, $"Courier New{s_separator} 11 px{s_separator} style=Regular", "Courier New", 11f, (int)GraphicsUnit.Pixel, (int)FontStyle.Regular };
-                yield return new object[] { culture, $"Courier New{s_separator} style=Bold", "Courier New", PropertyDefaultValue.FontSize, (int)GraphicsUnit.Point, (int)FontStyle.Bold };
-                yield return new object[] { culture, $"Courier New{s_separator} 11 px{s_separator} style=Bold{s_separator} Italic", "Courier New", 11f, (int)GraphicsUnit.Pixel, (int)(FontStyle.Bold | FontStyle.Italic) };
-                yield return new object[] { culture, $"Courier New{s_separator} 11 px{s_separator} style=Regular, Italic", "Courier New", 11f, (int)GraphicsUnit.Pixel, (int)(FontStyle.Regular | FontStyle.Italic) };
-                yield return new object[] { culture, $"Courier New{s_separator} 11 px{s_separator} style=Bold{s_separator} Italic{s_separator} Strikeout", "Courier New", 11f, (int)GraphicsUnit.Pixel, (int)(FontStyle.Bold | FontStyle.Italic | FontStyle.Strikeout) };
-                yield return new object[] { culture, $"Arial{s_separator} 11 px{s_separator} style=Bold, Italic, Strikeout", "Arial", 11f, (int)GraphicsUnit.Pixel, (int)(FontStyle.Bold | FontStyle.Italic | FontStyle.Strikeout) };
-                yield return new object[] { culture, $"arIAL{s_separator} 10{s_separator} style=bold", "arIAL", 10f, (int)GraphicsUnit.Point, (int)FontStyle.Bold };
-                yield return new object[] { culture, $"Arial{s_separator} 10{s_separator}", "Arial", 10f, (int)GraphicsUnit.Point, (int)FontStyle.Regular };
-                yield return new object[] { culture, $"Arial{s_separator}", "Arial", PropertyDefaultValue.FontSize, (int)GraphicsUnit.Point, (int)FontStyle.Regular };
-                yield return new object[] { culture, $"Arial{s_separator} 10{s_separator} style=12", "Arial", 10f, (int)GraphicsUnit.Point, (int)(FontStyle.Underline | FontStyle.Strikeout) };
-                yield return new object[] { culture, $"Courier New{s_separator} Style=Bold", "Courier New", PropertyDefaultValue.FontSize, (int)GraphicsUnit.Point, (int)FontStyle.Bold }; // FullFramework style keyword is case sensitive.
-                yield return new object[] { culture, $"{s_separator} 10{s_separator} style=bold", "", 10f, (int)GraphicsUnit.Point, (int)FontStyle.Bold };
+                testData.Add(culture,
+                             $"Courier New", 
+                             "Courier New", 
+                             PropertyDefaultValue.FontSize, 
+                             (int)GraphicsUnit.Point, 
+                             (int)FontStyle.Regular);
+
+                testData.Add(culture,
+                             $"Courier New{s_separator} 11", 
+                             "Courier New", 
+                             11f, 
+                             (int)GraphicsUnit.Point, 
+                             (int)FontStyle.Regular);
+
+                testData.Add(culture,
+                             $"Arial{s_separator} 11px",
+                             "Arial", 
+                             11f,
+                             (int)GraphicsUnit.Pixel, 
+                             (int)FontStyle.Regular);
+
+                testData.Add(culture,
+                             $"Courier New{s_separator} 11 px", 
+                             "Courier New", 
+                             11f, 
+                             (int)GraphicsUnit.Pixel, 
+                             (int)FontStyle.Regular);
+
+                testData.Add(culture,
+                             $"Courier New{s_separator} 11 px{s_separator} style=Regular", 
+                             "Courier New", 
+                             11f, 
+                             (int)GraphicsUnit.Pixel, 
+                             (int)FontStyle.Regular);
+
+                testData.Add(culture,
+                             $"Courier New{s_separator} style=Bold", 
+                             "Courier New", 
+                             PropertyDefaultValue.FontSize, 
+                             (int)GraphicsUnit.Point, 
+                             (int)FontStyle.Bold);
+
+                testData.Add(culture,
+                             $"Courier New{s_separator} 11 px{s_separator} style=Bold{s_separator} Italic",
+                             "Courier New", 
+                             11f,
+                             (int)GraphicsUnit.Pixel,
+                             (int)(FontStyle.Bold | FontStyle.Italic));
+
+                testData.Add(culture,
+                             $"Courier New{s_separator} 11 px{s_separator} style=Regular, Italic",
+                             "Courier New",
+                             11f,
+                             (int)GraphicsUnit.Pixel,
+                             (int)(FontStyle.Regular | FontStyle.Italic));
+
+                testData.Add(culture,
+                             $"Courier New{s_separator} 11 px{s_separator} style=Bold{s_separator} Italic{s_separator} Strikeout",
+                             "Courier New",
+                             11f, 
+                             (int)GraphicsUnit.Pixel, 
+                             (int)(FontStyle.Bold | FontStyle.Italic | FontStyle.Strikeout));
+
+                testData.Add(culture,
+                             $"Arial{s_separator} 11 px{s_separator} style=Bold, Italic, Strikeout",
+                             "Arial", 
+                             11f, 
+                             (int)GraphicsUnit.Pixel, 
+                             (int)(FontStyle.Bold | FontStyle.Italic | FontStyle.Strikeout));
+
+                testData.Add(culture,
+                            $"arIAL{s_separator} 10{s_separator} style=bold", 
+                            "arIAL", 
+                            10f, 
+                            (int)GraphicsUnit.Point, 
+                            (int)FontStyle.Bold);
+
+                testData.Add(culture,
+                            $"Arial{s_separator} 10{s_separator}", 
+                            "Arial", 
+                            10f, 
+                            (int)GraphicsUnit.Point, 
+                            (int)FontStyle.Regular);
+
+                testData.Add(culture,
+                            $"Arial{s_separator}",
+                            "Arial", 
+                            PropertyDefaultValue.FontSize, 
+                            (int)GraphicsUnit.Point, 
+                            (int)FontStyle.Regular);
+
+                testData.Add(culture,
+                            $"Arial{s_separator} 10{s_separator} style=12",
+                            "Arial", 
+                            10f, 
+                            (int)GraphicsUnit.Point, 
+                            (int)(FontStyle.Underline | FontStyle.Strikeout));
+
+                testData.Add(culture,
+                            $"Courier New{s_separator} Style=Bold", 
+                            "Courier New", 
+                            PropertyDefaultValue.FontSize, 
+                            (int)GraphicsUnit.Point, 
+                            (int)FontStyle.Bold); // FullFramework style keyword is case sensitive.
+
+                testData.Add(culture,
+                             $"{s_separator} 10{s_separator} style=bold", 
+                             "",
+                             10f, 
+                             (int)GraphicsUnit.Point, 
+                             (int)FontStyle.Bold);
 
                 // NOTE: in .NET runtime these tests will result in FontName='', but the implementation relies on GDI+, which we don't have...
-                yield return new object[] { culture, $"11px{s_separator} Style=Bold", $"11px", PropertyDefaultValue.FontSize, (int)GraphicsUnit.Point, (int)FontStyle.Bold };
-                yield return new object[] { culture, $"11px", "11px", PropertyDefaultValue.FontSize, (int)GraphicsUnit.Point, (int)FontStyle.Regular };
-                yield return new object[] { culture, $"Style=Bold", "Style=Bold", PropertyDefaultValue.FontSize, (int)GraphicsUnit.Point, (int)FontStyle.Regular };
+                testData.Add(culture, 
+                             $"11px{s_separator} Style=Bold",
+                             $"11px", 
+                             PropertyDefaultValue.FontSize,
+                             (int)GraphicsUnit.Point,
+                             (int)FontStyle.Bold);
+
+                testData.Add(culture, 
+                             $"11px", 
+                             "11px", 
+                             PropertyDefaultValue.FontSize, 
+                             (int)GraphicsUnit.Point, 
+                             (int)FontStyle.Regular);
+
+                testData.Add(culture, 
+                             $"Style=Bold", 
+                             "Style=Bold", 
+                             PropertyDefaultValue.FontSize, 
+                             (int)GraphicsUnit.Point, 
+                             (int)FontStyle.Regular);
             }
+
+            return testData;
         }
 
         [Theory]

--- a/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/ProjectFileReaderTests.FontConverter.cs
+++ b/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/ProjectFileReaderTests.FontConverter.cs
@@ -26,9 +26,10 @@ public partial class ProjectFileReaderTests
             "zh-CN"
         ];
 
-        public static TheoryData<string, string, PropertyValue.FontSize, int, int> TestConvertFormData()
+        public static TheoryData<CultureInfo, string, string, PropertyValue.FontSize, int, int> TestConvertFormData()
         {
-            var testData = new TheoryData<string, 
+            var testData = new TheoryData<CultureInfo,
+                                          string, 
                                           string, 
                                           PropertyValue.FontSize,
                                           int,

--- a/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/ProjectFileReaderTests.FontConverter.cs
+++ b/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/ProjectFileReaderTests.FontConverter.cs
@@ -39,139 +39,196 @@ public partial class ProjectFileReaderTests
             {
                 CultureInfo culture = new(cultureName);
 
-                testData.Add(culture,
-                             $"Courier New",
-                             "Courier New",
-                             PropertyDefaultValue.FontSize,
-                             (int)GraphicsUnit.Point,
-                             (int)FontStyle.Regular);
+                testData.Add
+                (
+                    culture,
+                    $"Courier New",
+                    "Courier New",
+                    PropertyDefaultValue.FontSize,
+                    (int)GraphicsUnit.Point,
+                    (int)FontStyle.Regular
+                );
 
-                testData.Add(culture,
-                             $"Courier New{s_separator} 11", 
-                             "Courier New", 
-                             11f, 
-                             (int)GraphicsUnit.Point, 
-                             (int)FontStyle.Regular);
+                testData.Add
+                (   
+                    culture,
+                    $"Courier New{s_separator} 11", 
+                    "Courier New", 
+                    11f, 
+                    (int)GraphicsUnit.Point, 
+                    (int)FontStyle.Regular
+                );
 
-                testData.Add(culture,
-                             $"Arial{s_separator} 11px",
-                             "Arial", 
-                             11f,
-                             (int)GraphicsUnit.Pixel, 
-                             (int)FontStyle.Regular);
+                testData.Add
+                (
+                    culture,
+                    $"Arial{s_separator} 11px",
+                    "Arial", 
+                    11f,
+                    (int)GraphicsUnit.Pixel, 
+                    (int)FontStyle.Regular
+                );
 
-                testData.Add(culture,
-                             $"Courier New{s_separator} 11 px", 
-                             "Courier New", 
-                             11f, 
-                             (int)GraphicsUnit.Pixel, 
-                             (int)FontStyle.Regular);
+                testData.Add
+                (
+                    culture,
+                    $"Courier New{s_separator} 11 px", 
+                    "Courier New", 
+                    11f, 
+                    (int)GraphicsUnit.Pixel, 
+                    (int)FontStyle.Regular
+                );
 
-                testData.Add(culture,
-                             $"Courier New{s_separator} 11 px{s_separator} style=Regular", 
-                             "Courier New", 
-                             11f, 
-                             (int)GraphicsUnit.Pixel, 
-                             (int)FontStyle.Regular);
+                testData.Add
+                (
+                    culture,
+                    $"Courier New{s_separator} 11 px{s_separator} style=Regular", 
+                    "Courier New", 
+                    11f, 
+                    (int)GraphicsUnit.Pixel, 
+                    (int)FontStyle.Regular
+                );
 
-                testData.Add(culture,
-                             $"Courier New{s_separator} style=Bold", 
-                             "Courier New", 
-                             PropertyDefaultValue.FontSize, 
-                             (int)GraphicsUnit.Point, 
-                             (int)FontStyle.Bold);
+                testData.Add
+                (
+                    culture,
+                    $"Courier New{s_separator} style=Bold", 
+                    "Courier New", 
+                    PropertyDefaultValue.FontSize, 
+                    (int)GraphicsUnit.Point, 
+                    (int)FontStyle.Bold
+                );
 
-                testData.Add(culture,
-                             $"Courier New{s_separator} 11 px{s_separator} style=Bold{s_separator} Italic",
-                             "Courier New", 
-                             11f,
-                             (int)GraphicsUnit.Pixel,
-                             (int)(FontStyle.Bold | FontStyle.Italic));
+                testData.Add
+                (
+                    culture,
+                    $"Courier New{s_separator} 11 px{s_separator} style=Bold{s_separator} Italic",
+                    "Courier New", 
+                    11f,
+                    (int)GraphicsUnit.Pixel,
+                    (int)(FontStyle.Bold | FontStyle.Italic)
+                );
 
-                testData.Add(culture,
-                             $"Courier New{s_separator} 11 px{s_separator} style=Regular, Italic",
-                             "Courier New",
-                             11f,
-                             (int)GraphicsUnit.Pixel,
-                             (int)(FontStyle.Regular | FontStyle.Italic));
+                testData.Add
+                (   
+                    culture,
+                    $"Courier New{s_separator} 11 px{s_separator} style=Regular, Italic",
+                    "Courier New",
+                    11f,
+                    (int)GraphicsUnit.Pixel,
+                    (int)(FontStyle.Regular | FontStyle.Italic)
+                );
 
-                testData.Add(culture,
-                             $"Courier New{s_separator} 11 px{s_separator} style=Bold{s_separator} Italic{s_separator} Strikeout",
-                             "Courier New",
-                             11f, 
-                             (int)GraphicsUnit.Pixel, 
-                             (int)(FontStyle.Bold | FontStyle.Italic | FontStyle.Strikeout));
+                testData.Add
+                (
+                    culture,
+                    $"Courier New{s_separator} 11 px{s_separator} style=Bold{s_separator} Italic{s_separator} Strikeout",
+                    "Courier New",
+                    11f, 
+                    (int)GraphicsUnit.Pixel, 
+                    (int)(FontStyle.Bold | FontStyle.Italic | FontStyle.Strikeout)
+                );
 
-                testData.Add(culture,
-                             $"Arial{s_separator} 11 px{s_separator} style=Bold, Italic, Strikeout",
-                             "Arial", 
-                             11f, 
-                             (int)GraphicsUnit.Pixel, 
-                             (int)(FontStyle.Bold | FontStyle.Italic | FontStyle.Strikeout));
+                testData.Add
+                (
+                    culture,
+                    $"Arial{s_separator} 11 px{s_separator} style=Bold, Italic, Strikeout",
+                    "Arial", 
+                    11f, 
+                    (int)GraphicsUnit.Pixel, 
+                    (int)(FontStyle.Bold | FontStyle.Italic | FontStyle.Strikeout)
+                );
 
-                testData.Add(culture,
-                            $"arIAL{s_separator} 10{s_separator} style=bold", 
-                            "arIAL", 
-                            10f, 
-                            (int)GraphicsUnit.Point, 
-                            (int)FontStyle.Bold);
+                testData.Add
+                (
+                    culture,
+                    $"arIAL{s_separator} 10{s_separator} style=bold", 
+                    "arIAL", 
+                    10f, 
+                    (int)GraphicsUnit.Point, 
+                    (int)FontStyle.Bold
+                );
 
-                testData.Add(culture,
-                            $"Arial{s_separator} 10{s_separator}", 
-                            "Arial", 
-                            10f, 
-                            (int)GraphicsUnit.Point, 
-                            (int)FontStyle.Regular);
+                testData.Add
+                (
+                    culture,
+                    $"Arial{s_separator} 10{s_separator}", 
+                    "Arial", 
+                    10f, 
+                    (int)GraphicsUnit.Point, 
+                    (int)FontStyle.Regular
+                );
 
-                testData.Add(culture,
-                            $"Arial{s_separator}",
-                            "Arial", 
-                            PropertyDefaultValue.FontSize, 
-                            (int)GraphicsUnit.Point, 
-                            (int)FontStyle.Regular);
+                testData.Add
+                (
+                    culture,
+                    $"Arial{s_separator}",
+                    "Arial", 
+                    PropertyDefaultValue.FontSize, 
+                    (int)GraphicsUnit.Point, 
+                    (int)FontStyle.Regular
+                );
 
-                testData.Add(culture,
-                            $"Arial{s_separator} 10{s_separator} style=12",
-                            "Arial", 
-                            10f, 
-                            (int)GraphicsUnit.Point, 
-                            (int)(FontStyle.Underline | FontStyle.Strikeout));
+                testData.Add
+                (
+                    culture,
+                    $"Arial{s_separator} 10{s_separator} style=12",
+                    "Arial", 
+                    10f, 
+                    (int)GraphicsUnit.Point, 
+                    (int)(FontStyle.Underline | FontStyle.Strikeout)
+                );
 
-                testData.Add(culture,
-                            $"Courier New{s_separator} Style=Bold", 
-                            "Courier New", 
-                            PropertyDefaultValue.FontSize, 
-                            (int)GraphicsUnit.Point, 
-                            (int)FontStyle.Bold); // FullFramework style keyword is case sensitive.
+                testData.Add
+                (
+                    culture,
+                    $"Courier New{s_separator} Style=Bold", 
+                    "Courier New", 
+                    PropertyDefaultValue.FontSize, 
+                    (int)GraphicsUnit.Point, 
+                    (int)FontStyle.Bold
+                ); // FullFramework style keyword is case sensitive.
 
-                testData.Add(culture,
-                             $"{s_separator} 10{s_separator} style=bold", 
-                             "",
-                             10f, 
-                             (int)GraphicsUnit.Point, 
-                             (int)FontStyle.Bold);
+                testData.Add
+                (
+                    culture,
+                    $"{s_separator} 10{s_separator} style=bold", 
+                    "",
+                    10f, 
+                    (int)GraphicsUnit.Point, 
+                    (int)FontStyle.Bold
+                );
 
                 // NOTE: in .NET runtime these tests will result in FontName='', but the implementation relies on GDI+, which we don't have...
-                testData.Add(culture, 
-                             $"11px{s_separator} Style=Bold",
-                             $"11px", 
-                             PropertyDefaultValue.FontSize,
-                             (int)GraphicsUnit.Point,
-                             (int)FontStyle.Bold);
+                testData.Add
+                (
+                    culture, 
+                    $"11px{s_separator} Style=Bold",
+                    $"11px", 
+                    PropertyDefaultValue.FontSize,
+                    (int)GraphicsUnit.Point,
+                    (int)FontStyle.Bold
+                );
 
-                testData.Add(culture, 
-                             $"11px", 
-                             "11px", 
-                             PropertyDefaultValue.FontSize, 
-                             (int)GraphicsUnit.Point, 
-                             (int)FontStyle.Regular);
+                testData.Add
+                (
+                    culture, 
+                    $"11px", 
+                    "11px", 
+                    PropertyDefaultValue.FontSize, 
+                    (int)GraphicsUnit.Point, 
+                    (int)FontStyle.Regular
+                );
 
-                testData.Add(culture, 
-                             $"Style=Bold", 
-                             "Style=Bold", 
-                             PropertyDefaultValue.FontSize, 
-                             (int)GraphicsUnit.Point, 
-                             (int)FontStyle.Regular);
+                testData.Add
+                (
+                    culture, 
+                    $"Style=Bold", 
+                    "Style=Bold", 
+                    PropertyDefaultValue.FontSize, 
+                    (int)GraphicsUnit.Point, 
+                    (int)FontStyle.Regular
+                );
             }
 
             return testData;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Makes progress to fix #11041 


## Proposed changes

- Changed untyped test data to use typed TheoryData objects.
- Allowing us to enable xUnit1024 errors in .editorconfig.
- Currently fixes test cases in Windows form analyzer (CSharp) with one exception 
   for the file reader font converter.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact
- No customer impact, just refactoring old test cases.

## Regression? 

- No

## Risk

-There should be no risk in moving to strongly typed parameterized test methods.

<!-- end TELL-MODE -->

## Test methodology <!-- How did you ensure quality? -->
- Because the tests are functionally identical, I used the tests that were already present. 

 

## Test environment(s) <!-- Remove any that don't apply -->

- <!-- use `dotnet --info` -->



 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11171)