### PR TITLE
Call NuGetAuthenticate after SetupNuGetSources

### DIFF
--- a/eng/pipelines/build-PR.yml
+++ b/eng/pipelines/build-PR.yml
@@ -51,6 +51,7 @@ jobs:
           arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
         env:
           Token: $(dn-bot-dnceng-artifact-feeds-rw)
+      - task: NuGetAuthenticate@1
 
       - task: MicroBuildSigningPlugin@2
         displayName: Install MicroBuild plugin for Signing

--- a/eng/pipelines/build.yml
+++ b/eng/pipelines/build.yml
@@ -55,6 +55,7 @@ jobs:
       arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
     env:
       Token: $(dn-bot-dnceng-artifact-feeds-rw)
+  - task: NuGetAuthenticate@1
 
   - task: MicroBuildSigningPlugin@2
     displayName: Install MicroBuild plugin for Signing


### PR DESCRIPTION
The new version of the powershell script will not place the creds in the nuget.config file, instead it will use standard environment variables. Update the YAML file to use NuGetAuthenticate to avoid a build break that may happen if the credential provider is not available.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11453)