### PR TITLE
Add core coverage for DesignBinding

### DIFF
--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DesignBindingTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DesignBindingTests.cs
@@ -1,0 +1,87 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+namespace System.Windows.Forms.Design.Tests;
+
+public sealed class DesignBindingTests
+{
+    [Fact]
+    public void Null_ReturnsDesignBindingWithNullValues()
+    {
+        var nullBinding = DesignBinding.Null;
+
+        nullBinding.DataSource.Should().BeNull();
+        nullBinding.DataMember.Should().BeNull();
+    }
+
+    [Fact]
+    public void Constructor_InitializesProperties()
+    {
+        object dataSource = new();
+        string dataMember = "TestMember";
+        var binding = new DesignBinding(dataSource, dataMember);
+
+        binding.DataSource.Should().Be(dataSource);
+        binding.DataMember.Should().Be(dataMember);
+    }
+
+    [Fact]
+    public void IsNull_ReturnsTrueWhenDataSourceIsNull()
+    {
+        var binding = new DesignBinding(null, "TestMember");
+        binding.IsNull.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsNull_ReturnsFalseWhenDataSourceIsNotNull()
+    {
+        var binding = new DesignBinding(new object(), "TestMember");
+        binding.IsNull.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(null, "")]
+    [InlineData("", "")]
+    [InlineData("Field", "Field")]
+    [InlineData("Object.Field", "Field")]
+    [InlineData("Object.SubObject.Field", "Field")]
+    public void DataField_ReturnsCorrectField(string dataMember, string expectedField)
+    {
+        var binding = new DesignBinding(new object(), dataMember);
+        binding.DataField.Should().Be(expectedField);
+    }
+
+    [Fact]
+    public void Equals_ReturnsTrueForMatchingDataSourceAndDataMember()
+    {
+        object dataSource = new();
+        string dataMember = "TestMember";
+        var binding = new DesignBinding(dataSource, dataMember);
+
+        binding.Equals(dataSource, dataMember).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Equals_ReturnsFalseForNonMatchingDataSource()
+    {
+        object dataSource = new();
+        string dataMember = "TestMember";
+        var binding = new DesignBinding(dataSource, dataMember);
+
+        binding.Equals(new object(), dataMember).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Equals_ReturnsFalseForNonMatchingDataMember()
+    {
+        object dataSource = new();
+        string dataMember = "TestMember";
+        var binding = new DesignBinding(dataSource, dataMember);
+
+        binding.Equals(dataSource, "DifferentMember").Should().BeFalse();
+    }
+}
+
+


### PR DESCRIPTION
Related https://github.com/dotnet/winforms/issues/10773

## Proposed changes

- Add unit test DesignBindingTests.cs for public properties and method of the DesignBinding.
- Enable nullability in DesignBinding.
