### PR TITLE
 8768 :: Resolve Addrange issue after sorting.

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
@@ -24,6 +24,7 @@ internal static partial class LocalAppContextSwitches
     internal const string DataGridViewUIAStartRowCountAtZeroSwitchName = "System.Windows.Forms.DataGridViewUIAStartRowCountAtZero";
     internal const string NoClientNotificationsSwitchName = "Switch.System.Windows.Forms.AccessibleObject.NoClientNotifications";
     internal const string EnableMsoComponentManagerSwitchName = "Switch.System.Windows.Forms.EnableMsoComponentManager";
+    internal const string TreeNodePrevNodeDoNotUseFixedIndexWithSortedTreeViewSwitchName = "System.Windows.Forms.TreeNodeDoNotUseFixedIndexWithSortedTreeView";
 
     private static int s_scaleTopLevelFormMinMaxSizeForDpi;
     private static int s_anchorLayoutV2;
@@ -34,6 +35,7 @@ internal static partial class LocalAppContextSwitches
     private static int s_dataGridViewUIAStartRowCountAtZero;
     private static int s_noClientNotifications;
     private static int s_enableMsoComponentManager;
+    private static int s_treeNodePrevNodeDoNotUseFixedIndexWithSortedTreeView;
 
     private static FrameworkName? s_targetFrameworkName;
 
@@ -200,6 +202,16 @@ internal static partial class LocalAppContextSwitches
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get => GetCachedSwitchValue(EnableMsoComponentManagerSwitchName, ref s_enableMsoComponentManager);
+    }
+
+    /// <summary>
+    ///  Indicates whether TreeNode.PrevNode uses a fixed index to return its value.
+    ///  Thus mirroring the behavior of the TreeNodeCollection.
+    /// </summary>
+    public static bool TreeNodePrevNodeDoNotUseFixedIndexWithSortedTreeView
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => GetCachedSwitchValue(TreeNodePrevNodeDoNotUseFixedIndexWithSortedTreeViewSwitchName, ref s_treeNodePrevNodeDoNotUseFixedIndexWithSortedTreeView);
     }
 
     internal static void SetLocalAppContextSwitchValue(string switchName, bool value)

--- a/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
@@ -106,6 +106,11 @@ internal static partial class LocalAppContextSwitches
                 return false;
             }
 
+            if (switchName == TreeNodeCollectionAddRangeRespectsSortOrderSwitchName)
+            {
+                return true;
+            }
+
             if (framework.Version.Major >= 8)
             {
                 // Behavior changes added in .NET 8

--- a/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
@@ -210,8 +210,8 @@ internal static partial class LocalAppContextSwitches
     }
 
     /// <summary>
