### PR TITLE
Skip test "TextBoxBase_Undo_CanUndo_Success" and "TextBoxBase_Copy_PasteNotEmpty_Success"

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/TextBoxBaseTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/TextBoxBaseTests.cs
@@ -4169,7 +4169,10 @@ public partial class TextBoxBaseTests
         Assert.True(control.IsHandleCreated);
     }
 
+    [ActiveIssue("https://github.com/dotnet/winforms/issues/11558")]
     [WinFormsFact]
+    [SkipOnArchitecture(TestArchitectures.X86,
+     "Flaky tests, see: https://github.com/dotnet/winforms/issues/11558")]
     public void TextBoxBase_Copy_PasteNotEmpty_Success()
     {
         using SubTextBox control = new()
@@ -7135,7 +7138,10 @@ public partial class TextBoxBaseTests
         Assert.Equal(0, createdCallCount);
     }
 
+    [ActiveIssue("https://github.com/dotnet/winforms/issues/11559")]
     [WinFormsFact]
+    [SkipOnArchitecture(TestArchitectures.X86,
+        "Flaky tests, see: https://github.com/dotnet/winforms/issues/11559")]
     public void TextBoxBase_Undo_CanUndo_Success()
     {
         using SubTextBox control = new()

--- a/src/System.Windows.Forms/tests/UnitTests/TextBoxBaseTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/TextBoxBaseTests.cs
@@ -4172,7 +4172,7 @@ public partial class TextBoxBaseTests
     [ActiveIssue("https://github.com/dotnet/winforms/issues/11558")]
     [WinFormsFact]
     [SkipOnArchitecture(TestArchitectures.X86,
-     "Flaky tests, see: https://github.com/dotnet/winforms/issues/11558")]
+        "Flaky tests, see: https://github.com/dotnet/winforms/issues/11558")]
     public void TextBoxBase_Copy_PasteNotEmpty_Success()
     {
         using SubTextBox control = new()


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Related #11559, #11558


## Proposed changes

- Add SkipOnArchitecture for test "TextBoxBase_Undo_CanUndo_Success" and "TextBoxBase_Copy_PasteNotEmpty_Success"
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11562)