### PR TITLE
Add test coverage for ListView

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
@@ -5919,4 +5919,51 @@ public class ListViewTests
 
         return listView;
     }
+
+    public class TestListView : ListView
+    {
+        public void InvokeOnRightToLeftLayoutChanged(EventArgs e)
+        {
+            base.OnRightToLeftLayoutChanged(e);
+        }
+    }
+
+    [WinFormsFact]
+    public void ListView_RightToLeftLayoutChanged_AddRemove_Success()
+    {
+        var listView = new TestListView();
+        int callCount = 0;
+        EventHandler handler = (sender, e) =>
+        {
+            Assert.Same(listView, sender);
+            Assert.Same(EventArgs.Empty, e);
+            callCount++;
+        };
+
+        listView.RightToLeftLayoutChanged += handler;
+        listView.RightToLeftLayoutChanged -= handler;
+        Assert.Equal(0, callCount);
+    }
+
+    [WinFormsFact]
+    public void ListView_RightToLeftLayoutChanged_Invoke_Success()
+    {
+        var listView = new TestListView();
+        int callCount = 0;
+        EventHandler handler = (sender, e) =>
+        {
+            Assert.Same(listView, sender);
+            Assert.Same(EventArgs.Empty, e);
+            callCount++;
+        };
+
+        listView.RightToLeftLayoutChanged += handler;
+        listView.InvokeOnRightToLeftLayoutChanged(EventArgs.Empty);
+        Assert.Equal(1, callCount);
+
+        listView.RightToLeftLayoutChanged -= handler;
+        listView.InvokeOnRightToLeftLayoutChanged(EventArgs.Empty);
+        Assert.Equal(1, callCount);
+    }
+
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
@@ -5772,6 +5772,31 @@ public class ListViewTests
         Assert.True(listView.IsHandleCreated);
     }
 
+    [WinFormsFact]
+    public void ListView_RightToLeftLayoutChanged_AddRemove_Invoke_Success()
+    {
+        using SubListView listView = new();
+        int callCount = 0;
+        EventHandler handler = (sender, e) =>
+        {
+            sender.Should().Be(listView);
+            e.Should().Be(EventArgs.Empty);
+            callCount++;
+        };
+
+        listView.RightToLeftLayoutChanged += handler;
+        listView.RightToLeftLayoutChanged -= handler;
+        callCount.Should().Be(0);
+
+        listView.RightToLeftLayoutChanged += handler;
+        listView.OnRightToLeftLayoutChanged(EventArgs.Empty);
+        callCount.Should().Be(1);
+
+        listView.RightToLeftLayoutChanged -= handler;
+        listView.OnRightToLeftLayoutChanged(EventArgs.Empty);
+        callCount.Should().Be(1);
+    }
+
     private class SubListViewItem : ListViewItem
     {
         public AccessibleObject CustomAccessibleObject { get; set; }
@@ -5867,6 +5892,7 @@ public class ListViewTests
         public new void OnGroupCollapsedStateChanged(ListViewGroupEventArgs e) => base.OnGroupCollapsedStateChanged(e);
 
         public new void SetStyle(ControlStyles flag, bool value) => base.SetStyle(flag, value);
+        public new void OnRightToLeftLayoutChanged(EventArgs e) => base.OnRightToLeftLayoutChanged(e);
     }
 
     private SubListView GetSubListViewWithData(View view, bool virtualMode, bool showGroups, bool withinGroup, bool createControl)
@@ -5918,52 +5944,5 @@ public class ListViewTests
         }
 
         return listView;
-    }
-
-    public class TestListView : ListView
-    {
-        public new void OnRightToLeftLayoutChanged(EventArgs e) => base.OnRightToLeftLayoutChanged(e);
-        public void InvokeOnRightToLeftLayoutChanged(EventArgs e)
-        {
-            base.OnRightToLeftLayoutChanged(e);
-        }
-    }
-
-    [WinFormsFact]
-    public void ListView_RightToLeftLayoutChanged_AddRemove_Success()
-    {
-        using TestListView listView = new();
-        int callCount = 0;
-        EventHandler handler = (sender, e) =>
-        {
-            sender.Should().Be(listView);
-            e.Should().Be(EventArgs.Empty);
-            callCount++;
-        };
-
-        listView.RightToLeftLayoutChanged += handler;
-        listView.RightToLeftLayoutChanged -= handler;
-        callCount.Should().Be(0);
-    }
-
-    [WinFormsFact]
-    public void ListView_RightToLeftLayoutChanged_Invoke_Success()
-    {
-        using TestListView listView = new();
-        int callCount = 0;
-        EventHandler handler = (sender, e) =>
-        {
-            sender.Should().Be(listView);
-            e.Should().Be(EventArgs.Empty);
-            callCount++;
-        };
-
-        listView.RightToLeftLayoutChanged += handler;
-        listView.InvokeOnRightToLeftLayoutChanged(EventArgs.Empty);
-        callCount.Should().Be(1);
-
-        listView.RightToLeftLayoutChanged -= handler;
-        listView.InvokeOnRightToLeftLayoutChanged(EventArgs.Empty);
-        callCount.Should().Be(1);
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
@@ -5797,6 +5797,96 @@ public class ListViewTests
         callCount.Should().Be(1);
     }
 
