### PR TITLE
Add code coverage for monthcalendar

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/MonthCalendar.CalendarBodyAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/MonthCalendar.CalendarBodyAccessibleObjectTests.cs
@@ -17,8 +17,9 @@ public class MonthCalendar_CalendarBodyAccessibleObjectTests
         CalendarAccessibleObject calendarAccessibleObject = new(controlAccessibleObject, 0, "Test name");
         CalendarBodyAccessibleObject accessibleObject = new(calendarAccessibleObject, controlAccessibleObject, 0);
 
-        Assert.Equal(calendarAccessibleObject, accessibleObject.Parent);
-        Assert.False(control.IsHandleCreated);
+        accessibleObject.Parent.Should().Be(calendarAccessibleObject);
+        control.IsHandleCreated.Should().BeFalse();
+        accessibleObject.RowOrColumnMajor.Should().Be(RowOrColumnMajor.RowOrColumnMajor_RowMajor);
     }
 
     [WinFormsFact]
@@ -328,13 +329,5 @@ public class MonthCalendar_CalendarBodyAccessibleObjectTests
 
         var accessibleObject = CreateCalendarBodyAccessibleObject(control);
         accessibleObject.CanGetNameInternal.Should().Be(expected);
-    }
-
-    [WinFormsFact]
-    public void CalendarBodyAccessibleObject_RowOrColumnMajor_ReturnsRowMajor()
-    {
-        using MonthCalendar control = new();
-        var accessibleObject = CreateCalendarBodyAccessibleObject(control);
-        accessibleObject.RowOrColumnMajor.Should().Be(RowOrColumnMajor.RowOrColumnMajor_RowMajor);
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/MonthCalendar.CalendarBodyAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/MonthCalendar.CalendarBodyAccessibleObjectTests.cs
@@ -243,4 +243,98 @@ public class MonthCalendar_CalendarBodyAccessibleObjectTests
 
         return bodyAccessibleObject;
     }
+
+    [WinFormsTheory]
+    [InlineData(-1, -1, null)]
+    [InlineData(5, 6, typeof(CalendarCellAccessibleObject))]
+    public void CalendarBodyAccessibleObject_GetItem_ReturnsExpectedResult_ForGivenIndices(int rowIndex, int columnIndex, Type expectedType)
+    {
+        using MonthCalendar control = new();
+        control.CreateControl();
+        CalendarBodyAccessibleObject accessibleObject = CreateCalendarBodyAccessibleObject(control);
+
+        var result = accessibleObject.GetItem(rowIndex, columnIndex);
+
+        if (expectedType is null)
+        {
+            result.Should().BeNull();
+        }
+        else
+        {
+            result.Should().NotBeNull();
+            result.Should().BeOfType(expectedType);
+        }
+
+        control.IsHandleCreated.Should().BeTrue();
+    }
+
+    [WinFormsTheory]
+    [InlineData(true, (int)MONTH_CALDENDAR_MESSAGES_VIEW.MCMV_MONTH, 6)]
+    [InlineData(false, (int)MONTH_CALDENDAR_MESSAGES_VIEW.MCMV_MONTH, 0)]
+    [InlineData(true, (int)MONTH_CALDENDAR_MESSAGES_VIEW.MCMV_YEAR, 0)]
+    [InlineData(true, (int)MONTH_CALDENDAR_MESSAGES_VIEW.MCMV_DECADE, 0)]
+    [InlineData(true, (int)MONTH_CALDENDAR_MESSAGES_VIEW.MCMV_CENTURY, 0)]
+    public void CalendarBodyAccessibleObject_GetRowHeaders_ReturnsExpected(bool showWeekNumbers, int viewInt, int expectedCount)
+    {
+        MONTH_CALDENDAR_MESSAGES_VIEW view = (MONTH_CALDENDAR_MESSAGES_VIEW)viewInt;
+        using MonthCalendar control = new() { ShowWeekNumbers = showWeekNumbers };
+        control.CreateControl();
+        PInvoke.SendMessage(control, PInvoke.MCM_SETCURRENTVIEW, 0, (nint)view);
+        CalendarBodyAccessibleObject accessibleObject = CreateCalendarBodyAccessibleObject(control);
+
+        var rowHeaders = accessibleObject.GetRowHeaders();
+
+        if (expectedCount == 0)
+        {
+            rowHeaders.Should().BeNull();
+        }
+        else
+        {
+            rowHeaders.Should().NotBeNull();
+            rowHeaders.Length.Should().Be(expectedCount);
+        }
+
+        control.IsHandleCreated.Should().BeTrue();
+    }
+
+    [WinFormsFact]
+    public void CalendarBodyAccessibleObject_GetRowHeaders_ReturnsCorrectType()
+    {
+        using MonthCalendar control = new() { ShowWeekNumbers = true };
+        control.CreateControl();
+        CalendarBodyAccessibleObject accessibleObject = CreateCalendarBodyAccessibleObject(control);
+
+        var rowHeaders = accessibleObject.GetRowHeaders();
+
+        rowHeaders.Should().AllBeOfType<CalendarWeekNumberCellAccessibleObject>();
+        control.IsHandleCreated.Should().BeTrue();
+    }
+
+    [WinFormsTheory]
+    [InlineData(null, false)] 
+    [InlineData("CustomName", false)] 
+    [InlineData("AccessibleName", false, true)]
+    public void CalendarBodyAccessibleObject_CanGetNameInternal_ShouldBeConsistentlyFalse(string name, bool expected, bool isAccessibleName = false)
+    {
+        using MonthCalendar control = new();
+        if (isAccessibleName)
+        {
+            control.AccessibleName = name;
+        }
+        else
+        {
+            control.Name = name;
+        }
+
+        var accessibleObject = CreateCalendarBodyAccessibleObject(control);
+        accessibleObject.CanGetNameInternal.Should().Be(expected);
+    }
+
+    [WinFormsFact]
+    public void CalendarBodyAccessibleObject_RowOrColumnMajor_ReturnsRowMajor()
+    {
+        using MonthCalendar control = new();
+        var accessibleObject = CreateCalendarBodyAccessibleObject(control);
+        accessibleObject.RowOrColumnMajor.Should().Be(RowOrColumnMajor.RowOrColumnMajor_RowMajor);
+    }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/MonthCalendar.CalendarButtonAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/MonthCalendar.CalendarButtonAccessibleObjectTests.cs
@@ -125,6 +125,18 @@ public class MonthCalendar_CalendarButtonAccessibleObjectTests
         control.IsHandleCreated.Should().BeTrue();
     }
 
