### PR TITLE
Update BinaryFormattedObject

### DIFF
--- a/src/System.Private.Windows.Core/src/System/IO/BinaryReaderExtensions.cs
+++ b/src/System.Private.Windows.Core/src/System/IO/BinaryReaderExtensions.cs
@@ -1,8 +1,11 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers.Binary;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
+
 namespace System.IO;
 
 internal static class BinaryReaderExtensions
@@ -48,5 +51,82 @@ internal static class BinaryReaderExtensions
     {
         Stream stream = reader.BaseStream;
         return stream.Length - stream.Position;
+    }
+
+    /// <summary>
+    ///  Reads an array of primitives.
+    /// </summary>
+    public static unsafe T[] ReadPrimitiveArray<T>(this BinaryReader reader, int count)
+        where T : unmanaged
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(count);
+        if (typeof(T) != typeof(bool)
+            && typeof(T) != typeof(byte)
+            && typeof(T) != typeof(sbyte)
+            && typeof(T) != typeof(char)
+            && typeof(T) != typeof(short)
+            && typeof(T) != typeof(ushort)
+            && typeof(T) != typeof(int)
+            && typeof(T) != typeof(uint)
+            && typeof(T) != typeof(long)
+            && typeof(T) != typeof(ulong)
+            && typeof(T) != typeof(float)
+            && typeof(T) != typeof(double))
+        {
+            throw new ArgumentException($"Cannot read primitives of {typeof(T).Name}.", nameof(T));
+        }
+
+        if (count > 0 && reader.Remaining() < count * (typeof(T) == typeof(char) ? 1 : sizeof(T)))
+        {
+            throw new SerializationException("Not enough data to fill array.");
+        }
+
+        if (count == 0)
+        {
+            return [];
+        }
+
+        if (typeof(T) == typeof(char))
+        {
+            // Need to handle different encodings
+            return (T[])(object)reader.ReadChars(count);
+        }
+
+        T[] array = new T[count];
+
+        fixed (T* a = array)
+        {
+            Span<byte> arrayData = new(a, array.Length * sizeof(T));
+
+            if (reader.Read(arrayData) != arrayData.Length)
+            {
+                throw new SerializationException("Not enough data to fill array.");
+            }
+
+            if (sizeof(T) != 1 && !BitConverter.IsLittleEndian)
+            {
+                if (sizeof(T) == 2)
+                {
+                    Span<ushort> ushorts = MemoryMarshal.Cast<byte, ushort>(arrayData);
+                    BinaryPrimitives.ReverseEndianness(ushorts, ushorts);
+                }
+                else if (sizeof(T) == 4)
+                {
+                    Span<int> ints = MemoryMarshal.Cast<byte, int>(arrayData);
+                    BinaryPrimitives.ReverseEndianness(ints, ints);
+                }
+                else if (sizeof(T) == 8)
+                {
+                    Span<long> longs = MemoryMarshal.Cast<byte, long>(arrayData);
+                    BinaryPrimitives.ReverseEndianness(longs, longs);
+                }
+                else
+                {
+                    throw new InvalidOperationException($"Cannot read primitives of {typeof(T).Name}.");
+                }
+            }
+        }
+
+        return array;
     }
 }

--- a/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/ArrayRecordExtensions.cs
+++ b/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/ArrayRecordExtensions.cs
@@ -1,0 +1,57 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.Serialization;
+
+namespace System.Windows.Forms.BinaryFormat;
+
+internal static class ArrayRecordExtensions
+{
+    internal static Array GetPrimitiveArray(this IPrimitiveTypeRecord primitiveArray) => primitiveArray.PrimitiveType switch
+    {
+        PrimitiveType.Boolean => ((ArrayRecord<bool>)primitiveArray).AsArray(),
+        PrimitiveType.Byte => ((ArrayRecord<byte>)primitiveArray).AsArray(),
+        PrimitiveType.Char => ((ArrayRecord<char>)primitiveArray).AsArray(),
+        PrimitiveType.Decimal => ((ArrayRecord<decimal>)primitiveArray).AsArray(),
+        PrimitiveType.Double => ((ArrayRecord<double>)primitiveArray).AsArray(),
+        PrimitiveType.Int16 => ((ArrayRecord<short>)primitiveArray).AsArray(),
+        PrimitiveType.Int32 => ((ArrayRecord<int>)primitiveArray).AsArray(),
+        PrimitiveType.Int64 => ((ArrayRecord<long>)primitiveArray).AsArray(),
+        PrimitiveType.SByte => ((ArrayRecord<sbyte>)primitiveArray).AsArray(),
+        PrimitiveType.Single => ((ArrayRecord<float>)primitiveArray).AsArray(),
+        PrimitiveType.TimeSpan => ((ArrayRecord<TimeSpan>)primitiveArray).AsArray(),
+        PrimitiveType.DateTime => ((ArrayRecord<DateTime>)primitiveArray).AsArray(),
+        PrimitiveType.UInt16 => ((ArrayRecord<ushort>)primitiveArray).AsArray(),
+        PrimitiveType.UInt32 => ((ArrayRecord<uint>)primitiveArray).AsArray(),
+        PrimitiveType.UInt64 => ((ArrayRecord<ulong>)primitiveArray).AsArray(),
+        _ => throw new SerializationException($"Unexpected primitive array type: '{primitiveArray.PrimitiveType}'")
+    };
+
+    /// <summary>
+    ///  Convert the source to an array, if it is not already an array.
+    /// </summary>
+    private static Array AsArray<T>(this ArrayRecord<T> record) where T : unmanaged
+    {
+        if (record.ArrayObjects is not T[] rawArray)
+        {
+            Debug.Fail("Should not have any primitive arrays that are not already arrays.");
+            throw new InvalidOperationException();
+        }
+
+        if (record is not IBinaryArray binaryArray || binaryArray.ArrayType is BinaryArrayType.Single or BinaryArrayType.Jagged)
+        {
+            return rawArray;
+        }
+
+        if (binaryArray.ArrayType is not BinaryArrayType.Rectangular)
+        {
+            // This should not be possible.
+            throw new NotSupportedException();
+        }
+
+        Array array = Array.CreateInstance(typeof(T), binaryArray.Lengths.ToArray());
+        Span<T> flatSpan = array.GetArrayData<T>();
+        rawArray.AsSpan().CopyTo(flatSpan);
+        return array;
+    }
+}

--- a/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/ArraySingleObject.cs
+++ b/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/ArraySingleObject.cs
@@ -13,23 +13,25 @@ namespace System.Windows.Forms.BinaryFormat;
 ///   </see>
 ///  </para>
 /// </remarks>
-internal sealed class ArraySingleObject : ArrayRecord<object>, IRecord<ArraySingleObject>
+internal sealed class ArraySingleObject :
+    ArrayRecord<object?>,
+    IRecord<ArraySingleObject>,
+    IBinaryFormatParseable<ArraySingleObject>
 {
     public static RecordType RecordType => RecordType.ArraySingleObject;
 
-    public ArraySingleObject(Id objectId, IReadOnlyList<object> arrayObjects)
+    public ArraySingleObject(Id objectId, IReadOnlyList<object?> arrayObjects)
         : base(new ArrayInfo(objectId, arrayObjects.Count), arrayObjects)
     { }
 
     static ArraySingleObject IBinaryFormatParseable<ArraySingleObject>.Parse(
-        BinaryReader reader,
-        RecordMap recordMap)
+        BinaryFormattedObject.ParseState state)
     {
         ArraySingleObject record = new(
-            ArrayInfo.Parse(reader, out Count length),
-            ReadRecords(reader, recordMap, length));
+            ArrayInfo.Parse(state.Reader, out Count length),
+            ReadRecords(state, length));
 
-        recordMap[record.ObjectId] = record;
+        state.RecordMap[record.ObjectId] = record;
         return record;
     }
 

--- a/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/ArraySinglePrimitive.cs
+++ b/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/ArraySinglePrimitive.cs
@@ -13,7 +13,11 @@ namespace System.Windows.Forms.BinaryFormat;
 ///   </see>
 ///  </para>
 /// </remarks>
-internal sealed class ArraySinglePrimitive<T> : ArrayRecord<T>, IRecord<ArraySinglePrimitive<T>>, IPrimitiveTypeRecord
+internal sealed class ArraySinglePrimitive<T> :
+    ArrayRecord<T>,
+    IBinaryFormatParseable<ArrayRecord>,
+    IRecord<ArraySinglePrimitive<T>>,
+    IPrimitiveTypeRecord
     where T : unmanaged
 {
     public PrimitiveType PrimitiveType { get; }
@@ -26,16 +30,15 @@ internal sealed class ArraySinglePrimitive<T> : ArrayRecord<T>, IRecord<ArraySin
         PrimitiveType = TypeInfo.GetPrimitiveType(typeof(T));
     }
 
