### PR TITLE
Add test coverage for ComboBox

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
@@ -315,7 +315,7 @@ public class ComboBoxTests
     }
 
     [WinFormsFact]
-    public void SimplifiedComboBoxTests()
+    public void ComboBox_BeginEndUpdate()
     {
         using ComboBox control1 = new();
         control1.BeginUpdate();
@@ -342,13 +342,13 @@ public class ComboBoxTests
     {
         using ComboBox control = new();
 
-        if (!control.IsHandleCreated)
+        control.IsHandleCreated.Should().BeFalse();
         {
             control.SelectedText.Should().BeEmpty();
         }
 
         control.CreateControl();
-        if (control.IsHandleCreated)
+        control.IsHandleCreated.Should().BeTrue();
         {
             control.SelectedText.Should().BeEmpty();
         }
@@ -361,7 +361,7 @@ public class ComboBoxTests
         }
 
         // Test SetWithoutHandle
-        if (!control.IsHandleCreated)
+        control.CreateControl();
         {
             control.SelectedText = "Test";
             control.SelectedText.Should().BeEmpty();
@@ -373,7 +373,6 @@ public class ComboBoxTests
         control.SelectionStart = 0;
         control.SelectionLength = 7;
         control.CreateControl();
-        if (control.IsHandleCreated)
         {
             control.SelectedText = "Test";
             control.Text.Should().Be("Test");

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
@@ -288,30 +288,30 @@ public class ComboBoxTests
     [WinFormsFact]
     public void VerifyAutoCompleteEntries()
     {
+        void AssertAutoCompleteCustomSource(string[] items, bool isHandleCreated)
+        {
+            using ComboBox control = new();
+
+            if (items is not null)
+            {
+                AutoCompleteStringCollection autoCompleteCustomSource = new();
+                autoCompleteCustomSource.AddRange(items);
+                control.AutoCompleteCustomSource = autoCompleteCustomSource;
+                control.AutoCompleteCustomSource.Should().BeEquivalentTo(autoCompleteCustomSource);
+            }
+            else
+            {
+                control.AutoCompleteCustomSource = null;
+                control.AutoCompleteCustomSource.Should().NotBeNull();
+                control.AutoCompleteCustomSource.Count.Should().Be(0);
+            }
+
+            control.IsHandleCreated.Should().Be(isHandleCreated);
+        }
+
         AssertAutoCompleteCustomSource(new[] { "item1", "item2" }, false);
         AssertAutoCompleteCustomSource(null, false);
         AssertAutoCompleteCustomSource(new[] { "item3", "item4" }, false);
-    }
-
-    private void AssertAutoCompleteCustomSource(string[] items, bool isHandleCreated)
-    {
-        using ComboBox control = new();
-
-        if (items is object)
-        {
-            AutoCompleteStringCollection autoCompleteCustomSource = new();
-            autoCompleteCustomSource.AddRange(items);
-            control.AutoCompleteCustomSource = autoCompleteCustomSource;
-            control.AutoCompleteCustomSource.Should().BeEquivalentTo(autoCompleteCustomSource);
-        }
-        else
-        {
-            control.AutoCompleteCustomSource = null;
-            control.AutoCompleteCustomSource.Should().NotBeNull();
-            control.AutoCompleteCustomSource.Count.Should().Be(0);
-        }
-
-        control.IsHandleCreated.Should().Be(isHandleCreated);
     }
 
     [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
@@ -286,7 +286,7 @@ public class ComboBoxTests
     }
 
     [WinFormsFact]
-    public void TestAutoCompleteCustomSource()
+    public void VerifyAutoCompleteEntries()
     {
         AssertAutoCompleteCustomSource(new[] { "item1", "item2" }, false);
         AssertAutoCompleteCustomSource(null, false);
@@ -319,8 +319,6 @@ public class ComboBoxTests
     {
         using ComboBox control1 = new();
         control1.BeginUpdate();
-        control1.BeginUpdate();
-        control1.EndUpdate();
         control1.EndUpdate();
 
         using ComboBox control2 = new() { AutoCompleteSource = AutoCompleteSource.ListItems };

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
@@ -312,7 +312,6 @@ public class ComboBoxTests
         }
 
         control.IsHandleCreated.Should().Be(isHandleCreated);
-
     }
 
     [WinFormsFact]
@@ -338,7 +337,6 @@ public class ComboBoxTests
         using ComboBox control4 = new();
         Exception exception = Record.Exception(() => control4.EndUpdate());
         exception.Should().BeNull();
-
     }
 
     [WinFormsFact]
@@ -355,7 +353,6 @@ public class ComboBoxTests
         if (control.IsHandleCreated)
         {
             control.SelectedText.Should().BeEmpty();
-
         }
 
         control.DropDownStyle = ComboBoxStyle.DropDownList;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
@@ -285,6 +285,115 @@ public class ComboBoxTests
         Assert.False(property.ShouldSerializeValue(control));
     }
 
+    [WinFormsFact]
+    public void TestAutoCompleteCustomSource()
+    {
+        AssertAutoCompleteCustomSource(new[] { "item1", "item2" }, false);
+        AssertAutoCompleteCustomSource(null, false);
+        AssertAutoCompleteCustomSource(new[] { "item3", "item4" }, false);
+    }
+
+    private void AssertAutoCompleteCustomSource(string[] items, bool isHandleCreated)
+    {
+        using ComboBox control = new();
+
+        if (items is object)
+        {
+            AutoCompleteStringCollection autoCompleteCustomSource = new();
+            autoCompleteCustomSource.AddRange(items);
+            control.AutoCompleteCustomSource = autoCompleteCustomSource;
+            control.AutoCompleteCustomSource.Should().BeEquivalentTo(autoCompleteCustomSource);
+        }
+        else
+        {
+            control.AutoCompleteCustomSource = null;
+            control.AutoCompleteCustomSource.Should().NotBeNull();
+            control.AutoCompleteCustomSource.Count.Should().Be(0);
+        }
+
+        control.IsHandleCreated.Should().Be(isHandleCreated);
+
+    }
+
+    [WinFormsFact]
+    public void SimplifiedComboBoxTests()
+    {
+        using ComboBox control1 = new();
+        control1.BeginUpdate();
+        control1.BeginUpdate();
+        control1.EndUpdate();
+        control1.EndUpdate();
+
+        using ComboBox control2 = new() { AutoCompleteSource = AutoCompleteSource.ListItems };
+        control2.BeginUpdate();
+        control2.EndUpdate();
+        control2.AutoCompleteMode.Should().Be(AutoCompleteMode.None);
+
+        using ComboBox control3 = new();
+        control3.BeginUpdate();
+        control3.CreateControl();
+        control3.EndUpdate();
+        control3.IsHandleCreated.Should().BeTrue();
+
+        using ComboBox control4 = new();
+        Exception exception = Record.Exception(() => control4.EndUpdate());
+        exception.Should().BeNull();
+
+    }
+
+    [WinFormsFact]
+    public void ComboBox_SelectedTextTests()
+    {
+        using ComboBox control = new();
+
+        if (!control.IsHandleCreated)
+        {
+            control.SelectedText.Should().BeEmpty();
+        }
+
+        control.CreateControl();
+        if (control.IsHandleCreated)
+        {
+            control.SelectedText.Should().BeEmpty();
+
+        }
+
+        control.DropDownStyle = ComboBoxStyle.DropDownList;
+        control.CreateControl();
+        if (control.DropDownStyle == ComboBoxStyle.DropDownList)
+        {
+            control.SelectedText.Should().BeEmpty();
+        }
+
+        // Test SetWithoutHandle
+        if (!control.IsHandleCreated)
+        {
+            control.SelectedText = "Test";
+            control.SelectedText.Should().BeEmpty();
+        }
+
+        // Test SetWithHandle
+        control.DropDownStyle = ComboBoxStyle.DropDown;
+        control.Text = "Initial";
+        control.SelectionStart = 0;
+        control.SelectionLength = 7;
+        control.CreateControl();
+        if (control.IsHandleCreated)
+        {
+            control.SelectedText = "Test";
+            control.Text.Should().Be("Test");
+        }
+
+        // Test SetWithDropDownListStyle
+        control.DropDownStyle = ComboBoxStyle.DropDownList;
+        control.CreateControl();
+        if (control.DropDownStyle == ComboBoxStyle.DropDownList)
+        {
+            control.SelectedText = "Test";
+            control.SelectedText.Should().BeEmpty();
+        }
+    }
+
     [WinFormsTheory]
     [CommonMemberData(typeof(CommonTestHelperEx), nameof(CommonTestHelperEx.GetImageTheoryData))]
     public void ComboBox_BackgroundImage_Set_GetReturnsExpected(Image value)


### PR DESCRIPTION
Related https://github.com/dotnet/winforms/issues/10453


## Proposed changes

- Add unit tests for ComboBox to test its properties: AutoCompleteCustomSource, SelectedText
- Add unit test for stability and reliability of ComboBox in EndUpdate and BeginUpdate settings


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11381)