### PR TITLE
Implement missing `RemoveToolTip` on `UpDownBase` to cleanup `ToolTip`

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/UpDown/UpDownBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/UpDown/UpDownBase.cs
@@ -983,4 +983,16 @@ public abstract partial class UpDownBase : ContainerControl
         toolTip.SetToolTip(_upDownEdit, caption);
         toolTip.SetToolTip(_upDownButtons, caption);
     }
+
+    internal override void RemoveToolTip(ToolTip toolTip)
+    {
+        if (toolTip is null)
+        {
+            return;
+        }
+
+        string? caption = toolTip.GetToolTip(this);
+        toolTip.SetToolTip(_upDownEdit, caption);
+        toolTip.SetToolTip(_upDownButtons, caption);
+    }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/UpDownBaseTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/UpDownBaseTests.cs
@@ -3032,6 +3032,13 @@ public class UpDownBaseTests
 
         Assert.Equal(text, actualEditToolTipText);
         Assert.Equal(text, actualButtonsToolTipText);
+
+        toolTip.SetToolTip(upDownBase, null); // Invokes UpDownBase's SetToolTip inside
+        actualEditToolTipText = toolTip.GetToolTip(upDownBase._upDownEdit);
+        actualButtonsToolTipText = toolTip.GetToolTip(upDownBase._upDownButtons);
+
+        Assert.Equal("", actualEditToolTipText);
+        Assert.Equal("", actualButtonsToolTipText);
     }
 
     private class CustomValidateUpDownBase : UpDownBase

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/UpDownBaseTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/UpDownBaseTests.cs
@@ -3021,24 +3021,24 @@ public class UpDownBaseTests
         string actualEditToolTipText = toolTip.GetToolTip(upDownBase._upDownEdit);
         string actualButtonsToolTipText = toolTip.GetToolTip(upDownBase._upDownButtons);
 
-        Assert.Empty(actualEditToolTipText);
-        Assert.Empty(actualButtonsToolTipText);
-        Assert.NotEqual(IntPtr.Zero, toolTip.Handle); // A workaround to create the toolTip native window Handle
+        actualEditToolTipText.Should().BeEmpty();
+        actualButtonsToolTipText.Should().BeEmpty();
+        toolTip.Handle.Should().NotBe(IntPtr.Zero); // A workaround to create the toolTip native window Handle
 
         string text = "Some test text";
         toolTip.SetToolTip(upDownBase, text); // Invokes UpDownBase's SetToolTip inside
         actualEditToolTipText = toolTip.GetToolTip(upDownBase._upDownEdit);
         actualButtonsToolTipText = toolTip.GetToolTip(upDownBase._upDownButtons);
 
-        Assert.Equal(text, actualEditToolTipText);
-        Assert.Equal(text, actualButtonsToolTipText);
+        actualEditToolTipText.Should().Be(text);
+        actualButtonsToolTipText.Should().Be(text);
 
         toolTip.SetToolTip(upDownBase, null); // Invokes UpDownBase's SetToolTip inside
         actualEditToolTipText = toolTip.GetToolTip(upDownBase._upDownEdit);
         actualButtonsToolTipText = toolTip.GetToolTip(upDownBase._upDownButtons);
 
-        Assert.Equal("", actualEditToolTipText);
-        Assert.Equal("", actualButtonsToolTipText);
+        actualEditToolTipText.Should().BeEmpty();
+        actualButtonsToolTipText.Should().BeEmpty();
     }
 
     private class CustomValidateUpDownBase : UpDownBase


### PR DESCRIPTION
Makes sure that the `_upDownEdit` and `_upDownButtons` have their tooltip removed.

Fixes #11417

I am unsure how to add tests for this. I manually tested the fix.