-    static ArraySinglePrimitive<T> IBinaryFormatParseable<ArraySinglePrimitive<T>>.Parse(
-        BinaryReader reader,
-        RecordMap recordMap)
+    static ArrayRecord IBinaryFormatParseable<ArrayRecord>.Parse(
+        BinaryFormattedObject.ParseState state)
     {
-        Id id = ArrayInfo.Parse(reader, out Count length);
-        PrimitiveType primitiveType = (PrimitiveType)reader.ReadByte();
+        Id id = ArrayInfo.Parse(state.Reader, out Count length);
+        PrimitiveType primitiveType = (PrimitiveType)state.Reader.ReadByte();
         Debug.Assert(typeof(T) == primitiveType.GetPrimitiveTypeType());
 
-        ArraySinglePrimitive<T> record = new(id, ReadPrimitiveTypes<T>(reader, length));
-        recordMap[record.ObjectId] = record;
+        ArraySinglePrimitive<T> record = new(id, ReadPrimitiveTypes<T>(state.Reader, length));
+        state.RecordMap[record.ObjectId] = record;
         return record;
     }
 

--- a/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/ArraySingleString.cs
+++ b/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/ArraySingleString.cs
@@ -13,23 +13,22 @@ namespace System.Windows.Forms.BinaryFormat;
 ///   </see>
 ///  </para>
 /// </remarks>
-internal sealed class ArraySingleString : ArrayRecord<object>, IRecord<ArraySingleString>
+internal sealed class ArraySingleString : ArrayRecord<object?>, IRecord<ArraySingleString>, IBinaryFormatParseable<ArraySingleString>
 {
     public static RecordType RecordType => RecordType.ArraySingleString;
 
-    public ArraySingleString(Id objectId, IReadOnlyList<object> arrayObjects)
+    public ArraySingleString(Id objectId, IReadOnlyList<object?> arrayObjects)
         : base(new ArrayInfo(objectId, arrayObjects.Count), arrayObjects)
     { }
 
     static ArraySingleString IBinaryFormatParseable<ArraySingleString>.Parse(
-        BinaryReader reader,
-        RecordMap recordMap)
+        BinaryFormattedObject.ParseState state)
     {
         ArraySingleString record = new(
-            ArrayInfo.Parse(reader, out Count length),
-            ReadRecords(reader, recordMap, length));
+            ArrayInfo.Parse(state.Reader, out Count length),
+            ReadRecords(state, length));
 
-        recordMap[record.ObjectId] = record;
+        state.RecordMap[record.ObjectId] = record;
         return record;
     }
 

