### PR TITLE
Add clipping and transforms from Graphics to DC when repainting watermark in SplitterPanelDesigner

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/SplitterPanelDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/SplitterPanelDesigner.cs
@@ -190,7 +190,7 @@ internal class SplitterPanelDesigner : PanelDesigner
         using Font drawFont = new("Arial", 8);
         int watermarkX = rectangle.Width / 2 - (int)g.MeasureString(name, drawFont).Width / 2;
         int watermarkY = rectangle.Height / 2;
-        TextRenderer.DrawText(g, name, drawFont, new Point(watermarkX, watermarkY), waterMarkTextColor, TextFormatFlags.Default);
+        TextRenderer.DrawText(g, name, drawFont, new Point(watermarkX, watermarkY), waterMarkTextColor, TextFormatFlags.PreserveGraphicsClipping | TextFormatFlags.PreserveGraphicsTranslateTransform);
     }
 
     protected override void OnPaintAdornments(PaintEventArgs pe)


### PR DESCRIPTION
Fixes #11790

## Proposed changes

- Since [applyClipping is always true when deleting the ComboBox](https://github.com/dotnet/winforms/issues/11790#issuecomment-2288199065), `TextRenderer.DrawText()` should be called with `TextFormatFlags.PreserveGraphicsClipping` flag to avoid the issue.

## Customer Impact

- None

## Regression?

- No

## Risk

- Minimal

## Screenshots

### Before
![before](https://github.com/user-attachments/assets/30fc04f5-0f67-406b-af42-04629bcd43a0)

### After

![after](https://github.com/user-attachments/assets/21dc85b5-ba80-47d7-bf80-de8bca33994e)

## Test methodology

- Manual

## Test environment(s)

- 9.0.100-preview.5.24307.3

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11876)