### PR TITLE
Put back AddStatement call in CodeDomSerializer

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializerBase.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializerBase.cs
@@ -2601,6 +2601,8 @@ public abstract partial class CodeDomSerializerBase
             }
             else if (statement is CodeVariableDeclarationStatement variableDecl)
             {
+                AddStatement(table, variableDecl.Name, variableDecl);
+
                 if (names is not null && variableDecl.Type is not null && !string.IsNullOrEmpty(variableDecl.Type.BaseType))
                 {
                     names[variableDecl.Name] = GetTypeNameFromCodeTypeReference(manager, variableDecl.Type);
@@ -2611,7 +2613,8 @@ public abstract partial class CodeDomSerializerBase
 
             if (expression is not null)
             {
-                // Simplify the expression as much as we can, looking for our target object in the process.  If we find an expression that refers to our target object, we're done and can move on to the next statement.
+                // Simplify the expression as much as we can, looking for our target object in the process. If we find an
+                // expression that refers to our target object, we're done and can move on to the next statement.
                 while (true)
                 {
                     if (expression is CodeCastExpression castEx)

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ResourceCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ResourceCodeDomSerializer.cs
@@ -351,26 +351,23 @@ internal partial class ResourceCodeDomSerializer : CodeDomSerializer
     }
 
     /// <summary>
-    ///  Serializes the given resource value into the resource set.  This does not effect the code dom values.  The resource is written into the current culture.
+    ///  Serializes the given resource value into the resource set. This does not effect the code dom values.
+    ///  The resource is written into the current culture.
     /// </summary>
     public static void WriteResource(IDesignerSerializationManager manager, string name, object? value)
     {
-        SetValueUsingCommonTraceScope(manager, name, value, false, false, true, false);
+        SerializationResourceManager sm = GetResourceManager(manager);
+        sm.SetValue(manager, name, value, forceInvariant: false, shouldSerializeInvariant: false, ensureInvariant: true, applyingCachedResources: false);
     }
 
     /// <summary>
-    ///  Serializes the given resource value into the resource set.  This does not effect the code dom values.  The resource is written into the invariant culture.
+    ///  Serializes the given resource value into the resource set. This does not effect the code dom values.
+    ///  The resource is written into the invariant culture.
     /// </summary>
     public static void WriteResourceInvariant(IDesignerSerializationManager manager, string name, object? value)
     {
-        SetValueUsingCommonTraceScope(manager, name, value, true, true, true, false);
-    }
-
-    private static void SetValueUsingCommonTraceScope(IDesignerSerializationManager manager, string name, object? value,
-        bool forceInvariant, bool shouldSerializeInvariant, bool ensureInvariant, bool applyingCachedResources)
-    {
         SerializationResourceManager sm = GetResourceManager(manager);
-        sm.SetValue(manager, name, value, forceInvariant, shouldSerializeInvariant, ensureInvariant, applyingCachedResources);
+        sm.SetValue(manager, name, value, forceInvariant: true, shouldSerializeInvariant: true, ensureInvariant: true, applyingCachedResources: false);
     }
 
     /// <summary>


### PR DESCRIPTION
Overlooked in the code review when removing the tracing.

I've done a full review twice. Two other small tweaks to WriteResource to remove the TraceScope name.

Fixes #11657
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11788)