### PR TITLE
fix issue 11243 TreeNodeCollection.AddRange has been broken in .NET 8 and no longer results in TreeNodes being drawn at the correct location

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/ArraySubsetEnumerator.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/ArraySubsetEnumerator.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections;
+
+namespace System.Windows.Forms;
+
+internal class ArraySubsetEnumerator : IEnumerator
+{
+    private readonly object[] _array;
+    private readonly int _total;
+    private int _current;
+
+    public ArraySubsetEnumerator(object[] array, int count)
+    {
+        Debug.Assert(count == 0 || array is not null, "if array is null, count should be 0");
+        Debug.Assert(array is null || count <= array.Length, "Trying to enumerate more than the array contains");
+        _array = array!;
+        _total = count;
+        _current = -1;
+    }
+
+    public bool MoveNext()
+    {
+        if (_current < _total - 1)
+        {
+            _current++;
+            return true;
+        }
+
+        return false;
+    }
+
+    public void Reset() => _current = -1;
+
+    public object? Current => _current == -1 ? null : _array[_current];
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeNode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeNode.cs
@@ -1312,7 +1312,7 @@ public partial class TreeNode : MarshalByRefObject, ICloneable, ISerializable
 
             while (_childCount > 0)
             {
-                _children[^1].Remove(true);
+                _children[_childCount - 1].Remove(true);
             }
 
             _children = [];

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeNode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeNode.cs
@@ -644,7 +644,7 @@ public partial class TreeNode : MarshalByRefObject, ICloneable, ISerializable
                 return null;
             }
 
-            return _children[^1];
+            return _children[_childCount - 1];
         }
     }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeNode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeNode.cs
@@ -89,6 +89,7 @@ public partial class TreeNode : MarshalByRefObject, ICloneable, ISerializable
 
     internal int _index;                  // our index into our parents child array
     internal int _childCount;
+    // this array should not be optimized as a list because we are inserting into the middle of it, not appending.
     internal TreeNode[] _children = [];
     internal TreeNode? _parent;
     internal TreeView? _treeView;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeNode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeNode.cs
