### PR TITLE
Add test coverage for CheckedListBox.CheckedItemCollection and CheckedIndexCollection

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CheckedListBox.CheckedIndexCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CheckedListBox.CheckedIndexCollectionTests.cs
@@ -52,32 +52,49 @@ public class CheckedListBox_CheckedIndexCollectionTests: IDisposable
     }
 
     [WinFormsTheory]
-    [InlineData([new string[] { "item1", "item2" }, new bool[] { true, false }, 0, true])]
-    [InlineData([new string[] { "item1", "item2" }, new bool[] { true, false }, 1, false])]
-    [InlineData([new string[] { "item1", "item2" }, new bool[] { false, false }, 0, false])]
-    public void CheckedIndexCollection_Contains_ReturnsExpected(string[] items, bool[] checkedStatus, int index, bool expected)
+    [InlineData(new string[] { "item1", "item2", "item3" }, new bool[] { true, false, true }, 0, true)]
+    [InlineData(new string[] { "item1", "item2", "item3" }, new bool[] { true, false, true }, 1, false)]
+    [InlineData(new string[] { "item1", "item2", "item3" }, new bool[] { false, true, false }, 1, true)]
+    [InlineData(new string[] { "item1", "item2", "item3" }, new bool[] { false, false, false }, 0, false)]
+    [InlineData(new string[] { "item1", "item2", "item3" }, new bool[] { true, false, true }, "invalid", false)]
+    public void CheckedIndexCollection_ContainsIntAndObject_ReturnsExpected(string[] items, bool[] checkedStates, object index, bool expected)
     {
         for (int i = 0; i < items.Length; i++)
         {
-            _checkedListBox.Items.Add(items[i], checkedStatus[i]);
+            _checkedListBox.Items.Add(items[i], checkedStates[i]);
         }
 
-        // Test Contains method
-        _collection.Contains(index).Should().Be(expected);
+        // Test Contains(int index) method
+        if (index is int indexAsInt)
+        {
+            _collection.Contains(indexAsInt).Should().Be(expected);
+        }
+
+        // Test IList.Contains(object? index) method
         ((IList)_collection).Contains(index).Should().Be(expected);
     }
 
     [WinFormsTheory]
-    [InlineData(true, 0)]
-    [InlineData(false, -1)]
-    public void CheckedIndexCollection_IndexOf_ReturnsExpected(bool isChecked, int expectedIndex)
+    [InlineData(new string[] { "item1", "item2", "item3" }, new bool[] { true, false, true }, 0, 0)]
+    [InlineData(new string[] { "item1", "item2", "item3" }, new bool[] { true, false, true }, 1, -1)]
+    [InlineData(new string[] { "item1", "item2", "item3" }, new bool[] { false, true, false }, 1, 0)]
+    [InlineData(new string[] { "item1", "item2", "item3" }, new bool[] { false, false, false }, 0, -1)]
+    [InlineData(new string[] { "item1", "item2", "item3" }, new bool[] { true, false, true }, "invalid", -1)]
+    public void CheckedIndexCollection_IndexOfIntAndObject_ReturnsExpected(string[] items, bool[] checkedStates, object index, int expected)
     {
-        _checkedListBox.Items.Add("item1", isChecked);
+        for (int i = 0; i < items.Length; i++)
+        {
+            _checkedListBox.Items.Add(items[i], checkedStates[i]);
+        }
 
-        // Test IndexOf method
-        _collection.IndexOf(0).Should().Be(expectedIndex);
-        ((IList)_collection).IndexOf(0).Should().Be(expectedIndex);
-        ((IList)_collection).IndexOf("invalid").Should().Be(-1);
+        // Test IndexOf(int index) method
+        if (index is int indexAsInt)
+        {
+            _collection.IndexOf(indexAsInt).Should().Be(expected);
+        }
+
+        // Test IList.IndexOf(object? index) method
+        ((IList)_collection).IndexOf(index).Should().Be(expected);
     }
 
     [WinFormsTheory]
@@ -121,5 +138,20 @@ public class CheckedListBox_CheckedIndexCollectionTests: IDisposable
         }
 
         enumerator.MoveNext().Should().BeFalse();
