### PR TITLE
Add test coverage for TreeView

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/TreeView.TreeViewAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/TreeView.TreeViewAccessibleObjectTests.cs
@@ -265,4 +265,23 @@ public class TreeViewAccessibleObjectTests
         Assert.Equal(node.AccessibilityObject, control.AccessibilityObject.HitTest(point.X, point.Y));
         Assert.True(control.IsHandleCreated);
     }
+
+    [WinFormsTheory]
+    [InlineData(new string[] { "Node 1", "Node 2", "Node 3" }, 3, false)] 
+    [InlineData(new string[] { }, 0, false)]
+    [InlineData(new string[] { "Node 1", "Node 2", "Node 3" }, 3, true)]
+    [InlineData(new string[] { }, 0, true)]
+    public void TreeViewAccessibleObject_GetChildCount_ReturnsExpected(string[] nodeNames, int expected, bool isHandleCreated)
+    {
+        using TreeView control = new();
+        control.Nodes.AddRange(nodeNames.Select(name => new TreeNode(name)).ToArray());
+
+        if (isHandleCreated)
+        {
+            control.CreateControl();
+        }
+
+        control.AccessibilityObject.GetChildCount().Should().Be(expected);
+        control.IsHandleCreated.Should().Be(isHandleCreated);
+    }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNodeCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNodeCollectionTests.cs
@@ -223,4 +223,185 @@ public class TreeNodeCollectionTests
         Assert.Throws<ArgumentNullException>("key", () => collection.Find(key, searchAllChildren: true));
         Assert.Throws<ArgumentNullException>("key", () => collection.Find(key, searchAllChildren: false));
     }