+    [WinFormsFact]
+    public void CalendarButtonAccessibleObject_CanGetDefaultActionInternal_ReturnsFalse()
+    {
+        using MonthCalendar control = new();
+        MonthCalendarAccessibleObject controlAccessibleObject = (MonthCalendarAccessibleObject)control.AccessibilityObject;
+        CalendarButtonAccessibleObject buttonAccessibleObject = new SubCalendarButtonAccessibleObject(controlAccessibleObject);
+
+        bool canGetDefaultActionInternal = buttonAccessibleObject.TestAccessor().Dynamic.CanGetDefaultActionInternal;
+
+        canGetDefaultActionInternal.Should().BeFalse();
+    }
+
     private class SubCalendarButtonAccessibleObject : CalendarButtonAccessibleObject
     {
         public SubCalendarButtonAccessibleObject(MonthCalendarAccessibleObject calendarAccessibleObject)

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/MonthCalendar.CalendarButtonAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/MonthCalendar.CalendarButtonAccessibleObjectTests.cs
@@ -15,9 +15,11 @@ public class MonthCalendar_CalendarButtonAccessibleObjectTests
         MonthCalendarAccessibleObject controlAccessibleObject = (MonthCalendarAccessibleObject)control.AccessibilityObject;
         CalendarButtonAccessibleObject buttonAccessibleObject = new SubCalendarButtonAccessibleObject(controlAccessibleObject);
 
-        Assert.Equal(controlAccessibleObject, buttonAccessibleObject.Parent);
-        Assert.Equal(controlAccessibleObject, buttonAccessibleObject.TestAccessor().Dynamic._monthCalendarAccessibleObject);
-        Assert.False(control.IsHandleCreated);
+        buttonAccessibleObject.Parent.Should().Be(controlAccessibleObject);
+
+        bool canGetDefaultActionInternal = buttonAccessibleObject.TestAccessor().Dynamic.CanGetDefaultActionInternal;
+        canGetDefaultActionInternal.Should().BeFalse();
+        control.IsHandleCreated.Should().BeFalse();
     }
 
     [WinFormsFact]
@@ -123,18 +125,6 @@ public class MonthCalendar_CalendarButtonAccessibleObjectTests
 
         action.Should().NotThrow();
         control.IsHandleCreated.Should().BeTrue();
-    }
-
-    [WinFormsFact]
-    public void CalendarButtonAccessibleObject_CanGetDefaultActionInternal_ReturnsFalse()
-    {
-        using MonthCalendar control = new();
-        MonthCalendarAccessibleObject controlAccessibleObject = (MonthCalendarAccessibleObject)control.AccessibilityObject;
-        CalendarButtonAccessibleObject buttonAccessibleObject = new SubCalendarButtonAccessibleObject(controlAccessibleObject);
-
-        bool canGetDefaultActionInternal = buttonAccessibleObject.TestAccessor().Dynamic.CanGetDefaultActionInternal;
-
-        canGetDefaultActionInternal.Should().BeFalse();
     }
 
     private class SubCalendarButtonAccessibleObject : CalendarButtonAccessibleObject

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/MonthCalendar.CalendarCellAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/MonthCalendar.CalendarCellAccessibleObjectTests.cs
@@ -16,10 +16,18 @@ public class MonthCalendar_CalendarCellAccessibleObjectTests
         using MonthCalendar control = new();
         CalendarCellAccessibleObject cellAccessibleObject = CreateCalendarCellAccessibleObject(control);
 
-        Assert.Equal(0, cellAccessibleObject.TestAccessor().Dynamic._calendarIndex);
-        Assert.Equal(0, cellAccessibleObject.TestAccessor().Dynamic._rowIndex);
-        Assert.Equal(0, cellAccessibleObject.TestAccessor().Dynamic._columnIndex);
-        Assert.False(control.IsHandleCreated);
+        int columnIndexResult = cellAccessibleObject.TestAccessor().Dynamic._columnIndex;
+        columnIndexResult.Should().Be(0);
+
+        int rowIndexResult = cellAccessibleObject.TestAccessor().Dynamic._rowIndex;
+        rowIndexResult.Should().Be(0);
+
+        int calendarIndexResult = cellAccessibleObject.TestAccessor().Dynamic._calendarIndex;
+        calendarIndexResult.Should().Be(0);
+
+        cellAccessibleObject.CanGetDescriptionInternal.Should().BeFalse();
+        cellAccessibleObject.GetColumnHeaderItems().Should().BeNull();
+        control.IsHandleCreated.Should().BeFalse();
     }
 
     public static IEnumerable<object[]> CalendarCellAccessibleObject_Bounds_ReturnsExpected_TestData()
@@ -248,25 +256,6 @@ public class MonthCalendar_CalendarCellAccessibleObjectTests
         Assert.Null(cell.FragmentNavigate(NavigateDirection.NavigateDirection_FirstChild));
         Assert.Null(cell.FragmentNavigate(NavigateDirection.NavigateDirection_LastChild));
         Assert.False(control.IsHandleCreated);
