### PR TITLE
Adding new strongly typed methods to Clipboard, DataObject and IDataObject.

### DIFF
--- a/docs/list-of-diagnostics.md
+++ b/docs/list-of-diagnostics.md
@@ -13,6 +13,7 @@ The acceptance criteria for adding an obsoletion includes:
 * Add new constants to `src\Common\src\Obsoletions.cs`, following the existing conventions
     * A `...Message` const using the same description added to the table below
     * A `...DiagnosticId` const for the `WFDEV###` id
+* If adding <Obsolete> attribute to Microsoft.VisualBasic.Forms assembly, edit src\Microsoft.VisualBasic.Forms\src\Obsoletions.vb file
 * Annotate `src` files by referring to the constants defined from `Obsoletions.cs`
     * Specify the `UrlFormat = Obsoletions.SharedUrlFormat`
     * Example: `[Obsolete(Obsoletions.DomainUpDownAccessibleObjectMessage, DiagnosticId = Obsoletions.DomainUpDownAccessibleObjectDiagnosticId, UrlFormat = Obsoletions.SharedUrlFormat)]`
@@ -39,6 +40,9 @@ The acceptance criteria for adding an obsoletion includes:
 |  __`WFDEV002`__ | `DomainUpDown.DomainUpDownAccessibleObject` is no longer used to provide accessible support for `DomainUpDown` controls. Use `ControlAccessibleObject` instead. |
 |  __`WFDEV003`__ | `DomainUpDown.DomainItemAccessibleObject` is no longer used to provide accessible support for `DomainUpDown` items. |
 |  __`WFDEV004`__ | `Form.OnClosing`, `Form.OnClosed` and the corresponding events are obsolete. Use `Form.OnFormClosing`, `Form.OnFormClosed`, `Form.FormClosing` and `Form.FormClosed` instead. |
+|  __`WFDEV005`__ | `Clipboard.GetData(string)` method is obsolete. Use `Clipboard.TryGetData<T>` methods instead. |
+|  __`WFDEV005`__ | `DataObject.GetData` methods are obsolete. Use the corresponding `DataObject.TryGetData<T>` instead. |
+|  __`WFDEV005`__ | `ClipboardProxy.GetData(As String)` method is obsolete. Use `ClipboardProxy.TryGetData(Of T)(As String, As T)` instead. |
 
 
 ## Analyzer Warnings

--- a/src/Common/src/Obsoletions.cs
+++ b/src/Common/src/Obsoletions.cs
@@ -9,7 +9,7 @@ internal static class Obsoletions
 {
     internal const string SharedUrlFormat = "https://aka.ms/winforms-warnings/{0}";
 
-    // Please see docs\project\list-of-diagnostics.md for instructions on the steps required
+    // Please see docs\list-of-diagnostics.md for instructions on the steps required
     // to introduce a new obsoletion, apply it to downlevel builds, claim a diagnostic id,
     // and ensure the "aka.ms/dotnet-warnings/{0}" URL points to documentation for the obsoletion
     // The diagnostic ids reserved for obsoletions are WFDEV### (WFDEV001 - WFDEV999).
@@ -24,4 +24,11 @@ internal static class Obsoletions
 
     internal const string FormOnClosingClosedMessage = "Form.OnClosing, Form.OnClosed and the corresponding events are obsolete. Use Form.OnFormClosing, Form.OnFormClosed, Form.FormClosing and Form.FormClosed instead.";
     internal const string FormOnClosingClosedDiagnosticId = "WFDEV004";
+
+    internal const string ClipboardGetDataMessage = "`Clipboard.GetData(string)` method is obsolete. Use `Clipboard.TryGetData<T>` methods instead.";
+    internal const string ClipboardGetDataDiagnosticId = "WFDEV005";
+
+    internal const string DataObjectGetDataMessage = "`DataObject.GetData` methods are obsolete. Use the corresponding `DataObject.TryGetData<T>` instead.";
+
+    internal const string ClipboardProxyGetDataMessage = "`ClipboardProxy.GetData(As String)` method is obsolete. Use `ClipboardProxy.TryGetData(Of T)(As String, As T)` instead.";
 }

--- a/src/Common/tests/TestUtilities/AppContextSwitchNames.cs
+++ b/src/Common/tests/TestUtilities/AppContextSwitchNames.cs
@@ -14,8 +14,23 @@ public static class AppContextSwitchNames
         = "System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization";
 
     /// <summary>
-    ///  Switch that controls <see cref="AppContext"/> switch caching.
+    ///  Switch that controls <see cref="AppContext"/> switch caching. This switch is set to
+    ///  <see langword="true" /> in our test assemblies.
     /// </summary>
     public const string LocalAppContext_DisableCaching
         = "TestSwitch.LocalAppContext.DisableCaching";
+
+    /// <summary>
+    ///  The switch that controls whether or not the <see cref="BinaryFormatter"/> is enabled in the
+    ///  Clipboard or drag and drop scenarios
+    /// </summary>
+    public const string ClipboardDragDropEnableUnsafeBinaryFormatterSerializationSwitchName
+        = "Windows.ClipboardDragDrop.EnableUnsafeBinaryFormatterSerialization";
+
+    /// <summary>
+    ///  The switch that controls whether or not the System.Windows.Forms.BinaryFormat.Deserializer
+    ///  is enabled in the Clipboard or drag and drop scenarios.
+    /// </summary>
+    public const string ClipboardDragDropEnableNrbfSerializationSwitchName
+        = "Windows.ClipboardDragDrop.EnableNrbfSerialization";
 }

--- a/src/Common/tests/TestUtilities/BinaryFormatterInClipboardDragDropScope.cs
+++ b/src/Common/tests/TestUtilities/BinaryFormatterInClipboardDragDropScope.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System;
+
+public readonly ref struct BinaryFormatterInClipboardDragDropScope
+{
+    private readonly AppContextSwitchScope _switchScope;
+
+    public BinaryFormatterInClipboardDragDropScope(bool enable)
+    {
+        Monitor.Enter(typeof(BinaryFormatterInClipboardDragDropScope));
+        _switchScope = new(AppContextSwitchNames.ClipboardDragDropEnableUnsafeBinaryFormatterSerializationSwitchName, GetDefaultValue, enable);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            _switchScope.Dispose();
+        }
+        finally
+        {
+            Monitor.Exit(typeof(BinaryFormatterInClipboardDragDropScope));
+        }
+    }
+
+    internal static bool GetDefaultValue()
+    {
+        var assemblies = AppDomain.CurrentDomain.GetAssemblies();
+        foreach (var assembly in assemblies)
+        {
+            if (assembly.FullName?.StartsWith("System.Windows.Forms.Primitives,", StringComparison.InvariantCultureIgnoreCase) == true)
+            {
+                var type = assembly.GetType("System.Windows.Forms.Primitives.LocalAppContextSwitches")
+                    ?? throw new InvalidOperationException("Could not find LocalAppContextSwitches type in System.Windows.Forms.Primitives assembly.");
+
+                bool value = type.TestAccessor().CreateDelegate<Func<string, bool>>("GetSwitchDefaultValue")
+                    (AppContextSwitchNames.ClipboardDragDropEnableUnsafeBinaryFormatterSerializationSwitchName);
+                return value;
+            }
+        }
+
+        throw new InvalidOperationException("Could not find System.Windows.Forms.Primitives assembly in the test process.");
+    }
+}

--- a/src/Common/tests/TestUtilities/NrbfSerializerInClipboardDragDropScope.cs
+++ b/src/Common/tests/TestUtilities/NrbfSerializerInClipboardDragDropScope.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System;
+
+public readonly ref struct NrbfSerializerInClipboardDragDropScope
+{
+    private readonly AppContextSwitchScope _switchScope;
+
+    public NrbfSerializerInClipboardDragDropScope(bool enable)
+    {
+        Monitor.Enter(typeof(NrbfSerializerInClipboardDragDropScope));
+        _switchScope = new(AppContextSwitchNames.ClipboardDragDropEnableNrbfSerializationSwitchName, GetDefaultValue, enable);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            _switchScope.Dispose();
+        }
+        finally
+        {
+            Monitor.Exit(typeof(NrbfSerializerInClipboardDragDropScope));
+        }
+    }
+
+    internal static bool GetDefaultValue()
+    {
+        var assemblies = AppDomain.CurrentDomain.GetAssemblies();
+        foreach (var assembly in assemblies)
+        {
+            if (assembly.FullName?.StartsWith("System.Windows.Forms.Primitives,", StringComparison.InvariantCultureIgnoreCase) == true)
+            {
+                var type = assembly.GetType("System.Windows.Forms.Primitives.LocalAppContextSwitches")
+                    ?? throw new InvalidOperationException("Could not find LocalAppContextSwitches type in System.Windows.Forms.Primitives assembly.");
+
+                bool value = type.TestAccessor().CreateDelegate<Func<string, bool>>("GetSwitchDefaultValue")
+                    (AppContextSwitchNames.ClipboardDragDropEnableNrbfSerializationSwitchName);
+                return value;
+            }
+        }
+
+        throw new InvalidOperationException("Could not find System.Windows.Forms.Primitives assembly in the test process.");
+    }
+}

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/MyServices/ClipboardProxy.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/MyServices/ClipboardProxy.vb
@@ -6,6 +6,8 @@ Imports System.ComponentModel
 Imports System.Drawing
 Imports System.IO
 Imports System.Windows.Forms
+Imports System.Reflection.Metadata
+Imports System.Runtime.InteropServices
 
 Namespace Microsoft.VisualBasic.MyServices
 
@@ -93,8 +95,15 @@ Namespace Microsoft.VisualBasic.MyServices
         ''' </summary>
         ''' <param name="format">The type of data being sought.</param>
         ''' <returns>The data.</returns>
+        <Obsolete(
+            Obsoletions.ClipboardProxyGetDataMessage,
+            False,
+            DiagnosticId:=Obsoletions.ClipboardGetDataDiagnosticId,
+            UrlFormat:=Obsoletions.SharedUrlFormat)>
         Public Function GetData(format As String) As Object
+#Disable Warning WFDEV005 ' Type or member is obsolete
             Return Clipboard.GetData(format)
+#Enable Warning WFDEV005
         End Function
 
         ''' <summary>
@@ -183,6 +192,16 @@ Namespace Microsoft.VisualBasic.MyServices
             Clipboard.SetFileDropList(filePaths)
         End Sub
 
+        ''' <inheritdoc cref="Clipboard.TryGetData(Of T)(String, Func(Of TypeName, Type), ByRef T)" />
+        Public Function TryGetData(Of T)(format As String, resolver As Func(Of TypeName, Type), <Out> ByRef data As T) As Boolean
+            Return Clipboard.TryGetData(format, resolver, data)
+        End Function
+
+        ''' <inheritdoc cref="Clipboard.TryGetData(Of T)(String, ByRef T)" />
+        Public Function TryGetData(Of T)(format As String, <Out> ByRef data As T) As Boolean
+            Return Clipboard.TryGetData(format, data)
+        End Function
+
         ''' <summary>
         '''  Saves the passed in <see cref="Image"/> to the clipboard.
         ''' </summary>
@@ -192,7 +211,7 @@ Namespace Microsoft.VisualBasic.MyServices
         End Sub
 
         ''' <summary>
-        '''  Saves the passed in String to the clipboard.
+        '''  Saves the passed in <see cref="String" /> to the clipboard.
         ''' </summary>
         ''' <param name="text">The <see cref="String"/> to save.</param>
         Public Sub SetText(text As String)

--- a/src/Microsoft.VisualBasic.Forms/src/Obsoletions.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Obsoletions.vb
@@ -1,0 +1,13 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+
+Friend NotInheritable Class Obsoletions
+
+    Friend Const SharedUrlFormat As String = "https://aka.ms/winforms-warnings/{0}"
+
+    ' Please see docs\list-Of-diagnostics.md for how to claim a diagnostic id.
+    ' The diagnostic ids reserved for obsoletions are WFDEV### (WFDEV001 - WFDEV999).
+
+    Friend Const ClipboardProxyGetDataMessage As String = "`ClipboardProxy.GetData(As String)` method is obsolete. Use `ClipboardProxy.TryGetData(Of T)(As String, As T)` instead."
+    Friend Const ClipboardGetDataDiagnosticId As String = "WFDEV005"
+End Class

--- a/src/Microsoft.VisualBasic.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualBasic.Forms/src/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.VisualBasic.MyServices.ClipboardProxy.TryGetData(Of T)(format As String, ByRef data As T) -> Boolean
+Microsoft.VisualBasic.MyServices.ClipboardProxy.TryGetData(Of T)(format As String, resolver As System.Func(Of System.Reflection.Metadata.TypeName, System.Type), ByRef data As T) -> Boolean

--- a/src/Microsoft.VisualBasic/tests/UnitTests/Microsoft/VisualBasic/MyServices/ClipboardProxyTests.cs
+++ b/src/Microsoft.VisualBasic/tests/UnitTests/Microsoft/VisualBasic/MyServices/ClipboardProxyTests.cs
@@ -111,8 +111,10 @@ public class ClipboardProxyTests
         // This test assembly does not reference the OOB package, we will write the NotSupportedException to the clipboard.
         clipboard.SetData(format, data);
         // Both methods return false.
-        clipboard.TryGetData(format, DataWithObjectField.Resolver, out DataWithObjectField? actual).Should()
-            .Be(System.Windows.Forms.Clipboard.TryGetData(format, DataWithObjectField.Resolver, out DataWithObjectField? expected));
+        Action tryGetData = () => clipboard.TryGetData(format, DataWithObjectField.Resolver, out DataWithObjectField? actual);
+        string actual = tryGetData.Should().Throw<NotSupportedException>().Which.Message;
+        Action tryGetData1 = () => System.Windows.Forms.Clipboard.TryGetData(format, DataWithObjectField.Resolver, out DataWithObjectField? expected);
+        string expected = tryGetData1.Should().Throw<NotSupportedException>().Which.Message;
         actual.Should().BeEquivalentTo(expected);
     }
 

--- a/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
@@ -230,7 +230,7 @@ internal static partial class LocalAppContextSwitches
     }
 
     /// <summary>
-    ///  If <see langword="true"/>, then Clipboard and DataObject Get and Set methods will attempts to deserialize
+    ///  If <see langword="true"/>, then Clipboard and DataObject Get and Set methods will attempts to serialize or deserialize
     ///  binary formatted content using either <see cref="BinaryFormatter"/> or System.Windows.Forms.BinaryFormat.Deserializer.
     ///  To use <see cref="BinaryFormatter"/>, application should also opt in into the
     ///  "System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization" option and reference the out-of-band

--- a/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.CompilerServices;
+using System.Runtime.Serialization.Formatters.Binary;
 using System.Runtime.Versioning;
 
 namespace System.Windows.Forms.Primitives;
@@ -25,6 +26,8 @@ internal static partial class LocalAppContextSwitches
     internal const string NoClientNotificationsSwitchName = "Switch.System.Windows.Forms.AccessibleObject.NoClientNotifications";
     internal const string EnableMsoComponentManagerSwitchName = "Switch.System.Windows.Forms.EnableMsoComponentManager";
     internal const string TreeNodeCollectionAddRangeRespectsSortOrderSwitchName = "System.Windows.Forms.TreeNodeCollectionAddRangeRespectsSortOrder";
+    internal const string ClipboardDragDropEnableUnsafeBinaryFormatterSerializationSwitchName = "Windows.ClipboardDragDrop.EnableUnsafeBinaryFormatterSerialization";
+    internal const string ClipboardDragDropEnableNrbfSerializationSwitchName = "Windows.ClipboardDragDrop.EnableNrbfSerialization";
 
     private static int s_scaleTopLevelFormMinMaxSizeForDpi;
     private static int s_anchorLayoutV2;
@@ -36,11 +39,13 @@ internal static partial class LocalAppContextSwitches
     private static int s_noClientNotifications;
     private static int s_enableMsoComponentManager;
     private static int s_treeNodeCollectionAddRangeRespectsSortOrder;
+    private static int s_clipboardDragDropEnableUnsafeBinaryFormatterSerialization;
+    private static int s_clipboardDragDropEnableNrbfSerialization;
 
     private static FrameworkName? s_targetFrameworkName;
 
     /// <summary>
-    ///  When there is no exception handler registered for a thread, rethrows the exception. The exception will
+    ///  When there is no exception handler registered for a thread, re-throws the exception. The exception will
     ///  not be presented in a dialog or swallowed when not in interactive mode. This is always opt-in and is
     ///  intended for scenarios where setting handlers for threads isn't practical.
     /// </summary>
@@ -102,6 +107,11 @@ internal static partial class LocalAppContextSwitches
     private static bool GetSwitchDefaultValue(string switchName)
     {
         if (switchName == TreeNodeCollectionAddRangeRespectsSortOrderSwitchName)
+        {
+            return true;
+        }
+
+        if (switchName == ClipboardDragDropEnableNrbfSerializationSwitchName)
         {
             return true;
         }
@@ -217,5 +227,37 @@ internal static partial class LocalAppContextSwitches
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get => GetCachedSwitchValue(TreeNodeCollectionAddRangeRespectsSortOrderSwitchName, ref s_treeNodeCollectionAddRangeRespectsSortOrder);
+    }
+
+    /// <summary>
+    ///  If <see langword="true"/>, then Clipboard and DataObject Get and Set methods will attempts to deserialize
+    ///  binary formatted content using either <see cref="BinaryFormatter"/> or System.Windows.Forms.BinaryFormat.Deserializer.
+    ///  To use <see cref="BinaryFormatter"/>, application should also opt in into the
+    ///  "System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization" option and reference the out-of-band
+    ///  "System.Runtime.Serialization.Formatters" NuGet package and opt out from using the System.Windows.Forms.BinaryFormat.Deserializer
+    ///  by setting "Windows.ClipboardDragDrop.EnableNrbfSerialization" to <see langword="true"/>
+    /// </summary>
+    public static bool ClipboardDragDropEnableUnsafeBinaryFormatterSerialization
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => GetCachedSwitchValue(ClipboardDragDropEnableUnsafeBinaryFormatterSerializationSwitchName,
+            ref s_clipboardDragDropEnableUnsafeBinaryFormatterSerialization);
+    }
+
+    /// <summary>
+    ///  If <see langword="true"/>, then Clipboard Get methods will prefer System.Windows.Forms.BinaryFormat.Deserializer
+    ///  to deserialize the payload, if needed.  If <see langword="false"/>, then <see cref="BinaryFormatter"/> is used
+    ///  to get full compatibility with the downlevel versions of .NET.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   This switch has no effect if "Windows.ClipboardDragDrop.EnableUnsafeBinaryFormatterSerialization"
+    ///   is set to <see langword="false"/>.
+    ///  </para>
+    /// </remarks>
+    public static bool ClipboardDragDropEnableNrbfSerialization
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => GetCachedSwitchValue(ClipboardDragDropEnableNrbfSerializationSwitchName, ref s_clipboardDragDropEnableNrbfSerialization);
     }
 }

--- a/src/System.Windows.Forms/src/GlobalSuppressions.cs
+++ b/src/System.Windows.Forms/src/GlobalSuppressions.cs
@@ -229,7 +229,6 @@
 [assembly: SuppressMessage("CodeQuality", "IDE0051:Remove unused private members", Justification = "Designer", Scope = "member", Target = "~M:System.Windows.Forms.MdiClient.ShouldSerializeLocation~System.Boolean")]
 
 // Ideally these should be different exceptions, but leaving them as shipped for compatibility
-[assembly: SuppressMessage("Usage", "CA2201:Do not raise reserved exception types", Justification = "Compat", Scope = "member", Target = "~M:System.Windows.Forms.DataObject.Composition.NativeToWinFormsAdapter.GetDataFromHGLOBAL(Windows.Win32.Foundation.HGLOBAL,System.String)~System.Object")]
 [assembly: SuppressMessage("Usage", "CA2201:Do not raise reserved exception types", Justification = "Compat", Scope = "member", Target = "~M:System.Windows.Forms.DataObject.Composition.NativeToWinFormsAdapter.ReadByteStreamFromHGLOBAL(Windows.Win32.Foundation.HGLOBAL,System.Boolean@)~System.IO.MemoryStream")]
 [assembly: SuppressMessage("Usage", "CA2201:Do not raise reserved exception types", Justification = "Compat", Scope = "member", Target = "~M:System.Windows.Forms.DataObject.Composition.NativeToRuntimeAdapter.System#Runtime#InteropServices#ComTypes#IDataObject#EnumFormatEtc(System.Runtime.InteropServices.ComTypes.DATADIR)~System.Runtime.InteropServices.ComTypes.IEnumFORMATETC")]
 [assembly: SuppressMessage("Usage", "CA2201:Do not raise reserved exception types", Justification = "Compat", Scope = "member", Target = "~M:System.Windows.Forms.Clipboard.SetDataObject(System.Object,System.Boolean,System.Int32,System.Int32)")]

--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -1,4 +1,21 @@
+static System.Windows.Forms.Clipboard.TryGetData<T>(string! format, out T data) -> bool
+static System.Windows.Forms.Clipboard.TryGetData<T>(string! format, System.Func<System.Reflection.Metadata.TypeName!, System.Type!>! resolver, out T data) -> bool
+static System.Windows.Forms.DataObjectExtensions.TryGetData<T>(this System.Windows.Forms.IDataObject! dataObject, out T data) -> bool
+static System.Windows.Forms.DataObjectExtensions.TryGetData<T>(this System.Windows.Forms.IDataObject! dataObject, string! format, bool autoConvert, out T data) -> bool
+static System.Windows.Forms.DataObjectExtensions.TryGetData<T>(this System.Windows.Forms.IDataObject! dataObject, string! format, out T data) -> bool
+static System.Windows.Forms.DataObjectExtensions.TryGetData<T>(this System.Windows.Forms.IDataObject! dataObject, string! format, System.Func<System.Reflection.Metadata.TypeName!, System.Type!>! resolver, bool autoConvert, out T data) -> bool
 System.Windows.Forms.DataGridViewCellStyle.Font.get -> System.Drawing.Font?
+System.Windows.Forms.DataObject.TryGetData<T>(out T data) -> bool
+System.Windows.Forms.DataObject.TryGetData<T>(string! format, bool autoConvert, out T data) -> bool
+System.Windows.Forms.DataObject.TryGetData<T>(string! format, out T data) -> bool
+System.Windows.Forms.DataObject.TryGetData<T>(string! format, System.Func<System.Reflection.Metadata.TypeName!, System.Type!>! resolver, bool autoConvert, out T data) -> bool
+System.Windows.Forms.DataObjectExtensions
+System.Windows.Forms.ITypedDataObject
+System.Windows.Forms.ITypedDataObject.TryGetData<T>(out T data) -> bool
+System.Windows.Forms.ITypedDataObject.TryGetData<T>(string! format, bool autoConvert, out T data) -> bool
+System.Windows.Forms.ITypedDataObject.TryGetData<T>(string! format, out T data) -> bool
+System.Windows.Forms.ITypedDataObject.TryGetData<T>(string! format, System.Func<System.Reflection.Metadata.TypeName!, System.Type!>! resolver, bool autoConvert, out T data) -> bool
+virtual System.Windows.Forms.DataObject.TryGetDataCore<T>(string! format, System.Func<System.Reflection.Metadata.TypeName!, System.Type!>? resolver, bool autoConvert, out T data) -> bool
 [WFO5001]static System.Windows.Forms.Application.SetColorMode(System.Windows.Forms.SystemColorMode systemColorMode) -> void
 [WFO5001]System.Windows.Forms.Form.FormBorderColorChanged -> System.EventHandler?
 [WFO5001]System.Windows.Forms.Form.FormCaptionBackColorChanged -> System.EventHandler?

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Internal/Formatter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Internal/Formatter.cs
@@ -525,9 +525,9 @@ internal static class Formatter
     }
 
     /// <summary>
-    ///  Extract the inner type from a nullable type
+    ///  Extract the inner type from a nullable type.
     /// </summary>
-    private static Type NullableUnwrap(Type type)
+    public static Type NullableUnwrap(Type type)
     {
         if (type == s_stringType) // ...performance optimization for the most common case
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Internal/TypeExtensions.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Internal/TypeExtensions.cs
@@ -12,6 +12,8 @@ namespace System.Windows.Forms;
 /// </summary>
 internal static class TypeExtensions
 {
+    private static readonly Type s_forwardedFromAttributeType = typeof(TypeForwardedFromAttribute);
+
     /// <summary>
     ///  Get the full assembly name this <paramref name="type"/> is forwarded from.
     /// </summary>
@@ -30,9 +32,10 @@ internal static class TypeExtensions
             attributedType = attributedType.GetElementType()!;
         }
 
-        foreach (Attribute first in attributedType.GetCustomAttributes(typeof(TypeForwardedFromAttribute), inherit: false))
+        object[] attributes = attributedType.GetCustomAttributes(s_forwardedFromAttributeType, inherit: false);
+        if (attributes.Length > 0 && attributes[0] is TypeForwardedFromAttribute attribute)
         {
-            name = ((TypeForwardedFromAttribute)first).AssemblyFullName;
+            name = attribute.AssemblyFullName;
             return true;
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Internal/TypeExtensions.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Internal/TypeExtensions.cs
@@ -156,6 +156,9 @@ internal static class TypeExtensions
         }
     }
 
+    /// <summary>
+    ///  Match <see cref="TypeName"/>s using all information that had been set by the caller.
+    /// </summary>
     public static bool Matches(this TypeName x, TypeName y)
     {
         if (x.IsArray != y.IsArray
@@ -231,6 +234,10 @@ internal static class TypeExtensions
         }
     }
 
