### PR TITLE
Disable test case "BindingContext_Item_GetIListSourceDataSourceWithDataMemberReturningIListNull_ThrowsArgumentNullException“

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/BindingContextTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/BindingContextTests.cs
@@ -664,7 +664,10 @@ public class BindingContextTests
         Assert.Same(manager, context[dataSource, "Property"]);
     }
 
+    [ActiveIssue("https://github.com/dotnet/winforms/issues/11795")]
     [Fact]
+    [SkipOnArchitecture(TestArchitectures.X86,
+        "Flaky tests, see: https://github.com/dotnet/winforms/issues/11795")]
     public void BindingContext_Item_GetIListSourceDataSourceWithDataMemberReturningIListNull_ThrowsArgumentNullException()
     {
         BindingContext context = [];


### PR DESCRIPTION
Related #11795

## Proposed changes

- Add SkipOnArchitecture for test "BindingContext_Item_GetIListSourceDataSourceWithDataMemberReturningIListNull_ThrowsArgumentNullException" 

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11796)