--- a/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/BinaryArray.PrimitiveBinaryArray.cs
+++ b/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/BinaryArray.PrimitiveBinaryArray.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Windows.Forms.BinaryFormat;
+
+internal static partial class BinaryArray
+{
+    /// <summary>
+    ///  <see cref="BinaryArray"/> of primitive values.
+    /// </summary>
+    /// <inheritdoc cref="BinaryArray"/>
+    private sealed class PrimitiveBinaryArray<T> : ArrayRecord<T>, IRecord<PrimitiveBinaryArray<T>>, IBinaryArray, IPrimitiveTypeRecord where T : unmanaged
+    {
+        public Count Rank { get; }
+        public BinaryArrayType ArrayType { get; }
+        public MemberTypeInfo TypeInfo { get; }
+        public IReadOnlyList<int> Lengths { get; }
+        public PrimitiveType PrimitiveType { get; }
+
+        internal PrimitiveBinaryArray(
+            Count rank,
+            BinaryArrayType arrayType,
+            IReadOnlyList<int> lengths,
+            ArrayInfo arrayInfo,
+            MemberTypeInfo typeInfo,
+            BinaryReader reader)
+            : base(arrayInfo, ReadPrimitiveTypes<T>(reader, arrayInfo.Length))
+        {
+            Rank = rank;
+            ArrayType = arrayType;
+            TypeInfo = typeInfo;
+            Lengths = lengths;
+            PrimitiveType = (PrimitiveType)typeInfo[0].Info!;
+        }
+
+        public override void Write(BinaryWriter writer)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/BinaryArray.cs
+++ b/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/BinaryArray.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Serialization;
+
 namespace System.Windows.Forms.BinaryFormat;
 
 /// <summary>
@@ -13,54 +15,141 @@ namespace System.Windows.Forms.BinaryFormat;
 ///   </see>
 ///  </para>
 /// </remarks>
-internal sealed class BinaryArray : ArrayRecord<object>, IRecord<BinaryArray>
+internal static partial class BinaryArray
 {
-    public Count Rank { get; }
-    public BinaryArrayType Type { get; }
-    public MemberTypeInfo TypeInfo { get; }
-
-    private BinaryArray(
-        Count rank,
-        BinaryArrayType type,
-        ArrayInfo arrayInfo,
-        MemberTypeInfo typeInfo,
-        IReadOnlyList<object> arrayObjects)
-        : base(arrayInfo, arrayObjects)
-    {
-        Rank = rank;
-        Type = type;
-        TypeInfo = typeInfo;
-    }
+    private const int MaxRanks = 32;
 
     public static RecordType RecordType => RecordType.BinaryArray;
 
-    static BinaryArray IBinaryFormatParseable<BinaryArray>.Parse(BinaryReader reader, RecordMap recordMap)
+    internal static IBinaryArray Parse(BinaryFormattedObject.ParseState state)
     {
-        Id objectId = reader.ReadInt32();
-        BinaryArrayType arrayType = (BinaryArrayType)reader.ReadByte();
-        Count rank = reader.ReadInt32();
-        Count length = reader.ReadInt32();
+        Id objectId = state.Reader.ReadInt32();
+        BinaryArrayType arrayType = (BinaryArrayType)state.Reader.ReadByte();
 
-        if (arrayType != BinaryArrayType.Single || rank != 1)
+        if (arrayType is not (BinaryArrayType.Single or BinaryArrayType.Rectangular or BinaryArrayType.Jagged))
         {
-            throw new NotSupportedException("Only single dimensional arrays are currently supported.");
+            if (arrayType is BinaryArrayType.SingleOffset or BinaryArrayType.RectangularOffset or BinaryArrayType.JaggedOffset)
+            {
+                throw new NotSupportedException("Offset arrays are not supported.");
+            }
+
+            throw new SerializationException("Invalid array type.");
         }
 
-        MemberTypeInfo memberTypeInfo = MemberTypeInfo.Parse(reader, 1);
-        List<object> arrayObjects = new(Math.Min(BinaryFormattedObject.MaxNewCollectionSize, length));
-        (BinaryType type, object? typeInfo) = memberTypeInfo[0];
-        for (int i = 0; i < length; i++)
+        int rank = state.Reader.ReadInt32();
+
+        if (arrayType is BinaryArrayType.Single or BinaryArrayType.Jagged)
         {
-            arrayObjects.Add(ReadValue(reader, recordMap, type, typeInfo));
+            // Jagged array is an array of arrays, there should always be one rank
+            // for the "outer" array.
+            if (rank != 1)
+            {
+                throw new SerializationException("Invalid array rank.");
+            }
+        }
+        else if (arrayType is BinaryArrayType.Rectangular)
+        {
+            // Multidimensional array
+            if (rank is < 2 or > MaxRanks)
+            {
+                throw new SerializationException("Invalid array rank.");
+            }
         }
 
-        BinaryArray record = new(rank, arrayType, new ArrayInfo(objectId, length), memberTypeInfo, arrayObjects);
-        recordMap[objectId] = record;
-        return record;
+        int[] lengths = new int[rank];
+        int length;
+
+        if (arrayType is not BinaryArrayType.Rectangular)
+        {
+            length = state.Reader.ReadInt32();
+            if (length < 0)
+            {
+                throw new SerializationException("Invalid array length.");
+            }
+
+            lengths[0] = length;
+        }
+        else
+        {
+            length = 1;
+
+            for (int i = 0; i < rank; i++)
+            {
+                int rankLength = state.Reader.ReadInt32();
+                if (rankLength < 0)
+                {
+                    throw new SerializationException("Invalid array length.");
+                }
+
+                // Rectangular (multidimensional) length is product of lengths.
+                //
+                // It is technically possible to have multidimensional arrays with
+                // a total length over int.MaxValue. Even with just bytes this would
+                // be a very large array (2GB). To constrain this reader we'll reject
+                // anything that goes over this.
+                length = checked(length * rankLength);
+                lengths[i] = rankLength;
+            }
+        }
+
+        MemberTypeInfo typeInfo = MemberTypeInfo.Parse(state.Reader, 1);
+        (BinaryType type, object? info) = typeInfo[0];
+
+        IBinaryArray array = type is not BinaryType.Primitive
+            ? new ObjectBinaryArray(rank, arrayType, lengths, new(objectId, length), typeInfo, state)
+            : (PrimitiveType)info! switch
+            {
+                PrimitiveType.Boolean => new PrimitiveBinaryArray<bool>(rank, arrayType, lengths, new(objectId, length), typeInfo, state.Reader),
+                PrimitiveType.Byte => new PrimitiveBinaryArray<byte>(rank, arrayType, lengths, new(objectId, length), typeInfo, state.Reader),
+                PrimitiveType.SByte => new PrimitiveBinaryArray<sbyte>(rank, arrayType, lengths, new(objectId, length), typeInfo, state.Reader),
+                PrimitiveType.Char => new PrimitiveBinaryArray<char>(rank, arrayType, lengths, new(objectId, length), typeInfo, state.Reader),
+                PrimitiveType.Int16 => new PrimitiveBinaryArray<short>(rank, arrayType, lengths, new(objectId, length), typeInfo, state.Reader),
+                PrimitiveType.UInt16 => new PrimitiveBinaryArray<ushort>(rank, arrayType, lengths, new(objectId, length), typeInfo, state.Reader),
+                PrimitiveType.Int32 => new PrimitiveBinaryArray<int>(rank, arrayType, lengths, new(objectId, length), typeInfo, state.Reader),
+                PrimitiveType.UInt32 => new PrimitiveBinaryArray<uint>(rank, arrayType, lengths, new(objectId, length), typeInfo, state.Reader),
+                PrimitiveType.Int64 => new PrimitiveBinaryArray<long>(rank, arrayType, lengths, new(objectId, length), typeInfo, state.Reader),
+                PrimitiveType.UInt64 => new PrimitiveBinaryArray<ulong>(rank, arrayType, lengths, new(objectId, length), typeInfo, state.Reader),
+                PrimitiveType.Single => new PrimitiveBinaryArray<float>(rank, arrayType, lengths, new(objectId, length), typeInfo, state.Reader),
+                PrimitiveType.Double => new PrimitiveBinaryArray<double>(rank, arrayType, lengths, new(objectId, length), typeInfo, state.Reader),
+                PrimitiveType.Decimal => new PrimitiveBinaryArray<decimal>(rank, arrayType, lengths, new(objectId, length), typeInfo, state.Reader),
+                PrimitiveType.DateTime => new PrimitiveBinaryArray<DateTime>(rank, arrayType, lengths, new(objectId, length), typeInfo, state.Reader),
+                PrimitiveType.TimeSpan => new PrimitiveBinaryArray<TimeSpan>(rank, arrayType, lengths, new(objectId, length), typeInfo, state.Reader),
+                _ => throw new SerializationException($"Invalid primitive type '{(PrimitiveType)info}'"),
+            };
+
+        state.RecordMap[objectId] = array;
+        return array;
     }
 
-    public override void Write(BinaryWriter writer)
+    /// <summary>
+    ///  <see cref="BinaryArray"/> of objects.
+    /// </summary>
+    /// <inheritdoc cref="BinaryArray"/>
+    private sealed class ObjectBinaryArray : ArrayRecord<object?>, IRecord<ObjectBinaryArray>, IBinaryArray
     {
-        throw new NotSupportedException();
+        public Count Rank { get; }
+        public BinaryArrayType ArrayType { get; }
+        public MemberTypeInfo TypeInfo { get; }
+        public IReadOnlyList<int> Lengths { get; }
+
+        internal ObjectBinaryArray(
+            Count rank,
+            BinaryArrayType type,
+            IReadOnlyList<int> lengths,
+            ArrayInfo arrayInfo,
+            MemberTypeInfo typeInfo,
+            BinaryFormattedObject.ParseState state)
+            : base(arrayInfo, ReadValues(state, typeInfo[0].Type, typeInfo[0].Info, arrayInfo.Length))
+        {
+            Rank = rank;
+            ArrayType = type;
+            TypeInfo = typeInfo;
+            Lengths = lengths;
+        }
+
+        public override void Write(BinaryWriter writer)
+        {
+            throw new NotSupportedException();
+        }
     }
 }

--- a/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/BinaryFormattedObject.Options.cs
+++ b/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/BinaryFormattedObject.Options.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters;
+
+namespace System.Windows.Forms.BinaryFormat;
+
+#pragma warning disable SYSLIB0050 // Type or member is obsolete
+
+internal sealed partial class BinaryFormattedObject
+{
+    internal sealed class Options
+    {
+        /// <summary>
+        ///  How exactly assembly names need to match for deserialization.
+        /// </summary>
+
+        public FormatterAssemblyStyle AssemblyMatching { get; set; } = FormatterAssemblyStyle.Simple;
+
+        /// <summary>
+        ///  Type name binder.
+        /// </summary>
+        public SerializationBinder? Binder { get; set; }
+
+        /// <summary>
+        ///  Optional type <see cref="ISerializationSurrogate"/> provider.
+        /// </summary>
+        public ISurrogateSelector? SurrogateSelector { get; set; }
+
+        /// <summary>
+        ///  Streaming context.
+        /// </summary>
+        public StreamingContext StreamingContext { get; set; } = new(StreamingContextStates.All);
+    }
+}
+
+#pragma warning restore SYSLIB0050 // Type or member is obsolete

--- a/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/BinaryFormattedObject.ParseState.cs
+++ b/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/BinaryFormattedObject.ParseState.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Windows.Forms.BinaryFormat;
+
+internal sealed partial class BinaryFormattedObject
+{
+    /// <summary>
+    ///  Parsing state for <see cref="BinaryFormattedObject"/>.
+    /// </summary>
+    internal sealed class ParseState
+    {
+        private readonly BinaryFormattedObject _format;
+
+        public ParseState(BinaryReader reader, BinaryFormattedObject format)
+        {
+            Reader = reader;
+            _format = format;
+        }
+
+        public BinaryReader Reader { get; }
+        public RecordMap RecordMap => _format._recordMap;
+
+        [UnconditionalSuppressMessage(
+            "Trimming",
+            "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code",
+            Justification = """
+                Incoming type names are coming off of the formatted stream. There is no way for user code to pass compile
+                time context for preserialized data. If a type can't be found on deserialization it won't matter any more
+                than any other case where the type can't be found (e.g. a missing assembly). The deserializer will fail
+                with information on the missing type that can be used to attribute to keep said type.
+                """)]
+        [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+        public Type GetType(string typeName, Id libraryId) => _format.GetType(typeName, libraryId);
+    }
+}

--- a/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/BinaryFormattedObject.TypeResolver.cs
+++ b/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/BinaryFormattedObject.TypeResolver.cs
@@ -1,0 +1,160 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Reflection;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters;
+
+#pragma warning disable SYSLIB0050 // Type or member is obsolete
+
+namespace System.Windows.Forms.BinaryFormat;
+
+internal sealed partial class BinaryFormattedObject
+{
+    internal sealed class TypeResolver
+    {
+        private readonly FormatterAssemblyStyle _assemblyMatching;
+        private readonly SerializationBinder? _binder;
+        private readonly IReadOnlyRecordMap _recordMap;
+
+        // This has to be Id as we use Id.Null for mscorlib types.
+        private readonly Dictionary<Id, Assembly> _assemblies = [];
+        private readonly Dictionary<(string TypeName, Id LibraryId), Type> _types = [];
+
+        private string? _lastTypeName;
+        private Id _lastLibraryId;
+
+        [AllowNull]
+        private Type _lastType;
+
+        public TypeResolver(Options options, IReadOnlyRecordMap recordMap)
+        {
+            _assemblyMatching = options.AssemblyMatching;
+            _binder = options.Binder;
+            _assemblies[Id.Null] = TypeInfo.MscorlibAssembly;
+            _recordMap = recordMap;
+        }
+
+        /// <summary>
+        ///  Resolves the given type name against the specified library.
+        /// </summary>
+        /// <param name="libraryId">The library id, or <see cref="Id.Null"/> for the "system" assembly.</param>
+        [RequiresUnreferencedCode("Calls System.Reflection.Assembly.GetType(String)")]
+        [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+        internal Type GetType(string typeName, Id libraryId)
+        {
+            if (libraryId == _lastLibraryId && string.Equals(typeName, _lastTypeName))
+            {
+                Debug.Assert(_lastType is not null);
+                return _lastType;
+            }
+
+            _lastLibraryId = libraryId;
+            _lastTypeName = typeName;
+
+            if (_types.TryGetValue((typeName, libraryId), out Type? cachedType))
+            {
+                _lastType = cachedType;
+                return cachedType;
+            }
+
+            string libraryName = libraryId.IsNull
+                ? TypeInfo.MscorlibAssemblyName
+                : ((BinaryLibrary)_recordMap[libraryId]).LibraryName;
+
+            if (_binder?.BindToType(libraryName, typeName) is Type binderType)
+            {
+                // BinaryFormatter is inconsistent about what caching behavior you get with binders.
+                // It would always cache the last item from the binder, but wouldn't put the result
+                // in the type cache. This could lead to inconsistent results if the binder didn't
+                // always return the same result for a given set of strings. Choosing to always cache
+                // for performance.
+
+                _types[(typeName, libraryId)] = binderType;
+                _lastType = binderType;
+                return binderType;
+            }
+
+            if (!_assemblies.TryGetValue(libraryId, out Assembly? assembly))
+            {
+                Debug.Assert(!libraryId.IsNull);
+
+                AssemblyName assemblyName = new(libraryName);
+                try
+                {
+                    assembly = Assembly.Load(assemblyName);
+                }
+                catch
+                {
+                    if (_assemblyMatching != FormatterAssemblyStyle.Simple)
+                    {
+                        throw;
+                    }
+
+                    assembly = Assembly.Load(assemblyName.Name!);
+                }
+
+                _assemblies.Add(libraryId, assembly);
+            }
+
+            Type? type = _assemblyMatching != FormatterAssemblyStyle.Simple
+                ? assembly.GetType(typeName)
+                : GetSimplyNamedTypeFromAssembly(assembly, typeName);
+
+            _lastType = type ?? throw new SerializationException($"Could not find type '{typeName}'.");
+            return _lastType;
+        }
+
+        [RequiresUnreferencedCode("Calls System.Reflection.Assembly.GetType(String, Boolean, Boolean)")]
+        private static Type? GetSimplyNamedTypeFromAssembly(Assembly assembly, string typeName)
+        {
+            // Catching any exceptions that could be thrown from a failure on assembly load
+            // This is necessary, for example, if there are generic parameters that are qualified
+            // with a version of the assembly that predates the one available.
+
+            try
+            {
+                return assembly.GetType(typeName, throwOnError: false, ignoreCase: false);
+            }
+            catch (TypeLoadException) { }
+            catch (FileNotFoundException) { }
+            catch (FileLoadException) { }
+            catch (BadImageFormatException) { }
+
+            return Type.GetType(typeName, ResolveSimpleAssemblyName, new TopLevelAssemblyTypeResolver(assembly).ResolveType, throwOnError: false);
+
+            static Assembly? ResolveSimpleAssemblyName(AssemblyName assemblyName)
+            {
+                try
+                {
+                    return Assembly.Load(assemblyName);
+                }
+                catch { }
+
+                try
+                {
+                    return Assembly.Load(assemblyName.Name!);
+                }
+                catch { }
+
+                return null;
+            }
+        }
+
+        private sealed class TopLevelAssemblyTypeResolver
+        {
+            private readonly Assembly _topLevelAssembly;
+
+            public TopLevelAssemblyTypeResolver(Assembly topLevelAssembly) => _topLevelAssembly = topLevelAssembly;
+
+            [RequiresUnreferencedCode("Calls System.Reflection.Assembly.GetType(String, Boolean, Boolean)")]
+            public Type? ResolveType(Assembly? assembly, string simpleTypeName, bool ignoreCase)
+            {
+                assembly ??= _topLevelAssembly;
+                return assembly.GetType(simpleTypeName, throwOnError: false, ignoreCase);
+            }
+        }
+    }
+}
+
+#pragma warning restore SYSLIB0050 // Type or member is obsolete

--- a/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/BinaryFormattedObjectExtensions.cs
+++ b/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/BinaryFormattedObjectExtensions.cs
@@ -68,7 +68,7 @@ internal static class BinaryFormattedObjectExtensions
                 return false;
             }
 
-            value = new PointF((float)classInfo["x"], (float)classInfo["y"]);
+            value = new PointF((float)classInfo["x"]!, (float)classInfo["y"]!);
 
             return true;
         }
@@ -96,10 +96,10 @@ internal static class BinaryFormattedObjectExtensions
             }
 
             value = new RectangleF(
-            (float)classInfo["x"],
-            (float)classInfo["y"],
-            (float)classInfo["width"],
-            (float)classInfo["height"]);
+                (float)classInfo["x"]!,
+                (float)classInfo["y"]!,
+                (float)classInfo["width"]!,
+                (float)classInfo["height"]!);
 
             return true;
         }
