### PR TITLE
fix winforms-designer/issues/2707  The comboBox incorrect display on form designer when setting its DropDownStyle as Simple after building the project

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.cs
@@ -119,7 +119,7 @@ public partial class ComboBox : ListControl
                  ControlStyles.UseTextForAccessibility |
                  ControlStyles.StandardClick, false);
 
-        _requestedHeight = DefaultSimpleStyleHeight;
+        _requestedHeight = ScaleHelper.ScaleToInitialSystemDpi(DefaultSimpleStyleHeight);
 
         // this class overrides GetPreferredSizeCore, let Control automatically cache the result
         SetExtendedState(ExtendedStates.UserPreferredSizeCache, true);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.cs
@@ -3333,8 +3333,7 @@ public partial class ComboBox : ListControl
     {
         // If we are changing height, store the requested height.
         // Requested height is used if the style is changed to simple.
-        // (
-        if ((specified & BoundsSpecified.Height) != BoundsSpecified.None)
+        if ((specified & BoundsSpecified.Height) != BoundsSpecified.None && DropDownStyle == ComboBoxStyle.Simple)
         {
             _requestedHeight = height;
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
@@ -2645,6 +2645,7 @@ public class ComboBoxTests
 
         comboBox.DropDownStyle = ComboBoxStyle.Simple;
 
+        comboBox.DropDownStyle.Should().Be(ComboBoxStyle.Simple);
         handleCreatedInvoked.Should().Be(2);
     }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
@@ -2631,7 +2631,7 @@ public class ComboBoxTests
     [WinFormsFact]
     public void ComboBox_CorrectHeightAfterSetDropDownStyleSimple()
     {
-        using ComboBox comboBox = new ComboBox();
+        using ComboBox comboBox = new();
 
         int handleCreatedInvoked = 0;
         comboBox.HandleCreated += (s, e) =>

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
@@ -2627,6 +2627,27 @@ public class ComboBoxTests
         control.SelectionLength.Should().Be(control.Text.Length);
     }
 
+    // Unit test for https://github.com/microsoft/winforms-designer/issues/2707
+    [WinFormsFact]
+    public void ComboBox_CorrectHeightAfterSetDropDownStyleSimple()
+    {
+        using ComboBox comboBox = new ComboBox();
+
+        int handleCreatedInvoked = 0;
+        comboBox.HandleCreated += (s, e) =>
+        {
+            handleCreatedInvoked++;
+        };
+
+        comboBox.CreateControl();
+
+        comboBox.DropDownStyle.Should().Be(ComboBoxStyle.DropDown);
+
+        comboBox.DropDownStyle = ComboBoxStyle.Simple;
+
+        handleCreatedInvoked.Should().Be(2);
+    }
+
     private void InitializeItems(ComboBox comboBox, int numItems)
     {
         for (int i = 0; i < numItems; i++)

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
@@ -2648,6 +2648,7 @@ public class ComboBoxTests
 
         comboBox.DropDownStyle = ComboBoxStyle.Simple;
 
+        // DefaultSimpleStyleHeight is 150 in ComboBox class
         comboBox.Height.Should().Be(150);
         comboBox.DropDownStyle.Should().Be(ComboBoxStyle.Simple);
         handleCreatedInvoked.Should().Be(2);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
@@ -2639,12 +2639,16 @@ public class ComboBoxTests
             handleCreatedInvoked++;
         };
 
+        comboBox.Height.Should().Be(23);
+
         comboBox.CreateControl();
 
+        comboBox.Height.Should().Be(23);
         comboBox.DropDownStyle.Should().Be(ComboBoxStyle.DropDown);
 
         comboBox.DropDownStyle = ComboBoxStyle.Simple;
 
+        comboBox.Height.Should().Be(150);
         comboBox.DropDownStyle.Should().Be(ComboBoxStyle.Simple);
         handleCreatedInvoked.Should().Be(2);
     }


### PR DESCRIPTION
Fixes [designer/issues/2707](https://github.com/microsoft/winforms-designer/issues/2707)

## Root Cause

We use `_requestedHeight` to set the height of a ComboBox when `DropDownStyle` is `ComboBoxStyle.Simple`

https://github.com/dotnet/winforms/blob/70a6a7b4a9af452160e636838f946b3f4327383c/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.cs#L61-L63

Let's go through the repro steps that was described here https://github.com/microsoft/winforms-designer/issues/2707#issuecomment-799222994



The following steps also can repro this issue:

1. Create a Winforms .Net Core project with a ComboBox
2. Close and reopen form designer
3. Set the DropDownStyle of comboBox as Simple

Step I : Create a Winforms .Net Core project with a ComboBox

I think this is the generated code
``` c#
        private void InitializeComponent()
        {
            comboBox1 = new ComboBox();
            SuspendLayout();
            // 
            // comboBox1
            // 
            comboBox1.FormattingEnabled = true;
            comboBox1.Location = new Point(44, 71);
            comboBox1.Name = "comboBox1";
            comboBox1.Size = new Size(121, 23);
            comboBox1.TabIndex = 0;
```
Step II: Close and reopen form designer
First ComboBox constrictor will be invoked 

https://github.com/dotnet/winforms/blob/70a6a7b4a9af452160e636838f946b3f4327383c/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.cs#L116-L126

`_requestedHeight` will be assigned to `DefaultSimpleStyleHeight`, which is 150.

https://github.com/dotnet/winforms/blob/70a6a7b4a9af452160e636838f946b3f4327383c/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.cs#L47

then `comboBox1.Size = new Size(121, 23);` will be executed, which will involve `SetBoundsCore` method

https://github.com/dotnet/winforms/blob/70a6a7b4a9af452160e636838f946b3f4327383c/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.cs#L3371-L3382

then height(23) will be assigned to `_requestedHeight`.

Step III: Set the DropDownStyle of comboBox as Simple

please see line 1170-1173

https://github.com/dotnet/winforms/blob/70a6a7b4a9af452160e636838f946b3f4327383c/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.cs#L1135-L1177

So step 3 will trigger HandleRecreate.
please see line 2435-2438, so eventually `SetBoundsCore` method will be triggered. And `_requestedHeight`(23)  will be assigned to `Height`


https://github.com/dotnet/winforms/blob/70a6a7b4a9af452160e636838f946b3f4327383c/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.cs#L2380-L2469

So the parameter  height here is 23, which is supposed to be 150.

https://github.com/dotnet/winforms/blob/70a6a7b4a9af452160e636838f946b3f4327383c/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.cs#L3371-L3382


## Proposed changes

- 
- Add a condition when `_requestedHeight` is assigned.
- 

## Before

![Core](https://user-images.githubusercontent.com/62929087/103183314-8a9da100-48ec-11eb-822f-e15e03bdbf06.gif)

## After

https://github.com/dotnet/winforms/assets/135201996/aaef3b5d-2ca0-4722-bbe1-f4b643eb7e1a



## Test methodology 

- 
- manually (build the binaries and copy System.windows.forms.dll to the program files\dotnet\shared)
- 