-    }
-
-    [WinFormsFact]
-    public void CalendarCellAccessibleObject_CanGetDescriptionInternal_ReturnsFalse()
-    {
-        using MonthCalendar control = new();
-        CalendarCellAccessibleObject cellAccessibleObject = CreateCalendarCellAccessibleObject(control);
-
-        bool canGetDescription = cellAccessibleObject.CanGetDescriptionInternal;
-
-        canGetDescription.Should().BeFalse();
-    }
-
-    [WinFormsFact]
-    public void CalendarCellAccessibleObject_GetColumnHeaderItems_ReturnsNull_IfHandleNotCreated()
-    {
-        using MonthCalendar control = new();
-        CalendarCellAccessibleObject cellAccessibleObject = CreateCalendarCellAccessibleObject(control);
-        cellAccessibleObject.GetColumnHeaderItems().Should().BeNull();
     }
 
     [WinFormsTheory]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/MonthCalendar.CalendarCellAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/MonthCalendar.CalendarCellAccessibleObjectTests.cs
@@ -249,4 +249,48 @@ public class MonthCalendar_CalendarCellAccessibleObjectTests
         Assert.Null(cell.FragmentNavigate(NavigateDirection.NavigateDirection_LastChild));
         Assert.False(control.IsHandleCreated);
     }
+
+    [WinFormsFact]
+    public void CalendarCellAccessibleObject_CanGetDescriptionInternal_ReturnsFalse()
+    {
+        using MonthCalendar control = new();
+        CalendarCellAccessibleObject cellAccessibleObject = CreateCalendarCellAccessibleObject(control);
+
+        bool canGetDescription = cellAccessibleObject.CanGetDescriptionInternal;
+
+        canGetDescription.Should().BeFalse();
+    }
+
+    [WinFormsFact]
+    public void CalendarCellAccessibleObject_GetColumnHeaderItems_ReturnsNull_IfHandleNotCreated()
+    {
+        using MonthCalendar control = new();
+        CalendarCellAccessibleObject cellAccessibleObject = CreateCalendarCellAccessibleObject(control);
+        cellAccessibleObject.GetColumnHeaderItems().Should().BeNull();
+    }
+
+    [WinFormsTheory]
+    [InlineData(true, 1, typeof(CalendarWeekNumberCellAccessibleObject))]
+    [InlineData(false, 0, null)]
+    public void CalendarCellAccessibleObject_GetRowHeaderItems_ReturnsCorrectly(bool showWeekNumbers, int expectedCount, Type expectedType)
+    {
+        using MonthCalendar control = new() { ShowWeekNumbers = showWeekNumbers };
+        control.CreateControl();
+        CalendarCellAccessibleObject cellAccessibleObject = CreateCalendarCellAccessibleObject(control, 0, 2, 2);
+
+        var rowHeaderItems = cellAccessibleObject.GetRowHeaderItems();
+
+        if (expectedCount == 0)
+        {
+            rowHeaderItems.Should().BeNull("no week number cells should be present as row headers when week numbers are not visible");
+        }
+        else
+        {
+            rowHeaderItems.Should().NotBeNull();
+            rowHeaderItems.Should().HaveCount(expectedCount, $"expected {expectedCount} week number cell(s) as row header(s)");
+            rowHeaderItems[0].Should().BeAssignableTo(expectedType, "the row header should match the expected type");
+        }
+
+        control.IsHandleCreated.Should().BeTrue();
+    }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/MonthCalendar.CalendarDayOfWeekCellAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/MonthCalendar.CalendarDayOfWeekCellAccessibleObjectTests.cs
@@ -209,4 +209,15 @@ public class MonthCalendar_CalendarDayOfWeekCellAccessibleObjectTests
 
         return cellAccessibleObject;
     }
+
+    [WinFormsFact]
+    public void CalendarDayOfWeekCellAccessibleObject_IsPatternSupported_CallsBaseForUnsupportedPatterns_UsingFluentAssertions()
+    {
+        using MonthCalendar control = new();
+        CalendarDayOfWeekCellAccessibleObject cellAccessibleObject = CreateCalendarDayOfWeekCellCellAccessibleObject(control);
+        UIA_PATTERN_ID basePatternId = UIA_PATTERN_ID.UIA_ExpandCollapsePatternId;
+
+        bool actual = cellAccessibleObject.IsPatternSupported(basePatternId);
+        actual.Should().BeFalse();
+    }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/MonthCalendar.CalendarDayOfWeekCellAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/MonthCalendar.CalendarDayOfWeekCellAccessibleObjectTests.cs
@@ -14,11 +14,18 @@ public class MonthCalendar_CalendarDayOfWeekCellAccessibleObjectTests
         using MonthCalendar control = new();
         CalendarDayOfWeekCellAccessibleObject cellAccessibleObject = CreateCalendarDayOfWeekCellCellAccessibleObject(control);
 
-        Assert.Equal(0, cellAccessibleObject.TestAccessor().Dynamic._calendarIndex);
-        Assert.Equal(0, cellAccessibleObject.TestAccessor().Dynamic._rowIndex);
-        Assert.Equal(0, cellAccessibleObject.TestAccessor().Dynamic._columnIndex);
-        Assert.Equal("Test name", cellAccessibleObject.Name);
-        Assert.False(control.IsHandleCreated);
+        int columnIndexResult = cellAccessibleObject.TestAccessor().Dynamic._columnIndex;
+        columnIndexResult.Should().Be(0);
+
+        int rowIndexResult = cellAccessibleObject.TestAccessor().Dynamic._rowIndex;
+        rowIndexResult.Should().Be(0);
+
+        int calendarIndexResult = cellAccessibleObject.TestAccessor().Dynamic._calendarIndex;
+        calendarIndexResult.Should().Be(0);
+
+        cellAccessibleObject.Name.Should().Be("Test name");
+        cellAccessibleObject.IsPatternSupported(UIA_PATTERN_ID.UIA_ExpandCollapsePatternId).Should().BeFalse();
+        control.IsHandleCreated.Should().BeFalse();
     }
 
     [WinFormsFact]
