### PR TITLE
Expanded IObjectReference support

### DIFF
--- a/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/Deserializer/ArrayRecordDeserialzer.cs
+++ b/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/Deserializer/ArrayRecordDeserialzer.cs
@@ -66,7 +66,7 @@ internal sealed class ArrayRecordDeserialzer : ObjectRecordDeserializer
     {
         while (_index < _arrayRecord.Length)
         {
-            (object? memberValue, Id reference) = GetMemberValue(_arrayRecord.ArrayObjects[_index]);
+            (object? memberValue, Id reference) = UnwrapMemberValue(_arrayRecord.ArrayObjects[_index]);
 
             if (s_missingValueSentinel == memberValue)
             {
@@ -74,9 +74,7 @@ internal sealed class ArrayRecordDeserialzer : ObjectRecordDeserializer
                 return reference;
             }
 
-            if (!reference.IsNull
-                && Deserializer.IncompleteObjects.Contains(reference)
-                && memberValue!.GetType().IsValueType)
+            if (memberValue is not null && DoesValueNeedUpdated(memberValue, reference))
             {
                 // Need to track a fixup for this index.
                 _hasFixups = true;

--- a/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/Deserializer/ClassRecordFieldInfoDeserializer.cs
+++ b/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/Deserializer/ClassRecordFieldInfoDeserializer.cs
@@ -67,7 +67,7 @@ internal sealed class ClassRecordFieldInfoDeserializer : ClassRecordDeserializer
                 throw new SerializationException($"Could not find field '{field.Name}' data for type '{field.DeclaringType!.Name}'.");
             }
 
-            (object? memberValue, Id reference) = GetMemberValue(rawValue);
+            (object? memberValue, Id reference) = UnwrapMemberValue(rawValue);
             if (s_missingValueSentinel == memberValue)
             {
                 // Record has not been encountered yet, need to pend iteration.
@@ -76,7 +76,7 @@ internal sealed class ClassRecordFieldInfoDeserializer : ClassRecordDeserializer
 
             field.SetValue(Object, memberValue);
 
-            if (!reference.IsNull && field.FieldType.IsValueType && Deserializer.IncompleteObjects.Contains(reference))
+            if (memberValue is not null && DoesValueNeedUpdated(memberValue, reference))
             {
                 // Need to track a fixup for this field.
                 _hasFixups = true;

--- a/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/Deserializer/ClassRecordSerializationInfoDeserializer.cs
+++ b/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/Deserializer/ClassRecordSerializationInfoDeserializer.cs
@@ -21,7 +21,6 @@ internal sealed class ClassRecordSerializationInfoDeserializer : ClassRecordDese
     private readonly SerializationInfo _serializationInfo;
     private readonly ISerializationSurrogate? _surrogate;
     private int _currentMemberIndex;
-    private bool _hasAnyReferences;
 
     internal ClassRecordSerializationInfoDeserializer(
         ClassRecord classRecord,
@@ -41,7 +40,7 @@ internal sealed class ClassRecordSerializationInfoDeserializer : ClassRecordDese
         while (_currentMemberIndex < _classRecord.MemberNames.Count)
         {
             string memberName = _classRecord.MemberNames[_currentMemberIndex];
-            (object? memberValue, Id reference) = GetMemberValue(_classRecord.MemberValues[_currentMemberIndex]);
+            (object? memberValue, Id reference) = UnwrapMemberValue(_classRecord.MemberValues[_currentMemberIndex]);
 
             if (s_missingValueSentinel == memberValue)
             {
@@ -49,24 +48,13 @@ internal sealed class ClassRecordSerializationInfoDeserializer : ClassRecordDese
                 return reference;
             }
 
-            // We know that primitive types are not going to have any fields that possibly have
-            // incomplete indirect references so we can do a simple optimization here.
-
-            if (!reference.IsNull
-                && memberValue!.GetType() is { } memberType
-                && !(memberType.IsPrimitive || memberType.IsEnum))
+            if (memberValue is not null && DoesValueNeedUpdated(memberValue, reference))
             {
-                _hasAnyReferences = true;
-
-                if (memberType.IsValueType && Deserializer.IncompleteObjects.Contains(reference))
-                {
-                    // All missing value types we assign will need to be reassigned to get the final value.
-                    Deserializer.PendValueUpdater(new SerializationInfoValueUpdater(
-                        _classRecord.ObjectId,
-                        reference,
-                        _serializationInfo,
-                        memberName));
-                }
+                Deserializer.PendValueUpdater(new SerializationInfoValueUpdater(
+                    _classRecord.ObjectId,
+                    reference,
+                    _serializationInfo,
+                    memberName));
             }
 
             _serializationInfo.AddValue(memberName, memberValue);
@@ -85,16 +73,7 @@ internal sealed class ClassRecordSerializationInfoDeserializer : ClassRecordDese
         // if there were no pending value types (which should also not happen if there are no cycles).
 
         PendingSerializationInfo pending = new(_classRecord.ObjectId, _serializationInfo, _surrogate);
-
-        if (_hasAnyReferences)
-        {
-            Deserializer.PendSerializationInfo(pending);
-        }
-        else
-        {
-            pending.Populate(Deserializer.DeserializedObjects, Deserializer.Options.StreamingContext);
-            Deserializer.CompleteObject(_classRecord.ObjectId);
-        }
+        Deserializer.PendSerializationInfo(pending);
 
         // No more missing member refs.
         return Id.Null;

--- a/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/Deserializer/Deserializer.cs
+++ b/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/Deserializer/Deserializer.cs
@@ -13,31 +13,37 @@ namespace System.Windows.Forms.BinaryFormat.Deserializer;
 /// </summary>
 /// <remarks>
 ///  <para>
-///   This has some constraints over the BinaryFormatter. Notably it does not support
-///   <see cref="IObjectReference"/>, which greatly simplifies the deserialization. It
-///   also does not allow offset arrays (arrays that have lower bounds other than zero).
+///   This has some constraints over the BinaryFormatter. Notably it does not support all <see cref="IObjectReference"/>
+///   usages or surrogates that replace object instances. This greatly simplifies the deserialization. It also does not
+///   allow offset arrays (arrays that have lower bounds other than zero) or multidimensional arrays that have more
+///   than <see cref="int.MaxValue"/> elements.
 ///  </para>
 ///  <para>
-///   This deserializer guarantees that all value types are observable in their final
-///   state. Object references (including within value types), may not be in their final
-///   state until the end of deserialization due to graph cycles. The instance will be
-///   the final instance, but it may directly or indirectly contain uncompleted value
-///   types. In general it is risky to dereference reference types in <see cref="ISerializable"/>
-///   constructors or in <see cref="ISerializationSurrogate"/> call backs.
+///   This deserializer ensures that all value types are assigned to fields or populated in <see cref="SerializationInfo"/>
+///   callbacks with their final state, throwing if that is impossible to attain due to graph cycles or data corruption.
+///   The value type instance may contain references to uncompleted reference types when there are cycles in the graph.
+///   In general it is risky to dereference reference types in <see cref="ISerializable"/> constructors or in
+///   <see cref="ISerializationSurrogate"/> call backs if there is any risk of the objects enabling a cycle.
 ///  </para>
 ///  <para>
-///   If you need to dereference reference types in <see cref="SerializationInfo"/> waiting
-///   for final state by implementing <see cref="IDeserializationCallback"/> or
-///   <see cref="OnDeserializedAttribute"/> is the safe way to do so. Surrogates are more
-///   complicated (<see cref="ISerializationSurrogate"/>). With surrogates you need to track
-///   the instances that need fixup and handle them after invoking the deserializer.
+///   If you need to dereference reference types in <see cref="SerializationInfo"/> waiting for final state by
+///   implementing <see cref="IDeserializationCallback"/> or <see cref="OnDeserializedAttribute"/> is the safer way to
+///   do so. This deserializer does not fire completed events until the entire graph has been deserialized. If a
+///   surrogate (<see cref="ISerializationSurrogate"/>) needs to dereference with potential cycles it would require
+///   tracking instances by stashing them in a provided <see cref="StreamingContext"/> to handle after invoking the
+///   deserializer.
 ///  </para>
 /// </remarks>
 /// <devdoc>
-///  <see cref="IObjectReference"/> makes deserializing difficult as you don't know the final
-///  type until you've finished populating the serialized type. If <see cref="SerializationInfo"/>
-///  is involved and you have a cycle you may never be able to complete the deserialization as
-///  the reference type values in the <see cref="SerializationInfo"/> can't get the final object.
+///  <see cref="IObjectReference"/> makes deserializing difficult as you don't know the final type until you've finished
+///  populating the serialized type. If <see cref="SerializationInfo"/> is involved and you have a cycle you may never
+///  be able to complete the deserialization as the reference type values in the <see cref="SerializationInfo"/> can't
+///  get the final object.
+///
+///  <see cref="IObjectReference"/> is really the only practical way to represent singletons. A common pattern is to
+///  nest an <see cref="IObjectReference"/> object in an <see cref="ISerializable"/> object. Specifying the nested
+///  type when <see cref="ISerializable.GetObjectData(SerializationInfo, StreamingContext)"/> is called by invoking
+///  <see cref="SerializationInfo.SetType(Type)"/> will get that type info serialized into the stream.
 /// </devdoc>
 internal sealed partial class Deserializer : IDeserializer
 {
@@ -56,10 +62,16 @@ internal sealed partial class Deserializer : IDeserializer
     // Surrogate cache.
     private readonly Dictionary<Type, ISerializationSurrogate?>? _surrogates;
 
-    // Queue of SerializationInfo objects that need to be applied.
-    // These are in depth first order, if there are no cycles in the graph this
-    // ensures that all objects are available when the SerializationInfo is applied.
+    // Queue of SerializationInfo objects that need to be applied. These are in depth first order,
+    // if there are no cycles in the graph this ensures that all objects are available when the
+    // SerializationInfo is applied.
+    //
+    // We also keep a hashset for quickly checking to make sure we do not complete objects before we
+    // actually apply the SerializationInfo. While we could mark them in the incomplete dependencies
+    // dictionary, to do so we'd need to know if any referenced object is going to get to this state
+    // even if it hasn't finished parsing, which isn't easy to do with cycles involved.
     private Queue<PendingSerializationInfo>? _pendingSerializationInfo;
+    private HashSet<int>? _pendingSerializationInfoIds;
 
     // Keeping a separate stack for ids for fast infinite loop checks.
     private readonly Stack<int> _parseStack = [];
@@ -80,6 +92,7 @@ internal sealed partial class Deserializer : IDeserializer
 
     private readonly Id _rootId;
 
+    // We group individual object events here to fire them all when we complete the graph.
     private event Action<object?>? OnDeserialization;
     private event Action<StreamingContext>? OnDeserialized;
 
@@ -119,8 +132,6 @@ internal sealed partial class Deserializer : IDeserializer
     {
         DeserializeRoot(_rootId);
 
-        object root = _deserializedObjects[_rootId];
-
         // Complete all pending SerializationInfo objects.
         int pendingCount = _pendingSerializationInfo?.Count ?? 0;
         while (_pendingSerializationInfo is not null && _pendingSerializationInfo.TryDequeue(out PendingSerializationInfo? pending))
@@ -145,12 +156,13 @@ internal sealed partial class Deserializer : IDeserializer
 
             // All _pendingSerializationInfo objects are considered incomplete.
             pending.Populate(_deserializedObjects, Options.StreamingContext);
+            _pendingSerializationInfoIds?.Remove(pending.ObjectId);
             ((IDeserializer)this).CompleteObject(pending.ObjectId);
         }
 
         if (_incompleteObjects.Count > 0 || (_pendingUpdates is not null && _pendingUpdates.Count > 0))
         {
-            // This should never happen.
+            // This should never happen outside of corrupted data.
             throw new SerializationException("Objects could not be deserialized completely.");
         }
 
@@ -159,7 +171,7 @@ internal sealed partial class Deserializer : IDeserializer
         OnDeserialization?.Invoke(null);
         OnDeserialized?.Invoke(Options.StreamingContext);
 
-        return root;
+        return _deserializedObjects[_rootId];
     }
 
     [RequiresUnreferencedCode("Calls DeserializeNew(Id)")]
@@ -276,6 +288,8 @@ internal sealed partial class Deserializer : IDeserializer
     {
         _pendingSerializationInfo ??= new();
         _pendingSerializationInfo.Enqueue(pending);
+        _pendingSerializationInfoIds ??= [];
+        _pendingSerializationInfoIds.Add(pending.ObjectId);
     }
 
     void IDeserializer.PendValueUpdater(ValueUpdater updater)
@@ -326,6 +340,11 @@ internal sealed partial class Deserializer : IDeserializer
                 {
                     OnDeserialization += callback.OnDeserialization;
                 }
+
+                if (@object is IObjectReference objectReference)
+                {
+                    _deserializedObjects[completedId] = objectReference.GetRealObject(Options.StreamingContext);
+                }
             }
 
             if (_incompleteDependencies is null)
@@ -335,11 +354,19 @@ internal sealed partial class Deserializer : IDeserializer
 
             Debug.Assert(_pendingUpdates is not null);
 
-            // When we've recursed, we've done so because there are no more dependencies for the current
-            // id, so we can remove it from the dictionary. We have to pend as we're iterating the dictionary.
+            // When we've recursed, we've done so because there are no more dependencies for the current id, so we can
+            // remove it from the dictionary. We have to pend as we can't remove while we're iterating the dictionary.
             if (!completed.IsNull)
             {
                 _incompleteDependencies.Remove(completed);
+
+                if (_pendingSerializationInfoIds is not null && _pendingSerializationInfoIds.Contains(completed))
+                {
+                    // We came back for an object that has no remaining direct dependencies, but still has
+                    // PendingSerializationInfo. As such it cannot be considered completed yet.
+                    continue;
+                }
+
                 completed = Id.Null;
             }
 

--- a/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/Deserializer/IDeserializer.cs
+++ b/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/Deserializer/IDeserializer.cs
@@ -23,10 +23,10 @@ internal interface IDeserializer
     /// </summary>
     /// <remarks>
     ///  <para>
-    ///   Objects are considered incomplete if they contain references to value types that need completed or if
-    ///   they have not yet finished evaluating all of their member data. They are also considered incomplete if
-    ///   they have <see cref="ISerializable"/> or a surrogate that has not yet been called with their
-    ///   <see cref="SerializationInfo"/>.
+    ///   Objects are considered incomplete if they contain references to value or <see cref="IObjectReference"/> types
+    ///   that need completed or if they have not yet finished evaluating all of their member data. They are also
+    ///   considered incomplete if they implement <see cref="ISerializable"/> or have a surrogate and the
+    ///   <see cref="SerializationInfo"/> has not yet been applied.
     ///  </para>
     /// </remarks>
     IReadOnlySet<int> IncompleteObjects { get; }

--- a/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/Deserializer/ObjectRecordDeserializer.cs
+++ b/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/Deserializer/ObjectRecordDeserializer.cs
@@ -6,6 +6,8 @@ using System.Runtime.Serialization;
 
 namespace System.Windows.Forms.BinaryFormat.Deserializer;
 
+#pragma warning disable SYSLIB0050 // Type or member is obsolete
+
 /// <summary>
 ///  Base class for <see cref="BinaryFormat.ObjectRecord"/> deserialization.
 /// </summary>
@@ -34,23 +36,57 @@ internal abstract partial class ObjectRecordDeserializer
     internal abstract Id Continue();
 
     /// <summary>
-    ///  Gets the actual object for a member value record. Returns <see cref="s_missingValueSentinel"/> if
+    ///  Gets the actual object for a member value primitive or record. Returns <see cref="s_missingValueSentinel"/> if
     ///  the object record has not been encountered yet.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private protected (object? value, Id id) GetMemberValue(object? memberValueRecord) => memberValueRecord switch
+    private protected (object? value, Id id) UnwrapMemberValue(object? memberValue)
     {
-        BinaryObjectString binaryString => (binaryString.Value, Id.Null),
-        ObjectRecord objectRecord => Deserializer.DeserializedObjects.TryGetValue(objectRecord.ObjectId, out object? value)
-            ? (value, objectRecord.ObjectId) : (s_missingValueSentinel, objectRecord.ObjectId),
-        MemberReference memberReference => Deserializer.DeserializedObjects.TryGetValue(memberReference.IdRef, out object? value)
-            ? (value, memberReference.IdRef) : (s_missingValueSentinel, memberReference.IdRef),
-        MemberPrimitiveTyped memberPrimitiveTyped => (memberPrimitiveTyped.Value, Id.Null),
-        ObjectNull or null => (null, Id.Null),
-        _ => TypeInfo.GetPrimitiveType(memberValueRecord.GetType()) != default
-            ? (memberValueRecord, Id.Null)
-            : throw new SerializationException($"Unexpected member type '{memberValueRecord.GetType()}'."),
-    };
+        return memberValue switch
+        {
+            // String
+            BinaryObjectString binaryString => (binaryString.Value, Id.Null),
+            // Inline record
+            ObjectRecord objectRecord => TryGetObject(objectRecord.ObjectId),
+            // Record reference
+            MemberReference memberReference => TryGetObject(memberReference.IdRef),
+            // Prmitive type record
+            MemberPrimitiveTyped memberPrimitiveTyped => (memberPrimitiveTyped.Value, Id.Null),
+            // Null
+            ObjectNull or null => (null, Id.Null),
+            // At this point should be an inline primitive
+            _ => TypeInfo.GetPrimitiveType(memberValue.GetType()) != default
+                ? (memberValue, Id.Null)
+                : throw new SerializationException($"Unexpected member type '{memberValue.GetType()}'."),
+        };
+
+        (object? value, Id id) TryGetObject(Id id)
+        {
+            if (!Deserializer.DeserializedObjects.TryGetValue(id, out object? value))
+            {
+                return (s_missingValueSentinel, id);
+            }
+
+            ValidateNewMemberObjectValue(value);
+            return (value, id);
+        }
+    }
+
+    /// <summary>
+    ///  Called for new non-primitive reference types.
+    /// </summary>
+    private protected virtual void ValidateNewMemberObjectValue(object value) { }
+
+    /// <summary>
+    ///  Returns <see langword="true"/> if the given record's value needs an updater applied.
+    /// </summary>
+    private protected bool DoesValueNeedUpdated(object value, Id valueRecord) =>
+        // Null Id is a primitive of some sort.
+        !valueRecord.IsNull
+            // IObjectReference is going to have it's object replaced.
+            && (value is IObjectReference
+                // Value types that aren't "complete" need to be reapplied.
+                || (Deserializer.IncompleteObjects.Contains(valueRecord) && value.GetType().IsValueType));
 
     [RequiresUnreferencedCode("Calls System.Windows.Forms.BinaryFormat.Deserializer.ClassRecordParser.Create(ClassRecord, IDeserializer)")]
     internal static ObjectRecordDeserializer Create(Id id, IRecord record, IDeserializer deserializer) => record switch
@@ -60,3 +96,5 @@ internal abstract partial class ObjectRecordDeserializer
         _ => throw new SerializationException($"Unexpected record type for {id}.")
     };
 }
+
+#pragma warning restore SYSLIB0050 // Type or member is obsolete

--- a/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/Deserializer/PendingSerializationInfo.cs
+++ b/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/Deserializer/PendingSerializationInfo.cs
@@ -8,7 +8,7 @@ namespace System.Windows.Forms.BinaryFormat.Deserializer;
 
 #pragma warning disable SYSLIB0050 // Type or member is obsolete
 
-internal sealed class PendingSerializationInfo
+internal sealed class PendingSerializationInfo : IEquatable<PendingSerializationInfo>
 {
     internal int ObjectId { get; }
     private readonly ISerializationSurrogate? _surrogate;
@@ -79,6 +79,10 @@ internal sealed class PendingSerializationInfo
 
         throw new SerializationException($"The constructor to deserialize an object of type '{type.FullName}' was not found.");
     }
+
+    public override bool Equals(object? obj) => Equals(obj as PendingSerializationInfo);
+    public bool Equals(PendingSerializationInfo? other) => other is not null && other.ObjectId == ObjectId;
+    public override int GetHashCode() => ObjectId;
 }
 
 #pragma warning restore SYSLIB0050 // Type or member is obsolete

--- a/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/Common/ArrayTests.cs
+++ b/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/Common/ArrayTests.cs
@@ -1,6 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Serialization;
+using System.Windows.Forms.BinaryFormat;
+
 namespace FormatTests.Common;
 
 public abstract class ArrayTests<T> : SerializationTest<T> where T : ISerializer
@@ -34,5 +37,133 @@ public abstract class ArrayTests<T> : SerializationTest<T> where T : ISerializer
         {
             Assert.Same(result[0], result[i]);
         }
+    }
+
+    [Theory]
+    [InlineData(-1, (byte)RecordType.ArraySingleObject)]
+    [InlineData(int.MinValue, (byte)RecordType.ArraySingleObject)]
+    [InlineData(-1, (byte)RecordType.ArraySinglePrimitive)]
+    [InlineData(int.MinValue, (byte)RecordType.ArraySinglePrimitive)]
+    [InlineData(-1, (byte)RecordType.ArraySingleString)]
+    [InlineData(int.MinValue, (byte)RecordType.ArraySingleString)]
+    public void NegativeLength(int length, byte recordType)
+    {
+        MemoryStream stream = new();
+        using (BinaryFormatWriterScope scope = new(stream))
+        {
+            scope.Writer.Write(recordType);
+
+            // Id
+            scope.Writer.Write(1);
+
+            // Length
+            scope.Writer.Write(length);
+        }
+
+        stream.Position = 0;
+        Action action = () => Deserialize(stream);
+        action.Should().Throw<SerializationException>();
+    }
+
+    [Theory]
+    [InlineData(-1, (byte)BinaryArrayType.Single)]
+    [InlineData(int.MinValue, (byte)BinaryArrayType.Single)]
+    [InlineData(-1, (byte)BinaryArrayType.Rectangular)]
+    [InlineData(int.MinValue, (byte)BinaryArrayType.Rectangular)]
+    [InlineData(-1, (byte)BinaryArrayType.Jagged)]
+    [InlineData(int.MinValue, (byte)BinaryArrayType.Jagged)]
+    public void BinaryArray_NegativeLength(int length, byte arrayType)
+    {
+        MemoryStream stream = new();
+        using (BinaryFormatWriterScope scope = new(stream))
+        {
+            scope.Writer.Write((byte)RecordType.BinaryArray);
+
+            // Id
+            scope.Writer.Write(1);
+            scope.Writer.Write(arrayType);
+
+            // Rank
+            scope.Writer.Write(1);
+
+            // Length
+            scope.Writer.Write(length);
+        }
+
+        stream.Position = 0;
+        Action action = () => Deserialize(stream);
+        action.Should().Throw<SerializationException>();
+    }
+
+    [Theory]
+    [InlineData(0, (byte)BinaryArrayType.Single)]
+    [InlineData(0, (byte)BinaryArrayType.Rectangular)]
+    [InlineData(0, (byte)BinaryArrayType.Jagged)]
+    [InlineData(-1, (byte)BinaryArrayType.Single)]
+    [InlineData(-1, (byte)BinaryArrayType.Rectangular)]
+    [InlineData(-1, (byte)BinaryArrayType.Jagged)]
+    [InlineData(int.MinValue, (byte)BinaryArrayType.Single)]
+    [InlineData(int.MinValue, (byte)BinaryArrayType.Rectangular)]
+    [InlineData(int.MinValue, (byte)BinaryArrayType.Jagged)]
+    [InlineData(33, (byte)BinaryArrayType.Rectangular)]
+    public void BinaryArray_InvalidRank(int rank, byte arrayType)
+    {
+        MemoryStream stream = new();
+        using (BinaryFormatWriterScope scope = new(stream))
+        {
+            scope.Writer.Write((byte)RecordType.BinaryArray);
+
+            // Id
+            scope.Writer.Write(1);
+            scope.Writer.Write(arrayType);
+
+            // Rank
+            scope.Writer.Write(rank);
+
+            // Lengths
+            int lengths = rank > 0 ? rank : 1;
+            for (int i = 0; i < lengths; i++)
+            {
+                scope.Writer.Write(0);
+            }
+
+            scope.Writer.Write((byte)BinaryType.Object);
+        }
+
+        stream.Position = 0;
+        Action action = () => Deserialize(stream);
+        action.Should().Throw<SerializationException>();
+    }
+
+    [Theory]
+    [InlineData(2, (byte)BinaryArrayType.Single)]
+    [InlineData(2, (byte)BinaryArrayType.Jagged)]
+    public virtual void BinaryArray_InvalidRank_Positive(int rank, byte arrayType)
+    {
+        MemoryStream stream = new();
+        using (BinaryFormatWriterScope scope = new(stream))
+        {
+            scope.Writer.Write((byte)RecordType.BinaryArray);
+
+            // Id
+            scope.Writer.Write(1);
+            scope.Writer.Write(arrayType);
+
+            // Rank
+            scope.Writer.Write(rank);
+
+            // Lengths
+            int lengths = rank > 0 ? rank : 1;
+            for (int i = 0; i < lengths; i++)
+            {
+                scope.Writer.Write(0);
+            }
+
+            scope.Writer.Write((byte)BinaryType.Object);
+        }
+
+        // BinaryFormatter doesn't reject these outright.
+        stream.Position = 0;
+        Deserialize(stream);
     }
 }

