### PR TITLE
Make the toolbar menu items support the support space key.

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripDropDown.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripDropDown.cs
@@ -1253,6 +1253,7 @@ public partial class ToolStripDropDown : ToolStrip
                    || !(dismissingItem.HasDropDownItems))
                 {    // clicking on a item w/dropdown does not dismiss window
                     Close(ToolStripDropDownCloseReason.ItemClicked);
+                    SelectPreviousToolStrip();
                 }
             }
         }
@@ -1359,7 +1360,7 @@ public partial class ToolStripDropDown : ToolStrip
     {
         // snap the owner item before calling hide as non-auto created dropdowns will
         // exit menu mode if there's no OwnerItem.
-        ToolStripItem? itemOnPreviousMenuToSelect = OwnerItem;
+        ToolStripItem? itemOnPreviousMenuToSelect = GetToplevelOwnerItem();
         Hide();
 
         if (itemOnPreviousMenuToSelect is not null)
@@ -1495,15 +1496,6 @@ public partial class ToolStripDropDown : ToolStrip
             SelectPreviousToolStrip();
 
             return true;
-        }
-
-        if ((keyData & Keys.KeyCode) == Keys.Enter)
-        {
-            if (base.ProcessDialogKey(keyData))
-            {
-                SelectPreviousToolStrip();
-                return true;
-            }
         }
 
         return base.ProcessDialogKey(keyData);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripDropDown.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripDropDown.cs
@@ -1489,12 +1489,21 @@ public partial class ToolStripDropDown : ToolStrip
             return true;
         }
 
-        if ((keyData & Keys.KeyCode) is Keys.Escape or Keys.Enter)
+        if ((keyData & Keys.KeyCode) == Keys.Escape)
         {
             SetCloseReason(ToolStripDropDownCloseReason.Keyboard);
             SelectPreviousToolStrip();
 
             return true;
+        }
+
+        if ((keyData & Keys.KeyCode) == Keys.Enter)
+        {
+            if (base.ProcessDialogKey(keyData))
+            {
+                SelectPreviousToolStrip();
+                return true;
+            }
         }
 
         return base.ProcessDialogKey(keyData);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripDropDown.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripDropDown.cs
@@ -1489,7 +1489,7 @@ public partial class ToolStripDropDown : ToolStrip
             return true;
         }
 
-        if ((keyData & Keys.KeyCode) == Keys.Escape)
+        if ((keyData & Keys.KeyCode) is Keys.Escape or Keys.Enter)
         {
             SetCloseReason(ToolStripDropDownCloseReason.Keyboard);
             SelectPreviousToolStrip();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripMenuItem.ToolStripMenuItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripMenuItem.ToolStripMenuItemAccessibleObject.cs
@@ -146,6 +146,22 @@ public partial class ToolStripMenuItem
                 _ => ToggleState.ToggleState_Indeterminate
             };
 
