### PR TITLE
Fix the issue: the program exits abnormally when helpNamespace property in helpProvider is empty

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Help/Help.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Help/Help.cs
@@ -105,10 +105,9 @@ public static class Help
         // resolve the out of memory condition with file names that include spaces.
         // If we can't, though, we can't assume that the path's no good: it might be in
         // the Windows help directory.
-        Uri? file = null;
+        Uri? file = Resolve(url) ?? throw new ArgumentException(string.Format(SR.HelpInvalidURL, url), nameof(url));
         string? pathAndFileName = url; // This is our best guess at the path yet.
 
-        file = Resolve(url);
         if (file is not null)
         {
             // Can't assume we have a good url
@@ -289,7 +288,7 @@ public static class Help
 
     private static int GetHelpFileType(string? url)
     {
-        if (url is null)
+        if (string.IsNullOrEmpty(url))
         {
             return HTMLFILE;
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Help/HelpProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Help/HelpProvider.cs
@@ -128,7 +128,7 @@ public class HelpProvider : Component, IExtenderProvider
         }
 
         // If we have a help file, and help keyword we try F1 help next
-        if (HelpNamespace is not null)
+        if (!string.IsNullOrEmpty(HelpNamespace))
         {
             if (!string.IsNullOrEmpty(keyword))
             {


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #11583 


## Proposed changes

- 
- 
- 

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- 
- 

## Regression? 

- Yes / No

## Risk

-

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->

### After

<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- 
- 
- 

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

- <!-- use `dotnet --info` -->


<!-- Mention language, UI scaling, or anything else that might be relevant -->
