### PR TITLE
Dispose controls that using in unit tests

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/ColorEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/ColorEditor.cs
@@ -13,8 +13,6 @@ namespace System.Drawing.Design;
 [CLSCompliant(false)]
 public partial class ColorEditor : UITypeEditor
 {
-    private ColorUI? _colorUI;
-
     /// <summary>
     ///  Edits the given object value using the editor style provided by ColorEditor.GetEditStyle.
     /// </summary>
@@ -25,7 +23,7 @@ public partial class ColorEditor : UITypeEditor
             return value;
         }
 
-        _colorUI ??= new ColorUI(this);
+        using ColorUI? _colorUI= new ColorUI(this);
 
         _colorUI.Start(editorService, value);
         editorService.DropDownControl(_colorUI);

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/ColorEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/ColorEditor.cs
@@ -23,7 +23,7 @@ public partial class ColorEditor : UITypeEditor
             return value;
         }
 
-        using ColorUI? _colorUI= new ColorUI(this);
+        using ColorUI? _colorUI = new(this);
 
         _colorUI.Start(editorService, value);
         editorService.DropDownControl(_colorUI);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/Control.ControlAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/Control.ControlAccessibleObjectTests.cs
@@ -229,26 +229,34 @@ public class Control_ControlAccessibleObjectTests
         yield return new object[] { (IntPtr)(-1) };
         yield return new object[] { (IntPtr)1 };
         yield return new object[] { (IntPtr)250 };
-        yield return new object[] { new Control().Handle };
+        Control control = new Control();
+        yield return new object[] { control.Handle, control };
     }
 
     [WinFormsTheory]
     [MemberData(nameof(Handle_Set_TestData))]
-    public void ControlAccessibleObject_Handle_Set_Success(IntPtr value)
+    public void ControlAccessibleObject_Handle_Set_Success(IntPtr value, Control control = null)
     {
-        using Control ownerControl = new();
-        ownerControl.CreateControl();
-        Assert.True(ownerControl.IsHandleCreated);
-        var accessibleObject = new Control.ControlAccessibleObject(ownerControl);
-        Assert.True(ownerControl.IsHandleCreated);
+        try
+        {
+            using Control ownerControl = new();
+            ownerControl.CreateControl();
+            Assert.True(ownerControl.IsHandleCreated);
+            var accessibleObject = new Control.ControlAccessibleObject(ownerControl);
+            Assert.True(ownerControl.IsHandleCreated);
 
-        // Set empty.
-        accessibleObject.Handle = value;
-        Assert.Equal(value, accessibleObject.Handle);
+            // Set empty.
+            accessibleObject.Handle = value;
+            Assert.Equal(value, accessibleObject.Handle);
 
-        // Set same.
-        accessibleObject.Handle = value;
-        Assert.Equal(value, accessibleObject.Handle);
+            // Set same.
+            accessibleObject.Handle = value;
+            Assert.Equal(value, accessibleObject.Handle);
+        }
+        finally
+        {
+            control?.Dispose();
+        }
     }
 
     [WinFormsTheory]
@@ -1361,7 +1369,7 @@ public class Control_ControlAccessibleObjectTests
         else
         {
             Assert.Equal(VARIANT.Empty, controlAccessibleObject.GetPropertyValue(UIA_PROPERTY_ID.UIA_NamePropertyId));
-        } 
+        }
     }
 
     public static IEnumerable<object[]> ControlAccessibleObject_GetPropertyValue_ControlTypeProperty_ReturnsCorrectValue_TestData()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/Control.ControlAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/Control.ControlAccessibleObjectTests.cs
@@ -229,7 +229,7 @@ public class Control_ControlAccessibleObjectTests
         yield return new object[] { (IntPtr)(-1) };
         yield return new object[] { (IntPtr)1 };
         yield return new object[] { (IntPtr)250 };
-        Control control = new Control();
+        Control control = new();
         yield return new object[] { control.Handle, control };
     }
 
@@ -245,11 +245,11 @@ public class Control_ControlAccessibleObjectTests
             var accessibleObject = new Control.ControlAccessibleObject(ownerControl);
             Assert.True(ownerControl.IsHandleCreated);
 
-            // Set empty.
+            // Set value.
             accessibleObject.Handle = value;
             Assert.Equal(value, accessibleObject.Handle);
 
