### PR TITLE
Miscellaneous trim fixes

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerHost.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerHost.cs
@@ -1240,7 +1240,7 @@ internal sealed partial class DesignerHost : Container, IDesignerLoaderHost2, ID
     [DynamicallyAccessedMembers(GetAllMembers)]
     MemberInfo[] IReflect.GetMember(string name, BindingFlags bindingAttr) => typeof(IDesignerHost).GetMember(name, bindingAttr);
 
-    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods | DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields | DynamicallyAccessedMemberTypes.PublicNestedTypes | DynamicallyAccessedMemberTypes.NonPublicNestedTypes | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties | DynamicallyAccessedMemberTypes.PublicEvents | DynamicallyAccessedMemberTypes.NonPublicEvents)]
+    [DynamicallyAccessedMembers(GetAllMembers)]
     MemberInfo[] IReflect.GetMembers(BindingFlags bindingAttr) => typeof(IDesignerHost).GetMembers(bindingAttr);
 
     [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerHost.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerHost.cs
@@ -1240,8 +1240,10 @@ internal sealed partial class DesignerHost : Container, IDesignerLoaderHost2, ID
     [DynamicallyAccessedMembers(GetAllMembers)]
     MemberInfo[] IReflect.GetMember(string name, BindingFlags bindingAttr) => typeof(IDesignerHost).GetMember(name, bindingAttr);
 
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods | DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields | DynamicallyAccessedMemberTypes.PublicNestedTypes | DynamicallyAccessedMemberTypes.NonPublicNestedTypes | DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties | DynamicallyAccessedMemberTypes.PublicEvents | DynamicallyAccessedMemberTypes.NonPublicEvents)]
     MemberInfo[] IReflect.GetMembers(BindingFlags bindingAttr) => typeof(IDesignerHost).GetMembers(bindingAttr);
 
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
     object? IReflect.InvokeMember(
         string name,
         BindingFlags invokeAttr,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TextBox/TextBoxAutoCompleteSourceConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TextBox/TextBoxAutoCompleteSourceConverter.cs
@@ -8,7 +8,6 @@ namespace System.Windows.Forms;
 internal class TextBoxAutoCompleteSourceConverter : EnumConverter
 {
     public TextBoxAutoCompleteSourceConverter(
-        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.PublicFields)]
         Type type) : base(type)
     {
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TextBox/TextBoxAutoCompleteSourceConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TextBox/TextBoxAutoCompleteSourceConverter.cs
@@ -7,8 +7,7 @@ namespace System.Windows.Forms;
 
 internal class TextBoxAutoCompleteSourceConverter : EnumConverter
 {
-    public TextBoxAutoCompleteSourceConverter(
-        Type type) : base(type)
+    public TextBoxAutoCompleteSourceConverter(Type type) : base(type)
     {
     }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/Containers/ContainerControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/Containers/ContainerControl.cs
@@ -251,6 +251,11 @@ public class ContainerControl : ScrollableControl, IContainerControl
     {
         get
         {
+            if (!Binding.IsSupported)
+            {
+                throw new NotSupportedException(SR.BindingNotSupported);
+            }
+
             BindingContext? bm = base.BindingContext;
             if (bm is null)
             {


### PR DESCRIPTION
Addresses the following warnings
 - [ContainerControl.BindingContext](https://github.com/dotnet/winforms/blob/0e3964e75d345cdb4d849e676d97042cf3e5f723/src/System.Windows.Forms/src/System/Windows/Forms/Layout/Containers/ContainerControl.cs#L254): Adds a feature switch to indicate that binding is not supported in default trimming
 - Missed earlier annotation in [IReflect.InvokeMember](https://github.com/dotnet/winforms/blob/0e3964e75d345cdb4d849e676d97042cf3e5f723/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerHost.cs#L1245)
 - `EnumConverter` no longer require a DAM annotation due to https://github.com/dotnet/runtime/pull/100347
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11175)