@@ -134,42 +134,42 @@ internal static class BinaryFormattedObjectExtensions
 
             if (IsPrimitiveTypeClassName(systemClass.Name) && systemClass.MemberTypeInfo[0].Type == BinaryType.Primitive)
             {
-                value = systemClass.MemberValues[0];
+                value = systemClass.MemberValues[0]!;
                 return true;
             }
 
             if (systemClass.Name == typeof(TimeSpan).FullName)
             {
-                value = new TimeSpan((long)systemClass.MemberValues[0]);
+                value = new TimeSpan((long)systemClass.MemberValues[0]!);
                 return true;
             }
 
             switch (systemClass.Name)
             {
                 case TypeInfo.TimeSpanType:
-                    value = new TimeSpan((long)systemClass.MemberValues[0]);
+                    value = new TimeSpan((long)systemClass.MemberValues[0]!);
                     return true;
                 case TypeInfo.DateTimeType:
-                    ulong ulongValue = (ulong)systemClass["dateData"];
+                    ulong ulongValue = (ulong)systemClass["dateData"]!;
                     value = Unsafe.As<ulong, DateTime>(ref ulongValue);
                     return true;
                 case TypeInfo.DecimalType:
                     ReadOnlySpan<int> bits =
                     [
-                        (int)systemClass["lo"],
-                        (int)systemClass["mid"],
-                        (int)systemClass["hi"],
-                        (int)systemClass["flags"]
+                        (int)systemClass["lo"]!,
+                        (int)systemClass["mid"]!,
+                        (int)systemClass["hi"]!,
+                        (int)systemClass["flags"]!
                     ];
 
                     value = new decimal(bits);
                     return true;
                 case TypeInfo.IntPtrType:
                     // Rehydrating still throws even though casting doesn't any more
-                    value = checked((nint)(long)systemClass.MemberValues[0]);
+                    value = checked((nint)(long)systemClass.MemberValues[0]!);
                     return true;
                 case TypeInfo.UIntPtrType:
-                    value = checked((nuint)(ulong)systemClass.MemberValues[0]);
+                    value = checked((nuint)(ulong)systemClass.MemberValues[0]!);
                     return true;
                 default:
                     return false;
@@ -211,7 +211,7 @@ internal static class BinaryFormattedObjectExtensions
             try
             {
                 // Lists serialize the entire backing array.
-                if ((size = (int)classInfo["_size"]) > array.Length)
+                if ((size = (int)classInfo["_size"]!) > array.Length)
                 {
                     return false;
                 }
@@ -290,7 +290,7 @@ internal static class BinaryFormattedObjectExtensions
             try
             {
                 // Lists serialize the entire backing array.
-                if ((size = (int)classInfo["_size"]) > array.Length)
+                if ((size = (int)classInfo["_size"]!) > array.Length)
                 {
                     return false;
                 }
@@ -303,7 +303,7 @@ internal static class BinaryFormattedObjectExtensions
             ArrayList arrayList = new(size);
             for (int i = 0; i < size; i++)
             {
-                if (!format.TryGetPrimitiveRecordValueOrNull((IRecord)array[i], out object? item))
+                if (!format.TryGetPrimitiveRecordValueOrNull((IRecord)array[i]!, out object? item))
                 {
                     return false;
                 }
@@ -402,8 +402,8 @@ internal static class BinaryFormattedObjectExtensions
             Hashtable temp = new(keys.Length);
             for (int i = 0; i < keys.Length; i++)
             {
-                if (!format.TryGetPrimitiveRecordValue((IRecord)keys[i], out object? key)
-                    || !format.TryGetPrimitiveRecordValueOrNull((IRecord)values[i], out object? value))
+                if (!format.TryGetPrimitiveRecordValue((IRecord)keys[i]!, out object? key)
+                    || !format.TryGetPrimitiveRecordValueOrNull((IRecord)values[i]!, out object? value))
                 {
                     return false;
                 }
@@ -473,7 +473,7 @@ internal static class BinaryFormattedObjectExtensions
                 return false;
             }
 
-            exception = new NotSupportedException(classInfo["Message"].ToString());
+            exception = new NotSupportedException(classInfo["Message"]!.ToString());
             return true;
         }
     }
@@ -507,7 +507,7 @@ internal static class BinaryFormattedObjectExtensions
     /// </summary>
     public static IEnumerable<string?> GetStringValues(this BinaryFormattedObject format, ArraySingleString array, int count)
         => array.ArrayObjects.Take(count).Select(record =>
-            format.Dereference((IRecord)record) switch
+            format.Dereference((IRecord)record!) switch
             {
                 BinaryObjectString stringRecord => stringRecord.Value,
                 _ => null

--- a/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/BinaryLibrary.cs
+++ b/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/BinaryLibrary.cs
@@ -13,7 +13,7 @@ namespace System.Windows.Forms.BinaryFormat;
 ///   </see>
 ///  </para>
 /// </remarks>
-internal sealed class BinaryLibrary : IRecord<BinaryLibrary>
+internal sealed class BinaryLibrary : IRecord<BinaryLibrary>, IBinaryFormatParseable<BinaryLibrary>
 {
     public Id LibraryId { get; }
     public string LibraryName { get; }
@@ -27,14 +27,13 @@ internal sealed class BinaryLibrary : IRecord<BinaryLibrary>
     public static RecordType RecordType => RecordType.BinaryLibrary;
 
     static BinaryLibrary IBinaryFormatParseable<BinaryLibrary>.Parse(
-        BinaryReader reader,
-        RecordMap recordMap)
+        BinaryFormattedObject.ParseState state)
     {
         BinaryLibrary record = new(
-            reader.ReadInt32(),
-            reader.ReadString());
+            state.Reader.ReadInt32(),
+            state.Reader.ReadString());
 
-        recordMap[record.LibraryId] = record;
+        state.RecordMap[record.LibraryId] = record;
         return record;
     }
 

--- a/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/BinaryObjectString.cs
+++ b/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/BinaryObjectString.cs
@@ -13,7 +13,7 @@ namespace System.Windows.Forms.BinaryFormat;
 ///   </see>
 ///  </para>
 /// </remarks>
-internal sealed class BinaryObjectString : IRecord<BinaryObjectString>
+internal sealed class BinaryObjectString : IRecord<BinaryObjectString>, IBinaryFormatParseable<BinaryObjectString>
 {
     public Id ObjectId { get; }
     public string Value { get; }
@@ -27,12 +27,11 @@ internal sealed class BinaryObjectString : IRecord<BinaryObjectString>
     }
 
     static BinaryObjectString IBinaryFormatParseable<BinaryObjectString>.Parse(
-        BinaryReader reader,
-        RecordMap recordMap)
+        BinaryFormattedObject.ParseState state)
     {
-        BinaryObjectString record = new(reader.ReadInt32(), reader.ReadString());
+        BinaryObjectString record = new(state.Reader.ReadInt32(), state.Reader.ReadString());
 
-        recordMap[record.ObjectId] = record;
+        state.RecordMap[record.ObjectId] = record;
         return record;
     }
 

--- a/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/ClassRecord.cs
+++ b/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/ClassRecord.cs
@@ -17,7 +17,8 @@ namespace System.Windows.Forms.BinaryFormat;
 internal abstract class ClassRecord : ObjectRecord
 {
     internal ClassInfo ClassInfo { get; }
-    public IReadOnlyList<object> MemberValues { get; }
+    public IReadOnlyList<object?> MemberValues { get; }
+    public MemberTypeInfo MemberTypeInfo { get; }
 
     public string Name => ClassInfo.Name;
     public override Id ObjectId => ClassInfo.ObjectId;
@@ -25,7 +26,7 @@ internal abstract class ClassRecord : ObjectRecord
 
     public IReadOnlyList<string> MemberNames => ClassInfo.MemberNames;
 
-    public object this[string memberName]
+    public object? this[string memberName]
     {
         get
         {
@@ -42,15 +43,10 @@ internal abstract class ClassRecord : ObjectRecord
         }
     }
 
-    private protected ClassRecord(ClassInfo classInfo, IReadOnlyList<object> memberValues)
+    private protected ClassRecord(ClassInfo classInfo, MemberTypeInfo memberTypeInfo, IReadOnlyList<object?> memberValues)
     {
         ClassInfo = classInfo;
         MemberValues = memberValues;
-    }
-
-    private protected static List<object> ReadDataFromClassInfo(BinaryReader reader, RecordMap recordMap, ClassInfo info)
-    {
-        // Not sure what gets us into this state yet.
-        return ReadRecords(reader, recordMap, info.MemberNames.Count);
+        MemberTypeInfo = memberTypeInfo;
     }
 }

--- a/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/ClassRecordExtensions.cs
+++ b/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/ClassRecordExtensions.cs
@@ -1,0 +1,78 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+namespace System.Windows.Forms.BinaryFormat;
+
+internal static class ClassRecordExtensions
+{
+    private static bool IsPrimitiveType(this SystemClassWithMembersAndTypes systemClass) =>
+        systemClass.IsPrimitiveTypeClassName() && systemClass.MemberTypeInfo[0].Type == BinaryType.Primitive;
+
+    private static bool IsPrimitiveTypeClassName(this SystemClassWithMembersAndTypes systemClass) => TypeInfo.GetPrimitiveType(systemClass.Name) switch
+    {
+        PrimitiveType.Boolean => true,
+        PrimitiveType.Byte => true,
+        PrimitiveType.Char => true,
+        PrimitiveType.Double => true,
+        PrimitiveType.Int32 => true,
+        PrimitiveType.Int64 => true,
+        PrimitiveType.SByte => true,
+        PrimitiveType.Single => true,
+        PrimitiveType.Int16 => true,
+        PrimitiveType.UInt16 => true,
+        PrimitiveType.UInt32 => true,
+        PrimitiveType.UInt64 => true,
+        _ => false,
+    };
+
+    internal static bool TryGetSystemPrimitive(this SystemClassWithMembersAndTypes systemClass, [NotNullWhen(true)] out object? value)
+    {
+        value = null;
+
+        if (systemClass.IsPrimitiveType())
+        {
+            value = systemClass.MemberValues[0];
+            Debug.Assert(value is not null);
+            return true;
+        }
+
+        if (systemClass.Name == typeof(TimeSpan).FullName)
+        {
+            value = new TimeSpan((long)systemClass.MemberValues[0]!);
+            return true;
+        }
+
+        switch (systemClass.Name)
+        {
+            case TypeInfo.TimeSpanType:
+                value = new TimeSpan((long)systemClass.MemberValues[0]!);
+                return true;
+            case TypeInfo.DateTimeType:
+                ulong ulongValue = (ulong)systemClass["dateData"]!;
+                value = Unsafe.As<ulong, DateTime>(ref ulongValue);
+                return true;
+            case TypeInfo.DecimalType:
+                ReadOnlySpan<int> bits =
+                [
+                    (int)systemClass["lo"]!,
+                    (int)systemClass["mid"]!,
+                    (int)systemClass["hi"]!,
+                    (int)systemClass["flags"]!
+                ];
+
+                value = new decimal(bits);
+                return true;
+            case TypeInfo.IntPtrType:
+                // Rehydrating still throws even though casting doesn't any more
+                value = checked((nint)(long)systemClass.MemberValues[0]!);
+                return true;
+            case TypeInfo.UIntPtrType:
+                value = checked((nuint)(ulong)systemClass.MemberValues[0]!);
+                return true;
+            default:
+                return false;
+        }
+    }
+}

--- a/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/ClassWithMembersAndTypes.cs
+++ b/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/ClassWithMembersAndTypes.cs
@@ -13,19 +13,20 @@ namespace System.Windows.Forms.BinaryFormat;
 ///   </see>
 ///  </para>
 /// </remarks>
-internal sealed class ClassWithMembersAndTypes : ClassRecord, IRecord<ClassWithMembersAndTypes>
+internal sealed class ClassWithMembersAndTypes :
+    ClassRecord,
+    IRecord<ClassWithMembersAndTypes>,
+    IBinaryFormatParseable<ClassWithMembersAndTypes>
 {
-    public MemberTypeInfo MemberTypeInfo { get; }
     public override Id LibraryId { get; }
 
     public ClassWithMembersAndTypes(
         ClassInfo classInfo,
         Id libraryId,
         MemberTypeInfo memberTypeInfo,
-        IReadOnlyList<object> memberValues)
-        : base(classInfo, memberValues)
+        IReadOnlyList<object?> memberValues)
+        : base(classInfo, memberTypeInfo, memberValues)
     {
-        MemberTypeInfo = memberTypeInfo;
         LibraryId = libraryId;
     }
 
@@ -41,20 +42,19 @@ internal sealed class ClassWithMembersAndTypes : ClassRecord, IRecord<ClassWithM
     public static RecordType RecordType => RecordType.ClassWithMembersAndTypes;
 
     static ClassWithMembersAndTypes IBinaryFormatParseable<ClassWithMembersAndTypes>.Parse(
-        BinaryReader reader,
-        RecordMap recordMap)
+        BinaryFormattedObject.ParseState state)
     {
-        ClassInfo classInfo = ClassInfo.Parse(reader, out Count memberCount);
-        MemberTypeInfo memberTypeInfo = MemberTypeInfo.Parse(reader, memberCount);
+        ClassInfo classInfo = ClassInfo.Parse(state.Reader, out Count memberCount);
+        MemberTypeInfo memberTypeInfo = MemberTypeInfo.Parse(state.Reader, memberCount);
 
         ClassWithMembersAndTypes record = new(
             classInfo,
-            reader.ReadInt32(),
+            state.Reader.ReadInt32(),
             memberTypeInfo,
-            ReadValuesFromMemberTypeInfo(reader, recordMap, memberTypeInfo));
+            ReadValuesFromMemberTypeInfo(state, memberTypeInfo));
 
         // Index this record by the id of the embedded ClassInfo's object id.
-        recordMap[record.ClassInfo.ObjectId] = record;
+        state.RecordMap[record.ClassInfo.ObjectId] = record;
         return record;
     }
 

