### PR TITLE
Add test coverage for TrackBar Accessible Object

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/TrackBar.TrackBarAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/TrackBar.TrackBarAccessibleObjectTests.cs
@@ -493,4 +493,49 @@ public class TrackBarAccessibleObjectTests
 
         return trackBar;
     }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("Test Default Action")]
+    public void TrackBarAccessibleObject_DefaultAction_ReturnsExpected(string accessibleDefaultActionDescription)
+    {
+        using TrackBar trackBar = new();
+        trackBar.CreateControl();
+        TrackBar.TrackBarAccessibleObject accessibleObject = (TrackBar.TrackBarAccessibleObject)trackBar.AccessibilityObject;
+
+        trackBar.AccessibleDefaultActionDescription = accessibleDefaultActionDescription;
+
+        accessibleObject.DefaultAction.Should().Be(accessibleDefaultActionDescription);
+    }
+
+    [Fact]
+    public void TrackBarAccessibleObject_DefaultAction_ThrowsArgumentNullException_IfOwnerNotSet()
+    {
+        Assert.Throws<ArgumentNullException>(() => new TrackBar.TrackBarAccessibleObject(null));
+    }
+
+    [Fact]
+    public void TrackBarAccessibleObject_HitTest_ReturnsExpected()
+    {
+        using TrackBar trackBar = new();
+        trackBar.CreateControl();
+        TrackBar.TrackBarAccessibleObject accessibleObject = (TrackBar.TrackBarAccessibleObject)trackBar.AccessibilityObject;
+
+        Point pointInThumb = new Point(accessibleObject.ThumbAccessibleObject.Bounds.X + 1, accessibleObject.ThumbAccessibleObject.Bounds.Y + 1);
+        accessibleObject.HitTest(pointInThumb.X, pointInThumb.Y).Should().Be(accessibleObject.ThumbAccessibleObject);
+
+        if (accessibleObject.FirstButtonAccessibleObject?.IsDisplayed ?? false)
+        {
+            Point pointInFirstButton = new Point(accessibleObject.FirstButtonAccessibleObject.Bounds.X + 1, accessibleObject.FirstButtonAccessibleObject.Bounds.Y + 1);
+            accessibleObject.HitTest(pointInFirstButton.X, pointInFirstButton.Y).Should().Be(accessibleObject.FirstButtonAccessibleObject);
+        }
+
+        if (accessibleObject.LastButtonAccessibleObject?.IsDisplayed ?? false)
+        {
+            Point pointInLastButton = new Point(accessibleObject.LastButtonAccessibleObject.Bounds.X + 1, accessibleObject.LastButtonAccessibleObject.Bounds.Y + 1);
+            accessibleObject.HitTest(pointInLastButton.X, pointInLastButton.Y).Should().Be(accessibleObject.LastButtonAccessibleObject);
+        }
+
+        accessibleObject.HitTest(-1, -1).Should().BeNull();
+    }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/TrackBar.TrackBarAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/TrackBar.TrackBarAccessibleObjectTests.cs
@@ -494,7 +494,7 @@ public class TrackBarAccessibleObjectTests
         return trackBar;
     }
 
-    [Theory]
+    [WinFormsTheory]
     [InlineData(null)]
     [InlineData("Test Default Action")]
     public void TrackBarAccessibleObject_DefaultAction_ReturnsExpected(string accessibleDefaultActionDescription)
@@ -508,13 +508,13 @@ public class TrackBarAccessibleObjectTests
         accessibleObject.DefaultAction.Should().Be(accessibleDefaultActionDescription);
     }
 
-    [Fact]
+    [WinFormsFact]
     public void TrackBarAccessibleObject_DefaultAction_ThrowsArgumentNullException_IfOwnerNotSet()
     {
         Assert.Throws<ArgumentNullException>(() => new TrackBar.TrackBarAccessibleObject(null));
     }
 
-    [Fact]
+    [WinFormsFact]
     public void TrackBarAccessibleObject_HitTest_ReturnsExpected()
     {
         using TrackBar trackBar = new();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/TrackBar.TrackBarChildAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/TrackBar.TrackBarChildAccessibleObjectTests.cs
@@ -107,7 +107,7 @@ public class TrackBar_TrackBarChildAccessibleObjectTests
         { }
     }
 
