### PR TITLE
Add unit tests for DomainUpDown

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DomainUpDownTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DomainUpDownTests.cs
@@ -1395,6 +1395,127 @@ public class DomainUpDownTests
         Assert.False(control.IsHandleCreated);
     }
 
+    [WinFormsTheory]
+    [InlineData(0, 1, false)]
+    [InlineData(1, 2, false)]
+    [InlineData(2, 2, false)] 
+    [InlineData(2, 0, true)] 
+    public void DomainUpDown_DownButton_InvokeWithItems_ChangesSelectedIndex(int initialIndex, int expectedIndex, bool wrap)
+    {
+        using DomainUpDown control = new();
+        control.Items.Add("Item1");
+        control.Items.Add("Item2");
+        control.Items.Add("Item3");
+        control.SelectedIndex = initialIndex;
+        control.Wrap = wrap;
+
+        control.DownButton();
+
+        control.SelectedIndex.Should().Be(expectedIndex);
+    }
+
+    [WinFormsTheory]
+    [InlineData(0, 2, false)]
+    [InlineData(1, 2, false)]
+    [InlineData(2, 2, false)] 
+    [InlineData(2, 1, true)] 
+    public void DomainUpDown_DownButton_InvokeMultipleTimes_ChangesSelectedIndex(int initialIndex, int expectedIndex, bool wrap)
+    {
+        using DomainUpDown control = new();
+        control.Items.Add("Item1");
+        control.Items.Add("Item2");
+        control.Items.Add("Item3");
+        control.SelectedIndex = initialIndex;
+        control.Wrap = wrap;
+
+        control.DownButton();
+        control.DownButton(); 
+
+        control.SelectedIndex.Should().Be(expectedIndex);
+    }
+
+    [WinFormsTheory]
+    [InlineData(new string[] { "Item1", "Item2", "Item3" }, 1)]
+    [InlineData(new string[] { "ItemA", "ItemB", "ItemC", "ItemD" }, 3)]
+    public void DomainUpDown_ToString_Invoke_ReturnsExpected(string[] items, int selectedIndex)
+    {
+        using DomainUpDown control = new();
+        for (int i = 0; i < items.Length; i++)
+        {
+            string item = items[i];
+            control.Items.Add(item);
+        }
+
+        control.SelectedIndex = selectedIndex;
+
+        string s = control.ToString();
+
+        s.Should().Contain($"Items.Count: {items.Length}");
+        s.Should().Contain($"SelectedIndex: {selectedIndex}");
+    }
+
+    [WinFormsTheory]
+    [InlineData("Item1", 0)]
+    [InlineData("Item2", 1)]
+    public void DomainUpDown_UpButton_MatchFound(string text, int expectedIndex)
+    {
+        using DomainUpDown control = new();
+        control.Items.AddRange(new string[] { "Item1", "Item2", "Item3" });
+        control.Text = text;
+        control.UpButton();
+        control.SelectedIndex.Should().Be(expectedIndex);
+    }
+
+    [WinFormsFact]
+    public void DomainUpDown_UpButton_NoMatchFound()
+    {
+        using DomainUpDown control = new();;
+        control.Items.AddRange(new string[] { "Item1", "Item2", "Item3" });
+        control.Text = "NoSuchItem";
+        control.UpButton();
+        control.SelectedIndex.Should().Be(-1);
+    }
+
+    [WinFormsFact]
+    public void DomainUpDown_UpButton_DecrementSelectedIndex()
+    {
+        using DomainUpDown control = new();
+        control.Items.AddRange(new string[] { "Item1", "Item2", "Item3" });
+        control.SelectedIndex = 2;
+        control.UpButton();
+        control.SelectedIndex.Should().Be(1);
+    }
+
+    [WinFormsFact]
+    public void DomainUpDown_UpButton_SelectedIndexAtStart_NoWrap()
+    {
+        using DomainUpDown control = new();
+        control.Items.AddRange(new string[] { "Item1", "Item2", "Item3" });
+        control.SelectedIndex = 0;
+        control.Wrap = false;
+        control.UpButton();
+        control.SelectedIndex.Should().Be(0);
+    }
+
+    [WinFormsFact]
+    public void DomainUpDown_UpButton_SelectedIndexAtStart_Wrap()
+    {
+        using DomainUpDown control = new();
+        control.Items.AddRange(new string[] { "Item1", "Item2", "Item3" });
+        control.SelectedIndex = 0;
+        control.Wrap = true;
+        control.UpButton();
+        control.SelectedIndex.Should().Be(2);
+    }
+
+    [WinFormsFact]
+    public void DomainUpDown_UpButton_EmptyItems()
+    {
+        using DomainUpDown control = new();
+        control.UpButton();
+        control.SelectedIndex.Should().Be(-1);
+    }
+
     public class SubDomainUpDown : DomainUpDown
     {
         public new const int ScrollStateAutoScrolling = ScrollableControl.ScrollStateAutoScrolling;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DomainUpDownTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DomainUpDownTests.cs
@@ -14,8 +14,8 @@ public class DomainUpDownTests : IDisposable
 
     public DomainUpDownTests()
     {
-        _control = new DomainUpDown();
-        _sub= new SubDomainUpDown();
+        _control = new();
+        _sub= new();
     }
 
     public void Dispose()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DomainUpDownTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DomainUpDownTests.cs
@@ -29,159 +29,158 @@ public class DomainUpDownTests : IDisposable
     [WinFormsFact]
     public void DomainUpDown_Ctor_Default()
     {
-        Assert.Null(_sub.ActiveControl);
-        Assert.False(_sub.AllowDrop);
-        Assert.Equal(AnchorStyles.Top | AnchorStyles.Left, _sub.Anchor);
-        Assert.False(_sub.AutoScroll);
-        Assert.Equal(SizeF.Empty, _sub.AutoScaleDimensions);
-        Assert.Equal(new SizeF(1, 1), _sub.AutoScaleFactor);
-        Assert.Equal(Size.Empty, _sub.AutoScrollMargin);
-        Assert.Equal(AutoScaleMode.Inherit, _sub.AutoScaleMode);
-        Assert.Equal(Size.Empty, _sub.AutoScrollMinSize);
-        Assert.Equal(Point.Empty, _sub.AutoScrollPosition);
-        Assert.False(_sub.AutoSize);
-        Assert.Equal(SystemColors.Window, _sub.BackColor);
-        Assert.Null(_sub.BackgroundImage);
-        Assert.Equal(ImageLayout.Tile, _sub.BackgroundImageLayout);
-        Assert.NotNull(_sub.BindingContext);
-        Assert.Same(_sub.BindingContext, _sub.BindingContext);
-        Assert.Equal(BorderStyle.Fixed3D, _sub.BorderStyle);
-        Assert.Equal(_sub.PreferredHeight, _sub.Bottom);
-        Assert.Equal(new Rectangle(0, 0, 120, _sub.PreferredHeight), _sub.Bounds);
-        Assert.False(_sub.CanEnableIme);
-        Assert.False(_sub.CanFocus);
-        Assert.True(_sub.CanRaiseEvents);
-        Assert.True(_sub.CausesValidation);
-        Assert.False(_sub.ChangingText);
+        _sub.ActiveControl.Should().BeNull();
+        _sub.AllowDrop.Should().BeFalse();
+        _sub.Anchor.Should().Be(AnchorStyles.Top | AnchorStyles.Left);
+        _sub.AutoScroll.Should().BeFalse();
+        _sub.AutoScaleDimensions.Should().Be(SizeF.Empty);
+        _sub.AutoScaleFactor.Should().Be(new SizeF(1, 1));
+        _sub.AutoScrollMargin.Should().Be(Size.Empty);
+        _sub.AutoScaleMode.Should().Be(AutoScaleMode.Inherit);
+        _sub.AutoScrollMinSize.Should().Be(Size.Empty);
+        _sub.AutoScrollPosition.Should().Be(Point.Empty);
+        _sub.AutoSize.Should().BeFalse();
+        _sub.BackColor.Should().Be(SystemColors.Window);
+        _sub.BackgroundImage.Should().BeNull();
+        _sub.BackgroundImageLayout.Should().Be(ImageLayout.Tile);
+        _sub.BindingContext.Should().NotBeNull();
+        _sub.BorderStyle.Should().Be(BorderStyle.Fixed3D);
+        _sub.Bottom.Should().Be(_sub.PreferredHeight);
+        _sub.Bounds.Should().Be(new Rectangle(0, 0, 120, _sub.PreferredHeight));
+        _sub.CanEnableIme.Should().BeFalse();
+        _sub.CanFocus.Should().BeFalse();
+        _sub.CanRaiseEvents.Should().BeTrue();
+        _sub.CausesValidation.Should().BeTrue();
+        _sub.ChangingText.Should().BeFalse();
         if (Application.UseVisualStyles)
         {
-            Assert.Equal(new Rectangle(0, 0, 120, Control.DefaultFont.Height + 7), _sub.ClientRectangle);
-            Assert.Equal(new Rectangle(0, 0, 120, Control.DefaultFont.Height + 7), _sub.DisplayRectangle);
-            Assert.Equal(new Size(120, Control.DefaultFont.Height + 7), _sub.ClientSize);
-            Assert.Equal(new Size(16, _sub.PreferredHeight), _sub.PreferredSize);
+            _sub.ClientRectangle.Should().Be(new Rectangle(0, 0, 120, Control.DefaultFont.Height + 7));
+            _sub.DisplayRectangle.Should().Be(new Rectangle(0, 0, 120, Control.DefaultFont.Height + 7));
+            _sub.ClientSize.Should().Be(new Size(120, Control.DefaultFont.Height + 7));
+            _sub.PreferredSize.Should().Be(new Size(16, _sub.PreferredHeight));
         }
         else
         {
-            Assert.Equal(new Rectangle(0, 0, 116, Control.DefaultFont.Height + 3), _sub.ClientRectangle);
-            Assert.Equal(new Rectangle(0, 0, 116, Control.DefaultFont.Height + 3), _sub.DisplayRectangle);
-            Assert.Equal(new Size(116, Control.DefaultFont.Height + 3), _sub.ClientSize);
-            Assert.Equal(new Size(20, _sub.PreferredHeight), _sub.PreferredSize);
+            _sub.ClientRectangle.Should().Be(new Rectangle(0, 0, 116, Control.DefaultFont.Height + 3));
+            _sub.DisplayRectangle.Should().Be(new Rectangle(0, 0, 116, Control.DefaultFont.Height + 3));
+            _sub.ClientSize.Should().Be(new Size(116, Control.DefaultFont.Height + 3));
+            _sub.PreferredSize.Should().Be(new Size(20, _sub.PreferredHeight));
         }
 
-        Assert.Null(_sub.Container);
-        Assert.False(_sub.ContainsFocus);
-        Assert.Null(_sub.ContextMenuStrip);
-        Assert.NotEmpty(_sub.Controls);
-        Assert.Same(_sub.Controls, _sub.Controls);
-        Assert.False(_sub.Created);
-        Assert.Equal(SizeF.Empty, _sub.CurrentAutoScaleDimensions);
-        Assert.Equal(Cursors.Default, _sub.Cursor);
-        Assert.Equal(Cursors.Default, _sub.DefaultCursor);
-        Assert.Equal(ImeMode.Inherit, _sub.DefaultImeMode);
-        Assert.Equal(new Padding(3), _sub.DefaultMargin);
-        Assert.Equal(Size.Empty, _sub.DefaultMaximumSize);
-        Assert.Equal(Size.Empty, _sub.DefaultMinimumSize);
-        Assert.Equal(Padding.Empty, _sub.DefaultPadding);
-        Assert.Equal(new Size(120, _sub.PreferredHeight), _sub.DefaultSize);
-        Assert.False(_sub.DesignMode);
-        Assert.Equal(DockStyle.None, _sub.Dock);
-        Assert.NotNull(_sub.DockPadding);
-        Assert.Same(_sub.DockPadding, _sub.DockPadding);
-        Assert.Equal(0, _sub.DockPadding.Top);
-        Assert.Equal(0, _sub.DockPadding.Bottom);
-        Assert.Equal(0, _sub.DockPadding.Left);
-        Assert.Equal(0, _sub.DockPadding.Right);
-        Assert.False(_sub.DoubleBuffered);
-        Assert.True(_sub.Enabled);
-        Assert.NotNull(_sub.Events);
-        Assert.Same(_sub.Events, _sub.Events);
-        Assert.False(_sub.Focused);
-        Assert.Equal(Control.DefaultFont, _sub.Font);
-        Assert.Equal(_sub.Font.Height, _sub.FontHeight);
-        Assert.Equal(SystemColors.WindowText, _sub.ForeColor);
-        Assert.True(_sub.HasChildren);
-        Assert.Equal(_sub.PreferredHeight, _sub.Height);
-        Assert.NotNull(_sub.HorizontalScroll);
-        Assert.Same(_sub.HorizontalScroll, _sub.HorizontalScroll);
-        Assert.False(_sub.HScroll);
-        Assert.Equal(ImeMode.NoControl, _sub.ImeMode);
-        Assert.Equal(ImeMode.NoControl, _sub.ImeModeBase);
-        Assert.True(_sub.InterceptArrowKeys);
-        Assert.False(_sub.InvokeRequired);
-        Assert.False(_sub.IsAccessible);
-        Assert.False(_sub.IsMirrored);
-        Assert.Empty(_sub.Items);
-        Assert.Same(_sub.Items, _sub.Items);
-        Assert.NotNull(_sub.LayoutEngine);
-        Assert.Same(_sub.LayoutEngine, _sub.LayoutEngine);
-        Assert.Equal(0, _sub.Left);
-        Assert.Equal(Point.Empty, _sub.Location);
-        Assert.Equal(new Padding(3), _sub.Margin);
-        Assert.Equal(Size.Empty, _sub.MaximumSize);
-        Assert.Equal(Size.Empty, _sub.MinimumSize);
-        Assert.Equal(Padding.Empty, _sub.Padding);
-        Assert.Null(_sub.Parent);
-        Assert.Equal(Control.DefaultFont.Height + 7, _sub.PreferredHeight);
-        Assert.Equal("Microsoft\u00AE .NET", _sub.ProductName);
-        Assert.False(_sub.ReadOnly);
-        Assert.False(_sub.RecreatingHandle);
-        Assert.Null(_sub.Region);
-        Assert.True(_sub.ResizeRedraw);
-        Assert.Equal(120, _sub.Right);
-        Assert.Equal(RightToLeft.No, _sub.RightToLeft);
-        Assert.Equal(-1, _sub.SelectedIndex);
-        Assert.Null(_sub.SelectedItem);
-        Assert.True(_sub.ShowFocusCues);
-        Assert.True(_sub.ShowKeyboardCues);
-        Assert.Null(_sub.Site);
-        Assert.Equal(new Size(120, _sub.PreferredHeight), _sub.Size);
-        Assert.Equal(0, _sub.TabIndex);
-        Assert.True(_sub.TabStop);
-        Assert.Empty(_sub.Text);
-        Assert.Equal(HorizontalAlignment.Left, _sub.TextAlign);
-        Assert.Equal(0, _sub.Top);
-        Assert.Null(_sub.TopLevelControl);
-        Assert.Equal(LeftRightAlignment.Right, _sub.UpDownAlign);
-        Assert.False(_sub.UserEdit);
-        Assert.False(_sub.UseWaitCursor);
-        Assert.True(_sub.Visible);
-        Assert.NotNull(_sub.VerticalScroll);
-        Assert.Same(_sub.VerticalScroll, _sub.VerticalScroll);
-        Assert.False(_sub.VScroll);
-        Assert.Equal(120, _sub.Width);
-        Assert.False(_sub.Wrap);
+        _sub.Container.Should().BeNull();
+        _sub.ContainsFocus.Should().BeFalse();
+        _sub.ContextMenuStrip.Should().BeNull();
+        _sub.Controls.Should().NotBeNull();
+        _sub.Controls.Should().BeSameAs(_sub.Controls);
+        _sub.Created.Should().BeFalse();
+        _sub.CurrentAutoScaleDimensions.Should().Be(SizeF.Empty);
+        _sub.Cursor.Should().Be(Cursors.Default);
+        _sub.DefaultCursor.Should().Be(Cursors.Default);
+        _sub.DefaultImeMode.Should().Be(ImeMode.Inherit);
+        _sub.DefaultMargin.Should().Be(new Padding(3));
+        _sub.DefaultMaximumSize.Should().Be(Size.Empty);
+        _sub.DefaultMinimumSize.Should().Be(Size.Empty);
+        _sub.DefaultPadding.Should().Be(Padding.Empty);
+        _sub.DefaultSize.Should().Be(new Size(120, _sub.PreferredHeight));
+        _sub.DesignMode.Should().BeFalse();
+        _sub.Dock.Should().Be(DockStyle.None);
+        _sub.DockPadding.Should().NotBeNull();
+        _sub.DockPadding.Should().BeSameAs(_sub.DockPadding);
+        _sub.DockPadding.Top.Should().Be(0);
+        _sub.DockPadding.Bottom.Should().Be(0);
+        _sub.DockPadding.Left.Should().Be(0);
+        _sub.DockPadding.Right.Should().Be(0);
+        _sub.DoubleBuffered.Should().BeFalse();
+        _sub.Enabled.Should().BeTrue();
+        _sub.Events.Should().NotBeNull();
+        _sub.Events.Should().BeSameAs(_sub.Events);
+        _sub.Focused.Should().BeFalse();
+        _sub.Font.Should().Be(Control.DefaultFont);
+        _sub.FontHeight.Should().Be(_sub.Font.Height);
+        _sub.ForeColor.Should().Be(SystemColors.WindowText);
+        _sub.HasChildren.Should().BeTrue();
+        _sub.Height.Should().Be(_sub.PreferredHeight);
+        _sub.HorizontalScroll.Should().NotBeNull();
+        _sub.HorizontalScroll.Should().BeSameAs(_sub.HorizontalScroll);
+        _sub.HScroll.Should().BeFalse();
+        _sub.ImeMode.Should().Be(ImeMode.NoControl);
+        _sub.ImeModeBase.Should().Be(ImeMode.NoControl);
+        _sub.InterceptArrowKeys.Should().BeTrue();
+        _sub.InvokeRequired.Should().BeFalse();
+        _sub.IsAccessible.Should().BeFalse();
+        _sub.IsMirrored.Should().BeFalse();
+        _sub.Items.Count.Should().Be(0);
+        _sub.Items.Should().BeSameAs(_sub.Items);
+        _sub.LayoutEngine.Should().NotBeNull();
+        _sub.LayoutEngine.Should().BeSameAs(_sub.LayoutEngine);
+        _sub.Left.Should().Be(0);
+        _sub.Location.Should().Be(Point.Empty);
+        _sub.Margin.Should().Be(new Padding(3));
+        _sub.MaximumSize.Should().Be(Size.Empty);
+        _sub.MinimumSize.Should().Be(Size.Empty);
+        _sub.Padding.Should().Be(Padding.Empty);
+        _sub.Parent.Should().BeNull();
+        _sub.PreferredHeight.Should().Be(Control.DefaultFont.Height + 7);
+        _sub.ProductName.Should().Be("Microsoft\u00AE .NET");
+        _sub.ReadOnly.Should().BeFalse();
+        _sub.RecreatingHandle.Should().BeFalse();
+        _sub.Region.Should().BeNull();
+        _sub.ResizeRedraw.Should().BeTrue();
+        _sub.Right.Should().Be(120);
+        _sub.RightToLeft.Should().Be(RightToLeft.No);
+        _sub.SelectedIndex.Should().Be(-1);
+        _sub.SelectedItem.Should().BeNull();
+        _sub.ShowFocusCues.Should().BeTrue();
+        _sub.ShowKeyboardCues.Should().BeTrue();
+        _sub.Site.Should().BeNull();
+        _sub.Size.Should().Be(new Size(120, _sub.PreferredHeight));
+        _sub.TabIndex.Should().Be(0);
+        _sub.TabStop.Should().BeTrue();
+        _sub.Text.Should().BeEmpty();
+        _sub.TextAlign.Should().Be(HorizontalAlignment.Left);
+        _sub.Top.Should().Be(0);
+        _sub.TopLevelControl.Should().BeNull();
+        _sub.UpDownAlign.Should().Be(LeftRightAlignment.Right);
+        _sub.UserEdit.Should().BeFalse();
+        _sub.UseWaitCursor.Should().BeFalse();
+        _sub.Visible.Should().BeTrue();
+        _sub.VerticalScroll.Should().NotBeNull();
+        _sub.VerticalScroll.Should().BeSameAs(_sub.VerticalScroll);
+        _sub.VScroll.Should().BeFalse();
+        _sub.Width.Should().Be(120);
+        _sub.Wrap.Should().BeFalse();
 
-        Assert.False(_sub.IsHandleCreated);
+        _sub.IsHandleCreated.Should().BeFalse();
     }
 
     [WinFormsFact]
     public void DomainUpDown_CreateParams_GetDefault_ReturnsExpected()
     {
         CreateParams createParams = _sub.CreateParams;
-        Assert.Null(createParams.Caption);
-        Assert.Null(createParams.ClassName);
+        createParams.Caption.Should().BeNull();
+        createParams.ClassName.Should().BeNull();
 
-        Assert.Equal(WNDCLASS_STYLES.CS_DBLCLKS, (WNDCLASS_STYLES)createParams.ClassStyle);
-        Assert.Equal(WINDOW_STYLE.WS_MAXIMIZEBOX | WINDOW_STYLE.WS_CLIPCHILDREN | WINDOW_STYLE.WS_CLIPSIBLINGS
-            | WINDOW_STYLE.WS_VISIBLE | WINDOW_STYLE.WS_CHILD, (WINDOW_STYLE)createParams.Style);
+        ((WNDCLASS_STYLES)createParams.ClassStyle).Should().Be(WNDCLASS_STYLES.CS_DBLCLKS);
+        ((WINDOW_STYLE)createParams.Style).Should().Be(WINDOW_STYLE.WS_MAXIMIZEBOX | WINDOW_STYLE.WS_CLIPCHILDREN | WINDOW_STYLE.WS_CLIPSIBLINGS
+            | WINDOW_STYLE.WS_VISIBLE | WINDOW_STYLE.WS_CHILD);
 
         if (Application.UseVisualStyles)
         {
-            Assert.Equal(WINDOW_EX_STYLE.WS_EX_CONTROLPARENT, (WINDOW_EX_STYLE)createParams.ExStyle);
+            ((WINDOW_EX_STYLE)createParams.ExStyle).Should().Be(WINDOW_EX_STYLE.WS_EX_CONTROLPARENT);
         }
         else
         {
-            Assert.Equal(WINDOW_EX_STYLE.WS_EX_CLIENTEDGE | WINDOW_EX_STYLE.WS_EX_CONTROLPARENT, (WINDOW_EX_STYLE)createParams.ExStyle);
+            ((WINDOW_EX_STYLE)createParams.ExStyle).Should().Be(WINDOW_EX_STYLE.WS_EX_CLIENTEDGE | WINDOW_EX_STYLE.WS_EX_CONTROLPARENT);
         }
 
-        Assert.Equal(_sub.PreferredHeight, createParams.Height);
-        Assert.Equal(IntPtr.Zero, createParams.Parent);
-        Assert.Null(createParams.Param);
-        Assert.Equal(120, createParams.Width);
-        Assert.Equal(0, createParams.X);
-        Assert.Equal(0, createParams.Y);
-        Assert.Same(createParams, _sub.CreateParams);
-        Assert.False(_sub.IsHandleCreated);
+        createParams.Height.Should().Be(_sub.PreferredHeight);
+        createParams.Parent.Should().Be(IntPtr.Zero);
+        createParams.Param.Should().BeNull();
+        createParams.Width.Should().Be(120);
+        createParams.X.Should().Be(0);
+        createParams.Y.Should().Be(0);
+        createParams.Should().BeSameAs(_sub.CreateParams);
+        _sub.IsHandleCreated.Should().BeFalse();
     }
 
     [WinFormsTheory]
@@ -190,20 +189,19 @@ public class DomainUpDownTests : IDisposable
     {
         _control.Padding = value;
 
-        Assert.Equal(expected, _control.Padding);
-        Assert.False(_control.IsHandleCreated);
+        _control.Padding.Should().Be(expected);
+        _control.IsHandleCreated.Should().BeFalse();
 
-        // Set same.
         _control.Padding = value;
-        Assert.Equal(expected, _control.Padding);
-        Assert.False(_control.IsHandleCreated);
+        _control.Padding.Should().Be(expected);
+        _control.IsHandleCreated.Should().BeFalse();
     }
 
     [WinFormsTheory]
     [CommonMemberData(typeof(CommonTestHelperEx), nameof(CommonTestHelperEx.GetPaddingNormalizedTheoryData))]
     public void DomainUpDown_Padding_SetWithHandle_GetReturnsExpected(Padding value, Padding expected)
     {
-        Assert.NotEqual(IntPtr.Zero, _control.Handle);
+        _control.Handle.Should().NotBe(IntPtr.Zero);
         int invalidatedCallCount = 0;
         _control.Invalidated += (sender, e) => invalidatedCallCount++;
         int styleChangedCallCount = 0;
@@ -212,19 +210,18 @@ public class DomainUpDownTests : IDisposable
         _control.HandleCreated += (sender, e) => createdCallCount++;
 
         _control.Padding = value;
-        Assert.Equal(expected, _control.Padding);
-        Assert.True(_control.IsHandleCreated);
-        Assert.Equal(0, invalidatedCallCount);
-        Assert.Equal(0, styleChangedCallCount);
-        Assert.Equal(0, createdCallCount);
+        _control.Padding.Should().Be(expected);
+        _control.IsHandleCreated.Should().BeTrue();
+        invalidatedCallCount.Should().Be(0);
+        styleChangedCallCount.Should().Be(0);
+        createdCallCount.Should().Be(0);
 
-        // Set same.
         _control.Padding = value;
-        Assert.Equal(expected, _control.Padding);
-        Assert.True(_control.IsHandleCreated);
-        Assert.Equal(0, invalidatedCallCount);
-        Assert.Equal(0, styleChangedCallCount);
-        Assert.Equal(0, createdCallCount);
+        _control.Padding.Should().Be(expected);
+        _control.IsHandleCreated.Should().BeTrue();
+        invalidatedCallCount.Should().Be(0);
+        styleChangedCallCount.Should().Be(0);
+        createdCallCount.Should().Be(0);
     }
 
     [WinFormsFact]
@@ -233,8 +230,8 @@ public class DomainUpDownTests : IDisposable
         int callCount = 0;
         EventHandler handler = (sender, e) =>
         {
-            Assert.Equal(_control, sender);
-            Assert.Same(EventArgs.Empty, e);
+            sender.Should().Be(_control);
+            e.Should().Be(EventArgs.Empty);
             callCount++;
         };
         _control.PaddingChanged += handler;
@@ -242,25 +239,25 @@ public class DomainUpDownTests : IDisposable
         // Set different.
         Padding padding1 = new(1);
         _control.Padding = padding1;
-        Assert.Equal(padding1, _control.Padding);
-        Assert.Equal(1, callCount);
+        _control.Padding.Should().Be(padding1);
+        callCount.Should().Be(1);
 
         // Set same.
         _control.Padding = padding1;
-        Assert.Equal(padding1, _control.Padding);
-        Assert.Equal(1, callCount);
+        _control.Padding.Should().Be(padding1);
+        callCount.Should().Be(1);
 
         // Set different.
         Padding padding2 = new(2);
         _control.Padding = padding2;
-        Assert.Equal(padding2, _control.Padding);
-        Assert.Equal(2, callCount);
+        _control.Padding.Should().Be(padding2);
+        callCount.Should().Be(2);
 
         // Remove handler.
         _control.PaddingChanged -= handler;
         _control.Padding = padding1;
-        Assert.Equal(padding1, _control.Padding);
-        Assert.Equal(2, callCount);
+        _control.Padding.Should().Be(padding1);
+        callCount.Should().Be(2);
     }
 
     [WinFormsFact]
