### PR TITLE
Disable binary formatter for trimming

### DIFF
--- a/src/System.Windows.Forms/src/Resources/SR.resx
+++ b/src/System.Windows.Forms/src/Resources/SR.resx
@@ -6967,4 +6967,7 @@ Stack trace where the illegal operation occurred was:
   <data name="BindingNotSupported" xml:space="preserve">
     <value>Binding operations are not supported when application trimming is enabled.</value>
   </data>
+  <data name="BinaryFormatterNotSupported" xml:space="preserve">
+    <value>BinaryFormatter is not supported when application trimming is enabled.</value>
+  </data>
 </root>

--- a/src/System.Windows.Forms/src/Resources/SR.resx
+++ b/src/System.Windows.Forms/src/Resources/SR.resx
@@ -6968,6 +6968,6 @@ Stack trace where the illegal operation occurred was:
     <value>Binding operations are not supported when application trimming is enabled.</value>
   </data>
   <data name="BinaryFormatterNotSupported" xml:space="preserve">
-    <value>BinaryFormatter is not supported when application trimming is enabled.</value>
+    <value>Using the BinaryFormatter is not supported.</value>
   </data>
 </root>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
@@ -287,6 +287,11 @@
         <target state="translated">Strukturovaný objekt DataBinding přijímá jako zdroj dat objekt IList nebo IListSource.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BinaryFormatterNotSupported">
+        <source>BinaryFormatter is not supported when application trimming is enabled.</source>
+        <target state="new">BinaryFormatter is not supported when application trimming is enabled.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BindableComponentBindingContextChangedDescr">
         <source>Occurs when the binding context has changed.</source>
         <target state="translated">Vyvolá se při změně kontextu vazby.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
@@ -288,8 +288,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BinaryFormatterNotSupported">
-        <source>BinaryFormatter is not supported when application trimming is enabled.</source>
-        <target state="new">BinaryFormatter is not supported when application trimming is enabled.</target>
+        <source>Using the BinaryFormatter is not supported.</source>
+        <target state="new">Using the BinaryFormatter is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="BindableComponentBindingContextChangedDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
@@ -288,8 +288,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BinaryFormatterNotSupported">
-        <source>BinaryFormatter is not supported when application trimming is enabled.</source>
-        <target state="new">BinaryFormatter is not supported when application trimming is enabled.</target>
+        <source>Using the BinaryFormatter is not supported.</source>
+        <target state="new">Using the BinaryFormatter is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="BindableComponentBindingContextChangedDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
@@ -287,6 +287,11 @@
         <target state="translated">Das komplexe DataBinding akzeptiert als Datenquelle entweder IList oder IListSource.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BinaryFormatterNotSupported">
+        <source>BinaryFormatter is not supported when application trimming is enabled.</source>
+        <target state="new">BinaryFormatter is not supported when application trimming is enabled.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BindableComponentBindingContextChangedDescr">
         <source>Occurs when the binding context has changed.</source>
         <target state="translated">Tritt auf, wenn sich der Bindungskontext geändert hat.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
@@ -288,8 +288,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BinaryFormatterNotSupported">
-        <source>BinaryFormatter is not supported when application trimming is enabled.</source>
-        <target state="new">BinaryFormatter is not supported when application trimming is enabled.</target>
+        <source>Using the BinaryFormatter is not supported.</source>
+        <target state="new">Using the BinaryFormatter is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="BindableComponentBindingContextChangedDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
@@ -287,6 +287,11 @@
         <target state="translated">El DataBinding complejo acepta como origen de datos IList o IListSource.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BinaryFormatterNotSupported">
+        <source>BinaryFormatter is not supported when application trimming is enabled.</source>
+        <target state="new">BinaryFormatter is not supported when application trimming is enabled.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BindableComponentBindingContextChangedDescr">
         <source>Occurs when the binding context has changed.</source>
         <target state="translated">Se produce cuando el contexto de enlace ha cambiado.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
@@ -287,6 +287,11 @@
         <target state="translated">DataBinding complexe accepte IList ou IListSource comme source de données.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BinaryFormatterNotSupported">
