### PR TITLE
Fix SystemRuntimeSerializationFormatters package version dependency

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -67,6 +67,10 @@ Note: if the Uri is a new place, you will need to add a subscription from that p
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>4a0a04cf3e8b8c2a3613270df7f838246e4597e8</Sha>
     </Dependency>
+    <Dependency Name="System.Runtime.Serialization.Formatters" Version="9.0.0-preview.6.24318.4">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>4a0a04cf3e8b8c2a3613270df7f838246e4597e8</Sha>
+    </Dependency>
     <!-- These dependencies are required by windowsdesktop for coherency. -->
     <Dependency Name="Microsoft.Win32.Registry.AccessControl" Version="9.0.0-preview.6.24318.7">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -24,6 +24,7 @@
     <MicrosoftNETCoreILDAsmPackageVersion>9.0.0-preview.6.24318.7</MicrosoftNETCoreILDAsmPackageVersion>
     <SystemDiagnosticsPerformanceCounterPackageVersion>9.0.0-preview.6.24318.7</SystemDiagnosticsPerformanceCounterPackageVersion>
     <SystemRuntimeCompilerServicesUnsafePackageVersion>6.0.0</SystemRuntimeCompilerServicesUnsafePackageVersion>
+    <SystemRuntimeSerializationFormattersPackageVersion>9.0.0-preview.6.24318.4</SystemRuntimeSerializationFormattersPackageVersion>
     <SystemSecurityCryptographyPkcsPackageVersion>9.0.0-preview.6.24318.7</SystemSecurityCryptographyPkcsPackageVersion>
     <SystemSecurityCryptographyProtectedDataPackageVersion>9.0.0-preview.6.24318.7</SystemSecurityCryptographyProtectedDataPackageVersion>
     <SystemTextEncodingsWebPackageVersion>9.0.0-preview.6.24318.7</SystemTextEncodingsWebPackageVersion>
@@ -109,6 +110,5 @@
     <MicrosoftWindowsDesktopAppRefv30PackageVersion>3.0.0</MicrosoftWindowsDesktopAppRefv30PackageVersion>
     <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
     <VsWherePackageVersion>2.6.7</VsWherePackageVersion>
-    <SystemRuntimeSerializationFormattersVersion>9.0.0-preview.6.24318.4</SystemRuntimeSerializationFormattersVersion>
   </PropertyGroup>
 </Project>

--- a/src/System.Private.Windows.Core/tests/BinaryFormatTests/BinaryFormatTests.csproj
+++ b/src/System.Private.Windows.Core/tests/BinaryFormatTests/BinaryFormatTests.csproj
@@ -35,7 +35,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
-    <PackageReference Include="System.Runtime.Serialization.Formatters" Version="$(SystemRuntimeSerializationFormattersVersion)" />
+    <PackageReference Include="System.Runtime.Serialization.Formatters" Version="$(SystemRuntimeSerializationFormattersPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System.Windows.Forms.Design.Tests.csproj
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System.Windows.Forms.Design.Tests.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisCSharpPackageVersion)" />
-    <PackageReference Include="System.Runtime.Serialization.Formatters" Version="$(SystemRuntimeSerializationFormattersVersion)" />
+    <PackageReference Include="System.Runtime.Serialization.Formatters" Version="$(SystemRuntimeSerializationFormattersPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/System.Windows.Forms/tests/ComDisabledTests/ComDisabled.Tests.csproj
+++ b/src/System.Windows.Forms/tests/ComDisabledTests/ComDisabled.Tests.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
-    <PackageReference Include="System.Runtime.Serialization.Formatters" Version="$(SystemRuntimeSerializationFormattersVersion)" />
+    <PackageReference Include="System.Runtime.Serialization.Formatters" Version="$(SystemRuntimeSerializationFormattersPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/System.Windows.Forms/tests/UnitTests/System.Windows.Forms.Tests.csproj
+++ b/src/System.Windows.Forms/tests/UnitTests/System.Windows.Forms.Tests.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
-    <PackageReference Include="System.Runtime.Serialization.Formatters" Version="$(SystemRuntimeSerializationFormattersVersion)" />
+    <PackageReference Include="System.Runtime.Serialization.Formatters" Version="$(SystemRuntimeSerializationFormattersPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Move SystemRuntimeSerializationFormattersPackageVersion in `Versions.prop` and add entry in Version.Details.xml on it to have maestro bump verison in updates
- Update naming to match existing naming pattern
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11553)