### PR TITLE
Dispose KeyboardToolTip when DataGridView is disposed

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridView.Methods.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridView.Methods.cs
@@ -5727,6 +5727,12 @@ public partial class DataGridView
             _dataGridViewOper[OperationInDispose] = true;
             try
             {
+                if (Properties.TryGetObject(s_propToolTip, out ToolTip? keyboardToolTip))
+                {
+                    // null is never set for s_propToolTip
+                    keyboardToolTip!.Dispose();
+                }
+
                 // Remove any Columns contained in this control
                 for (int i = 0; i < Columns.Count; i++)
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip/ToolTip.cs
@@ -1724,6 +1724,12 @@ public partial class ToolTip : Component, IExtenderProvider, IHandle<HWND>
             return;
         }
 
+        if (win is Control control && control.IsDisposed)
+        {
+            Debug.Fail("The passed in control is disposed.");
+            return;
+        }
+
         if (GetHandleCreated())
         {
             ToolInfoWrapper<HandleRef<HWND>> info = new(Control.GetSafeHandle(win));

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTests.cs
@@ -4073,6 +4073,9 @@ public partial class DataGridViewTests : IDisposable
     [WinFormsFact]
     public void DataGridView_Dispose_KeyboardToolTip_Disposed()
     {
+        // Test to ensure disposal of the DataGridView KeyboardToolTip
+        // to avoid calls to disposed DataGridView from
+        // the KeyBoardToolTip as seen in https://github.com/dotnet/winforms/issues/11837
         DataGridView dataGridView = new();
         int toolTipDisposeCount = 0;
         ToolTip toolTip = dataGridView.KeyboardToolTip;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTests.cs
@@ -4069,4 +4069,15 @@ public partial class DataGridViewTests : IDisposable
         _dataGridView.CurrentCell = _dataGridView.Rows[_dataGridView.NewRowIndex].Cells[1];
         callCount.Should().Be(1);
     }
+
+    [WinFormsFact]
+    public void DataGridView_Dispose_KeyboardToolTip_Disposed()
+    {
+        DataGridView dataGridView = new();
+        int toolTipDisposeCount = 0;
+        ToolTip toolTip = dataGridView.KeyboardToolTip;
+        toolTip.Disposed += (sender, e) => toolTipDisposeCount++;
+        dataGridView.Dispose();
+        toolTipDisposeCount.Should().Be(1);
+    }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes https://github.com/dotnet/winforms/issues/11837

`DataGridView` completely owns its `KeyboardToolTip` so it should be disposed of when the DataGridView is disposed of to avoid a situation where calls to the KeyboardToolTip leads to the disposed DataGridView.
Also added a debug failto catch any other places we might be getting into the `Hide` method with a disposed control.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11873)