-    ///  Indicates whether TreeNode.PrevNode uses a fixed index to return its value.
-    ///  Thus mirroring the behavior of the TreeNodeCollection.
+    ///  When set to (default), API will insert nodes in the sorted order.
+    ///  To get behavior compatible with the previous versions of .NET and .NET Framework, set this switch to.
     /// </summary>
     public static bool TreeNodeCollectionAddRangeRespectsSortOrder
     {

--- a/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
@@ -24,7 +24,7 @@ internal static partial class LocalAppContextSwitches
     internal const string DataGridViewUIAStartRowCountAtZeroSwitchName = "System.Windows.Forms.DataGridViewUIAStartRowCountAtZero";
     internal const string NoClientNotificationsSwitchName = "Switch.System.Windows.Forms.AccessibleObject.NoClientNotifications";
     internal const string EnableMsoComponentManagerSwitchName = "Switch.System.Windows.Forms.EnableMsoComponentManager";
-    internal const string TreeNodePrevNodeDoNotUseFixedIndexWithSortedTreeViewSwitchName = "System.Windows.Forms.TreeNodeDoNotUseFixedIndexWithSortedTreeView";
+    internal const string TreeNodeCollectionAddRangeRespectsSortOrderSwitchName = "System.Windows.Forms.TreeNodeCollectionAddRangeRespectsSortOrder";
 
     private static int s_scaleTopLevelFormMinMaxSizeForDpi;
     private static int s_anchorLayoutV2;
@@ -35,7 +35,7 @@ internal static partial class LocalAppContextSwitches
     private static int s_dataGridViewUIAStartRowCountAtZero;
     private static int s_noClientNotifications;
     private static int s_enableMsoComponentManager;
-    private static int s_treeNodePrevNodeDoNotUseFixedIndexWithSortedTreeView;
+    private static int s_treeNodeCollectionAddRangeRespectsSortOrder;
 
     private static FrameworkName? s_targetFrameworkName;
 
@@ -208,10 +208,10 @@ internal static partial class LocalAppContextSwitches
     ///  Indicates whether TreeNode.PrevNode uses a fixed index to return its value.
     ///  Thus mirroring the behavior of the TreeNodeCollection.
     /// </summary>
-    public static bool TreeNodePrevNodeDoNotUseFixedIndexWithSortedTreeView
+    public static bool TreeNodeCollectionAddRangeRespectsSortOrder
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => GetCachedSwitchValue(TreeNodePrevNodeDoNotUseFixedIndexWithSortedTreeViewSwitchName, ref s_treeNodePrevNodeDoNotUseFixedIndexWithSortedTreeView);
+        get => GetCachedSwitchValue(TreeNodeCollectionAddRangeRespectsSortOrderSwitchName, ref s_treeNodeCollectionAddRangeRespectsSortOrder);
     }
 
     internal static void SetLocalAppContextSwitchValue(string switchName, bool value)
@@ -229,6 +229,11 @@ internal static partial class LocalAppContextSwitches
         if (switchName == ApplyParentFontToMenusSwitchName)
         {
             s_applyParentFontToMenus = value ? 1 : 0;
+        }
+
+        if (switchName == TreeNodeCollectionAddRangeRespectsSortOrderSwitchName)
+        {
+            s_treeNodeCollectionAddRangeRespectsSortOrder = value ? 1 : 0;
         }
     }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeNodeCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeNodeCollection.cs
@@ -4,6 +4,7 @@
 using System.Collections;
 using System.ComponentModel;
 using System.Drawing.Design;
+using System.Windows.Forms.Primitives;
 
 namespace System.Windows.Forms;
 
@@ -219,7 +220,7 @@ public class TreeNodeCollection : IList
             tv.BeginUpdate();
         }
 
-        if (tv is null || !tv.Sorted)
+        if (!LocalAppContextSwitches.TreeNodePrevNodeDoNotUseFixedIndexWithSortedTreeView || tv is null || !tv.Sorted)
         {
             _owner.Nodes.FixedIndex = _owner._childCount;
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeNodeCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeNodeCollection.cs
@@ -220,7 +220,7 @@ public class TreeNodeCollection : IList
             tv.BeginUpdate();
         }
 
-        if (!LocalAppContextSwitches.TreeNodePrevNodeDoNotUseFixedIndexWithSortedTreeView || tv is null || !tv.Sorted)
+        if (!LocalAppContextSwitches.TreeNodeCollectionAddRangeRespectsSortOrder || tv is null || !tv.Sorted)
         {
             _owner.Nodes.FixedIndex = _owner._childCount;
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeNodeCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeNodeCollection.cs
@@ -219,7 +219,11 @@ public class TreeNodeCollection : IList
             tv.BeginUpdate();
         }
 
-        _owner.Nodes.FixedIndex = _owner._childCount;
+        if (tv is null || !tv.Sorted)
+        {
+            _owner.Nodes.FixedIndex = _owner._childCount;
+        }
+
         _owner.EnsureCapacity(nodes.Length);
         for (int i = nodes.Length - 1; i >= 0; i--)
         {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNodeCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNodeCollectionTests.cs
@@ -214,6 +214,39 @@ public class TreeNodeCollectionTests
         Assert.Empty(collection.Find(key, searchAllChildren: false));
     }
 
