### PR TITLE
Utilize TypeName Parser API in ResXSerializationBinder

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Resources/ResXSerializationBinderTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Resources/ResXSerializationBinderTests.cs
@@ -1,0 +1,118 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System.ComponentModel.Design;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Reflection.Metadata;
+
+namespace System.Resources.Tests;
+
+public  class ResXSerializationBinderTests
+{
+    [Fact]
+    public void ResXSerializationBinder_BindToType_FullyQualifiedName()
+    {
+        CustomTypeResolutionService typeResolutionService = new();
+        ResXSerializationBinder binder = new(typeResolutionService);
+        binder.BindToType(typeof(Button).Assembly.FullName!, typeof(Button).FullName!).Should().Be(typeof(Button));
+        typeResolutionService.FullyQualifiedAssemblyNamePath.Should().BeTrue();
+        typeResolutionService.FullyQualifiedAssemblyNameNoVersionPath.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ResXSerializationBinder_BindToType_FullName()
+    {
+        CustomTypeResolutionService typeResolutionService = new();
+        ResXSerializationBinder binder = new(typeResolutionService);
+        string assemblyName = typeof(MyClass).Assembly.FullName!;
+        binder.BindToType(assemblyName, typeof(MyClass).FullName!).Should().Be(typeof(MyClass));
+        typeResolutionService.FullNamePath.Should().BeTrue();
+        typeResolutionService.FullyQualifiedAssemblyNameNoVersionPath.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ResXSerializationBinder_BindToType_FullyQualifiedNameNoVersion()
+    {
+        CustomTypeResolutionService typeResolutionService = new();
+        ResXSerializationBinder binder = new(typeResolutionService);
+        string assemblyName = typeof(Form).Assembly.FullName!;
+        binder.BindToType(assemblyName, typeof(Form).FullName!).Should().Be(typeof(Form));
+        typeResolutionService.FullyQualifiedAssemblyNameNoVersionPath.Should().BeTrue();
+        typeResolutionService.FullNamePath.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ResXSerializationBinder_BindToName_TypeNameConverter_NoNameChange()
+    {
+        ResXSerializationBinder binder = new(type => type?.AssemblyQualifiedName ?? string.Empty);
+        binder.BindToName(typeof(Button), out string? assemblyName, out string? typeName);
+        assemblyName.Should().Be(typeof(Button).Assembly.FullName);
+        typeName.Should().BeNull();
+    }
+
+    [Fact]
+    public void ResXSerializationBinder_BindToName_TypeNameConverter_NameChange()
+    {
+        string testAssemblyName = "TestAssembly";
+        string testTypeName = "TestType";
+        ResXSerializationBinder binder = new(type => $"{testTypeName}, {testAssemblyName}");
+        binder.BindToName(typeof(Button), out string? assemblyName, out string? typeName);
+        assemblyName.Should().Be(testAssemblyName);
+        typeName.Should().Be(typeName);
+    }
+
+    private class CustomTypeResolutionService : ITypeResolutionService
+    {
+        public bool FullNamePath { get; private set; }
+        public bool FullyQualifiedAssemblyNamePath { get; private set; }
+        public bool FullyQualifiedAssemblyNameNoVersionPath { get; private set; }
+        private readonly string _formNoVersionFullyQualifiedName;
+
+        public CustomTypeResolutionService()
+        {
+            TypeName parsed = TypeName.Parse($"{typeof(Form).FullName}, {typeof(Form).Assembly.FullName}");
+            AssemblyNameInfo? assemblyNameInfo = parsed.AssemblyName;
+            _formNoVersionFullyQualifiedName = $"{typeof(Form).FullName}, {new AssemblyNameInfo(
+                assemblyNameInfo!.Name,
+                version: null,
+                assemblyNameInfo.CultureName,
+                assemblyNameInfo.Flags,
+                assemblyNameInfo.PublicKeyOrToken).FullName}";
+        }
+
+        public Assembly? GetAssembly(AssemblyName name) => throw new NotImplementedException();
+        public Assembly? GetAssembly(AssemblyName name, bool throwOnError) => throw new NotImplementedException();
+        public string? GetPathOfAssembly(AssemblyName name) => throw new NotImplementedException();
+        public Type? GetType(string typeName)
+        {
+            if (typeName == $"{typeof(Button).FullName}, {typeof(Button).Assembly.FullName}")
+            {
+                FullyQualifiedAssemblyNamePath = true;
+                return typeof(Button);
+            }
+            else if (typeName == typeof(MyClass).FullName)
+            {
+                FullNamePath = true;
+                return typeof(MyClass);
+            }
+            else if (typeName == _formNoVersionFullyQualifiedName)
+            {
+                FullyQualifiedAssemblyNameNoVersionPath = true;
+                return typeof(Form);
+            }
+
+            return null;
+        }
+
+        [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+        public Type? GetType([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] string name, bool throwOnError) => throw new NotImplementedException();
+        [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+        public Type? GetType([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] string name, bool throwOnError, bool ignoreCase) => throw new NotImplementedException();
+        public void ReferenceAssembly(AssemblyName name) => throw new NotImplementedException();
+    }
+
+    private class MyClass { }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/System/Resources/ResXSerializationBinderTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Resources/ResXSerializationBinderTests.cs
@@ -27,8 +27,7 @@ public  class ResXSerializationBinderTests
     {
         CustomTypeResolutionService typeResolutionService = new();
         ResXSerializationBinder binder = new(typeResolutionService);
-        string assemblyName = typeof(MyClass).Assembly.FullName!;
-        binder.BindToType(assemblyName, typeof(MyClass).FullName!).Should().Be(typeof(MyClass));
+        binder.BindToType(typeof(MyClass).Assembly.FullName!, typeof(MyClass).FullName!).Should().Be(typeof(MyClass));
         typeResolutionService.FullNamePath.Should().BeTrue();
         typeResolutionService.FullyQualifiedAssemblyNameNoVersionPath.Should().BeFalse();
     }
@@ -38,8 +37,7 @@ public  class ResXSerializationBinderTests
     {
         CustomTypeResolutionService typeResolutionService = new();
         ResXSerializationBinder binder = new(typeResolutionService);
-        string assemblyName = typeof(Form).Assembly.FullName!;
-        binder.BindToType(assemblyName, typeof(Form).FullName!).Should().Be(typeof(Form));
+        binder.BindToType(typeof(Form).Assembly.FullName!, typeof(Form).FullName!).Should().Be(typeof(Form));
         typeResolutionService.FullyQualifiedAssemblyNameNoVersionPath.Should().BeTrue();
         typeResolutionService.FullNamePath.Should().BeFalse();
     }


### PR DESCRIPTION
- Utilize new [TypeName parser API](https://github.com/dotnet/runtime/pull/100094) in `ResXSerializationBinder` where we had been manually picking apart the type name to redirect to/from .NET Framework type names
- Add tests for ResXSerializationBinder to ensure behavior before/after is the same
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11312)