+        <source>BinaryFormatter is not supported when application trimming is enabled.</source>
+        <target state="new">BinaryFormatter is not supported when application trimming is enabled.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BindableComponentBindingContextChangedDescr">
         <source>Occurs when the binding context has changed.</source>
         <target state="translated">Se produit lorsque le contexte de liaison change.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
@@ -288,8 +288,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BinaryFormatterNotSupported">
-        <source>BinaryFormatter is not supported when application trimming is enabled.</source>
-        <target state="new">BinaryFormatter is not supported when application trimming is enabled.</target>
+        <source>Using the BinaryFormatter is not supported.</source>
+        <target state="new">Using the BinaryFormatter is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="BindableComponentBindingContextChangedDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
@@ -287,6 +287,11 @@
         <target state="translated">L'origine dati di un'associazione dati complessa può essere solo IList o IListSource.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BinaryFormatterNotSupported">
+        <source>BinaryFormatter is not supported when application trimming is enabled.</source>
+        <target state="new">BinaryFormatter is not supported when application trimming is enabled.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BindableComponentBindingContextChangedDescr">
         <source>Occurs when the binding context has changed.</source>
         <target state="translated">Si verifica quando il contesto di associazione viene modificato.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
@@ -288,8 +288,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BinaryFormatterNotSupported">
-        <source>BinaryFormatter is not supported when application trimming is enabled.</source>
-        <target state="new">BinaryFormatter is not supported when application trimming is enabled.</target>
+        <source>Using the BinaryFormatter is not supported.</source>
+        <target state="new">Using the BinaryFormatter is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="BindableComponentBindingContextChangedDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
@@ -288,8 +288,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BinaryFormatterNotSupported">
-        <source>BinaryFormatter is not supported when application trimming is enabled.</source>
-        <target state="new">BinaryFormatter is not supported when application trimming is enabled.</target>
+        <source>Using the BinaryFormatter is not supported.</source>
+        <target state="new">Using the BinaryFormatter is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="BindableComponentBindingContextChangedDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
@@ -287,6 +287,11 @@
         <target state="translated">Complex DataBinding は IList または IListSource のどちらかをデータソースとして受け入れます。</target>
         <note />
       </trans-unit>
+      <trans-unit id="BinaryFormatterNotSupported">
+        <source>BinaryFormatter is not supported when application trimming is enabled.</source>
+        <target state="new">BinaryFormatter is not supported when application trimming is enabled.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BindableComponentBindingContextChangedDescr">
         <source>Occurs when the binding context has changed.</source>
         <target state="translated">バインド コンテキストが変更されたときに発生します。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
@@ -287,6 +287,11 @@
         <target state="translated">IList 또는 IListSource를 복합 DataBinding의 데이터 소스로 사용할 수 있습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BinaryFormatterNotSupported">
+        <source>BinaryFormatter is not supported when application trimming is enabled.</source>
+        <target state="new">BinaryFormatter is not supported when application trimming is enabled.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BindableComponentBindingContextChangedDescr">
         <source>Occurs when the binding context has changed.</source>
         <target state="translated">바인딩 컨텍스트가 변경될 때 발생합니다.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
@@ -288,8 +288,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BinaryFormatterNotSupported">
-        <source>BinaryFormatter is not supported when application trimming is enabled.</source>
-        <target state="new">BinaryFormatter is not supported when application trimming is enabled.</target>
+        <source>Using the BinaryFormatter is not supported.</source>
+        <target state="new">Using the BinaryFormatter is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="BindableComponentBindingContextChangedDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
@@ -288,8 +288,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BinaryFormatterNotSupported">
-        <source>BinaryFormatter is not supported when application trimming is enabled.</source>
-        <target state="new">BinaryFormatter is not supported when application trimming is enabled.</target>
+        <source>Using the BinaryFormatter is not supported.</source>
+        <target state="new">Using the BinaryFormatter is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="BindableComponentBindingContextChangedDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
@@ -287,6 +287,11 @@
         <target state="translated">Złożony element DataBinding akceptuje jako źródło danych zarówno elementy IList, jak i IListSource.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BinaryFormatterNotSupported">
