### PR TITLE
Minor changes in the Clipboard code

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/Clipboard.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/Clipboard.cs
@@ -22,8 +22,8 @@ public static class Clipboard
     /// <summary>
     ///  Overload that uses default values for retryTimes and retryDelay.
     /// </summary>
-    public static void SetDataObject(object data, bool copy)
-        => SetDataObject(data, copy, retryTimes: 10, retryDelay: 100);
+    public static void SetDataObject(object data, bool copy) =>
+        SetDataObject(data, copy, retryTimes: 10, retryDelay: 100);
 
     /// <summary>
     ///  Places data on the system <see cref="Clipboard"/> and uses copy to specify whether the data
@@ -144,8 +144,8 @@ public static class Clipboard
 
         // We did not place the data on the clipboard. Fall back to old behavior.
         return dataObject is IDataObject ido && !Marshal.IsComObject(dataObject)
-                ? ido
-                : new DataObject(dataObject);
+            ? ido
+            : new DataObject(dataObject);
     }
 
     /// <summary>
@@ -162,12 +162,11 @@ public static class Clipboard
     ///  Indicates whether there is data on the Clipboard that is in the specified format
     ///  or can be converted to that format.
     /// </summary>
-    public static bool ContainsData(string? format)
-        => !string.IsNullOrWhiteSpace(format) && ContainsData(format, autoConvert: false);
+    public static bool ContainsData(string? format) =>
+        !string.IsNullOrWhiteSpace(format) && ContainsData(format, autoConvert: false);
 
     private static bool ContainsData(string format, bool autoConvert) =>
-        GetDataObject() is { } dataObject
-        && dataObject.GetDataPresent(format, autoConvert: autoConvert);
+        GetDataObject() is { } dataObject && dataObject.GetDataPresent(format, autoConvert: autoConvert);
 
     /// <summary>
     ///  Indicates whether there is data on the Clipboard that is in the <see cref="DataFormats.FileDrop"/> format
@@ -197,21 +196,21 @@ public static class Clipboard
     }
 
     /// <summary>
-    ///  Retrieves an audio stream from the Clipboard.
+    ///  Retrieves an audio stream from the <see cref="Clipboard"/>.
     /// </summary>
     public static Stream? GetAudioStream() => GetData(DataFormats.WaveAudioConstant) as Stream;
 
     /// <summary>
-    ///  Retrieves data from the Clipboard in the specified format.
+    ///  Retrieves data from the <see cref="Clipboard"/> in the specified format.
     /// </summary>
-    public static object? GetData(string format)
-        => string.IsNullOrWhiteSpace(format) ? null : GetData(format, autoConvert: false);
+    public static object? GetData(string format) =>
+        string.IsNullOrWhiteSpace(format) ? null : GetData(format, autoConvert: false);
 
-    private static object? GetData(string format, bool autoConvert)
-        => GetDataObject() is { } dataObject ? dataObject.GetData(format, autoConvert) : null;
+    private static object? GetData(string format, bool autoConvert) =>
+        GetDataObject() is { } dataObject ? dataObject.GetData(format, autoConvert) : null;
 
     /// <summary>
-    ///  Retrieves a collection of file names from the Clipboard.
+    ///  Retrieves a collection of file names from the <see cref="Clipboard"/>.
     /// </summary>
     public static StringCollection GetFileDropList()
     {
@@ -226,17 +225,17 @@ public static class Clipboard
     }
 
     /// <summary>
-    ///  Retrieves an image from the Clipboard.
+    ///  Retrieves an image from the <see cref="Clipboard"/>.
     /// </summary>
     public static Image? GetImage() => GetData(DataFormats.Bitmap, autoConvert: true) as Image;
 
     /// <summary>
-    ///  Retrieves text data from the Clipboard in the <see cref="TextDataFormat.UnicodeText"/> format.
+    ///  Retrieves text data from the <see cref="Clipboard"/> in the <see cref="TextDataFormat.UnicodeText"/> format.
     /// </summary>
     public static string GetText() => GetText(TextDataFormat.UnicodeText);
 
     /// <summary>
