### PR TITLE
Fix Cursor Display Incorrectly On Drag

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DropSource.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DropSource.cs
@@ -68,7 +68,7 @@ internal class DropSource : IDropSource.Interface, IDropSourceNotify.Interface, 
 
         _peer.OnGiveFeedback(gfbEvent);
 
-        if (IsDropTargetWindowInCurrentThread() && !gfbEvent.Equals(_lastGiveFeedbackEventArgs))
+        if (IsDropTargetWindowInCurrentThread() && gfbEvent.DragImage is not null && !gfbEvent.Equals(_lastGiveFeedbackEventArgs))
         {
             _lastGiveFeedbackEventArgs = gfbEvent.Clone();
             UpdateDragImage(_lastGiveFeedbackEventArgs, _dataObject, _lastHwndTarget);
@@ -106,7 +106,7 @@ internal class DropSource : IDropSource.Interface, IDropSourceNotify.Interface, 
 
     public HRESULT DragLeaveTarget()
     {
-        if (IsDropTargetWindowInCurrentThread())
+        if (IsDropTargetWindowInCurrentThread() && _lastGiveFeedbackEventArgs?.DragImage is not null)
         {
             DragDropHelper.DragLeave();
         }


### PR DESCRIPTION
Related to https://github.com/dotnet/winforms/issues/11847

Regression was introduced in https://github.com/dotnet/winforms/pull/10319 because we had removed a condition to check whether drag image is present. Re-adding that conditional the PR originally took out in DropSource. I checked this issue is fixed and the issue linked PR resolved remains fixed.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11853)