--- a/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/IBinaryArray.cs
+++ b/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/IBinaryArray.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Windows.Forms.BinaryFormat;
+
+/// <summary>
+///  Binary array record.
+/// </summary>
+/// <inheritdoc cref="BinaryArray"/>
+internal interface IBinaryArray : IRecord
+{
+    /// <summary>
+    ///  Rank (dimensions) of the array.
+    /// </summary>
+    Count Rank { get; }
+
+    /// <summary>
+    ///  Type of the array.
+    /// </summary>
+    BinaryArrayType ArrayType { get; }
+
+    /// <summary>
+    ///  Lengths of the array (for each dimension).
+    /// </summary>
+    IReadOnlyList<int> Lengths { get; }
+
+    /// <summary>
+    ///  Array element type information.
+    /// </summary>
+    MemberTypeInfo TypeInfo { get; }
+}

--- a/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/IBinaryFormatParseable.cs
+++ b/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/IBinaryFormatParseable.cs
@@ -11,8 +11,5 @@ internal interface IBinaryFormatParseable<T> where T : IRecord
     /// <summary>
     ///  Creates the type utilizaing the given <see cref="BinaryReader"/>.
     /// </summary>
-    /// <param name="recordMap">
-    ///  Record map for looking up referenced records. If this record has an id it will be added to the map.
-    /// </param>
-    static abstract T Parse(BinaryReader reader, RecordMap recordMap);
+    static abstract T Parse(BinaryFormattedObject.ParseState state);
 }

