### PR TITLE
Add remaining missing designer instances to DemoConsole, in complement to #11678

### DIFF
--- a/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/MainForm.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/MainForm.Designer.cs
@@ -38,6 +38,7 @@ partial class MainForm
         this.tabPage3 = new System.Windows.Forms.TabPage();
         this.tabPage4 = new System.Windows.Forms.TabPage();
         this.tabPage5 = new System.Windows.Forms.TabPage();
+        this.tabPage6 = new System.Windows.Forms.TabPage();
         this.propertyGrid = new PropertyGridExt();
         this.menuStrip1 = new System.Windows.Forms.MenuStrip();
         this.editToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -88,6 +89,7 @@ partial class MainForm
         this.tabControl1.Controls.Add(this.tabPage3);
         this.tabControl1.Controls.Add(this.tabPage4);
         this.tabControl1.Controls.Add(this.tabPage5);
+        this.tabControl1.Controls.Add(this.tabPage6);
         this.tabControl1.Dock = System.Windows.Forms.DockStyle.Fill;
         this.tabControl1.Location = new System.Drawing.Point(0, 0);
         this.tabControl1.Name = "tabControl1";
@@ -144,6 +146,16 @@ partial class MainForm
         this.tabPage5.TabIndex = 3;
         this.tabPage5.Text = "tabPage5";
         this.tabPage5.UseVisualStyleBackColor = true;
+        // 
+        // tabPage6
+        // 
+        this.tabPage6.Location = new System.Drawing.Point(4, 25);
+        this.tabPage6.Name = "tabPage6";
+        this.tabPage6.Padding = new System.Windows.Forms.Padding(3);
+        this.tabPage6.Size = new System.Drawing.Size(585, 473);
+        this.tabPage6.TabIndex = 3;
+        this.tabPage6.Text = "tabPage6";
+        this.tabPage6.UseVisualStyleBackColor = true;
 
         // 
         // menuStrip1
@@ -324,6 +336,7 @@ partial class MainForm
     private System.Windows.Forms.TabPage tabPage3;
     private System.Windows.Forms.TabPage tabPage4;
     private System.Windows.Forms.TabPage tabPage5;
+    private System.Windows.Forms.TabPage tabPage6;
     private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemTools;
     private System.Windows.Forms.ToolStripMenuItem toolStripMenuItemTabOrder;
 