@@ -268,21 +265,20 @@ public class DomainUpDownTests : IDisposable
     {
         _sub.SelectedIndex = -1;
 
-        Assert.Equal(-1, _sub.SelectedIndex);
-        Assert.Null(_sub.SelectedItem);
-        Assert.Empty(_sub.Text);
-        Assert.False(_sub.UserEdit);
-        Assert.False(_sub.ChangingText);
-        Assert.False(_sub.IsHandleCreated);
+        _sub.SelectedIndex.Should().Be(-1);
+        _sub.SelectedItem.Should().BeNull();
+        _sub.Text.Should().BeEmpty();
+        _sub.UserEdit.Should().BeFalse();
+        _sub.ChangingText.Should().BeFalse();
+        _sub.IsHandleCreated.Should().BeFalse();
 
-        // Set same.
         _sub.SelectedIndex = -1;
-        Assert.Equal(-1, _sub.SelectedIndex);
-        Assert.Null(_sub.SelectedItem);
-        Assert.Empty(_sub.Text);
-        Assert.False(_sub.UserEdit);
-        Assert.False(_sub.ChangingText);
-        Assert.False(_sub.IsHandleCreated);
+        _sub.SelectedIndex.Should().Be(-1);
+        _sub.SelectedItem.Should().BeNull();
+        _sub.Text.Should().BeEmpty();
+        _sub.UserEdit.Should().BeFalse();
+        _sub.ChangingText.Should().BeFalse();
+        _sub.IsHandleCreated.Should().BeFalse();
     }
 
     [WinFormsTheory]
@@ -295,30 +291,30 @@ public class DomainUpDownTests : IDisposable
         _sub.Items.Add("Item2");
 
         _sub.SelectedIndex = value;
-        Assert.Equal(value, _sub.SelectedIndex);
-        Assert.Equal(expected, _sub.SelectedItem);
-        Assert.Equal(expectedText, _sub.Text);
-        Assert.False(_sub.UserEdit);
-        Assert.False(_sub.ChangingText);
-        Assert.False(_sub.IsHandleCreated);
+        _sub.SelectedIndex.Should().Be(value);
+        _sub.SelectedItem.Should().Be(expected);
+        _sub.Text.Should().Be(expectedText);
+        _sub.UserEdit.Should().BeFalse();
+        _sub.ChangingText.Should().BeFalse();
+        _sub.IsHandleCreated.Should().BeFalse();
 
         // Set same.
         _sub.SelectedIndex = value;
-        Assert.Equal(value, _sub.SelectedIndex);
-        Assert.Equal(expected, _sub.SelectedItem);
-        Assert.Equal(expectedText, _sub.Text);
-        Assert.False(_sub.UserEdit);
-        Assert.False(_sub.ChangingText);
-        Assert.False(_sub.IsHandleCreated);
+        _sub.SelectedIndex.Should().Be(value);
+        _sub.SelectedItem.Should().Be(expected);
+        _sub.Text.Should().Be(expectedText);
+        _sub.UserEdit.Should().BeFalse();
+        _sub.ChangingText.Should().BeFalse();
+        _sub.IsHandleCreated.Should().BeFalse();
 
         // Set none.
         _sub.SelectedIndex = -1;
-        Assert.Equal(-1, _sub.SelectedIndex);
-        Assert.Null(_sub.SelectedItem);
-        Assert.Equal(expectedText, _sub.Text);
-        Assert.Equal(expectedUserEdit, _sub.UserEdit);
-        Assert.False(_sub.ChangingText);
-        Assert.False(_sub.IsHandleCreated);
+        _sub.SelectedIndex.Should().Be(-1);
+        _sub.SelectedItem.Should().BeNull();
+        _sub.Text.Should().Be(expectedText);
+        _sub.UserEdit.Should().Be(expectedUserEdit);
+        _sub.ChangingText.Should().BeFalse();
+        _sub.IsHandleCreated.Should().BeFalse();
     }
 
     [WinFormsTheory]
@@ -332,33 +328,33 @@ public class DomainUpDownTests : IDisposable
         _sub.Items.Add("Item2");
 
         _sub.SelectedIndex = value;
-        Assert.Equal(value, _sub.SelectedIndex);
-        Assert.Equal(expected, _sub.SelectedItem);
-        Assert.Equal(expectedText, _sub.Text);
-        Assert.Equal(!expectedUserEdit, _sub.UserEdit);
-        Assert.False(_sub.ChangingText);
-        Assert.False(_sub.IsHandleCreated);
+        _sub.SelectedIndex.Should().Be(value);
+        _sub.SelectedItem.Should().Be(expected);
+        _sub.Text.Should().Be(expectedText);
+        _sub.UserEdit.Should().Be(!expectedUserEdit);
+        _sub.ChangingText.Should().BeFalse();
+        _sub.IsHandleCreated.Should().BeFalse();
 
         // Set same.
         _sub.SelectedIndex = value;
-        Assert.Equal(value, _sub.SelectedIndex);
-        Assert.Equal(expected, _sub.SelectedItem);
-        Assert.Equal(expectedText, _sub.Text);
-        Assert.Equal(!expectedUserEdit, _sub.UserEdit);
-        Assert.False(_sub.ChangingText);
-        Assert.False(_sub.IsHandleCreated);
+        _sub.SelectedIndex.Should().Be(value);
+        _sub.SelectedItem.Should().Be(expected);
+        _sub.Text.Should().Be(expectedText);
+        _sub.UserEdit.Should().Be(!expectedUserEdit);
+        _sub.ChangingText.Should().BeFalse();
+        _sub.IsHandleCreated.Should().BeFalse();
 
         // Set none.
         _sub.SelectedIndex = -1;
-        Assert.Equal(-1, _sub.SelectedIndex);
-        Assert.Null(_sub.SelectedItem);
-        Assert.Equal(expectedText, _sub.Text);
-        Assert.True(_sub.UserEdit);
-        Assert.False(_sub.ChangingText);
-        Assert.False(_sub.IsHandleCreated);
+        _sub.SelectedIndex.Should().Be(-1);
+        _sub.SelectedItem.Should().BeNull();
+        _sub.Text.Should().Be(expectedText);
+        _sub.UserEdit.Should().BeTrue();
+        _sub.ChangingText.Should().BeFalse();
+        _sub.IsHandleCreated.Should().BeFalse();
     }
 
-    [WinFormsFact]
+   [WinFormsFact]
     public void DomainUpDown_SelectedIndex_SetWithHandler_CallsSelectedItemChanged()
     {
         _control.Items.Add("Item1");
@@ -368,15 +364,15 @@ public class DomainUpDownTests : IDisposable
         int callCount = 0;
         EventHandler textChangedHandler = (sender, e) =>
         {
-            Assert.Same(_control, sender);
-            Assert.Same(EventArgs.Empty, e);
+            sender.Should().Be(_control);
+            e.Should().Be(EventArgs.Empty);
             textChangedCallCount++;
         };
         EventHandler handler = (sender, e) =>
         {
-            Assert.Same(_control, sender);
-            Assert.Same(EventArgs.Empty, e);
-            Assert.Equal(textChangedCallCount - 1, callCount);
+            sender.Should().Be(_control);
+            e.Should().Be(EventArgs.Empty);
+            (textChangedCallCount - 1).Should().Be(callCount);
             callCount++;
         };
         _control.TextChanged += textChangedHandler;
@@ -384,35 +380,35 @@ public class DomainUpDownTests : IDisposable
 
         // Set different.
         _control.SelectedIndex = 0;
-        Assert.Equal(0, _control.SelectedIndex);
-        Assert.Equal(1, textChangedCallCount);
-        Assert.Equal(1, callCount);
+        _control.SelectedIndex.Should().Be(0);
+        textChangedCallCount.Should().Be(1);
+        callCount.Should().Be(1);
 
         // Set same.
         _control.SelectedIndex = 0;
-        Assert.Equal(0, _control.SelectedIndex);
-        Assert.Equal(1, textChangedCallCount);
-        Assert.Equal(1, callCount);
+        _control.SelectedIndex.Should().Be(0);
+        textChangedCallCount.Should().Be(1);
+        callCount.Should().Be(1);
 
         // Set different.
         _control.SelectedIndex = 1;
-        Assert.Equal(1, _control.SelectedIndex);
-        Assert.Equal(2, textChangedCallCount);
-        Assert.Equal(2, callCount);
+        _control.SelectedIndex.Should().Be(1);
+        textChangedCallCount.Should().Be(2);
+        callCount.Should().Be(2);
 
         // Set none.
         _control.SelectedIndex = -1;
-        Assert.Equal(-1, _control.SelectedIndex);
-        Assert.Equal(2, textChangedCallCount);
-        Assert.Equal(2, callCount);
+        _control.SelectedIndex.Should().Be(-1);
+        textChangedCallCount.Should().Be(2);
+        callCount.Should().Be(2);
 
         // Remove handler.
         _control.TextChanged -= textChangedHandler;
         _control.SelectedItemChanged -= handler;
         _control.SelectedIndex = 0;
-        Assert.Equal(0, _control.SelectedIndex);
-        Assert.Equal(2, textChangedCallCount);
-        Assert.Equal(2, callCount);
+        _control.SelectedIndex.Should().Be(0);
+        textChangedCallCount.Should().Be(2);
+        callCount.Should().Be(2);
     }
 
     [WinFormsTheory]
@@ -421,7 +417,7 @@ public class DomainUpDownTests : IDisposable
     [InlineData(1)]
     public void DomainUpDown_SelectedIndex_SetInvalidValueEmpty_ThrowsArgumentOutOfRangeException(int value)
     {
-        Assert.Throws<ArgumentOutOfRangeException>("value", () => _control.SelectedIndex = value);
+        _control.Invoking(c => c.SelectedIndex = value).Should().Throw<ArgumentOutOfRangeException>().And.ParamName.Should().Be("value");
     }
 
     [WinFormsTheory]
@@ -431,7 +427,7 @@ public class DomainUpDownTests : IDisposable
     public void DomainUpDown_SelectedIndex_SetInvalidValueNotEmpty_ThrowsArgumentOutOfRangeException(int value)
     {
         _control.Items.Add("Item");
-        Assert.Throws<ArgumentOutOfRangeException>("value", () => _control.SelectedIndex = value);
+        _control.Invoking(c => c.SelectedIndex = value).Should().Throw<ArgumentOutOfRangeException>().And.ParamName.Should().Be("value");
     }
 
     [WinFormsTheory]
@@ -440,21 +436,21 @@ public class DomainUpDownTests : IDisposable
     public void DomainUpDown_SelectedItem_SetEmpty_Nop(object value)
     {
         _sub.SelectedItem = value;
-        Assert.Equal(-1, _sub.SelectedIndex);
-        Assert.Null(_sub.SelectedItem);
-        Assert.Empty(_sub.Text);
-        Assert.False(_sub.UserEdit);
-        Assert.False(_sub.ChangingText);
-        Assert.False(_sub.IsHandleCreated);
+        _sub.SelectedIndex.Should().Be(-1);
+        _sub.SelectedItem.Should().BeNull();
+        _sub.Text.Should().BeEmpty();
+        _sub.UserEdit.Should().BeFalse();
+        _sub.ChangingText.Should().BeFalse();
+        _sub.IsHandleCreated.Should().BeFalse();
 
         // Set same.
         _sub.SelectedItem = value;
-        Assert.Equal(-1, _sub.SelectedIndex);
-        Assert.Null(_sub.SelectedItem);
-        Assert.Empty(_sub.Text);
-        Assert.False(_sub.UserEdit);
-        Assert.False(_sub.ChangingText);
-        Assert.False(_sub.IsHandleCreated);
+        _sub.SelectedIndex.Should().Be(-1);
+        _sub.SelectedItem.Should().BeNull();
+        _sub.Text.Should().BeEmpty();
+        _sub.UserEdit.Should().BeFalse();
+        _sub.ChangingText.Should().BeFalse();
+        _sub.IsHandleCreated.Should().BeFalse();
     }
 
     [WinFormsTheory]
@@ -468,39 +464,39 @@ public class DomainUpDownTests : IDisposable
         _sub.Items.Add("Item2");
 
         _sub.SelectedItem = value;
-        Assert.Equal(expectedSelectedIndex, _sub.SelectedIndex);
-        Assert.Equal(expected, _sub.SelectedItem);
-        Assert.Equal(expectedText, _sub.Text);
-        Assert.False(_sub.UserEdit);
-        Assert.False(_sub.ChangingText);
-        Assert.False(_sub.IsHandleCreated);
+        _sub.SelectedIndex.Should().Be(expectedSelectedIndex);
+        _sub.SelectedItem.Should().Be(expected);
+        _sub.Text.Should().Be(expectedText);
+        _sub.UserEdit.Should().BeFalse();
+        _sub.ChangingText.Should().BeFalse();
+        _sub.IsHandleCreated.Should().BeFalse();
 
         // Set same.
         _sub.SelectedItem = value;
-        Assert.Equal(expectedSelectedIndex, _sub.SelectedIndex);
-        Assert.Equal(expected, _sub.SelectedItem);
-        Assert.Equal(expectedText, _sub.Text);
-        Assert.False(_sub.UserEdit);
-        Assert.False(_sub.ChangingText);
-        Assert.False(_sub.IsHandleCreated);
+        _sub.SelectedIndex.Should().Be(expectedSelectedIndex);
+        _sub.SelectedItem.Should().Be(expected);
+        _sub.Text.Should().Be(expectedText);
+        _sub.UserEdit.Should().BeFalse();
+        _sub.ChangingText.Should().BeFalse();
+        _sub.IsHandleCreated.Should().BeFalse();
 
         // Set no such item.
         _sub.SelectedItem = "NoSuchItem";
-        Assert.Equal(expectedSelectedIndex, _sub.SelectedIndex);
-        Assert.Equal(expected, _sub.SelectedItem);
-        Assert.Equal(expectedText, _sub.Text);
-        Assert.False(_sub.UserEdit);
-        Assert.False(_sub.ChangingText);
-        Assert.False(_sub.IsHandleCreated);
+        _sub.SelectedIndex.Should().Be(expectedSelectedIndex);
+        _sub.SelectedItem.Should().Be(expected);
+        _sub.Text.Should().Be(expectedText);
+        _sub.UserEdit.Should().BeFalse();
+        _sub.ChangingText.Should().BeFalse();
+        _sub.IsHandleCreated.Should().BeFalse();
 
         // Set none.
         _sub.SelectedItem = null;
-        Assert.Equal(-1, _sub.SelectedIndex);
-        Assert.Null(_sub.SelectedItem);
-        Assert.Equal(expectedText, _sub.Text);
-        Assert.Equal(expectedUserEdit, _sub.UserEdit);
-        Assert.False(_sub.ChangingText);
-        Assert.False(_sub.IsHandleCreated);
+        _sub.SelectedIndex.Should().Be(-1);
+        _sub.SelectedItem.Should().BeNull();
+        _sub.Text.Should().Be(expectedText);
+        _sub.UserEdit.Should().Be(expectedUserEdit);
+        _sub.ChangingText.Should().BeFalse();
+        _sub.IsHandleCreated.Should().BeFalse();
     }
 
     [WinFormsTheory]
@@ -515,39 +511,39 @@ public class DomainUpDownTests : IDisposable
         _sub.Items.Add("Item2");
 
         _sub.SelectedItem = value;
-        Assert.Equal(expectedSelectedIndex, _sub.SelectedIndex);
-        Assert.Equal(expected, _sub.SelectedItem);
-        Assert.Equal(expectedText, _sub.Text);
-        Assert.Equal(!expectedUserEdit, _sub.UserEdit);
-        Assert.False(_sub.ChangingText);
-        Assert.False(_sub.IsHandleCreated);
+        _sub.SelectedIndex.Should().Be(expectedSelectedIndex);
+        _sub.SelectedItem.Should().Be(expected);
+        _sub.Text.Should().Be(expectedText);
+        _sub.UserEdit.Should().Be(!expectedUserEdit);
+        _sub.ChangingText.Should().BeFalse();
+        _sub.IsHandleCreated.Should().BeFalse();
 
         // Set same.
         _sub.SelectedItem = value;
-        Assert.Equal(expectedSelectedIndex, _sub.SelectedIndex);
-        Assert.Equal(expected, _sub.SelectedItem);
-        Assert.Equal(expectedText, _sub.Text);
-        Assert.Equal(!expectedUserEdit, _sub.UserEdit);
-        Assert.False(_sub.ChangingText);
-        Assert.False(_sub.IsHandleCreated);
+        _sub.SelectedIndex.Should().Be(expectedSelectedIndex);
+        _sub.SelectedItem.Should().Be(expected);
+        _sub.Text.Should().Be(expectedText);
+        _sub.UserEdit.Should().Be(!expectedUserEdit);
+        _sub.ChangingText.Should().BeFalse();
+        _sub.IsHandleCreated.Should().BeFalse();
 
         // Set no such item.
         _sub.SelectedItem = "NoSuchItem";
-        Assert.Equal(expectedSelectedIndex, _sub.SelectedIndex);
-        Assert.Equal(expected, _sub.SelectedItem);
-        Assert.Equal(expectedText, _sub.Text);
-        Assert.Equal(!expectedUserEdit, _sub.UserEdit);
-        Assert.False(_sub.ChangingText);
-        Assert.False(_sub.IsHandleCreated);
+        _sub.SelectedIndex.Should().Be(expectedSelectedIndex);
+        _sub.SelectedItem.Should().Be(expected);
+        _sub.Text.Should().Be(expectedText);
+        _sub.UserEdit.Should().Be(!expectedUserEdit);
+        _sub.ChangingText.Should().BeFalse();
+        _sub.IsHandleCreated.Should().BeFalse();
 
         // Set none.
         _sub.SelectedItem = null;
-        Assert.Equal(-1, _sub.SelectedIndex);
-        Assert.Null(_sub.SelectedItem);
-        Assert.Equal(expectedText, _sub.Text);
-        Assert.True(_sub.UserEdit);
-        Assert.False(_sub.ChangingText);
-        Assert.False(_sub.IsHandleCreated);
+        _sub.SelectedIndex.Should().Be(-1);
+        _sub.SelectedItem.Should().BeNull();
+        _sub.Text.Should().Be(expectedText);
+        _sub.UserEdit.Should().BeTrue();
+        _sub.ChangingText.Should().BeFalse();
+        _sub.IsHandleCreated.Should().BeFalse();
     }
 
     [WinFormsFact]
@@ -560,15 +556,15 @@ public class DomainUpDownTests : IDisposable
         int callCount = 0;
         EventHandler textChangedHandler = (sender, e) =>
         {
-            Assert.Same(_control, sender);
-            Assert.Same(EventArgs.Empty, e);
+            sender.Should().Be(_control);
+            e.Should().Be(EventArgs.Empty);
             textChangedCallCount++;
         };
         EventHandler handler = (sender, e) =>
         {
-            Assert.Same(_control, sender);
-            Assert.Same(EventArgs.Empty, e);
-            Assert.Equal(textChangedCallCount - 1, callCount);
+            sender.Should().Be(_control);
+            e.Should().Be(EventArgs.Empty);
+            (textChangedCallCount - 1).Should().Be(callCount);
             callCount++;
         };
         _control.TextChanged += textChangedHandler;
@@ -576,35 +572,35 @@ public class DomainUpDownTests : IDisposable
 
         // Set different.
         _control.SelectedItem = "Item1";
-        Assert.Equal("Item1", _control.SelectedItem);
-        Assert.Equal(1, textChangedCallCount);
-        Assert.Equal(1, callCount);
+        _control.SelectedItem.Should().Be("Item1");
+        textChangedCallCount.Should().Be(1);
+        callCount.Should().Be(1);
 
         // Set same.
         _control.SelectedItem = "Item1";
