### PR TITLE
Move all Clipboard related tests to a new class and remove SkipOnArchitecture label

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/TextBoxBaseTests.ClipboardTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/TextBoxBaseTests.ClipboardTests.cs
@@ -1,0 +1,245 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Windows.Forms.Tests;
+
+public partial class TextBoxBaseTests
+{
+    [Collection("Sequential")]
+    public class ClipboardTests
+    {
+        [ActiveIssue("https://github.com/dotnet/winforms/issues/11497")]
+        [WinFormsFact]
+        [SkipOnArchitecture(TestArchitectures.X86,
+            "Flaky tests, see: https://github.com/dotnet/winforms/issues/11497")]
+        public void TextBoxBase_ClearUndo_CanUndo_Success()
+        {
+            using SubTextBox control = new()
+            {
+                Text = "abc",
+                SelectionStart = 1,
+                SelectionLength = 2
+            };
+            control.Copy();
+
+            control.Text = "text";
+            control.SelectionLength = 2;
+            control.Paste();
+            Assert.Equal("bcxt", control.Text);
+
+            control.ClearUndo();
+            control.Undo();
+            Assert.Equal("bcxt", control.Text);
+        }
+
+        [ActiveIssue("https://github.com/dotnet/winforms/issues/11558")]
+        [WinFormsFact]
+        [SkipOnArchitecture(TestArchitectures.X86,
+            "Flaky tests, see: https://github.com/dotnet/winforms/issues/11558")]
+        public void TextBoxBase_Copy_PasteNotEmpty_Success()
+        {
+            using SubTextBox control = new()
+            {
+                Text = "abc",
+                SelectionStart = 1,
+                SelectionLength = 2
+            };
+            control.Copy();
+            Assert.Equal("abc", control.Text);
+            Assert.True(control.IsHandleCreated);
+
+            control.Text = "text";
+            control.SelectionLength = 2;
+            control.Paste();
+            Assert.Equal("bcxt", control.Text);
+            Assert.True(control.CanUndo);
+            Assert.True(control.Modified);
+            Assert.True(control.IsHandleCreated);
+        }
+
+        [ActiveIssue("https://github.com/dotnet/winforms/issues/11498")]
+        [WinFormsFact]
+        [SkipOnArchitecture(TestArchitectures.X86,
+            "Flaky tests, see: https://github.com/dotnet/winforms/issues/11498")]
+        public void TextBoxBase_Copy_PasteNotEmptyWithHandle_Success()
+        {
+            using SubTextBox control = new()
+            {
+                Text = "abc",
+                SelectionStart = 1,
+                SelectionLength = 2
+            };
+            Assert.NotEqual(IntPtr.Zero, control.Handle);
+            int invalidatedCallCount = 0;
+            control.Invalidated += (sender, e) => invalidatedCallCount++;
+            int styleChangedCallCount = 0;
+            control.StyleChanged += (sender, e) => styleChangedCallCount++;
+            int createdCallCount = 0;
+            control.HandleCreated += (sender, e) => createdCallCount++;
+
+            control.Copy();
+            Assert.Equal("abc", control.Text);
+            Assert.True(control.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
+
+            control.Text = "text";
+            control.SelectionLength = 2;
+            control.Paste();
+            Assert.Equal("bcxt", control.Text);
+            Assert.True(control.CanUndo);
+            Assert.True(control.Modified);
+            Assert.True(control.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
+        }
+
+        [WinFormsFact]
+        public void TextBoxBase_Cut_PasteNotEmpty_Success()
+        {
+            using SubTextBox control = new()
+            {
+                Text = "abc",
+                SelectionStart = 1,
+                SelectionLength = 2
+            };
+            control.Cut();
+            Assert.Equal("a", control.Text);
+            Assert.True(control.IsHandleCreated);
+
+            control.Text = "text";
+            control.SelectionLength = 2;
+            control.Paste();
+            Assert.Equal("bcxt", control.Text);
+            Assert.True(control.CanUndo);
+            Assert.True(control.Modified);
+            Assert.True(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TextBoxBase_Cut_PasteNotEmptyWithHandle_Success()
+        {
+            using SubTextBox control = new()
+            {
+                Text = "abc",
+                SelectionStart = 1,
+                SelectionLength = 2
+            };
+            Assert.NotEqual(IntPtr.Zero, control.Handle);
+            int invalidatedCallCount = 0;
+            control.Invalidated += (sender, e) => invalidatedCallCount++;
+            int styleChangedCallCount = 0;
+            control.StyleChanged += (sender, e) => styleChangedCallCount++;
+            int createdCallCount = 0;
+            control.HandleCreated += (sender, e) => createdCallCount++;
+
+            control.Cut();
+            Assert.Equal("a", control.Text);
+            Assert.True(control.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
+
+            control.Text = "text";
+            control.SelectionLength = 2;
+            control.Paste();
+            Assert.Equal("bcxt", control.Text);
+            Assert.True(control.CanUndo);
+            Assert.True(control.Modified);
+            Assert.True(control.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
+        }
+
+        [WinFormsFact]
+        public void TextBoxBase_Paste_InvokeEmpty_Success()
+        {
+            using SubTextBox control = new();
+            control.Paste();
+            Assert.NotNull(control.Text);
+            Assert.True(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TextBoxBase_Paste_InvokeNotEmpty_Success()
+        {
+            using SubTextBox control = new()
+            {
+                Text = "abc",
+                SelectionStart = 1,
+                SelectionLength = 2
+            };
+            control.Paste();
+            Assert.Equal("abc", control.Text);
+            Assert.True(control.IsHandleCreated);
+        }
+
+        [ActiveIssue("https://github.com/dotnet/winforms/issues/11559")]
+        [WinFormsFact]
+        [SkipOnArchitecture(TestArchitectures.X86,
+            "Flaky tests, see: https://github.com/dotnet/winforms/issues/11559")]
+        public void TextBoxBase_Undo_CanUndo_Success()
+        {
+            using SubTextBox control = new()
+            {
+                Text = "abc",
+                SelectionStart = 1,
+                SelectionLength = 2
+            };
+            control.Copy();
+
+            control.Text = "text";
+            control.SelectionLength = 2;
+            control.Paste();
+            Assert.Equal("bcxt", control.Text);
+
+            control.Undo();
+            Assert.Equal("text", control.Text);
+        }
+
+        [WinFormsFact]
+        public void TextBoxBase_Copy_PasteEmpty_Success()
+        {
+            using SubTextBox control = new();
+            control.Copy();
+            Assert.Empty(control.Text);
+            Assert.True(control.IsHandleCreated);
+
+            control.Text = "text";
+            control.SelectionLength = 2;
+            Assert.Equal("text", control.Text);
+            Assert.True(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TextBoxBase_Copy_PasteEmptyWithHandle_Success()
+        {
+            using SubTextBox control = new();
+            Assert.NotEqual(IntPtr.Zero, control.Handle);
+            int invalidatedCallCount = 0;
+            control.Invalidated += (sender, e) => invalidatedCallCount++;
+            int styleChangedCallCount = 0;
+            control.StyleChanged += (sender, e) => styleChangedCallCount++;
+            int createdCallCount = 0;
+            control.HandleCreated += (sender, e) => createdCallCount++;
+
+            control.Copy();
+            Assert.Empty(control.Text);
+            Assert.True(control.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
+
+            control.Text = "text";
+            control.SelectionLength = 2;
+            Assert.Equal("text", control.Text);
+            Assert.True(control.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/TextBoxBaseTests.ClipboardTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/TextBoxBaseTests.ClipboardTests.cs
@@ -8,10 +8,7 @@ public partial class TextBoxBaseTests
     [Collection("Sequential")]
     public class ClipboardTests
     {
-        [ActiveIssue("https://github.com/dotnet/winforms/issues/11497")]
         [WinFormsFact]
-        [SkipOnArchitecture(TestArchitectures.X86,
-            "Flaky tests, see: https://github.com/dotnet/winforms/issues/11497")]
         public void TextBoxBase_ClearUndo_CanUndo_Success()
         {
             using SubTextBox control = new()
@@ -32,10 +29,7 @@ public partial class TextBoxBaseTests
             Assert.Equal("bcxt", control.Text);
         }
 
-        [ActiveIssue("https://github.com/dotnet/winforms/issues/11558")]
         [WinFormsFact]
-        [SkipOnArchitecture(TestArchitectures.X86,
-            "Flaky tests, see: https://github.com/dotnet/winforms/issues/11558")]
         public void TextBoxBase_Copy_PasteNotEmpty_Success()
         {
             using SubTextBox control = new()
@@ -57,10 +51,7 @@ public partial class TextBoxBaseTests
             Assert.True(control.IsHandleCreated);
         }
 
-        [ActiveIssue("https://github.com/dotnet/winforms/issues/11498")]
         [WinFormsFact]
-        [SkipOnArchitecture(TestArchitectures.X86,
-            "Flaky tests, see: https://github.com/dotnet/winforms/issues/11498")]
         public void TextBoxBase_Copy_PasteNotEmptyWithHandle_Success()
         {
             using SubTextBox control = new()
@@ -177,10 +168,7 @@ public partial class TextBoxBaseTests
             Assert.True(control.IsHandleCreated);
         }
 
-        [ActiveIssue("https://github.com/dotnet/winforms/issues/11559")]
         [WinFormsFact]
-        [SkipOnArchitecture(TestArchitectures.X86,
-            "Flaky tests, see: https://github.com/dotnet/winforms/issues/11559")]
         public void TextBoxBase_Undo_CanUndo_Success()
         {
             using SubTextBox control = new()

--- a/src/System.Windows.Forms/tests/UnitTests/TextBoxBaseTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/TextBoxBaseTests.cs
@@ -4131,136 +4131,6 @@ public partial class TextBoxBaseTests
         Assert.Equal(0, createdCallCount);
     }
 
-    [ActiveIssue("https://github.com/dotnet/winforms/issues/11497")]
-    [WinFormsFact]
-    [SkipOnArchitecture(TestArchitectures.X86,
-        "Flaky tests, see: https://github.com/dotnet/winforms/issues/11497")]
-    public void TextBoxBase_ClearUndo_CanUndo_Success()
-    {
-        using SubTextBox control = new()
-        {
-            Text = "abc",
-            SelectionStart = 1,
-            SelectionLength = 2
-        };
-        control.Copy();
-
-        control.Text = "text";
-        control.SelectionLength = 2;
-        control.Paste();
-        Assert.Equal("bcxt", control.Text);
-
-        control.ClearUndo();
-        control.Undo();
-        Assert.Equal("bcxt", control.Text);
-    }
-
-    [WinFormsFact]
-    public void TextBoxBase_Copy_PasteEmpty_Success()
-    {
-        using SubTextBox control = new();
-        control.Copy();
-        Assert.Empty(control.Text);
-        Assert.True(control.IsHandleCreated);
-
-        control.Text = "text";
-        control.SelectionLength = 2;
-        Assert.Equal("text", control.Text);
-        Assert.True(control.IsHandleCreated);
-    }
-
-    [ActiveIssue("https://github.com/dotnet/winforms/issues/11558")]
-    [WinFormsFact]
-    [SkipOnArchitecture(TestArchitectures.X86,
-        "Flaky tests, see: https://github.com/dotnet/winforms/issues/11558")]
-    public void TextBoxBase_Copy_PasteNotEmpty_Success()
-    {
-        using SubTextBox control = new()
-        {
-            Text = "abc",
-            SelectionStart = 1,
-            SelectionLength = 2
-        };
-        control.Copy();
-        Assert.Equal("abc", control.Text);
-        Assert.True(control.IsHandleCreated);
-
-        control.Text = "text";
-        control.SelectionLength = 2;
-        control.Paste();
-        Assert.Equal("bcxt", control.Text);
-        Assert.True(control.CanUndo);
-        Assert.True(control.Modified);
-        Assert.True(control.IsHandleCreated);
-    }
-
-    [WinFormsFact]
-    public void TextBoxBase_Copy_PasteEmptyWithHandle_Success()
-    {
-        using SubTextBox control = new();
-        Assert.NotEqual(IntPtr.Zero, control.Handle);
-        int invalidatedCallCount = 0;
-        control.Invalidated += (sender, e) => invalidatedCallCount++;
-        int styleChangedCallCount = 0;
-        control.StyleChanged += (sender, e) => styleChangedCallCount++;
-        int createdCallCount = 0;
-        control.HandleCreated += (sender, e) => createdCallCount++;
-
-        control.Copy();
-        Assert.Empty(control.Text);
-        Assert.True(control.IsHandleCreated);
-        Assert.Equal(0, invalidatedCallCount);
-        Assert.Equal(0, styleChangedCallCount);
-        Assert.Equal(0, createdCallCount);
-
-        control.Text = "text";
-        control.SelectionLength = 2;
-        Assert.Equal("text", control.Text);
-        Assert.True(control.IsHandleCreated);
-        Assert.Equal(0, invalidatedCallCount);
-        Assert.Equal(0, styleChangedCallCount);
-        Assert.Equal(0, createdCallCount);
-    }
-
-    [ActiveIssue("https://github.com/dotnet/winforms/issues/11498")]
-    [WinFormsFact]
-    [SkipOnArchitecture(TestArchitectures.X86,
-        "Flaky tests, see: https://github.com/dotnet/winforms/issues/11498")]
-    public void TextBoxBase_Copy_PasteNotEmptyWithHandle_Success()
-    {
-        using SubTextBox control = new()
-        {
-            Text = "abc",
-            SelectionStart = 1,
-            SelectionLength = 2
-        };
-        Assert.NotEqual(IntPtr.Zero, control.Handle);
-        int invalidatedCallCount = 0;
-        control.Invalidated += (sender, e) => invalidatedCallCount++;
-        int styleChangedCallCount = 0;
-        control.StyleChanged += (sender, e) => styleChangedCallCount++;
-        int createdCallCount = 0;
-        control.HandleCreated += (sender, e) => createdCallCount++;
-
-        control.Copy();
-        Assert.Equal("abc", control.Text);
-        Assert.True(control.IsHandleCreated);
-        Assert.Equal(0, invalidatedCallCount);
-        Assert.Equal(0, styleChangedCallCount);
-        Assert.Equal(0, createdCallCount);
-
-        control.Text = "text";
-        control.SelectionLength = 2;
-        control.Paste();
-        Assert.Equal("bcxt", control.Text);
-        Assert.True(control.CanUndo);
-        Assert.True(control.Modified);
-        Assert.True(control.IsHandleCreated);
-        Assert.Equal(0, invalidatedCallCount);
-        Assert.Equal(0, styleChangedCallCount);
-        Assert.Equal(0, createdCallCount);
-    }
-
     [WinFormsFact]
     public void TextBoxBase_CreateHandle_Invoke_Success()
     {
@@ -4310,28 +4180,6 @@ public partial class TextBoxBaseTests
     }
 
     [WinFormsFact]
-    public void TextBoxBase_Cut_PasteNotEmpty_Success()
-    {
-        using SubTextBox control = new()
-        {
-            Text = "abc",
-            SelectionStart = 1,
-            SelectionLength = 2
-        };
-        control.Cut();
-        Assert.Equal("a", control.Text);
-        Assert.True(control.IsHandleCreated);
-
-        control.Text = "text";
-        control.SelectionLength = 2;
-        control.Paste();
-        Assert.Equal("bcxt", control.Text);
-        Assert.True(control.CanUndo);
-        Assert.True(control.Modified);
-        Assert.True(control.IsHandleCreated);
-    }
-
-    [WinFormsFact]
     public void TextBoxBase_Cut_PasteEmptyWithHandle_Success()
     {
         using SubTextBox control = new();
@@ -4353,42 +4201,6 @@ public partial class TextBoxBaseTests
         control.Text = "text";
         control.SelectionLength = 2;
         Assert.Equal("text", control.Text);
-        Assert.True(control.IsHandleCreated);
-        Assert.Equal(0, invalidatedCallCount);
-        Assert.Equal(0, styleChangedCallCount);
-        Assert.Equal(0, createdCallCount);
-    }
-
-    [WinFormsFact]
-    public void TextBoxBase_Cut_PasteNotEmptyWithHandle_Success()
-    {
-        using SubTextBox control = new()
-        {
-            Text = "abc",
-            SelectionStart = 1,
-            SelectionLength = 2
-        };
-        Assert.NotEqual(IntPtr.Zero, control.Handle);
-        int invalidatedCallCount = 0;
-        control.Invalidated += (sender, e) => invalidatedCallCount++;
-        int styleChangedCallCount = 0;
-        control.StyleChanged += (sender, e) => styleChangedCallCount++;
-        int createdCallCount = 0;
-        control.HandleCreated += (sender, e) => createdCallCount++;
-
-        control.Cut();
-        Assert.Equal("a", control.Text);
-        Assert.True(control.IsHandleCreated);
-        Assert.Equal(0, invalidatedCallCount);
-        Assert.Equal(0, styleChangedCallCount);
-        Assert.Equal(0, createdCallCount);
-
-        control.Text = "text";
-        control.SelectionLength = 2;
-        control.Paste();
-        Assert.Equal("bcxt", control.Text);
-        Assert.True(control.CanUndo);
-        Assert.True(control.Modified);
         Assert.True(control.IsHandleCreated);
         Assert.Equal(0, invalidatedCallCount);
         Assert.Equal(0, styleChangedCallCount);
@@ -5987,29 +5799,6 @@ public partial class TextBoxBaseTests
         Assert.False(control.IsHandleCreated);
     }
 
-    [WinFormsFact]
-    public void TextBoxBase_Paste_InvokeEmpty_Success()
-    {
-        using SubTextBox control = new();
-        control.Paste();
-        Assert.NotNull(control.Text);
-        Assert.True(control.IsHandleCreated);
-    }
-
-    [WinFormsFact]
-    public void TextBoxBase_Paste_InvokeNotEmpty_Success()
-    {
-        using SubTextBox control = new()
-        {
-            Text = "abc",
-            SelectionStart = 1,
-            SelectionLength = 2
-        };
-        control.Paste();
-        Assert.Equal("abc", control.Text);
-        Assert.True(control.IsHandleCreated);
-    }
-
     public static IEnumerable<object[]> ProcessCmdKey_TestData()
     {
         foreach (bool shortcutsEnabled in new bool[] { true, false })
@@ -7136,29 +6925,6 @@ public partial class TextBoxBaseTests
         Assert.Equal(0, invalidatedCallCount);
         Assert.Equal(0, styleChangedCallCount);
         Assert.Equal(0, createdCallCount);
-    }
-
-    [ActiveIssue("https://github.com/dotnet/winforms/issues/11559")]
-    [WinFormsFact]
-    [SkipOnArchitecture(TestArchitectures.X86,
-        "Flaky tests, see: https://github.com/dotnet/winforms/issues/11559")]
-    public void TextBoxBase_Undo_CanUndo_Success()
-    {
-        using SubTextBox control = new()
-        {
-            Text = "abc",
-            SelectionStart = 1,
-            SelectionLength = 2
-        };
-        control.Copy();
-
-        control.Text = "text";
-        control.SelectionLength = 2;
-        control.Paste();
-        Assert.Equal("bcxt", control.Text);
-
-        control.Undo();
-        Assert.Equal("text", control.Text);
     }
 
     public static IEnumerable<object[]> WndProc_ContextMenuWithoutContextMenuStrip_TestData()


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Related #11227


## Proposed changes

- Move all Clipboard related tests to a new class and remove SkipOnArchitecture label
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11606)