### PR TITLE
Add code coverage for MaskDescriptorTemplate

### DIFF
--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/MaskDescriptorTemplateTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/MaskDescriptorTemplateTests.cs
@@ -13,18 +13,29 @@ public class MaskDescriptorTemplateTests
     [InlineData("00000", "Numeric (5-digits)", "12345", typeof(int), "en-US", false, true)]
     [InlineData("invalid-mask", "Invalid Mask", "invalid", typeof(int), "en-US", false, false)]
     [InlineData("invalid-mask", "Invalid Mask", "invalid", typeof(int), "en-US", true, true)]
-    public void MaskDescriptorTemplate_Constructor_Validation(string mask, string name, string sample, Type validatingType, string cultureName, bool skipValidation, bool isValid)
+    [InlineData(null, "Null Mask", "sample", typeof(int), "en-US", false, false)]
+    [InlineData("00000", null, "sample", typeof(int), "en-US", false, false)]
+    [InlineData("00000", "Numeric (5-digits)", null, typeof(int), "en-US", false, false)]
+    [InlineData("00000", "Numeric (5-digits)", "12345", null, "en-US", false, false)]
+    public void MaskDescriptorTemplate_Constructor_Validation(string? mask, string? name, string? sample, Type? validatingType, string? cultureName, bool skipValidation, bool isValid)
     {
+        if (mask is null || name is null || sample is null || validatingType is null || cultureName is null)
+        {
+            isValid.Should().BeFalse();
+            return;
+        }
+
         CultureInfo culture = new(cultureName);
 
         MaskDescriptorTemplate descriptor = new(mask, name, sample, validatingType, culture, skipValidation);
 
+        descriptor.Name.Should().Be(name);
+        descriptor.Sample.Should().Be(sample);
+        descriptor.ValidatingType.Should().Be(validatingType);
+        descriptor.Culture.Should().Be(culture);
+
         if (isValid)
         {
-            descriptor.Mask.Should().Be(mask);
-            descriptor.Name.Should().Be(name);
-            descriptor.Sample.Should().Be(sample);
-            descriptor.ValidatingType.Should().Be(validatingType);
             descriptor.Culture.Should().Be(culture);
         }
         else
@@ -34,17 +45,23 @@ public class MaskDescriptorTemplateTests
     }
 
     [Theory]
-    [InlineData("en-US", "Numeric (5-digits)", "Phone number")]
-    [InlineData("fr-FR", "Numérique (5 chiffres)", "Numéro de téléphone (France)")]
-    [InlineData("de-DE", "Datum kurz", "Postleitzahl")]
-    public void GetLocalizedMaskDescriptors_ReturnsCorrectDescriptors(string cultureName, string expectedName1, string expectedName2)
+    [InlineData("en-US", 9)]
+    [InlineData("fr-FR", 7)]
+    [InlineData("de-DE", 4)]
+    [InlineData("ko-KR", 12)]
+    [InlineData("zh-CHT", 10)]
+    [InlineData("zh-CHS", 13)]
+    [InlineData("ja-JP", 14)]
+    [InlineData("es-ES", 9)]
+    [InlineData("it-IT", 7)]
+    [InlineData("ar-SA", 5)]
+    public void GetLocalizedMaskDescriptors_ReturnsCorrectDescriptors(string cultureName, int templateCount)
     {
         CultureInfo culture = new(cultureName);
 
         var descriptors = MaskDescriptorTemplate.GetLocalizedMaskDescriptors(culture);
 
         descriptors.Should().NotBeEmpty();
-        descriptors.Should().Contain(d => d.Name == expectedName1);
-        descriptors.Should().Contain(d => d.Name == expectedName2);
+        descriptors.Count.Should().Be(templateCount);
     }
 }

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/MaskDescriptorTemplateTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/MaskDescriptorTemplateTests.cs
@@ -1,0 +1,52 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System.Globalization;
+
+namespace System.Windows.Forms.Design.Tests;
+
+public class MaskDescriptorTemplateTests
+{
+    [Theory]
+    [InlineData("00000", "Numeric (5-digits)", "12345", typeof(int), "en-US", false, true)]
+    [InlineData("invalid-mask", "Invalid Mask", "invalid", typeof(int), "en-US", false, false)]
+    [InlineData("invalid-mask", "Invalid Mask", "invalid", typeof(int), "en-US", true, true)]
+    public void MaskDescriptorTemplate_Constructor_Validation(string mask, string name, string sample, Type validatingType, string cultureName, bool skipValidation, bool isValid)
+    {
+        CultureInfo culture = new(cultureName);
+
+        MaskDescriptorTemplate descriptor = new(mask, name, sample, validatingType, culture, skipValidation);
+
+        if (isValid)
+        {
+            descriptor.Mask.Should().Be(mask);
+            descriptor.Name.Should().Be(name);
+            descriptor.Sample.Should().Be(sample);
+            descriptor.ValidatingType.Should().Be(validatingType);
+            descriptor.Culture.Should().Be(culture);
+        }
+        else
+        {
+            descriptor.Mask.Should().BeNull();
+        }
+    }
+
+    [Theory]
+    [InlineData("en-US", "Numeric (5-digits)", "Phone number")]
+    [InlineData("fr-FR", "Numérique (5 chiffres)", "Numéro de téléphone (France)")]
+    [InlineData("de-DE", "Datum kurz", "Postleitzahl")]
+    public void GetLocalizedMaskDescriptors_ReturnsCorrectDescriptors(string cultureName, string expectedName1, string expectedName2)
+    {
+        CultureInfo culture = new(cultureName);
+
+        var descriptors = MaskDescriptorTemplate.GetLocalizedMaskDescriptors(culture);
+
+        descriptors.Should().NotBeEmpty();
+        descriptors.Should().Contain(d => d.Name == expectedName1);
+        descriptors.Should().Contain(d => d.Name == expectedName2);
+    }
+}
+
+

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/MaskDescriptorTemplateTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/MaskDescriptorTemplateTests.cs
@@ -13,13 +13,12 @@ public class MaskDescriptorTemplateTests
     [InlineData("00000", "Numeric (5-digits)", "12345", typeof(int), "en-US", false, true)]
     [InlineData("invalid-mask", "Invalid Mask", "invalid", typeof(int), "en-US", false, false)]
     [InlineData("invalid-mask", "Invalid Mask", "invalid", typeof(int), "en-US", true, true)]
-    [InlineData(null, "Null Mask", "sample", typeof(int), "en-US", false, false)]
     [InlineData("00000", null, "sample", typeof(int), "en-US", false, false)]
     [InlineData("00000", "Numeric (5-digits)", null, typeof(int), "en-US", false, false)]
     [InlineData("00000", "Numeric (5-digits)", "12345", null, "en-US", false, false)]
     public void MaskDescriptorTemplate_Constructor_Validation(string? mask, string? name, string? sample, Type? validatingType, string? cultureName, bool skipValidation, bool isValid)
     {
-        if (mask is null || name is null || sample is null || validatingType is null || cultureName is null)
+        if (name is null || sample is null || validatingType is null || cultureName is null)
         {
             isValid.Should().BeFalse();
             return;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/MaskDescriptorTemplateTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/MaskDescriptorTemplateTests.cs
@@ -48,5 +48,3 @@ public class MaskDescriptorTemplateTests
         descriptors.Should().Contain(d => d.Name == expectedName2);
     }
 }
-
-


### PR DESCRIPTION
Related https://github.com/dotnet/winforms/issues/10773

Proposed changes
Add unit test file: MaskDescriptorTemplateTests.cs for public properties/Methods of the MaskDescriptorTemplate
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11743)