### PR TITLE
Fix no recent activity label in pull requests

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -135,6 +135,8 @@ configuration:
       - not:
           isAction:
             action: Closed
+      - isActivitySender:
+          issueAuthor: True
       - hasLabel:
           label: ':zzz: no-recent-activity'
       then:


### PR DESCRIPTION
Attempts to fix 'Remove no recent activity label from pull requests' action from dotnet-policy-service as any activity on it currently removes the label. This copies the same conditions that are on remove waiting for author feedback label
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11372)