### PR TITLE
Add code coverage for treeview

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/TreeNode.TreeNodeAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/TreeNode.TreeNodeAccessibleObjectTests.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Drawing;
 using Windows.Win32.UI.Accessibility;
 using static System.Windows.Forms.TreeNode;
 
@@ -14,8 +15,12 @@ public class TreeNodeAccessibleObjectTests
         using TreeView control = new();
         TreeNode node = new(control);
 
-        Assert.NotNull(node.AccessibilityObject);
-        Assert.False(control.IsHandleCreated);
+        node.AccessibilityObject.Should().NotBeNull();      
+        node.AccessibilityObject.CanGetDefaultActionInternal.Should().BeFalse();
+        node.AccessibilityObject.CanGetNameInternal.Should().BeFalse();
+        node.AccessibilityObject.IsItemSelected.Should().BeFalse();
+        node.AccessibilityObject.CanGetValueInternal.Should().BeFalse();
+        control.IsHandleCreated.Should().BeFalse();
     }
 
     [WinFormsFact]
@@ -582,6 +587,36 @@ public class TreeNodeAccessibleObjectTests
         Assert.True(secondLevelNode.IsAccessibilityObjectDisconnected);
         Assert.True(thirdLevelNode.IsAccessibilityObjectDisconnected);
         Assert.True(control.IsHandleCreated);
+    }
+
+    [WinFormsTheory]
+    [InlineData(false, false, true)]
+    [InlineData(true, true, false)]
+    public void TreeNodeAccessibleObject_Bounds_ShouldMatchExpected_IfConditionsMet(bool createControl, bool makeNodeVisible, bool expectBoundsEmpty)
+    {
+        using TreeView treeView = new();
+        TreeNode node = new("Node");
+        treeView.Nodes.Add(node);
+
+        if (createControl)
+        {
+            treeView.CreateControl();
+            if (makeNodeVisible)
+            {
+                treeView.ExpandAll();
+            }
+        }
+
+        var accessibleObject = node.AccessibilityObject;
+
+        if (expectBoundsEmpty)
+        {
+            accessibleObject.Bounds.Should().Be(Rectangle.Empty);
+        }
+        else
+        {
+            accessibleObject.Bounds.Should().NotBe(Rectangle.Empty);
+        }
     }
 
     private class AccessibilityObjectDisconnectTrackingTreeNode : TreeNode

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNodeCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNodeCollectionTests.cs
@@ -242,8 +242,8 @@ public class TreeNodeCollectionTests
         treeView.Sort();
         treeView.CreateControl();
 
-        TreeNode[] treeNodeArray = new TreeNode[]
-        {
+        TreeNode[] treeNodeArray =
+        [
             new()
             {
                 Name = "2",
@@ -254,7 +254,7 @@ public class TreeNodeCollectionTests
                 Name = "1",
                 Text = "1"
             }
-        };
+        ];
 
         treeView.Nodes.AddRange(treeNodeArray);
 
@@ -281,8 +281,8 @@ public class TreeNodeCollectionTests
             Name = "7",
             Text = "7"
         };
-        TreeNode[] treeNodeArray = new TreeNode[]
-        {
+        TreeNode[] treeNodeArray =
+        [
             new()
             {
                 Name = "2",
@@ -293,7 +293,7 @@ public class TreeNodeCollectionTests
                 Name = "1",
                 Text = "1"
             }
-        };
+        ];
 
         TreeNode treeNode;
         using (TreeNodeCollectionAddRangeRespectsSortOrderScope scope = new(enable: true))
@@ -501,5 +501,38 @@ public class TreeNodeCollectionTests
 
         treeNode.Should().Be(collection[0]);
         treeNode.ImageIndex.Should().Be(imageIndex);
