### PR TITLE
Adds Value type

### DIFF
--- a/Winforms.sln
+++ b/Winforms.sln
@@ -177,6 +177,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TrimTestBinaryDeserializati
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BinaryFormatTests", "src\System.Private.Windows.Core\tests\BinaryFormatTests\BinaryFormatTests.csproj", "{57EC5288-9513-46CF-8FB7-626199690D90}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Private.Windows.Core.Tests", "src\System.Private.Windows.Core\tests\System.Private.Windows.Core.Tests\System.Private.Windows.Core.Tests.csproj", "{B653C860-9B52-4597-9921-24DA79A4E6B1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -981,6 +983,22 @@ Global
 		{57EC5288-9513-46CF-8FB7-626199690D90}.Release|x64.Build.0 = Release|Any CPU
 		{57EC5288-9513-46CF-8FB7-626199690D90}.Release|x86.ActiveCfg = Release|Any CPU
 		{57EC5288-9513-46CF-8FB7-626199690D90}.Release|x86.Build.0 = Release|Any CPU
+		{B653C860-9B52-4597-9921-24DA79A4E6B1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B653C860-9B52-4597-9921-24DA79A4E6B1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B653C860-9B52-4597-9921-24DA79A4E6B1}.Debug|arm64.ActiveCfg = Debug|Any CPU
+		{B653C860-9B52-4597-9921-24DA79A4E6B1}.Debug|arm64.Build.0 = Debug|Any CPU
+		{B653C860-9B52-4597-9921-24DA79A4E6B1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B653C860-9B52-4597-9921-24DA79A4E6B1}.Debug|x64.Build.0 = Debug|Any CPU
+		{B653C860-9B52-4597-9921-24DA79A4E6B1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B653C860-9B52-4597-9921-24DA79A4E6B1}.Debug|x86.Build.0 = Debug|Any CPU
+		{B653C860-9B52-4597-9921-24DA79A4E6B1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B653C860-9B52-4597-9921-24DA79A4E6B1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B653C860-9B52-4597-9921-24DA79A4E6B1}.Release|arm64.ActiveCfg = Release|Any CPU
+		{B653C860-9B52-4597-9921-24DA79A4E6B1}.Release|arm64.Build.0 = Release|Any CPU
+		{B653C860-9B52-4597-9921-24DA79A4E6B1}.Release|x64.ActiveCfg = Release|Any CPU
+		{B653C860-9B52-4597-9921-24DA79A4E6B1}.Release|x64.Build.0 = Release|Any CPU
+		{B653C860-9B52-4597-9921-24DA79A4E6B1}.Release|x86.ActiveCfg = Release|Any CPU
+		{B653C860-9B52-4597-9921-24DA79A4E6B1}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1044,6 +1062,7 @@ Global
 		{55F3174F-C1FE-4C8F-AF71-2512630088F8} = {583F1292-AE8D-4511-B8D8-A81FE4642DDC}
 		{CFBCC732-C988-4FE7-A21B-98A142365374} = {680FB14C-7B0C-4D63-9F1A-18ACCDB0F52A}
 		{57EC5288-9513-46CF-8FB7-626199690D90} = {583F1292-AE8D-4511-B8D8-A81FE4642DDC}
+		{B653C860-9B52-4597-9921-24DA79A4E6B1} = {583F1292-AE8D-4511-B8D8-A81FE4642DDC}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7B1B0433-F612-4E5A-BE7E-FCF5B9F6E136}

--- a/src/System.Private.Windows.Core/src/Properties/AssemblyInfo.cs
+++ b/src/System.Private.Windows.Core/src/Properties/AssemblyInfo.cs
@@ -15,6 +15,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("System.Windows.Forms.Primitives.Tests, PublicKey=00000000000000000400000000000000")]
 [assembly: InternalsVisibleTo("System.Windows.Forms.Primitives.TestUtilities, PublicKey=00000000000000000400000000000000")]
 [assembly: InternalsVisibleTo("System.Windows.Forms.Tests, PublicKey=00000000000000000400000000000000")]
+[assembly: InternalsVisibleTo("System.Private.Windows.Core.Tests, PublicKey=00000000000000000400000000000000")]
 [assembly: InternalsVisibleTo("BinaryFormatTests, PublicKey=00000000000000000400000000000000")]
 [assembly: InternalsVisibleTo("System.Windows.Forms.TestUtilities, PublicKey=00000000000000000400000000000000")]
 [assembly: InternalsVisibleTo("System.Windows.Forms.UI.IntegrationTests, PublicKey=00000000000000000400000000000000")]

--- a/src/System.Private.Windows.Core/src/System/Value.DateTimeOffsetFlag.cs
+++ b/src/System.Private.Windows.Core/src/System/Value.DateTimeOffsetFlag.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System;
+
+internal readonly partial struct Value
+{
+    private sealed class DateTimeOffsetFlag : TypeFlag<DateTimeOffset>
+    {
+        public static DateTimeOffsetFlag Instance { get; } = new();
+
+        public override DateTimeOffset To(in Value value)
+            => new(new DateTime(value._union.Ticks, DateTimeKind.Utc));
+    }
+}

--- a/src/System.Private.Windows.Core/src/System/Value.DateTimeOffsetFlag.cs
+++ b/src/System.Private.Windows.Core/src/System/Value.DateTimeOffsetFlag.cs
@@ -9,7 +9,6 @@ internal readonly partial struct Value
     {
         public static DateTimeOffsetFlag Instance { get; } = new();
 
-        public override DateTimeOffset To(in Value value)
-            => new(new DateTime(value._union.Ticks, DateTimeKind.Utc));
+        public override DateTimeOffset To(in Value value) => new(new DateTime(value._union.Ticks, DateTimeKind.Utc));
     }
 }

--- a/src/System.Private.Windows.Core/src/System/Value.NullableTemplate.cs
+++ b/src/System.Private.Windows.Core/src/System/Value.NullableTemplate.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+
+namespace System;
+
+internal readonly partial struct Value
+{
+    [StructLayout(LayoutKind.Sequential)]
+    private readonly struct NullableTemplate<T> where T : unmanaged
+    {
+        public readonly bool _hasValue;
+        public readonly T _value;
+
+        public NullableTemplate(T value)
+        {
+            _value = value;
+            _hasValue = true;
+        }
+    }
+}

--- a/src/System.Private.Windows.Core/src/System/Value.PackedDateTimeOffset.cs
+++ b/src/System.Private.Windows.Core/src/System/Value.PackedDateTimeOffset.cs
@@ -1,0 +1,77 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System;
+
+internal readonly partial struct Value
+{
+    /// <summary>
+    ///  Allows packing some <see cref="DateTimeOffset"/> values into a single <see cref="ulong"/>.
+    /// </summary>
+    private readonly struct PackedDateTimeOffset
+    {
+        // HHHHHMMT TTT...
+        //
+        // HHHHH   - hour bits 1-31
+        // MM      - minutes flag
+        // T       - ticks bit
+        //            00 - :00
+        //            01 - :15
+        //            10 - :30
+        //            11 - :45
+
+        // Base local tick time 1800 [DateTime(1800, 1, 1).Ticks]
+        private const ulong BaseTicks = 567709344000000000;
+        private const ulong MaxTicks = BaseTicks + TickMask;
+
+        // Hours go from -14 to 14. We add 14 to get our number to store.
+        private const int HourOffset = 14;
+
+        private const ulong TickMask    = 0b00000001_11111111_11111111_11111111__11111111_11111111_11111111_11111111;
+        private const ulong MinuteMask  = 0b00000110_00000000_00000000_00000000__00000000_00000000_00000000_00000000;
+        private const ulong HourMask    = 0b11111000_00000000_00000000_00000000__00000000_00000000_00000000_00000000;
+
+        private const int MinuteShift = 57;
+        private const int HourShift = 59;
+
+        private readonly ulong _data;
+
+        private PackedDateTimeOffset(ulong data) => _data = data;
+
+        public static bool TryCreate(DateTimeOffset dateTime, TimeSpan offset, out PackedDateTimeOffset packed)
+        {
+            bool result = false;
+            packed = default;
+
+            ulong ticks = (ulong)dateTime.Ticks;
+            if (ticks is > BaseTicks and < MaxTicks)
+            {
+                ulong data = default;
+                int minutes = offset.Minutes;
+                if (minutes % 15 == 0)
+                {
+                    data = (ulong)(minutes / 15) << MinuteShift;
+                    int hours = offset.Hours + HourOffset;
+
+                    // Only valid offset hours are -14 to 14
+                    Debug.Assert(hours is >= 0 and <= 28);
+                    data |= (ulong)hours << HourShift;
+                    data |= ticks - BaseTicks;
+                    packed = new(data);
+                    result = true;
+                }
+            }
+
+            return result;
+        }
+
+        public DateTimeOffset Extract()
+        {
+            TimeSpan offset = new(
+                (int)(((_data & HourMask) >> HourShift) - HourOffset),
+                (int)((_data & MinuteMask) >> MinuteShift),
+                0);
+            return new((long)((_data & TickMask) + BaseTicks), offset);
+        }
+    }
+}

--- a/src/System.Private.Windows.Core/src/System/Value.PackedDateTimeOffsetFlag.cs
+++ b/src/System.Private.Windows.Core/src/System/Value.PackedDateTimeOffsetFlag.cs
@@ -9,7 +9,6 @@ internal readonly partial struct Value
     {
         public static PackedDateTimeOffsetFlag Instance { get; } = new();
 
-        public override DateTimeOffset To(in Value value)
-            => value._union.PackedDateTimeOffset.Extract();
+        public override DateTimeOffset To(in Value value) => value._union.PackedDateTimeOffset.Extract();
     }
 }

--- a/src/System.Private.Windows.Core/src/System/Value.PackedDateTimeOffsetFlag.cs
+++ b/src/System.Private.Windows.Core/src/System/Value.PackedDateTimeOffsetFlag.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System;
+
+internal readonly partial struct Value
+{
+    private sealed class PackedDateTimeOffsetFlag : TypeFlag<DateTimeOffset>
+    {
+        public static PackedDateTimeOffsetFlag Instance { get; } = new();
+
+        public override DateTimeOffset To(in Value value)
+            => value._union.PackedDateTimeOffset.Extract();
+    }
+}

--- a/src/System.Private.Windows.Core/src/System/Value.StraightCastFlag.cs
+++ b/src/System.Private.Windows.Core/src/System/Value.StraightCastFlag.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+namespace System;
+
+internal readonly partial struct Value
+{
+    /// <summary>
+    ///  <see cref="TypeFlag"/> that handles types that are a simple cast from a <see cref="Union"/>
+    ///  to a <typeparamref name="T"/>.
+    /// </summary>
+    private sealed class StraightCastFlag<T> : TypeFlag<T>
+    {
+        public static StraightCastFlag<T> Instance { get; } = new();
+
+        public override T To(in Value value)
+            => Unsafe.As<Union, T>(ref Unsafe.AsRef(in value._union));
+    }
+}

--- a/src/System.Private.Windows.Core/src/System/Value.StraightCastFlag.cs
+++ b/src/System.Private.Windows.Core/src/System/Value.StraightCastFlag.cs
@@ -15,7 +15,6 @@ internal readonly partial struct Value
     {
         public static StraightCastFlag<T> Instance { get; } = new();
 
-        public override T To(in Value value)
-            => Unsafe.As<Union, T>(ref Unsafe.AsRef(in value._union));
+        public override T To(in Value value) => Unsafe.As<Union, T>(ref Unsafe.AsRef(in value._union));
     }
 }

--- a/src/System.Private.Windows.Core/src/System/Value.TypeFlag.cs
+++ b/src/System.Private.Windows.Core/src/System/Value.TypeFlag.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+namespace System;
+
+internal readonly partial struct Value
+{
+    /// <summary>
+    ///  A flag that represents the <see cref="System.Type"/> of a <see cref="Union"/> in a <see cref="Value"/>.
+    ///  Also provides the functionality to convert any <see cref="Value"/> to an <see langword="object"/> that
+    ///  already isn't an <see langword="object"/>.
+    /// </summary>
+    private abstract class TypeFlag
+    {
+        public abstract Type Type
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get;
+        }
+
+        /// <summary>
+        ///  Converts the given <see cref="Value"/> to an <see langword="object"/>.
+        /// </summary>
+        public abstract object ToObject(in Value value);
+    }
+
+    /// <summary>
+    ///  Strongly typed <see cref="TypeFlag"/>.
+    /// </summary>
+    private abstract class TypeFlag<T> : TypeFlag
+    {
+        public sealed override Type Type
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => typeof(T);
+        }
+
+        public override object ToObject(in Value value) => To(value)!;
+        public abstract T To(in Value value);
+    }
+}

--- a/src/System.Private.Windows.Core/src/System/Value.TypeFlags.cs
+++ b/src/System.Private.Windows.Core/src/System/Value.TypeFlags.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System;
+
+internal readonly partial struct Value
+{
+    private static class TypeFlags
+    {
+        internal static StraightCastFlag<bool> Boolean { get; } = StraightCastFlag<bool>.Instance;
+        internal static StraightCastFlag<char> Char { get; } = StraightCastFlag<char>.Instance;
+        internal static StraightCastFlag<byte> Byte { get; } = StraightCastFlag<byte>.Instance;
+        internal static StraightCastFlag<sbyte> SByte { get; } = StraightCastFlag<sbyte>.Instance;
+        internal static StraightCastFlag<short> Int16 { get; } = StraightCastFlag<short>.Instance;
+        internal static StraightCastFlag<ushort> UInt16 { get; } = StraightCastFlag<ushort>.Instance;
+        internal static StraightCastFlag<int> Int32 { get; } = StraightCastFlag<int>.Instance;
+        internal static StraightCastFlag<uint> UInt32 { get; } = StraightCastFlag<uint>.Instance;
+        internal static StraightCastFlag<long> Int64 { get; } = StraightCastFlag<long>.Instance;
+        internal static StraightCastFlag<ulong> UInt64 { get; } = StraightCastFlag<ulong>.Instance;
+        internal static StraightCastFlag<float> Single { get; } = StraightCastFlag<float>.Instance;
+        internal static StraightCastFlag<double> Double { get; } = StraightCastFlag<double>.Instance;
+        internal static StraightCastFlag<DateTime> DateTime { get; } = StraightCastFlag<DateTime>.Instance;
+        internal static DateTimeOffsetFlag DateTimeOffset { get; } = DateTimeOffsetFlag.Instance;
+        internal static PackedDateTimeOffsetFlag PackedDateTimeOffset { get; } = PackedDateTimeOffsetFlag.Instance;
+    }
+}

--- a/src/System.Private.Windows.Core/src/System/Value.Union.cs
+++ b/src/System.Private.Windows.Core/src/System/Value.Union.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+
+namespace System;
+
+internal readonly partial struct Value
+{
+    /// <summary>
+    ///  Data union for the <see cref="Value"/> type.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   Data can be any blittable type, but should be 8 bytes or less to avoid growing the size of the
+    ///   <see cref="Value"/> type.
+    ///  </para>
+    /// </remarks>
+    [StructLayout(LayoutKind.Explicit, CharSet = CharSet.Unicode)]
+    private struct Union
+    {
+        [FieldOffset(0)] public byte Byte;
+        [FieldOffset(0)] public sbyte SByte;
+        [FieldOffset(0)] public char Char;
+        [FieldOffset(0)] public bool Boolean;
+        [FieldOffset(0)] public short Int16;
+        [FieldOffset(0)] public ushort UInt16;
+        [FieldOffset(0)] public int Int32;
+        [FieldOffset(0)] public uint UInt32;
+        [FieldOffset(0)] public long Int64;
+        [FieldOffset(0)] public long Ticks;
+        [FieldOffset(0)] public ulong UInt64;
+        [FieldOffset(0)] public float Single;                   // 4 bytes
+        [FieldOffset(0)] public double Double;                  // 8 bytes
+        [FieldOffset(0)] public DateTime DateTime;              // 8 bytes  (ulong)
+        [FieldOffset(0)] public PackedDateTimeOffset PackedDateTimeOffset;
+        [FieldOffset(0)] public (int Offset, int Count) Segment;
+    }
+}

