### PR TITLE
Fix OnItemChecked method throw exception when the ListViewItem is clone object.

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ListView/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ListView/ListView.cs
@@ -4835,7 +4835,7 @@ public partial class ListView : Control
             return;
         }
 
-        if (IsAccessibilityObjectCreated)
+        if (IsAccessibilityObjectCreated && e.Item.ListView == this)
         {
             ListViewItem item = e.Item;
             ToggleState oldValue = item.Checked ? ToggleState.ToggleState_Off : ToggleState.ToggleState_On;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ListView/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ListView/ListView.cs
@@ -4835,7 +4835,7 @@ public partial class ListView : Control
             return;
         }
 
-        if (IsAccessibilityObjectCreated && e.Item.ListView == this)
+        if (e.Item.ListView == this && IsAccessibilityObjectCreated)
         {
             ListViewItem item = e.Item;
             ToggleState oldValue = item.Checked ? ToggleState.ToggleState_Off : ToggleState.ToggleState_On;

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/CloneTestListView.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/CloneTestListView.cs
@@ -12,9 +12,6 @@ internal class CloneTestListView : ListView
             return;
         }
 
-        if (e.Item.ListView == this)
-        {
-            base.OnItemChecked(e);
-        }
+        base.OnItemChecked(e);
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
@@ -7,7 +7,6 @@ using System.Windows.Forms.Automation;
 using Microsoft.DotNet.RemoteExecutor;
 using Windows.Win32.UI.Accessibility;
 using static System.Windows.Forms.ListViewItem;
-using static System.Windows.Forms.VisualStyles.VisualStyleElement.Button;
 
 using Point = System.Drawing.Point;
 using Size = System.Drawing.Size;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
@@ -7,6 +7,8 @@ using System.Windows.Forms.Automation;
 using Microsoft.DotNet.RemoteExecutor;
 using Windows.Win32.UI.Accessibility;
 using static System.Windows.Forms.ListViewItem;
+using static System.Windows.Forms.VisualStyles.VisualStyleElement.Button;
+
 using Point = System.Drawing.Point;
 using Size = System.Drawing.Size;
 
@@ -4405,6 +4407,38 @@ public class ListViewTests
         Assert.Equal(expectedCallCount, customAccessibleObject?.RaiseAutomationEventCalls);
     }
 
+    [WinFormsFact]
+    // Regression test for https://github.com/dotnet/winforms/issues/11658
+    public void ListView_OnItemChecked_VirtualMode()
+    {
+        ListViewItem listItem1 = new("Test 1");
+
+        using SubListView listView = new SubListView
+        {
+            VirtualMode = true,
+            VirtualListSize = 1,
+            CheckBoxes = true
+        };
+
+        listView.RetrieveVirtualItem += (s, e) =>
+        {
+            e.Item = e.ItemIndex switch
+            {
+                0 => listItem1,
+                _ => throw new NotImplementedException()
+            };
+        };
+        listView.CreateControl();
+
+        AccessibleObject accessibleObject = listView.AccessibilityObject;
+        listView.Items[0].Focused = true;
+        listView.OnGotFocus(new EventArgs());
+        var clone = (ListViewItem)listView.Items[0].Clone();
+        clone.Checked = true;
+        Action action = () => listView.OnItemChecked(new ItemCheckedEventArgs(clone));
+        action.Should().NotThrow();
+    }
+
     public static IEnumerable<object[]> ListView_Checkboxes_VirtualMode_Disabling_TestData()
     {
         foreach (View view in Enum.GetValues(typeof(View)))
@@ -6134,6 +6168,8 @@ public class ListViewTests
         public new void OnAfterLabelEdit(LabelEditEventArgs e) => base.OnAfterLabelEdit(e);
 
         public new void OnCacheVirtualItems(CacheVirtualItemsEventArgs e) => base.OnCacheVirtualItems(e);
+
+        public new void OnItemChecked(ItemCheckedEventArgs e) => base.OnItemChecked(e);
     }
 
     private SubListView GetSubListViewWithData(View view, bool virtualMode, bool showGroups, bool withinGroup, bool createControl)


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #11658

Add `e.item.ListView == this` to the OnItemChecked method to avoid throwing an accessiblity object not created exception when the ListViewItem is a clone.

## Proposed changes

- Verify that this item belongs to this ListView in OnItemChecked method.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- When the ListViewItem is a clone, the OnItemChecked method does not throw an accessiblity object not created exception.

## Regression? 

- Yes

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![2](https://github.com/user-attachments/assets/9b07ad74-f5d0-4d52-b331-7b7bee9a72c1)

### After

![1](https://github.com/user-attachments/assets/30585e1f-a108-4a49-9cbe-c883145ebfe4)


## Test methodology <!-- How did you ensure quality? -->

- Manually

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

- 9.0.100-preview.7.24407.12


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11892)