### PR TITLE
Attempt to use `BinaryFormattedObject`/`BinaryFormatWriter` before `BinaryFormatter`

### DIFF
--- a/src/System.Windows.Forms.Design/src/Resources/SR.resx
+++ b/src/System.Windows.Forms.Design/src/Resources/SR.resx
@@ -1626,4 +1626,7 @@ Press Ctrl+Enter to accept Text.</value>
   <data name="CollectionEditorCreateInstanceError" xml:space="preserve">
     <value>Neither {0} nor {1} can create an instance of {2}.</value>
   </data>
+  <data name="BinaryFormatterNotSupported" xml:space="preserve">
+    <value>Using the BinaryFormatter is not supported in trimmed applications.</value>
+  </data>
 </root>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.cs.xlf
@@ -137,6 +137,11 @@
         <target state="translated">Editor vlastností bajtového pole</target>
         <note />
       </trans-unit>
+      <trans-unit id="BinaryFormatterNotSupported">
+        <source>Using the BinaryFormatter is not supported in trimmed applications.</source>
+        <target state="new">Using the BinaryFormatter is not supported in trimmed applications.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BindingFormattingDialogCustomFormat">
         <source>Custo&amp;m format</source>
         <target state="translated">Vl&amp;astní formát</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.de.xlf
@@ -137,6 +137,11 @@
         <target state="translated">Bytearray-Eigenschaften-Editor</target>
         <note />
       </trans-unit>
+      <trans-unit id="BinaryFormatterNotSupported">
+        <source>Using the BinaryFormatter is not supported in trimmed applications.</source>
+        <target state="new">Using the BinaryFormatter is not supported in trimmed applications.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BindingFormattingDialogCustomFormat">
         <source>Custo&amp;m format</source>
         <target state="translated">Benutzerdef. For&amp;mat</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.es.xlf
@@ -137,6 +137,11 @@
         <target state="translated">Editor de propiedades de matrices de bytes</target>
         <note />
       </trans-unit>
+      <trans-unit id="BinaryFormatterNotSupported">
+        <source>Using the BinaryFormatter is not supported in trimmed applications.</source>
+        <target state="new">Using the BinaryFormatter is not supported in trimmed applications.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BindingFormattingDialogCustomFormat">
         <source>Custo&amp;m format</source>
         <target state="translated">&amp;Personalizar formato</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.fr.xlf
@@ -137,6 +137,11 @@
         <target state="translated">Éditeur de propriétés du tableau d'octets</target>
         <note />
       </trans-unit>
+      <trans-unit id="BinaryFormatterNotSupported">
+        <source>Using the BinaryFormatter is not supported in trimmed applications.</source>
+        <target state="new">Using the BinaryFormatter is not supported in trimmed applications.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BindingFormattingDialogCustomFormat">
         <source>Custo&amp;m format</source>
         <target state="translated">For&amp;mat personnalisé</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.it.xlf
@@ -137,6 +137,11 @@
         <target state="translated">Editor proprietà matrici di byte</target>
         <note />
       </trans-unit>
+      <trans-unit id="BinaryFormatterNotSupported">
+        <source>Using the BinaryFormatter is not supported in trimmed applications.</source>
+        <target state="new">Using the BinaryFormatter is not supported in trimmed applications.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BindingFormattingDialogCustomFormat">
         <source>Custo&amp;m format</source>
         <target state="translated">For&amp;mato personalizzato</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.ja.xlf
@@ -137,6 +137,11 @@
         <target state="translated">バイト配列プロパティ エディター</target>
         <note />
       </trans-unit>
+      <trans-unit id="BinaryFormatterNotSupported">
+        <source>Using the BinaryFormatter is not supported in trimmed applications.</source>
+        <target state="new">Using the BinaryFormatter is not supported in trimmed applications.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BindingFormattingDialogCustomFormat">
         <source>Custo&amp;m format</source>
         <target state="translated">カスタム書式(&amp;M)</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.ko.xlf
@@ -137,6 +137,11 @@
         <target state="translated">바이트 배열 속성 편집기</target>
         <note />
       </trans-unit>
+      <trans-unit id="BinaryFormatterNotSupported">
+        <source>Using the BinaryFormatter is not supported in trimmed applications.</source>
+        <target state="new">Using the BinaryFormatter is not supported in trimmed applications.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BindingFormattingDialogCustomFormat">
         <source>Custo&amp;m format</source>
         <target state="translated">사용자 지정 서식(&amp;M)</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.pl.xlf
