### PR TITLE
Add unit tests for CheckedListBox and CheckedListBox.CheckedListBoxItemAccessibleObject

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/CheckedListBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/CheckedListBoxTests.cs
@@ -843,6 +843,19 @@ public class CheckedListBoxTests
         callCount.Should().Be(1);
     }
 
+    [WinFormsFact]
+    public void CheckedListBox_DrawItemEvent_AddRemove_Success()
+    {
+        using SubCheckedListBox checkedListBox = new();
+        DrawItemEventHandler handler = (sender, e) => { };
+
+        Action actAdd = () => checkedListBox.DrawItem += handler;
+        Action actRemove = () => checkedListBox.DrawItem -= handler;
+
+        actAdd.Should().NotThrow();
+        actRemove.Should().NotThrow();
+    }
+
     private class SubCheckedListBox : CheckedListBox
     {
         public new int _listItemBordersHeight => base._listItemBordersHeight;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/CheckedListBoxItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/CheckedListBoxItemAccessibleObjectTests.cs
@@ -323,4 +323,52 @@ public class CheckedListBoxItemAccessibleObjectTests
         Assert.Equal(isChecked, bool.Parse(((BSTR)accessibleObject.GetPropertyValue(UIA_PROPERTY_ID.UIA_ValueValuePropertyId)).ToStringAndFree()));
         Assert.False(checkedListBox.IsHandleCreated);
     }
+
+    [WinFormsFact]
+    public void CheckedListBoxItemAccessibleObject_State_ReturnsNone_WhenHandleNotCreated()
+    {
+        using CheckedListBox checkedListBox = new();
+        var item = new CheckedListBox.CheckedListBoxItemAccessibleObject(
+            checkedListBox,
+            new ItemArray.Entry("Item 1"),
+            (CheckedListBoxAccessibleObject)checkedListBox.AccessibilityObject);
+
+        item.State.Should().Be(AccessibleStates.None);
+    }
+
+    [WinFormsTheory]
+    [InlineData(null, AccessibleStates.Indeterminate)]
+    [InlineData(true, AccessibleStates.Checked)]
+    [InlineData(false, AccessibleStates.None)]
+    public void CheckedListBoxItemAccessibleObject_State_ReturnsExpected(bool? isChecked, AccessibleStates expectedState)
+    {
+        using CheckedListBox checkedListBox = new();
+        checkedListBox.Items.Add("Item 1",
+            isChecked.HasValue
+                ? (isChecked.Value ? CheckState.Checked : CheckState.Unchecked)
+                : CheckState.Indeterminate);
+        checkedListBox.CreateControl();
+        var item = new CheckedListBox.CheckedListBoxItemAccessibleObject(
+            checkedListBox,
+            checkedListBox.Items.InnerArray.GetEntryObject(0, 0),
+            (CheckedListBoxAccessibleObject)checkedListBox.AccessibilityObject);
+
+        item.State.Should().HaveFlag(expectedState);
+    }
+
+    [WinFormsFact]
+    public void CheckedListBoxItemAccessibleObject_State_ReturnsExpected_ForSelectedAndFocusedItem()
+    {
+        using CheckedListBox checkedListBox = new();
+        checkedListBox.Items.Add("Item 1");
+        checkedListBox.CreateControl();
+        checkedListBox.SelectedIndex = 0; // Select and focus the first item
+        var item = new CheckedListBox.CheckedListBoxItemAccessibleObject(
+            checkedListBox,
+            checkedListBox.Items.InnerArray.GetEntryObject(0, 0),
+            (CheckedListBoxAccessibleObject)checkedListBox.AccessibilityObject);
+
+        item.State.Should().HaveFlag(AccessibleStates.Selected)
+                       .And.HaveFlag(AccessibleStates.Focused);
+    }
 }


### PR DESCRIPTION
Related https://github.com/dotnet/winforms/issues/10453
## Proposed changes

- Add unit test for CheckedListBox to test its event: DrawItem
- Add unit tests for CheckedListBox.CheckedListBoxItemAccessibleObject to test its property: AccessibleStates 

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11647)