-    ///  Retrieves text data from the Clipboard in the format indicated by the specified
+    ///  Retrieves text data from the <see cref="Clipboard"/> in the format indicated by the specified
     ///  <see cref="TextDataFormat"/> value.
     /// </summary>
     public static string GetText(TextDataFormat format)
@@ -246,15 +245,15 @@ public static class Clipboard
     }
 
     /// <summary>
-    ///  Clears the Clipboard and then adds data in the <see cref="DataFormats.WaveAudio"/> format.
+    ///  Clears the <see cref="Clipboard"/> and then adds data in the <see cref="DataFormats.WaveAudio"/> format.
     /// </summary>
     public static void SetAudio(byte[] audioBytes) => SetAudio(new MemoryStream(audioBytes.OrThrowIfNull()));
 
     /// <summary>
-    ///  Clears the Clipboard and then adds data in the <see cref="DataFormats.WaveAudio"/> format.
+    ///  Clears the <see cref="Clipboard"/> and then adds data in the <see cref="DataFormats.WaveAudio"/> format.
     /// </summary>
-    public static void SetAudio(Stream audioStream)
-        => SetDataObject(new DataObject(DataFormats.WaveAudioConstant, audioStream.OrThrowIfNull()), copy: true);
+    public static void SetAudio(Stream audioStream) =>
+        SetDataObject(new DataObject(DataFormats.WaveAudioConstant, audioStream.OrThrowIfNull()), copy: true);
 
     /// <summary>
     ///  Clears the Clipboard and then adds data in the specified format.
@@ -299,8 +298,8 @@ public static class Clipboard
     /// <summary>
     ///  Clears the Clipboard and then adds an <see cref="Image"/> in the <see cref="DataFormats.Bitmap"/> format.
     /// </summary>
-    public static void SetImage(Image image)
-        => SetDataObject(new DataObject(DataFormats.BitmapConstant, autoConvert: true, image.OrThrowIfNull()), copy: true);
+    public static void SetImage(Image image) =>
+        SetDataObject(new DataObject(DataFormats.BitmapConstant, autoConvert: true, image.OrThrowIfNull()), copy: true);
 
     /// <summary>
     ///  Clears the Clipboard and then adds text data in the <see cref="TextDataFormat.UnicodeText"/> format.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.ComposedDataObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.ComposedDataObject.cs
@@ -74,12 +74,12 @@ public unsafe partial class DataObject
         public IDataObject? OriginalIDataObject { get; private set; }
 
         /// <summary>
-        ///  We are restricting serialization of formats that represent strings, bitmaps or OLE types.
+        ///  We are restricting binary serialization and deserialization of formats that represent strings, bitmaps or OLE types.
         /// </summary>
         /// <param name="format">format name</param>
-        /// <returns>true - serialize only safe types, strings or bitmaps.</returns>
-        private static bool RestrictDeserializationToSafeTypes(string format)
-            => format is DataFormats.StringConstant
+        /// <returns><see langword="true" /> - serialize only safe types, strings or bitmaps.</returns>
+        private static bool RestrictDeserializationToSafeTypes(string format) =>
+            format is DataFormats.StringConstant
                 or BitmapFullName
                 or DataFormats.CsvConstant
                 or DataFormats.DibConstant
@@ -111,15 +111,15 @@ public unsafe partial class DataObject
         #endregion
 
         #region Com.IDataObject.Interface
