### PR TITLE
Using solid border for selected control in the DemoConsole application.

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerUtils.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerUtils.cs
@@ -22,7 +22,7 @@ internal static class DesignerUtils
     private static SolidBrush s_hoverBrush = new(Color.FromArgb(alpha: 50, SystemColors.Highlight));
     // brush used to draw the resizeable selection borders around controls/components
     private static HatchBrush s_selectionBorderBrush =
-        new(HatchStyle.Percent50, SystemColors.ControlDarkDark, Color.Transparent);
+        new(HatchStyle.Percent50, SystemColors.ControlDarkDark, SystemColors.ControlDarkDark);
     // Pens and Brushes used via GDI to render our grabhandles
     private static HBRUSH s_grabHandleFillBrushPrimary =
         PInvoke.CreateSolidBrush((COLORREF)(uint)ColorTranslator.ToWin32(SystemColors.Window));

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerUtils.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerUtils.cs
@@ -164,7 +164,7 @@ internal static class DesignerUtils
         s_hoverBrush = new SolidBrush(Color.FromArgb(50, SystemColors.Highlight));
 
         s_selectionBorderBrush.Dispose();
-        s_selectionBorderBrush = new HatchBrush(HatchStyle.Percent50, SystemColors.ControlDarkDark, Color.Transparent);
+        s_selectionBorderBrush = new HatchBrush(HatchStyle.Percent50, SystemColors.ControlDarkDark, SystemColors.ControlDarkDark);
 
         PInvokeCore.DeleteObject(s_grabHandleFillBrushPrimary);
         s_grabHandleFillBrushPrimary = PInvoke.CreateSolidBrush((COLORREF)(uint)ColorTranslator.ToWin32(SystemColors.Window));


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #11353


## Proposed changes

- Changing the `selectionBorderBrush `to use `SystemColors.ControlDarkDark` instead of  `Color.Transparent` as backcolor

<!-- We are in TELL-MODE the following section must be completed -->

## Regression? 

-   No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
The selected control has a dashed border in the DemoConsole application.
![image](https://github.com/dotnet/winforms/assets/132890443/896451eb-07f5-40b2-856e-333437643ed3)

### After
The selected control should have a solid border in the DemoConsole application.
![image](https://github.com/dotnet/winforms/assets/132890443/2ab3cf52-a6f8-42d9-8465-cfe4a45c04a4)

## Test methodology <!-- How did you ensure quality? -->

- Manually


## Test environment(s) <!-- Remove any that don't apply -->

- .net 9.0.0-preview.5.24258.12


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11362)