### PR TITLE
Add a manual test case for clones ListViewItem to WinformsControlsApp

### DIFF
--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/CloneTestListView.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/CloneTestListView.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace WinFormsControlsTest;
+
+internal class CloneTestListView : ListView
+{
+    public void InvokeOnItemChecked(ItemCheckedEventArgs e)
+    {
+        if (!CheckBoxes)
+        {
+            return;
+        }
+
+        if (e.Item.ListView == this)
+        {
+            base.OnItemChecked(e);
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ListViewTest.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ListViewTest.Designer.cs
@@ -35,6 +35,7 @@ partial class ListViewTest
         System.ComponentModel.ComponentResourceManager resources = new(typeof(ListViewTest));
         this.imageList1 = new System.Windows.Forms.ImageList(this.components);
         this.listView1 = new System.Windows.Forms.ListView();
+        this.listView3 = new SubListView();
         this.columnHeader1 = (System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader());
         this.columnHeader2 = (System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader());
         this.imageList2 = new System.Windows.Forms.ImageList(this.components);
@@ -81,6 +82,20 @@ partial class ListViewTest
         this.listView1.SmallImageList = this.imageList1;
         this.listView1.TabIndex = 0;
         this.listView1.UseCompatibleStateImageBehavior = false;
+        this.listView1.Dock = DockStyle.Fill;
+        // 
+        // listView3
+        // 
+        this.listView3.CheckBoxes = true;
+        this.listView3.HideSelection = false;
+        this.listView3.Name = "listView1";
+        this.listView3.TabIndex = 1;
+        this.listView3.UseCompatibleStateImageBehavior = false;
+        this.listView3.VirtualListSize = 3;
+        this.listView3.VirtualMode = true;
+        this.listView1.Size = new System.Drawing.Size(439, 40);
+        this.listView3.Dock = DockStyle.Bottom;
+        this.listView3.Click += new System.EventHandler(this.listView3_Click);
         // 
         // imageList2
         // 
@@ -139,6 +154,7 @@ partial class ListViewTest
         this.Controls.Add(this.btnLoadImagesListView1);
         this.Controls.Add(this.btnClearListView1);
         this.Controls.Add(this.listView1);
+        this.Controls.Add(this.listView3);
         this.Name = "ListViewTest";
         this.Text = "ListView Test";
         this.ResumeLayout(false);
@@ -147,6 +163,7 @@ partial class ListViewTest
     #endregion
 
     private System.Windows.Forms.ListView listView1;
+    private SubListView listView3;
     private System.Windows.Forms.ImageList imageList1;
     private System.Windows.Forms.ImageList imageList2;
     private System.Windows.Forms.ImageList LargeImageList;

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ListViewTest.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ListViewTest.Designer.cs
@@ -35,7 +35,7 @@ partial class ListViewTest
         System.ComponentModel.ComponentResourceManager resources = new(typeof(ListViewTest));
         this.imageList1 = new System.Windows.Forms.ImageList(this.components);
         this.listView1 = new System.Windows.Forms.ListView();
-        this.listView3 = new SubListView();
+        this.listView3 = new CloneTestListView();
         this.columnHeader1 = (System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader());
         this.columnHeader2 = (System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader());
         this.imageList2 = new System.Windows.Forms.ImageList(this.components);
@@ -163,7 +163,7 @@ partial class ListViewTest
     #endregion
 
     private System.Windows.Forms.ListView listView1;
-    private SubListView listView3;
+    private CloneTestListView listView3;
     private System.Windows.Forms.ImageList imageList1;
     private System.Windows.Forms.ImageList imageList2;
     private System.Windows.Forms.ImageList LargeImageList;

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ListViewTest.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ListViewTest.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Drawing;
-
 namespace WinFormsControlsTest;
 
 [DesignerCategory("Default")]
@@ -35,6 +34,18 @@ public partial class ListViewTest : Form
 
         AddCollapsibleGroupToListView();
         AddGroupTasks();
+
+        string[] TestItems = { "Item 1", "Item 2", "Item 3" };
+        listView3.RetrieveVirtualItem += (s, e) =>
+        {
+            e.Item = e.ItemIndex switch
+            {
+                0 => new ListViewItem(TestItems[0]),
+                1 => new ListViewItem(TestItems[1]),
+                2 => new ListViewItem(TestItems[2]),
+                _ => throw new ArgumentOutOfRangeException(),
+            };
+        };
     }
 
     private void CreateMyListView()
@@ -196,6 +207,15 @@ public partial class ListViewTest : Form
         MessageBox.Show(this, "listView2_Click", "event");
     }
 
+    private void listView3_Click(object sender, System.EventArgs e)
+    {
+        var item = ((System.Windows.Forms.ListView)sender).FocusedItem;
+        var clone = (ListViewItem)item.Clone();
+        clone.Checked = true;
+        listView3.TryOnItemChecked(new ItemCheckedEventArgs(clone));
+        MessageBox.Show(this, $"Click {clone.Text} in ListView3", "Click Event");
+    }
+
     private void listView2_SelectedIndexChanged(object sender, System.EventArgs e)
     {
         // MessageBox.Show(this, "listView2_SelectedIndexChanged", "event");
@@ -262,5 +282,21 @@ public partial class ListViewTest : Form
         LargeImageList.Images[listView1.SelectedIndices[0]] = bitmap;
 
         listView1.Refresh();
+    }
+
+    protected class SubListView : ListView
+    {        
+        public void TryOnItemChecked(ItemCheckedEventArgs e)
+        {
+            if (!CheckBoxes)
+            {
+                return;
+            }
+
+            if(e.Item.ListView == this)
+            {
+                base.OnItemChecked(e);
+            }
+        }
     }
 }

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ListViewTest.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ListViewTest.cs
@@ -35,6 +35,7 @@ public partial class ListViewTest : Form
         AddCollapsibleGroupToListView();
         AddGroupTasks();
 
