### PR TITLE
Add test case for NotifyIconDesigner

### DIFF
--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/NotifyIconDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/NotifyIconDesignerTests.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+namespace System.Windows.Forms.Design.Tests;
+
+public sealed class NotifyIconDesignerTests
+{
+    [Fact]
+    public void Visible_WithDefaultNotifyIcon_ShouldBeTrue()
+    {
+        using NotifyIconDesigner notifyIconDesigner = new();
+        using NotifyIcon icon = new();
+        notifyIconDesigner.Initialize(icon);
+        notifyIconDesigner.InitializeNewComponent(null);
+
+        icon.Visible.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ActionLists_WithDefaultNotifyIcon_ShouldReturnExpectedValue()
+    {
+        using NotifyIconDesigner notifyIconDesigner = new();
+        using NotifyIcon icon = new();
+        notifyIconDesigner.Initialize(icon);
+        notifyIconDesigner.ActionLists.Count.Should().Be(1);
+    }
+}


### PR DESCRIPTION
Related to #10773 

## Proposed changes

- Add test case for NotifyIconDesigner.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11774)