@@ -208,16 +215,5 @@ public class MonthCalendar_CalendarDayOfWeekCellAccessibleObjectTests
         CalendarDayOfWeekCellAccessibleObject cellAccessibleObject = new(rowAccessibleObject, bodyAccessibleObject, controlAccessibleObject, calendarIndex, rowIndex, columnIndex, "Test name");
 
         return cellAccessibleObject;
-    }
-
-    [WinFormsFact]
-    public void CalendarDayOfWeekCellAccessibleObject_IsPatternSupported_CallsBaseForUnsupportedPatterns_UsingFluentAssertions()
-    {
-        using MonthCalendar control = new();
-        CalendarDayOfWeekCellAccessibleObject cellAccessibleObject = CreateCalendarDayOfWeekCellCellAccessibleObject(control);
-        UIA_PATTERN_ID basePatternId = UIA_PATTERN_ID.UIA_ExpandCollapsePatternId;
-
-        bool actual = cellAccessibleObject.IsPatternSupported(basePatternId);
-        actual.Should().BeFalse();
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/MonthCalendar.CalendarHeaderAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/MonthCalendar.CalendarHeaderAccessibleObjectTests.cs
@@ -61,4 +61,14 @@ public class MonthCalendar_CalendarHeaderAccessibleObjectTests
 
         return headerAccessibleObject;
     }
+
+    [WinFormsFact]
+    public void CalendarHeaderAccessibleObject_CanGetNameInternal_ReturnsFalse()
+    {
+        using MonthCalendar control = new();
+        CalendarHeaderAccessibleObject headerAccessibleObject = CreateCalendarHeaderAccessibleObject(control);
+        bool canGetName = headerAccessibleObject.CanGetNameInternal;
+
+        canGetName.Should().BeFalse();
+    }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/MonthCalendar.CalendarHeaderAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/MonthCalendar.CalendarHeaderAccessibleObjectTests.cs
@@ -24,6 +24,7 @@ public class MonthCalendar_CalendarHeaderAccessibleObjectTests
         headerAccessibleObject.FragmentNavigate(NavigateDirection.NavigateDirection_PreviousSibling).Should().BeNull();
         headerAccessibleObject.FragmentNavigate(NavigateDirection.NavigateDirection_FirstChild).Should().BeNull();
         headerAccessibleObject.FragmentNavigate(NavigateDirection.NavigateDirection_LastChild).Should().BeNull();
+        headerAccessibleObject.CanGetNameInternal.Should().BeFalse();
     }
 
     [WinFormsFact]
@@ -60,15 +61,5 @@ public class MonthCalendar_CalendarHeaderAccessibleObjectTests
         CalendarHeaderAccessibleObject headerAccessibleObject = new(calendarAccessibleObject, controlAccessibleObject, calendarIndex);
 
         return headerAccessibleObject;
-    }
-
-    [WinFormsFact]
-    public void CalendarHeaderAccessibleObject_CanGetNameInternal_ReturnsFalse()
-    {
-        using MonthCalendar control = new();
-        CalendarHeaderAccessibleObject headerAccessibleObject = CreateCalendarHeaderAccessibleObject(control);
-        bool canGetName = headerAccessibleObject.CanGetNameInternal;
-
-        canGetName.Should().BeFalse();
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/MonthCalendar.CalendarNextButtonAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/MonthCalendar.CalendarNextButtonAccessibleObjectTests.cs
@@ -30,6 +30,8 @@ public class MonthCalendar_CalendarNextButtonAccessibleObjectTests
 
         nextButtonAccessibleObject.FragmentNavigate(NavigateDirection.NavigateDirection_PreviousSibling).Should().BeSameAs(previousButton);
         nextButtonAccessibleObject.FragmentNavigate(NavigateDirection.NavigateDirection_NextSibling).Should().BeSameAs(firstCalendar);
+        nextButtonAccessibleObject.CanGetDescriptionInternal.Should().BeFalse();
+        nextButtonAccessibleObject.CanGetNameInternal.Should().BeFalse();
 
         Rectangle actual = nextButtonAccessibleObject.Bounds;
         Rectangle actualInClientCoordinates = control.RectangleToClient(actual);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/MonthCalendar.CalendarPreviousButtonAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/MonthCalendar.CalendarPreviousButtonAccessibleObjectTests.cs
@@ -15,8 +15,10 @@ public class MonthCalendar_CalendarPreviousButtonAccessibleObjectTests
         var controlAccessibleObject = (MonthCalendarAccessibleObject)control.AccessibilityObject;
         CalendarPreviousButtonAccessibleObject previousButtonAccessibleObject = new(controlAccessibleObject);
 
-        Assert.Equal(controlAccessibleObject, previousButtonAccessibleObject.TestAccessor().Dynamic._monthCalendarAccessibleObject);
-        Assert.False(control.IsHandleCreated);
+        controlAccessibleObject.Should().BeEquivalentTo(previousButtonAccessibleObject.TestAccessor().Dynamic._monthCalendarAccessibleObject);
+        control.IsHandleCreated.Should().BeFalse();
+        previousButtonAccessibleObject.CanGetDescriptionInternal.Should().BeFalse();
+        previousButtonAccessibleObject.CanGetNameInternal.Should().BeFalse();
     }
 
     [WinFormsFact]
@@ -93,19 +95,5 @@ public class MonthCalendar_CalendarPreviousButtonAccessibleObjectTests
         Assert.Null(prevButton.FragmentNavigate(NavigateDirection.NavigateDirection_FirstChild));
         Assert.Null(prevButton.FragmentNavigate(NavigateDirection.NavigateDirection_LastChild));
         Assert.False(control.IsHandleCreated);
