### PR TITLE
fix issue 10307: TabPage should not be moved in the DemoConsole application

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
@@ -398,6 +398,8 @@ public partial class ControlDesigner : ComponentDesigner
     protected void BaseWndProc(ref Message m)
         => m.ResultInternal = PInvoke.DefWindowProc(m.HWND, (uint)m.MsgInternal, m.WParamInternal, m.LParamInternal);
 
+    internal override bool CanBeAssociatedWith(IDesigner parentDesigner) => CanBeParentedTo(parentDesigner);
+
     /// <summary>
     ///  Determines if the this designer can be parented to the specified designer -- generally this means if the
     ///  control for this designer can be parented into the given ParentControlDesigner's designer.


### PR DESCRIPTION

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #10307

## Root cause

When drag begins, this is the call stack of InProc designer
![image](https://github.com/dotnet/winforms/assets/135201996/239f0a15-c1c4-485e-a520-a7fbd80e5377)

here `ControlDesigner.CanBeAssociatedWith` is an override method.


**But in this case (DemoConsole), there is no override method, so it comes to base method.** which always return true.

https://github.com/dotnet/winforms/blob/3bf6970715b552384bfb28a2752c385ad8353a27/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ComponentDesigner.cs#L53

So the following logic will not be executed.

I guess this might be a careless omission.

## Proposed changes

- 
- Add override method `CanBeAssociatedWith`
- 


## Risk

- low

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before


https://github.com/dotnet/winforms/assets/104609169/61c945b7-b584-478b-a981-7638e738db0e

### After

![Runtime_issue_10307](https://github.com/dotnet/winforms/assets/135201996/c7878678-a86f-42c1-9354-555d3ccacf47)


## Test methodology <!-- How did you ensure quality? -->

- 
- manually 
- 


## Test environment(s) <!-- Remove any that don't apply -->

- <!-- use `dotnet --info` -->




 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11199)