### PR TITLE
Create AccessibleObject for PrintStatusDialog

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintControllerWithStatusDialog.BackgroundThread.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintControllerWithStatusDialog.BackgroundThread.cs
@@ -86,7 +86,7 @@ public partial class PrintControllerWithStatusDialog
         private void ThreadUnsafeUpdateLabel()
         {
             // "page {0} of {1}"
-            _dialog!._cancellingLabel.Text = string.Format(
+            _dialog!._cancellingTextBox.Text = string.Format(
                 SR.PrintControllerWithStatusDialog_NowPrinting,
                 _parent._pageNumber,
                 _parent._document?.DocumentName);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintControllerWithStatusDialog.StatusDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintControllerWithStatusDialog.StatusDialog.cs
@@ -11,7 +11,7 @@ public partial class PrintControllerWithStatusDialog
 {
     private class StatusDialog : Form
     {
-        internal TextBox _cancellingLabel;
+        internal TextBox _cancellingTextBox;
         private Button _cancelButton;
         private TableLayoutPanel? _tableLayoutPanel;
         private readonly BackgroundThread _backgroundThread;
@@ -24,7 +24,7 @@ public partial class PrintControllerWithStatusDialog
             MinimumSize = Size;
         }
 
-        [MemberNotNull(nameof(_cancellingLabel))]
+        [MemberNotNull(nameof(_cancellingTextBox))]
         [MemberNotNull(nameof(_cancelButton))]
         private void InitializeComponent()
         {
@@ -34,7 +34,7 @@ public partial class PrintControllerWithStatusDialog
                 RightToLeft = RightToLeft.Yes;
             }
 
-            _cancellingLabel = new TextBox()
+            _cancellingTextBox = new TextBox()
             {
                 AutoSize = true,
                 Location = new Point(8, 16),
@@ -46,7 +46,7 @@ public partial class PrintControllerWithStatusDialog
                 Anchor = AnchorStyles.None
             };
 
-            _cancellingLabel.TextChanged += _cancellingLabel_TextChanged;
+            _cancellingTextBox.TextChanged += OnCancellingTextBoxTextChanged;
 
             _cancelButton = new Button()
             {
@@ -73,7 +73,7 @@ public partial class PrintControllerWithStatusDialog
             _tableLayoutPanel.ColumnStyles.Add(new(SizeType.Percent, 100F));
             _tableLayoutPanel.RowStyles.Add(new(SizeType.Percent, 50F));
             _tableLayoutPanel.RowStyles.Add(new(SizeType.Percent, 50F));
-            _tableLayoutPanel.Controls.Add(_cancellingLabel, 0, 0);
+            _tableLayoutPanel.Controls.Add(_cancellingTextBox, 0, 0);
             _tableLayoutPanel.Controls.Add(_cancelButton, 0, 1);
 
             AutoScaleDimensions = new Size(6, 13);
@@ -91,22 +91,22 @@ public partial class PrintControllerWithStatusDialog
         private void CancelClick(object? sender, EventArgs e)
         {
             _cancelButton.Enabled = false;
-            _cancellingLabel.Text = SR.PrintControllerWithStatusDialog_Canceling;
+            _cancellingTextBox.Text = SR.PrintControllerWithStatusDialog_Canceling;
             _backgroundThread._canceled = true;
         }
 
         protected override AccessibleObject CreateAccessibilityInstance() => new ControlAccessibleObject(this);
 
-        private void _cancellingLabel_TextChanged(object? sender, EventArgs e)
+        private void OnCancellingTextBoxTextChanged(object? sender, EventArgs e)
         {
-            if (!_cancellingLabel.IsAccessibilityObjectCreated)
+            if (!_cancellingTextBox.IsAccessibilityObjectCreated)
             {
                 return;
             }
 
-            using var textVariant = (VARIANT)_cancellingLabel.Text;
-            _cancellingLabel.AccessibilityObject?.RaiseAutomationEvent(UIA_EVENT_ID.UIA_Text_TextChangedEventId);
-            _cancellingLabel.AccessibilityObject?.RaiseAutomationPropertyChangedEvent(UIA_PROPERTY_ID.UIA_NamePropertyId, textVariant, textVariant);
+            using var textVariant = (VARIANT)_cancellingTextBox.Text;
+            _cancellingTextBox.AccessibilityObject?.RaiseAutomationEvent(UIA_EVENT_ID.UIA_Text_TextChangedEventId);
+            _cancellingTextBox.AccessibilityObject?.RaiseAutomationPropertyChangedEvent(UIA_PROPERTY_ID.UIA_NamePropertyId, textVariant, textVariant);
         }
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #11456 


## Proposed changes

- Create AccessibleObject for PrintStatusDialog
- Change the type of `_cancellingLabel` to a read-only Textbox so that the page counts changing can be announced, since the Label control itself cannot directly receive focus. 

<!-- We are in TELL-MODE the following section must be completed -->

## Regression? 

- Yes 

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

The screen reader does not announce any information about “Generating Previews”.
![image](https://github.com/dotnet/winforms/assets/132890443/c87f92b7-31f6-44aa-9ef2-bbb7a9f2c8b3)


### After

![AfterChanges](https://github.com/dotnet/winforms/assets/132890443/cab7ef74-467f-4c3f-8550-289f2fe3b434)


## Test methodology <!-- How did you ensure quality? -->

- Manually

## Test environment(s) <!-- Remove any that don't apply -->

- .net 9.0.0-preview.6.24307.2


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11523)