### PR TITLE
Add test coverage for PropertyGrid

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/PropertyGridToolStrip.PropertyGridToolStripAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/PropertyGridToolStrip.PropertyGridToolStripAccessibleObjectTests.cs
@@ -55,9 +55,9 @@ public class PropertyGridToolStrip_PropertyGridToolStripAccessibleObjectTests
     {
         using PropertyGrid propertyGrid = new();
         propertyGrid.AccessibleName = parentAccessibleName;
-        using var propertyGridToolStrip = new PropertyGridToolStrip(propertyGrid);
+        using PropertyGridToolStrip propertyGridToolStrip = new(propertyGrid);
         propertyGridToolStrip.AccessibleName = toolStripAccessibleName;
-        var accessibleObject = new PropertyGridToolStrip.PropertyGridToolStripAccessibleObject(propertyGridToolStrip, propertyGrid);
+        PropertyGridToolStrip.PropertyGridToolStripAccessibleObject accessibleObject = new(propertyGridToolStrip, propertyGrid);
 
         string name = accessibleObject.Name;
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/PropertyGridToolStrip.PropertyGridToolStripAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/PropertyGridToolStrip.PropertyGridToolStripAccessibleObjectTests.cs
@@ -47,4 +47,22 @@ public class PropertyGridToolStrip_PropertyGridToolStripAccessibleObjectTests
         Assert.False(propertyGrid.IsHandleCreated);
         Assert.False(propertyGridToolStrip.IsHandleCreated);
     }
+
+    [WinFormsTheory]
+    [InlineData("Test Name", null, "Test Name")]
+    [InlineData(null, "Parent Name", "Parent Name")]
+    public void PropertyGridToolStripAccessibleObject_Name_ReturnsExpected(string toolStripAccessibleName, string parentAccessibleName, string expectedName)
+    {
+        using PropertyGrid propertyGrid = new();
+        propertyGrid.AccessibleName = parentAccessibleName;
+        using var propertyGridToolStrip = new PropertyGridToolStrip(propertyGrid);
+        propertyGridToolStrip.AccessibleName = toolStripAccessibleName;
+        var accessibleObject = new PropertyGridToolStrip.PropertyGridToolStripAccessibleObject(propertyGridToolStrip, propertyGrid);
+
+        string name = accessibleObject.Name;
+
+        name.Should().Be(expectedName);
+        propertyGrid.IsHandleCreated.Should().BeFalse();
+        propertyGridToolStrip.IsHandleCreated.Should().BeFalse();
+    }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridTests.cs
@@ -4081,8 +4081,8 @@ public partial class PropertyGridTests
             eventArgs = e;
         };
 
-        var tab1 = new TestPropertyTab();
-        var tab2 = new TestPropertyTab();
+        TestPropertyTab tab1 = new();
+        TestPropertyTab tab2 = new();
 
         var oldTab = tab2;
         var newTab = tab1;
@@ -4110,7 +4110,7 @@ public partial class PropertyGridTests
             actualSender = sender;
         };
 
-        var gridItemMock = new Mock<GridItem>();
+        Mock<GridItem> gridItemMock = new();
         var gridItem = gridItemMock.Object;
 
         var accessor = propertyGrid.TestAccessor();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridTests.cs
@@ -4083,8 +4083,6 @@ public partial class PropertyGridTests
 
         var tab1 = new TestPropertyTab();
         var tab2 = new TestPropertyTab();
-        propertyGrid.PropertyTabs.AddTabType(tab2.GetType());
-        propertyGrid.PropertyTabs.AddTabType(tab1.GetType());
 
         var oldTab = tab2;
         var newTab = tab1;
@@ -4121,7 +4119,7 @@ public partial class PropertyGridTests
         eventCallCount.Should().Be(1);
         eventArgs.Should().NotBeNull();
         actualSender.Should().Be(propertyGrid);
-        eventArgs?.NewSelection.Should().Be(gridItem);
+        eventArgs.NewSelection.Should().Be(gridItem);
     }
 
     private class SubToolStripRenderer : ToolStripRenderer

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridTests.cs
@@ -4068,6 +4068,62 @@ public partial class PropertyGridTests
         public string Property1 { get; set; }
     }
 
+    [WinFormsFact]
+    public void PropertyGrid_PropertyTabChangedEventTriggered()
+    {
+        using PropertyGrid propertyGrid = new();
+        int eventCallCount = 0;
+        PropertyTabChangedEventArgs eventArgs = null;
+
+        propertyGrid.PropertyTabChanged += (sender, e) =>
+        {
+            eventCallCount++;
+            eventArgs = e;
+        };
+
+        var tab1 = new TestPropertyTab();
+        var tab2 = new TestPropertyTab();
+        propertyGrid.PropertyTabs.AddTabType(tab2.GetType());
+        propertyGrid.PropertyTabs.AddTabType(tab1.GetType());
+
+        var oldTab = tab2;
+        var newTab = tab1;
+        var accessor = propertyGrid.TestAccessor();
+        accessor.Dynamic.OnPropertyTabChanged(new PropertyTabChangedEventArgs(oldTab, newTab));
+
+        eventCallCount.Should().Be(1);
+        eventArgs.Should().NotBeNull();
+        eventArgs.OldTab.Should().Be(oldTab);
+        eventArgs.NewTab.Should().Be(newTab);
+    }
+
+    [WinFormsFact]
+    public void PropertyGrid_SelectedGridItemChanged_TriggeredCorrectly()
+    {
+        using PropertyGrid propertyGrid = new();
+        int eventCallCount = 0;
+        SelectedGridItemChangedEventArgs eventArgs = null;
+        object actualSender = null;
+
+        propertyGrid.SelectedGridItemChanged += (sender, e) =>
+        {
+            eventCallCount++;
+            eventArgs = e;
+            actualSender = sender;
+        };
+
+        var gridItemMock = new Mock<GridItem>();
+        var gridItem = gridItemMock.Object;
+
+        var accessor = propertyGrid.TestAccessor();
+        accessor.Dynamic.OnSelectedGridItemChanged(new SelectedGridItemChangedEventArgs(null, gridItem));
+
+        eventCallCount.Should().Be(1);
+        eventArgs.Should().NotBeNull();
+        actualSender.Should().Be(propertyGrid);
+        eventArgs?.NewSelection.Should().Be(gridItem);
+    }
+
     private class SubToolStripRenderer : ToolStripRenderer
     {
     }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Related https://github.com/dotnet/winforms/issues/10453


## Proposed changes

- Add unit tests for PropertyGrid to test its events: SelectedGridItemChanged, PropertyTabChanged.
- Add unit tests for PropertyGridToolStripAccessibleObject to test its methods: Name.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11587)