### PR TITLE
Add test coverage for BaseContextMenuStrip

### DIFF
--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/BaseContextMenuStripTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/BaseContextMenuStripTests.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Drawing;
+using Moq;
+
+namespace System.Windows.Forms.Design.Tests;
+
+public sealed class BaseContextMenuStripTests
+{
+    [Fact]
+    public void RefreshItems_SetsFontFromIUIService()
+    {
+        var serviceProviderMock = new Mock<IServiceProvider>();
+        var uiServiceMock = new Mock<IUIService>();        
+        Font expectedFont = new Font("Arial", 12.0f);
+        uiServiceMock.Setup(uis => uis.Styles["DialogFont"]).Returns(expectedFont);
+        serviceProviderMock.Setup(sp => sp.GetService(typeof(IUIService))).Returns(uiServiceMock.Object);
+
+        using BaseContextMenuStrip contextMenuStrip = new(serviceProviderMock.Object);
+        contextMenuStrip.Font = new Font("Times New Roman", 10.0f, FontStyle.Italic);
+        for (int i = 0; i < 3; i++)
+        {
+            contextMenuStrip.Items.Add(new ToolStripMenuItem());
+        }
+
+        contextMenuStrip.RefreshItems();
+
+        contextMenuStrip.Font.Should().Be(expectedFont);
+        foreach (var item in contextMenuStrip.Items.OfType<ToolStripMenuItem>())
+        {
+            item.Font.Should().Be(expectedFont);
+        }     
+    }
+}


### PR DESCRIPTION
Related https://github.com/dotnet/winforms/issues/10773

## Proposed changes

- Add unit test for BaseContextMenuStrip to test its method: RefreshItems