### PR TITLE
Simplify completed callbacks

### DIFF
--- a/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/Deserializer/ClassRecordDeserializer.cs
+++ b/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/Deserializer/ClassRecordDeserializer.cs
@@ -15,10 +15,18 @@ internal abstract class ClassRecordDeserializer : ObjectRecordDeserializer
 {
     private readonly bool _onlyAllowPrimitives;
 
-    private protected ClassRecordDeserializer(ClassRecord classRecord, object @object, IDeserializer deserializer)
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+    private readonly Type _type;
+
+    private protected ClassRecordDeserializer(
+        ClassRecord classRecord,
+        object @object,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type type,
+        IDeserializer deserializer)
         : base(classRecord, deserializer)
     {
         Object = @object;
+        _type = type;
 
         // We want to be able to complete IObjectReference without having to evaluate their dependencies
         // for circular references. See ValidateNewMemberObjectValue below for more.
@@ -88,6 +96,8 @@ internal abstract class ClassRecordDeserializer : ObjectRecordDeserializer
             throw new SerializationException($"IObjectReference type '{type}' can only have primitive member data.");
         }
     }
+
+    private protected void RegisterCompleteEvents() => Deserializer.RegisterCompleteEvents(_type, Object);
 }
 
 #pragma warning restore SYSLIB0050 // Type or member is obsolete

--- a/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/Deserializer/ClassRecordFieldInfoDeserializer.cs
+++ b/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/Deserializer/ClassRecordFieldInfoDeserializer.cs
@@ -23,15 +23,13 @@ internal sealed class ClassRecordFieldInfoDeserializer : ClassRecordDeserializer
     internal ClassRecordFieldInfoDeserializer(
         ClassRecord classRecord,
         object @object,
-        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicFields | DynamicallyAccessedMemberTypes.PublicFields)]
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
         Type type,
         IDeserializer deserializer)
-        : base(classRecord, @object, deserializer)
+        : base(classRecord, @object, type, deserializer)
     {
         _classRecord = classRecord;
-#pragma warning disable IL2067 // GetSerializableMembers is not attributed correctly. Should just be fields.
         _fieldInfo = FormatterServices.GetSerializableMembers(type);
-#pragma warning restore IL2067
         _isValueType = type.IsValueType;
     }
 
@@ -85,6 +83,9 @@ internal sealed class ClassRecordFieldInfoDeserializer : ClassRecordDeserializer
 
             _currentFieldIndex++;
         }
+
+        // Register after all members are parsed, to ensure that completion events are triggered in depth-first order.
+        RegisterCompleteEvents();
 
         if (!_hasFixups || !_isValueType)
         {

--- a/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/Deserializer/ClassRecordSerializationInfoDeserializer.cs
+++ b/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/Deserializer/ClassRecordSerializationInfoDeserializer.cs
@@ -25,9 +25,9 @@ internal sealed class ClassRecordSerializationInfoDeserializer : ClassRecordDese
     internal ClassRecordSerializationInfoDeserializer(
         ClassRecord classRecord,
         object @object,
-        Type type,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type type,
         ISerializationSurrogate? surrogate,
-        IDeserializer deserializer) : base(classRecord, @object, deserializer)
+        IDeserializer deserializer) : base(classRecord, @object, type, deserializer)
     {
         _classRecord = classRecord;
         _surrogate = surrogate;
@@ -60,6 +60,9 @@ internal sealed class ClassRecordSerializationInfoDeserializer : ClassRecordDese
             _serializationInfo.AddValue(memberName, memberValue);
             _currentMemberIndex++;
         }
+
+        // Register after all members are parsed, to ensure that completion events are triggered in depth-first order.
+        RegisterCompleteEvents();
 
         // We can't complete these in the same way we do with direct field sets as user code can dereference the
         // reference type members from the SerializationInfo that aren't fully completed (due to cycles). With direct

--- a/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/Deserializer/IDeserializer.cs
+++ b/src/System.Private.Windows.Core/src/System/Windows/Forms/BinaryFormat/Deserializer/IDeserializer.cs
@@ -67,6 +67,15 @@ internal interface IDeserializer
     ///  Check for a surrogate for the given type. If none exists, returns <see langword="null"/>.
     /// </summary>
     ISerializationSurrogate? GetSurrogate(Type type);
