### PR TITLE
Set default trim values for WinForms

### DIFF
--- a/pkg/Microsoft.Private.Winforms/sdk/dotnet-wpf/Microsoft.NET.Sdk.WindowsDesktop.WindowsForms.targets
+++ b/pkg/Microsoft.Private.Winforms/sdk/dotnet-wpf/Microsoft.NET.Sdk.WindowsDesktop.WindowsForms.targets
@@ -17,7 +17,6 @@
     <_MdiWindowDialogSupport Condition="'$(_MdiWindowDialogSupport)' == ''">false</_MdiWindowDialogSupport>
     <_WinFormsImageIndexConverterSupport Condition="'$(_WinFormsImageIndexConverterSupport)' == ''">false</_WinFormsImageIndexConverterSupport>
     <_UseComponentModelRegisteredTypes Condition="'$(_UseComponentModelRegisteredTypes)' == ''">true</_UseComponentModelRegisteredTypes>
-    <_EnableUnsafeBinaryFormatterInNativeObjectSerialization Condition="'$(_EnableUnsafeBinaryFormatterInNativeObjectSerialization)' == ''">false</_EnableUnsafeBinaryFormatterInNativeObjectSerialization>
   </PropertyGroup>
 
 </Project>

--- a/pkg/Microsoft.Private.Winforms/sdk/dotnet-wpf/Microsoft.NET.Sdk.WindowsDesktop.WindowsForms.targets
+++ b/pkg/Microsoft.Private.Winforms/sdk/dotnet-wpf/Microsoft.NET.Sdk.WindowsDesktop.WindowsForms.targets
@@ -5,6 +5,19 @@
     It is referenced via Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.targets.
    -->
 
-<Project>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!-- We disable features for trimmed apps here so that the feature
+      switches can flow to the runtimeconfig.json. -->
+  <PropertyGroup Condition="'$(PublishTrimmed)' == 'true'">
+    <_WinFormsBindingSupport Condition="'$(_WinFormsBindingSupport)' == ''">false</_WinFormsBindingSupport>
+    <_WinFormsUITypeEditorSupport Condition="'$(_WinFormsUITypeEditorSupport)' == ''">false</_WinFormsUITypeEditorSupport>
+    <_ActiveXImplSupport Condition="'$(_ActiveXImplSupport)' == ''">false</_ActiveXImplSupport>
+    <_WinFormsDesignTimeFeaturesSupport Condition="'$(_WinFormsDesignTimeFeaturesSupport)' == ''">false</_WinFormsDesignTimeFeaturesSupport>
+    <_MdiWindowDialogSupport Condition="'$(_MdiWindowDialogSupport)' == ''">false</_MdiWindowDialogSupport>
+    <_WinFormsImageIndexConverterSupport Condition="'$(_WinFormsImageIndexConverterSupport)' == ''">false</_WinFormsImageIndexConverterSupport>
+    <_UseComponentModelRegisteredTypes Condition="'$(_UseComponentModelRegisteredTypes)' == ''">true</_UseComponentModelRegisteredTypes>
+    <_EnableUnsafeBinaryFormatterInNativeObjectSerialization Condition="'$(_EnableUnsafeBinaryFormatterInNativeObjectSerialization)' == ''">false</_EnableUnsafeBinaryFormatterInNativeObjectSerialization>
+  </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Setting default WinForms `msbuild` trim values so that simple WinForms applications like [TrimTest](https://github.com/dotnet/winforms/blob/main/src/System.Windows.Forms/tests/IntegrationTests/TrimTest/TrimTest.csproj) will not generate any trim warnings. These will be used in trimming to set the [RuntimeHostConfigurationOptions](https://github.com/dotnet/sdk/pull/41702) for WinForms trimming.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11568)