### PR TITLE
Skip test "MenuStrip_WndProc_InvokeMouseActivate_Success" and "MenuStrip_WndProc_InvokeMouseActivateWithHandle_Success"

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MenuStripTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MenuStripTests.cs
@@ -742,7 +742,10 @@ public class MenuStripTests
         Assert.False(control.IsHandleCreated);
     }
 
+    [ActiveIssue("https://github.com/dotnet/winforms/issues/11560")]
     [WinFormsFact]
+    [SkipOnArchitecture(TestArchitectures.X64,
+        "Flaky tests, see: https://github.com/dotnet/winforms/issues/11560")]
     public void MenuStrip_WndProc_InvokeMouseActivate_Success()
     {
         using SubMenuStrip control = new();
@@ -756,7 +759,10 @@ public class MenuStripTests
         Assert.True(control.IsHandleCreated);
     }
 
+    [ActiveIssue("https://github.com/dotnet/winforms/issues/11561")]
     [WinFormsFact]
+    [SkipOnArchitecture(TestArchitectures.X64,
+        "Flaky tests, see: https://github.com/dotnet/winforms/issues/11561")]
     public void MenuStrip_WndProc_InvokeMouseActivateWithHandle_Success()
     {
         using SubMenuStrip control = new();


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Related #11560, #11561


## Proposed changes

- Add SkipOnArchitecture for test "MenuStrip_WndProc_InvokeMouseActivate_Success" and "MenuStrip_WndProc_InvokeMouseActivateWithHandle_Success"
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11563)