--- a/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/IReadOnlyRecordMap.cs
+++ b/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/IReadOnlyRecordMap.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Windows.Forms.BinaryFormat;
+
+/// <summary>
+///  Map of records.
+/// </summary>
+internal interface IReadOnlyRecordMap
+{
+    IRecord this[Id id] { get; }
+}

--- a/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/IRecord.cs
+++ b/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/IRecord.cs
@@ -14,6 +14,6 @@ internal interface IRecord : IBinaryWriteable
 /// <summary>
 ///  Typed record interface.
 /// </summary>
-internal interface IRecord<T> : IRecord, IBinaryFormatParseable<T> where T : class, IRecord
+internal interface IRecord<T> : IRecord where T : class, IRecord
 {
 }

--- a/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/MemberPrimitiveTyped.cs
+++ b/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/MemberPrimitiveTyped.cs
@@ -13,7 +13,11 @@ namespace System.Windows.Forms.BinaryFormat;
 ///   </see>
 ///  </para>
 /// </remarks>
-internal sealed class MemberPrimitiveTyped : Record, IRecord<MemberPrimitiveTyped>, IPrimitiveTypeRecord
+internal sealed class MemberPrimitiveTyped :
+    Record,
+    IRecord<MemberPrimitiveTyped>,
+    IPrimitiveTypeRecord,
+    IBinaryFormatParseable<MemberPrimitiveTyped>
 {
     public PrimitiveType PrimitiveType { get; }
     public object Value { get; }
@@ -40,13 +44,12 @@ internal sealed class MemberPrimitiveTyped : Record, IRecord<MemberPrimitiveType
     public static RecordType RecordType => RecordType.MemberPrimitiveTyped;
 
     static MemberPrimitiveTyped IBinaryFormatParseable<MemberPrimitiveTyped>.Parse(
-        BinaryReader reader,
-        RecordMap recordMap)
+        BinaryFormattedObject.ParseState state)
     {
-        PrimitiveType primitiveType = (PrimitiveType)reader.ReadByte();
+        PrimitiveType primitiveType = (PrimitiveType)state.Reader.ReadByte();
         return new(
             primitiveType,
-            ReadPrimitiveType(reader, primitiveType));
+            ReadPrimitiveType(state.Reader, primitiveType));
     }
 
     public override void Write(BinaryWriter writer)

--- a/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/MemberReference.cs
+++ b/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/MemberReference.cs
@@ -13,7 +13,7 @@ namespace System.Windows.Forms.BinaryFormat;
 ///   </see>
 ///  </para>
 /// </remarks>
-internal sealed class MemberReference : IRecord<MemberReference>
+internal sealed class MemberReference : IRecord<MemberReference>, IBinaryFormatParseable<MemberReference>
 {
     public Id IdRef { get; }
 
@@ -22,8 +22,7 @@ internal sealed class MemberReference : IRecord<MemberReference>
     public static RecordType RecordType => RecordType.MemberReference;
 
     static MemberReference IBinaryFormatParseable<MemberReference>.Parse(
-        BinaryReader reader,
-        RecordMap recordMap) => new(reader.ReadInt32());
+        BinaryFormattedObject.ParseState state) => new(state.Reader.ReadInt32());
 
     public void Write(BinaryWriter writer)
     {

--- a/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/MessageEnd.cs
+++ b/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/MessageEnd.cs
@@ -6,7 +6,7 @@ namespace System.Windows.Forms.BinaryFormat;
 /// <summary>
 ///  Record that marks the end of the binary format stream.
 /// </summary>
-internal sealed class MessageEnd : IRecord<MessageEnd>
+internal sealed class MessageEnd : IRecord<MessageEnd>, IBinaryFormatParseable<MessageEnd>
 {
     public static MessageEnd Instance { get; } = new();
 
@@ -15,8 +15,7 @@ internal sealed class MessageEnd : IRecord<MessageEnd>
     public static RecordType RecordType => RecordType.MessageEnd;
 
     static MessageEnd IBinaryFormatParseable<MessageEnd>.Parse(
-        BinaryReader reader,
-        RecordMap recordMap) => Instance;
+        BinaryFormattedObject.ParseState state) => Instance;
 
     public void Write(BinaryWriter writer) => writer.Write((byte)RecordType);
 }

--- a/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/NullRecord.ObjectNullMultiple.cs
+++ b/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/NullRecord.ObjectNullMultiple.cs
@@ -15,16 +15,18 @@ internal abstract partial class NullRecord
     ///   </see>
     ///  </para>
     /// </remarks>