-    }
-
-    [WinFormsFact]
-    public void CalendarPreviousButtonAccessibleObject_CanGetDescriptionInternal_And_CanGetNameInternal_ReturnFalse()
-    {
-        using MonthCalendar control = new();
-        var controlAccessibleObject = (MonthCalendarAccessibleObject)control.AccessibilityObject;
-        CalendarPreviousButtonAccessibleObject previousButtonAccessibleObject = new(controlAccessibleObject);
-
-        bool canGetDescription = previousButtonAccessibleObject.CanGetDescriptionInternal;
-        bool canGetName = previousButtonAccessibleObject.CanGetNameInternal;
-
-        canGetDescription.Should().BeFalse();
-        canGetName.Should().BeFalse();
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/MonthCalendar.CalendarPreviousButtonAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/MonthCalendar.CalendarPreviousButtonAccessibleObjectTests.cs
@@ -94,4 +94,18 @@ public class MonthCalendar_CalendarPreviousButtonAccessibleObjectTests
         Assert.Null(prevButton.FragmentNavigate(NavigateDirection.NavigateDirection_LastChild));
         Assert.False(control.IsHandleCreated);
     }
+
+    [WinFormsFact]
+    public void CalendarPreviousButtonAccessibleObject_CanGetDescriptionInternal_And_CanGetNameInternal_ReturnFalse()
+    {
+        using MonthCalendar control = new();
+        var controlAccessibleObject = (MonthCalendarAccessibleObject)control.AccessibilityObject;
+        CalendarPreviousButtonAccessibleObject previousButtonAccessibleObject = new(controlAccessibleObject);
+
+        bool canGetDescription = previousButtonAccessibleObject.CanGetDescriptionInternal;
+        bool canGetName = previousButtonAccessibleObject.CanGetNameInternal;
+
+        canGetDescription.Should().BeFalse();
+        canGetName.Should().BeFalse();
+    }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/MonthCalendar.CalendarRowAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/MonthCalendar.CalendarRowAccessibleObjectTests.cs
@@ -14,9 +14,15 @@ public class MonthCalendar_CalendarRowAccessibleObjectTests
         using MonthCalendar control = new();
         CalendarRowAccessibleObject rowAccessibleObject = CreateCalendarRowAccessibleObject(control);
 
-        Assert.Equal(0, rowAccessibleObject.TestAccessor().Dynamic._calendarIndex);
-        Assert.Equal(0, rowAccessibleObject.TestAccessor().Dynamic._rowIndex);
-        Assert.False(control.IsHandleCreated);
+        int calendarIndexResult = rowAccessibleObject.TestAccessor().Dynamic._calendarIndex;
+        calendarIndexResult.Should().Be(0);
+
+        int rowIndexResult = rowAccessibleObject.TestAccessor().Dynamic._rowIndex;
+        rowIndexResult.Should().Be(0);
+
+        control.IsHandleCreated.Should().BeFalse();
+        rowAccessibleObject.CanGetDescriptionInternal.Should().BeFalse();
+        rowAccessibleObject.CanGetNameInternal.Should().BeFalse();
     }
 
     [WinFormsTheory]
@@ -206,15 +212,5 @@ public class MonthCalendar_CalendarRowAccessibleObjectTests
         CalendarRowAccessibleObject rowAccessibleObject = new(bodyAccessibleObject, controlAccessibleObject, calendarIndex, rowIndex);
 
         return rowAccessibleObject;
-    }
-
-    [WinFormsFact]
-    public void CalendarRowAccessibleObject_CanGetDescriptionAndNameInternal_ShouldBeFalse()
-    {
-        using MonthCalendar control = new();
-        CalendarRowAccessibleObject rowAccessibleObject = CreateCalendarRowAccessibleObject(control);
-
-        rowAccessibleObject.CanGetDescriptionInternal.Should().BeFalse();
-        rowAccessibleObject.CanGetNameInternal.Should().BeFalse();
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/MonthCalendar.CalendarRowAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/MonthCalendar.CalendarRowAccessibleObjectTests.cs
@@ -209,12 +209,12 @@ public class MonthCalendar_CalendarRowAccessibleObjectTests
     }
 
     [WinFormsFact]
-    public void CalendarRowAccessibleObject_CanGetDescriptionInternal_ReturnsFalse()
+    public void CalendarRowAccessibleObject_CanGetDescriptionAndNameInternal_ShouldBeFalse()
     {
         using MonthCalendar control = new();
         CalendarRowAccessibleObject rowAccessibleObject = CreateCalendarRowAccessibleObject(control);
 
         rowAccessibleObject.CanGetDescriptionInternal.Should().BeFalse();
-        control.IsHandleCreated.Should().BeFalse();
+        rowAccessibleObject.CanGetNameInternal.Should().BeFalse();
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/MonthCalendar.CalendarTodayLinkAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/MonthCalendar.CalendarTodayLinkAccessibleObjectTests.cs
@@ -114,4 +114,18 @@ public class MonthCalendar_CalendarTodayLinkAccessibleObjectTests
         Assert.Null(todayLink.FragmentNavigate(NavigateDirection.NavigateDirection_LastChild));
         Assert.False(control.IsHandleCreated);
     }
+
+    [WinFormsFact]
+    public void CalendarTodayLinkAccessibleObject_CanGetDescriptionInternalAndCanGetNameInternal_ReturnsFalse()
+    {
+        using MonthCalendar control = new();
+        var controlAccessibleObject = (MonthCalendarAccessibleObject)control.AccessibilityObject;
+        CalendarTodayLinkAccessibleObject todayLinkAccessibleObject = new(controlAccessibleObject);
+
+        bool canGetDescription = todayLinkAccessibleObject.TestAccessor().Dynamic.CanGetDescriptionInternal;
+        bool canGetName = todayLinkAccessibleObject.TestAccessor().Dynamic.CanGetNameInternal;
+
+        canGetDescription.Should().BeFalse();
+        canGetName.Should().BeFalse();
+    }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/MonthCalendar.CalendarTodayLinkAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/MonthCalendar.CalendarTodayLinkAccessibleObjectTests.cs
@@ -14,9 +14,15 @@ public class MonthCalendar_CalendarTodayLinkAccessibleObjectTests
         using MonthCalendar control = new();
         var controlAccessibleObject = (MonthCalendarAccessibleObject)control.AccessibilityObject;
         CalendarTodayLinkAccessibleObject todayLinkAccessibleObject = new(controlAccessibleObject);
