### PR TITLE
Add Deserialization Event Order Tests

### DIFF
--- a/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/Deserializer/Deserializer.cs
+++ b/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/Deserializer/Deserializer.cs
@@ -168,8 +168,8 @@ internal sealed partial class Deserializer : IDeserializer
 
         // Notify [OnDeserialized] instance methods for all relevant deserialized objects,
         // then callback IDeserializationCallback on all objects that implement it.
-        OnDeserialization?.Invoke(null);
         OnDeserialized?.Invoke(Options.StreamingContext);
+        OnDeserialization?.Invoke(null);
 
         return _deserializedObjects[_rootId];
     }
@@ -342,10 +342,11 @@ internal sealed partial class Deserializer : IDeserializer
                 completed = Id.Null;
             }
 
-            if (_recordMap[completedId] is ClassRecord classRecord)
+            if (_recordMap[completedId] is ClassRecord classRecord
+                && (_incompleteDependencies is null || !_incompleteDependencies.ContainsKey(completedId)))
             {
-                // Hook any finished events for this object. Doing at the end of deserialization for simplicity.
-                // (If we knew there were no cycles in the graph we could fire these as we go.)
+                // There are no remaining dependencies. Hook any finished events for this object.
+                // Doing at the end of deserialization for simplicity.
 
                 Type type = _typeResolver.GetType(classRecord.Name, classRecord.LibraryId);
                 object @object = _deserializedObjects[completedId];

--- a/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/Common/EventOrderTests.cs
+++ b/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/Common/EventOrderTests.cs
@@ -1,0 +1,1023 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.Serialization;
+using FormatTests.Common.TestTypes;
+using ValueType = FormatTests.Common.TestTypes.ValueType;
+
+namespace FormatTests.Common;
+
+[Collection("Sequential")]
+public abstract class EventOrderTests<T> : SerializationTest<T> where T : ISerializer
+{
+    #region Depth0
+    #region NoCycle
+    [Fact]
+    public void Depth0_NoCycle_ISerializable()
+    {
+        BinaryTreeNodeWithEventsISerializable root = new() { Name = "root" };
+
+        try
+        {
+            Deserialize(Serialize(root));
+            List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
+            deserializeOrder.Should().Equal("roots", "rootp", "rooti");
+        }
+        finally
+        {
+            BinaryTreeNodeWithEventsTracker.DeserializationOrder.Clear();
+        }
+    }
+
+    [Fact]
+    public void Depth0_NoCycle_ISerializable_WithValueType()
+    {
+        string[] expected = IsBinaryFormatterDeserializer
+            ? ["p", "roots", "valuep", "valuei", "rooti"]
+            : ["roots", "valuep", "rootp", "valuei", "rooti"];
+        BinaryTreeNodeWithEventsISerializable root = new() { Name = "root", Value = new ValueType() { Name = "value" } };
+
+        try
+        {
+            Deserialize(Serialize(root));
+            List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
+            deserializeOrder.Should().Equal(expected);
+        }
+        finally
+        {
+            BinaryTreeNodeWithEventsTracker.DeserializationOrder.Clear();
+        }
+    }
+
+    [Fact]
+    public void Depth0_NoCycle_ISerializable_WithValueTypeISerializable()
+    {
+        BinaryTreeNodeWithEventsISerializable root = new() { Name = "root", Value = new ValueTypeISerializable() { Name = "value" } };
+
+        try
+        {
+            Deserialize(Serialize(root));
+            List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
+            deserializeOrder.Should().Equal("values", "roots", "valuep", "rootp", "valuei", "rooti");
+        }
+        finally
+        {
+            BinaryTreeNodeWithEventsTracker.DeserializationOrder.Clear();
+        }
+    }
+
+    [Fact]
+    public void Depth0_NoCycle()
+    {
+        BinaryTreeNodeWithEvents root = new() { Name = "root" };
+
+        try
+        {
+            Deserialize(Serialize(root));
+            List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
+            deserializeOrder.Should().Equal("rootp", "rooti");
+        }
+        finally
+        {
+            BinaryTreeNodeWithEventsTracker.DeserializationOrder.Clear();
+        }
+    }
+
+    [Fact]
+    public void Depth0_NoCycle_Surrogate()
+    {
+        SurrogateSelector selector = CreateSurrogateSelector<BinaryTreeNodeWithEvents>(new BinaryTreeNodeWithEventsSurrogate());
+        BinaryTreeNodeWithEvents root = new() { Name = "root" };
+
+        try
+        {
+            Stream stream = Serialize(root);
+            Deserialize(stream, surrogateSelector: selector);
+            List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
+            deserializeOrder.Should().Equal("roots", "rootp", "rooti");
+        }
+        finally
+        {
+            BinaryTreeNodeWithEventsTracker.DeserializationOrder.Clear();
+        }
+    }
+
+    [Fact]
+    public void Depth0_NoCycle_WithValueType()
+    {
+        string[] expected = IsBinaryFormatterDeserializer
+            ? ["rootp", "valuep", "valuei", "rooti"]
+            : ["valuep", "rootp", "valuei", "rooti"];
+        BinaryTreeNodeWithEvents root = new() { Name = "root", Value = new ValueType() { Name = "value" } };
+
+        try
+        {
+            Deserialize(Serialize(root));
+            List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
+            deserializeOrder.Should().Equal(expected);
+        }
+        finally
+        {
+            BinaryTreeNodeWithEventsTracker.DeserializationOrder.Clear();
+        }
+    }
+
+    [Fact]
+    public void Depth0_NoCycle_WithValueTypeISerializable()
+    {
+        BinaryTreeNodeWithEvents root = new() { Name = "root", Value = new ValueTypeISerializable() { Name = "value" } };
+
+        try
+        {
+            Deserialize(Serialize(root));
+            List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
+            deserializeOrder.Should().Equal("values", "valuep", "rootp", "valuei", "rooti");
+        }
+        finally
+        {
+            BinaryTreeNodeWithEventsTracker.DeserializationOrder.Clear();
+        }
+    }
+
+    [Fact]
+    public void Depth0_NoCycle_ValueTypeWithSurrogate()
+    {
+        string[] expected = IsBinaryFormatterDeserializer
+            ? ["p", "roots", "valuep", "valuei", "rooti"]
+            : ["roots", "valuep", "rootp", "valuei", "rooti"];
+        SurrogateSelector selector = CreateSurrogateSelector<BinaryTreeNodeWithEvents>(new BinaryTreeNodeWithEventsSurrogate());
+        BinaryTreeNodeWithEvents root = new() { Name = "root", Value = new ValueType() { Name = "value" } };
+
+        try
+        {
+            Stream stream = Serialize(root);
+            Deserialize(stream, surrogateSelector: selector);
+            List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
+            deserializeOrder.Should().Equal(expected);
+        }
+        finally
+        {
+            BinaryTreeNodeWithEventsTracker.DeserializationOrder.Clear();
+        }
+    }
+
+    [Fact]
+    public void Depth0_NoCycle_ValueTypeISerializableWithSurrogate()
+    {;
+        SurrogateSelector selector = CreateSurrogateSelector<BinaryTreeNodeWithEvents>(new BinaryTreeNodeWithEventsSurrogate());
+        BinaryTreeNodeWithEvents root = new() { Name = "root", Value = new ValueTypeISerializable() { Name = "value" } };
+
+        try
+        {
+            Stream stream = Serialize(root);
+            Deserialize(stream, surrogateSelector: selector);
+            List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
+            deserializeOrder.Should().Equal("values", "roots", "valuep", "rootp", "valuei", "rooti");
+        }
+        finally
+        {
+            BinaryTreeNodeWithEventsTracker.DeserializationOrder.Clear();
+        }
+    }
+
+    #endregion NoCycle
+
+    #region Cycle
+    [Fact]
+    public void Depth0_SelfCycle_ISerializable()
+    {
+        string[] expected = IsBinaryFormatterDeserializer
+            ? ["p", "roots", "rooti"]
+            : ["roots", "rootp", "rooti"];
+        BinaryTreeNodeWithEventsISerializable root = new() { Name = "root" };
+        root.Left = root;
+        try
+        {
+            Deserialize(Serialize(root));
+            List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
+            deserializeOrder.Should().Equal(expected);
+        }
+        finally
+        {
+            BinaryTreeNodeWithEventsTracker.DeserializationOrder.Clear();
+        }
+    }
+
+    [Fact]
+    public void Depth0_SelfCycle_ISerializable_WithValueType()
+    {
+        string[] expected = IsBinaryFormatterDeserializer
+            ? ["p", "roots", "valuep", "valuei", "rooti"]
+            : ["roots", "valuep", "rootp", "valuei", "rooti"];
+        BinaryTreeNodeWithEventsISerializable root = new() { Name = "root", Value = new ValueType() { Name = "value" } };
+        root.Left = root;
+        try
+        {
+            Deserialize(Serialize(root));
+            List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
+            deserializeOrder.Should().Equal(expected);
+        }
+        finally
+        {
+            BinaryTreeNodeWithEventsTracker.DeserializationOrder.Clear();
+        }
+    }
+
+    [Fact]
+    public void Depth0_SelfCycle_ISerializable_WithValueTypeISerializable()
+    {
+        BinaryTreeNodeWithEventsISerializable root = new() { Name = "root", Value = new ValueTypeISerializable() { Name = "value" } };
+        root.Left = root;
+        try
+        {
+            Deserialize(Serialize(root));
+            List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
+            deserializeOrder.Should().Equal("values", "roots", "valuep", "rootp", "valuei", "rooti");
+        }
+        finally
+        {
+            BinaryTreeNodeWithEventsTracker.DeserializationOrder.Clear();
+        }
+    }
+
+    [Fact]
+    public void Depth0_SelfCycle()
+    {
+        BinaryTreeNodeWithEvents root = new() { Name = "root" };
+        root.Left = root;
+
+        try
+        {
+            Deserialize(Serialize(root));
+            List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
+            deserializeOrder.Should().Equal("rootp", "rooti");
+        }
+        finally
+        {
+            BinaryTreeNodeWithEventsTracker.DeserializationOrder.Clear();
+        }
+    }
+
+    [Fact]
+    public void Depth0_SelfCycle_Surrogate()
+    {
+        SurrogateSelector selector = CreateSurrogateSelector<BinaryTreeNodeWithEvents>(new BinaryTreeNodeWithEventsSurrogate());
+        BinaryTreeNodeWithEvents root = new() { Name = "root" };
+        root.Left = root;
+
+        try
+        {
+            Stream stream = Serialize(root);
+            if (IsBinaryFormatterDeserializer)
+            {
+                Action action = () => Deserialize(stream, surrogateSelector: selector);
+            }
+            else
+            {
+                Deserialize(stream, surrogateSelector: selector);
+                List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
+                deserializeOrder.Should().Equal("roots", "rootp", "rooti");
+            }
+        }
+        finally
+        {
+            BinaryTreeNodeWithEventsTracker.DeserializationOrder.Clear();
+        }
+    }
+
+    [Fact]
+    public void Depth0_SelfCycle_WithValueType()
+    {
+        string[] expected = IsBinaryFormatterDeserializer
+            ? ["rootp", "valuep", "valuei", "rooti"]
+            : ["valuep", "rootp", "valuei", "rooti"];
+        BinaryTreeNodeWithEvents root = new() { Name = "root", Value = new ValueType() { Name = "value" } };
+        root.Left = root;
+
+        try
+        {
+            Deserialize(Serialize(root));
+            List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
+            deserializeOrder.Should().Equal(expected);
+        }
+        finally
+        {
+            BinaryTreeNodeWithEventsTracker.DeserializationOrder.Clear();
+        }
+    }
+
+    [Fact]
+    public void Depth0_SelfCycle_WithValueTypeISerializable()
+    {
+        BinaryTreeNodeWithEvents root = new() { Name = "root", Value = new ValueTypeISerializable() { Name = "value" } };
+        root.Left = root;
+
+        try
+        {
+            Deserialize(Serialize(root));
+            List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
+            deserializeOrder.Should().Equal("values", "valuep", "rootp", "valuei", "rooti");
+        }
+        finally
+        {
+            BinaryTreeNodeWithEventsTracker.DeserializationOrder.Clear();
+        }
+    }
+    #endregion Cycle
+    #endregion Depth0
+
+    #region Depth1
+    #region NoCycle
+    [Fact]
+    public void Depth1_NoCycle_ISerializable()
+    {
+        string[] expected = IsBinaryFormatterDeserializer
+            ? ["p", "childs", "roots", "rootp", "rooti", "childi"]
+            : ["childs", "roots", "childp", "rootp", "childi", "rooti"];
+        BinaryTreeNodeWithEventsISerializable child = new() { Name = "child" };
+        BinaryTreeNodeWithEventsISerializable root = new() { Name = "root", Left = child };
+
+        try
+        {
+            Deserialize(Serialize(root));
+            List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
+            deserializeOrder.Should().Equal(expected);
+        }
+        finally
+        {
+            BinaryTreeNodeWithEventsTracker.DeserializationOrder.Clear();
+        }
+    }
+
+    [Fact]
+    public void Depth1_NoCycle_ISerializable_WithValueType()
+    {
+        string[] expected = IsBinaryFormatterDeserializer
+            ? ["p", "childs", "roots", "valuep", "rootp", "valuei", "rooti", "childi"]
+            : ["childs", "roots", "valuep", "childp", "rootp", "valuei", "childi", "rooti"];
+        BinaryTreeNodeWithEventsISerializable child = new() { Name = "child" };
+        BinaryTreeNodeWithEventsISerializable root = new() { Name = "root", Left = child, Value = new ValueType() { Name = "value" } };
+
+        try
+        {
+            Deserialize(Serialize(root));
+            List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
+            deserializeOrder.Should().Equal(expected);
+        }
+        finally
+        {
+            BinaryTreeNodeWithEventsTracker.DeserializationOrder.Clear();
+        }
+    }
+
+    [Fact]
+    public void Depth1_NoCycle_ISerializable_WithValueTypeISerializable()
+    {
+        string[] expected = IsBinaryFormatterDeserializer
+            ? ["p", "values", "childs", "roots", "valuep", "rootp", "valuei", "rooti", "childi"]
+            : ["childs", "values", "roots", "childp", "valuep", "rootp", "childi", "valuei", "rooti"];
+        BinaryTreeNodeWithEventsISerializable child = new() { Name = "child" };
+        BinaryTreeNodeWithEventsISerializable root = new() { Name = "root", Left = child, Value = new ValueTypeISerializable() { Name = "value" } };
+
+        try
+        {
+            Deserialize(Serialize(root));
+            List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
+            deserializeOrder.Should().Equal(expected);
+        }
+        finally
+        {
+            BinaryTreeNodeWithEventsTracker.DeserializationOrder.Clear();
+        }
+    }
+
+    [Fact]
+    public void Depth1_NoCycle_ISerializable_WithValueTypeISerializable_WithReference()
+    {
+        string[] expected = IsBinaryFormatterDeserializer
+            ? ["p", "childs", "values", "roots", "valuep", "rootp", "valuei", "rooti", "childi"]
+            : ["childs", "values", "roots", "childp", "valuep", "rootp", "childi", "valuei", "rooti"];
+        BinaryTreeNodeWithEventsISerializable child = new() { Name = "child" };
+        BinaryTreeNodeWithEventsISerializable root = new()
+        {
+            Name = "root",
+            Left = child,
+            Value = new ValueTypeISerializable() { Name = "value", Reference = child }
+        };
+
+        try
+        {
+            Deserialize(Serialize(root));
+            List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
+            deserializeOrder.Should().Equal(expected);
+        }
+        finally
+        {
+            BinaryTreeNodeWithEventsTracker.DeserializationOrder.Clear();
+        }
+    }
+
+    [Fact]
+    public void Depth1_NoCycle()
+    {
+        string[] expected = IsBinaryFormatterDeserializer
+            ? ["childp", "rootp", "rooti", "childi"]
+            : ["childp", "rootp", "childi", "rooti"];
+        BinaryTreeNodeWithEvents child = new() { Name = "child" };
+        BinaryTreeNodeWithEvents root = new() { Name = "root", Left = child };
+
+        try
+        {
+            Deserialize(Serialize(root));
+            List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
+            deserializeOrder.Should().Equal(expected);
+        }
+        finally
+        {
+            BinaryTreeNodeWithEventsTracker.DeserializationOrder.Clear();
+        }
+    }
+
+    [Fact]
+    public void Depth1_NoCycle_Surrogate()
+    {
+        string[] expected = IsBinaryFormatterDeserializer
+            ? ["p", "childs", "roots", "rootp", "rooti", "childi"]
+            : ["childs", "roots", "childp", "rootp", "childi", "rooti"];
+        SurrogateSelector selector = CreateSurrogateSelector<BinaryTreeNodeWithEvents>(new BinaryTreeNodeWithEventsSurrogate());
+        BinaryTreeNodeWithEvents child = new() { Name = "child" };
+        BinaryTreeNodeWithEvents root = new() { Name = "root", Left = child };
+
+        try
+        {
+            Stream stream = Serialize(root);
+            Deserialize(stream, surrogateSelector: selector);
+            List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
+            deserializeOrder.Should().Equal(expected);
+        }
+        finally
+        {
+            BinaryTreeNodeWithEventsTracker.DeserializationOrder.Clear();
+        }
+    }
+
+    [Fact]
+    public void Depth1_NoCycle_WithValueType()
+    {
+        string[] expected = IsBinaryFormatterDeserializer
+            ? ["childp", "valuep", "rootp", "valuei", "rooti", "childi"]
+            : ["childp", "valuep", "rootp", "childi", "valuei", "rooti"];
+        BinaryTreeNodeWithEvents child = new() { Name = "child" };
+        BinaryTreeNodeWithEvents root = new() { Name = "root", Left = child, Value = new ValueType() { Name = "value" } };
+
+        try
+        {
+            Deserialize(Serialize(root));
+            List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
+            deserializeOrder.Should().Equal(expected);
+        }
+        finally
+        {
+            BinaryTreeNodeWithEventsTracker.DeserializationOrder.Clear();
+        }
+    }
+
+    [Fact]
+    public void Depth1_NoCycle_WithValueTypeISerializable()
+    {
+        string[] expected = IsBinaryFormatterDeserializer
+            ? ["childp", "values", "valuep", "rootp", "valuei", "rooti", "childi"]
+            : ["values", "childp", "valuep", "rootp", "childi", "valuei", "rooti" ];
+        BinaryTreeNodeWithEvents child = new() { Name = "child" };
+        BinaryTreeNodeWithEvents root = new() { Name = "root", Left = child, Value = new ValueTypeISerializable() { Name = "value" } };
+
+        try
+        {
+            Deserialize(Serialize(root));
+            List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
+            deserializeOrder.Should().Equal(expected);
+        }
+        finally
+        {
+            BinaryTreeNodeWithEventsTracker.DeserializationOrder.Clear();
+        }
+    }
+    #endregion NoCycle
+
+    #region Cycle
+    [Fact]
+    public void Depth1_Cycle_ISerializable()
+    {
+        string[] expected = IsBinaryFormatterDeserializer
+            ? ["p", "childs", "roots", "rootp", "rooti", "childi"]
+            : ["childs", "roots", "childp", "rootp", "childi", "rooti"];
+        BinaryTreeNodeWithEventsISerializable child = new() { Name = "child" };
+        BinaryTreeNodeWithEventsISerializable root = new() { Name = "root", Left = child };
+        child.Left = root;
+
+        try
+        {
+            Deserialize(Serialize(root));
+            List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
+            deserializeOrder.Should().Equal(expected);
+        }
+        finally
+        {
+            BinaryTreeNodeWithEventsTracker.DeserializationOrder.Clear();
+        }
+    }
+
+    [Fact]
+    public void Depth1_Cycle_ISerializable_WithValueType()
+    {
+        string[] expected = IsBinaryFormatterDeserializer
+            ? ["p", "childs", "roots", "value2p", "rootp", "value1p", "value2i", "rooti", "value1i", "childi"]
+            : ["childs", "roots", "value1p", "value2p", "childp", "rootp", "value1i", "value2i", "childi", "rooti"];
+        BinaryTreeNodeWithEventsISerializable child = new() { Name = "child", Value = new ValueType() { Name = "value1" } };
+        BinaryTreeNodeWithEventsISerializable root = new() { Name = "root", Left = child, Value = new ValueType() { Name = "value2" } };
+        child.Left = root;
+        try
+        {
+            Deserialize(Serialize(root));
+            List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
+            deserializeOrder.Should().Equal(expected);
+        }
+        finally
+        {
+            BinaryTreeNodeWithEventsTracker.DeserializationOrder.Clear();
+        }
+    }
+
+    [Fact]
+    public void Depth1_Cycle_ISerializable_WithValueTypeISerializable()
+    {
+        string[] expected = IsBinaryFormatterDeserializer
+            ? ["value2s", "value1s", "childs", "roots", "value2p", "rootp", "value1p", "childp", "value2i", "rooti", "value1i", "childi"]
+            : ["value1s", "childs", "value2s", "roots", "value1p", "childp", "value2p", "rootp", "value1i", "childi", "value2i", "rooti"];
+        BinaryTreeNodeWithEventsISerializable child = new() { Name = "child", Value = new ValueTypeISerializable() { Name = "value1" } };
+        BinaryTreeNodeWithEventsISerializable root = new() { Name = "root", Left = child, Value = new ValueTypeISerializable() { Name = "value2" } };
+        child.Left = root;
+        try
+        {
+            Deserialize(Serialize(root));
+            List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
+            deserializeOrder.Should().Equal(expected);
+        }
+        finally
+        {
+            BinaryTreeNodeWithEventsTracker.DeserializationOrder.Clear();
+        }
+    }
+
+    [Fact]
+    public void Depth1_Cycle()
+    {
+        string[] expected = IsBinaryFormatterDeserializer
+            ? ["childp", "rootp", "rooti", "childi"]
+            : ["childp", "rootp", "childi", "rooti"];
+        BinaryTreeNodeWithEvents child = new() { Name = "child" };
+        BinaryTreeNodeWithEvents root = new() { Name = "root", Left = child };
+        child.Left = root;
+
+        try
+        {
+            Deserialize(Serialize(root));
+            List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
+            deserializeOrder.Should().Equal(expected);
+        }
+        finally
+        {
+            BinaryTreeNodeWithEventsTracker.DeserializationOrder.Clear();
+        }
+    }
+
+    [Fact]
+    public void Depth1_Cycle_Surrogate()
+    {
+        SurrogateSelector selector = CreateSurrogateSelector<BinaryTreeNodeWithEvents>(new BinaryTreeNodeWithEventsSurrogate());
+        BinaryTreeNodeWithEvents child = new() { Name = "child" };
+        BinaryTreeNodeWithEvents root = new() { Name = "root", Left = child };
+        child.Left = root;
+
+        try
+        {
+            Stream stream = Serialize(root);
+            if (IsBinaryFormatterDeserializer)
+            {
+                Action action = () => Deserialize(stream, surrogateSelector: selector);
+                action.Should().Throw<SerializationException>();
+            }
+            else
+            {
+                Deserialize(stream, surrogateSelector: selector);
+                List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
+                deserializeOrder.Should().Equal("childs", "roots", "childp", "rootp", "childi", "rooti");
+            }
+        }
+        finally
+        {
+            BinaryTreeNodeWithEventsTracker.DeserializationOrder.Clear();
+        }
+    }
+
+    [Fact]
+    public void Depth1_Cycle_WithValueType()
+    {
+        string[] expected = IsBinaryFormatterDeserializer
+            ? ["childp", "value2p", "rootp", "value1p", "value2i", "rooti", "value1i", "childi"]
+            : ["value1p", "childp", "value2p", "rootp", "value1i", "childi", "value2i", "rooti"];
+        BinaryTreeNodeWithEvents child = new() { Name = "child", Value = new ValueType() { Name = "value1" } };
+        BinaryTreeNodeWithEvents root = new() { Name = "root", Left = child, Value = new ValueType() { Name = "value2" } };
+        child.Left = root;
+
+        try
+        {
+            Deserialize(Serialize(root));
+            List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
+            deserializeOrder.Should().Equal(expected);
+        }
+        finally
+        {
+            BinaryTreeNodeWithEventsTracker.DeserializationOrder.Clear();
+        }
+    }
+
+    [Fact]
+    public void Depth1_Cycle_WithValueTypeISerializable()
+    {
+        string[] expected = IsBinaryFormatterDeserializer
+            ? ["value2s", "value1s", "value2p", "rootp", "value1p", "childp", "value2i", "rooti", "value1i", "childi"]
+            : ["value1s", "value2s", "value1p", "childp", "value2p", "rootp", "value1i", "childi", "value2i", "rooti"];
+        BinaryTreeNodeWithEvents child = new() { Name = "child", Value = new ValueTypeISerializable() { Name = "value1" } };
+        BinaryTreeNodeWithEvents root = new() { Name = "root", Left = child, Value = new ValueTypeISerializable() { Name = "value2" } };
+        child.Left = root;
+
+        try
+        {
+            Deserialize(Serialize(root));
+            List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
+            deserializeOrder.Should().Equal(expected);
+        }
+        finally
+        {
+            BinaryTreeNodeWithEventsTracker.DeserializationOrder.Clear();
+        }
+    }
+    #endregion Cycle
+    #endregion Depth1
+
+    #region Depth2
+    #region NoCycle
+    [Fact]
+    public void Depth2_NoCycle_ISerializable()
+    {
+        string[] expected = IsBinaryFormatterDeserializer
+            ? ["p", "child2s", "child1s", "roots", "rootp", "child1p", "rooti", "child1i", "child2i"]
+            : ["child2s", "child1s", "roots", "child2p", "child1p", "rootp", "child2i", "child1i", "rooti"];
+        BinaryTreeNodeWithEventsISerializable child2 = new() { Name = "child2" };
+        BinaryTreeNodeWithEventsISerializable child1 = new() { Name = "child1", Left = child2 };
+        BinaryTreeNodeWithEventsISerializable root = new() { Name = "root", Left = child1 };
+
+        try
+        {
+            Deserialize(Serialize(root));
+            List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
+            deserializeOrder.Should().Equal(expected);
+        }
+        finally
+        {
+            BinaryTreeNodeWithEventsTracker.DeserializationOrder.Clear();
+        }
+    }
+
+    [Fact]
+    public void Depth2_NoCycle_ISerializable_WithValueType()
+    {
+        string[] expected = IsBinaryFormatterDeserializer
+            ? ["p", "child2s", "child1s", "roots", "valuep", "rootp", "child1p", "valuei", "rooti", "child1i", "child2i"]
+            : ["child2s", "child1s", "roots", "valuep", "child2p", "child1p", "rootp", "valuei", "child2i", "child1i", "rooti"];
+        BinaryTreeNodeWithEventsISerializable child2 = new() { Name = "child2" };
+        BinaryTreeNodeWithEventsISerializable child1 = new() { Name = "child1", Left = child2 };
+        BinaryTreeNodeWithEventsISerializable root = new() { Name = "root", Left = child1, Value = new ValueType() { Name = "value" } };
+
+        try
+        {
+            Deserialize(Serialize(root));
+            List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
+            deserializeOrder.Should().Equal(expected);
+        }
+        finally
+        {
+            BinaryTreeNodeWithEventsTracker.DeserializationOrder.Clear();
+        }
+    }
+
+    [Fact]
+    public void Depth2_NoCycle_ISerializable_WithValueTypeISerializable()
+    {
+        string[] expected = IsBinaryFormatterDeserializer
+            ? ["p", "values", "child2s", "child1s", "roots", "valuep", "rootp", "child1p", "valuei", "rooti", "child1i", "child2i"]
+            : ["child2s", "child1s", "values", "roots", "child2p", "child1p", "valuep", "rootp", "child2i", "child1i", "valuei", "rooti"];
+        BinaryTreeNodeWithEventsISerializable child2 = new() { Name = "child2" };
+        BinaryTreeNodeWithEventsISerializable child1 = new() { Name = "child1", Left = child2 };
+        BinaryTreeNodeWithEventsISerializable root = new() { Name = "root", Left = child1, Value = new ValueTypeISerializable() { Name = "value" } };
+
+        try
+        {
+            Deserialize(Serialize(root));
+            List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
+            deserializeOrder.Should().Equal(expected);
+        }
+        finally
+        {
+            BinaryTreeNodeWithEventsTracker.DeserializationOrder.Clear();
+        }
+    }
+
+    [Fact]
+    public void Depth2_NoCycle_ISerializable_WithValueTypeISerializable_WithReference()
+    {
+        string[] expected = IsBinaryFormatterDeserializer
+            ? ["p", "child2s", "values", "child1s", "roots", "valuep", "rootp", "child1p", "valuei", "rooti", "child1i", "child2i"]
+            : ["child2s", "child1s", "values", "roots", "child2p", "child1p", "valuep", "rootp", "child2i", "child1i", "valuei", "rooti"];
+        BinaryTreeNodeWithEventsISerializable child2 = new() { Name = "child2" };
+        BinaryTreeNodeWithEventsISerializable child1 = new() { Name = "child1", Left = child2 };
+        BinaryTreeNodeWithEventsISerializable root = new()
+        {
+            Name = "root",
+            Left = child1,
+            Value = new ValueTypeISerializable() { Name = "value", Reference = child2 }
+        };
+
+        try
+        {
+            Deserialize(Serialize(root));
+            List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
+            deserializeOrder.Should().Equal(expected);
+        }
+        finally
+        {
+            BinaryTreeNodeWithEventsTracker.DeserializationOrder.Clear();
+        }
+    }
+
+    [Fact]
+    public void Depth2_NoCycle()
+    {
+        string[] expected = IsBinaryFormatterDeserializer
+            ? ["child2p", "rootp", "child1p", "rooti", "child1i", "child2i"]
+            : ["child2p", "child1p", "rootp", "child2i", "child1i", "rooti"];
+        BinaryTreeNodeWithEvents child2 = new() { Name = "child2" };
+        BinaryTreeNodeWithEvents child1 = new() { Name = "child1", Left = child2 };
+        BinaryTreeNodeWithEvents root = new() { Name = "root", Left = child1 };
+
+        try
+        {
+            Deserialize(Serialize(root));
+            List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
+            deserializeOrder.Should().Equal(expected);
+        }
+        finally
+        {
+            BinaryTreeNodeWithEventsTracker.DeserializationOrder.Clear();
+        }
+    }
+
+    [Fact]
+    public void Depth2_NoCycle_Surrogate()
+    {
+        string[] expected = IsBinaryFormatterDeserializer
+            ? ["p", "child2s", "child1s", "roots", "rootp", "child1p", "rooti", "child1i", "child2i"]
+            : ["child2s", "child1s", "roots", "child2p", "child1p", "rootp", "child2i", "child1i", "rooti"];
+        SurrogateSelector selector = CreateSurrogateSelector<BinaryTreeNodeWithEvents>(new BinaryTreeNodeWithEventsSurrogate());
+        BinaryTreeNodeWithEvents child2 = new() { Name = "child2" };
+        BinaryTreeNodeWithEvents child1 = new() { Name = "child1", Left = child2 };
+        BinaryTreeNodeWithEvents root = new() { Name = "root", Left = child1 };
+
+        try
+        {
+            Stream stream = Serialize(root);
+            Deserialize(stream, surrogateSelector: selector);
+            List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
+            deserializeOrder.Should().Equal(expected);
+        }
+        finally
+        {
+            BinaryTreeNodeWithEventsTracker.DeserializationOrder.Clear();
+        }
+    }
+
+    [Fact]
+    public void Depth2_NoCycle_WithValueType()
+    {
+        string[] expected = IsBinaryFormatterDeserializer
+            ? ["child2p", "valuep", "rootp", "child1p", "valuei", "rooti", "child1i", "child2i"]
+            : ["child2p", "child1p", "valuep", "rootp", "child2i", "child1i", "valuei", "rooti"];
+        BinaryTreeNodeWithEvents child2 = new() { Name = "child2" };
+        BinaryTreeNodeWithEvents child1 = new() { Name = "child1", Left = child2 };
+        BinaryTreeNodeWithEvents root = new() { Name = "root", Left = child1, Value = new ValueType() { Name = "value" } };
+
+        try
+        {
+            Deserialize(Serialize(root));
+            List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
+            deserializeOrder.Should().Equal(expected);
+        }
+        finally
+        {
+            BinaryTreeNodeWithEventsTracker.DeserializationOrder.Clear();
+        }
+    }
+
+    [Fact]
+    public void Depth2_NoCycle_WithValueTypeISerializable()
+    {
+        string[] expected = IsBinaryFormatterDeserializer
+            ? ["child2p", "values", "valuep", "rootp", "child1p", "valuei", "rooti", "child1i", "child2i"]
+            : ["values", "child2p", "child1p", "valuep", "rootp", "child2i", "child1i", "valuei", "rooti"];
+        BinaryTreeNodeWithEvents child2 = new() { Name = "child2" };
+        BinaryTreeNodeWithEvents child1 = new() { Name = "child1", Left = child2 };
+        BinaryTreeNodeWithEvents root = new() { Name = "root", Left = child1, Value = new ValueTypeISerializable() { Name = "value" } };
+
+        try
+        {
+            Deserialize(Serialize(root));
+            List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
+            deserializeOrder.Should().Equal(expected);
+        }
+        finally
+        {
+            BinaryTreeNodeWithEventsTracker.DeserializationOrder.Clear();
+        }
+    }
+    #endregion NoCycle
+
+    #region Cycle
+    [Fact]
+    public void Depth2_Cycle_ISerializable()
+    {
+        string[] expected = IsBinaryFormatterDeserializer
+            ? ["p", "child2s", "child1s", "roots", "rootp", "child1p", "rooti", "child1i", "child2i"]
+            : ["child2s", "child1s", "roots", "child2p", "child1p", "rootp", "child2i", "child1i", "rooti"];
+        BinaryTreeNodeWithEventsISerializable child2 = new() { Name = "child2" };
+        BinaryTreeNodeWithEventsISerializable child1 = new() { Name = "child1", Left = child2 };
+        BinaryTreeNodeWithEventsISerializable root = new() { Name = "root", Left = child1 };
+        child2.Left = root;
+
+        try
+        {
+            Deserialize(Serialize(root));
+            List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
+            deserializeOrder.Should().Equal(expected);
+        }
+        finally
+        {
+            BinaryTreeNodeWithEventsTracker.DeserializationOrder.Clear();
+        }
+    }
+
+    [Fact]
+    public void Depth2_Cycle_ISerializable_WithValueType()
+    {
+        string[] expected = IsBinaryFormatterDeserializer
+            ? ["p", "child2s", "child1s", "roots", "value3p", "rootp", "value2p", "child1p", "value1p", "value3i", "rooti", "value2i", "child1i", "value1i", "child2i"]
+            : ["child2s", "child1s", "roots", "value1p", "value2p", "value3p", "child2p", "child1p", "rootp", "value1i", "value2i", "value3i", "child2i", "child1i", "rooti"];
+        BinaryTreeNodeWithEventsISerializable child2 = new() { Name = "child2", Value = new ValueType() { Name = "value1" } };
+        BinaryTreeNodeWithEventsISerializable child1 = new() { Name = "child1", Left = child2, Value = new ValueType() { Name = "value2" } };
+        BinaryTreeNodeWithEventsISerializable root = new() { Name = "root", Left = child1, Value = new ValueType() { Name = "value3" } };
+        child2.Left = root;
+        try
+        {
+            Deserialize(Serialize(root));
+            List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
+            deserializeOrder.Should().Equal(expected);
+        }
+        finally
+        {
+            BinaryTreeNodeWithEventsTracker.DeserializationOrder.Clear();
+        }
+    }
+
+    [Fact]
+    public void Depth2_Cycle_ISerializable_WithValueTypeISerializable()
+    {
+        string[] expected = IsBinaryFormatterDeserializer
+            ? ["value3s", "value2s", "value1s", "child2s", "child1s", "roots", "value3p", "rootp", "value2p", "child1p", "value1p", "child2p", "value3i", "rooti", "value2i", "child1i", "value1i", "child2i" ]
+            : ["value1s", "child2s", "value2s", "child1s", "value3s", "roots", "value1p", "child2p", "value2p", "child1p", "value3p", "rootp", "value1i", "child2i", "value2i", "child1i", "value3i", "rooti"];
+        BinaryTreeNodeWithEventsISerializable child2 = new() { Name = "child2", Value = new ValueTypeISerializable() { Name = "value1" } };
+        BinaryTreeNodeWithEventsISerializable child1 = new() { Name = "child1", Left = child2, Value = new ValueTypeISerializable() { Name = "value2" } };
+        BinaryTreeNodeWithEventsISerializable root = new() { Name = "root", Left = child1, Value = new ValueTypeISerializable() { Name = "value3" } };
+        child2.Left = root;
+        try
+        {
+            Deserialize(Serialize(root));
+            List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
+            deserializeOrder.Should().Equal(expected);
+        }
+        finally
+        {
+            BinaryTreeNodeWithEventsTracker.DeserializationOrder.Clear();
+        }
+    }
+
+    [Fact]
+    public void Depth2_Cycle()
+    {
+        string[] expected = IsBinaryFormatterDeserializer
+            ? ["child2p", "rootp", "child1p", "rooti", "child1i", "child2i"]
+            : ["child2p", "child1p", "rootp", "child2i", "child1i", "rooti"];
+        BinaryTreeNodeWithEvents child2 = new() { Name = "child2" };
+        BinaryTreeNodeWithEvents child1 = new() { Name = "child1", Left = child2 };
+        BinaryTreeNodeWithEvents root = new() { Name = "root", Left = child1 };
+        child2.Left = root;
+
+        try
+        {
+            Deserialize(Serialize(root));
+            List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
+            deserializeOrder.Should().Equal(expected);
+        }
+        finally
+        {
+            BinaryTreeNodeWithEventsTracker.DeserializationOrder.Clear();
+        }
+    }
+
+    [Fact]
+    public void Depth2_Cycle_Surrogate()
+    {
+        SurrogateSelector selector = CreateSurrogateSelector<BinaryTreeNodeWithEvents>(new BinaryTreeNodeWithEventsSurrogate());
+        BinaryTreeNodeWithEvents child2 = new() { Name = "child2" };
+        BinaryTreeNodeWithEvents child1 = new() { Name = "child1", Left = child2 };
+        BinaryTreeNodeWithEvents root = new() { Name = "root", Left = child1 };
+        child2.Left = root;
+
+        try
+        {
+            Stream stream = Serialize(root);
+            if (IsBinaryFormatterDeserializer)
+            {
+                Action action = () => Deserialize(stream, surrogateSelector: selector);
+                action.Should().Throw<SerializationException>();
+            }
+            else
+            {
+                Deserialize(stream, surrogateSelector: selector);
+                List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
+                deserializeOrder.Should().Equal("child2s", "child1s", "roots", "child2p", "child1p", "rootp", "child2i", "child1i", "rooti");
+            }
+        }
+        finally
+        {
+            BinaryTreeNodeWithEventsTracker.DeserializationOrder.Clear();
+        }
+    }
+
+    [Fact]
+    public void Depth2_Cycle_WithValueType()
+    {
+        string[] expected = IsBinaryFormatterDeserializer
+            ? ["child2p", "value3p", "rootp", "value2p", "child1p", "value1p", "value3i", "rooti", "value2i", "child1i", "value1i", "child2i"]
+            : ["value1p", "child2p", "value2p", "child1p", "value3p", "rootp", "value1i", "child2i", "value2i", "child1i", "value3i", "rooti"];
+        BinaryTreeNodeWithEvents child2 = new() { Name = "child2", Value = new ValueType() { Name = "value1" } };
+        BinaryTreeNodeWithEvents child1 = new() { Name = "child1", Left = child2, Value = new ValueType() { Name = "value2" } };
+        BinaryTreeNodeWithEvents root = new() { Name = "root", Left = child1, Value = new ValueType() { Name = "value3" } };
+        child2.Left = root;
+
+        try
+        {
+            Deserialize(Serialize(root));
+            List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
+            deserializeOrder.Should().Equal(expected);
+        }
+        finally
+        {
+            BinaryTreeNodeWithEventsTracker.DeserializationOrder.Clear();
+        }
+    }
+
+    [Fact]
+    public void Depth2_Cycle_WithValueTypeISerializable()
+    {
+        string[] expected = IsBinaryFormatterDeserializer
+            ? ["value3s", "value2s", "value1s", "value3p", "rootp", "value2p", "child1p", "value1p", "child2p", "value3i", "rooti", "value2i", "child1i", "value1i", "child2i"]
+            : ["value1s", "value2s", "value3s", "value1p", "child2p", "value2p", "child1p", "value3p", "rootp", "value1i", "child2i", "value2i", "child1i", "value3i", "rooti"];
+        BinaryTreeNodeWithEvents child2 = new() { Name = "child2", Value = new ValueTypeISerializable() { Name = "value1" } };
+        BinaryTreeNodeWithEvents child1 = new() { Name = "child1", Left = child2, Value = new ValueTypeISerializable() { Name = "value2" } };
+        BinaryTreeNodeWithEvents root = new() { Name = "root", Left = child1, Value = new ValueTypeISerializable() { Name = "value3" } };
+        child2.Left = root;
+
+        try
+        {
+            Deserialize(Serialize(root));
+            List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
+            deserializeOrder.Should().Equal(expected);
+        }
+        finally
+        {
+            BinaryTreeNodeWithEventsTracker.DeserializationOrder.Clear();
+        }
+    }
+    #endregion Cycle
+    #endregion Depth2
+}

--- a/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/Common/SerializationTest.cs
+++ b/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/Common/SerializationTest.cs
@@ -4,6 +4,7 @@
 using System.Buffers;
 using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters;
+using FormatTests.Formatter;
 
 namespace FormatTests.Common;
 
@@ -83,4 +84,6 @@ public abstract class SerializationTest<TSerializer> where TSerializer : ISerial
 
         return selector;
     }
