### PR TITLE
Add test coverage for PropertyGrid.PropertyTabCollection

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGrid.PropertyTabCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGrid.PropertyTabCollectionTests.cs
@@ -1,0 +1,132 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel;
+using System.Drawing;
+using System.Windows.Forms.Design;
+
+namespace System.Windows.Forms.Tests
+{
+    public class PropertyTabCollectionTests
+    {
+        [WinFormsTheory]
+        [InlineData(null, 0)]
+        [InlineData(typeof(PropertyGrid), 1)] // PropertyGrid initially contains one PropertiesTab
+        public void Count_ReturnsCorrectCount(Type ownerType, int expectedCount)
+        {
+            if (ownerType is null)
+            {
+                expectedCount.Should().Be(0);
+            }
+            else
+            {
+                var owner = Activator.CreateInstance(ownerType) as PropertyGrid;
+                TestPropertyTabCollection propertyTabCollection = new(owner);
+                propertyTabCollection.Count.Should().Be(expectedCount);
+            }
+        }
+
+        [WinFormsTheory]
+        [InlineData(null, 0, null, typeof(InvalidOperationException))]
+        [InlineData(typeof(PropertyGrid), 0, typeof(PropertyGridInternal.PropertiesTab), null)]
+        [InlineData(typeof(PropertyGrid), 1, typeof(TestPropertyTab), null)]
+        [InlineData(typeof(PropertyGrid), 2, null, typeof(ArgumentOutOfRangeException))]
+        public void Indexer_ReturnsCorrectTab_OrThrows(Type ownerType, int index, Type expectedTabType, Type expectedExceptionType)
+        {
+            TestPropertyTabCollection propertyTabCollection = null;
+            if (ownerType is object)
+            {
+                var owner = Activator.CreateInstance(ownerType) as PropertyGrid;
+                propertyTabCollection = new(owner);
+                propertyTabCollection.AddTabType(typeof(TestPropertyTab));
+            }
+
+            Action act = () =>
+            {
+                if (propertyTabCollection is null)
+                {
+                    throw new InvalidOperationException();
+                }
+
+                var tab = propertyTabCollection[index];
+            };
+
+            if (expectedExceptionType is null)
+            {
+                act.Should().NotThrow();
+                var tab = propertyTabCollection[index];
+                tab.Should().BeOfType(expectedTabType);
+            }
+            else
+            {
+                act.Should().Throw<Exception>().Which.Should().BeOfType(expectedExceptionType);
+            }
+        }
+
+        [WinFormsTheory]
+        [InlineData(null, typeof(TestPropertyTab), typeof(ArgumentNullException), 0, false)]
+        [InlineData(typeof(PropertyGrid), typeof(TestPropertyTab), null, 2, false)]
+        [InlineData(typeof(PropertyGrid), typeof(TestPropertyTab), null, 2, true)]
+        public void AddTabType_WithDifferentInputs(Type ownerType, Type tabType, Type expectedExceptionType, int expectedCount, bool addTwice)
+        {
+            if (ownerType is null)
+            {
+                Action act = () => new TestPropertyTabCollection(null).AddTabType(tabType);
+                act.Should().Throw<Exception>().Which.Should().BeOfType(expectedExceptionType);
+            }
+            else
+            {
+                var owner = Activator.CreateInstance(ownerType) as PropertyGrid;
+                TestPropertyTabCollection propertyTabCollection = new(owner);
+                int initialCount = propertyTabCollection.Count;
+
+                Action act = () =>
+                {
+                    propertyTabCollection.AddTabType(tabType);
+                    if (addTwice)
+                    {
+                        propertyTabCollection.AddTabType(tabType);
+                    }
+                };
+
+                if (expectedExceptionType is null)
+                {
+                    act.Should().NotThrow();
+                    propertyTabCollection.Count.Should().Be(expectedCount);
+                    if (propertyTabCollection.Count > initialCount)
+                    {
+                        propertyTabCollection[initialCount].Should().BeOfType<TestPropertyTab>();
+                    }
+                }
+                else
+                {
+                    act.Should().Throw<Exception>().Which.Should().BeOfType(expectedExceptionType);
+                }
+            }
+        }
+
+        public class TestPropertyTabCollection : PropertyGrid.PropertyTabCollection
+        {
+            public TestPropertyTabCollection(PropertyGrid ownerPropertyGrid) : base(ownerPropertyGrid)
+            {
+            }
+        }
+
+        public class TestPropertyTab : PropertyTab
+        {
+            public override string TabName => "Test Tab";
+
+            public override PropertyDescriptorCollection GetProperties(object component, Attribute[] attributes)
+            {
+                return TypeDescriptor.GetProperties(component, attributes);
+            }
+
+            public override PropertyDescriptorCollection GetProperties(ITypeDescriptorContext context, object component, Attribute[] attributes)
+            {
+                return TypeDescriptor.GetProperties(component, attributes);
+            }
+
+            public override Bitmap Bitmap => new(1, 1);
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGrid.PropertyTabCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGrid.PropertyTabCollectionTests.cs
@@ -5,136 +5,88 @@ using System.ComponentModel;
 using System.Drawing;
 using System.Windows.Forms.Design;
 
-namespace System.Windows.Forms.Tests
+namespace System.Windows.Forms.Tests;
+
+public class PropertyTabCollectionTests
 {
-    public class PropertyTabCollectionTests
+    [WinFormsTheory]
+    [InlineData(typeof(PropertyGrid))]
+    public void Count_ReturnsCorrectCount(Type ownerType)
     {
-        [WinFormsTheory]
-        [InlineData(typeof(PropertyGrid))]
-        public void Count_ReturnsCorrectCount(Type ownerType)
+        var owner = Activator.CreateInstance(ownerType) as PropertyGrid;
+        TestPropertyTabCollection propertyTabCollection = new(owner);
+        propertyTabCollection.Count.Should().Be(1); // PropertyGrid initially contains one PropertiesTab
+    }
+
+    [WinFormsTheory]
+    [InlineData(typeof(PropertyGrid), 0, typeof(PropertyGridInternal.PropertiesTab))]
+    [InlineData(typeof(PropertyGrid), 1, typeof(TestPropertyTab))]
+    public void Indexer_ReturnsCorrectTab(Type ownerType, int index, Type expectedTabType)
+    {
+        var owner = Activator.CreateInstance(ownerType) as PropertyGrid;
+        TestPropertyTabCollection propertyTabCollection = new(owner);
+        propertyTabCollection.AddTabType(typeof(TestPropertyTab));
+
+        var tab = propertyTabCollection[index];
+        tab.Should().BeOfType(expectedTabType);
+    }
+
+    [WinFormsTheory]
+    [InlineData(typeof(PropertyGrid), typeof(TestPropertyTab), 2, false)]
+    [InlineData(typeof(PropertyGrid), typeof(TestPropertyTab), 2, true)]
+    public void AddTabType_WithDifferentInputs(Type ownerType, Type tabType, int expectedCount, bool addTwice)
+    {
+        var owner = Activator.CreateInstance(ownerType) as PropertyGrid;
+        TestPropertyTabCollection propertyTabCollection = new(owner);
+        int initialCount = propertyTabCollection.Count;
+
+        propertyTabCollection.AddTabType(tabType);
+        if (addTwice)
         {
-            var owner = Activator.CreateInstance(ownerType) as PropertyGrid;
-            TestPropertyTabCollection propertyTabCollection = new(owner);
-            propertyTabCollection.Count.Should().Be(1); // PropertyGrid initially contains one PropertiesTab
+            propertyTabCollection.AddTabType(tabType);
         }
 
-        [WinFormsTheory]
-        [InlineData(typeof(PropertyGrid), 0, typeof(PropertyGridInternal.PropertiesTab), null)]
-        [InlineData(typeof(PropertyGrid), 1, typeof(TestPropertyTab), null)]
-        public void Indexer_ReturnsCorrectTab_OrThrows(Type ownerType, int index, Type expectedTabType, Type expectedExceptionType)
+        propertyTabCollection.Count.Should().Be(expectedCount);
+        if (propertyTabCollection.Count > initialCount)
         {
-            TestPropertyTabCollection propertyTabCollection = null;
-            if (ownerType is object)
-            {
-                var owner = Activator.CreateInstance(ownerType) as PropertyGrid;
-                propertyTabCollection = new(owner);
-                propertyTabCollection.AddTabType(typeof(TestPropertyTab));
-            }
-
-            Action act = () =>
-            {
-                if (propertyTabCollection is null)
-                {
-                    throw new InvalidOperationException();
-                }
-
-                var tab = propertyTabCollection[index];
-            };
-
-            if (expectedExceptionType is null)
-            {
-                act.Should().NotThrow();
-                var tab = propertyTabCollection[index];
-                tab.Should().BeOfType(expectedTabType);
-            }
-            else
-            {
-                act.Should().Throw<Exception>().Which.Should().BeOfType(expectedExceptionType);
-            }
+            propertyTabCollection[initialCount].Should().BeOfType<TestPropertyTab>();
         }
+    }
 
-        [WinFormsTheory]
-        [InlineData(typeof(PropertyGrid), typeof(TestPropertyTab), null, 2, false)]
-        [InlineData(typeof(PropertyGrid), typeof(TestPropertyTab), null, 2, true)]
-        public void AddTabType_WithDifferentInputs(Type ownerType, Type tabType, Type expectedExceptionType, int expectedCount, bool addTwice)
+    public class TestPropertyTabCollection : PropertyGrid.PropertyTabCollection
+    {
+        public TestPropertyTabCollection(PropertyGrid ownerPropertyGrid) : base(ownerPropertyGrid)
         {
-            if (ownerType is null)
-            {
-                Action act = () => new TestPropertyTabCollection(null).AddTabType(tabType);
-                act.Should().Throw<Exception>().Which.Should().BeOfType(expectedExceptionType);
-            }
-            else
-            {
-                var owner = Activator.CreateInstance(ownerType) as PropertyGrid;
-                TestPropertyTabCollection propertyTabCollection = new(owner);
-                int initialCount = propertyTabCollection.Count;
+        }
+    }
 
-                Action act = () =>
-                {
-                    propertyTabCollection.AddTabType(tabType);
-                    if (addTwice)
-                    {
-                        propertyTabCollection.AddTabType(tabType);
-                    }
-                };
+    public class TestPropertyTab : PropertyTab, IDisposable
+    {
+        private Bitmap _bitmap;
 
-                if (expectedExceptionType is null)
+        public override string TabName => "Test Tab";
+
+        public override PropertyDescriptorCollection GetProperties(object component, Attribute[] attributes) => TypeDescriptor.GetProperties(component, attributes);
+
+        public override PropertyDescriptorCollection GetProperties(ITypeDescriptorContext context, object component, Attribute[] attributes) => TypeDescriptor.GetProperties(component, attributes);
+
+        public override Bitmap Bitmap
+        {
+            get
+            {
+                if (_bitmap is null)
                 {
-                    act.Should().NotThrow();
-                    propertyTabCollection.Count.Should().Be(expectedCount);
-                    if (propertyTabCollection.Count > initialCount)
-                    {
-                        propertyTabCollection[initialCount].Should().BeOfType<TestPropertyTab>();
-                    }
+                    _bitmap = new Bitmap(1, 1);
                 }
-                else
-                {
-                    act.Should().Throw<Exception>().Which.Should().BeOfType(expectedExceptionType);
-                }
+
+                return _bitmap;
             }
         }
 
-        public class TestPropertyTabCollection : PropertyGrid.PropertyTabCollection
+        public override void Dispose()
         {
-            public TestPropertyTabCollection(PropertyGrid ownerPropertyGrid) : base(ownerPropertyGrid)
-            {
-            }
-        }
-
-        public class TestPropertyTab : PropertyTab, IDisposable
-        {
-            private Bitmap _bitmap;
-
-            public override string TabName => "Test Tab";
-
-            public override PropertyDescriptorCollection GetProperties(object component, Attribute[] attributes)
-            {
-                return TypeDescriptor.GetProperties(component, attributes);
-            }
-
-            public override PropertyDescriptorCollection GetProperties(ITypeDescriptorContext context, object component, Attribute[] attributes)
-            {
-                return TypeDescriptor.GetProperties(component, attributes);
-            }
-
-            public override Bitmap Bitmap
-            {
-                get
-                {
-                    if (_bitmap is null)
-                    {
-                        _bitmap = new Bitmap(1, 1);
-                    }
-
-                    return _bitmap;
-                }
-            }
-
-            public override void Dispose()
-            {
-                _bitmap?.Dispose();
-                base.Dispose();
-            }
+            _bitmap?.Dispose();
+            base.Dispose();
         }
     }
 }


### PR DESCRIPTION
Related https://github.com/dotnet/winforms/issues/10453


## Proposed changes

- Add unit test for PropertyGrid.PropertyTabCollection to test its properties: Count, this.
- Add unit test for PropertyGrid.PropertyTabCollection to test its method: AddTabType.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11711)