-            // Set same.
+            // Set same value.
             accessibleObject.Handle = value;
             Assert.Equal(value, accessibleObject.Handle);
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/Control.ControlAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/Control.ControlAccessibleObjectTests.cs
@@ -223,45 +223,46 @@ public class Control_ControlAccessibleObjectTests
         Assert.Equal(accessibleDescription, accessibleObject.Description);
     }
 
-    public static TheoryData<IntPtr, Control> Handle_Set_TestData()
+    public static TheoryData<object> Handle_Set_DataTestData()
     {
-        Control control = new();
-        var data = new TheoryData<IntPtr, Control>
+        return new TheoryData<object>
         {
-            { IntPtr.Zero, null },
-            { new IntPtr(-1), null },
-            { new IntPtr(1), null },
-            { new IntPtr(250), null },
-            { control.Handle, control }
+            null,
+            IntPtr.Zero,
+            new IntPtr(-1),
+            new IntPtr(1),
+            new IntPtr(250)
         };
-
-        return data;
     }
 
     [WinFormsTheory]
-    [MemberData(nameof(Handle_Set_TestData))]
-    public void ControlAccessibleObject_Handle_Set_Success(IntPtr value, Control control)
+    [MemberData(nameof(Handle_Set_DataTestData))]
+    public void ControlAccessibleObject_Handle_Set_Success(object testValue)
     {
-        try
+        IntPtr value;
+        if (testValue is null)
         {
-            using Control ownerControl = new();
-            ownerControl.CreateControl();
-            Assert.True(ownerControl.IsHandleCreated);
-            var accessibleObject = new Control.ControlAccessibleObject(ownerControl);
-            Assert.True(ownerControl.IsHandleCreated);
-
-            // Set value.
-            accessibleObject.Handle = value;
-            Assert.Equal(value, accessibleObject.Handle);
-
-            // Set same value.
-            accessibleObject.Handle = value;
-            Assert.Equal(value, accessibleObject.Handle);
+            using Control control = new();
+            value = control.Handle;
         }
-        finally
+        else
         {
-            control?.Dispose();
+            value = (IntPtr)testValue;
         }
+
+        using Control ownerControl = new();
+        ownerControl.CreateControl();
+        Assert.True(ownerControl.IsHandleCreated);
+        var accessibleObject = new Control.ControlAccessibleObject(ownerControl);
+        Assert.True(ownerControl.IsHandleCreated);
+
+        // Set value.
+        accessibleObject.Handle = value;
+        Assert.Equal(value, accessibleObject.Handle);
+
+        // Set same value.
+        accessibleObject.Handle = value;
+        Assert.Equal(value, accessibleObject.Handle);
     }
 
     [WinFormsTheory]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/Control.ControlAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/Control.ControlAccessibleObjectTests.cs
@@ -223,19 +223,24 @@ public class Control_ControlAccessibleObjectTests
         Assert.Equal(accessibleDescription, accessibleObject.Description);
     }
 
-    public static IEnumerable<object[]> Handle_Set_TestData()
+    public static TheoryData<IntPtr, Control> Handle_Set_TestData()
     {
-        yield return new object[] { IntPtr.Zero };
-        yield return new object[] { (IntPtr)(-1) };
-        yield return new object[] { (IntPtr)1 };
-        yield return new object[] { (IntPtr)250 };
         Control control = new();
-        yield return new object[] { control.Handle, control };
+        var data = new TheoryData<IntPtr, Control>
+        {
+            { IntPtr.Zero, null },
+            { new IntPtr(-1), null },
+            { new IntPtr(1), null },
+            { new IntPtr(250), null },
+            { control.Handle, control }
+        };
+
+        return data;
     }
 
     [WinFormsTheory]
     [MemberData(nameof(Handle_Set_TestData))]
