### PR TITLE
Add Untriaged to Issue when Author Responds

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -243,7 +243,7 @@ configuration:
           label: ':mailbox_with_no_mail: waiting-author-feedback'
       - addLabel:
           label: 'untriaged'
-      description: Remove needs author feedback label when the author comments on an issue
+      description: Remove needs author feedback label when the author comments on an issue and adds untriaged label
     - if:
       - payloadType: Issue_Comment
       - hasLabel:

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -241,6 +241,8 @@ configuration:
       then:
       - removeLabel:
           label: ':mailbox_with_no_mail: waiting-author-feedback'
+      - addLabel:
+          label: 'untriaged'
       description: Remove needs author feedback label when the author comments on an issue
     - if:
       - payloadType: Issue_Comment


### PR DESCRIPTION
If issue was waiting for author feedback and author responds, have the bot add untriaged label to ensure we see it again during triage if not earlier
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11683)