+
+    public static bool IsBinaryFormatterDeserializer => typeof(TSerializer) == typeof(BinaryFormatterSerializer);
 }

--- a/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/Common/TestTypes/BinaryTreeNodeWithEvents.cs
+++ b/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/Common/TestTypes/BinaryTreeNodeWithEvents.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.Serialization;
+
+namespace FormatTests.Common.TestTypes;
+
+[Serializable]
+public class BinaryTreeNodeWithEvents : IDeserializationCallback, BinaryTreeNodeWithEventsBase
+{
+    public string Name { get; set; } = string.Empty;
+    public BinaryTreeNodeWithEvents? Left { get; set; }
+    public BinaryTreeNodeWithEvents? Right { get; set; }
+    public ValueTypeBase? Value { get; set; }
+
+    public BinaryTreeNodeWithEvents() { }
+
+    [OnDeserialized]
+    private void OnDeserialized(StreamingContext context) => BinaryTreeNodeWithEventsTracker.DeserializationOrder.Add($"{Name}p");
+
+    public void GetObjectData(SerializationInfo info, StreamingContext context)
+    {
+        info.AddValue(nameof(Name), Name);
+        info.AddValue(nameof(Left), Left);
+        info.AddValue(nameof(Right), Right);
+        info.AddValue(nameof(Value), Value);
+    }
+
+    public void OnDeserialization(object? sender) => BinaryTreeNodeWithEventsTracker.DeserializationOrder.Add($"{Name}i");
+}
+
+public class BinaryTreeNodeWithEventsSurrogate : ISerializationSurrogate
+{
+    public void GetObjectData(object obj, SerializationInfo info, StreamingContext context) => throw new NotImplementedException();
+    public object SetObjectData(object obj, SerializationInfo info, StreamingContext context, ISurrogateSelector? selector)
+    {
+        BinaryTreeNodeWithEvents node = (BinaryTreeNodeWithEvents)obj;
+        node.Name = info.GetString("<Name>k__BackingField")!;
+        node.Left = (BinaryTreeNodeWithEvents)info.GetValue("<Left>k__BackingField", typeof(BinaryTreeNodeWithEvents))!;
+        node.Right = (BinaryTreeNodeWithEvents)info.GetValue("<Right>k__BackingField", typeof(BinaryTreeNodeWithEvents))!;
+        node.Value = (ValueTypeBase)info.GetValue("<Value>k__BackingField", typeof(ValueTypeBase))!;
+        BinaryTreeNodeWithEventsTracker.DeserializationOrder.Add($"{node.Name}s");
+
+        return node;
+    }
+}

