### PR TITLE
Visual Styles enabled or disabled, remove differentiation for border style in the left side of the row header when the style would have been set to `Outset`

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridView.cs
@@ -505,7 +505,7 @@ public partial class DataGridView : Control, ISupportInitialize
                         dgvabs = new DataGridViewAdvancedBorderStyle();
                         if (RightToLeftInternal)
                         {
-                            dgvabs.LeftInternal = DataGridViewAdvancedCellBorderStyle.Outset;
+                            dgvabs.LeftInternal = DataGridViewAdvancedCellBorderStyle.Single;
                         }
                         else
                         {
@@ -1250,7 +1250,7 @@ public partial class DataGridView : Control, ISupportInitialize
                             break;
 
                         case DataGridViewCellBorderStyle.Raised:
-                            AdvancedCellBorderStyle.All = DataGridViewAdvancedCellBorderStyle.Outset;
+                            AdvancedCellBorderStyle.All = DataGridViewAdvancedCellBorderStyle.Single;
                             break;
 
                         case DataGridViewCellBorderStyle.Sunken:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewRow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewRow.cs
@@ -418,7 +418,7 @@ public partial class DataGridViewRow : DataGridViewBand
 
                     if (DataGridView.RightToLeftInternal)
                     {
-                        dataGridViewAdvancedBorderStylePlaceholder.LeftInternal = DataGridViewAdvancedCellBorderStyle.Outset;
+                        dataGridViewAdvancedBorderStylePlaceholder.LeftInternal = DataGridViewAdvancedCellBorderStyle.Single;
                     }
                     else
                     {
@@ -522,7 +522,7 @@ public partial class DataGridViewRow : DataGridViewBand
                 case DataGridViewAdvancedCellBorderStyle.OutsetPartial:
                     if (DataGridView is not null && DataGridView.RightToLeftInternal)
                     {
-                        dataGridViewAdvancedBorderStylePlaceholder.LeftInternal = DataGridViewAdvancedCellBorderStyle.Outset;
+                        dataGridViewAdvancedBorderStylePlaceholder.LeftInternal = DataGridViewAdvancedCellBorderStyle.Single;
                         dataGridViewAdvancedBorderStylePlaceholder.RightInternal = DataGridViewAdvancedCellBorderStyle.OutsetDouble;
                     }
                     else

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewRowTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewRowTests.cs
@@ -3581,7 +3581,7 @@ public class DataGridViewRowTests
                 yield return new object[]
                 {
                     true, true, RightToLeft.Yes, DataGridViewAdvancedCellBorderStyle.OutsetPartial, true, true, isFirstDisplayedRow, isLastVisibleRow,
-                    true, DataGridViewAdvancedCellBorderStyle.Outset, DataGridViewAdvancedCellBorderStyle.Outset, DataGridViewAdvancedCellBorderStyle.None, DataGridViewAdvancedCellBorderStyle.None
+                    true, DataGridViewAdvancedCellBorderStyle.Single, DataGridViewAdvancedCellBorderStyle.Outset, DataGridViewAdvancedCellBorderStyle.None, DataGridViewAdvancedCellBorderStyle.None
                 };
             }
         }
@@ -3596,7 +3596,7 @@ public class DataGridViewRowTests
             yield return new object[]
             {
                 true, false, RightToLeft.Yes, DataGridViewAdvancedCellBorderStyle.OutsetPartial, true, true, true, isLastVisibleRow,
-                true, DataGridViewAdvancedCellBorderStyle.Outset, DataGridViewAdvancedCellBorderStyle.Outset, DataGridViewAdvancedCellBorderStyle.OutsetDouble, DataGridViewAdvancedCellBorderStyle.None
+                true, DataGridViewAdvancedCellBorderStyle.Single, DataGridViewAdvancedCellBorderStyle.Outset, DataGridViewAdvancedCellBorderStyle.OutsetDouble, DataGridViewAdvancedCellBorderStyle.None
             };
         }
 
