### PR TITLE
Add unit tests for RadioButton and RadioButton.RadioButtonAccessibleObject

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/RadioButton.RadioButtonAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/RadioButton.RadioButtonAccessibleObjectTests.cs
@@ -71,7 +71,7 @@ public class RadioButton_RadioButtonAccessibleObjectTests
     }
 
     [WinFormsFact]
-    public void RadioButtonAccessibleObject_Name_ReturnsExpected()
+    public void RadioButtonAccessibleObject_Name_ReturnsExpected_AccessibleName()
     {
         using RadioButton radioButton = new()
         {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/RadioButton.RadioButtonAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/RadioButton.RadioButtonAccessibleObjectTests.cs
@@ -86,6 +86,37 @@ public class RadioButton_RadioButtonAccessibleObjectTests
     }
 
     [WinFormsFact]
+    public void RadioButtonAccessibleObject_Name_ReturnsExpected_FromText()
+    {
+        using RadioButton radioButton = new() { Text = "TestText" };
+        RadioButtonAccessibleObject radioButtonAccessibleObject = new(radioButton);
+
+        radioButtonAccessibleObject.Name.Should().Be("TestText");
+    }
+
+    [WinFormsTheory]
+    [InlineData(true, "TestText")]
+    [InlineData(false, "&TestText")]
+    public void RadioButtonAccessibleObject_Name_ReturnsExpected_FromText_WithOrWithoutMnemonics(bool useMnemonic, string expectedName)
+    {
+        using RadioButton radioButton = new() { Text = "&TestText", UseMnemonic = useMnemonic };
+        RadioButtonAccessibleObject radioButtonAccessibleObject = new(radioButton);
+
+        radioButtonAccessibleObject.Name.Should().Be(expectedName);
+    }
+
+    [WinFormsTheory]
+    [InlineData(true, "Alt+r")]
+    [InlineData(false, null)]
+    public void RadioButtonAccessibleObject_KeyboardShortcut_ReturnsExpected(bool useMnemonic, string expectedShortcut)
+    {
+        using RadioButton radioButton = new() { Text = "&RadioButton", UseMnemonic = useMnemonic };
+        RadioButtonAccessibleObject radioButtonAccessibleObject = new(radioButton);
+
+        radioButtonAccessibleObject.KeyboardShortcut.Should().Be(expectedShortcut);
+    }
+
+    [WinFormsFact]
     public void RadioButtonAccessibleObject_Role_Custom_ReturnsExpected()
     {
         using RadioButton radioButton = new()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RadioButtonTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RadioButtonTests.cs
@@ -172,30 +172,30 @@ public class RadioButtonTests : AbstractButtonBaseTests
         Assert.Throws<InvalidEnumArgumentException>("value", () => control.CheckAlign = value);
     }
 
-    public static TheoryData<ContentAlignment, ContentAlignment> CheckAlignData => new()
+    public static TheoryData<ContentAlignment> CheckAlignData => new()
     {
-         { ContentAlignment.TopLeft, ContentAlignment.TopLeft },
-         { ContentAlignment.TopRight, ContentAlignment.TopRight },
-         { ContentAlignment.BottomCenter, ContentAlignment.BottomCenter },
-         { ContentAlignment.BottomLeft, ContentAlignment.BottomLeft },
-         { ContentAlignment.BottomRight, ContentAlignment.BottomRight },
-         { ContentAlignment.MiddleLeft, ContentAlignment.MiddleLeft },
-         { ContentAlignment.MiddleRight, ContentAlignment.MiddleRight },
-         { ContentAlignment.TopCenter, ContentAlignment.TopCenter },
-         { ContentAlignment.MiddleCenter, ContentAlignment.MiddleCenter }
+        ContentAlignment.TopLeft,
+        ContentAlignment.TopRight,
+        ContentAlignment.BottomCenter,
+        ContentAlignment.BottomLeft,
+        ContentAlignment.BottomRight,
+        ContentAlignment.MiddleLeft,
+        ContentAlignment.MiddleRight,
+        ContentAlignment.TopCenter,
+        ContentAlignment.MiddleCenter
     };
 
     [WinFormsTheory]
     [MemberData(nameof(CheckAlignData))]
-    public void RadioButton_CheckAlign_Set_GetReturnsExpected(ContentAlignment value, ContentAlignment expected)
+    public void RadioButton_CheckAlign_Set_GetReturnsExpected(ContentAlignment value)
     {
         using RadioButton control = new();
         control.CheckAlign = value;
-        control.CheckAlign.Should().Be(expected);
+        control.CheckAlign.Should().Be(value);
 
         // Set same.
         control.CheckAlign = value;
-        control.CheckAlign.Should().Be(expected);
+        control.CheckAlign.Should().Be(value);
     }
 
     [WinFormsTheory]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RadioButtonTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RadioButtonTests.cs
@@ -172,6 +172,32 @@ public class RadioButtonTests : AbstractButtonBaseTests
         Assert.Throws<InvalidEnumArgumentException>("value", () => control.CheckAlign = value);
     }
 
+    public static TheoryData<ContentAlignment, ContentAlignment> CheckAlignData => new()
+    {
+         { ContentAlignment.TopLeft, ContentAlignment.TopLeft },
+         { ContentAlignment.TopRight, ContentAlignment.TopRight },
+         { ContentAlignment.BottomCenter, ContentAlignment.BottomCenter },
+         { ContentAlignment.BottomLeft, ContentAlignment.BottomLeft },
+         { ContentAlignment.BottomRight, ContentAlignment.BottomRight },
+         { ContentAlignment.MiddleLeft, ContentAlignment.MiddleLeft },
+         { ContentAlignment.MiddleRight, ContentAlignment.MiddleRight },
+         { ContentAlignment.TopCenter, ContentAlignment.TopCenter },
+         { ContentAlignment.MiddleCenter, ContentAlignment.MiddleCenter }
+    };
+
+    [WinFormsTheory]
+    [MemberData(nameof(CheckAlignData))]
+    public void RadioButton_CheckAlign_Set_GetReturnsExpected(ContentAlignment value, ContentAlignment expected)
+    {
+        using RadioButton control = new();
+        control.CheckAlign = value;
+        control.CheckAlign.Should().Be(expected);
+
+        // Set same.
+        control.CheckAlign = value;
+        control.CheckAlign.Should().Be(expected);
+    }
+
     [WinFormsTheory]
     [BoolData]
     public void RadioRadioButton_TabStop_Set_GetReturnsExpected(bool value)


### PR DESCRIPTION
Related https://github.com/dotnet/winforms/issues/10453

## Proposed changes
- Add unit test for RadioButton to test its property: CheckAlign
- Add unit test for RadioButton.RadioButtonAccessibleObject to test its properties: Name, KeyboardShortcut

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11687)