### PR TITLE
Add test coverage for PropertyGrid

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridTests.cs
@@ -4109,7 +4109,6 @@ public partial class PropertyGridTests
         public string Property2 { get; set; }
     }
 
-
     private class SubToolStripRenderer : ToolStripRenderer
     {
     }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridTests.cs
@@ -4090,7 +4090,7 @@ public partial class PropertyGridTests
     public void PropertyGrid_ResetSelectedProperty_Invoke_Success()
     {
         using PropertyGrid propertyGrid = new();
-        var testObject = new TestObject { Property1 = "ChangedValue1", Property2 = "ChangedValue2" };
+        var testObject = new TestObject { Property1 = "ChangedValue1"};
         propertyGrid.SelectedObject = testObject;
 
         propertyGrid.ResetSelectedProperty();
@@ -4104,9 +4104,6 @@ public partial class PropertyGridTests
     {
         [DefaultValue("Default1")]
         public string Property1 { get; set; }
-
-        [DefaultValue("Default2")]
-        public string Property2 { get; set; }
     }
 
     private class SubToolStripRenderer : ToolStripRenderer

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridTests.cs
@@ -4049,44 +4049,6 @@ public partial class PropertyGridTests
     }
 
     [WinFormsFact]
-    public void PropertyGrid_CollapseAndExpandAllGridItems_CollapseAndExpandCorrectly()
-    {
-        using PropertyGrid propertyGrid = new();
-        var testObject = new { Property1 = "Value1", Property2 = "Value2" };
-        propertyGrid.SelectedObject = testObject;
-
-        foreach (GridItem item in propertyGrid.SelectedGridItem.GridItems)
-        {
-            item.Expanded = true;
-        }
-
-        foreach (GridItem item in propertyGrid.SelectedGridItem.GridItems)
-        {
-            item.Expanded.Should().BeTrue();
-        }
-
-        foreach (GridItem item in propertyGrid.SelectedGridItem.GridItems)
-        {
-            item.Expanded = false;
-        }
-
-        foreach (GridItem item in propertyGrid.SelectedGridItem.GridItems)
-        {
-            item.Expanded.Should().BeFalse();
-        }
-
-        foreach (GridItem item in propertyGrid.SelectedGridItem.GridItems)
-        {
-            item.Expanded = true;
-        }
-
-        foreach (GridItem item in propertyGrid.SelectedGridItem.GridItems)
-        {
-            item.Expanded.Should().BeTrue();
-        }
-    }
-
-    [WinFormsFact]
     public void PropertyGrid_ResetSelectedProperty_Invoke_Success()
     {
         using PropertyGrid propertyGrid = new();


### PR DESCRIPTION
Related https://github.com/dotnet/winforms/issues/10453

## Proposed changes

- Add unit tests for PropertyGrid to test its events: PropertyValueChanged, PropertySortChanged, SelectedObjectsChanged.
- Add unit tests for PropertyGrid to test its methods: CollapseAndExpandAllGridItems, ResetSelectedProperty.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11476)