### PR TITLE
Disable test Button_Press_Enter_Fires_OnClickAsync and enable Button_PerformClick_Fires_OnClickAsync

### DIFF
--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/ButtonTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/ButtonTests.cs
@@ -311,10 +311,7 @@ public class ButtonTests : ControlTestBase
         });
     }
 
-    [ActiveIssue("https://github.com/dotnet/winforms/issues/11327")]
     [WinFormsFact]
-    [SkipOnArchitecture(TestArchitectures.X64,
-       "Flaky tests, see: https://github.com/dotnet/winforms/issues/11327")]
     public async Task Button_PerformClick_Fires_OnClickAsync()
     {
         await RunTestAsync((form, button) =>
@@ -330,7 +327,10 @@ public class ButtonTests : ControlTestBase
         });
     }
 
+    [ActiveIssue("https://github.com/dotnet/winforms/issues/11327")]
     [WinFormsFact]
+    [SkipOnArchitecture(TestArchitectures.X64,
+       "Flaky tests, see: https://github.com/dotnet/winforms/issues/11327")]
     public async Task Button_Press_Enter_Fires_OnClickAsync()
     {
         await RunTestAsync(async (form, button) =>


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Related #11327


## Proposed changes

- Add tag `SkipOnArchitecture `to test case `Button_Press_Enter_Fires_OnClickAsync ` and remove wrongly added tag on test `Button_PerformClick_Fires_OnClickAsync`

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11395) 