+     
+        controlAccessibleObject.Should().BeEquivalentTo(todayLinkAccessibleObject.TestAccessor().Dynamic._monthCalendarAccessibleObject);
+        control.IsHandleCreated.Should().BeFalse();
 
-        Assert.Equal(controlAccessibleObject, todayLinkAccessibleObject.TestAccessor().Dynamic._monthCalendarAccessibleObject);
-        Assert.False(control.IsHandleCreated);
+        bool canGetDescriptionInternalResult = todayLinkAccessibleObject.TestAccessor().Dynamic.CanGetDescriptionInternal;
+        canGetDescriptionInternalResult.Should().BeFalse();
+
+        bool CanGetNameInternalResult = todayLinkAccessibleObject.TestAccessor().Dynamic.CanGetNameInternal;
+        CanGetNameInternalResult.Should().BeFalse();
     }
 
     [WinFormsFact]
@@ -113,19 +119,5 @@ public class MonthCalendar_CalendarTodayLinkAccessibleObjectTests
         Assert.Null(todayLink.FragmentNavigate(NavigateDirection.NavigateDirection_FirstChild));
         Assert.Null(todayLink.FragmentNavigate(NavigateDirection.NavigateDirection_LastChild));
         Assert.False(control.IsHandleCreated);
-    }
-
-    [WinFormsFact]
-    public void CalendarTodayLinkAccessibleObject_CanGetDescriptionInternalAndCanGetNameInternal_ReturnsFalse()
-    {
-        using MonthCalendar control = new();
-        var controlAccessibleObject = (MonthCalendarAccessibleObject)control.AccessibilityObject;
-        CalendarTodayLinkAccessibleObject todayLinkAccessibleObject = new(controlAccessibleObject);
-
-        bool canGetDescription = todayLinkAccessibleObject.TestAccessor().Dynamic.CanGetDescriptionInternal;
-        bool canGetName = todayLinkAccessibleObject.TestAccessor().Dynamic.CanGetNameInternal;
-
-        canGetDescription.Should().BeFalse();
-        canGetName.Should().BeFalse();
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/MonthCalendar.CalendarWeekNumberCellAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/MonthCalendar.CalendarWeekNumberCellAccessibleObjectTests.cs
@@ -196,6 +196,22 @@ public class MonthCalendar_CalendarWeekNumberCellAccessibleObjectTests
         Assert.False(control.IsHandleCreated);
     }
 
+    [WinFormsTheory]
+    [InlineData((int)UIA_PATTERN_ID.UIA_InvokePatternId, false)]
+    [InlineData((int)UIA_PATTERN_ID.UIA_GridItemPatternId, false)]
+    [InlineData((int)UIA_PATTERN_ID.UIA_TableItemPatternId, false)]
+    [InlineData(9999, false)]
+    public void CalendarWeekNumberCellAccessibleObject_IsPatternSupported_ReturnsExpected(int patternIdAsInt, bool expected)
+    {
+        using MonthCalendar control = new();
+
+        CalendarWeekNumberCellAccessibleObject cellAccessibleObject = CreateCalendarWeekNumberCellAccessibleObject(control);
+        UIA_PATTERN_ID patternId = (UIA_PATTERN_ID)patternIdAsInt;
+        bool isSupported = cellAccessibleObject.IsPatternSupported(patternId);
+
+        isSupported.Should().Be(expected, $"because pattern {patternId} support should be {expected} for CalendarWeekNumberCellAccessibleObject.");
+    }
+
     private CalendarWeekNumberCellAccessibleObject CreateCalendarWeekNumberCellAccessibleObject(MonthCalendar control, int calendarIndex = 0, int rowIndex = 0, int columnIndex = 0)
     {
         MonthCalendarAccessibleObject controlAccessibleObject = (MonthCalendarAccessibleObject)control.AccessibilityObject;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/MonthCalendar.CalendarWeekNumberCellAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/MonthCalendar.CalendarWeekNumberCellAccessibleObjectTests.cs
@@ -200,16 +200,16 @@ public class MonthCalendar_CalendarWeekNumberCellAccessibleObjectTests
     [InlineData((int)UIA_PATTERN_ID.UIA_InvokePatternId, false)]
     [InlineData((int)UIA_PATTERN_ID.UIA_GridItemPatternId, false)]
     [InlineData((int)UIA_PATTERN_ID.UIA_TableItemPatternId, false)]
+    [InlineData((int)UIA_PATTERN_ID.UIA_LegacyIAccessiblePatternId, true)]
     [InlineData(9999, false)]
     public void CalendarWeekNumberCellAccessibleObject_IsPatternSupported_ReturnsExpected(int patternIdAsInt, bool expected)
     {
         using MonthCalendar control = new();
 
         CalendarWeekNumberCellAccessibleObject cellAccessibleObject = CreateCalendarWeekNumberCellAccessibleObject(control);
-        UIA_PATTERN_ID patternId = (UIA_PATTERN_ID)patternIdAsInt;
-        bool isSupported = cellAccessibleObject.IsPatternSupported(patternId);
+        bool isSupported = cellAccessibleObject.IsPatternSupported((UIA_PATTERN_ID)patternIdAsInt);
 
-        isSupported.Should().Be(expected, $"because pattern {patternId} support should be {expected} for CalendarWeekNumberCellAccessibleObject.");
+        isSupported.Should().Be(expected, $"because pattern {(UIA_PATTERN_ID)patternIdAsInt} support should be {expected} for CalendarWeekNumberCellAccessibleObject.");
     }
 
     private CalendarWeekNumberCellAccessibleObject CreateCalendarWeekNumberCellAccessibleObject(MonthCalendar control, int calendarIndex = 0, int rowIndex = 0, int columnIndex = 0)

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/MonthCalendar.MonthCalendarAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/MonthCalendar.MonthCalendarAccessibleObjectTests.cs
@@ -119,26 +119,6 @@ public class MonthCalendar_MonthCalendarAccessibleObjectTests
         Assert.Equal(-1, accessibleObject.ColumnCount);
     }
 
