### PR TITLE
Stop locking internal objects with `this`

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.AdornerWindow.MouseHook.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.AdornerWindow.MouseHook.cs
@@ -31,6 +31,7 @@ public sealed partial class BehaviorService
 
             private bool _isHooked;
             private int _lastLButtonDownTimeStamp;
+            private readonly Lock _lock = new();
 
             public MouseHook()
             {
@@ -60,7 +61,7 @@ public sealed partial class BehaviorService
             private unsafe void HookMouse()
             {
                 Debug.Assert(s_adornerWindowList.Count > 0, "No AdornerWindow available to create the mouse hook");
-                lock (this)
+                lock (_lock)
                 {
                     if (_mouseHookHandle != 0 || s_adornerWindowList.Count == 0)
                     {
@@ -126,7 +127,7 @@ public sealed partial class BehaviorService
 
             private void UnhookMouse()
             {
-                lock (this)
+                lock (_lock)
                 {
                     if (_mouseHookHandle != 0)
                     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ActiveX/AxHost.AxContainer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ActiveX/AxHost.AxContainer.cs
@@ -33,6 +33,7 @@ public abstract partial class AxHost
         private HashSet<Control>? _components;
         private Dictionary<Control, ExtenderProxy>? _extenderCache;
         private AxHost? _controlInEditMode;
+        private readonly Lock _lock = new();
 
         internal AxContainer(ContainerControl parent)
         {
@@ -123,7 +124,7 @@ public abstract partial class AxHost
 
         internal void AddControl(AxHost control)
         {
-            lock (this)
+            lock (_lock)
             {
                 if (_containerCache.Contains(control))
                 {
@@ -148,7 +149,7 @@ public abstract partial class AxHost
 
         internal void RemoveControl(AxHost control)
         {
-            lock (this)
+            lock (_lock)
             {
                 _containerCache.Remove(control);
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/GridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/GridEntry.cs
@@ -63,6 +63,8 @@ internal abstract partial class GridEntry : GridItem, ITypeDescriptorContext
 
     private bool _lastPaintWithExplorerStyle;
 
+    private readonly Lock _lock = new();
+
     private static Color InvertColor(Color color)
         => Color.FromArgb(color.A, (byte)~color.R, (byte)~color.G, (byte)~color.B);
 
@@ -2266,8 +2268,7 @@ internal abstract partial class GridEntry : GridItem, ITypeDescriptorContext
 
     protected virtual void AddEventHandler(object key, Delegate handler)
     {
-        // Locking 'this' here is ok since this is an internal class.
-        lock (this)
+        lock (_lock)
         {
             if (handler is null)
             {
@@ -2298,8 +2299,7 @@ internal abstract partial class GridEntry : GridItem, ITypeDescriptorContext
 
     protected virtual Delegate? GetEventHandler(object key)
     {
-        // Locking 'this' here is ok since this is an internal class.
-        lock (this)
+        lock (_lock)
         {
             for (EventEntry? e = _eventList; e is not null; e = e.Next)
             {
@@ -2315,8 +2315,7 @@ internal abstract partial class GridEntry : GridItem, ITypeDescriptorContext
 
     protected virtual void RemoveEventHandler(object key, Delegate handler)
     {
-        // Locking this here is ok since this is an internal class.
-        lock (this)
+        lock (_lock)
         {
             if (handler is null)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.MouseHook.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.MouseHook.cs
@@ -20,6 +20,8 @@ internal partial class PropertyGridView
 
         private bool _processing;
 
+        private readonly Lock _lock = new();
+
         public MouseHook(Control control, IMouseHookClient client, PropertyGridView gridView)
         {
             _control = control;
@@ -76,8 +78,7 @@ internal partial class PropertyGridView
         /// </summary>
         private unsafe void HookMouse()
         {
-            // Locking 'this' here is ok since this is an internal class.
-            lock (this)
+            lock (_lock)
             {
                 if (!_mouseHookHandle.IsNull)
                 {
@@ -138,8 +139,7 @@ internal partial class PropertyGridView
         /// </summary>
         private void UnhookMouse()
         {
-            // Locking 'this' here is ok since this is an internal class.
-            lock (this)
+            lock (_lock)
             {
                 if (!_mouseHookHandle.IsNull)
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripManager.ModalMenuFilter.HostedWindowsFormsMessageHook.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripManager.ModalMenuFilter.HostedWindowsFormsMessageHook.cs
@@ -14,6 +14,7 @@ public static partial class ToolStripManager
             private HHOOK _messageHookHandle;
             private bool _isHooked;
             private HOOKPROC? _callBack;
+            private readonly Lock _lock = new();
 
             public HostedWindowsFormsMessageHook()
             {
@@ -53,7 +54,7 @@ public static partial class ToolStripManager
 
             private unsafe void InstallMessageHook()
             {
-                lock (this)
+                lock (_lock)
                 {
                     if (!_messageHookHandle.IsNull)
                     {
@@ -99,7 +100,7 @@ public static partial class ToolStripManager
 
             private void UninstallMessageHook()
             {
-                lock (this)
+                lock (_lock)
                 {
                     if (!_messageHookHandle.IsNull)
                     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NativeWindow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NativeWindow.cs
@@ -40,6 +40,8 @@ public unsafe partial class NativeWindow : MarshalByRefObject, IWin32Window, IHa
     private static readonly Lock s_internalSyncObject = new();
     private static readonly Lock s_createWindowSyncObject = new();
 
+    private readonly Lock _lock = new();
+
     // Our window procedure delegate
     private WNDPROC? _windowProc;
 
@@ -88,7 +90,7 @@ public unsafe partial class NativeWindow : MarshalByRefObject, IWin32Window, IHa
         HWND handle;
         bool ownedHandle;
 
-        lock (this)
+        lock (_lock)
         {
             handle = HWND;
             ownedHandle = _ownHandle;
@@ -291,7 +293,7 @@ public unsafe partial class NativeWindow : MarshalByRefObject, IWin32Window, IHa
 
     internal unsafe void AssignHandle(HWND hwnd, bool assignUniqueID)
     {
-        lock (this)
+        lock (_lock)
         {
             CheckReleased();
             Debug.Assert(!hwnd.IsNull);
@@ -383,7 +385,7 @@ public unsafe partial class NativeWindow : MarshalByRefObject, IWin32Window, IHa
     /// </summary>
     private void CheckReleased()
     {
-        if (Handle != IntPtr.Zero)
+        if (Handle != 0)
         {
             throw new InvalidOperationException(SR.HandleAlreadyExists);
         }
@@ -394,7 +396,7 @@ public unsafe partial class NativeWindow : MarshalByRefObject, IWin32Window, IHa
     /// </summary>
     public virtual unsafe void CreateHandle(CreateParams cp)
     {
-        lock (this)
+        lock (_lock)
         {
             CheckReleased();
             WindowClass windowClass = WindowClass.Create(cp.ClassName, (WNDCLASS_STYLES)cp.ClassStyle);
@@ -522,7 +524,7 @@ public unsafe partial class NativeWindow : MarshalByRefObject, IWin32Window, IHa
     /// </summary>
     public virtual void DestroyHandle()
     {
-        lock (this)
+        lock (_lock)
         {
             if (!HWND.IsNull)
             {
@@ -670,7 +672,7 @@ public unsafe partial class NativeWindow : MarshalByRefObject, IWin32Window, IHa
             return;
         }
 
-        lock (this)
+        lock (_lock)
         {
             if (HWND.IsNull)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintControllerWithStatusDialog.BackgroundThread.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintControllerWithStatusDialog.BackgroundThread.cs
@@ -12,6 +12,7 @@ public partial class PrintControllerWithStatusDialog
         private readonly Thread _thread;
         private bool _alreadyStopped;
         private StatusDialog? _dialog;
+        private readonly Lock _lock = new();
 
         // Called from any thread
         internal BackgroundThread(PrintControllerWithStatusDialog parent)
@@ -28,7 +29,7 @@ public partial class PrintControllerWithStatusDialog
         // Called from any thread
         internal void Stop()
         {
-            lock (this)
+            lock (_lock)
             {
                 if (_dialog is { } dialog && dialog.IsHandleCreated)
                 {
@@ -55,7 +56,7 @@ public partial class PrintControllerWithStatusDialog
         {
             try
             {
-                lock (this)
+                lock (_lock)
                 {
                     if (_alreadyStopped)
                     {
@@ -74,7 +75,7 @@ public partial class PrintControllerWithStatusDialog
             }
             finally
             {
-                lock (this)
+                lock (_lock)
                 {
                     _dialog?.Dispose();
                     _dialog = null;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Timer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Timer.cs
@@ -150,13 +150,11 @@ public class Timer : Component
                 }
 
                 _interval = value;
-                if (Enabled)
+
+                if (Enabled && !DesignMode)
                 {
                     // Change the timer value, don't tear down the timer itself.
-                    if (!DesignMode && _timerWindow is not null)
-                    {
-                        _timerWindow.RestartTimer(value);
-                    }
+                    _timerWindow?.RestartTimer(value);
                 }
             }
         }


### PR DESCRIPTION
Better to have explicit lock objects from a maintenance perspective.

Ideally we can whittle down some of the other locks on non Lock objects, but we need to be very careful about where we might be inadvertently exposing the ability to lock externally. Even if you can technically do so, we might want to take the breaking change for some of these in 10.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11842)