### PR TITLE
Fix DesignerSerializationVisibility code fixes both for VB and C#

### DIFF
--- a/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/Analyzers/MissingPropertySerializationConfiguration/ControlPropertySerializationDiagnosticAnalyzerTest.cs
+++ b/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/Analyzers/MissingPropertySerializationConfiguration/ControlPropertySerializationDiagnosticAnalyzerTest.cs
@@ -109,22 +109,25 @@ public class ControlPropertySerializationDiagnosticAnalyzerTest
             [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
             public float ScaleFactor { get; set; } = 1.0f;
 
+            [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
             public SizeF ScaledSize
             {
                 get => _scaleSize;
                 set => _scaleSize = value;
             }
 
+            [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
             public PointF ScaledLocation { get; set; }
         }
+
         """;
 
     // We are testing the analyzer with all versions of the .NET SDK from 6.0 on.
     public static IEnumerable<object[]> GetReferenceAssemblies()
     {
-        // yield return [ReferenceAssemblies.Net.Net60Windows];
-        // yield return [ReferenceAssemblies.Net.Net70Windows];
-        // yield return [ReferenceAssemblies.Net.Net80Windows];
+        yield return [ReferenceAssemblies.Net.Net60Windows];
+        yield return [ReferenceAssemblies.Net.Net70Windows];
+        yield return [ReferenceAssemblies.Net.Net80Windows];
         yield return [ReferenceAssemblies.Net.Net90Windows];
     }
 

--- a/src/System.Windows.Forms.Analyzers.CodeFixes.CSharp/System/Windows/Forms/CSharp/CodeFixes/AddDesignerSerializationVisibility/AddDesignerSerializationVisibilityCodeFixProvider.cs
+++ b/src/System.Windows.Forms.Analyzers.CodeFixes.CSharp/System/Windows/Forms/CSharp/CodeFixes/AddDesignerSerializationVisibility/AddDesignerSerializationVisibilityCodeFixProvider.cs
@@ -119,22 +119,22 @@ internal sealed class AddDesignerSerializationVisibilityCodeFixProvider : CodeFi
             .OfType<CompilationUnitSyntax>()
             .First();
 
-        var originalCompilationUnit = compilationUnit;
+        CompilationUnitSyntax originalCompilationUnit = compilationUnit;
 
         if (!hasUsings)
         {
             // We need to add a new line before the namespace/file-scoped-namespace declaration:
-            SyntaxTriviaList? leadingTriviaForNamespace = compilationUnit
+            SyntaxTriviaList? firstNodesLeadingTrivia = compilationUnit
                 .DescendantNodes()
-                .OfType<BaseNamespaceDeclarationSyntax>()
                 .FirstOrDefault()
                 .GetLeadingTrivia();
 
-            if (leadingTriviaForNamespace is not null)
-            {
-                compilationUnit = compilationUnit
-                    .WithLeadingTrivia(leadingTriviaForNamespace.Value.Add(SyntaxFactory.CarriageReturnLineFeed));
-            }
+            compilationUnit = firstNodesLeadingTrivia is null
+                ? compilationUnit
+                    .WithLeadingTrivia(SyntaxFactory.CarriageReturnLineFeed)
+                : compilationUnit
+                    .WithLeadingTrivia(firstNodesLeadingTrivia.Value
+                        .Add(SyntaxFactory.CarriageReturnLineFeed));
         }
 
         UsingDirectiveSyntax usingDirective = SyntaxFactory

--- a/src/System.Windows.Forms.Analyzers.CodeFixes.VisualBasic/AddDesignerSerializationVisibility/AddDesignerSerializationVisibilityCodeFixProvider.vb
+++ b/src/System.Windows.Forms.Analyzers.CodeFixes.VisualBasic/AddDesignerSerializationVisibility/AddDesignerSerializationVisibilityCodeFixProvider.vb
@@ -116,25 +116,60 @@ Namespace Global.System.Windows.Forms.VisualBasic.CodeFixes.AddDesignerSerializa
             ' Produce a new root, which has the updated property with the attribute.
             root = root.ReplaceNode(propertyDeclarationSyntax, newProperty)
 
-            ' Let's check if we already have the imports statement:
-            If Not root.DescendantNodes().OfType(Of ImportsStatementSyntax)().
-                    Any(Function(u) u.ImportsClauses.OfType(Of SimpleImportsClauseSyntax)().
-                        Any(Function(i) i.Name.ToString() = SystemComponentModelName)) Then
+            ' Let's check if we already have the Imports directive:
+            If root.DescendantNodes().
+                OfType(Of ImportsStatementSyntax)().
+                Any(Function(i) i?.ImportsClauses.FirstOrDefault()?.ToString() = SystemComponentModelName) Then
 
-                Dim importsStatement As ImportsStatementSyntax = SyntaxFactory.
+                document = document.WithSyntaxRoot(root)
+                Return document
+            End If
+
+            ' Let's check if we have _an_ Imports directive:
+            Dim hasImports As Boolean = root.DescendantNodes().
+                OfType(Of ImportsStatementSyntax)().
+                FirstOrDefault() IsNot Nothing
+
+            ' Get the compilation unit:
+            Dim compilationUnit As CompilationUnitSyntax = root.
+                DescendantNodesAndSelf().
+                OfType(Of CompilationUnitSyntax)().
+                First()
+
+            Dim originalCompilationUnit = compilationUnit
+
+            If Not hasImports Then
+
+                ' We need to add a new line before the namespace/file-scoped-namespace declaration:
+                Dim firstNodesLeadingTrivia As SyntaxTriviaList? = compilationUnit.
+                    DescendantNodes().
+                    FirstOrDefault().
+                    GetLeadingTrivia()
+
+                compilationUnit = If(
+                    firstNodesLeadingTrivia IsNot Nothing,
+                    compilationUnit.WithLeadingTrivia(firstNodesLeadingTrivia.Value.
+                            Add(SyntaxFactory.CarriageReturnLineFeed)),
+                    compilationUnit.WithLeadingTrivia(SyntaxFactory.CarriageReturnLineFeed))
+            End If
+
+            Dim importsStatement As ImportsStatementSyntax = SyntaxFactory.
                     ImportsStatement(SyntaxFactory.SingletonSeparatedList(Of ImportsClauseSyntax)(
                         SyntaxFactory.SimpleImportsClause(
                             SyntaxFactory.ParseName(SystemComponentModelName)))).
                     WithAdditionalAnnotations(Simplifier.Annotation, Formatter.Annotation)
 
-                ' We need to add the imports statement:
-                Dim firstNode As SyntaxNode = root.DescendantNodes().First()
-                root = root.InsertNodesBefore(firstNode, {importsStatement})
-            End If
-
-            document = document.WithSyntaxRoot(root)
+            importsStatement = importsStatement.
+                NormalizeWhitespace().
+                WithTrailingTrivia(SyntaxFactory.CarriageReturnLineFeed).
+                WithAdditionalAnnotations(Formatter.Annotation)
 
             ' Generate the new document:
+            document = document.WithSyntaxRoot(
+                root.ReplaceNode(
+                    originalCompilationUnit,
+                    compilationUnit.AddImports(importsStatement)))
+
             Return document
         End Function
     End Class

--- a/src/System.Windows.Forms.Analyzers.VisualBasic/tests/UnitTests/System.Windows.Forms.Analyzers.VisualBasic.Tests/MissingPropertySerializationConfigurationAnalyzerTest.vb
+++ b/src/System.Windows.Forms.Analyzers.VisualBasic/tests/UnitTests/System.Windows.Forms.Analyzers.VisualBasic.Tests/MissingPropertySerializationConfigurationAnalyzerTest.vb
@@ -8,8 +8,7 @@ Imports Xunit
 Public Class ControlPropertySerializationDiagnosticAnalyzerTest
 
     Private Const ProblematicCode As String =
-"
-Imports System.Drawing
+"Imports System.Drawing
 Imports System.Windows.Forms
 
 Namespace VBControls
@@ -76,9 +75,9 @@ End Namespace
 "
 
     Private Const FixedCode As String =
-"Imports System.ComponentModel
-Imports System.Drawing
+"Imports System.Drawing
 Imports System.Windows.Forms
+Imports System.ComponentModel
 
 Namespace VBControls
 


### PR DESCRIPTION
We found some additional cases, where the new code fixes which inserts the `DesignerSerializationVisibility` Attribute, do not act as expected, when they need to add `using` or `Imports` statements.

* When no usings existed before, a cast failed both for VB and for C#, so the Imports/Using did not get added.
* The formatting/simplifying of the properties whose `DesignerSerializationVisibility` attribute got added, was overzealous and did more than it was supposed to. It's really limited now to the sheer adding of the attribute.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11904)