+    }
+
+    [WinFormsTheory]
+    [InlineData("name1", true)]
+    [InlineData("name2", true)]
+    [InlineData("NonExistentNode", false)]
+    public void TreeNodeCollection_Contains_VariousScenarios_ReturnsExpected(string nodeName, bool expected)
+    {
+        var collection = CreateCollectionWithNodes();
+        TreeNode node = new(nodeName);
+        collection.Add(node);
+
+        bool result = collection.Contains(collection[nodeName]);
+
+        if (nodeName == "NonExistentNode")
+        {
+            collection.Remove(node);
+        }
+
+        result.Should().Be(expected);
+    }
+
+    [WinFormsFact]
+    public void TreeNodeCollection_Contains_SpecialCases_ReturnsFalse()
+    {
+        var collection = CreateCollectionWithNodes();
+        var nodeToRemove = collection[0];
+
+        collection.Remove(nodeToRemove);
+        collection.Contains(nodeToRemove).Should().BeFalse();
+
+        collection.Clear();
+        collection.Contains(nodeToRemove).Should().BeFalse();
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
@@ -7531,6 +7531,42 @@ public class TreeViewTests
         treeView.ToString().Should().Be($"System.Windows.Forms.TreeView, Nodes.Count: 2, Nodes[0]: {treeView.Nodes[0]}");
     }
 
+    [WinFormsFact]
+    public void ArraySubsetEnumerator_Behavior_AfterMoveNextAndReset()
+    {
+        object[] array = { "a", "b", "c" };
+        ArraySubsetEnumerator enumerator = new(array, 2);
+
+        enumerator.MoveNext().Should().BeTrue();
+        enumerator.Current.Should().Be("a");
+
+        enumerator.MoveNext().Should().BeTrue();
+        enumerator.Current.Should().Be("b");
+
+        enumerator.Reset();
+        enumerator.Current.Should().BeNull();
+
+        enumerator.MoveNext().Should().BeTrue();
+        enumerator.Current.Should().Be("a");
+    }
+
+    [WinFormsTheory]
+    [InlineData(5, 100, 5)] 
+    [InlineData(10, 100, 5)] 
+    public void TreeView_VisibleCount_MultipleNodes_ReturnsExpected(int nodeCount, int controlHeight, int expectedVisibleCount)
+    {
+        using TreeView treeView = new();
+
+        for (int i = 0; i < nodeCount; i++)
+        {
+            treeView.Nodes.Add($"Node{i}");
+        }
+
+        treeView.CreateControl();
+        treeView.Height = controlHeight;
+        treeView.VisibleCount.Should().Be(expectedVisibleCount);
+    }
+
     private class SubTreeView : TreeView
     {
         public new bool CanEnableIme => base.CanEnableIme;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
@@ -7551,9 +7551,9 @@ public class TreeViewTests
     }
 
     [WinFormsTheory]
-    [InlineData(5, 100, 5)] 
-    [InlineData(10, 100, 5)] 
-    public void TreeView_VisibleCount_MultipleNodes_ReturnsExpected(int nodeCount, int controlHeight, int expectedVisibleCount)
+    [InlineData(5)]
+    [InlineData(10)]
+    public void TreeView_VisibleCount_MultipleNodes_ReturnsExpected(int nodeCount)
     {
         using TreeView treeView = new();
 
@@ -7563,8 +7563,8 @@ public class TreeViewTests
         }
 
         treeView.CreateControl();
-        treeView.Height = controlHeight;
-        treeView.VisibleCount.Should().Be(expectedVisibleCount);
+        treeView.Height = 100; 
+        treeView.VisibleCount.Should().Be(5); 
     }
 
     private class SubTreeView : TreeView


### PR DESCRIPTION
related https://github.com/dotnet/winforms/issues/10453

**Proposed changes**
- Add unit tests for TreeView to test its properties:CanGetDefaultActionInternal, CanGetNameInternal, IsItemSelected, CanGetValueInternal, VisibleCount
- Add unit tests for TreeView to test its methods: Contains(), Reset()
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11686)