-        HRESULT Com.IDataObject.Interface.GetData(Com.FORMATETC* pformatetcIn, Com.STGMEDIUM* pmedium) => _nativeDataObject.GetData(pformatetcIn, pmedium);
-        HRESULT Com.IDataObject.Interface.GetDataHere(Com.FORMATETC* pformatetc, Com.STGMEDIUM* pmedium) => _nativeDataObject.GetDataHere(pformatetc, pmedium);
-        HRESULT Com.IDataObject.Interface.QueryGetData(Com.FORMATETC* pformatetc) => _nativeDataObject.QueryGetData(pformatetc);
-        HRESULT Com.IDataObject.Interface.GetCanonicalFormatEtc(Com.FORMATETC* pformatectIn, Com.FORMATETC* pformatetcOut) => _nativeDataObject.GetCanonicalFormatEtc(pformatectIn, pformatetcOut);
-        HRESULT Com.IDataObject.Interface.SetData(Com.FORMATETC* pformatetc, Com.STGMEDIUM* pmedium, BOOL fRelease) => _nativeDataObject.SetData(pformatetc, pmedium, fRelease);
-        HRESULT Com.IDataObject.Interface.EnumFormatEtc(uint dwDirection, Com.IEnumFORMATETC** ppenumFormatEtc) => _nativeDataObject.EnumFormatEtc(dwDirection, ppenumFormatEtc);
         HRESULT Com.IDataObject.Interface.DAdvise(Com.FORMATETC* pformatetc, uint advf, Com.IAdviseSink* pAdvSink, uint* pdwConnection) => _nativeDataObject.DAdvise(pformatetc, advf, pAdvSink, pdwConnection);
         HRESULT Com.IDataObject.Interface.DUnadvise(uint dwConnection) => _nativeDataObject.DUnadvise(dwConnection);
         HRESULT Com.IDataObject.Interface.EnumDAdvise(Com.IEnumSTATDATA** ppenumAdvise) => _nativeDataObject.EnumDAdvise(ppenumAdvise);
+        HRESULT Com.IDataObject.Interface.EnumFormatEtc(uint dwDirection, Com.IEnumFORMATETC** ppenumFormatEtc) => _nativeDataObject.EnumFormatEtc(dwDirection, ppenumFormatEtc);
+        HRESULT Com.IDataObject.Interface.GetCanonicalFormatEtc(Com.FORMATETC* pformatectIn, Com.FORMATETC* pformatetcOut) => _nativeDataObject.GetCanonicalFormatEtc(pformatectIn, pformatetcOut);
+        HRESULT Com.IDataObject.Interface.GetData(Com.FORMATETC* pformatetcIn, Com.STGMEDIUM* pmedium) => _nativeDataObject.GetData(pformatetcIn, pmedium);
+        HRESULT Com.IDataObject.Interface.GetDataHere(Com.FORMATETC* pformatetc, Com.STGMEDIUM* pmedium) => _nativeDataObject.GetDataHere(pformatetc, pmedium);
+        HRESULT Com.IDataObject.Interface.QueryGetData(Com.FORMATETC* pformatetc) => _nativeDataObject.QueryGetData(pformatetc);
+        HRESULT Com.IDataObject.Interface.SetData(Com.FORMATETC* pformatetc, Com.STGMEDIUM* pmedium, BOOL fRelease) => _nativeDataObject.SetData(pformatetc, pmedium, fRelease);
         #endregion
 
         #region ComTypes.IDataObject

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.cs
@@ -91,53 +91,34 @@ public unsafe partial class DataObject :
     /// <inheritdoc cref="ComposedDataObject.OriginalIDataObject"/>
     internal IDataObject? OriginalIDataObject => _innerData.OriginalIDataObject;
 
-    /// <summary>
-    ///  Retrieves the data associated with the specified data format, using an automated conversion parameter to
-    ///  determine whether to convert the data to the format.
-    /// </summary>
+    #region IDataObject
     public virtual object? GetData(string format, bool autoConvert) =>
         ((IDataObject)_innerData).GetData(format, autoConvert);
 
-    /// <summary>
-    ///  Retrieves the data associated with the specified data format.
-    /// </summary>
     public virtual object? GetData(string format) => GetData(format, autoConvert: true);
 
-    /// <summary>
-    ///  Retrieves the data associated with the specified class type format.
-    /// </summary>
     public virtual object? GetData(Type format) => format is null ? null : GetData(format.FullName!);
 