-    [Fact]
+    [WinFormsFact]
     public void TrackBarChildAccessibleObject_Role_ReturnsExpected()
     {
         using TrackBar control = new();
@@ -115,7 +115,7 @@ public class TrackBar_TrackBarChildAccessibleObjectTests
         accessibleObject.Role.Should().Be(AccessibleRole.None);
     }
 
-    [Fact]
+    [WinFormsFact]
     public void TrackBarChildAccessibleObject_State_ReturnsExpected()
     {
         using TrackBar control = new();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/TrackBar.TrackBarChildAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/TrackBar.TrackBarChildAccessibleObjectTests.cs
@@ -106,4 +106,22 @@ public class TrackBar_TrackBarChildAccessibleObjectTests
         public SubTrackBarChildAccessibleObject(TrackBar owningTrackBar) : base(owningTrackBar)
         { }
     }
+
+    [Fact]
+    public void TrackBarChildAccessibleObject_Role_ReturnsExpected()
+    {
+        using TrackBar control = new();
+        var accessibleObject = new SubTrackBarChildAccessibleObject(control);
+        accessibleObject.Role.Should().Be(AccessibleRole.None);
+    }
+
+    [Fact]
+    public void TrackBarChildAccessibleObject_State_ReturnsExpected()
+    {
+        using TrackBar control = new();
+        var accessibleObject = new SubTrackBarChildAccessibleObject(control);
+
+        accessibleObject.State.Should().Be(AccessibleStates.None);
+        control.IsHandleCreated.Should().BeFalse();
+    }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/TrackBar.TrackBarFirstButtonAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/TrackBar.TrackBarFirstButtonAccessibleObjectTests.cs
@@ -397,4 +397,30 @@ public class TrackBar_TrackBarFirstButtonAccessibleObjectTests
 
         return trackBarAccessibleObject.FirstButtonAccessibleObject;
     }
+
+    [WinFormsTheory]
+    [InlineData(Orientation.Horizontal, RightToLeft.No, false)]
+    [InlineData(Orientation.Horizontal, RightToLeft.Yes, true)]
+    public void TrackBarFirstButtonAccessibleObject_Name_ReturnsDecreaseName_IfHorizontalAndNotMirrored(Orientation orientation, RightToLeft rightToLeft, bool rightToLeftLayout)
+    {
+        using TrackBar control = GetTrackBar(orientation, rightToLeft, rightToLeftLayout, true, 5, 0, 10);
+        var accessibleObject = GetTrackBarFirstButton(control);
+
+        accessibleObject.Name.Should().Be(SR.TrackBarLargeDecreaseButtonName);
+        control.IsHandleCreated.Should().BeTrue();
+    }
+
+    [WinFormsTheory]
+    [InlineData(Orientation.Vertical, RightToLeft.Yes, true)]
+    [InlineData(Orientation.Vertical, RightToLeft.Yes, false)]
+    [InlineData(Orientation.Vertical, RightToLeft.No, true)]
+    [InlineData(Orientation.Vertical, RightToLeft.No, false)]
+    public void TrackBarFirstButtonAccessibleObject_Name_ReturnsIncreaseName_IfVertical(Orientation orientation, RightToLeft rightToLeft, bool rightToLeftLayout)
+    {
+        using TrackBar control = GetTrackBar(orientation, rightToLeft, rightToLeftLayout, true, 5, 0, 10);
+        var accessibleObject = GetTrackBarFirstButton(control);
+
+        accessibleObject.Name.Should().Be(SR.TrackBarLargeIncreaseButtonName);
+        control.IsHandleCreated.Should().BeTrue();
+    }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Related https://github.com/dotnet/winforms/issues/10453


## Proposed changes

- Add unit test for TrackBar Accessible Object in three files: TrackBarAccessibleObjectTests, TrackBarChildAccessibleObjectTests, TrackBarFirstButtonAccessibleObjectTests
- Test TrackBarAccessibleObjectTests method and property: HitTest, DefaultAction
- Test TrackBarChildAccessibleObjectTests properties: Role, State
- Test TrackBarFirstButtonAccessibleObjectTests property: Name
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11397)