+    }
+
+    [WinFormsTheory]
+    [InlineData(new string[] { "item1", "item2", "item3" }, new bool[] { true, false, true }, 0, 0)]
+    [InlineData(new string[] { "item1", "item2", "item3" }, new bool[] { true, false, true }, 1, 2)]
+    [InlineData(new string[] { "item1", "item2", "item3" }, new bool[] { false, true, false }, 0, 1)]
+    public void CheckedIndexCollection_ItemGet_ReturnsExpected(string[] items, bool[] checkedStates, int index, int expected)
+    {
+        for (int i = 0; i < items.Length; i++)
+        {
+            _checkedListBox.Items.Add(items[i], checkedStates[i]);
+        }
+
+        int result = (int)((IList)_collection)[index];
+        result.Should().Be(expected);
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CheckedListBox.CheckedItemCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CheckedListBox.CheckedItemCollectionTests.cs
@@ -1,0 +1,123 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections;
+
+namespace System.Windows.Forms.Tests;
+
+public class CheckedListBox_CheckedItemCollectionTests : IDisposable
+{
+    private readonly CheckedListBox _checkedListBox;
+    private readonly CheckedListBox.CheckedItemCollection _collection;
+
+    public CheckedListBox_CheckedItemCollectionTests()
+    {
+        _checkedListBox = new CheckedListBox();
+        _collection = new CheckedListBox.CheckedItemCollection(_checkedListBox);
+    }
+
+    public void Dispose()
+    {
+        _checkedListBox.Items.Clear();
+        _checkedListBox.Dispose();
+    }
+
+    [WinFormsFact]
+    public void CheckedItemCollection_Properties_ReturnExpected()
+    {
+        // Test properties: Count, SyncRoot, IsSynchronized, IsFixedSize, IsReadOnly
+        _collection.Count.Should().Be(0);
+        ((ICollection)_collection).SyncRoot.Should().BeSameAs(_collection);
+        ((ICollection)_collection).IsSynchronized.Should().BeFalse();
+        ((IList)_collection).IsFixedSize.Should().BeTrue();
+        _collection.IsReadOnly.Should().BeTrue();
+    }
+
+    [WinFormsFact]
+    public void CheckedItemCollection_Methods_ThrowNotSupportedException()
+    {
+        // Test methods: Add, Clear, Insert, Remove, RemoveAt that should throw NotSupportedException
+        ((Action)(() => ((IList)_collection)[0] = 1)).Should().Throw<NotSupportedException>();
+        ((IList)_collection).Invoking(c => c.Add(1)).Should().Throw<NotSupportedException>();
+        ((IList)_collection).Invoking(c => c.Clear()).Should().Throw<NotSupportedException>();
+        ((IList)_collection).Invoking(c => c.Insert(0, 1)).Should().Throw<NotSupportedException>();
+        ((IList)_collection).Invoking(c => c.Remove(1)).Should().Throw<NotSupportedException>();
+        ((IList)_collection).Invoking(c => c.RemoveAt(0)).Should().Throw<NotSupportedException>();
+    }
+
+    [WinFormsFact]
+    public void CheckedItemCollection_ItemGet_ReturnsExpected()
+    {
+        _checkedListBox.Items.Add("item1", true);
+        _checkedListBox.Items.Add("item2", false);
+
+        _collection.Count.Should().Be(1);
+        _collection[0].Should().Be("item1");
+    }
+
+    [WinFormsTheory]
+    [InlineData(new string[] { "item1", "item2" }, new bool[] { true, false }, "item1", true)]
+    [InlineData(new string[] { "item1", "item2" }, new bool[] { false, true }, "item2", true)]
+    [InlineData(new string[] { "item1", "item2" }, new bool[] { false, false }, "item1", false)]
+    public void CheckedItemCollection_Contains_ReturnsExpected(string[] items, bool[] checkedStates, string item, bool expected)
+    {
+        for (int i = 0; i < items.Length; i++)
+        {
+            _checkedListBox.Items.Add(items[i], checkedStates[i]);
+        }
+
+        _collection.Contains(item).Should().Be(expected);
+    }
+
+    [WinFormsTheory]
+    [InlineData(new string[] { "item1", "item2" }, new bool[] { true, false }, "item1", 0)]
+    [InlineData(new string[] { "item1", "item2" }, new bool[] { false, true }, "item2", 0)]
+    [InlineData(new string[] { "item1", "item2" }, new bool[] { false, false }, "item1", -1)]
+    public void CheckedItemCollection_IndexOf_ReturnsExpected(string[] items, bool[] checkedStates, string item, int expected)
+    {
+        for (int i = 0; i < items.Length; i++)
+        {
+            _checkedListBox.Items.Add(items[i], checkedStates[i]);
+        }
+
+        _collection.IndexOf(item).Should().Be(expected);
+    }
+
+    [WinFormsTheory]
+    [InlineData(new string[] { "item1", "item2" }, new bool[] { true, false }, new object[] { "item1", null })]
+    [InlineData(new string[] { "item1", "item2" }, new bool[] { false, true }, new object[] { "item2", null })]
+    [InlineData(new string[] { "item1", "item2" }, new bool[] { false, false }, new object[] { null, null })]
+    public void CheckedItemCollection_CopyTo_CopiesExpectedValues(string[] items, bool[] checkedStates, object[] expected)
+    {
+        for (int i = 0; i < items.Length; i++)
+        {
+            _checkedListBox.Items.Add(items[i], checkedStates[i]);
+        }
+
+        object[] array = new object[items.Length];
+        ((ICollection)_collection).CopyTo(array, 0);
+
+        array.Should().Equal(expected);
+    }
+
+    [WinFormsTheory]
+    [InlineData(new object[] { "item1", "item2", "item3" }, new bool[] { true, false, true }, new object[] { "item1", "item3" })]
+    [InlineData(new object[] { "item1", "item2", "item3" }, new bool[] { false, true, false }, new object[] { "item2" })]
+    [InlineData(new object[] { "item1", "item2", "item3" }, new bool[] { false, false, false }, new object[] { })]
+    public void CheckedItemCollection_GetEnumerator_ReturnsExpected(object[] items, bool[] checkedStates, object[] expected)
+    {
+        for (int i = 0; i < items.Length; i++)
+        {
+            _checkedListBox.Items.Add(items[i], checkedStates[i]);
+        }
+
+        IEnumerator enumerator = _collection.GetEnumerator();
+        List<object> result = new List<object>();
+        while (enumerator.MoveNext())
+        {
+            result.Add(enumerator.Current);
+        }
+
+        result.Should().Equal(expected);
+    }
+}


### PR DESCRIPTION
Related https://github.com/dotnet/winforms/issues/10453


## Proposed changes

-  Add unit tests for CheckedListBox.CheckedItemCollection  to test its properties: SyncRoot, IsSynchronized, IsFixedSize, IsReadOnly
- Add unit tests for CheckedListBox.CheckedItemCollection to test its methods: Add, Clear, Insert, Remove, RemoveAt, Contains, IndexOf, CopyTo, GetEnumerator
- Update unit tests for CheckedListBox.CheckedIndexCollection to test its methods: Contains, IndexOf