--- a/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/Common/TestTypes/BinaryTreeNodeWithEventsBase.cs
+++ b/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/Common/TestTypes/BinaryTreeNodeWithEventsBase.cs
@@ -1,0 +1,6 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace FormatTests.Common.TestTypes;
+
+public interface BinaryTreeNodeWithEventsBase { }

--- a/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/Common/TestTypes/BinaryTreeNodeWithEventsISerializable.cs
+++ b/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/Common/TestTypes/BinaryTreeNodeWithEventsISerializable.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.Serialization;
+
+namespace FormatTests.Common.TestTypes;
+
+[Serializable]
+public class BinaryTreeNodeWithEventsISerializable : ISerializable, IDeserializationCallback, BinaryTreeNodeWithEventsBase
+{
+    public string Name { get; set; } = string.Empty;
+    public BinaryTreeNodeWithEventsISerializable? Left { get; set; }
+    public BinaryTreeNodeWithEventsISerializable? Right { get; set; }
+    public ValueTypeBase? Value { get; set; }
+
+    public BinaryTreeNodeWithEventsISerializable() { }
+
+    protected BinaryTreeNodeWithEventsISerializable(SerializationInfo serializationInfo, StreamingContext streamingContext)
+    {
+        Name = serializationInfo.GetString(nameof(Name))!;
+        Left = (BinaryTreeNodeWithEventsISerializable?)serializationInfo.GetValue(nameof(Left), typeof(BinaryTreeNodeWithEventsISerializable));
+        Right = (BinaryTreeNodeWithEventsISerializable?)serializationInfo.GetValue(nameof(Right), typeof(BinaryTreeNodeWithEventsISerializable));
+        Value = (ValueTypeBase?)serializationInfo.GetValue(nameof(Value), typeof(ValueTypeBase));
+        BinaryTreeNodeWithEventsTracker.DeserializationOrder.Add($"{Name}s");
+    }
+
+    [OnDeserialized]
+    private void OnDeserialized(StreamingContext context) => BinaryTreeNodeWithEventsTracker.DeserializationOrder.Add($"{Name}p");
+
+    public void GetObjectData(SerializationInfo info, StreamingContext context)
+    {
+        info.AddValue(nameof(Name), Name);
+        info.AddValue(nameof(Left), Left);
+        info.AddValue(nameof(Right), Right);
+        info.AddValue(nameof(Value), Value);
+    }
+
+    public void OnDeserialization(object? sender) => BinaryTreeNodeWithEventsTracker.DeserializationOrder.Add($"{Name}i");
+}
+
+public class BinaryTreeNodeWithEventsTracker
+{
+    public static List<string> DeserializationOrder { get; } = new();
+}

