### PR TITLE
Issue 11496 skip unstable test CheckBoxRenderer_DrawCheckBox_OverloadWithSizeAndText

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CheckBoxRendererTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CheckBoxRendererTests.cs
@@ -44,8 +44,8 @@ public class CheckBoxRendererTests : AbstractButtonBaseTests
     [InlineData(CheckBoxState.MixedNormal)]
     public void CheckBoxRenderer_DrawCheckBox_OverloadWithSizeAndText(CheckBoxState cBState)
     {
-        // Skip validation of CheckBoxState.CheckedNormal in X86 due to the active issue "https://github.com/dotnet/winforms/issues/11496"
-        if (cBState== CheckBoxState.CheckedNormal
+        // Skip validation of CheckBoxState.CheckedNormal on X86 due to the active issue "https://github.com/dotnet/winforms/issues/11496"
+        if (cBState == CheckBoxState.CheckedNormal
             && RuntimeInformation.ProcessArchitecture == Architecture.X86)
         {
             return;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CheckBoxRendererTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CheckBoxRendererTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Drawing;
+using System.Runtime.InteropServices;
 using System.Windows.Forms.Metafiles;
 using System.Windows.Forms.VisualStyles;
 
@@ -37,11 +38,19 @@ public class CheckBoxRendererTests : AbstractButtonBaseTests
         );
     }
 
+    [ActiveIssue("https://github.com/dotnet/winforms/issues/11496")]
     [WinFormsTheory]
     [InlineData(CheckBoxState.CheckedNormal)]
     [InlineData(CheckBoxState.MixedNormal)]
     public void CheckBoxRenderer_DrawCheckBox_OverloadWithSizeAndText(CheckBoxState cBState)
     {
+        // Skip validation of CheckBoxState.CheckedNormal in X86 due to the active issue "https://github.com/dotnet/winforms/issues/11496"
+        if (cBState== CheckBoxState.CheckedNormal
+            && RuntimeInformation.ProcessArchitecture == Architecture.X86)
+        {
+            return;
+        }
+
         using Form form = new();
         using CheckBox control = (CheckBox)CreateButton();
         form.Controls.Add(control);


### PR DESCRIPTION
Related #11496


## Proposed changes

- Add judgement in unit test `CheckBoxRenderer_DrawCheckBox_OverloadWithSizeAndText ` to skip validation of CheckBoxState.CheckedNormal on X86 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11499)