-    /// <summary>
-    ///  Determines whether data stored in this instance is associated with, or can be converted to,
-    ///  the specified format.
-    /// </summary>
-    public virtual bool GetDataPresent(Type format) => format is not null && GetDataPresent(format.FullName!);
-
-    /// <summary>
-    ///  Determines whether data stored in this instance is associated with the specified format, using an
-    ///  automatic conversion parameter to determine whether to convert the data to the format.
-    /// </summary>
     public virtual bool GetDataPresent(string format, bool autoConvert) =>
         ((IDataObject)_innerData).GetDataPresent(format, autoConvert);
 
-    /// <summary>
-    ///  Determines whether data stored in this instance is associated with, or can be converted to,
-    ///  the specified format.
-    /// </summary>
     public virtual bool GetDataPresent(string format) => GetDataPresent(format, autoConvert: true);
 
-    /// <summary>
-    ///  Gets a list of all formats that data stored in this instance is associated with or can be converted to,
-    ///  using an automatic conversion parameter <paramref name="autoConvert"/> to determine whether to retrieve
-    ///  all formats that the data can be converted to or only native data formats.
-    /// </summary>
+    public virtual bool GetDataPresent(Type format) => format is not null && GetDataPresent(format.FullName!);
+
     public virtual string[] GetFormats(bool autoConvert) => ((IDataObject)_innerData).GetFormats(autoConvert);
 
-    /// <summary>
-    ///  Gets a list of all formats that data stored in this instance is associated with or can be converted to.
-    /// </summary>
     public virtual string[] GetFormats() => GetFormats(autoConvert: true);
+
+    public virtual void SetData(string format, bool autoConvert, object? data) =>
+        ((IDataObject)_innerData).SetData(format, autoConvert, data);
+
+    public virtual void SetData(string format, object? data) => ((IDataObject)_innerData).SetData(format, data);
+
+    public virtual void SetData(Type format, object? data) => ((IDataObject)_innerData).SetData(format, data);
+
+    public virtual void SetData(object? data) => ((IDataObject)_innerData).SetData(data);
+    #endregion
 
     public virtual bool ContainsAudio() => GetDataPresent(DataFormats.WaveAudioConstant, autoConvert: false);
 
@@ -180,8 +161,8 @@ public unsafe partial class DataObject :
 
     public virtual void SetAudio(byte[] audioBytes) => SetAudio(new MemoryStream(audioBytes.OrThrowIfNull()));
 
-    public virtual void SetAudio(Stream audioStream)
-        => SetData(DataFormats.WaveAudioConstant, autoConvert: false, audioStream.OrThrowIfNull());
+    public virtual void SetAudio(Stream audioStream) =>
+        SetData(DataFormats.WaveAudioConstant, autoConvert: false, audioStream.OrThrowIfNull());
 
     public virtual void SetFileDropList(StringCollection filePaths)
     {
@@ -239,78 +220,63 @@ public unsafe partial class DataObject :
         _ => [format]
     };
 
-    int ComTypes.IDataObject.DAdvise(ref FORMATETC pFormatetc, ADVF advf, IAdviseSink pAdvSink, out int pdwConnection)
-        => ((ComTypes.IDataObject)_innerData).DAdvise(ref pFormatetc, advf, pAdvSink, out pdwConnection);
+    #region ComTypes.IDataObject
+    int ComTypes.IDataObject.DAdvise(ref FORMATETC pFormatetc, ADVF advf, IAdviseSink pAdvSink, out int pdwConnection) =>
+        ((ComTypes.IDataObject)_innerData).DAdvise(ref pFormatetc, advf, pAdvSink, out pdwConnection);
 
     void ComTypes.IDataObject.DUnadvise(int dwConnection) => ((ComTypes.IDataObject)_innerData).DUnadvise(dwConnection);
 
-    int ComTypes.IDataObject.EnumDAdvise(out IEnumSTATDATA? enumAdvise)
-        => ((ComTypes.IDataObject)_innerData).EnumDAdvise(out enumAdvise);
+    int ComTypes.IDataObject.EnumDAdvise(out IEnumSTATDATA? enumAdvise) =>
+        ((ComTypes.IDataObject)_innerData).EnumDAdvise(out enumAdvise);
 