--- a/src/System.Private.Windows.Core/src/System/Value.cs
+++ b/src/System.Private.Windows.Core/src/System/Value.cs
@@ -1,0 +1,947 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+namespace System;
+
+/// <summary>
+///  A struct that can hold any value type or reference type without boxing primitive types or enums. Behavior matches
+///  casting to/from <see langword="object"/>.
+/// </summary>
+/// <devdoc>
+///  Everything in this struct is designed to be as fast as possible. Changing logic should not be done without
+///  detailed performance measurements.
+/// </devdoc>
+internal readonly partial struct Value
+{
+    // Do not add more fields to this struct. It is important that it stays 16 bytes in size for maximum efficiency.
+
+    private readonly Union _union;
+    private readonly object? _object;
+
+    /// <summary>
+    ///  Creates a new <see cref="Value"/> with the given <see langword="object"/>. To avoid boxing enums, use the
+    ///  <see cref="Create{T}(T)"/> method instead.
+    /// </summary>
+    public Value(object? value)
+    {
+        _object = value;
+        _union = default;
+    }
+
+    /// <summary>
+    ///  The <see cref="System.Type"/> of the value stored in this <see cref="Value"/>.
+    /// </summary>
+    public readonly Type? Type
+    {
+        get
+        {
+            Type? type;
+            if (_object is null)
+            {
+                type = null;
+            }
+            else if (_object is TypeFlag typeFlag)
+            {
+                type = typeFlag.Type;
+            }
+            else
+            {
+                type = _object.GetType();
+
+                if (_union.UInt64 != 0)
+                {
+                    Debug.Assert(type.IsArray);
+
+                    // We have an ArraySegment
+                    if (type == typeof(byte[]))
+                    {
+                        type = typeof(ArraySegment<byte>);
+                    }
+                    else if (type == typeof(char[]))
+                    {
+                        type = typeof(ArraySegment<char>);
+                    }
+                    else
+                    {
+                        Debug.Fail($"Unexpected type {type.Name}.");
+                    }
+                }
+            }
+
+            return type;
+        }
+    }
+
+    [DoesNotReturn]
+    private static void ThrowInvalidCast() => throw new InvalidCastException();
+
+    [DoesNotReturn]
+    private static void ThrowInvalidOperation() => throw new InvalidOperationException();
+
+    #region Byte
+    public Value(byte value)
+    {
+        _object = TypeFlags.Byte;
+        _union.Byte = value;
+    }
+
+    public Value(byte? value)
+    {
+        if (value.HasValue)
+        {
+            _object = TypeFlags.Byte;
+            _union.Byte = value.Value;
+        }
+        else
+        {
+            _object = null;
+        }
+    }
+
+    public static implicit operator Value(byte value) => new(value);
+    public static explicit operator byte(in Value value) => value.GetValue<byte>();
+    public static implicit operator Value(byte? value) => new(value);
+    public static explicit operator byte?(in Value value) => value.GetValue<byte?>();
+    #endregion
+
+    #region SByte
+    public Value(sbyte value)
+    {
+        _object = TypeFlags.SByte;
+        _union.SByte = value;
+    }
+
+    public Value(sbyte? value)
+    {
+        if (value.HasValue)
+        {
+            _object = TypeFlags.SByte;
+            _union.SByte = value.Value;
+        }
+        else
+        {
+            _object = null;
+        }
+    }
+
+    public static implicit operator Value(sbyte value) => new(value);
+    public static explicit operator sbyte(in Value value) => value.GetValue<sbyte>();
+    public static implicit operator Value(sbyte? value) => new(value);
+    public static explicit operator sbyte?(in Value value) => value.GetValue<sbyte?>();
+    #endregion
+
+    #region Boolean
+    public Value(bool value)
+    {
+        _object = TypeFlags.Boolean;
+        _union.Boolean = value;
+    }
+
+    public Value(bool? value)
+    {
+        if (value.HasValue)
+        {
+            _object = TypeFlags.Boolean;
+            _union.Boolean = value.Value;
+        }
+        else
+        {
+            _object = null;
+        }
+    }
+
+    public static implicit operator Value(bool value) => new(value);
+    public static explicit operator bool(in Value value) => value.GetValue<bool>();
+    public static implicit operator Value(bool? value) => new(value);
+    public static explicit operator bool?(in Value value) => value.GetValue<bool?>();
+    #endregion
+
+    #region Char
+    public Value(char value)
+    {
+        _object = TypeFlags.Char;
+        _union.Char = value;
+    }
+
+    public Value(char? value)
+    {
+        if (value.HasValue)
+        {
+            _object = TypeFlags.Char;
+            _union.Char = value.Value;
+        }
+        else
+        {
+            _object = null;
+        }
+    }
+
+    public static implicit operator Value(char value) => new(value);
+    public static explicit operator char(in Value value) => value.GetValue<char>();
+    public static implicit operator Value(char? value) => new(value);
+    public static explicit operator char?(in Value value) => value.GetValue<char?>();
+    #endregion
+
+    #region Int16
+    public Value(short value)
+    {
+        _object = TypeFlags.Int16;
+        _union.Int16 = value;
+    }
+
+    public Value(short? value)
+    {
+        if (value.HasValue)
+        {
+            _object = TypeFlags.Int16;
+            _union.Int16 = value.Value;
+        }
+        else
+        {
+            _object = null;
+        }
+    }
+
+    public static implicit operator Value(short value) => new(value);
+    public static explicit operator short(in Value value) => value.GetValue<short>();
+    public static implicit operator Value(short? value) => new(value);
+    public static explicit operator short?(in Value value) => value.GetValue<short?>();
+    #endregion
+
+    #region Int32
+    public Value(int value)
+    {
+        _object = TypeFlags.Int32;
+        _union.Int32 = value;
+    }
+
+    public Value(int? value)
+    {
+        if (value.HasValue)
+        {
+            _object = TypeFlags.Int32;
+            _union.Int32 = value.Value;
+        }
+        else
+        {
+            _object = null;
+        }
+    }
+
+    public static implicit operator Value(int value) => new(value);
+    public static explicit operator int(in Value value) => value.GetValue<int>();
+    public static implicit operator Value(int? value) => new(value);
+    public static explicit operator int?(in Value value) => value.GetValue<int?>();
+    #endregion
+
+    #region Int64
+    public Value(long value)
+    {
+        _object = TypeFlags.Int64;
+        _union.Int64 = value;
+    }
+
+    public Value(long? value)
+    {
+        if (value.HasValue)
+        {
+            _object = TypeFlags.Int64;
+            _union.Int64 = value.Value;
+        }
+        else
+        {
+            _object = null;
+        }
+    }
+
+    public static implicit operator Value(long value) => new(value);
+    public static explicit operator long(in Value value) => value.GetValue<long>();
+    public static implicit operator Value(long? value) => new(value);
+    public static explicit operator long?(in Value value) => value.GetValue<long?>();
+    #endregion
+
+    #region UInt16
+    public Value(ushort value)
+    {
+        _object = TypeFlags.UInt16;
+        _union.UInt16 = value;
+    }
+
+    public Value(ushort? value)
+    {
+        if (value.HasValue)
+        {
+            _object = TypeFlags.UInt16;
+            _union.UInt16 = value.Value;
+        }
+        else
+        {
+            _object = null;
+        }
+    }
+
+    public static implicit operator Value(ushort value) => new(value);
+    public static explicit operator ushort(in Value value) => value.GetValue<ushort>();
+    public static implicit operator Value(ushort? value) => new(value);
+    public static explicit operator ushort?(in Value value) => value.GetValue<ushort?>();
+    #endregion
+
+    #region UInt32
+    public Value(uint value)
+    {
+        _object = TypeFlags.UInt32;
+        _union.UInt32 = value;
+    }
+
+    public Value(uint? value)
+    {
+        if (value.HasValue)
+        {
+            _object = TypeFlags.UInt32;
+            _union.UInt32 = value.Value;
+        }
+        else
+        {
+            _object = null;
+        }
+    }
+
+    public static implicit operator Value(uint value) => new(value);
+    public static explicit operator uint(in Value value) => value.GetValue<uint>();
+    public static implicit operator Value(uint? value) => new(value);
+    public static explicit operator uint?(in Value value) => value.GetValue<uint?>();
+    #endregion
+
+    #region UInt64
+    public Value(ulong value)
+    {
+        _object = TypeFlags.UInt64;
+        _union.UInt64 = value;
+    }
+
+    public Value(ulong? value)
+    {
+        if (value.HasValue)
+        {
+            _object = TypeFlags.UInt64;
+            _union.UInt64 = value.Value;
+        }
+        else
+        {
+            _object = null;
+        }
+    }
+
+    public static implicit operator Value(ulong value) => new(value);
+    public static explicit operator ulong(in Value value) => value.GetValue<ulong>();
+    public static implicit operator Value(ulong? value) => new(value);
+    public static explicit operator ulong?(in Value value) => value.GetValue<ulong?>();
+    #endregion
+
+    #region Single
+    public Value(float value)
+    {
+        _object = TypeFlags.Single;
+        _union.Single = value;
+    }
+
+    public Value(float? value)
+    {
+        if (value.HasValue)
+        {
+            _object = TypeFlags.Single;
+            _union.Single = value.Value;
+        }
+        else
+        {
+            _object = null;
+        }
+    }
+
+    public static implicit operator Value(float value) => new(value);
+    public static explicit operator float(in Value value) => value.GetValue<float>();
+    public static implicit operator Value(float? value) => new(value);
+    public static explicit operator float?(in Value value) => value.GetValue<float?>();
+    #endregion
+
+    #region Double
+    public Value(double value)
+    {
+        _object = TypeFlags.Double;
+        _union.Double = value;
+    }
+
+    public Value(double? value)
+    {
+        if (value.HasValue)
+        {
+            _object = TypeFlags.Double;
+            _union.Double = value.Value;
+        }
+        else
+        {
+            _object = null;
+        }
+    }
+
+    public static implicit operator Value(double value) => new(value);
+    public static explicit operator double(in Value value) => value.GetValue<double>();
+    public static implicit operator Value(double? value) => new(value);
+    public static explicit operator double?(in Value value) => value.GetValue<double?>();
+    #endregion
+
+    #region DateTimeOffset
+    public Value(DateTimeOffset value)
+    {
+        TimeSpan offset = value.Offset;
+        if (offset.Ticks == 0)
+        {
+            // This is a UTC time
+            _union.Ticks = value.Ticks;
+            _object = TypeFlags.DateTimeOffset;
+        }
+        else if (PackedDateTimeOffset.TryCreate(value, offset, out PackedDateTimeOffset packed))
+        {
+            _union.PackedDateTimeOffset = packed;
+            _object = TypeFlags.PackedDateTimeOffset;
+        }
+        else
+        {
+            _object = value;
+        }
+    }
+
+    public Value(DateTimeOffset? value)
+    {
+        if (!value.HasValue)
+        {
+            _object = null;
+        }
+        else
+        {
+            this = new(value.Value);
+        }
+    }
+
+    public static implicit operator Value(DateTimeOffset value) => new(value);
+    public static explicit operator DateTimeOffset(in Value value) => value.GetValue<DateTimeOffset>();
+    public static implicit operator Value(DateTimeOffset? value) => new(value);
+    public static explicit operator DateTimeOffset?(in Value value) => value.GetValue<DateTimeOffset?>();
+    #endregion
+
+    #region DateTime
+    public Value(DateTime value)
+    {
+        _union.DateTime = value;
+        _object = TypeFlags.DateTime;
+    }
+
+    public Value(DateTime? value)
+    {
+        if (value.HasValue)
+        {
+            _object = TypeFlags.DateTime;
+            _union.DateTime = value.Value;
+        }
+        else
+        {
+            _object = value;
+        }
+    }
+
+    public static implicit operator Value(DateTime value) => new(value);
+    public static explicit operator DateTime(in Value value) => value.GetValue<DateTime>();
+    public static implicit operator Value(DateTime? value) => new(value);
+    public static explicit operator DateTime?(in Value value) => value.GetValue<DateTime?>();
+    #endregion
+
+    #region ArraySegment
+    public Value(ArraySegment<byte> segment)
+    {
+        byte[]? array = segment.Array;
+        ArgumentNullException.ThrowIfNull(array, nameof(segment));
+
+        _object = array;
+        if (segment.Offset == 0 && segment.Count == 0)
+        {
+            _union.UInt64 = ulong.MaxValue;
+        }
+        else
+        {
+            _union.Segment = (segment.Offset, segment.Count);
+        }
+    }
+
+    public static implicit operator Value(ArraySegment<byte> value) => new(value);
+    public static explicit operator ArraySegment<byte>(in Value value) => value.GetValue<ArraySegment<byte>>();
+
+    public Value(ArraySegment<char> segment)
+    {
+        char[]? array = segment.Array;
+        ArgumentNullException.ThrowIfNull(array, nameof(segment));
+
+        _object = array;
+        if (segment.Offset == 0 && segment.Count == 0)
+        {
+            _union.UInt64 = ulong.MaxValue;
+        }
+        else
+        {
+            _union.Segment = (segment.Offset, segment.Count);
+        }
+    }
+
+    public static implicit operator Value(ArraySegment<char> value) => new(value);
+    public static explicit operator ArraySegment<char>(in Value value) => value.GetValue<ArraySegment<char>>();
+    #endregion
+
+    #region Decimal
+    public static implicit operator Value(decimal value) => new(value);
+    public static explicit operator decimal(in Value value) => value.GetValue<decimal>();
+    public static implicit operator Value(decimal? value) => value.HasValue ? new(value.Value) : new(value);
+    public static explicit operator decimal?(in Value value) => value.GetValue<decimal?>();
+    #endregion
+
+    #region T
+
+    /// <summary>
+    ///  Creates a new <see cref="Value"/> with the given value. This method can always be used and avoids boxing enums.
+    /// </summary>
+    public static Value Create<T>(T value)
+    {
+        // Explicit cast for types we don't box
+        if (typeof(T) == typeof(bool))
+            return new(Unsafe.As<T, bool>(ref Unsafe.AsRef(in value)));
+        if (typeof(T) == typeof(byte))
+            return new(Unsafe.As<T, byte>(ref Unsafe.AsRef(in value)));
+        if (typeof(T) == typeof(sbyte))
+            return new(Unsafe.As<T, sbyte>(ref Unsafe.AsRef(in value)));
+        if (typeof(T) == typeof(char))
+            return new(Unsafe.As<T, char>(ref Unsafe.AsRef(in value)));
+        if (typeof(T) == typeof(short))
+            return new(Unsafe.As<T, short>(ref Unsafe.AsRef(in value)));
+        if (typeof(T) == typeof(int))
+            return new(Unsafe.As<T, int>(ref Unsafe.AsRef(in value)));
+        if (typeof(T) == typeof(long))
+            return new(Unsafe.As<T, long>(ref Unsafe.AsRef(in value)));
+        if (typeof(T) == typeof(ushort))
+            return new(Unsafe.As<T, ushort>(ref Unsafe.AsRef(in value)));
+        if (typeof(T) == typeof(uint))
+            return new(Unsafe.As<T, uint>(ref Unsafe.AsRef(in value)));
+        if (typeof(T) == typeof(ulong))
+            return new(Unsafe.As<T, ulong>(ref Unsafe.AsRef(in value)));
+        if (typeof(T) == typeof(float))
+            return new(Unsafe.As<T, float>(ref Unsafe.AsRef(in value)));
+        if (typeof(T) == typeof(double))
+            return new(Unsafe.As<T, double>(ref Unsafe.AsRef(in value)));
+        if (typeof(T) == typeof(DateTime))
+            return new(Unsafe.As<T, DateTime>(ref Unsafe.AsRef(in value)));
+        if (typeof(T) == typeof(DateTimeOffset))
+            return new(Unsafe.As<T, DateTimeOffset>(ref Unsafe.AsRef(in value)));
+
+        if (typeof(T) == typeof(bool?))
+            return new(Unsafe.As<T, bool?>(ref Unsafe.AsRef(in value)));
+        if (typeof(T) == typeof(byte?))
+            return new(Unsafe.As<T, byte?>(ref Unsafe.AsRef(in value)));
+        if (typeof(T) == typeof(sbyte?))
+            return new(Unsafe.As<T, sbyte?>(ref Unsafe.AsRef(in value)));
+        if (typeof(T) == typeof(char?))
+            return new(Unsafe.As<T, char?>(ref Unsafe.AsRef(in value)));
+        if (typeof(T) == typeof(short?))
+            return new(Unsafe.As<T, short?>(ref Unsafe.AsRef(in value)));
+        if (typeof(T) == typeof(int?))
+            return new(Unsafe.As<T, int?>(ref Unsafe.AsRef(in value)));
+        if (typeof(T) == typeof(long?))
+            return new(Unsafe.As<T, long?>(ref Unsafe.AsRef(in value)));
+        if (typeof(T) == typeof(ushort?))
+            return new(Unsafe.As<T, ushort?>(ref Unsafe.AsRef(in value)));
+        if (typeof(T) == typeof(uint?))
+            return new(Unsafe.As<T, uint?>(ref Unsafe.AsRef(in value)));
+        if (typeof(T) == typeof(ulong?))
+            return new(Unsafe.As<T, ulong?>(ref Unsafe.AsRef(in value)));
+        if (typeof(T) == typeof(float?))
+            return new(Unsafe.As<T, float?>(ref Unsafe.AsRef(in value)));
+        if (typeof(T) == typeof(double?))
+            return new(Unsafe.As<T, double?>(ref Unsafe.AsRef(in value)));
+        if (typeof(T) == typeof(DateTime?))
+            return new(Unsafe.As<T, DateTime?>(ref Unsafe.AsRef(in value)));
+        if (typeof(T) == typeof(DateTimeOffset?))
+            return new(Unsafe.As<T, DateTimeOffset?>(ref Unsafe.AsRef(in value)));
+
+        if (typeof(T) == typeof(ArraySegment<byte>))
+            return new(Unsafe.As<T, ArraySegment<byte>>(ref Unsafe.AsRef(in value)));
+        if (typeof(T) == typeof(ArraySegment<char>))
+            return new(Unsafe.As<T, ArraySegment<char>>(ref Unsafe.AsRef(in value)));
+
+        if (typeof(T).IsEnum)
+        {
+            Debug.Assert(Unsafe.SizeOf<T>() <= sizeof(ulong));
+            return new Value(StraightCastFlag<T>.Instance, Unsafe.As<T, ulong>(ref value));
+        }
+
+        return new Value(value);
+    }
+
+    [SkipLocalsInit]
+    private Value(object o, ulong u)
+    {
+        Unsafe.SkipInit(out _union);
+        _object = o;
+        _union.UInt64 = u;
+    }
+
+    /// <summary>
+    ///  Tries to get the value stored in this <see cref="Value"/> as the given type. Returns <see langword="true"/> if
+    ///  the type matches.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   All types can be requested as <see langword="object"/>. Primitive types can be requested as their own type or
+    ///   as a nullable of that type. Enums can be requested as their own type or a nullable of that type.
+    ///  </para>
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public readonly unsafe bool TryGetValue<T>(out T value)
+    {
+        bool success;
+
+        // Checking the type gets all of the non-relevant compares elided by the JIT
+        if (_object is not null && ((typeof(T) == typeof(bool) && _object == TypeFlags.Boolean)
+            || (typeof(T) == typeof(byte) && _object == TypeFlags.Byte)
+            || (typeof(T) == typeof(char) && _object == TypeFlags.Char)
+            || (typeof(T) == typeof(double) && _object == TypeFlags.Double)
+            || (typeof(T) == typeof(short) && _object == TypeFlags.Int16)
+            || (typeof(T) == typeof(int) && _object == TypeFlags.Int32)
+            || (typeof(T) == typeof(long) && _object == TypeFlags.Int64)
+            || (typeof(T) == typeof(sbyte) && _object == TypeFlags.SByte)
+            || (typeof(T) == typeof(float) && _object == TypeFlags.Single)
+            || (typeof(T) == typeof(ushort) && _object == TypeFlags.UInt16)
+            || (typeof(T) == typeof(uint) && _object == TypeFlags.UInt32)
+            || (typeof(T) == typeof(ulong) && _object == TypeFlags.UInt64)))
+        {
+            value = Unsafe.As<Union, T>(ref Unsafe.AsRef(in _union));
+            success = true;
+        }
+        else if (typeof(T) == typeof(DateTime) && _object == TypeFlags.DateTime)
+        {
+            value = Unsafe.As<DateTime, T>(ref Unsafe.AsRef(in _union.DateTime));
+            success = true;
+        }
+        else if (typeof(T) == typeof(DateTimeOffset) && _object == TypeFlags.DateTimeOffset)
+        {
+            DateTimeOffset dto = new(_union.Ticks, TimeSpan.Zero);
+            value = Unsafe.As<DateTimeOffset, T>(ref Unsafe.AsRef(in dto));
+            success = true;
+        }
+        else if (typeof(T) == typeof(DateTimeOffset) && _object == TypeFlags.PackedDateTimeOffset)
+        {
+            DateTimeOffset dto = _union.PackedDateTimeOffset.Extract();
+            value = Unsafe.As<DateTimeOffset, T>(ref Unsafe.AsRef(in dto));
+            success = true;
+        }
+        else if (typeof(T).IsValueType)
+        {
+            success = TryGetValueSlow(out value);
+        }
+        else
+        {
+            success = TryGetObjectSlow(out value);
+        }
+
+        return success;
+    }
+
+    private readonly bool TryGetValueSlow<T>(out T value)
+    {
+        // Single return has a significant performance benefit.
+
+        bool result = false;
+
+        if (_object is null)
+        {
+            // A null is stored, it can only be assigned to a reference type or nullable.
+            value = default!;
+            result = Nullable.GetUnderlyingType(typeof(T)) is not null;
+        }
+        else if (typeof(T).IsEnum && _object is TypeFlag<T> typeFlag)
+        {
+            value = typeFlag.To(in this);
+            result = true;
+        }
+        else if (_object is T t)
+        {
+            value = t;
+            result = true;
+        }
+        else if (typeof(T) == typeof(ArraySegment<byte>))
+        {
+            ulong bits = _union.UInt64;
+            if (bits != 0 && _object is byte[] byteArray)
+            {
+                ArraySegment<byte> segment = bits != ulong.MaxValue
+                    ? new(byteArray, _union.Segment.Offset, _union.Segment.Count)
+                    : new(byteArray, 0, 0);
+                value = Unsafe.As<ArraySegment<byte>, T>(ref segment);
+                result = true;
+            }
+            else
+            {
+                value = default!;
+            }
+        }
+        else if (typeof(T) == typeof(ArraySegment<char>))
+        {
+            ulong bits = _union.UInt64;
+            if (bits != 0 && _object is char[] charArray)
+            {
+                ArraySegment<char> segment = bits != ulong.MaxValue
+                    ? new(charArray, _union.Segment.Offset, _union.Segment.Count)
+                    : new(charArray, 0, 0);
+                value = Unsafe.As<ArraySegment<char>, T>(ref segment);
+                result = true;
+            }
+            else
+            {
+                value = default!;
+            }
+        }
+        else if (typeof(T) == typeof(int?) && _object == TypeFlags.Int32)
+        {
+            int? @int = _union.Int32;
+            value = Unsafe.As<int?, T>(ref Unsafe.AsRef(in @int));
+            result = true;
+        }
+        else if (typeof(T) == typeof(long?) && _object == TypeFlags.Int64)
+        {
+            long? @long = _union.Int64;
+            value = Unsafe.As<long?, T>(ref Unsafe.AsRef(in @long));
+            result = true;
+        }
+        else if (typeof(T) == typeof(bool?) && _object == TypeFlags.Boolean)
+        {
+            bool? @bool = _union.Boolean;
+            value = Unsafe.As<bool?, T>(ref Unsafe.AsRef(in @bool));
+            result = true;
+        }
+        else if (typeof(T) == typeof(float?) && _object == TypeFlags.Single)
+        {
+            float? single = _union.Single;
+            value = Unsafe.As<float?, T>(ref Unsafe.AsRef(in single));
+            result = true;
+        }
+        else if (typeof(T) == typeof(double?) && _object == TypeFlags.Double)
+        {
+            double? @double = _union.Double;
+            value = Unsafe.As<double?, T>(ref Unsafe.AsRef(in @double));
+            result = true;
+        }
+        else if (typeof(T) == typeof(uint?) && _object == TypeFlags.UInt32)
+        {
+            uint? @uint = _union.UInt32;
+            value = Unsafe.As<uint?, T>(ref Unsafe.AsRef(in @uint));
+            result = true;
+        }
+        else if (typeof(T) == typeof(ulong?) && _object == TypeFlags.UInt64)
+        {
+            ulong? @ulong = _union.UInt64;
+            value = Unsafe.As<ulong?, T>(ref Unsafe.AsRef(in @ulong));
+            result = true;
+        }
+        else if (typeof(T) == typeof(char?) && _object == TypeFlags.Char)
+        {
+            char? @char = _union.Char;
+            value = Unsafe.As<char?, T>(ref Unsafe.AsRef(in @char));
+            result = true;
+        }
+        else if (typeof(T) == typeof(short?) && _object == TypeFlags.Int16)
+        {
+            short? @short = _union.Int16;
+            value = Unsafe.As<short?, T>(ref Unsafe.AsRef(in @short));
+            result = true;
+        }
+        else if (typeof(T) == typeof(ushort?) && _object == TypeFlags.UInt16)
+        {
+            ushort? @ushort = _union.UInt16;
+            value = Unsafe.As<ushort?, T>(ref Unsafe.AsRef(in @ushort));
+            result = true;
+        }
+        else if (typeof(T) == typeof(byte?) && _object == TypeFlags.Byte)
+        {
+            byte? @byte = _union.Byte;
+            value = Unsafe.As<byte?, T>(ref Unsafe.AsRef(in @byte));
+            result = true;
+        }
+        else if (typeof(T) == typeof(sbyte?) && _object == TypeFlags.SByte)
+        {
+            sbyte? @sbyte = _union.SByte;
+            value = Unsafe.As<sbyte?, T>(ref Unsafe.AsRef(in @sbyte));
+            result = true;
+        }
+        else if (typeof(T) == typeof(DateTime?) && _object == TypeFlags.DateTime)
+        {
+            DateTime? dateTime = _union.DateTime;
+            value = Unsafe.As<DateTime?, T>(ref Unsafe.AsRef(in dateTime));
+            result = true;
+        }
+        else if (typeof(T) == typeof(DateTimeOffset?) && _object == TypeFlags.DateTimeOffset)
+        {
+            DateTimeOffset? dto = new DateTimeOffset(_union.Ticks, TimeSpan.Zero);
+            value = Unsafe.As<DateTimeOffset?, T>(ref Unsafe.AsRef(in dto));
+            result = true;
+        }
+        else if (typeof(T) == typeof(DateTimeOffset?) && _object == TypeFlags.PackedDateTimeOffset)
+        {
+            DateTimeOffset? dto = _union.PackedDateTimeOffset.Extract();
+            value = Unsafe.As<DateTimeOffset?, T>(ref Unsafe.AsRef(in dto));
+            result = true;
+        }
+        else if (Nullable.GetUnderlyingType(typeof(T)) is Type underlyingType
+            && underlyingType.IsEnum
+            && _object is TypeFlag underlyingTypeFlag
+            && underlyingTypeFlag.Type == underlyingType)
+        {
+            // Asked for a nullable enum and we've got that type.
+
+            // We've got multiple layouts, depending on the size of the enum backing field. We can't use the
+            // nullable itself (e.g. default(T)) as a template as it gets treated specially by the runtime.
+
+            int size = Unsafe.SizeOf<T>();
+
+            switch (size)
+            {
+                case (2):
+                    NullableTemplate<byte> byteTemplate = new(_union.Byte);
+                    value = Unsafe.As<NullableTemplate<byte>, T>(ref Unsafe.AsRef(in byteTemplate));
+                    result = true;
+                    break;
+                case (4):
+                    NullableTemplate<ushort> ushortTemplate = new(_union.UInt16);
+                    value = Unsafe.As<NullableTemplate<ushort>, T>(ref Unsafe.AsRef(in ushortTemplate));
+                    result = true;
+                    break;
+                case (8):
+                    NullableTemplate<uint> uintTemplate = new(_union.UInt32);
+                    value = Unsafe.As<NullableTemplate<uint>, T>(ref Unsafe.AsRef(in uintTemplate));
+                    result = true;
+                    break;
+                case (16):
+                    NullableTemplate<ulong> ulongTemplate = new(_union.UInt64);
+                    value = Unsafe.As<NullableTemplate<ulong>, T>(ref Unsafe.AsRef(in ulongTemplate));
+                    result = true;
+                    break;
+                default:
+                    ThrowInvalidOperation();
+                    value = default!;
+                    result = false;
+                    break;
+            }
+        }
+        else
+        {
+            value = default!;
+            result = false;
+        }
+
+        return result;
+    }
+
+    private readonly bool TryGetObjectSlow<T>(out T value)
+    {
+        // Single return has a significant performance benefit.
+
+        bool result = false;
+
+        if (_object is null)
+        {
+            value = default!;
+        }
+        else if (typeof(T) == typeof(char[]))
+        {
+            if (_union.UInt64 == 0 && _object is char[])
+            {
+                value = (T)_object;
+                result = true;
+            }
+            else
+            {
+                // Don't allow "implicit" cast to array if we stored a segment.
+                value = default!;
+                result = false;
+            }
+        }
+        else if (typeof(T) == typeof(byte[]))
+        {
+            if (_union.UInt64 == 0 && _object is byte[])
+            {
+                value = (T)_object;
+                result = true;
+            }
+            else
+            {
+                // Don't allow "implicit" cast to array if we stored a segment.
+                value = default!;
+                result = false;
+            }
+        }
+        else if (typeof(T) == typeof(object))
+        {
+            // This case must also come before the _object is T case to make sure we don't leak our flags.
+            if (_object is TypeFlag flag)
+            {
+                value = (T)flag.ToObject(this);
+                result = true;
+            }
+            else if (_union.UInt64 != 0 && _object is char[] chars)
+            {
+                value = _union.UInt64 != ulong.MaxValue
+                    ? (T)(object)new ArraySegment<char>(chars, _union.Segment.Offset, _union.Segment.Count)
+                    : (T)(object)new ArraySegment<char>(chars, 0, 0);
+                result = true;
+            }
+            else if (_union.UInt64 != 0 && _object is byte[] bytes)
+            {
+                value = _union.UInt64 != ulong.MaxValue
+                    ? (T)(object)new ArraySegment<byte>(bytes, _union.Segment.Offset, _union.Segment.Count)
+                    : (T)(object)new ArraySegment<byte>(bytes, 0, 0);
+                result = true;
+            }
+            else
+            {
+                value = (T)_object;
+                result = true;
+            }
+        }
+        else if (_object is T t)
+        {
+            value = t;
+            result = true;
+        }
+        else
+        {
+            value = default!;
+            result = false;
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    ///  Gets the value as the specified <typeparamref name="T"/>.
+    /// </summary>
+    /// <exception cref="InvalidCastException">
+    ///  The value is not of type <typeparamref name="T"/>.
+    /// </exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public readonly T GetValue<T>()
+    {
+        if (!TryGetValue(out T value))
+        {
+            ThrowInvalidCast();
+        }
+
+        return value;
+    }
+    #endregion
+}

--- a/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/GlobalUsings.cs
+++ b/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/GlobalUsings.cs
@@ -1,0 +1,9 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+global using Windows.Win32;
+global using Windows.Win32.Foundation;
+global using Windows.Win32.Graphics.Gdi;
+global using Windows.Win32.UI.WindowsAndMessaging;
+global using Xunit;
+global using FluentAssertions;

--- a/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/GlobalUsings.cs
+++ b/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/GlobalUsings.cs
@@ -1,9 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-global using Windows.Win32;
-global using Windows.Win32.Foundation;
-global using Windows.Win32.Graphics.Gdi;
-global using Windows.Win32.UI.WindowsAndMessaging;
 global using Xunit;
+#pragma warning disable IDE0005 // Using directive is unnecessary.
 global using FluentAssertions;
+#pragma warning restore IDE0005 // Using directive is unnecessary.

--- a/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System.Private.Windows.Core.Tests.csproj
+++ b/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System.Private.Windows.Core.Tests.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(TargetFramework)-windows7.0</TargetFramework>
+    <DisableTransitiveFrameworkReferences>true</DisableTransitiveFrameworkReferences>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NoWarn>$(NoWarn);618</NoWarn>
+    <Nullable>enable</Nullable>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <RootNamespace />
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\System.Private.Windows.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Value/Creation.cs
+++ b/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Value/Creation.cs
@@ -1,0 +1,65 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.ValueTests;
+
+public class Creation
+{
+    [Fact]
+    public void CreateIsAllocationFree()
+    {
+        var watch = MemoryWatch.Create;
+
+        Value.Create((byte)default);
+        watch.Validate();
+        Value.Create((sbyte)default);
+        watch.Validate();
+        Value.Create((char)default);
+        watch.Validate();
+        Value.Create((double)default);
+        watch.Validate();
+        Value.Create((short)default);
+        watch.Validate();
+        Value.Create((int)default);
+        watch.Validate();
+        Value.Create((long)default);
+        watch.Validate();
+        Value.Create((ushort)default);
+        watch.Validate();
+        Value.Create((uint)default);
+        watch.Validate();
+        Value.Create((ulong)default);
+        watch.Validate();
+        Value.Create((float)default);
+        watch.Validate();
+        Value.Create((double)default);
+        watch.Validate();
+
+        Value.Create((bool?)default);
+        watch.Validate();
+        Value.Create((byte?)default);
+        watch.Validate();
+        Value.Create((sbyte?)default);
+        watch.Validate();
+        Value.Create((char?)default);
+        watch.Validate();
+        Value.Create((double?)default);
+        watch.Validate();
+        Value.Create((short?)default);
+        watch.Validate();
+        Value.Create((int?)default);
+        watch.Validate();
+        Value.Create((long?)default);
+        watch.Validate();
+        Value.Create((ushort?)default);
+        watch.Validate();
+        Value.Create((uint?)default);
+        watch.Validate();
+        Value.Create((ulong?)default);
+        watch.Validate();
+        Value.Create((float?)default);
+        watch.Validate();
+        Value.Create((double?)default);
+        watch.Validate();
+    }
+}

--- a/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Value/MemoryWatch.cs
+++ b/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Value/MemoryWatch.cs
@@ -1,0 +1,92 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.ValueTests;
+
+public ref struct MemoryWatch
+{
+    private static bool s_jit;
+    private long _allocations;
+
+    public static void JIT()
+    {
+        if (s_jit)
+        {
+            return;
+        }
+
+        // JITing allocates, so make sure we've got all of our <T> methods created.
+
+        Value.Create((bool)default).GetValue<bool>();
+        Value.Create((byte)default).GetValue<byte>();
+        Value.Create((sbyte)default).GetValue<sbyte>();
+        Value.Create((char)default).GetValue<char>();
+        Value.Create((double)default).GetValue<double>();
+        Value.Create((short)default).GetValue<short>();
+        Value.Create((int)default).GetValue<int>();
+        Value.Create((long)default).GetValue<long>();
+        Value.Create((ushort)default).GetValue<ushort>();
+        Value.Create((uint)default).GetValue<uint>();
+        Value.Create((ulong)default).GetValue<ulong>();
+        Value.Create((float)default).GetValue<float>();
+        Value.Create((double)default).GetValue<double>();
+        Value.Create((DateTime)default).GetValue<DateTime>();
+        Value.Create((DateTimeOffset)default).GetValue<DateTimeOffset>();
+
+        Value.Create((bool?)default).GetValue<bool?>();
+        Value.Create((byte?)default).GetValue<byte?>();
+        Value.Create((sbyte?)default).GetValue<sbyte?>();
+        Value.Create((char?)default).GetValue<char?>();
+        Value.Create((double?)default).GetValue<double?>();
+        Value.Create((short?)default).GetValue<short?>();
+        Value.Create((int?)default).GetValue<int?>();
+        Value.Create((long?)default).GetValue<long?>();
+        Value.Create((ushort?)default).GetValue<ushort?>();
+        Value.Create((uint?)default).GetValue<uint?>();
+        Value.Create((ulong?)default).GetValue<ulong?>();
+        Value.Create((float?)default).GetValue<float?>();
+        Value.Create((double?)default).GetValue<double?>();
+        Value.Create((DateTime?)default).GetValue<DateTime?>();
+        Value.Create((DateTimeOffset?)default).GetValue<DateTimeOffset?>();
+
+        Value value = default;
+        value.TryGetValue(out bool _);
+        value.TryGetValue(out byte _);
+        value.TryGetValue(out sbyte _);
+        value.TryGetValue(out char _);
+        value.TryGetValue(out double _);
+        value.TryGetValue(out short _);
+        value.TryGetValue(out int _);
+        value.TryGetValue(out long _);
+        value.TryGetValue(out ushort _);
+        value.TryGetValue(out uint _);
+        value.TryGetValue(out ulong _);
+        value.TryGetValue(out float _);
+        value.TryGetValue(out double _);
+        value.TryGetValue(out DateTime _);
+        value.TryGetValue(out DateTimeOffset _);
+
+        s_jit = true;
+    }
+
+    public MemoryWatch(long allocations) => _allocations = allocations;
+
+    public static MemoryWatch Create
+    {
+        get
+        {
+            JIT();
+            return new(GC.GetAllocatedBytesForCurrentThread());
+        }
+    }
+
+    public void Dispose() => Validate();
+
+    public void Validate()
+    {
+        Assert.Equal(0, GC.GetAllocatedBytesForCurrentThread() - _allocations);
+
+        // Assert.Equal allocates
+        _allocations = GC.GetAllocatedBytesForCurrentThread();
+    }
+}

--- a/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Value/StoringArrays.cs
+++ b/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Value/StoringArrays.cs
@@ -1,0 +1,91 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.ValueTests;
+
+public class StoringArrays
+{
+    [Fact]
+    public void ByteArray()
+    {
+        byte[] b = new byte[10];
+        Value value;
+
+        value = Value.Create(b);
+        Assert.Equal(typeof(byte[]), value.Type);
+        Assert.Same(b, value.GetValue<byte[]>());
+        Assert.Equal(b, (byte[])value.GetValue<object>());
+
+        Assert.Throws<InvalidCastException>(() => value.GetValue<ArraySegment<byte>>());
+    }
+
+    [Fact]
+    public void CharArray()
+    {
+        char[] b = new char[10];
+        Value value;
+
+        value = Value.Create(b);
+        Assert.Equal(typeof(char[]), value.Type);
+        Assert.Same(b, value.GetValue<char[]>());
+        Assert.Equal(b, (char[])value.GetValue<object>());
+
+        Assert.Throws<InvalidCastException>(() => value.GetValue<ArraySegment<char>>());
+    }
+
+    [Fact]
+    public void ByteSegment()
+    {
+        byte[] b = new byte[10];
+        Value value;
+
+        ArraySegment<byte> segment = new(b);
+        value = Value.Create(segment);
+        Assert.Equal(typeof(ArraySegment<byte>), value.Type);
+        Assert.Equal(segment, value.GetValue<ArraySegment<byte>>());
+        Assert.Equal(segment, (ArraySegment<byte>)value.GetValue<object>());
+        Assert.Throws<InvalidCastException>(() => value.GetValue<byte[]>());
+
+        segment = new(b, 0, 0);
+        value = Value.Create(segment);
+        Assert.Equal(typeof(ArraySegment<byte>), value.Type);
+        Assert.Equal(segment, value.GetValue<ArraySegment<byte>>());
+        Assert.Equal(segment, (ArraySegment<byte>)value.GetValue<object>());
+        Assert.Throws<InvalidCastException>(() => value.GetValue<byte[]>());
+
+        segment = new(b, 1, 1);
+        value = Value.Create(segment);
+        Assert.Equal(typeof(ArraySegment<byte>), value.Type);
+        Assert.Equal(segment, value.GetValue<ArraySegment<byte>>());
+        Assert.Equal(segment, (ArraySegment<byte>)value.GetValue<object>());
+        Assert.Throws<InvalidCastException>(() => value.GetValue<byte[]>());
+    }
+
+    [Fact]
+    public void CharSegment()
+    {
+        char[] b = new char[10];
+        Value value;
+
+        ArraySegment<char> segment = new(b);
+        value = Value.Create(segment);
+        Assert.Equal(typeof(ArraySegment<char>), value.Type);
+        Assert.Equal(segment, value.GetValue<ArraySegment<char>>());
+        Assert.Equal(segment, (ArraySegment<char>)value.GetValue<object>());
+        Assert.Throws<InvalidCastException>(() => value.GetValue<char[]>());
+
+        segment = new(b, 0, 0);
+        value = Value.Create(segment);
+        Assert.Equal(typeof(ArraySegment<char>), value.Type);
+        Assert.Equal(segment, value.GetValue<ArraySegment<char>>());
+        Assert.Equal(segment, (ArraySegment<char>)value.GetValue<object>());
+        Assert.Throws<InvalidCastException>(() => value.GetValue<char[]>());
+
+        segment = new(b, 1, 1);
+        value = Value.Create(segment);
+        Assert.Equal(typeof(ArraySegment<char>), value.Type);
+        Assert.Equal(segment, value.GetValue<ArraySegment<char>>());
+        Assert.Equal(segment, (ArraySegment<char>)value.GetValue<object>());
+        Assert.Throws<InvalidCastException>(() => value.GetValue<char[]>());
+    }
+}

--- a/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Value/StoringBoolean.cs
+++ b/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Value/StoringBoolean.cs
@@ -1,0 +1,174 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.ValueTests;
+
+public class StoringBoolean
+{
+    public static TheoryData<bool> BoolData => new()
+    {
+        { true },
+        { false }
+    };
+
+    [Theory]
+    [MemberData(nameof(BoolData))]
+    public void BooleanImplicit(bool @bool)
+    {
+        Value value;
+        using (MemoryWatch.Create)
+        {
+            value = @bool;
+        }
+
+        Assert.Equal(@bool, value.GetValue<bool>());
+        Assert.Equal(typeof(bool), value.Type);
+
+        bool? source = @bool;
+        using (MemoryWatch.Create)
+        {
+            value = source;
+        }
+
+        Assert.Equal(source, value.GetValue<bool?>());
+        Assert.Equal(typeof(bool), value.Type);
+    }
+
+    [Theory]
+    [MemberData(nameof(BoolData))]
+    public void BooleanCreate(bool @bool)
+    {
+        Value value;
+        using (MemoryWatch.Create)
+        {
+            value = Value.Create(@bool);
+        }
+
+        Assert.Equal(@bool, value.GetValue<bool>());
+        Assert.Equal(typeof(bool), value.Type);
+
+        bool? source = @bool;
+
+        using (MemoryWatch.Create)
+        {
+            value = Value.Create(source);
+        }
+
+        Assert.Equal(source, value.GetValue<bool?>());
+        Assert.Equal(typeof(bool), value.Type);
+    }
+
+    [Theory]
+    [MemberData(nameof(BoolData))]
+    public void BooleanInOut(bool @bool)
+    {
+        Value value;
+        bool success;
+        bool result;
+
+        using (MemoryWatch.Create)
+        {
+            value = new(@bool);
+            success = value.TryGetValue(out result);
+        }
+
+        Assert.True(success);
+        Assert.Equal(@bool, result);
+
+        Assert.Equal(@bool, value.GetValue<bool>());
+        Assert.Equal(@bool, (bool)value);
+    }
+
+    [Theory]
+    [MemberData(nameof(BoolData))]
+    public void NullableBooleanInBooleanOut(bool @bool)
+    {
+        bool? source = @bool;
+        Value value;
+        bool success;
+        bool result;
+
+        using (MemoryWatch.Create)
+        {
+            value = new(source);
+            success = value.TryGetValue(out result);
+        }
+
+        Assert.True(success);
+        Assert.Equal(@bool, result);
+
+        Assert.Equal(@bool, value.GetValue<bool>());
+
+        Assert.Equal(@bool, (bool)value);
+    }
+
+    [Theory]
+    [MemberData(nameof(BoolData))]
+    public void BooleanInNullableBooleanOut(bool @bool)
+    {
+        bool source = @bool;
+        Value value = new(source);
+        bool success = value.TryGetValue(out bool? result);
+        Assert.True(success);
+        Assert.Equal(@bool, result);
+
+        Assert.Equal(@bool, (bool?)value);
+    }
+
+    [Theory]
+    [MemberData(nameof(BoolData))]
+    public void BoxedBoolean(bool @bool)
+    {
+        bool i = @bool;
+        object o = i;
+        Value value = new(o);
+
+        Assert.Equal(typeof(bool), value.Type);
+        Assert.True(value.TryGetValue(out bool result));
+        Assert.Equal(@bool, result);
+        Assert.True(value.TryGetValue(out bool? nullableResult));
+        Assert.Equal(@bool, nullableResult!.Value);
+
+        bool? n = @bool;
+        o = n;
+        value = new(o);
+
+        Assert.Equal(typeof(bool), value.Type);
+        Assert.True(value.TryGetValue(out result));
+        Assert.Equal(@bool, result);
+        Assert.True(value.TryGetValue(out nullableResult));
+        Assert.Equal(@bool, nullableResult!.Value);
+    }
+
+    [Fact]
+    public void NullBoolean()
+    {
+        bool? source = null;
+        Value value;
+
+        using (MemoryWatch.Create)
+        {
+            value = source;
+        }
+
+        Assert.Null(value.Type);
+        Assert.Equal(source, value.GetValue<bool?>());
+        Assert.False(value.GetValue<bool?>().HasValue);
+    }
+
+    [Theory]
+    [MemberData(nameof(BoolData))]
+    public void OutAsObject(bool @bool)
+    {
+        Value value = new(@bool);
+        object o = value.GetValue<object>();
+        Assert.Equal(typeof(bool), o.GetType());
+        Assert.Equal(@bool, (bool)o);
+
+        bool? n = @bool;
+        value = new(n);
+        o = value.GetValue<object>();
+        Assert.Equal(typeof(bool), o.GetType());
+        Assert.Equal(@bool, (bool)o);
+    }
+}

--- a/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Value/StoringByte.cs
+++ b/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Value/StoringByte.cs
@@ -1,0 +1,145 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.ValueTests;
+
+public class StoringByte
+{
+    public static TheoryData<byte> ByteData => new()
+    {
+        { 42 },
+        { byte.MaxValue },
+        { byte.MinValue }
+    };
+
+    [Theory]
+    [MemberData(nameof(ByteData))]
+    public void ByteImplicit(byte @byte)
+    {
+        Value value = @byte;
+        Assert.Equal(@byte, value.GetValue<byte>());
+        Assert.Equal(typeof(byte), value.Type);
+
+        byte? source = @byte;
+        value = source;
+        Assert.Equal(source, value.GetValue<byte?>());
+        Assert.Equal(typeof(byte), value.Type);
+    }
+
+    [Theory]
+    [MemberData(nameof(ByteData))]
+    public void ByteCreate(byte @byte)
+    {
+        Value value;
+        using (MemoryWatch.Create)
+        {
+            value = Value.Create(@byte);
+        }
+
+        Assert.Equal(@byte, value.GetValue<byte>());
+        Assert.Equal(typeof(byte), value.Type);
+
+        byte? source = @byte;
+
+        using (MemoryWatch.Create)
+        {
+            value = Value.Create(source);
+        }
+
+        Assert.Equal(source, value.GetValue<byte?>());
+        Assert.Equal(typeof(byte), value.Type);
+    }
+
+    [Theory]
+    [MemberData(nameof(ByteData))]
+    public void ByteInOut(byte @byte)
+    {
+        Value value = new(@byte);
+        bool success = value.TryGetValue(out byte result);
+        Assert.True(success);
+        Assert.Equal(@byte, result);
+
+        Assert.Equal(@byte, value.GetValue<byte>());
+        Assert.Equal(@byte, (byte)value);
+    }
+
+    [Theory]
+    [MemberData(nameof(ByteData))]
+    public void NullableByteInByteOut(byte @byte)
+    {
+        byte? source = @byte;
+        Value value = new(source);
+
+        bool success = value.TryGetValue(out byte result);
+        Assert.True(success);
+        Assert.Equal(@byte, result);
+
+        Assert.Equal(@byte, value.GetValue<byte>());
+
+        Assert.Equal(@byte, (byte)value);
+    }
+
+    [Theory]
+    [MemberData(nameof(ByteData))]
+    public void ByteInNullableByteOut(byte @byte)
+    {
+        byte source = @byte;
+        Value value = new(source);
+        bool success = value.TryGetValue(out byte? result);
+        Assert.True(success);
+        Assert.Equal(@byte, result);
+
+        Assert.Equal(@byte, (byte?)value);
+    }
+
+    [Theory]
+    [MemberData(nameof(ByteData))]
+    public void BoxedByte(byte @byte)
+    {
+        byte i = @byte;
+        object o = i;
+        Value value = new(o);
+
+        Assert.Equal(typeof(byte), value.Type);
+        Assert.True(value.TryGetValue(out byte result));
+        Assert.Equal(@byte, result);
+        Assert.True(value.TryGetValue(out byte? nullableResult));
+        Assert.Equal(@byte, nullableResult!.Value);
+
+        byte? n = @byte;
+        o = n;
+        value = new(o);
+
+        Assert.Equal(typeof(byte), value.Type);
+        Assert.True(value.TryGetValue(out result));
+        Assert.Equal(@byte, result);
+        Assert.True(value.TryGetValue(out nullableResult));
+        Assert.Equal(@byte, nullableResult!.Value);
+    }
+
+    [Fact]
+    public void NullByte()
+    {
+        byte? source = null;
+        Value value = source;
+        Assert.Null(value.Type);
+        Assert.Equal(source, value.GetValue<byte?>());
+        Assert.False(value.GetValue<byte?>().HasValue);
+    }
+
+    [Theory]
+    [MemberData(nameof(ByteData))]
+    public void OutAsObject(byte @byte)
+    {
+        Value value = new(@byte);
+        object o = value.GetValue<object>();
+        Assert.Equal(typeof(byte), o.GetType());
+        Assert.Equal(@byte, (byte)o);
+
+        byte? n = @byte;
+        value = new(n);
+        o = value.GetValue<object>();
+        Assert.Equal(typeof(byte), o.GetType());
+        Assert.Equal(@byte, (byte)o);
+    }
+}

--- a/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Value/StoringChar.cs
+++ b/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Value/StoringChar.cs
@@ -1,0 +1,145 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.ValueTests;
+
+public class StoringChar
+{
+    public static TheoryData<char> CharData => new()
+    {
+        { '!' },
+        { char.MaxValue },
+        { char.MinValue }
+    };
+
+    [Theory]
+    [MemberData(nameof(CharData))]
+    public void CharImplicit(char @char)
+    {
+        Value value = @char;
+        Assert.Equal(@char, value.GetValue<char>());
+        Assert.Equal(typeof(char), value.Type);
+
+        char? source = @char;
+        value = source;
+        Assert.Equal(source, value.GetValue<char?>());
+        Assert.Equal(typeof(char), value.Type);
+    }
+
+    [Theory]
+    [MemberData(nameof(CharData))]
+    public void CharCreate(char @char)
+    {
+        Value value;
+        using (MemoryWatch.Create)
+        {
+            value = Value.Create(@char);
+        }
+
+        Assert.Equal(@char, value.GetValue<char>());
+        Assert.Equal(typeof(char), value.Type);
+
+        char? source = @char;
+
+        using (MemoryWatch.Create)
+        {
+            value = Value.Create(source);
+        }
+
+        Assert.Equal(source, value.GetValue<char?>());
+        Assert.Equal(typeof(char), value.Type);
+    }
+
+    [Theory]
+    [MemberData(nameof(CharData))]
+    public void CharInOut(char @char)
+    {
+        Value value = new(@char);
+        bool success = value.TryGetValue(out char result);
+        Assert.True(success);
+        Assert.Equal(@char, result);
+
+        Assert.Equal(@char, value.GetValue<char>());
+        Assert.Equal(@char, (char)value);
+    }
+
+    [Theory]
+    [MemberData(nameof(CharData))]
+    public void NullableCharInCharOut(char @char)
+    {
+        char? source = @char;
+        Value value = new(source);
+
+        bool success = value.TryGetValue(out char result);
+        Assert.True(success);
+        Assert.Equal(@char, result);
+
+        Assert.Equal(@char, value.GetValue<char>());
+
+        Assert.Equal(@char, (char)value);
+    }
+
+    [Theory]
+    [MemberData(nameof(CharData))]
+    public void CharInNullableCharOut(char @char)
+    {
+        char source = @char;
+        Value value = new(source);
+        bool success = value.TryGetValue(out char? result);
+        Assert.True(success);
+        Assert.Equal(@char, result);
+
+        Assert.Equal(@char, (char?)value);
+    }
+
+    [Theory]
+    [MemberData(nameof(CharData))]
+    public void BoxedChar(char @char)
+    {
+        char i = @char;
+        object o = i;
+        Value value = new(o);
+
+        Assert.Equal(typeof(char), value.Type);
+        Assert.True(value.TryGetValue(out char result));
+        Assert.Equal(@char, result);
+        Assert.True(value.TryGetValue(out char? nullableResult));
+        Assert.Equal(@char, nullableResult!.Value);
+
+        char? n = @char;
+        o = n;
+        value = new(o);
+
+        Assert.Equal(typeof(char), value.Type);
+        Assert.True(value.TryGetValue(out result));
+        Assert.Equal(@char, result);
+        Assert.True(value.TryGetValue(out nullableResult));
+        Assert.Equal(@char, nullableResult!.Value);
+    }
+
+    [Fact]
+    public void NullChar()
+    {
+        char? source = null;
+        Value value = source;
+        Assert.Null(value.Type);
+        Assert.Equal(source, value.GetValue<char?>());
+        Assert.False(value.GetValue<char?>().HasValue);
+    }
+
+    [Theory]
+    [MemberData(nameof(CharData))]
+    public void OutAsObject(char @char)
+    {
+        Value value = new(@char);
+        object o = value.GetValue<object>();
+        Assert.Equal(typeof(char), o.GetType());
+        Assert.Equal(@char, (char)o);
+
+        char? n = @char;
+        value = new(n);
+        o = value.GetValue<object>();
+        Assert.Equal(typeof(char), o.GetType());
+        Assert.Equal(@char, (char)o);
+    }
+}

--- a/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Value/StoringDateTime.cs
+++ b/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Value/StoringDateTime.cs
@@ -1,0 +1,97 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.ValueTests;
+
+public class StoringDateTime
+{
+    public static TheoryData<DateTime> DateTimeData => new()
+    {
+        { DateTime.Now },
+        { DateTime.UtcNow },
+        { DateTime.MaxValue },
+        { DateTime.MinValue }
+    };
+
+    [Theory]
+    [MemberData(nameof(DateTimeData))]
+    public void DateTimeImplicit(DateTime @DateTime)
+    {
+        Value value = @DateTime;
+        Assert.Equal(@DateTime, value.GetValue<DateTime>());
+        Assert.Equal(typeof(DateTime), value.Type);
+
+        DateTime? source = @DateTime;
+        value = source;
+        Assert.Equal(source, value.GetValue<DateTime?>());
+        Assert.Equal(typeof(DateTime), value.Type);
+    }
+
+    [Theory]
+    [MemberData(nameof(DateTimeData))]
+    public void DateTimeInOut(DateTime @DateTime)
+    {
+        Value value = new(@DateTime);
+        bool success = value.TryGetValue(out DateTime result);
+        Assert.True(success);
+        Assert.Equal(@DateTime, result);
+
+        Assert.Equal(@DateTime, value.GetValue<DateTime>());
+        Assert.Equal(@DateTime, (DateTime)value);
+    }
+
+    [Theory]
+    [MemberData(nameof(DateTimeData))]
+    public void NullableDateTimeInDateTimeOut(DateTime @DateTime)
+    {
+        DateTime? source = @DateTime;
+        Value value = new(source);
+
+        bool success = value.TryGetValue(out DateTime result);
+        Assert.True(success);
+        Assert.Equal(@DateTime, result);
+
+        Assert.Equal(@DateTime, value.GetValue<DateTime>());
+
+        Assert.Equal(@DateTime, (DateTime)value);
+    }
+
+    [Theory]
+    [MemberData(nameof(DateTimeData))]
+    public void DateTimeInNullableDateTimeOut(DateTime @DateTime)
+    {
+        DateTime source = @DateTime;
+        Value value = new(source);
+        bool success = value.TryGetValue(out DateTime? result);
+        Assert.True(success);
+        Assert.Equal(@DateTime, result);
+
+        Assert.Equal(@DateTime, (DateTime?)value);
+    }
+
+    [Fact]
+    public void NullDateTime()
+    {
+        DateTime? source = null;
+        Value value = source;
+        Assert.Null(value.Type);
+        Assert.Equal(source, value.GetValue<DateTime?>());
+        Assert.False(value.GetValue<DateTime?>().HasValue);
+    }
+
+    [Theory]
+    [MemberData(nameof(DateTimeData))]
+    public void OutAsObject(DateTime @DateTime)
+    {
+        Value value = new(@DateTime);
+        object o = value.GetValue<object>();
+        Assert.Equal(typeof(DateTime), o.GetType());
+        Assert.Equal(@DateTime, (DateTime)o);
+
+        DateTime? n = @DateTime;
+        value = new(n);
+        o = value.GetValue<object>();
+        Assert.Equal(typeof(DateTime), o.GetType());
+        Assert.Equal(@DateTime, (DateTime)o);
+    }
+}

--- a/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Value/StoringDateTimeOffset.cs
+++ b/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Value/StoringDateTimeOffset.cs
@@ -1,0 +1,97 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.ValueTests;
+
+public class StoringDateTimeOffset
+{
+    public static TheoryData<DateTimeOffset> DateTimeOffsetData => new()
+    {
+        { DateTimeOffset.Now },
+        { DateTimeOffset.UtcNow },
+        { DateTimeOffset.MaxValue },
+        { DateTimeOffset.MinValue }
+    };
+
+    [Theory]
+    [MemberData(nameof(DateTimeOffsetData))]
+    public void DateTimeOffsetImplicit(DateTimeOffset @DateTimeOffset)
+    {
+        Value value = @DateTimeOffset;
+        Assert.Equal(@DateTimeOffset, value.GetValue<DateTimeOffset>());
+        Assert.Equal(typeof(DateTimeOffset), value.Type);
+
+        DateTimeOffset? source = @DateTimeOffset;
+        value = source;
+        Assert.Equal(source, value.GetValue<DateTimeOffset?>());
+        Assert.Equal(typeof(DateTimeOffset), value.Type);
+    }
+
+    [Theory]
+    [MemberData(nameof(DateTimeOffsetData))]
+    public void DateTimeOffsetInOut(DateTimeOffset @DateTimeOffset)
+    {
+        Value value = new(@DateTimeOffset);
+        bool success = value.TryGetValue(out DateTimeOffset result);
+        Assert.True(success);
+        Assert.Equal(@DateTimeOffset, result);
+
+        Assert.Equal(@DateTimeOffset, value.GetValue<DateTimeOffset>());
+        Assert.Equal(@DateTimeOffset, (DateTimeOffset)value);
+    }
+
+    [Theory]
+    [MemberData(nameof(DateTimeOffsetData))]
+    public void NullableDateTimeOffsetInDateTimeOffsetOut(DateTimeOffset @DateTimeOffset)
+    {
+        DateTimeOffset? source = @DateTimeOffset;
+        Value value = new(source);
+
+        bool success = value.TryGetValue(out DateTimeOffset result);
+        Assert.True(success);
+        Assert.Equal(@DateTimeOffset, result);
+
+        Assert.Equal(@DateTimeOffset, value.GetValue<DateTimeOffset>());
+
+        Assert.Equal(@DateTimeOffset, (DateTimeOffset)value);
+    }
+
+    [Theory]
+    [MemberData(nameof(DateTimeOffsetData))]
+    public void DateTimeOffsetInNullableDateTimeOffsetOut(DateTimeOffset @DateTimeOffset)
+    {
+        DateTimeOffset source = @DateTimeOffset;
+        Value value = new(source);
+        bool success = value.TryGetValue(out DateTimeOffset? result);
+        Assert.True(success);
+        Assert.Equal(@DateTimeOffset, result);
+
+        Assert.Equal(@DateTimeOffset, (DateTimeOffset?)value);
+    }
+
+    [Fact]
+    public void NullDateTimeOffset()
+    {
+        DateTimeOffset? source = null;
+        Value value = source;
+        Assert.Null(value.Type);
+        Assert.Equal(source, value.GetValue<DateTimeOffset?>());
+        Assert.False(value.GetValue<DateTimeOffset?>().HasValue);
+    }
+
+    [Theory]
+    [MemberData(nameof(DateTimeOffsetData))]
+    public void OutAsObject(DateTimeOffset @DateTimeOffset)
+    {
+        Value value = new(@DateTimeOffset);
+        object o = value.GetValue<object>();
+        Assert.Equal(typeof(DateTimeOffset), o.GetType());
+        Assert.Equal(@DateTimeOffset, (DateTimeOffset)o);
+
+        DateTimeOffset? n = @DateTimeOffset;
+        value = new(n);
+        o = value.GetValue<object>();
+        Assert.Equal(typeof(DateTimeOffset), o.GetType());
+        Assert.Equal(@DateTimeOffset, (DateTimeOffset)o);
+    }
+}

--- a/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Value/StoringDecimal.cs
+++ b/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Value/StoringDecimal.cs
@@ -1,0 +1,95 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.ValueTests;
+
+public class StoringDecimal
+{
+    public static TheoryData<decimal> DecimalData => new()
+    {
+        { 42 },
+        { decimal.MaxValue },
+        { decimal.MinValue }
+    };
+
+    [Fact]
+    public void DecimalImplicit()
+    {
+        Value value = (decimal)42.0;
+        Assert.Equal((decimal)42.0, value.GetValue<decimal>());
+        Assert.Equal(typeof(decimal), value.Type);
+
+        decimal? source = (decimal?)42.0;
+        value = source;
+        Assert.Equal(source, value.GetValue<decimal?>());
+        Assert.Equal(typeof(decimal), value.Type);
+    }
+
+    [Theory]
+    [MemberData(nameof(DecimalData))]
+    public void DecimalInOut(decimal @decimal)
+    {
+        Value value = new(@decimal);
+        bool success = value.TryGetValue(out decimal result);
+        Assert.True(success);
+        Assert.Equal(@decimal, result);
+
+        Assert.Equal(@decimal, value.GetValue<decimal>());
+        Assert.Equal(@decimal, (decimal)value);
+    }
+
+    [Theory]
+    [MemberData(nameof(DecimalData))]
+    public void NullableDecimalInDecimalOut(decimal @decimal)
+    {
+        decimal? source = @decimal;
+        Value value = new(source);
+
+        bool success = value.TryGetValue(out decimal result);
+        Assert.True(success);
+        Assert.Equal(@decimal, result);
+
+        Assert.Equal(@decimal, value.GetValue<decimal>());
+
+        Assert.Equal(@decimal, (decimal)value);
+    }
+
+    [Theory]
+    [MemberData(nameof(DecimalData))]
+    public void DecimalInNullableDecimalOut(decimal @decimal)
+    {
+        decimal source = @decimal;
+        Value value = new(source);
+        bool success = value.TryGetValue(out decimal? result);
+        Assert.True(success);
+        Assert.Equal(@decimal, result);
+
+        Assert.Equal(@decimal, (decimal?)value);
+    }
+
+    [Fact]
+    public void NullDecimal()
+    {
+        decimal? source = null;
+        Value value = source;
+        Assert.Null(value.Type);
+        Assert.Equal(source, value.GetValue<decimal?>());
+        Assert.False(value.GetValue<decimal?>().HasValue);
+    }
+
+    [Theory]
+    [MemberData(nameof(DecimalData))]
+    public void OutAsObject(decimal @decimal)
+    {
+        Value value = new(@decimal);
+        object o = value.GetValue<object>();
+        Assert.Equal(typeof(decimal), o.GetType());
+        Assert.Equal(@decimal, (decimal)o);
+
+        decimal? n = @decimal;
+        value = new(n);
+        o = value.GetValue<object>();
+        Assert.Equal(typeof(decimal), o.GetType());
+        Assert.Equal(@decimal, (decimal)o);
+    }
+}

--- a/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Value/StoringDouble.cs
+++ b/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Value/StoringDouble.cs
@@ -1,0 +1,149 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.ValueTests;
+
+public class StoringDouble
+{
+    public static TheoryData<double> DoubleData => new()
+    {
+        { 0d },
+        { 42d },
+        { double.MaxValue },
+        { double.MinValue },
+        { double.NaN },
+        { double.NegativeInfinity },
+        { double.PositiveInfinity }
+    };
+
+    [Theory]
+    [MemberData(nameof(DoubleData))]
+    public void DoubleImplicit(double @double)
+    {
+        Value value = @double;
+        Assert.Equal(@double, value.GetValue<double>());
+        Assert.Equal(typeof(double), value.Type);
+
+        double? source = @double;
+        value = source;
+        Assert.Equal(source, value.GetValue<double?>());
+        Assert.Equal(typeof(double), value.Type);
+    }
+
+    [Theory]
+    [MemberData(nameof(DoubleData))]
+    public void DoubleCreate(double @double)
+    {
+        Value value;
+        using (MemoryWatch.Create)
+        {
+            value = Value.Create(@double);
+        }
+
+        Assert.Equal(@double, value.GetValue<double>());
+        Assert.Equal(typeof(double), value.Type);
+
+        double? source = @double;
+
+        using (MemoryWatch.Create)
+        {
+            value = Value.Create(source);
+        }
+
+        Assert.Equal(source, value.GetValue<double?>());
+        Assert.Equal(typeof(double), value.Type);
+    }
+
+    [Theory]
+    [MemberData(nameof(DoubleData))]
+    public void DoubleInOut(double @double)
+    {
+        Value value = new(@double);
+        bool success = value.TryGetValue(out double result);
+        Assert.True(success);
+        Assert.Equal(@double, result);
+
+        Assert.Equal(@double, value.GetValue<double>());
+        Assert.Equal(@double, (double)value);
+    }
+
+    [Theory]
+    [MemberData(nameof(DoubleData))]
+    public void NullableDoubleInDoubleOut(double @double)
+    {
+        double? source = @double;
+        Value value = new(source);
+
+        bool success = value.TryGetValue(out double result);
+        Assert.True(success);
+        Assert.Equal(@double, result);
+
+        Assert.Equal(@double, value.GetValue<double>());
+
+        Assert.Equal(@double, (double)value);
+    }
+
+    [Theory]
+    [MemberData(nameof(DoubleData))]
+    public void DoubleInNullableDoubleOut(double @double)
+    {
+        double source = @double;
+        Value value = new(source);
+        bool success = value.TryGetValue(out double? result);
+        Assert.True(success);
+        Assert.Equal(@double, result);
+
+        Assert.Equal(@double, (double)value);
+    }
+
+    [Theory]
+    [MemberData(nameof(DoubleData))]
+    public void BoxedDouble(double @double)
+    {
+        double i = @double;
+        object o = i;
+        Value value = new(o);
+
+        Assert.Equal(typeof(double), value.Type);
+        Assert.True(value.TryGetValue(out double result));
+        Assert.Equal(@double, result);
+        Assert.True(value.TryGetValue(out double? nullableResult));
+        Assert.Equal(@double, nullableResult!.Value);
+
+        double? n = @double;
+        o = n;
+        value = new(o);
+
+        Assert.Equal(typeof(double), value.Type);
+        Assert.True(value.TryGetValue(out result));
+        Assert.Equal(@double, result);
+        Assert.True(value.TryGetValue(out nullableResult));
+        Assert.Equal(@double, nullableResult!.Value);
+    }
+
+    [Fact]
+    public void NullDouble()
+    {
+        double? source = null;
+        Value value = source;
+        Assert.Null(value.Type);
+        Assert.Equal(source, value.GetValue<double?>());
+        Assert.False(value.GetValue<double?>().HasValue);
+    }
+
+    [Theory]
+    [MemberData(nameof(DoubleData))]
+    public void OutAsObject(double @double)
+    {
+        Value value = new(@double);
+        object o = value.GetValue<object>();
+        Assert.Equal(typeof(double), o.GetType());
+        Assert.Equal(@double, (double)o);
+
+        double? n = @double;
+        value = new(n);
+        o = value.GetValue<object>();
+        Assert.Equal(typeof(double), o.GetType());
+        Assert.Equal(@double, (double)o);
+    }
+}

--- a/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Value/StoringEnum.cs
+++ b/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Value/StoringEnum.cs
@@ -1,0 +1,174 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+namespace System.ValueTests;
+
+public class StoringEnum
+{
+    [Fact]
+    public void BasicFunctionality()
+    {
+        InitType();
+        DayOfWeek day = DayOfWeek.Monday;
+
+        MemoryWatch watch = MemoryWatch.Create;
+        Value value = Value.Create(day);
+        DayOfWeek outDay = value.GetValue<DayOfWeek>();
+        watch.Validate();
+
+        Assert.Equal(day, outDay);
+        Assert.Equal(typeof(DayOfWeek), value.Type);
+    }
+
+    [Fact]
+    public void NullableEnum()
+    {
+        DayOfWeek? day = DayOfWeek.Monday;
+
+        Value value = Value.Create(day);
+        DayOfWeek outDay = value.GetValue<DayOfWeek>();
+
+        Assert.Equal(day.Value, outDay);
+        Assert.Equal(typeof(DayOfWeek), value.Type);
+    }
+
+    [Fact]
+    public void ToFromNullableEnum()
+    {
+        DayOfWeek day = DayOfWeek.Monday;
+        Value value = Value.Create(day);
+        Assert.True(value.TryGetValue(out DayOfWeek? nullDay));
+        Assert.Equal(day, nullDay);
+
+        value = Value.Create((DayOfWeek?)day);
+        Assert.True(value.TryGetValue(out DayOfWeek outDay));
+        Assert.Equal(day, outDay);
+    }
+
+    [Fact]
+    public void BoxedEnum()
+    {
+        DayOfWeek day = DayOfWeek.Monday;
+        Value value = new(day);
+        Assert.True(value.TryGetValue(out DayOfWeek? nullDay));
+        Assert.Equal(day, nullDay);
+
+        value = new((DayOfWeek?)day);
+        Assert.True(value.TryGetValue(out DayOfWeek outDay));
+        Assert.Equal(day, outDay);
+    }
+
+    [Theory]
+    [InlineData(ByteEnum.MinValue)]
+    [InlineData(ByteEnum.MaxValue)]
+    public void ByteSize(ByteEnum @enum)
+    {
+        Value value = Value.Create(@enum);
+        Assert.True(value.TryGetValue(out ByteEnum result));
+        Assert.Equal(@enum, result);
+        Assert.True(value.TryGetValue(out ByteEnum? nullResult));
+        Assert.Equal(@enum, nullResult!.Value);
+        value = Value.Create((ByteEnum?)@enum);
+        Assert.True(value.TryGetValue(out result));
+        Assert.Equal(@enum, result);
+        Assert.True(value.TryGetValue(out nullResult));
+        Assert.Equal(@enum, nullResult!.Value);
+
+        // Create boxed
+        value = new(@enum);
+        Assert.True(value.TryGetValue(out result));
+        Assert.Equal(@enum, result);
+        Assert.True(value.TryGetValue(out nullResult));
+        Assert.Equal(@enum, nullResult!.Value);
+        value = new((ByteEnum?)@enum);
+        Assert.True(value.TryGetValue(out result));
+        Assert.Equal(@enum, result);
+        Assert.True(value.TryGetValue(out nullResult));
+        Assert.Equal(@enum, nullResult!.Value);
+    }
+
+    [Theory]
+    [InlineData(ShortEnum.MinValue)]
+    [InlineData(ShortEnum.MaxValue)]
+    public void ShortSize(ShortEnum @enum)
+    {
+        Value value = Value.Create(@enum);
+        Assert.True(value.TryGetValue(out ShortEnum result));
+        Assert.Equal(@enum, result);
+        Assert.True(value.TryGetValue(out ShortEnum? nullResult));
+        Assert.Equal(@enum, nullResult!.Value);
+        value = Value.Create((ShortEnum?)@enum);
+        Assert.True(value.TryGetValue(out result));
+        Assert.Equal(@enum, result);
+        Assert.True(value.TryGetValue(out nullResult));
+        Assert.Equal(@enum, nullResult!.Value);
+
+        // Create boxed
+        value = new(@enum);
+        Assert.True(value.TryGetValue(out result));
+        Assert.Equal(@enum, result);
+        Assert.True(value.TryGetValue(out nullResult));
+        Assert.Equal(@enum, nullResult!.Value);
+        value = new((ShortEnum?)@enum);
+        Assert.True(value.TryGetValue(out result));
+        Assert.Equal(@enum, result);
+        Assert.True(value.TryGetValue(out nullResult));
+        Assert.Equal(@enum, nullResult!.Value);
+    }
+
+    [Theory]
+    [InlineData(LongEnum.MinValue)]
+    [InlineData(LongEnum.MaxValue)]
+    public void LongSize(LongEnum @enum)
+    {
+        Value value = Value.Create(@enum);
+        Assert.True(value.TryGetValue(out LongEnum result));
+        Assert.Equal(@enum, result);
+        Assert.True(value.TryGetValue(out LongEnum? nullResult));
+        Assert.Equal(@enum, nullResult!.Value);
+        value = Value.Create((LongEnum?)@enum);
+        Assert.True(value.TryGetValue(out result));
+        Assert.Equal(@enum, result);
+        Assert.True(value.TryGetValue(out nullResult));
+        Assert.Equal(@enum, nullResult!.Value);
+
+        // Create boxed
+        value = new(@enum);
+        Assert.True(value.TryGetValue(out result));
+        Assert.Equal(@enum, result);
+        Assert.True(value.TryGetValue(out nullResult));
+        Assert.Equal(@enum, nullResult!.Value);
+        value = new((LongEnum?)@enum);
+        Assert.True(value.TryGetValue(out result));
+        Assert.Equal(@enum, result);
+        Assert.True(value.TryGetValue(out nullResult));
+        Assert.Equal(@enum, nullResult!.Value);
+    }
+
+    [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+    internal static DayOfWeek InitType()
+    {
+        DayOfWeek day = DayOfWeek.Monday;
+        return Value.Create(day).GetValue<DayOfWeek>();
+    }
+
+    public enum ByteEnum : byte
+    {
+        MinValue = byte.MinValue,
+        MaxValue = byte.MaxValue
+    }
+
+    public enum ShortEnum : short
+    {
+        MinValue = short.MinValue,
+        MaxValue = short.MaxValue
+    }
+
+    public enum LongEnum : long
+    {
+        MinValue = long.MinValue,
+        MaxValue = long.MaxValue
+    }
+}

--- a/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Value/StoringFloat.cs
+++ b/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Value/StoringFloat.cs
@@ -1,0 +1,149 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.ValueTests;
+
+public class StoringFloat
+{
+    public static TheoryData<float> FloatData => new()
+    {
+        { 0f },
+        { 42f },
+        { float.MaxValue },
+        { float.MinValue },
+        { float.NaN },
+        { float.NegativeInfinity },
+        { float.PositiveInfinity }
+    };
+
+    [Theory]
+    [MemberData(nameof(FloatData))]
+    public void FloatImplicit(float @float)
+    {
+        Value value = @float;
+        Assert.Equal(@float, value.GetValue<float>());
+        Assert.Equal(typeof(float), value.Type);
+
+        float? source = @float;
+        value = source;
+        Assert.Equal(source, value.GetValue<float?>());
+        Assert.Equal(typeof(float), value.Type);
+    }
+
+    [Theory]
+    [MemberData(nameof(FloatData))]
+    public void FloatCreate(float @float)
+    {
+        Value value;
+        using (MemoryWatch.Create)
+        {
+            value = Value.Create(@float);
+        }
+
+        Assert.Equal(@float, value.GetValue<float>());
+        Assert.Equal(typeof(float), value.Type);
+
+        float? source = @float;
+
+        using (MemoryWatch.Create)
+        {
+            value = Value.Create(source);
+        }
+
+        Assert.Equal(source, value.GetValue<float?>());
+        Assert.Equal(typeof(float), value.Type);
+    }
+
+    [Theory]
+    [MemberData(nameof(FloatData))]
+    public void FloatInOut(float @float)
+    {
+        Value value = new(@float);
+        bool success = value.TryGetValue(out float result);
+        Assert.True(success);
+        Assert.Equal(@float, result);
+
+        Assert.Equal(@float, value.GetValue<float>());
+        Assert.Equal(@float, (float)value);
+    }
+
+    [Theory]
+    [MemberData(nameof(FloatData))]
+    public void NullableFloatInFloatOut(float @float)
+    {
+        float? source = @float;
+        Value value = new(source);
+
+        bool success = value.TryGetValue(out float result);
+        Assert.True(success);
+        Assert.Equal(@float, result);
+
+        Assert.Equal(@float, value.GetValue<float>());
+
+        Assert.Equal(@float, (float)value);
+    }
+
+    [Theory]
+    [MemberData(nameof(FloatData))]
+    public void FloatInNullableFloatOut(float @float)
+    {
+        float source = @float;
+        Value value = new(source);
+        bool success = value.TryGetValue(out float? result);
+        Assert.True(success);
+        Assert.Equal(@float, result);
+
+        Assert.Equal(@float, (float?)value);
+    }
+
+    [Theory]
+    [MemberData(nameof(FloatData))]
+    public void BoxedFloat(float @float)
+    {
+        float i = @float;
+        object o = i;
+        Value value = new(o);
+
+        Assert.Equal(typeof(float), value.Type);
+        Assert.True(value.TryGetValue(out float result));
+        Assert.Equal(@float, result);
+        Assert.True(value.TryGetValue(out float? nullableResult));
+        Assert.Equal(@float, nullableResult!.Value);
+
+        float? n = @float;
+        o = n;
+        value = new(o);
+
+        Assert.Equal(typeof(float), value.Type);
+        Assert.True(value.TryGetValue(out result));
+        Assert.Equal(@float, result);
+        Assert.True(value.TryGetValue(out nullableResult));
+        Assert.Equal(@float, nullableResult!.Value);
+    }
+
+    [Fact]
+    public void NullFloat()
+    {
+        float? source = null;
+        Value value = source;
+        Assert.Null(value.Type);
+        Assert.Equal(source, value.GetValue<float?>());
+        Assert.False(value.GetValue<float?>().HasValue);
+    }
+
+    [Theory]
+    [MemberData(nameof(FloatData))]
+    public void OutAsObject(float @float)
+    {
+        Value value = new(@float);
+        object o = value.GetValue<object>();
+        Assert.Equal(typeof(float), o.GetType());
+        Assert.Equal(@float, (float)o);
+
+        float? n = @float;
+        value = new(n);
+        o = value.GetValue<object>();
+        Assert.Equal(typeof(float), o.GetType());
+        Assert.Equal(@float, (float)o);
+    }
+}

--- a/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Value/StoringInt.cs
+++ b/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Value/StoringInt.cs
@@ -1,0 +1,145 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.ValueTests;
+
+public class StoringInt
+{
+    public static TheoryData<int> IntData => new()
+    {
+        { 0 },
+        { 42 },
+        { int.MaxValue },
+        { int.MinValue }
+    };
+
+    [Theory]
+    [MemberData(nameof(IntData))]
+    public void IntImplicit(int @int)
+    {
+        Value value = @int;
+        Assert.Equal(@int, value.GetValue<int>());
+        Assert.Equal(typeof(int), value.Type);
+
+        int? source = @int;
+        value = source;
+        Assert.Equal(source, value.GetValue<int?>());
+        Assert.Equal(typeof(int), value.Type);
+    }
+
+    [Theory]
+    [MemberData(nameof(IntData))]
+    public void IntCreate(int @int)
+    {
+        Value value;
+        using (MemoryWatch.Create)
+        {
+            value = Value.Create(@int);
+        }
+
+        Assert.Equal(@int, value.GetValue<int>());
+        Assert.Equal(typeof(int), value.Type);
+
+        int? source = @int;
+
+        using (MemoryWatch.Create)
+        {
+            value = Value.Create(source);
+        }
+
+        Assert.Equal(source, value.GetValue<int?>());
+        Assert.Equal(typeof(int), value.Type);
+    }
+
+    [Theory]
+    [MemberData(nameof(IntData))]
+    public void IntInOut(int @int)
+    {
+        Value value = new(@int);
+        bool success = value.TryGetValue(out int result);
+        Assert.True(success);
+        Assert.Equal(@int, result);
+
+        Assert.Equal(@int, value.GetValue<int>());
+        Assert.Equal(@int, (int)value);
+    }
+
+    [Theory]
+    [MemberData(nameof(IntData))]
+    public void NullableIntInIntOut(int @int)
+    {
+        int? source = @int;
+        Value value = new(source);
+
+        bool success = value.TryGetValue(out int result);
+        Assert.True(success);
+        Assert.Equal(@int, result);
+
+        Assert.Equal(@int, value.GetValue<int>());
+
+        Assert.Equal(@int, (int)value);
+    }
+
+    [Theory]
+    [MemberData(nameof(IntData))]
+    public void IntInNullableIntOut(int @int)
+    {
+        int source = @int;
+        Value value = new(source);
+        Assert.True(value.TryGetValue(out int? result));
+        Assert.Equal(@int, result);
+
+        Assert.Equal(@int, (int?)value);
+    }
+
+    [Theory]
+    [MemberData(nameof(IntData))]
+    public void BoxedInt(int @int)
+    {
+        int i = @int;
+        object o = i;
+        Value value = new(o);
+
+        Assert.Equal(typeof(int), value.Type);
+        Assert.True(value.TryGetValue(out int result));
+        Assert.Equal(@int, result);
+        Assert.True(value.TryGetValue(out int? nullableResult));
+        Assert.Equal(@int, nullableResult!.Value);
+
+        int? n = @int;
+        o = n;
+        value = new(o);
+
+        Assert.Equal(typeof(int), value.Type);
+        Assert.True(value.TryGetValue(out result));
+        Assert.Equal(@int, result);
+        Assert.True(value.TryGetValue(out nullableResult));
+        Assert.Equal(@int, nullableResult!.Value);
+    }
+
+    [Fact]
+    public void NullInt()
+    {
+        int? source = null;
+        Value value = source;
+        Assert.Null(value.Type);
+        Assert.Equal(source, value.GetValue<int?>());
+        Assert.False(value.GetValue<int?>().HasValue);
+    }
+
+    [Theory]
+    [MemberData(nameof(IntData))]
+    public void OutAsObject(int @int)
+    {
+        Value value = new(@int);
+        object o = value.GetValue<object>();
+        Assert.Equal(typeof(int), o.GetType());
+        Assert.Equal(@int, (int)o);
+
+        int? n = @int;
+        value = new(n);
+        o = value.GetValue<object>();
+        Assert.Equal(typeof(int), o.GetType());
+        Assert.Equal(@int, (int)o);
+    }
+}

--- a/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Value/StoringLong.cs
+++ b/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Value/StoringLong.cs
@@ -1,0 +1,146 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.ValueTests;
+
+public class StoringLong
+{
+    public static TheoryData<long> LongData => new()
+    {
+        { 0 },
+        { 42 },
+        { long.MaxValue },
+        { long.MinValue }
+    };
+
+    [Theory]
+    [MemberData(nameof(LongData))]
+    public void LongImplicit(long @long)
+    {
+        Value value = @long;
+        Assert.Equal(@long, value.GetValue<long>());
+        Assert.Equal(typeof(long), value.Type);
+
+        long? source = @long;
+        value = source;
+        Assert.Equal(source, value.GetValue<long>());
+        Assert.Equal(typeof(long), value.Type);
+    }
+
+    [Theory]
+    [MemberData(nameof(LongData))]
+    public void LongCreate(long @long)
+    {
+        Value value;
+        using (MemoryWatch.Create)
+        {
+            value = Value.Create(@long);
+        }
+
+        Assert.Equal(@long, value.GetValue<long>());
+        Assert.Equal(typeof(long), value.Type);
+
+        long? source = @long;
+
+        using (MemoryWatch.Create)
+        {
+            value = Value.Create(source);
+        }
+
+        Assert.Equal(source, value.GetValue<long?>());
+        Assert.Equal(typeof(long), value.Type);
+    }
+
+    [Theory]
+    [MemberData(nameof(LongData))]
+    public void LongInOut(long @long)
+    {
+        Value value = new(@long);
+        bool success = value.TryGetValue(out long result);
+        Assert.True(success);
+        Assert.Equal(@long, result);
+
+        Assert.Equal(@long, value.GetValue<long>());
+        Assert.Equal(@long, (long)value);
+    }
+
+    [Theory]
+    [MemberData(nameof(LongData))]
+    public void NullableLongInLongOut(long @long)
+    {
+        long? source = @long;
+        Value value = new(source);
+
+        bool success = value.TryGetValue(out long result);
+        Assert.True(success);
+        Assert.Equal(@long, result);
+
+        Assert.Equal(@long, value.GetValue<long>());
+
+        Assert.Equal(@long, (long)value);
+    }
+
+    [Theory]
+    [MemberData(nameof(LongData))]
+    public void LongInNullableLongOut(long @long)
+    {
+        long source = @long;
+        Value value = new(source);
+        bool success = value.TryGetValue(out long? result);
+        Assert.True(success);
+        Assert.Equal(@long, result);
+
+        Assert.Equal(@long, (long?)value);
+    }
+
+    [Theory]
+    [MemberData(nameof(LongData))]
+    public void BoxedLong(long @long)
+    {
+        long i = @long;
+        object o = i;
+        Value value = new(o);
+
+        Assert.Equal(typeof(long), value.Type);
+        Assert.True(value.TryGetValue(out long result));
+        Assert.Equal(@long, result);
+        Assert.True(value.TryGetValue(out long? nullableResult));
+        Assert.Equal(@long, nullableResult!.Value);
+
+        long? n = @long;
+        o = n;
+        value = new(o);
+
+        Assert.Equal(typeof(long), value.Type);
+        Assert.True(value.TryGetValue(out result));
+        Assert.Equal(@long, result);
+        Assert.True(value.TryGetValue(out nullableResult));
+        Assert.Equal(@long, nullableResult!.Value);
+    }
+
+    [Fact]
+    public void NullLong()
+    {
+        long? source = null;
+        Value value = source;
+        Assert.Null(value.Type);
+        Assert.Equal(source, value.GetValue<long?>());
+        Assert.False(value.GetValue<long?>().HasValue);
+    }
+
+    [Theory]
+    [MemberData(nameof(LongData))]
+    public void OutAsObject(long @long)
+    {
+        Value value = new(@long);
+        object o = value.GetValue<object>();
+        Assert.Equal(typeof(long), o.GetType());
+        Assert.Equal(@long, (long)o);
+
+        long? n = @long;
+        value = new(n);
+        o = value.GetValue<object>();
+        Assert.Equal(typeof(long), o.GetType());
+        Assert.Equal(@long, (long)o);
+    }
+}

--- a/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Value/StoringNull.cs
+++ b/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Value/StoringNull.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.ValueTests;
+
+public class StoringNull
+{
+    [Fact]
+    public void GetIntFromStoredNull()
+    {
+        Value nullValue = new((object?)null);
+        Assert.Throws<InvalidCastException>(() => _ = nullValue.GetValue<int>());
+
+        Value nullFastValue = new((object?)null);
+        Assert.Throws<InvalidCastException>(() => _ = nullFastValue.GetValue<int>());
+
+        bool success = nullFastValue.TryGetValue(out int result);
+        Assert.False(success);
+
+        Assert.Equal(default(int), result);
+    }
+}

--- a/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Value/StoringObject.cs
+++ b/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Value/StoringObject.cs
@@ -1,0 +1,60 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.ValueTests;
+
+public class StoringObject
+{
+    [Fact]
+    public void BasicStorage()
+    {
+        A a = new();
+        Value value = new(a);
+        Assert.Equal(typeof(A), value.Type);
+        Assert.Same(a, value.GetValue<A>());
+
+        bool success = value.TryGetValue(out B result);
+        Assert.False(success);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void DerivedRetrieval()
+    {
+        B b = new();
+        Value value = new(b);
+        Assert.Equal(typeof(B), value.Type);
+        Assert.Same(b, value.GetValue<A>());
+        Assert.Same(b, value.GetValue<B>());
+
+        bool success = value.TryGetValue(out C result);
+        Assert.False(success);
+        Assert.Null(result);
+
+        Assert.Throws<InvalidCastException>(() => value.GetValue<C>());
+
+        A a = new B();
+        value = new(a);
+        Assert.Equal(typeof(B), value.Type);
+    }
+
+    [Fact]
+    public void AsInterface()
+    {
+        I a = new A();
+        Value value = new(a);
+        Assert.Equal(typeof(A), value.Type);
+
+        Assert.Same(a, value.GetValue<A>());
+        Assert.Same(a, value.GetValue<I>());
+    }
+
+    private class A : I { }
+    private class B : A, I { }
+    private class C : B, I { }
+
+    private interface I
+    {
+        string? ToString();
+    }
+}

--- a/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Value/StoringSByte.cs
+++ b/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Value/StoringSByte.cs
@@ -1,0 +1,121 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.ValueTests;
+
+public class StoringSByte
+{
+    public static TheoryData<sbyte> SByteData => new()
+    {
+        { 0 },
+        { 42 },
+        { sbyte.MaxValue },
+        { sbyte.MinValue }
+    };
+
+    [Theory]
+    [MemberData(nameof(SByteData))]
+    public void SByteImplicit(sbyte @sbyte)
+    {
+        Value value = @sbyte;
+        Assert.Equal(@sbyte, value.GetValue<sbyte>());
+        Assert.Equal(typeof(sbyte), value.Type);
+
+        sbyte? source = @sbyte;
+        value = source;
+        Assert.Equal(source, value.GetValue<sbyte?>());
+        Assert.Equal(typeof(sbyte), value.Type);
+    }
+
+    [Theory]
+    [MemberData(nameof(SByteData))]
+    public void SByteCreate(sbyte @sbyte)
+    {
+        Value value;
+        using (MemoryWatch.Create)
+        {
+            value = Value.Create(@sbyte);
+        }
+
+        Assert.Equal(@sbyte, value.GetValue<sbyte>());
+        Assert.Equal(typeof(sbyte), value.Type);
+
+        sbyte? source = @sbyte;
+
+        using (MemoryWatch.Create)
+        {
+            value = Value.Create(source);
+        }
+
+        Assert.Equal(source, value.GetValue<sbyte?>());
+        Assert.Equal(typeof(sbyte), value.Type);
+    }
+
+    [Theory]
+    [MemberData(nameof(SByteData))]
+    public void SByteInOut(sbyte @sbyte)
+    {
+        Value value = new(@sbyte);
+        bool success = value.TryGetValue(out sbyte result);
+        Assert.True(success);
+        Assert.Equal(@sbyte, result);
+
+        Assert.Equal(@sbyte, value.GetValue<sbyte>());
+        Assert.Equal(@sbyte, (sbyte)value);
+    }
+
+    [Theory]
+    [MemberData(nameof(SByteData))]
+    public void NullableSByteInSByteOut(sbyte @sbyte)
+    {
+        sbyte? source = @sbyte;
+        Value value = new(source);
+
+        bool success = value.TryGetValue(out sbyte result);
+        Assert.True(success);
+        Assert.Equal(@sbyte, result);
+
+        Assert.Equal(@sbyte, value.GetValue<sbyte>());
+
+        Assert.Equal(@sbyte, (sbyte)value);
+    }
+
+    [Theory]
+    [MemberData(nameof(SByteData))]
+    public void SByteInNullableSByteOut(sbyte @sbyte)
+    {
+        sbyte source = @sbyte;
+        Value value = new(source);
+        bool success = value.TryGetValue(out sbyte? result);
+        Assert.True(success);
+        Assert.Equal(@sbyte, result);
+
+        Assert.Equal(@sbyte, (sbyte?)value);
+    }
+
+    [Fact]
+    public void NullSByte()
+    {
+        sbyte? source = null;
+        Value value = source;
+        Assert.Null(value.Type);
+        Assert.Equal(source, value.GetValue<sbyte?>());
+        Assert.False(value.GetValue<sbyte?>().HasValue);
+    }
+
+    [Theory]
+    [MemberData(nameof(SByteData))]
+    public void OutAsObject(sbyte @sbyte)
+    {
+        Value value = new(@sbyte);
+        object o = value.GetValue<object>();
+        Assert.Equal(typeof(sbyte), o.GetType());
+        Assert.Equal(@sbyte, (sbyte)o);
+
+        sbyte? n = @sbyte;
+        value = new(n);
+        o = value.GetValue<object>();
+        Assert.Equal(typeof(sbyte), o.GetType());
+        Assert.Equal(@sbyte, (sbyte)o);
+    }
+}

--- a/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Value/StoringShort.cs
+++ b/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Value/StoringShort.cs
@@ -1,0 +1,146 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.ValueTests;
+
+public class StoringShort
+{
+    public static TheoryData<short> ShortData => new()
+    {
+        { 0 },
+        { 42 },
+        { short.MaxValue },
+        { short.MinValue }
+    };
+
+    [Theory]
+    [MemberData(nameof(ShortData))]
+    public void ShortImplicit(short @short)
+    {
+        Value value = @short;
+        Assert.Equal(@short, value.GetValue<short>());
+        Assert.Equal(typeof(short), value.Type);
+
+        short? source = @short;
+        value = source;
+        Assert.Equal(source, value.GetValue<short?>());
+        Assert.Equal(typeof(short), value.Type);
+    }
+
+    [Theory]
+    [MemberData(nameof(ShortData))]
+    public void ShortCreate(short @short)
+    {
+        Value value;
+        using (MemoryWatch.Create)
+        {
+            value = Value.Create(@short);
+        }
+
+        Assert.Equal(@short, value.GetValue<short>());
+        Assert.Equal(typeof(short), value.Type);
+
+        short? source = @short;
+
+        using (MemoryWatch.Create)
+        {
+            value = Value.Create(source);
+        }
+
+        Assert.Equal(source, value.GetValue<short?>());
+        Assert.Equal(typeof(short), value.Type);
+    }
+
+    [Theory]
+    [MemberData(nameof(ShortData))]
+    public void ShortInOut(short @short)
+    {
+        Value value = new(@short);
+        bool success = value.TryGetValue(out short result);
+        Assert.True(success);
+        Assert.Equal(@short, result);
+
+        Assert.Equal(@short, value.GetValue<short>());
+        Assert.Equal(@short, (short)value);
+    }
+
+    [Theory]
+    [MemberData(nameof(ShortData))]
+    public void NullableShortInShortOut(short @short)
+    {
+        short? source = @short;
+        Value value = new(source);
+
+        bool success = value.TryGetValue(out short result);
+        Assert.True(success);
+        Assert.Equal(@short, result);
+
+        Assert.Equal(@short, value.GetValue<short>());
+
+        Assert.Equal(@short, (short)value);
+    }
+
+    [Theory]
+    [MemberData(nameof(ShortData))]
+    public void ShortInNullableShortOut(short @short)
+    {
+        short source = @short;
+        Value value = new(source);
+        bool success = value.TryGetValue(out short? result);
+        Assert.True(success);
+        Assert.Equal(@short, result);
+
+        Assert.Equal(@short, (short?)value);
+    }
+
+    [Theory]
+    [MemberData(nameof(ShortData))]
+    public void BoxedShort(short @short)
+    {
+        short i = @short;
+        object o = i;
+        Value value = new(o);
+
+        Assert.Equal(typeof(short), value.Type);
+        Assert.True(value.TryGetValue(out short result));
+        Assert.Equal(@short, result);
+        Assert.True(value.TryGetValue(out short? nullableResult));
+        Assert.Equal(@short, nullableResult!.Value);
+
+        short? n = @short;
+        o = n;
+        value = new(o);
+
+        Assert.Equal(typeof(short), value.Type);
+        Assert.True(value.TryGetValue(out result));
+        Assert.Equal(@short, result);
+        Assert.True(value.TryGetValue(out nullableResult));
+        Assert.Equal(@short, nullableResult!.Value);
+    }
+
+    [Fact]
+    public void NullShort()
+    {
+        short? source = null;
+        Value value = source;
+        Assert.Null(value.Type);
+        Assert.Equal(source, value.GetValue<short?>());
+        Assert.False(value.GetValue<short?>().HasValue);
+    }
+
+    [Theory]
+    [MemberData(nameof(ShortData))]
+    public void OutAsObject(short @short)
+    {
+        Value value = new(@short);
+        object o = value.GetValue<object>();
+        Assert.Equal(typeof(short), o.GetType());
+        Assert.Equal(@short, (short)o);
+
+        short? n = @short;
+        value = new(n);
+        o = value.GetValue<object>();
+        Assert.Equal(typeof(short), o.GetType());
+        Assert.Equal(@short, (short)o);
+    }
+}

--- a/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Value/StoringUInt.cs
+++ b/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Value/StoringUInt.cs
@@ -1,0 +1,145 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.ValueTests;
+
+public class StoringUInt
+{
+    public static TheoryData<uint> UIntData => new()
+    {
+        { 42 },
+        { uint.MaxValue },
+        { uint.MinValue }
+    };
+
+    [Theory]
+    [MemberData(nameof(UIntData))]
+    public void UIntImplicit(uint @uint)
+    {
+        Value value = @uint;
+        Assert.Equal(@uint, value.GetValue<uint>());
+        Assert.Equal(typeof(uint), value.Type);
+
+        uint? source = @uint;
+        value = source;
+        Assert.Equal(source, value.GetValue<uint?>());
+        Assert.Equal(typeof(uint), value.Type);
+    }
+
+    [Theory]
+    [MemberData(nameof(UIntData))]
+    public void UIntCreate(uint @uint)
+    {
+        Value value;
+        using (MemoryWatch.Create)
+        {
+            value = Value.Create(@uint);
+        }
+
+        Assert.Equal(@uint, value.GetValue<uint>());
+        Assert.Equal(typeof(uint), value.Type);
+
+        uint? source = @uint;
+
+        using (MemoryWatch.Create)
+        {
+            value = Value.Create(source);
+        }
+
+        Assert.Equal(source, value.GetValue<uint?>());
+        Assert.Equal(typeof(uint), value.Type);
+    }
+
+    [Theory]
+    [MemberData(nameof(UIntData))]
+    public void UIntInOut(uint @uint)
+    {
+        Value value = new(@uint);
+        bool success = value.TryGetValue(out uint result);
+        Assert.True(success);
+        Assert.Equal(@uint, result);
+
+        Assert.Equal(@uint, value.GetValue<uint>());
+        Assert.Equal(@uint, (uint)value);
+    }
+
+    [Theory]
+    [MemberData(nameof(UIntData))]
+    public void NullableUIntInUIntOut(uint @uint)
+    {
+        uint? source = @uint;
+        Value value = new(source);
+
+        bool success = value.TryGetValue(out uint result);
+        Assert.True(success);
+        Assert.Equal(@uint, result);
+
+        Assert.Equal(@uint, value.GetValue<uint>());
+
+        Assert.Equal(@uint, (uint)value);
+    }
+
+    [Theory]
+    [MemberData(nameof(UIntData))]
+    public void UIntInNullableUIntOut(uint @uint)
+    {
+        uint source = @uint;
+        Value value = new(source);
+        bool success = value.TryGetValue(out uint? result);
+        Assert.True(success);
+        Assert.Equal(@uint, result);
+
+        Assert.Equal(@uint, (uint?)value);
+    }
+
+    [Theory]
+    [MemberData(nameof(UIntData))]
+    public void BoxedUInt(uint @uint)
+    {
+        uint i = @uint;
+        object o = i;
+        Value value = new(o);
+
+        Assert.Equal(typeof(uint), value.Type);
+        Assert.True(value.TryGetValue(out uint result));
+        Assert.Equal(@uint, result);
+        Assert.True(value.TryGetValue(out uint? nullableResult));
+        Assert.Equal(@uint, nullableResult!.Value);
+
+        uint? n = @uint;
+        o = n;
+        value = new(o);
+
+        Assert.Equal(typeof(uint), value.Type);
+        Assert.True(value.TryGetValue(out result));
+        Assert.Equal(@uint, result);
+        Assert.True(value.TryGetValue(out nullableResult));
+        Assert.Equal(@uint, nullableResult!.Value);
+    }
+
+    [Fact]
+    public void NullUInt()
+    {
+        uint? source = null;
+        Value value = source;
+        Assert.Null(value.Type);
+        Assert.Equal(source, value.GetValue<uint?>());
+        Assert.False(value.GetValue<uint?>().HasValue);
+    }
+
+    [Theory]
+    [MemberData(nameof(UIntData))]
+    public void OutAsObject(uint @uint)
+    {
+        Value value = new(@uint);
+        object o = value.GetValue<object>();
+        Assert.Equal(typeof(uint), o.GetType());
+        Assert.Equal(@uint, (uint)o);
+
+        uint? n = @uint;
+        value = new(n);
+        o = value.GetValue<object>();
+        Assert.Equal(typeof(uint), o.GetType());
+        Assert.Equal(@uint, (uint)o);
+    }
+}

--- a/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Value/StoringUShort.cs
+++ b/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Value/StoringUShort.cs
@@ -1,0 +1,145 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.ValueTests;
+
+public class StoringUShort
+{
+    public static TheoryData<ushort> UShortData => new()
+    {
+        { 42 },
+        { ushort.MaxValue },
+        { ushort.MinValue }
+    };
+
+    [Theory]
+    [MemberData(nameof(UShortData))]
+    public void UShortImplicit(ushort @ushort)
+    {
+        Value value = @ushort;
+        Assert.Equal(@ushort, value.GetValue<ushort>());
+        Assert.Equal(typeof(ushort), value.Type);
+
+        ushort? source = @ushort;
+        value = source;
+        Assert.Equal(source, value.GetValue<ushort?>());
+        Assert.Equal(typeof(ushort), value.Type);
+    }
+
+    [Theory]
+    [MemberData(nameof(UShortData))]
+    public void UShortCreate(ushort @ushort)
+    {
+        Value value;
+        using (MemoryWatch.Create)
+        {
+            value = Value.Create(@ushort);
+        }
+
+        Assert.Equal(@ushort, value.GetValue<ushort>());
+        Assert.Equal(typeof(ushort), value.Type);
+
+        ushort? source = @ushort;
+
+        using (MemoryWatch.Create)
+        {
+            value = Value.Create(source);
+        }
+
+        Assert.Equal(source, value.GetValue<ushort?>());
+        Assert.Equal(typeof(ushort), value.Type);
+    }
+
+    [Theory]
+    [MemberData(nameof(UShortData))]
+    public void UShortInOut(ushort @ushort)
+    {
+        Value value = new(@ushort);
+        bool success = value.TryGetValue(out ushort result);
+        Assert.True(success);
+        Assert.Equal(@ushort, result);
+
+        Assert.Equal(@ushort, value.GetValue<ushort>());
+        Assert.Equal(@ushort, (ushort)value);
+    }
+
+    [Theory]
+    [MemberData(nameof(UShortData))]
+    public void NullableUShortInUShortOut(ushort @ushort)
+    {
+        ushort? source = @ushort;
+        Value value = new(source);
+
+        bool success = value.TryGetValue(out ushort result);
+        Assert.True(success);
+        Assert.Equal(@ushort, result);
+
+        Assert.Equal(@ushort, value.GetValue<ushort>());
+
+        Assert.Equal(@ushort, (ushort)value);
+    }
+
+    [Theory]
+    [MemberData(nameof(UShortData))]
+    public void UShortInNullableUShortOut(ushort @ushort)
+    {
+        ushort source = @ushort;
+        Value value = new(source);
+        bool success = value.TryGetValue(out ushort? result);
+        Assert.True(success);
+        Assert.Equal(@ushort, result);
+
+        Assert.Equal(@ushort, (ushort?)value);
+    }
+
+    [Theory]
+    [MemberData(nameof(UShortData))]
+    public void BoxedUShort(ushort @ushort)
+    {
+        ushort i = @ushort;
+        object o = i;
+        Value value = new(o);
+
+        Assert.Equal(typeof(ushort), value.Type);
+        Assert.True(value.TryGetValue(out ushort result));
+        Assert.Equal(@ushort, result);
+        Assert.True(value.TryGetValue(out ushort? nullableResult));
+        Assert.Equal(@ushort, nullableResult!.Value);
+
+        ushort? n = @ushort;
+        o = n;
+        value = new(o);
+
+        Assert.Equal(typeof(ushort), value.Type);
+        Assert.True(value.TryGetValue(out result));
+        Assert.Equal(@ushort, result);
+        Assert.True(value.TryGetValue(out nullableResult));
+        Assert.Equal(@ushort, nullableResult!.Value);
+    }
+
+    [Fact]
+    public void NullUShort()
+    {
+        ushort? source = null;
+        Value value = source;
+        Assert.Null(value.Type);
+        Assert.Equal(source, value.GetValue<ushort?>());
+        Assert.False(value.GetValue<ushort?>().HasValue);
+    }
+
+    [Theory]
+    [MemberData(nameof(UShortData))]
+    public void OutAsObject(ushort @ushort)
+    {
+        Value value = new(@ushort);
+        object o = value.GetValue<object>();
+        Assert.Equal(typeof(ushort), o.GetType());
+        Assert.Equal(@ushort, (ushort)o);
+
+        ushort? n = @ushort;
+        value = new(n);
+        o = value.GetValue<object>();
+        Assert.Equal(typeof(ushort), o.GetType());
+        Assert.Equal(@ushort, (ushort)o);
+    }
+}

--- a/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Value/StoringUlong.cs
+++ b/src/System.Private.Windows.Core/tests/System.Private.Windows.Core.Tests/System/Value/StoringUlong.cs
@@ -1,0 +1,145 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.ValueTests;
+
+public class StoringULong
+{
+    public static TheoryData<ulong> ULongData => new()
+    {
+        { 42 },
+        { ulong.MaxValue },
+        { ulong.MinValue }
+    };
+
+    [Theory]
+    [MemberData(nameof(ULongData))]
+    public void ULongImplicit(ulong @ulong)
+    {
+        Value value = @ulong;
+        Assert.Equal(@ulong, value.GetValue<ulong>());
+        Assert.Equal(typeof(ulong), value.Type);
+
+        ulong? source = @ulong;
+        value = source;
+        Assert.Equal(source, value.GetValue<ulong?>());
+        Assert.Equal(typeof(ulong), value.Type);
+    }
+
+    [Theory]
+    [MemberData(nameof(ULongData))]
+    public void ULongCreate(ulong @ulong)
+    {
+        Value value;
+        using (MemoryWatch.Create)
+        {
+            value = Value.Create(@ulong);
+        }
+
+        Assert.Equal(@ulong, value.GetValue<ulong>());
+        Assert.Equal(typeof(ulong), value.Type);
+
+        ulong? source = @ulong;
+
+        using (MemoryWatch.Create)
+        {
+            value = Value.Create(source);
+        }
+
+        Assert.Equal(source, value.GetValue<ulong?>());
+        Assert.Equal(typeof(ulong), value.Type);
+    }
+
+    [Theory]
+    [MemberData(nameof(ULongData))]
+    public void ULongInOut(ulong @ulong)
+    {
+        Value value = new(@ulong);
+        bool success = value.TryGetValue(out ulong result);
+        Assert.True(success);
+        Assert.Equal(@ulong, result);
+
+        Assert.Equal(@ulong, value.GetValue<ulong>());
+        Assert.Equal(@ulong, (ulong)value);
+    }
+
+    [Theory]
+    [MemberData(nameof(ULongData))]
+    public void NullableULongInULongOut(ulong @ulong)
+    {
+        ulong? source = @ulong;
+        Value value = new(source);
+
+        bool success = value.TryGetValue(out ulong result);
+        Assert.True(success);
+        Assert.Equal(@ulong, result);
+
+        Assert.Equal(@ulong, value.GetValue<ulong>());
+
+        Assert.Equal(@ulong, (ulong)value);
+    }
+
+    [Theory]
+    [MemberData(nameof(ULongData))]
+    public void ULongInNullableULongOut(ulong @ulong)
+    {
+        ulong source = @ulong;
+        Value value = new(source);
+        bool success = value.TryGetValue(out ulong? result);
+        Assert.True(success);
+        Assert.Equal(@ulong, result);
+
+        Assert.Equal(@ulong, (ulong?)value);
+    }
+
+    [Theory]
+    [MemberData(nameof(ULongData))]
+    public void BoxedULong(ulong @ulong)
+    {
+        ulong i = @ulong;
+        object o = i;
+        Value value = new(o);
+
+        Assert.Equal(typeof(ulong), value.Type);
+        Assert.True(value.TryGetValue(out ulong result));
+        Assert.Equal(@ulong, result);
+        Assert.True(value.TryGetValue(out ulong? nullableResult));
+        Assert.Equal(@ulong, nullableResult!.Value);
+
+        ulong? n = @ulong;
+        o = n;
+        value = new(o);
+
+        Assert.Equal(typeof(ulong), value.Type);
+        Assert.True(value.TryGetValue(out result));
+        Assert.Equal(@ulong, result);
+        Assert.True(value.TryGetValue(out nullableResult));
+        Assert.Equal(@ulong, nullableResult!.Value);
+    }
+
+    [Fact]
+    public void NullULong()
+    {
+        ulong? source = null;
+        Value value = source;
+        Assert.Null(value.Type);
+        Assert.Equal(source, value.GetValue<ulong?>());
+        Assert.False(value.GetValue<ulong?>().HasValue);
+    }
+
+    [Theory]
+    [MemberData(nameof(ULongData))]
+    public void OutAsObject(ulong @ulong)
+    {
+        Value value = new(@ulong);
+        object o = value.GetValue<object>();
+        Assert.Equal(typeof(ulong), o.GetType());
+        Assert.Equal(@ulong, (ulong)o);
+
+        ulong? n = @ulong;
+        value = new(n);
+        o = value.GetValue<object>();
+        Assert.Equal(typeof(ulong), o.GetType());
+        Assert.Equal(@ulong, (ulong)o);
+    }
+}


### PR DESCRIPTION
This gives us the ability to store primitives without boxing/unboxing them.

Replacing PropertyStore's internals with this will greatly simplify its implementation and handle far more than just int.

Also adds a dedicated unit test project for the Core assembly.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11666)