### PR TITLE
Skip unstable test DataGridView_OnColumnHeadersHeightChanged_InvokeWithHandle_CallsColumnHeadersHeightChanged

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTests.cs
@@ -1903,7 +1903,7 @@ public partial class DataGridViewTests
             {
                 // Skip verification of DataGridViewColumnHeadersHeightSizeMode = DisableResizing and columnHeadersVisible = true
                 // in X86 due to the active issue "https://github.com/dotnet/winforms/issues/11322"
-                if (columnHeadersWidthSizeMode== DataGridViewColumnHeadersHeightSizeMode.DisableResizing
+                if (columnHeadersWidthSizeMode == DataGridViewColumnHeadersHeightSizeMode.DisableResizing
                     && columnHeadersVisible is true
                     && RuntimeInformation.ProcessArchitecture == Architecture.X86)
                   continue;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTests.cs
@@ -4,6 +4,7 @@
 using System.ComponentModel;
 using System.Data;
 using System.Drawing;
+using System.Runtime.InteropServices;
 
 namespace System.Windows.Forms.Tests;
 
@@ -1900,9 +1901,11 @@ public partial class DataGridViewTests
         {
             foreach (bool columnHeadersVisible in new bool[] { true, false })
             {
-                // Skip verification of DataGridViewColumnHeadersHeightSizeMode=DisableResizing and columnHeadersVisible=true
-                // due to the active issue "https://github.com/dotnet/winforms/issues/11322"
-                if (columnHeadersWidthSizeMode== DataGridViewColumnHeadersHeightSizeMode.DisableResizing && columnHeadersVisible is true)
+                // Skip verification of DataGridViewColumnHeadersHeightSizeMode = DisableResizing and columnHeadersVisible = true
+                // in X86 due to the active issue "https://github.com/dotnet/winforms/issues/11322"
+                if (columnHeadersWidthSizeMode== DataGridViewColumnHeadersHeightSizeMode.DisableResizing
+                    && columnHeadersVisible is true
+                    && RuntimeInformation.ProcessArchitecture == Architecture.X86)
                   continue;
 
                 yield return new object[] { columnHeadersWidthSizeMode, columnHeadersVisible, null };

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTests.cs
@@ -1900,12 +1900,18 @@ public partial class DataGridViewTests
         {
             foreach (bool columnHeadersVisible in new bool[] { true, false })
             {
+                // Skip verification of DataGridViewColumnHeadersHeightSizeMode=DisableResizing and columnHeadersVisible=true
+                // due to the active issue "https://github.com/dotnet/winforms/issues/11322"
+                if (columnHeadersWidthSizeMode== DataGridViewColumnHeadersHeightSizeMode.DisableResizing && columnHeadersVisible is true)
+                  continue;
+
                 yield return new object[] { columnHeadersWidthSizeMode, columnHeadersVisible, null };
                 yield return new object[] { columnHeadersWidthSizeMode, columnHeadersVisible, new EventArgs() };
             }
         }
     }
 
+    [ActiveIssue("https://github.com/dotnet/winforms/issues/11322")]
     [WinFormsTheory]
     [MemberData(nameof(OnColumnHeadersHeightChanged_TestData))]
     public void DataGridView_OnColumnHeadersHeightChanged_Invoke_CallsColumnHeadersHeightChanged(DataGridViewColumnHeadersHeightSizeMode columnHeadersWidthSizeMode, bool columnHeadersVisible, EventArgs eventArgs)


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Related https://github.com/dotnet/winforms/issues/11322


## Proposed changes

- Add judgment logic to the x86 test to skip the following test scenarios `System.Windows.Forms.Tests.DataGridViewTests.DataGridView_OnColumnHeadersHeightChanged_InvokeWithHandle_CallsColumnHeadersHeightChanged(columnHeadersWidthSizeMode: DisableResizing, columnHeadersVisible: True, eventArgs: EventArgs { })`  and `System.Windows.Forms.Tests.DataGridViewTests.DataGridView_OnColumnHeadersHeightChanged_InvokeWithHandle_CallsColumnHeadersHeightChanged(columnHeadersWidthSizeMode: DisableResizing, columnHeadersVisible: True, eventArgs: null)`

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11323)