### PR TITLE
Fix custom collection editor not being invoked in .NET Core projects

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CollectionEditor.CollectionForm.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CollectionEditor.CollectionForm.cs
@@ -190,5 +190,30 @@ public partial class CollectionEditor
         ///  This is called when the value property in the <see cref="CollectionForm"/> has changed.
         /// </summary>
         protected abstract void OnEditValueChanged();
+
+        /// <summary>
+        ///  Gets a custom editor for the specified property descriptor, if available.
+        /// </summary>
+        protected UITypeEditor? GetCustomEditor(PropertyDescriptor? propertyDescriptor)
+        {
+            if (propertyDescriptor is null)
+            {
+                return null;
+            }
+
+            var editorAttribute = propertyDescriptor.Attributes[typeof(EditorAttribute)] as EditorAttribute;
+            if (editorAttribute is null)
+            {
+                return null;
+            }
+
+            var editorType = Type.GetType(editorAttribute.EditorTypeName);
+            if (editorType is null)
+            {
+                return null;
+            }
+
+            return Activator.CreateInstance(editorType) as UITypeEditor;
+        }
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CollectionEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CollectionEditor.cs
@@ -225,6 +225,13 @@ public partial class CollectionEditor : UITypeEditor
 
         Context = context;
 
+        // Check for custom editor
+        var customEditor = GetCustomEditor(context?.PropertyDescriptor);
+        if (customEditor != null)
+        {
+            return customEditor.EditValue(context, provider, value);
+        }
+
         // Child modal dialog - launching in SystemAware mode.
         CollectionForm localCollectionForm = ScaleHelper.InvokeInSystemAwareContext(CreateCollectionForm);
         ITypeDescriptorContext? lastContext = Context;
@@ -408,5 +415,30 @@ public partial class CollectionEditor : UITypeEditor
         {
             helpService.ShowHelpFromKeyword(HelpTopic);
         }
+    }
+
+    /// <summary>
+    ///  Gets a custom editor for the specified property descriptor, if available.
+    /// </summary>
+    private UITypeEditor? GetCustomEditor(PropertyDescriptor? propertyDescriptor)
+    {
+        if (propertyDescriptor is null)
+        {
+            return null;
+        }
+
+        var editorAttribute = propertyDescriptor.Attributes[typeof(EditorAttribute)] as EditorAttribute;
+        if (editorAttribute is null)
+        {
+            return null;
+        }
+
+        var editorType = Type.GetType(editorAttribute.EditorTypeName);
+        if (editorType is null)
+        {
+            return null;
+        }
+
+        return Activator.CreateInstance(editorType) as UITypeEditor;
     }
 }


### PR DESCRIPTION
Fixes #11821

Add support for custom CollectionEditors in .NET Core projects.

* **CollectionEditor.cs**
  - Add a method `GetCustomEditor` to check for custom editors.
  - Modify the `EditValue` method to use the custom editor if available.

* **CollectionEditor.CollectionForm.cs**
  - Add a method `GetCustomEditor` to check for custom editors.

* **CollectionEditor.FilterListBox.cs**
  - Add support for custom drawing of list items by handling the `WM_DRAWITEM` message.
  - Implement the `ListBox_drawItem` method to draw custom list items.


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11874)