+        internal void OnCheckStateChanged(CheckState oldValue, CheckState newValue)
+        {
+            RaiseAutomationPropertyChangedEvent(
+                UIA_PROPERTY_ID.UIA_ToggleToggleStatePropertyId,
+                (VARIANT)(int)CheckStateToToggleState(oldValue),
+                (VARIANT)(int)CheckStateToToggleState(newValue));
+        }
+
+        private static ToggleState CheckStateToToggleState(CheckState checkState)
+            => checkState switch
+            {
+                CheckState.Checked => ToggleState.ToggleState_On,
+                CheckState.Unchecked => ToggleState.ToggleState_Off,
+                _ => ToggleState.ToggleState_Indeterminate
+            };
+
         #endregion
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripMenuItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripMenuItem.cs
@@ -1049,6 +1049,12 @@ public partial class ToolStripMenuItem : ToolStripDropDownItem
     {
         if (Enabled && !HasDropDownItems && (ShortcutKeys == keyData || keyData == Keys.Space))
         {
+            if (keyData == Keys.Space)
+            {
+                Checked = !Checked;
+                return true;
+            }
+
             FireEvent(ToolStripItemEventType.Click);
             return true;
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripMenuItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripMenuItem.cs
@@ -1060,11 +1060,7 @@ public partial class ToolStripMenuItem : ToolStripDropDownItem
         {
             if (keyData is Keys.Space)
             {
-                if (CheckOnClick)
-                {
-                    Checked = !Checked;
-                }
-
+                Checked = CheckOnClick ? !Checked : Checked;
                 return true;
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripMenuItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripMenuItem.cs
@@ -1049,9 +1049,13 @@ public partial class ToolStripMenuItem : ToolStripDropDownItem
     {
         if (Enabled && !HasDropDownItems && (ShortcutKeys == keyData || keyData == Keys.Space))
         {
-            if (keyData == Keys.Space)
+            if (keyData is Keys.Space)
             {
-                Checked = !Checked;
+                if (CheckOnClick)
+                {
+                    Checked = !Checked;
+                }
+
                 return true;
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripMenuItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripMenuItem.cs
@@ -1047,7 +1047,7 @@ public partial class ToolStripMenuItem : ToolStripDropDownItem
 
     protected internal override bool ProcessCmdKey(ref Message m, Keys keyData)
     {
-        if (Enabled && ShortcutKeys == keyData && !HasDropDownItems)
+        if (Enabled && !HasDropDownItems && (ShortcutKeys == keyData || keyData == Keys.Space))
         {
             FireEvent(ToolStripItemEventType.Click);
             return true;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripMenuItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripMenuItem.cs
@@ -19,6 +19,7 @@ namespace System.Windows.Forms;
     $"System.ComponentModel.Design.Serialization.CodeDomSerializer, {AssemblyRef.SystemDesign}")]
 public partial class ToolStripMenuItem : ToolStripDropDownItem
 {
+    private CheckState _prevCheckState = CheckState.Unchecked;
     private static readonly MenuTimer s_menuTimer = new();
 
     private static readonly int s_propShortcutKeys = PropertyStore.CreateKey();
@@ -311,6 +312,7 @@ public partial class ToolStripMenuItem : ToolStripDropDownItem
 
             if (value != CheckState)
             {
+                _prevCheckState = CheckState;
                 Properties.SetInteger(s_propCheckState, (int)value);
                 OnCheckedChanged(EventArgs.Empty);
                 OnCheckStateChanged(EventArgs.Empty);
@@ -820,6 +822,13 @@ public partial class ToolStripMenuItem : ToolStripDropDownItem
     protected virtual void OnCheckStateChanged(EventArgs e)
     {
         AccessibilityNotifyClients(AccessibleEvents.StateChange);
+
+        if (IsAccessibilityObjectCreated &&
+            AccessibilityObject is ToolStripMenuItemAccessibleObject accessibilityObject)
+        {
+            accessibilityObject.OnCheckStateChanged(_prevCheckState, CheckState);
+        }
+
         ((EventHandler?)Events[s_eventCheckStateChanged])?.Invoke(this, e);
     }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #11449


## Proposed changes

- Modify the ProcessCmdKey() method to support space key.
- Make a focus on the MenuStrip after the user hits enter to check it.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- MenuItems does not respond to the spacebar key to check/uncheck the menu and enter key executes it and closes the menu without focus the menustrip.

## Regression? 

- No

## Risk

-Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
![BeforeChanges](https://github.com/dotnet/winforms/assets/133954995/e6c59fa4-7228-4f7d-a86a-02f90158287c)

<!-- TODO -->

### After
![AfterChanges](https://github.com/dotnet/winforms/assets/133954995/fa448a40-4a2d-4a4b-893e-6db944c97137)

<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- Manual


## Test environment(s) <!-- Remove any that don't apply -->

- 9.0.100-preview.6.24312.9


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11520)