### PR TITLE
Fix AxHosts.csproj build errors with Preview 7 SDK

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "9.0.100-preview.5.24307.3",
+    "dotnet": "9.0.100-preview.7.24407.12",
     "runtimes": {
       "dotnet/x64": [
         "$(VSRedistCommonNetCoreSharedFrameworkx6490PackageVersion)"
@@ -11,7 +11,7 @@
     }
   },
   "sdk": {
-    "version": "9.0.100-preview.5.24307.3"
+    "version": "9.0.100-preview.7.24407.12"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "9.0.0-beta.24408.2",

--- a/src/BuildAssist/BuildAssist.msbuildproj
+++ b/src/BuildAssist/BuildAssist.msbuildproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <_AxHostsPath>$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', '..', 'System.Windows.Forms', 'tests', 'AxHosts', 'AxHosts.csproj'))</_AxHostsPath>
-    <_ProjectArgs>/p:Configuration=$(Configuration) /p:Platform=AnyCPU</_ProjectArgs>
+    <_ProjectArgs>/p:BuildWithNetFrameworkHostedCompiler=false /p:Configuration=$(Configuration) /p:Platform=AnyCPU</_ProjectArgs>
   </PropertyGroup>
 
   <Target Name="BuildAxHosts" BeforeTargets="AfterBuild" DependsOnTargets="FindFrameworkMsbuild">


### PR DESCRIPTION
Related: https://github.com/dotnet/sdk/pull/42699

Implemented [suggestion](https://github.com/dotnet/sdk/pull/42699#issuecomment-2288280126) to resolve build error when moving to use Preview 7 SDK
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11878)
 