-    IEnumFORMATETC ComTypes.IDataObject.EnumFormatEtc(DATADIR dwDirection)
-        => ((ComTypes.IDataObject)_innerData).EnumFormatEtc(dwDirection);
+    IEnumFORMATETC ComTypes.IDataObject.EnumFormatEtc(DATADIR dwDirection) =>
+        ((ComTypes.IDataObject)_innerData).EnumFormatEtc(dwDirection);
 
-    int ComTypes.IDataObject.GetCanonicalFormatEtc(ref FORMATETC pformatetcIn, out FORMATETC pformatetcOut)
-        => ((ComTypes.IDataObject)_innerData).GetCanonicalFormatEtc(ref pformatetcIn, out pformatetcOut);
+    int ComTypes.IDataObject.GetCanonicalFormatEtc(ref FORMATETC pformatetcIn, out FORMATETC pformatetcOut) =>
+        ((ComTypes.IDataObject)_innerData).GetCanonicalFormatEtc(ref pformatetcIn, out pformatetcOut);
 
-    void ComTypes.IDataObject.GetData(ref FORMATETC formatetc, out STGMEDIUM medium)
-        => ((ComTypes.IDataObject)_innerData).GetData(ref formatetc, out medium);
+    void ComTypes.IDataObject.GetData(ref FORMATETC formatetc, out STGMEDIUM medium) =>
+        ((ComTypes.IDataObject)_innerData).GetData(ref formatetc, out medium);
 
-    void ComTypes.IDataObject.GetDataHere(ref FORMATETC formatetc, ref STGMEDIUM medium)
-        => ((ComTypes.IDataObject)_innerData).GetDataHere(ref formatetc, ref medium);
+    void ComTypes.IDataObject.GetDataHere(ref FORMATETC formatetc, ref STGMEDIUM medium) =>
+        ((ComTypes.IDataObject)_innerData).GetDataHere(ref formatetc, ref medium);
 
-    int ComTypes.IDataObject.QueryGetData(ref FORMATETC formatetc)
-        => ((ComTypes.IDataObject)_innerData).QueryGetData(ref formatetc);
+    int ComTypes.IDataObject.QueryGetData(ref FORMATETC formatetc) =>
+        ((ComTypes.IDataObject)_innerData).QueryGetData(ref formatetc);
 
-    void ComTypes.IDataObject.SetData(ref FORMATETC pFormatetcIn, ref STGMEDIUM pmedium, bool fRelease)
-        => ((ComTypes.IDataObject)_innerData).SetData(ref pFormatetcIn, ref pmedium, fRelease);
+    void ComTypes.IDataObject.SetData(ref FORMATETC pFormatetcIn, ref STGMEDIUM pmedium, bool fRelease) =>
+        ((ComTypes.IDataObject)_innerData).SetData(ref pFormatetcIn, ref pmedium, fRelease);
 
-    /// <summary>
-    ///  Stores the specified data and its associated format in this instance, using the automatic conversion
-    ///  parameter to specify whether the data can be converted to another format.
-    /// </summary>
-    public virtual void SetData(string format, bool autoConvert, object? data) =>
-        ((IDataObject)_innerData).SetData(format, autoConvert, data);
+    #endregion
 
-    /// <summary>
-    ///  Stores the specified data and its associated format in this instance.
-    /// </summary>
-    public virtual void SetData(string format, object? data) => ((IDataObject)_innerData).SetData(format, data);
+    #region Com.IDataObject
 
-    /// <summary>
-    ///  Stores the specified data and its associated class type in this instance.
-    /// </summary>
-    public virtual void SetData(Type format, object? data) => ((IDataObject)_innerData).SetData(format!, data);
+    HRESULT Com.IDataObject.Interface.DAdvise(Com.FORMATETC* pformatetc, uint advf, Com.IAdviseSink* pAdvSink, uint* pdwConnection) =>
+        ((Com.IDataObject.Interface)_innerData).DAdvise(pformatetc, advf, pAdvSink, pdwConnection);
 
