### PR TITLE
Fix WindowsFormsApplicationBase.IsSingleInstance

### DIFF
--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBase.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBase.vb
@@ -1006,28 +1006,26 @@ Namespace Microsoft.VisualBasic.ApplicationServices
 
         ''' <summary>
         ''' Generates the name for the remote singleton that we use to channel multiple instances
-        ''' to the same application model thread.
+        ''' to the same application model thread for the current user.
         ''' </summary>
         ''' <returns>A string unique to the application that should be the same for versions of
         '''  the application that have the same Major and Minor Version Number
         ''' </returns>
         ''' <remarks>If GUID Attribute does not exist fall back to unique ModuleVersionId</remarks>
         Private Shared Function GetApplicationInstanceID(ByVal Entry As Assembly) As String
+            Dim guidAttribute As GuidAttribute = Entry.GetCustomAttribute(Of GuidAttribute)()
+            Dim currentUserSID As String = Principal.WindowsIdentity.GetCurrent().User.Value
 
-            Dim guidAttrib As GuidAttribute = Entry.GetCustomAttribute(Of GuidAttribute)()
-
-            If guidAttrib IsNot Nothing Then
-
+            If guidAttribute IsNot Nothing Then
                 Dim version As Version = Entry.GetName.Version
-
                 If version IsNot Nothing Then
-                    Return $"{guidAttrib.Value}{version.Major}.{version.Minor}"
+                    Return $"{guidAttribute.Value}{version.Major}.{version.Minor}-{currentUserSID}"
                 Else
-                    Return guidAttrib.Value
+                    Return $"{guidAttribute.Value}-{currentUserSID}"
                 End If
             End If
 
-            Return Entry.ManifestModule.ModuleVersionId.ToString()
+            Return $"{Entry.ManifestModule.ModuleVersionId}-{currentUserSID}"
         End Function
     End Class
 End Namespace


### PR DESCRIPTION
Add currentUserSID to `GetApplicationInstanceID` for use in `TryCreatePipeServer` to avoid system wide blocking. Used in conjunction with `PipeOptions.CurrentUserOnly`.

Fixes #3715