### PR TITLE
Expose CacheEntry from RefCountedCache

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/GdiPlus/GdiPlusCache.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/GdiPlus/GdiPlusCache.cs
@@ -21,8 +21,8 @@ internal static class GdiPlusCache
     // Picking soft and hard limits expecting that 30 of each is a reasonable upper limit of permanently reserved
     // space. These items are roughly .5KB each, with _most_ of the memory being native (in the GDI+ object).
 
-    private static PenCache PenCache => s_penCache ??= new PenCache(softLimit: 30, hardLimit: 40);
-    private static SolidBrushCache BrushCache => s_brushCache ??= new SolidBrushCache(softLimit: 30, hardLimit: 40);
+    private static PenCache PenCache => s_penCache ??= new(softLimit: 30, hardLimit: 40);
+    private static SolidBrushCache BrushCache => s_brushCache ??= new(softLimit: 30, hardLimit: 40);
 
     private static PenCache.Scope GetPenScope(Color color)
     {
@@ -38,7 +38,7 @@ internal static class GdiPlusCache
             }
         }
 
-        return PenCache.GetEntry(color);
+        return PenCache.GetEntry(color).CreateScope();
     }
 
     private static SolidBrushCache.Scope GetSolidBrushScope(Color color)
@@ -55,7 +55,7 @@ internal static class GdiPlusCache
             }
         }
 
-        return BrushCache.GetEntry(color);
+        return BrushCache.GetEntry(color).CreateScope();
     }
 
     /// <summary>

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/RefCountedCache.CacheEntry.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/RefCountedCache.CacheEntry.cs
@@ -61,6 +61,8 @@ internal abstract partial class RefCountedCache<TObject, TCacheEntryData, TKey>
         /// </summary>
         public abstract TObject Object { get; }
 
+        public Scope CreateScope() => new Scope(this);
+
         private string DebuggerDisplay => $"Object: {Object} RefCount: {RefCount}";
 
         /// <summary>

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/RefCountedCache.CacheEntry.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/RefCountedCache.CacheEntry.cs
@@ -61,7 +61,7 @@ internal abstract partial class RefCountedCache<TObject, TCacheEntryData, TKey>
         /// </summary>
         public abstract TObject Object { get; }
 
-        public Scope CreateScope() => new Scope(this);
+        public Scope CreateScope() => new(this);
 
         private string DebuggerDisplay => $"Object: {Object} RefCount: {RefCount}";
 

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/SinglyLinkedList.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/SinglyLinkedList.cs
@@ -76,7 +76,7 @@ internal class SinglyLinkedList<T>
         private Node? _current = null;
         private Node? _previous = null;
 
-        public readonly Node? Current => _current;
+        public readonly Node Current => _current!;
 
         /// <summary>
         ///  Resets the enumerator.

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/RefCacheTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/RefCacheTests.cs
@@ -11,10 +11,10 @@ public class RefCacheTests
     public void RefCountTests()
     {
         ObjectCache<object> cache = new(5, 10);
-        var firstScope = cache.GetEntry(1);
+        var firstScope = cache.GetEntry(1).CreateScope();
         Assert.Equal(1, firstScope.RefCount);
         object first = firstScope.Object;
-        var secondScope = cache.GetEntry(1);
+        var secondScope = cache.GetEntry(1).CreateScope();
         object second = secondScope.Object;
         Assert.Equal(2, firstScope.RefCount);
         Assert.Equal(2, secondScope.RefCount);
@@ -23,7 +23,7 @@ public class RefCacheTests
         Assert.Equal(1, secondScope.RefCount);
         secondScope.Dispose();
         Assert.Equal(0, secondScope.RefCount);
-        using var thirdScope = cache.GetEntry(1);
+        using var thirdScope = cache.GetEntry(1).CreateScope();
         Assert.Equal(1, thirdScope.RefCount);
         Assert.Same(first, thirdScope.Object);
     }
@@ -34,18 +34,18 @@ public class RefCacheTests
         ObjectCache<DisposalCounter> cache = new(2, 4);
 
         // Fill to the hard limit
-        var firstScope = cache.GetEntry(1);
-        var secondScope = cache.GetEntry(2);
-        var thirdScope = cache.GetEntry(3);
-        var fourthScope = cache.GetEntry(4);
+        var firstScope = cache.GetEntry(1).CreateScope();
+        var secondScope = cache.GetEntry(2).CreateScope();
+        var thirdScope = cache.GetEntry(3).CreateScope();
+        var fourthScope = cache.GetEntry(4).CreateScope();
         Assert.Equal(0, firstScope.Object.DisposeCount);
         Assert.Equal(0, secondScope.Object.DisposeCount);
         Assert.Equal(0, thirdScope.Object.DisposeCount);
         Assert.Equal(0, fourthScope.Object.DisposeCount);
 
         // New objects shouldn't be cached
-        var fifthScope = cache.GetEntry(5);
-        var sixthScope = cache.GetEntry(5);
+        var fifthScope = cache.GetEntry(5).CreateScope();
+        var sixthScope = cache.GetEntry(5).CreateScope();
 
         Assert.NotSame(fifthScope.Object, sixthScope.Object);
 