+    [WinFormsFact]
+    public void ListView_TextChanged_AddRemove_Success()
+    {
+        using SubListView listView = new();
+        int callCount = 0;
+        EventHandler handler = (_, _) => callCount++;
+
+        listView.TextChanged += handler;
+        listView.Text = "New Text";
+        callCount.Should().Be(1);
+        listView.Text.Should().Be("New Text");
+
+        listView.TextChanged -= handler;
+        listView.Text = "Another Text";
+        callCount.Should().Be(1);
+        listView.Text.Should().Be("Another Text");
+    }
+
+    [WinFormsFact]
+    public void ListView_AfterLabelEditEvent_AddRemoveEvent()
+    {
+        using SubListView listView = new();
+        int callCount = 0;
+
+        LabelEditEventHandler handler = (sender, e) =>
+        {
+            callCount++;
+        };
+
+        listView.AfterLabelEdit += handler;
+        callCount.Should().Be(0);
+
+        listView.AfterLabelEdit -= handler;
+        callCount.Should().Be(0);
+    }
+
+    [WinFormsFact]
+    public void ListView_BeforeLabelEditEvent_AddRemove_Invoke_CallsBeforeLabelEdit()
+    {
+        using SubListView listView = new();
+        int callCount = 0;
+
+        LabelEditEventHandler handler = (sender, e) =>
+        {
+            sender.Should().BeSameAs(listView);
+            e.Should().NotBeNull();
+            callCount++;
+        };
+
+        listView.BeforeLabelEdit += handler;
+        callCount.Should().Be(0);
+
+        listView.BeforeLabelEdit -= handler;
+        callCount.Should().Be(0);
+
+        listView.BeforeLabelEdit += handler;
+
+        listView.OnBeforeLabelEdit(new LabelEditEventArgs(1));
+        callCount.Should().Be(1);
+
+        listView.BeforeLabelEdit -= handler;
+        listView.OnBeforeLabelEdit(new LabelEditEventArgs(1));
+        callCount.Should().Be(1);
+    }
+
+    [WinFormsFact]
+    public void ListView_CacheVirtualItemsEvent_Test()
+    {
+        using SubListView listView = new();
+        int callCount = 0;
+        CacheVirtualItemsEventHandler handler = (sender, e) =>
+        {
+            callCount.Should().Be(0);
+
+            sender.Should().BeSameAs(listView);
+            e.Should().NotBeNull();
+            callCount++;
+        };
+
+        listView.CacheVirtualItems += handler;
+
+        listView.OnCacheVirtualItems(new CacheVirtualItemsEventArgs(1, 2));
+        callCount.Should().Be(1);
+
+        listView.CacheVirtualItems -= handler;
+
+        listView.OnCacheVirtualItems(new CacheVirtualItemsEventArgs(1, 2));
+        callCount.Should().Be(1);
+    }
+
     private class SubListViewItem : ListViewItem
     {
         public AccessibleObject CustomAccessibleObject { get; set; }
@@ -5892,7 +5982,12 @@ public class ListViewTests
         public new void OnGroupCollapsedStateChanged(ListViewGroupEventArgs e) => base.OnGroupCollapsedStateChanged(e);
 
         public new void SetStyle(ControlStyles flag, bool value) => base.SetStyle(flag, value);
+
         public new void OnRightToLeftLayoutChanged(EventArgs e) => base.OnRightToLeftLayoutChanged(e);
+
+        public new void OnBeforeLabelEdit(LabelEditEventArgs e) => base.OnBeforeLabelEdit(e);
+        
+        public new void OnCacheVirtualItems(CacheVirtualItemsEventArgs e) => base.OnCacheVirtualItems(e);
     }
 
     private SubListView GetSubListViewWithData(View view, bool virtualMode, bool showGroups, bool withinGroup, bool createControl)

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
@@ -5922,6 +5922,7 @@ public class ListViewTests
 
     public class TestListView : ListView
     {
+        public new void OnRightToLeftLayoutChanged(EventArgs e) => base.OnRightToLeftLayoutChanged(e);
         public void InvokeOnRightToLeftLayoutChanged(EventArgs e)
         {
             base.OnRightToLeftLayoutChanged(e);
@@ -5931,39 +5932,38 @@ public class ListViewTests
     [WinFormsFact]
     public void ListView_RightToLeftLayoutChanged_AddRemove_Success()
     {
-        var listView = new TestListView();
+        using TestListView listView = new();
         int callCount = 0;
         EventHandler handler = (sender, e) =>
         {
-            Assert.Same(listView, sender);
-            Assert.Same(EventArgs.Empty, e);
+            sender.Should().Be(listView);
+            e.Should().Be(EventArgs.Empty);
             callCount++;
         };
 
         listView.RightToLeftLayoutChanged += handler;
         listView.RightToLeftLayoutChanged -= handler;
-        Assert.Equal(0, callCount);
+        callCount.Should().Be(0);
     }
 
     [WinFormsFact]
     public void ListView_RightToLeftLayoutChanged_Invoke_Success()
     {
-        var listView = new TestListView();
+        using TestListView listView = new();
         int callCount = 0;
         EventHandler handler = (sender, e) =>
         {
-            Assert.Same(listView, sender);
-            Assert.Same(EventArgs.Empty, e);
+            sender.Should().Be(listView);
+            e.Should().Be(EventArgs.Empty);
             callCount++;
         };
 
         listView.RightToLeftLayoutChanged += handler;
         listView.InvokeOnRightToLeftLayoutChanged(EventArgs.Empty);
-        Assert.Equal(1, callCount);
+        callCount.Should().Be(1);
 
         listView.RightToLeftLayoutChanged -= handler;
         listView.InvokeOnRightToLeftLayoutChanged(EventArgs.Empty);
-        Assert.Equal(1, callCount);
+        callCount.Should().Be(1);
     }
-
 }


### PR DESCRIPTION
Related https://github.com/dotnet/winforms/issues/10453

## Proposed changes

- Add unit tests for ListView to test its events: TextChanged,  AfterLabelEdit,  BeforeLabelEdit,  CacheVirtualItems

<!-- We are in TELL-MODE the following section must be completed -->



 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11377)