+
+    private TreeNodeCollection CreateCollectionWithNodes()
+    {
+        using TreeView treeView = new();
+
+        TreeNode child1 = new() { Name = "name1" };
+        TreeNode child2 = new() { Name = "name2" };
+        TreeNodeCollection collection = treeView.Nodes;
+        collection.Add(child1);
+        collection.Add(child2);
+
+        return collection;
+    }
+
+    public static TheoryData<string, string> KeyAndExpectedNodeNameData => new()
+    {
+        { "name1", "name1" },
+        { "NAME1", "name1" },
+        { "NoSuchName", null },
+        { null, null },
+        { string.Empty, null }
+    };
+
+    [WinFormsTheory]
+    [MemberData(nameof(KeyAndExpectedNodeNameData))]
+    public void TreeNodeCollection_Item_GetKey_ReturnsExpected(string key, string expectedNodeName)
+    {
+        TreeNodeCollection collection = CreateCollectionWithNodes();
+        collection[key]?.Name.Should().Be(expectedNodeName);
+    }
+
+    [WinFormsFact]
+    public void TreeNodeCollection_IsReadOnly_ReturnsExpected()
+    {
+        using TreeView treeView = new();
+
+        TreeNodeCollection collection = treeView.Nodes;
+        collection.IsReadOnly.Should().BeFalse();
+    }
+
+    [WinFormsTheory]
+    [InlineData("key1", "text1", 1)]
+    public void TreeNodeCollection_Add_KeyTextImageIndex_Success(string key, string text, int imageIndex)
+    {
+        using TreeView treeView = new();
+
+        TreeNodeCollection collection = treeView.Nodes;
+        TreeNode treeNode = collection.Add(key, text, imageIndex);
+
+        treeNode.Should().Be(collection[0]);
+        treeNode.Name.Should().Be(key);
+        treeNode.Text.Should().Be(text);
+        treeNode.ImageIndex.Should().Be(imageIndex);
+    }
+
+    [WinFormsTheory]
+    [InlineData("key1", "text1", "imageKey1")]
+    public void TreeNodeCollection_Add_KeyTextImageKey_Success(string key, string text, string imageKey)
+    {
+        using TreeView treeView = new();
+
+        TreeNodeCollection collection = treeView.Nodes;
+        TreeNode treeNode = collection.Add(key, text, imageKey);
+
+        treeNode.Should().Be(collection[0]);
+        treeNode.Name.Should().Be(key);
+        treeNode.Text.Should().Be(text);
+        treeNode.ImageKey.Should().Be(imageKey);
+    }
+
+    [WinFormsTheory]
+    [InlineData("key1", "text1", 1, 2)]
+    public void TreeNodeCollection_Add_KeyTextImageIndexSelectedImageIndex_Success(string key, string text, int imageIndex, int selectedImageIndex)
+    {
+        using TreeView treeView = new();
+
+        TreeNodeCollection collection = treeView.Nodes;
+        TreeNode treeNode = collection.Add(key, text, imageIndex, selectedImageIndex);
+
+        treeNode.Should().Be(collection[0]);
+        treeNode.Name.Should().Be(key);
+        treeNode.Text.Should().Be(text);
+        treeNode.ImageIndex.Should().Be(imageIndex);
+        treeNode.SelectedImageIndex.Should().Be(selectedImageIndex);
+    }
+
+    [WinFormsTheory]
+    [InlineData("key1", "text1", "imageKey1", "selectedImageKey1")]
+    public void TreeNodeCollection_Add_KeyTextImageKeySelectedImageKey_Success(string key, string text, string imageKey, string selectedImageKey)
+    {
+        using TreeView treeView = new();
+
+        TreeNodeCollection collection = treeView.Nodes;
+        TreeNode treeNode = collection.Add(key, text, imageKey, selectedImageKey);
+
+        treeNode.Should().Be(collection[0]);
+        treeNode.Name.Should().Be(key);
+        treeNode.Text.Should().Be(text);
+        treeNode.ImageKey.Should().Be(imageKey);
+        treeNode.SelectedImageKey.Should().Be(selectedImageKey);
+    }
+
+    [WinFormsTheory]
+    [InlineData("Node 0")]
+    public void TreeNodeCollection_Insert_String_Success(string text)
+    {
+        using TreeView treeView = new();
+
+        TreeNodeCollection collection = treeView.Nodes;
+        TreeNode treeNode = collection.Insert(0, text);
+
+        treeNode.Should().Be(collection[0]);
+        treeNode.Text.Should().Be(text);
+    }
+
+    [WinFormsTheory]
+    [InlineData("key", "Node 0")]
+    public void TreeNodeCollection_Insert_StringKey_Success(string key, string text)
+    {
+        using TreeView treeView = new();
+
+        TreeNodeCollection collection = treeView.Nodes;
+        TreeNode treeNode = collection.Insert(0, key, text);
+
+        treeNode.Text.Should().Be(text);
+        treeNode.Name.Should().Be(key);
+    }
+
+    [WinFormsTheory]
+    [InlineData("key", "Node 0", 0)]
+    public void TreeNodeCollection_Insert_StringKeyImageIndex_Success(string key, string text, int imageIndex)
+    {
+        using TreeView treeView = new();
+
+        TreeNodeCollection collection = treeView.Nodes;
+        TreeNode treeNode = collection.Insert(0, key, text, imageIndex);
+
+        treeNode.Should().Be(collection[0]);
+        treeNode.ImageIndex.Should().Be(imageIndex);
+    }
+
+    [WinFormsTheory]
+    [InlineData("key", "Node 0", "imageKey")]
+    public void TreeNodeCollection_Insert_StringKeyImageKey_Success(string key, string text, string imageKey)
+    {
+        using TreeView treeView = new();
+
+        TreeNodeCollection collection = treeView.Nodes;
+        TreeNode treeNode = collection.Insert(0, key, text, imageKey);
+
+        treeNode.Should().Be(collection[0]);
+        treeNode.ImageKey.Should().Be(imageKey);
+    }
+
+    [WinFormsTheory]
+    [InlineData("key", "Node 0", 0, 1)]
+    public void TreeNodeCollection_Insert_StringKeyImageIndexSelectedImageIndex_Success(string key, string text, int imageIndex, int selectedImageIndex)
+    {
+        using TreeView treeView = new();
+
+        TreeNodeCollection collection = treeView.Nodes;
+        TreeNode treeNode = collection.Insert(0, key, text, imageIndex, selectedImageIndex);
+
+        treeNode.Should().Be(collection[0]);
+        treeNode.ImageIndex.Should().Be(imageIndex);
+        treeNode.SelectedImageIndex.Should().Be(selectedImageIndex);
+    }
+
+    [WinFormsTheory]
+    [InlineData("key", "Node 0", "imageKey", "selectedImageKey")]
+    public void TreeNodeCollection_Insert_StringKeyImageKeySelectedImageKey_Success(string key, string text, string imageKey, string selectedImageKey)
+    {
+        using TreeView treeView = new();
+
+        TreeNodeCollection collection = treeView.Nodes;
+        TreeNode treeNode = collection.Insert(0, key, text, imageKey, selectedImageKey);
+
+        treeNode.Should().Be(collection[0]);
+        treeNode.ImageKey.Should().Be(imageKey);
+        treeNode.SelectedImageKey.Should().Be(selectedImageKey);
+    }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNodeCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNodeCollectionTests.cs
@@ -264,13 +264,24 @@ public class TreeNodeCollectionTests
     }
 
     [WinFormsTheory]
