### PR TITLE
Add code coverage for LabelAccessibleObject

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/LabelAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/LabelAccessibleObjectTests.cs
@@ -142,17 +142,6 @@ public class LabelAccessibleObjectTests
         Assert.Equal(1, accessibilityObject.RaiseAutomationNotificationCallCount);
     }
 
-    [WinFormsFact]
-    public void LabelAccessibleObject_Name_ReturnsExpected()
-    {
-        using Label label = new() { AccessibleName = "Test Accessible Name" };
-        LabelAccessibleObject accessibleObject = (LabelAccessibleObject)label.AccessibilityObject;
-
-        string name = accessibleObject.Name;
-
-        name.Should().Be("Test Accessible Name");
-    }
-
     [WinFormsTheory]
     [InlineData("&File", false, "&File")]
     [InlineData("&File", true, "File")]
@@ -175,11 +164,13 @@ public class LabelAccessibleObjectTests
     }
 
     [WinFormsTheory]
+    [InlineData("Test Accessible Name", "Test Accessible Name", false)]
+    [InlineData("Test Accessible Name", "Test Accessible Name", true)]
     [InlineData("", null, false)]
     [InlineData("", null, true)]
-    [InlineData(null, null, false)]
+    [InlineData(null, null, false)] 
     [InlineData(null, null, true)]
-    public void LabelAccessibleObject_Name_ReturnsExpected_WithEmptyOrNullText(string labelText, string expectedName, bool useMnemonic)
+    public void LabelAccessibleObject_Name_ReturnsExpected_WithVariousText(string labelText, string expectedName, bool useMnemonic)
     {
         using Label label = new() { Text = labelText, UseMnemonic = useMnemonic };
         LabelAccessibleObject accessibleObject = (LabelAccessibleObject)label.AccessibilityObject;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/LabelAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/LabelAccessibleObjectTests.cs
@@ -142,6 +142,53 @@ public class LabelAccessibleObjectTests
         Assert.Equal(1, accessibilityObject.RaiseAutomationNotificationCallCount);
     }
 
+    [WinFormsFact]
+    public void LabelAccessibleObject_Name_ReturnsExpected()
+    {
+        using Label label = new() { AccessibleName = "Test Accessible Name" };
+        LabelAccessibleObject accessibleObject = (LabelAccessibleObject)label.AccessibilityObject;
+
+        string name = accessibleObject.Name;
+
+        name.Should().Be("Test Accessible Name");
+    }
+
+    [WinFormsTheory]
+    [InlineData("&File", false, "&File")]
+    [InlineData("&File", true, "File")]
+    public void LabelAccessibleObject_Name_ReturnsExpected_WithUseMnemonic(string text, bool useMnemonic, string expectedName)
+    {
+        using Label label = new() { Text = text, UseMnemonic = useMnemonic };
+        LabelAccessibleObject accessibleObject = (LabelAccessibleObject)label.AccessibilityObject;
+
+        string name = accessibleObject.Name;
+
+        name.Should().Be(expectedName);
+    }
+
+    [WinFormsFact]
+    public void LabelAccessibleObject_ThrowsArgumentNullException_WhenOwnerIsNull()
+    {
+        Action action = () => new Label.LabelAccessibleObject(null);
+
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [WinFormsTheory]
+    [InlineData("", null, false)]
+    [InlineData("", null, true)]
+    [InlineData(null, null, false)]
+    [InlineData(null, null, true)]
+    public void LabelAccessibleObject_Name_ReturnsExpected_WithEmptyOrNullText(string labelText, string expectedName, bool useMnemonic)
+    {
+        using Label label = new() { Text = labelText, UseMnemonic = useMnemonic };
+        LabelAccessibleObject accessibleObject = (LabelAccessibleObject)label.AccessibilityObject;
+
+        string name = accessibleObject.Name;
+
+        name.Should().Be(expectedName);
+    }
+
     private class LabelWithCustomAccessibleObject : Label
     {
         private readonly Func<UIA_PROPERTY_ID, VARIANT, bool> _checkRaisedEvent;


### PR DESCRIPTION
Related https://github.com/dotnet/winforms/issues/10453

## Proposed changes

- Add unit tests for Label.LabelAccessibleObject to test Name property 

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11521)