### PR TITLE
Fix some record issues

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/ArrayRecord.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/ArrayRecord.cs
@@ -14,14 +14,14 @@ namespace System.Windows.Forms.BinaryFormat;
 ///  can be coalesced into an <see cref="NullRecord.ObjectNullMultiple"/> or <see cref="NullRecord.ObjectNullMultiple256"/>
 ///  record.
 /// </devdoc>
-internal abstract class ArrayRecord : Record, IEnumerable
+internal abstract class ArrayRecord : ObjectRecord, IEnumerable
 {
     public ArrayInfo ArrayInfo { get; }
 
     /// <summary>
     ///  Identifier for the array.
     /// </summary>
-    public Id ObjectId => ArrayInfo.ObjectId;
+    public override Id ObjectId => ArrayInfo.ObjectId;
 
     /// <summary>
     ///  Length of the array.

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/BinaryArray.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/BinaryArray.cs
@@ -54,7 +54,9 @@ internal sealed class BinaryArray : ArrayRecord<object>, IRecord<BinaryArray>
             arrayObjects.Add(ReadValue(reader, recordMap, type, typeInfo));
         }
 
-        return new(rank, arrayType, new ArrayInfo(objectId, length), memberTypeInfo, arrayObjects);
+        BinaryArray record = new(rank, arrayType, new ArrayInfo(objectId, length), memberTypeInfo, arrayObjects);
+        recordMap[objectId] = record;
+        return record;
     }
 
     public override void Write(BinaryWriter writer)

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/ClassRecord.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/ClassRecord.cs
@@ -14,13 +14,15 @@ namespace System.Windows.Forms.BinaryFormat;
 ///   </see>.
 ///  </para>
 /// </remarks>
-internal abstract class ClassRecord : Record
+internal abstract class ClassRecord : ObjectRecord
 {
     internal ClassInfo ClassInfo { get; }
     public IReadOnlyList<object> MemberValues { get; }
 
     public string Name => ClassInfo.Name;
-    public virtual Id ObjectId => ClassInfo.ObjectId;
+    public override Id ObjectId => ClassInfo.ObjectId;
+    public virtual Id LibraryId => Id.Null;
+
     public IReadOnlyList<string> MemberNames => ClassInfo.MemberNames;
 
     public object this[string memberName]

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/ClassWithMembers.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/ClassWithMembers.cs
@@ -15,7 +15,7 @@ namespace System.Windows.Forms.BinaryFormat;
 /// </remarks>
 internal sealed class ClassWithMembers : ClassRecord, IRecord<ClassWithMembers>
 {
-    public Id LibraryId { get; }
+    public override Id LibraryId { get; }
 
     public ClassWithMembers(ClassInfo classInfo, Id libraryId, IReadOnlyList<object> memberValues)
         : base(classInfo, memberValues)

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/ClassWithMembersAndTypes.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/ClassWithMembersAndTypes.cs
@@ -16,7 +16,7 @@ namespace System.Windows.Forms.BinaryFormat;
 internal sealed class ClassWithMembersAndTypes : ClassRecord, IRecord<ClassWithMembersAndTypes>
 {
     public MemberTypeInfo MemberTypeInfo { get; }
-    public Id LibraryId { get; }
+    public override Id LibraryId { get; }
 
     public ClassWithMembersAndTypes(
         ClassInfo classInfo,

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/ObjectRecord.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/BinaryFormat/ObjectRecord.cs
@@ -1,0 +1,9 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Windows.Forms.BinaryFormat;
+
+internal abstract class ObjectRecord : Record
+{
+    public abstract Id ObjectId { get; }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Id.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Id.cs
@@ -9,20 +9,34 @@ namespace System.Windows.Forms;
 internal readonly struct Id : IEquatable<Id>
 {
     private readonly int _id;
+    private readonly bool _isNull = true;
 
     // It is possible that the id may be negative with value types. See BinaryObjectWriter.InternalGetId.
-    private Id(int id) => _id = id;
+    private Id(int id)
+    {
+        _id = id;
+        _isNull = false;
+    }
 
-    public static implicit operator int(Id value) => value._id;
+    private Id(bool isNull)
+    {
+        _id = 0;
+        _isNull = isNull;
+    }
+
+    public static Id Null => new(isNull: true);
+    public bool IsNull => _isNull;
+
+    public static implicit operator int(Id value) => value._isNull ? throw new InvalidOperationException() : value._id;
     public static implicit operator Id(int value) => new(value);
 
     public override bool Equals([NotNullWhen(true)] object? obj)
         => (obj is Id id && Equals(id)) || (obj is int value && value == _id);
 
-    public bool Equals(Id other) => _id == other._id || -1 * _id == other._id;
+    public bool Equals(Id other) => _isNull == other._isNull && _id == other._id;
 
-    public override readonly int GetHashCode() => _id < 0 ? (-1 * _id).GetHashCode() : _id.GetHashCode();
-    public override readonly string ToString() => _id.ToString();
+    public override readonly int GetHashCode() => _id.GetHashCode();
+    public override readonly string ToString() => _isNull ? "<null>" : _id.ToString();
 
     public static bool operator ==(Id left, Id right) => left.Equals(right);
 

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/IdTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/IdTests.cs
@@ -6,9 +6,9 @@ namespace System.Windows.Forms.Tests;
 public class IdTests
 {
     [Fact]
-    public void IdSignedAreEquivalent()
+    public void IdSignedNotAreEquivalent()
     {
-        ((Id)1).Should().Be((Id)(-1));
+        ((Id)1).Should().NotBe((Id)(-1));
     }
 
     [Fact]


### PR DESCRIPTION
- BinaryArray was not putting itself in the record map
- Id negative and positive values are not equivalent
- Add "null" Id
- Add base ObjectRecord to surface ObjectId
- Handle BinaryLibrary records occuring before other record data
- Raise LibraryId to ClassRecord
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11196)