-        Assert.Equal("Item1", _control.SelectedItem);
-        Assert.Equal(1, textChangedCallCount);
-        Assert.Equal(1, callCount);
+        _control.SelectedItem.Should().Be("Item1");
+        textChangedCallCount.Should().Be(1);
+        callCount.Should().Be(1);
 
         // Set different.
         _control.SelectedItem = "Item2";
-        Assert.Equal("Item2", _control.SelectedItem);
-        Assert.Equal(2, textChangedCallCount);
-        Assert.Equal(2, callCount);
+        _control.SelectedItem.Should().Be("Item2");
+        textChangedCallCount.Should().Be(2);
+        callCount.Should().Be(2);
 
         // Set none.
         _control.SelectedItem = null;
-        Assert.Null(_control.SelectedItem);
-        Assert.Equal(2, textChangedCallCount);
-        Assert.Equal(2, callCount);
+        _control.SelectedItem.Should().BeNull();
+        textChangedCallCount.Should().Be(2);
+        callCount.Should().Be(2);
 
         // Remove handler.
         _control.TextChanged -= textChangedHandler;
         _control.SelectedItemChanged -= handler;
         _control.SelectedItem = "Item1";
-        Assert.Equal("Item1", _control.SelectedItem);
-        Assert.Equal(2, textChangedCallCount);
-        Assert.Equal(2, callCount);
+        _control.SelectedItem.Should().Be("Item1");
+        textChangedCallCount.Should().Be(2);
+        callCount.Should().Be(2);
     }
 
     public static IEnumerable<object[]> Sorted_Set_TestData()
@@ -623,27 +619,27 @@ public class DomainUpDownTests : IDisposable
         _sub.UserEdit = userEdit;
         _sub.Sorted = value;
 
-        Assert.Equal(value, _sub.Sorted);
-        Assert.Empty(_sub.Items);
-        Assert.Equal(-1, _sub.SelectedIndex);
-        Assert.Equal(userEdit, _sub.UserEdit);
-        Assert.False(_sub.IsHandleCreated);
+        _sub.Sorted.Should().Be(value);
+        _sub.Items.Count.Should().Be(0);
+        _sub.SelectedIndex.Should().Be(-1);
+        _sub.UserEdit.Should().Be(userEdit);
+        _sub.IsHandleCreated.Should().BeFalse();
 
         // Set same.
         _sub.Sorted = value;
-        Assert.Equal(value, _sub.Sorted);
-        Assert.Empty(_sub.Items);
-        Assert.Equal(-1, _sub.SelectedIndex);
-        Assert.Equal(userEdit, _sub.UserEdit);
-        Assert.False(_sub.IsHandleCreated);
+        _sub.Sorted.Should().Be(value);
+        _sub.Items.Count.Should().Be(0);
+        _sub.SelectedIndex.Should().Be(-1);
+        _sub.UserEdit.Should().Be(userEdit);
+        _sub.IsHandleCreated.Should().BeFalse();
 
         // Set different.
         _sub.Sorted = !value;
-        Assert.Equal(!value, _sub.Sorted);
-        Assert.Empty(_sub.Items);
-        Assert.Equal(-1, _sub.SelectedIndex);
-        Assert.Equal(userEdit, _sub.UserEdit);
-        Assert.False(_sub.IsHandleCreated);
+        _sub.Sorted.Should().Be(!value);
+        _sub.Items.Count.Should().Be(0);
+        _sub.SelectedIndex.Should().Be(-1);
+        _sub.UserEdit.Should().Be(userEdit);
+        _sub.IsHandleCreated.Should().BeFalse();
     }
 
     public static IEnumerable<object[]> Sorted_WithItems_TestData()
@@ -667,26 +663,26 @@ public class DomainUpDownTests : IDisposable
         _sub.UserEdit = userEdit;
 
         _sub.Sorted = value;
-        Assert.Equal(value, _sub.Sorted);
-        Assert.Equal(expectedItems, _sub.Items.Cast<string>());
-        Assert.Equal(-1, _sub.SelectedIndex);
-        Assert.False(_sub.IsHandleCreated);
+        _sub.Sorted.Should().Be(value);
+        _sub.Items.Cast<string>().Should().Equal(expectedItems);
+        _sub.SelectedIndex.Should().Be(-1);
+        _sub.IsHandleCreated.Should().BeFalse();
 
         // Set same.
         _sub.Sorted = value;
-        Assert.Equal(value, _sub.Sorted);
-        Assert.Equal(expectedItems, _sub.Items.Cast<string>());
-        Assert.Equal(-1, _sub.SelectedIndex);
-        Assert.Equal(userEdit, _sub.UserEdit);
-        Assert.False(_sub.IsHandleCreated);
+        _sub.Sorted.Should().Be(value);
+        _sub.Items.Cast<string>().Should().Equal(expectedItems);
+        _sub.SelectedIndex.Should().Be(-1);
+        _sub.UserEdit.Should().Be(userEdit);
+        _sub.IsHandleCreated.Should().BeFalse();
 
         // Set different.
         _sub.Sorted = !value;
-        Assert.Equal(!value, _sub.Sorted);
-        Assert.Equal(new string[] { "a", "a", "B", "c", "d" }, _sub.Items.Cast<string>());
-        Assert.Equal(-1, _sub.SelectedIndex);
-        Assert.Equal(userEdit, _sub.UserEdit);
-        Assert.False(_sub.IsHandleCreated);
+        _sub.Sorted.Should().Be(!value);
+        _sub.Items.Cast<string>().Should().Equal(new string[] { "a", "a", "B", "c", "d" });
+        _sub.SelectedIndex.Should().Be(-1);
+        _sub.UserEdit.Should().Be(userEdit);
+        _sub.IsHandleCreated.Should().BeFalse();
     }
 
     public static IEnumerable<object[]> Sorted_WithItemsWithSelection_TestData()
@@ -710,26 +706,26 @@ public class DomainUpDownTests : IDisposable
         _sub.UserEdit = userEdit;
 
         _sub.Sorted = value;
-        Assert.Equal(value, _sub.Sorted);
-        Assert.Equal(expectedItems, _sub.Items.Cast<string>());
-        Assert.Equal(expectedSelectedIndex, _sub.SelectedIndex);
-        Assert.False(_sub.IsHandleCreated);
+        _sub.Sorted.Should().Be(value);
+        _sub.Items.Cast<string>().Should().Equal(expectedItems);
+        _sub.SelectedIndex.Should().Be(expectedSelectedIndex);
+        _sub.IsHandleCreated.Should().BeFalse();
 
         // Set same.
         _sub.Sorted = value;
-        Assert.Equal(value, _sub.Sorted);
-        Assert.Equal(expectedItems, _sub.Items.Cast<string>());
-        Assert.Equal(expectedSelectedIndex, _sub.SelectedIndex);
-        Assert.Equal(userEdit, _sub.UserEdit);
-        Assert.False(_sub.IsHandleCreated);
+        _sub.Sorted.Should().Be(value);
+        _sub.Items.Cast<string>().Should().Equal(expectedItems);
+        _sub.SelectedIndex.Should().Be(expectedSelectedIndex);
+        _sub.UserEdit.Should().Be(userEdit);
+        _sub.IsHandleCreated.Should().BeFalse();
 
         // Set different.
         _sub.Sorted = !value;
-        Assert.Equal(!value, _sub.Sorted);
-        Assert.Equal(new string[] { "a", "a", "B", "c", "d" }, _sub.Items.Cast<string>());
-        Assert.Equal(expectedSelectedIndex, _sub.SelectedIndex);
-        Assert.Equal(userEdit, _sub.UserEdit);
-        Assert.False(_sub.IsHandleCreated);
+        _sub.Sorted.Should().Be(!value);
+        _sub.Items.Cast<string>().Should().Equal(new string[] { "a", "a", "B", "c", "d" });
+        _sub.SelectedIndex.Should().Be(expectedSelectedIndex);
+        _sub.UserEdit.Should().Be(userEdit);
+        _sub.IsHandleCreated.Should().BeFalse();
     }
 
     [WinFormsTheory]
@@ -737,7 +733,7 @@ public class DomainUpDownTests : IDisposable
     public void DomainUpDown_Sorted_SetWithHandle_GetReturnsExpected(bool userEdit, bool value)
     {
         _sub.UserEdit = userEdit;
-        Assert.NotEqual(IntPtr.Zero, _sub.Handle);
+        _sub.Handle.Should().NotBe(IntPtr.Zero);
         int invalidatedCallCount = 0;
         _sub.Invalidated += (sender, e) => invalidatedCallCount++;
         int styleChangedCallCount = 0;
@@ -746,36 +742,36 @@ public class DomainUpDownTests : IDisposable
         _sub.HandleCreated += (sender, e) => createdCallCount++;
 
         _sub.Sorted = value;
-        Assert.Equal(value, _sub.Sorted);
-        Assert.Empty(_sub.Items);
-        Assert.Equal(-1, _sub.SelectedIndex);
-        Assert.Equal(userEdit, _sub.UserEdit);
-        Assert.True(_sub.IsHandleCreated);
-        Assert.Equal(0, invalidatedCallCount);
-        Assert.Equal(0, styleChangedCallCount);
-        Assert.Equal(0, createdCallCount);
+        _sub.Sorted.Should().Be(value);
+        _sub.Items.Count.Should().Be(0);
+        _sub.SelectedIndex.Should().Be(-1);
+        _sub.UserEdit.Should().Be(userEdit);
+        _sub.IsHandleCreated.Should().BeTrue();
+        invalidatedCallCount.Should().Be(0);
+        styleChangedCallCount.Should().Be(0);
+        createdCallCount.Should().Be(0);
 
         // Set same.
         _sub.Sorted = value;
-        Assert.Equal(value, _sub.Sorted);
-        Assert.Empty(_sub.Items);
-        Assert.Equal(-1, _sub.SelectedIndex);
-        Assert.Equal(userEdit, _sub.UserEdit);
-        Assert.True(_sub.IsHandleCreated);
-        Assert.Equal(0, invalidatedCallCount);
-        Assert.Equal(0, styleChangedCallCount);
-        Assert.Equal(0, createdCallCount);
+        _sub.Sorted.Should().Be(value);
+        _sub.Items.Count.Should().Be(0);
+        _sub.SelectedIndex.Should().Be(-1);
+        _sub.UserEdit.Should().Be(userEdit);
+        _sub.IsHandleCreated.Should().BeTrue();
+        invalidatedCallCount.Should().Be(0);
+        styleChangedCallCount.Should().Be(0);
+        createdCallCount.Should().Be(0);
 
         // Set different.
         _sub.Sorted = !value;
-        Assert.Equal(!value, _sub.Sorted);
-        Assert.Empty(_sub.Items);
-        Assert.Equal(-1, _sub.SelectedIndex);
-        Assert.Equal(userEdit, _sub.UserEdit);
-        Assert.True(_sub.IsHandleCreated);
-        Assert.Equal(0, invalidatedCallCount);
-        Assert.Equal(0, styleChangedCallCount);
-        Assert.Equal(0, createdCallCount);
+        _sub.Sorted.Should().Be(!value);
+        _sub.Items.Count.Should().Be(0);
+        _sub.SelectedIndex.Should().Be(-1);
+        _sub.UserEdit.Should().Be(userEdit);
+        _sub.IsHandleCreated.Should().BeTrue();
+        invalidatedCallCount.Should().Be(0);
+        styleChangedCallCount.Should().Be(0);
+        createdCallCount.Should().Be(0);
     }
 
     [WinFormsTheory]
@@ -787,7 +783,7 @@ public class DomainUpDownTests : IDisposable
         _sub.Items.Add("a");
         _sub.Items.Add("a");
         _sub.Items.Add("d");
-        Assert.NotEqual(IntPtr.Zero, _sub.Handle);
+        _sub.Handle.Should().NotBe(IntPtr.Zero);
         int invalidatedCallCount = 0;
         _sub.Invalidated += (sender, e) => invalidatedCallCount++;
         int styleChangedCallCount = 0;
@@ -797,35 +793,35 @@ public class DomainUpDownTests : IDisposable
         _sub.UserEdit = userEdit;
 
         _sub.Sorted = value;
-        Assert.Equal(value, _sub.Sorted);
-        Assert.Equal(expectedItems, _sub.Items.Cast<string>());
-        Assert.Equal(-1, _sub.SelectedIndex);
-        Assert.True(_sub.IsHandleCreated);
-        Assert.Equal(0, invalidatedCallCount);
-        Assert.Equal(0, styleChangedCallCount);
-        Assert.Equal(0, createdCallCount);
+        _sub.Sorted.Should().Be(value);
+        _sub.Items.Cast<string>().Should().Equal(expectedItems);
+        _sub.SelectedIndex.Should().Be(-1);
+        _sub.IsHandleCreated.Should().BeTrue();
+        invalidatedCallCount.Should().Be(0);
+        styleChangedCallCount.Should().Be(0);
+        createdCallCount.Should().Be(0);
 
         // Set same.
         _sub.Sorted = value;
-        Assert.Equal(value, _sub.Sorted);
-        Assert.Equal(expectedItems, _sub.Items.Cast<string>());
-        Assert.Equal(-1, _sub.SelectedIndex);
-        Assert.Equal(userEdit, _sub.UserEdit);
-        Assert.True(_sub.IsHandleCreated);
-        Assert.Equal(0, invalidatedCallCount);
-        Assert.Equal(0, styleChangedCallCount);
-        Assert.Equal(0, createdCallCount);
+        _sub.Sorted.Should().Be(value);
+        _sub.Items.Cast<string>().Should().Equal(expectedItems);
+        _sub.SelectedIndex.Should().Be(-1);
+        _sub.UserEdit.Should().Be(userEdit);
+        _sub.IsHandleCreated.Should().BeTrue();
+        invalidatedCallCount.Should().Be(0);
+        styleChangedCallCount.Should().Be(0);
+        createdCallCount.Should().Be(0);
 
         // Set different.
         _sub.Sorted = !value;
-        Assert.Equal(!value, _sub.Sorted);
-        Assert.Equal(new string[] { "a", "a", "B", "c", "d" }, _sub.Items.Cast<string>());
-        Assert.Equal(-1, _sub.SelectedIndex);
-        Assert.Equal(userEdit, _sub.UserEdit);
-        Assert.True(_sub.IsHandleCreated);
-        Assert.Equal(0, invalidatedCallCount);
-        Assert.Equal(0, styleChangedCallCount);
-        Assert.Equal(0, createdCallCount);
+        _sub.Sorted.Should().Be(!value);
+        _sub.Items.Cast<string>().Should().Equal(new string[] { "a", "a", "B", "c", "d" });
+        _sub.SelectedIndex.Should().Be(-1);
+        _sub.UserEdit.Should().Be(userEdit);
+        _sub.IsHandleCreated.Should().BeTrue();
+        invalidatedCallCount.Should().Be(0);
+        styleChangedCallCount.Should().Be(0);
+        createdCallCount.Should().Be(0);
     }
 
     [WinFormsTheory]
@@ -837,7 +833,7 @@ public class DomainUpDownTests : IDisposable
         _sub.Items.Add("a");
         _sub.Items.Add("a");
         _sub.Items.Add("d");
-        Assert.NotEqual(IntPtr.Zero, _sub.Handle);
+        _sub.Handle.Should().NotBe(IntPtr.Zero);
         int invalidatedCallCount = 0;
         _sub.Invalidated += (sender, e) => invalidatedCallCount++;
         int styleChangedCallCount = 0;
@@ -848,35 +844,35 @@ public class DomainUpDownTests : IDisposable
         _sub.UserEdit = userEdit;
 
         _sub.Sorted = value;
-        Assert.Equal(value, _sub.Sorted);
-        Assert.Equal(expectedItems, _sub.Items.Cast<string>());
-        Assert.Equal(expectedSelectedIndex, _sub.SelectedIndex);
-        Assert.True(_sub.IsHandleCreated);
-        Assert.Equal(0, invalidatedCallCount);
-        Assert.Equal(0, styleChangedCallCount);
-        Assert.Equal(0, createdCallCount);
+        _sub.Sorted.Should().Be(value);
+        _sub.Items.Cast<string>().Should().Equal(expectedItems);
+        _sub.SelectedIndex.Should().Be(expectedSelectedIndex);
+        _sub.IsHandleCreated.Should().BeTrue();
+        invalidatedCallCount.Should().Be(0);
+        styleChangedCallCount.Should().Be(0);
+        createdCallCount.Should().Be(0);
 
         // Set same.
         _sub.Sorted = value;
-        Assert.Equal(value, _sub.Sorted);
-        Assert.Equal(expectedItems, _sub.Items.Cast<string>());
-        Assert.Equal(expectedSelectedIndex, _sub.SelectedIndex);
-        Assert.Equal(userEdit, _sub.UserEdit);
-        Assert.True(_sub.IsHandleCreated);
-        Assert.Equal(0, invalidatedCallCount);
-        Assert.Equal(0, styleChangedCallCount);
-        Assert.Equal(0, createdCallCount);
+        _sub.Sorted.Should().Be(value);
+        _sub.Items.Cast<string>().Should().Equal(expectedItems);
+        _sub.SelectedIndex.Should().Be(expectedSelectedIndex);
+        _sub.UserEdit.Should().Be(userEdit);
+        _sub.IsHandleCreated.Should().BeTrue();
+        invalidatedCallCount.Should().Be(0);
+        styleChangedCallCount.Should().Be(0);
+        createdCallCount.Should().Be(0);
 
         // Set different.
         _sub.Sorted = !value;
-        Assert.Equal(!value, _sub.Sorted);
-        Assert.Equal(new string[] { "a", "a", "B", "c", "d" }, _sub.Items.Cast<string>());
-        Assert.Equal(expectedSelectedIndex, _sub.SelectedIndex);
-        Assert.Equal(userEdit, _sub.UserEdit);
-        Assert.True(_sub.IsHandleCreated);
-        Assert.Equal(0, invalidatedCallCount);
-        Assert.Equal(0, styleChangedCallCount);
-        Assert.Equal(0, createdCallCount);
+        _sub.Sorted.Should().Be(!value);
+        _sub.Items.Cast<string>().Should().Equal(new string[] { "a", "a", "B", "c", "d" });
+        _sub.SelectedIndex.Should().Be(expectedSelectedIndex);
+        _sub.UserEdit.Should().Be(userEdit);
+        _sub.IsHandleCreated.Should().BeTrue();
+        invalidatedCallCount.Should().Be(0);
+        styleChangedCallCount.Should().Be(0);
+        createdCallCount.Should().Be(0);
     }
 
     [WinFormsTheory]
@@ -885,25 +881,25 @@ public class DomainUpDownTests : IDisposable
     {
         _control.Wrap = value;
 
-        Assert.Equal(value, _control.Wrap);
-        Assert.False(_control.IsHandleCreated);
+        _control.Wrap.Should().Be(value);
+        _control.IsHandleCreated.Should().BeFalse();
 
         // Set same.
         _control.Wrap = value;
-        Assert.Equal(value, _control.Wrap);
-        Assert.False(_control.IsHandleCreated);
+        _control.Wrap.Should().Be(value);
+        _control.IsHandleCreated.Should().BeFalse();
 
         // Set different.
         _control.Wrap = !value;
-        Assert.Equal(!value, _control.Wrap);
-        Assert.False(_control.IsHandleCreated);
+        _control.Wrap.Should().Be(!value);
+        _control.IsHandleCreated.Should().BeFalse();
     }
 
     [WinFormsTheory]
     [BoolData]
     public void DomainUpDown_Wrap_SetWithHandle_GetReturnsExpected(bool value)
     {
-        Assert.NotEqual(IntPtr.Zero, _control.Handle);
+        _control.Handle.Should().NotBe(IntPtr.Zero);
         int invalidatedCallCount = 0;
         _control.Invalidated += (sender, e) => invalidatedCallCount++;
         int styleChangedCallCount = 0;
@@ -912,50 +908,51 @@ public class DomainUpDownTests : IDisposable
         _control.HandleCreated += (sender, e) => createdCallCount++;
 
         _control.Wrap = value;
-        Assert.Equal(value, _control.Wrap);
-        Assert.True(_control.IsHandleCreated);
-        Assert.Equal(0, invalidatedCallCount);
-        Assert.Equal(0, styleChangedCallCount);
-        Assert.Equal(0, createdCallCount);
+        _control.Wrap.Should().Be(value);
+        _control.IsHandleCreated.Should().BeTrue();
+        invalidatedCallCount.Should().Be(0);
+        styleChangedCallCount.Should().Be(0);
+        createdCallCount.Should().Be(0);
 
         // Set same.
         _control.Wrap = value;
-        Assert.Equal(value, _control.Wrap);
-        Assert.True(_control.IsHandleCreated);
-        Assert.Equal(0, invalidatedCallCount);
-        Assert.Equal(0, styleChangedCallCount);
-        Assert.Equal(0, createdCallCount);
+        _control.Wrap.Should().Be(value);
+        _control.IsHandleCreated.Should().BeTrue();
+        invalidatedCallCount.Should().Be(0);
+        styleChangedCallCount.Should().Be(0);
+        createdCallCount.Should().Be(0);
 
         // Set different.
         _control.Wrap = !value;
-        Assert.Equal(!value, _control.Wrap);
-        Assert.True(_control.IsHandleCreated);
-        Assert.Equal(0, invalidatedCallCount);
-        Assert.Equal(0, styleChangedCallCount);
-        Assert.Equal(0, createdCallCount);
+        _control.Wrap.Should().Be(!value);
+        _control.IsHandleCreated.Should().BeTrue();
+        invalidatedCallCount.Should().Be(0);
+        styleChangedCallCount.Should().Be(0);
+        createdCallCount.Should().Be(0);
     }
 
     [WinFormsFact]
     public void DomainUpDown_CreateAccessibilityInstance_Invoke_ReturnsExpected()
     {
-        Control.ControlAccessibleObject instance = Assert.IsAssignableFrom<Control.ControlAccessibleObject>(_sub.CreateAccessibilityInstance());
-        Assert.NotNull(instance);
-        Assert.Same(_sub, instance.Owner);
-        Assert.Equal(AccessibleRole.SpinButton, instance.Role);
-        Assert.NotSame(_sub.CreateAccessibilityInstance(), instance);
-        Assert.NotSame(_sub.AccessibilityObject, instance);
+        UpDownBase.UpDownBaseAccessibleObject instance = _sub.CreateAccessibilityInstance() as UpDownBase.UpDownBaseAccessibleObject;
+        instance.Should().NotBeNull().And.BeOfType<UpDownBase.UpDownBaseAccessibleObject>();
+        instance.Owner.Should().Be(_sub);
+        instance.Role.Should().Be(AccessibleRole.SpinButton);
+        _sub.CreateAccessibilityInstance().Should().NotBeSameAs(instance);
+        _sub.AccessibilityObject.Should().NotBeSameAs(instance);
     }
 
     [WinFormsFact]
     public void DomainUpDown_CreateAccessibilityInstance_InvokeWithCustomRole_ReturnsExpected()
     {
         _sub.AccessibleRole = AccessibleRole.HelpBalloon;
-        Control.ControlAccessibleObject instance = Assert.IsAssignableFrom<Control.ControlAccessibleObject>(_sub.CreateAccessibilityInstance());
-        Assert.NotNull(instance);
-        Assert.Same(_sub, instance.Owner);
-        Assert.Equal(AccessibleRole.HelpBalloon, instance.Role);
-        Assert.NotSame(_sub.CreateAccessibilityInstance(), instance);
-        Assert.NotSame(_sub.AccessibilityObject, instance);
+        var instance = _sub.CreateAccessibilityInstance() as UpDownBase.UpDownBaseAccessibleObject;
+    
+        instance.Should().NotBeNull().And.BeOfType<UpDownBase.UpDownBaseAccessibleObject>();
+        instance.Owner.Should().Be(_sub);
+        instance.Role.Should().Be(AccessibleRole.HelpBalloon);
+        _sub.CreateAccessibilityInstance().Should().NotBeSameAs(instance);
+        _sub.AccessibilityObject.Should().NotBeSameAs(instance);
     }
 
     public static IEnumerable<object[]> DownButton_TestData()