-    public void ControlAccessibleObject_Handle_Set_Success(IntPtr value, Control control = null)
+    public void ControlAccessibleObject_Handle_Set_Success(IntPtr value, Control control)
     {
         try
         {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AxHostTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AxHostTests.cs
@@ -1347,7 +1347,7 @@ public class AxHostTests
     [WinFormsFact]
     public void AxHost_EndInit_InvokeWithParent_CreatesControl()
     {
-        Control parent = new();
+        using Control parent = new();
         using SubAxHost control = new(WebBrowserClsidString)
         {
             Parent = parent

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.ControlCollection.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.ControlCollection.cs
@@ -1119,17 +1119,24 @@ public class ControlControlCollectionTests
     public void ControlCollection_Add_DifferentThreadValueOwner_ThrowsArgumentException()
     {
         Control owner = null;
-        Thread thread = new(() =>
+        try
         {
-            owner = new Control();
-            Assert.NotEqual(IntPtr.Zero, owner.Handle);
-        });
-        thread.Start();
-        thread.Join();
+            Thread thread = new(() =>
+            {
+                owner = new Control();
+                Assert.NotEqual(IntPtr.Zero, owner.Handle);
+            });
+            thread.Start();
+            thread.Join();
 
-        using Control control = new();
-        var collection = new Control.ControlCollection(owner);
-        Assert.Throws<ArgumentException>(() => collection.Add(control));
+            using Control control = new();
+            var collection = new Control.ControlCollection(owner);
+            Assert.Throws<ArgumentException>(() => collection.Add(control));
+        }
+        finally
+        {
+            owner?.Dispose();
+        }
     }
 
     [Fact] // cross-thread access
@@ -1147,6 +1154,8 @@ public class ControlControlCollectionTests
         using Control owner = new();
         var collection = new Control.ControlCollection(owner);
         Assert.Throws<ArgumentException>(() => collection.Add(control));
+
+        control?.Dispose();
     }
 
     [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.ControlCollection.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.ControlCollection.cs
@@ -1143,19 +1143,24 @@ public class ControlControlCollectionTests
     public void ControlCollection_Add_DifferentThreadValueControl_ThrowsArgumentException()
     {
         Control control = null;
-        Thread thread = new(() =>
+        try
         {
-            control = new Control();
-            Assert.NotEqual(IntPtr.Zero, control.Handle);
-        });
-        thread.Start();
-        thread.Join();
+            Thread thread = new(() =>
+            {
+                control = new Control();
+                Assert.NotEqual(IntPtr.Zero, control.Handle);
+            });
+            thread.Start();
+            thread.Join();
 
-        using Control owner = new();
-        var collection = new Control.ControlCollection(owner);
-        Assert.Throws<ArgumentException>(() => collection.Add(control));
-
-        control?.Dispose();
+            using Control owner = new();
+            var collection = new Control.ControlCollection(owner);
+            Assert.Throws<ArgumentException>(() => collection.Add(control));
+        }
+        finally
+        {
+            control?.Dispose();
+        }
     }
 
     [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.Properties.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.Properties.cs
@@ -52,21 +52,25 @@ public partial class ControlTests
         Assert.Same(control, accessibleObject.Owner);
     }
 
-    public static IEnumerable<object[]> AccessibilityObject_CustomCreateAccessibilityInstance_TestData()
+    public static TheoryData<AccessibleObject, AccessibleObject, Control> AccessibilityObject_CustomCreateAccessibilityInstance_TestData()
     {
-        yield return new object[] { null, null };
-
         AccessibleObject accessibleObject = new();
-        yield return new object[] { accessibleObject, accessibleObject };
-
         Control control = new();
         var controlAccessibleObject = new Control.ControlAccessibleObject(control);
-        yield return new object[] { controlAccessibleObject, controlAccessibleObject, control };
+
+        var data = new TheoryData<AccessibleObject, AccessibleObject, Control>
+        {
+            { null, null, null },
+            { accessibleObject, accessibleObject, null },
+            { controlAccessibleObject, controlAccessibleObject, control }
+        };
+
+        return data;
     }
 
     [WinFormsTheory]
     [MemberData(nameof(AccessibilityObject_CustomCreateAccessibilityInstance_TestData))]
-    public void Control_AccessibilityObject_GetCustomCreateAccessibilityInstance_ReturnsExpected(AccessibleObject result, AccessibleObject expected, Control originalControl = null)
+    public void Control_AccessibilityObject_GetCustomCreateAccessibilityInstance_ReturnsExpected(AccessibleObject result, AccessibleObject expected, Control originalControl)
     {
         try
         {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.Properties.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.Properties.cs
@@ -52,42 +52,47 @@ public partial class ControlTests
         Assert.Same(control, accessibleObject.Owner);
     }
 
-    public static TheoryData<AccessibleObject, AccessibleObject, Control> AccessibilityObject_CustomCreateAccessibilityInstance_TestData()
+    public static TheoryData<AccessibleObject, AccessibleObject> AccessibilityObject_CustomCreateAccessibilityInstance_TestData()
     {
         AccessibleObject accessibleObject = new();
-        Control control = new();
-        var controlAccessibleObject = new Control.ControlAccessibleObject(control);
-
-        var data = new TheoryData<AccessibleObject, AccessibleObject, Control>
+        return new TheoryData<AccessibleObject, AccessibleObject>
         {
-            { null, null, null },
-            { accessibleObject, accessibleObject, null },
-            { controlAccessibleObject, controlAccessibleObject, control }
+            { null, null },
+            { accessibleObject, accessibleObject },
         };
-
-        return data;
     }
 
     [WinFormsTheory]
     [MemberData(nameof(AccessibilityObject_CustomCreateAccessibilityInstance_TestData))]
-    public void Control_AccessibilityObject_GetCustomCreateAccessibilityInstance_ReturnsExpected(AccessibleObject result, AccessibleObject expected, Control originalControl)
+    public void Control_AccessibilityObject_GetCustomCreateAccessibilityInstance_ReturnsExpected(AccessibleObject result, AccessibleObject expected)
     {
-        try
+        using (new NoAssertContext())
         {
-            using (new NoAssertContext())
+            using CustomCreateAccessibilityInstanceControl control = new()
             {
-                using CustomCreateAccessibilityInstanceControl control = new()
-                {
-                    CreateAccessibilityResult = result
-                };
-                Assert.Same(expected, control.AccessibilityObject);
-                Assert.Same(control.AccessibilityObject, control.AccessibilityObject);
-                Assert.False(control.IsHandleCreated);
-            }
+                CreateAccessibilityResult = result
+            };
+            Assert.Same(expected, control.AccessibilityObject);
+            Assert.Same(control.AccessibilityObject, control.AccessibilityObject);
+            Assert.False(control.IsHandleCreated);
         }
-        finally
+    }
+
+    [WinFormsFact]
+    public void Control_AccessibilityObject_GetCustomCreateAccessibilityInstance_WithRealControlAccessibleObject_ReturnsExpected()
+    {
+        using Control control1 = new();
+        var controlAccessibleObject = new Control.ControlAccessibleObject(control1);
+
+        using (new NoAssertContext())
         {
-            originalControl?.Dispose();
+            using CustomCreateAccessibilityInstanceControl control = new()
+            {
+                CreateAccessibilityResult = controlAccessibleObject
+            };
+            Assert.Same(controlAccessibleObject, control.AccessibilityObject);
+            Assert.Same(control.AccessibilityObject, control.AccessibilityObject);
+            Assert.False(control.IsHandleCreated);
         }
     }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.Properties.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.Properties.cs
@@ -59,23 +59,31 @@ public partial class ControlTests
         AccessibleObject accessibleObject = new();
         yield return new object[] { accessibleObject, accessibleObject };
 
-        var controlAccessibleObject = new Control.ControlAccessibleObject(new Control());
-        yield return new object[] { controlAccessibleObject, controlAccessibleObject };
+        Control control = new();
+        var controlAccessibleObject = new Control.ControlAccessibleObject(control);
+        yield return new object[] { controlAccessibleObject, controlAccessibleObject, control };
     }
 
     [WinFormsTheory]
     [MemberData(nameof(AccessibilityObject_CustomCreateAccessibilityInstance_TestData))]
-    public void Control_AccessibilityObject_GetCustomCreateAccessibilityInstance_ReturnsExpected(AccessibleObject result, AccessibleObject expected)
+    public void Control_AccessibilityObject_GetCustomCreateAccessibilityInstance_ReturnsExpected(AccessibleObject result, AccessibleObject expected, Control originalControl = null)
     {
-        using (new NoAssertContext())
+        try
         {
-            using CustomCreateAccessibilityInstanceControl control = new()
+            using (new NoAssertContext())
             {
-                CreateAccessibilityResult = result
-            };
-            Assert.Same(expected, control.AccessibilityObject);
-            Assert.Same(control.AccessibilityObject, control.AccessibilityObject);
-            Assert.False(control.IsHandleCreated);
+                using CustomCreateAccessibilityInstanceControl control = new()
+                {
+                    CreateAccessibilityResult = result
+                };
+                Assert.Same(expected, control.AccessibilityObject);
+                Assert.Same(control.AccessibilityObject, control.AccessibilityObject);
+                Assert.False(control.IsHandleCreated);
+            }
+        }
+        finally
+        {
+            originalControl?.Dispose();
         }
     }
 