-    /// <summary>
-    ///  Stores the specified data in this instance, using the class of the data for the format.
-    /// </summary>
-    public virtual void SetData(object? data) => ((IDataObject)_innerData).SetData(data);
+    HRESULT Com.IDataObject.Interface.DUnadvise(uint dwConnection) =>
+        ((Com.IDataObject.Interface)_innerData).DUnadvise(dwConnection);
 
-    HRESULT Com.IDataObject.Interface.GetData(Com.FORMATETC* pformatetcIn, Com.STGMEDIUM* pmedium)
-        => ((Com.IDataObject.Interface)_innerData).GetData(pformatetcIn, pmedium);
+    HRESULT Com.IDataObject.Interface.EnumDAdvise(Com.IEnumSTATDATA** ppenumAdvise) =>
+        ((Com.IDataObject.Interface)_innerData).EnumDAdvise(ppenumAdvise);
 
-    HRESULT Com.IDataObject.Interface.GetDataHere(Com.FORMATETC* pformatetc, Com.STGMEDIUM* pmedium)
-        => ((Com.IDataObject.Interface)_innerData).GetDataHere(pformatetc, pmedium);
+    HRESULT Com.IDataObject.Interface.EnumFormatEtc(uint dwDirection, Com.IEnumFORMATETC** ppenumFormatEtc) =>
+        ((Com.IDataObject.Interface)_innerData).EnumFormatEtc(dwDirection, ppenumFormatEtc);
 
-    HRESULT Com.IDataObject.Interface.QueryGetData(Com.FORMATETC* pformatetc)
-        => ((Com.IDataObject.Interface)_innerData).QueryGetData(pformatetc);
+    HRESULT Com.IDataObject.Interface.GetData(Com.FORMATETC* pformatetcIn, Com.STGMEDIUM* pmedium) =>
+        ((Com.IDataObject.Interface)_innerData).GetData(pformatetcIn, pmedium);
 
-    HRESULT Com.IDataObject.Interface.GetCanonicalFormatEtc(Com.FORMATETC* pformatectIn, Com.FORMATETC* pformatetcOut)
-        => ((Com.IDataObject.Interface)_innerData).GetCanonicalFormatEtc(pformatectIn, pformatetcOut);
+    HRESULT Com.IDataObject.Interface.GetDataHere(Com.FORMATETC* pformatetc, Com.STGMEDIUM* pmedium) =>
+        ((Com.IDataObject.Interface)_innerData).GetDataHere(pformatetc, pmedium);
 
-    HRESULT Com.IDataObject.Interface.SetData(Com.FORMATETC* pformatetc, Com.STGMEDIUM* pmedium, BOOL fRelease)
-        => ((Com.IDataObject.Interface)_innerData).SetData(pformatetc, pmedium, fRelease);
+    HRESULT Com.IDataObject.Interface.QueryGetData(Com.FORMATETC* pformatetc) =>
+        ((Com.IDataObject.Interface)_innerData).QueryGetData(pformatetc);
 
-    HRESULT Com.IDataObject.Interface.EnumFormatEtc(uint dwDirection, Com.IEnumFORMATETC** ppenumFormatEtc)
-        => ((Com.IDataObject.Interface)_innerData).EnumFormatEtc(dwDirection, ppenumFormatEtc);
+    HRESULT Com.IDataObject.Interface.GetCanonicalFormatEtc(Com.FORMATETC* pformatectIn, Com.FORMATETC* pformatetcOut) =>
+        ((Com.IDataObject.Interface)_innerData).GetCanonicalFormatEtc(pformatectIn, pformatetcOut);
 