+        <source>BinaryFormatter is not supported when application trimming is enabled.</source>
+        <target state="new">BinaryFormatter is not supported when application trimming is enabled.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BindableComponentBindingContextChangedDescr">
         <source>Occurs when the binding context has changed.</source>
         <target state="translated">Występuje, gdy kontekst powiązania zostanie zmieniony.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
@@ -287,6 +287,11 @@
         <target state="translated">DataBinding complexa aceita IList ou IListSource como fonte de dados.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BinaryFormatterNotSupported">
+        <source>BinaryFormatter is not supported when application trimming is enabled.</source>
+        <target state="new">BinaryFormatter is not supported when application trimming is enabled.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BindableComponentBindingContextChangedDescr">
         <source>Occurs when the binding context has changed.</source>
         <target state="translated">Ocorre quando o contexto de associação foi alterado.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
@@ -288,8 +288,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BinaryFormatterNotSupported">
-        <source>BinaryFormatter is not supported when application trimming is enabled.</source>
-        <target state="new">BinaryFormatter is not supported when application trimming is enabled.</target>
+        <source>Using the BinaryFormatter is not supported.</source>
+        <target state="new">Using the BinaryFormatter is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="BindableComponentBindingContextChangedDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
@@ -288,8 +288,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BinaryFormatterNotSupported">
-        <source>BinaryFormatter is not supported when application trimming is enabled.</source>
-        <target state="new">BinaryFormatter is not supported when application trimming is enabled.</target>
+        <source>Using the BinaryFormatter is not supported.</source>
+        <target state="new">Using the BinaryFormatter is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="BindableComponentBindingContextChangedDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
@@ -287,6 +287,11 @@
         <target state="translated">Для составного DataBinding источником данных может служить IList или IListSource.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BinaryFormatterNotSupported">
+        <source>BinaryFormatter is not supported when application trimming is enabled.</source>
+        <target state="new">BinaryFormatter is not supported when application trimming is enabled.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BindableComponentBindingContextChangedDescr">
         <source>Occurs when the binding context has changed.</source>
         <target state="translated">Происходит при изменении контекста привязки.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
@@ -288,8 +288,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BinaryFormatterNotSupported">
-        <source>BinaryFormatter is not supported when application trimming is enabled.</source>
-        <target state="new">BinaryFormatter is not supported when application trimming is enabled.</target>
+        <source>Using the BinaryFormatter is not supported.</source>
+        <target state="new">Using the BinaryFormatter is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="BindableComponentBindingContextChangedDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
@@ -287,6 +287,11 @@
         <target state="translated">Karmaşık DataBinding, veri kaynağı olarak ya IList ya da IListSource kabul eder.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BinaryFormatterNotSupported">
+        <source>BinaryFormatter is not supported when application trimming is enabled.</source>
+        <target state="new">BinaryFormatter is not supported when application trimming is enabled.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BindableComponentBindingContextChangedDescr">
         <source>Occurs when the binding context has changed.</source>
         <target state="translated">Bağlama bağlamı değiştiğinde gerçekleşir.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
@@ -287,6 +287,11 @@
         <target state="translated">复杂的 DataBinding 接受 IList 或 IListSource 作为数据源。</target>
         <note />
       </trans-unit>
+      <trans-unit id="BinaryFormatterNotSupported">
+        <source>BinaryFormatter is not supported when application trimming is enabled.</source>
+        <target state="new">BinaryFormatter is not supported when application trimming is enabled.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BindableComponentBindingContextChangedDescr">
         <source>Occurs when the binding context has changed.</source>
         <target state="translated">当绑定上下文发生更改时发生。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
