### PR TITLE
BinaryFormat test updates

### DIFF
--- a/src/Common/tests/TestUtilities/XUnit/EnumerableTupleTheoryData.cs
+++ b/src/Common/tests/TestUtilities/XUnit/EnumerableTupleTheoryData.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections;
+
+namespace Xunit;
+
+/// <summary>
+///  Theory data for tuple enumeration.
+/// </summary>
+public class EnumerableTupleTheoryData<T1, T2> : IReadOnlyCollection<object[]>
+    where T1 : notnull
+    where T2 : notnull
+{
+    private readonly IEnumerable<(T1, T2)> _data;
+
+    public int Count => _data.Count();
+
+    public EnumerableTupleTheoryData(IEnumerable<(T1, T2)> data) => _data = data;
+
+    public IEnumerator<object[]> GetEnumerator() =>
+        _data.Select(i => new object[] { i.Item1, i.Item2 }).GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}
+
+/// <inheritdoc cref="EnumerableTupleTheoryData{T1, T2}"/>
+public class EnumerableTupleTheoryData<T1, T2, T3> : IReadOnlyCollection<object[]>
+    where T1 : notnull
+    where T2 : notnull
+    where T3 : notnull
+{
+    private readonly IEnumerable<(T1, T2, T3)> _data;
+
+    public int Count => _data.Count();
+
+    public EnumerableTupleTheoryData(IEnumerable<(T1, T2, T3)> data) => _data = data;
+
+    public IEnumerator<object[]> GetEnumerator() =>
+        _data.Select(i => new object[] { i.Item1, i.Item2, i.Item3 }).GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/Deserializer/ArrayRecordDeserializer.cs
+++ b/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/Deserializer/ArrayRecordDeserializer.cs
@@ -88,7 +88,7 @@ internal sealed class ArrayRecordDeserializer : ObjectRecordDeserializer
                 continue;
             }
 
-            if (_arrayType is not BinaryArrayType.Rectangular || _elementType.IsValueType)
+            if (_elementType.IsValueType)
             {
                 _array.SetArrayValueByFlattenedIndex(memberValue, _index);
             }

--- a/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/Legacy/EqualityExtensions.cs
+++ b/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/Legacy/EqualityExtensions.cs
@@ -26,6 +26,15 @@ public static class EqualityExtensions
 {
     private static readonly ConcurrentDictionary<Type, MethodInfo?> s_extensionMethods = new();
 
+    private static readonly (MethodInfo Method, string FirstParameterName)[] s_equalityMethods =
+    (
+        from method in typeof(EqualityExtensions).GetMethods()!
+         where method.Name == "IsEqual" && method.IsGenericMethodDefinition
+         let parameters = method.GetParameters()
+         where parameters.Length == 3
+         select (method, parameters[0].ParameterType.Name)
+    ).ToArray();
+
     private static MethodInfo? GetExtensionMethod(Type extendedType)
     {
         if (s_extensionMethods.TryGetValue(extendedType, out MethodInfo? existing))
@@ -35,18 +44,12 @@ public static class EqualityExtensions
 
         if (extendedType.IsGenericType)
         {
-            IEnumerable<MethodInfo>? x = typeof(EqualityExtensions).GetMethods()
-                ?.Where(m =>
-                    m.Name == "IsEqual" &&
-                    m.GetParameters().Length == 3 &&
-                    m.IsGenericMethodDefinition);
-
-            MethodInfo? method = typeof(EqualityExtensions).GetMethods()
-                ?.SingleOrDefault(m =>
-                    m.Name == "IsEqual" &&
-                    m.GetParameters().Length == 3 &&
-                    m.GetParameters()[0].ParameterType.Name == extendedType.Name &&
-                    m.IsGenericMethodDefinition);
+            MethodInfo? method =
+            (
+                from m in s_equalityMethods
+                where m.FirstParameterName == extendedType.Name
+                select m.Method
+            ).SingleOrDefault();
 
             // If extension method found, make it generic and return
             if (method is not null)


### PR DESCRIPTION
The most expensive thing we're doing in the binary format tests is getting the validation test method for types. I've added a cache for this, which cuts a third of the testing time for the project.

Also adding some theory data helper classes for tuples for clarity and minor perf.

Finally, no need to call the slow method for array index sets for multidimensional arrays.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11321)