-    [WinFormsFact]
-    public void MonthCalendarAccessibleObject_RowCount_IsZero_IfHandleIsNotCreated()
-    {
-        using MonthCalendar monthCalendar = new();
-        var accessibleObject = (MonthCalendarAccessibleObject)monthCalendar.AccessibilityObject;
-
-        Assert.False(monthCalendar.IsHandleCreated);
-        Assert.Equal(0, accessibleObject.RowCount);
-    }
-
-    [WinFormsFact]
-    public void MonthCalendarAccessibleObject_CalendarsAccessibleObjects_IsNull_IfHandleIsNotCreated()
-    {
-        using MonthCalendar monthCalendar = new();
-        var accessibleObject = (MonthCalendarAccessibleObject)monthCalendar.AccessibilityObject;
-
-        Assert.False(monthCalendar.IsHandleCreated);
-        Assert.Null(accessibleObject.CalendarsAccessibleObjects);
-    }
-
     public static IEnumerable<object[]> MonthCalendarAccessibleObject_Date_ReturnsExpected_TestData()
     {
         yield return new object[] { new DateTime(2000, 1, 1) };
@@ -309,12 +289,15 @@ public class MonthCalendar_MonthCalendarAccessibleObjectTests
     }
 
     [WinFormsFact]
-    public void GetColumnHeaders_ShouldReturnNull()
+    public void MonthCalendarAccessibleObject_Constructor_InitializesPropertiesCorrectly()
     {
         using MonthCalendar monthCalendar = new();
         MonthCalendarAccessibleObject accessibleObject = new(monthCalendar);
 
         accessibleObject.GetColumnHeaders().Should().BeNull();
+        accessibleObject.RowCount.Should().Be(0);
+        accessibleObject.CalendarsAccessibleObjects.Should().BeNull();
+        monthCalendar.IsHandleCreated.Should().BeFalse();
     }
 
     [WinFormsFact]
@@ -398,35 +381,18 @@ public class MonthCalendar_MonthCalendarAccessibleObjectTests
     }
 
     [WinFormsFact]
-    public void MonthCalendarAccessibleObject_SetFocus_RaisesAutomationEvent_IfFocusedCellIsNotNull()
+    public void MonthCalendarAccessibleObject_FocusedCell_Validation_WhenOwnerHasFocusedDate()
     {
-        using MonthCalendar monthCalendar = new();
-        monthCalendar.CreateControl();
-        var accessibleObject = (MonthCalendarAccessibleObject)monthCalendar.AccessibilityObject;
+        using MonthCalendar calendar = new();
+        calendar.CreateControl();
+        MonthCalendarAccessibleObject accessibleObject = new(calendar);
 
-        var focusedCell = accessibleObject.FocusedCell;
-        focusedCell.Should().NotBeNull();
+        calendar.SetDate(DateTime.Today);
+        var focusedCellAfterSetDate = accessibleObject.FocusedCell;
+        focusedCellAfterSetDate.Should().NotBeNull();
+        focusedCellAfterSetDate.DateRange.Start.Date.Should().Be(DateTime.Today);
 
-        bool eventRaised = false;
-        focusedCell.RaiseAutomationEvent(UIA_EVENT_ID.UIA_AutomationFocusChangedEventId);
-        eventRaised = true;
-
-        accessibleObject.SetFocus();
-        eventRaised.Should().BeTrue();
-        monthCalendar.IsHandleCreated.Should().BeTrue();
-    }
-
-    [WinFormsFact]
-    public void MonthCalendarAccessibleObject_SetFocus_DoesNotRaiseAutomationEvent_IfFocusedCellIsNull()
-    {
-        using MonthCalendar monthCalendar = new();
-        var accessibleObject = (MonthCalendarAccessibleObject)monthCalendar.AccessibilityObject;
-
-        accessibleObject.FocusedCell.Should().BeNull();
-
-        bool eventRaised = false;
-
-        accessibleObject.SetFocus();
-        eventRaised.Should().BeFalse();
+        var focusedCellAfterSecondCall = accessibleObject.FocusedCell;
+        focusedCellAfterSetDate.Should().BeSameAs(focusedCellAfterSecondCall);
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/MonthCalendar.MonthCalendarAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/MonthCalendar.MonthCalendarAccessibleObjectTests.cs
@@ -275,4 +275,158 @@ public class MonthCalendar_MonthCalendarAccessibleObjectTests
 
         Assert.Equal(lastCalendar, accessibleObject.FragmentNavigate(NavigateDirection.NavigateDirection_LastChild));
     }
