### PR TITLE
Refactor to use `GetService<T>` and reduce nesting

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ListView/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ListView/ListView.cs
@@ -6168,24 +6168,20 @@ public partial class ListView : Control
 
             ISite? site = Site;
 
-            if (site is not null)
+            if (site?.TryGetService(out IComponentChangeService? service) == true)
             {
-                IComponentChangeService? cs = (IComponentChangeService?)site.GetService(typeof(IComponentChangeService));
-                if (cs is not null)
+                try
                 {
-                    try
+                    service.OnComponentChanging(this, null);
+                }
+                catch (CheckoutException coEx)
+                {
+                    if (coEx == CheckoutException.Canceled)
                     {
-                        cs.OnComponentChanging(this, null);
+                        return false;
                     }
-                    catch (CheckoutException coEx)
-                    {
-                        if (coEx == CheckoutException.Canceled)
-                        {
-                            return false;
-                        }
 
-                        throw;
-                    }
+                    throw;
                 }
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/WebBrowser/WebBrowserContainer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/WebBrowser/WebBrowserContainer.cs
@@ -270,28 +270,23 @@ internal unsafe class WebBrowserContainer : IOleContainer.Interface, IOleInPlace
 
     private bool RegisterControl(WebBrowserBase ctl)
     {
-        if (ctl.Site is ISite site)
+        if (ctl.Site is not ISite site || site.Container is not IContainer container)
         {
-            if (site.Container is IContainer cont)
-            {
-                if (_associatedContainer is not null)
-                {
-                    return cont == _associatedContainer;
-                }
-                else
-                {
-                    _associatedContainer = cont;
-                    if (site.GetService(typeof(IComponentChangeService)) is IComponentChangeService ccs)
-                    {
-                        ccs.ComponentRemoved += new ComponentEventHandler(OnComponentRemoved);
-                    }
-
-                    return true;
-                }
-            }
+            return false;
         }
 
-        return false;
+        if (_associatedContainer is not null)
+        {
+            return container == _associatedContainer;
+        }
+
+        _associatedContainer = container;
+        if (site.TryGetService(out IComponentChangeService? service))
+        {
+            service.ComponentRemoved += new ComponentEventHandler(OnComponentRemoved);
+        }
+
+        return true;
     }
 
     private void OnComponentRemoved(object? sender, ComponentEventArgs e)
@@ -314,16 +309,15 @@ internal unsafe class WebBrowserContainer : IOleContainer.Interface, IOleInPlace
 
         _containerCache.Add(ctl);
 
-        if (_associatedContainer is null)
+        if (_associatedContainer is not null || ctl.Site is not ISite site)
         {
-            if (ctl.Site is ISite site)
-            {
-                _associatedContainer = site.Container;
-                if (site.GetService(typeof(IComponentChangeService)) is IComponentChangeService ccs)
-                {
-                    ccs.ComponentRemoved += new ComponentEventHandler(OnComponentRemoved);
-                }
-            }
+            return;
+        }
+
+        _associatedContainer = site.Container;
+        if (site.TryGetService(out IComponentChangeService? service))
+        {
+            service.ComponentRemoved += new ComponentEventHandler(OnComponentRemoved);
         }
     }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Design/ComponentEditorForm.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Design/ComponentEditorForm.cs
@@ -167,13 +167,9 @@ public partial class ComponentEditorForm : Form
     private void OnConfigureUI()
     {
         Font? uiFont = DefaultFont;
-        if (_component.Site is not null)
+        if (_component.Site?.TryGetService(out IUIService? uiService) == true)
         {
-            IUIService? uiService = (IUIService?)_component.Site.GetService(typeof(IUIService));
-            if (uiService is not null)
-            {
-                uiFont = (Font?)uiService.Styles["DialogFont"];
-            }
+            uiFont = (Font?)uiService.Styles["DialogFont"];
         }
 
         Font = uiFont;


### PR DESCRIPTION
Refactor remaining `GetService` calls to use `GetService<T>` and reduce nesting in `System.Windows.Forms`.