### PR TITLE
fix issue 11243 TreeNodeCollection.AddRange has been broken in .NET 8 and no longer results in TreeNodes being drawn at the correct location

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeNode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeNode.cs
@@ -810,14 +810,7 @@ public partial class TreeNode : MarshalByRefObject, ICloneable, ISerializable
                 return null;
             }
 
-            // fixedIndex is used for perf. optimization in case of adding big ranges of nodes
             int currentInd = _index;
-            int fixedInd = _parent.Nodes.FixedIndex;
-
-            if (fixedInd > 0)
-            {
-                currentInd = fixedInd;
-            }
 
             if (currentInd > 0 && currentInd <= _parent.Nodes.Count)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeNodeCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeNodeCollection.cs
@@ -216,7 +216,7 @@ public class TreeNodeCollection : IList
 
         for (int i = 0; i < nodes.Length; i++)
         {
-            AddInternal(nodes[i], 0);
+            AddInternal(nodes[i]);
         }
 
         if (tv is not null && nodes.Length > TreeNode.MAX_TREENODES_OPS)
@@ -279,9 +279,9 @@ public class TreeNodeCollection : IList
     /// <summary>
     ///  Adds a new child node to this node.  Child node is positioned after siblings.
     /// </summary>
-    public virtual int Add(TreeNode node) => AddInternal(node, 0);
+    public virtual int Add(TreeNode node) => AddInternal(node);
 
-    private int AddInternal(TreeNode node, int delta)
+    private int AddInternal(TreeNode node)
     {
         ArgumentNullException.ThrowIfNull(node);
 


### PR DESCRIPTION
Fixes #11243 

<!-- 
## Proposed changes

- 
- 
- 


## Customer Impact

- 
- 

## Regression? 

- Yes / No

## Risk

-

 -->

## Screenshots 

### Before
![image](https://github.com/dotnet/winforms/assets/47542151/c7285c5e-b422-4627-8d5d-620a49d5cb81)

### After
![image](https://github.com/dotnet/winforms/assets/135201996/f7e85eaf-c072-441d-ba68-6d3deaf33f49)


## Test methodology 

- 
-  manually 
- 
<!-- 
## Accessibility testing 
 -->

## Test environment(s) 
9.0.0-preview.4.24219.3