-    HRESULT Com.IDataObject.Interface.DAdvise(Com.FORMATETC* pformatetc, uint advf, Com.IAdviseSink* pAdvSink, uint* pdwConnection)
-        => ((Com.IDataObject.Interface)_innerData).DAdvise(pformatetc, advf, pAdvSink, pdwConnection);
+    HRESULT Com.IDataObject.Interface.SetData(Com.FORMATETC* pformatetc, Com.STGMEDIUM* pmedium, BOOL fRelease) =>
+        ((Com.IDataObject.Interface)_innerData).SetData(pformatetc, pmedium, fRelease);
 
-    HRESULT Com.IDataObject.Interface.DUnadvise(uint dwConnection)
-        => ((Com.IDataObject.Interface)_innerData).DUnadvise(dwConnection);
-
-    HRESULT Com.IDataObject.Interface.EnumDAdvise(Com.IEnumSTATDATA** ppenumAdvise)
-        => ((Com.IDataObject.Interface)_innerData).EnumDAdvise(ppenumAdvise);
+    #endregion
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/IDataObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/IDataObject.cs
@@ -10,7 +10,7 @@ public interface IDataObject
 {
     /// <summary>
     ///  Retrieves the data associated with the specified data format, using
-    ///  autoConvert to determine whether to convert the data to the  format.
+    ///  <paramref name="autoConvert"/> to determine whether to convert the data to the  format.
     /// </summary>
     object? GetData(string format, bool autoConvert);
 
@@ -23,30 +23,6 @@ public interface IDataObject
     ///  Retrieves the data associated with the specified class type format.
     /// </summary>
     object? GetData(Type format);
-
-    /// <summary>
-    ///  Stores the specified data and its associated format in  this instance,
-    ///  using autoConvert to specify whether the data can be converted to
-    ///  another format.
-    /// </summary>
-    void SetData(string format, bool autoConvert, object? data);
-
-    /// <summary>
-    ///  Stores the specified data and its associated format in this instance.
-    /// </summary>
-    void SetData(string format, object? data);
-
-    /// <summary>
-    ///  Stores the specified data and its associated class type in this
-    ///  instance.
-    /// </summary>
-    void SetData(Type format, object? data);
-
-    /// <summary>
-    ///  Stores the specified data in this instance, using the class of the
-    ///  data for the format.
-    /// </summary>
-    void SetData(object? data);
 
     /// <summary>
     ///  Determines whether data stored in this instance is  associated with the
@@ -69,8 +45,8 @@ public interface IDataObject
 
     /// <summary>
     ///  Gets a list of all formats that data stored in this instance is
-    ///  associated with or can be converted to, using autoConvert to determine
-    ///  whether to retrieve all formats that the data can be converted to or'
+    ///  associated with or can be converted to, using <paramref name="autoConvert"/> to determine
+    ///  whether to retrieve all formats that the data can be converted to, or
     ///  only native data formats.
     /// </summary>
     string[] GetFormats(bool autoConvert);
@@ -80,4 +56,27 @@ public interface IDataObject
     ///  associated with or can be converted to.
     /// </summary>
     string[] GetFormats();
+
+    /// <summary>
+    ///  Stores the specified data and its associated format in this instance,
+    ///  using autoConvert to specify whether the data can be converted to
+    ///  another format.
+    /// </summary>
+    void SetData(string format, bool autoConvert, object? data);
+
+    /// <summary>
+    ///  Stores the specified data and its associated format in this instance.
+    /// </summary>
+    void SetData(string format, object? data);
+
+    /// <summary>
+    ///  Stores the specified data and its associated class type in this instance.
+    /// </summary>
+    void SetData(Type format, object? data);
+
+    /// <summary>
+    ///  Stores the specified data in this instance, using the class of the
+    ///  data for the format.
+    /// </summary>
+    void SetData(object? data);
 }


### PR DESCRIPTION
Reordered IDataObject's and DataObject's methods alphabetically.
Removed explicit xml doc comments on DataObject's implementation of the managed IDataObject interface 
Removed a duplicate test (format != DataFormats.BitmapConstant) in TryGetBitmapData
Changed return type to MemoryStream from Stream in ReadByteStreamFromHGLOBAL

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11413)