### PR TITLE
Skip unstable tests in "ButtonTests", "ListViewTests" and "NumericUpDownTests"

### DIFF
--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/ButtonTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/ButtonTests.cs
@@ -51,7 +51,10 @@ public class ButtonTests : ControlTestBase
         });
     }
 
+    [ActiveIssue("https://github.com/dotnet/winforms/issues/11324")]
     [WinFormsFact]
+    [SkipOnArchitecture(TestArchitectures.X64,
+    "Flaky tests, see: https://github.com/dotnet/winforms/issues/11324")]
     public async Task Button_DialogResult_SpaceToClickFocusedButtonAsync()
     {
         await RunTestAsync(async (form, button) =>
@@ -87,7 +90,10 @@ public class ButtonTests : ControlTestBase
         });
     }
 
+    [ActiveIssue("https://github.com/dotnet/winforms/issues/11326")]
     [WinFormsFact]
+    [SkipOnArchitecture(TestArchitectures.X64,
+        "Flaky tests, see: https://github.com/dotnet/winforms/issues/11326")]
     public async Task Button_CancelButton_EscapeClicksCancelButtonAsync()
     {
         await RunTestAsync(async (form, button) =>
@@ -305,7 +311,10 @@ public class ButtonTests : ControlTestBase
         });
     }
 
+    [ActiveIssue("https://github.com/dotnet/winforms/issues/11327")]
     [WinFormsFact]
+    [SkipOnArchitecture(TestArchitectures.X64,
+       "Flaky tests, see: https://github.com/dotnet/winforms/issues/11327")]
     public async Task Button_PerformClick_Fires_OnClickAsync()
     {
         await RunTestAsync((form, button) =>
@@ -341,7 +350,10 @@ public class ButtonTests : ControlTestBase
         });
     }
 
+    [ActiveIssue("https://github.com/dotnet/winforms/issues/11325")]
     [WinFormsFact]
+    [SkipOnArchitecture(TestArchitectures.X64,
+       "Flaky tests, see: https://github.com/dotnet/winforms/issues/11325")]
     public async Task Button_Hotkey_Fires_OnClickAsync()
     {
         await RunTestAsync(async (form, button) =>

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/ButtonTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/ButtonTests.cs
@@ -54,7 +54,7 @@ public class ButtonTests : ControlTestBase
     [ActiveIssue("https://github.com/dotnet/winforms/issues/11324")]
     [WinFormsFact]
     [SkipOnArchitecture(TestArchitectures.X64,
-    "Flaky tests, see: https://github.com/dotnet/winforms/issues/11324")]
+        "Flaky tests, see: https://github.com/dotnet/winforms/issues/11324")]
     public async Task Button_DialogResult_SpaceToClickFocusedButtonAsync()
     {
         await RunTestAsync(async (form, button) =>

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/ListViewTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/ListViewTests.cs
@@ -42,7 +42,7 @@ public class ListViewTests : ControlTestBase
     [ActiveIssue("https://github.com/dotnet/winforms/issues/11328")]
     [WinFormsFact]
     [SkipOnArchitecture(TestArchitectures.X64,
-      "Flaky tests, see: https://github.com/dotnet/winforms/issues/11328")]
+        "Flaky tests, see: https://github.com/dotnet/winforms/issues/11328")]
     public async Task ListView_Group_NavigateKeyboard_SucceedsAsync()
     {
         await RunTestAsync(async (form, listView) =>

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/ListViewTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/ListViewTests.cs
@@ -39,7 +39,10 @@ public class ListViewTests : ControlTestBase
         });
     }
 
+    [ActiveIssue("https://github.com/dotnet/winforms/issues/11328")]
     [WinFormsFact]
+    [SkipOnArchitecture(TestArchitectures.X64,
+      "Flaky tests, see: https://github.com/dotnet/winforms/issues/11328")]
     public async Task ListView_Group_NavigateKeyboard_SucceedsAsync()
     {
         await RunTestAsync(async (form, listView) =>

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/NumericUpDownTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/NumericUpDownTests.cs
@@ -12,7 +12,10 @@ public class NumericUpDownTests : ControlTestBase
     {
     }
 
+    [ActiveIssue("https://github.com/dotnet/winforms/issues/11329")]
     [WinFormsFact]
+    [SkipOnArchitecture(TestArchitectures.X64,
+        "Flaky tests, see: https://github.com/dotnet/winforms/issues/11329")]
     public async Task NumericUpDownAccessibleObject_Focused_ReturnsCorrectValueAsync()
     {
         await RunSingleControlTestAsync<NumericUpDown>(async (form, control) =>


### PR DESCRIPTION

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Related #11324, #11325, #11326, #11327, #11328, #11329


## Proposed changes

- Add `SkipOnArchitecture `for following unstable test cases to disable them in X64 run
   1. Button_DialogResult_SpaceToClickFocusedButtonAsync
   2. Button_Hotkey_Fires_OnClickAsync
   3. Button_CancelButton_EscapeClicksCancelButtonAsync
   4. Button_PerformClick_Fires_OnClickAsync
   5. ListView_Group_NavigateKeyboard_SucceedsAsync
   6.  NumericUpDownAccessibleObject_Focused_ReturnsCorrectValueAsync


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11330)