### PR TITLE
Suppress CodeQL for BinaryFormatter deserialization in several files

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomComponentSerializationService.CodeDomSerializationStore.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomComponentSerializationService.CodeDomSerializationStore.cs
@@ -225,7 +225,7 @@ public sealed partial class CodeDomComponentSerializationService
             {
                 _resourceStream.Seek(0, SeekOrigin.Begin);
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
-                Hashtable? resources = new BinaryFormatter().Deserialize(_resourceStream) as Hashtable;
+                Hashtable? resources = new BinaryFormatter().Deserialize(_resourceStream) as Hashtable; // CodeQL[SM03722, SM04191] : The operation is essential for the design experience when users are running their own designers they have created. This cannot be achieved without BinaryFormatter
 #pragma warning restore SYSLIB0011 // Type or member is obsolete
                 _resources = new LocalResourceManager(resources);
             }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/CommandSet.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/CommandSet.cs
@@ -1865,7 +1865,7 @@ internal partial class CommandSet : IDisposable
                     {
                         s.Seek(0, SeekOrigin.Begin);
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
-                        object serializationData = new BinaryFormatter().Deserialize(s);
+                        object serializationData = new BinaryFormatter().Deserialize(s); // CodeQL[SM03722, SM04191] : The operation is essential for the design experience when users are running their own designers they have created. This cannot be achieved without BinaryFormatter
 #pragma warning restore SYSLIB0011 // Type or member is obsolete
                         using (ScaleHelper.EnterDpiAwarenessScope(DPI_AWARENESS_CONTEXT.DPI_AWARENESS_CONTEXT_SYSTEM_AWARE))
                         {

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/OleDragDropHandler.ComponentDataObject.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/OleDragDropHandler.ComponentDataObject.cs
@@ -139,7 +139,7 @@ internal partial class OleDragDropHandler
             {
                 SerializationStream!.Seek(0, SeekOrigin.Begin);
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
-                return new BinaryFormatter().Deserialize(SerializationStream);
+                return new BinaryFormatter().Deserialize(SerializationStream); // CodeQL[SM03722, SM04191] : The operation is essential for the design experience when users are running their own designers they have created. This cannot be achieved without BinaryFormatter
 #pragma warning restore SYSLIB0011 // Type or member is obsolete
             }
             else if (format.Equals(NestedToolboxItemFormat))
@@ -211,7 +211,7 @@ internal partial class OleDragDropHandler
             try
             {
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
-                _serializationData ??= new BinaryFormatter().Deserialize(SerializationStream!);
+                _serializationData ??= new BinaryFormatter().Deserialize(SerializationStream!); // CodeQL[SM03722, SM04191] : The operation is essential for the design experience when users are running their own designers they have created. This cannot be achieved without BinaryFormatter
 #pragma warning restore SYSLIB0011 // Type or member is obsolete
 
                 if (removeCurrentComponents && _components is not null)

--- a/src/System.Windows.Forms/src/System/Resources/ResXDataNode.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResXDataNode.cs
@@ -447,7 +447,8 @@ public sealed class ResXDataNode : ISerializable
             Binder = new ResXSerializationBinder(typeResolver)
         };
 
-        object? result = _binaryFormatter.Deserialize(stream);
+        // cs/dangerous-binary-deserialization
+        object? result = _binaryFormatter.Deserialize(stream); // CodeQL[SM03722] : BinaryFormatter is intended to be used as a fallback for unsupported types. Users must explicitly opt into this behavior
         if (result is ResXNullRef)
         {
             result = null;

--- a/src/System.Windows.Forms/src/System/Resources/ResXSerializationBinder.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResXSerializationBinder.cs
@@ -66,7 +66,8 @@ internal class ResXSerializationBinder : SerializationBinder
         type ??= _typeResolver.GetType(parsed.FullName);
 
         // Hand back what we found or null to let the default loader take over.
-        return type;
+        // cs/deserialization/nullbindtotype
+        return type; // CodeQL[SM04225] : This binder isn't intended as a security facility; it's allowable for us to return null.
     }
 
     public override void BindToName(Type serializedType, out string? assemblyName, out string? typeName)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ActiveX/AxHost.PropertyBagStream.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ActiveX/AxHost.PropertyBagStream.cs
@@ -43,7 +43,7 @@ public abstract unsafe partial class AxHost
             {
                 stream.Position = position;
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
-                _bag = (Hashtable)new BinaryFormatter().Deserialize(stream);
+                _bag = (Hashtable)new BinaryFormatter().Deserialize(stream); // CodeQL[SM03722, SM04191] : BinaryFormatter is intended to be used as a fallback for unsupported types. Users must explicitly opt into this behavior"
             }
             catch (Exception inner) when (!inner.IsCriticalException())
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ActiveX/Control.ActiveXImpl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ActiveX/Control.ActiveXImpl.cs
@@ -1157,7 +1157,7 @@ public partial class Control
                         }
 
                         stream.Position = 0;
-                        deserialized = new BinaryFormatter().Deserialize(stream);
+                        deserialized = new BinaryFormatter().Deserialize(stream); // CodeQL[SM03722, SM04191] : BinaryFormatter is intended to be used as a fallback for unsupported types. Users must explicitly opt into this behavior
                     }
 #pragma warning restore
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.Composition.NativeToWinFormsAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.Composition.NativeToWinFormsAdapter.cs
@@ -204,11 +204,12 @@ public unsafe partial class DataObject
 
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
 #pragma warning disable SYSLIB0050 // Type or member is obsolete
+                        // cs/dangerous-binary-deserialization
                         return new BinaryFormatter()
                         {
                             Binder = restrictDeserialization ? new BitmapBinder() : null,
                             AssemblyFormat = FormatterAssemblyStyle.Simple
-                        }.Deserialize(stream);
+                        }.Deserialize(stream); // CodeQL[SM03722] : BinaryFormatter is intended to be used as a fallback for unsupported types. Users must explicitly opt into this behavior
 #pragma warning restore SYSLIB0050
 #pragma warning restore SYSLIB0011
                     }


### PR DESCRIPTION
Fixes #11804

## Proposed changes

- Suppresses CodeQL for BinaryFormatter deserialization for several files
- Wasn't able to suppress CodeQl for 2 files, due to the following reasons:
  - `src/System.Windows.Forms/src/System/Resources/ResXSerializationBinder.cs`, line 69: No reference to `BinaryFormatter` in the whole file (except in a comment)
  - `src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.ComposedDataObject.NativeDataObjectToWinFormsAdapter.cs`, line 208: The file could not be found

## Customer Impact

- None

## Regression?

- No

## Risk

- Minimal

## Test environment(s)

- 9.0.100-preview.5.24307.3
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11805)