### PR TITLE
fix The RichTextBox control is not support the SmartTag under ToolStripContainer tab

### DIFF
--- a/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/MainForm.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/MainForm.cs
@@ -308,7 +308,7 @@ public partial class MainForm : Form
                         splitContainer.BackColor = Color.Red;
 
                         RichTextBox richTextBox = surface.CreateControl<RichTextBox>(new Size(0, 0), new Point(0, 0));
-                        richTextBox.Dock = DockStyle.Left;
+                        richTextBox.Dock = DockStyle.Fill;
                         richTextBox.Width = toolStripContainer.Width;
                         richTextBox.Text = "I'm a RichTextBox";
 
@@ -337,8 +337,6 @@ public partial class MainForm : Form
                         panel.Dock = DockStyle.Bottom;
                         NumericUpDown numericUpDown = surface.CreateControl<NumericUpDown>(new(50, 10), new(10, 10));
                         panel.Controls.Add(numericUpDown);
-
-                        tabPage6.Controls.AddRange(toolStripContainer, splitter, panel);
                     }
 
                     break;


### PR DESCRIPTION


<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #11792


## Proposed changes

- 
- `surface.CreateControl` will add the Control to the designer form, so we don't have to add these controls to `tabPage6`
- 

<!-- 

## Customer Impact

- 
- 

## Regression? 

- Yes / No

## Risk

 -->




## Screenshots 

### Before

![image](https://github.com/user-attachments/assets/ffa669d9-f81e-4156-886b-487b8067fd44)

### After

![image](https://github.com/user-attachments/assets/a285ecd4-5cf2-4b7f-b940-b5c1fad9d7e7)
![image](https://github.com/user-attachments/assets/7be37a43-084b-459d-a69c-d8aef8eec574)


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11822)