+        // Manual test for https://github.com/dotnet/winforms/issues/11658
         string[] TestItems = { "Item 1", "Item 2", "Item 3" };
         listView3.RetrieveVirtualItem += (s, e) =>
         {
@@ -201,25 +202,23 @@ public partial class ListViewTest : Form
         MessageBox.Show(this, $"Task at group index {e.GroupIndex} was clicked", "GroupClick Event");
     }
 
-    private void listView2_Click(object sender, System.EventArgs e)
+    private void listView2_Click(object sender, EventArgs e)
     {
         Debug.WriteLine(listView1.TileSize);
         MessageBox.Show(this, "listView2_Click", "event");
     }
 
-    private void listView3_Click(object sender, System.EventArgs e)
+    private void listView3_Click(object sender, EventArgs e)
     {
-        var item = ((System.Windows.Forms.ListView)sender).FocusedItem;
+        var item = ((ListView)sender).FocusedItem;
         var clone = (ListViewItem)item.Clone();
         clone.Checked = true;
-        listView3.TryOnItemChecked(new ItemCheckedEventArgs(clone));
+        listView3.InvokeOnItemChecked(new ItemCheckedEventArgs(clone));
         MessageBox.Show(this, $"Click {clone.Text} in ListView3", "Click Event");
     }
 
-    private void listView2_SelectedIndexChanged(object sender, System.EventArgs e)
+    private void listView2_SelectedIndexChanged(object sender, EventArgs e)
     {
-        // MessageBox.Show(this, "listView2_SelectedIndexChanged", "event");
-
         if (sender is not ListView listView2)
         {
             return;
@@ -282,21 +281,5 @@ public partial class ListViewTest : Form
         LargeImageList.Images[listView1.SelectedIndices[0]] = bitmap;
 
         listView1.Refresh();
-    }
-
-    protected class SubListView : ListView
-    {        
-        public void TryOnItemChecked(ItemCheckedEventArgs e)
-        {
-            if (!CheckBoxes)
-            {
-                return;
-            }
-
-            if(e.Item.ListView == this)
-            {
-                base.OnItemChecked(e);
-            }
-        }
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

https://github.com/dotnet/winforms/issues/11658#issuecomment-2246680860

Add a manual test case for clones ListViewItem to WinformsControlsApp.

### Description 

When we try to call the ListView's derived class to use a clone of ListViewItem, we need to be aware that the clone's ListView is actually null, so we need to add an extra judgment when calling methods like OnItemChecked
```
if (e.Item.ListView == this)
{
     ...
} 
```
to ensure that the code doesn't throw an exception at runtime because the ListView property of the cloned object is null.

### Before
![2](https://github.com/user-attachments/assets/00091c79-75b6-4455-a8c2-876ba8eb4053)

### After
![1](https://github.com/user-attachments/assets/669bde1e-c9c7-43a5-8291-f393eea7e12d)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11785)