@@ -10506,7 +10514,7 @@ public partial class ControlTests
     }
 
     [WinFormsTheory]
-    [CommonMemberData(typeof(ControlTests), nameof(ControlTests.Get_Control_ShowFocusCues_GetWithHandleMessageSent_ReturnsExpected))]
+    [CommonMemberData(typeof(ControlTests), nameof(Get_Control_ShowFocusCues_GetWithHandleMessageSent_ReturnsExpected))]
     public void Control_ShowFocusCues_GetWithHandleMessageSent_ReturnsExpected(int wParam, bool expected)
     {
         using SubControl control = new();
@@ -10565,7 +10573,7 @@ public partial class ControlTests
     }
 
     [WinFormsTheory]
-    [CommonMemberData(typeof(ControlTests), nameof(ControlTests.Get_Control_ShowKeyboardCues_GetWithHandleMessageSent_ReturnsExpected))]
+    [CommonMemberData(typeof(ControlTests), nameof(Get_Control_ShowKeyboardCues_GetWithHandleMessageSent_ReturnsExpected))]
     public void Control_ShowKeyboardCues_GetWithHandleMessageSent_ReturnsExpected(int wParam, bool expected)
     {
         using SubControl control = new();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ScreenTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ScreenTests.cs
@@ -93,7 +93,7 @@ public class ScreenTests
         VerifyScreen(screen);
     }
 