@@ -977,13 +974,13 @@ public class DomainUpDownTests : IDisposable
         _sub.Wrap = wrap;
 
         _sub.DownButton();
-        Assert.Equal(-1, _sub.SelectedIndex);
-        Assert.Equal(userEdit, _sub.UserEdit);
+        _sub.SelectedIndex.Should().Be(-1);
+        _sub.UserEdit.Should().Be(userEdit);
 
         // Call again.
         _sub.DownButton();
-        Assert.Equal(-1, _sub.SelectedIndex);
-        Assert.Equal(userEdit, _sub.UserEdit);
+        _sub.SelectedIndex.Should().Be(-1);
+        _sub.UserEdit.Should().Be(userEdit);
     }
 
     [WinFormsTheory]
@@ -993,16 +990,16 @@ public class DomainUpDownTests : IDisposable
         _sub.UserEdit = userEdit;
         _sub.Wrap = wrap;
 
-        Assert.Empty(_sub.Items);
+        _sub.Items.Count.Should().Be(0);
 
         _sub.DownButton();
-        Assert.Equal(-1, _sub.SelectedIndex);
-        Assert.Equal(userEdit, _sub.UserEdit);
+        _sub.SelectedIndex.Should().Be(-1);
+        _sub.UserEdit.Should().Be(userEdit);
 
         // Call again.
         _sub.DownButton();
-        Assert.Equal(-1, _sub.SelectedIndex);
-        Assert.Equal(userEdit, _sub.UserEdit);
+        _sub.SelectedIndex.Should().Be(-1);
+        _sub.UserEdit.Should().Be(userEdit);
     }
 
     public static IEnumerable<object[]> DownButton_WithItems_TestData()
@@ -1024,29 +1021,29 @@ public class DomainUpDownTests : IDisposable
         _sub.Items.Add("c");
 
         _sub.DownButton();
-        Assert.Equal(0, _sub.SelectedIndex);
-        Assert.False(_sub.UserEdit);
+        _sub.SelectedIndex.Should().Be(0);
+        _sub.UserEdit.Should().BeFalse();
 
         // Call again.
         _sub.DownButton();
-        Assert.Equal(1, _sub.SelectedIndex);
-        Assert.False(_sub.UserEdit);
+        _sub.SelectedIndex.Should().Be(1);
+        _sub.UserEdit.Should().BeFalse();
 
         // Call again.
         _sub.DownButton();
-        Assert.Equal(2, _sub.SelectedIndex);
-        Assert.False(_sub.UserEdit);
+        _sub.SelectedIndex.Should().Be(2);
+        _sub.UserEdit.Should().BeFalse();
 
         // Call again.
         _sub.DownButton();
-        Assert.Equal(expectedWrapSelectedIndex, _sub.SelectedIndex);
-        Assert.False(_sub.UserEdit);
+        _sub.SelectedIndex.Should().Be(expectedWrapSelectedIndex);
+        _sub.UserEdit.Should().BeFalse();
     }
 
     [WinFormsFact]
     public void DomainUpDown_GetAutoSizeMode_Invoke_ReturnsExpected()
     {
-        Assert.Equal(AutoSizeMode.GrowOnly, _sub.GetAutoSizeMode());
+        _sub.GetAutoSizeMode().Should().Be(AutoSizeMode.GrowOnly);
     }
 
     [WinFormsTheory]
@@ -1060,7 +1057,7 @@ public class DomainUpDownTests : IDisposable
     [InlineData((-1), false)]
     public void DomainUpDown_GetScrollState_Invoke_ReturnsExpected(int bit, bool expected)
     {
-        Assert.Equal(expected, _sub.GetScrollState(bit));
+        _sub.GetScrollState(bit).Should().Be(expected);
     }
 
     [WinFormsTheory]
@@ -1086,16 +1083,16 @@ public class DomainUpDownTests : IDisposable
     [InlineData((ControlStyles)(-1), false)]
     public void DomainUpDown_GetStyle_Invoke_ReturnsExpected(ControlStyles flag, bool expected)
     {
-        Assert.Equal(expected, _sub.GetStyle(flag));
+        _sub.GetStyle(flag).Should().Be(expected);
 
         // Call again to test caching.
-        Assert.Equal(expected, _sub.GetStyle(flag));
+        _sub.GetStyle(flag).Should().Be(expected);
     }
 
     [WinFormsFact]
     public void DomainUpDown_GetTopLevel_Invoke_ReturnsExpected()
     {
-        Assert.False(_sub.GetTopLevel());
+        _sub.GetTopLevel().Should().BeFalse();
     }
 
     [WinFormsTheory]
@@ -1119,14 +1116,15 @@ public class DomainUpDownTests : IDisposable
         _control.Items.Add("foo3");
         _control.Items.Add("Cowman");
         _control.Items.Add("foo4");
-        Assert.Equal(expected, _control.MatchIndex(text, false, start));
+        _control.MatchIndex(text, false, start).Should().Be(expected);
     }
 
     [WinFormsFact]
     public void DomainUpDown_MatchIndex_NullText_ThrowsNullReferenceException()
     {
         _control.Items.Add("item1");
-        Assert.Throws<NullReferenceException>(() => _control.MatchIndex(null, false, 0));
+        Action act = () => _control.MatchIndex(null, false, 0);
+        act.Should().Throw<NullReferenceException>();
     }
 
     public static IEnumerable<object[]> OnChanged_TestData()
@@ -1142,20 +1140,20 @@ public class DomainUpDownTests : IDisposable
         int callCount = 0;
         EventHandler handler = (sender, e) =>
         {
-            Assert.Same(_sub, sender);
-            Assert.Same(eventArgs, e);
+            sender.Should().Be(_sub);
+            e.Should().Be(eventArgs);
             callCount++;
         };
 
-        // Call with handler.
-        _sub.SelectedItemChanged += handler;
-        _sub.OnSelectedItemChanged(source, eventArgs);
-        Assert.Equal(1, callCount);
+    // Call with handler.
+    _sub.SelectedItemChanged += handler;
+    _sub.OnSelectedItemChanged(source, eventArgs);
+    callCount.Should().Be(1);
 
-        // Remove handler.
-        _sub.SelectedItemChanged -= handler;
-        _sub.OnSelectedItemChanged(source, eventArgs);
-        Assert.Equal(1, callCount);
+    // Remove handler.
+    _sub.SelectedItemChanged -= handler;
+    _sub.OnSelectedItemChanged(source, eventArgs);
+    callCount.Should().Be(1);
     }
 
     [WinFormsTheory]
@@ -1165,20 +1163,20 @@ public class DomainUpDownTests : IDisposable
         int callCount = 0;
         EventHandler handler = (sender, e) =>
         {
-            Assert.Same(_sub, sender);
-            Assert.Same(eventArgs, e);
+            sender.Should().Be(_sub);
+            e.Should().Be(eventArgs);
             callCount++;
         };
 
         // Call with handler.
         _sub.SelectedItemChanged += handler;
         _sub.OnSelectedItemChanged(source, eventArgs);
-        Assert.Equal(1, callCount);
+        callCount.Should().Be(1);
 
         // Remove handler.
         _sub.SelectedItemChanged -= handler;
         _sub.OnSelectedItemChanged(source, eventArgs);
-        Assert.Equal(1, callCount);
+        callCount.Should().Be(1);
     }
 
     public static IEnumerable<object[]> UpButton_TestData()
@@ -1200,32 +1198,32 @@ public class DomainUpDownTests : IDisposable
         _sub.Wrap = wrap;
 
         _sub.UpButton();
-        Assert.Equal(-1, _sub.SelectedIndex);
-        Assert.Equal(userEdit, _sub.UserEdit);
+        _sub.SelectedIndex.Should().Be(-1);
+        _sub.UserEdit.Should().Be(userEdit);
 
         // Call again.
         _sub.UpButton();
-        Assert.Equal(-1, _sub.SelectedIndex);
-        Assert.Equal(userEdit, _sub.UserEdit);
+        _sub.SelectedIndex.Should().Be(-1);
+        _sub.UserEdit.Should().Be(userEdit);
     }
 
     [WinFormsTheory]
     [MemberData(nameof(UpButton_TestData))]
     public void DomainUpDown_UpButton_InvokeEmpty_Nop(bool userEdit, bool wrap)
     {
-         _sub.UserEdit = userEdit;
+        _sub.UserEdit = userEdit;
         _sub.Wrap = wrap;
 
-        Assert.Empty(_sub.Items);
+        _sub.Items.Count.Should().Be(0);
 
         _sub.UpButton();
-        Assert.Equal(-1, _sub.SelectedIndex);
-        Assert.Equal(userEdit, _sub.UserEdit);
+        _sub.SelectedIndex.Should().Be(-1);
+        _sub.UserEdit.Should().Be(userEdit);
 
         // Call again.
         _sub.UpButton();
-        Assert.Equal(-1, _sub.SelectedIndex);
-        Assert.Equal(userEdit, _sub.UserEdit);
+        _sub.SelectedIndex.Should().Be(-1);
+        _sub.UserEdit.Should().Be(userEdit);
     }
 
     public static IEnumerable<object[]> UpButton_WithItems_TestData()
@@ -1248,23 +1246,23 @@ public class DomainUpDownTests : IDisposable
         _sub.SelectedIndex = 2;
 
         _sub.UpButton();
-        Assert.Equal(1, _sub.SelectedIndex);
-        Assert.False(_sub.UserEdit);
+        _sub.SelectedIndex.Should().Be(1);
+        _sub.UserEdit.Should().BeFalse();
 
         // Call again.
         _sub.UpButton();
-        Assert.Equal(0, _sub.SelectedIndex);
-        Assert.False(_sub.UserEdit);
+        _sub.SelectedIndex.Should().Be(0);
+        _sub.UserEdit.Should().BeFalse();
 
         // Call again.
         _sub.UpButton();
-        Assert.Equal(expectedWrapSelectedIndex1, _sub.SelectedIndex);
-        Assert.False(_sub.UserEdit);
+        _sub.SelectedIndex.Should().Be(expectedWrapSelectedIndex1);
+        _sub.UserEdit.Should().BeFalse();
 
         // Call again.
         _sub.UpButton();
-        Assert.Equal(expectedWrapSelectedIndex2, _sub.SelectedIndex);
-        Assert.False(_sub.UserEdit);
+        _sub.SelectedIndex.Should().Be(expectedWrapSelectedIndex2);
+        _sub.UserEdit.Should().BeFalse();
     }
 
     [WinFormsTheory]
@@ -1278,17 +1276,17 @@ public class DomainUpDownTests : IDisposable
         _sub.ChangingText = changingText;
 
         _sub.UpdateEditText();
-        Assert.Empty(_sub.Text);
-        Assert.False(_sub.UserEdit);
-        Assert.False(_sub.ChangingText);
-        Assert.False(_sub.IsHandleCreated);
+        _sub.Text.Should().BeEmpty();
+        _sub.UserEdit.Should().BeFalse();
+        _sub.ChangingText.Should().BeFalse();
+        _sub.IsHandleCreated.Should().BeFalse();
 
         // Call again.
         _sub.UpdateEditText();
-        Assert.Empty(_sub.Text);
-        Assert.False(_sub.UserEdit);
-        Assert.False(_sub.ChangingText);
-        Assert.False(_sub.IsHandleCreated);
+        _sub.Text.Should().BeEmpty();
+        _sub.UserEdit.Should().BeFalse();
+        _sub.ChangingText.Should().BeFalse();
+        _sub.IsHandleCreated.Should().BeFalse();
     }
 
     [WinFormsTheory]
@@ -1304,17 +1302,17 @@ public class DomainUpDownTests : IDisposable
         _sub.ChangingText = changingText;
 
         _sub.UpdateEditText();
-        Assert.Empty(_sub.Text);
-        Assert.False(_sub.UserEdit);
-        Assert.False(_sub.ChangingText);
-        Assert.False(_sub.IsHandleCreated);
+        _sub.Text.Should().BeEmpty();
+        _sub.UserEdit.Should().BeFalse();
+        _sub.ChangingText.Should().BeFalse();
+        _sub.IsHandleCreated.Should().BeFalse();
 
         // Call again.
         _sub.UpdateEditText();
-        Assert.Empty(_sub.Text);
-        Assert.False(_sub.UserEdit);
-        Assert.False(_sub.ChangingText);
-        Assert.False(_sub.IsHandleCreated);
+        _sub.Text.Should().BeEmpty();
+        _sub.UserEdit.Should().BeFalse();
+        _sub.ChangingText.Should().BeFalse();
+        _sub.IsHandleCreated.Should().BeFalse();
     }
 
     [WinFormsTheory]
@@ -1332,17 +1330,17 @@ public class DomainUpDownTests : IDisposable
         _sub.ChangingText = changingText;
 
         _sub.UpdateEditText();
-        Assert.Equal("Item1", _sub.Text);
-        Assert.False(_sub.UserEdit);
-        Assert.False(_sub.ChangingText);
-        Assert.False(_sub.IsHandleCreated);
+        _sub.Text.Should().Be("Item1");
+        _sub.UserEdit.Should().BeFalse();
+        _sub.ChangingText.Should().BeFalse();
+        _sub.IsHandleCreated.Should().BeFalse();
 
         // Call again.
         _sub.UpdateEditText();
-        Assert.Equal("Item1", _sub.Text);
-        Assert.False(_sub.UserEdit);
-        Assert.False(_sub.ChangingText);
-        Assert.False(_sub.IsHandleCreated);
+        _sub.Text.Should().Be("Item1");
+        _sub.UserEdit.Should().BeFalse();
+        _sub.ChangingText.Should().BeFalse();
+        _sub.IsHandleCreated.Should().BeFalse();
     }
 
     [WinFormsTheory]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DomainUpDownTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DomainUpDownTests.cs
@@ -15,7 +15,7 @@ public class DomainUpDownTests : IDisposable
     public DomainUpDownTests()
     {
         _control = new();
-        _sub= new();
+        _sub = new();
     }
 
     public void Dispose()
@@ -1145,15 +1145,15 @@ public class DomainUpDownTests : IDisposable
             callCount++;
         };
 
-    // Call with handler.
-    _sub.SelectedItemChanged += handler;
-    _sub.OnSelectedItemChanged(source, eventArgs);
-    callCount.Should().Be(1);
+        // Call with handler.
+        _sub.SelectedItemChanged += handler;
+        _sub.OnSelectedItemChanged(source, eventArgs);
+        callCount.Should().Be(1);
 
-    // Remove handler.
-    _sub.SelectedItemChanged -= handler;
-    _sub.OnSelectedItemChanged(source, eventArgs);
-    callCount.Should().Be(1);
+        // Remove handler.
+        _sub.SelectedItemChanged -= handler;
+        _sub.OnSelectedItemChanged(source, eventArgs);
+        callCount.Should().Be(1);
     }
 
     [WinFormsTheory]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DomainUpDownTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DomainUpDownTests.cs
@@ -7,142 +7,157 @@ using System.Windows.Forms.TestUtilities;
 
 namespace System.Windows.Forms.Tests;
 