@@ -1198,8 +1198,6 @@ public partial class TreeNode : MarshalByRefObject, ICloneable, ISerializable
             CompareInfo compare = Application.CurrentCulture.CompareInfo;
             for (int i = 0; i < _childCount; i++)
             {
-                // newOrder.Add(children[i]);
-
                 int min = -1;
                 for (int j = 0; j < _childCount; j++)
                 {
@@ -1234,8 +1232,6 @@ public partial class TreeNode : MarshalByRefObject, ICloneable, ISerializable
             IComparer sorter = parentTreeView.TreeViewNodeSorter;
             for (int i = 0; i < _childCount; i++)
             {
-                // newOrder.Add(children[i]);
-
                 int min = -1;
                 for (int j = 0; j < _childCount; j++)
                 {
@@ -1595,7 +1591,7 @@ public partial class TreeNode : MarshalByRefObject, ICloneable, ISerializable
     }
 
     /// <summary>
-    ///  Makes sure there is enough room to add n children
+    ///  Makes sure there is enough room to add <paramref name="num" /> children.
     /// </summary>
     internal void EnsureCapacity(int num)
     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeNode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeNode.cs
@@ -88,7 +88,8 @@ public partial class TreeNode : MarshalByRefObject, ICloneable, ISerializable
     }
 
     internal int _index;                  // our index into our parents child array
-    internal List<TreeNode> _childNodes = [];
+    internal int _childCount;
+    internal TreeNode[] _children;
     internal TreeNode? _parent;
     internal TreeView? _treeView;
     private bool _expandOnRealization;
@@ -372,7 +373,7 @@ public partial class TreeNode : MarshalByRefObject, ICloneable, ISerializable
     ///  The first child node of this node.
     /// </summary>
     [Browsable(false)]
-    public TreeNode? FirstNode => _childNodes.Count == 0 ? null : _childNodes[0];
+    public TreeNode? FirstNode => _childCount == 0 ? null : _children[0];
 
     private TreeNode? FirstVisibleParent
     {
@@ -638,12 +639,12 @@ public partial class TreeNode : MarshalByRefObject, ICloneable, ISerializable
     {
         get
         {
-            if (_childNodes.Count == 0)
+            if (_childCount == 0)
             {
                 return null;
             }
 
-            return _childNodes[^1];
+            return _children[^1];
         }
     }
 
@@ -1122,25 +1123,24 @@ public partial class TreeNode : MarshalByRefObject, ICloneable, ISerializable
         int iT;
         string nodeText = node.Text;
 
-        int nodeCount = _childNodes.Count;
-        if (nodeCount > 0)
+        if (_childCount > 0)
         {
             if (parentTreeView.TreeViewNodeSorter is null)
             {
                 CompareInfo compare = Application.CurrentCulture.CompareInfo;
 
                 // Optimize for the case where they're already sorted
-                if (compare.Compare(_childNodes[nodeCount - 1].Text, nodeText) <= 0)
+                if (compare.Compare(_children[_childCount - 1].Text, nodeText) <= 0)
                 {
-                    index = nodeCount;
+                    index = _childCount;
                 }
                 else
                 {
                     // Insert at appropriate sorted spot
-                    for (iMin = 0, iLim = nodeCount; iMin < iLim;)
+                    for (iMin = 0, iLim = _childCount; iMin < iLim;)
                     {
                         iT = (iMin + iLim) / 2;
-                        if (compare.Compare(_childNodes[iT].Text, nodeText) <= 0)
+                        if (compare.Compare(_children[iT].Text, nodeText) <= 0)
                         {
                             iMin = iT + 1;
                         }
@@ -1157,10 +1157,10 @@ public partial class TreeNode : MarshalByRefObject, ICloneable, ISerializable
             {
                 IComparer sorter = parentTreeView.TreeViewNodeSorter;
                 // Insert at appropriate sorted spot
-                for (iMin = 0, iLim = nodeCount; iMin < iLim;)
+                for (iMin = 0, iLim = _childCount; iMin < iLim;)
                 {
                     iT = (iMin + iLim) / 2;
-                    if (sorter.Compare(_childNodes[iT] /*previous*/, node/*current*/) <= 0)
+                    if (sorter.Compare(_children[iT] /*previous*/, node/*current*/) <= 0)
                     {
                         iMin = iT + 1;
                     }
@@ -1187,23 +1187,23 @@ public partial class TreeNode : MarshalByRefObject, ICloneable, ISerializable
 
     private void SortChildren(TreeView? parentTreeView)
     {
-        if (_childNodes.Count <= 0)
+        if (_childCount <= 0)
         {
             return;
         }
 
-        List<TreeNode> newOrder = new(_childNodes.Count);
+        TreeNode[] newOrder = new TreeNode[_childCount];
         if (parentTreeView is null || parentTreeView.TreeViewNodeSorter is null)
         {
             CompareInfo compare = Application.CurrentCulture.CompareInfo;
-            for (int i = 0; i < _childNodes.Count; i++)
+            for (int i = 0; i < _childCount; i++)
             {
-                newOrder.Add(_childNodes[i]);
+                // newOrder.Add(children[i]);
 
                 int min = -1;
-                for (int j = 0; j < _childNodes.Count; j++)
+                for (int j = 0; j < _childCount; j++)
                 {
-                    if (_childNodes[j] is null)
+                    if (_children[j] is null)
                     {
                         continue;
                     }
@@ -1214,32 +1214,32 @@ public partial class TreeNode : MarshalByRefObject, ICloneable, ISerializable
                         continue;
                     }
 
-                    if (compare.Compare(_childNodes[j].Text, _childNodes[min].Text) <= 0)
+                    if (compare.Compare(_children[j].Text, _children[min].Text) <= 0)
                     {
                         min = j;
                     }
                 }
 
                 Debug.Assert(min != -1, "Bad sorting");
-                newOrder[i] = _childNodes[min];
-                _childNodes[min] = null!;
+                newOrder[i] = _children[min];
+                _children[min] = null!;
                 newOrder[i]._index = i;
                 newOrder[i].SortChildren(parentTreeView);
             }
 
-            _childNodes = newOrder;
+            _children = newOrder;
         }
         else
         {
             IComparer sorter = parentTreeView.TreeViewNodeSorter;
-            for (int i = 0; i < _childNodes.Count; i++)
+            for (int i = 0; i < _childCount; i++)
             {
-                newOrder.Add(_childNodes[i]);
+                // newOrder.Add(children[i]);
 
                 int min = -1;
-                for (int j = 0; j < _childNodes.Count; j++)
+                for (int j = 0; j < _childCount; j++)
                 {
-                    if (_childNodes[j] is null)
+                    if (_children[j] is null)
                     {
                         continue;
                     }
@@ -1250,20 +1250,20 @@ public partial class TreeNode : MarshalByRefObject, ICloneable, ISerializable
                         continue;
                     }
 
-                    if (sorter.Compare(_childNodes[j] /*previous*/, _childNodes[min] /*current*/) <= 0)
+                    if (sorter.Compare(_children[j] /*previous*/, _children[min] /*current*/) <= 0)
                     {
                         min = j;
                     }
                 }
 
                 Debug.Assert(min != -1, "Bad sorting");
-                newOrder[i] = _childNodes[min];
-                _childNodes[min] = null!;
+                newOrder[i] = _children[min];
+                _children[min] = null!;
                 newOrder[i]._index = i;
                 newOrder[i].SortChildren(parentTreeView);
             }
 
-            _childNodes = newOrder;
+            _children = newOrder;
         }
     }
 
@@ -1307,19 +1307,19 @@ public partial class TreeNode : MarshalByRefObject, ICloneable, ISerializable
             {
                 tv._nodesCollectionClear = true;
 
-                if (_childNodes.Count > MAX_TREENODES_OPS)
+                if (_childCount > MAX_TREENODES_OPS)
                 {
                     isBulkOperation = true;
                     tv.BeginUpdate();
                 }
             }
 
-            while (_childNodes.Count > 0)
+            while (_childCount > 0)
             {
-                _childNodes[^1].Remove(true);
+                _children[^1].Remove(true);
             }
 
-            _childNodes.Clear();
+            _children = null;
 
             if (tv is not null && isBulkOperation)
             {
@@ -1375,12 +1375,12 @@ public partial class TreeNode : MarshalByRefObject, ICloneable, ISerializable
             node.StateImageIndexer.Key = StateImageIndexer.Key;
         }
 
-        int nodeCount = _childNodes.Count;
-        if (nodeCount > 0)
+        if (_childCount > 0)
         {
-            for (int i = 0; i < nodeCount; i++)
+            node._children = new TreeNode[_childCount];
+            for (int i = 0; i < _childCount; i++)
             {
-                node.Nodes.Add((TreeNode)_childNodes[i].Clone());
+                node.Nodes.Add((TreeNode)_children[i].Clone());
             }
         }
 
@@ -1418,19 +1418,18 @@ public partial class TreeNode : MarshalByRefObject, ICloneable, ISerializable
         }
         else
         {
-            int nodeCount = _childNodes.Count;
-            if (!ignoreChildren && nodeCount > 0)
+            if (!ignoreChildren && _childCount > 0)
             {
                 // Virtual root should collapse all its children
-                for (int i = 0; i < nodeCount; i++)
+                for (int i = 0; i < _childCount; i++)
                 {
-                    if (tv.SelectedNode == _childNodes[i])
+                    if (tv.SelectedNode == _children[i])
                     {
                         setSelection = true;
                     }
 
-                    _childNodes[i].DoCollapse(tv);
-                    _childNodes[i].Collapse();
+                    _children[i].DoCollapse(tv);
+                    _children[i].Collapse();
                 }
             }
 
@@ -1596,6 +1595,36 @@ public partial class TreeNode : MarshalByRefObject, ICloneable, ISerializable
     }
 
     /// <summary>
+    ///  Makes sure there is enough room to add n children
+    /// </summary>
+    internal void EnsureCapacity(int num)
+    {
+        Debug.Assert(num > 0, "required capacity can not be less than 1");
+        int size = num;
+        if (size < 4)
+        {
+            size = 4;
+        }
+
+        if (_children is null)
+        {
+            _children = new TreeNode[size];
+        }
+        else if (_childCount + num > _children.Length)
+        {
+            int newSize = _childCount + num;
+            if (num == 1)
+            {
+                newSize = _childCount * 2;
+            }
+
+            TreeNode[] bigger = new TreeNode[newSize];
+            Array.Copy(_children, 0, bigger, 0, _childCount);
+            _children = bigger;
+        }
+    }
+
+    /// <summary>
     ///  Ensures the node's StateImageIndex value is properly set.
     /// </summary>
     private void EnsureStateImageValue()
@@ -1661,9 +1690,9 @@ public partial class TreeNode : MarshalByRefObject, ICloneable, ISerializable
     public void ExpandAll()
     {
         Expand();
-        for (int i = 0; i < _childNodes.Count; i++)
+        for (int i = 0; i < _childCount; i++)
         {
-            _childNodes[i].ExpandAll();
+            _children[i].ExpandAll();
         }
     }
 
@@ -1721,12 +1750,12 @@ public partial class TreeNode : MarshalByRefObject, ICloneable, ISerializable
     /// </summary>
     public int GetNodeCount(bool includeSubTrees)
     {
-        int total = _childNodes.Count;
+        int total = _childCount;
         if (includeSubTrees)
         {
-            for (int i = 0; i < _childNodes.Count; i++)
+            for (int i = 0; i < _childCount; i++)
             {
-                total += _childNodes[i].GetNodeCount(true);
+                total += _children[i].GetNodeCount(true);
             }
         }
 
@@ -1756,15 +1785,16 @@ public partial class TreeNode : MarshalByRefObject, ICloneable, ISerializable
     /// </summary>
     internal void InsertNodeAt(int index, TreeNode node)
     {
+        EnsureCapacity(1);
         node._parent = this;
         node._index = index;
-
-        _childNodes.Insert(index, node);
-        for (int i = index + 1; i < _childNodes.Count; i++)
+        for (int i = _childCount; i > index; --i)
         {
-            _childNodes[i]._index = i;
+            (_children[i] = _children[i - 1])._index = i;
         }
 
+        _children[index] = node;
+        _childCount++;
         node.Realize(false);
 
         if (TreeView is not null && node == TreeView._selectedNode)
@@ -1881,9 +1911,9 @@ public partial class TreeNode : MarshalByRefObject, ICloneable, ISerializable
             }
         }
 
-        for (int i = _childNodes.Count - 1; i >= 0; i--)
+        for (int i = _childCount - 1; i >= 0; i--)
         {
-            _childNodes[i].Realize(true);
+            _children[i].Realize(true);
         }
 
         // If node expansion was requested before the handle was created,
@@ -1915,20 +1945,22 @@ public partial class TreeNode : MarshalByRefObject, ICloneable, ISerializable
         bool expanded = IsExpanded;
 
         // unlink our children
-        for (int i = 0; i < _childNodes.Count; i++)
+        for (int i = 0; i < _childCount; i++)
         {
-            _childNodes[i].Remove(false);
+            _children[i].Remove(false);
         }
 
         // children = null;
         // unlink ourself
         if (notify && _parent is not null)
         {
-            _parent._childNodes.RemoveAt(_index);
-            for (int i = _index; i < _parent._childNodes.Count; i++)
+            for (int i = _index; i < _parent._childCount - 1; ++i)
             {
-                _parent._childNodes[i]._index = i;
+                (_parent._children[i] = _parent._children[i + 1])._index = i;
             }
+
+            _parent._children[_parent._childCount - 1] = null;
+            _parent._childCount--;
 
             _parent = null;
         }
@@ -2041,14 +2073,13 @@ public partial class TreeNode : MarshalByRefObject, ICloneable, ISerializable
             si.AddValue(nameof(StateImageKey), StateImageIndexer.Key);
         }
 
-        int nodeCount = _childNodes.Count;
-        si.AddValue("ChildCount", nodeCount);
+        si.AddValue("ChildCount", _childCount);
 
-        if (nodeCount > 0)
+        if (_childCount > 0)
         {
-            for (int i = 0; i < nodeCount; i++)
+            for (int i = 0; i < _childCount; i++)
             {
-                si.AddValue($"children{i}", _childNodes[i], typeof(TreeNode));
+                si.AddValue($"children{i}", _children[i], typeof(TreeNode));
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeNode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeNode.cs
@@ -89,7 +89,7 @@ public partial class TreeNode : MarshalByRefObject, ICloneable, ISerializable
 
     internal int _index;                  // our index into our parents child array
     internal int _childCount;
-    internal TreeNode[] _children;
+    internal TreeNode[] _children = [];
     internal TreeNode? _parent;
     internal TreeView? _treeView;
     private bool _expandOnRealization;
@@ -1315,7 +1315,7 @@ public partial class TreeNode : MarshalByRefObject, ICloneable, ISerializable
                 _children[^1].Remove(true);
             }
 
-            _children = null;
+            _children = [];
 
             if (tv is not null && isBulkOperation)
             {
@@ -1602,7 +1602,7 @@ public partial class TreeNode : MarshalByRefObject, ICloneable, ISerializable
             size = 4;
         }
 
-        if (_children is null)
+        if (_children is null || _children.Length == 0)
         {
             _children = new TreeNode[size];
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeNode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeNode.cs
@@ -1955,7 +1955,9 @@ public partial class TreeNode : MarshalByRefObject, ICloneable, ISerializable
                 (_parent._children[i] = _parent._children[i + 1])._index = i;
             }
 
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
             _parent._children[_parent._childCount - 1] = null;
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
             _parent._childCount--;
 
             _parent = null;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeNodeCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeNodeCollection.cs
@@ -223,7 +223,7 @@ public class TreeNodeCollection : IList
         _owner.EnsureCapacity(nodes.Length);
         for (int i = nodes.Length - 1; i >= 0; i--)
         {
-            AddInternal(nodes[i], i);
+            AddInternal(nodes[i], delta: i);
         }
 
         _owner.Nodes.FixedIndex = -1;
@@ -287,7 +287,7 @@ public class TreeNodeCollection : IList
     /// <summary>
     ///  Adds a new child node to this node.  Child node is positioned after siblings.
     /// </summary>
-    public virtual int Add(TreeNode node) => AddInternal(node, 0);
+    public virtual int Add(TreeNode node) => AddInternal(node, delta: 0);
 
     private int AddInternal(TreeNode node, int delta)
     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeNodeCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeNodeCollection.cs
@@ -32,18 +32,18 @@ public class TreeNodeCollection : IList
         get
         {
             ArgumentOutOfRangeException.ThrowIfNegative(index);
-            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, _owner._childNodes.Count);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, _owner._childCount);
 
-            return _owner._childNodes[index];
+            return _owner._children[index];
         }
         set
         {
             ArgumentOutOfRangeException.ThrowIfNegative(index);
-            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, _owner._childNodes.Count);
+            ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, _owner._childCount);
             ArgumentNullException.ThrowIfNull(value);
 
             TreeView tv = _owner._treeView!;
-            TreeNode actual = _owner._childNodes[index];
+            TreeNode actual = _owner._children[index];
 
             if (value._treeView is not null && value._treeView.Handle != tv.Handle)
             {
@@ -111,7 +111,7 @@ public class TreeNodeCollection : IList
 
     // Make this property available to Intellisense. (Removed the EditorBrowsable attribute.)
     [Browsable(false)]
-    public int Count => _owner._childNodes.Count;
+    public int Count => _owner._childCount;
 
     object ICollection.SyncRoot => this;
 
@@ -219,9 +219,9 @@ public class TreeNodeCollection : IList
             tv.BeginUpdate();
         }
 
-        _owner.Nodes.FixedIndex = _owner._childNodes.Count;
-        _owner._childNodes.EnsureCapacity(nodes.Length);
-        for (int i = 0; i < nodes.Length; i++)
+        _owner.Nodes.FixedIndex = _owner._childCount;
+        _owner.EnsureCapacity(nodes.Length);
+        for (int i = nodes.Length - 1; i >= 0; i--)
         {
             AddInternal(nodes[i], i);
         }
@@ -327,10 +327,12 @@ public class TreeNodeCollection : IList
         {
             // if fixedIndex != -1 capacity was ensured by AddRange
             Debug.Assert(delta == 0, "delta should be 0");
-            node._index = _owner._childNodes.Count;
+            _owner.EnsureCapacity(1);
+            node._index = _owner._childCount;
         }
 
-        _owner._childNodes.Add(node);
+        _owner._children[node._index] = node;
+        _owner._childCount++;
         node.Realize(false);
 
         if (tv is not null && node == tv._selectedNode)
@@ -457,9 +459,9 @@ public class TreeNodeCollection : IList
             index = 0;
         }
 
-        if (index > _owner._childNodes.Count)
+        if (index > _owner._childCount)
         {
-            index = _owner._childNodes.Count;
+            index = _owner._childCount;
         }
 
         _owner.InsertNodeAt(index, node);
@@ -575,9 +577,9 @@ public class TreeNodeCollection : IList
 
     public void CopyTo(Array dest, int index)
     {
-        if (_owner._childNodes.Count > 0)
+        if (_owner._childCount > 0)
         {
-            ((ICollection)_owner._childNodes).CopyTo(dest, index);
+            Array.Copy(_owner._children, 0, dest, index, _owner._childCount);
         }
     }
 
@@ -611,5 +613,15 @@ public class TreeNodeCollection : IList
         }
     }
 
