### PR TITLE
Specify a version of cmake in global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -21,6 +21,6 @@
     "Microsoft.NET.Sdk.IL": "9.0.0-preview.6.24305.2"
   },
   "native-tools": {
-    "cmake": "latest"
+    "cmake": "3.22.6"
   }
 }

--- a/global.json
+++ b/global.json
@@ -21,6 +21,6 @@
     "Microsoft.NET.Sdk.IL": "9.0.0-preview.6.24305.2"
   },
   "native-tools": {
-    "cmake": "3.22.6"
+    "cmake": "3.21.0"
   }
 }


### PR DESCRIPTION
`latest` is not supported by Arcade, and there's no `latest` archive in the Azure blob store, so force a supported value here.

```
CommonLibrary\DownloadAndExtract : Download failed from
  https://netcorenativeassets.blob.core.windows.net/resource-packages/external/windows/cmake/cmake-latest-win64-x64.zip
  At C:\d\source-indexer\bin\repo\winforms\eng\common\native\install-tool.ps1:90 char:22
```
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11490)