### PR TITLE
Add Tests for ObjectReference in EventOrderTests

### DIFF
--- a/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/Common/EventOrderTests.cs
+++ b/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/Common/EventOrderTests.cs
@@ -13,6 +13,63 @@ public abstract class EventOrderTests<T> : SerializationTest<T> where T : ISeria
     #region Depth0
     #region NoCycle
     [Fact]
+    public void Depth0_NoCycle_ObjectReference_AsRoot()
+    {
+        ObjectReferenceISerializable root = new();
+
+        try
+        {
+            Deserialize(Serialize(root));
+            List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
+            deserializeOrder.Should().Equal("objects", "objectp", "objecti");
+        }
+        finally
+        {
+            BinaryTreeNodeWithEventsTracker.DeserializationOrder.Clear();
+        }
+    }
+
+    [Fact]
+    public void Depth0_NoCycle_ObjectReference()
+    {
+        string[] expected = IsBinaryFormatterDeserializer
+            ? ["objectp", "objects", "rootp", "rooti", "objecti"]
+            : ["objects", "objectp", "rootp", "objecti", "rooti"];
+        BinaryTreeNodeWithEvents root = new() { Name = "root", ObjectReference = new ObjectReferenceISerializable() };
+
+        try
+        {
+            Deserialize(Serialize(root));
+            List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
+            deserializeOrder.Should().Equal(expected);
+        }
+        finally
+        {
+            BinaryTreeNodeWithEventsTracker.DeserializationOrder.Clear();
+        }
+    }
+
+    [Fact]
+    public void Depth0_NoCycle_ISerializable_ObjectReference()
+    {
+        string[] expected = IsBinaryFormatterDeserializer
+            ? ["objectp", "objects", "roots", "rootp", "rooti", "objecti"]
+            : ["objects", "roots", "objectp", "rootp", "objecti", "rooti"];
+        BinaryTreeNodeWithEventsISerializable root = new() { Name = "root", ObjectReference = new ObjectReferenceISerializable() };
+
+        try
+        {
+            Deserialize(Serialize(root));
+            List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
+            deserializeOrder.Should().Equal(expected);
+        }
+        finally
+        {
+            BinaryTreeNodeWithEventsTracker.DeserializationOrder.Clear();
+        }
+    }
+
+    [Fact]
     public void Depth0_NoCycle_ISerializable()
     {
         BinaryTreeNodeWithEventsISerializable root = new() { Name = "root" };
@@ -328,6 +385,48 @@ public abstract class EventOrderTests<T> : SerializationTest<T> where T : ISeria
 
     #region Depth1
     #region NoCycle
+    [Fact]
+    public void Depth1_NoCycle_ObjectReference()
+    {
+        string[] expected = IsBinaryFormatterDeserializer
+            ? ["objectp", "objects", "rootp", "childp", "rooti", "childi", "objecti"]
+            : ["objects", "objectp", "childp", "rootp", "objecti", "childi", "rooti"];
+        BinaryTreeNodeWithEvents child = new() { Name = "child", ObjectReference = new ObjectReferenceISerializable() };
+        BinaryTreeNodeWithEvents root = new() { Name = "root", Left = child };
+
+        try
+        {
+            Deserialize(Serialize(root));
+            List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
+            deserializeOrder.Should().Equal(expected);
+        }
+        finally
+        {
+            BinaryTreeNodeWithEventsTracker.DeserializationOrder.Clear();
+        }
+    }
+
+    [Fact]
+    public void Depth1_NoCycle_ISerializable_ObjectReference()
+    {
+        string[] expected = IsBinaryFormatterDeserializer
+            ? ["objectp", "objects", "childs", "roots", "rootp", "childp", "rooti", "childi", "objecti"]
+            : ["objects", "childs", "roots", "objectp", "childp", "rootp", "objecti", "childi", "rooti"];
+        BinaryTreeNodeWithEventsISerializable child = new() { Name = "child", ObjectReference = new ObjectReferenceISerializable() };
+        BinaryTreeNodeWithEventsISerializable root = new() { Name = "root", Left = child };
+
+        try
+        {
+            Deserialize(Serialize(root));
+            List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
+            deserializeOrder.Should().Equal(expected);
+        }
+        finally
+        {
+            BinaryTreeNodeWithEventsTracker.DeserializationOrder.Clear();
+        }
+    }
+
     [Fact]
     public void Depth1_NoCycle_ISerializable()
     {
@@ -668,6 +767,50 @@ public abstract class EventOrderTests<T> : SerializationTest<T> where T : ISeria
 
     #region Depth2
     #region NoCycle
+    [Fact]
+    public void Depth2_NoCycle_ObjectReference()
+    {
+        string[] expected = IsBinaryFormatterDeserializer
+            ? ["objectp", "objects", "rootp", "child1p", "child2p", "rooti", "child1i", "child2i", "objecti"]
+            : ["objects", "objectp", "child2p", "child1p", "rootp", "objecti", "child2i", "child1i", "rooti"];
+        BinaryTreeNodeWithEvents child2 = new() { Name = "child2", ObjectReference = new ObjectReferenceISerializable() };
+        BinaryTreeNodeWithEvents child1 = new() { Name = "child1", Left = child2 };
+        BinaryTreeNodeWithEvents root = new() { Name = "root", Left = child1 };
+
+        try
+        {
+            Deserialize(Serialize(root));
+            List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
+            deserializeOrder.Should().Equal(expected);
+        }
+        finally
+        {
+            BinaryTreeNodeWithEventsTracker.DeserializationOrder.Clear();
+        }
+    }
+
+    [Fact]
+    public void Depth2_NoCycle_ISerializable_ObjectReference()
+    {
+        string[] expected = IsBinaryFormatterDeserializer
+            ? ["objectp", "objects", "child2s", "child1s", "roots", "rootp", "child1p", "child2p", "rooti", "child1i", "child2i", "objecti"]
+            : ["objects", "child2s", "child1s", "roots", "objectp", "child2p", "child1p", "rootp", "objecti", "child2i", "child1i", "rooti"];
+        BinaryTreeNodeWithEventsISerializable child2 = new() { Name = "child2", ObjectReference = new ObjectReferenceISerializable() };
+        BinaryTreeNodeWithEventsISerializable child1 = new() { Name = "child1", Left = child2 };
+        BinaryTreeNodeWithEventsISerializable root = new() { Name = "root", Left = child1 };
+
+        try
+        {
+            Deserialize(Serialize(root));
+            List<string> deserializeOrder = BinaryTreeNodeWithEventsTracker.DeserializationOrder;
+            deserializeOrder.Should().Equal(expected);
+        }
+        finally
+        {
+            BinaryTreeNodeWithEventsTracker.DeserializationOrder.Clear();
+        }
+    }
+
     [Fact]
     public void Depth2_NoCycle_ISerializable()
     {

--- a/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/Common/TestTypes/BinaryTreeNodeWithEvents.cs
+++ b/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/Common/TestTypes/BinaryTreeNodeWithEvents.cs
@@ -12,6 +12,7 @@ public class BinaryTreeNodeWithEvents : IDeserializationCallback, BinaryTreeNode
     public BinaryTreeNodeWithEvents? Left { get; set; }
     public BinaryTreeNodeWithEvents? Right { get; set; }
     public ValueTypeBase? Value { get; set; }
+    public object? ObjectReference { get; set; }
 
     public BinaryTreeNodeWithEvents() { }
 
@@ -24,6 +25,7 @@ public class BinaryTreeNodeWithEvents : IDeserializationCallback, BinaryTreeNode
         info.AddValue(nameof(Left), Left);
         info.AddValue(nameof(Right), Right);
         info.AddValue(nameof(Value), Value);
+        info.AddValue(nameof(ObjectReference), ObjectReference);
     }
 
     public void OnDeserialization(object? sender) => BinaryTreeNodeWithEventsTracker.DeserializationOrder.Add($"{Name}i");
@@ -39,6 +41,7 @@ public class BinaryTreeNodeWithEventsSurrogate : ISerializationSurrogate
         node.Left = (BinaryTreeNodeWithEvents)info.GetValue("<Left>k__BackingField", typeof(BinaryTreeNodeWithEvents))!;
         node.Right = (BinaryTreeNodeWithEvents)info.GetValue("<Right>k__BackingField", typeof(BinaryTreeNodeWithEvents))!;
         node.Value = (ValueTypeBase)info.GetValue("<Value>k__BackingField", typeof(ValueTypeBase))!;
+        node.ObjectReference = info.GetValue("<ObjectReference>k__BackingField", typeof(object))!;
         BinaryTreeNodeWithEventsTracker.DeserializationOrder.Add($"{node.Name}s");
 
         return node;

--- a/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/Common/TestTypes/BinaryTreeNodeWithEventsISerializable.cs
+++ b/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/Common/TestTypes/BinaryTreeNodeWithEventsISerializable.cs
@@ -12,6 +12,7 @@ public class BinaryTreeNodeWithEventsISerializable : ISerializable, IDeserializa
     public BinaryTreeNodeWithEventsISerializable? Left { get; set; }
     public BinaryTreeNodeWithEventsISerializable? Right { get; set; }
     public ValueTypeBase? Value { get; set; }
+    public object? ObjectReference { get; set; }
 
     public BinaryTreeNodeWithEventsISerializable() { }
 
@@ -21,6 +22,7 @@ public class BinaryTreeNodeWithEventsISerializable : ISerializable, IDeserializa
         Left = (BinaryTreeNodeWithEventsISerializable?)serializationInfo.GetValue(nameof(Left), typeof(BinaryTreeNodeWithEventsISerializable));
         Right = (BinaryTreeNodeWithEventsISerializable?)serializationInfo.GetValue(nameof(Right), typeof(BinaryTreeNodeWithEventsISerializable));
         Value = (ValueTypeBase?)serializationInfo.GetValue(nameof(Value), typeof(ValueTypeBase));
+        ObjectReference = serializationInfo.GetValue(nameof(ObjectReference), typeof(object));
         BinaryTreeNodeWithEventsTracker.DeserializationOrder.Add($"{Name}s");
     }
 
@@ -33,6 +35,7 @@ public class BinaryTreeNodeWithEventsISerializable : ISerializable, IDeserializa
         info.AddValue(nameof(Left), Left);
         info.AddValue(nameof(Right), Right);
         info.AddValue(nameof(Value), Value);
+        info.AddValue(nameof(ObjectReference), ObjectReference);
     }
 
     public void OnDeserialization(object? sender) => BinaryTreeNodeWithEventsTracker.DeserializationOrder.Add($"{Name}i");