-    internal sealed class ObjectNullMultiple : NullRecord, IRecord<ObjectNullMultiple>
+    internal sealed class ObjectNullMultiple :
+        NullRecord,
+        IRecord<ObjectNullMultiple>,
+        IBinaryFormatParseable<ObjectNullMultiple>
     {
         public static RecordType RecordType => RecordType.ObjectNullMultiple;
 
         public ObjectNullMultiple(Count count) => NullCount = count;
 
         static ObjectNullMultiple IBinaryFormatParseable<ObjectNullMultiple>.Parse(
-            BinaryReader reader,
-            RecordMap recordMap)
-            => new(reader.ReadInt32());
+            BinaryFormattedObject.ParseState state)
+            => new(state.Reader.ReadInt32());
 
         public void Write(BinaryWriter writer)
         {

--- a/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/NullRecord.ObjectNullMultiple256.cs
+++ b/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/NullRecord.ObjectNullMultiple256.cs
@@ -15,15 +15,17 @@ internal abstract partial class NullRecord
     ///   </see>
     ///  </para>
     /// </remarks>
-    internal sealed class ObjectNullMultiple256 : NullRecord, IRecord<ObjectNullMultiple256>
+    internal sealed class ObjectNullMultiple256 :
+        NullRecord,
+        IRecord<ObjectNullMultiple256>,
+        IBinaryFormatParseable<ObjectNullMultiple256>
     {
         public static RecordType RecordType => RecordType.ObjectNullMultiple256;
 
         public ObjectNullMultiple256(Count count) => NullCount = count;
 
         static ObjectNullMultiple256 IBinaryFormatParseable<ObjectNullMultiple256>.Parse(
-            BinaryReader reader,
-            RecordMap recordMap) => new(reader.ReadByte());
+            BinaryFormattedObject.ParseState state) => new(state.Reader.ReadByte());
 
         public void Write(BinaryWriter writer)
         {

--- a/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/ObjectNull.cs
+++ b/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/ObjectNull.cs
@@ -13,19 +13,18 @@ namespace System.Windows.Forms.BinaryFormat;
 ///   </see>
 ///  </para>
 /// </remarks>
-internal sealed class ObjectNull : NullRecord, IRecord<ObjectNull>
+internal sealed class ObjectNull : NullRecord, IRecord<ObjectNull>, IBinaryFormatParseable<ObjectNull>
 {
     public static ObjectNull Instance { get; } = new();
 
     private ObjectNull() { }
 
-    public override Count NullCount => Count.One;
+    public override Count NullCount => 1;
 
     public static RecordType RecordType => RecordType.ObjectNull;
 
     static ObjectNull IBinaryFormatParseable<ObjectNull>.Parse(
-        BinaryReader reader,
-        RecordMap recordMap) => Instance;
+        BinaryFormattedObject.ParseState state) => Instance;
 
     public void Write(BinaryWriter writer) => writer.Write((byte)RecordType);
 

--- a/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/RecordMap.cs
+++ b/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/RecordMap.cs
@@ -6,7 +6,7 @@ namespace System.Windows.Forms.BinaryFormat;
 /// <summary>
 ///  Map of records that ensures that IDs are only entered once.
 /// </summary>
-internal class RecordMap
+internal class RecordMap : IReadOnlyRecordMap
 {
     private readonly Dictionary<int, IRecord> _records = [];
 

--- a/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/SerializationHeader.cs
+++ b/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/SerializationHeader.cs
@@ -13,7 +13,7 @@ namespace System.Windows.Forms.BinaryFormat;
 ///   </see>
 ///  </para>
 /// </remarks>
-internal sealed class SerializationHeader : IRecord<SerializationHeader>
+internal sealed class SerializationHeader : IRecord<SerializationHeader>, IBinaryFormatParseable<SerializationHeader>
 {
     /// <summary>
     ///  The id of the root object record.
@@ -45,13 +45,12 @@ internal sealed class SerializationHeader : IRecord<SerializationHeader>
     };
 
     static SerializationHeader IBinaryFormatParseable<SerializationHeader>.Parse(
-        BinaryReader reader,
-        RecordMap recordMap) => new()
+        BinaryFormattedObject.ParseState state) => new()
         {
-            RootId = reader.ReadInt32(),
-            HeaderId = reader.ReadInt32(),
-            MajorVersion = reader.ReadInt32(),
-            MinorVersion = reader.ReadInt32(),
+            RootId = state.Reader.ReadInt32(),
+            HeaderId = state.Reader.ReadInt32(),
+            MajorVersion = state.Reader.ReadInt32(),
+            MinorVersion = state.Reader.ReadInt32()
         };
 
     public void Write(BinaryWriter writer)

--- a/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/Support/SerializationExtensions.cs
+++ b/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/Support/SerializationExtensions.cs
@@ -1,7 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
+using System.Runtime.InteropServices;
 using System.Runtime.Serialization;
 
 namespace System.Windows.Forms.BinaryFormat;
@@ -23,4 +25,21 @@ internal static class SerializationExtensions
             : (SerializationException)ExceptionDispatchInfo.SetRemoteStackTrace(
                 new SerializationException(ex.Message, ex),
                 ex.StackTrace ?? string.Empty);
+
+    /// <summary>
+    ///  Gets a span over any array, including multi-dimensional arrays.
+    /// </summary>
+    public static Span<T> GetArrayData<T>(this Array array)
+    {
+        if (array.GetType().UnderlyingSystemType.IsAssignableFrom(typeof(T)))
+        {
+            throw new InvalidCastException($"Cannot cast array of type {array.GetType().UnderlyingSystemType} to {typeof(T)}.");
+        }
+
+        Span<T> data = MemoryMarshal.CreateSpan(ref Unsafe.As<byte, T>(
+            ref MemoryMarshal.GetArrayDataReference(array)),
+            checked((int)array.LongLength));
+
+        return data;
+    }
 }

--- a/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/SystemClassWithMembers.cs
+++ b/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/SystemClassWithMembers.cs
@@ -13,30 +13,32 @@ namespace System.Windows.Forms.BinaryFormat;
 ///   </see>
 ///  </para>
 /// </remarks>
-internal sealed class SystemClassWithMembers : ClassRecord, IRecord<SystemClassWithMembers>
+internal sealed class SystemClassWithMembers : ClassRecord, IRecord<SystemClassWithMembers>, IBinaryFormatParseable<SystemClassWithMembers>
 {
-    public SystemClassWithMembers(ClassInfo classInfo, IReadOnlyList<object> memberValues)
-        : base(classInfo, memberValues) { }
+    private SystemClassWithMembers(ClassInfo classInfo, MemberTypeInfo memberTypeInfo, IReadOnlyList<object?> memberValues)
+        : base(classInfo, memberTypeInfo, memberValues) { }
 
     public static RecordType RecordType => RecordType.SystemClassWithMembers;
 
     static SystemClassWithMembers IBinaryFormatParseable<SystemClassWithMembers>.Parse(
-        BinaryReader reader,
-        RecordMap recordMap)
+        BinaryFormattedObject.ParseState state)
     {
-        ClassInfo classInfo = ClassInfo.Parse(reader, out _);
+        ClassInfo classInfo = ClassInfo.Parse(state.Reader, out _);
+        MemberTypeInfo memberTypeInfo = MemberTypeInfo.CreateFromClassInfoAndLibrary(state, classInfo, Id.Null);
         SystemClassWithMembers record = new(
             classInfo,
-            ReadDataFromClassInfo(reader, recordMap, classInfo));
+            memberTypeInfo,
+            ReadValuesFromMemberTypeInfo(state, memberTypeInfo));
 
         // Index this record by the id of the embedded ClassInfo's object id.
-        recordMap[record.ClassInfo.ObjectId] = record;
+        state.RecordMap[record.ClassInfo.ObjectId] = record;
         return record;
     }
 
     public override void Write(BinaryWriter writer)
     {
-        writer.Write((byte)RecordType);
-        ClassInfo.Write(writer);
+        // Really shouldn't be writing this record type. It isn't as safe as the typed variant
+        // and saves very little space.
+        throw new NotSupportedException();
     }
 }

--- a/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/SystemClassWithMembersAndTypes.cs
+++ b/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/SystemClassWithMembersAndTypes.cs
@@ -13,43 +13,42 @@ namespace System.Windows.Forms.BinaryFormat;
 ///   </see>
 ///  </para>
 /// </remarks>
-internal sealed class SystemClassWithMembersAndTypes : ClassRecord, IRecord<SystemClassWithMembersAndTypes>
+internal sealed class SystemClassWithMembersAndTypes :
+    ClassRecord,
+    IRecord<SystemClassWithMembersAndTypes>,
+    IBinaryFormatParseable<SystemClassWithMembersAndTypes>
 {
-    public MemberTypeInfo MemberTypeInfo { get; }
-
     public SystemClassWithMembersAndTypes(
         ClassInfo classInfo,
         MemberTypeInfo memberTypeInfo,
-        IReadOnlyList<object> memberValues)
-        : base(classInfo, memberValues)
+        IReadOnlyList<object?> memberValues)
+        : base(classInfo, memberTypeInfo, memberValues)
     {
-        MemberTypeInfo = memberTypeInfo;
     }
 
     public SystemClassWithMembersAndTypes(
         ClassInfo classInfo,
         MemberTypeInfo memberTypeInfo,
-        params object[] memberValues)
-        : this(classInfo, memberTypeInfo, (IReadOnlyList<object>)memberValues)
+        params object?[] memberValues)
+        : this(classInfo, memberTypeInfo, (IReadOnlyList<object?>)memberValues)
     {
     }
 
     public static RecordType RecordType => RecordType.SystemClassWithMembersAndTypes;
 
     static SystemClassWithMembersAndTypes IBinaryFormatParseable<SystemClassWithMembersAndTypes>.Parse(
-        BinaryReader reader,
-        RecordMap recordMap)
+        BinaryFormattedObject.ParseState state)
     {
-        ClassInfo classInfo = ClassInfo.Parse(reader, out Count memberCount);
-        MemberTypeInfo memberTypeInfo = MemberTypeInfo.Parse(reader, memberCount);
+        ClassInfo classInfo = ClassInfo.Parse(state.Reader, out Count memberCount);
+        MemberTypeInfo memberTypeInfo = MemberTypeInfo.Parse(state.Reader, memberCount);
 
         SystemClassWithMembersAndTypes record = new(
             classInfo,
             memberTypeInfo,
-            ReadValuesFromMemberTypeInfo(reader, recordMap, memberTypeInfo));
+            ReadValuesFromMemberTypeInfo(state, memberTypeInfo));
 
         // Index this record by the id of the embedded ClassInfo's object id.
-        recordMap[record.ClassInfo.ObjectId] = record;
+        state.RecordMap[record.ClassInfo.ObjectId] = record;
         return record;
     }
 

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/System/Windows/Forms/BinaryFormat/BinaryFormatTestExtensions.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/System/Windows/Forms/BinaryFormat/BinaryFormatTestExtensions.cs
@@ -12,7 +12,11 @@ internal static class BinaryFormatTestExtensions
     /// <summary>
     ///  Serializes the object using the <see cref="BinaryFormatter"/> and reads it into a <see cref="BinaryFormattedObject"/>.
     /// </summary>
-    public static BinaryFormattedObject SerializeAndParse(this object source) => new(source.Serialize());
+    public static BinaryFormattedObject SerializeAndParse(this object source)
+    {
+        using Stream stream = source.Serialize();
+        return new(stream);
+    }
 
     /// <summary>
     ///  Serializes the object using the <see cref="BinaryFormatter"/>.

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/BinaryFormattedObjectTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/BinaryFormattedObjectTests.cs
@@ -115,14 +115,14 @@ public class BinaryFormattedObjectTests
         ArraySingleObject array = (ArraySingleObject)format[2];
         array.ArrayInfo.ObjectId.Should().Be(2);
         array.ArrayInfo.Length.Should().Be(1);
-        BinaryObjectString value = (BinaryObjectString)array.ArrayObjects[0];
+        BinaryObjectString value = (BinaryObjectString)array.ArrayObjects[0]!;
         value.ObjectId.Should().Be(4);
         value.Value.Should().Be("This");
 
         array = (ArraySingleObject)format[3];
         array.ArrayInfo.ObjectId.Should().Be(3);
         array.ArrayInfo.Length.Should().Be(1);
