### PR TITLE
belated feedback on https://github.com/dotnet/winforms/pull/11835/

### DIFF
--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities.Tests/PathLengthTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities.Tests/PathLengthTests.cs
@@ -21,14 +21,16 @@ public class PathLengthTests
 
         const int MaxRootLength = 40;
 
-        int maxLength = 260 - (currentRootLength > MaxRootLength
-            ? MaxRootLength
-            : MaxRootLength + (MaxRootLength - currentRootLength));
+        // Workaround for MAX_PATH limitation - https://learn.microsoft.com/windows/win32/fileio/maximum-file-path-limitation?tabs=registry
+        // Leave a char for the trailing null (MAX_PATH is 260)
+        int maxLength = 260 - 1 - (currentRootLength > MaxRootLength
+            ? 0
+            : MaxRootLength - currentRootLength);
 
         FileSystemEnumerable<string> enumerable = new(
             currentPath,
             (ref FileSystemEntry entry) => entry.ToFullPath(),
-            new EnumerationOptions() {  RecurseSubdirectories = true })
+            new EnumerationOptions() { RecurseSubdirectories = true })
             {
                 ShouldIncludePredicate = (ref FileSystemEntry entry) =>
                     // Directory doesn't contain a trailing slash


### PR DESCRIPTION
This test compares length of file paths in this repo against the MAX_PATH const, we assume that path length of the repo root is 40 chars or less, this leaves MAX_PATH - 1 - 40 chars for the path that we see in the GH (portion from src to .cs). This test enforces this limit be enumerating all repo files, getting the full path length and comparing this length against the maximim. Maximum full path length should be compensated for repo roots that are shorter than 40.

```
MaxRootLength + <relative path to the file>.Length < 259
MaxRootLength + <full path to the file>.Length  - currentRootLength  < 259
<full path to the file>.Length  < 259 - MaxRootLength + currentRootLength  
```
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11882)