### PR TITLE
Add test coverage for TreeView

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewImageKeyConverterTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewImageKeyConverterTests.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Windows.Forms.Tests;
+
+public class TreeViewImageKeyConverterTests
+{
+    private readonly TreeViewImageKeyConverter _converter = new();
+
+    [WinFormsTheory]
+    [InlineData(null, "(default)")]
+    [InlineData("", "(default)")]
+    [InlineData("non-empty", "non-empty")]
+    public void TreeViewImageKeyConverter_ConvertTo_StringDestinationType_ReturnsExpected(string value, string expected)
+    {
+        object result = _converter.ConvertTo(context: null, culture: null, value: value, destinationType: typeof(string));
+        result.Should().Be(expected);
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
@@ -7401,24 +7401,31 @@ public class TreeViewTests
         accessibilityObject.Should().BeOfType<TreeViewLabelEditAccessibleObject>();
     }
 
-    private void AddNodes(TreeView control, string rootNodeName, string childNodeName = null)
-    {
-        TreeNode rootNode = new(rootNodeName);
-        if (childNodeName is not null)
-        {
-            rootNode.Nodes.Add(new TreeNode(childNodeName));
-        }
-
-        control.Nodes.Add(rootNode);
-    }
-
     private TreeView InitializeTreeViewWithNodes()
     {
         TreeView treeView = new();
-        AddNodes(treeView, "Root1", "Child1");
+        AddNodes(treeView, "Root1", "Child1", "GrandChild1");
         AddNodes(treeView, "Root2");
 
         return treeView;
+    }
+
+    private void AddNodes(TreeView treeView, string root, string child = null, string grandChild = null)
+    {
+        TreeNode rootNode = new(root);
+        treeView.Nodes.Add(rootNode);
+
+        if (child is not null)
+        {
+            TreeNode childNode = new(child);
+            rootNode.Nodes.Add(childNode);
+
+            if (grandChild is not null)
+            {
+                TreeNode grandChildNode = new(grandChild);
+                childNode.Nodes.Add(grandChildNode);
+            }
+        }
     }
 
     [WinFormsFact]
@@ -7452,7 +7459,7 @@ public class TreeViewTests
         countWithoutSubTrees.Should().Be(2);
 
         int countWithSubTrees = treeView.GetNodeCount(true);
-        countWithSubTrees.Should().Be(3);
+        countWithSubTrees.Should().Be(4);
     }
 
     [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
@@ -7462,8 +7462,8 @@ public class TreeViewTests
         using TreeView treeView = new();
 
         treeView.Indent = 10;
-        var resetIndentMethod = treeView.GetType().GetMethod("ResetIndent", BindingFlags.NonPublic | BindingFlags.Instance);
-        resetIndentMethod.Invoke(treeView, null);
+        var accessor = treeView.TestAccessor();
+        accessor.Dynamic.ResetIndent();
 
         treeView.Indent.Should().Be(19);
     }
@@ -7474,8 +7474,8 @@ public class TreeViewTests
         using TreeView treeView = new();
 
         treeView.ItemHeight = 10;
-        var resetItemHeightMethod = treeView.GetType().GetMethod("ResetItemHeight", BindingFlags.NonPublic | BindingFlags.Instance);
-        resetItemHeightMethod.Invoke(treeView, null);
+        var accessor = treeView.TestAccessor();
+        accessor.Dynamic.ResetItemHeight();
 
         treeView.ItemHeight.Should().Be(19);
     }
@@ -7485,13 +7485,13 @@ public class TreeViewTests
     {
         using TreeView treeView = new();
 
-        var shouldSerializeIndentMethod = treeView.GetType().GetMethod("ShouldSerializeIndent", BindingFlags.NonPublic | BindingFlags.Instance);
-        bool result = (bool)shouldSerializeIndentMethod.Invoke(treeView, null);
+        var accessor = treeView.TestAccessor();
+        bool result = accessor.Dynamic.ShouldSerializeIndent();
 
         result.Should().BeFalse();
 
         treeView.Indent = 10;
-        result = (bool)shouldSerializeIndentMethod.Invoke(treeView, null);
+        result = accessor.Dynamic.ShouldSerializeIndent();
 
         result.Should().BeTrue();
     }
@@ -7501,13 +7501,13 @@ public class TreeViewTests
     {
         using TreeView treeView = new();
 
-        var shouldSerializeItemHeightMethod = treeView.GetType().GetMethod("ShouldSerializeItemHeight", BindingFlags.NonPublic | BindingFlags.Instance);
-        bool result = (bool)shouldSerializeItemHeightMethod.Invoke(treeView, null);
+        var accessor = treeView.TestAccessor();
+        bool result = accessor.Dynamic.ShouldSerializeItemHeight();
 
         result.Should().BeFalse();
 
         treeView.ItemHeight = 10;
-        result = (bool)shouldSerializeItemHeightMethod.Invoke(treeView, null);
+        result = accessor.Dynamic.ShouldSerializeItemHeight();
 
         result.Should().BeTrue();
     }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
@@ -4,7 +4,6 @@
 using System.Collections;
 using System.ComponentModel;
 using System.Drawing;
-using System.Reflection;
 using System.Windows.Forms.TestUtilities;
 using Moq;
 


### PR DESCRIPTION
related https://github.com/dotnet/winforms/issues/10453

## Proposed changes
- Add unit tests for TreeView to test its properties:TopNode, accessibilityObject, ItemHeight,Indent
- Add unit tests for TreeView to test its methods: ConvertTo, CollapseAll, ExpandAll, GetNodeCount, ShouldSerializeIndent, shouldSerializeItemHeightMethod, ToString
<!-- We are in TELL-MODE the following section must be completed -->