@@ -66,7 +66,7 @@ public class RefCacheTests
         Assert.Equal(1, fifthScope.Object.DisposeCount);
         Assert.Equal(1, sixthScope.Object.DisposeCount);
 
-        using var seventhScope = cache.GetEntry(7);
+        using var seventhScope = cache.GetEntry(7).CreateScope();
 
         // Now that the other scopes are closed, the earliest entries should have been cleaned
         Assert.Equal(1, firstScope.Object.DisposeCount);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewTopLeftHeaderCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewTopLeftHeaderCell.cs
@@ -267,7 +267,7 @@ public partial class DataGridViewTopLeftHeaderCell : DataGridViewColumnHeaderCel
 
                 if (!brushColor.HasTransparency())
                 {
-                    using RefCountedCache<SolidBrush, Color, Color>.Scope brush = brushColor.GetCachedSolidBrushScope();
+                    using var brush = brushColor.GetCachedSolidBrushScope();
                     graphics.FillRectangle(brush, valBounds);
                 }
             }
@@ -374,19 +374,19 @@ public partial class DataGridViewTopLeftHeaderCell : DataGridViewColumnHeaderCel
 
             if (DataGridView.AdvancedColumnHeadersBorderStyle.All == DataGridViewAdvancedCellBorderStyle.Inset)
             {
-                using RefCountedCache<Pen, Color, Color>.Scope penControlDark = darkColor.GetCachedPenScope();
+                using var penControlDark = darkColor.GetCachedPenScope();
                 graphics.DrawLine(penControlDark, bounds.X, bounds.Y, bounds.X, bounds.Bottom - 1);
                 graphics.DrawLine(penControlDark, bounds.X, bounds.Y, bounds.Right - 1, bounds.Y);
             }
             else if (DataGridView.AdvancedColumnHeadersBorderStyle.All == DataGridViewAdvancedCellBorderStyle.Outset)
             {
-                using RefCountedCache<Pen, Color, Color>.Scope penControlLightLight = lightColor.GetCachedPenScope();
+                using var penControlLightLight = lightColor.GetCachedPenScope();
                 graphics.DrawLine(penControlLightLight, bounds.X, bounds.Y, bounds.X, bounds.Bottom - 1);
                 graphics.DrawLine(penControlLightLight, bounds.X, bounds.Y, bounds.Right - 1, bounds.Y);
             }
             else if (DataGridView.AdvancedColumnHeadersBorderStyle.All == DataGridViewAdvancedCellBorderStyle.InsetDouble)
             {
-                using RefCountedCache<Pen, Color, Color>.Scope penControlDark = darkColor.GetCachedPenScope();
+                using var penControlDark = darkColor.GetCachedPenScope();
                 graphics.DrawLine(penControlDark, bounds.X + 1, bounds.Y + 1, bounds.X + 1, bounds.Bottom - 1);
                 graphics.DrawLine(penControlDark, bounds.X + 1, bounds.Y + 1, bounds.Right - 1, bounds.Y + 1);
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Rendering/FontCache.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Rendering/FontCache.cs
@@ -33,9 +33,9 @@ internal sealed partial class FontCache : RefCountedCache<HFONT, FontCache.Data,
     ///  <paramref name="font"/> and <paramref name="quality"/>. The scope MUST be disposed to release the ref
     ///  count accurately. Use the result in a using statement to avoid leaking fonts.
     /// </summary>
-    public Scope GetEntry(Font font, FONT_QUALITY quality = FONT_QUALITY.DEFAULT_QUALITY) => GetEntry((font, quality));
+    public CacheEntry GetEntry(Font font, FONT_QUALITY quality = FONT_QUALITY.DEFAULT_QUALITY) => GetEntry((font, quality));
 
-    public override Scope GetEntry((Font Font, FONT_QUALITY Quality) key)
+    public override CacheEntry GetEntry((Font Font, FONT_QUALITY Quality) key)
     {
         lock (_lock)
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Rendering/GdiCache.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Rendering/GdiCache.cs
@@ -92,7 +92,7 @@ internal static partial class GdiCache
     {
         Debug.Assert(font is not null);
 #if DEBUG
-        return font is null ? new FontCache.Scope() : s_fontCache.GetEntry(font, quality);
+        return font is null ? new FontCache.Scope() : s_fontCache.GetEntry(font, quality).CreateScope();
 #else
         return font is null ? default : s_fontCache.GetEntry(font, quality);
 #endif

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Rendering/GdiCache.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Rendering/GdiCache.cs
@@ -94,7 +94,7 @@ internal static partial class GdiCache
 #if DEBUG
         return font is null ? new FontCache.Scope() : s_fontCache.GetEntry(font, quality).CreateScope();
 #else
-        return font is null ? default : s_fontCache.GetEntry(font, quality);
+        return font is null ? default : s_fontCache.GetEntry(font, quality).CreateScope();
 #endif
     }
 


### PR DESCRIPTION
We'll need to expose the cache entry to retain handles for fonts that we expose the HFONT on. Notably this would be with calls to WM_SETFONT.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11811)