### PR TITLE
Default font scaling corrections and optimizations. Fix #11037.

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/ScaleHelper.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/ScaleHelper.cs
@@ -215,31 +215,14 @@ internal static partial class ScaleHelper
     internal static bool IsScalingRequired => InitialSystemDpi != OneHundredPercentLogicalDpi;
 
     /// <summary>
-    ///  Creates a scaled version of the given <see cref="Font"/> to the Windows Accessibility Text Size setting (also
+    ///  Creates a scaled version of the given non system <see cref="Font"/> to the Windows Accessibility Text Size setting (also
     ///  known as Text Scaling) if needed, otherwise returns <see langword="null"/>.
     /// </summary>
     internal static Font? ScaleToSystemTextSize(Font? font)
     {
-        if (!OsVersion.IsWindows10_1507OrGreater() || font is null || font.IsSystemFont)
+        if (font is null || font.IsSystemFont || !OsVersion.IsWindows10_1507OrGreater())
         {
             return null;
-        }
-
-        if (font.IsSystemFont)
-        {
-            // Recreating the SystemFont will have it scaled to the right size for the current setting. This could be
-            // done more efficiently by querying the OS to see if this is necessary for the specific font.
-            //
-            // This should never return null.
-            Font newSystemFont = SystemFonts.GetFontByName(font.SystemFontName)!;
-            if (newSystemFont.Size == font.Size)
-            {
-                // No point in keeping an identical one, free the resource.
-                newSystemFont.Dispose();
-                return null;
-            }
-
-            return newSystemFont;
         }
 
         // The default(100) and max(225) text scale factor is value what Settings display text scale

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
@@ -26,7 +26,7 @@ public sealed partial class Application
     private static EventHandlerList? s_eventHandlers;
     private static Font? s_defaultFont;
     /// <summary>
-    /// Scaled version of non system <see cref="s_defaultFont"/>.
+    ///  Scaled version of non system <see cref="s_defaultFont"/>.
     /// </summary>
     private static Font? s_defaultFontScaled;
     private static string? s_startupPath;
@@ -1212,15 +1212,18 @@ public sealed partial class Application
     }
 
     /// <summary>