--- a/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/Common/BasicObjectTests.cs
+++ b/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/Common/BasicObjectTests.cs
@@ -19,23 +19,23 @@ public abstract class BasicObjectTests<T> : SerializationTest<T> where T : ISeri
 
         int platformIndex = serializedData.GetPlatformIndex();
         for (int i = 0; i < serializedData.Length; i++)
-        for (FormatterAssemblyStyle assemblyMatching = 0; assemblyMatching <= FormatterAssemblyStyle.Full; assemblyMatching++)
-        {
-            object deserialized = DeserializeFromBase64Chars(serializedData[i].Base64Blob, assemblyMatching: assemblyMatching);
-
-            if (deserialized is StringComparer)
+            for (FormatterAssemblyStyle assemblyMatching = 0; assemblyMatching <= FormatterAssemblyStyle.Full; assemblyMatching++)
             {
-                // StringComparer derived classes are not public and they don't serialize the actual type.
-                value.Should().BeAssignableTo<StringComparer>();
-            }
-            else
-            {
-                deserialized.Should().BeOfType(value.GetType());
-            }
+                object deserialized = DeserializeFromBase64Chars(serializedData[i].Base64Blob, assemblyMatching: assemblyMatching);
 
-            bool isSamePlatform = i == platformIndex;
-            EqualityExtensions.CheckEquals(value, deserialized, isSamePlatform);
-        }
+                if (deserialized is StringComparer)
+                {
+                    // StringComparer derived classes are not public and they don't serialize the actual type.
+                    value.Should().BeAssignableTo<StringComparer>();
+                }
+                else
+                {
+                    deserialized.Should().BeOfType(value.GetType());
+                }
+
+                bool isSamePlatform = i == platformIndex;
+                EqualityExtensions.CheckEquals(value, deserialized, isSamePlatform);
+            }
     }
 
     [Theory]