@@ -3608,7 +3608,7 @@ public class DataGridViewRowTests
         yield return new object[]
         {
             false, true, RightToLeft.Yes, DataGridViewAdvancedCellBorderStyle.OutsetPartial, true, true, true, true,
-            true, DataGridViewAdvancedCellBorderStyle.Outset, DataGridViewAdvancedCellBorderStyle.OutsetDouble, DataGridViewAdvancedCellBorderStyle.Outset, DataGridViewAdvancedCellBorderStyle.Outset
+            true, DataGridViewAdvancedCellBorderStyle.Single, DataGridViewAdvancedCellBorderStyle.OutsetDouble, DataGridViewAdvancedCellBorderStyle.Outset, DataGridViewAdvancedCellBorderStyle.Outset
         };
         yield return new object[]
         {
@@ -3618,7 +3618,7 @@ public class DataGridViewRowTests
         yield return new object[]
         {
             false, true, RightToLeft.Yes, DataGridViewAdvancedCellBorderStyle.OutsetPartial, true, true, true, false,
-            true, DataGridViewAdvancedCellBorderStyle.Outset, DataGridViewAdvancedCellBorderStyle.OutsetDouble, DataGridViewAdvancedCellBorderStyle.Outset, DataGridViewAdvancedCellBorderStyle.OutsetPartial
+            true, DataGridViewAdvancedCellBorderStyle.Single, DataGridViewAdvancedCellBorderStyle.OutsetDouble, DataGridViewAdvancedCellBorderStyle.Outset, DataGridViewAdvancedCellBorderStyle.OutsetPartial
         };
         yield return new object[]
         {
@@ -3628,7 +3628,7 @@ public class DataGridViewRowTests
         yield return new object[]
         {
             false, true, RightToLeft.Yes, DataGridViewAdvancedCellBorderStyle.OutsetPartial, true, true, false, true,
-            true, DataGridViewAdvancedCellBorderStyle.Outset, DataGridViewAdvancedCellBorderStyle.OutsetDouble, DataGridViewAdvancedCellBorderStyle.OutsetPartial, DataGridViewAdvancedCellBorderStyle.Outset
+            true, DataGridViewAdvancedCellBorderStyle.Single, DataGridViewAdvancedCellBorderStyle.OutsetDouble, DataGridViewAdvancedCellBorderStyle.OutsetPartial, DataGridViewAdvancedCellBorderStyle.Outset
         };
         yield return new object[]
         {
@@ -3638,7 +3638,7 @@ public class DataGridViewRowTests
         yield return new object[]
         {
             false, true, RightToLeft.Yes, DataGridViewAdvancedCellBorderStyle.OutsetPartial, true, true, false, false,
-            true, DataGridViewAdvancedCellBorderStyle.Outset, DataGridViewAdvancedCellBorderStyle.OutsetDouble, DataGridViewAdvancedCellBorderStyle.OutsetPartial, DataGridViewAdvancedCellBorderStyle.OutsetPartial
+            true, DataGridViewAdvancedCellBorderStyle.Single, DataGridViewAdvancedCellBorderStyle.OutsetDouble, DataGridViewAdvancedCellBorderStyle.OutsetPartial, DataGridViewAdvancedCellBorderStyle.OutsetPartial
         };
         yield return new object[]
         {
@@ -3648,7 +3648,7 @@ public class DataGridViewRowTests
         yield return new object[]
         {
             false, false, RightToLeft.Yes, DataGridViewAdvancedCellBorderStyle.OutsetPartial, true, true, true, true,
-            true, DataGridViewAdvancedCellBorderStyle.Outset, DataGridViewAdvancedCellBorderStyle.OutsetDouble, DataGridViewAdvancedCellBorderStyle.OutsetDouble, DataGridViewAdvancedCellBorderStyle.Outset
+            true, DataGridViewAdvancedCellBorderStyle.Single, DataGridViewAdvancedCellBorderStyle.OutsetDouble, DataGridViewAdvancedCellBorderStyle.OutsetDouble, DataGridViewAdvancedCellBorderStyle.Outset
         };
         yield return new object[]
         {
@@ -3658,7 +3658,7 @@ public class DataGridViewRowTests
         yield return new object[]
         {
             false, false, RightToLeft.Yes, DataGridViewAdvancedCellBorderStyle.OutsetPartial, true, true, false, false,
-            true, DataGridViewAdvancedCellBorderStyle.Outset, DataGridViewAdvancedCellBorderStyle.OutsetDouble, DataGridViewAdvancedCellBorderStyle.OutsetPartial, DataGridViewAdvancedCellBorderStyle.OutsetPartial
+            true, DataGridViewAdvancedCellBorderStyle.Single, DataGridViewAdvancedCellBorderStyle.OutsetDouble, DataGridViewAdvancedCellBorderStyle.OutsetPartial, DataGridViewAdvancedCellBorderStyle.OutsetPartial
         };
 
         // Single.


### PR DESCRIPTION
Fixes #5961

## Proposed changes

- If DataGridView is `RightToLeft`, with either visual styles enabled or not, remove differentiation for border style in the left side of the row header when the style would have been set to `Outset`

## Customer Impact

- Will be able to see left border of the row header when control is set to `RightToLeft`

## Regression?

- No

## Risk

- Minimal

## Screenshots

### Before

- Visual styles enabled

![before_visual_style_on](https://github.com/dotnet/winforms/assets/30190295/2a81bc2f-aadb-4815-8f26-cac200b48ef8)
- Visual styles disabled

![before_visual_style_off](https://github.com/dotnet/winforms/assets/30190295/50e9e8cb-928a-4abd-bc62-e03d7aeaff53)
### After

- Visual styles enabled

![after_visual_style_on](https://github.com/dotnet/winforms/assets/30190295/d49a050e-fd76-4dc1-ad15-8fa5e171e261)
- Visual styles disabled

![after_visual_style_off](https://github.com/dotnet/winforms/assets/30190295/0a30cf23-1310-4b0c-a37d-50232ef941e5)
## Test methodology

- Manual

## Accessibility testing

- Accessibility insights

## Test environment(s)

- `dotnet 9.0.100-preview.3.24204.13`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11345)