-    public IEnumerator GetEnumerator() => _owner._childNodes.GetEnumerator();
+    public IEnumerator GetEnumerator()
+    {
+        if (_owner._children is not null)
+        {
+            return new ArraySubsetEnumerator(_owner._children, _owner._childCount);
+        }
+        else
+        {
+            return Array.Empty<TreeNode>().GetEnumerator();
+        }
+    }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/SerializableTypesTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/SerializableTypesTests.cs
@@ -368,7 +368,7 @@ public class SerializableTypesTests
             Assert.Equal("node1", result.Text);
             Assert.Equal(-1, result.ImageIndex); // No image list
             Assert.Equal("key", result.SelectedImageKey);
-            Assert.Equal(2, result._childNodes.Count);
+            Assert.Equal(2, result._childCount);
             Assert.Equal("node2", result.FirstNode.Text);
             Assert.Equal("node3", result.LastNode.Text);
             Assert.Equal("tool tip text", result.ToolTipText);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/TreeNode.TreeNodeAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/TreeNode.TreeNodeAccessibleObjectTests.cs
@@ -503,7 +503,7 @@ public class TreeNodeAccessibleObjectTests
         node.Nodes.Add("ChildNode");
 
         Assert.True(node.AccessibilityObject.IsPatternSupported(UIA_PATTERN_ID.UIA_ExpandCollapsePatternId));