--- a/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/Common/TestTypes/ValueType.cs
+++ b/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/Common/TestTypes/ValueType.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.Serialization;
+
+namespace FormatTests.Common.TestTypes;
+
+[Serializable]
+public struct ValueType : ValueTypeBase
+{
+    public ValueType()
+    {
+    }
+
+    public string Name { get; set; } = string.Empty;
+
+    public BinaryTreeNodeWithEventsBase? Reference { get; set; }
+
+    public readonly void OnDeserialization(object? sender) => BinaryTreeNodeWithEventsTracker.DeserializationOrder.Add($"{Name}i");
+
+    [OnDeserialized]
+    private readonly void OnDeserialized(StreamingContext context) => BinaryTreeNodeWithEventsTracker.DeserializationOrder.Add($"{Name}p");
+}

--- a/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/Common/TestTypes/ValueTypeBase.cs
+++ b/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/Common/TestTypes/ValueTypeBase.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.Serialization;
+
+namespace FormatTests.Common.TestTypes;
+
+public interface ValueTypeBase : IDeserializationCallback
+{
+    public string Name { get; set; }
+
+    public BinaryTreeNodeWithEventsBase? Reference { get; set; }
+}

--- a/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/Common/TestTypes/ValueTypeISerializable.cs
+++ b/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/Common/TestTypes/ValueTypeISerializable.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.Serialization;
+
+namespace FormatTests.Common.TestTypes;
+
+[Serializable]
+public struct ValueTypeISerializable : ISerializable, ValueTypeBase
+{
+    public string Name { get; set; } = string.Empty;
+
+    public BinaryTreeNodeWithEventsBase? Reference { get; set; }
+
+    private ValueTypeISerializable(SerializationInfo serializationInfo, StreamingContext streamingContext)
+    {
+        Name = serializationInfo.GetString(nameof(Name))!;
+        Reference = (BinaryTreeNodeWithEventsISerializable?)serializationInfo.GetValue(nameof(Reference), typeof(BinaryTreeNodeWithEventsISerializable));
+        BinaryTreeNodeWithEventsTracker.DeserializationOrder.Add($"{Name}s");
+    }
+
+    public readonly void GetObjectData(SerializationInfo info, StreamingContext context)
+    {
+        info.AddValue(nameof(Name), Name);
+        info.AddValue(nameof(Reference), Reference);
+    }
+
+    [OnDeserialized]
+    private readonly void OnDeserialized(StreamingContext context) => BinaryTreeNodeWithEventsTracker.DeserializationOrder.Add($"{Name}p");
+    public readonly void OnDeserialization(object? sender) => BinaryTreeNodeWithEventsTracker.DeserializationOrder.Add($"{Name}i");
+}

--- a/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/FormattedObject/EventOrderTests.cs
+++ b/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/FormattedObject/EventOrderTests.cs
@@ -1,0 +1,8 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace FormatTests.FormattedObject;
+
+public class EventOrderTests : Common.EventOrderTests<FormattedObjectSerializer>
+{
+}

--- a/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/Formatter/EventOrderTests.cs
+++ b/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/Formatter/EventOrderTests.cs
@@ -1,0 +1,8 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace FormatTests.Formatter;
+
+public class EventOrderTests : Common.EventOrderTests<BinaryFormatterSerializer>
+{
+}


### PR DESCRIPTION
- Adds tests for BinaryFormatter and Deserializer to capture what can be observed about the deserialization state in different scenarios based on the various hooks available (`IDeserializationCallback`, `OnDeserialized`, `ISerializable`).
- Flip the ordering of `OnDeserialized` and `IDeserializationCallback` in the deserializer since BinaryFormatter always fires `IDeserializationCallback` last
- Fix bug where multiple callbacks to `OnDeserialized` and `IDeserializationCallback` was occuring in scenario with ISerializable value types
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11336)