-    [InlineData("key1", "text1", 1)]
-    public void TreeNodeCollection_Add_KeyTextImageIndex_Success(string key, string text, int imageIndex)
+    [InlineData("key1", "text1", 1, null)]
+    [InlineData("key1", "text1", 1, 2)]
+    public void TreeNodeCollection_Add_KeyTextImageIndexSelectedImageIndex_Success(string key, string text, int imageIndex, int? selectedImageIndex)
     {
         using TreeView treeView = new();
 
         TreeNodeCollection collection = treeView.Nodes;
-        TreeNode treeNode = collection.Add(key, text, imageIndex);
+        TreeNode treeNode;
+
+        if (selectedImageIndex.HasValue)
+        {
+            treeNode = collection.Add(key, text, imageIndex, selectedImageIndex.Value);
+            treeNode.SelectedImageIndex.Should().Be(selectedImageIndex.Value);
+        }
+        else
+        {
+            treeNode = collection.Add(key, text, imageIndex);
+        }
 
         treeNode.Should().Be(collection[0]);
         treeNode.Name.Should().Be(key);
@@ -294,22 +305,6 @@ public class TreeNodeCollectionTests
     }
 
     [WinFormsTheory]
-    [InlineData("key1", "text1", 1, 2)]
-    public void TreeNodeCollection_Add_KeyTextImageIndexSelectedImageIndex_Success(string key, string text, int imageIndex, int selectedImageIndex)
-    {
-        using TreeView treeView = new();
-
-        TreeNodeCollection collection = treeView.Nodes;
-        TreeNode treeNode = collection.Add(key, text, imageIndex, selectedImageIndex);
-
-        treeNode.Should().Be(collection[0]);
-        treeNode.Name.Should().Be(key);
-        treeNode.Text.Should().Be(text);
-        treeNode.ImageIndex.Should().Be(imageIndex);
-        treeNode.SelectedImageIndex.Should().Be(selectedImageIndex);
-    }
-
-    [WinFormsTheory]
     [InlineData("key1", "text1", "imageKey1", "selectedImageKey1")]
     public void TreeNodeCollection_Add_KeyTextImageKeySelectedImageKey_Success(string key, string text, string imageKey, string selectedImageKey)
     {
@@ -326,82 +321,70 @@ public class TreeNodeCollectionTests
     }
 
     [WinFormsTheory]
-    [InlineData("Node 0")]
-    public void TreeNodeCollection_Insert_String_Success(string text)
+    [InlineData("Node 0", null, null, null)]
+    [InlineData("Node 0", "key", null, null)]
+    [InlineData("Node 0", "key", "imageKey", null)]
+    [InlineData("Node 0", "key", "imageKey", "selectedImageKey")]
+    public void TreeNodeCollection_Insert_StringKeyImageKeySelectedImageKey_Success(string text, string key, string imageKey, string selectedImageKey)
     {
         using TreeView treeView = new();
 
         TreeNodeCollection collection = treeView.Nodes;
-        TreeNode treeNode = collection.Insert(0, text);
+        TreeNode treeNode;
+
+        if (key is not null)
+        {
+            if (imageKey is not null)
+            {
+                if (selectedImageKey is not null)
+                {
+                    treeNode = collection.Insert(0, key, text, imageKey, selectedImageKey);
+                    treeNode.SelectedImageKey.Should().Be(selectedImageKey);
+                }
+                else
+                {
+                    treeNode = collection.Insert(0, key, text, imageKey);
+                }
+
+                treeNode.ImageKey.Should().Be(imageKey);
+            }
+            else
+            {
+                treeNode = collection.Insert(0, key, text);
+            }
+
+            treeNode.Name.Should().Be(key);
+        }
+        else
+        {
+            treeNode = collection.Insert(0, text);
+        }
 
         treeNode.Should().Be(collection[0]);
         treeNode.Text.Should().Be(text);
     }
 
     [WinFormsTheory]
