### PR TITLE
Correct the logic of the function GetStandardValues of the file TextBoxAutoCompleteSourceConverter

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TextBox/TextBoxAutoCompleteSourceConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TextBox/TextBoxAutoCompleteSourceConverter.cs
@@ -23,7 +23,7 @@ internal class TextBoxAutoCompleteSourceConverter : EnumConverter
         {
             if (values[i] is object currentItem)
             {
-                if (string.Equals(currentItem.ToString(), "ListItems"))
+                if (!string.Equals(currentItem.ToString(), nameof(AutoCompleteSource.ListItems)))
                 {
                     list.Add(currentItem);
                 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TextBoxAutoCompleteSourceConverterTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TextBoxAutoCompleteSourceConverterTests.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Moq;
+using System.ComponentModel;
+using static System.ComponentModel.TypeConverter;
+
+namespace System.Windows.Forms.Tests;
+
+public class TextBoxAutoCompleteSourceConverterTests
+{
+    [Fact]
+    public void TextBoxAutoCompleteSourceConverter_GetStandardValues_HasContext_ReturnsExpected()
+    {
+        TextBoxAutoCompleteSourceConverter converter = new(typeof(AutoCompleteSource));
+        Mock<ITypeDescriptorContext> mockContext = new(MockBehavior.Strict);
+        StandardValuesCollection valuesCollection = converter.GetStandardValues(mockContext.Object);
+
+        valuesCollection.Count.Should().Be(8);
+
+        List<object> value = valuesCollection.TestAccessor().Dynamic._values;
+        value.Should().Contain(AutoCompleteSource.AllUrl);
+        value.Should().Contain(AutoCompleteSource.AllSystemSources);
+        value.Should().Contain(AutoCompleteSource.CustomSource);
+        value.Should().Contain(AutoCompleteSource.HistoryList);
+        value.Should().Contain(AutoCompleteSource.RecentlyUsedList);
+        value.Should().Contain(AutoCompleteSource.FileSystem);
+        value.Should().Contain(AutoCompleteSource.FileSystemDirectories);
+        value.Should().Contain(AutoCompleteSource.None);
+    }
+}


### PR DESCRIPTION

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #11806 

## Cause:
This issue caused the PR #8276

## Proposed changes

- Correct the logic of the function GetStandardValues of the file TextBoxAutoCompleteSourceConverter


<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- The "AutoCompleteSource" property of the TextBox control can be used normally

## Regression? 

- Yes 

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
The value set for the property "AutoCompleteSource" of the TextBox control is missing
<img width="284" alt="image" src="https://github.com/user-attachments/assets/42de3c31-1286-4877-a348-d82feef8bac0">

### After
The value of the "AutoCompleteSource" property of the TextBox control is fully displayed
<img width="359" alt="image" src="https://github.com/user-attachments/assets/34819284-f17c-4b1d-afb2-74d3dd5f7686">


## Test methodology <!-- How did you ensure quality? -->

- Manually(Tested in DemoConsole)
 

## Test environment(s) <!-- Remove any that don't apply -->

-  .net 9.0.0-rc.1.24406.14


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11865)