### PR TITLE
Don't dispose FontFamily objects from installed fonts

### DIFF
--- a/src/System.Drawing.Common/src/System/Drawing/Font.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Font.cs
@@ -485,7 +485,9 @@ public sealed unsafe class Font : MarshalByRefObject, ICloneable, IDisposable, I
         PInvoke.GdipGetFontSize(_nativeFont, &size).ThrowIfFailed();
         PInvoke.GdipGetFontStyle(_nativeFont, (int*)&style).ThrowIfFailed();
         PInvoke.GdipGetFamily(_nativeFont, &family).ThrowIfFailed();
-        SetFontFamily(new FontFamily(family));
+
+        // Fonts from native HFONTs are always from the installed font collection.
+        SetFontFamily(new FontFamily(family, fromInstalledFontCollection: true));
         Initialize(_fontFamily, size, style, unit, gdiCharSet, gdiVerticalFont);
     }
 
@@ -524,8 +526,7 @@ public sealed unsafe class Font : MarshalByRefObject, ICloneable, IDisposable, I
 
         if (_fontFamily is null)
         {
-            // GDI+ FontFamily is a singleton object.
-            SetFontFamily(new FontFamily(family.NativeFamily));
+            SetFontFamily(family.Clone());
         }
 
         if (_nativeFont is null)

--- a/src/System.Drawing.Common/src/System/Drawing/FontConverter.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/FontConverter.cs
@@ -378,22 +378,6 @@ public class FontConverter : TypeConverter
                 }
             }
 
-            // font family not found in installed fonts
-            if (fontFamily is null)
-            {
-                collection = new PrivateFontCollection();
-                FontFamily[] privateFontList = collection.Families;
-                foreach (FontFamily font in privateFontList)
-                {
-                    if (name.Equals(font.Name, StringComparison.OrdinalIgnoreCase))
-                    {
-                        fontFamily = font;
-                        break;
-                    }
-                }
-            }
-
-            // font family not found in private fonts also
             fontFamily ??= FontFamily.GenericSansSerif;
         }
 

--- a/src/System.Drawing.Common/src/System/Drawing/Text/FontCollection.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Text/FontCollection.cs
@@ -39,6 +39,8 @@ public abstract unsafe class FontCollection : IDisposable, IPointer<GpFontCollec
                 return [];
             }
 
