### PR TITLE
Unhighlighting the ToolStripMenuItem when it is in the drop-down menu

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripHighContrastRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripHighContrastRenderer.cs
@@ -180,7 +180,7 @@ internal class ToolStripHighContrastRenderer : ToolStripSystemRenderer
             e.Graphics.DrawRectangle(SystemPens.ButtonHighlight, 0, 0, e.Item.Width - 1, e.Item.Height - 1);
         }
 
-        if (e.Item is ToolStripMenuItem menuItem && (menuItem.Checked || menuItem.Selected))
+        if (e.Item is ToolStripMenuItem menuItem && !e.Item.IsOnDropDown && (menuItem.Checked || menuItem.Selected))
         {
             Graphics g = e.Graphics;
             Rectangle bounds = new(Point.Empty, menuItem.Size);
@@ -238,6 +238,7 @@ internal class ToolStripHighContrastRenderer : ToolStripSystemRenderer
             ((ToolStripButton)e.Item).Checked) ||
             (typeof(ToolStripMenuItem).IsAssignableFrom(e.Item.GetType()) &&
             ((ToolStripMenuItem)e.Item).DisplayStyle != ToolStripItemDisplayStyle.Image &&
+            !e.Item.IsOnDropDown &&
             ((ToolStripMenuItem)e.Item).Checked))
         {
             e.TextColor = SystemColors.HighlightText;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripHighContrastRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripHighContrastRenderer.cs
@@ -233,13 +233,13 @@ internal class ToolStripHighContrastRenderer : ToolStripSystemRenderer
 
         // ToolstripButtons and ToolstripMenuItems that are checked are rendered with a highlight
         // background. In that case, set the text color to highlight as well.
-        if ((typeof(ToolStripButton).IsAssignableFrom(e.Item.GetType()) &&
-            ((ToolStripButton)e.Item).DisplayStyle != ToolStripItemDisplayStyle.Image &&
-            ((ToolStripButton)e.Item).Checked) ||
-            (typeof(ToolStripMenuItem).IsAssignableFrom(e.Item.GetType()) &&
-            ((ToolStripMenuItem)e.Item).DisplayStyle != ToolStripItemDisplayStyle.Image &&
-            !e.Item.IsOnDropDown &&
-            ((ToolStripMenuItem)e.Item).Checked))
+        if ((typeof(ToolStripButton).IsAssignableFrom(e.Item.GetType())
+            && ((ToolStripButton)e.Item).DisplayStyle != ToolStripItemDisplayStyle.Image
+            && ((ToolStripButton)e.Item).Checked)
+            || (typeof(ToolStripMenuItem).IsAssignableFrom(e.Item.GetType())
+            && ((ToolStripMenuItem)e.Item).DisplayStyle != ToolStripItemDisplayStyle.Image
+            && !e.Item.IsOnDropDown
+            && ((ToolStripMenuItem)e.Item).Checked))
         {
             e.TextColor = SystemColors.HighlightText;
         }

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ToolStripTests.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ToolStripTests.Designer.cs
@@ -61,6 +61,8 @@ partial class ToolStripTests
         this.toolStrip4_MenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
         this.toolStrip4_SubMenuItem = new System.Windows.Forms.ToolStripMenuItem();
         this.uncheckedCheckOnClickToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+        this.thirdLevelItem = new System.Windows.Forms.ToolStripMenuItem();
+        this.thirdLevelButton = new System.Windows.Forms.ToolStripButton();
         this.checkCheckOnClickToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
         this.checkedCheckOnClickFToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
         this.indeterminateToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -240,6 +242,23 @@ partial class ToolStripTests
         this.checkCheckOnClickToolStripMenuItem.Name = "checkCheckOnClickToolStripMenuItem";
         this.checkCheckOnClickToolStripMenuItem.Size = new System.Drawing.Size(481, 44);
         this.checkCheckOnClickToolStripMenuItem.Text = "Checked_CheckOnClick(T)";
+        this.checkCheckOnClickToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[] { thirdLevelItem, thirdLevelButton });
+        // 
+        // thirdLevelItem
+        // 
+        this.thirdLevelItem.CheckOnClick = true;
+        this.thirdLevelItem.Name = "thirdLevelItem";
+        this.thirdLevelItem.Size = new System.Drawing.Size(481, 44);
+        this.thirdLevelItem.Text = "thirdLevelItem";
+        this.thirdLevelItem.CheckState = System.Windows.Forms.CheckState.Checked;
+        // 
+        // thirdLevelButton
+        // 
+        this.thirdLevelButton.CheckOnClick = true;
+        this.thirdLevelButton.Name = "thirdLevelButton";
+        this.thirdLevelButton.Size = new System.Drawing.Size(481, 44);
+        this.thirdLevelButton.Text = "thirdLevelButton";
+        this.thirdLevelButton.CheckState = System.Windows.Forms.CheckState.Checked;
         // 
         // checkedCheckOnClickFToolStripMenuItem
         // 
@@ -405,6 +424,7 @@ partial class ToolStripTests
     private System.Windows.Forms.ToolStripButton toolStrip2_Button4;
     private System.Windows.Forms.ToolStripButton toolStrip2_Button5;
     private System.Windows.Forms.ToolStripButton toolStrip2_Button6;
+    private System.Windows.Forms.ToolStripButton thirdLevelButton;
     private System.Windows.Forms.ToolStripSplitButton toolStrip2_SplitButton1;
     private System.Windows.Forms.ToolStripDropDownButton toolStrip2_DropDownButton1;
     private System.Windows.Forms.ToolStripMenuItem toolStrip2_DropDownButton1_ChildButton1;
@@ -415,6 +435,7 @@ partial class ToolStripTests
     private System.Windows.Forms.ToolStripMenuItem toolStrip3_MenuItem2;
     private System.Windows.Forms.ToolStripMenuItem toolStrip4_MenuItem1;
     private System.Windows.Forms.ToolStripMenuItem toolStrip4_SubMenuItem;
+    private System.Windows.Forms.ToolStripMenuItem thirdLevelItem;
     private System.Windows.Forms.ToolStripMenuItem uncheckedCheckOnClickToolStripMenuItem;
     private System.Windows.Forms.ToolStripMenuItem checkCheckOnClickToolStripMenuItem;
     private System.Windows.Forms.ToolStripMenuItem checkedCheckOnClickFToolStripMenuItem;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #11550


## Proposed changes

- Unhighlighting the ToolStripMenuItem when it is in the drop-down menu 
- Add third level menu item in ToolStripTests.cs of the test project `WinformsControlsTest`

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- The color contrast of the toolStripMenuItem's indeterminate state icon is sufficient, regardless of whether the selected state is enabled or disabled.

## Regression? 

- Yes 

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
toolStripMenuItem is highlighted in unfocused state when its check property is enabled, this causes the color contrast of indeterminate state icon for toolStripMenuItem is less than 3:1.
![image](https://github.com/dotnet/winforms/assets/132890443/4c74455b-f7e5-4ead-8dc7-e1a1e0dba954)

### After
Unhighlighting the ToolStripMenuItem when it is in the drop-down menu
![image](https://github.com/dotnet/winforms/assets/132890443/b3dd9c08-6810-488a-b1eb-1043ba380c9a)

## Test methodology <!-- How did you ensure quality? -->

- Manually

## Test environment(s) <!-- Remove any that don't apply -->

- .net 9.0.0-preview.6.24318.5


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11557)