### PR TITLE
Dark mode/Visual Styles (VB Only) fix

### DIFF
--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBase.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBase.vb
@@ -550,6 +550,10 @@ Namespace Microsoft.VisualBasic.ApplicationServices
             Debug.Assert(dpiSetResult, "We could net set the HighDpiMode.")
 
             ' Now, let's set VisualStyles and ColorMode:
+            If (_enableVisualStyles) Then
+                Application.EnableVisualStyles()
+            End If
+
             Application.SetColorMode(_colorMode)
 
 #Enable Warning WFO5001 ' Type is for evaluation purposes only and is subject to change or removal in future updates.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
@@ -50,7 +50,7 @@ public sealed partial class Application
 
     private const string DarkModeKeyPath = "HKEY_CURRENT_USER\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize";
     private const string DarkModeKey = "AppsUseLightTheme";
-    private const int SystemDarkModeDisabled = -1;
+    private const int SystemDarkModeDisabled = 1;
 
     /// <summary>
     ///  Events the user can hook into
@@ -284,7 +284,7 @@ public sealed partial class Application
                 return;
             }
 
-            if (GetSystemColorModeInternal() > SystemDarkModeDisabled)
+            if (GetSystemColorModeInternal() != SystemDarkModeDisabled)
             {
                 s_systemColorMode = SystemColorMode.Dark;
                 return;
@@ -367,10 +367,11 @@ public sealed partial class Application
 
         try
         {
-            systemColorMode = (Registry.GetValue(
+            // 0 for dark mode and |1| for light mode.
+            systemColorMode = Math.Abs((Registry.GetValue(
                 keyName: DarkModeKeyPath,
                 valueName: DarkModeKey,
-                defaultValue: SystemDarkModeDisabled) as int?) ?? systemColorMode;
+                defaultValue: SystemDarkModeDisabled) as int?) ?? systemColorMode);
         }
         catch (Exception ex) when (!ex.IsCriticalException())
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
@@ -252,11 +252,7 @@ public sealed partial class Application
     /// </summary>
     [Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
     public static SystemColorMode ColorMode =>
-        !s_systemColorMode.HasValue
-            ? SystemColorMode.Classic
-            : s_systemColorMode.Value == SystemColorMode.System
-                ? SystemColorMode
-                : s_systemColorMode.Value;
+        s_systemColorMode ?? SystemColorMode.Classic;
 
     /// <summary>
     ///  Sets the default dark mode for the application.
@@ -388,7 +384,7 @@ public sealed partial class Application
     [Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
     public static bool IsDarkModeEnabled =>
         !SystemInformation.HighContrast
-        && (ColorMode == SystemColorMode.Dark);
+        && (SystemColorMode == SystemColorMode.Dark);
 
     /// <summary>
     ///  Gets the path for the executable file that started the application.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
@@ -50,7 +50,7 @@ public sealed partial class Application
 
     private const string DarkModeKeyPath = "HKEY_CURRENT_USER\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize";
     private const string DarkModeKey = "AppsUseLightTheme";
-    private const int DarkModeNotAvailable = -1;
+    private const int SystemDarkModeDisabled = -1;
 
     /// <summary>
     ///  Events the user can hook into
@@ -277,9 +277,16 @@ public sealed partial class Application
                 return;
             }
 
-            if (GetSystemColorModeInternal() > -1)
+            if ((systemColorMode == SystemColorMode.Dark && IsSystemDarkModeAvailable)
+                || systemColorMode == SystemColorMode.Classic)
             {
                 s_systemColorMode = systemColorMode;
+                return;
+            }
+
+            if (GetSystemColorModeInternal() > SystemDarkModeDisabled)
+            {
+                s_systemColorMode = SystemColorMode.Dark;
                 return;
             }
 
@@ -348,34 +355,32 @@ public sealed partial class Application
             ? SystemColorMode.Dark
             : SystemColorMode.Classic;
 
-    // Returns 0 if dark mode is available, otherwise -1 (DarkModeNotAvailable)
+    // Returns 0 if dark mode is enabled in the system, otherwise -1 (SystemDarkModeDisabled)
     private static int GetSystemColorModeInternal()
     {
-        if (SystemInformation.HighContrast)
+        if (!IsSystemDarkModeAvailable)
         {
-            return DarkModeNotAvailable;
+            return SystemDarkModeDisabled;
         }
 
-        int systemColorMode = DarkModeNotAvailable;
+        int systemColorMode = SystemDarkModeDisabled;
 
-        // Dark mode is supported when we are >= W11/22000
-        // Technically, we could go earlier, but then the APIs we're using weren't officially public.
-        if (OsVersion.IsWindows11_OrGreater())
+        try
         {
-            try
-            {
-                systemColorMode = (Registry.GetValue(
-                    keyName: DarkModeKeyPath,
-                    valueName: DarkModeKey,
-                    defaultValue: DarkModeNotAvailable) as int?) ?? systemColorMode;
-            }
-            catch (Exception ex) when (!ex.IsCriticalException())
-            {
-            }
+            systemColorMode = (Registry.GetValue(
+                keyName: DarkModeKeyPath,
+                valueName: DarkModeKey,
+                defaultValue: SystemDarkModeDisabled) as int?) ?? systemColorMode;
+        }
+        catch (Exception ex) when (!ex.IsCriticalException())
+        {
         }
 
         return systemColorMode;
     }
+
+    private static bool IsSystemDarkModeAvailable =>
+        !SystemInformation.HighContrast && OsVersion.IsWindows11_OrGreater();
 
     /// <summary>
     ///  Gets a value indicating whether the application is running in a dark system color context.
@@ -384,7 +389,7 @@ public sealed partial class Application
     [Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
     public static bool IsDarkModeEnabled =>
         !SystemInformation.HighContrast
-        && (SystemColorMode == SystemColorMode.Dark);
+        && (ColorMode == SystemColorMode.Dark);
 
     /// <summary>
     ///  Gets the path for the executable file that started the application.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -2496,7 +2496,7 @@ public partial class Form : ContainerControl
     [Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
     protected virtual void OnFormCaptionTextColorChanged(EventArgs e)
     {
-        if (Events[s_formCaptionBackColorChanged] is EventHandler eventHandler)
+        if (Events[s_formCaptionTextColorChanged] is EventHandler eventHandler)
         {
             eventHandler(this, e);
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -2314,8 +2314,21 @@ public partial class Form : ContainerControl
     }
 
     /// <summary>
-    ///  Sets or gets the rounding style of the corners using the <see cref="FormCornerPreference"/> enum.
+    ///  Sets or gets the rounding style of the Form's corners using the <see cref="FormCornerPreference"/> enum.
     /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   Note: Reading this property is only for tracking purposes. If the Form's corner preference is
+    ///   changed through other external means (Win32 calls), reading this property will not reflect
+    ///   those changes, as the Win32 API does not provide a mechanism to retrieve the current title
+    ///   bar color.
+    ///  </para>
+    ///  <para>
+    ///   The property only reflects the value that was previously set using this property. The
+    ///   <see cref="FormCornerPreferenceChanged"/> event is raised accordingly when the value is
+    ///   changed, which allows the property to be participating in binding scenarios.
+    ///  </para>
+    /// </remarks>
     [DefaultValue(FormCornerPreference.Default)]
     [SRCategory(nameof(SR.CatWindowStyle))]
     [SRDescription(nameof(SR.FormCornerPreferenceDescr))]
@@ -2341,7 +2354,14 @@ public partial class Form : ContainerControl
                 _ => throw new ArgumentOutOfRangeException(nameof(value))
             };
 
-            Properties.AddOrRemoveValue(s_propFormCornerPreference, value);
+            if (value == FormCornerPreference.Default)
+            {
+                Properties.RemoveValue(s_propFormCornerPreference);
+            }
+            else
+            {
+                Properties.AddValue(s_propFormCornerPreference, value);
+            }
 
             if (IsHandleCreated)
             {
@@ -2388,6 +2408,19 @@ public partial class Form : ContainerControl
     /// <summary>
     ///  Sets or gets the Form's border color.
     /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   Note: Reading this property is only for tracking purposes. If the Form's border color is
+    ///   changed through other external means (Win32 calls), reading this property will not reflect
+    ///   those changes, as the Win32 API does not provide a mechanism to retrieve the current title
+    ///   bar color.
+    ///  </para>
+    ///  <para>
+    ///   The property only reflects the value that was previously set using this property. The
+    ///   <see cref="FormBorderColorChanged"/> event is raised accordingly when the value is
+    ///   changed, which allows the property to be participating in binding scenarios.
+    ///  </para>
+    /// </remarks>
     [SRCategory(nameof(SR.CatWindowStyle))]
     [SRDescription(nameof(SR.FormBorderColorDescr))]
     [Browsable(false)]
@@ -2427,6 +2460,19 @@ public partial class Form : ContainerControl
     /// <summary>
     ///  Sets or gets the Form's title bar back color.
     /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   Note: Reading this property is only for tracking purposes. If the window's title bar color is
+    ///   changed through other external means (Win32 calls), reading this property will not reflect
+    ///   those changes, as the Win32 API does not provide a mechanism to retrieve the current title
+    ///   bar color.
+    ///  </para>
+    ///  <para>
+    ///   The property only reflects the value that was previously set using this property. The
+    ///   <see cref="FormCaptionBackColorChanged"/> event is raised accordingly when the value is
+    ///   changed, which allows the property to be participating in binding scenarios.
+    ///  </para>
+    /// </remarks>
     [SRCategory(nameof(SR.CatWindowStyle))]
     [SRDescription(nameof(SR.FormCaptionBackColorDescr))]
     [Browsable(false)]
@@ -2454,6 +2500,19 @@ public partial class Form : ContainerControl
     /// <summary>
     ///  Raises the <see cref="FormCaptionBackColor"/> event when the <see cref="FormCaptionBackColor"/> property changes.
     /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   Note: Reading this property is only for tracking purposes. If the Form's title bar's back color
+    ///   (window caption background) is changed through other external means (Win32 calls), reading this
+    ///   property will not reflect those changes, as the Win32 API does not provide a mechanism to retrieve
+    ///   the current title bar color.
+    ///  </para>
+    ///  <para>
+    ///   The property only reflects the value that was previously set using this property. The
+    ///   <see cref="FormBorderColorChanged"/> event is raised accordingly when the value is
+    ///   changed, which allows the property to be participating in binding scenarios.
+    ///  </para>
+    /// </remarks>
     [Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
     protected virtual void OnFormCaptionBackColorChanged(EventArgs e)
     {
@@ -2464,8 +2523,21 @@ public partial class Form : ContainerControl
     }
 
     /// <summary>
-    ///  Sets or gets the Form's title bar back color.
+    ///  Sets or gets the Form's title bar text color.
     /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   Note: Reading this property is only for tracking purposes. If the Form's title bar's text color
+    ///   (window caption text) is changed through other external means (Win32 calls), reading this property
+    ///   will not reflect those changes, as the Win32 API does not provide a mechanism to retrieve the
+    ///   current title bar color.
+    ///  </para>
+    ///  <para>
+    ///   The property only reflects the value that was previously set using this property. The
+    ///   <see cref="FormBorderColorChanged"/> event is raised accordingly when the value is
+    ///   changed, which allows the property to be participating in binding scenarios.
+    ///  </para>
+    /// </remarks>
     [SRCategory(nameof(SR.CatWindowStyle))]
     [SRDescription(nameof(SR.FormCaptionTextColorDescr))]
     [Browsable(false)]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -4309,6 +4309,29 @@ public partial class Form : ContainerControl
     {
         _formStateEx[s_formStateExUseMdiChildProc] = (IsMdiChild && Visible) ? 1 : 0;
         base.OnHandleCreated(e);
+
+        if (Properties.TryGetValue(s_propFormBorderColor, out Color? formBorderColor))
+        {
+            SetFormAttributeColorInternal(DWMWINDOWATTRIBUTE.DWMWA_BORDER_COLOR, formBorderColor.Value);
+        }
+
+        if (Properties.TryGetValue(s_propFormCaptionBackColor, out Color? formCaptionBackColor))
+        {
+            SetFormAttributeColorInternal(DWMWINDOWATTRIBUTE.DWMWA_CAPTION_COLOR, formCaptionBackColor.Value);
+        }
+
+        if (Properties.TryGetValue(s_propFormCaptionTextColor, out Color? formCaptionTextColor))
+        {
+            SetFormAttributeColorInternal(DWMWINDOWATTRIBUTE.DWMWA_TEXT_COLOR, formCaptionTextColor.Value);
+        }
+
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+        if (Properties.TryGetValue(s_propFormCornerPreference, out FormCornerPreference? cornerPreference))
+        {
+            SetFormCornerPreferenceInternal(cornerPreference.Value);
+        }
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
         UpdateLayered();
     }
 
@@ -5912,7 +5935,7 @@ public partial class Form : ContainerControl
     ///   This method immediately returns, even if the form is large and takes a long time to be set up.
     ///  </para>
     ///  <para>
-    ///   If the form is already displayed asynchronously by <see cref="Form.ShowAsync"/>, an <see cref="InvalidOperationException"/> will be thrown.
+    ///   If the form is already displayed asynchronously by <see cref="ShowAsync"/>, an <see cref="InvalidOperationException"/> will be thrown.
     ///  </para>
     ///  <para>
     ///   An <see cref="InvalidOperationException"/> will also occur if no <see cref="WindowsFormsSynchronizationContext"/> could be retrieved or installed.
@@ -5947,7 +5970,7 @@ public partial class Form : ContainerControl
     ///   This method immediately returns, even if the form is large and takes a long time to be set up.
     ///  </para>
     ///  <para>
-    ///   If the form is already displayed asynchronously by <see cref="Form.ShowAsync"/>, an <see cref="InvalidOperationException"/> will be thrown.
+    ///   If the form is already displayed asynchronously by <see cref="ShowAsync"/>, an <see cref="InvalidOperationException"/> will be thrown.
     ///  </para>
     ///  <para>
     ///   An <see cref="InvalidOperationException"/> will also occur if no <see cref="WindowsFormsSynchronizationContext"/> could be retrieved or installed.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -135,6 +135,10 @@ public partial class Form : ContainerControl
     private static readonly int s_propOpacity = PropertyStore.CreateKey();
     private static readonly int s_propTransparencyKey = PropertyStore.CreateKey();
     private static readonly int s_propFormCornerPreference = PropertyStore.CreateKey();
+    private static readonly int s_propFormBorderColor = PropertyStore.CreateKey();
+
+    private static readonly int s_propFormCaptionTextColor = PropertyStore.CreateKey();
+    private static readonly int s_propFormCaptionBackColor = PropertyStore.CreateKey();
 
     // Form per instance members
     // Note: Do not add anything to this list unless absolutely necessary.
@@ -2376,6 +2380,9 @@ public partial class Form : ContainerControl
     ///  Raises the <see cref="FormCornerPreferenceChanged"/> event when the
     ///  <see cref="FormCornerPreference"/> property changes.
     /// </summary>
+    /// <param name="e">
+    ///  An <see cref="EventArgs"/> that contains the event data, in this case empty.
+    /// </param>
     [Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
     protected virtual void OnFormCornerPreferenceChanged(EventArgs e)
     {
@@ -2408,6 +2415,11 @@ public partial class Form : ContainerControl
     /// <summary>
     ///  Sets or gets the Form's border color.
     /// </summary>
+    /// <returns>
+    ///  The <see cref="Color"/> which has be previously set using this property or <see cref="Color.Empty"/>.
+    ///  Note that the underlying Win32 API does not provide a reliable mechanism to retrieve the current
+    ///  border color.
+    /// </returns>
     /// <remarks>
     ///  <para>
     ///   Note: Reading this property is only for tracking purposes. If the Form's border color is
@@ -2428,13 +2440,15 @@ public partial class Form : ContainerControl
     [Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
     public Color FormBorderColor
     {
-        get => GetFormAttributeColorInternal(DWMWINDOWATTRIBUTE.DWMWA_BORDER_COLOR);
+        get => Properties.GetValueOrDefault(s_propFormBorderColor, Color.Empty);
         set
         {
             if (value == FormBorderColor)
             {
                 return;
             }
+
+            Properties.AddValue(s_propFormBorderColor, value);
 
             if (IsHandleCreated)
             {
@@ -2448,6 +2462,9 @@ public partial class Form : ContainerControl
     /// <summary>
     ///  Raises the <see cref="FormBorderColorChanged"/> event when the <see cref="FormBorderColor"/> property changes.
     /// </summary>
+    /// <param name="e">
+    ///  An <see cref="EventArgs"/> that contains the event data, in this case empty.
+    /// </param>
     [Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
     protected virtual void OnFormBorderColorChanged(EventArgs e)
     {
@@ -2458,8 +2475,13 @@ public partial class Form : ContainerControl
     }
 
     /// <summary>
-    ///  Sets or gets the Form's title bar back color.
+    ///  Sets or gets the Form's title bar back color (caption back color).
     /// </summary>
+    /// <returns>
+    ///  The <see cref="Color"/>, which has be previously set using this property or <see cref="Color.Empty"/>.
+    ///  Note that the underlying Win32 API does not provide a reliable mechanism to retrieve the current title
+    ///  bar color.
+    /// </returns>
     /// <remarks>
     ///  <para>
     ///   Note: Reading this property is only for tracking purposes. If the window's title bar color is
@@ -2480,13 +2502,15 @@ public partial class Form : ContainerControl
     [Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
     public Color FormCaptionBackColor
     {
-        get => GetFormAttributeColorInternal(DWMWINDOWATTRIBUTE.DWMWA_CAPTION_COLOR);
+        get => Properties.GetValueOrDefault(s_propFormCaptionBackColor, Color.Empty);
         set
         {
             if (value == FormCaptionBackColor)
             {
                 return;
             }
+
+            Properties.AddValue(s_propFormCaptionBackColor, value);
 
             if (IsHandleCreated)
             {
@@ -2498,21 +2522,12 @@ public partial class Form : ContainerControl
     }
 
     /// <summary>
-    ///  Raises the <see cref="FormCaptionBackColor"/> event when the <see cref="FormCaptionBackColor"/> property changes.
+    ///  Raises the <see cref="FormCaptionBackColorChanged"/> event when the <see cref="FormCaptionBackColor"/>
+    ///  property changes.
     /// </summary>
-    /// <remarks>
-    ///  <para>
-    ///   Note: Reading this property is only for tracking purposes. If the Form's title bar's back color
-    ///   (window caption background) is changed through other external means (Win32 calls), reading this
-    ///   property will not reflect those changes, as the Win32 API does not provide a mechanism to retrieve
-    ///   the current title bar color.
-    ///  </para>
-    ///  <para>
-    ///   The property only reflects the value that was previously set using this property. The
-    ///   <see cref="FormBorderColorChanged"/> event is raised accordingly when the value is
-    ///   changed, which allows the property to be participating in binding scenarios.
-    ///  </para>
-    /// </remarks>
+    /// <param name="e">
+    ///  An <see cref="EventArgs"/> that contains the event data, in this case empty.
+    /// </param>
     [Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
     protected virtual void OnFormCaptionBackColorChanged(EventArgs e)
     {
@@ -2523,8 +2538,13 @@ public partial class Form : ContainerControl
     }
 
     /// <summary>
-    ///  Sets or gets the Form's title bar text color.
+    ///  Sets or gets the Form's title bar text color (windows caption text color).
     /// </summary>
+    /// <returns>
+    ///  The <see cref="Color"/>, which has be previously set using this property or <see cref="Color.Empty"/>.
+    ///  Note that the underlying Win32 API does not provide a reliable mechanism to retrieve the current title
+    ///  bar text color.
+    /// </returns>
     /// <remarks>
     ///  <para>
     ///   Note: Reading this property is only for tracking purposes. If the Form's title bar's text color
@@ -2534,7 +2554,7 @@ public partial class Form : ContainerControl
     ///  </para>
     ///  <para>
     ///   The property only reflects the value that was previously set using this property. The
-    ///   <see cref="FormBorderColorChanged"/> event is raised accordingly when the value is
+    ///   <see cref="FormCaptionTextColorChanged"/> event is raised accordingly when the value is
     ///   changed, which allows the property to be participating in binding scenarios.
     ///  </para>
     /// </remarks>
@@ -2545,13 +2565,15 @@ public partial class Form : ContainerControl
     [Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
     public Color FormCaptionTextColor
     {
-        get => GetFormAttributeColorInternal(DWMWINDOWATTRIBUTE.DWMWA_TEXT_COLOR);
+        get => Properties.GetValueOrDefault(s_propFormCaptionTextColor, Color.Empty);
         set
         {
             if (value == FormCaptionTextColor)
             {
                 return;
             }
+
+            Properties.AddValue(s_propFormCaptionTextColor, value);
 
             if (IsHandleCreated)
             {
@@ -2563,8 +2585,12 @@ public partial class Form : ContainerControl
     }
 
     /// <summary>
-    ///  Raises the <see cref="FormCaptionTextColor"/> event when the <see cref="FormCaptionTextColor"/> property changes.
+    ///  Raises the <see cref="FormCaptionTextColorChanged"/> event when the
+    ///  <see cref="FormCaptionTextColor"/> property changes.
     /// </summary>
+    /// <param name="e">
+    ///  An <see cref="EventArgs"/> that contains the event data, in this case empty.
+    /// </param>
     [Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
     protected virtual void OnFormCaptionTextColorChanged(EventArgs e)
     {


### PR DESCRIPTION
* Fixes issue where in Visual Basic the "classic" Visual Styles are no longer get set. (This is a breaking change, since in VB the classic Visual Styles are no longer set, even if they are enabled in the VS App Framework Property Pages.) 
NOTE: This has nothing to do with the originally considered `VisualStylesMode` Experimental feature in the dark mode context.

* Fixes issue where instead of the `FormCaptionTextColorChanged` event the `FormCaptionBackColorChanged` event is raised (This is not a breaking change, since these are completely new events.)

Fixes #11898.
Fixes #11897.
Fixes #11895.
Fixes #11910.