--- a/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/Common/TestTypes/ObjectReferenceISerializable.cs
+++ b/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/Common/TestTypes/ObjectReferenceISerializable.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.Serialization;
+
+namespace FormatTests.Common.TestTypes;
+
+[Serializable]
+public class ObjectReferenceISerializable : ISerializable, IObjectReference, IDeserializationCallback
+{
+    public ObjectReferenceISerializable() { }
+
+    protected ObjectReferenceISerializable(SerializationInfo serializationInfo, StreamingContext streamingContext)
+    {
+        BinaryTreeNodeWithEventsTracker.DeserializationOrder.Add($"objects");
+    }
+
+    public void GetObjectData(SerializationInfo info, StreamingContext context) { }
+
+    public object GetRealObject(StreamingContext context) => new InnerObject();
+
+    public void OnDeserialization(object? sender) => BinaryTreeNodeWithEventsTracker.DeserializationOrder.Add($"objecti");
+
+    [OnDeserialized]
+    private void OnDeserialized(StreamingContext context) => BinaryTreeNodeWithEventsTracker.DeserializationOrder.Add($"objectp");
+}
+
+public class InnerObject : IDeserializationCallback
+{
+    public void OnDeserialization(object? sender) => BinaryTreeNodeWithEventsTracker.DeserializationOrder.Add($"inneri");
+
+    [OnDeserialized]
+    private void OnDeserialized(StreamingContext context) => BinaryTreeNodeWithEventsTracker.DeserializationOrder.Add($"innerp");
+}


### PR DESCRIPTION
Add tests for `IObjectReference` in EventOrderTests to ensure deserialization events relating to `IObjectReference` only fired once
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11348)