### PR TITLE
Only Send TBM_SETTICFREQ if AutoTick Enabled

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TrackBar/TrackBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TrackBar/TrackBar.cs
@@ -573,21 +573,20 @@ public partial class TrackBar : Control, ISupportInitialize
                 return;
             }
 
-            if (recreateHandle)
-            {
-                RecreateHandle();
-            }
-
             if (_autoDrawTicks)
             {
                 PInvoke.SendMessage(this, PInvoke.TBM_SETTICFREQ, (WPARAM)value);
             }
+
+            if (recreateHandle)
+            {
+                RecreateHandle();
+            }
             else
             {
                 DrawTicksManually();
+                Invalidate();
             }
-
-            Invalidate();
         }
     }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TrackBar/TrackBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TrackBar/TrackBar.cs
@@ -566,25 +566,28 @@ public partial class TrackBar : Control, ISupportInitialize
             }
 
             _tickFrequency = value;
-            // Determine if the decision of whether the ticks drawing,
-            // is performed by the native control or the Windows Forms runtime
-            // is still valid. If it's no longer valid, we'll need to recreate the native control.
+
             bool recreateHandle = ShouldRecreateHandle();
-            if (IsHandleCreated)
+            if (!IsHandleCreated)
+            {
+                return;
+            }
+
+            if (recreateHandle)
+            {
+                RecreateHandle();
+            }
+
+            if (_autoDrawTicks)
             {
                 PInvoke.SendMessage(this, PInvoke.TBM_SETTICFREQ, (WPARAM)value);
-                // If user opts out of TrackBarModernRendering then recreateHandle
-                // will always be false.
-                if (recreateHandle)
-                {
-                    RecreateHandle();
-                }
-                else
-                {
-                    DrawTicks();
-                    Invalidate();
-                }
             }
+            else
+            {
+                DrawTicksManually();
+            }
+
+            Invalidate();
         }
     }
 
@@ -762,11 +765,14 @@ public partial class TrackBar : Control, ISupportInitialize
 
     /// <summary>
     ///  Check if the value of the max is greater then the taskbar size.
-    ///  If so then we divide the value by size and only that many ticks to be drawn on the screen.
+    ///  If so then we divide the value by size and only that many ticks to be drawn on the screen
+    ///  via TBM_SETTIC.
     /// </summary>
-    private void DrawTicks()
+    /// <remarks>
+    ///  <para>This should not be called if <see cref="_autoDrawTicks"/> is <see langword="true"/></para>
+    /// </remarks>
+    private void DrawTicksManually()
     {
-        // Will be true if they opt out TrackBarModernRendering.
         if (_tickStyle == TickStyle.None || _autoDrawTicks)
         {
             return;
@@ -854,8 +860,15 @@ public partial class TrackBar : Control, ISupportInitialize
         Debug.Assert(_autoDrawTicks == ShouldAutoDrawTicks());
         PInvoke.SendMessage(this, PInvoke.TBM_SETRANGEMIN, (WPARAM)(BOOL)false, (LPARAM)_minimum);
         PInvoke.SendMessage(this, PInvoke.TBM_SETRANGEMAX, (WPARAM)(BOOL)false, (LPARAM)_maximum);
-        PInvoke.SendMessage(this, PInvoke.TBM_SETTICFREQ, (WPARAM)_tickFrequency);
-        DrawTicks();
+        if (_autoDrawTicks)
+        {
+            PInvoke.SendMessage(this, PInvoke.TBM_SETTICFREQ, (WPARAM)_tickFrequency);
+        }
+        else
+        {
+            DrawTicksManually();
+        }
+
         PInvoke.SendMessage(this, PInvoke.TBM_SETPAGESIZE, (WPARAM)0, (LPARAM)_largeChange);
         PInvoke.SendMessage(this, PInvoke.TBM_SETLINESIZE, (WPARAM)0, (LPARAM)_smallChange);
         SetTrackBarPosition();
@@ -1048,7 +1061,7 @@ public partial class TrackBar : Control, ISupportInitialize
                 PInvoke.SendMessage(this, PInvoke.TBM_SETRANGEMAX, (WPARAM)(BOOL)true, (LPARAM)_maximum);
                 if (!_autoDrawTicks)
                 {
-                    DrawTicks();
+                    DrawTicksManually();
                 }
 
                 Invalidate();
@@ -1138,10 +1151,11 @@ public partial class TrackBar : Control, ISupportInitialize
     }
 
     /// <summary>
-    /// Determine if the decision of whether the ticks drawing,
-    /// is performed by the native control or the Windows Forms runtime
-    /// is still valid. If it's no longer valid, we'll need to recreate the native control.
-    /// If user opts out of TrackBarModernRendering then this will always return false.
+    ///  Determine if the previous decision of whether drawing ticks
+    ///  is performed by the native control or the Windows Forms runtime
+    ///  is still valid. If it's no longer valid, the native control needs to be recreated.
+    ///  If user opts out of <see cref="LocalAppContextSwitches.TrackBarModernRendering"/>
+    ///  then this will always return false.
     /// </summary>
     private bool ShouldRecreateHandle() => IsHandleCreated && _autoDrawTicks != ShouldAutoDrawTicks();
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/winforms/issues/11639

[Docs](https://learn.microsoft.com/en-us/windows/win32/controls/tbm-setticfreq) for `TBM_SETTICFREQ` explicitly calls out that the trackbar must have style `TBS_AUTOTICKS` to use this message. We had not checked to ensure that was the case before sending `TBM_SETTICFREQ`. As it turns out, sending this message without the trackbar having style `TBS_AUTOTICKS` actually messes up the native side's internal state, causing this issue under certain values. The fix here is to make sure that we always check if the trackbar has `TBS_AUTOTICKS` before sending `TBM_SETTICFREQ`. We had been doing this incorrectly in 2 places which I have gone ahead in fix. I also did minor clean up.

**Before:**
scenario 1: issue repro - Trackbar does not have TBS_AUTOTICK on start up
![image](https://github.com/user-attachments/assets/69ce25bd-56e1-4793-b429-84d322f6f27d)


scenario 2: Trackbar has TBS_AUTOTICK on start up, but after property change (via button click) conditions re-evaluated and trackbar recreated to not have TBS_AUTOTICK
![trackbarissue](https://github.com/user-attachments/assets/78c46155-2975-419b-8a61-71b4145585ec)

**After:**
scenario 1:
![image](https://github.com/user-attachments/assets/32e474b5-9ae5-416b-865b-cfd3ddc4ac0a)


scenario 2:
![trackbarfixed](https://github.com/user-attachments/assets/ebe37fce-e059-4133-b74a-3cd66b462c30)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11696)