### PR TITLE
Enable internal builds using new arcade templates

### DIFF
--- a/azure-pipelines-PR.yml
+++ b/azure-pipelines-PR.yml
@@ -69,7 +69,6 @@ variables:
     - name: _InternalRuntimeDownloadArgs
       value: ''
   - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-    - group: DotNetBuilds storage account read tokens
     - group: AzureDevOps-Artifact-Feeds-Pats
     - name: _InternalRuntimeDownloadArgs
       value: /p:DotNetRuntimeSourceFeed=https://dotnetbuilds.blob.core.windows.net/internal

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,7 +42,6 @@ variables:
 
 # used for post-build phases
 - group: DotNet-Winforms-SDLValidation-Params
-- group: DotNetBuilds storage account read tokens
 - group: AzureDevOps-Artifact-Feeds-Pats
 - name: _InternalRuntimeDownloadArgs
   value: /p:DotNetRuntimeSourceFeed=https://dotnetbuilds.blob.core.windows.net/internal

--- a/eng/pipelines/build-PR.yml
+++ b/eng/pipelines/build-PR.yml
@@ -43,16 +43,10 @@ jobs:
     - checkout: self
       clean: true
 
-    - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-      - task: PowerShell@2
-        displayName: Setup Private Feeds Credentials
-        inputs:
-          filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-          arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
-        env:
-          Token: $(dn-bot-dnceng-artifact-feeds-rw)
-      - task: NuGetAuthenticate@1
+    - template: /eng/common/templates/steps/enable-internal-sources.yml
+    - template: /eng/common/templates/steps/enable-internal-runtimes.yml
 
+    - ${{ if ne(variables['System.TeamProject'], 'public') }}:
       - task: MicroBuildSigningPlugin@2
         displayName: Install MicroBuild plugin for Signing
         inputs:

--- a/eng/pipelines/build.yml
+++ b/eng/pipelines/build.yml
@@ -48,14 +48,8 @@ jobs:
   - checkout: self
     clean: true
 
-  - task: PowerShell@2
-    displayName: Setup Private Feeds Credentials
-    inputs:
-      filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-      arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
-    env:
-      Token: $(dn-bot-dnceng-artifact-feeds-rw)
-  - task: NuGetAuthenticate@1
+  - template: /eng/common/templates-official/steps/enable-internal-sources.yml
+  - template: /eng/common/templates-official/steps/enable-internal-runtimes.yml
 
   - task: MicroBuildSigningPlugin@2
     displayName: Install MicroBuild plugin for Signing


### PR DESCRIPTION
Enables internal builds (access to internal runtimes and feeds) via azure account tokens and dSAS templates instead of PATs and account SAS.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11480)