### PR TITLE
Fix refactoring in tooltips

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip/ToolTip.cs
@@ -1498,20 +1498,10 @@ public partial class ToolTip : Component, IExtenderProvider, IHandle<HWND>
             pointY = optimalPoint.Y;
 
             // Update TipInfo for the tool with optimal position.
-            if (tool is Control toolAsControl)
+            if ((tool is Control toolAsControl && _tools.TryGetValue(toolAsControl, out TipInfo? tipInfo)) ||
+                (ownerWindow is Control ownerWindowAsControl && _tools.TryGetValue(ownerWindowAsControl, out tipInfo)))
             {
-                if (!_tools.TryGetValue(toolAsControl, out TipInfo? tipInfo))
-                {
-                    if (ownerWindow is Control ownerWindowAsControl
-                        && _tools.TryGetValue(ownerWindowAsControl, out tipInfo))
-                    {
-                        tipInfo.Position = new Point(pointX, pointY);
-                    }
-                }
-                else
-                {
-                    tipInfo.Position = new Point(pointX, pointY);
-                }
+                tipInfo.Position = new Point(pointX, pointY);
             }
 
             // Ensure that the tooltip bubble is moved to the optimal position even when a mouse tooltip is being replaced with a keyboard tooltip.


### PR DESCRIPTION
Introduced in  https://github.com/dotnet/winforms/commit/ca1199eb6cfaf8ecd26ee429761764ea264dd2f5 -

Tooltip owner window is used for tooltip placement when tool is not a control, this is the case of ToolStripItems.


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11388)