### PR TITLE
Issue 2053861 fix combo box flickering issue

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.FlatComboAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.FlatComboAdapter.cs
@@ -62,6 +62,11 @@ public partial class ComboBox
 
         public virtual void DrawPopUpCombo(ComboBox comboBox, Graphics g)
         {
+            if (comboBox.DropDownStyle == ComboBoxStyle.Simple)
+            {
+                return;
+            }
+
             bool rightToLeft = comboBox.RightToLeft == RightToLeft.Yes;
 
             // Draw a dark border around everything if we're in popup mode

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.FlatComboAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.FlatComboAdapter.cs
@@ -60,6 +60,38 @@ public partial class ComboBox
             return (combo.ClientRectangle == _clientRect && combo.RightToLeft == _origRightToLeft);
         }
 
+        public virtual void DrawPopUpCombo(ComboBox comboBox, Graphics g)
+        {
+            bool rightToLeft = comboBox.RightToLeft == RightToLeft.Yes;
+
+            // Draw a dark border around everything if we're in popup mode
+            if ((!comboBox.Enabled) || (comboBox.FlatStyle == FlatStyle.Popup))
+            {
+                bool focused = comboBox.ContainsFocus || comboBox.MouseIsOver;
+                Color borderPenColor = GetPopupOuterBorderColor(comboBox, focused);
+
+                using var borderPen = borderPenColor.GetCachedPenScope();
+                Pen innerPen = comboBox.Enabled ? borderPen : SystemPens.Control;
+
+                // Around the dropdown
+                if (rightToLeft)
+                {
+                    g.DrawRectangle(
+                        innerPen,
+                        new Rectangle(_outerBorder.X, _outerBorder.Y, _dropDownRect.Width + 1, _outerBorder.Height));
+                }
+                else
+                {
+                    g.DrawRectangle(
+                        innerPen,
+                        new Rectangle(_dropDownRect.X, _outerBorder.Y, _outerBorder.Right - _dropDownRect.X, _outerBorder.Height));
+                }
+
+                // Around the whole comboBox.
+                g.DrawRectangle(borderPen, _outerBorder);
+            }
+        }
+
         /// <summary>
         ///  Paints over the edges of the combo box to make it appear flat.
         /// </summary>
@@ -107,33 +139,6 @@ public partial class ComboBox
             using var innerBorderPen = innerBorderColor.GetCachedPenScope();
             g.DrawRectangle(innerBorderPen, _innerBorder);
             g.DrawRectangle(innerBorderPen, _innerInnerBorder);
-
-            // Draw a dark border around everything if we're in popup mode
-            if ((!comboBox.Enabled) || (comboBox.FlatStyle == FlatStyle.Popup))
-            {
-                bool focused = comboBox.ContainsFocus || comboBox.MouseIsOver;
-                Color borderPenColor = GetPopupOuterBorderColor(comboBox, focused);
-
-                using var borderPen = borderPenColor.GetCachedPenScope();
-                Pen innerPen = comboBox.Enabled ? borderPen : SystemPens.Control;
-
-                // Around the dropdown
-                if (rightToLeft)
-                {
-                    g.DrawRectangle(
-                        innerPen,
-                        new Rectangle(_outerBorder.X, _outerBorder.Y, _dropDownRect.Width + 1, _outerBorder.Height));
-                }
-                else
-                {
-                    g.DrawRectangle(
-                        innerPen,
-                        new Rectangle(_dropDownRect.X, _outerBorder.Y, _outerBorder.Right - _dropDownRect.X, _outerBorder.Height));
-                }
-
-                // Around the whole combobox.
-                g.DrawRectangle(borderPen, _outerBorder);
-            }
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.FlatComboAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.FlatComboAdapter.cs
@@ -73,7 +73,7 @@ public partial class ComboBox
                 using var borderPen = borderPenColor.GetCachedPenScope();
                 Pen innerPen = comboBox.Enabled ? borderPen : SystemPens.Control;
 
-                // Around the dropdown
+                // Draw a border around the dropdown.
                 if (rightToLeft)
                 {
                     g.DrawRectangle(
@@ -87,7 +87,7 @@ public partial class ComboBox
                         new Rectangle(_dropDownRect.X, _outerBorder.Y, _outerBorder.Right - _dropDownRect.X, _outerBorder.Height));
                 }
 
-                // Around the whole comboBox.
+                // Draw a border around the whole comboBox.
                 g.DrawRectangle(borderPen, _outerBorder);
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.cs
@@ -3885,7 +3885,14 @@ public partial class ComboBox : ListControl
                     }
 
                     using Graphics g = Graphics.FromHdcInternal((IntPtr)dc);
-                    FlatComboBoxAdapter.DrawFlatCombo(this, g);
+                    if ((!Enabled || FlatStyle == FlatStyle.Popup) && MouseIsOver)
+                    {
+                        FlatComboBoxAdapter.DrawPopUpCombo(this, g);
+                    }
+                    else
+                    {
+                        FlatComboBoxAdapter.DrawFlatCombo(this, g);
+                    }
 
                     return;
                 }

--- a/src/System.Windows.Forms/tests/UnitTests/TextBoxBaseTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/TextBoxBaseTests.cs
@@ -4131,7 +4131,10 @@ public partial class TextBoxBaseTests
         Assert.Equal(0, createdCallCount);
     }
 
+    [ActiveIssue("https://github.com/dotnet/winforms/issues/11497")]
     [WinFormsFact]
+    [SkipOnArchitecture(TestArchitectures.X86,
+        "Flaky tests, see: https://github.com/dotnet/winforms/issues/11497")]
     public void TextBoxBase_ClearUndo_CanUndo_Success()
     {
         using SubTextBox control = new()
@@ -4216,7 +4219,10 @@ public partial class TextBoxBaseTests
         Assert.Equal(0, createdCallCount);
     }
 
+    [ActiveIssue("https://github.com/dotnet/winforms/issues/11498")]
     [WinFormsFact]
+    [SkipOnArchitecture(TestArchitectures.X86,
+        "Flaky tests, see: https://github.com/dotnet/winforms/issues/11498")]
     public void TextBoxBase_Copy_PasteNotEmptyWithHandle_Success()
     {
         using SubTextBox control = new()


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #[2053861]( https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2053861)

## Proposed changes

- Separate `DrawPopUpCombo `from `DrawFlatCombo `method，draw the outer black border only when the ComboBox mouse is over

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Combobox no longer flickers when hovering over it

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
Combo box flashes when you move the mouse over it
![BeforeChange](https://github.com/dotnet/winforms/assets/132890443/8ea275c8-bf51-46a5-8091-c167aa0dd4be)

### After
Combo boxes no longer flicker when you move the mouse over them
![AfterChange](https://github.com/dotnet/winforms/assets/132890443/7c81c9de-9231-41ed-bdb6-8eec70e45cae)


## Test methodology <!-- How did you ensure quality? -->

- Manually

## Test environment(s) <!-- Remove any that don't apply -->

- .net 9.0.0-preview.6.24305.2


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11529)