-        Assert.True(node._childNodes.Count > 0);
+        Assert.True(node._childCount > 0);
         Assert.False(control.IsHandleCreated);
     }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
@@ -7305,6 +7305,55 @@ public class TreeViewTests
         Assert.Equal(treeNode2, parent.Nodes[0]);
     }
 
+    // Regression test for https://github.com/dotnet/winforms/issues/11243
+    [WinFormsFact]
+    public void TreeView_TreeNodeAddRangeSequence()
+    {
+        using TreeView treeView = new()
+        {
+            Dock = DockStyle.Fill,
+        };
+
+        using Form form = new()
+        {
+            Width = 200,
+            Height = 200,
+        };
+
+        TreeNode treeNode1 = new("a1");
+        TreeNode treeNode2 = new("b1");
+        TreeNode treeNode3 = new("c1");
+        TreeNode rootNode = new("Root", [new TreeNode("child")]);
+
+        treeView.Nodes.Add(rootNode);
+        form.Controls.Add(treeView);
+
+        form.Load += (s, e) =>
+        {
+            treeView.Nodes[0].Nodes.AddRange(treeNode1, treeNode2, treeNode3);
+            treeView.Nodes[0].ExpandAll();
+        };
+        form.Show();
+
+        TreeNode childNode1 = treeView.Nodes[0].Nodes[0];
+        TreeNode childNode2 = treeView.Nodes[0].Nodes[1];
+        TreeNode childNode3 = treeView.Nodes[0].Nodes[2];
+        TreeNode childNode4 = treeView.Nodes[0].Nodes[3];
+
+        childNode1.Text.Should().Be("child");
+
+        childNode1.NextVisibleNode.Should().NotBeNull();
+        childNode1.NextVisibleNode.Text.Should().Be("a1");
+
+        childNode2.NextVisibleNode.Should().NotBeNull();
+        childNode2.NextVisibleNode.Text.Should().Be("b1");
+
+        childNode3.NextVisibleNode.Should().NotBeNull();
+        childNode3.NextVisibleNode.Text.Should().Be("c1");
+
+        childNode4.NextVisibleNode.Should().BeNull();
+    }
+
     private class SubTreeView : TreeView
     {
         public new bool CanEnableIme => base.CanEnableIme;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
@@ -7311,34 +7311,56 @@ public class TreeViewTests
     {
         using TreeView treeView = new();
 
-        TreeNode treeNode1 = new("a1");
-        TreeNode treeNode2 = new("b1");
-        TreeNode treeNode3 = new("c1");
+        TreeNode treeNode1 = new("a0");
+        TreeNode treeNode2 = new("b0");
+        TreeNode treeNode3 = new("c0");
+        TreeNode treeNode4 = new("a1");
+        TreeNode treeNode5 = new("b1");
+        TreeNode treeNode6 = new("c1");
+        TreeNode treeNode7 = new("a2");
         TreeNode rootNode = new("Root", [new TreeNode("child")]);
 
         treeView.Nodes.Add(rootNode);
         treeView.CreateControl();
 
-        rootNode.Nodes.AddRange(treeNode1, treeNode2, treeNode3);
+        rootNode.Nodes.AddRange(treeNode1, treeNode2, treeNode3, treeNode4, treeNode5, treeNode6, treeNode7);
         rootNode.ExpandAll();
+
+        rootNode.Should().Be(treeView.Nodes[0]);
 
         TreeNode childNode1 = rootNode.Nodes[0];
         TreeNode childNode2 = rootNode.Nodes[1];
         TreeNode childNode3 = rootNode.Nodes[2];
         TreeNode childNode4 = rootNode.Nodes[3];
+        TreeNode childNode5 = rootNode.Nodes[4];
+        TreeNode childNode6 = rootNode.Nodes[5];
+        TreeNode childNode7 = rootNode.Nodes[6];
+        TreeNode childNode8 = rootNode.Nodes[7];
 
         childNode1.Text.Should().Be("child");
 
         childNode1.NextVisibleNode.Should().NotBeNull();
-        childNode1.NextVisibleNode.Text.Should().Be("a1");
+        childNode1.NextVisibleNode.Text.Should().Be("a0");
 
         childNode2.NextVisibleNode.Should().NotBeNull();
-        childNode2.NextVisibleNode.Text.Should().Be("b1");
+        childNode2.NextVisibleNode.Text.Should().Be("b0");
 
         childNode3.NextVisibleNode.Should().NotBeNull();
-        childNode3.NextVisibleNode.Text.Should().Be("c1");
+        childNode3.NextVisibleNode.Text.Should().Be("c0");
 
-        childNode4.NextVisibleNode.Should().BeNull();
+        childNode4.NextVisibleNode.Should().NotBeNull();
+        childNode4.NextVisibleNode.Text.Should().Be("a1");
+
+        childNode5.NextVisibleNode.Should().NotBeNull();
+        childNode5.NextVisibleNode.Text.Should().Be("b1");
+
+        childNode6.NextVisibleNode.Should().NotBeNull();
+        childNode6.NextVisibleNode.Text.Should().Be("c1");
+
+        childNode7.NextVisibleNode.Should().NotBeNull();
+        childNode7.NextVisibleNode.Text.Should().Be("a2");
+
+        childNode8.NextVisibleNode.Should().BeNull();
     }
 
     private class SubTreeView : TreeView

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
@@ -7309,16 +7309,7 @@ public class TreeViewTests
     [WinFormsFact]
     public void TreeView_TreeNodeAddRangeSequence()
     {
-        using TreeView treeView = new()
-        {
-            Dock = DockStyle.Fill,
-        };
-
-        using Form form = new()
-        {
-            Width = 200,
-            Height = 200,
-        };
+        using TreeView treeView = new();
 
         TreeNode treeNode1 = new("a1");
         TreeNode treeNode2 = new("b1");
@@ -7326,19 +7317,15 @@ public class TreeViewTests
         TreeNode rootNode = new("Root", [new TreeNode("child")]);
 
         treeView.Nodes.Add(rootNode);
-        form.Controls.Add(treeView);
+        treeView.CreateControl();
 
-        form.Load += (s, e) =>
-        {
-            treeView.Nodes[0].Nodes.AddRange(treeNode1, treeNode2, treeNode3);
-            treeView.Nodes[0].ExpandAll();
-        };
-        form.Show();
+        rootNode.Nodes.AddRange(treeNode1, treeNode2, treeNode3);
+        rootNode.ExpandAll();
 
-        TreeNode childNode1 = treeView.Nodes[0].Nodes[0];
-        TreeNode childNode2 = treeView.Nodes[0].Nodes[1];
-        TreeNode childNode3 = treeView.Nodes[0].Nodes[2];
-        TreeNode childNode4 = treeView.Nodes[0].Nodes[3];
+        TreeNode childNode1 = rootNode.Nodes[0];
+        TreeNode childNode2 = rootNode.Nodes[1];
+        TreeNode childNode3 = rootNode.Nodes[2];
+        TreeNode childNode4 = rootNode.Nodes[3];
 
         childNode1.Text.Should().Be("child");
 


### PR DESCRIPTION
Fixes #11243 

<!-- 
## Proposed changes

- 
- 
- 


## Customer Impact

- 
- 

## Regression? 

- Yes / No

## Risk

-

 -->

## Screenshots 

### Before
![image](https://github.com/dotnet/winforms/assets/47542151/c7285c5e-b422-4627-8d5d-620a49d5cb81)

### After
![image](https://github.com/dotnet/winforms/assets/135201996/f7e85eaf-c072-441d-ba68-6d3deaf33f49)


## Test methodology 

- 
-  manually 
- 
<!-- 
## Accessibility testing 
 -->

## Test environment(s) 
9.0.0-preview.4.24219.3