### PR TITLE
Recreate VB tests only based on Features 10 (Review 1st)

### DIFF
--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft.VisualBasic.Forms.vbproj
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft.VisualBasic.Forms.vbproj
@@ -11,6 +11,7 @@
     <OptionExplicit>On</OptionExplicit>
     <OptionStrict>On</OptionStrict>
     <OptionInfer>Off</OptionInfer>
+    <RootNamespace></RootNamespace>
     <LangVersion>Latest</LangVersion>
     <VBRuntime>None</VBRuntime>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft.VisualBasic.Forms.vbproj
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft.VisualBasic.Forms.vbproj
@@ -1,4 +1,4 @@
-<Project>
+﻿<Project>
   <!--
     https://github.com/dotnet/winforms/issues/2107#issuecomment-559289716
     https://github.com/microsoft/msbuild/issues/4923#issuecomment-554265394
@@ -10,8 +10,7 @@
     <Deterministic>true</Deterministic>
     <OptionExplicit>On</OptionExplicit>
     <OptionStrict>On</OptionStrict>
-    <OptionInfer>On</OptionInfer>
-    <RootNamespace></RootNamespace>
+    <OptionInfer>Off</OptionInfer>
     <LangVersion>Latest</LangVersion>
     <VBRuntime>None</VBRuntime>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>

--- a/src/Microsoft.VisualBasic.Forms/tests/UnitTests/Microsoft.VisualBasic.Forms.Tests.vbproj
+++ b/src/Microsoft.VisualBasic.Forms/tests/UnitTests/Microsoft.VisualBasic.Forms.Tests.vbproj
@@ -13,6 +13,7 @@
     <MyType>WindowsFormsWithCustomSubMain</MyType>
     <UseApplicationFramework>True</UseApplicationFramework>
     <OutputType>Library</OutputType>
+    <RootNamespace></RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.VisualBasic.Forms/tests/UnitTests/Microsoft.VisualBasic.Forms.Tests.vbproj
+++ b/src/Microsoft.VisualBasic.Forms/tests/UnitTests/Microsoft.VisualBasic.Forms.Tests.vbproj
@@ -1,14 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
+<PropertyGroup>
     <SourceTargetFramework>$(TargetFramework)</SourceTargetFramework>
     <TargetFramework>$(TargetFramework)-windows7.0</TargetFramework>
     <DisableTransitiveFrameworkReferences>true</DisableTransitiveFrameworkReferences>
-    <RootNamespace>Microsoft.VisualBasic.Forms.Tests</RootNamespace>
+    <RootNamespace></RootNamespace>
     <LangVersion>latest</LangVersion>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <OptionExplicit>On</OptionExplicit>
+    <OptionInfer>Off</OptionInfer>
+    <OptionStrict>On</OptionStrict>
+    <MyType>WindowsFormsWithCustomSubMain</MyType>
+    <UseApplicationFramework>True</UseApplicationFramework>
+    <OutputType>Library</OutputType>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\System.Design\src\System.Design.Facade.csproj" />
     <ProjectReference Include="..\..\..\System.Drawing\src\System.Drawing.Facade.csproj" />

--- a/src/Microsoft.VisualBasic.Forms/tests/UnitTests/Microsoft.VisualBasic.Forms.Tests.vbproj
+++ b/src/Microsoft.VisualBasic.Forms/tests/UnitTests/Microsoft.VisualBasic.Forms.Tests.vbproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-<PropertyGroup>
+  <PropertyGroup>
     <SourceTargetFramework>$(TargetFramework)</SourceTargetFramework>
     <TargetFramework>$(TargetFramework)-windows7.0</TargetFramework>
     <DisableTransitiveFrameworkReferences>true</DisableTransitiveFrameworkReferences>

