### PR TITLE
Fix image rendering in LinkLabel

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/Labels/LinkLabel.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/Labels/LinkLabel.cs
@@ -1155,18 +1155,16 @@ public partial class LinkLabel : Label, IButtonControl
 
         Rectangle imageBounds = CalcImageRenderBounds(image, ClientRectangle, RtlTranslateAlignment(ImageAlign));
 
-        using GraphicsStateScope backgroundPaintScope = new(e.Graphics);
+        using (GraphicsStateScope backgroundPaintScope = new(e.Graphics))
         {
             e.Graphics.ExcludeClip(imageBounds);
             base.OnPaintBackground(e);
         }
 
         using GraphicsStateScope imagePaintScope = new(e.Graphics);
-        {
-            e.Graphics.IntersectClip(imageBounds);
-            base.OnPaintBackground(e);
-            DrawImage(e.Graphics, image, ClientRectangle, RtlTranslateAlignment(ImageAlign));
-        }
+        e.Graphics.IntersectClip(imageBounds);
+        base.OnPaintBackground(e);
+        DrawImage(e.Graphics, image, ClientRectangle, RtlTranslateAlignment(ImageAlign));
     }
 
     protected override void OnFontChanged(EventArgs e)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGrid.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGrid.cs
@@ -176,7 +176,7 @@ public partial class PropertyGrid : ContainerControl, IComPropertyBrowser, IProp
             _toolStrip = new PropertyGridToolStrip(this);
 
             // SetupToolbar should perform the layout
-            using SuspendLayoutScope suspendToolStripLayout = new(_toolStrip, performLayout: false);
+            using (SuspendLayoutScope suspendToolStripLayout = new(_toolStrip, performLayout: false))
             {
                 _toolStrip.ShowItemToolTips = true;
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewCellTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewCellTests.cs
@@ -5494,9 +5494,7 @@ public class DataGridViewCellTests
     {
         using Bitmap image = new(10, 10);
         using Graphics graphics = Graphics.FromImage(image);
-        {
-            Assert.Equal(Size.Empty, DataGridViewCell.MeasureTextSize(graphics, text, SystemFonts.DefaultFont, TextFormatFlags.Default));
-        }
+        Assert.Equal(Size.Empty, DataGridViewCell.MeasureTextSize(graphics, text, SystemFonts.DefaultFont, TextFormatFlags.Default));
     }
 
     [WinFormsTheory]


### PR DESCRIPTION
Didn't have the using scope correct. Did a regex to try and find other places where this mistake might have been made and fixed another found in PropertyGrid.

Fixes #11680

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11684)