-        value = (BinaryObjectString)array.ArrayObjects[0];
+        value = (BinaryObjectString)array.ArrayObjects[0]!;
         value.ObjectId.Should().Be(5);
         value.Value.Should().Be("That");
     }
@@ -169,7 +169,7 @@ public class BinaryFormattedObjectTests
             new MemberReference(3)
         });
 
-        ArrayRecord<object> array = (ArrayRecord<object>)format[(MemberReference)systemClass.MemberValues[5]];
+        ArrayRecord<object> array = (ArrayRecord<object>)format[(MemberReference)systemClass.MemberValues[5]!];
 
         array.ArrayInfo.ObjectId.Should().Be(2);
         array.ArrayInfo.Length.Should().Be(3);
@@ -177,7 +177,7 @@ public class BinaryFormattedObjectTests
         value.ObjectId.Should().Be(4);
         value.Value.Should().BeOneOf("Yowza", "Youza", "Meeza");
 
-        array = (ArrayRecord<object>)format[(MemberReference)systemClass["Values"]];
+        array = (ArrayRecord<object>)format[(MemberReference)systemClass["Values"]!];
         array.ArrayInfo.ObjectId.Should().Be(3);
         array.ArrayInfo.Length.Should().Be(3);
         array.ArrayObjects[0].Should().BeOfType<ObjectNull>();
@@ -309,7 +309,7 @@ public class BinaryFormattedObjectTests
         ArraySingleString array = (ArraySingleString)format[1];
         array.ArrayInfo.ObjectId.Should().Be(1);
         array.ArrayInfo.Length.Should().Be(3);
-        BinaryObjectString value = (BinaryObjectString)array.ArrayObjects[0];
+        BinaryObjectString value = (BinaryObjectString)array.ArrayObjects[0]!;
     }
 
     [Fact]
@@ -328,7 +328,7 @@ public class BinaryFormattedObjectTests
             ObjectNull.Instance,
             ObjectNull.Instance
         });
-        BinaryObjectString value = (BinaryObjectString)array.ArrayObjects[0];
+        BinaryObjectString value = (BinaryObjectString)array.ArrayObjects[0]!;
     }
 
     [Fact]
@@ -338,8 +338,8 @@ public class BinaryFormattedObjectTests
         ArraySingleString array = (ArraySingleString)format[1];
         array.ArrayInfo.ObjectId.Should().Be(1);
         array.ArrayInfo.Length.Should().Be(3);
-        BinaryObjectString value = (BinaryObjectString)array.ArrayObjects[0];
-        MemberReference reference = (MemberReference)array.ArrayObjects[2];
+        BinaryObjectString value = (BinaryObjectString)array.ArrayObjects[0]!;
+        MemberReference reference = (MemberReference)array.ArrayObjects[2]!;
         reference.IdRef.Should().Be(value.ObjectId);
     }
 

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/ListTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/BinaryFormat/ListTests.cs
@@ -38,7 +38,7 @@ public class ListTests
         systemClass.MemberTypeInfo[0].Should().Be((BinaryType.ObjectArray, null));
 
         ArraySingleObject array = (ArraySingleObject)format[2];
-        MemberPrimitiveTyped primitve = (MemberPrimitiveTyped)array[0];
+        MemberPrimitiveTyped primitve = (MemberPrimitiveTyped)array[0]!;
         primitve.Value.Should().Be(value);
     }
 
@@ -57,7 +57,7 @@ public class ListTests
         systemClass.MemberTypeInfo[0].Should().Be((BinaryType.ObjectArray, null));
 
         ArraySingleObject array = (ArraySingleObject)format[2];
-        BinaryObjectString binaryString = (BinaryObjectString)array[0];
+        BinaryObjectString binaryString = (BinaryObjectString)array[0]!;
         binaryString.Value.Should().Be("JarJar");
     }
 

--- a/src/System.Windows.Forms/src/System/Resources/ResXDataNode.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResXDataNode.cs
@@ -427,7 +427,7 @@ public sealed class ResXDataNode : ISerializable
 
         try
         {
-            BinaryFormattedObject format = new(stream, leaveOpen: true);
+            BinaryFormattedObject format = new(stream);
             if (format.TryGetObject(out object? value))
             {
                 return value;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ActiveX/AxHost.PropertyBagStream.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ActiveX/AxHost.PropertyBagStream.cs
@@ -23,7 +23,7 @@ public abstract unsafe partial class AxHost
             long position = stream.Position;
             try
             {
-                BinaryFormattedObject format = new(stream, leaveOpen: true);
+                BinaryFormattedObject format = new(stream);
                 if (format.TryGetPrimitiveHashtable(out _bag!))
                 {
                     return;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ActiveX/Control.ActiveXImpl.PropertyBagStream.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ActiveX/Control.ActiveXImpl.PropertyBagStream.cs
@@ -22,7 +22,7 @@ public partial class Control
 
             internal void Read(IStream* istream)
             {
-                Stream stream = new DataStreamFromComStream(istream);
+                using DataStreamFromComStream stream = new(istream);
                 bool success = false;
 
                 try

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ActiveX/Control.ActiveXImpl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ActiveX/Control.ActiveXImpl.cs
@@ -1124,7 +1124,7 @@ public partial class Control
                     object? deserialized = null;
                     try
                     {
-                        BinaryFormattedObject format = new(stream, leaveOpen: true);
+                        BinaryFormattedObject format = new(stream);
                         success = format.TryGetObject(out deserialized);
                     }
                     catch (Exception ex) when (!ex.IsCriticalException())

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.ComposedDataObject.NativeDataObjectToWinFormsAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.ComposedDataObject.NativeDataObjectToWinFormsAdapter.cs
@@ -183,7 +183,7 @@ public unsafe partial class DataObject
                         long startPosition = stream.Position;
                         try
                         {
-                            if (new BinaryFormattedObject(stream, leaveOpen: true).TryGetObject(out object? value))
+                            if (new BinaryFormattedObject(stream).TryGetObject(out object? value))
                             {
                                 return value;
                             }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/ComboBox.ComboBoxItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/ComboBox.ComboBoxItemAccessibleObjectTests.cs
@@ -278,7 +278,7 @@ public class ComboBox_ComboBoxItemAccessibleObjectTests
             {
                 int itemsCount = 41;
 
-                for (int index = 0; index < itemsCount; index++)
+                for (int index = 0; index < itemsCount; index += 10)
                 {
                     yield return new object[] { comboBoxStyle, scrollingDown, index, itemsCount };
                 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/ToolStripMenuItem.ToolStripMenuItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/ToolStripMenuItem.ToolStripMenuItemAccessibleObjectTests.cs
@@ -36,7 +36,7 @@ public class ToolStripMenuItem_ToolStripMenuItemAccessibleObjectTests
     }
 
     [ActiveIssue("https://github.com/dotnet/winforms/issues/10244")]
-    [WinFormsFact]
+    [WinFormsFact(Skip = "https://github.com/dotnet/winforms/issues/10244")]
     [SkipOnArchitecture(TestArchitectures.X86 | TestArchitectures.X64,
         "InvokePattern.Invoke blocks on a menu item")]
     public void ToolStripMenuItemAccessibleObject_InvokePattern_Invoke_WithPopUpDialog()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/BinaryFormat/WinFormsBinaryFormattedObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/BinaryFormat/WinFormsBinaryFormattedObjectTests.cs
@@ -37,7 +37,7 @@ public class WinFormsBinaryFormattedObjectTests
         WinFormsBinaryFormatWriter.WriteBitmap(stream, bitmap);
 
         stream.Position = 0;
-        BinaryFormattedObject binary = new(stream, leaveOpen: true);
+        BinaryFormattedObject binary = new(stream);
 
         binary.TryGetBitmap(out object? result).Should().BeTrue();
         using Bitmap deserialized = result.Should().BeOfType<Bitmap>().Which;
@@ -99,7 +99,7 @@ public class WinFormsBinaryFormattedObjectTests
         using MemoryStream memoryStream = new();
         WinFormsBinaryFormatWriter.WriteImageListStreamer(memoryStream, stream);
         memoryStream.Position = 0;
-        BinaryFormattedObject binary = new(memoryStream, leaveOpen: true);
+        BinaryFormattedObject binary = new(memoryStream);
 
         binary.TryGetImageListStreamer(out object? result).Should().BeTrue();
         using ImageListStreamer deserialized = result.Should().BeOfType<ImageListStreamer>().Which;


### PR DESCRIPTION
This change updated BinaryFormattedObject to:

1. Support the ClassWithMembers and SystemClassWithMembers records correctly
2. Change to object? instead of object with ObjectNull records
3. Optimize reading all primitive array types
4. Always leave the incoming stream open
5. Support multidimensional and jagged arrays
6. Move some properties higher for simpler handling

Also made two small tweaks to tests. Added Skip= to one that hangs to keep it from running in Test Explorer. Also reduced the matrix for one exceptionally long running test.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11256)