### PR TITLE
fix issue 10579: The selected icon for Icon property cannot be refreshed in time when adding the icon by using "Choose Icon..." command line until clicked any where in the propertyGide Window

### DIFF
--- a/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DesignSurfaceExt/PropertyGridExt.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DesignSurfaceExt/PropertyGridExt.cs
@@ -2,13 +2,40 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel.Design;
+using System.Reflection;
 using System.Windows.Forms;
 
 namespace DesignSurfaceExt;
 
 public class PropertyGridExt : PropertyGrid
 {
-    public IDesignerHost DesignerHost { get; set; }
+    private IDesignerHost _host;
+    private IComponentChangeService _componentChangeService;
+    public IDesignerHost DesignerHost
+    {
+        get
+        {
+            return _host;
+        }
+        set
+        {
+            if (value is not null)
+            {
+                _componentChangeService ??= (IComponentChangeService)value.GetService(typeof(IComponentChangeService));
+                if (_componentChangeService is not null)
+                {
+                    _componentChangeService.ComponentChanged += (sender, e) =>
+                    {
+                        MethodInfo methodInfo = typeof(PropertyGrid).GetMethod("OnComponentChanged", BindingFlags.NonPublic | BindingFlags.Instance);
+
+                        methodInfo.Invoke(this, [sender, e]);
+                    };
+                }
+            }
+
+            _host = value;
+        }
+    }
 
     protected override void OnSelectedObjectsChanged(EventArgs e) => base.OnSelectedObjectsChanged(e);
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #10579

## Root cause 
`PropertyGrid` binds `ComponentChanged` to refresh icons when some properties are changed.
But in this case, `PropertyGrid` didn't bind  `ComponentChanged`, so bind it manually.


https://github.com/dotnet/winforms/blob/b6745a5b5075bef05415d1600a5125282410a71b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGrid.cs#L243-L284

https://github.com/dotnet/winforms/blob/b6745a5b5075bef05415d1600a5125282410a71b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGrid.cs#L2445-L2468

## Proposed changes

- 
-  Add `ComponentChanged` handler to `PropertyGrid`
- 

<!-- We are in TELL-MODE the following section must be completed

## Customer Impact

- 
- 

## Regression? 

- Yes / No

## Risk

-
 -->
<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
![DemoConsole](https://github.com/dotnet/winforms/assets/38325459/b0529be4-0432-4768-a074-af71510b757b)
<!-- TODO -->

### After
![Runtime_issue_10579](https://github.com/dotnet/winforms/assets/135201996/9017935d-5d9d-4149-8d19-70b9a785e841)

<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- 
-  manually 
- 

<!--## Accessibility testing   Remove this section if PR does not change UI -->


## Test environment(s) <!-- Remove any that don't apply -->
9.0.0-preview.4.24204.3
- <!-- use `dotnet --info` -->


<!-- Mention language, UI scaling, or anything else that might be relevant -->
