### PR TITLE
Fix:The SplitContainer control cannot be deleted successfully under ToolStripContainer tab #11793

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/SplitContainerDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/SplitContainerDesigner.cs
@@ -36,10 +36,19 @@ internal partial class SplitContainerDesigner : ParentControlDesigner
     /// <summary>
     ///  Gets the design-time supported actions on the control.
     /// </summary>
-    public override DesignerActionListCollection ActionLists => new()
+    public override DesignerActionListCollection ActionLists
     {
-        new OrientationActionList(this)
-    };
+        get
+        {
+            DesignerActionListCollection designerActionListCollection = new();
+            if (HasComponent)
+            {
+                designerActionListCollection.Add(new OrientationActionList(this));
+            }
+
+            return designerActionListCollection;
+        }
+    }
 
     /// <summary>
     ///  The <see cref="SplitContainerDesigner"/> will not re-parent any controls that are within it's lasso at creation time.

--- a/src/System.Windows.Forms.Design/tests/UnitTests/SplitContainerDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/SplitContainerDesignerTests.cs
@@ -60,8 +60,6 @@ public class SplitContainerDesignerTests
 
         splitContainerDesigner.Dispose();
 
-        Action action = () => _ = splitContainerDesigner.ActionLists;
-        action.Should().NotThrow();
         splitContainerDesigner.ActionLists.Count.Should().Be(0);
     }
 }

--- a/src/System.Windows.Forms.Design/tests/UnitTests/SplitContainerDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/SplitContainerDesignerTests.cs
@@ -62,5 +62,6 @@ public class SplitContainerDesignerTests
 
         Action action = () => _ = splitContainerDesigner.ActionLists;
         action.Should().NotThrow();
+        splitContainerDesigner.ActionLists.Count.Should().Be(0);
     }
 }

--- a/src/System.Windows.Forms.Design/tests/UnitTests/SplitContainerDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/SplitContainerDesignerTests.cs
@@ -4,17 +4,14 @@
 using System.ComponentModel.Design;
 using Moq;
 using System.Windows.Forms.Design.Tests.Mocks;
+using System.ComponentModel;
 
 namespace System.Windows.Forms.Design.Tests;
 
 public class SplitContainerDesignerTests
 {
-    [WinFormsFact]
-    public void SplitContainerDesigner_AssociatedComponentsTest()
+    private Mock<ISite> GetMockSize(SplitContainer splitContainer, SplitContainerDesigner splitContainerDesigner)
     {
-        using SplitContainer splitContainer = new();
-        using SplitContainerDesigner splitContainerDesigner = new();
-
         Mock<IDesignerHost> mockDesignerHost = new(MockBehavior.Strict);
         mockDesignerHost
             .Setup(h => h.RootComponent)
@@ -27,7 +24,16 @@ public class SplitContainerDesignerTests
             .Setup(s => s.GetService(typeof(IComponentChangeService)))
             .Returns(mockComponentChangeService.Object);
 
-        var mockSite = MockSite.CreateMockSiteWithDesignerHost(mockDesignerHost.Object);
+        return  MockSite.CreateMockSiteWithDesignerHost(mockDesignerHost.Object);
+    }
+
+    [WinFormsFact]
+    public void SplitContainerDesigner_AssociatedComponentsTest()
+    {
+        using SplitContainer splitContainer = new();
+        using SplitContainerDesigner splitContainerDesigner = new();
+
+        var mockSite = GetMockSize(splitContainer, splitContainerDesigner);
         splitContainer.Site = mockSite.Object;
 
         splitContainerDesigner.Initialize(splitContainer);
@@ -38,5 +44,23 @@ public class SplitContainerDesignerTests
         control.Parent = splitContainer.Panel1;
 
         Assert.Equal(1, splitContainerDesigner.AssociatedComponents.Count);
+    }
+
+    // Regression test for https://github.com/dotnet/winforms/issues/11793
+    [WinFormsFact]
+    public void SplitContainerDesigner_ActionListsTest()
+    {
+        using SplitContainer splitContainer = new();
+        SplitContainerDesigner splitContainerDesigner = new();
+
+        var mockSite = GetMockSize(splitContainer, splitContainerDesigner);
+        splitContainer.Site = mockSite.Object;
+
+        splitContainerDesigner.Initialize(splitContainer);
+
+        splitContainerDesigner.Dispose();
+
+        Action action = () => _ = splitContainerDesigner.ActionLists;
+        action.Should().NotThrow();
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #11793


## Proposed changes

When `SplitContainer` is deleted, two things will happen
1.`SplitContainerDesigner.Dispose(bool)` will be invoked,and eventually `ComponentDesigner.Dispose(bool)` will be invoked.
So in the end, `SplitContainerDesigner.Component` will be null

https://github.com/dotnet/winforms/blob/ab9eb71f903d7771849887a15ab5ff3f37ba4c00/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ComponentDesigner.cs#L452-L464

2. `SplitContainerDesigner.ActionList` will be accessed.

https://github.com/dotnet/winforms/blob/ab9eb71f903d7771849887a15ab5ff3f37ba4c00/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/SplitContainerDesigner.cs#L39-L42

https://github.com/dotnet/winforms/blob/ab9eb71f903d7771849887a15ab5ff3f37ba4c00/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/SplitContainerDesigner.OrientationActionList.cs#L20-L35

please see line 21,`SplitContainerDesigner.Component` is accessed.

https://github.com/dotnet/winforms/blob/ab9eb71f903d7771849887a15ab5ff3f37ba4c00/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ComponentDesigner.cs#L172

when `Component` is accessed and it is null, exception will be thrown.


<hr>
InProcDesigner works fine because:


```c#
class ComponentDesigner
        protected virtual void Dispose(bool disposing) {
            if (disposing) {
                IComponentChangeService cs = (IComponentChangeService)GetService(typeof(IComponentChangeService));
                if (cs != null)
                {
                    cs.ComponentRename -= new ComponentRenameEventHandler(this.OnComponentRename);
                }
            
                component = null;
                inheritedProps = null;
            }
        }


        public IComponent Component {
            get {
                return component;
            }
        }
```

OOP Designer works fine because:


```c#
class ComponentDesigner
    protected override void Dispose(bool disposing)
    {
        if (disposing)
        {
            ComponentChangeService.ComponentRename -= OnComponentRename;
        }

        base.Dispose(disposing);
    }


    public IComponent Component
    {
        get => _component ?? throw new InvalidOperationException(SR.DesignerUninitialized);
        private set => _component = value.OrThrowIfArgumentIsNull();
    }
```




<!-- 
## Customer Impact

- 
- 

## Regression? 

- Yes / No

## Risk

-
 -->


## Screenshots

### Before

![image](https://github.com/user-attachments/assets/233b725b-9c5c-4ef6-8e15-b1477e110c0a)
![GHIssue4](https://github.com/user-attachments/assets/34f61fbf-1302-4904-8ccd-b16363096f11)

### After

![issue_11793](https://github.com/user-attachments/assets/ed8c7f15-9789-484a-b96d-1916b650abc9)

<!-- 
## Test methodology 

- 
- 
- 

## Accessibility testing  




 

## Test environment(s) 
 -->



 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11830)