### PR TITLE
Refactor `Propertystore` tests

### DIFF
--- a/src/System.Private.Windows.Core/src/System/Value.cs
+++ b/src/System.Private.Windows.Core/src/System/Value.cs
@@ -732,7 +732,7 @@ internal readonly partial struct Value
         {
             // A null is stored, it can only be assigned to a reference type or nullable.
             value = default!;
-            result = Nullable.GetUnderlyingType(typeof(T)) is not null;
+            result = value is not null || Nullable.GetUnderlyingType(typeof(T)) is not null;
         }
         else if (typeof(T).IsEnum && _object is TypeFlag<T> typeFlag)
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyStore.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyStore.cs
@@ -210,7 +210,7 @@ internal class PropertyStore
     ///  Tries to get the value for the given key, allowing explicitly set <see langword="null"/> values.
     ///  Returns <see langword="true"/> if the value was found.
     /// </summary>
-    public bool TryGetValueOrNull<T>(int key, out T? value) where T : class
+    public bool TryGetValueOrNull<T>(int key, out T? value)
     {
         if (_values.TryGetValue(key, out Value foundValue))
         {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyStoreTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyStoreTests.cs
@@ -51,9 +51,9 @@ public class PropertyStoreTests
     public void PropertyStore_TryGetValue_Exists(int key, object? value)
     {
         PropertyStore store = new();
-        store.SetObject(key, value);
-        Assert.True(store.ContainsObject(key), "PropertyStore does not contain key.");
-        Assert.True(store.TryGetObject(key, out object? outValue));
+        store.AddValue(key, value);
+        Assert.True(store.ContainsKey(key), "PropertyStore does not contain key.");
+        Assert.True(store.TryGetValue(key, out object? outValue));
         Assert.Equal(value, outValue);
     }
 
@@ -62,9 +62,9 @@ public class PropertyStoreTests
     public void PropertyStore_TryGetValue_Exists_Null(int key, object? value)
     {
         PropertyStore store = new();
-        store.SetObject(key, null);
-        Assert.True(store.ContainsObject(key), "PropertyStore does not contain key.");
-        Assert.True(store.TryGetObject(key, out object? outValue));
+        store.AddValue<object?>(key, null);
+        Assert.True(store.ContainsKey(key), "PropertyStore does not contain key.");
+        Assert.True(store.TryGetValueOrNull(key, out object? outValue));
         Assert.NotEqual(value, outValue);
     }
 
@@ -73,10 +73,10 @@ public class PropertyStoreTests
     public void PropertyStore_TryGetValue_NotExists(int key, object? value)
     {
         PropertyStore store = new();
-        store.SetObject(key, null);
-        store.RemoveObject(key);
-        Assert.False(store.ContainsObject(key), "PropertyStore contains key.");
-        Assert.False(store.TryGetObject(key, out object? outValue), "PropertyStore contains key.");
+        store.AddValue<object?>(key, null);
+        store.RemoveValue(key);
+        Assert.False(store.ContainsKey(key), "PropertyStore contains key.");
+        Assert.False(store.TryGetValue(key, out object? outValue), "PropertyStore contains key.");
         Assert.NotEqual(value, outValue);
     }
 
@@ -84,8 +84,8 @@ public class PropertyStoreTests
     public void PropertyStore_TryGetValue_Enum_Unset_IsDefault()
     {
         PropertyStore store = new();
-        Assert.False(store.ContainsObject(s_formWindowState), "PropertyStore contains key.");
-        Assert.False(store.TryGetObject(s_formWindowState, out FormWindowState outValue), "PropertyStore contains key.");
+        Assert.False(store.ContainsKey(s_formWindowState), "PropertyStore contains key.");
+        Assert.False(store.TryGetValue(s_formWindowState, out FormWindowState outValue), "PropertyStore contains key.");
         FormWindowState windowState = default;
         Assert.Equal(windowState, outValue);
     }
@@ -94,8 +94,8 @@ public class PropertyStoreTests
     public void PropertyStore_TryGetValue_Struct_Unset_IsDefault()
     {
         PropertyStore store = new();
-        Assert.False(store.ContainsObject(s_color), "PropertyStore contains key.");
-        Assert.False(store.TryGetObject(s_color, out Color outValue), "PropertyStore contains key.");
+        Assert.False(store.ContainsKey(s_color), "PropertyStore contains key.");
+        Assert.False(store.TryGetValue(s_color, out Color outValue), "PropertyStore contains key.");
         Color color = default;
         Assert.Equal(color, outValue);
     }
@@ -104,8 +104,8 @@ public class PropertyStoreTests
     public void PropertyStore_TryGetValue_Primitive_Unset_IsDefault()
     {
         PropertyStore store = new();
-        Assert.False(store.ContainsObject(s_int), "PropertyStore does not contain key.");
-        Assert.False(store.TryGetObject(s_int, out int outValue), "PropertyStore contains key.");
+        Assert.False(store.ContainsKey(s_int), "PropertyStore does not contain key.");
+        Assert.False(store.TryGetValue(s_int, out int outValue), "PropertyStore contains key.");
         int intDefault = default;
         Assert.Equal(intDefault, outValue);
     }
@@ -114,9 +114,9 @@ public class PropertyStoreTests
     public void PropertyStore_TryGetValue_Enum_Null()
     {
         PropertyStore store = new();
-        store.SetObject(s_formWindowState, null);
-        Assert.True(store.ContainsObject(s_formWindowState), "PropertyStore contains key.");
-        Assert.True(store.TryGetObject(s_formWindowState, out FormWindowState outValue), "PropertyStore contains key.");
+        store.AddValue<FormWindowState?>(s_formWindowState, null);
+        Assert.True(store.ContainsKey(s_formWindowState), "PropertyStore contains key.");
+        Assert.True(store.TryGetValueOrNull(s_formWindowState, out FormWindowState outValue), "PropertyStore contains key.");
         FormWindowState windowState = default;
         Assert.Equal(windowState, outValue);
     }
@@ -125,9 +125,9 @@ public class PropertyStoreTests
     public void PropertyStore_TryGetValue_Struct_Null()
     {
         PropertyStore store = new();
-        store.SetObject(s_color, null);
-        Assert.True(store.ContainsObject(s_color), "PropertyStore does not contain key.");
-        Assert.True(store.TryGetObject(s_color, out Color outValue), "PropertyStore does not contain key.");
+        store.AddValue<Color?>(s_color, null);
+        Assert.True(store.ContainsKey(s_color), "PropertyStore does not contain key.");
+        Assert.True(store.TryGetValueOrNull(s_color, out Color outValue), "PropertyStore does not contain key.");
         Color color = default;
         Assert.Equal(color, outValue);
     }
@@ -136,9 +136,9 @@ public class PropertyStoreTests
     public void PropertyStore_TryGetValue_Primitive_Null()
     {
         PropertyStore store = new();
-        store.SetObject(s_int, null);
-        Assert.True(store.ContainsObject(s_int), "PropertyStore does not contain key.");
-        Assert.True(store.TryGetObject(s_int, out int outValue), "PropertyStore does not contain key.");
+        store.AddValue<int?>(s_int, null);
+        Assert.True(store.ContainsKey(s_int), "PropertyStore does not contain key.");
+        Assert.True(store.TryGetValueOrNull(s_int, out int outValue), "PropertyStore does not contain key.");
         int intDefault = default;
         Assert.Equal(intDefault, outValue);
     }
@@ -147,9 +147,9 @@ public class PropertyStoreTests
     public void PropertyStore_TryGetValue_Enum_Nullable()
     {
         PropertyStore store = new();
-        store.SetObject(s_formWindowState, null);
-        Assert.True(store.ContainsObject(s_formWindowState), "PropertyStore does not contain key.");
-        Assert.True(store.TryGetObject(s_formWindowState, out FormWindowState? outValue), "PropertyStore does not contain key.");
+        store.AddValue<FormWindowState?>(s_formWindowState, null);
+        Assert.True(store.ContainsKey(s_formWindowState), "PropertyStore does not contain key.");
+        Assert.True(store.TryGetValueOrNull(s_formWindowState, out FormWindowState? outValue), "PropertyStore does not contain key.");
         Assert.Null(outValue);
     }
 
@@ -157,9 +157,9 @@ public class PropertyStoreTests
     public void PropertyStore_TryGetValue_Struct_Nullable()
     {
         PropertyStore store = new();
-        store.SetObject(s_color, null);
-        Assert.True(store.ContainsObject(s_color), "PropertyStore does not contain key.");
-        Assert.True(store.TryGetObject(s_color, out Color? outValue), "PropertyStore does not contain key.");
+        store.AddValue<Color?>(s_color, null);
+        Assert.True(store.ContainsKey(s_color), "PropertyStore does not contain key.");
+        Assert.True(store.TryGetValueOrNull(s_color, out Color? outValue), "PropertyStore does not contain key.");
         Assert.Null(outValue);
     }
 
@@ -167,9 +167,9 @@ public class PropertyStoreTests
     public void PropertyStore_TryGetValue_Primitive_Nullable()
     {
         PropertyStore store = new();
-        store.SetObject(s_int, null);
-        Assert.True(store.ContainsObject(s_int), "PropertyStore contains key.");
-        Assert.True(store.TryGetObject(s_int, out int? outValue), "PropertyStore contains key.");
+        store.AddValue<int?>(s_int, null);
+        Assert.True(store.ContainsKey(s_int), "PropertyStore contains key.");
+        Assert.True(store.TryGetValueOrNull(s_int, out int? outValue), "PropertyStore contains key.");
         Assert.Null(outValue);
     }
 
@@ -177,8 +177,8 @@ public class PropertyStoreTests
     public void PropertyStore_TryGetValue_Enum_Unset_Nullable()
     {
         PropertyStore store = new();
-        Assert.False(store.ContainsObject(s_formWindowState), "PropertyStore contains key.");
-        Assert.False(store.TryGetObject(s_formWindowState, out FormWindowState? outValue), "PropertyStore contains key.");
+        Assert.False(store.ContainsKey(s_formWindowState), "PropertyStore contains key.");
+        Assert.False(store.TryGetValue(s_formWindowState, out FormWindowState? outValue), "PropertyStore contains key.");
         Assert.Null(outValue);
     }
 
@@ -186,8 +186,8 @@ public class PropertyStoreTests
     public void PropertyStore_TryGetValue_Struct_Unset_Nullable()
     {
         PropertyStore store = new();
-        Assert.False(store.ContainsObject(s_color), "PropertyStore contains key.");
-        Assert.False(store.TryGetObject(s_color, out Color? outValue), "PropertyStore contains key.");
+        Assert.False(store.ContainsKey(s_color), "PropertyStore contains key.");
+        Assert.False(store.TryGetValue(s_color, out Color? outValue), "PropertyStore contains key.");
         Assert.Null(outValue);
     }
 
@@ -195,8 +195,8 @@ public class PropertyStoreTests
     public void PropertyStore_TryGetValue_Primitive_Unset_Nullable()
     {
         PropertyStore store = new();
-        Assert.False(store.ContainsObject(s_int), "PropertyStore contains key.");
-        Assert.False(store.TryGetObject(s_int, out int? outValue), "PropertyStore contains key.");
+        Assert.False(store.ContainsKey(s_int), "PropertyStore contains key.");
+        Assert.False(store.TryGetValue(s_int, out int? outValue), "PropertyStore contains key.");
         Assert.Null(outValue);
     }
 


### PR DESCRIPTION
Related: #9508

I ran into issues when working on converting the api usage. So I've focused specifically on the tests in `PropertyStoreTests` to fix any issues.

**Original**
```csharp
    [WinFormsFact]
    public void PropertyStore_TryGetValue_Enum_Null()
    {
        PropertyStore store = new();
        store.SetObject(s_formWindowState, null);
        Assert.True(store.ContainsObject(s_formWindowState), "PropertyStore contains key.");
        Assert.True(store.TryGetObject(s_formWindowState, out FormWindowState outValue), "PropertyStore contains key.");
        FormWindowState windowState = default;
        Assert.Equal(windowState, outValue);
    }
```
**Converted**
```csharp
[WinFormsFact]
public void PropertyStore_TryGetValue_Enum_Null()
{
    PropertyStore store = new();
    store.AddValue<FormWindowState?>(s_formWindowState, null);
    Assert.True(store.ContainsKey(s_formWindowState), "PropertyStore contains key.");
    Assert.True(store.TryGetValue(s_formWindowState, out FormWindowState? outValue), "PropertyStore contains key.");
    // fails above
    FormWindowState windowState = default;
    Assert.Equal(windowState, outValue);
}
```

Here `TryGetValue` will return `false`. In some parts of the code, a null value is significant.
Here is an example:
https://github.com/dotnet/winforms/blob/9d22ed9401f33fe161f694f9053e682212ef9453/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripItem.cs#L1895-L1915

So I think we would need to be quite careful here to not accidentally convert these to TryGetValue and to maybe use `TryGetValueOrNull`? That then also caused problems in edge cases where a default value is expected for structs like `Color`.

```csharp
[WinFormsFact]
public void PropertyStore_TryGetValue_Struct_Null()
{
    PropertyStore store = new();
    store.AddValue<Color?>(s_color, null);
    Assert.True(store.ContainsKey(s_color), "PropertyStore does not contain key.");
    Assert.True(store.TryGetValueOrNull(s_color, out Color outValue), "PropertyStore does not contain key.");
    Color color = default;
    Assert.Equal(color, outValue);
}
```
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11719)