-    /// Scale <see cref="s_defaultFont"/> or <see cref="s_defaultFontScaled"/> if needed.
+    ///  Scale <see cref="s_defaultFont"/> or <see cref="s_defaultFontScaled"/> if needed.
     /// </summary>
     internal static void ScaleDefaultFont()
     {
         if (s_defaultFont is null)
+        {
             return;
+        }
 
         if (s_defaultFont.IsSystemFont)
         {
+            s_defaultFontScaled?.Dispose();
             s_defaultFontScaled = null;
             // Recreating the SystemFont will have it scaled to the right size for the current setting. This could be
             // done more efficiently by querying the OS to see if this is necessary for the specific font.
@@ -1242,6 +1245,7 @@ public sealed partial class Application
             Font? font = ScaleHelper.ScaleToSystemTextSize(s_defaultFont);
             if (font is null || !font.Equals(s_defaultFontScaled)) // change s_defaultFontScaled only if needed
             {
+                s_defaultFontScaled?.Dispose();
                 s_defaultFontScaled = font;
             }
             else

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
@@ -25,6 +25,9 @@ public sealed partial class Application
     /// </summary>
     private static EventHandlerList? s_eventHandlers;
     private static Font? s_defaultFont;
+    /// <summary>
+    /// Scaled version of non system <see cref="s_defaultFont"/>.
+    /// </summary>
     private static Font? s_defaultFontScaled;
     private static string? s_startupPath;
     private static string? s_executablePath;
@@ -1204,23 +1207,48 @@ public sealed partial class Application
         if (NativeWindow.AnyHandleCreated)
             throw new InvalidOperationException(string.Format(SR.Win32WindowAlreadyCreated, nameof(SetDefaultFont)));
 
-        // If user made a prior call to this API with a different custom fonts, we want to clean it up.
-        if (s_defaultFont is not null && !ReferenceEquals(s_defaultFont, font))
-        {
-            s_defaultFont.Dispose();
-        }
-
         s_defaultFont = font;
         ScaleDefaultFont();
     }
 
+    /// <summary>
+    /// Scale <see cref="s_defaultFont"/> or <see cref="s_defaultFontScaled"/> if needed.
+    /// </summary>
     internal static void ScaleDefaultFont()
     {
-        // It is possible the existing scaled font will be identical after scaling the default font again. Figuring
-        // that out requires additional complexity that doesn't appear to be strictly necessary.
-        s_defaultFontScaled?.Dispose();
-        s_defaultFontScaled = null;
-        s_defaultFontScaled = ScaleHelper.ScaleToSystemTextSize(s_defaultFont);
+        if (s_defaultFont is null)
+            return;
+
+        if (s_defaultFont.IsSystemFont)
+        {
+            s_defaultFontScaled = null;
+            // Recreating the SystemFont will have it scaled to the right size for the current setting. This could be
+            // done more efficiently by querying the OS to see if this is necessary for the specific font.
+            //
+            // This should never return null.
+            Font newSystemFont = SystemFonts.GetFontByName(s_defaultFont.SystemFontName)!;
+            if (s_defaultFont.Equals(newSystemFont))
+            {
+                // No point in keeping an identical one, free the resource.
+                newSystemFont.Dispose();
+            }
+            else
+            {
+                s_defaultFont = newSystemFont;
+            }
+        }
+        else // non system Font
+        {
+            Font? font = ScaleHelper.ScaleToSystemTextSize(s_defaultFont);
+            if (font is null || !font.Equals(s_defaultFontScaled)) // change s_defaultFontScaled only if needed
+            {
+                s_defaultFontScaled = font;
+            }
+            else
+            {
+                font.Dispose();
+            }
+        }
     }
 
     /// <summary>

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ApplicationTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ApplicationTests.cs
@@ -223,8 +223,10 @@ public class ApplicationTests
     public void Application_SetDefaultFont_SystemFont()
     {
         var applicationTestAccessor = typeof(Application).TestAccessor().Dynamic;
-        Assert.Null(applicationTestAccessor.s_defaultFont);
-        Assert.Null(applicationTestAccessor.s_defaultFontScaled);
+        Font font = applicationTestAccessor.s_defaultFont;
+        font.Should().BeNull();
+        font = applicationTestAccessor.s_defaultFontScaled;
+        font.Should().BeNull();
 
         // This a unholy, but generally at this stage NativeWindow.AnyHandleCreated=true,
         // And we won't be able to set the font, unless we flip the bit
@@ -234,30 +236,32 @@ public class ApplicationTests
         {
             nativeWindowTestAccessor.t_anyHandleCreated = false;
             using Font sysFont = SystemFonts.CaptionFont;
-            Assert.True(sysFont.IsSystemFont);
+            sysFont.IsSystemFont.Should().BeTrue();
             Application.SetDefaultFont(sysFont);
-            Assert.Null(applicationTestAccessor.s_defaultFontScaled);
+            font = applicationTestAccessor.s_defaultFontScaled;
+            font.Should().BeNull();
             // Because we set default font to system font, then in this test it must not be changed,
             // unless, of course, after calling SystemFonts.CaptionFont and this check
             // HKCU\Software\Microsoft\Accessibility\TextScaleFactor is not changed
-            Assert.True(sysFont == Application.DefaultFont);
+            Application.DefaultFont.Should().BeSameAs(sysFont);
 
             // create fake system font
             using Font fakeSysFont = sysFont.WithSize(sysFont.Size * 1.25f);
             // set IsSystemFont flag
             fakeSysFont.TestAccessor().Dynamic.SetSystemFontName(sysFont.SystemFontName);
-            Assert.True(fakeSysFont.IsSystemFont);
+            fakeSysFont.IsSystemFont.Should().BeTrue();
             Application.SetDefaultFont(fakeSysFont);
-            Assert.Null(applicationTestAccessor.s_defaultFontScaled);
-            Assert.False(fakeSysFont.Equals(Application.DefaultFont));
-            Assert.False(sysFont == Application.DefaultFont);
-            Assert.True(sysFont.Equals(Application.DefaultFont));
+            font = applicationTestAccessor.s_defaultFontScaled;
+            font.Should().BeNull();
+            Application.DefaultFont.Should().NotBe(fakeSysFont, "Because we got a new real system font.");
+            Application.DefaultFont.Should().NotBeSameAs(sysFont, "Because we got a new system font.");
+            Application.DefaultFont.Should().Be(sysFont, "Because the new system font is the same as our original system font.");
         }
         finally
         {
             // Flip the bit back
             nativeWindowTestAccessor.t_anyHandleCreated = currentAnyHandleCreated;
-            applicationTestAccessor.s_defaultFont.Dispose();
+            applicationTestAccessor.s_defaultFont?.Dispose();
             applicationTestAccessor.s_defaultFont = null;
         }
     }
@@ -266,11 +270,13 @@ public class ApplicationTests
     public void Application_SetDefaultFont_NonSystemFont()
     {
         var applicationTestAccessor = typeof(Application).TestAccessor().Dynamic;
-        Assert.Null(applicationTestAccessor.s_defaultFont);
-        Assert.Null(applicationTestAccessor.s_defaultFontScaled);
+        Font font = applicationTestAccessor.s_defaultFont;
+        font.Should().BeNull();
+        font = applicationTestAccessor.s_defaultFontScaled;
+        font.Should().BeNull();
 
-        using Font font = new(new FontFamily("Arial"), 12f);
-        Assert.False(font.IsSystemFont);
+        using Font customFont = new(new FontFamily("Arial"), 12f);
+        customFont.IsSystemFont.Should().BeFalse();
 
         // This a unholy, but generally at this stage NativeWindow.AnyHandleCreated=true,
         // And we won't be able to set the font, unless we flip the bit
@@ -279,33 +285,34 @@ public class ApplicationTests
         try
         {
             nativeWindowTestAccessor.t_anyHandleCreated = false;
-            Application.SetDefaultFont(font);
+            Application.SetDefaultFont(customFont);
+            font = applicationTestAccessor.s_defaultFontScaled;
             if (!OsVersion.IsWindows10_1507OrGreater())
             {
-                Assert.Null(applicationTestAccessor.s_defaultFontScaled);
-                Assert.True(font == Application.DefaultFont);
+                font.Should().BeNull();
+                Application.DefaultFont.Should().BeSameAs(customFont);
                 return;
             }
 
             // Retrieve the text scale factor, which is set via Settings > Display > Make Text Bigger.
             using RegistryKey key = Registry.CurrentUser.OpenSubKey("Software\\Microsoft\\Accessibility");
-            int textScale = (int)(key?.GetValue("TextScaleFactor", 100) ?? 100);
+            int textScale = (int)(key?.GetValue("TextScaleFactor", 100) ?? 100);            
             if (textScale == 100) // Application.DefaultFont must be the same
-            {
-                Assert.Null(applicationTestAccessor.s_defaultFontScaled);
-                Assert.True(font == Application.DefaultFont);
+            {                
+                font.Should().BeNull("Because TextScaleFactor == 100.");
+                Application.DefaultFont.Should().BeSameAs(customFont, "Because TextScaleFactor == 100.");
             }
             else // Application.DefaultFont must be a new scaled font
             {
-                Assert.NotNull(applicationTestAccessor.s_defaultFontScaled);
-                Assert.False(font.Equals(Application.DefaultFont));
+                font.Should().NotBeNull("Because TextScaleFactor != 100.");
+                Application.DefaultFont.Should().NotBe(customFont, "Because textScaleFactor != 100 and we got a new scaled font.");
             }
         }
         finally
         {
             // Flip the bit back
             nativeWindowTestAccessor.t_anyHandleCreated = currentAnyHandleCreated;
-            applicationTestAccessor.s_defaultFont.Dispose();
+            applicationTestAccessor.s_defaultFont?.Dispose();
             applicationTestAccessor.s_defaultFont = null;
             applicationTestAccessor.s_defaultFontScaled?.Dispose();
             applicationTestAccessor.s_defaultFontScaled = null;


### PR DESCRIPTION
Fixes #11037


## Proposed changes

- Сhange the default font only if it has really changed. Most of these problems already was solved in f36b0db2400247c3ed68b9538f92ab6914896b1d.
- Not use scaled default font for system fonts.
- Not dispose user (external) fonts.

## Customer Impact
- Fewer font changing related actions and a bit less memory use.
- Bug fixes.

## Regression? 

- Yes

## Risk

- Minimal.


## Test methodology
- Existing unit tests.
- New unit tests.
- Manually with test app: [DefFontTest.zip](https://github.com/dotnet/winforms/files/14957130/DefFontTest.zip)


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11206)