--- a/src/Microsoft.VisualBasic.Forms/tests/UnitTests/System/Windows/Forms/AssemblyPublicKeyIsAsExpectedTest.vb
+++ b/src/Microsoft.VisualBasic.Forms/tests/UnitTests/System/Windows/Forms/AssemblyPublicKeyIsAsExpectedTest.vb
@@ -1,0 +1,28 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+
+Imports System.Text
+Imports FluentAssertions
+Imports Xunit
+
+Namespace Microsoft.VisualBasic.Forms.Tests
+
+    Public Class AssemblyPublicKeyIsAsExpectedTest
+        Private Const AssemblyPK As String = "002400000480000094000000060200000024000052534131000400000100010007d1fa57c4aed9f0a32e84aa0faefd0de9e8fd6aec8f87fb03766c834c99921eb23be79ad9d5dcc1dd9ad236132102900b723cf980957fc4e177108fc607774f29e8320e92ea05ece4e821c0a5efe8f1645c4c0c93c1ab99285d622caa652c1dfad63d745d6f2de5f17e5eaf0fc4963d261c8a12436518206dc093344d5ad293"
+
+        ''' <summary>
+        '''  Test to find out a correct PublicKey in InternalsVisibleTo for assembly under test.
+        ''' </summary>
+        <WinFormsFact>
+        Public Sub AssemblyPublicKeyIsAsExpected()
+            Dim publicKey() As Byte = GetType(ControlTests).Assembly.GetName().GetPublicKey()
+            Dim sb As New StringBuilder
+            For Each [byte] As Byte In publicKey
+                sb.AppendFormat("{0:x2}", [byte])
+            Next
+
+            AssemblyPK.Should.Be(sb.ToString())
+        End Sub
+
+    End Class
+End Namespace

--- a/src/Microsoft.VisualBasic.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.vb
+++ b/src/Microsoft.VisualBasic.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.vb
@@ -2,9 +2,11 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 
 Imports System.Windows.Forms
+Imports FluentAssertions
 Imports Xunit
 
 Namespace Microsoft.VisualBasic.Forms.Tests
+
     Partial Public Class ControlTests
 
         Public Shared Function FaultingFunc(a As Integer) As Integer
@@ -20,9 +22,12 @@ Namespace Microsoft.VisualBasic.Forms.Tests
             Using _control As New Control
                 _control.CreateControl()
 
-                Dim invoker As Action = AddressOf FaultingMethod
-                Dim exception As Exception = Assert.Throws(Of DivideByZeroException)(
-                    Sub() _control.Invoke(invoker))
+                Dim testCode As Action =
+                    Sub()
+                        _control.Invoke(AddressOf FaultingMethod)
+                    End Sub
+
+                Dim exception As Exception = Assert.Throws(Of DivideByZeroException)(testCode)
 
                 '    Expecting something Like the following.
                 '    The first frame must be the this method, followed by MarshaledInvoke at previous location.
@@ -38,8 +43,8 @@ Namespace Microsoft.VisualBasic.Forms.Tests
                 '       at System.Windows.Forms.Control.Invoke(Delegate method) in ...\winforms\src\System.Windows.Forms\src\System\Windows\Forms\Control.cs:line 6393
                 '       at Microsoft.VisualBasic.Forms.Tests.Microsoft.VisualBasic.Forms.Tests.ControlTests._Closure$__1-1._Lambda$__0() in ...\winforms\src\Microsoft.VisualBasic.Forms\tests\UnitTests\ControlTests.vb:line 18
 
-                Assert.Contains(NameOf(FaultingMethod), exception.StackTrace)
-                Assert.Contains(" System.Windows.Forms.Control.Invoke(Action method) ", exception.StackTrace)
+                exception.StackTrace.Should.Contain(NameOf(FaultingMethod))
+                exception.StackTrace.Should.Contain(" System.Windows.Forms.Control.Invoke(Action method) ")
             End Using
         End Sub
 
@@ -48,9 +53,11 @@ Namespace Microsoft.VisualBasic.Forms.Tests
             Using _control As New Control
                 _control.CreateControl()
 
-                Dim invoker As New MethodInvoker(AddressOf FaultingMethod)
-                Dim exception As Exception = Assert.Throws(Of DivideByZeroException)(
-                    Sub() _control.Invoke(invoker))
+                Dim testCode As Action =
+                    Sub()
+                        _control.Invoke(New MethodInvoker(AddressOf FaultingMethod))
+                    End Sub
+                Dim exception As Exception = Assert.Throws(Of DivideByZeroException)(testCode)
 
                 '    Expecting something Like the following.
                 '    The first frame must be the this method, followed by MarshaledInvoke at previous location.
@@ -66,8 +73,8 @@ Namespace Microsoft.VisualBasic.Forms.Tests
                 '       at System.Windows.Forms.Control.Invoke(Delegate method) in ...\winforms\src\System.Windows.Forms\src\System\Windows\Forms\Control.cs:line 6393
                 '       at Microsoft.VisualBasic.Forms.Tests.Microsoft.VisualBasic.Forms.Tests.ControlTests._Closure$__1-1._Lambda$__0() in ...\winforms\src\Microsoft.VisualBasic.Forms\tests\UnitTests\ControlTests.vb:line 18
 
-                Assert.Contains(NameOf(FaultingMethod), exception.StackTrace)
-                Assert.Contains(" System.Windows.Forms.Control.Invoke(Delegate method) ", exception.StackTrace)
+                exception.StackTrace.Should.Contain(NameOf(FaultingMethod))
+                exception.StackTrace.Should.Contain(" System.Windows.Forms.Control.Invoke(Delegate method) ")
             End Using
         End Sub
 
@@ -76,11 +83,13 @@ Namespace Microsoft.VisualBasic.Forms.Tests
             Using _control As New Control
                 _control.CreateControl()
 
-                Dim invoker As Func(Of Integer, Integer) = AddressOf FaultingFunc
-                Dim exception As Exception = Assert.Throws(Of DivideByZeroException)(
+                Dim testCode As Action =
                     Sub()
-                        Dim result As Integer = _control.Invoke(Function() invoker(19))
-                    End Sub)
+                        Dim result As Integer =
+                            _control.Invoke(Function() CType(AddressOf FaultingFunc, Func(Of Integer, Integer))(19))
+                    End Sub
+
+                Dim exception As Exception = Assert.Throws(Of DivideByZeroException)(testCode)
 
                 '    Expecting something Like the following.
                 '    The first frame must be the this method, followed by MarshaledInvoke at previous location.
@@ -94,8 +103,8 @@ Namespace Microsoft.VisualBasic.Forms.Tests
                 '       at Microsoft.VisualBasic.Forms.Tests.Microsoft.VisualBasic.Forms.Tests.ControlTests._Closure$__4-1._Lambda$__0() in ...\winforms\src\Microsoft.VisualBasic.Forms\tests\UnitTests\ControlTests.vb:line 111
                 '       at Xunit.Assert.RecordException(Action testCode) in C:\Dev\xunit\xunit\src\xunit.assert\Asserts\Record.cs:line 27
 
-                Assert.Contains(NameOf(FaultingFunc), exception.StackTrace)
-                Assert.Contains(" System.Windows.Forms.Control.Invoke[T](Func`1 method) ", exception.StackTrace)
+                exception.StackTrace.Should.Contain(NameOf(FaultingFunc))
+                exception.StackTrace.Should.Contain(" System.Windows.Forms.Control.Invoke[T](Func`1 method) ")
             End Using
         End Sub
 

--- a/src/Microsoft.VisualBasic.Forms/tests/UnitTests/System/Windows/Forms/TimeTests.vb
+++ b/src/Microsoft.VisualBasic.Forms/tests/UnitTests/System/Windows/Forms/TimeTests.vb
@@ -23,6 +23,17 @@ Namespace Microsoft.VisualBasic.Forms.Tests
             Date.Now.Should.BeAfter(New Date)
         End Sub
 
+        <WinFormsFact>
+        Public Sub TimeTestsDataIteratorTests()
+            Dim testClass As New TimeData
+            testClass.IEnumerable_GetEnumerator.Should.NotBeNull()
+        End Sub
+
+        <WinFormsFact>
+        Public Sub VbTickCountCloseToEnvironmentTickCount()
+            Dim tickCount As Integer = Math.Abs(Environment.TickCount - My.Computer.Clock.TickCount)
+            Call (tickCount < PrecisionTickLimit).Should.BeTrue()
+        End Sub
 
         <WinFormsTheory>
         <ClassData(GetType(TimeData))>
@@ -31,12 +42,6 @@ Namespace Microsoft.VisualBasic.Forms.Tests
             vbTime,
             systemTime,
             acceptableDifferenceInTicks:=PrecisionTickLimit).Should.BeTrue()
-        End Sub
-
-        <WinFormsFact>
-        Public Sub VbTickCountCloseToEnvironmentTickCount()
-            Dim tickCount As Integer = Math.Abs(Environment.TickCount - My.Computer.Clock.TickCount)
-            Call (tickCount < PrecisionTickLimit).Should.BeTrue()
         End Sub
 
         <WinFormsFact>

--- a/src/Microsoft.VisualBasic.Forms/tests/UnitTests/System/Windows/Forms/TimeTests.vb
+++ b/src/Microsoft.VisualBasic.Forms/tests/UnitTests/System/Windows/Forms/TimeTests.vb
@@ -1,0 +1,62 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+
+Imports FluentAssertions
+Imports Xunit
+
+Namespace Microsoft.VisualBasic.Forms.Tests
+
+    Public Class TimeTests
+        Private Const PrecisionTickLimit As Integer = 1000
+
+        Private Function TimesEqual(
+            vbTime As Date,
+            systemTime As Date,
+            acceptableDifferenceInTicks As Long) As Boolean
+
+            Dim diff As TimeSpan = systemTime - vbTime
+            Return Math.Abs(diff.TotalMicroseconds) < acceptableDifferenceInTicks
+        End Function
+
+        <WinFormsFact>
+        Public Sub SystemTimeNotNew()
+            Date.Now.Should.BeAfter(New Date)
+        End Sub
+
+
+        <WinFormsTheory>
+        <ClassData(GetType(TimeData))>
+        Public Sub VbTimeCloseToDateUtcNow(systemTime As Date, vbTime As Date)
+            TimesEqual(
+            vbTime,
+            systemTime,
+            acceptableDifferenceInTicks:=PrecisionTickLimit).Should.BeTrue()
+        End Sub
+
+        <WinFormsFact>
+        Public Sub VbTickCountCloseToEnvironmentTickCount()
+            Dim tickCount As Integer = Math.Abs(Environment.TickCount - My.Computer.Clock.TickCount)
+            Call (tickCount < PrecisionTickLimit).Should.BeTrue()
+        End Sub
+
+        <WinFormsFact>
+        Public Sub VbTimeNotNew()
+            My.Computer.Clock.LocalTime.Should.BeAfter(New Date)
+        End Sub
+
+        Protected Friend Class TimeData
+            Implements IEnumerable(Of Object())
+
+            Public Iterator Function GetEnumerator() As IEnumerator(Of Object()) Implements IEnumerable(Of Object()).GetEnumerator
+                Yield {My.Computer.Clock.GmtTime, Date.UtcNow}
+                Yield {My.Computer.Clock.LocalTime, Date.Now}
+            End Function
+
+            Public Function IEnumerable_GetEnumerator() As IEnumerator Implements IEnumerable.GetEnumerator
+                Return GetEnumerator()
+            End Function
+
+        End Class
+
+    End Class
+End Namespace

--- a/src/Microsoft.VisualBasic.Forms/tests/UnitTests/System/Windows/Forms/UserTests.UserIdentity.vb
+++ b/src/Microsoft.VisualBasic.Forms/tests/UnitTests/System/Windows/Forms/UserTests.UserIdentity.vb
@@ -1,0 +1,42 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+
+Imports System.Security.Principal
+
+Namespace Microsoft.VisualBasic.Forms.Tests
+
+    Partial Public Class UserTests
+
+        Public Class UserIdentity
+            Implements IIdentity
+
+            Private ReadOnly _authenticationType As String
+            Private ReadOnly _name As String
+
+            Public Sub New(authenticationType As String, name As String, isAuthenticated As Boolean)
+                _authenticationType = authenticationType
+                _name = name
+            End Sub
+
+            Public ReadOnly Property AuthenticationType As String Implements IIdentity.AuthenticationType
+                Get
+                    Return _authenticationType
+                End Get
+            End Property
+
+            Public ReadOnly Property IsAuthenticated As Boolean Implements IIdentity.IsAuthenticated
+                Get
+                    Return True
+                End Get
+            End Property
+
+            Public ReadOnly Property Name As String Implements IIdentity.Name
+                Get
+                    Return _name
+                End Get
+            End Property
+
+        End Class
+
+    End Class
+End Namespace

--- a/src/Microsoft.VisualBasic.Forms/tests/UnitTests/System/Windows/Forms/UserTests.UserPrincipal.vb
+++ b/src/Microsoft.VisualBasic.Forms/tests/UnitTests/System/Windows/Forms/UserTests.UserPrincipal.vb
@@ -1,0 +1,34 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+
+Imports System.Security.Principal
+
+Namespace Microsoft.VisualBasic.Forms.Tests
+
+    Partial Public Class UserTests
+
+        Private NotInheritable Class UserPrincipal
+            Implements IPrincipal
+
+            Private _role As String
+            Private _userIdentity As IIdentity
+
+            Public Sub New(authenticationType As String, name As String, isAuthenticated As Boolean, role As String)
+                _userIdentity = New UserIdentity(authenticationType, name, isAuthenticated)
+                _role = role
+            End Sub
+
+            Public ReadOnly Property Identity As IIdentity Implements IPrincipal.Identity
+                Get
+                    Return _userIdentity
+                End Get
+            End Property
+
+            Public Function IsInRole(role As String) As Boolean Implements IPrincipal.IsInRole
+                Return role = _role
+            End Function
+
+        End Class
+
+    End Class
+End Namespace

--- a/src/Microsoft.VisualBasic.Forms/tests/UnitTests/System/Windows/Forms/UserTests.vb
+++ b/src/Microsoft.VisualBasic.Forms/tests/UnitTests/System/Windows/Forms/UserTests.vb
@@ -1,0 +1,65 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+
+Imports FluentAssertions
+Imports Microsoft.VisualBasic.ApplicationServices
+Imports Xunit
+
+Namespace Microsoft.VisualBasic.Forms.Tests
+
+    Partial Public Class UserTests
+
+        <WinFormsFact>
+        Public Sub UserBaseTest()
+            Dim testUser As New User
+            testUser.CurrentPrincipal.Should.BeNull()
+            Dim userPrincipal As New UserPrincipal(
+                authenticationType:="Basic",
+                name:="Test",
+                isAuthenticated:=True,
+                role:="Guest")
+            testUser.CurrentPrincipal = userPrincipal
+            testUser.CurrentPrincipal.Should.NotBeNull()
+            testUser.CurrentPrincipal.Should.Be(userPrincipal)
+            userPrincipal.Identity.AuthenticationType.Should.Be("Basic")
+        End Sub
+
+        <WinFormsFact>
+        Public Sub UserGetNameTest()
+            Dim testUser As New User With {
+                .CurrentPrincipal = New UserPrincipal(
+                authenticationType:="Basic",
+                name:="Test",
+                isAuthenticated:=True,
+                role:="Guest")
+            }
+            testUser.Name.Should.Be("Test")
+        End Sub
+
+        <WinFormsFact>
+        Public Sub UserIsAuthenticatedTest()
+            Dim testUser As New User With {
+                .CurrentPrincipal = New UserPrincipal(
+                authenticationType:="Basic",
+                name:="Test",
+                isAuthenticated:=True,
+                role:="Guest")
+            }
+            testUser.IsAuthenticated.Should.BeTrue()
+        End Sub
+
+        <WinFormsFact>
+        Public Sub UserIsInRoleTest()
+            Dim testUser As New User With {
+                .CurrentPrincipal = New UserPrincipal(
+                authenticationType:="Basic",
+                name:="Test",
+                isAuthenticated:=True,
+                role:="Guest")
+            }
+            testUser.IsInRole("Guest").Should.BeTrue()
+            testUser.IsInRole("Basic").Should.BeFalse()
+        End Sub
+
+    End Class
+End Namespace

--- a/src/Microsoft.VisualBasic/tests/UnitTests/Microsoft/VisualBasic/Devices/AudioTests.cs
+++ b/src/Microsoft.VisualBasic/tests/UnitTests/Microsoft/VisualBasic/Devices/AudioTests.cs
@@ -1,16 +1,43 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.ComponentModel;
+using FluentAssertions;
+
 namespace Microsoft.VisualBasic.Devices.Tests;
 
 public class AudioTests
 {
+    private static string GetUniqueName() => Guid.NewGuid().ToString("D");
+
     [Fact]
     public void Play()
     {
         string location = Path.Combine(Path.GetTempPath(), GetUniqueName());
         Audio audio = new();
-        Assert.Throws<FileNotFoundException>(() => audio.Play(location));
+        Action testCode = () => audio.Play(location);
+        testCode.Should().Throw<FileNotFoundException>();
+    }
+
+    [Fact]
+    public void PlayInvalidMode_Throws()
+    {
+        string location = Path.Combine(Path.GetTempPath(), GetUniqueName());
+        Audio audio = new();
+        Action testCode = () => audio.Play(location, (AudioPlayMode)(-1));
+        testCode.Should().Throw<InvalidEnumArgumentException>();
+    }
+
+    [Theory]
+    [InlineData(AudioPlayMode.Background)]
+    [InlineData(AudioPlayMode.BackgroundLoop)]
+    [InlineData(AudioPlayMode.WaitToComplete)]
+    public void PlayAllModes_Throws(AudioPlayMode mode)
+    {
+        string location = Path.Combine(Path.GetTempPath(), GetUniqueName());
+        Audio audio = new();
+        Action testCode = () => audio.Play(location, mode);
+        testCode.Should().Throw<FileNotFoundException>();
     }
 
     // Not tested:
@@ -22,6 +49,4 @@ public class AudioTests
         Audio audio = new();
         audio.Stop();
     }
-
-    private static string GetUniqueName() => Guid.NewGuid().ToString("D");
 }

--- a/src/Microsoft.VisualBasic/tests/UnitTests/Microsoft/VisualBasic/MyServices/ClipboardProxyTests.cs
+++ b/src/Microsoft.VisualBasic/tests/UnitTests/Microsoft/VisualBasic/MyServices/ClipboardProxyTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Drawing;
+using FluentAssertions;
 using Microsoft.VisualBasic.Devices;
 using DataFormats = System.Windows.Forms.DataFormats;
 using TextDataFormat = System.Windows.Forms.TextDataFormat;
@@ -12,44 +13,14 @@ namespace Microsoft.VisualBasic.MyServices.Tests;
 [CollectionDefinition("Sequential", DisableParallelization = true)]
 public class ClipboardProxyTests
 {
-    [WinFormsFact]
-    public void Clear()
-    {
-        var clipboard = (new Computer()).Clipboard;
-        string text = GetUniqueText();
-        clipboard.SetText(text);
-        Assert.True(System.Windows.Forms.Clipboard.ContainsText());
-        clipboard.Clear();
-        Assert.False(System.Windows.Forms.Clipboard.ContainsText());
-    }
-
-    [WinFormsFact]
-    public void Text()
-    {
-        var clipboard = (new Computer()).Clipboard;
-        string text = GetUniqueText();
-        clipboard.SetText(text, TextDataFormat.UnicodeText);
-        Assert.Equal(System.Windows.Forms.Clipboard.ContainsText(), clipboard.ContainsText());
-        Assert.Equal(System.Windows.Forms.Clipboard.GetText(), clipboard.GetText());
-        Assert.Equal(System.Windows.Forms.Clipboard.GetText(TextDataFormat.UnicodeText), clipboard.GetText(TextDataFormat.UnicodeText));
-        Assert.Equal(text, clipboard.GetText(TextDataFormat.UnicodeText));
-    }
-
-    [WinFormsFact]
-    public void Image()
-    {
-        var clipboard = (new Computer()).Clipboard;
-        Bitmap image = new(2, 2);
-        Assert.Equal(System.Windows.Forms.Clipboard.ContainsImage(), clipboard.ContainsImage());
-        Assert.Equal(System.Windows.Forms.Clipboard.GetImage(), clipboard.GetImage());
-        clipboard.SetImage(image);
-    }
+    private static string GetUniqueText() => Guid.NewGuid().ToString("D");
 
     [WinFormsFact]
     public void Audio()
     {
         var clipboard = (new Computer()).Clipboard;
-        Assert.Equal(System.Windows.Forms.Clipboard.ContainsAudio(), clipboard.ContainsAudio());
+        clipboard.ContainsAudio().Should().Be(System.Windows.Forms.Clipboard.ContainsAudio());
+
         // Not tested:
         //   Public Function GetAudioStream() As Stream
         //   Public Sub SetAudio(audioBytes As Byte())
@@ -57,13 +28,14 @@ public class ClipboardProxyTests
     }
 
     [WinFormsFact]
-    public void FileDropList()
+    public void Clear()
     {
         var clipboard = (new Computer()).Clipboard;
-        Assert.Equal(System.Windows.Forms.Clipboard.ContainsFileDropList(), clipboard.ContainsFileDropList());
-        // Not tested:
-        //   Public Function GetFileDropList() As StringCollection
-        //   Public Sub SetFileDropList(filePaths As StringCollection)
+        string text = GetUniqueText();
+        clipboard.SetText(text);
+        System.Windows.Forms.Clipboard.ContainsText().Should().BeTrue();
+        clipboard.Clear();
+        System.Windows.Forms.Clipboard.ContainsText().Should().BeFalse();
     }
 
     [WinFormsFact]
@@ -85,5 +57,35 @@ public class ClipboardProxyTests
         clipboard.SetDataObject(new System.Windows.Forms.DataObject(data));
     }
 
-    private static string GetUniqueText() => Guid.NewGuid().ToString("D");
+    [WinFormsFact]
+    public void FileDropList()
+    {
+        var clipboard = (new Computer()).Clipboard;
+        System.Windows.Forms.Clipboard.ContainsFileDropList().Should().Be(clipboard.ContainsFileDropList());
+        // Not tested:
+        //   Public Function GetFileDropList() As StringCollection
+        //   Public Sub SetFileDropList(filePaths As StringCollection)
+    }
+
+    [WinFormsFact]
+    public void Image()
+    {
+        var clipboard = (new Computer()).Clipboard;
+        using Bitmap image = new(2, 2);
+        System.Windows.Forms.Clipboard.ContainsImage().Should().Be(clipboard.ContainsImage());
+        System.Windows.Forms.Clipboard.GetImage().Should().Be(clipboard.GetImage());
+        clipboard.SetImage(image);
+    }
+
+    [WinFormsFact]
+    public void Text()
+    {
+        var clipboard = (new Computer()).Clipboard;
+        string text = GetUniqueText();
+        clipboard.SetText(text, TextDataFormat.UnicodeText);
+        System.Windows.Forms.Clipboard.ContainsText().Should().Be(clipboard.ContainsText());
+        System.Windows.Forms.Clipboard.GetText().Should().Be(clipboard.GetText());
+        System.Windows.Forms.Clipboard.GetText(TextDataFormat.UnicodeText).Should().Be(clipboard.GetText(TextDataFormat.UnicodeText));
+        clipboard.GetText(TextDataFormat.UnicodeText).Should().Be(text);
+    }
 }


### PR DESCRIPTION
Partially Fixes #11655 Replace PR #11819 targeting Features/10.0

## Proposed changes
Add tests to VB Runtime that require no changes to existing code and change existing VB Test to use FluentAssertions 

## Customer Impact
Improves code coverage

## Regression? 

- No

## Risk
- None, only adds test

## Test methodology <!-- How did you ensure quality? -->
Only adds and improves tests and improves test coverage 

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11864)