+
+    /// <summary>
+    ///  Register the deserialization complete events for the given object.
+    /// </summary>
+    void RegisterCompleteEvents(
+        // The only way to preserve base, non-public methods is to use All.
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+        Type type,
+        object @object);
 }
 
 #pragma warning restore SYSLIB0050 // Type or member is obsolete

--- a/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/Common/EventOrderTests.cs
+++ b/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/Common/EventOrderTests.cs
@@ -354,7 +354,7 @@ public abstract class EventOrderTests<T> : SerializationTest<T> where T : ISeria
     {
         string[] expected = IsBinaryFormatterDeserializer
             ? ["p", "childs", "roots", "valuep", "rootp", "valuei", "rooti", "childi"]
-            : ["childs", "roots", "valuep", "childp", "rootp", "valuei", "childi", "rooti"];
+            : ["childs", "roots", "childp", "valuep", "rootp", "childi", "valuei", "rooti"];
         BinaryTreeNodeWithEventsISerializable child = new() { Name = "child" };
         BinaryTreeNodeWithEventsISerializable root = new() { Name = "root", Left = child, Value = new ValueType() { Name = "value" } };
 
@@ -532,7 +532,7 @@ public abstract class EventOrderTests<T> : SerializationTest<T> where T : ISeria
     {
         string[] expected = IsBinaryFormatterDeserializer
             ? ["p", "childs", "roots", "value2p", "rootp", "value1p", "value2i", "rooti", "value1i", "childi"]
-            : ["childs", "roots", "value1p", "value2p", "childp", "rootp", "value1i", "value2i", "childi", "rooti"];
+            : ["childs", "roots", "value1p", "childp", "value2p", "rootp", "value1i", "childi", "value2i", "rooti"];
         BinaryTreeNodeWithEventsISerializable child = new() { Name = "child", Value = new ValueType() { Name = "value1" } };
         BinaryTreeNodeWithEventsISerializable root = new() { Name = "root", Left = child, Value = new ValueType() { Name = "value2" } };
         child.Left = root;
@@ -695,7 +695,7 @@ public abstract class EventOrderTests<T> : SerializationTest<T> where T : ISeria
     {
         string[] expected = IsBinaryFormatterDeserializer
             ? ["p", "child2s", "child1s", "roots", "valuep", "rootp", "child1p", "valuei", "rooti", "child1i", "child2i"]
-            : ["child2s", "child1s", "roots", "valuep", "child2p", "child1p", "rootp", "valuei", "child2i", "child1i", "rooti"];
+            : ["child2s", "child1s", "roots", "child2p", "child1p", "valuep", "rootp", "child2i", "child1i", "valuei", "rooti"];
         BinaryTreeNodeWithEventsISerializable child2 = new() { Name = "child2" };
         BinaryTreeNodeWithEventsISerializable child1 = new() { Name = "child1", Left = child2 };
         BinaryTreeNodeWithEventsISerializable root = new() { Name = "root", Left = child1, Value = new ValueType() { Name = "value" } };
@@ -881,7 +881,7 @@ public abstract class EventOrderTests<T> : SerializationTest<T> where T : ISeria
     {
         string[] expected = IsBinaryFormatterDeserializer
             ? ["p", "child2s", "child1s", "roots", "value3p", "rootp", "value2p", "child1p", "value1p", "value3i", "rooti", "value2i", "child1i", "value1i", "child2i"]
-            : ["child2s", "child1s", "roots", "value1p", "value2p", "value3p", "child2p", "child1p", "rootp", "value1i", "value2i", "value3i", "child2i", "child1i", "rooti"];
+            : ["child2s", "child1s", "roots", "value1p", "child2p", "value2p", "child1p", "value3p", "rootp", "value1i", "child2i", "value2i", "child1i", "value3i", "rooti"];
         BinaryTreeNodeWithEventsISerializable child2 = new() { Name = "child2", Value = new ValueType() { Name = "value1" } };
         BinaryTreeNodeWithEventsISerializable child1 = new() { Name = "child1", Left = child2, Value = new ValueType() { Name = "value2" } };
         BinaryTreeNodeWithEventsISerializable root = new() { Name = "root", Left = child1, Value = new ValueType() { Name = "value3" } };


### PR DESCRIPTION
Always hook completed callbacks in the same order that we parse the graph. This gives more predictable results and simplifies the logic a bit.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11343)