--- a/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/Common/CorruptedTests.cs
+++ b/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/Common/CorruptedTests.cs
@@ -35,7 +35,7 @@ public abstract class CorruptedTests<T> : SerializationTest<T> where T : ISerial
     }
 
     [Fact]
-    public void ValueTypeReferencesSelf2()
+    public virtual void ValueTypeReferencesSelf2()
     {
         MemoryStream stream = new();
 
@@ -56,7 +56,7 @@ public abstract class CorruptedTests<T> : SerializationTest<T> where T : ISerial
     }
 
     [Fact]
-    public void ValueTypeReferencesSelf3()
+    public virtual void ValueTypeReferencesSelf3()
     {
         MemoryStream stream = new();
 

--- a/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/Common/ObjectReferenceTests.cs
+++ b/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/Common/ObjectReferenceTests.cs
@@ -1,0 +1,128 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.Serialization;
+using System.Text;
+
+namespace FormatTests.Common;
+
+public abstract class ObjectReferenceTests<T> : SerializationTest<T> where T : ISerializer
+{
+    [Fact]
+    public void DBNull_Deserialize()
+    {
+        object deserialized = RoundTrip(DBNull.Value);
+        deserialized.Should().BeSameAs(DBNull.Value);
+    }
+
+    [Theory]
+    [MemberData(nameof(SupportedTypesTestData))]
+    public void SupportedTypes_Deserialize(object value)
+    {
+        object deserialized = RoundTrip(value);
+        deserialized.Should().NotBeNull();
+    }
+
+    public static TheoryData<object> SupportedTypesTestData { get; } = new()
+    {
+        ObjectReferenceNoFields.Value,
+        new SerializableWithNestedSurrogate { Message = "Hello"}
+    };
+
+    [Fact]
+    public void Singleton_NoFields_Deserialize()
+    {
+        // Representing singletons is the most common pattern for IObjectReference.
+        object deserialized = RoundTrip(ObjectReferenceNoFields.Value);
+        deserialized.Should().BeSameAs(ObjectReferenceNoFields.Value);
+    }
+
+    [Serializable]
+    public sealed class ObjectReferenceNoFields : IObjectReference
+    {
+        public static ObjectReferenceNoFields Value { get; } = new();
+
+        private ObjectReferenceNoFields() { }
+
+        object IObjectReference.GetRealObject(StreamingContext context) => Value;
+    }
+
+    [Fact]
+    public void NestedSurrogate_Deserialize()
+    {
+        object deserialized = RoundTrip(new SerializableWithNestedSurrogate { Message = "Hello" });
+        deserialized.Should().BeOfType<SerializableWithNestedSurrogate>().Which.Message.Should().Be("Hello");
+    }
+
+    [Serializable]
+#pragma warning disable CA2229 // Implement serialization constructors
+    public sealed class SerializableWithNestedSurrogate : ISerializable
+#pragma warning restore CA2229
+    {
+        public string Message { get; set; } = string.Empty;
+
+        void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            info.SetType(typeof(SerializationSurrogate));
+            info.AddValue(nameof(Message), Encoding.UTF8.GetBytes(Message));
+        }
+
+        [Serializable]
+        private sealed class SerializationSurrogate : IObjectReference, ISerializable
+        {
+            private readonly byte[] _bytes;
+
+            private SerializationSurrogate(SerializationInfo info, StreamingContext context)
+            {
+                _bytes = (byte[])(info.GetValue(nameof(Message), typeof(byte[])) ?? throw new InvalidOperationException());
+            }
+
+            void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context) =>
+                throw new InvalidOperationException();
+
+            object IObjectReference.GetRealObject(StreamingContext context)
+                => new SerializableWithNestedSurrogate() { Message = Encoding.UTF8.GetString(_bytes) };
+        }
+    }
+
+    [Fact]
+    public void NestedSurrogate_NullableEnum_Deserialize()
+    {
+        object deserialized = RoundTrip(new SerializableWithNestedSurrogate_NullableEnum());
+        deserialized.Should().BeOfType<SerializableWithNestedSurrogate_NullableEnum>().Which.Day.Should().BeNull();
+
+        deserialized = RoundTrip(new SerializableWithNestedSurrogate_NullableEnum { Day = DayOfWeek.Monday });
+        deserialized.Should().BeOfType<SerializableWithNestedSurrogate_NullableEnum>().Which.Day.Should().Be(DayOfWeek.Monday);
+    }
+
+    [Serializable]
+#pragma warning disable CA2229 // Implement serialization constructors
+    public sealed class SerializableWithNestedSurrogate_NullableEnum : ISerializable
+#pragma warning restore CA2229
+    {
+        public DayOfWeek? Day { get; set; }
+
+        void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            info.SetType(typeof(SerializationSurrogate));
+            info.AddValue(nameof(Day), Day);
+        }
+
+        [Serializable]
+        private sealed class SerializationSurrogate : IObjectReference, ISerializable
+        {
+            private readonly DayOfWeek? _day;
+
+            private SerializationSurrogate(SerializationInfo info, StreamingContext context)
+            {
+                _day = (DayOfWeek?)(info.GetValue(nameof(Day), typeof(DayOfWeek?)));
+            }
+
+            void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context) =>
+                throw new InvalidOperationException();
+
+            object IObjectReference.GetRealObject(StreamingContext context)
+                => new SerializableWithNestedSurrogate_NullableEnum() { Day = _day };
+        }
+    }
+}

