### PR TITLE
Add source.dot.net stage 1 asset publication 

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -113,7 +113,7 @@ extends:
       - ${{ if eq(variables.enableSourceIndex, 'true') }}:
         - template: /eng/common/templates-official/job/source-index-stage1.yml@self
           parameters:
-            sourceIndexBuildCommand: eng\cibuild.cmd -restore -build -configuration $(_BuildConfig) /p:Platform=x64 /p:TargetArchitecture=x64 /bl:msbuild.binlog
+            sourceIndexBuildCommand: eng\cibuild.cmd -restore -build -configuration Release /p:Platform=x64 /p:TargetArchitecture=x64 /bl:msbuild.binlog
             binlogPath: msbuild.binlog
             pool:
               name: $(DncEngInternalBuildPool)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,6 +61,9 @@ variables:
   value: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName) /p:Sign=$(_Sign)
 - name: _Sign
   value: true
+#- ${{ if and(notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
+- name: enableSourceIndex
+  value: true
 resources:
   repositories:
   - repository: 1ESPipelineTemplates
@@ -106,6 +109,15 @@ extends:
           name: Windows_arm64
           targetArchitecture: arm64
           skipTests: $(SkipTests)
+
+      - ${{ if eq(variables.enableSourceIndex, 'true') }}:
+        - template: /eng/common/templates-official/job/source-index-stage1.yml@self
+          parameters:
+            sourceIndexBuildCommand: eng\cibuild.cmd -restore -build -configuration $(_BuildConfig) /p:Platform=x64 /p:TargetArchitecture=x64 /bl:msbuild.binlog
+            binlogPath: msbuild.binlog
+            pool:
+              name: $(DncEngInternalBuildPool)
+              demands: ImageOverride -equals 1es-windows-2022
 
     - ${{ if eq(variables['EnableLoc'], 'true') }}:
       - stage: OneLocBuild

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,9 +61,9 @@ variables:
   value: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName) /p:Sign=$(_Sign)
 - name: _Sign
   value: true
-#- ${{ if and(notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
-- name: enableSourceIndex
-  value: true
+- ${{ if and(notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
+  - name: enableSourceIndex
+    value: true
 resources:
   repositories:
   - repository: 1ESPipelineTemplates


### PR DESCRIPTION
This is a prerequisite for inclusion on source.dot.net.

It seems a first attempt was made to add winforms.git to source.dot.net [in late 2018](https://github.com/dotnet/source-indexer/commit/34f0c3d814b0e50c030ed46aee2a98f464243acf), but it started failing at some point leading to being missed during index generation.

Generally speaking, "V2" repositories (data sent in by individual repo CI) are more robust for inclusion than the old V1 repos (repo data generated during source-indexer CI runs) - as such we aren't really interested in adding or fixing any V1 repos, and would like to move to V2.

This move also allows the repo owners who know their code best to fine-tune their build flags and environment far more easily than for V1 repos.

Please note that there is https://github.com/dotnet/dnceng/issues/2974 where V2 repository publishing can occasionally fail due to obscure permissions errors from Azure since we switched uploads from SAS to Managed Identity (currently about 6 failures per day total across all repositories).

Closes: https://github.com/dotnet/source-indexer/issues/138
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11667)