--- a/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/MainForm.MyScrollableControl.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/MainForm.MyScrollableControl.cs
@@ -1,0 +1,35 @@
+﻿using System.Drawing;
+using System.Windows.Forms;
+
+namespace TestConsole;
+
+public partial class MainForm
+{
+    internal class MyScrollableControl : ScrollableControl
+    {
+        internal void InjectControl(MyUserControl control)
+        {
+            Controls.Add(control);
+        }
+
+        internal MyScrollableControl()
+        {
+            BackColor = Color.Red;
+            AutoScrollMinSize = new Size(800, 800);
+            DoubleBuffered = true;
+        }
+
+        protected override void OnScroll(ScrollEventArgs se)
+        {
+            base.OnScroll(se);
+            Invalidate();
+        }
+
+        protected override void OnPaint(PaintEventArgs e)
+        {
+            base.OnPaint(e);
+            var graphics = e.Graphics;
+            graphics.Clear(BackColor);
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/MainForm.MyUserControl.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/MainForm.MyUserControl.cs
@@ -1,0 +1,46 @@
+﻿using System.Drawing;
+using System.Windows.Forms;
+
+namespace TestConsole;
+
+public partial class MainForm
+{
+    internal class MyUserControl : UserControl
+    {
+        public MyUserControl()
+        {
+            InitializeComponent();
+        }
+
+        public void InitializeComponent()
+        {
+            VScroll = false;
+            AutoScrollMinSize = new(1, 1);
+            HScroll = false;
+            BackColor = Color.LightBlue;
+
+            TextBox textBox = new()
+            {
+                Text = "UserControl TextBox 1",
+                Dock = DockStyle.Top,
+                Size = new(30, 30)
+            };
+
+            TextBox textBox1 = new()
+            {
+                Text = "UserControl TextBox 2",
+                Dock = DockStyle.Top,
+                Size = new(30, 30)
+            };
+
+            TextBox textBox2 = new()
+            {
+                Text = "UserControl TextBox 3",
+                Dock = DockStyle.Bottom,
+                Size = new(30, 30)
+            };
+
+            Controls.AddRange(textBox2, textBox1, textBox);
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/MainForm.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/MainForm.cs
@@ -278,7 +278,7 @@ public partial class MainForm : Form
                         rootComponent.Text = "Root Component hosted by the DesignSurface N.6";
 
                         ToolStripContainer toolStripContainer = surface.CreateControl<ToolStripContainer>(new Size(800, 200), new Point(0, 0));
-                        toolStripContainer.Dock = DockStyle.Top;
+                        toolStripContainer.Dock = DockStyle.Fill;
 
                         MenuStrip menuStrip1 = new();
                         MenuStrip menuStrip2 = new();
@@ -319,6 +319,7 @@ public partial class MainForm : Form
                         MyScrollableControl scrollableControl = surface.CreateControl<MyScrollableControl>(new Size(0, 0), new Point(0, 0));
                         scrollableControl.Dock = DockStyle.Fill;
                         scrollableControl.InjectControl(userControl);
+
                         SplitterPanel splitterPanel1 = splitContainer.Panel1;
                         SplitterPanel splitterPanel2 = splitContainer.Panel2;
                         splitterPanel1.Controls.Add(richTextBox);
@@ -327,6 +328,17 @@ public partial class MainForm : Form
                         toolStripContainer.ContentPanel.Controls.AddRange(splitContainer);
 
                         Component component = surface.CreateComponent<Component>();
+
+                        Splitter splitter = surface.CreateControl<Splitter>(new(5, 0), new(0, 0));
+                        splitter.BackColor = Color.Green;
+                        splitter.Dock = DockStyle.Bottom;
+
+                        Panel panel = surface.CreateControl<Panel>(new(0, tabPage6.Height/2), new(0, 0));
+                        panel.Dock = DockStyle.Bottom;
+                        NumericUpDown numericUpDown = surface.CreateControl<NumericUpDown>(new(50, 10), new(10, 10));
+                        panel.Controls.Add(numericUpDown);
+
+                        tabPage6.Controls.AddRange(toolStripContainer, splitter, panel);
                     }
 
                     break;

--- a/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/MainForm.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/MainForm.cs
@@ -4,6 +4,7 @@ using System.ComponentModel.Design;
 
 using DesignSurfaceExt;
 using Timer = System.Windows.Forms.Timer;
+using System.ComponentModel;
 
 namespace TestConsole;
 
@@ -25,12 +26,14 @@ public partial class MainForm : Form
         CreateDesignSurface(3);
         CreateDesignSurface(4);
         CreateDesignSurface(5);
+        CreateDesignSurface(6);
 
         tabPage1.Text = "Use SnapLines";
         tabPage2.Text = "Use Grid (Snap to the grid)";
         tabPage3.Text = "Use Grid";
         tabPage4.Text = "Align control by hand";
         tabPage5.Text = "TabControl and TableLayoutPanel";
+        tabPage6.Text = "ToolStripContainer";
 
         // - enable the UndoEngines
         for (int i = 0; i < tabControl1.TabCount; i++)
@@ -93,6 +96,9 @@ public partial class MainForm : Form
                 surface.UseNoGuides();
                 break;
             case 5:
+                surface.UseNoGuides();
+                break;
+            case 6:
                 surface.UseNoGuides();
                 break;
             default:
@@ -265,6 +271,66 @@ public partial class MainForm : Form
                     }
 
                     break;
+                case 6:
+                    {
+                        rootComponent = surface.CreateRootComponent<Form>(new Size(800, 600));
+                        rootComponent.BackColor = Color.Pink;
+                        rootComponent.Text = "Root Component hosted by the DesignSurface N.6";
+
+                        ToolStripContainer toolStripContainer = surface.CreateControl<ToolStripContainer>(new Size(800, 200), new Point(0, 0));
+                        toolStripContainer.Dock = DockStyle.Top;
+
+                        MenuStrip menuStrip1 = new();
+                        MenuStrip menuStrip2 = new();
+
+                        ToolStripMenuItem toolStripMenuItem1 = new("TopMenuItem1");
+                        ToolStripMenuItem toolStripMenuItem2 = new("TopMenuItem2");
+                        ToolStripMenuItem menu1 = new("BottomMenuItem1");
+                        ToolStripMenuItem menuNew1 = new("BottomMenuItem2");
+
+                        menuStrip1.Items.Add(toolStripMenuItem1);
+                        menuStrip1.Items.Add(toolStripMenuItem2);
+                        menuStrip2.Items.Add(menu1);
+                        menuStrip2.Items.Add(menuNew1);
+
+                        toolStripMenuItem1.DropDownItems.Add("DropDownItem1");
+                        toolStripMenuItem2.DropDownItems.Add("DropDownItem12");
+
+                        ToolStripPanel topToolStripPanel = surface.CreateControl<ToolStripPanel>(new(50, 50), new(0, 0));
+                        topToolStripPanel = toolStripContainer.TopToolStripPanel;
+                        topToolStripPanel.Join(menuStrip1);
+                        ToolStripPanel bottomToolStripPanel = surface.CreateControl<ToolStripPanel>(new(50, 50), new(0, 0));
+                        bottomToolStripPanel = toolStripContainer.BottomToolStripPanel;
+                        bottomToolStripPanel.Join(menuStrip2);
+
+                        SplitContainer splitContainer = surface.CreateControl<SplitContainer>(new(0, 0), new(0, 0));
+                        splitContainer.Dock = DockStyle.Fill;
+                        splitContainer.BackColor = Color.Red;
+
+                        RichTextBox richTextBox = surface.CreateControl<RichTextBox>(new Size(0, 0), new Point(0, 0));
+                        richTextBox.Dock = DockStyle.Left;
+                        richTextBox.Width = toolStripContainer.Width;
+                        richTextBox.Text = "I'm a RichTextBox";
+
+                        MyUserControl userControl = surface.CreateControl<MyUserControl>(new Size(0, 0), new Point(0, 0));
+                        userControl.Dock = DockStyle.Fill;
+                        userControl.BackColor = Color.LightSkyBlue;
+
+                        MyScrollableControl scrollableControl = surface.CreateControl<MyScrollableControl>(new Size(0, 0), new Point(0, 0));
+                        scrollableControl.Dock = DockStyle.Fill;
+                        scrollableControl.InjectControl(userControl);
+                        SplitterPanel splitterPanel1 = splitContainer.Panel1;
+                        SplitterPanel splitterPanel2 = splitContainer.Panel2;
+                        splitterPanel1.Controls.Add(richTextBox);
+                        splitterPanel2.Controls.Add(scrollableControl);
+
+                        toolStripContainer.ContentPanel.Controls.AddRange(splitContainer);
+
+                        Component component = surface.CreateComponent<Component>();
+                    }
+
+                    break;
+
                 default:
                     Console.WriteLine("Invalid selection");
                     break;
@@ -297,6 +363,9 @@ public partial class MainForm : Form
                     break;
                 case 5:
                     view.Parent = tabPage5;
+                    break;
+                case 6:
+                    view.Parent = tabPage6;
                     break;
                 default:
                     Console.WriteLine("Invalid selection");


### PR DESCRIPTION
Related #11669 #11678

## Proposed changes

- Adds remaining missing controls from #4908 to the `DemoConsole` app, in the new tab (ToolStripContainer) added by PR #11678.
- Inserts instances of missing designers in the newly created tab:
  - `System.Windows.Forms.Design.UpDownBaseDesigner` (base class of `NumericUpDown`)
  - `System.Windows.Forms.Design.SplitterDesigner`
- Won't need to add because instances already exist in other tabs of the `DemoConsole` app:
  - `System.Windows.Forms.Design.TextBoxBaseDesigner` (base class of `TextBox`)
  - `System.Windows.Forms.Design.ButtonBaseDesigner` (base class of `Button`)
- The remainder of the controls [could not be instantiated](https://github.com/dotnet/winforms/pull/11707#issuecomment-2237840141) and [will be investigated separately](https://github.com/dotnet/winforms/pull/11707#discussion_r1685102761):
  - `System.Windows.Forms.Design.WebBrowserDesigner`
  - `System.Windows.Forms.Design.BindingNavigatorDesigner`
  - `System.Windows.Forms.Design.UserControlDocumentDesigner`
  - `System.Windows.Forms.Design.StatusBarDesigner`
  - `System.Windows.Forms.Design.FormDocumentDesigner`
  - `System.Windows.Forms.Design.ParentControlDesigner`
  - `System.Windows.Forms.Design.DocumentDesigner`
  - `System.Windows.Forms.Design.ToolStripDropDownDesigner`
  - `System.Windows.Forms.Design.DataGridViewColumnDesigner`

## Customer Impact

- None

## Regression?

- No

## Risk

- Minimal

## Screenshots

### Before

Only 5 tabs:

### After

## Test methodology

- Manual|Integration tests

## Test environment(s)

- 9.0.100-preview.5.24307.3