+            bool installedFontCollection = GetType() == typeof(InstalledFontCollection);
+
             GpFontFamily*[] gpFamilies = new GpFontFamily*[numFound];
             fixed (GpFontFamily** f = gpFamilies)
             {
@@ -49,9 +51,9 @@ public abstract unsafe class FontCollection : IDisposable, IPointer<GpFontCollec
             FontFamily[] families = new FontFamily[numFound];
             for (int f = 0; f < numFound; f++)
             {
-                GpFontFamily* native;
-                PInvoke.GdipCloneFontFamily(gpFamilies[f], &native).ThrowIfFailed();
-                families[f] = new FontFamily(native);
+                // GetFontCollectionFamilyList doesn't ref count the returned families. The internal constructor
+                // here will add a ref if the font collection is not the installed font collection.
+                families[f] = new FontFamily(gpFamilies[f], installedFontCollection);
             }
 
             GC.KeepAlive(this);

--- a/src/System.Drawing.Common/tests/System/Drawing/FontFamilyTests.cs
+++ b/src/System.Drawing.Common/tests/System/Drawing/FontFamilyTests.cs
@@ -54,7 +54,7 @@ public class FontFamilyTests
     [Fact]
     public void Ctor_NullFontName_ThrowsArgumentNullException()
     {
-        AssertExtensions.Throws<ArgumentNullException>("name", () => new FontFamily((string)null!));
+        AssertExtensions.Throws<ArgumentNullException>("name", () => new FontFamily(null!));
         AssertExtensions.Throws<ArgumentNullException>("name", () => new FontFamily(null!, null));
     }
 

--- a/src/System.Drawing.Common/tests/System/Drawing/FontFamilyTests.cs
+++ b/src/System.Drawing.Common/tests/System/Drawing/FontFamilyTests.cs
@@ -188,19 +188,25 @@ public class FontFamilyTests
     [Fact]
     public void IsStyleAvailable_Disposed_ThrowsArgumentException()
     {
-        FontFamily fontFamily = FontFamily.GenericMonospace;
-        fontFamily.Dispose();
+        using PrivateFontCollection collection = new();
+        collection.AddFontFile(Helpers.GetTestFontPath("CodeNewRoman.otf"));
 
-        AssertExtensions.Throws<ArgumentException>(null, () => fontFamily.IsStyleAvailable(FontStyle.Italic));
+        FontFamily family = new("Code New Roman", collection);
+        family.Dispose();
+
+        AssertExtensions.Throws<ArgumentException>(null, () => family.IsStyleAvailable(FontStyle.Italic));
     }
 
     [Fact]
     public void GetEmHeight_Disposed_ThrowsArgumentException()
     {
-        FontFamily fontFamily = FontFamily.GenericMonospace;
-        fontFamily.Dispose();
+        using PrivateFontCollection collection = new();
+        collection.AddFontFile(Helpers.GetTestFontPath("CodeNewRoman.otf"));
 
-        AssertExtensions.Throws<ArgumentException>(null, () => fontFamily.GetEmHeight(FontStyle.Italic));
+        FontFamily family = new("Code New Roman", collection);
+        family.Dispose();
+
+        AssertExtensions.Throws<ArgumentException>(null, () => family.GetEmHeight(FontStyle.Italic));
     }
 
     private const int FrenchLCID = 1036;
@@ -223,37 +229,49 @@ public class FontFamilyTests
     [Fact]
     public void GetName_Disposed_ThrowsArgumentException()
     {
-        FontFamily fontFamily = FontFamily.GenericMonospace;
-        fontFamily.Dispose();
+        using PrivateFontCollection collection = new();
+        collection.AddFontFile(Helpers.GetTestFontPath("CodeNewRoman.otf"));
 
-        AssertExtensions.Throws<ArgumentException>(null, () => fontFamily.GetName(0));
+        FontFamily family = new("Code New Roman", collection);
+        family.Dispose();
+
+        AssertExtensions.Throws<ArgumentException>(null, () => family.GetName(0));
     }
 
     [Fact]
     public void GetCellAscent_Disposed_ThrowsArgumentException()
     {
-        FontFamily fontFamily = FontFamily.GenericMonospace;
-        fontFamily.Dispose();
+        using PrivateFontCollection collection = new();
+        collection.AddFontFile(Helpers.GetTestFontPath("CodeNewRoman.otf"));
 
-        AssertExtensions.Throws<ArgumentException>(null, () => fontFamily.GetCellAscent(FontStyle.Italic));
+        FontFamily family = new("Code New Roman", collection);
+        family.Dispose();
+
+        AssertExtensions.Throws<ArgumentException>(null, () => family.GetCellAscent(FontStyle.Italic));
     }
 
     [Fact]
     public void GetCellDescent_Disposed_ThrowsArgumentException()
     {
-        FontFamily fontFamily = FontFamily.GenericMonospace;
-        fontFamily.Dispose();
+        using PrivateFontCollection collection = new();
+        collection.AddFontFile(Helpers.GetTestFontPath("CodeNewRoman.otf"));
 
-        AssertExtensions.Throws<ArgumentException>(null, () => fontFamily.GetCellDescent(FontStyle.Italic));
+        FontFamily family = new("Code New Roman", collection);
+        family.Dispose();
+
+        AssertExtensions.Throws<ArgumentException>(null, () => family.GetCellDescent(FontStyle.Italic));
     }
 
     [Fact]
     public void GetLineSpacing_Disposed_ThrowsArgumentException()
     {
-        FontFamily fontFamily = FontFamily.GenericMonospace;
-        fontFamily.Dispose();
+        using PrivateFontCollection collection = new();
+        collection.AddFontFile(Helpers.GetTestFontPath("CodeNewRoman.otf"));
 
-        AssertExtensions.Throws<ArgumentException>(null, () => fontFamily.GetLineSpacing(FontStyle.Italic));
+        FontFamily family = new("Code New Roman", collection);
+        family.Dispose();
+
+        AssertExtensions.Throws<ArgumentException>(null, () => family.GetLineSpacing(FontStyle.Italic));
     }
 
     [Fact]

--- a/src/System.Drawing.Common/tests/System/Drawing/FontTests.cs
+++ b/src/System.Drawing.Common/tests/System/Drawing/FontTests.cs
@@ -334,7 +334,10 @@ public class FontTests
     [Fact]
     public void Ctor_DisposedFamily_ThrowsArgumentException()
     {
-        FontFamily family = FontFamily.GenericSansSerif;
+        using PrivateFontCollection collection = new();
+        collection.AddFontFile(Helpers.GetTestFontPath("CodeNewRoman.otf"));
+
+        FontFamily family = new("Code New Roman", collection);
         family.Dispose();
 
         AssertExtensions.Throws<ArgumentException>(null, () => new Font(family, 10));


### PR DESCRIPTION
There is no need to track or dispose of FontFamily objects from the installed font collection. This collection is a static in GDI+. Ref counting needs to be done only when coming from a private collection.

- Should fix ref count issues with private font collections
- Static FontFamily objects are now safe to use after "disposal"
- Removes an unnecessary creation of an empty private font collection in FontConverter
- Reuses FontFamily instances if from installed fonts
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11829)