+
+    [WinFormsFact]
+    public void MonthCalendarAccessibleObject_TodayDate_ReturnsOwnerTodayDate_IfOwnerIsNotNull()
+    {
+        using MonthCalendar monthCalendar = new();
+        DateTime expectedTodayDate = new(2023, 1, 1);
+        monthCalendar.TodayDate = expectedTodayDate;
+        var accessibleObject = new MonthCalendarAccessibleObject(monthCalendar);
+
+        accessibleObject.TodayDate.Should().Be(expectedTodayDate);
+    }
+
+    [WinFormsTheory]
+    [BoolData]
+    public void MonthCalendarAccessibleObject_ShowWeekNumbers_IsExpected(bool showWeekNumbers)
+    {
+        using MonthCalendar monthCalendar = new();
+        monthCalendar.ShowWeekNumbers = showWeekNumbers;
+        var accessibleObject = (MonthCalendarAccessibleObject)monthCalendar.AccessibilityObject;
+
+        accessibleObject.ShowWeekNumbers.Should().Be(showWeekNumbers);
+    }
+
+    [WinFormsFact]
+    public void MonthCalendarAccessibleObject_FirstDayOfWeek_ReturnsExpected()
+    {
+        using MonthCalendar monthCalendar = new();
+        monthCalendar.FirstDayOfWeek = Day.Monday;
+        var accessibleObject = (MonthCalendarAccessibleObject)monthCalendar.AccessibilityObject;
+
+        accessibleObject.FirstDayOfWeek.Should().Be(DayOfWeek.Monday);
+    }
+
+    [WinFormsFact]
+    public void GetColumnHeaders_ShouldReturnNull()
+    {
+        using MonthCalendar monthCalendar = new();
+        MonthCalendarAccessibleObject accessibleObject = new(monthCalendar);
+
+        accessibleObject.GetColumnHeaders().Should().BeNull();
+    }
+
+    [WinFormsFact]
+    public void MonthCalendarAccessibleObject_GetFocus_ReturnsFocusedCell()
+    {
+        using MonthCalendar monthCalendar = new();
+        monthCalendar.CreateControl();
+        var accessibleObject = (MonthCalendarAccessibleObject)monthCalendar.AccessibilityObject;
+
+        DateTime focusedDate = new(2023, 10, 1);
+        monthCalendar.SetDate(focusedDate);
+
+        var focusedCell = accessibleObject.FocusedCell;
+        var focus = accessibleObject.GetFocus();
+
+        focus.Should().Be(focusedCell);
+        monthCalendar.IsHandleCreated.Should().BeTrue();
+    }
+
+    [WinFormsFact]
+    public void MonthCalendarAccessibleObject_GetFocus_ReturnsNull_IfNoFocusedCell()
+    {
+        using MonthCalendar monthCalendar = new();
+
+        var accessibleObject = (MonthCalendarAccessibleObject)monthCalendar.AccessibilityObject;
+        var focus = accessibleObject.GetFocus();
+
+        focus.Should().BeNull();
+    }
+
+    [WinFormsFact]
+    public void CanGetHelpInternal_ShouldBeFalse()
+    {
+        using MonthCalendar monthCalendar = new();
+        MonthCalendarAccessibleObject accessibleObject = new(monthCalendar);
+
+        accessibleObject.CanGetHelpInternal.Should().BeFalse();
+        monthCalendar.IsHandleCreated.Should().BeFalse();
+    }
+
+    [WinFormsTheory]
+    [BoolData]
+    public void MonthCalendarAccessibleObject_IsEnabled_ReturnsExpected(bool enabled)
+    {
+        using MonthCalendar monthCalendar = new();
+        monthCalendar.Enabled = enabled;
+        var accessibleObject = (MonthCalendarAccessibleObject)monthCalendar.AccessibilityObject;
+
+        accessibleObject.IsEnabled.Should().Be(enabled);
+    }
+
+    [WinFormsTheory]
+    [BoolData]
+    public void MonthCalendarAccessibleObject_RowOrColumnMajor_ReturnsExpected(bool createControl)
+    {
+        using MonthCalendar monthCalendar = new();
+        if (createControl)
+        {
+            monthCalendar.CreateControl();
+        }
+
+        var accessibleObject = (MonthCalendarAccessibleObject)monthCalendar.AccessibilityObject;
+
+        accessibleObject.RowOrColumnMajor.Should().Be(RowOrColumnMajor.RowOrColumnMajor_RowMajor);
+        monthCalendar.IsHandleCreated.Should().Be(createControl);
+    }
+
+    [WinFormsFact]
+    public void MonthCalendarAccessibleObject_SelectionRange_ReturnsExpected_IfHandleIsCreated()
+    {
+        using MonthCalendar monthCalendar = new();
+        monthCalendar.CreateControl();
+        var accessibleObject = (MonthCalendarAccessibleObject)monthCalendar.AccessibilityObject;
+
+        SelectionRange expected = monthCalendar.SelectionRange;
+        SelectionRange actual = accessibleObject.SelectionRange;
+
+        actual.Start.Should().Be(expected.Start);
+        actual.End.Should().Be(expected.End);
+        monthCalendar.IsHandleCreated.Should().BeTrue();
+    }
+
+    [WinFormsFact]
+    public void MonthCalendarAccessibleObject_SetFocus_RaisesAutomationEvent_IfFocusedCellIsNotNull()
+    {
+        using MonthCalendar monthCalendar = new();
+        monthCalendar.CreateControl();
+        var accessibleObject = (MonthCalendarAccessibleObject)monthCalendar.AccessibilityObject;
+
+        var focusedCell = accessibleObject.FocusedCell;
+        focusedCell.Should().NotBeNull();
+
+        bool eventRaised = false;
+        focusedCell.RaiseAutomationEvent(UIA_EVENT_ID.UIA_AutomationFocusChangedEventId);
+        eventRaised = true;
+
+        accessibleObject.SetFocus();
+        eventRaised.Should().BeTrue();
+        monthCalendar.IsHandleCreated.Should().BeTrue();
+    }
+
+    [WinFormsFact]
+    public void MonthCalendarAccessibleObject_SetFocus_DoesNotRaiseAutomationEvent_IfFocusedCellIsNull()
+    {
+        using MonthCalendar monthCalendar = new();
+        var accessibleObject = (MonthCalendarAccessibleObject)monthCalendar.AccessibilityObject;
+
+        accessibleObject.FocusedCell.Should().BeNull();
+
+        bool eventRaised = false;
+
+        accessibleObject.SetFocus();
+        eventRaised.Should().BeFalse();
+    }
 }


### PR DESCRIPTION
related https://github.com/dotnet/winforms/issues/10453

## Proposed changes
- Add unit tests for MonthCalendar to test its properties:AccessibleName, RowOrColumnMajor, canGetDefaultActionInternal, GetColumnHeaderItems, IsPatternSupported, CanGetNameInternal, CanGetDescriptionInternal, ShowWeekNumbers
- Add unit tests for MonthCalendar to test its methods: GetItem(), GetRowHeaders(), GetRowHeaderItems(), GetColumnHeaderItems(), 

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11619)