### PR TITLE
Issue 11760 fix tool strip combo box display

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.FlatComboAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.FlatComboAdapter.cs
@@ -23,6 +23,8 @@ public partial class ComboBox
         private const int OFFSET_2PIXELS = 2;
         protected static int s_offsetPixels = OFFSET_2PIXELS;
 
+        private bool SmallButton { get; }
+
         public FlatComboAdapter(ComboBox comboBox, bool smallButton)
         {
             // adapter is re-created when combobox is resized, see IsValid method, thus we don't need to handle DPI changed explicitly
@@ -35,6 +37,8 @@ public partial class ComboBox
             _innerInnerBorder = new Rectangle(_innerBorder.X + 1, _innerBorder.Y + 1, _innerBorder.Width - 2, _innerBorder.Height - 2);
             _dropDownRect = new Rectangle(_innerBorder.Right + 1, _innerBorder.Y, dropDownButtonWidth, _innerBorder.Height + 1);
 
+            SmallButton = smallButton;
+
             // fill in several pixels of the dropdown rect with white so that it looks like the combo button is thinner.
             if (smallButton)
             {
@@ -46,7 +50,7 @@ public partial class ComboBox
 
             _origRightToLeft = comboBox.RightToLeft;
 
-            if (_origRightToLeft == RightToLeft.Yes)
+            if (smallButton && _origRightToLeft == RightToLeft.Yes)
             {
                 _innerBorder.X = _clientRect.Width - _innerBorder.Right;
                 _innerInnerBorder.X = _clientRect.Width - _innerInnerBorder.Right;
@@ -65,6 +69,11 @@ public partial class ComboBox
             if (comboBox.DropDownStyle == ComboBoxStyle.Simple)
             {
                 return;
+            }
+
+            if (SmallButton)
+            {
+                DrawFlatCombo(comboBox, g);
             }
 
             bool rightToLeft = comboBox.RightToLeft == RightToLeft.Yes;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.FlatComboAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.FlatComboAdapter.cs
@@ -23,9 +23,9 @@ public partial class ComboBox
         private const int OFFSET_2PIXELS = 2;
         protected static int s_offsetPixels = OFFSET_2PIXELS;
 
-        private bool SmallButton { get; }
+        private bool ShouldRedrawAsSmallButton { get; }
 
-        public FlatComboAdapter(ComboBox comboBox, bool smallButton)
+        public FlatComboAdapter(ComboBox comboBox, bool shouldRedrawAsSmallButton)
         {
             // adapter is re-created when combobox is resized, see IsValid method, thus we don't need to handle DPI changed explicitly
             s_offsetPixels = comboBox.LogicalToDeviceUnits(OFFSET_2PIXELS);
@@ -37,10 +37,10 @@ public partial class ComboBox
             _innerInnerBorder = new Rectangle(_innerBorder.X + 1, _innerBorder.Y + 1, _innerBorder.Width - 2, _innerBorder.Height - 2);
             _dropDownRect = new Rectangle(_innerBorder.Right + 1, _innerBorder.Y, dropDownButtonWidth, _innerBorder.Height + 1);
 
-            SmallButton = smallButton;
+            ShouldRedrawAsSmallButton = shouldRedrawAsSmallButton;
 
             // fill in several pixels of the dropdown rect with white so that it looks like the combo button is thinner.
-            if (smallButton)
+            if (shouldRedrawAsSmallButton)
             {
                 _whiteFillRect = _dropDownRect;
                 _whiteFillRect.Width = WhiteFillRectWidth;
@@ -50,7 +50,7 @@ public partial class ComboBox
 
             _origRightToLeft = comboBox.RightToLeft;
 
-            if (smallButton && _origRightToLeft == RightToLeft.Yes)
+            if (_origRightToLeft == RightToLeft.Yes)
             {
                 _innerBorder.X = _clientRect.Width - _innerBorder.Right;
                 _innerInnerBorder.X = _clientRect.Width - _innerInnerBorder.Right;
@@ -71,7 +71,7 @@ public partial class ComboBox
                 return;
             }
 
-            if (SmallButton)
+            if (ShouldRedrawAsSmallButton)
             {
                 DrawFlatCombo(comboBox, g);
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.cs
@@ -3976,5 +3976,5 @@ public partial class ComboBox : ListControl
     }
 
     internal virtual FlatComboAdapter CreateFlatComboAdapterInstance()
-        => new(this, smallButton: false);
+        => new(this, shouldRedrawAsSmallButton: false);
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripComboBox.ToolStripComboBoxControl.ToolStripComboBoxFlatComboAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripComboBox.ToolStripComboBoxControl.ToolStripComboBoxFlatComboAdapter.cs
@@ -12,7 +12,7 @@ public partial class ToolStripComboBox
     {
         internal class ToolStripComboBoxFlatComboAdapter : FlatComboAdapter
         {
-            public ToolStripComboBoxFlatComboAdapter(ComboBox comboBox) : base(comboBox, smallButton: true)
+            public ToolStripComboBoxFlatComboAdapter(ComboBox comboBox) : base(comboBox, shouldRedrawAsSmallButton: true)
             {
             }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #11760

## Proposed changes

- When the control is ToolStripComboBox, redraw the control when the mouse hovers. (It's mean that revert the changes of PR #11529 when the ComboBox's dropdown button is using small button)

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- The ToolStripComboBox can be used normally without weird display

## Regression? 

- Yes

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
When hovering over drop-down arrow of ToolStripComboBox, an additional blue hover effect appears outside the icon.

https://github.com/user-attachments/assets/65127428-e7df-4c92-878d-def027ca0be6

### After

No additional blue hover effect appears outside the icon.

![KeepSmallButton](https://github.com/user-attachments/assets/5f941c36-c502-4f84-ab0d-2503c078ea3c)


## Test methodology <!-- How did you ensure quality? -->

- Manually

## Test environment(s) <!-- Remove any that don't apply -->

- 9.0.0-preview.7.24370.5

<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11761)