-public class DomainUpDownTests
+public class DomainUpDownTests : IDisposable
 {
+    private readonly DomainUpDown _control;
+    private readonly SubDomainUpDown _sub;
+
+    public DomainUpDownTests()
+    {
+        _control = new DomainUpDown();
+        _sub= new SubDomainUpDown();
+    }
+
+    public void Dispose()
+    {
+       _control.Items.Clear();
+       _control.Dispose();
+       _sub.Items.Clear();
+       _sub.Dispose();
+    }
+
     [WinFormsFact]
     public void DomainUpDown_Ctor_Default()
     {
-        using SubDomainUpDown control = new();
-        Assert.Null(control.ActiveControl);
-        Assert.False(control.AllowDrop);
-        Assert.Equal(AnchorStyles.Top | AnchorStyles.Left, control.Anchor);
-        Assert.False(control.AutoScroll);
-        Assert.Equal(SizeF.Empty, control.AutoScaleDimensions);
-        Assert.Equal(new SizeF(1, 1), control.AutoScaleFactor);
-        Assert.Equal(Size.Empty, control.AutoScrollMargin);
-        Assert.Equal(AutoScaleMode.Inherit, control.AutoScaleMode);
-        Assert.Equal(Size.Empty, control.AutoScrollMinSize);
-        Assert.Equal(Point.Empty, control.AutoScrollPosition);
-        Assert.False(control.AutoSize);
-        Assert.Equal(SystemColors.Window, control.BackColor);
-        Assert.Null(control.BackgroundImage);
-        Assert.Equal(ImageLayout.Tile, control.BackgroundImageLayout);
-        Assert.NotNull(control.BindingContext);
-        Assert.Same(control.BindingContext, control.BindingContext);
-        Assert.Equal(BorderStyle.Fixed3D, control.BorderStyle);
-        Assert.Equal(control.PreferredHeight, control.Bottom);
-        Assert.Equal(new Rectangle(0, 0, 120, control.PreferredHeight), control.Bounds);
-        Assert.False(control.CanEnableIme);
-        Assert.False(control.CanFocus);
-        Assert.True(control.CanRaiseEvents);
-        Assert.True(control.CausesValidation);
-        Assert.False(control.ChangingText);
+        Assert.Null(_sub.ActiveControl);
+        Assert.False(_sub.AllowDrop);
+        Assert.Equal(AnchorStyles.Top | AnchorStyles.Left, _sub.Anchor);
+        Assert.False(_sub.AutoScroll);
+        Assert.Equal(SizeF.Empty, _sub.AutoScaleDimensions);
+        Assert.Equal(new SizeF(1, 1), _sub.AutoScaleFactor);
+        Assert.Equal(Size.Empty, _sub.AutoScrollMargin);
+        Assert.Equal(AutoScaleMode.Inherit, _sub.AutoScaleMode);
+        Assert.Equal(Size.Empty, _sub.AutoScrollMinSize);
+        Assert.Equal(Point.Empty, _sub.AutoScrollPosition);
+        Assert.False(_sub.AutoSize);
+        Assert.Equal(SystemColors.Window, _sub.BackColor);
+        Assert.Null(_sub.BackgroundImage);
+        Assert.Equal(ImageLayout.Tile, _sub.BackgroundImageLayout);
+        Assert.NotNull(_sub.BindingContext);
+        Assert.Same(_sub.BindingContext, _sub.BindingContext);
+        Assert.Equal(BorderStyle.Fixed3D, _sub.BorderStyle);
+        Assert.Equal(_sub.PreferredHeight, _sub.Bottom);
+        Assert.Equal(new Rectangle(0, 0, 120, _sub.PreferredHeight), _sub.Bounds);
+        Assert.False(_sub.CanEnableIme);
+        Assert.False(_sub.CanFocus);
+        Assert.True(_sub.CanRaiseEvents);
+        Assert.True(_sub.CausesValidation);
+        Assert.False(_sub.ChangingText);
         if (Application.UseVisualStyles)
         {
-            Assert.Equal(new Rectangle(0, 0, 120, Control.DefaultFont.Height + 7), control.ClientRectangle);
-            Assert.Equal(new Rectangle(0, 0, 120, Control.DefaultFont.Height + 7), control.DisplayRectangle);
-            Assert.Equal(new Size(120, Control.DefaultFont.Height + 7), control.ClientSize);
-            Assert.Equal(new Size(16, control.PreferredHeight), control.PreferredSize);
+            Assert.Equal(new Rectangle(0, 0, 120, Control.DefaultFont.Height + 7), _sub.ClientRectangle);
+            Assert.Equal(new Rectangle(0, 0, 120, Control.DefaultFont.Height + 7), _sub.DisplayRectangle);
+            Assert.Equal(new Size(120, Control.DefaultFont.Height + 7), _sub.ClientSize);
+            Assert.Equal(new Size(16, _sub.PreferredHeight), _sub.PreferredSize);
         }
         else
         {
-            Assert.Equal(new Rectangle(0, 0, 116, Control.DefaultFont.Height + 3), control.ClientRectangle);
-            Assert.Equal(new Rectangle(0, 0, 116, Control.DefaultFont.Height + 3), control.DisplayRectangle);
-            Assert.Equal(new Size(116, Control.DefaultFont.Height + 3), control.ClientSize);
-            Assert.Equal(new Size(20, control.PreferredHeight), control.PreferredSize);
+            Assert.Equal(new Rectangle(0, 0, 116, Control.DefaultFont.Height + 3), _sub.ClientRectangle);
+            Assert.Equal(new Rectangle(0, 0, 116, Control.DefaultFont.Height + 3), _sub.DisplayRectangle);
+            Assert.Equal(new Size(116, Control.DefaultFont.Height + 3), _sub.ClientSize);
+            Assert.Equal(new Size(20, _sub.PreferredHeight), _sub.PreferredSize);
         }
 
-        Assert.Null(control.Container);
-        Assert.False(control.ContainsFocus);
-        Assert.Null(control.ContextMenuStrip);
-        Assert.NotEmpty(control.Controls);
-        Assert.Same(control.Controls, control.Controls);
-        Assert.False(control.Created);
-        Assert.Equal(SizeF.Empty, control.CurrentAutoScaleDimensions);
-        Assert.Equal(Cursors.Default, control.Cursor);
-        Assert.Equal(Cursors.Default, control.DefaultCursor);
-        Assert.Equal(ImeMode.Inherit, control.DefaultImeMode);
-        Assert.Equal(new Padding(3), control.DefaultMargin);
-        Assert.Equal(Size.Empty, control.DefaultMaximumSize);
-        Assert.Equal(Size.Empty, control.DefaultMinimumSize);
-        Assert.Equal(Padding.Empty, control.DefaultPadding);
-        Assert.Equal(new Size(120, control.PreferredHeight), control.DefaultSize);
-        Assert.False(control.DesignMode);
-        Assert.Equal(DockStyle.None, control.Dock);
-        Assert.NotNull(control.DockPadding);
-        Assert.Same(control.DockPadding, control.DockPadding);
-        Assert.Equal(0, control.DockPadding.Top);
-        Assert.Equal(0, control.DockPadding.Bottom);
-        Assert.Equal(0, control.DockPadding.Left);
-        Assert.Equal(0, control.DockPadding.Right);
-        Assert.False(control.DoubleBuffered);
-        Assert.True(control.Enabled);
-        Assert.NotNull(control.Events);
-        Assert.Same(control.Events, control.Events);
-        Assert.False(control.Focused);
-        Assert.Equal(Control.DefaultFont, control.Font);
-        Assert.Equal(control.Font.Height, control.FontHeight);
-        Assert.Equal(SystemColors.WindowText, control.ForeColor);
-        Assert.True(control.HasChildren);
-        Assert.Equal(control.PreferredHeight, control.Height);
-        Assert.NotNull(control.HorizontalScroll);
-        Assert.Same(control.HorizontalScroll, control.HorizontalScroll);
-        Assert.False(control.HScroll);
-        Assert.Equal(ImeMode.NoControl, control.ImeMode);
-        Assert.Equal(ImeMode.NoControl, control.ImeModeBase);
-        Assert.True(control.InterceptArrowKeys);
-        Assert.False(control.InvokeRequired);
-        Assert.False(control.IsAccessible);
-        Assert.False(control.IsMirrored);
-        Assert.Empty(control.Items);
-        Assert.Same(control.Items, control.Items);
-        Assert.NotNull(control.LayoutEngine);
-        Assert.Same(control.LayoutEngine, control.LayoutEngine);
-        Assert.Equal(0, control.Left);
-        Assert.Equal(Point.Empty, control.Location);
-        Assert.Equal(new Padding(3), control.Margin);
-        Assert.Equal(Size.Empty, control.MaximumSize);
-        Assert.Equal(Size.Empty, control.MinimumSize);
-        Assert.Equal(Padding.Empty, control.Padding);
-        Assert.Null(control.Parent);
-        Assert.Equal(Control.DefaultFont.Height + 7, control.PreferredHeight);
-        Assert.Equal("Microsoft\u00AE .NET", control.ProductName);
-        Assert.False(control.ReadOnly);
-        Assert.False(control.RecreatingHandle);
-        Assert.Null(control.Region);
-        Assert.True(control.ResizeRedraw);
-        Assert.Equal(120, control.Right);
-        Assert.Equal(RightToLeft.No, control.RightToLeft);
-        Assert.Equal(-1, control.SelectedIndex);
-        Assert.Null(control.SelectedItem);
-        Assert.True(control.ShowFocusCues);
-        Assert.True(control.ShowKeyboardCues);
-        Assert.Null(control.Site);
-        Assert.Equal(new Size(120, control.PreferredHeight), control.Size);
-        Assert.Equal(0, control.TabIndex);
-        Assert.True(control.TabStop);
-        Assert.Empty(control.Text);
-        Assert.Equal(HorizontalAlignment.Left, control.TextAlign);
-        Assert.Equal(0, control.Top);
-        Assert.Null(control.TopLevelControl);
-        Assert.Equal(LeftRightAlignment.Right, control.UpDownAlign);
-        Assert.False(control.UserEdit);
-        Assert.False(control.UseWaitCursor);
-        Assert.True(control.Visible);
-        Assert.NotNull(control.VerticalScroll);
-        Assert.Same(control.VerticalScroll, control.VerticalScroll);
-        Assert.False(control.VScroll);
-        Assert.Equal(120, control.Width);
-        Assert.False(control.Wrap);
+        Assert.Null(_sub.Container);
+        Assert.False(_sub.ContainsFocus);
+        Assert.Null(_sub.ContextMenuStrip);
+        Assert.NotEmpty(_sub.Controls);
+        Assert.Same(_sub.Controls, _sub.Controls);
+        Assert.False(_sub.Created);
+        Assert.Equal(SizeF.Empty, _sub.CurrentAutoScaleDimensions);
+        Assert.Equal(Cursors.Default, _sub.Cursor);
+        Assert.Equal(Cursors.Default, _sub.DefaultCursor);
+        Assert.Equal(ImeMode.Inherit, _sub.DefaultImeMode);
+        Assert.Equal(new Padding(3), _sub.DefaultMargin);
+        Assert.Equal(Size.Empty, _sub.DefaultMaximumSize);
+        Assert.Equal(Size.Empty, _sub.DefaultMinimumSize);
+        Assert.Equal(Padding.Empty, _sub.DefaultPadding);
+        Assert.Equal(new Size(120, _sub.PreferredHeight), _sub.DefaultSize);
+        Assert.False(_sub.DesignMode);
+        Assert.Equal(DockStyle.None, _sub.Dock);
+        Assert.NotNull(_sub.DockPadding);
+        Assert.Same(_sub.DockPadding, _sub.DockPadding);
+        Assert.Equal(0, _sub.DockPadding.Top);
+        Assert.Equal(0, _sub.DockPadding.Bottom);
+        Assert.Equal(0, _sub.DockPadding.Left);
+        Assert.Equal(0, _sub.DockPadding.Right);
+        Assert.False(_sub.DoubleBuffered);
+        Assert.True(_sub.Enabled);
+        Assert.NotNull(_sub.Events);
+        Assert.Same(_sub.Events, _sub.Events);
+        Assert.False(_sub.Focused);
+        Assert.Equal(Control.DefaultFont, _sub.Font);
+        Assert.Equal(_sub.Font.Height, _sub.FontHeight);
+        Assert.Equal(SystemColors.WindowText, _sub.ForeColor);
+        Assert.True(_sub.HasChildren);
+        Assert.Equal(_sub.PreferredHeight, _sub.Height);
+        Assert.NotNull(_sub.HorizontalScroll);
+        Assert.Same(_sub.HorizontalScroll, _sub.HorizontalScroll);
+        Assert.False(_sub.HScroll);
+        Assert.Equal(ImeMode.NoControl, _sub.ImeMode);
+        Assert.Equal(ImeMode.NoControl, _sub.ImeModeBase);
+        Assert.True(_sub.InterceptArrowKeys);
+        Assert.False(_sub.InvokeRequired);
+        Assert.False(_sub.IsAccessible);
+        Assert.False(_sub.IsMirrored);
+        Assert.Empty(_sub.Items);
+        Assert.Same(_sub.Items, _sub.Items);
+        Assert.NotNull(_sub.LayoutEngine);
+        Assert.Same(_sub.LayoutEngine, _sub.LayoutEngine);
+        Assert.Equal(0, _sub.Left);
+        Assert.Equal(Point.Empty, _sub.Location);
+        Assert.Equal(new Padding(3), _sub.Margin);
+        Assert.Equal(Size.Empty, _sub.MaximumSize);
+        Assert.Equal(Size.Empty, _sub.MinimumSize);
+        Assert.Equal(Padding.Empty, _sub.Padding);
+        Assert.Null(_sub.Parent);
+        Assert.Equal(Control.DefaultFont.Height + 7, _sub.PreferredHeight);
+        Assert.Equal("Microsoft\u00AE .NET", _sub.ProductName);
+        Assert.False(_sub.ReadOnly);
+        Assert.False(_sub.RecreatingHandle);
+        Assert.Null(_sub.Region);
+        Assert.True(_sub.ResizeRedraw);
+        Assert.Equal(120, _sub.Right);
+        Assert.Equal(RightToLeft.No, _sub.RightToLeft);
+        Assert.Equal(-1, _sub.SelectedIndex);
+        Assert.Null(_sub.SelectedItem);
+        Assert.True(_sub.ShowFocusCues);
+        Assert.True(_sub.ShowKeyboardCues);
+        Assert.Null(_sub.Site);
+        Assert.Equal(new Size(120, _sub.PreferredHeight), _sub.Size);
+        Assert.Equal(0, _sub.TabIndex);
+        Assert.True(_sub.TabStop);
+        Assert.Empty(_sub.Text);
+        Assert.Equal(HorizontalAlignment.Left, _sub.TextAlign);
+        Assert.Equal(0, _sub.Top);
+        Assert.Null(_sub.TopLevelControl);
+        Assert.Equal(LeftRightAlignment.Right, _sub.UpDownAlign);
+        Assert.False(_sub.UserEdit);
+        Assert.False(_sub.UseWaitCursor);
+        Assert.True(_sub.Visible);
+        Assert.NotNull(_sub.VerticalScroll);
+        Assert.Same(_sub.VerticalScroll, _sub.VerticalScroll);
+        Assert.False(_sub.VScroll);
+        Assert.Equal(120, _sub.Width);
+        Assert.False(_sub.Wrap);
 
-        Assert.False(control.IsHandleCreated);
+        Assert.False(_sub.IsHandleCreated);
     }
 
     [WinFormsFact]
     public void DomainUpDown_CreateParams_GetDefault_ReturnsExpected()
     {
-        using SubDomainUpDown control = new();
-        CreateParams createParams = control.CreateParams;
+        CreateParams createParams = _sub.CreateParams;
         Assert.Null(createParams.Caption);
         Assert.Null(createParams.ClassName);
 
@@ -159,57 +174,54 @@ public class DomainUpDownTests
             Assert.Equal(WINDOW_EX_STYLE.WS_EX_CLIENTEDGE | WINDOW_EX_STYLE.WS_EX_CONTROLPARENT, (WINDOW_EX_STYLE)createParams.ExStyle);
         }
 
-        Assert.Equal(control.PreferredHeight, createParams.Height);
+        Assert.Equal(_sub.PreferredHeight, createParams.Height);
         Assert.Equal(IntPtr.Zero, createParams.Parent);
         Assert.Null(createParams.Param);
         Assert.Equal(120, createParams.Width);
         Assert.Equal(0, createParams.X);
         Assert.Equal(0, createParams.Y);
-        Assert.Same(createParams, control.CreateParams);
-        Assert.False(control.IsHandleCreated);
+        Assert.Same(createParams, _sub.CreateParams);
+        Assert.False(_sub.IsHandleCreated);
     }
 
     [WinFormsTheory]
     [CommonMemberData(typeof(CommonTestHelperEx), nameof(CommonTestHelperEx.GetPaddingNormalizedTheoryData))]
     public void DomainUpDown_Padding_Set_GetReturnsExpected(Padding value, Padding expected)
     {
-        using DomainUpDown control = new()
-        {
-            Padding = value
-        };
-        Assert.Equal(expected, control.Padding);
-        Assert.False(control.IsHandleCreated);
+        _control.Padding = value;
+
+        Assert.Equal(expected, _control.Padding);
+        Assert.False(_control.IsHandleCreated);
 
         // Set same.
-        control.Padding = value;
-        Assert.Equal(expected, control.Padding);
-        Assert.False(control.IsHandleCreated);
+        _control.Padding = value;
+        Assert.Equal(expected, _control.Padding);
+        Assert.False(_control.IsHandleCreated);
     }
 
     [WinFormsTheory]
     [CommonMemberData(typeof(CommonTestHelperEx), nameof(CommonTestHelperEx.GetPaddingNormalizedTheoryData))]
     public void DomainUpDown_Padding_SetWithHandle_GetReturnsExpected(Padding value, Padding expected)
     {
-        using DomainUpDown control = new();
-        Assert.NotEqual(IntPtr.Zero, control.Handle);
+        Assert.NotEqual(IntPtr.Zero, _control.Handle);
         int invalidatedCallCount = 0;
-        control.Invalidated += (sender, e) => invalidatedCallCount++;
+        _control.Invalidated += (sender, e) => invalidatedCallCount++;
         int styleChangedCallCount = 0;
-        control.StyleChanged += (sender, e) => styleChangedCallCount++;
+        _control.StyleChanged += (sender, e) => styleChangedCallCount++;
         int createdCallCount = 0;
-        control.HandleCreated += (sender, e) => createdCallCount++;
+        _control.HandleCreated += (sender, e) => createdCallCount++;
 
-        control.Padding = value;
-        Assert.Equal(expected, control.Padding);
-        Assert.True(control.IsHandleCreated);
+        _control.Padding = value;
+        Assert.Equal(expected, _control.Padding);
+        Assert.True(_control.IsHandleCreated);
         Assert.Equal(0, invalidatedCallCount);
         Assert.Equal(0, styleChangedCallCount);
         Assert.Equal(0, createdCallCount);
 
         // Set same.
-        control.Padding = value;
-        Assert.Equal(expected, control.Padding);
-        Assert.True(control.IsHandleCreated);
+        _control.Padding = value;
+        Assert.Equal(expected, _control.Padding);
+        Assert.True(_control.IsHandleCreated);
         Assert.Equal(0, invalidatedCallCount);
         Assert.Equal(0, styleChangedCallCount);
         Assert.Equal(0, createdCallCount);
@@ -218,62 +230,59 @@ public class DomainUpDownTests
     [WinFormsFact]
     public void DomainUpDown_Padding_SetWithHandler_CallsPaddingChanged()
     {
-        using DomainUpDown control = new();
         int callCount = 0;
         EventHandler handler = (sender, e) =>
         {
-            Assert.Equal(control, sender);
+            Assert.Equal(_control, sender);
             Assert.Same(EventArgs.Empty, e);
             callCount++;
         };
-        control.PaddingChanged += handler;
+        _control.PaddingChanged += handler;
 
         // Set different.
         Padding padding1 = new(1);
-        control.Padding = padding1;
-        Assert.Equal(padding1, control.Padding);
+        _control.Padding = padding1;
+        Assert.Equal(padding1, _control.Padding);
         Assert.Equal(1, callCount);
 
         // Set same.
-        control.Padding = padding1;
-        Assert.Equal(padding1, control.Padding);
+        _control.Padding = padding1;
+        Assert.Equal(padding1, _control.Padding);
         Assert.Equal(1, callCount);
 
         // Set different.
         Padding padding2 = new(2);
-        control.Padding = padding2;
-        Assert.Equal(padding2, control.Padding);
+        _control.Padding = padding2;
+        Assert.Equal(padding2, _control.Padding);
         Assert.Equal(2, callCount);
 
         // Remove handler.
-        control.PaddingChanged -= handler;
-        control.Padding = padding1;
-        Assert.Equal(padding1, control.Padding);
+        _control.PaddingChanged -= handler;
+        _control.Padding = padding1;
+        Assert.Equal(padding1, _control.Padding);
         Assert.Equal(2, callCount);
     }
 
     [WinFormsFact]
     public void DomainUpDown_SelectedIndex_SetEmpty_Nop()
     {
-        using SubDomainUpDown control = new()
-        {
-            SelectedIndex = -1
-        };
-        Assert.Equal(-1, control.SelectedIndex);
-        Assert.Null(control.SelectedItem);
-        Assert.Empty(control.Text);
-        Assert.False(control.UserEdit);
-        Assert.False(control.ChangingText);
-        Assert.False(control.IsHandleCreated);
+        _sub.SelectedIndex = -1;
+
+        Assert.Equal(-1, _sub.SelectedIndex);
+        Assert.Null(_sub.SelectedItem);
+        Assert.Empty(_sub.Text);
+        Assert.False(_sub.UserEdit);
+        Assert.False(_sub.ChangingText);
+        Assert.False(_sub.IsHandleCreated);
 
         // Set same.
-        control.SelectedIndex = -1;
-        Assert.Equal(-1, control.SelectedIndex);
-        Assert.Null(control.SelectedItem);
-        Assert.Empty(control.Text);
-        Assert.False(control.UserEdit);
-        Assert.False(control.ChangingText);
-        Assert.False(control.IsHandleCreated);
+        _sub.SelectedIndex = -1;
+        Assert.Equal(-1, _sub.SelectedIndex);
+        Assert.Null(_sub.SelectedItem);
+        Assert.Empty(_sub.Text);
+        Assert.False(_sub.UserEdit);
+        Assert.False(_sub.ChangingText);
+        Assert.False(_sub.IsHandleCreated);
     }
 
     [WinFormsTheory]
@@ -282,35 +291,34 @@ public class DomainUpDownTests
     [InlineData(-1, null, "", false)]
     public void DomainUpDown_SelectedIndex_SetNotEmpty_GetReturnsExpected(int value, object expected, string expectedText, bool expectedUserEdit)
     {
-        using SubDomainUpDown control = new();
-        control.Items.Add("Item1");
-        control.Items.Add("Item2");
+        _sub.Items.Add("Item1");
+        _sub.Items.Add("Item2");
 
-        control.SelectedIndex = value;
-        Assert.Equal(value, control.SelectedIndex);
-        Assert.Equal(expected, control.SelectedItem);
-        Assert.Equal(expectedText, control.Text);
-        Assert.False(control.UserEdit);
-        Assert.False(control.ChangingText);
-        Assert.False(control.IsHandleCreated);
+        _sub.SelectedIndex = value;
+        Assert.Equal(value, _sub.SelectedIndex);
+        Assert.Equal(expected, _sub.SelectedItem);
+        Assert.Equal(expectedText, _sub.Text);
+        Assert.False(_sub.UserEdit);
+        Assert.False(_sub.ChangingText);
+        Assert.False(_sub.IsHandleCreated);
 
         // Set same.
-        control.SelectedIndex = value;
-        Assert.Equal(value, control.SelectedIndex);
-        Assert.Equal(expected, control.SelectedItem);
-        Assert.Equal(expectedText, control.Text);
-        Assert.False(control.UserEdit);
-        Assert.False(control.ChangingText);
-        Assert.False(control.IsHandleCreated);
+        _sub.SelectedIndex = value;
+        Assert.Equal(value, _sub.SelectedIndex);
+        Assert.Equal(expected, _sub.SelectedItem);
+        Assert.Equal(expectedText, _sub.Text);
+        Assert.False(_sub.UserEdit);
+        Assert.False(_sub.ChangingText);
+        Assert.False(_sub.IsHandleCreated);
 
         // Set none.
-        control.SelectedIndex = -1;
-        Assert.Equal(-1, control.SelectedIndex);
-        Assert.Null(control.SelectedItem);
-        Assert.Equal(expectedText, control.Text);
-        Assert.Equal(expectedUserEdit, control.UserEdit);
-        Assert.False(control.ChangingText);
-        Assert.False(control.IsHandleCreated);
+        _sub.SelectedIndex = -1;
+        Assert.Equal(-1, _sub.SelectedIndex);
+        Assert.Null(_sub.SelectedItem);
+        Assert.Equal(expectedText, _sub.Text);
+        Assert.Equal(expectedUserEdit, _sub.UserEdit);
+        Assert.False(_sub.ChangingText);
+        Assert.False(_sub.IsHandleCreated);
     }
 
     [WinFormsTheory]
@@ -319,94 +327,90 @@ public class DomainUpDownTests
     [InlineData(-1, null, "", false)]
     public void DomainUpDown_SelectedIndex_SetUserEdit_GetReturnsExpected(int value, object expected, string expectedText, bool expectedUserEdit)
     {
-        using SubDomainUpDown control = new()
-        {
-            UserEdit = true
-        };
-        control.Items.Add("Item1");
-        control.Items.Add("Item2");
+        _sub.UserEdit=true;
+        _sub.Items.Add("Item1");
+        _sub.Items.Add("Item2");
 
-        control.SelectedIndex = value;
-        Assert.Equal(value, control.SelectedIndex);
-        Assert.Equal(expected, control.SelectedItem);
-        Assert.Equal(expectedText, control.Text);
-        Assert.Equal(!expectedUserEdit, control.UserEdit);
-        Assert.False(control.ChangingText);
-        Assert.False(control.IsHandleCreated);
+        _sub.SelectedIndex = value;
+        Assert.Equal(value, _sub.SelectedIndex);
+        Assert.Equal(expected, _sub.SelectedItem);
+        Assert.Equal(expectedText, _sub.Text);
+        Assert.Equal(!expectedUserEdit, _sub.UserEdit);
+        Assert.False(_sub.ChangingText);
+        Assert.False(_sub.IsHandleCreated);
 
         // Set same.
-        control.SelectedIndex = value;
-        Assert.Equal(value, control.SelectedIndex);
-        Assert.Equal(expected, control.SelectedItem);
-        Assert.Equal(expectedText, control.Text);
-        Assert.Equal(!expectedUserEdit, control.UserEdit);
-        Assert.False(control.ChangingText);
-        Assert.False(control.IsHandleCreated);
+        _sub.SelectedIndex = value;
+        Assert.Equal(value, _sub.SelectedIndex);
+        Assert.Equal(expected, _sub.SelectedItem);
+        Assert.Equal(expectedText, _sub.Text);
+        Assert.Equal(!expectedUserEdit, _sub.UserEdit);
+        Assert.False(_sub.ChangingText);
+        Assert.False(_sub.IsHandleCreated);
 
         // Set none.
-        control.SelectedIndex = -1;
-        Assert.Equal(-1, control.SelectedIndex);
-        Assert.Null(control.SelectedItem);
-        Assert.Equal(expectedText, control.Text);
-        Assert.True(control.UserEdit);
-        Assert.False(control.ChangingText);
-        Assert.False(control.IsHandleCreated);
+        _sub.SelectedIndex = -1;
+        Assert.Equal(-1, _sub.SelectedIndex);
+        Assert.Null(_sub.SelectedItem);
+        Assert.Equal(expectedText, _sub.Text);
+        Assert.True(_sub.UserEdit);
+        Assert.False(_sub.ChangingText);
+        Assert.False(_sub.IsHandleCreated);
     }
 
     [WinFormsFact]
     public void DomainUpDown_SelectedIndex_SetWithHandler_CallsSelectedItemChanged()
     {
-        using DomainUpDown control = new();
-        control.Items.Add("Item1");
-        control.Items.Add("Item2");
+        _control.Items.Add("Item1");
+        _control.Items.Add("Item2");
 
         int textChangedCallCount = 0;
         int callCount = 0;
         EventHandler textChangedHandler = (sender, e) =>
         {
-            Assert.Same(control, sender);
+            Assert.Same(_control, sender);
             Assert.Same(EventArgs.Empty, e);
             textChangedCallCount++;
         };
         EventHandler handler = (sender, e) =>
         {
-            Assert.Same(control, sender);
+            Assert.Same(_control, sender);
             Assert.Same(EventArgs.Empty, e);
             Assert.Equal(textChangedCallCount - 1, callCount);
             callCount++;
         };
-        control.TextChanged += textChangedHandler;
-        control.SelectedItemChanged += handler;
+        _control.TextChanged += textChangedHandler;
+        _control.SelectedItemChanged += handler;
 
         // Set different.
-        control.SelectedIndex = 0;
-        Assert.Equal(0, control.SelectedIndex);
+        _control.SelectedIndex = 0;
+        Assert.Equal(0, _control.SelectedIndex);
         Assert.Equal(1, textChangedCallCount);
         Assert.Equal(1, callCount);
 
         // Set same.
-        control.SelectedIndex = 0;
-        Assert.Equal(0, control.SelectedIndex);
+        _control.SelectedIndex = 0;
+        Assert.Equal(0, _control.SelectedIndex);
         Assert.Equal(1, textChangedCallCount);
         Assert.Equal(1, callCount);
 
         // Set different.
-        control.SelectedIndex = 1;
-        Assert.Equal(1, control.SelectedIndex);
+        _control.SelectedIndex = 1;
+        Assert.Equal(1, _control.SelectedIndex);
         Assert.Equal(2, textChangedCallCount);
         Assert.Equal(2, callCount);
 
         // Set none.
-        control.SelectedIndex = -1;
-        Assert.Equal(-1, control.SelectedIndex);
+        _control.SelectedIndex = -1;
+        Assert.Equal(-1, _control.SelectedIndex);
         Assert.Equal(2, textChangedCallCount);
         Assert.Equal(2, callCount);
 
         // Remove handler.
-        control.TextChanged -= textChangedHandler;
-        control.SelectedItemChanged -= handler;
-        control.SelectedIndex = 0;
-        Assert.Equal(0, control.SelectedIndex);
+        _control.TextChanged -= textChangedHandler;
+        _control.SelectedItemChanged -= handler;
+        _control.SelectedIndex = 0;
+        Assert.Equal(0, _control.SelectedIndex);
         Assert.Equal(2, textChangedCallCount);
         Assert.Equal(2, callCount);
     }
@@ -417,8 +421,7 @@ public class DomainUpDownTests
     [InlineData(1)]
     public void DomainUpDown_SelectedIndex_SetInvalidValueEmpty_ThrowsArgumentOutOfRangeException(int value)
     {
-        using DomainUpDown control = new();
-        Assert.Throws<ArgumentOutOfRangeException>("value", () => control.SelectedIndex = value);
+        Assert.Throws<ArgumentOutOfRangeException>("value", () => _control.SelectedIndex = value);
     }
 
     [WinFormsTheory]
@@ -427,9 +430,8 @@ public class DomainUpDownTests
     [InlineData(2)]
     public void DomainUpDown_SelectedIndex_SetInvalidValueNotEmpty_ThrowsArgumentOutOfRangeException(int value)
     {
-        using DomainUpDown control = new();
-        control.Items.Add("Item");
-        Assert.Throws<ArgumentOutOfRangeException>("value", () => control.SelectedIndex = value);
+        _control.Items.Add("Item");
+        Assert.Throws<ArgumentOutOfRangeException>("value", () => _control.SelectedIndex = value);
     }
 
     [WinFormsTheory]
@@ -437,25 +439,22 @@ public class DomainUpDownTests
     [InlineData("NoSuchItem")]
     public void DomainUpDown_SelectedItem_SetEmpty_Nop(object value)
     {
-        using SubDomainUpDown control = new()
-        {
-            SelectedItem = value
-        };
-        Assert.Equal(-1, control.SelectedIndex);
-        Assert.Null(control.SelectedItem);
-        Assert.Empty(control.Text);
-        Assert.False(control.UserEdit);
-        Assert.False(control.ChangingText);
-        Assert.False(control.IsHandleCreated);
+        _sub.SelectedItem = value;
+        Assert.Equal(-1, _sub.SelectedIndex);
+        Assert.Null(_sub.SelectedItem);
+        Assert.Empty(_sub.Text);
+        Assert.False(_sub.UserEdit);
+        Assert.False(_sub.ChangingText);
+        Assert.False(_sub.IsHandleCreated);
 
         // Set same.
-        control.SelectedItem = value;
-        Assert.Equal(-1, control.SelectedIndex);
-        Assert.Null(control.SelectedItem);
-        Assert.Empty(control.Text);
-        Assert.False(control.UserEdit);
-        Assert.False(control.ChangingText);
-        Assert.False(control.IsHandleCreated);
+        _sub.SelectedItem = value;
+        Assert.Equal(-1, _sub.SelectedIndex);
+        Assert.Null(_sub.SelectedItem);
+        Assert.Empty(_sub.Text);
+        Assert.False(_sub.UserEdit);
+        Assert.False(_sub.ChangingText);
+        Assert.False(_sub.IsHandleCreated);
     }
 
     [WinFormsTheory]
@@ -465,44 +464,43 @@ public class DomainUpDownTests
     [InlineData(null, -1, null, "", false)]
     public void DomainUpDown_SelectedItem_SetNotEmpty_GetReturnsExpected(object value, int expectedSelectedIndex, object expected, string expectedText, bool expectedUserEdit)
     {
-        using SubDomainUpDown control = new();
-        control.Items.Add("Item1");
-        control.Items.Add("Item2");
+        _sub.Items.Add("Item1");
+        _sub.Items.Add("Item2");
 
-        control.SelectedItem = value;
-        Assert.Equal(expectedSelectedIndex, control.SelectedIndex);
-        Assert.Equal(expected, control.SelectedItem);
-        Assert.Equal(expectedText, control.Text);
-        Assert.False(control.UserEdit);
-        Assert.False(control.ChangingText);
-        Assert.False(control.IsHandleCreated);
+        _sub.SelectedItem = value;
+        Assert.Equal(expectedSelectedIndex, _sub.SelectedIndex);
+        Assert.Equal(expected, _sub.SelectedItem);
+        Assert.Equal(expectedText, _sub.Text);
+        Assert.False(_sub.UserEdit);
+        Assert.False(_sub.ChangingText);
+        Assert.False(_sub.IsHandleCreated);
 
         // Set same.
-        control.SelectedItem = value;
-        Assert.Equal(expectedSelectedIndex, control.SelectedIndex);
-        Assert.Equal(expected, control.SelectedItem);
-        Assert.Equal(expectedText, control.Text);
-        Assert.False(control.UserEdit);
-        Assert.False(control.ChangingText);
-        Assert.False(control.IsHandleCreated);
+        _sub.SelectedItem = value;
+        Assert.Equal(expectedSelectedIndex, _sub.SelectedIndex);
+        Assert.Equal(expected, _sub.SelectedItem);
+        Assert.Equal(expectedText, _sub.Text);
+        Assert.False(_sub.UserEdit);
+        Assert.False(_sub.ChangingText);
+        Assert.False(_sub.IsHandleCreated);
 
         // Set no such item.
-        control.SelectedItem = "NoSuchItem";
-        Assert.Equal(expectedSelectedIndex, control.SelectedIndex);
-        Assert.Equal(expected, control.SelectedItem);
-        Assert.Equal(expectedText, control.Text);
-        Assert.False(control.UserEdit);
-        Assert.False(control.ChangingText);
-        Assert.False(control.IsHandleCreated);
+        _sub.SelectedItem = "NoSuchItem";
+        Assert.Equal(expectedSelectedIndex, _sub.SelectedIndex);
+        Assert.Equal(expected, _sub.SelectedItem);
+        Assert.Equal(expectedText, _sub.Text);
+        Assert.False(_sub.UserEdit);
+        Assert.False(_sub.ChangingText);
+        Assert.False(_sub.IsHandleCreated);
 
         // Set none.
-        control.SelectedItem = null;
-        Assert.Equal(-1, control.SelectedIndex);
-        Assert.Null(control.SelectedItem);
-        Assert.Equal(expectedText, control.Text);
-        Assert.Equal(expectedUserEdit, control.UserEdit);
-        Assert.False(control.ChangingText);
-        Assert.False(control.IsHandleCreated);
+        _sub.SelectedItem = null;
+        Assert.Equal(-1, _sub.SelectedIndex);
+        Assert.Null(_sub.SelectedItem);
+        Assert.Equal(expectedText, _sub.Text);
+        Assert.Equal(expectedUserEdit, _sub.UserEdit);
+        Assert.False(_sub.ChangingText);
+        Assert.False(_sub.IsHandleCreated);
     }
 
     [WinFormsTheory]
@@ -512,103 +510,99 @@ public class DomainUpDownTests
     [InlineData(null, -1, null, "", false)]
     public void DomainUpDown_SelectedItem_SetUserEdit_GetReturnsExpected(object value, int expectedSelectedIndex, object expected, string expectedText, bool expectedUserEdit)
     {
-        using SubDomainUpDown control = new()
-        {
-            UserEdit = true
-        };
-        control.Items.Add("Item1");
-        control.Items.Add("Item2");
+        _sub.UserEdit = true;
+        _sub.Items.Add("Item1");
+        _sub.Items.Add("Item2");
 
-        control.SelectedItem = value;
-        Assert.Equal(expectedSelectedIndex, control.SelectedIndex);
-        Assert.Equal(expected, control.SelectedItem);
-        Assert.Equal(expectedText, control.Text);
-        Assert.Equal(!expectedUserEdit, control.UserEdit);
-        Assert.False(control.ChangingText);
-        Assert.False(control.IsHandleCreated);
+        _sub.SelectedItem = value;
+        Assert.Equal(expectedSelectedIndex, _sub.SelectedIndex);
+        Assert.Equal(expected, _sub.SelectedItem);
+        Assert.Equal(expectedText, _sub.Text);
+        Assert.Equal(!expectedUserEdit, _sub.UserEdit);
+        Assert.False(_sub.ChangingText);
+        Assert.False(_sub.IsHandleCreated);
 
         // Set same.
-        control.SelectedItem = value;
-        Assert.Equal(expectedSelectedIndex, control.SelectedIndex);
-        Assert.Equal(expected, control.SelectedItem);
-        Assert.Equal(expectedText, control.Text);
-        Assert.Equal(!expectedUserEdit, control.UserEdit);
-        Assert.False(control.ChangingText);
-        Assert.False(control.IsHandleCreated);
+        _sub.SelectedItem = value;
+        Assert.Equal(expectedSelectedIndex, _sub.SelectedIndex);
+        Assert.Equal(expected, _sub.SelectedItem);
+        Assert.Equal(expectedText, _sub.Text);
+        Assert.Equal(!expectedUserEdit, _sub.UserEdit);
+        Assert.False(_sub.ChangingText);
+        Assert.False(_sub.IsHandleCreated);
 
         // Set no such item.
-        control.SelectedItem = "NoSuchItem";
-        Assert.Equal(expectedSelectedIndex, control.SelectedIndex);
-        Assert.Equal(expected, control.SelectedItem);
-        Assert.Equal(expectedText, control.Text);
-        Assert.Equal(!expectedUserEdit, control.UserEdit);
-        Assert.False(control.ChangingText);
-        Assert.False(control.IsHandleCreated);
+        _sub.SelectedItem = "NoSuchItem";
+        Assert.Equal(expectedSelectedIndex, _sub.SelectedIndex);
+        Assert.Equal(expected, _sub.SelectedItem);
+        Assert.Equal(expectedText, _sub.Text);
+        Assert.Equal(!expectedUserEdit, _sub.UserEdit);
+        Assert.False(_sub.ChangingText);
+        Assert.False(_sub.IsHandleCreated);
 
         // Set none.
-        control.SelectedItem = null;
-        Assert.Equal(-1, control.SelectedIndex);
-        Assert.Null(control.SelectedItem);
-        Assert.Equal(expectedText, control.Text);
-        Assert.True(control.UserEdit);
-        Assert.False(control.ChangingText);
-        Assert.False(control.IsHandleCreated);
+        _sub.SelectedItem = null;
+        Assert.Equal(-1, _sub.SelectedIndex);
+        Assert.Null(_sub.SelectedItem);
+        Assert.Equal(expectedText, _sub.Text);
+        Assert.True(_sub.UserEdit);
+        Assert.False(_sub.ChangingText);
+        Assert.False(_sub.IsHandleCreated);
     }
 
     [WinFormsFact]
     public void DomainUpDown_SelectedItem_SetWithHandler_CallsSelectedItemChanged()
     {
-        using DomainUpDown control = new();
-        control.Items.Add("Item1");
-        control.Items.Add("Item2");
+        _control.Items.Add("Item1");
+        _control.Items.Add("Item2");
 
         int textChangedCallCount = 0;
         int callCount = 0;
         EventHandler textChangedHandler = (sender, e) =>
         {
-            Assert.Same(control, sender);
+            Assert.Same(_control, sender);
             Assert.Same(EventArgs.Empty, e);
             textChangedCallCount++;
         };
         EventHandler handler = (sender, e) =>
         {
-            Assert.Same(control, sender);
+            Assert.Same(_control, sender);
             Assert.Same(EventArgs.Empty, e);
             Assert.Equal(textChangedCallCount - 1, callCount);
             callCount++;
         };
-        control.TextChanged += textChangedHandler;
-        control.SelectedItemChanged += handler;
+        _control.TextChanged += textChangedHandler;
+        _control.SelectedItemChanged += handler;
 
         // Set different.
-        control.SelectedItem = "Item1";
-        Assert.Equal("Item1", control.SelectedItem);
+        _control.SelectedItem = "Item1";
+        Assert.Equal("Item1", _control.SelectedItem);
         Assert.Equal(1, textChangedCallCount);
         Assert.Equal(1, callCount);
 
         // Set same.
-        control.SelectedItem = "Item1";
-        Assert.Equal("Item1", control.SelectedItem);
+        _control.SelectedItem = "Item1";
+        Assert.Equal("Item1", _control.SelectedItem);
         Assert.Equal(1, textChangedCallCount);
         Assert.Equal(1, callCount);
 
         // Set different.
-        control.SelectedItem = "Item2";
-        Assert.Equal("Item2", control.SelectedItem);
+        _control.SelectedItem = "Item2";
+        Assert.Equal("Item2", _control.SelectedItem);
         Assert.Equal(2, textChangedCallCount);
         Assert.Equal(2, callCount);
 
         // Set none.
-        control.SelectedItem = null;
-        Assert.Null(control.SelectedItem);
+        _control.SelectedItem = null;
+        Assert.Null(_control.SelectedItem);
         Assert.Equal(2, textChangedCallCount);
         Assert.Equal(2, callCount);
 
         // Remove handler.
-        control.TextChanged -= textChangedHandler;
-        control.SelectedItemChanged -= handler;
-        control.SelectedItem = "Item1";
-        Assert.Equal("Item1", control.SelectedItem);
+        _control.TextChanged -= textChangedHandler;
+        _control.SelectedItemChanged -= handler;
+        _control.SelectedItem = "Item1";
+        Assert.Equal("Item1", _control.SelectedItem);
         Assert.Equal(2, textChangedCallCount);
         Assert.Equal(2, callCount);
     }
@@ -626,32 +620,30 @@ public class DomainUpDownTests
     [MemberData(nameof(Sorted_Set_TestData))]
     public void DomainUpDown_Sorted_Set_GetReturnsExpected(bool userEdit, bool value)
     {
-        using SubDomainUpDown control = new()
-        {
-            UserEdit = userEdit,
-            Sorted = value
-        };
-        Assert.Equal(value, control.Sorted);
-        Assert.Empty(control.Items);
-        Assert.Equal(-1, control.SelectedIndex);
-        Assert.Equal(userEdit, control.UserEdit);
-        Assert.False(control.IsHandleCreated);
+        _sub.UserEdit = userEdit;
+        _sub.Sorted = value;
+
+        Assert.Equal(value, _sub.Sorted);
+        Assert.Empty(_sub.Items);
+        Assert.Equal(-1, _sub.SelectedIndex);
+        Assert.Equal(userEdit, _sub.UserEdit);
+        Assert.False(_sub.IsHandleCreated);
 
         // Set same.
-        control.Sorted = value;
-        Assert.Equal(value, control.Sorted);
-        Assert.Empty(control.Items);
-        Assert.Equal(-1, control.SelectedIndex);
-        Assert.Equal(userEdit, control.UserEdit);
-        Assert.False(control.IsHandleCreated);
+        _sub.Sorted = value;
+        Assert.Equal(value, _sub.Sorted);
+        Assert.Empty(_sub.Items);
+        Assert.Equal(-1, _sub.SelectedIndex);
+        Assert.Equal(userEdit, _sub.UserEdit);
+        Assert.False(_sub.IsHandleCreated);
 
         // Set different.
-        control.Sorted = !value;
-        Assert.Equal(!value, control.Sorted);
-        Assert.Empty(control.Items);
-        Assert.Equal(-1, control.SelectedIndex);
-        Assert.Equal(userEdit, control.UserEdit);
-        Assert.False(control.IsHandleCreated);
+        _sub.Sorted = !value;
+        Assert.Equal(!value, _sub.Sorted);
+        Assert.Empty(_sub.Items);
+        Assert.Equal(-1, _sub.SelectedIndex);
+        Assert.Equal(userEdit, _sub.UserEdit);
+        Assert.False(_sub.IsHandleCreated);
     }
 
     public static IEnumerable<object[]> Sorted_WithItems_TestData()
@@ -667,35 +659,34 @@ public class DomainUpDownTests
     [MemberData(nameof(Sorted_WithItems_TestData))]
     public void DomainUpDown_Sorted_SetWithItems_GetReturnsExpected(bool userEdit, bool value, string[] expectedItems)
     {
-        using SubDomainUpDown control = new();
-        control.Items.Add("c");
-        control.Items.Add("B");
-        control.Items.Add("a");
-        control.Items.Add("a");
-        control.Items.Add("d");
-        control.UserEdit = userEdit;
+        _sub.Items.Add("c");
+        _sub.Items.Add("B");
+        _sub.Items.Add("a");
+        _sub.Items.Add("a");
+        _sub.Items.Add("d");
+        _sub.UserEdit = userEdit;
 
-        control.Sorted = value;
-        Assert.Equal(value, control.Sorted);
-        Assert.Equal(expectedItems, control.Items.Cast<string>());
-        Assert.Equal(-1, control.SelectedIndex);
-        Assert.False(control.IsHandleCreated);
+        _sub.Sorted = value;
+        Assert.Equal(value, _sub.Sorted);
+        Assert.Equal(expectedItems, _sub.Items.Cast<string>());
+        Assert.Equal(-1, _sub.SelectedIndex);
+        Assert.False(_sub.IsHandleCreated);
 
         // Set same.
-        control.Sorted = value;
-        Assert.Equal(value, control.Sorted);
-        Assert.Equal(expectedItems, control.Items.Cast<string>());
-        Assert.Equal(-1, control.SelectedIndex);
-        Assert.Equal(userEdit, control.UserEdit);
-        Assert.False(control.IsHandleCreated);
+        _sub.Sorted = value;
+        Assert.Equal(value, _sub.Sorted);
+        Assert.Equal(expectedItems, _sub.Items.Cast<string>());
+        Assert.Equal(-1, _sub.SelectedIndex);
+        Assert.Equal(userEdit, _sub.UserEdit);
+        Assert.False(_sub.IsHandleCreated);
 
         // Set different.
-        control.Sorted = !value;
-        Assert.Equal(!value, control.Sorted);
-        Assert.Equal(new string[] { "a", "a", "B", "c", "d" }, control.Items.Cast<string>());
-        Assert.Equal(-1, control.SelectedIndex);
-        Assert.Equal(userEdit, control.UserEdit);
-        Assert.False(control.IsHandleCreated);
+        _sub.Sorted = !value;
+        Assert.Equal(!value, _sub.Sorted);
+        Assert.Equal(new string[] { "a", "a", "B", "c", "d" }, _sub.Items.Cast<string>());
+        Assert.Equal(-1, _sub.SelectedIndex);
+        Assert.Equal(userEdit, _sub.UserEdit);
+        Assert.False(_sub.IsHandleCreated);
     }
 
     public static IEnumerable<object[]> Sorted_WithItemsWithSelection_TestData()
@@ -710,82 +701,78 @@ public class DomainUpDownTests
     [MemberData(nameof(Sorted_WithItemsWithSelection_TestData))]
     public void DomainUpDown_Sorted_SetWithItemsWithSelection_GetReturnsExpected(bool userEdit, bool value, string[] expectedItems, int expectedSelectedIndex)
     {
-        using SubDomainUpDown control = new();
-        control.Items.Add("c");
-        control.Items.Add("B");
-        control.Items.Add("a");
-        control.Items.Add("a");
-        control.Items.Add("d");
-        control.SelectedItem = "B";
-        control.UserEdit = userEdit;
+        _sub.Items.Add("c");
+        _sub.Items.Add("B");
+        _sub.Items.Add("a");
+        _sub.Items.Add("a");
+        _sub.Items.Add("d");
+        _sub.SelectedItem = "B";
+        _sub.UserEdit = userEdit;
 
-        control.Sorted = value;
-        Assert.Equal(value, control.Sorted);
-        Assert.Equal(expectedItems, control.Items.Cast<string>());
-        Assert.Equal(expectedSelectedIndex, control.SelectedIndex);
-        Assert.False(control.IsHandleCreated);
+        _sub.Sorted = value;
+        Assert.Equal(value, _sub.Sorted);
+        Assert.Equal(expectedItems, _sub.Items.Cast<string>());
+        Assert.Equal(expectedSelectedIndex, _sub.SelectedIndex);
+        Assert.False(_sub.IsHandleCreated);
 
         // Set same.
-        control.Sorted = value;
-        Assert.Equal(value, control.Sorted);
-        Assert.Equal(expectedItems, control.Items.Cast<string>());
-        Assert.Equal(expectedSelectedIndex, control.SelectedIndex);
-        Assert.Equal(userEdit, control.UserEdit);
-        Assert.False(control.IsHandleCreated);
+        _sub.Sorted = value;
+        Assert.Equal(value, _sub.Sorted);
+        Assert.Equal(expectedItems, _sub.Items.Cast<string>());
+        Assert.Equal(expectedSelectedIndex, _sub.SelectedIndex);
+        Assert.Equal(userEdit, _sub.UserEdit);
+        Assert.False(_sub.IsHandleCreated);
 
         // Set different.
-        control.Sorted = !value;
-        Assert.Equal(!value, control.Sorted);
-        Assert.Equal(new string[] { "a", "a", "B", "c", "d" }, control.Items.Cast<string>());
-        Assert.Equal(expectedSelectedIndex, control.SelectedIndex);
-        Assert.Equal(userEdit, control.UserEdit);
-        Assert.False(control.IsHandleCreated);
+        _sub.Sorted = !value;
+        Assert.Equal(!value, _sub.Sorted);
+        Assert.Equal(new string[] { "a", "a", "B", "c", "d" }, _sub.Items.Cast<string>());
+        Assert.Equal(expectedSelectedIndex, _sub.SelectedIndex);
+        Assert.Equal(userEdit, _sub.UserEdit);
+        Assert.False(_sub.IsHandleCreated);
     }
 
     [WinFormsTheory]
     [MemberData(nameof(Sorted_Set_TestData))]
     public void DomainUpDown_Sorted_SetWithHandle_GetReturnsExpected(bool userEdit, bool value)
     {
-        using SubDomainUpDown control = new()
-        {
-            UserEdit = userEdit
-        };
-        Assert.NotEqual(IntPtr.Zero, control.Handle);
+        _sub.UserEdit = userEdit;
+        Assert.NotEqual(IntPtr.Zero, _sub.Handle);
         int invalidatedCallCount = 0;
-        control.Invalidated += (sender, e) => invalidatedCallCount++;
+        _sub.Invalidated += (sender, e) => invalidatedCallCount++;
         int styleChangedCallCount = 0;
-        control.StyleChanged += (sender, e) => styleChangedCallCount++;
+        _sub.StyleChanged += (sender, e) => styleChangedCallCount++;
         int createdCallCount = 0;
-        control.HandleCreated += (sender, e) => createdCallCount++;
+        _sub.HandleCreated += (sender, e) => createdCallCount++;
 
-        control.Sorted = value;
-        Assert.Equal(value, control.Sorted);
-        Assert.Empty(control.Items);
-        Assert.Equal(-1, control.SelectedIndex);
-        Assert.Equal(userEdit, control.UserEdit);
-        Assert.True(control.IsHandleCreated);
+        _sub.Sorted = value;
+        Assert.Equal(value, _sub.Sorted);
+        Assert.Empty(_sub.Items);
+        Assert.Equal(-1, _sub.SelectedIndex);
+        Assert.Equal(userEdit, _sub.UserEdit);
+        Assert.True(_sub.IsHandleCreated);
         Assert.Equal(0, invalidatedCallCount);
         Assert.Equal(0, styleChangedCallCount);
         Assert.Equal(0, createdCallCount);
 
         // Set same.
-        control.Sorted = value;
-        Assert.Equal(value, control.Sorted);
-        Assert.Empty(control.Items);
-        Assert.Equal(-1, control.SelectedIndex);
-        Assert.Equal(userEdit, control.UserEdit);
-        Assert.True(control.IsHandleCreated);
+        _sub.Sorted = value;
+        Assert.Equal(value, _sub.Sorted);
+        Assert.Empty(_sub.Items);
+        Assert.Equal(-1, _sub.SelectedIndex);
+        Assert.Equal(userEdit, _sub.UserEdit);
+        Assert.True(_sub.IsHandleCreated);
         Assert.Equal(0, invalidatedCallCount);
         Assert.Equal(0, styleChangedCallCount);
         Assert.Equal(0, createdCallCount);
 
         // Set different.
-        control.Sorted = !value;
-        Assert.Equal(!value, control.Sorted);
-        Assert.Empty(control.Items);
-        Assert.Equal(-1, control.SelectedIndex);
-        Assert.Equal(userEdit, control.UserEdit);
-        Assert.True(control.IsHandleCreated);
+        _sub.Sorted = !value;
+        Assert.Equal(!value, _sub.Sorted);
+        Assert.Empty(_sub.Items);
+        Assert.Equal(-1, _sub.SelectedIndex);
+        Assert.Equal(userEdit, _sub.UserEdit);
+        Assert.True(_sub.IsHandleCreated);
         Assert.Equal(0, invalidatedCallCount);
         Assert.Equal(0, styleChangedCallCount);
         Assert.Equal(0, createdCallCount);
@@ -795,48 +782,47 @@ public class DomainUpDownTests
     [MemberData(nameof(Sorted_WithItems_TestData))]
     public void DomainUpDown_Sorted_SetWithItemsWithHandle_GetReturnsExpected(bool userEdit, bool value, string[] expectedItems)
     {
-        using SubDomainUpDown control = new();
-        control.Items.Add("c");
-        control.Items.Add("B");
-        control.Items.Add("a");
-        control.Items.Add("a");
-        control.Items.Add("d");
-        Assert.NotEqual(IntPtr.Zero, control.Handle);
+        _sub.Items.Add("c");
+        _sub.Items.Add("B");
+        _sub.Items.Add("a");
+        _sub.Items.Add("a");
+        _sub.Items.Add("d");
+        Assert.NotEqual(IntPtr.Zero, _sub.Handle);
         int invalidatedCallCount = 0;
-        control.Invalidated += (sender, e) => invalidatedCallCount++;
+        _sub.Invalidated += (sender, e) => invalidatedCallCount++;
         int styleChangedCallCount = 0;
-        control.StyleChanged += (sender, e) => styleChangedCallCount++;
+        _sub.StyleChanged += (sender, e) => styleChangedCallCount++;
         int createdCallCount = 0;
-        control.HandleCreated += (sender, e) => createdCallCount++;
-        control.UserEdit = userEdit;
+        _sub.HandleCreated += (sender, e) => createdCallCount++;
+        _sub.UserEdit = userEdit;
 
-        control.Sorted = value;
-        Assert.Equal(value, control.Sorted);
-        Assert.Equal(expectedItems, control.Items.Cast<string>());
-        Assert.Equal(-1, control.SelectedIndex);
-        Assert.True(control.IsHandleCreated);
+        _sub.Sorted = value;
+        Assert.Equal(value, _sub.Sorted);
+        Assert.Equal(expectedItems, _sub.Items.Cast<string>());
+        Assert.Equal(-1, _sub.SelectedIndex);
+        Assert.True(_sub.IsHandleCreated);
         Assert.Equal(0, invalidatedCallCount);
         Assert.Equal(0, styleChangedCallCount);
         Assert.Equal(0, createdCallCount);
 
         // Set same.
-        control.Sorted = value;
-        Assert.Equal(value, control.Sorted);
-        Assert.Equal(expectedItems, control.Items.Cast<string>());
-        Assert.Equal(-1, control.SelectedIndex);
-        Assert.Equal(userEdit, control.UserEdit);
-        Assert.True(control.IsHandleCreated);
+        _sub.Sorted = value;
+        Assert.Equal(value, _sub.Sorted);
+        Assert.Equal(expectedItems, _sub.Items.Cast<string>());
+        Assert.Equal(-1, _sub.SelectedIndex);
+        Assert.Equal(userEdit, _sub.UserEdit);
+        Assert.True(_sub.IsHandleCreated);
         Assert.Equal(0, invalidatedCallCount);
         Assert.Equal(0, styleChangedCallCount);
         Assert.Equal(0, createdCallCount);
 
         // Set different.
-        control.Sorted = !value;
-        Assert.Equal(!value, control.Sorted);
-        Assert.Equal(new string[] { "a", "a", "B", "c", "d" }, control.Items.Cast<string>());
-        Assert.Equal(-1, control.SelectedIndex);
-        Assert.Equal(userEdit, control.UserEdit);
-        Assert.True(control.IsHandleCreated);
+        _sub.Sorted = !value;
+        Assert.Equal(!value, _sub.Sorted);
+        Assert.Equal(new string[] { "a", "a", "B", "c", "d" }, _sub.Items.Cast<string>());
+        Assert.Equal(-1, _sub.SelectedIndex);
+        Assert.Equal(userEdit, _sub.UserEdit);
+        Assert.True(_sub.IsHandleCreated);
         Assert.Equal(0, invalidatedCallCount);
         Assert.Equal(0, styleChangedCallCount);
         Assert.Equal(0, createdCallCount);
@@ -846,49 +832,48 @@ public class DomainUpDownTests
     [MemberData(nameof(Sorted_WithItemsWithSelection_TestData))]
     public void DomainUpDown_Sorted_SetWithItemsWithSelectionWithHandle_GetReturnsExpected(bool userEdit, bool value, string[] expectedItems, int expectedSelectedIndex)
     {
-        using SubDomainUpDown control = new();
-        control.Items.Add("c");
-        control.Items.Add("B");
-        control.Items.Add("a");
-        control.Items.Add("a");
-        control.Items.Add("d");
-        Assert.NotEqual(IntPtr.Zero, control.Handle);
+        _sub.Items.Add("c");
+        _sub.Items.Add("B");
+        _sub.Items.Add("a");
+        _sub.Items.Add("a");
+        _sub.Items.Add("d");
+        Assert.NotEqual(IntPtr.Zero, _sub.Handle);
         int invalidatedCallCount = 0;
-        control.Invalidated += (sender, e) => invalidatedCallCount++;
+        _sub.Invalidated += (sender, e) => invalidatedCallCount++;
         int styleChangedCallCount = 0;
-        control.StyleChanged += (sender, e) => styleChangedCallCount++;
+        _sub.StyleChanged += (sender, e) => styleChangedCallCount++;
         int createdCallCount = 0;
-        control.HandleCreated += (sender, e) => createdCallCount++;
-        control.SelectedItem = "B";
-        control.UserEdit = userEdit;
+        _sub.HandleCreated += (sender, e) => createdCallCount++;
+        _sub.SelectedItem = "B";
+        _sub.UserEdit = userEdit;
 
-        control.Sorted = value;
-        Assert.Equal(value, control.Sorted);
-        Assert.Equal(expectedItems, control.Items.Cast<string>());
-        Assert.Equal(expectedSelectedIndex, control.SelectedIndex);
-        Assert.True(control.IsHandleCreated);
+        _sub.Sorted = value;
+        Assert.Equal(value, _sub.Sorted);
+        Assert.Equal(expectedItems, _sub.Items.Cast<string>());
+        Assert.Equal(expectedSelectedIndex, _sub.SelectedIndex);
+        Assert.True(_sub.IsHandleCreated);
         Assert.Equal(0, invalidatedCallCount);
         Assert.Equal(0, styleChangedCallCount);
         Assert.Equal(0, createdCallCount);
 
         // Set same.
-        control.Sorted = value;
-        Assert.Equal(value, control.Sorted);
-        Assert.Equal(expectedItems, control.Items.Cast<string>());
-        Assert.Equal(expectedSelectedIndex, control.SelectedIndex);
-        Assert.Equal(userEdit, control.UserEdit);
-        Assert.True(control.IsHandleCreated);
+        _sub.Sorted = value;
+        Assert.Equal(value, _sub.Sorted);
+        Assert.Equal(expectedItems, _sub.Items.Cast<string>());
+        Assert.Equal(expectedSelectedIndex, _sub.SelectedIndex);
+        Assert.Equal(userEdit, _sub.UserEdit);
+        Assert.True(_sub.IsHandleCreated);
         Assert.Equal(0, invalidatedCallCount);
         Assert.Equal(0, styleChangedCallCount);
         Assert.Equal(0, createdCallCount);
 
         // Set different.
-        control.Sorted = !value;
-        Assert.Equal(!value, control.Sorted);
-        Assert.Equal(new string[] { "a", "a", "B", "c", "d" }, control.Items.Cast<string>());
-        Assert.Equal(expectedSelectedIndex, control.SelectedIndex);
-        Assert.Equal(userEdit, control.UserEdit);
-        Assert.True(control.IsHandleCreated);
+        _sub.Sorted = !value;
+        Assert.Equal(!value, _sub.Sorted);
+        Assert.Equal(new string[] { "a", "a", "B", "c", "d" }, _sub.Items.Cast<string>());
+        Assert.Equal(expectedSelectedIndex, _sub.SelectedIndex);
+        Assert.Equal(userEdit, _sub.UserEdit);
+        Assert.True(_sub.IsHandleCreated);
         Assert.Equal(0, invalidatedCallCount);
         Assert.Equal(0, styleChangedCallCount);
         Assert.Equal(0, createdCallCount);
@@ -898,56 +883,53 @@ public class DomainUpDownTests
     [BoolData]
     public void DomainUpDown_Wrap_Set_GetReturnsExpected(bool value)
     {
-        using DomainUpDown control = new()
-        {
-            Wrap = value
-        };
-        Assert.Equal(value, control.Wrap);
-        Assert.False(control.IsHandleCreated);
+        _control.Wrap = value;
+
+        Assert.Equal(value, _control.Wrap);
+        Assert.False(_control.IsHandleCreated);
 
         // Set same.
-        control.Wrap = value;
-        Assert.Equal(value, control.Wrap);
-        Assert.False(control.IsHandleCreated);
+        _control.Wrap = value;
+        Assert.Equal(value, _control.Wrap);
+        Assert.False(_control.IsHandleCreated);
 
         // Set different.
-        control.Wrap = !value;
-        Assert.Equal(!value, control.Wrap);
-        Assert.False(control.IsHandleCreated);
+        _control.Wrap = !value;
+        Assert.Equal(!value, _control.Wrap);
+        Assert.False(_control.IsHandleCreated);
     }
 
     [WinFormsTheory]
     [BoolData]
     public void DomainUpDown_Wrap_SetWithHandle_GetReturnsExpected(bool value)
     {
-        using DomainUpDown control = new();
-        Assert.NotEqual(IntPtr.Zero, control.Handle);
+        Assert.NotEqual(IntPtr.Zero, _control.Handle);
         int invalidatedCallCount = 0;
-        control.Invalidated += (sender, e) => invalidatedCallCount++;
+        _control.Invalidated += (sender, e) => invalidatedCallCount++;
         int styleChangedCallCount = 0;
-        control.StyleChanged += (sender, e) => styleChangedCallCount++;
+        _control.StyleChanged += (sender, e) => styleChangedCallCount++;
         int createdCallCount = 0;
-        control.HandleCreated += (sender, e) => createdCallCount++;
+        _control.HandleCreated += (sender, e) => createdCallCount++;
 
-        control.Wrap = value;
-        Assert.Equal(value, control.Wrap);
-        Assert.True(control.IsHandleCreated);
+        _control.Wrap = value;
+        Assert.Equal(value, _control.Wrap);
+        Assert.True(_control.IsHandleCreated);
         Assert.Equal(0, invalidatedCallCount);
         Assert.Equal(0, styleChangedCallCount);
         Assert.Equal(0, createdCallCount);
 
         // Set same.
-        control.Wrap = value;
-        Assert.Equal(value, control.Wrap);
-        Assert.True(control.IsHandleCreated);
+        _control.Wrap = value;
+        Assert.Equal(value, _control.Wrap);
+        Assert.True(_control.IsHandleCreated);
         Assert.Equal(0, invalidatedCallCount);
         Assert.Equal(0, styleChangedCallCount);
         Assert.Equal(0, createdCallCount);
 
         // Set different.
-        control.Wrap = !value;
-        Assert.Equal(!value, control.Wrap);
-        Assert.True(control.IsHandleCreated);
+        _control.Wrap = !value;
+        Assert.Equal(!value, _control.Wrap);
+        Assert.True(_control.IsHandleCreated);
         Assert.Equal(0, invalidatedCallCount);
         Assert.Equal(0, styleChangedCallCount);
         Assert.Equal(0, createdCallCount);
@@ -956,28 +938,24 @@ public class DomainUpDownTests
     [WinFormsFact]
     public void DomainUpDown_CreateAccessibilityInstance_Invoke_ReturnsExpected()
     {
-        using SubDomainUpDown control = new();
-        Control.ControlAccessibleObject instance = Assert.IsAssignableFrom<Control.ControlAccessibleObject>(control.CreateAccessibilityInstance());
+        Control.ControlAccessibleObject instance = Assert.IsAssignableFrom<Control.ControlAccessibleObject>(_sub.CreateAccessibilityInstance());
         Assert.NotNull(instance);
-        Assert.Same(control, instance.Owner);
+        Assert.Same(_sub, instance.Owner);
         Assert.Equal(AccessibleRole.SpinButton, instance.Role);
-        Assert.NotSame(control.CreateAccessibilityInstance(), instance);
-        Assert.NotSame(control.AccessibilityObject, instance);
+        Assert.NotSame(_sub.CreateAccessibilityInstance(), instance);
+        Assert.NotSame(_sub.AccessibilityObject, instance);
     }
 
     [WinFormsFact]
     public void DomainUpDown_CreateAccessibilityInstance_InvokeWithCustomRole_ReturnsExpected()
     {
-        using SubDomainUpDown control = new()
-        {
-            AccessibleRole = AccessibleRole.HelpBalloon
-        };
-        Control.ControlAccessibleObject instance = Assert.IsAssignableFrom<Control.ControlAccessibleObject>(control.CreateAccessibilityInstance());
+        _sub.AccessibleRole = AccessibleRole.HelpBalloon;
+        Control.ControlAccessibleObject instance = Assert.IsAssignableFrom<Control.ControlAccessibleObject>(_sub.CreateAccessibilityInstance());
         Assert.NotNull(instance);
-        Assert.Same(control, instance.Owner);
+        Assert.Same(_sub, instance.Owner);
         Assert.Equal(AccessibleRole.HelpBalloon, instance.Role);
-        Assert.NotSame(control.CreateAccessibilityInstance(), instance);
-        Assert.NotSame(control.AccessibilityObject, instance);
+        Assert.NotSame(_sub.CreateAccessibilityInstance(), instance);
+        Assert.NotSame(_sub.AccessibilityObject, instance);
     }
 
     public static IEnumerable<object[]> DownButton_TestData()
@@ -995,41 +973,36 @@ public class DomainUpDownTests
     [MemberData(nameof(DownButton_TestData))]
     public void DomainUpDown_DownButton_InvokeWithoutItems_Nop(bool userEdit, bool wrap)
     {
-        using SubDomainUpDown control = new()
-        {
-            UserEdit = userEdit,
-            Wrap = wrap
-        };
+        _sub.UserEdit = userEdit;
+        _sub.Wrap = wrap;
 
-        control.DownButton();
-        Assert.Equal(-1, control.SelectedIndex);
-        Assert.Equal(userEdit, control.UserEdit);
+        _sub.DownButton();
+        Assert.Equal(-1, _sub.SelectedIndex);
+        Assert.Equal(userEdit, _sub.UserEdit);
 
         // Call again.
-        control.DownButton();
-        Assert.Equal(-1, control.SelectedIndex);
-        Assert.Equal(userEdit, control.UserEdit);
+        _sub.DownButton();
+        Assert.Equal(-1, _sub.SelectedIndex);
+        Assert.Equal(userEdit, _sub.UserEdit);
     }
 
     [WinFormsTheory]
     [MemberData(nameof(DownButton_TestData))]
     public void DomainUpDown_DownButton_InvokeEmpty_Nop(bool userEdit, bool wrap)
     {
-        using SubDomainUpDown control = new()
-        {
-            UserEdit = userEdit,
-            Wrap = wrap
-        };
-        Assert.Empty(control.Items);
+        _sub.UserEdit = userEdit;
+        _sub.Wrap = wrap;
 
-        control.DownButton();
-        Assert.Equal(-1, control.SelectedIndex);
-        Assert.Equal(userEdit, control.UserEdit);
+        Assert.Empty(_sub.Items);
+
+        _sub.DownButton();
+        Assert.Equal(-1, _sub.SelectedIndex);
+        Assert.Equal(userEdit, _sub.UserEdit);
 
         // Call again.
-        control.DownButton();
-        Assert.Equal(-1, control.SelectedIndex);
-        Assert.Equal(userEdit, control.UserEdit);
+        _sub.DownButton();
+        Assert.Equal(-1, _sub.SelectedIndex);
+        Assert.Equal(userEdit, _sub.UserEdit);
     }
 
     public static IEnumerable<object[]> DownButton_WithItems_TestData()
@@ -1044,40 +1017,36 @@ public class DomainUpDownTests
     [MemberData(nameof(DownButton_WithItems_TestData))]
     public void DomainUpDown_DownButton_InvokeWithItems_Nop(bool userEdit, bool wrap, int expectedWrapSelectedIndex)
     {
-        using SubDomainUpDown control = new()
-        {
-            UserEdit = userEdit,
-            Wrap = wrap
-        };
-        control.Items.Add("a");
-        control.Items.Add("b");
-        control.Items.Add("c");
+        _sub.UserEdit = userEdit;
+        _sub.Wrap = wrap;
+        _sub.Items.Add("a");
+        _sub.Items.Add("b");
+        _sub.Items.Add("c");
 
-        control.DownButton();
-        Assert.Equal(0, control.SelectedIndex);
-        Assert.False(control.UserEdit);
+        _sub.DownButton();
+        Assert.Equal(0, _sub.SelectedIndex);
+        Assert.False(_sub.UserEdit);
 
         // Call again.
-        control.DownButton();
-        Assert.Equal(1, control.SelectedIndex);
-        Assert.False(control.UserEdit);
+        _sub.DownButton();
+        Assert.Equal(1, _sub.SelectedIndex);
+        Assert.False(_sub.UserEdit);
 
         // Call again.
-        control.DownButton();
-        Assert.Equal(2, control.SelectedIndex);
-        Assert.False(control.UserEdit);
+        _sub.DownButton();
+        Assert.Equal(2, _sub.SelectedIndex);
+        Assert.False(_sub.UserEdit);
 
         // Call again.
-        control.DownButton();
-        Assert.Equal(expectedWrapSelectedIndex, control.SelectedIndex);
-        Assert.False(control.UserEdit);
+        _sub.DownButton();
+        Assert.Equal(expectedWrapSelectedIndex, _sub.SelectedIndex);
+        Assert.False(_sub.UserEdit);
     }
 
     [WinFormsFact]
     public void DomainUpDown_GetAutoSizeMode_Invoke_ReturnsExpected()
     {
-        using SubDomainUpDown control = new();
-        Assert.Equal(AutoSizeMode.GrowOnly, control.GetAutoSizeMode());
+        Assert.Equal(AutoSizeMode.GrowOnly, _sub.GetAutoSizeMode());
     }
 
     [WinFormsTheory]
@@ -1091,8 +1060,7 @@ public class DomainUpDownTests
     [InlineData((-1), false)]
     public void DomainUpDown_GetScrollState_Invoke_ReturnsExpected(int bit, bool expected)
     {
-        using SubDomainUpDown control = new();
-        Assert.Equal(expected, control.GetScrollState(bit));
+        Assert.Equal(expected, _sub.GetScrollState(bit));
     }
 
     [WinFormsTheory]
@@ -1118,18 +1086,16 @@ public class DomainUpDownTests
     [InlineData((ControlStyles)(-1), false)]
     public void DomainUpDown_GetStyle_Invoke_ReturnsExpected(ControlStyles flag, bool expected)
     {
-        using SubDomainUpDown control = new();
-        Assert.Equal(expected, control.GetStyle(flag));
+        Assert.Equal(expected, _sub.GetStyle(flag));
 
         // Call again to test caching.
-        Assert.Equal(expected, control.GetStyle(flag));
+        Assert.Equal(expected, _sub.GetStyle(flag));
     }
 
     [WinFormsFact]
     public void DomainUpDown_GetTopLevel_Invoke_ReturnsExpected()
     {
-        using SubDomainUpDown control = new();
-        Assert.False(control.GetTopLevel());
+        Assert.False(_sub.GetTopLevel());
     }
 
     [WinFormsTheory]
@@ -1148,21 +1114,19 @@ public class DomainUpDownTests
     [InlineData("", 0, -1)]
     public void DomainUpDown_MatchIndex(string text, int start, int expected)
     {
-        using DomainUpDown control = new();
-        control.Items.Add("foo1");
-        control.Items.Add("foo2");
-        control.Items.Add("foo3");
-        control.Items.Add("Cowman");
-        control.Items.Add("foo4");
-        Assert.Equal(expected, control.MatchIndex(text, false, start));
+        _control.Items.Add("foo1");
+        _control.Items.Add("foo2");
+        _control.Items.Add("foo3");
+        _control.Items.Add("Cowman");
+        _control.Items.Add("foo4");
+        Assert.Equal(expected, _control.MatchIndex(text, false, start));
     }
 
     [WinFormsFact]
     public void DomainUpDown_MatchIndex_NullText_ThrowsNullReferenceException()
     {
-        using DomainUpDown control = new();
-        control.Items.Add("item1");
-        Assert.Throws<NullReferenceException>(() => control.MatchIndex(null, false, 0));
+        _control.Items.Add("item1");
+        Assert.Throws<NullReferenceException>(() => _control.MatchIndex(null, false, 0));
     }
 
     public static IEnumerable<object[]> OnChanged_TestData()
@@ -1175,23 +1139,22 @@ public class DomainUpDownTests
     [MemberData(nameof(OnChanged_TestData))]
     public void DomainUpDown_OnChanged_Invoke_CallsSelectedItemChanged(object source, EventArgs eventArgs)
     {
-        using SubDomainUpDown control = new();
         int callCount = 0;
         EventHandler handler = (sender, e) =>
         {
-            Assert.Same(control, sender);
+            Assert.Same(_sub, sender);
             Assert.Same(eventArgs, e);
             callCount++;
         };
 
         // Call with handler.
-        control.SelectedItemChanged += handler;
-        control.OnSelectedItemChanged(source, eventArgs);
+        _sub.SelectedItemChanged += handler;
+        _sub.OnSelectedItemChanged(source, eventArgs);
         Assert.Equal(1, callCount);
 
         // Remove handler.
-        control.SelectedItemChanged -= handler;
-        control.OnSelectedItemChanged(source, eventArgs);
+        _sub.SelectedItemChanged -= handler;
+        _sub.OnSelectedItemChanged(source, eventArgs);
         Assert.Equal(1, callCount);
     }
 
@@ -1199,23 +1162,22 @@ public class DomainUpDownTests
     [MemberData(nameof(OnChanged_TestData))]
     public void DomainUpDown_OnSelectedItemChanged_Invoke_CallsSelectedItemChanged(object source, EventArgs eventArgs)
     {
-        using SubDomainUpDown control = new();
         int callCount = 0;
         EventHandler handler = (sender, e) =>
         {
-            Assert.Same(control, sender);
+            Assert.Same(_sub, sender);
             Assert.Same(eventArgs, e);
             callCount++;
         };
 
         // Call with handler.
-        control.SelectedItemChanged += handler;
-        control.OnSelectedItemChanged(source, eventArgs);
+        _sub.SelectedItemChanged += handler;
+        _sub.OnSelectedItemChanged(source, eventArgs);
         Assert.Equal(1, callCount);
 
         // Remove handler.
-        control.SelectedItemChanged -= handler;
-        control.OnSelectedItemChanged(source, eventArgs);
+        _sub.SelectedItemChanged -= handler;
+        _sub.OnSelectedItemChanged(source, eventArgs);
         Assert.Equal(1, callCount);
     }
 
@@ -1234,41 +1196,36 @@ public class DomainUpDownTests
     [MemberData(nameof(UpButton_TestData))]
     public void DomainUpDown_UpButton_InvokeWithoutItems_Nop(bool userEdit, bool wrap)
     {
-        using SubDomainUpDown control = new()
-        {
-            UserEdit = userEdit,
-            Wrap = wrap
-        };
+        _sub.UserEdit = userEdit;
+        _sub.Wrap = wrap;
 
-        control.UpButton();
-        Assert.Equal(-1, control.SelectedIndex);
-        Assert.Equal(userEdit, control.UserEdit);
+        _sub.UpButton();
+        Assert.Equal(-1, _sub.SelectedIndex);
+        Assert.Equal(userEdit, _sub.UserEdit);
 
         // Call again.
-        control.UpButton();
-        Assert.Equal(-1, control.SelectedIndex);
-        Assert.Equal(userEdit, control.UserEdit);
+        _sub.UpButton();
+        Assert.Equal(-1, _sub.SelectedIndex);
+        Assert.Equal(userEdit, _sub.UserEdit);
     }
 
     [WinFormsTheory]
     [MemberData(nameof(UpButton_TestData))]
     public void DomainUpDown_UpButton_InvokeEmpty_Nop(bool userEdit, bool wrap)
     {
-        using SubDomainUpDown control = new()
-        {
-            UserEdit = userEdit,
-            Wrap = wrap
-        };
-        Assert.Empty(control.Items);
+         _sub.UserEdit = userEdit;
+        _sub.Wrap = wrap;
 
-        control.UpButton();
-        Assert.Equal(-1, control.SelectedIndex);
-        Assert.Equal(userEdit, control.UserEdit);
+        Assert.Empty(_sub.Items);
+
+        _sub.UpButton();
+        Assert.Equal(-1, _sub.SelectedIndex);
+        Assert.Equal(userEdit, _sub.UserEdit);
 
         // Call again.
-        control.UpButton();
-        Assert.Equal(-1, control.SelectedIndex);
-        Assert.Equal(userEdit, control.UserEdit);
+        _sub.UpButton();
+        Assert.Equal(-1, _sub.SelectedIndex);
+        Assert.Equal(userEdit, _sub.UserEdit);
     }
 
     public static IEnumerable<object[]> UpButton_WithItems_TestData()
@@ -1283,34 +1240,31 @@ public class DomainUpDownTests
     [MemberData(nameof(UpButton_WithItems_TestData))]
     public void DomainUpDown_UpButton_InvokeWithItems_Nop(bool userEdit, bool wrap, int expectedWrapSelectedIndex1, int expectedWrapSelectedIndex2)
     {
-        using SubDomainUpDown control = new()
-        {
-            UserEdit = userEdit,
-            Wrap = wrap
-        };
-        control.Items.Add("a");
-        control.Items.Add("b");
-        control.Items.Add("c");
-        control.SelectedIndex = 2;
+        _sub.UserEdit = userEdit;
+        _sub.Wrap = wrap;
+        _sub.Items.Add("a");
+        _sub.Items.Add("b");
+        _sub.Items.Add("c");
+        _sub.SelectedIndex = 2;
 
-        control.UpButton();
-        Assert.Equal(1, control.SelectedIndex);
-        Assert.False(control.UserEdit);
+        _sub.UpButton();
+        Assert.Equal(1, _sub.SelectedIndex);
+        Assert.False(_sub.UserEdit);
 
         // Call again.
-        control.UpButton();
-        Assert.Equal(0, control.SelectedIndex);
-        Assert.False(control.UserEdit);
+        _sub.UpButton();
+        Assert.Equal(0, _sub.SelectedIndex);
+        Assert.False(_sub.UserEdit);
 
         // Call again.
-        control.UpButton();
-        Assert.Equal(expectedWrapSelectedIndex1, control.SelectedIndex);
-        Assert.False(control.UserEdit);
+        _sub.UpButton();
+        Assert.Equal(expectedWrapSelectedIndex1, _sub.SelectedIndex);
+        Assert.False(_sub.UserEdit);
 
         // Call again.
-        control.UpButton();
-        Assert.Equal(expectedWrapSelectedIndex2, control.SelectedIndex);
-        Assert.False(control.UserEdit);
+        _sub.UpButton();
+        Assert.Equal(expectedWrapSelectedIndex2, _sub.SelectedIndex);
+        Assert.False(_sub.UserEdit);
     }
 
     [WinFormsTheory]
@@ -1320,23 +1274,21 @@ public class DomainUpDownTests
     [InlineData(false, false)]
     public void DomainUpDown_UpdateEditText_InvokeEmpty_Success(bool userEdit, bool changingText)
     {
-        using SubDomainUpDown control = new()
-        {
-            UserEdit = userEdit,
-            ChangingText = changingText
-        };
-        control.UpdateEditText();
-        Assert.Empty(control.Text);
-        Assert.False(control.UserEdit);
-        Assert.False(control.ChangingText);
-        Assert.False(control.IsHandleCreated);
+        _sub.UserEdit = userEdit;
+        _sub.ChangingText = changingText;
+
+        _sub.UpdateEditText();
+        Assert.Empty(_sub.Text);
+        Assert.False(_sub.UserEdit);
+        Assert.False(_sub.ChangingText);
+        Assert.False(_sub.IsHandleCreated);
 
         // Call again.
-        control.UpdateEditText();
-        Assert.Empty(control.Text);
-        Assert.False(control.UserEdit);
-        Assert.False(control.ChangingText);
-        Assert.False(control.IsHandleCreated);
+        _sub.UpdateEditText();
+        Assert.Empty(_sub.Text);
+        Assert.False(_sub.UserEdit);
+        Assert.False(_sub.ChangingText);
+        Assert.False(_sub.IsHandleCreated);
     }
 
     [WinFormsTheory]
@@ -1346,24 +1298,23 @@ public class DomainUpDownTests
     [InlineData(false, false)]
     public void DomainUpDown_UpdateEditText_InvokeNotEmpty_Success(bool userEdit, bool changingText)
     {
-        using SubDomainUpDown control = new();
-        control.Items.Add("Item1");
-        control.Items.Add("Item2");
-        control.UserEdit = userEdit;
-        control.ChangingText = changingText;
+        _sub.Items.Add("Item1");
+        _sub.Items.Add("Item2");
+        _sub.UserEdit = userEdit;
+        _sub.ChangingText = changingText;
 
-        control.UpdateEditText();
-        Assert.Empty(control.Text);
-        Assert.False(control.UserEdit);
-        Assert.False(control.ChangingText);
-        Assert.False(control.IsHandleCreated);
+        _sub.UpdateEditText();
+        Assert.Empty(_sub.Text);
+        Assert.False(_sub.UserEdit);
+        Assert.False(_sub.ChangingText);
+        Assert.False(_sub.IsHandleCreated);
 
         // Call again.
-        control.UpdateEditText();
-        Assert.Empty(control.Text);
-        Assert.False(control.UserEdit);
-        Assert.False(control.ChangingText);
-        Assert.False(control.IsHandleCreated);
+        _sub.UpdateEditText();
+        Assert.Empty(_sub.Text);
+        Assert.False(_sub.UserEdit);
+        Assert.False(_sub.ChangingText);
+        Assert.False(_sub.IsHandleCreated);
     }
 
     [WinFormsTheory]
@@ -1373,142 +1324,132 @@ public class DomainUpDownTests
     [InlineData(false, false)]
     public void DomainUpDown_UpdateEditText_InvokeNotEmptyWithSelection_Success(bool userEdit, bool changingText)
     {
-        using SubDomainUpDown control = new();
-        control.Items.Add("Item1");
-        control.Items.Add("Item2");
-        control.SelectedIndex = 0;
-        control.Text = "Text";
-        control.UserEdit = userEdit;
-        control.ChangingText = changingText;
+        _sub.Items.Add("Item1");
+        _sub.Items.Add("Item2");
+        _sub.SelectedIndex = 0;
+        _sub.Text = "Text";
+        _sub.UserEdit = userEdit;
+        _sub.ChangingText = changingText;
 
-        control.UpdateEditText();
-        Assert.Equal("Item1", control.Text);
-        Assert.False(control.UserEdit);
-        Assert.False(control.ChangingText);
-        Assert.False(control.IsHandleCreated);
+        _sub.UpdateEditText();
+        Assert.Equal("Item1", _sub.Text);
+        Assert.False(_sub.UserEdit);
+        Assert.False(_sub.ChangingText);
+        Assert.False(_sub.IsHandleCreated);
 
         // Call again.
-        control.UpdateEditText();
-        Assert.Equal("Item1", control.Text);
-        Assert.False(control.UserEdit);
-        Assert.False(control.ChangingText);
-        Assert.False(control.IsHandleCreated);
+        _sub.UpdateEditText();
+        Assert.Equal("Item1", _sub.Text);
+        Assert.False(_sub.UserEdit);
+        Assert.False(_sub.ChangingText);
+        Assert.False(_sub.IsHandleCreated);
     }
 
-     public class DomainUpDownTests1 : IDisposable
-     {
-        private readonly DomainUpDown _control;
+    [WinFormsTheory]
+    [InlineData(0, 1, false)]
+    [InlineData(1, 2, false)]
+    [InlineData(2, 2, false)] 
+    [InlineData(2, 0, true)] 
+    public void DomainUpDown_DownButton_InvokeWithItems_ChangesSelectedIndex(int initialIndex, int expectedIndex, bool wrap)
+    {
+        _control.Items.AddRange(new string[] { "Item1", "Item2", "Item3" });
 
-        public DomainUpDownTests1()
-        {
-            _control = new DomainUpDown();
-            _control.Items.AddRange(new string[] { "Item1", "Item2", "Item3" });
-        }
+        _control.SelectedIndex = initialIndex;
+        _control.Wrap = wrap;
 
-        public void Dispose()
-        {
-            _control.Items.Clear();
-            _control.Dispose();
-        }
+        _control.DownButton();
 
-        [WinFormsTheory]
-        [InlineData(0, 1, false)]
-        [InlineData(1, 2, false)]
-        [InlineData(2, 2, false)] 
-        [InlineData(2, 0, true)] 
-        public void DomainUpDown_DownButton_InvokeWithItems_ChangesSelectedIndex(int initialIndex, int expectedIndex, bool wrap)
-        {
-            _control.SelectedIndex = initialIndex;
-            _control.Wrap = wrap;
+        _control.SelectedIndex.Should().Be(expectedIndex);
+    }
 
-            _control.DownButton();
+    [WinFormsTheory]
+    [InlineData(0, 2, false)]
+    [InlineData(1, 2, false)]
+    [InlineData(2, 2, false)] 
+    [InlineData(2, 1, true)] 
+    public void DomainUpDown_DownButton_InvokeMultipleTimes_ChangesSelectedIndex(int initialIndex, int expectedIndex, bool wrap)
+    {
+        _control.Items.AddRange(new string[] { "Item1", "Item2", "Item3" });
 
-            _control.SelectedIndex.Should().Be(expectedIndex);
-        }
+        _control.SelectedIndex = initialIndex;
+        _control.Wrap = wrap;
 
-        [WinFormsTheory]
-        [InlineData(0, 2, false)]
-        [InlineData(1, 2, false)]
-        [InlineData(2, 2, false)] 
-        [InlineData(2, 1, true)] 
-        public void DomainUpDown_DownButton_InvokeMultipleTimes_ChangesSelectedIndex(int initialIndex, int expectedIndex, bool wrap)
-        {
-            _control.SelectedIndex = initialIndex;
-            _control.Wrap = wrap;
+        _control.DownButton();
+        _control.DownButton(); 
 
-            _control.DownButton();
-            _control.DownButton(); 
+        _control.SelectedIndex.Should().Be(expectedIndex);
+    }
 
-            _control.SelectedIndex.Should().Be(expectedIndex);
-        }
+    [WinFormsTheory]
+    [InlineData(new string[] { "Item1", "Item2", "Item3" }, 1)]
+    [InlineData(new string[] { "ItemA", "ItemB", "ItemC", "ItemD" }, 3)]
+    public void DomainUpDown_ToString_Invoke_ReturnsExpected(string[] items, int selectedIndex)
+    {
+        _control.Items.Clear();
+        _control.Items.AddRange(items);
+        _control.SelectedIndex = selectedIndex;
 
-        [WinFormsTheory]
-        [InlineData(new string[] { "Item1", "Item2", "Item3" }, 1)]
-        [InlineData(new string[] { "ItemA", "ItemB", "ItemC", "ItemD" }, 3)]
-        public void DomainUpDown_ToString_Invoke_ReturnsExpected(string[] items, int selectedIndex)
-        {
-            _control.Items.Clear();
-            _control.Items.AddRange(items);
-            _control.SelectedIndex = selectedIndex;
+        string s = _control.ToString();
 
-            string s = _control.ToString();
+        s.Should().Contain($"Items.Count: {items.Length}");
+        s.Should().Contain($"SelectedIndex: {selectedIndex}");
+    }
 
-            s.Should().Contain($"Items.Count: {items.Length}");
-            s.Should().Contain($"SelectedIndex: {selectedIndex}");
-        }
+    [WinFormsTheory]
+    [InlineData("Item1", 0)]
+    [InlineData("Item2", 1)]
+    public void DomainUpDown_UpButton_MatchFound(string text, int expectedIndex)
+    {
+        _control.Items.AddRange(new string[] { "Item1", "Item2", "Item3" });
+        _control.Text = text;
+        _control.UpButton();
+        _control.SelectedIndex.Should().Be(expectedIndex);
+    }
 
-        [WinFormsTheory]
-        [InlineData("Item1", 0)]
-        [InlineData("Item2", 1)]
-        public void DomainUpDown_UpButton_MatchFound(string text, int expectedIndex)
-        {
-            _control.Text = text;
-            _control.UpButton();
-            _control.SelectedIndex.Should().Be(expectedIndex);
-        }
+    [WinFormsFact]
+    public void DomainUpDown_UpButton_NoMatchFound()
+    {
+        _control.Text = "NoSuchItem";
+        _control.UpButton();
+        _control.SelectedIndex.Should().Be(-1);
+    }
 
-        [WinFormsFact]
-        public void DomainUpDown_UpButton_NoMatchFound()
-        {
-            _control.Text = "NoSuchItem";
-            _control.UpButton();
-            _control.SelectedIndex.Should().Be(-1);
-        }
+    [WinFormsFact]
+    public void DomainUpDown_UpButton_DecrementSelectedIndex()
+    {
+        _control.Items.AddRange(new string[] { "Item1", "Item2", "Item3" });
+        _control.SelectedIndex = 2;
+        _control.UpButton();
+        _control.SelectedIndex.Should().Be(1);
+    }
 
-        [WinFormsFact]
-        public void DomainUpDown_UpButton_DecrementSelectedIndex()
-        {
-            _control.SelectedIndex = 2;
-            _control.UpButton();
-            _control.SelectedIndex.Should().Be(1);
-        }
+    [WinFormsFact]
+    public void DomainUpDown_UpButton_SelectedIndexAtStart_NoWrap()
+    {
+        _control.Items.AddRange(new string[] { "Item1", "Item2", "Item3" });
+        _control.SelectedIndex = 0;
+        _control.Wrap = false;
+        _control.UpButton();
+        _control.SelectedIndex.Should().Be(0);
+    }
 
-        [WinFormsFact]
-        public void DomainUpDown_UpButton_SelectedIndexAtStart_NoWrap()
-        {
-            _control.SelectedIndex = 0;
-            _control.Wrap = false;
-            _control.UpButton();
-            _control.SelectedIndex.Should().Be(0);
-        }
+    [WinFormsFact]
+    public void DomainUpDown_UpButton_SelectedIndexAtStart_Wrap()
+    {
+        _control.Items.AddRange(new string[] { "Item1", "Item2", "Item3" });
+        _control.SelectedIndex = 0;
+        _control.Wrap = true;
+        _control.UpButton();
+        _control.SelectedIndex.Should().Be(2);
+    }
 
-        [WinFormsFact]
-        public void DomainUpDown_UpButton_SelectedIndexAtStart_Wrap()
-        {
-            _control.SelectedIndex = 0;
-            _control.Wrap = true;
-            _control.UpButton();
-            _control.SelectedIndex.Should().Be(2);
-        }
-
-        [WinFormsFact]
-        public void DomainUpDown_UpButton_EmptyItems()
-        {
-            _control.Items.Clear();
-            _control.UpButton();
-            _control.SelectedIndex.Should().Be(-1);
-        }
-     }
+    [WinFormsFact]
+    public void DomainUpDown_UpButton_EmptyItems()
+    {
+        _control.Items.Clear();
+        _control.UpButton();
+        _control.SelectedIndex.Should().Be(-1);
+    }
 
     public class SubDomainUpDown : DomainUpDown
     {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DomainUpDownTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DomainUpDownTests.cs
@@ -1395,126 +1395,120 @@ public class DomainUpDownTests
         Assert.False(control.IsHandleCreated);
     }
 
-    [WinFormsTheory]
-    [InlineData(0, 1, false)]
-    [InlineData(1, 2, false)]
-    [InlineData(2, 2, false)] 
-    [InlineData(2, 0, true)] 
-    public void DomainUpDown_DownButton_InvokeWithItems_ChangesSelectedIndex(int initialIndex, int expectedIndex, bool wrap)
-    {
-        using DomainUpDown control = new();
-        control.Items.Add("Item1");
-        control.Items.Add("Item2");
-        control.Items.Add("Item3");
-        control.SelectedIndex = initialIndex;
-        control.Wrap = wrap;
+     public class DomainUpDownTests1 : IDisposable
+     {
+        private readonly DomainUpDown _control;
 
-        control.DownButton();
-
-        control.SelectedIndex.Should().Be(expectedIndex);
-    }
-
-    [WinFormsTheory]
-    [InlineData(0, 2, false)]
-    [InlineData(1, 2, false)]
-    [InlineData(2, 2, false)] 
-    [InlineData(2, 1, true)] 
-    public void DomainUpDown_DownButton_InvokeMultipleTimes_ChangesSelectedIndex(int initialIndex, int expectedIndex, bool wrap)
-    {
-        using DomainUpDown control = new();
-        control.Items.Add("Item1");
-        control.Items.Add("Item2");
-        control.Items.Add("Item3");
-        control.SelectedIndex = initialIndex;
-        control.Wrap = wrap;
-
-        control.DownButton();
-        control.DownButton(); 
-
-        control.SelectedIndex.Should().Be(expectedIndex);
-    }
-
-    [WinFormsTheory]
-    [InlineData(new string[] { "Item1", "Item2", "Item3" }, 1)]
-    [InlineData(new string[] { "ItemA", "ItemB", "ItemC", "ItemD" }, 3)]
-    public void DomainUpDown_ToString_Invoke_ReturnsExpected(string[] items, int selectedIndex)
-    {
-        using DomainUpDown control = new();
-        for (int i = 0; i < items.Length; i++)
+        public DomainUpDownTests1()
         {
-            string item = items[i];
-            control.Items.Add(item);
+            _control = new DomainUpDown();
+            _control.Items.AddRange(new string[] { "Item1", "Item2", "Item3" });
         }
 
-        control.SelectedIndex = selectedIndex;
+        public void Dispose()
+        {
+            _control.Items.Clear();
+            _control.Dispose();
+        }
 
-        string s = control.ToString();
+        [WinFormsTheory]
+        [InlineData(0, 1, false)]
+        [InlineData(1, 2, false)]
+        [InlineData(2, 2, false)] 
+        [InlineData(2, 0, true)] 
+        public void DomainUpDown_DownButton_InvokeWithItems_ChangesSelectedIndex(int initialIndex, int expectedIndex, bool wrap)
+        {
+            _control.SelectedIndex = initialIndex;
+            _control.Wrap = wrap;
 
-        s.Should().Contain($"Items.Count: {items.Length}");
-        s.Should().Contain($"SelectedIndex: {selectedIndex}");
-    }
+            _control.DownButton();
 
-    [WinFormsTheory]
-    [InlineData("Item1", 0)]
-    [InlineData("Item2", 1)]
-    public void DomainUpDown_UpButton_MatchFound(string text, int expectedIndex)
-    {
-        using DomainUpDown control = new();
-        control.Items.AddRange(new string[] { "Item1", "Item2", "Item3" });
-        control.Text = text;
-        control.UpButton();
-        control.SelectedIndex.Should().Be(expectedIndex);
-    }
+            _control.SelectedIndex.Should().Be(expectedIndex);
+        }
 
-    [WinFormsFact]
-    public void DomainUpDown_UpButton_NoMatchFound()
-    {
-        using DomainUpDown control = new();;
-        control.Items.AddRange(new string[] { "Item1", "Item2", "Item3" });
-        control.Text = "NoSuchItem";
-        control.UpButton();
-        control.SelectedIndex.Should().Be(-1);
-    }
+        [WinFormsTheory]
+        [InlineData(0, 2, false)]
+        [InlineData(1, 2, false)]
+        [InlineData(2, 2, false)] 
+        [InlineData(2, 1, true)] 
+        public void DomainUpDown_DownButton_InvokeMultipleTimes_ChangesSelectedIndex(int initialIndex, int expectedIndex, bool wrap)
+        {
+            _control.SelectedIndex = initialIndex;
+            _control.Wrap = wrap;
 
-    [WinFormsFact]
-    public void DomainUpDown_UpButton_DecrementSelectedIndex()
-    {
-        using DomainUpDown control = new();
-        control.Items.AddRange(new string[] { "Item1", "Item2", "Item3" });
-        control.SelectedIndex = 2;
-        control.UpButton();
-        control.SelectedIndex.Should().Be(1);
-    }
+            _control.DownButton();
+            _control.DownButton(); 
 
-    [WinFormsFact]
-    public void DomainUpDown_UpButton_SelectedIndexAtStart_NoWrap()
-    {
-        using DomainUpDown control = new();
-        control.Items.AddRange(new string[] { "Item1", "Item2", "Item3" });
-        control.SelectedIndex = 0;
-        control.Wrap = false;
-        control.UpButton();
-        control.SelectedIndex.Should().Be(0);
-    }
+            _control.SelectedIndex.Should().Be(expectedIndex);
+        }
 
-    [WinFormsFact]
-    public void DomainUpDown_UpButton_SelectedIndexAtStart_Wrap()
-    {
-        using DomainUpDown control = new();
-        control.Items.AddRange(new string[] { "Item1", "Item2", "Item3" });
-        control.SelectedIndex = 0;
-        control.Wrap = true;
-        control.UpButton();
-        control.SelectedIndex.Should().Be(2);
-    }
+        [WinFormsTheory]
+        [InlineData(new string[] { "Item1", "Item2", "Item3" }, 1)]
+        [InlineData(new string[] { "ItemA", "ItemB", "ItemC", "ItemD" }, 3)]
+        public void DomainUpDown_ToString_Invoke_ReturnsExpected(string[] items, int selectedIndex)
+        {
+            _control.Items.Clear();
+            _control.Items.AddRange(items);
+            _control.SelectedIndex = selectedIndex;
 
-    [WinFormsFact]
-    public void DomainUpDown_UpButton_EmptyItems()
-    {
-        using DomainUpDown control = new();
-        control.UpButton();
-        control.SelectedIndex.Should().Be(-1);
-    }
+            string s = _control.ToString();
+
+            s.Should().Contain($"Items.Count: {items.Length}");
+            s.Should().Contain($"SelectedIndex: {selectedIndex}");
+        }
+
+        [WinFormsTheory]
+        [InlineData("Item1", 0)]
+        [InlineData("Item2", 1)]
+        public void DomainUpDown_UpButton_MatchFound(string text, int expectedIndex)
+        {
+            _control.Text = text;
+            _control.UpButton();
+            _control.SelectedIndex.Should().Be(expectedIndex);
+        }
+
+        [WinFormsFact]
+        public void DomainUpDown_UpButton_NoMatchFound()
+        {
+            _control.Text = "NoSuchItem";
+            _control.UpButton();
+            _control.SelectedIndex.Should().Be(-1);
+        }
+
+        [WinFormsFact]
+        public void DomainUpDown_UpButton_DecrementSelectedIndex()
+        {
+            _control.SelectedIndex = 2;
+            _control.UpButton();
+            _control.SelectedIndex.Should().Be(1);
+        }
+
+        [WinFormsFact]
+        public void DomainUpDown_UpButton_SelectedIndexAtStart_NoWrap()
+        {
+            _control.SelectedIndex = 0;
+            _control.Wrap = false;
+            _control.UpButton();
+            _control.SelectedIndex.Should().Be(0);
+        }
+
+        [WinFormsFact]
+        public void DomainUpDown_UpButton_SelectedIndexAtStart_Wrap()
+        {
+            _control.SelectedIndex = 0;
+            _control.Wrap = true;
+            _control.UpButton();
+            _control.SelectedIndex.Should().Be(2);
+        }
+
+        [WinFormsFact]
+        public void DomainUpDown_UpButton_EmptyItems()
+        {
+            _control.Items.Clear();
+            _control.UpButton();
+            _control.SelectedIndex.Should().Be(-1);
+        }
+     }
 
     public class SubDomainUpDown : DomainUpDown
     {


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

related https://github.com/dotnet/winforms/issues/10453


## Proposed changes

- Add unit tests for DomainUpDown to test DownButton and UpButton methods: Verify the behavior of the DownButton and UpButton methods in the DomainUpDown class and how they change the SelectedIndex under different conditions
-  Add unit test for DomainUpDown to test ToString method: Test ToString method's output, ensuring it correctly reflects the state of the Items collection and the SelectedIndex.


<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- None

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->

## Test methodology <!-- How did you ensure quality? -->

- Unit tests

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11331)