@@ -137,6 +137,11 @@
         <target state="translated">Edytor właściwości tablicy bajtowej</target>
         <note />
       </trans-unit>
+      <trans-unit id="BinaryFormatterNotSupported">
+        <source>Using the BinaryFormatter is not supported in trimmed applications.</source>
+        <target state="new">Using the BinaryFormatter is not supported in trimmed applications.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BindingFormattingDialogCustomFormat">
         <source>Custo&amp;m format</source>
         <target state="translated">Format &amp;niestandardowy</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.pt-BR.xlf
@@ -137,6 +137,11 @@
         <target state="translated">Editor de Propriedade da Matriz de Bytes</target>
         <note />
       </trans-unit>
+      <trans-unit id="BinaryFormatterNotSupported">
+        <source>Using the BinaryFormatter is not supported in trimmed applications.</source>
+        <target state="new">Using the BinaryFormatter is not supported in trimmed applications.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BindingFormattingDialogCustomFormat">
         <source>Custo&amp;m format</source>
         <target state="translated">For&amp;mato personalizado</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.ru.xlf
@@ -137,6 +137,11 @@
         <target state="translated">Редактор свойств байтового массива</target>
         <note />
       </trans-unit>
+      <trans-unit id="BinaryFormatterNotSupported">
+        <source>Using the BinaryFormatter is not supported in trimmed applications.</source>
+        <target state="new">Using the BinaryFormatter is not supported in trimmed applications.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BindingFormattingDialogCustomFormat">
         <source>Custo&amp;m format</source>
         <target state="translated">Спец&amp;иальный формат</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.tr.xlf
@@ -137,6 +137,11 @@
         <target state="translated">Bayt Dizisi Özellik Düzenleyicisi</target>
         <note />
       </trans-unit>
+      <trans-unit id="BinaryFormatterNotSupported">
+        <source>Using the BinaryFormatter is not supported in trimmed applications.</source>
+        <target state="new">Using the BinaryFormatter is not supported in trimmed applications.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BindingFormattingDialogCustomFormat">
         <source>Custo&amp;m format</source>
         <target state="translated">&amp;Özel biçim</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.zh-Hans.xlf
@@ -137,6 +137,11 @@
         <target state="translated">字节数组属性编辑器</target>
         <note />
       </trans-unit>
+      <trans-unit id="BinaryFormatterNotSupported">
+        <source>Using the BinaryFormatter is not supported in trimmed applications.</source>
+        <target state="new">Using the BinaryFormatter is not supported in trimmed applications.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BindingFormattingDialogCustomFormat">
         <source>Custo&amp;m format</source>
         <target state="translated">自定义格式(&amp;M)</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.zh-Hant.xlf
@@ -137,6 +137,11 @@
         <target state="translated">位元組陣列屬性編輯器</target>
         <note />
       </trans-unit>
+      <trans-unit id="BinaryFormatterNotSupported">
+        <source>Using the BinaryFormatter is not supported in trimmed applications.</source>
+        <target state="new">Using the BinaryFormatter is not supported in trimmed applications.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BindingFormattingDialogCustomFormat">
         <source>Custo&amp;m format</source>
         <target state="translated">自訂格式(&amp;M)</target>

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomComponentSerializationService.CodeDomSerializationStore.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomComponentSerializationService.CodeDomSerializationStore.cs
@@ -51,7 +51,7 @@ public sealed partial class CodeDomComponentSerializationService
         private ICollection? _errors;
 
 #pragma warning disable IDE0075 // Simplify conditional expression - the simpler expression is hard to read
-        internal static bool EnableUnsafeBinaryFormatterInNativeObjectSerialization { get; } =
+        internal static bool EnableUnsafeBinaryFormatterInNativeObjectSerialization =>
             AppContext.TryGetSwitch("System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization", out bool isEnabled)
                 ? isEnabled
                 : true;
@@ -174,7 +174,7 @@ public sealed partial class CodeDomComponentSerializationService
 
                     try
                     {
-                        success = BinaryFormatWriter.TryWriteFrameworkObject(_resourceStream, _resources.Data);
+                        success = BinaryFormatWriter.TryWriteHashtable(_resourceStream, _resources.Data);
                     }
                     catch (Exception ex) when (!ex.IsCriticalException())
                     {


### PR DESCRIPTION
Fixes #11607 
Related: #9428

Work was based on other usages in `System.Windows.Forms`.

#9416 is not fixed, because I was unable to use `WinFormsBinaryFormatWriter` as its internal to `System.Windows.Forms`. Which allows bitmap serializing.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11614)