--- a/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/FormattedObject/ArrayTests.cs
+++ b/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/FormattedObject/ArrayTests.cs
@@ -3,6 +3,7 @@
 
 using System.Collections;
 using System.Drawing;
+using System.Runtime.Serialization;
 using System.Windows.Forms;
 using System.Windows.Forms.BinaryFormat;
 
@@ -92,4 +93,11 @@ public class ArrayTests : Common.ArrayTests<FormattedObjectSerializer>
         new Point[] { new() },
         new object[] { new() },
     };
+
+    public override void BinaryArray_InvalidRank_Positive(int rank, byte arrayType)
+    {
+        // BinaryFormatter doesn't throw on these.
+        Action action = () => base.BinaryArray_InvalidRank_Positive(rank, arrayType);
+        action.Should().Throw<SerializationException>();
+    }
 }

--- a/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/FormattedObject/CorruptedTests.cs
+++ b/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/FormattedObject/CorruptedTests.cs
@@ -1,8 +1,21 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.Serialization;
+
 namespace FormatTests.FormattedObject;
 
 public class CorruptedTests : Common.CorruptedTests<FormattedObjectSerializer>
 {
+    public override void ValueTypeReferencesSelf2()
+    {
+        Action action = base.ValueTypeReferencesSelf2;
+        action.Should().Throw<SerializationException>();
+    }
+
+    public override void ValueTypeReferencesSelf3()
+    {
+        Action action = base.ValueTypeReferencesSelf3;
+        action.Should().Throw<SerializationException>();
+    }
 }

--- a/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/FormattedObject/ObjectReferenceTests.cs
+++ b/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/FormattedObject/ObjectReferenceTests.cs
@@ -1,0 +1,8 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace FormatTests.FormattedObject;
+
+public class ObjectReferenceTests : Common.ObjectReferenceTests<FormattedObjectSerializer>
+{
+}

--- a/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/Formatter/ObjectReferenceTests.cs
+++ b/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/Formatter/ObjectReferenceTests.cs
@@ -1,0 +1,8 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace FormatTests.Formatter;
+
+public class ObjectReferenceTests : Common.ObjectReferenceTests<BinaryFormatterSerializer>
+{
+}


### PR DESCRIPTION
Allow types that implement IObjectReference that only have primitives or arrays of primitives in them.

Also fix an issue with finishing dependencies for pending objects and a number of new tests.