-    [InlineData("key", "Node 0")]
-    public void TreeNodeCollection_Insert_StringKey_Success(string key, string text)
-    {
-        using TreeView treeView = new();
-
-        TreeNodeCollection collection = treeView.Nodes;
-        TreeNode treeNode = collection.Insert(0, key, text);
-
-        treeNode.Text.Should().Be(text);
-        treeNode.Name.Should().Be(key);
-    }
-
-    [WinFormsTheory]
-    [InlineData("key", "Node 0", 0)]
-    public void TreeNodeCollection_Insert_StringKeyImageIndex_Success(string key, string text, int imageIndex)
-    {
-        using TreeView treeView = new();
-
-        TreeNodeCollection collection = treeView.Nodes;
-        TreeNode treeNode = collection.Insert(0, key, text, imageIndex);
-
-        treeNode.Should().Be(collection[0]);
-        treeNode.ImageIndex.Should().Be(imageIndex);
-    }
-
-    [WinFormsTheory]
-    [InlineData("key", "Node 0", "imageKey")]
-    public void TreeNodeCollection_Insert_StringKeyImageKey_Success(string key, string text, string imageKey)
-    {
-        using TreeView treeView = new();
-
-        TreeNodeCollection collection = treeView.Nodes;
-        TreeNode treeNode = collection.Insert(0, key, text, imageKey);
-
-        treeNode.Should().Be(collection[0]);
-        treeNode.ImageKey.Should().Be(imageKey);
-    }
-
-    [WinFormsTheory]
+    [InlineData("key", "Node 0", 0, null)]
     [InlineData("key", "Node 0", 0, 1)]