@@ -288,8 +288,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BinaryFormatterNotSupported">
-        <source>BinaryFormatter is not supported when application trimming is enabled.</source>
-        <target state="new">BinaryFormatter is not supported when application trimming is enabled.</target>
+        <source>Using the BinaryFormatter is not supported.</source>
+        <target state="new">Using the BinaryFormatter is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="BindableComponentBindingContextChangedDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
@@ -287,6 +287,11 @@
         <target state="translated">複雜 DataBinding 接受以 IList 或 IListSource 做為資料來源。</target>
         <note />
       </trans-unit>
+      <trans-unit id="BinaryFormatterNotSupported">
+        <source>BinaryFormatter is not supported when application trimming is enabled.</source>
+        <target state="new">BinaryFormatter is not supported when application trimming is enabled.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BindableComponentBindingContextChangedDescr">
         <source>Occurs when the binding context has changed.</source>
         <target state="translated">在繫結內容變更時發生。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
@@ -288,8 +288,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BinaryFormatterNotSupported">
-        <source>BinaryFormatter is not supported when application trimming is enabled.</source>
-        <target state="new">BinaryFormatter is not supported when application trimming is enabled.</target>
+        <source>Using the BinaryFormatter is not supported.</source>
+        <target state="new">Using the BinaryFormatter is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="BindableComponentBindingContextChangedDescr">

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.ComposedDataObject.NativeDataObjectToWinFormsAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.ComposedDataObject.NativeDataObjectToWinFormsAdapter.cs
@@ -16,6 +16,11 @@ public unsafe partial class DataObject
 {
     internal unsafe partial class ComposedDataObject
     {
+        [FeatureGuard(typeof(RequiresUnreferencedCodeAttribute))]
+#pragma warning disable IDE0075 // Simplify conditional expression - the simpler expression is hard to read
+        private static bool EnableUnsafeBinaryFormatterInNativeObjectSerialization { get; } = AppContext.TryGetSwitch("System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization", out bool isEnabled) ? isEnabled : false;
+#pragma warning restore IDE0075 //Simplify conditional expression
+
         /// <summary>
         ///  Maps native pointer <see cref="Com.IDataObject"/> to <see cref="IDataObject"/>.
         /// </summary>
@@ -186,6 +191,11 @@ public unsafe partial class DataObject
                         catch (Exception ex) when (!ex.IsCriticalException())
                         {
                             // Couldn't parse for some reason, let the BinaryFormatter try to handle it.
+                        }
+
+                        if (EnableUnsafeBinaryFormatterInNativeObjectSerialization)
+                        {
+                            throw new NotSupportedException(SR.BinaryFormatterNotSupported);
                         }
 
                         stream.Position = startPosition;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.ComposedDataObject.NativeDataObjectToWinFormsAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.ComposedDataObject.NativeDataObjectToWinFormsAdapter.cs
@@ -193,7 +193,7 @@ public unsafe partial class DataObject
                             // Couldn't parse for some reason, let the BinaryFormatter try to handle it.
                         }
 
-                        if (EnableUnsafeBinaryFormatterInNativeObjectSerialization)
+                        if (!EnableUnsafeBinaryFormatterInNativeObjectSerialization)
                         {
                             throw new NotSupportedException(SR.BinaryFormatterNotSupported);
                         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.ComposedDataObject.NativeDataObjectToWinFormsAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.ComposedDataObject.NativeDataObjectToWinFormsAdapter.cs
@@ -16,6 +16,7 @@ public unsafe partial class DataObject
 {
     internal unsafe partial class ComposedDataObject
     {
+        [FeatureSwitchDefinition("System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization")]
         [FeatureGuard(typeof(RequiresUnreferencedCodeAttribute))]
 #pragma warning disable IDE0075 // Simplify conditional expression - the simpler expression is hard to read
         private static bool EnableUnsafeBinaryFormatterInNativeObjectSerialization { get; } = AppContext.TryGetSwitch("System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization", out bool isEnabled) ? isEnabled : false;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.ComposedDataObject.NativeDataObjectToWinFormsAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.ComposedDataObject.NativeDataObjectToWinFormsAdapter.cs
@@ -17,9 +17,8 @@ public unsafe partial class DataObject
     internal unsafe partial class ComposedDataObject
     {
         [FeatureSwitchDefinition("System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization")]
-        [FeatureGuard(typeof(RequiresUnreferencedCodeAttribute))]
 #pragma warning disable IDE0075 // Simplify conditional expression - the simpler expression is hard to read
-        private static bool EnableUnsafeBinaryFormatterInNativeObjectSerialization { get; } = AppContext.TryGetSwitch("System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization", out bool isEnabled) ? isEnabled : false;
+        private static bool EnableUnsafeBinaryFormatterInNativeObjectSerialization { get; } = AppContext.TryGetSwitch("System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization", out bool isEnabled) ? isEnabled : true;
 #pragma warning restore IDE0075 //Simplify conditional expression
 
         /// <summary>
@@ -194,6 +193,9 @@ public unsafe partial class DataObject
                             // Couldn't parse for some reason, let the BinaryFormatter try to handle it.
                         }
 
+                        // This check is to help in trimming scenarios with a trim warning on a call to BinaryFormatter.Deserialize(), which has a RequiresUnreferencedCode annotation.
+                        // If the flag is false, the trimmer will not generate a warning, since BinaryFormatter.Deserialize() will not be called,
+                        // If the flag is true, the trimmer will generate a warning for calling a method that has a RequiresUnreferencedCode annotation.
                         if (!EnableUnsafeBinaryFormatterInNativeObjectSerialization)
                         {
                             throw new NotSupportedException(SR.BinaryFormatterNotSupported);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.ComposedDataObject.NativeDataObjectToWinFormsAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.ComposedDataObject.NativeDataObjectToWinFormsAdapter.cs
@@ -19,7 +19,7 @@ public unsafe partial class DataObject
         [FeatureSwitchDefinition("System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization")]
 #pragma warning disable IDE0075 // Simplify conditional expression - the simpler expression is hard to read
         private static bool EnableUnsafeBinaryFormatterInNativeObjectSerialization { get; } = AppContext.TryGetSwitch("System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization", out bool isEnabled) ? isEnabled : true;
-#pragma warning restore IDE0075 //Simplify conditional expression
+#pragma warning restore IDE0075
 
         /// <summary>
         ///  Maps native pointer <see cref="Com.IDataObject"/> to <see cref="IDataObject"/>.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.ComposedDataObject.WinFormsDataObjectToNativeAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.ComposedDataObject.WinFormsDataObjectToNativeAdapter.cs
@@ -339,7 +339,7 @@ public unsafe partial class DataObject
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
                 if (!success)
                 {
-                    if (EnableUnsafeBinaryFormatterInNativeObjectSerialization)
+                    if (!EnableUnsafeBinaryFormatterInNativeObjectSerialization)
                     {
                         throw new NotSupportedException(SR.BinaryFormatterNotSupported);
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.ComposedDataObject.WinFormsDataObjectToNativeAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.ComposedDataObject.WinFormsDataObjectToNativeAdapter.cs
@@ -339,6 +339,9 @@ public unsafe partial class DataObject
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
                 if (!success)
                 {
+                    // This check is to help in trimming scenarios with a trim warning on a call to BinaryFormatter.Serialize(), which has a RequiresUnreferencedCode annotation.
+                    // If the flag is false, the trimmer will not generate a warning, since BinaryFormatter.Serialize(), will not be called,
+                    // If the flag is true, the trimmer will generate a warning for calling a method that has a RequiresUnreferencedCode annotation.
                     if (!EnableUnsafeBinaryFormatterInNativeObjectSerialization)
                     {
                         throw new NotSupportedException(SR.BinaryFormatterNotSupported);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.ComposedDataObject.WinFormsDataObjectToNativeAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.ComposedDataObject.WinFormsDataObjectToNativeAdapter.cs
@@ -339,6 +339,11 @@ public unsafe partial class DataObject
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
                 if (!success)
                 {
+                    if (EnableUnsafeBinaryFormatterInNativeObjectSerialization)
+                    {
+                        throw new NotSupportedException(SR.BinaryFormatterNotSupported);
+                    }
+
                     new BinaryFormatter()
                     {
                         Binder = restrictSerialization ? new BitmapBinder() : null

--- a/src/System.Windows.Forms/tests/ComDisabledTests/ClipboardComTests.cs
+++ b/src/System.Windows.Forms/tests/ComDisabledTests/ClipboardComTests.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Drawing;
+
 namespace System.Windows.Forms.Tests;
 
 public partial class ClipboardTests
@@ -11,5 +13,14 @@ public partial class ClipboardTests
         Clipboard.SetText("text");
         Assert.Equal("text", Clipboard.GetText());
         Assert.True(Clipboard.ContainsText());
+    }
+
+    [WinFormsFact]
+    public void ClipBoard_SetData_CustomFormat_Color()
+    {
+        string format = nameof(ClipBoard_SetData_CustomFormat_Color);
+        Clipboard.SetData(format, Color.Black);
+        Assert.True(Clipboard.ContainsData(format));
+        Assert.Equal(Color.Black, Clipboard.GetData(format));
     }
 }

--- a/src/System.Windows.Forms/tests/ComDisabledTests/ComDisabled.Tests.csproj
+++ b/src/System.Windows.Forms/tests/ComDisabledTests/ComDisabled.Tests.csproj
@@ -7,6 +7,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <BuiltInComInteropSupport>false</BuiltInComInteropSupport>
+    <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.Windows.Forms/tests/UnitTests/System.Windows.Forms.Tests.csproj
+++ b/src/System.Windows.Forms/tests/UnitTests/System.Windows.Forms.Tests.csproj
@@ -7,6 +7,7 @@
     <AssemblyName>System.Windows.Forms.Tests</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/System.Windows.Forms/tests/UnitTests/System.Windows.Forms.Tests.csproj
+++ b/src/System.Windows.Forms/tests/UnitTests/System.Windows.Forms.Tests.csproj
@@ -7,7 +7,6 @@
     <AssemblyName>System.Windows.Forms.Tests</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ClipboardTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ClipboardTests.cs
@@ -469,8 +469,6 @@ public partial class ClipboardTests
         Clipboard.SetData(format, Color.Black);
         Assert.True(Clipboard.ContainsData(format));
 
-        NotSupportedException value = (NotSupportedException)Clipboard.GetData(format);
-
         using MemoryStream stream = new();
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
         BinaryFormatter formatter = new();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ClipboardTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ClipboardTests.cs
@@ -460,20 +460,10 @@ public partial class ClipboardTests
     }
 
     [WinFormsFact]
-    public void ClipBoard_SetData_CustomFormat_Color()
-    {
-        using BinaryFormatterScope scope = new(enable: true);
-        string format = nameof(ClipBoard_SetData_CustomFormat_Color);
-        Clipboard.SetData(format, Color.Black);
-        Assert.True(Clipboard.ContainsData(format));
-        Assert.Equal(Color.Black, Clipboard.GetData(format));
-    }
-
-    [WinFormsFact]
     public void ClipBoard_SetData_CustomFormat_Color_BinaryFormatterDisabled_SerializesException()
     {
         using BinaryFormatterScope scope = new(enable: false);
-        string format = nameof(ClipBoard_SetData_CustomFormat_Color);
+        string format = nameof(ClipBoard_SetData_CustomFormat_Color_BinaryFormatterDisabled_SerializesException);
 
         // This will fail and NotSupportedException will be put on the Clipboard instead.
         Clipboard.SetData(format, Color.Black);
@@ -489,9 +479,8 @@ public partial class ClipboardTests
         {
             formatter.Serialize(stream, new object());
         }
-        catch (NotSupportedException ex)
+        catch (NotSupportedException)
         {
-            Assert.Equal(ex.Message, value.Message);
             return;
         }
 


### PR DESCRIPTION
Added a feature switch check with the default set to true (enable using `BinaryFormatter` for compatibility). The feature switch flag is used so as to not generate a trim warning when the flag is false, which is the expectation in trimming. The trimmer will generate a warning if the feature is enabled to use the `BinaryFormatter`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11230)