### PR TITLE
Adjusting the counter to fix the naming errors in DemoConsole App

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "9.0.100-preview.5.24307.3",
+    "dotnet": "9.0.100-preview.4.24267.66",
     "runtimes": {
       "dotnet/x64": [
         "$(VSRedistCommonNetCoreSharedFrameworkx6490PackageVersion)"
@@ -11,7 +11,7 @@
     }
   },
   "sdk": {
-    "version": "9.0.100-preview.5.24307.3"
+    "version": "9.0.100-preview.4.24267.66"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "9.0.0-beta.24368.9",

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "9.0.100-preview.4.24267.66",
+    "dotnet": "9.0.100-preview.5.24307.3",
     "runtimes": {
       "dotnet/x64": [
         "$(VSRedistCommonNetCoreSharedFrameworkx6490PackageVersion)"
@@ -11,7 +11,7 @@
     }
   },
   "sdk": {
-    "version": "9.0.100-preview.4.24267.66"
+    "version": "9.0.100-preview.5.24307.3"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "9.0.0-beta.24368.9",

--- a/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DesignSurfaceExt/NameCreationServiceImp.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DesignSurfaceExt/NameCreationServiceImp.cs
@@ -29,11 +29,15 @@ internal sealed class NameCreationServiceImp : INameCreationService
                 count++;
 
                 string name = comp.Site.Name;
-                if (name.StartsWith(type.Name, StringComparison.OrdinalIgnoreCase))
+                if (name.Contains(type.Name))
                 {
                     try
                     {
-                        int value = int.Parse(name[type.Name.Length..]);
+                        int value = name.IndexOf(type.Name, StringComparison.Ordinal) != -1 ?
+                            name[(name.IndexOf(type.Name, StringComparison.Ordinal) + type.Name.Length)..].Length == 0 ?
+                            0 :
+                            int.Parse(name[(name.IndexOf(type.Name, StringComparison.Ordinal) + type.Name.Length)..]) :
+                            0;
                         if (value < min)
                             min = value;
                         if (value > max)

--- a/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DesignSurfaceExt/NameCreationServiceImp.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DesignSurfaceExt/NameCreationServiceImp.cs
@@ -29,7 +29,7 @@ internal sealed class NameCreationServiceImp : INameCreationService
                 count++;
 
                 string name = comp.Site.Name;
-                if (name.StartsWith(type.Name, StringComparison.Ordinal))
+                if (name.StartsWith(type.Name, StringComparison.OrdinalIgnoreCase))
                 {
                     try
                     {

--- a/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DesignSurfaceExt/NameCreationServiceImp.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DesignSurfaceExt/NameCreationServiceImp.cs
@@ -26,18 +26,13 @@ internal sealed class NameCreationServiceImp : INameCreationService
         {
             if (cc[i] is Component comp && comp.GetType() == type)
             {
-                count++;
-
                 string name = comp.Site.Name;
-                if (name.Contains(type.Name))
+                if (name.StartsWith(type.Name, StringComparison.Ordinal))
                 {
+                    count++;
                     try
                     {
-                        int value = name.IndexOf(type.Name, StringComparison.Ordinal) != -1 ?
-                            name[(name.IndexOf(type.Name, StringComparison.Ordinal) + type.Name.Length)..].Length == 0 ?
-                            0 :
-                            int.Parse(name[(name.IndexOf(type.Name, StringComparison.Ordinal) + type.Name.Length)..]) :
-                            0;
+                        int value = int.Parse(name[type.Name.Length..]);
                         if (value < min)
                             min = value;
                         if (value > max)


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #11700

When adding a control, the counter should not count by the control type, but by Text+Type.Name.

Assuming that there is already a ToolStripMenuItem named Test in the contextScript, when we add the default ToolStripMenuItem, when the first ToolStripMenuItem is found, the counter takes on the value of +1, but in the subsequent codes does not satisfy the name. StartsWith() condition in the subsequent code, causing the counter to take the value of 1.
This causes the program to enter the else branch:

https://github.com/dotnet/winforms/blob/a52e943ec837fdec352cd8bd542266d01a278568/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DesignSurfaceExt/NameCreationServiceImp.cs#L63-L66

## Proposed changes

- Adjusting the Counter Position to make sure the control name can be correctly assigned.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- The control name can be correctly assigned.

## Regression? 

- No

## Risk

- Min

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

https://github.com/user-attachments/assets/c53f1f80-35f1-4fbf-8167-67d0a168246c

<!-- TODO -->

### After
![aftera](https://github.com/user-attachments/assets/53fdaad2-2a2a-42f6-be90-0705d968e2ef)

<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- Manual


## Test environment(s) <!-- Remove any that don't apply -->

- 9.0.100-preview.4.24267.66


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11732)