-    public void TreeNodeCollection_Insert_StringKeyImageIndexSelectedImageIndex_Success(string key, string text, int imageIndex, int selectedImageIndex)
+    public void TreeNodeCollection_Insert_StringKeyImageIndexSelectedImageIndex_Success(string key, string text, int imageIndex, int? selectedImageIndex)
     {
         using TreeView treeView = new();
 
         TreeNodeCollection collection = treeView.Nodes;
-        TreeNode treeNode = collection.Insert(0, key, text, imageIndex, selectedImageIndex);
+        TreeNode treeNode;
+
+        if (selectedImageIndex.HasValue)
+        {
+            treeNode = collection.Insert(0, key, text, imageIndex, selectedImageIndex.Value);
+            treeNode.SelectedImageIndex.Should().Be(selectedImageIndex.Value);
+        }
+        else
+        {
+            treeNode = collection.Insert(0, key, text, imageIndex);
+        }
 
         treeNode.Should().Be(collection[0]);
         treeNode.ImageIndex.Should().Be(imageIndex);
-        treeNode.SelectedImageIndex.Should().Be(selectedImageIndex);
-    }
-
-    [WinFormsTheory]
-    [InlineData("key", "Node 0", "imageKey", "selectedImageKey")]
-    public void TreeNodeCollection_Insert_StringKeyImageKeySelectedImageKey_Success(string key, string text, string imageKey, string selectedImageKey)
-    {
-        using TreeView treeView = new();
-
-        TreeNodeCollection collection = treeView.Nodes;
-        TreeNode treeNode = collection.Insert(0, key, text, imageKey, selectedImageKey);
-
-        treeNode.Should().Be(collection[0]);
-        treeNode.ImageKey.Should().Be(imageKey);
-        treeNode.SelectedImageKey.Should().Be(selectedImageKey);
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNodeConverterTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNodeConverterTests.cs
@@ -1,0 +1,54 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel.Design.Serialization;
+using System.Collections;
+
+namespace System.Windows.Forms.Tests;
+
+public class TreeNodeConverterTests
+{
+    [WinFormsTheory]
+    [InlineData(typeof(InstanceDescriptor), true)]
+    [InlineData(typeof(string), true)]
+    [InlineData(typeof(int), false)]
+    public void TreeNodeConverter_CanConvertTo_Invoke_ReturnsExpected(Type destinationType, bool expected)
+    {
+        TreeNodeConverter converter = new();
+        converter.CanConvertTo(null, destinationType).Should().Be(expected);
+    }
+
+    [WinFormsTheory]
+    [InlineData(typeof(InstanceDescriptor), true)]
+    [InlineData(typeof(string), true)]
+    [InlineData(typeof(int), false)]
+    public void TreeNodeConverter_ConvertTo_Invoke_ReturnsExpected(Type destinationType, bool canConvert)
+    {
+        TreeNodeConverter converter = new();
+        TreeNode node = new("Test");
+
+        if (canConvert)
+        {
+            object result = converter.ConvertTo(null, null, node, destinationType);
+            if (destinationType == typeof(InstanceDescriptor))
+            {
+                result.Should().BeOfType<InstanceDescriptor>();
+                var descriptor = (InstanceDescriptor)result;
+                IList arguments = descriptor.Arguments as IList;
+                arguments.Should().NotBeNull();
+                arguments[0].Should().Be(node.Text);
+            }
+            else if (destinationType == typeof(string))
+            {
+                result.Should().BeOfType<string>();
+                string text = (string)result;
+                text.Should().Be("TreeNode: " + node.Text);
+            }
+        }
+        else
+        {
+            converter.Invoking(c => c.ConvertTo(null, null, node, destinationType))
+                .Should().Throw<NotSupportedException>();
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNodeTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNodeTests.cs
@@ -4632,6 +4632,233 @@ public class TreeNodeTests
         Assert.False((bool)KeyboardToolTipStateMachine.Instance.TestAccessor().Dynamic.IsToolTracked(treeSubNode));
     }
 
+    [WinFormsTheory]
+    [InlineData(10, 10)]
+    [InlineData(-10, -10)]
+    [InlineData(0, 0)]
+    public void TreeNodeAccessibleObject_HitTest_ReturnsExpected(int x, int y)
+    {
+        using TreeView treeView = new();
+        TreeNode treeNode = new("Node 1");
+        treeView.Nodes.Add(treeNode);
+
+        TreeNode.TreeNodeAccessibleObject accessibleObject = new(treeNode, treeView);
+        AccessibleObject hitTestResult = accessibleObject.HitTest(x, y);
+
+        if (x < 0 || y < 0)
+        {
+            hitTestResult.Should().BeNull();
+        }
+        else
+        {
+            hitTestResult.Should().Be(treeView.AccessibilityObject.HitTest(x, y));
+        }
+    }
+
+    [WinFormsTheory]
+    [InlineData(null)]
+    [InlineData(typeof(ContextMenuStrip))]
+    public void TreeNode_ContextMenuStrip_Set_GetReturnsExpected(object value)
+    {
+        TreeNode treeNode = new()
+        {
+            ContextMenuStrip = value as ContextMenuStrip
+        };
+
+        treeNode.ContextMenuStrip.Should().Be(value as ContextMenuStrip);
+    }
+
+    [WinFormsTheory]
+    [InlineData("Node1", "Node2")]
+    public void TreeNode_FromHandle_Invoke_ReturnsExpected(string nodeName1, string nodeName2)
+    {
+        using TreeView treeView = new();
+
+        TreeNode node1 = new(nodeName1);
+        TreeNode node2 = new(nodeName2);
+        treeView.Nodes.Add(node1);
+        treeView.CreateControl();
+
+        TreeNode result1 = TreeNode.FromHandle(treeView, node1.Handle);
+        result1.Should().Be(node1);
+
+        TreeNode result2 = TreeNode.FromHandle(treeView, node2.Handle);
+        result2.Should().BeNull();
+    }
+
+    [WinFormsTheory]
+    [BoolData]
+    public void TreeNode_RowBounds_Get_ReturnsExpected(bool isNodeRemoved)
+    {
+        using TreeView treeView = new();
+        TreeNode treeNode = new();
+        treeView.Nodes.Add(treeNode);
+
+        if (isNodeRemoved)
+        {
+            treeNode.Remove();
+        }
+
+        if (isNodeRemoved)
+        {
+            treeNode.RowBounds.Should().Be(Rectangle.Empty);
+        }
+        else
+        {
+            treeNode.RowBounds.Should().NotBe(Rectangle.Empty);
+        }
+    }
+
+    [WinFormsTheory]
+    [InlineData("Node1", "ChildNode1", "ChildNode2", true)]
+    [InlineData("Node2", "ChildNode3", "ChildNode4", false)]
+    public void TreeNode_Clone_ReturnsExpected(string nodeName, string childNode1, string childNode2, bool isChecked)
+    {
+        TreeNode treeNode = new()
+        {
+            Text = nodeName,
+            Checked = isChecked
+        };
+
+        treeNode.Nodes.Add(new TreeNode(childNode1));
+        treeNode.Nodes.Add(new TreeNode(childNode2));
+        TreeNode clonedNode = (TreeNode)treeNode.Clone();
+
+        clonedNode.Text.Should().Be(treeNode.Text);
+        clonedNode.Checked.Should().Be(treeNode.Checked);
+        clonedNode.Nodes.Count.Should().Be(treeNode.Nodes.Count);
+        clonedNode.Nodes[0].Text.Should().Be(treeNode.Nodes[0].Text);
+        clonedNode.Nodes[1].Text.Should().Be(treeNode.Nodes[1].Text);
+    }
+
+    [WinFormsTheory]
+    [BoolData]
+    public void TreeNode_Collapse_ReturnsExpected(bool initiallyExpanded)
+    {
+        TreeNode treeNode = new();
+        treeNode.Nodes.Add(new TreeNode("childNode1"));
+        treeNode.Nodes.Add(new TreeNode("childNode2"));
+
+        if (initiallyExpanded)
+        {
+            treeNode.ExpandAll();
+            treeNode.IsExpanded.Should().BeTrue();
+        }
+
+        treeNode.Collapse();
+        treeNode.IsExpanded.Should().BeFalse();
+    }
+
+    [WinFormsTheory]
+    [BoolData]
+    public void TreeNode_EnsureVisible_InvokeWithTreeView_CallsExpected(bool initiallyVisible)
+    {
+        using TreeView treeView = new();
+        TreeNode treeNode = new();
+        treeView.Nodes.Add(treeNode);
+
+        if (initiallyVisible)
+        {
+            treeNode.EnsureVisible();
+            treeNode.IsVisible.Should().BeTrue();
+        }
+
+        treeNode.EnsureVisible();
+        treeNode.IsVisible.Should().BeTrue();
+    }
+
+    [WinFormsFact]
+    public void TreeNode_EnsureVisible_InvokeWithoutTreeView_NoAction()
+    {
+        TreeNode treeNode = new();
+
+        treeNode.Invoking(tn => tn.EnsureVisible()).Should().NotThrow();
+    }
+
+    [WinFormsFact]
+    public void TreeNode_EnsureVisible_InvokeWithDisposedTreeView_NoAction()
+    {
+        using TreeView treeView = new();
+        TreeNode treeNode = new();
+        treeView.Nodes.Add(treeNode);
+        treeView.Dispose();
+
+        treeNode.Invoking(tn => tn.EnsureVisible()).Should().NotThrow();
+    }
+
+    private TreeNode CreateTreeNodeStructure(int depth, int breadth, bool initiallyExpanded)
+    {
+        TreeNode node = new();
+        if (depth > 0)
+        {
+            for (int i = 0; i < breadth; i++)
+            {
+                node.Nodes.Add(CreateTreeNodeStructure(depth - 1, breadth, initiallyExpanded));
+            }
+        }
+
+        if (initiallyExpanded)
+        {
+            node.Expand();
+        }
+
+        return node;
+    }
+
+    private void CheckExpandedState(TreeNode node, bool expectedState)
+    {
+        node.IsExpanded.Should().Be(expectedState);
+        foreach (TreeNode child in node.Nodes)
+        {
+            CheckExpandedState(child, expectedState);
+        }
+    }
+
+    [WinFormsTheory]
+    [InlineData(0, false)]
+    [InlineData(1, false)]
+    [InlineData(1, true)]
+    public void TreeNode_ExpandAll_Invoke_Success(int depth, bool initiallyExpanded)
+    {
+        var node = CreateTreeNodeStructure(depth, 2, initiallyExpanded);
+        CheckExpandedState(node, initiallyExpanded);
+        node.ExpandAll();
+
+        CheckExpandedState(node, true);
+    }
+
+    [WinFormsTheory]
+    [InlineData(0, false, 0)]
+    [InlineData(2, true, 4)]
+    public void TreeNode_GetNodeCount_ReturnsExpected(int childrenCount, bool includeSubTrees, int expectedCount)
+    {
+        TreeNode node = new();
+        for (int i = 0; i < childrenCount; i++)
+        {
+            TreeNode child = new();
+            child.Nodes.Add(new TreeNode());
+            node.Nodes.Add(child);
+        }
+
+        int result = node.GetNodeCount(includeSubTrees);
+        result.Should().Be(expectedCount);
+    }
+
+    [WinFormsFact]
+    public void TreeNode_Toggle_WhenNodeIsExpanded_CollapsesNode()
+    {
+        using TreeView treeView = new();
+
+        TreeNode node = new();
+        treeView.Nodes.Add(node);
+
+        node.Toggle();
+        node.IsExpanded.Should().BeTrue();
+
+        node.Toggle();
+        node.IsExpanded.Should().BeFalse();
+    }
+
     private class InvalidSetItemTreeView : TreeView
     {
         public bool MakeInvalid { get; set; }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNodeTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNodeTests.cs
@@ -4733,24 +4733,6 @@ public class TreeNodeTests
 
     [WinFormsTheory]
     [BoolData]
-    public void TreeNode_Collapse_ReturnsExpected(bool initiallyExpanded)
-    {
-        TreeNode treeNode = new();
-        treeNode.Nodes.Add(new TreeNode("childNode1"));
-        treeNode.Nodes.Add(new TreeNode("childNode2"));
-
-        if (initiallyExpanded)
-        {
-            treeNode.ExpandAll();
-            treeNode.IsExpanded.Should().BeTrue();
-        }
-
-        treeNode.Collapse();
-        treeNode.IsExpanded.Should().BeFalse();
-    }
-
-    [WinFormsTheory]
-    [BoolData]
     public void TreeNode_EnsureVisible_InvokeWithTreeView_CallsExpected(bool initiallyVisible)
     {
         using TreeView treeView = new();
@@ -4815,16 +4797,27 @@ public class TreeNodeTests
     }
 
     [WinFormsTheory]
-    [InlineData(0, false)]
-    [InlineData(1, false)]
-    [InlineData(1, true)]
-    public void TreeNode_ExpandAll_Invoke_Success(int depth, bool initiallyExpanded)
+    [InlineData(0, false, true)]
+    [InlineData(1, false, false)]
+    [InlineData(1, true, false)]
+    public void TreeNode_ExpandCollapse_Invoke_Success(int depth, bool initiallyExpanded, bool collapse)
     {
         var node = CreateTreeNodeStructure(depth, 2, initiallyExpanded);
         CheckExpandedState(node, initiallyExpanded);
-        node.ExpandAll();
 
-        CheckExpandedState(node, true);
+        if (collapse)
+        {
+            node.ExpandAll();
+            CheckExpandedState(node, true);
+
+            node.Collapse();
+            CheckExpandedState(node, false);
+        }
+        else
+        {
+            node.ExpandAll();
+            CheckExpandedState(node, true);
+        }
     }
 
     [WinFormsTheory]


### PR DESCRIPTION
related https://github.com/dotnet/winforms/issues/10453


## Proposed changes
- Add unit tests for TreeView to test its properties: Name, IsReadOnly, ContextMenuStrip, RowBounds, IsVisible, IsExpanded, EnsureVisible
- Add unit tests for TreeView to test its methods: GetChildCount, Add, Insert, CanConvertTo, ConvertTo, HitTest, FromHandle, ExpandAll, Clone, Collapse, GetNodeCount, Toggle

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact
- None

## Regression? 
- No

## Risk
- Minimal

## Test methodology <!-- How did you ensure quality? -->
- Unit tests

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11293)