+    [WinFormsFact]
+    [InlineData("7")]
+    public void TreeNodeCollection_Sort_ShouldAfterAddingItems(string key)
+    {
+        using TreeView treeView = new();
+        TreeNode child1 = new()
+        {
+            Name = "8"
+        };
+        TreeNode child2 = new()
+        {
+            Name = "5"
+        };
+        TreeNode child3 = new()
+        {
+            Name = "7"
+        };
+
+        treeView.Nodes.Add(child1);
+        treeView.Nodes.Add(child2);
+        treeView.Nodes.Add(child3);
+
+        treeView.Sort();
+
+        treeView.Nodes.AddRange(new TreeNode[]
+        {
+            new ("2"),
+            new ("1")
+        });
+
+        Assert.NotEmpty(treeView.Nodes.Find(key, searchAllChildren: true));
+    }
+
     [WinFormsTheory]
     [NullAndEmptyStringData]
     public void TreeNodeCollection_Find_NullOrEmptyKey_ThrowsArgumentNullException(string key)

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNodeCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNodeCollectionTests.cs
@@ -214,22 +214,25 @@ public class TreeNodeCollectionTests
         Assert.Empty(collection.Find(key, searchAllChildren: false));
     }
 
-    [WinFormsTheory]
-    [InlineData("7")]
-    public void TreeNodeCollection_Sort_ShouldAfterAddingItems(string key)
+    [WinFormsFact]
+    public void TreeNodeCollection_Sort_ShouldAfterAddingItems()
     {
         using TreeView treeView = new();
+        string key = "7";
         TreeNode child1 = new()
         {
-            Name = "8"
+            Name = "8",
+            Text = "8"
         };
         TreeNode child2 = new()
         {
-            Name = "5"
+            Name = "5",
+            Text = "5"
         };
         TreeNode child3 = new()
         {
-            Name = "7"
+            Name = "7",
+            Text = "7"
         };
 
         treeView.Nodes.Add(child1);
@@ -237,14 +240,24 @@ public class TreeNodeCollectionTests
         treeView.Nodes.Add(child3);
 
         treeView.Sort();
-
+        treeView.CreateControl();
         treeView.Nodes.AddRange(new TreeNode[]
         {
-            new ("2"),
-            new ("1")
+            new()
+            {
+                Name = "2",
+                Text = "2"
+            },
+            new()
+            {
+                Name = "1",
+                Text = "1"
+            }
         });
 
-        treeView.Nodes.Find(key, searchAllChildren: true).Should().NotBeNull();
+        TreeNode treeNode = treeView.Nodes.Find(key, searchAllChildren: true)[0];
+        treeNode.Should().NotBeNull();
+        treeView.Nodes.IndexOf(treeNode).Should().Be(3);
     }
 
     [WinFormsTheory]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNodeCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNodeCollectionTests.cs
@@ -214,7 +214,7 @@ public class TreeNodeCollectionTests
         Assert.Empty(collection.Find(key, searchAllChildren: false));
     }
 
-    [WinFormsFact]
+    [WinFormsTheory]
     [InlineData("7")]
     public void TreeNodeCollection_Sort_ShouldAfterAddingItems(string key)
     {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNodeCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNodeCollectionTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Drawing;
+using System.Windows.Forms.Primitives;
 
 namespace System.Windows.Forms.Tests;
 
@@ -241,7 +242,8 @@ public class TreeNodeCollectionTests
 
         treeView.Sort();
         treeView.CreateControl();
-        treeView.Nodes.AddRange(new TreeNode[]
+
+        TreeNode[] treeNodeArray = new TreeNode[]
         {
             new()
             {
@@ -253,11 +255,77 @@ public class TreeNodeCollectionTests
                 Name = "1",
                 Text = "1"
             }
-        });
+        };
+
+        treeView.Nodes.AddRange(treeNodeArray);
 
         TreeNode treeNode = treeView.Nodes.Find(key, searchAllChildren: true)[0];
         treeNode.Should().NotBeNull();
         treeView.Nodes.IndexOf(treeNode).Should().Be(3);