+    /// <summary>
+    ///  Convert <paramref name="type"/> to <see cref="TypeName"/>. This method removes nullability wrapper
+    ///  from the top level type only because <see cref="TypeName"/> in the serialization root record is not nullable.
+    /// </summary>
     public static TypeName ToTypeName(this Type type)
     {
         // Unwrap type that is matched against the root record type.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Internal/TypeExtensions.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Internal/TypeExtensions.cs
@@ -1,0 +1,230 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+using System.Runtime.CompilerServices;
+
+namespace System.Windows.Forms;
+
+/// <summary>
+///  Helper methods for comparing <see cref="Type"/>s and <see cref="TypeName"/>s.
+/// </summary>
+internal static class TypeExtensions
+{
+    /// <summary>
+    ///  Get the full assembly name this <paramref name="type"/> is forwarded from.
+    /// </summary>
+    /// <returns>
+    ///  <see langword="true"/> if the <paramref name="type"/> is forwarded from another assembly;
+    ///  otherwise, <see langword="false"/>.
+    /// </returns>
+    public static bool TryGetForwardedFromName(this Type type, [NotNullWhen(true)] out string? name)
+    {
+        name = default;
+
+        // Special case types like arrays.
+        Type attributedType = type;
+        while (attributedType.HasElementType)
+        {
+            attributedType = attributedType.GetElementType()!;
+        }
+
+        foreach (Attribute first in attributedType.GetCustomAttributes(typeof(TypeForwardedFromAttribute), inherit: false))
+        {
+            name = ((TypeForwardedFromAttribute)first).AssemblyFullName;
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    ///  The entry point for matching <paramref name="type"/> to <paramref name="typeName"/>. The top level <see cref="Type"/>
+    ///  can be nullable, as the user would request a nullable type read from the clipboard payload, but the root record would
+    ///  serialize a non-nullable type, thus <paramref name="typeName"/> from the root record is not nullable.
+    /// </summary>
+    public static bool MatchExceptAssemblyVersion(this Type type, TypeName typeName)
+    {
+        type = Formatter.NullableUnwrap(type);
+
+        return type.MatchLessAssemblyVersion(typeName);
+    }
+
+    /// <summary>
+    ///  Match namespace-qualified type names and assembly names with no version.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///  Read the <see cref="TypeForwardedFromAttribute"/> from the <paramref name="type"/> to match the unified assembly names,
+    ///  because <paramref name="typeName"/> had been serialized with the forwarded from assembly name by our serializers.
+    ///  </para>
+    /// </remarks>
+    // based on https://github.com/dotnet/runtime/blob/1474fc3fafca26b4b051be7dacdba8ac2804c56e/src/libraries/System.Formats.Nrbf/src/System/Formats/Nrbf/SerializationRecord.cs#L68
+    private static bool MatchLessAssemblyVersion(this Type type, TypeName typeName)
+    {
+        // We don't need to check for pointers and references to arrays,
+        // as it's impossible to serialize them with BF.
+        if (type is null || type.IsPointer || type.IsByRef)
+        {
+            return false;
+        }
+
+        // At first, check the non-allocating properties for mismatch.
+        if (type.IsArray != typeName.IsArray
+            || type.IsConstructedGenericType != typeName.IsConstructedGenericType
+            || type.IsNested != typeName.IsNested
+            || (type.IsArray && type.GetArrayRank() != typeName.GetArrayRank())
+            || type.IsSZArray != typeName.IsSZArray // int[] vs int[*]
+            )
+        {
+            return false;
+        }
+
+        if (!type.TryGetForwardedFromName(out string? name))
+        {
+            name = type.Assembly.FullName;
+        }
+
+        if (!AssemblyNamesLessVersionMatch(name, typeName.AssemblyName))
+        {
+            return false;
+        }
+
+        if (type.FullName == typeName.FullName)
+        {
+            return true;
+        }
+
+        if (typeName.IsArray)
+        {
+            return MatchLessAssemblyVersion(type.GetElementType()!, typeName.GetElementType());
+        }
+
+        if (type.IsConstructedGenericType)
+        {
+            if (!MatchLessAssemblyVersion(type.GetGenericTypeDefinition(), typeName.GetGenericTypeDefinition()))
+            {
+                return false;
+            }
+
+            ImmutableArray<TypeName> genericNames = typeName.GetGenericArguments();
+            Type[] genericTypes = type.GetGenericArguments();
+
+            if (genericNames.Length != genericTypes.Length)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < genericTypes.Length; i++)
+            {
+                if (!MatchLessAssemblyVersion(genericTypes[i], genericNames[i]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        return false;
+
+        static bool AssemblyNamesLessVersionMatch(string? fullName, AssemblyNameInfo? nameInfo)
+        {
+            if (string.Equals(fullName, nameInfo?.FullName, StringComparison.InvariantCultureIgnoreCase))
+            {
+                return true;
+            }
+
+            if (fullName is null || nameInfo is null)
+            {
+                return false;
+            }
+
+            if (!AssemblyNameInfo.TryParse(fullName, out AssemblyNameInfo? nameInfo1))
+            {
+                return false;
+            }
+
+            // Match everything except for the versions.
+            return nameInfo.Name == nameInfo1.Name
+                && ((nameInfo.CultureName ?? string.Empty) == nameInfo1.CultureName)
+                && nameInfo.PublicKeyOrToken.AsSpan().SequenceEqual(nameInfo1.PublicKeyOrToken.AsSpan());
+        }
+    }
+
+    public static bool Matches(this TypeName x, TypeName y)
+    {
+        if (x.IsArray != y.IsArray
+            || x.IsConstructedGenericType != y.IsConstructedGenericType
+            || x.IsNested != y.IsNested
+            || (x.IsArray && x.GetArrayRank() != y.GetArrayRank())
+            || x.IsSZArray != y.IsSZArray // int[] vs int[*]
+            )
+        {
+            return false;
+        }
+
+        if (!AssemblyNamesMatch(x.AssemblyName, y.AssemblyName))
+        {
+            return false;
+        }
+
+        if (x.FullName == y.FullName)
+        {
+            return true;
+        }
+
+        if (y.IsArray)
+        {
+            return Matches(x.GetElementType(), y.GetElementType());
+        }
+
+        if (x.IsConstructedGenericType)
+        {
+            if (!Matches(x.GetGenericTypeDefinition(), y.GetGenericTypeDefinition()))
+            {
+                return false;
+            }
+
+            ImmutableArray<TypeName> genericNamesY = y.GetGenericArguments();
+            ImmutableArray<TypeName> genericNamesX = x.GetGenericArguments();
+
+            if (genericNamesX.Length != genericNamesY.Length)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < genericNamesX.Length; i++)
+            {
+                if (!Matches(genericNamesX[i], genericNamesY[i]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        return false;
+
+        static bool AssemblyNamesMatch(AssemblyNameInfo? name1, AssemblyNameInfo? name2)
+        {
+            if (name1 is null && name2 is null)
+            {
+                return true;
+            }
+
+            if (name1 is null || name2 is null)
+            {
+                return false;
+            }
+
+            // Case-sensitive comparisons.
+            return name1.Name == name2.Name
+                && name1.CultureName == name2.CultureName
+                && name1.Version == name2.Version
+                && name1.PublicKeyOrToken.AsSpan().SequenceEqual(name2.PublicKeyOrToken.AsSpan());
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/Clipboard.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/Clipboard.cs
@@ -450,8 +450,7 @@ public static class Clipboard
     ///  Retrieves a <see cref="Bitmap"/> from the <see cref="Clipboard"/>.
     /// </summary>
     /// <devdoc>
-    ///  <see cref="Bitmap"/>s are re-hydrated from a <see cref="SerializationRecord"/> by reading a byte array
-    ///  but if that fails, <see cref="BinaryFormatter"/> is restricted by the <see cref="DataObject.BitmapBinder"/>.
+    ///  <see cref="Bitmap"/>s are re-hydrated from a <see cref="SerializationRecord"/> by reading a byte array.
     /// </devdoc>
     public static Image? GetImage() => GetTypedDataIfAvailable<Image>(DataFormats.Bitmap);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/Clipboard.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/Clipboard.cs
@@ -422,7 +422,7 @@ public static class Clipboard
         {
             // TODO (TanyaSo): localize string
             throw new NotSupportedException(string.Format(
-                "IDataObject({0}) on the Clipboard doesn't implement `ITypedDataObject` interface and can't be read" +
+                "Data object `{0}` doesn't implement `ITypedDataObject` interface and can't be read" +
                     " using `TryGetData<T>(string, out T)` method.",
                 dataObject.GetType().FullName));
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/Clipboard.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/Clipboard.cs
@@ -3,7 +3,10 @@
 
 using System.Collections.Specialized;
 using System.Drawing;
+using System.Formats.Nrbf;
+using System.Reflection.Metadata;
 using System.Runtime.InteropServices;
+using System.Runtime.Serialization.Formatters.Binary;
 using Windows.Win32.System.Com;
 using Com = Windows.Win32.System.Com;
 
@@ -17,11 +20,13 @@ public static class Clipboard
     /// <summary>
     ///  Places non-persistent data on the system <see cref="Clipboard"/>.
     /// </summary>
+    /// <inheritdoc cref="SetDataObject(object, bool, int, int)"/>
     public static void SetDataObject(object data) => SetDataObject(data, copy: false);
 
     /// <summary>
     ///  Overload that uses default values for retryTimes and retryDelay.
     /// </summary>
+    /// <inheritdoc cref="SetDataObject(object, bool, int, int)"/>
     public static void SetDataObject(object data, bool copy) =>
         SetDataObject(data, copy, retryTimes: 10, retryDelay: 100);
 
@@ -29,6 +34,11 @@ public static class Clipboard
     ///  Places data on the system <see cref="Clipboard"/> and uses copy to specify whether the data
     ///  should remain on the <see cref="Clipboard"/> after the application exits.
     /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   See remarks for <see cref="DataObject(object)"/> for recommendations on how to implement custom <paramref name="data"/>.
+    ///  </para>
+    /// </remarks>
     public static unsafe void SetDataObject(object data, bool copy, int retryTimes, int retryDelay)
     {
         if (Application.OleRequired() != ApartmentState.STA)
@@ -81,7 +91,7 @@ public static class Clipboard
         if (Application.OleRequired() != ApartmentState.STA)
         {
             // Only throw if a message loop was started. This makes the case of trying to query the clipboard from the
-            // finalizer or non-ui MTA thread silently fail, instead of making the application die.
+            // finalizer or non-UI MTA thread silently fail, instead of making the application die.
             return Application.MessageLoop ? throw new ThreadStateException(SR.ThreadMustBeSTA) : null;
         }
 
@@ -218,7 +228,7 @@ public static class Clipboard
     /// <summary>
     ///  Retrieves an audio stream from the <see cref="Clipboard"/>.
     /// </summary>
-    public static Stream? GetAudioStream() => GetData(DataFormats.WaveAudioConstant) as Stream;
+    public static Stream? GetAudioStream() => GetTypedDataIfAvailable<Stream>(DataFormats.WaveAudioConstant);
 
     /// <summary>
     ///  Retrieves data from the <see cref="Clipboard"/> in the specified format.
@@ -226,11 +236,200 @@ public static class Clipboard
     /// <exception cref="ThreadStateException">
     ///  The current thread is not in single-threaded apartment (STA) mode.
     /// </exception>
+    [Obsolete(
+        Obsoletions.ClipboardGetDataMessage,
+        error: false,
+        DiagnosticId = Obsoletions.ClipboardGetDataDiagnosticId,
+        UrlFormat = Obsoletions.SharedUrlFormat)]
     public static object? GetData(string format) =>
         string.IsNullOrWhiteSpace(format) ? null : GetData(format, autoConvert: false);
 
     private static object? GetData(string format, bool autoConvert) =>
         GetDataObject() is IDataObject dataObject ? dataObject.GetData(format, autoConvert) : null;
+
+    /// <summary>
+    ///  Retrieves data from the <see cref="Clipboard"/> in the specified format if that data is of type <typeparamref name="T"/>.
+    ///  This is an alternative to <see cref="GetData(string)"/> that uses <see cref="BinaryFormatter"/> only when application
+    ///  enabled the <see cref="AppContext"/> switch named "Windows.ClipboardDragDrop.EnableUnsafeBinaryFormatterSerialization".
+    ///  By default the NRBF deserializer attempts to deserialize the stream.  It can be disabled in favor of <see cref="BinaryFormatter"/>
+    ///  with <see cref="AppContext"/> switch named "Windows.ClipboardDragDrop.EnableNrbfSerialization".
+    /// </summary>
+    /// <param name="format">
+    ///  <para>
+    ///   The format of the data to retrieve.  See the <see cref="DataFormats"/> class for a set of predefined data formats.
+    ///  </para>
+    /// </param>
+    /// <param name="resolver">
+    ///  <para>
+    ///   A <see cref="Func{Type, TypeName}"/> that is used only when deserializing non-OLE formats.  It returns the type if
+    ///   <see cref="TypeName"/> is allowed or throws a <see cref="NotSupportedException"/> if <see cref="TypeName"/> is not
+    ///   expected.  It should not return a <see langword="null"/>.  It should resolve type requested by the user as
+    ///   <typeparamref name="T"/>, as well as types of its fields, unless they are primitive or known types.
+    ///  </para>
+    ///  <para>
+    ///   The following types are resolved automatically:
+    ///  </para>
+    ///  <list type="bullet">
+    ///   <item>
+    ///    <description>
+    ///     NRBF primitive types <see href="https://learn.microsoft.com/openspecs/windows_protocols/ms-nrbf/4e77849f-89e3-49db-8fb9-e77ee4bc7214"/>
+    ///     (bool, byte, char, decimal, double, short, int, long, sbyte, ushort, uint, ulong, float, string, TimeSpan, DateTime).
+    ///    </description>
+    ///   </item>
+    ///   <item>
+    ///    <description>
+    ///     System.Drawing.Primitive.dll exchange types (PointF, RectangleF, Point, Rectangle, SizeF, Size, Color).
+    ///    </description>
+    ///   </item>
+    ///   <item>
+    ///    <description>
+    ///     Types commonly used in WinForms applications (System.Drawing.Bitmap, System.Windows.Forms.ImageListStreamer,
+    ///     System.NotSupportedException, only the message is re-hydrated, List{T} where T is an NRBF primitive type,
+    ///     and arrays of NRBF primitive types).
+    ///    </description>
+    ///   </item>
+    ///  </list>
+    ///  <para>
+    ///   <see cref="TypeName"/> parameter can be matched according to the user requirements, for example, only namespace-qualified
+    ///   type names, or full type and assembly names, or full type names and short assembly names.
+    ///  </para>
+    /// </param>
+    /// <param name="data">
+    ///  <para>
+    ///   Out parameter that contains the retrieved data in the specified format, or <see lanfword="null"/> if the data is
+    ///   unavailable in the specified format, or is of a wrong <see cref="Type"/>.
+    ///  </para>
+    /// </param>
+    /// <returns>
+    ///  <see langword="true"/> if the data of this format is present on the clipboard and the value is
+    ///  of a matching type and that value can be successfully retrieved, or <see langword="false"/>
+    ///  if the format is not present or the value is of a wrong  <see cref="Type"/>.
+    /// </returns>
+    /// <remarks>
+    ///  <para>
+    ///   Avoid loading assemblies named in the <see cref="TypeName"/> argument of the resolver function.  Resolve only types
+    ///   available at the compile time, for example do not call the <see cref="Type.GetType(string)"/> method.
+    ///  </para>
+    ///  <para>
+    ///   Some common types, for example <see cref="Bitmap"/>, are type-forwarded from .NET Framework assemblies using the
+    ///   <see cref="Runtime.CompilerServices.TypeForwardedFromAttribute"/>.  <see cref="BinaryFormatter"/> serializes these types
+    ///   using the forwarded from assembly information.  The resolver function should take this into account and either
+    ///   match only namespace qualified type names or read the <see cref="Runtime.CompilerServices.TypeForwardedFromAttribute.AssemblyFullName"/>
+    ///   from the allowed type and match it to the <see cref="AssemblyNameInfo.FullName"/> property of <see cref="TypeName.AssemblyName"/>.
+    ///  </para>
+    ///  <para>
+    ///   Make sure to match short assembly names if other information, such as version, is not needed, for example, when your
+    ///   application can read multiple versions of the type.  For exact matching, including assembly version, resolver
+    ///   function is required, however primitive and common types are always matched after assembly version is removed.
+    ///  </para>
+    ///  <para>
+    ///   Arrays, generic types, and nullable value types have full element name, including its assembly name, in the
+    ///   <see cref="TypeName.FullName"/> property.  Resolver function should either remove or type-forward these assembly
+    ///   names when matching.
+    ///  </para>
+    /// </remarks>
+    /// <exception cref="NotSupportedException">
+    ///  If application does not support <see cref="BinaryFormatter"/> and the object can't be deserialized otherwise, or
+    ///  application supports <see cref="BinaryFormatter"/> but <typeparamref name="T"/> is an <see cref="object"/>,
+    ///  or not a concrete type, or if <paramref name="resolver"/> does not resolve the actual payload type.  Or
+    ///  the <see cref="IDataObject"/> on the <see cref="Clipboard"/> does not implement <see cref="ITypedDataObject"/>
+    ///  interface.
+    ///  </exception>
+    /// <example>
+    ///  <![CDATA[
+    ///   using System.Reflection.Metadata;
+    ///
+    ///   internal static Type MyExactMatchResolver(TypeName typeName)
+    ///   {
+    ///        // The preferred approach is to resolve types at build time to avoid assembly loading at runtime.
+    ///        (Type type, TypeName typeName)[] allowedTypes =
+    ///        [
+    ///            (typeof(MyClass1), TypeName.Parse(typeof(MyClass1).AssemblyQualifiedName)),
+    ///            (typeof(MyClass2), TypeName.Parse(typeof(MyClass2).AssemblyQualifiedName))
+    ///        ];
+    ///
+    ///        foreach (var (type, name) in allowedTypes)
+    ///        {
+    ///            // Namespace-qualified type name, using case-sensitive comparison for C#.
+    ///            if (name.FullName != typeName.FullName)
+    ///            {
+    ///                continue;
+    ///            }
+    ///
+    ///            AssemblyNameInfo? info1 = typeName.AssemblyName;
+    ///            AssemblyNameInfo? info2 = name.AssemblyName;
+    ///
+    ///            if (info1 is null && info2 is null)
+    ///            {
+    ///                return type;
+    ///            }
+    ///
+    ///            if (info1 is null || info2 is null)
+    ///            {
+    ///                continue;
+    ///            }
+    ///
+    ///            // Full assembly name comparison, case sensitive.
+    ///            if (info1.Name == info2.Name
+    ///                 && info1.Version == info2.Version
+    ///                 && ((info1.CultureName ?? string.Empty) == info2.CultureName)
+    ///                 && info1.PublicKeyOrToken.AsSpan().SequenceEqual(info2.PublicKeyOrToken.AsSpan()))
+    ///            {
+    ///                return type;
+    ///            }
+    ///        }
+    ///
+    ///        throw new NotSupportedException($"Can't resolve {typeName.AssemblyQualifiedName}");
+    ///    }
+    ///  ]]>
+    /// </example>
+    [CLSCompliant(false)]
+    public static bool TryGetData<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(
+        string format,
+        Func<TypeName, Type> resolver,
+        [NotNullWhen(true), MaybeNullWhen(false)] out T data)
+    {
+        data = default;
+        resolver.OrThrowIfNull();
+
+        return GetTypedDataObject<T>(format, out ITypedDataObject? typed)
+            && typed.TryGetData(format, resolver, autoConvert: false, out data);
+    }
+
+    /// <inheritdoc cref="TryGetData{T}(string, Func{TypeName, Type}, out T)"/>
+    public static bool TryGetData<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(
+        string format,
+        [NotNullWhen(true), MaybeNullWhen(false)] out T data)
+    {
+        data = default;
+
+        return GetTypedDataObject<T>(format, out ITypedDataObject? typed) && typed.TryGetData(format, out data);
+    }
+
+    private static bool GetTypedDataObject<T>(
+        string format,
+        [NotNullWhen(true), MaybeNullWhen(false)] out ITypedDataObject typed)
+    {
+        typed = default;
+        if (!DataObject.IsValidFormatAndType<T>(format)
+            || GetDataObject() is not { } dataObject)
+        {
+            // Invalid format or no object on the clipboard at all.
+            return false;
+        }
+
+        if (dataObject is not ITypedDataObject typedDataObject)
+        {
+            // TODO (TanyaSo): localize string
+            throw new NotSupportedException(string.Format(
+                "IDataObject({0}) on the Clipboard doesn't implement `ITypedDataObject` interface and can't be read" +
+                    " using `TryGetData<T>(string, out T)` method.",
+                dataObject.GetType().FullName));
+        }
+
+        typed = typedDataObject;
+        return true;
+    }
 
     /// <summary>
     ///  Retrieves a collection of file names from the <see cref="Clipboard"/>.
@@ -239,7 +438,7 @@ public static class Clipboard
     {
         StringCollection result = [];
 
-        if (GetData(DataFormats.FileDropConstant, autoConvert: true) is string[] strings)
+        if (GetTypedDataIfAvailable<string[]?>(DataFormats.FileDropConstant) is string[] strings)
         {
             result.AddRange(strings);
         }
@@ -248,9 +447,13 @@ public static class Clipboard
     }
 
     /// <summary>
-    ///  Retrieves an image from the <see cref="Clipboard"/>.
+    ///  Retrieves a <see cref="Bitmap"/> from the <see cref="Clipboard"/>.
     /// </summary>
-    public static Image? GetImage() => GetData(DataFormats.Bitmap, autoConvert: true) as Image;
+    /// <devdoc>
+    ///  <see cref="Bitmap"/>s are re-hydrated from a <see cref="SerializationRecord"/> by reading a byte array
+    ///  but if that fails, <see cref="BinaryFormatter"/> is restricted by the <see cref="DataObject.BitmapBinder"/>.
+    /// </devdoc>
+    public static Image? GetImage() => GetTypedDataIfAvailable<Image>(DataFormats.Bitmap);
 
     /// <summary>
     ///  Retrieves text data from the <see cref="Clipboard"/> in the <see cref="TextDataFormat.UnicodeText"/> format.
@@ -264,7 +467,24 @@ public static class Clipboard
     public static string GetText(TextDataFormat format)
     {
         SourceGenerated.EnumValidator.Validate(format, nameof(format));
-        return GetData(ConvertToDataFormats(format)) as string ?? string.Empty;
+
+        return GetTypedDataIfAvailable<string>(ConvertToDataFormats(format)) is string text ? text : string.Empty;
+    }
+
+    private static T? GetTypedDataIfAvailable<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(string format)
+    {
+        IDataObject? data = GetDataObject();
+        if (data is ITypedDataObject typed)
+        {
+            return typed.TryGetData(format, autoConvert: true, out T? value) ? value : default;
+        }
+
+        if (data is IDataObject dataObject)
+        {
+            return dataObject.GetData(format, autoConvert: true) is T value ? value : default;
+        }
+
+        return default;
     }
 
     /// <summary>
@@ -281,6 +501,11 @@ public static class Clipboard
     /// <summary>
     ///  Clears the Clipboard and then adds data in the specified format.
     /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   See remarks for <see cref="DataObject(object)"/> for recommendations on how to implement custom <paramref name="data"/>.
+    ///  </para>
+    /// </remarks>
     public static void SetData(string format, object data)
     {
         if (string.IsNullOrWhiteSpace(format.OrThrowIfNull()))

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.Composition.BinaryFormatUtilities.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.Composition.BinaryFormatUtilities.cs
@@ -84,6 +84,7 @@ public unsafe partial class DataObject
                 catch (Exception ex) when (!ex.IsCriticalException())
                 {
                     // Couldn't parse for some reason, let BinaryFormatter handle the legacy invocation.
+                    // The types APIs can't compare the specified type when the root record is not available.
                     if (legacyMode && LocalAppContextSwitches.ClipboardDragDropEnableUnsafeBinaryFormatterSerialization)
                     {
                         stream.Position = startPosition;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.Composition.BinaryFormatUtilities.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.Composition.BinaryFormatUtilities.cs
@@ -1,11 +1,16 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Formats.Nrbf;
+using System.Private.Windows.Core.BinaryFormat;
+using System.Reflection.Metadata;
+using System.Runtime.ExceptionServices;
 using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Windows.Forms.BinaryFormat;
 using System.Windows.Forms.Nrbf;
+using System.Windows.Forms.Primitives;
 
 namespace System.Windows.Forms;
 
@@ -32,46 +37,146 @@ public unsafe partial class DataObject
                     Debug.Fail($"Unexpected exception writing binary formatted data. {ex.Message}");
                 }
 
-                if (restrictSerialization)
-                {
-                    throw new SerializationException(string.Format(SR.UnexpectedTypeForClipboardFormat, data.GetType().FullName));
-                }
-
-#pragma warning disable SYSLIB0011 // Type or member is obsolete
-                // This check is to help in trimming scenarios with a trim warning on a call to BinaryFormatter.Serialize(),
-                // which has a RequiresUnreferencedCode annotation.
-                // If the flag is false, the trimmer will not generate a warning, since BinaryFormatter.Serialize(), will not be called,
-                // If the flag is true, the trimmer will generate a warning for calling a method that has a RequiresUnreferencedCode annotation.
+                // This check is to help in trimming scenarios with a trim warning on a call to
+                // BinaryFormatter.Serialize(), which has a RequiresUnreferencedCode annotation.
+                // If the flag is false, the trimmer will not generate a warning, since BinaryFormatter.Serialize(),
+                // will not be called,
+                // If the flag is true, the trimmer will generate a warning for calling a method that has a
+                // RequiresUnreferencedCode annotation.
                 if (!EnableUnsafeBinaryFormatterInNativeObjectSerialization)
                 {
                     throw new NotSupportedException(SR.BinaryFormatterNotSupported);
                 }
 
+                if (!LocalAppContextSwitches.ClipboardDragDropEnableUnsafeBinaryFormatterSerialization)
+                {
+                    // TODO (TanyaSo): localize string
+                    throw new NotSupportedException("BinaryFormatter is not supported in Clipboard or drag and drop scenarios.");
+                }
+
                 stream.Position = position;
-                new BinaryFormatter().Serialize(stream, data);
+#pragma warning disable SYSLIB0011 // Type or member is obsolete
+                new BinaryFormatter()
+                {
+                    Binder = restrictSerialization ? new BitmapBinder() : null
+                }.Serialize(stream, data);
 #pragma warning restore SYSLIB0011
             }
 
-            internal static object ReadObjectFromStream(MemoryStream stream, bool restrictDeserialization)
+            internal static object? ReadObjectFromStream<T>(
+                MemoryStream stream,
+                bool restrictDeserialization,
+                Func<TypeName, Type>? resolver,
+                bool legacyMode)
             {
                 long startPosition = stream.Position;
+                SerializationRecord? record;
+
+                SerializationBinder binder = restrictDeserialization
+                    ? new BitmapBinder()
+                    : new DataObject.Composition.Binder(typeof(T), resolver, legacyMode);
+
+                IReadOnlyDictionary<SerializationRecordId, SerializationRecord> recordMap;
                 try
                 {
-                    if (stream.Decode().TryGetCommonObject(out object? value))
-                    {
-                        return value;
-                    }
+                    record = stream.Decode(out recordMap);
                 }
                 catch (Exception ex) when (!ex.IsCriticalException())
                 {
-                    // Couldn't parse for some reason, let the BinaryFormatter try to handle it.
+                    // Couldn't parse for some reason, let BinaryFormatter handle the legacy invocation.
+                    if (legacyMode && LocalAppContextSwitches.ClipboardDragDropEnableUnsafeBinaryFormatterSerialization)
+                    {
+                        stream.Position = startPosition;
+                        return ReadObjectWithBinaryFormatter<T>(stream, binder);
+                    }
+
+                    // For example offset arrays throw from the decoder -
+                    // https://learn.microsoft.com/dotnet/api/system.array.createinstance?#system-array-createinstance(system-type-system-int32()-system-int32())
+                    if (ex is NotSupportedException)
+                    {
+                        throw;
+                    }
+
+                    throw ExceptionDispatchInfo.SetRemoteStackTrace(
+                        new NotSupportedException(ex.Message, ex), ex.StackTrace ?? string.Empty);
                 }
 
-                if (restrictDeserialization)
+                // For the new TryGet APIs, ensure that the stream contains the requested type,
+                // or type that can be assigned to the requested type.
+                if (!legacyMode && !typeof(T).MatchExceptAssemblyVersion(record.TypeName))
                 {
-                    throw new RestrictedTypeDeserializationException(SR.UnexpectedClipboardType);
+#if false // TODO (TanyaSo): - modify TryGetObjectFromJson to take a resolver and rename to HasJsonData???
+                    // Return true if the payload contains valid JsonData<T> struct, type matches or not
+                    // run IsAssignable in the JSON method
+                    if (record.TryGetObjectFromJson(binder.GetType, out object? data))
+                    {
+                        return data;
+                    }
+#endif
+
+                    if (!TypeNameIsAssignableToType(record.TypeName, typeof(T), (ITypeResolver)binder))
+                    {
+                        return null;
+                    }
                 }
 
+                if (record.TryGetCommonObject(out object? value))
+                {
+                    return value;
+                }
+
+                if (!LocalAppContextSwitches.ClipboardDragDropEnableUnsafeBinaryFormatterSerialization)
+                {
+                    // TODO (TanyaSo): localize string
+                    throw new NotSupportedException(string.Format(
+                        "BinaryFormatter is not supported in Clipboard or drag and drop scenarios." +
+                            "  Enable it and use 'TryGetData<T>' API with a 'resolver'" +
+                            " function that defines a set of allowed types, to deserialize '{0}'.",
+                        typeof(T).FullName));
+                }
+
+                // NRBF deserializer is more secure than the BinaryFormatter is:
+                // 1. Doesn't allow arrays that have a non-zero base index (can't create these in C# or VB)
+                // 2. Only allows IObjectReference types that contain primitives (to avoid observable cycle
+                //    dependencies to indeterminate state)
+                // But it usually requires a resolver.
+                if (LocalAppContextSwitches.ClipboardDragDropEnableNrbfSerialization)
+                {
+                    try
+                    {
+                        return record.Deserialize(recordMap, (ITypeResolver)binder);
+                    }
+                    catch (Exception ex) when (!ex.IsCriticalException() && legacyMode)
+                    {
+                    }
+                }
+
+                stream.Position = startPosition;
+                return ReadObjectWithBinaryFormatter<T>(stream, binder);
+            }
+
+            private static bool TypeNameIsAssignableToType(TypeName typeName, Type type, ITypeResolver resolver)
+            {
+                try
+                {
+                    return resolver.GetType(typeName)?.IsAssignableTo(type) == true;
+                }
+                catch (Exception ex) when (!ex.IsCriticalException())
+                {
+                    // Clipboard contains a wrong type, we want the API to return false to the caller.
+                    // TODO (TanyaSo): this does not special-case the NotSupportedException from the failed SetData call., but we probably want to
+                    // bubble it up to the user app.
+                    // if (typeName.FullName == typeof(NotSupportedException).FullName)
+                    // {
+                    //    throw new NotSupportedException("SetData had failed.");
+                    // }
+                }
+
+                return false;
+            }
+
+            private static object? ReadObjectWithBinaryFormatter<T>(MemoryStream stream, SerializationBinder binder)
+            {
                 // This check is to help in trimming scenarios with a trim warning on a call to BinaryFormatter.Deserialize(),
                 // which has a RequiresUnreferencedCode annotation.
                 // If the flag is false, the trimmer will not generate a warning, since BinaryFormatter.Deserialize() will not be called,
@@ -81,21 +186,18 @@ public unsafe partial class DataObject
                     throw new NotSupportedException(SR.BinaryFormatterNotSupported);
                 }
 
-                stream.Position = startPosition;
-
-#pragma warning disable SYSLIB0011 // Type or member is obsolete
-#pragma warning disable SYSLIB0050 // Type or member is obsolete
+#pragma warning disable SYSLIB0011, SYSLIB0050 // Type or member is obsolete
 #pragma warning disable CA2300 // Do not use insecure deserializer BinaryFormatter
-#pragma warning disable CA2301 // The method 'object BinaryFormatter.Deserialize(Stream serializationStream)' is insecure when deserializing untrusted data without a SerializationBinder to restrict the type of objects in the deserialized object graph.
+#pragma warning disable CA2302 // Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize
                 // cs/dangerous-binary-deserialization
                 return new BinaryFormatter()
                 {
+                    Binder = binder,
                     AssemblyFormat = FormatterAssemblyStyle.Simple
                 }.Deserialize(stream); // CodeQL[SM03722] : BinaryFormatter is intended to be used as a fallback for unsupported types. Users must explicitly opt into this behavior.
 #pragma warning restore CA2300
-#pragma warning restore CA2301
-#pragma warning restore SYSLIB0050
-#pragma warning restore SYSLIB0011
+#pragma warning restore CA2302
+#pragma warning restore SYSLIB0050, SYSLIB0011
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.Composition.BinaryFormatUtilities.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.Composition.BinaryFormatUtilities.cs
@@ -116,6 +116,14 @@ public unsafe partial class DataObject
 
                     if (!TypeNameIsAssignableToType(record.TypeName, typeof(T), (ITypeResolver)binder))
                     {
+                        // If clipboard containes an exception from SetData, we will get its message and throw.
+                        if (record.TypeName.FullName == typeof(NotSupportedException).FullName
+                            && record.TryGetNotSupportedException(out object? @object)
+                            && @object is NotSupportedException exception)
+                        {
+                            throw new NotSupportedException(exception.Message);
+                        }
+
                         return null;
                     }
                 }
@@ -163,13 +171,7 @@ public unsafe partial class DataObject
                 }
                 catch (Exception ex) when (!ex.IsCriticalException())
                 {
-                    // Clipboard contains a wrong type, we want the API to return false to the caller.
-                    // TODO (TanyaSo): this does not special-case the NotSupportedException from the failed SetData call., but we probably want to
-                    // bubble it up to the user app.
-                    // if (typeName.FullName == typeof(NotSupportedException).FullName)
-                    // {
-                    //    throw new NotSupportedException("SetData had failed.");
-                    // }
+                    // Clipboard contains a wrong type, we want the typed API to return false to the caller.
                 }
 
                 return false;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.Composition.Binder.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.Composition.Binder.cs
@@ -207,15 +207,6 @@ public unsafe partial class DataObject
                 return resolved;
             }
 
-            public static Type? GetKnownType(string assemblyName, string fullTypeName, TypeName? typeName)
-            {
-                InitializeCommonTypes();
-
-                typeName ??= TypeName.Parse($"{fullTypeName}, {assemblyName}");
-
-                return s_knownTypes.TryGetValue(typeName, out Type? type) ? type : null;
-            }
-
             private Type? GetCachedType(string assemblyName, string fullTypeName, TypeName? typeName)
             {
                 InitializeCommonTypes();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.Composition.Binder.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.Composition.Binder.cs
@@ -6,7 +6,6 @@ using System.Reflection.Metadata;
 using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Binary;
 using Switches = System.Windows.Forms.Primitives.LocalAppContextSwitches;
-using TypeInfo = System.Private.Windows.Core.BinaryFormat.TypeInfo;
 
 namespace System.Windows.Forms;
 
@@ -32,76 +31,76 @@ public unsafe partial class DataObject
             private readonly Func<TypeName, Type>? _resolver;
             private readonly bool _legacyMode;
 
-            // This is needed to resolve primitive fields of the requested type T.
-            private static readonly Dictionary<string, Type> s_mscorlibTypeCache = new()
-            {
-                { "System.Byte", typeof(byte) },
-                { "System.SByte", typeof(sbyte) },
-                { "System.Int16", typeof(short) },
-                { "System.UInt16", typeof(ushort) },
-                { "System.Int32", typeof(int) },
-                { "System.UInt32", typeof(uint) },
-                { "System.Int64", typeof(long) },
-                { "System.UInt64", typeof(ulong) },
-                { "System.Double", typeof(double) },
-                { "System.Single", typeof(float) },
-                { "System.Char", typeof(char) },
-                { "System.Boolean", typeof(bool) },
-                { "System.String", typeof(string) },
-                { "System.Decimal", typeof(decimal) },
-                { "System.DateTime", typeof(DateTime) },
-                { "System.TimeSpan", typeof(TimeSpan) },
-                { "System.IntPtr", typeof(IntPtr) },
-                { "System.UIntPtr", typeof(UIntPtr) },
-                { TypeInfo.NotSupportedExceptionType, typeof(NotSupportedException) },
-                { "System.Collections.Generic.List`1[[System.Byte, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(List<byte>) },
-                { "System.Collections.Generic.List`1[[System.SByte, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(List<sbyte>) },
-                { "System.Collections.Generic.List`1[[System.Int16, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(List<short>) },
-                { "System.Collections.Generic.List`1[[System.UInt16, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(List<ushort>) },
-                { "System.Collections.Generic.List`1[[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(List<int>) },
-                { "System.Collections.Generic.List`1[[System.UInt32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(List<uint>) },
-                { "System.Collections.Generic.List`1[[System.Int64, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(List<long>) },
-                { "System.Collections.Generic.List`1[[System.UInt64, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(List<ulong>) },
-                { "System.Collections.Generic.List`1[[System.Single, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(List<float>) },
-                { "System.Collections.Generic.List`1[[System.Double, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(List<double>) },
-                { "System.Collections.Generic.List`1[[System.Char, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(List<char>) },
-                { "System.Collections.Generic.List`1[[System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(List<bool>) },
-                { "System.Collections.Generic.List`1[[System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(List<string>) },
-                { "System.Collections.Generic.List`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(List<decimal>) },
-                { "System.Collections.Generic.List`1[[System.DateTime, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(List<DateTime>) },
-                { "System.Collections.Generic.List`1[[System.TimeSpan, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(List<TimeSpan>) },
-                { "System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(byte[]) },
-                { "System.SByte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(sbyte[]) },
-                { "System.Int16[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(short[]) },
-                { "System.UInt16[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(ushort[]) },
-                { "System.Int32[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(int[]) },
-                { "System.UInt32[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(uint[]) },
-                { "System.Int64[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(long[]) },
-                { "System.UInt64[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(ulong[]) },
-                { "System.Single[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(float[]) },
-                { "System.Double[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(double[]) },
-                { "System.Char[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(char[]) },
-                { "System.Boolean[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(bool[]) },
-                { "System.String[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(string[]) },
-                { "System.Decimal[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(decimal[]) },
-                { "System.DateTime[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(DateTime[]) },
-                { "System.TimeSpan[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(TimeSpan[]) }
-            };
-
-            private static readonly Dictionary<(string, string), Type> s_commonTypes = new()
-            {
-                { ("System.Windows.Forms.ImageListStreamer", "System.Windows.Forms"), typeof(ImageListStreamer) },
-                { ("System.Drawing.Bitmap", "System.Drawing"), typeof(Drawing.Bitmap) },
+            // These types are read from and written to serialized stream manually, accessing record field by field.
+            // Thus they are re-hydrated with no formatters and are safe.  The default resolver should recognize them
+            // to resolve primitive types or fields of the specified type T.
+            private static readonly Type[] s_types =
+            [
+                typeof(byte),
+                typeof(sbyte),
+                typeof(short),
+                typeof(ushort),
+                typeof(int),
+                typeof(uint),
+                typeof(long),
+                typeof(ulong),
+                typeof(double),
+                typeof(float),
+                typeof(char),
+                typeof(bool),
+                typeof(string),
+                typeof(decimal),
+                typeof(DateTime),
+                typeof(TimeSpan),
+                typeof(IntPtr),
+                typeof(UIntPtr),
+                typeof(NotSupportedException),
+                typeof(List<byte>),
+                typeof(List<sbyte>),
+                typeof(List<short>),
+                typeof(List<ushort>),
+                typeof(List<int>),
+                typeof(List<uint>),
+                typeof(List<long>),
+                typeof(List<ulong>),
+                typeof(List<float>),
+                typeof(List<double>),
+                typeof(List<char>),
+                typeof(List<bool>),
+                typeof(List<string>),
+                typeof(List<decimal>),
+                typeof(List<DateTime>),
+                typeof(List<TimeSpan>),
+                typeof(byte[]),
+                typeof(sbyte[]),
+                typeof(short[]),
+                typeof(ushort[]),
+                typeof(int[]),
+                typeof(uint[]),
+                typeof(long[]),
+                typeof(ulong[]),
+                typeof(float[]),
+                typeof(double[]),
+                typeof(char[]),
+                typeof(bool[]),
+                typeof(string[]),
+                typeof(decimal[]),
+                typeof(DateTime[]),
+                typeof(TimeSpan[]),
+                typeof(ImageListStreamer),
+                typeof(Drawing.Bitmap),
                 // The following are exchange types, they are serialized with the .NET Framework assembly name.
                 // In .NET they are located in System.Drawing.Primitives.
-                { ("System.Drawing.RectangleF", "System.Drawing"), typeof(Drawing.RectangleF) },
-                { ("System.Drawing.PointF", "System.Drawing"), typeof(Drawing.PointF) },
-                { ("System.Drawing.SizeF", "System.Drawing"), typeof(Drawing.SizeF) },
-                { ("System.Drawing.Rectangle", "System.Drawing"), typeof(Drawing.Rectangle) },
-                { ("System.Drawing.Point", "System.Drawing"), typeof(Drawing.Point) },
-                { ("System.Drawing.Size", "System.Drawing"), typeof(Drawing.Size) },
-                { ("System.Drawing.Color", "System.Drawing"), typeof(Drawing.Color) }
-            };
+                typeof(Drawing.RectangleF),
+                typeof(Drawing.PointF),
+                typeof(Drawing.SizeF),
+                typeof(Drawing.Rectangle),
+                typeof(Drawing.Point),
+                typeof(Drawing.Size),
+                typeof(Drawing.Color)
+            ];
+
+            private static Dictionary<TypeName, Type>? s_knownTypes;
 
             private readonly Dictionary<TypeName, Type> _userTypes = new(TypeNameComparer.Default);
 
@@ -111,10 +110,10 @@ public unsafe partial class DataObject
             /// </summary>
             /// <param name="type"><see cref="Type"/> that the user expects to read from the binary formatted stream.</param>
             /// <param name="resolver">
-            ///  Provides the list of custom allowed types that user consideres safe to deserialize from the payload.
+            ///  Provides the list of custom allowed types that user considers safe to deserialize from the payload.
             ///  Resolver should recognize the closure of all non-primitive and not known types in the payload,
             ///  such as field types and types in the inheritance hierarchy and the code to match these types to the
-            ///  <see cref="TypeName"/>s read from the derialized stream.
+            ///  <see cref="TypeName"/>s read from the deserialized stream.
             /// </param>
             /// <param name="legacyMode">
             ///  <see langword="true"/> if the user had not requested any specific type, i.e. the call originates from
@@ -129,18 +128,32 @@ public unsafe partial class DataObject
 
                 if (resolver is null)
                 {
-                    // resolver was not provided by the user, we will match the T using our default method:
+                    // Resolver was not provided by the user, we will match the T using our default method:
                     // 1. If the type is a Value type and nullable, unwrap it
                     // 2. Check if the type had been forwarded from another assembly
                     // 3. Match assembly name with no version
                     // 4. Match namespace and type name
                     type = Formatter.NullableUnwrap(type.OrThrowIfNull());
 
-                    TypeName typeName = type.TryGetForwardedFromName(out string? name)
-                        ? TypeName.Parse($"{type.FullName.OrThrowIfNull()}, {name}")
-                        : TypeName.Parse(type.AssemblyQualifiedName.OrThrowIfNull());
+                    TypeName typeName = type.ToTypeName();
 
                     _userTypes.Add(typeName, type);
+                }
+            }
+
+            [MemberNotNull(nameof(s_knownTypes))]
+            private static void InitializeCommonTypes()
+            {
+                if (s_knownTypes is not null)
+                {
+                    return;
+                }
+
+                s_knownTypes = new(TypeNameComparer.Default);
+
+                foreach (Type type in s_types)
+                {
+                    s_knownTypes.Add(type.ToTypeName(), type);
                 }
             }
 
@@ -196,33 +209,22 @@ public unsafe partial class DataObject
 
             public static Type? GetKnownType(string assemblyName, string fullTypeName, TypeName? typeName)
             {
-                // We assume all built-in types are normalized to the mscorlib assembly, as BinaryFormatter
-                // is doing it for compatibility with .NET Framework.
-                if (assemblyName.Equals(TypeInfo.MscorlibAssemblyName, StringComparison.Ordinal)
-                    && s_mscorlibTypeCache.TryGetValue(fullTypeName, out Type? builtIn))
-                {
-                    return builtIn;
-                }
+                InitializeCommonTypes();
 
-                AssemblyNameInfo assemblyNameInfo = typeName is null
-                    ? AssemblyNameInfo.Parse(assemblyName)
-                    : typeName.AssemblyName!; // caller validated that TypeName has a not-null AssemblyNameInfo.
+                typeName ??= TypeName.Parse($"{fullTypeName}, {assemblyName}");
 
-                // Ignore version, culture, and public key token and compare the short names.
-                string shortAssemblyName = assemblyNameInfo.Name;
-                return s_commonTypes.TryGetValue((fullTypeName, shortAssemblyName), out Type? knownType) ? knownType : null;
+                return s_knownTypes.TryGetValue(typeName, out Type? type) ? type : null;
             }
 
             private Type? GetCachedType(string assemblyName, string fullTypeName, TypeName? typeName)
             {
-                Type? type = GetKnownType(assemblyName, fullTypeName, typeName);
-                if (type is not null)
-                {
-                    return type;
-                }
+                InitializeCommonTypes();
 
                 typeName ??= TypeName.Parse($"{fullTypeName}, {assemblyName}");
-                return _userTypes.TryGetValue(typeName, out type) ? type : null;
+
+                return s_knownTypes.TryGetValue(typeName, out Type? type)
+                    ? type
+                    : _userTypes.TryGetValue(typeName, out type) ? type : null;
             }
 
             [RequiresUnreferencedCode("Calls System.Reflection.Assembly.GetType(String)")]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.Composition.Binder.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.Composition.Binder.cs
@@ -1,0 +1,244 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Private.Windows.Core.BinaryFormat;
+using System.Reflection.Metadata;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters.Binary;
+using Switches = System.Windows.Forms.Primitives.LocalAppContextSwitches;
+using TypeInfo = System.Private.Windows.Core.BinaryFormat.TypeInfo;
+
+namespace System.Windows.Forms;
+
+public unsafe partial class DataObject
+{
+    internal unsafe partial class Composition
+    {
+        /// <summary>
+        ///  A type resolver for use in the <see cref="NativeToWinFormsAdapter"/> when processing binary formatted stream
+        ///  contained in our <see cref="DataObject"/> class using the typed consumption side APIs, such as
+        ///  <see cref="TryGetData{T}(out T)"/>.  This class recognizes primitive types, exchange types from
+        ///  System.Drawing.Primitives, <see cref="List{T}"/>s or arrays of primitive types, and common WinForms types.
+        ///  The user can provide a custom resolver for additional types.  If the resolver function is not provided,
+        ///  the <see cref="Type"/> parameter specified by the user is resolved automatically.
+        /// </summary>
+        /// <remarks>
+        ///  <para>
+        ///   This class is used in <see cref="BinaryFormatter"/> and NRBF deserialization.
+        ///  </para>
+        /// </remarks>
+        internal sealed class Binder : SerializationBinder, ITypeResolver
+        {
+            private readonly Func<TypeName, Type>? _resolver;
+            private readonly bool _legacyMode;
+
+            // This is needed to resolve primitive fields of the requested type T.
+            private static readonly Dictionary<string, Type> s_mscorlibTypeCache = new()
+            {
+                { "System.Byte", typeof(byte) },
+                { "System.SByte", typeof(sbyte) },
+                { "System.Int16", typeof(short) },
+                { "System.UInt16", typeof(ushort) },
+                { "System.Int32", typeof(int) },
+                { "System.UInt32", typeof(uint) },
+                { "System.Int64", typeof(long) },
+                { "System.UInt64", typeof(ulong) },
+                { "System.Double", typeof(double) },
+                { "System.Single", typeof(float) },
+                { "System.Char", typeof(char) },
+                { "System.Boolean", typeof(bool) },
+                { "System.String", typeof(string) },
+                { "System.Decimal", typeof(decimal) },
+                { "System.DateTime", typeof(DateTime) },
+                { "System.TimeSpan", typeof(TimeSpan) },
+                { "System.IntPtr", typeof(IntPtr) },
+                { "System.UIntPtr", typeof(UIntPtr) },
+                { TypeInfo.NotSupportedExceptionType, typeof(NotSupportedException) },
+                { "System.Collections.Generic.List`1[[System.Byte, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(List<byte>) },
+                { "System.Collections.Generic.List`1[[System.SByte, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(List<sbyte>) },
+                { "System.Collections.Generic.List`1[[System.Int16, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(List<short>) },
+                { "System.Collections.Generic.List`1[[System.UInt16, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(List<ushort>) },
+                { "System.Collections.Generic.List`1[[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(List<int>) },
+                { "System.Collections.Generic.List`1[[System.UInt32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(List<uint>) },
+                { "System.Collections.Generic.List`1[[System.Int64, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(List<long>) },
+                { "System.Collections.Generic.List`1[[System.UInt64, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(List<ulong>) },
+                { "System.Collections.Generic.List`1[[System.Single, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(List<float>) },
+                { "System.Collections.Generic.List`1[[System.Double, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(List<double>) },
+                { "System.Collections.Generic.List`1[[System.Char, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(List<char>) },
+                { "System.Collections.Generic.List`1[[System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(List<bool>) },
+                { "System.Collections.Generic.List`1[[System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(List<string>) },
+                { "System.Collections.Generic.List`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(List<decimal>) },
+                { "System.Collections.Generic.List`1[[System.DateTime, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(List<DateTime>) },
+                { "System.Collections.Generic.List`1[[System.TimeSpan, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(List<TimeSpan>) },
+                { "System.Byte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(byte[]) },
+                { "System.SByte[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(sbyte[]) },
+                { "System.Int16[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(short[]) },
+                { "System.UInt16[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(ushort[]) },
+                { "System.Int32[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(int[]) },
+                { "System.UInt32[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(uint[]) },
+                { "System.Int64[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(long[]) },
+                { "System.UInt64[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(ulong[]) },
+                { "System.Single[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(float[]) },
+                { "System.Double[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(double[]) },
+                { "System.Char[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(char[]) },
+                { "System.Boolean[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(bool[]) },
+                { "System.String[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(string[]) },
+                { "System.Decimal[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(decimal[]) },
+                { "System.DateTime[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(DateTime[]) },
+                { "System.TimeSpan[], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(TimeSpan[]) }
+            };
+
+            private static readonly Dictionary<(string, string), Type> s_commonTypes = new()
+            {
+                { ("System.Windows.Forms.ImageListStreamer", "System.Windows.Forms"), typeof(ImageListStreamer) },
+                { ("System.Drawing.Bitmap", "System.Drawing"), typeof(Drawing.Bitmap) },
+                // The following are exchange types, they are serialized with the .NET Framework assembly name.
+                // In .NET they are located in System.Drawing.Primitives.
+                { ("System.Drawing.RectangleF", "System.Drawing"), typeof(Drawing.RectangleF) },
+                { ("System.Drawing.PointF", "System.Drawing"), typeof(Drawing.PointF) },
+                { ("System.Drawing.SizeF", "System.Drawing"), typeof(Drawing.SizeF) },
+                { ("System.Drawing.Rectangle", "System.Drawing"), typeof(Drawing.Rectangle) },
+                { ("System.Drawing.Point", "System.Drawing"), typeof(Drawing.Point) },
+                { ("System.Drawing.Size", "System.Drawing"), typeof(Drawing.Size) },
+                { ("System.Drawing.Color", "System.Drawing"), typeof(Drawing.Color) }
+            };
+
+            private readonly Dictionary<TypeName, Type> _userTypes = new(TypeNameComparer.Default);
+
+            /// <summary>
+            ///  Type resolver for use with <see cref="BinaryFormatter"/> and NRBF deserializers to restrict types
+            ///  that can be instantiated.
+            /// </summary>
+            /// <param name="type"><see cref="Type"/> that the user expects to read from the binary formatted stream.</param>
+            /// <param name="resolver">
+            ///  Provides the list of custom allowed types that user consideres safe to deserialize from the payload.
+            ///  Resolver should recognize the closure of all non-primitive and not known types in the payload,
+            ///  such as field types and types in the inheritance hierarchy and the code to match these types to the
+            ///  <see cref="TypeName"/>s read from the derialized stream.
+            /// </param>
+            /// <param name="legacyMode">
+            ///  <see langword="true"/> if the user had not requested any specific type, i.e. the call originates from
+            ///  <see cref="GetData(string)"/> API family, that returns an <see cref="object"/>.  <see langword="false"/>
+            ///  if the user had requested a specific type by calling <see cref="TryGetData{T}(out T)"/> API family.
+            /// </param>
+            public Binder(Type type, Func<TypeName, Type>? resolver, bool legacyMode)
+            {
+                Debug.Assert(!legacyMode || (legacyMode && resolver is null), "GetData methods should not provide a resolver.");
+                _resolver = resolver;
+                _legacyMode = legacyMode;
+
+                if (resolver is null)
+                {
+                    // resolver was not provided by the user, we will match the T using our default method:
+                    // 1. If the type is a Value type and nullable, unwrap it
+                    // 2. Check if the type had been forwarded from another assembly
+                    // 3. Match assembly name with no version
+                    // 4. Match namespace and type name
+                    type = Formatter.NullableUnwrap(type.OrThrowIfNull());
+
+                    TypeName typeName = type.TryGetForwardedFromName(out string? name)
+                        ? TypeName.Parse($"{type.FullName.OrThrowIfNull()}, {name}")
+                        : TypeName.Parse(type.AssemblyQualifiedName.OrThrowIfNull());
+
+                    _userTypes.Add(typeName, type);
+                }
+            }
+
+            public override Type? BindToType(string assemblyName, string typeName)
+            {
+                ArgumentException.ThrowIfNullOrWhiteSpace(assemblyName);
+                ArgumentException.ThrowIfNullOrWhiteSpace(typeName);
+
+                if (GetCachedType(assemblyName, typeName, typeName: null) is Type type)
+                {
+                    return type;
+                }
+
+                if (_legacyMode)
+                {
+                    // TODO (TanyaSo): localize string
+                    return Switches.ClipboardDragDropEnableUnsafeBinaryFormatterSerialization
+                        ? null
+                        : throw new NotSupportedException(string.Format(
+                            "BinaryFormatter is not supported in Clipboard or drag and drop scenarios." +
+                                "  Enable it and use 'TryGetData<T>' API with a 'resolver'" +
+                                " function that defines a set of allowed types, to deserialize '{0}'.",
+                            $"{assemblyName}.{typeName}"));
+                }
+
+                TypeName parsed = TypeName.Parse($"{typeName}, {assemblyName}");
+                return UseResolver(parsed);
+            }
+
+            [RequiresUnreferencedCode("Calls user-provided method that resolves types from names.")]
+            [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+            private Type UseResolver(TypeName typeName)
+            {
+                if (_resolver is null)
+                {
+                    // TODO (TanyaSo): localize string
+                    throw new NotSupportedException(string.Format(
+                        "Use 'TryGetData<T>' method with a 'resolver' function that defines a set of allowed types, to deserialize '{0}'.",
+                        typeName.AssemblyQualifiedName));
+                }
+
+                // This helper method is called after we verified that _resolver is not null.
+                Type resolved = _resolver!(typeName)
+                    ?? throw new NotSupportedException(string.Format(
+                        "'resolver' function provided in 'TryGetData<T>' method should not return a null.  " +
+                            "It should throw a 'System.NotSupportedException' when encountering unsupported types, " +
+                            "unless type {0} is one of the allowed types, then the 'Type' should be returned.",
+                        typeName.AssemblyQualifiedName));
+
+                _userTypes.Add(typeName, resolved);
+                return resolved;
+            }
+
+            public static Type? GetKnownType(string assemblyName, string fullTypeName, TypeName? typeName)
+            {
+                // We assume all built-in types are normalized to the mscorlib assembly, as BinaryFormatter
+                // is doing it for compatibility with .NET Framework.
+                if (assemblyName.Equals(TypeInfo.MscorlibAssemblyName, StringComparison.Ordinal)
+                    && s_mscorlibTypeCache.TryGetValue(fullTypeName, out Type? builtIn))
+                {
+                    return builtIn;
+                }
+
+                AssemblyNameInfo assemblyNameInfo = typeName is null
+                    ? AssemblyNameInfo.Parse(assemblyName)
+                    : typeName.AssemblyName!; // caller validated that TypeName has a not-null AssemblyNameInfo.
+
+                // Ignore version, culture, and public key token and compare the short names.
+                string shortAssemblyName = assemblyNameInfo.Name;
+                return s_commonTypes.TryGetValue((fullTypeName, shortAssemblyName), out Type? knownType) ? knownType : null;
+            }
+
+            private Type? GetCachedType(string assemblyName, string fullTypeName, TypeName? typeName)
+            {
+                Type? type = GetKnownType(assemblyName, fullTypeName, typeName);
+                if (type is not null)
+                {
+                    return type;
+                }
+
+                typeName ??= TypeName.Parse($"{fullTypeName}, {assemblyName}");
+                return _userTypes.TryGetValue(typeName, out type) ? type : null;
+            }
+
+            [RequiresUnreferencedCode("Calls System.Reflection.Assembly.GetType(String)")]
+            [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+            public Type GetType(TypeName typeName)
+            {
+                typeName.OrThrowIfNull();
+
+                if (typeName.AssemblyName is not AssemblyNameInfo info
+                    || info.FullName is not string fullName)
+                {
+                    throw new ArgumentException(message: null, nameof(typeName));
+                }
+
+                return GetCachedType(fullName, typeName.FullName, typeName) is Type type ? type : UseResolver(typeName);
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.Composition.NativeToWinFormsAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.Composition.NativeToWinFormsAdapter.cs
@@ -253,7 +253,7 @@ public unsafe partial class DataObject
                 Func<TypeName, Type>? resolver,
                 bool legacyMode,
                 out bool doNotContinue,
-                [NotNullWhen(true)]out T? data)
+                [NotNullWhen(true)] out T? data)
             {
                 data = default;
                 doNotContinue = false;
@@ -316,6 +316,7 @@ public unsafe partial class DataObject
                 // get the data out.
                 Debug.WriteLineIf(hr == HRESULT.CLIPBRD_E_BAD_DATA, "CLIPBRD_E_BAD_DATA returned when trying to get clipboard data.");
                 Debug.WriteLineIf(hr == HRESULT.DV_E_TYMED, "DV_E_TYMED returned when trying to get clipboard data.");
+                // This happens in copy == false case when the managed type does not have the [Serializable] attribute.
                 Debug.WriteLineIf(hr == HRESULT.E_UNEXPECTED, "E_UNEXPECTED returned when trying to get clipboard data.");
                 Debug.WriteLineIf(hr == HRESULT.COR_E_SERIALIZATION,
                     "COR_E_SERIALIZATION returned when trying to get clipboard data, for example, BinaryFormatter threw SerializationException.");
@@ -458,7 +459,7 @@ public unsafe partial class DataObject
 
             private static void ThrowIfFormatAndTypeRequireResolver<T>(string format)
             {
-                // Restricted format is either read directly from the HGLOBAL or is deserialized with the BitmapBinder restriction.
+                // Restricted format is either read directly from the HGLOBAL or serialization record is read manually.
                 if (!IsRestrictedFormat(format)
                     // This check is a convenience for simple usages if TryGetData APIs that don't take the resolver.
                     && IsUnboundedType())

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.Composition.NativeToWinFormsAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.Composition.NativeToWinFormsAdapter.cs
@@ -17,7 +17,7 @@ public unsafe partial class DataObject
         /// <summary>
         ///  Maps native pointer <see cref="Com.IDataObject"/> to <see cref="IDataObject"/>.
         /// </summary>
-        private unsafe class NativeToWinFormsAdapter : IDataObject, ITypedDataObject, Com.IDataObject.Interface
+        private unsafe class NativeToWinFormsAdapter : ITypedDataObject, Com.IDataObject.Interface
         {
             private readonly AgileComPointer<Com.IDataObject> _nativeDataObject;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.Composition.NativeToWinFormsAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.Composition.NativeToWinFormsAdapter.cs
@@ -323,7 +323,7 @@ public unsafe partial class DataObject
                 bool result = false;
                 try
                 {
-                    if (medium.tymed == Com.TYMED.TYMED_HGLOBAL && !medium.hGlobal.IsNull)
+                    if (medium.tymed == Com.TYMED.TYMED_HGLOBAL && !medium.hGlobal.IsNull && hr != HRESULT.COR_E_SERIALIZATION)
                     {
                         result = TryGetDataFromHGLOBAL(medium.hGlobal, format, resolver, legacyMode, out data);
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.Composition.TypeNameComparer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.Composition.TypeNameComparer.cs
@@ -1,0 +1,89 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Reflection.Metadata;
+
+namespace System.Windows.Forms;
+public unsafe partial class DataObject
+{
+    internal unsafe partial class Composition
+    {
+        /// <summary>
+        ///  Match <see cref="TypeName"/>s by matching full namespace-qualified type names and full assembly names,
+        ///  including the version.
+        /// </summary>
+        internal sealed class TypeNameComparer : IEqualityComparer<TypeName>
+        {
+            private TypeNameComparer()
+            {
+            }
+
+            internal static IEqualityComparer<TypeName> Default { get; } = new TypeNameComparer();
+
+            public bool Equals(TypeName? x, TypeName? y)
+            {
+                if (x is null && y is null)
+                {
+                    return true;
+                }
+
+                if (x is null || y is null)
+                {
+                    return false;
+                }
+
+                return x.Matches(y);
+            }
+
+            public int GetHashCode(TypeName obj)
+            {
+                if (obj is null)
+                {
+                    return 0;
+                }
+
+                if (obj.IsArray)
+                {
+                    return true.GetHashCode() ^ obj.GetArrayRank() ^ GetHashCode(obj.GetElementType());
+                }
+
+                int hashCode;
+                if (obj.IsConstructedGenericType)
+                {
+                    hashCode = "constructed".GetHashCode() ^ GetHashCode(obj.GetGenericTypeDefinition());
+                    foreach (TypeName genericName in obj.GetGenericArguments())
+                    {
+                        hashCode ^= GetHashCode(genericName);
+                    }
+
+                    return hashCode;
+                }
+
+                hashCode = obj.FullName.GetHashCode();
+                if (obj.AssemblyName is AssemblyNameInfo info)
+                {
+                    hashCode ^= info.Name.GetHashCode();
+                    if (info.Version is not null)
+                    {
+                        hashCode ^= info.Version.GetHashCode();
+                    }
+
+                    if (info.CultureName is not null)
+                    {
+                        hashCode ^= info.CultureName.GetHashCode();
+                    }
+
+                    if (!info.PublicKeyOrToken.IsDefaultOrEmpty)
+                    {
+                        foreach (byte b in info.PublicKeyOrToken)
+                        {
+                            hashCode ^= b.GetHashCode();
+                        }
+                    }
+                }
+
+                return hashCode;
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.Composition.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.Composition.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Reflection.Metadata;
 using System.Runtime.InteropServices.ComTypes;
 using Com = Windows.Win32.System.Com;
 using ComTypes = System.Runtime.InteropServices.ComTypes;
@@ -13,7 +14,7 @@ public unsafe partial class DataObject
     ///  Contains the logic to move between <see cref="IDataObject"/>, <see cref="Com.IDataObject.Interface"/>,
     ///  and <see cref="ComTypes.IDataObject"/> calls.
     /// </summary>
-    internal unsafe partial class Composition : IDataObject, Com.IDataObject.Interface, ComTypes.IDataObject
+    internal unsafe partial class Composition : IDataObject, ITypedDataObject, Com.IDataObject.Interface, ComTypes.IDataObject
     {
         private const Com.TYMED AllowedTymeds = Com.TYMED.TYMED_HGLOBAL | Com.TYMED.TYMED_ISTREAM | Com.TYMED.TYMED_GDI;
 
@@ -116,6 +117,30 @@ public unsafe partial class DataObject
         public void SetData(string format, object? data) => _winFormsDataObject.SetData(format, data);
         public void SetData(Type format, object? data) => _winFormsDataObject.SetData(format, data);
         public void SetData(object? data) => _winFormsDataObject.SetData(data);
+        #endregion
+
+        #region ITypedDataObject
+        public bool TryGetData<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(
+            string format,
+            Func<TypeName, Type> resolver,
+            bool autoConvert,
+            [NotNullWhen(true), MaybeNullWhen(false)] out T data) =>
+                _winFormsDataObject.TryGetData(format, resolver, autoConvert, out data);
+
+        public bool TryGetData<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(
+            string format,
+            bool autoConvert,
+            [NotNullWhen(true), MaybeNullWhen(false)] out T data) =>
+                _winFormsDataObject.TryGetData(format, resolver: null!, autoConvert, out data);
+
+        public bool TryGetData<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(
+            string format,
+            [NotNullWhen(true), MaybeNullWhen(false)] out T data) =>
+                _winFormsDataObject.TryGetData(format, resolver: null!, autoConvert: false, out data);
+
+        public bool TryGetData<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(
+            [NotNullWhen(true), MaybeNullWhen(false)] out T data) =>
+                _winFormsDataObject.TryGetData(typeof(T).FullName!, resolver: null!, autoConvert: false, out data);
         #endregion
 
         #region Com.IDataObject.Interface

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.Composition.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.Composition.cs
@@ -14,7 +14,7 @@ public unsafe partial class DataObject
     ///  Contains the logic to move between <see cref="IDataObject"/>, <see cref="Com.IDataObject.Interface"/>,
     ///  and <see cref="ComTypes.IDataObject"/> calls.
     /// </summary>
-    internal unsafe partial class Composition : IDataObject, ITypedDataObject, Com.IDataObject.Interface, ComTypes.IDataObject
+    internal unsafe partial class Composition : ITypedDataObject, Com.IDataObject.Interface, ComTypes.IDataObject
     {
         private const Com.TYMED AllowedTymeds = Com.TYMED.TYMED_HGLOBAL | Com.TYMED.TYMED_ISTREAM | Com.TYMED.TYMED_GDI;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.DataStore.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.DataStore.cs
@@ -10,7 +10,7 @@ namespace System.Windows.Forms;
 
 public partial class DataObject
 {
-    private sealed partial class DataStore : IDataObject, ITypedDataObject
+    private sealed partial class DataStore : ITypedDataObject
     {
         private readonly Dictionary<string, DataStoreEntry> _mappedData = new(BackCompatibleStringComparer.Default);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.DataStore.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.DataStore.cs
@@ -3,58 +3,62 @@
 
 using System.Collections.Specialized;
 using System.Drawing;
+using System.Reflection.Metadata;
 using System.Runtime.Serialization;
 
 namespace System.Windows.Forms;
 
 public partial class DataObject
 {
-    private sealed partial class DataStore : IDataObject
+    private sealed partial class DataStore : IDataObject, ITypedDataObject
     {
         private readonly Dictionary<string, DataStoreEntry> _mappedData = new(BackCompatibleStringComparer.Default);
 
-        public object? GetData(string format, bool autoConvert)
+        private bool TryGetDataInternal<T>(
+            string format,
+            bool autoConvert,
+            [NotNullWhen(true), MaybeNullWhen(false)] out T data)
         {
+            data = default;
             if (string.IsNullOrWhiteSpace(format))
             {
-                return null;
+                return false;
             }
 
-            object? baseVar = null;
-            if (_mappedData.TryGetValue(format, out DataStoreEntry? dse))
+            if (_mappedData.TryGetValue(format, out DataStoreEntry? dse) && dse.Data is T t)
             {
-                baseVar = dse.Data;
+                data = t;
+                return true;
             }
 
-            object? original = baseVar;
-
-            if (autoConvert
-                && (dse is null || dse.AutoConvert)
-                && (baseVar is null || baseVar is MemoryStream))
+            if (!autoConvert
+                || !(dse is null || dse.AutoConvert)
+                || GetMappedFormats(format) is not { } mappedFormats)
             {
-                string[]? mappedFormats = GetMappedFormats(format);
-                if (mappedFormats is not null)
+                return false;
+            }
+
+            for (int i = 0; i < mappedFormats.Length; i++)
+            {
+                if (format.Equals(mappedFormats[i]))
                 {
-                    for (int i = 0; i < mappedFormats.Length; i++)
-                    {
-                        if (!format.Equals(mappedFormats[i]))
-                        {
-                            if (_mappedData.TryGetValue(mappedFormats[i], out DataStoreEntry? found))
-                            {
-                                baseVar = found.Data;
-                            }
+                    continue;
+                }
 
-                            if (baseVar is not null and not MemoryStream)
-                            {
-                                original = null;
-                                break;
-                            }
-                        }
-                    }
+                if (_mappedData.TryGetValue(mappedFormats[i], out DataStoreEntry? found) && found.Data is T value)
+                {
+                    data = value;
+                    return true;
                 }
             }
 
-            return original ?? baseVar;
+            return false;
+        }
+
+        public object? GetData(string format, bool autoConvert)
+        {
+            TryGetDataInternal(format, autoConvert, out object? data);
+            return data;
         }
 
         public object? GetData(string format) => GetData(format, autoConvert: true);
@@ -74,14 +78,7 @@ public partial class DataObject
             // and let the system provide the conversion for us.
             if (data is Bitmap && format.Equals(DataFormats.Dib))
             {
-                if (autoConvert)
-                {
-                    format = DataFormats.Bitmap;
-                }
-                else
-                {
-                    throw new NotSupportedException(SR.DataObjectDibNotSupported);
-                }
+                format = autoConvert ? DataFormats.Bitmap : throw new NotSupportedException(SR.DataObjectDibNotSupported);
             }
 
             _mappedData[format] = new DataStoreEntry(data, autoConvert);
@@ -181,5 +178,27 @@ public partial class DataObject
         }
 
         public string[] GetFormats() => GetFormats(autoConvert: true);
+
+        public bool TryGetData<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(
+            string format,
+            Func<TypeName, Type> resolver,
+            bool autoConvert,
+            [NotNullWhen(true), MaybeNullWhen(false)] out T data) =>
+                TryGetDataInternal(format, autoConvert, out data);
+
+        public bool TryGetData<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(
+            string format,
+            bool autoConvert,
+            [NotNullWhen(true), MaybeNullWhen(false)] out T data) =>
+                TryGetDataInternal(format, autoConvert, out data);
+
+        public bool TryGetData<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(
+            string format,
+            [NotNullWhen(true), MaybeNullWhen(false)] out T data) =>
+                TryGetDataInternal(format, autoConvert: false, out data);
+
+        public bool TryGetData<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(
+            [NotNullWhen(true), MaybeNullWhen(false)] out T data) =>
+                TryGetDataInternal(typeof(T).FullName!, autoConvert: false, out data);
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.DataStore.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.DataStore.cs
@@ -32,7 +32,7 @@ public partial class DataObject
             }
 
             if (!autoConvert
-                || !(dse is null || dse.AutoConvert)
+                || (dse is not null && !dse.AutoConvert)
                 || GetMappedFormats(format) is not { } mappedFormats)
             {
                 return false;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.cs
@@ -16,7 +16,6 @@ namespace System.Windows.Forms;
 /// </summary>
 [ClassInterface(ClassInterfaceType.None)]
 public unsafe partial class DataObject :
-    IDataObject,
     ITypedDataObject,
     Com.IDataObject.Interface,
     ComTypes.IDataObject,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.cs
@@ -174,7 +174,7 @@ public unsafe partial class DataObject :
     #endregion
 
     /// <summary>
-    ///  Override this method in the derived class to provide custom data retrieval logic.
+    ///  Override this method in the derived class to provide custom data retrieval logic using the typed APIs.
     /// </summary>
     /// <inheritdoc cref="ITypedDataObject.TryGetData{T}(string, Func{TypeName, Type}, bool, out T)" />
     [CLSCompliant(false)]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Specialized;
 using System.Drawing;
+using System.Reflection.Metadata;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
 using Com = Windows.Win32.System.Com;
@@ -16,6 +17,7 @@ namespace System.Windows.Forms;
 [ClassInterface(ClassInterfaceType.None)]
 public unsafe partial class DataObject :
     IDataObject,
+    ITypedDataObject,
     Com.IDataObject.Interface,
     ComTypes.IDataObject,
     Com.IManagedWrapper<Com.IDataObject>
@@ -30,19 +32,27 @@ public unsafe partial class DataObject :
     ///  Initializes a new instance of the <see cref="DataObject"/> class, with the raw <see cref="Com.IDataObject"/>
     ///  and the managed data object the raw pointer is associated with.
     /// </summary>
+    /// <inheritdoc cref="DataObject(object)"/>
     internal DataObject(Com.IDataObject* data) => _innerData = Composition.CreateFromNativeDataObject(data);
 
     /// <summary>
     ///  Initializes a new instance of the <see cref="DataObject"/> class, which can store arbitrary data.
     /// </summary>
-    public DataObject()
-    {
-        _innerData = Composition.CreateFromWinFormsDataObject(new DataStore());
-    }
+    /// <inheritdoc cref="DataObject(object)"/>
+    public DataObject() => _innerData = Composition.CreateFromWinFormsDataObject(new DataStore());
 
     /// <summary>
     ///  Initializes a new instance of the <see cref="DataObject"/> class, containing the specified data.
     /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   If <paramref name="data"/> implements an <see cref="IDataObject"/> interface,
+    ///   we strongly recommend implementing <see cref="ITypedDataObject"/> interface to support the
+    ///   `TryGetData{T}` API family that restricts deserialization to the requested and known types.
+    ///   <see cref="Clipboard.TryGetData{T}(string, out T)"/> will throw <see cref="NotSupportedException"/>
+    ///   if <see cref="ITypedDataObject"/> is not implemented.
+    ///  </para>
+    /// </remarks>
     public DataObject(object data)
     {
         if (data is DataObject dataObject)
@@ -92,10 +102,25 @@ public unsafe partial class DataObject :
     internal IDataObject? OriginalIDataObject => _innerData.OriginalIDataObject;
 
     #region IDataObject
+    [Obsolete(
+        Obsoletions.DataObjectGetDataMessage,
+        error: false,
+        DiagnosticId = Obsoletions.ClipboardGetDataDiagnosticId,
+        UrlFormat = Obsoletions.SharedUrlFormat)]
     public virtual object? GetData(string format, bool autoConvert) => _innerData.GetData(format, autoConvert);
 
+    [Obsolete(
+        Obsoletions.DataObjectGetDataMessage,
+        error: false,
+        DiagnosticId = Obsoletions.ClipboardGetDataDiagnosticId,
+        UrlFormat = Obsoletions.SharedUrlFormat)]
     public virtual object? GetData(string format) => GetData(format, autoConvert: true);
 
+    [Obsolete(
+        Obsoletions.DataObjectGetDataMessage,
+        error: false,
+        DiagnosticId = Obsoletions.ClipboardGetDataDiagnosticId,
+        UrlFormat = Obsoletions.SharedUrlFormat)]
     public virtual object? GetData(Type format) => format is null ? null : GetData(format.FullName!);
 
     public virtual bool GetDataPresent(string format, bool autoConvert) => _innerData.GetDataPresent(format, autoConvert);
@@ -118,6 +143,48 @@ public unsafe partial class DataObject :
     public virtual void SetData(object? data) => _innerData.SetData(data);
     #endregion
 
+    #region ITypedDataObject
+    [CLSCompliant(false)]
+    public bool TryGetData<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(
+        string format,
+        Func<TypeName, Type> resolver,
+        bool autoConvert,
+        [NotNullWhen(true), MaybeNullWhen(false)] out T data)
+    {
+        data = default;
+        resolver.OrThrowIfNull();
+
+        return TryGetDataInternal(format, resolver, autoConvert, out data);
+    }
+
+    public bool TryGetData<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(
+        string format,
+        bool autoConvert,
+        [NotNullWhen(true), MaybeNullWhen(false)] out T data) =>
+            TryGetDataInternal(format, resolver: null, autoConvert, out data);
+
+    public bool TryGetData<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(
+        string format,
+        [NotNullWhen(true), MaybeNullWhen(false)] out T data) =>
+            TryGetDataInternal(format, resolver: null, autoConvert: false, out data);
+
+    public bool TryGetData<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(
+        [NotNullWhen(true), MaybeNullWhen(false)] out T data) =>
+            TryGetDataInternal(typeof(T).FullName!, resolver: null, autoConvert: false, out data);
+    #endregion
+
+    /// <summary>
+    ///  Override this method in the derived class to provide custom data retrieval logic.
+    /// </summary>
+    /// <inheritdoc cref="ITypedDataObject.TryGetData{T}(string, Func{TypeName, Type}, bool, out T)" />
+    [CLSCompliant(false)]
+    protected virtual bool TryGetDataCore<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(
+        string format,
+        Func<TypeName, Type>? resolver,
+        bool autoConvert,
+        [NotNullWhen(true), MaybeNullWhen(false)] out T data) =>
+            _innerData.TryGetData(format, resolver!, autoConvert, out data);
+
     public virtual bool ContainsAudio() => GetDataPresent(DataFormats.WaveAudioConstant, autoConvert: false);
 
     public virtual bool ContainsFileDropList() => GetDataPresent(DataFormats.FileDropConstant, autoConvert: true);
@@ -133,6 +200,7 @@ public unsafe partial class DataObject :
         return GetDataPresent(ConvertToDataFormats(format), autoConvert: false);
     }
 
+#pragma warning disable WFDEV005 // Type or member is obsolete
     public virtual Stream? GetAudioStream() => GetData(DataFormats.WaveAudio, autoConvert: false) as Stream;
 
     public virtual StringCollection GetFileDropList()
@@ -154,6 +222,7 @@ public unsafe partial class DataObject :
         SourceGenerated.EnumValidator.Validate(format, nameof(format));
         return GetData(ConvertToDataFormats(format), autoConvert: false) is string text ? text : string.Empty;
     }
+#pragma warning restore WFDEV005
 
     public virtual string GetText() => GetText(TextDataFormat.UnicodeText);
 
@@ -181,6 +250,63 @@ public unsafe partial class DataObject :
         SourceGenerated.EnumValidator.Validate(format, nameof(format));
 
         SetData(ConvertToDataFormats(format), false, textData);
+    }
+
+    private bool TryGetDataInternal<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(
+        string format,
+        Func<TypeName, Type>? resolver,
+        bool autoConvert,
+        [NotNullWhen(true), MaybeNullWhen(false)] out T data)
+    {
+        data = default;
+
+        if (!IsValidFormatAndType<T>(format))
+        {
+            // Resolver implementation is specific to the overridden TryGetDataCore method,
+            // can't validate if a non-null resolver is required for unbounded types.
+            return false;
+        }
+
+        return TryGetDataCore(format, resolver, autoConvert, out data);
+    }
+
+    /// <summary>
+    ///  Verify if the specified format is valid and compatible with the specified type <typeparamref name="T"/>.
+    /// </summary>
+    internal static bool IsValidFormatAndType<T>(string format)
+    {
+        if (string.IsNullOrWhiteSpace(format))
+        {
+            return false;
+        }
+
+        if (IsValidPredefinedFormatTypeCombination(format))
+        {
+            return true;
+        }
+
+        // TODO (TanyaSo): localize string
+        throw new NotSupportedException(string.Format(
+            "Type '{0}' is not compatible with the specified format '{1}'.",
+            typeof(T).FullName, format));
+
+        static bool IsValidPredefinedFormatTypeCombination(string format) => format switch
+        {
+            DataFormats.TextConstant
+                or DataFormats.UnicodeTextConstant
+                or DataFormats.StringConstant
+                or DataFormats.RtfConstant
+                or DataFormats.HtmlConstant
+                or DataFormats.OemTextConstant => typeof(string) == typeof(T),
+
+            DataFormats.FileDropConstant
+                or CF_DEPRECATED_FILENAME
+                or CF_DEPRECATED_FILENAMEW => typeof(string[]) == typeof(T),
+
+            DataFormats.BitmapConstant or BitmapFullName =>
+                typeof(Bitmap) == typeof(T) || typeof(Image) == typeof(T),
+            _ => true
+        };
     }
 
     private static string ConvertToDataFormats(TextDataFormat format) => format switch

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObjectExtensions.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObjectExtensions.cs
@@ -1,0 +1,64 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Windows.Forms;
+
+/// <summary>
+///  Extension methods for data objects.
+/// </summary>
+public static class DataObjectExtensions
+{
+    private static ITypedDataObject GetTypedDataObjectOrThrow(IDataObject dataObject)
+    {
+        ArgumentNullException.ThrowIfNull(dataObject);
+
+        if (dataObject is not ITypedDataObject typed)
+        {
+            // TODO (TanyaSo) : localize string
+            throw new NotSupportedException(string.Format(
+                "Data object({0}) should implement 'ITypedDataObject' interface to support 'TryGetData<T> methods.",
+                dataObject.GetType().FullName));
+        }
+
+        return typed;
+    }
+
+    /// <inheritdoc cref="ITypedDataObject.TryGetData{T}(out T)"/>
+    /// <exception cref="NotSupportedException">if the <paramref name="dataObject"/> does not implement <see cref="ITypedDataObject" />.</exception>
+    /// <exception cref="ArgumentNullException">if the <paramref name="dataObject"/> is <see langword="null"/></exception>
+    public static bool TryGetData<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(
+        this IDataObject dataObject,
+        [NotNullWhen(true), MaybeNullWhen(false)] out T data) =>
+            GetTypedDataObjectOrThrow(dataObject).TryGetData(out data);
+
+    /// <inheritdoc cref="ITypedDataObject.TryGetData{T}(string, out T)"/>
+    /// <exception cref="NotSupportedException">if the <paramref name="dataObject"/> does not implement <see cref="ITypedDataObject" />.</exception>
+    /// <exception cref="ArgumentNullException">if the <paramref name="dataObject"/> is <see langword="null"/></exception>
+    public static bool TryGetData<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(
+        this IDataObject dataObject,
+        string format,
+        [NotNullWhen(true), MaybeNullWhen(false)] out T data) =>
+            GetTypedDataObjectOrThrow(dataObject).TryGetData(format, out data);
+
+    /// <inheritdoc cref="ITypedDataObject.TryGetData{T}(string, bool, out T)"/>
+    /// <exception cref="NotSupportedException">if the <paramref name="dataObject"/> does not implement <see cref="ITypedDataObject" />.</exception>
+    /// <exception cref="ArgumentNullException">if the <paramref name="dataObject"/> is <see langword="null"/></exception>
+    public static bool TryGetData<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(
+        this IDataObject dataObject,
+        string format,
+        bool autoConvert,
+        [NotNullWhen(true), MaybeNullWhen(false)] out T data) =>
+            GetTypedDataObjectOrThrow(dataObject).TryGetData(format, autoConvert, out data);
+
+    /// <inheritdoc cref="ITypedDataObject.TryGetData{T}(string, Func{Reflection.Metadata.TypeName, Type}, bool, out T)"/>
+    /// <exception cref="NotSupportedException">if the <paramref name="dataObject"/> does not implement <see cref="ITypedDataObject" />.</exception>
+    /// <exception cref="ArgumentNullException">if the <paramref name="dataObject"/> is <see langword="null"/></exception>
+    [CLSCompliant(false)]
+    public static bool TryGetData<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(
+        this IDataObject dataObject,
+        string format,
+        Func<Reflection.Metadata.TypeName, Type> resolver,
+        bool autoConvert,
+        [NotNullWhen(true), MaybeNullWhen(false)] out T data) =>
+            GetTypedDataObjectOrThrow(dataObject).TryGetData(format, resolver, autoConvert, out data);
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/IDataObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/IDataObject.cs
@@ -8,8 +8,8 @@ namespace System.Windows.Forms;
 /// </summary>
 ///  <remarks>
 ///  <para>
-///   When implementing a <see cref="IDataObject"/>, implement <see cref="ITypedDataObject"/>
-///   interface as well.  This interface will ensure that only data of a specified <see cref="Type"/>
+///   When implementing a <see cref="IDataObject"/>, consider implementing <see cref="ITypedDataObject"/>
+///   interface instead.  This interface will ensure that only data of a specified <see cref="Type"/>
 ///   is exchanged.  If <see cref="ITypedDataObject"/> is not implemented by a data object exchanged
 ///   in the clipboard or drag and drop scenarios, the APIs that specify a <see cref="Type"/>,
 ///   such as <see cref="Clipboard.TryGetData{T}(string, out T)"/>, will throw a <see cref="NotSupportedException"/>.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/IDataObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/IDataObject.cs
@@ -6,6 +6,15 @@ namespace System.Windows.Forms;
 /// <summary>
 ///  Provides a format-independent mechanism for transferring data.
 /// </summary>
+///  <remarks>
+///  <para>
+///   When implementing a <see cref="IDataObject"/>, implement <see cref="ITypedDataObject"/>
+///   interface as well.  This interface will ensure that only data of a specified <see cref="Type"/>
+///   is exchanged.  If <see cref="ITypedDataObject"/> is not implemented by a data object exchanged
+///   in the clipboard or drag and drop scenarios, the APIs that specify a <see cref="Type"/>,
+///   such as <see cref="Clipboard.TryGetData{T}(string, out T)"/>, will throw a <see cref="NotSupportedException"/>.
+///  </para>
+///  </remarks>
 public interface IDataObject
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/ITypedDataObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/ITypedDataObject.cs
@@ -13,12 +13,13 @@ namespace System.Windows.Forms;
 ///  <para>
 ///   Implement this interface to use your data object with <see cref="Clipboard.TryGetData{T}(string, out T)"/>
 ///   family of methods as well as in the drag and drop operations.  This interface will ensure that only
-///   data of the specified <see cref="Type"/> is exchanged.  When implementing a  <see cref="IDataObject"/>
+///   data of the specified <see cref="Type"/> is exchanged.  Otherwise the APIs that specify a <see cref="Type"/> parameter
+///   will throw a <see cref="NotSupportedException"/>.This is replacement of <see cref="IDataObject"/>
 ///   interface, implement this interface as well.  Otherwise the APIs that specify a <see cref="Type"/> parameter
 ///   will throw a <see cref="NotSupportedException"/>.
 ///  </para>
 /// </remarks>
-public interface ITypedDataObject
+public interface ITypedDataObject : IDataObject
 {
     /// <summary>
     ///  Retrieves data associated with data format named after <typeparamref name="T"/>,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/ITypedDataObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/ITypedDataObject.cs
@@ -1,0 +1,85 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Reflection.Metadata;
+using System.Runtime.Serialization.Formatters.Binary;
+
+namespace System.Windows.Forms;
+
+/// <summary>
+///  Provides a format-independent mechanism for reading data of a specified <see cref="Type"/>.
+/// </summary>
+/// <remarks>
+///  <para>
+///   Implement this interface to use your data object with <see cref="Clipboard.TryGetData{T}(string, out T)"/>
+///   family of methods as well as in the drag and drop operations.  This interface will ensure that only
+///   data of the specified <see cref="Type"/> is exchanged.  When implementing a  <see cref="IDataObject"/>
+///   interface, implement this interface as well.  Otherwise the APIs that specify a <see cref="Type"/> parameter
+///   will throw a <see cref="NotSupportedException"/>.
+///  </para>
+/// </remarks>
+public interface ITypedDataObject
+{
+    /// <summary>
+    ///  Retrieves data associated with data format named after <typeparamref name="T"/>,
+    ///  if that data is of type <typeparamref name="T"/>.
+    /// </summary>
+    /// <inheritdoc cref="TryGetData{T}(string, Func{TypeName, Type}, bool, out T)"/>
+    bool TryGetData<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(
+        [NotNullWhen(true), MaybeNullWhen(false)] out T data);
+
+    /// <summary>
+    ///  Retrieves data associated with the specified format if that data is of type <typeparamref name="T"/>.
+    /// </summary>
+    /// <inheritdoc cref="TryGetData{T}(string, Func{TypeName, Type}, bool, out T)"/>
+    bool TryGetData<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(
+        string format,
+        [NotNullWhen(true), MaybeNullWhen(false)] out T data);
+
+    /// <summary>
+    ///  Retrieves data in a specified format if that data is of type <typeparamref name="T"/>,
+    ///  optionally converting the data to the specified format.
+    /// </summary>
+    /// <inheritdoc cref="TryGetData{T}(string, Func{TypeName, Type}, bool, out T)"/>
+    bool TryGetData<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(
+        string format,
+        bool autoConvert,
+        [NotNullWhen(true), MaybeNullWhen(false)] out T data);
+
+    /// <summary>
+    ///  <see cref="BinaryFormatter"/> compatible overload that retrieves typed data associated with the specified data format.
+    /// </summary>
+    /// <param name="resolver">
+    ///  A user-provided function that defines a closure of <see cref="Type"/>s that can be retrieved from
+    ///  the exchange medium.
+    /// </param>
+    /// <param name="format">
+    ///  A string that specifies what format to retrieve the data as.  See the <see cref="DataFormats"/> class for
+    ///  a set of predefined data formats.
+    /// </param>
+    /// <param name="autoConvert">
+    ///  <see langword="true"/> to attempt to automatically convert the data to the specified format;
+    ///  <see langword="false"/> for no data format conversion.
+    /// </param>
+    /// <param name="data">
+    ///  A data object with the data in the specified format, or <see langword="null"/> if the data is not available
+    ///  in the specified format or is of a wrong type.
+    /// </param>
+    /// <returns>
+    ///  <see langword="true"/> if the data of this format is present and the value is
+    ///  of a matching type and that value can be successfully retrieved, or <see langword="false"/>
+    ///  if the format is not present or the value is not of the right type.
+    /// </returns>
+    /// <remarks>
+    ///  <para>
+    ///   Implement this method for backward compatibility with binary formatted data when binary formatters are enabled.
+    ///  </para>
+    /// </remarks>
+    bool TryGetData<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(
+        string format,
+#pragma warning disable CS3001 // Argument type is not CLS-compliant
+        Func<TypeName, Type> resolver,
+#pragma warning restore CS3001
+        bool autoConvert,
+        [NotNullWhen(true), MaybeNullWhen(false)] out T data);
+}

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/DesignBehaviorsTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/DesignBehaviorsTests.cs
@@ -183,7 +183,9 @@ public class DesignBehaviorsTests : ControlTestBase
 
         public ToolboxItem DeserializeToolboxItem(object serializedObject, IDesignerHost? host)
         {
+#pragma warning disable WFDEV005 // Type or member is obsolete
             ToolboxItem? item = ((DataObject)serializedObject)?.GetData(typeof(ToolboxItem)) as ToolboxItem;
+#pragma warning restore WFDEV005
             return item!;
         }
 

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/runtimeconfig.template.json
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/runtimeconfig.template.json
@@ -1,6 +1,8 @@
 {
   "configProperties": {
     "System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization": false,
+    "Windows.ClipboardDragDrop.EnableUnsafeBinaryFormatterSerialization": false,
+    "Windows.ClipboardDragDrop.EnableNrbfSerialization": true,
     "System.Windows.Forms.AnchorLayoutV2": false,
     "System.Windows.Forms.ApplyParentFontToMenus": true,
     "System.Windows.Forms.DataGridViewUIAStartRowCountAtZero": false,

--- a/src/System.Windows.Forms/tests/UnitTests/System.Windows.Forms.Tests.csproj
+++ b/src/System.Windows.Forms/tests/UnitTests/System.Windows.Forms.Tests.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>$(TargetFramework)-windows7.0</TargetFramework>
     <DisableTransitiveFrameworkReferences>true</DisableTransitiveFrameworkReferences>
     <AssemblyName>System.Windows.Forms.Tests</AssemblyName>
+    <RootNamespace />
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/BinaryFormat/WinFormsBinaryFormattedObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/BinaryFormat/WinFormsBinaryFormattedObjectTests.cs
@@ -21,11 +21,11 @@ public class WinFormsBinaryFormattedObjectTests
     {
         using Bitmap bitmap = new(10, 10);
         SerializationRecord rootRecord = bitmap.SerializeAndDecode();
-        Formats.Nrbf.ClassRecord root = rootRecord.Should().BeAssignableTo<Formats.Nrbf.ClassRecord>().Subject;
+        ClassRecord root = rootRecord.Should().BeAssignableTo<ClassRecord>().Subject;
         root.TypeNameMatches(typeof(Bitmap)).Should().BeTrue();
         root.TypeName.FullName.Should().Be(typeof(Bitmap).FullName);
         root.TypeName.AssemblyName!.FullName.Should().Be(AssemblyRef.SystemDrawing);
-        Formats.Nrbf.ArrayRecord arrayRecord = root.GetArrayRecord("Data")!;
+        ArrayRecord arrayRecord = root.GetArrayRecord("Data")!;
         arrayRecord.Should().BeAssignableTo<SZArrayRecord<byte>>();
         rootRecord.TryGetBitmap(out object? result).Should().BeTrue();
         using Bitmap deserialized = result.Should().BeOfType<Bitmap>().Which;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/BinaryFormatUtilitiesTests.BinaryFormatterFullCompatScope.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/BinaryFormatUtilitiesTests.BinaryFormatterFullCompatScope.cs
@@ -5,13 +5,13 @@ namespace System.Windows.Forms.Tests;
 
 public partial class BinaryFormatUtilitiesTests
 {
-    internal readonly ref struct FullCompatScope : IDisposable
+    internal readonly ref struct BinaryFormatterFullCompatScope : IDisposable
     {
         private readonly BinaryFormatterScope _binaryFormatterScope;
         private readonly BinaryFormatterInClipboardDragDropScope _binaryFormatterInClipboardDragDropScope;
         private readonly NrbfSerializerInClipboardDragDropScope _nrbfSerializerInClipboardDragDropScope;
 
-        public FullCompatScope()
+        public BinaryFormatterFullCompatScope()
         {
             _binaryFormatterScope = new(enable: true);
             _binaryFormatterInClipboardDragDropScope = new(enable: true);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/BinaryFormatUtilitiesTests.FullCompatScope.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/BinaryFormatUtilitiesTests.FullCompatScope.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Windows.Forms.Tests;
+
+public partial class BinaryFormatUtilitiesTests
+{
+    internal readonly ref struct FullCompatScope : IDisposable
+    {
+        private readonly BinaryFormatterScope _binaryFormatterScope;
+        private readonly BinaryFormatterInClipboardDragDropScope _binaryFormatterInClipboardDragDropScope;
+        private readonly NrbfSerializerInClipboardDragDropScope _nrbfSerializerInClipboardDragDropScope;
+
+        public FullCompatScope()
+        {
+            _binaryFormatterScope = new(enable: true);
+            _binaryFormatterInClipboardDragDropScope = new(enable: true);
+            _nrbfSerializerInClipboardDragDropScope = new(enable: false);
+        }
+
+        public void Dispose()
+        {
+            _binaryFormatterScope.Dispose();
+            _binaryFormatterInClipboardDragDropScope.Dispose();
+            _nrbfSerializerInClipboardDragDropScope.Dispose();
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/BinaryFormatUtilitiesTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/BinaryFormatUtilitiesTests.cs
@@ -544,6 +544,8 @@ public partial class BinaryFormatUtilitiesTests : IDisposable
             [
                 (typeof(TestData).FullName!, typeof(TestData)),
                 (typeof(TestDataBase.InnerData).FullName!, typeof(TestDataBase.InnerData)),
+                ("System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(decimal?)),
+                ("System.Collections.Generic.List`1[[System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]", typeof(List<decimal?>))
             ];
 
             string fullName = typeName.FullName;
@@ -848,8 +850,23 @@ public partial class BinaryFormatUtilitiesTests : IDisposable
         // BinaryFormatter resolves primitive types or arrays of primitive types with no resolver.
         public int? Count;
         public DateTime? Today = DateTime.Now;
+
+        public byte[] ByteArray = [8, 9];
+        public sbyte[] SbyteArray = [8, 9];
+        public short[] ShortArray = [8, 9];
+        public ushort[] UshortArray = [8, 9];
+        public int[] IntArray = [8, 9];
+        public uint[] UintArray = [8, 9];
+        public long[] LongArray = [8, 9];
+        public ulong[] UlongArray = [8, 9];
         public float[] FloatArray = [1.0f, 2.0f, 3.0f];
+        public double[] DoubleArray = [1.0, 2.0, 3.0];
+        public char[] CharArray = ['a', 'b', 'c'];
+        public bool[] BoolArray = [true, false];
+        public string[] StringArray = ["a", "b", "c"];
+        public decimal[] DecimalArray = [1.0m, 2.0m, 3.0m];
         public TimeSpan[] TimeSpanArray = [TimeSpan.FromHours(1)];
+        public DateTime[] DateTimeArray = [DateTime.Now];
 
         // Common WinForms types are resolved using the intrinsic binder.
         public NotSupportedException Exception = new();
@@ -873,6 +890,7 @@ public partial class BinaryFormatUtilitiesTests : IDisposable
         public List<float> Floats = [1.0f, 2.0f, 3.0f];
         public List<double> Doubles = [1.0, 2.0, 3.0];
         public List<decimal> Decimals = [1.0m, 2.0m, 3.0m];
+        public List<decimal?> NullableDecimals = [null, 2.0m, 3.0m];
         public List<DateTime> DateTimes = [DateTime.Now];
         // System.Runtime.Serialization.SerializationException : Invalid BinaryFormatter stream.
         // System.NotSupportedException : Can't resolve System.Collections.Generic.List`1[[System.TimeSpan, System.Private.CoreLib, Version=10.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]
@@ -886,8 +904,24 @@ public partial class BinaryFormatUtilitiesTests : IDisposable
             Inner.Should().BeEquivalentTo(other.Inner);
             Count.Should().Be(other.Count);
             Today.Should().Be(other.Today);
+
+            ByteArray.Should().BeEquivalentTo(other.ByteArray);
+            SbyteArray.Should().BeEquivalentTo(other.SbyteArray);
+            ShortArray.Should().BeEquivalentTo(other.ShortArray);
+            UshortArray.Should().BeEquivalentTo(other.UshortArray);
+            IntArray.Should().BeEquivalentTo(other.IntArray);
+            UintArray.Should().BeEquivalentTo(other.UintArray);
+            LongArray.Should().BeEquivalentTo(other.LongArray);
+            UlongArray.Should().BeEquivalentTo(other.UlongArray);
             FloatArray.Should().BeEquivalentTo(other.FloatArray);
+            DoubleArray.Should().BeEquivalentTo(other.DoubleArray);
+            CharArray.Should().BeEquivalentTo(other.CharArray);
+            BoolArray.Should().BeEquivalentTo(other.BoolArray);
+            StringArray.Should().BeEquivalentTo(other.StringArray);
+            DecimalArray.Should().BeEquivalentTo(other.DecimalArray);
             TimeSpanArray.Should().BeEquivalentTo(other.TimeSpanArray);
+            DateTimeArray.Should().BeEquivalentTo(other.DateTimeArray);
+
             Exception.Should().BeEquivalentTo(other.Exception);
             Point.Should().Be(other.Point);
             Rectangle.Should().Be(other.Rectangle);
@@ -910,6 +944,7 @@ public partial class BinaryFormatUtilitiesTests : IDisposable
             Floats.Should().BeEquivalentTo(other.Floats);
             Doubles.Should().BeEquivalentTo(other.Doubles);
             Decimals.Should().BeEquivalentTo(other.Decimals);
+            NullableDecimals.Should().BeEquivalentTo(other.NullableDecimals);
             DateTimes.Should().BeEquivalentTo(other.DateTimes);
             // TimeSpans.Should().BeEquivalentTo(other.TimeSpans);
             Strings.Should().BeEquivalentTo(other.Strings);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/BinaryFormatUtilitiesTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/BinaryFormatUtilitiesTests.cs
@@ -120,24 +120,24 @@ public partial class BinaryFormatUtilitiesTests : IDisposable
 
     public static TheoryData<ArrayList> PrimitiveArrayListObjects_TheoryData =>
     [
-        new ArrayList { null },
-        new ArrayList { null, "something" },
-        new ArrayList { false, true },
-        new ArrayList { char.MinValue, char.MaxValue },
-        new ArrayList { byte.MinValue, byte.MaxValue },
-        new ArrayList { sbyte.MinValue, sbyte.MaxValue },
-        new ArrayList { short.MinValue, short.MaxValue },
-        new ArrayList { ushort.MinValue, ushort.MaxValue },
-        new ArrayList { int.MinValue, int.MaxValue },
-        new ArrayList { uint.MinValue, uint.MaxValue },
-        new ArrayList { long.MinValue, long.MaxValue },
-        new ArrayList { ulong.MinValue, ulong.MaxValue },
-        new ArrayList { float.MinValue, float.MaxValue },
-        new ArrayList { double.MinValue, double.MaxValue },
-        new ArrayList { decimal.MinValue, decimal.MaxValue },
-        new ArrayList { DateTime.MinValue, DateTime.MaxValue },
-        new ArrayList { TimeSpan.MinValue, TimeSpan.MaxValue },
-        new ArrayList { "a", "b", "c" }
+        [null],
+        [null, "something"],
+        [false, true],
+        [char.MinValue, char.MaxValue],
+        [byte.MinValue, byte.MaxValue],
+        [sbyte.MinValue, sbyte.MaxValue],
+        [short.MinValue, short.MaxValue],
+        [ushort.MinValue, ushort.MaxValue],
+        [int.MinValue, int.MaxValue],
+        [uint.MinValue, uint.MaxValue],
+        [long.MinValue, long.MaxValue],
+        [ulong.MinValue, ulong.MaxValue],
+        [float.MinValue, float.MaxValue],
+        [double.MinValue, double.MaxValue],
+        [decimal.MinValue, decimal.MaxValue],
+        [DateTime.MinValue, DateTime.MaxValue],
+        [TimeSpan.MinValue, TimeSpan.MaxValue],
+        ["a", "b", "c"]
     ];
 
     public static TheoryData<Hashtable> PrimitiveTypeHashtables_TheoryData =>
@@ -162,9 +162,9 @@ public partial class BinaryFormatUtilitiesTests : IDisposable
 
     public static TheoryData<NotSupportedException> NotSupportedException_TestData =>
     [
-        new NotSupportedException(),
-        new NotSupportedException("Error message"),
-        new NotSupportedException(null)
+        new(),
+        new("Error message"),
+        new(null)
     ];
 
     public static TheoryData<IList> Lists_UnsupportedTestData =>

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/BinaryFormatUtilitiesTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/BinaryFormatUtilitiesTests.cs
@@ -356,7 +356,7 @@ public partial class BinaryFormatUtilitiesTests : IDisposable
         Action writer = () => WriteObjectToStream(value, restrictSerialization: true);
         writer.Should().Throw<SerializationException>();
 
-        using FullCompatScope scope = new();
+        using BinaryFormatterFullCompatScope scope = new();
         writer.Should().Throw<SerializationException>();
     }
 
@@ -372,7 +372,7 @@ public partial class BinaryFormatUtilitiesTests : IDisposable
         value.SetValue(203u, 2, 4);
 
         // Can read offset array with the BinaryFormatter.
-        using FullCompatScope scope = new();
+        using BinaryFormatterFullCompatScope scope = new();
         var result = RoundTripObject(value).Should().BeOfType<uint[,]>().Subject;
 
         result.Rank.Should().Be(2);
@@ -393,7 +393,7 @@ public partial class BinaryFormatUtilitiesTests : IDisposable
     {
         // Not a known type, while 'List<object>' is resolved by default, 'object' requires a custom resolver.
         List<object> value = ["text"];
-        using (FullCompatScope scope = new())
+        using (BinaryFormatterFullCompatScope scope = new())
         {
             WriteObjectToStream(value);
 
@@ -453,7 +453,7 @@ public partial class BinaryFormatUtilitiesTests : IDisposable
 
         ReadObjectFromStream<Control>(restrictDeserialization: true, NotSupportedResolver).Should().BeNull();
 
-        using FullCompatScope scope = new();
+        using BinaryFormatterFullCompatScope scope = new();
         ReadObjectFromStream<Control>(restrictDeserialization: true, NotSupportedResolver).Should().BeNull();
     }
 
@@ -471,7 +471,7 @@ public partial class BinaryFormatUtilitiesTests : IDisposable
     {
         int?[] value = [101, null, 303];
 
-        using FullCompatScope scope = new();
+        using BinaryFormatterFullCompatScope scope = new();
         WriteObjectToStream(value);
         Action read = () => ReadObjectFromStream<int?[]>(restrictDeserialization, NotSupportedResolver);
 
@@ -491,7 +491,7 @@ public partial class BinaryFormatUtilitiesTests : IDisposable
         value.SetValue(202u, 2, 3);
         value.SetValue(203u, 2, 4);
 
-        using FullCompatScope scope = new();
+        using BinaryFormatterFullCompatScope scope = new();
         WriteObjectToStream(value);
         Action read = () => ReadObjectFromStream<uint[,]>(restrictDeserialization, NotSupportedResolver);
 
@@ -503,7 +503,7 @@ public partial class BinaryFormatUtilitiesTests : IDisposable
     {
         int?[] value = [101, null, 303];
 
-        using FullCompatScope scope = new();
+        using BinaryFormatterFullCompatScope scope = new();
         RoundTripOfType<int?[]>(value, NullableIntArrayResolver).Should().BeEquivalentTo(value);
     }
 
@@ -533,7 +533,7 @@ public partial class BinaryFormatUtilitiesTests : IDisposable
     {
         TestData value = new(new(10, 10), 2);
 
-        using FullCompatScope scope = new();
+        using BinaryFormatterFullCompatScope scope = new();
         var result = RoundTripOfType<TestDataBase>(value, TestDataResolver).Should().BeOfType<TestData>().Subject;
 
         result.Equals(value, value.Bitmap.Size);
@@ -565,7 +565,7 @@ public partial class BinaryFormatUtilitiesTests : IDisposable
     {
         TestData value = new(new(10, 10), 2);
 
-        using FullCompatScope scope = new();
+        using BinaryFormatterFullCompatScope scope = new();
         WriteObjectToStream(value);
 
         // Resolver that returns a null is blocked in our SerializationBinder wrapper.
@@ -604,7 +604,7 @@ public partial class BinaryFormatUtilitiesTests : IDisposable
     {
         using Font value = new("Microsoft Sans Serif", emSize: 10);
 
-        using FullCompatScope scope = new();
+        using BinaryFormatterFullCompatScope scope = new();
 
         using Font result = RoundTripOfType<Font>(value, FontResolver).Should().BeOfType<Font>().Subject;
         result.Should().Be(value);
@@ -645,7 +645,7 @@ public partial class BinaryFormatUtilitiesTests : IDisposable
         }
 
         // Deserialize using the binary formatter.
-        using FullCompatScope scope = new();
+        using BinaryFormatterFullCompatScope scope = new();
         // GetData case.
         stream.Position = 0;
         var result = Utilities.ReadObjectFromStream<object>(
@@ -679,7 +679,7 @@ public partial class BinaryFormatUtilitiesTests : IDisposable
     {
         TestDataBase.InnerData value = new("simple class");
 
-        using FullCompatScope scope = new();
+        using BinaryFormatterFullCompatScope scope = new();
 
         RoundTripOfType<TestDataBase.InnerData>(value, resolver: null)
             .Should().BeOfType<TestDataBase.InnerData>().Which.Should().BeEquivalentTo(value);
@@ -702,7 +702,7 @@ public partial class BinaryFormatUtilitiesTests : IDisposable
     {
         MyClass1 value = new(value: 1);
 
-        using FullCompatScope scope = new();
+        using BinaryFormatterFullCompatScope scope = new();
         WriteObjectToStream(value);
 
         // legacyMode == true follows the GetData path.
@@ -732,7 +732,7 @@ public partial class BinaryFormatUtilitiesTests : IDisposable
     {
         MyClass1 value = new(value: 1);
 
-        using FullCompatScope scope = new();
+        using BinaryFormatterFullCompatScope scope = new();
         WriteObjectToStream(value);
 
         // SerializationException will be swallowed up the call stack, when reading HGLOBAL.
@@ -760,7 +760,7 @@ public partial class BinaryFormatUtilitiesTests : IDisposable
     {
         MyClass1 value = new(value: 1);
 
-        using FullCompatScope scope = new();
+        using BinaryFormatterFullCompatScope scope = new();
         WriteObjectToStream(value);
 
         ReadObjectFromStream<MyClass1>(restrictDeserialization: false, MyClass1.MyExactMatchResolver)
@@ -772,7 +772,7 @@ public partial class BinaryFormatUtilitiesTests : IDisposable
     {
         MyClass1 value = new(value: 1);
 
-        using FullCompatScope scope = new();
+        using BinaryFormatterFullCompatScope scope = new();
         WriteObjectToStream(value);
 
         Action read = () => ReadObjectFromStream<MyClass1>(restrictDeserialization: true, MyClass1.MyExactMatchResolver);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ClipboardTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ClipboardTests.cs
@@ -111,8 +111,9 @@ public class ClipboardTests
     [WinFormsFact]
     public void Clipboard_GetDataObject_InvokeMultipleTimes_Success()
     {
-        IDataObject? result = Clipboard.GetDataObject();
-        (result == Clipboard.GetDataObject()).Should().BeFalse();
+        DataObject result1 = Clipboard.GetDataObject().Should().BeOfType<DataObject>().Subject;
+        DataObject result2 = Clipboard.GetDataObject().Should().BeOfType<DataObject>().Subject;
+        result1.GetFormats().Should().BeEquivalentTo(result2.GetFormats());
     }
 
     [WinFormsFact]
@@ -261,8 +262,7 @@ public class ClipboardTests
     {
         Clipboard.SetDataObject(data);
 
-        var dataObject = Clipboard.GetDataObject();
-        Assert.NotNull(dataObject);
+        DataObject dataObject = Clipboard.GetDataObject().Should().BeOfType<DataObject>().Subject;
         dataObject.GetData(data.GetType()).Should().Be(data);
         Clipboard.ContainsData(data.GetType().FullName).Should().BeTrue();
     }
@@ -433,7 +433,8 @@ public class ClipboardTests
         using Bitmap bitmap = new(10, 10);
         bitmap.SetPixel(1, 2, Color.FromArgb(0x01, 0x02, 0x03, 0x04));
         Clipboard.SetImage(bitmap);
-        Bitmap result = Assert.IsType<Bitmap>(Clipboard.GetImage());
+
+        var result = Clipboard.GetImage().Should().BeOfType<Bitmap>().Subject;
         result.Size.Should().Be(bitmap.Size);
         result.GetPixel(1, 2).Should().Be(Color.FromArgb(0xFF, 0xD2, 0xD2, 0xD2));
         Clipboard.ContainsImage().Should().BeTrue();
@@ -445,6 +446,7 @@ public class ClipboardTests
         try
         {
             using Metafile metafile = new("bitmaps/telescope_01.wmf");
+            // SetImage fails silently and corrupts the clipboard state for anything other than a bitmap.
             Clipboard.SetImage(metafile);
 
             Clipboard.GetImage().Should().BeNull();
@@ -462,6 +464,7 @@ public class ClipboardTests
         try
         {
             using Metafile metafile = new("bitmaps/milkmateya01.emf");
+            // SetImage fails silently and corrupts the clipboard for everything other than a bitmap.
             Clipboard.SetImage(metafile);
 
             Clipboard.GetImage().Should().BeNull();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ClipboardTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ClipboardTests.cs
@@ -310,7 +310,7 @@ public class ClipboardTests
         DataObject dataObject = new(data);
         Clipboard.SetDataObject(dataObject, copy, retryTimes, retryDelay);
 
-        DataObject actual = Clipboard.GetDataObject().Should().BeOfType<DataObject>().Which;
+        DataObject actual = Clipboard.GetDataObject().Should().BeOfType<DataObject>().Subject;
         actual.GetData(data.GetType()).Should().Be(data);
         Clipboard.ContainsData(data.GetType().FullName).Should().BeTrue();
     }
@@ -324,7 +324,7 @@ public class ClipboardTests
     {
         Clipboard.SetDataObject(data, copy, retryTimes, retryDelay);
 
-        DataObject dataObject = Clipboard.GetDataObject().Should().BeOfType<DataObject>().Which;
+        DataObject dataObject = Clipboard.GetDataObject().Should().BeOfType<DataObject>().Subject;
         dataObject.GetData(data.GetType()).Should().Be(data);
         Clipboard.ContainsData(data.GetType().FullName).Should().BeTrue();
     }
@@ -577,7 +577,7 @@ public class ClipboardTests
         Clipboard.SetDataObject(realDataObject);
 
         IDataObject? clipboardDataObject = Clipboard.GetDataObject();
-        var dataObject = clipboardDataObject.Should().BeOfType<DataObject>().Which;
+        var dataObject = clipboardDataObject.Should().BeOfType<DataObject>().Subject;
         dataObject.IsWrappedForClipboard.Should().BeTrue();
 
         Clipboard.SetDataObject(clipboardDataObject!);
@@ -659,7 +659,7 @@ public class ClipboardTests
         SetClipboardData((uint)CLIPBOARD_FORMAT.CF_UNICODETEXT, (HANDLE)Marshal.StringToHGlobalUni(testString));
         CloseClipboard().Should().BeTrue();
 
-        DataObject dataObject = Clipboard.GetDataObject().Should().BeOfType<DataObject>().Which;
+        DataObject dataObject = Clipboard.GetDataObject().Should().BeOfType<DataObject>().Subject;
         dataObject.GetData(DataFormats.Text).Should().Be(testString);
     }
 
@@ -723,7 +723,7 @@ public class ClipboardTests
     {
         TestData expected = new(DateTime.Now);
         string format = "TestData";
-        using FullCompatScope scope = new();
+        using BinaryFormatterFullCompatScope scope = new();
         Clipboard.SetData(format, expected);
 
         Clipboard.TryGetData(format, TestData.TestDataResolver, out TestData? data).Should().BeTrue();
@@ -855,7 +855,7 @@ public class ClipboardTests
         value.SetValue(202u, 2, 3);
         value.SetValue(203u, 2, 4);
 
-        using FullCompatScope scope = new();
+        using BinaryFormatterFullCompatScope scope = new();
         Clipboard.SetData("test", value);
 
         var result = Clipboard.GetData("test").Should().BeOfType<uint[,]>().Subject;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataObjectExtensionsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataObjectExtensionsTests.cs
@@ -1,0 +1,261 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System.Diagnostics.CodeAnalysis;
+using System.Drawing;
+using System.Reflection.Metadata;
+
+namespace System.Windows.Forms.Tests;
+
+public class DataObjectExtensionsTests
+{
+    [Fact]
+    public void TryGetData_Throws_ArgumentNullException()
+    {
+        // 'this' is null.
+        Action tryGetData1 = () => DataObjectExtensions.TryGetData<string>(dataObject: null!, out _);
+        tryGetData1.Should().Throw<ArgumentNullException>();
+        Action tryGetData2 = () => DataObjectExtensions.TryGetData<string>(dataObject: null!, DataFormats.Text, out _);
+        tryGetData2.Should().Throw<ArgumentNullException>();
+        Action tryGetData3 = () => DataObjectExtensions.TryGetData<string>(dataObject: null!, DataFormats.Dib, autoConvert: true, out _);
+        tryGetData3.Should().Throw<ArgumentNullException>();
+        Action tryGetData4 = () => DataObjectExtensions.TryGetData<string>(dataObject: null!, DataFormats.EmfConstant, autoConvert: false, out _);
+        tryGetData4.Should().Throw<ArgumentNullException>();
+        Action tryGetData5 = () => DataObjectExtensions.TryGetData<string>(dataObject: null!, DataFormats.UnicodeText, Resolver, autoConvert: true, out _);
+        tryGetData5.Should().Throw<ArgumentNullException>();
+        Action tryGetData6 = () => DataObjectExtensions.TryGetData<string>(dataObject: null!, DataFormats.Serializable, Resolver, autoConvert: false, out _);
+        tryGetData6.Should().Throw<ArgumentNullException>();
+    }
+
+    private static Type Resolver(TypeName typeName) => typeof(string);
+
+    [Fact]
+    public void TryGetData_Throws_NotSupportedException()
+    {
+        UntypedDataObject dataObject = new();
+        Action tryGetData = () => dataObject.TryGetData<string>(out _);
+        tryGetData.Should().Throw<NotSupportedException>();
+        dataObject.VerifyGetDataWasNotCalled();
+    }
+
+    [Fact]
+    public void TryGetData_String_Throws_NotSupportedException()
+    {
+        UntypedDataObject dataObject = new();
+        Action tryGetData = () => dataObject.TryGetData<string>(DataFormats.Text, out _);
+        tryGetData.Should().Throw<NotSupportedException>();
+        dataObject.VerifyGetDataWasNotCalled();
+    }
+
+    [Theory]
+    [BoolData]
+    public void TryGetData_StringBool_Throws_NotSupportedException(bool autoConvert)
+    {
+        UntypedDataObject dataObject = new();
+        Action tryGetData = () => dataObject.TryGetData<string>(DataFormats.CommaSeparatedValue, autoConvert, out _);
+        tryGetData.Should().Throw<NotSupportedException>();
+        dataObject.VerifyGetDataWasNotCalled();
+    }
+
+    [Theory]
+    [BoolData]
+    public void TryGetData_StringFuncBool_Throws_NotSupportedException(bool autoConvert)
+    {
+        UntypedDataObject dataObject = new();
+        Action tryGetData = () => dataObject.TryGetData<string>(DataFormats.UnicodeText, Resolver, autoConvert, out _);
+        tryGetData.Should().Throw<NotSupportedException>();
+        dataObject.VerifyGetDataWasNotCalled();
+    }
+
+    [Fact]
+    public void DataObject_ReturnFalse()
+    {
+        DataObject dataObject = new();
+        dataObject.TryGetData(out string? text).Should().BeFalse();
+        text.Should().BeNull();
+    }
+
+    [Fact]
+    public void DataObject_String_ReturnsFalse()
+    {
+        DataObject dataObject = new();
+        dataObject.TryGetData(DataFormats.Dib, out Bitmap? bitmap).Should().BeFalse();
+        bitmap.Should().BeNull();
+    }
+
+    [Theory]
+    [BoolData]
+    public void DataObject_StringBool_ReturnFalse(bool autoConvert)
+    {
+        DataObject dataObject = new();
+        dataObject.TryGetData(DataFormats.Serializable, autoConvert, out Font? font).Should().BeFalse();
+        font.Should().BeNull();
+    }
+
+    [Theory]
+    [BoolData]
+    public void DataObject_StringFuncBool_ReturnFalse(bool autoConvert)
+    {
+        DataObject dataObject = new();
+        dataObject.TryGetData(DataFormats.SymbolicLink, Resolver, autoConvert, out DateTime? date).Should().BeFalse();
+        date.Should().BeNull();
+    }
+
+    [Fact]
+    public void TypedDataObject_CallsITypedDataObject()
+    {
+        TypedDataObject dataObject = new();
+        dataObject.TryGetData(out string? _).Should().BeFalse();
+        dataObject.VerifyTryGetDataCalled();
+    }
+
+    [Fact]
+    public void TypedDataObject_String_CallsITypedDataObject()
+    {
+        TypedDataObject dataObject = new();
+        dataObject.TryGetData(DataFormats.Dib, out Bitmap? _).Should().BeFalse();
+        dataObject.VerifyTryGetDataStringCalled();
+    }
+
+    [Theory]
+    [BoolData]
+    public void TypedDataObject_StringBool_CallsITypedDataObject(bool autoConvert)
+    {
+        TypedDataObject dataObject = new();
+        dataObject.TryGetData(DataFormats.FileDrop, autoConvert, out int? _).Should().BeFalse();
+        dataObject.VerifyTryGetDataStringBoolCalled();
+    }
+
+    [Theory]
+    [BoolData]
+    public void TypedDataObject_StringFuncBool_CallsITypedDataObject(bool autoConvert)
+    {
+        TypedDataObject dataObject = new();
+        dataObject.TryGetData(DataFormats.SymbolicLink, Resolver, autoConvert, out DateTime? date).Should().BeFalse();
+        dataObject.VerifyTryGetDataStringFuncBoolCalled();
+    }
+
+    internal class UntypedDataObject : IDataObject
+    {
+        public void VerifyGetDataWasNotCalled()
+        {
+            GetDataType_Count.Should().Be(0);
+            GetDataString_Count.Should().Be(0);
+            GetDataStringBool_Count.Should().Be(0);
+        }
+
+        private int GetDataStringBool_Count { get; set; }
+        public object? GetData(string format, bool autoConvert)
+        {
+            GetDataStringBool_Count++;
+            return null;
+        }
+
+        private int GetDataString_Count { get; set; }
+        public object? GetData(string format)
+        {
+            GetDataString_Count++;
+            return null;
+        }
+
+        private int GetDataType_Count { get; set; }
+        public object? GetData(Type format)
+        {
+            GetDataType_Count++;
+            return null;
+        }
+
+        public bool GetDataPresent(string format, bool autoConvert) => throw new NotImplementedException();
+        public bool GetDataPresent(string format) => throw new NotImplementedException();
+        public bool GetDataPresent(Type format) => throw new NotImplementedException();
+        public string[] GetFormats(bool autoConvert) => throw new NotImplementedException();
+        public string[] GetFormats() => throw new NotImplementedException();
+        public void SetData(string format, bool autoConvert, object? data) => throw new NotImplementedException();
+        public void SetData(string format, object? data) => throw new NotImplementedException();
+        public void SetData(Type format, object? data) => throw new NotImplementedException();
+        public void SetData(object? data) => throw new NotImplementedException();
+    }
+
+    internal class TypedDataObject : IDataObject, ITypedDataObject
+    {
+        public object? GetData(string format, bool autoConvert) => throw new NotImplementedException();
+        public object? GetData(string format) => throw new NotImplementedException();
+        public object? GetData(Type format) => throw new NotImplementedException();
+        public bool GetDataPresent(string format, bool autoConvert) => throw new NotImplementedException();
+        public bool GetDataPresent(string format) => throw new NotImplementedException();
+        public bool GetDataPresent(Type format) => throw new NotImplementedException();
+        public string[] GetFormats(bool autoConvert) => throw new NotImplementedException();
+        public string[] GetFormats() => throw new NotImplementedException();
+        public void SetData(string format, bool autoConvert, object? data) => throw new NotImplementedException();
+        public void SetData(string format, object? data) => throw new NotImplementedException();
+        public void SetData(Type format, object? data) => throw new NotImplementedException();
+        public void SetData(object? data) => throw new NotImplementedException();
+
+        private int _tryGetDataCalledCount;
+        private int _tryGetDataStringCalledCount;
+        private int _tryGetDataStringBoolCalledCount;
+        private int _tryGetDataStringFuncBoolCalledCount;
+
+        public void VerifyTryGetDataCalled()
+        {
+            _tryGetDataCalledCount.Should().Be(1);
+            _tryGetDataStringCalledCount.Should().Be(0);
+            _tryGetDataStringBoolCalledCount.Should().Be(0);
+            _tryGetDataStringFuncBoolCalledCount.Should().Be(0);
+        }
+
+        public void VerifyTryGetDataStringCalled()
+        {
+            _tryGetDataCalledCount.Should().Be(0);
+            _tryGetDataStringCalledCount.Should().Be(1);
+            _tryGetDataStringBoolCalledCount.Should().Be(0);
+            _tryGetDataStringFuncBoolCalledCount.Should().Be(0);
+        }
+
+        public void VerifyTryGetDataStringBoolCalled()
+        {
+            _tryGetDataCalledCount.Should().Be(0);
+            _tryGetDataStringCalledCount.Should().Be(0);
+            _tryGetDataStringBoolCalledCount.Should().Be(1);
+            _tryGetDataStringFuncBoolCalledCount.Should().Be(0);
+        }
+
+        public void VerifyTryGetDataStringFuncBoolCalled()
+        {
+            _tryGetDataCalledCount.Should().Be(0);
+            _tryGetDataStringCalledCount.Should().Be(0);
+            _tryGetDataStringBoolCalledCount.Should().Be(0);
+            _tryGetDataStringFuncBoolCalledCount.Should().Be(1);
+        }
+
+        public bool TryGetData<T>([MaybeNullWhen(false), NotNullWhen(true)] out T data)
+        {
+            _tryGetDataCalledCount++;
+            data = default;
+            return false;
+        }
+
+        public bool TryGetData<T>(string format, [MaybeNullWhen(false), NotNullWhen(true)] out T data)
+        {
+            _tryGetDataStringCalledCount++;
+            data = default;
+            return false;
+        }
+
+        public bool TryGetData<T>(string format, bool autoConvert, [MaybeNullWhen(false), NotNullWhen(true)] out T data)
+        {
+            _tryGetDataStringBoolCalledCount++;
+            data = default;
+            return false;
+        }
+
+        public bool TryGetData<T>(string format, Func<TypeName, Type> resolver, bool autoConvert, [MaybeNullWhen(false), NotNullWhen(true)] out T data)
+        {
+            _tryGetDataStringFuncBoolCalledCount++;
+            data = default;
+            return false;
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataObjectExtensionsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataObjectExtensionsTests.cs
@@ -178,7 +178,7 @@ public class DataObjectExtensionsTests
         public void SetData(object? data) => throw new NotImplementedException();
     }
 
-    internal class TypedDataObject : IDataObject, ITypedDataObject
+    internal class TypedDataObject : ITypedDataObject
     {
         public object? GetData(string format, bool autoConvert) => throw new NotImplementedException();
         public object? GetData(string format) => throw new NotImplementedException();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataObjectTests.ClipboardTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataObjectTests.ClipboardTests.cs
@@ -13,6 +13,7 @@ public partial class DataObjectTests
     // we should not run this test at the same time as other tests using the same format.
     [Collection("Sequential")]
     [UISettings(MaxAttempts = 3)] // Try up to 3 times before failing.
+    #pragma warning disable WFDEV005 // Type or member is obsolete
     public class ClipboardTests
     {
         public static TheoryData<string, bool> GetData_StringBool_TheoryData()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataObjectTests.cs
@@ -3,7 +3,9 @@
 
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
+using System.Reflection.Metadata;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
 using System.Runtime.Serialization;
@@ -18,6 +20,7 @@ namespace System.Windows.Forms.Tests;
 // NB: doesn't require thread affinity
 public partial class DataObjectTests
 {
+#pragma warning disable WFDEV005  // Type or member is obsolete
     private static readonly string[] s_restrictedClipboardFormats =
     [
         DataFormats.CommaSeparatedValue,
@@ -362,6 +365,143 @@ public partial class DataObjectTests
         mockDataObject.Object.GetData(format).Should().BeSameAs(expectedResult);
         mockDataObject.Verify(o => o.GetData(formatName), Times.Exactly(expectedCallCount));
     }
+
+    #nullable enable
+    internal class DataObjectOverridesTryGetDataCore : DataObject
+    {
+        private readonly string _format;
+        private readonly Func<TypeName, Type>? _resolver;
+        private readonly bool _autoConvert;
+
+        public DataObjectOverridesTryGetDataCore(string format, Func<TypeName, Type>? resolver, bool autoConvert) : base()
+        {
+            _format = format;
+            _resolver = resolver;
+            _autoConvert = autoConvert;
+        }
+
+        public int Count { get; private set; }
+        public static Type Resolver(TypeName _) => typeof(string);
+
+        protected override bool TryGetDataCore<T>(
+            string format,
+            Func<TypeName, Type>? resolver,
+            bool autoConvert,
+            [NotNullWhen(true), MaybeNullWhen(false)] out T data)
+        {
+            format.Should().Be(_format);
+            resolver.Should().BeEquivalentTo(_resolver);
+            autoConvert.Should().Be(_autoConvert);
+            typeof(T).Should().Be(typeof(string));
+
+            Count++;
+            data = default;
+            return false;
+        }
+    }
+
+    [Fact]
+    public void DataObject_TryGetData_InvokeString_CallsTryGetDataCore()
+    {
+        DataObjectOverridesTryGetDataCore dataObject = new(typeof(string).FullName!, resolver: null, autoConvert: false);
+        dataObject.Count.Should().Be(0);
+
+        dataObject.TryGetData(out string? data).Should().BeFalse();
+        data.Should().BeNull();
+        dataObject.Count.Should().Be(1);
+    }
+
+    public static TheoryData<string> RestrictedAndUnrestrictedFormat =>
+    [
+        DataFormats.CommaSeparatedValue,
+        "something custom"
+    ];
+
+    [Theory]
+    [MemberData(nameof(RestrictedAndUnrestrictedFormat))]
+    public void TryGetData_InvokeStringString_CallsTryGetDataCore(string format)
+    {
+        DataObjectOverridesTryGetDataCore dataObject = new(format, null, autoConvert: false);
+        dataObject.Count.Should().Be(0);
+
+        dataObject.TryGetData(format, out string? data).Should().BeFalse();
+        data.Should().BeNull();
+        dataObject.Count.Should().Be(1);
+    }
+
+    [Fact]
+    public void TryGetData_InvokeStringString_ValidationFails()
+    {
+        string format = DataFormats.Bitmap;
+        DataObjectOverridesTryGetDataCore dataObject = new(format, null, autoConvert: false);
+        dataObject.Count.Should().Be(0);
+
+        // Incompatible format and type.
+        Action tryGetData = () => dataObject.TryGetData(format, out string? data);
+        tryGetData.Should().Throw<NotSupportedException>();
+        dataObject.Count.Should().Be(0);
+    }
+
+    public static TheoryData<string, bool> FormatAndAutoConvert => new()
+    {
+        { DataFormats.CommaSeparatedValue, true },
+        { "something custom", true },
+        { DataFormats.CommaSeparatedValue, false },
+        { "something custom", false }
+    };
+
+    [Theory]
+    [MemberData(nameof(FormatAndAutoConvert))]
+    public void TryGetData_InvokeStringBoolString_CallsTryGetDataCore(string format, bool autoConvert)
+    {
+        DataObjectOverridesTryGetDataCore dataObject = new(format, resolver: null, autoConvert);
+        dataObject.Count.Should().Be(0);
+
+        dataObject.TryGetData(format, autoConvert, out string? data).Should().BeFalse();
+        data.Should().BeNull();
+        dataObject.Count.Should().Be(1);
+    }
+
+    private static Type NotSupportedResolver(TypeName typeName) => throw new NotSupportedException();
+
+    [Theory]
+    [BoolData]
+    public void TryGetData_InvokeStringBoolString_ValidationFails(bool autoConvert)
+    {
+        string format = DataFormats.Bitmap;
+        DataObjectOverridesTryGetDataCore dataObject = new(format, NotSupportedResolver, autoConvert);
+        dataObject.Count.Should().Be(0);
+
+        Action tryGetData = () => dataObject.TryGetData(format, autoConvert, out string? data);
+        tryGetData.Should().Throw<NotSupportedException>();
+        dataObject.Count.Should().Be(0);
+    }
+
+    [Theory]
+    [MemberData(nameof(FormatAndAutoConvert))]
+    public void DataObject_TryGetData_InvokeStringFuncBoolString_CallsTryGetDataCore(string format, bool autoConvert)
+    {
+        DataObjectOverridesTryGetDataCore dataObject = new(format, DataObjectOverridesTryGetDataCore.Resolver, autoConvert);
+        dataObject.Count.Should().Be(0);
+
+        dataObject.TryGetData(format, DataObjectOverridesTryGetDataCore.Resolver, autoConvert, out string? data).Should().BeFalse();
+        data.Should().BeNull();
+        dataObject.Count.Should().Be(1);
+    }
+
+    [Theory]
+    [BoolData]
+    public void TryGetData_InvokeStringFuncBoolString_ValidationFails(bool autoConvert)
+    {
+        string format = DataFormats.Bitmap;
+        DataObjectOverridesTryGetDataCore dataObject = new(format, DataObjectOverridesTryGetDataCore.Resolver, autoConvert);
+        dataObject.Count.Should().Be(0);
+
+        Action tryGetData = () => dataObject.TryGetData(format, DataObjectOverridesTryGetDataCore.Resolver, autoConvert, out string? data);
+        tryGetData.Should().Throw<NotSupportedException>();
+        dataObject.Count.Should().Be(0);
+    }
+    #nullable disable
 
     [Theory]
     [MemberData(nameof(GetData_String_TheoryData))]
@@ -1011,6 +1151,58 @@ public partial class DataObjectTests
         ((Action)(() => dataObject.SetData(null))).Should().Throw<ArgumentNullException>().WithParameterName("data");
     }
 
+    public static TheoryData<string, string, bool, bool> SetData_StringObject_TheoryData()
+    {
+        TheoryData<string, string, bool, bool> theoryData = new();
+        foreach (string format in s_restrictedClipboardFormats)
+        {
+            if (string.IsNullOrWhiteSpace(format) || format == typeof(Bitmap).FullName || format.StartsWith("FileName", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            theoryData.Add(format, null, format == DataFormats.FileDrop, format == DataFormats.Bitmap);
+            theoryData.Add(format, "input", format == DataFormats.FileDrop, format == DataFormats.Bitmap);
+        }
+
+        theoryData.Add(typeof(Bitmap).FullName, null, false, true);
+        theoryData.Add(typeof(Bitmap).FullName, "input", false, true);
+
+        theoryData.Add("FileName", null, true, false);
+        theoryData.Add("FileName", "input", true, false);
+
+        theoryData.Add("FileNameW", null, true, false);
+        theoryData.Add("FileNameW", "input", true, false);
+
+        return theoryData;
+    }
+
+    [Theory]
+    [MemberData(nameof(SetData_StringObject_TheoryData))]
+    private void DataObject_SetData_InvokeStringObject_GetReturnsExpected(string format, string input, bool expectedContainsFileDropList, bool expectedContainsImage)
+    {
+        DataObject dataObject = new();
+        dataObject.SetData(format, input);
+
+        dataObject.GetDataPresent(format).Should().BeTrue();
+        dataObject.GetDataPresent(format, autoConvert: false).Should().BeTrue();
+        dataObject.GetDataPresent(format, autoConvert: true).Should().BeTrue();
+
+        dataObject.GetData(format).Should().Be(input);
+        dataObject.GetData(format, autoConvert: false).Should().Be(input);
+        dataObject.GetData(format, autoConvert: true).Should().Be(input);
+
+        dataObject.ContainsAudio().Should().Be(format == DataFormats.WaveAudio);
+        dataObject.ContainsFileDropList().Should().Be(expectedContainsFileDropList);
+        dataObject.ContainsImage().Should().Be(expectedContainsImage);
+        dataObject.ContainsText().Should().Be(format == DataFormats.UnicodeText);
+        dataObject.ContainsText(TextDataFormat.Text).Should().Be(format == DataFormats.UnicodeText);
+        dataObject.ContainsText(TextDataFormat.UnicodeText).Should().Be(format == DataFormats.UnicodeText);
+        dataObject.ContainsText(TextDataFormat.Rtf).Should().Be(format == DataFormats.Rtf);
+        dataObject.ContainsText(TextDataFormat.Html).Should().Be(format == DataFormats.Html);
+        dataObject.ContainsText(TextDataFormat.CommaSeparatedValue).Should().Be(format == DataFormats.CommaSeparatedValue);
+    }
+
     [Theory]
     [InlineData(DataFormats.SerializableConstant, null)]
     [InlineData(DataFormats.SerializableConstant, "input")]
@@ -1028,6 +1220,17 @@ public partial class DataObjectTests
         dataObject.GetData(format).Should().Be(input);
         dataObject.GetData(format, autoConvert: false).Should().Be(input);
         dataObject.GetData(format, autoConvert: true).Should().Be(input);
+
+        _ = dataObject.TryGetData(format, out object _).Should().Be(input is not null);
+        _ = dataObject.TryGetData(format, autoConvert: false, out object _).Should().Be(input is not null);
+        _ = dataObject.TryGetData(format, autoConvert: true, out object _).Should().Be(input is not null);
+        _ = dataObject.TryGetData(format, NotSupportedResolver, autoConvert: true, out object _).Should().Be(input is not null);
+        _ = dataObject.TryGetData(format, NotSupportedResolver, autoConvert: false, out object _).Should().Be(input is not null);
+
+        dataObject.TryGetData(format, NotSupportedResolver, autoConvert: false, out string data).Should().Be(input is not null);
+        data.Should().Be(input);
+        dataObject.TryGetData(format, NotSupportedResolver, autoConvert: true, out data).Should().Be(input is not null);
+        data.Should().Be(input);
 
         dataObject.ContainsAudio().Should().BeFalse();
         dataObject.ContainsFileDropList().Should().BeFalse();
@@ -1089,6 +1292,66 @@ public partial class DataObjectTests
         mockDataObject.Verify(o => o.SetData(format, data), Times.Once());
     }
 
+    public static TheoryData<string, bool, string, bool, bool> SetData_StringBoolObject_TheoryData()
+    {
+        TheoryData<string, bool, string, bool, bool> theoryData = new();
+
+        foreach (string format in s_restrictedClipboardFormats)
+        {
+            if (string.IsNullOrWhiteSpace(format) || format == typeof(Bitmap).FullName || format.StartsWith("FileName", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            foreach (bool autoConvert in new bool[] { true, false })
+            {
+                theoryData.Add(format, autoConvert, null, format == DataFormats.FileDrop, format == DataFormats.Bitmap);
+                theoryData.Add(format, autoConvert, "input", format == DataFormats.FileDrop, format == DataFormats.Bitmap);
+            }
+        }
+
+        theoryData.Add(typeof(Bitmap).FullName, false, null, false, false);
+        theoryData.Add(typeof(Bitmap).FullName, false, "input", false, false);
+        theoryData.Add(typeof(Bitmap).FullName, true, null, false, true);
+        theoryData.Add(typeof(Bitmap).FullName, true, "input", false, true);
+
+        theoryData.Add("FileName", false, null, false, false);
+        theoryData.Add("FileName", false, "input", false, false);
+        theoryData.Add("FileName", true, null, true, false);
+        theoryData.Add("FileName", true, "input", true, false);
+
+        theoryData.Add("FileNameW", false, null, false, false);
+        theoryData.Add("FileNameW", false, "input", false, false);
+        theoryData.Add("FileNameW", true, null, true, false);
+        theoryData.Add("FileNameW", true, "input", true, false);
+
+        return theoryData;
+    }
+
+    [Theory]
+    [MemberData(nameof(SetData_StringBoolObject_TheoryData))]
+    private void DataObject_SetData_InvokeStringBoolObject_GetReturnsExpected(string format, bool autoConvert, string input, bool expectedContainsFileDropList, bool expectedContainsImage)
+    {
+        DataObject dataObject = new();
+        dataObject.SetData(format, autoConvert, input);
+
+        dataObject.GetData(format, autoConvert: false).Should().Be(input);
+        dataObject.GetData(format, autoConvert: true).Should().Be(input);
+
+        dataObject.GetDataPresent(format, autoConvert: true).Should().BeTrue();
+        dataObject.GetDataPresent(format, autoConvert: false).Should().BeTrue();
+
+        dataObject.ContainsAudio().Should().Be(format == DataFormats.WaveAudio);
+        dataObject.ContainsFileDropList().Should().Be(expectedContainsFileDropList);
+        dataObject.ContainsImage().Should().Be(expectedContainsImage);
+        dataObject.ContainsText().Should().Be(format == DataFormats.UnicodeText);
+        dataObject.ContainsText(TextDataFormat.Text).Should().Be(format == DataFormats.UnicodeText);
+        dataObject.ContainsText(TextDataFormat.UnicodeText).Should().Be(format == DataFormats.UnicodeText);
+        dataObject.ContainsText(TextDataFormat.Rtf).Should().Be(format == DataFormats.Rtf);
+        dataObject.ContainsText(TextDataFormat.Html).Should().Be(format == DataFormats.Html);
+        dataObject.ContainsText(TextDataFormat.CommaSeparatedValue).Should().Be(format == DataFormats.CommaSeparatedValue);
+    }
+
     [Theory]
     [InlineData("something custom", false, "input")]
     [InlineData("something custom", false, null)]
@@ -1098,13 +1361,26 @@ public partial class DataObjectTests
     [InlineData(DataFormats.SerializableConstant, false, null)]
     [InlineData(DataFormats.SerializableConstant, true, "input")]
     [InlineData(DataFormats.SerializableConstant, true, null)]
-    private void DataObject_SetData_InvokeStringBoolObject_Unbounded_GetReturnsExpected(string format, bool autoConvert, string input)
+    private void DataObject_SetData_InvokeStringBoolObject_Unbounded(string format, bool autoConvert, string input)
     {
         DataObject dataObject = new();
         dataObject.SetData(format, autoConvert, input);
 
         dataObject.GetData(format, autoConvert: false).Should().Be(input);
         dataObject.GetData(format, autoConvert: true).Should().Be(input);
+
+        dataObject.TryGetData(format, out string data).Should().Be(input is not null);
+        data.Should().Be(input);
+
+        dataObject.TryGetData(format, autoConvert: false, out data).Should().Be(input is not null);
+        data.Should().Be(input);
+        dataObject.TryGetData(format, autoConvert: true, out data).Should().Be(input is not null);
+        data.Should().Be(input);
+
+        dataObject.TryGetData(format, NotSupportedResolver, autoConvert: false, out data).Should().Be(input is not null);
+        data.Should().Be(input);
+        dataObject.TryGetData(format, NotSupportedResolver, autoConvert: true, out data).Should().Be(input is not null);
+        data.Should().Be(input);
 
         dataObject.GetDataPresent(format, autoConvert: true).Should().BeTrue();
         dataObject.GetDataPresent(format, autoConvert: false).Should().BeTrue();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataObjectTests.cs
@@ -1574,7 +1574,7 @@ public partial class DataObjectTests
 
         public int QueryGetData(ref FORMATETC format)
         {
-            // do not check the requested storage medium, we always return a metafile handle, thats what Office does
+            // do not check the requested storage medium, we always return a metafile handle, that's what Office does
 
             if (format.cfFormat != (short)CLIPBOARD_FORMAT.CF_ENHMETAFILE || format.dwAspect != DVASPECT.DVASPECT_CONTENT || format.lindex != -1)
                 return (int)HRESULT.DV_E_FORMATETC;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DragDropHelperTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DragDropHelperTests.cs
@@ -109,8 +109,8 @@ public class DragDropHelperTests
         {
             DragDropHelper.SetDragImage(dataObject, dragImage, cursorOffset, useDefaultDragImage);
             // This DataObject is backed up by the DataStore.
-            Assert.True(dataObject.TryGetData(DragDropHelper.DRAGIMAGEBITS, out DragDropFormat dragDropFormat));
-            Assert.NotNull(dragDropFormat);
+            dataObject.TryGetData(DragDropHelper.DRAGIMAGEBITS, out DragDropFormat dragDropFormat).Should().BeTrue();
+            dragDropFormat.Should().NotBeNull();
             void* basePtr = PInvokeCore.GlobalLock(dragDropFormat.Medium.hGlobal);
             SHDRAGIMAGE* pDragImage = (SHDRAGIMAGE*)basePtr;
             bool isDragImageNull = BitOperations.LeadingZeroCount((uint)(nint)pDragImage->hbmpDragImage).Equals(32);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DragDropHelperTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DragDropHelperTests.cs
@@ -108,7 +108,9 @@ public class DragDropHelperTests
         try
         {
             DragDropHelper.SetDragImage(dataObject, dragImage, cursorOffset, useDefaultDragImage);
-            DragDropFormat dragDropFormat = (DragDropFormat)dataObject.GetData(DragDropHelper.DRAGIMAGEBITS);
+            // This DataObject is backed up by the DataStore.
+            Assert.True(dataObject.TryGetData(DragDropHelper.DRAGIMAGEBITS, out DragDropFormat dragDropFormat));
+            Assert.NotNull(dragDropFormat);
             void* basePtr = PInvokeCore.GlobalLock(dragDropFormat.Medium.hGlobal);
             SHDRAGIMAGE* pDragImage = (SHDRAGIMAGE*)basePtr;
             bool isDragImageNull = BitOperations.LeadingZeroCount((uint)(nint)pDragImage->hbmpDragImage).Equals(32);
@@ -132,7 +134,9 @@ public class DragDropHelperTests
         try
         {
             DragDropHelper.SetDragImage(dataObject, e);
-            DragDropFormat dragDropFormat = (DragDropFormat)dataObject.GetData(DragDropHelper.DRAGIMAGEBITS);
+            // This DataObject is backed up by the DataStore.
+            dataObject.TryGetData(DragDropHelper.DRAGIMAGEBITS, out DragDropFormat dragDropFormat).Should().BeTrue();
+            dragDropFormat.Should().NotBeNull();
             void* basePtr = PInvokeCore.GlobalLock(dragDropFormat.Medium.hGlobal);
             SHDRAGIMAGE* pDragImage = (SHDRAGIMAGE*)basePtr;
             bool isDragImageNull = BitOperations.LeadingZeroCount((uint)(nint)pDragImage->hbmpDragImage).Equals(32);
@@ -181,7 +185,8 @@ public class DragDropHelperTests
         {
             DragDropHelper.SetDropDescription(dataObject, dropImageType, message, messageReplacementToken);
             DragDropHelper.ClearDropDescription(dataObject);
-            DragDropFormat dragDropFormat = (DragDropFormat)dataObject.GetData(PInvoke.CFSTR_DROPDESCRIPTION);
+            dataObject.TryGetData(PInvoke.CFSTR_DROPDESCRIPTION, autoConvert: false, out DragDropFormat dragDropFormat).Should().BeTrue();
+            dragDropFormat.Should().NotBeNull();
             void* basePtr = PInvokeCore.GlobalLock(dragDropFormat.Medium.hGlobal);
             DROPDESCRIPTION* pDropDescription = (DROPDESCRIPTION*)basePtr;
             DROPIMAGETYPE type = pDropDescription->type;
@@ -247,7 +252,7 @@ public class DragDropHelperTests
 
         foreach (string format in dataObject.GetFormats())
         {
-            if (dataObject.GetData(format) is DragDropFormat dragDropFormat)
+            if (dataObject.TryGetData(format, out DragDropFormat dragDropFormat))
             {
                 Assert.Equal(nint.Zero, (nint)dragDropFormat.Medium.pUnkForRelease);
                 Assert.Equal(Com.TYMED.TYMED_NULL, dragDropFormat.Medium.tymed);
@@ -263,7 +268,7 @@ public class DragDropHelperTests
         try
         {
             DragDropHelper.SetDropDescription(e);
-            DragDropFormat dragDropFormat = (DragDropFormat)e.Data.GetData(PInvoke.CFSTR_DROPDESCRIPTION);
+            e.Data.TryGetData(PInvoke.CFSTR_DROPDESCRIPTION, out DragDropFormat dragDropFormat).Should().BeTrue();
             void* basePtr = PInvokeCore.GlobalLock(dragDropFormat.Medium.hGlobal);
             DROPDESCRIPTION* pDropDescription = (DROPDESCRIPTION*)basePtr;
             DROPIMAGETYPE type = pDropDescription->type;
@@ -290,7 +295,7 @@ public class DragDropHelperTests
         try
         {
             DragDropHelper.SetDropDescription(dataObject, dropImageType, message, messageReplacementToken);
-            DragDropFormat dragDropFormat = (DragDropFormat)dataObject.GetData(PInvoke.CFSTR_DROPDESCRIPTION);
+            dataObject.TryGetData(PInvoke.CFSTR_DROPDESCRIPTION, autoConvert: false, out DragDropFormat dragDropFormat).Should().BeTrue();
             void* basePtr = PInvokeCore.GlobalLock(dragDropFormat.Medium.hGlobal);
             DROPDESCRIPTION* pDropDescription = (DROPDESCRIPTION*)basePtr;
             DROPIMAGETYPE type = pDropDescription->type;
@@ -321,7 +326,7 @@ public class DragDropHelperTests
         try
         {
             DragDropHelper.SetInDragLoop(dataObject, inDragLoop);
-            DragDropFormat dragDropFormat = (DragDropFormat)dataObject.GetData(PInvoke.CFSTR_INDRAGLOOP);
+            dataObject.TryGetData(PInvoke.CFSTR_INDRAGLOOP, out DragDropFormat dragDropFormat).Should().BeTrue();
             void* basePtr = PInvokeCore.GlobalLock(dragDropFormat.Medium.hGlobal);
             bool inShellDragLoop = (basePtr is not null) && (*(BOOL*)basePtr == true);
             PInvokeCore.GlobalUnlock(dragDropFormat.Medium.hGlobal);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/NativeToWinFormsAdapterTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/NativeToWinFormsAdapterTests.cs
@@ -17,7 +17,7 @@ public unsafe class NativeToWinFormsAdapterTests
         "something custom"
     ];
 
-    // These formats might contain known types or types deserialized with BitmapBinder.
+    // These formats contain only known types.
     public static TheoryData<string> UndefinedRestrictedFormat() =>
     [
         DataFormats.CommaSeparatedValue,

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/NativeToWinFormsAdapterTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/NativeToWinFormsAdapterTests.cs
@@ -55,8 +55,8 @@ public unsafe class NativeToWinFormsAdapterTests
 
     private const string InvalidTypeFormatCombinationMessage = "Type '*' is not compatible with the specified format '*'.";
     private const string RequiresResolverMessage =
-        "'*' is not a concrete type, and could allow for unbounded deserialization.  Use a concrete type or" +
-        " define a resolver function that supports types that you are retrieving from the Clipboard or being dragged and dropped.";
+        $"'*' is not a concrete type, and could allow for unbounded deserialization.  Use a concrete type or" +
+        $" define a resolver function that supports types that you are retrieving from the Clipboard or being dragged and dropped.";
     private const string UseTryGetDataWithResolver =
         "Use 'TryGetData<T>' method with a 'resolver' function that defines a set of allowed types, to deserialize '*'.";
     private const string FormatterDisabledMessage =

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/NativeToWinFormsAdapterTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/NativeToWinFormsAdapterTests.cs
@@ -285,13 +285,13 @@ public unsafe class NativeToWinFormsAdapterTests
 
     [WinFormsTheory]
     [MemberData(nameof(UndefinedRestrictedFormat))]
-    public void TryGetData_AsConcreteType_Custom_ReturnsFalse(string format)
+    public void TryGetData_AsConcreteType_Custom_FormatterDisabledException(string format)
     {
         (DataObject dataObject, TestData _) = SetDataObject(format);
 
         // Formatters are not supported, HGLOBAL contains NotSupportedException.
-        dataObject.TryGetData(format, out TestData? testData).Should().BeFalse();
-        testData.Should().BeNull();
+        Action tryGetData = () => dataObject.TryGetData(format, out TestData? testData);
+        tryGetData.Should().Throw<NotSupportedException>().WithMessage(expectedWildcardPattern: FormatterDisabledMessage);
     }
 
     [WinFormsTheory]
@@ -348,13 +348,13 @@ public unsafe class NativeToWinFormsAdapterTests
 
     [WinFormsTheory]
     [MemberData(nameof(UndefinedRestrictedFormat))]
-    public void TryGetData_WithResolver_AsConcreteType_Custom_ReturnFalse(string format)
+    public void TryGetData_WithResolver_AsConcreteType_Custom_FormatterDisabledException(string format)
     {
         (DataObject dataObject, TestData _) = SetDataObject(format);
 
         // Formatter is not enabled, HGLOBAL contains NotSupportedException.
-        dataObject.TryGetData(format, TestData.Resolver, autoConvert: true, out TestData? testData).Should().BeFalse();
-        testData.Should().BeNull();
+        Action tryGetData = () => dataObject.TryGetData(format, TestData.Resolver, autoConvert: true, out TestData? testData);
+        tryGetData.Should().Throw<NotSupportedException>().WithMessage(expectedWildcardPattern: FormatterDisabledMessage);
 
         dataObject.TryGetData(format, out NotSupportedException? ex).Should().BeTrue();
         ex.Should().BeOfType<NotSupportedException>().Which.Message.Should().Be(FormatterDisabledMessage);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/NativeToWinFormsAdapterTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/NativeToWinFormsAdapterTests.cs
@@ -1,0 +1,539 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System.Drawing;
+using System.Reflection.Metadata;
+using Com = Windows.Win32.System.Com;
+
+namespace System.Windows.Forms.Tests;
+
+public unsafe class NativeToWinFormsAdapterTests
+{
+    public static TheoryData<string> UnboundedFormat() =>
+    [
+        DataFormats.Serializable,
+        "something custom"
+    ];
+
+    // These formats might contain known types or types deserialized with BitmapBinder.
+    public static TheoryData<string> UndefinedRestrictedFormat() =>
+    [
+        DataFormats.CommaSeparatedValue,
+        DataFormats.Dib,
+        DataFormats.Dif,
+        DataFormats.PenData,
+        DataFormats.Riff,
+        DataFormats.Tiff,
+        DataFormats.WaveAudio,
+        DataFormats.SymbolicLink,
+        DataFormats.EnhancedMetafile,
+        DataFormats.MetafilePict,
+        DataFormats.Palette
+    ];
+
+    public static TheoryData<string> BitmapFormat() =>
+    [
+        DataFormats.Bitmap,
+        "System.Drawing.Bitmap"
+    ];
+
+    // These formats set and get strings by accessing HGLOBAL directly.
+    public static TheoryData<string> StringFormat() =>
+    [
+         DataFormats.Text,
+         DataFormats.UnicodeText,
+         DataFormats.StringConstant,
+         DataFormats.Rtf,
+         DataFormats.Html,
+         DataFormats.OemText,
+         DataFormats.FileDrop,
+         "FileName",
+         "FileNameW"
+    ];
+
+    private const string InvalidTypeFormatCombinationMessage = "Type '*' is not compatible with the specified format '*'.";
+    private const string RequiresResolverMessage =
+        "'*' is not a concrete type, and could allow for unbounded deserialization.  Use a concrete type or" +
+        " define a resolver function that supports types that you are retrieving from the Clipboard or being dragged and dropped.";
+    private const string UseTryGetDataWithResolver =
+        "Use 'TryGetData<T>' method with a 'resolver' function that defines a set of allowed types, to deserialize '*'.";
+    private const string FormatterDisabledMessage =
+        "BinaryFormatter serialization and deserialization are disabled within this application. See https://aka.ms/binaryformatter for more information.";
+
+    [WinFormsTheory]
+    [MemberData(nameof(UndefinedRestrictedFormat))]
+    public void TryGetData_AsObject_Primitive_Success(string format)
+    {
+        DataObject native = new();
+        // Primitive type is serialized by generating the record field by field.
+        native.SetData(format, 1);
+        DataObject dataObject = new(ComHelpers.GetComPointer<Com.IDataObject>(native));
+
+        // Format is compatible with `object` type, validation passed.
+        // The `int` type can be assigned to an `object`, thus record type matched the requested type.
+        // The primitive type is read from the serialization record field by field.
+        dataObject.TryGetData(format, out object? value).Should().BeTrue();
+        value.Should().Be(1);
+    }
+
+    [WinFormsTheory]
+    [MemberData(nameof(UnboundedFormat))]
+    public void TryGetData_AsObject_Primitive_RequiresResolver(string format)
+    {
+        DataObject native = new();
+        // Primitive type is serialized by generating the record field by field.
+        native.SetData(format, 1);
+        DataObject dataObject = new(ComHelpers.GetComPointer<Com.IDataObject>(native));
+
+        Action tryGetData = () => dataObject.TryGetData(format, out object? value);
+        tryGetData.Should().Throw<NotSupportedException>().WithMessage(expectedWildcardPattern: RequiresResolverMessage);
+
+        dataObject.TryGetData(format, Resolver, autoConvert: false, out object? value).Should().BeTrue();
+        value.Should().Be(1);
+
+        static Type Resolver(TypeName typeName) => typeof(int);
+    }
+
+    [WinFormsTheory]
+    [MemberData(nameof(StringFormat))]
+    [MemberData(nameof(BitmapFormat))]
+    public void TryGetData_AsObject_Primitive_InvalidTypeFormatCombination(string format)
+    {
+        DataObject native = new();
+        native.SetData(format, 1);
+        DataObject dataObject = new(ComHelpers.GetComPointer<Com.IDataObject>(native));
+
+        // Throw when validating arguments, as these formats allow exactly strings or bitmaps only.
+        Action tryGetData = () => dataObject.TryGetData(format, out object? _);
+        tryGetData.Should().Throw<NotSupportedException>()
+            .WithMessage(expectedWildcardPattern: InvalidTypeFormatCombinationMessage);
+    }
+
+    private static (DataObject dataObject, TestData value) SetDataObject(string format)
+    {
+        DataObject native = new();
+        TestData value = new(new(6, 7));
+        // This code does not flush the data.
+        native.SetData(format, value);
+        DataObject dataObject = new(ComHelpers.GetComPointer<Com.IDataObject>(native));
+
+        return (dataObject, value);
+    }
+
+    [WinFormsTheory]
+    [MemberData(nameof(UnboundedFormat))]
+    public void TryGetData_AsObject_Custom_RequiresResolver(string format)
+    {
+        (DataObject dataObject, TestData _) = SetDataObject(format);
+        Action tryGetData = () => dataObject.TryGetData(format, out object? _);
+
+        tryGetData.Should().Throw<NotSupportedException>().WithMessage(expectedWildcardPattern: RequiresResolverMessage);
+    }
+
+    [WinFormsTheory]
+    [MemberData(nameof(UnboundedFormat))]
+    public void TryGetData_AsObject_Custom_FormatterEnabled_RequiresResolver(string format)
+    {
+        (DataObject dataObject, TestData _) = SetDataObject(format);
+        Action tryGetData = () => dataObject.TryGetData(format, out object? _);
+
+        using BinaryFormatterScope scope = new(enable: true);
+        using BinaryFormatterInClipboardDragDropScope clipboardScope = new(enable: true);
+
+        tryGetData.Should().Throw<NotSupportedException>().WithMessage(expectedWildcardPattern: RequiresResolverMessage);
+    }
+
+    [WinFormsTheory]
+    [MemberData(nameof(StringFormat))]
+    [MemberData(nameof(BitmapFormat))]
+    public void TryGetData_AsObject_Custom_InvalidTypeFormatCombination(string format)
+    {
+        (DataObject dataObject, TestData _) = SetDataObject(format);
+        Action tryGetData = () => dataObject.TryGetData(format, out object? _);
+
+        // Type-Format combination is validated before the we attempt to serialize data.
+        tryGetData.Should().Throw<NotSupportedException>()
+            .WithMessage(expectedWildcardPattern: InvalidTypeFormatCombinationMessage);
+    }
+
+    [WinFormsTheory]
+    [MemberData(nameof(UndefinedRestrictedFormat))]
+    public void TryGetData_AsObject_Custom_ReturnsNotSupportedException(string format)
+    {
+        (DataObject dataObject, TestData _) = SetDataObject(format);
+
+        // SetData writes NotSupportedException to HGLOBAL to indicate that formatters are disabled.
+        dataObject.TryGetData(format, out object? result).Should().BeTrue();
+        result.Should().BeOfType<NotSupportedException>().Which.Message.Should().Be(FormatterDisabledMessage);
+    }
+
+    [WinFormsTheory]
+    [MemberData(nameof(UndefinedRestrictedFormat))]
+    public void TryGetData_AsObject_Custom_FormatterEnabled_ReturnsMemoryStream(string format)
+    {
+        (DataObject dataObject, TestData _) = SetDataObject(format);
+
+        using BinaryFormatterScope scope = new(enable: true);
+        using BinaryFormatterInClipboardDragDropScope clipboardScope = new(enable: true);
+
+        // TODO (TanyaSo)
+        // This will throw SerializationException and put a stream that is not prefixed by a serialization GUID into the HGLOBAL.
+        dataObject.TryGetData(format, out object? result).Should().BeTrue();
+        result.Should().BeOfType<MemoryStream>();
+    }
+
+    [WinFormsTheory]
+    [MemberData(nameof(UndefinedRestrictedFormat))]
+    public void TryGetData_AsInterface_ListOfPrimitives_Success(string format)
+    {
+        DataObject native = new();
+        List<int> value = [1];
+        native.SetData(format, value);
+        DataObject dataObject = new(ComHelpers.GetComPointer<Com.IDataObject>(native));
+
+        dataObject.TryGetData(format, out IList<int>? list).Should().BeTrue();
+        list.Should().BeEquivalentTo(value);
+    }
+
+    [WinFormsTheory]
+    [MemberData(nameof(UnboundedFormat))]
+    public void TryGetData_AsInterface_ListOfPrimitives_RequiresResolver(string format)
+    {
+        DataObject native = new();
+        List<int> value = [1];
+        native.SetData(format, value);
+        DataObject dataObject = new(ComHelpers.GetComPointer<Com.IDataObject>(native));
+
+        // Theoretically we don't require a resolver here, but this is an exception.  In the more common cases resolver
+        // is required to instantiate non-concrete types.
+        Action tryGetData = () => dataObject.TryGetData(format, out IList<int>? _);
+        tryGetData.Should().Throw<NotSupportedException>().WithMessage(expectedWildcardPattern: RequiresResolverMessage);
+    }
+
+    [WinFormsTheory]
+    [MemberData(nameof(StringFormat))]
+    [MemberData(nameof(BitmapFormat))]
+    public void TryGetData_AsInterface_ListOfPrimitives_InvalidTypeFormatCombination(string format)
+    {
+        DataObject native = new();
+        List<int> value = [1];
+        native.SetData(format, value);
+        DataObject dataObject = new(ComHelpers.GetComPointer<Com.IDataObject>(native));
+
+        Action tryGetData = () => dataObject.TryGetData(format, out IList<int>? _);
+        tryGetData.Should().Throw<NotSupportedException>()
+            .WithMessage(expectedWildcardPattern: InvalidTypeFormatCombinationMessage);
+    }
+
+    [WinFormsTheory]
+    [MemberData(nameof(UnboundedFormat))]
+    [MemberData(nameof(UndefinedRestrictedFormat))]
+    public void TryGetData_AsConcreteType_ListOfPrimitives_Success(string format)
+    {
+        DataObject native = new();
+        List<int> value = [1];
+        native.SetData(format, value);
+        DataObject dataObject = new(ComHelpers.GetComPointer<Com.IDataObject>(native));
+
+        dataObject.TryGetData(format, out List<int>? list).Should().BeTrue();
+        list.Should().BeEquivalentTo(value);
+    }
+
+    [WinFormsTheory]
+    [MemberData(nameof(StringFormat))]
+    [MemberData(nameof(BitmapFormat))]
+    public void TryGetData_AsConcreteType_ListOfPrimitives_InvalidTypeFormatCombination(string format)
+    {
+        DataObject native = new();
+        List<int> value = [1];
+        native.SetData(format, value);
+        DataObject dataObject = new(ComHelpers.GetComPointer<Com.IDataObject>(native));
+
+        Action tryGetData = () => dataObject.TryGetData(format, out List<int>? _);
+        tryGetData.Should().Throw<NotSupportedException>()
+            .WithMessage(expectedWildcardPattern: InvalidTypeFormatCombinationMessage);
+    }
+
+    [WinFormsTheory]
+    [MemberData(nameof(UnboundedFormat))]
+    public void TryGetData_AsConcreteType_Custom_FormatterEnabled_RequiresResolver(string format)
+    {
+        (DataObject dataObject, TestData _) = SetDataObject(format);
+        Action tryGetData = () => dataObject.TryGetData(format, out TestData? _);
+
+        using BinaryFormatterScope scope = new(enable: true);
+        using BinaryFormatterInClipboardDragDropScope clipboardScope = new(enable: true);
+
+        tryGetData.Should().Throw<NotSupportedException>().WithMessage(expectedWildcardPattern: UseTryGetDataWithResolver);
+    }
+
+    [WinFormsTheory]
+    [MemberData(nameof(UndefinedRestrictedFormat))]
+    public void TryGetData_AsConcreteType_Custom_FormatterEnabled_ReturnsFalse(string format)
+    {
+        (DataObject dataObject, TestData _) = SetDataObject(format);
+
+        using BinaryFormatterScope scope = new(enable: true);
+        using BinaryFormatterInClipboardDragDropScope clipboardScope = new(enable: true);
+
+        // Format-type combination is invalid, serialization aborted, HGLOBAL contains MemoryStream.
+        dataObject.TryGetData(format, out TestData? testData).Should().BeFalse();
+        testData.Should().BeNull();
+    }
+
+    [WinFormsTheory]
+    [MemberData(nameof(UndefinedRestrictedFormat))]
+    public void TryGetData_AsConcreteType_Custom_ReturnsFalse(string format)
+    {
+        (DataObject dataObject, TestData _) = SetDataObject(format);
+
+        // Formatters are not supported, HGLOBAL contains NotSupportedException.
+        dataObject.TryGetData(format, out TestData? testData).Should().BeFalse();
+        testData.Should().BeNull();
+    }
+
+    [WinFormsTheory]
+    [MemberData(nameof(StringFormat))]
+    [MemberData(nameof(BitmapFormat))]
+    public void TryGetData_AsConcreteType_Custom_InvalidTypeFormatCombination(string format)
+    {
+        (DataObject dataObject, TestData _) = SetDataObject(format);
+
+        Action tryGetData = () => dataObject.TryGetData(format, out TestData? _);
+        tryGetData.Should().Throw<NotSupportedException>()
+            .WithMessage(expectedWildcardPattern: InvalidTypeFormatCombinationMessage);
+    }
+
+    [WinFormsTheory]
+    [MemberData(nameof(UnboundedFormat))]
+    public void TryGetData_WithResolver_AsConcreteType_Custom_FormatterEnabled_Success(string format)
+    {
+        (DataObject dataObject, TestData value) = SetDataObject(format);
+
+        using BinaryFormatterScope scope = new(enable: true);
+        using BinaryFormatterInClipboardDragDropScope clipboardScope = new(enable: true);
+
+        dataObject.TryGetData(format, TestData.Resolver, autoConvert: true, out TestData? testData).Should().BeTrue();
+        testData.Should().BeEquivalentTo(value);
+    }
+
+    [WinFormsTheory]
+    [MemberData(nameof(StringFormat))]
+    [MemberData(nameof(BitmapFormat))]
+    public void TryGetData_WithResolver_AsConcreteType_Custom_InvalidTypeFormatCombination(string format)
+    {
+        (DataObject dataObject, TestData _) = SetDataObject(format);
+        Action tryGetData = () => dataObject.TryGetData(format, TestData.Resolver, autoConvert: true, out TestData? _);
+
+        tryGetData.Should().Throw<NotSupportedException>()
+            .WithMessage(expectedWildcardPattern: InvalidTypeFormatCombinationMessage);
+    }
+
+    [WinFormsTheory]
+    [MemberData(nameof(StringFormat))]
+    [MemberData(nameof(BitmapFormat))]
+    public void TryGetData_WithResolver_AsConcreteType_Custom_FormatterEnabled_InvalidTypeFormatCombination(string format)
+    {
+        (DataObject dataObject, TestData _) = SetDataObject(format);
+        Action tryGetData = () => dataObject.TryGetData(format, TestData.Resolver, autoConvert: true, out TestData? _);
+
+        using BinaryFormatterScope scope = new(enable: true);
+        using BinaryFormatterInClipboardDragDropScope clipboardScope = new(enable: true);
+
+        tryGetData.Should().Throw<NotSupportedException>()
+            .WithMessage(expectedWildcardPattern: InvalidTypeFormatCombinationMessage);
+    }
+
+    [WinFormsTheory]
+    [MemberData(nameof(UndefinedRestrictedFormat))]
+    public void TryGetData_WithResolver_AsConcreteType_Custom_ReturnFalse(string format)
+    {
+        (DataObject dataObject, TestData _) = SetDataObject(format);
+
+        // Formatter is not enabled, HGLOBAL contains NotSupportedException.
+        dataObject.TryGetData(format, TestData.Resolver, autoConvert: true, out TestData? testData).Should().BeFalse();
+        testData.Should().BeNull();
+
+        dataObject.TryGetData(format, out NotSupportedException? ex).Should().BeTrue();
+        ex.Should().BeOfType<NotSupportedException>().Which.Message.Should().Be(FormatterDisabledMessage);
+    }
+
+    [WinFormsTheory]
+    [MemberData(nameof(UndefinedRestrictedFormat))]
+    public void TryGetData_AsAbstract_Custom_FormatterEnabled_ReturnFalse(string format)
+    {
+        (DataObject dataObject, TestData _) = SetDataObject(format);
+
+        using BinaryFormatterScope scope = new(enable: true);
+        using BinaryFormatterInClipboardDragDropScope clipboardScope = new(enable: true);
+
+        // Format-type combination is invalid, serialization aborted, HGLOBAL contains MemoryStream.
+        dataObject.TryGetData(format, out AbstractBase? testData).Should().BeFalse();
+        testData.Should().BeNull();
+
+        dataObject.TryGetData(format, out MemoryStream? stream).Should().BeTrue();
+        stream.Should().NotBeNull();
+    }
+
+    [WinFormsTheory]
+    [MemberData(nameof(StringFormat))]
+    [MemberData(nameof(BitmapFormat))]
+    public void TryGetData_AsAbstract_Custom_InvalidTypeFormatCombination(string format)
+    {
+        (DataObject dataObject, TestData _) = SetDataObject(format);
+
+        Action tryGetData = () => dataObject.TryGetData(format, out AbstractBase? _);
+        tryGetData.Should().Throw<NotSupportedException>()
+            .WithMessage(expectedWildcardPattern: InvalidTypeFormatCombinationMessage);
+    }
+
+    [WinFormsTheory]
+    [MemberData(nameof(UnboundedFormat))]
+    public void TryGetData_AsAbstract_Custom_RequiresResolver(string format)
+    {
+        (DataObject dataObject, TestData _) = SetDataObject(format);
+        Action tryGetData = () => dataObject.TryGetData(format, out AbstractBase? _);
+
+        tryGetData.Should().Throw<NotSupportedException>().WithMessage(expectedWildcardPattern: RequiresResolverMessage);
+
+        dataObject.TryGetData(format, out NotSupportedException? ex).Should().BeTrue();
+        ex.Should().BeOfType<NotSupportedException>().Which.Message.Should().Be(FormatterDisabledMessage);
+    }
+
+    [WinFormsTheory]
+    [MemberData(nameof(UnboundedFormat))]
+    public void TryGetData_AsAbstract_Custom_FormatterEnabled_RequiresResolver(string format)
+    {
+        (DataObject dataObject, TestData _) = SetDataObject(format);
+        Action tryGetData = () => dataObject.TryGetData(format, out AbstractBase? _);
+
+        using BinaryFormatterScope scope = new(enable: true);
+        using BinaryFormatterInClipboardDragDropScope clipboardScope = new(enable: true);
+
+        tryGetData.Should().Throw<NotSupportedException>().WithMessage(expectedWildcardPattern: RequiresResolverMessage);
+    }
+
+    [WinFormsTheory]
+    [MemberData(nameof(UndefinedRestrictedFormat))]
+    public void TryGetData_WithResolver_AsAbstract_Custom_FormatterEnabled_ReturnFalse(string format)
+    {
+        (DataObject dataObject, TestData _) = SetDataObject(format);
+
+        using BinaryFormatterScope scope = new(enable: true);
+        using BinaryFormatterInClipboardDragDropScope clipboardScope = new(enable: true);
+
+        // Format-type combination is validated, but HGLOBAL contains a MemoryStream
+        dataObject.TryGetData(format, TestData.Resolver, autoConvert: true, out AbstractBase? testData).Should().BeFalse();
+        testData.Should().BeNull();
+    }
+
+    [WinFormsTheory]
+    [MemberData(nameof(UnboundedFormat))]
+    public void TryGetData_WithResolver_AsAbstract_Custom_FormatterEnabled_Success(string format)
+    {
+        (DataObject dataObject, TestData value) = SetDataObject(format);
+
+        using BinaryFormatterScope scope = new(enable: true);
+        using BinaryFormatterInClipboardDragDropScope clipboardScope = new(enable: true);
+
+        dataObject.TryGetData(format, TestData.Resolver, autoConvert: true, out AbstractBase? testData).Should().BeTrue();
+        testData.Should().BeEquivalentTo(value);
+    }
+
+    [WinFormsTheory]
+    [MemberData(nameof(StringFormat))]
+    [MemberData(nameof(BitmapFormat))]
+    public void TryGetData_WithResolver_AsAbstract_Custom_InvalidTypeFormatCombination(string format)
+    {
+        (DataObject dataObject, TestData _) = SetDataObject(format);
+
+        // Nothing is written to HGLOBAL in this test because format-type combination is invalid.
+        Action tryGetData = () => dataObject.TryGetData(format, TestData.Resolver, autoConvert: true, out AbstractBase? _);
+        tryGetData.Should().Throw<NotSupportedException>()
+            .WithMessage(expectedWildcardPattern: InvalidTypeFormatCombinationMessage);
+    }
+
+    [WinFormsTheory]
+    [MemberData(nameof(UnboundedFormat))]
+    public void TryGetData_AsConcrete_NotSerializable_FormatterEnabled_ReturnFalse(string format)
+    {
+        DataObject native = new();
+        NotSerializableData value = new(1);
+        native.SetData(format, value);
+        DataObject dataObject = new(ComHelpers.GetComPointer<Com.IDataObject>(native));
+
+        using BinaryFormatterScope scope = new(enable: true);
+        using BinaryFormatterInClipboardDragDropScope clipboardScope = new(enable: true);
+
+        // E_UNEXPECTED and a NULL HGLOBAL is returned from the COM GetData, we have no stream to deserialize.
+        dataObject.TryGetData(format, out NotSerializableData? data).Should().BeFalse();
+        data.Should().BeNull();
+    }
+
+    // This class does not have [Serializable] attribute, serialization stream will be corrupt.
+    private class NotSerializableData
+    {
+        public NotSerializableData(int value)
+        {
+            Value = value;
+        }
+
+        public int Value;
+    }
+
+    [Serializable]
+    private class TestData : AbstractBase
+    {
+        public TestData(Point point)
+        {
+            Location = point;
+            Inner = new InnerData("inner");
+        }
+
+        public Point Location;
+        public InnerData? Inner;
+
+        public override void DoStuff() { }
+
+        [Serializable]
+        internal class InnerData
+        {
+            public InnerData(string text)
+            {
+                Text = text;
+            }
+
+            public string Text;
+        }
+
+        public static Type Resolver(TypeName typeName)
+        {
+            (string name, Type type)[] allowedTypes =
+            [
+                (typeof(TestData).FullName!, typeof(TestData)),
+                (typeof(InnerData).FullName!, typeof(InnerData)),
+                (typeof(AbstractBase).FullName!, typeof(AbstractBase)),
+            ];
+
+            string fullName = typeName.FullName;
+            foreach (var (name, type) in allowedTypes)
+            {
+                // Namespace-qualified type name.
+                if (name == fullName)
+                {
+                    return type;
+                }
+            }
+
+            throw new NotSupportedException($"Can't resolve {fullName}");
+        }
+    }
+
+    [Serializable]
+    internal abstract class AbstractBase
+    {
+        public abstract void DoStuff();
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/NativeToWinFormsAdapterTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/NativeToWinFormsAdapterTests.cs
@@ -171,17 +171,17 @@ public unsafe class NativeToWinFormsAdapterTests
 
     [WinFormsTheory]
     [MemberData(nameof(UndefinedRestrictedFormat))]
-    public void TryGetData_AsObject_Custom_FormatterEnabled_ReturnsMemoryStream(string format)
+    public void TryGetData_AsObject_Custom_FormatterEnabled_ReturnsFalse(string format)
     {
         (DataObject dataObject, TestData _) = SetDataObject(format);
 
         using BinaryFormatterScope scope = new(enable: true);
         using BinaryFormatterInClipboardDragDropScope clipboardScope = new(enable: true);
 
-        // TODO (TanyaSo)
-        // This will throw SerializationException and put a stream that is not prefixed by a serialization GUID into the HGLOBAL.
-        dataObject.TryGetData(format, out object? result).Should().BeTrue();
-        result.Should().BeOfType<MemoryStream>();
+        // This will throw SerializationException from SetData and put a stream that is not prefixed
+        // by a serialization GUID into the HGLOBAL.
+        dataObject.TryGetData(format, out object? result).Should().BeFalse();
+        result.Should().BeNull();
     }
 
     [WinFormsTheory]
@@ -278,7 +278,7 @@ public unsafe class NativeToWinFormsAdapterTests
         using BinaryFormatterScope scope = new(enable: true);
         using BinaryFormatterInClipboardDragDropScope clipboardScope = new(enable: true);
 
-        // Format-type combination is invalid, serialization aborted, HGLOBAL contains MemoryStream.
+        // Format-type combination is invalid, serialization threw an exception.
         dataObject.TryGetData(format, out TestData? testData).Should().BeFalse();
         testData.Should().BeNull();
     }
@@ -369,12 +369,9 @@ public unsafe class NativeToWinFormsAdapterTests
         using BinaryFormatterScope scope = new(enable: true);
         using BinaryFormatterInClipboardDragDropScope clipboardScope = new(enable: true);
 
-        // Format-type combination is invalid, serialization aborted, HGLOBAL contains MemoryStream.
+        // Format-type combination is invalid, serialization threw an exception.
         dataObject.TryGetData(format, out AbstractBase? testData).Should().BeFalse();
         testData.Should().BeNull();
-
-        dataObject.TryGetData(format, out MemoryStream? stream).Should().BeTrue();
-        stream.Should().NotBeNull();
     }
 
     [WinFormsTheory]
@@ -424,7 +421,7 @@ public unsafe class NativeToWinFormsAdapterTests
         using BinaryFormatterScope scope = new(enable: true);
         using BinaryFormatterInClipboardDragDropScope clipboardScope = new(enable: true);
 
-        // Format-type combination is validated, but HGLOBAL contains a MemoryStream
+        // Format-type combination is validated, but serialization threw an exception
         dataObject.TryGetData(format, TestData.Resolver, autoConvert: true, out AbstractBase? testData).Should().BeFalse();
         testData.Should().BeNull();
     }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RichTextBoxTests.ClipboardTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RichTextBoxTests.ClipboardTests.cs
@@ -20,7 +20,9 @@ public partial class RichTextBoxTests
             using MemoryStream memoryStream = new();
             using Bitmap bitmap = new(100, 100);
             bitmap.Save(memoryStream, Drawing.Imaging.ImageFormat.Png);
+#pragma warning disable WFDEV005 // Type or member is obsolete
             Clipboard.SetData("Embed Source", memoryStream);
+#pragma warning restore WFDEV005
 
             control.Text.Should().BeEmpty();
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripItemTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripItemTests.cs
@@ -4,8 +4,8 @@
 using System.ComponentModel;
 using System.Drawing;
 using System.Runtime.InteropServices.ComTypes;
-using Moq;
 using System.Windows.Forms.TestUtilities;
+using Moq;
 using IComDataObject = System.Runtime.InteropServices.ComTypes.IDataObject;
 using Size = System.Drawing.Size;
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TypeExtensionsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TypeExtensionsTests.cs
@@ -1,0 +1,103 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System.Drawing;
+using System.Reflection.Metadata;
+using System.Runtime.CompilerServices;
+
+namespace System.Windows.Forms.Tests;
+
+public class TypeExtensionsTests
+{
+    public static TheoryData<Type, TypeName, bool> MatchesNameAndAssemblyLessVersionData() => new()
+    {
+        // int type is forwarded to mscorlib, type name with CoreLib will not match.
+        { typeof(int), TypeName.Parse(typeof(int).AssemblyQualifiedName), false },
+        { typeof(int), TypeName.Parse("System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"), true },
+        { typeof(int?), TypeName.Parse("System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"), true },
+        { typeof(int?[]), TypeName.Parse("System.Nullable`1[[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]][], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"), true},
+        { typeof(DayOfWeek), TypeName.Parse("System.Nullable`1[[System.DayOfWeek, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"), false },
+        { typeof(Bitmap), TypeName.Parse("System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"), true },
+        // Assembly version is incorrect.
+        { typeof(Bitmap), TypeName.Parse("System.Drawing.Bitmap, System.Drawing, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"), true },
+        // Public key token is incorrect.
+        { typeof(Bitmap), TypeName.Parse("System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f1AAAAAAA"), false },
+        // Culture is incorrect.
+        { typeof(Bitmap), TypeName.Parse("System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=en-US, PublicKeyToken=b03f5f7f11d50a3a"), false },
+        // Namespace name is incorrect.
+        { typeof(Bitmap), TypeName.Parse("System.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"), false },
+        { typeof(Bitmap), TypeName.Parse("System.Drawing.MyBitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"), false },
+        { typeof(Bitmap?[]), TypeName.Parse("System.Drawing.Bitmap[], System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"), true },
+        { typeof(Dictionary<string, Bitmap>), TypeName.Parse("System.Collections.Generic.Dictionary`2[[System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089],[System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"), true },
+        { typeof(Dictionary<string, Bitmap?>), TypeName.Parse("System.Collections.Generic.Dictionary`2[[System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089],[System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"), true },
+        { typeof(NonForwardedType), TypeName.Parse("System.Windows.Forms.Tests.TypeExtensionsTests.NonForwardedType"), false },
+        // Namespace name is incorrect.
+        { typeof(NonForwardedType), TypeName.Parse("System.Windows.Forms.Tests.TypeExtensionstests+NonForwardedType"), false },
+        // Assembly information is missing.
+        { typeof(NonForwardedType), TypeName.Parse("System.Windows.Forms.Tests.TypeExtensionsTests+NonForwardedType"), false },
+        { typeof(NonForwardedType), TypeName.Parse("System.Windows.Forms.Tests.TypeExtensionsTests+NonForwardedType, System.Windows.Forms.Tests"), false },
+        // Assembly name is cased differently.
+        { typeof(NonForwardedType), TypeName.Parse("System.Windows.Forms.Tests.TypeExtensionsTests+NonForwardedType, System.windows.Forms.Tests, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"), true },
+        // Namespace name is incorrect.
+        { typeof(NonForwardedType), TypeName.Parse("System.Windows.Forms.Tests.typeExtensionsTests+NonForwardedType, System.Windows.Forms.Tests"), false },
+        { typeof(ForwardedType), TypeName.Parse("System.Windows.Forms.Tests.TypeExtensionsTests+ForwardedType, Abc"), true },
+    };
+
+    [Theory]
+    [MemberData(nameof(MatchesNameAndAssemblyLessVersionData))]
+    public void MatchesLessAssemblyVersion(Type type, TypeName typeName, bool matches) =>
+        // Match full type names and assembly names without version.
+        type.MatchExceptAssemblyVersion(typeName).Should().Be(matches);
+
+    public static TheoryData<TypeName, TypeName, bool> MatchesTypeNameData() => new()
+    {
+        { TypeName.Parse("System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"), TypeName.Parse("System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"), true },
+        { TypeName.Parse("System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"), TypeName.Parse("System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"), false },
+        { TypeName.Parse("System.Collections.Generic.Dictionary`2[[System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089],[System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"), TypeName.Parse("System.Collections.Generic.Dictionary`2[[System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089],[System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"), true },
+        { TypeName.Parse("System.Collections.Generic.Dictionary`2[[System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089],[System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"), TypeName.Parse("System.Collections.Generic.Dictionary`2[[System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089],[System.Drawing.Bitmap, System.Drawing, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"), false },
+        { TypeName.Parse("System.Collections.Generic.Dictionary`2[[System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089],[System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"), TypeName.Parse("System.Collections.Generic.Dictionary`2[[System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089],[System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]], mscorlib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"), false },
+        { TypeName.Parse("System.Drawing.Bitmap[], System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"), TypeName.Parse("System.Drawing.Bitmap[], System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"), true },
+        { TypeName.Parse("System.Drawing.Bitmap[], System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"), TypeName.Parse("System.Drawing.Bitmap[], System.Drawing, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"), false },
+        { TypeName.Parse("System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"), TypeName.Parse("System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"), true },
+        { TypeName.Parse("System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"), TypeName.Parse("System.Drawing.Bitmap, System.Drawing, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"), false },
+    };
+
+    [Theory]
+    [MemberData(nameof(MatchesTypeNameData))]
+    public void Matches_TypeName(TypeName x, TypeName y, bool matches) =>
+        // Match TypeName objects including assembly version.
+        x.Matches(y).Should().Be(matches);
+
+    [Fact]
+    public void TryGetForwardedFromName_ReturnsTrue()
+    {
+        typeof(int?).TryGetForwardedFromName(out string? name).Should().BeTrue();
+        name.Should().Be("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089");
+        typeof(int).TryGetForwardedFromName(out name).Should().BeTrue();
+        name.Should().Be("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089");
+        typeof(ForwardedType).TryGetForwardedFromName(out name).Should().BeTrue();
+        name.Should().Be("Abc");
+        typeof(ForwardedType[]).TryGetForwardedFromName(out name).Should().BeTrue();
+        name.Should().Be("Abc");
+        typeof(ForwardedType?[]).TryGetForwardedFromName(out name).Should().BeTrue();
+        name.Should().Be("Abc");
+    }
+
+    [Fact]
+    public void TryGetForwardedFromName_ReturnsFalse()
+    {
+        typeof(NonForwardedType).TryGetForwardedFromName(out string? name).Should().BeFalse();
+        name.Should().BeNull();
+        typeof(NonForwardedType[]).TryGetForwardedFromName(out name).Should().BeFalse();
+        name.Should().BeNull();
+        typeof(NonForwardedType?[]).TryGetForwardedFromName(out name).Should().BeFalse();
+        name.Should().BeNull();
+    }
+
+    [TypeForwardedFrom("Abc")]
+    private class ForwardedType { }
+
+    private class NonForwardedType { }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TypeExtensionsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TypeExtensionsTests.cs
@@ -4,6 +4,7 @@
 #nullable enable
 
 using System.Drawing;
+using System.Private.Windows.Core.BinaryFormat;
 using System.Reflection.Metadata;
 using System.Runtime.CompilerServices;
 
@@ -15,10 +16,10 @@ public class TypeExtensionsTests
     {
         // int type is forwarded to mscorlib, type name with CoreLib will not match.
         { typeof(int), TypeName.Parse(typeof(int).AssemblyQualifiedName), false },
-        { typeof(int), TypeName.Parse("System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"), true },
-        { typeof(int?), TypeName.Parse("System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"), true },
-        { typeof(int?[]), TypeName.Parse("System.Nullable`1[[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]][], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"), true},
-        { typeof(DayOfWeek), TypeName.Parse("System.Nullable`1[[System.DayOfWeek, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"), false },
+        { typeof(int), TypeName.Parse($"System.Int32, {Mscorlib}"), true },
+        { typeof(int?), TypeName.Parse($"System.Int32, {Mscorlib}"), true },
+        { typeof(int?[]), TypeName.Parse($"System.Nullable`1[[System.Int32, {Mscorlib}]][], {Mscorlib}"), true},
+        { typeof(DayOfWeek), TypeName.Parse($"System.Nullable`1[[System.DayOfWeek, {Mscorlib}]], {Mscorlib}"), false },
         { typeof(Bitmap), TypeName.Parse("System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"), true },
         // Assembly version is incorrect.
         { typeof(Bitmap), TypeName.Parse("System.Drawing.Bitmap, System.Drawing, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"), true },
@@ -30,10 +31,10 @@ public class TypeExtensionsTests
         { typeof(Bitmap), TypeName.Parse("System.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"), false },
         { typeof(Bitmap), TypeName.Parse("System.Drawing.MyBitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"), false },
         { typeof(Bitmap?[]), TypeName.Parse("System.Drawing.Bitmap[], System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"), true },
-        { typeof(Dictionary<string, Bitmap>), TypeName.Parse("System.Collections.Generic.Dictionary`2[[System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089],[System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"), true },
-        { typeof(Dictionary<string, Bitmap?>), TypeName.Parse("System.Collections.Generic.Dictionary`2[[System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089],[System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"), true },
+        { typeof(Dictionary<string, Bitmap>), TypeName.Parse($"System.Collections.Generic.Dictionary`2[[System.String, {Mscorlib}],[System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]], {Mscorlib}"), true },
+        { typeof(Dictionary<string, Bitmap?>), TypeName.Parse($"System.Collections.Generic.Dictionary`2[[System.String, {Mscorlib}],[System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]], {Mscorlib}"), true },
         { typeof(NonForwardedType), TypeName.Parse("System.Windows.Forms.Tests.TypeExtensionsTests.NonForwardedType"), false },
-        // Namespace name is incorrect.
+        // Namespace name is cased differently.
         { typeof(NonForwardedType), TypeName.Parse("System.Windows.Forms.Tests.TypeExtensionstests+NonForwardedType"), false },
         // Assembly information is missing.
         { typeof(NonForwardedType), TypeName.Parse("System.Windows.Forms.Tests.TypeExtensionsTests+NonForwardedType"), false },
@@ -53,15 +54,15 @@ public class TypeExtensionsTests
 
     public static TheoryData<TypeName, TypeName, bool> MatchesTypeNameData() => new()
     {
-        { TypeName.Parse("System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"), TypeName.Parse("System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"), true },
-        { TypeName.Parse("System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"), TypeName.Parse("System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"), false },
-        { TypeName.Parse("System.Collections.Generic.Dictionary`2[[System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089],[System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"), TypeName.Parse("System.Collections.Generic.Dictionary`2[[System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089],[System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"), true },
-        { TypeName.Parse("System.Collections.Generic.Dictionary`2[[System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089],[System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"), TypeName.Parse("System.Collections.Generic.Dictionary`2[[System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089],[System.Drawing.Bitmap, System.Drawing, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"), false },
-        { TypeName.Parse("System.Collections.Generic.Dictionary`2[[System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089],[System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]], mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"), TypeName.Parse("System.Collections.Generic.Dictionary`2[[System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089],[System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]], mscorlib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"), false },
-        { TypeName.Parse("System.Drawing.Bitmap[], System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"), TypeName.Parse("System.Drawing.Bitmap[], System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"), true },
-        { TypeName.Parse("System.Drawing.Bitmap[], System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"), TypeName.Parse("System.Drawing.Bitmap[], System.Drawing, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"), false },
-        { TypeName.Parse("System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"), TypeName.Parse("System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"), true },
-        { TypeName.Parse("System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"), TypeName.Parse("System.Drawing.Bitmap, System.Drawing, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"), false },
+        { TypeName.Parse($"System.Int32, {Mscorlib}"), TypeName.Parse($"System.Int32,  {Mscorlib}"), true },
+        { TypeName.Parse($"System.Int32, {Mscorlib}"), TypeName.Parse($"System.String, {Mscorlib}"), false },
+        { TypeName.Parse($"System.Collections.Generic.Dictionary`2[[System.String, {Mscorlib}],[System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]], {Mscorlib}"), TypeName.Parse($"System.Collections.Generic.Dictionary`2[[System.String, {Mscorlib}],[System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]], {Mscorlib}"), true },
+        { TypeName.Parse($"System.Collections.Generic.Dictionary`2[[System.String, {Mscorlib}],[System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]], {Mscorlib}"), TypeName.Parse($"System.Collections.Generic.Dictionary`2[[System.String, {Mscorlib}],[System.Drawing.Bitmap, System.Drawing, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]], {Mscorlib}"), false },
+        { TypeName.Parse($"System.Collections.Generic.Dictionary`2[[System.String, {Mscorlib}],[System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]], {Mscorlib}"), TypeName.Parse($"System.Collections.Generic.Dictionary`2[[System.String, {Mscorlib}],[System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]], mscorlib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"), false },
+        { TypeName.Parse($"System.Drawing.Bitmap[], System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"), TypeName.Parse($"System.Drawing.Bitmap[], System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"), true },
+        { TypeName.Parse($"System.Drawing.Bitmap[], System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"), TypeName.Parse($"System.Drawing.Bitmap[], System.Drawing, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"), false },
+        { TypeName.Parse($"System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"), TypeName.Parse($"System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"), true },
+        { TypeName.Parse($"System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"), TypeName.Parse($"System.Drawing.Bitmap, System.Drawing, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a"), false },
     };
 
     [Theory]
@@ -74,9 +75,9 @@ public class TypeExtensionsTests
     public void TryGetForwardedFromName_ReturnsTrue()
     {
         typeof(int?).TryGetForwardedFromName(out string? name).Should().BeTrue();
-        name.Should().Be("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089");
+        name.Should().Be(Mscorlib);
         typeof(int).TryGetForwardedFromName(out name).Should().BeTrue();
-        name.Should().Be("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089");
+        name.Should().Be(Mscorlib);
         typeof(ForwardedType).TryGetForwardedFromName(out name).Should().BeTrue();
         name.Should().Be("Abc");
         typeof(ForwardedType[]).TryGetForwardedFromName(out name).Should().BeTrue();
@@ -94,6 +95,40 @@ public class TypeExtensionsTests
         name.Should().BeNull();
         typeof(NonForwardedType?[]).TryGetForwardedFromName(out name).Should().BeFalse();
         name.Should().BeNull();
+    }
+
+    private const string Mscorlib = TypeInfo.MscorlibAssemblyName;
+
+    [Fact]
+    public void ForwardedTypeToTypeName()
+    {
+        TypeName name = typeof(ForwardedType).ToTypeName();
+        name.FullName.Should().Be("System.Windows.Forms.Tests.TypeExtensionsTests+ForwardedType");
+        name.AssemblyName!.FullName.Should().Be("Abc");
+
+        name = typeof(ForwardedType[]).ToTypeName();
+        name.FullName.Should().Be("System.Windows.Forms.Tests.TypeExtensionsTests+ForwardedType[]");
+        name.AssemblyName!.FullName.Should().Be("Abc");
+
+        name = typeof(ForwardedType?[]).ToTypeName();
+        name.FullName.Should().Be("System.Windows.Forms.Tests.TypeExtensionsTests+ForwardedType[]");
+        name.AssemblyName!.FullName.Should().Be("Abc");
+
+        name = typeof(List<ForwardedType>).ToTypeName();
+        name.FullName.Should().Be($"System.Collections.Generic.List`1[[System.Windows.Forms.Tests.TypeExtensionsTests+ForwardedType, Abc]]");
+        name.AssemblyName!.FullName.Should().Be(Mscorlib);
+
+        name = typeof(List<Dictionary<int, string>>).ToTypeName();
+        name.FullName.Should().Be($"System.Collections.Generic.List`1[[System.Collections.Generic.Dictionary`2[[System.Int32, {Mscorlib}],[System.String, {Mscorlib}]], {Mscorlib}]]");
+        name.AssemblyName!.FullName.Should().Be(Mscorlib);
+
+        name = typeof(List<Dictionary<string, int?>>).ToTypeName();
+        name.FullName.Should().Be($"System.Collections.Generic.List`1[[System.Collections.Generic.Dictionary`2[[System.String, {Mscorlib}],[System.Nullable`1[[System.Int32, {Mscorlib}]], {Mscorlib}]], {Mscorlib}]]");
+        name.AssemblyName!.FullName.Should().Be(Mscorlib);
+
+        name = typeof(List<Dictionary<int, string?>>).ToTypeName();
+        name.FullName.Should().Be($"System.Collections.Generic.List`1[[System.Collections.Generic.Dictionary`2[[System.Int32, {Mscorlib}],[System.String, {Mscorlib}]], {Mscorlib}]]");
+        name.AssemblyName!.FullName.Should().Be(Mscorlib);
     }
 
     [TypeForwardedFrom("Abc")]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TypeNameComparerTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TypeNameComparerTests.cs
@@ -1,0 +1,106 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System.Reflection.Metadata;
+
+namespace System.Windows.Forms.Tests;
+
+public class TypeNameComparerTests
+{
+    private class TestType { }
+
+    public static TheoryData<TypeName, Type> TypeNameComparerSuccess() => new()
+    {
+        { TypeName.Parse(typeof(int).AssemblyQualifiedName), typeof(int) },
+        { TypeName.Parse($"{typeof(int).FullName}, {typeof(int).Assembly.FullName}"), typeof(int) },
+        { TypeName.Parse(typeof(int[]).AssemblyQualifiedName), typeof(int[]) },
+        { TypeName.Parse($"{typeof(int[]).FullName}, {typeof(int[]).Assembly.FullName}"), typeof(int[]) },
+        { TypeName.Parse(typeof(List<int>).AssemblyQualifiedName), typeof(List<int>) },
+        { TypeName.Parse($"{typeof(List<int>).FullName}, {typeof(List<int>).Assembly.FullName}"), typeof(List<int>) },
+        { TypeName.Parse(typeof(TestType).AssemblyQualifiedName), typeof(TestType) },
+        { TypeName.Parse($"{typeof(TestType).FullName}, {typeof(TestType).Assembly.FullName}"), typeof(TestType) },
+    };
+
+    [Theory]
+    [MemberData(nameof(TypeNameComparerSuccess))]
+    public void DictionaryLookupSucceeds(TypeName name, Type expected)
+    {
+        Dictionary<TypeName, Type> types = new(DataObject.Composition.TypeNameComparer.Default)
+        {
+            { TypeName.Parse(typeof(int).AssemblyQualifiedName), typeof(int) },
+            { TypeName.Parse(typeof(int[]).AssemblyQualifiedName), typeof(int[]) },
+            { TypeName.Parse(typeof(List<int>).AssemblyQualifiedName), typeof(List<int>) },
+            { TypeName.Parse(typeof(TestType).AssemblyQualifiedName), typeof(TestType) },
+        };
+
+        types.TryGetValue(name, out Type? resolvedType).Should().BeTrue();
+        resolvedType.Should().Be(expected);
+    }
+
+    public static TheoryData<TypeName> TypeNameComparerFail() =>
+    [
+        TypeName.Parse("System.Int32[], System.Private.CoreLib, Version=9.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e"),
+        TypeName.Parse("System.Int32, System.Private.CoreLib, Version=9.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e"),
+        TypeName.Parse("System.Int32, System.Private.CoreLib, Culture=neutral, PublicKeyToken=7cec85d7bea7798e"),
+        TypeName.Parse($"System.Collections.Generic.List`1[[System.Int32, System.Private.CoreLib, Version=9.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]], {typeof(List<int>).Assembly.FullName}"),
+        TypeName.Parse($"{typeof(TestType).FullName}, {typeof(int).Assembly.FullName}")
+    ];
+
+    [Theory]
+    [MemberData(nameof(TypeNameComparerFail))]
+    public void DictionaryLookupVersionMismatch(TypeName name)
+    {
+        Dictionary<TypeName, Type> types = new(DataObject.Composition.TypeNameComparer.Default)
+        {
+            { TypeName.Parse(typeof(int).AssemblyQualifiedName), typeof(int) },
+            { TypeName.Parse(typeof(int[]).AssemblyQualifiedName), typeof(int[]) },
+            { TypeName.Parse(typeof(List<int>).AssemblyQualifiedName), typeof(List<int>) },
+            { TypeName.Parse(typeof(TestType).AssemblyQualifiedName), typeof(TestType) },
+        };
+
+        types.TryGetValue(name, out Type? _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void DictionaryLookupFails()
+    {
+        Dictionary<TypeName, Type> types = new(DataObject.Composition.TypeNameComparer.Default)
+        {
+            { TypeName.Parse(typeof(int).AssemblyQualifiedName), typeof(int) },
+            { TypeName.Parse(typeof(int[]).AssemblyQualifiedName), typeof(int[]) },
+            { TypeName.Parse(typeof(List<int>).AssemblyQualifiedName), typeof(List<int>) },
+            { TypeName.Parse(typeof(TestType).AssemblyQualifiedName), typeof(TestType) },
+        };
+
+        TypeName name = TypeName.Parse(typeof(int).AssemblyQualifiedName);
+        AssemblyNameInfo info = name.AssemblyName!;
+        string testName = $"{name.FullName}, {info.Name}, Version={info.Version!}, Culture=neutral, PublicKeyToken=null";
+        name = TypeName.Parse(testName);
+        types.TryGetValue(name, out Type? _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void TypeNameComparer_Null()
+    {
+        var comparer = DataObject.Composition.TypeNameComparer.Default;
+
+        comparer.Equals(null, null).Should().BeTrue();
+        comparer.Equals(null, TypeName.Parse(typeof(int).AssemblyQualifiedName)).Should().BeFalse();
+        comparer.Equals(TypeName.Parse(typeof(int).AssemblyQualifiedName), null).Should().BeFalse();
+        comparer.Equals(
+            TypeName.Parse(typeof(int).AssemblyQualifiedName),
+            TypeName.Parse($"{typeof(int).FullName}, {typeof(int).Assembly.FullName}")).Should().BeTrue();
+    }
+
+    [Fact]
+    public void TypeNameComparer_GetHashCode()
+    {
+        var comparer = DataObject.Composition.TypeNameComparer.Default;
+
+        int hash = comparer.GetHashCode(TypeName.Parse(typeof(int).AssemblyQualifiedName));
+        comparer.GetHashCode(TypeName.Parse(typeof(int).AssemblyQualifiedName)).Should().Be(hash);
+        comparer.GetHashCode(TypeName.Parse($"{typeof(int).FullName}, {typeof(int).Assembly.FullName}")).Should().Be(hash);
+    }
+}


### PR DESCRIPTION
Related to #https://github.com/dotnet/winforms/issues/12362
Fixes https://github.com/dotnet/winforms/issues/11350

The `TryGetData` methods use NRBF deserializer by default and will fall back to use BinaryFormatter if the application opts into BinaryFormatter use in this context.
The `GetData` methods have a compatibility mode when the appropriate AppContext switches are enabled but by default they can read only known and primitive types or POCOs with primitive fields. These methods in the `DataObjec`t class are obsoleted.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11545)