### PR TITLE
fix issue 11450  Color contrast ratio of focus indicator over 'toolStripSplitButton1' is 1.247:1 which is less than 3:1: A11y_.NET CoreWinforms_StripControls_Toolstripwithmenuitem_NonTextContrast

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/StatusStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/StatusStrip.cs
@@ -29,7 +29,6 @@ public partial class StatusStrip : ToolStrip
         SuspendLayout();
         CanOverflow = false;
         LayoutStyle = ToolStripLayoutStyle.Table;
-        RenderMode = ToolStripRenderMode.System;
         GripStyle = ToolStripGripStyle.Hidden;
 
         SetStyle(ControlStyles.ResizeRedraw, true);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/StatusStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/StatusStrip.cs
@@ -427,17 +427,6 @@ public partial class StatusStrip : ToolStrip
         base.SetDisplayedItems();
     }
 
-    internal override void ResetRenderMode()
-    {
-        RenderMode = ToolStripRenderMode.System;
-    }
-
-    internal override bool ShouldSerializeRenderMode()
-    {
-        // We should NEVER serialize custom.
-        return (RenderMode is not ToolStripRenderMode.System and not ToolStripRenderMode.Custom);
-    }
-
     /// <summary>
     ///  Override this function if you want to do custom table layouts for the
     ///  StatusStrip.  The default layoutstyle is tablelayout, and we need to play

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/StatusStripTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/StatusStripTests.cs
@@ -554,7 +554,7 @@ public partial class StatusStripTests
 
         control.RenderMode = ToolStripRenderMode.System;
         Assert.Equal(ToolStripRenderMode.System, control.RenderMode);
-        Assert.False(property.CanResetValue(control));
+        Assert.True(property.CanResetValue(control));
 
         control.Renderer = new SubToolStripRenderer();
         Assert.Equal(ToolStripRenderMode.Custom, control.RenderMode);
@@ -562,10 +562,10 @@ public partial class StatusStripTests
 
         control.RenderMode = ToolStripRenderMode.ManagerRenderMode;
         Assert.Equal(ToolStripRenderMode.ManagerRenderMode, control.RenderMode);
-        Assert.True(property.CanResetValue(control));
+        Assert.False(property.CanResetValue(control));
 
         property.ResetValue(control);
-        Assert.Equal(ToolStripRenderMode.System, control.RenderMode);
+        Assert.Equal(ToolStripRenderMode.ManagerRenderMode, control.RenderMode);
         Assert.False(property.CanResetValue(control));
     }
 
@@ -582,7 +582,7 @@ public partial class StatusStripTests
 
         control.RenderMode = ToolStripRenderMode.System;
         Assert.Equal(ToolStripRenderMode.System, control.RenderMode);
-        Assert.False(property.ShouldSerializeValue(control));
+        Assert.True(property.ShouldSerializeValue(control));
 
         control.Renderer = new SubToolStripRenderer();
         Assert.Equal(ToolStripRenderMode.Custom, control.RenderMode);
@@ -590,10 +590,10 @@ public partial class StatusStripTests
 
         control.RenderMode = ToolStripRenderMode.ManagerRenderMode;
         Assert.Equal(ToolStripRenderMode.ManagerRenderMode, control.RenderMode);
-        Assert.True(property.ShouldSerializeValue(control));
+        Assert.False(property.ShouldSerializeValue(control));
 
         property.ResetValue(control);
-        Assert.Equal(ToolStripRenderMode.System, control.RenderMode);
+        Assert.Equal(ToolStripRenderMode.ManagerRenderMode, control.RenderMode);
         Assert.False(property.ShouldSerializeValue(control));
     }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/StatusStripTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/StatusStripTests.cs
@@ -121,8 +121,8 @@ public partial class StatusStripTests
         Assert.Null(control.Region);
         Assert.NotNull(control.Renderer);
         Assert.Same(control.Renderer, control.Renderer);
-        Assert.IsType<ToolStripSystemRenderer>(control.Renderer);
-        Assert.Equal(ToolStripRenderMode.System, control.RenderMode);
+        Assert.IsType<ToolStripProfessionalRenderer>(control.Renderer);
+        Assert.Equal(ToolStripRenderMode.ManagerRenderMode, control.RenderMode);
         Assert.True(control.ResizeRedraw);
         Assert.Equal(200, control.Right);
         Assert.Equal(RightToLeft.No, control.RightToLeft);


### PR DESCRIPTION
Fixes #11450
 
 
## Proposed changes
 
- 
- Remove RenderMode
-
 
<!--  
 
## Customer Impact
 
- 
-
 
 
## Regression?
 
- Yes / No
 
## Risk
 
-
-->
 
 
## Screenshots <!-- Remove this section if PR does not change UI -->
 
### Before
 
![image](https://github.com/dotnet/winforms/assets/135201996/3dad208c-b507-446d-ab84-1634a79651e1)
 
### After
 
![image](https://github.com/dotnet/winforms/assets/135201996/a10df783-e767-4bb3-a302-e35d4c1e4f03)
 
<!-- 
## Test methodology
 
- 
- manual 
- 
-->
 
 
## Test environment(s)
 
 9.0.0-preview.6.24305.2
 
<!-- Mention language, UI scaling, or anything else that might be relevant -->
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11502)