+    }
+
+    [WinFormsFact]
+    public void TreeNodeCollection_TreeNodeCollectionAddRangeRespectsSortOrderSwitch()
+    {
+        TreeNode child1 = new()
+        {
+            Name = "8",
+            Text = "8"
+        };
+        TreeNode child2 = new()
+        {
+            Name = "5",
+            Text = "5"
+        };
+        TreeNode child3 = new()
+        {
+            Name = "7",
+            Text = "7"
+        };
+        TreeNode[] treeNodeArray = new TreeNode[]
+        {
+            new()
+            {
+                Name = "2",
+                Text = "2"
+            },
+            new()
+            {
+                Name = "1",
+                Text = "1"
+            }
+        };
+
+        LocalAppContextSwitches.SetLocalAppContextSwitchValue(LocalAppContextSwitches.TreeNodeCollectionAddRangeRespectsSortOrderSwitchName, true);
+        using TreeView treeView2 = new();
+
+        treeView2.Nodes.Add(child1);
+        treeView2.Nodes.Add(child2);
+        treeView2.Nodes.Add(child3);
+
+        treeView2.CreateControl();
+        treeView2.Sort();
+        treeView2.Nodes.AddRange(treeNodeArray);
+
+        TreeNode treeNode = treeView2.Nodes.Find("2", searchAllChildren: true)[0];
+        treeNode.Should().NotBeNull();
+        treeView2.Nodes.IndexOf(treeNode).Should().Be(1);
+        treeView2.Nodes.Clear();
+
+        LocalAppContextSwitches.SetLocalAppContextSwitchValue(LocalAppContextSwitches.TreeNodeCollectionAddRangeRespectsSortOrderSwitchName, false);
+        using TreeView treeView3 = new();
+
+        treeView3.Nodes.Add(child1);
+        treeView3.Nodes.Add(child2);
+        treeView3.Nodes.Add(child3);
+
+        treeView3.CreateControl();
+        treeView3.Sort();
+        treeView3.Nodes.AddRange(treeNodeArray);
+
+        treeNode = treeView3.Nodes.Find("2", searchAllChildren: true)[0];
+        treeNode.Should().NotBeNull();
+        treeView3.Nodes.IndexOf(treeNode).Should().Be(1);
     }
 
     [WinFormsTheory]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNodeCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNodeCollectionTests.cs
@@ -244,7 +244,7 @@ public class TreeNodeCollectionTests
             new ("1")
         });
 
-        Assert.NotEmpty(treeView.Nodes.Find(key, searchAllChildren: true));
+        treeView.Nodes.Find(key, searchAllChildren: true).Should().NotBeNull();
     }
 
     [WinFormsTheory]


### PR DESCRIPTION
Fixes #8768 

## Proposed changes
if tree is already sorted then we don't want to set fixed Index value. due to these reason It is misbehave. 

## Customer Impact

- No

## Regression? 

- Yes

## Risk

- No

### Before

When the user adds a value to the treenode list and sorts it using treeview.sort(), it works fine. Subsequently, when the user adds individual trees through the add event, it functions as expected and sorts the entire tree automatically. However, if the user adds multiple values through AddRange, it does not work as expected.

### After
I've fixed the sorting issue we discussed earlier, and now everything is working smoothly. When users add values individually or use treeview.sort(), the sorting works fine. Even when they add multiple values at once using AddRange, the sorting behaves as expected.

## Test methodology 

- Testcase added

## Test environment(s)

- tested with .net core 8.0

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11423)