-    [Fact]
+    [WinFormsFact]
     public void Screen_FromHandle_RealHandle_ReturnsExpected()
     {
         Control control = new();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ScreenTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ScreenTests.cs
@@ -88,16 +88,25 @@ public class ScreenTests
     public static IEnumerable<object[]> FromHandle_TestData()
     {
         yield return new object[] { IntPtr.Zero };
-        yield return new object[] { new Control().Handle };
+
+        Control control = new();
+        yield return new object[] { control.Handle, control };
     }
 
     [Theory]
     [MemberData(nameof(FromHandle_TestData))]
-    public void Screen_FromHandle_Invoke_ReturnsExpected(IntPtr handle)
+    public void Screen_FromHandle_Invoke_ReturnsExpected(IntPtr handle, Control control = null)
     {
-        Screen screen = Screen.FromHandle(handle);
-        Assert.NotNull(screen);
-        VerifyScreen(screen);
+        try
+        {
+            Screen screen = Screen.FromHandle(handle);
+            Assert.NotNull(screen);
+            VerifyScreen(screen);
+        }
+        finally
+        {
+            control?.Dispose();
+        }
     }
 
     public static IEnumerable<object[]> FromPoint_TestData()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ScreenTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ScreenTests.cs
@@ -85,21 +85,21 @@ public class ScreenTests
         Assert.Throws<ArgumentNullException>("control", () => Screen.FromControl(null));
     }
 
-    public static IEnumerable<object[]> FromHandle_TestData()
+    [Fact]
+    public void Screen_FromHandle_ZeroHandle_ReturnsExpected()
     {
-        yield return new object[] { IntPtr.Zero };
-
-        Control control = new();
-        yield return new object[] { control.Handle, control };
+        Screen screen = Screen.FromHandle(IntPtr.Zero);
+        Assert.NotNull(screen);
+        VerifyScreen(screen);
     }
 
-    [Theory]
-    [MemberData(nameof(FromHandle_TestData))]
-    public void Screen_FromHandle_Invoke_ReturnsExpected(IntPtr handle, Control control = null)
+    [Fact]
+    public void Screen_FromHandle_RealHandle_ReturnsExpected()
     {
+        Control control = new();
         try
         {
-            Screen screen = Screen.FromHandle(handle);
+            Screen screen = Screen.FromHandle(control.Handle);
             Assert.NotNull(screen);
             VerifyScreen(screen);
         }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #3361


## Proposed changes

- Add `using` or `control?.Dispose()` to unit tests

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- lower risk of hanging CI test runs

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

- Tests were leaving controls for GC to collect

### After

- Controls are disposed before UI thread terminates


## Test methodology <!-- How did you ensure quality? -->

- Set a breakpoint in the Control.Dispose function to confirm that it is executed successfully
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11751)