### PR TITLE
[RC1/9.0] Backport Dark Mode fix

### DIFF
--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBase.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBase.vb
@@ -550,6 +550,10 @@ Namespace Microsoft.VisualBasic.ApplicationServices
             Debug.Assert(dpiSetResult, "We could net set the HighDpiMode.")
 
             ' Now, let's set VisualStyles and ColorMode:
+            If (_enableVisualStyles) Then
+                Application.EnableVisualStyles()
+            End If
+
             Application.SetColorMode(_colorMode)
 
 #Enable Warning WFO5001 ' Type is for evaluation purposes only and is subject to change or removal in future updates.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
@@ -45,12 +45,12 @@ public sealed partial class Application
     private static bool s_useWaitCursor;
 
 #pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-    private static SystemColorMode? s_systemColorMode;
+    private static SystemColorMode? s_colorMode;
 #pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
     private const string DarkModeKeyPath = "HKEY_CURRENT_USER\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize";
     private const string DarkModeKey = "AppsUseLightTheme";
-    private const int DarkModeNotAvailable = -1;
+    private const int SystemDarkModeDisabled = 1;
 
     /// <summary>
     ///  Events the user can hook into
@@ -247,27 +247,51 @@ public sealed partial class Application
         => ThreadContext.FromCurrent().CustomThreadExceptionHandlerAttached;
 
     /// <summary>
-    ///  Gets the default dark mode for the application. This is the SystemColorMode which either has been set
-    ///  by <see cref="SetColorMode(SystemColorMode)"/> or its default value <see cref="SystemColorMode.Classic"/>.
+    ///  Gets the default color mode (dark mode) for the application.
     /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///    This is the <see cref="SystemColorMode"/> which either has been set by <see cref="SetColorMode(SystemColorMode)"/>
+    ///    or its default value <see cref="SystemColorMode.Classic"/>. If it has been set to <see cref="SystemColorMode.System"/>,
+    ///    then the actual color mode is determined by the system settings (which can be retrieved by the
+    ///    static (shared in VB) <see cref="Application.SystemColorMode"/> property.
+    ///  </para>
+    /// </remarks>
     [Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
     public static SystemColorMode ColorMode =>
-        !s_systemColorMode.HasValue
-            ? SystemColorMode.Classic
-            : s_systemColorMode.Value == SystemColorMode.System
-                ? SystemColorMode
-                : s_systemColorMode.Value;
+        s_colorMode ?? SystemColorMode.Classic;
 
     /// <summary>
-    ///  Sets the default dark mode for the application.
+    ///  Sets the default color mode (dark mode) for the application.
     /// </summary>
-    /// <param name="systemColorMode">The default dark mode to set.</param>
+    /// <param name="systemColorMode">The application's default color mode (dark mode) to set.</param>
+    /// <remarks>
+    ///  <para>
+    ///    You should use this method to set the default color mode (dark mode) for the application. Set it,
+    ///    before creating any UI elements, to ensure that the correct color mode is used. You can set it to
+    ///    dark mode (<see cref="SystemColorMode.Dark"/>), light mode (<see cref="SystemColorMode.Classic"/>)
+    ///    or to the system setting (<see cref="SystemColorMode.System"/>).
+    ///  </para>
+    ///  <para>
+    ///    If you set it to <see cref="SystemColorMode.System"/>, the actual color mode is determined by the
+    ///    Windows system settings. If the system setting is changed, the application will not automatically
+    ///    adapt to the new setting.
+    ///  </para>
+    ///  <para>
+    ///    Note that the dark color mode is only available from Windows 11 on or later versions. If the system
+    ///    is set to a high contrast mode, the dark mode is not available.
+    ///  </para>
+    ///  <para>
+    ///    <b>Note for Visual Basic:</b> If you are using the Visual Basic Application Framework, you should set the
+    ///    color mode by handling the Application Events (see "WindowsFormsApplicationBase.ApplyApplicationDefaults").
+    ///  </para>
+    /// </remarks>
     [Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
     public static void SetColorMode(SystemColorMode systemColorMode)
     {
         try
         {
-            // Can't use the Generator here, since it cannot deal with experimentals.
+            // Can't use the Generator here, since it cannot deal with [Experimental].
             _ = systemColorMode switch
             {
                 SystemColorMode.Classic => systemColorMode,
@@ -276,18 +300,12 @@ public sealed partial class Application
                 _ => throw new ArgumentOutOfRangeException(nameof(systemColorMode))
             };
 
-            if (systemColorMode == s_systemColorMode)
+            if (systemColorMode == s_colorMode)
             {
                 return;
             }
 
-            if (GetSystemColorModeInternal() > -1)
-            {
-                s_systemColorMode = systemColorMode;
-                return;
-            }
-
-            s_systemColorMode = SystemColorMode.Classic;
+            s_colorMode = systemColorMode;
         }
         finally
         {
@@ -315,6 +333,7 @@ public sealed partial class Application
             bool complete = false;
             bool success = PInvoke.SendMessageCallback(hwnd, PInvoke.WM_SYSCOLORCHANGE + MessageId.WM_REFLECT, () => complete = true);
             Debug.Assert(success);
+
             if (!success)
             {
                 return;
@@ -357,25 +376,21 @@ public sealed partial class Application
     {
         if (SystemInformation.HighContrast)
         {
-            return DarkModeNotAvailable;
+            return SystemDarkModeDisabled;
         }
 
-        int systemColorMode = DarkModeNotAvailable;
+        int systemColorMode = SystemDarkModeDisabled;
 
-        // Dark mode is supported when we are >= W11/22000
-        // Technically, we could go earlier, but then the APIs we're using weren't officially public.
-        if (OsVersion.IsWindows11_OrGreater())
+        try
         {
-            try
-            {
-                systemColorMode = (Registry.GetValue(
-                    keyName: DarkModeKeyPath,
-                    valueName: DarkModeKey,
-                    defaultValue: DarkModeNotAvailable) as int?) ?? systemColorMode;
-            }
-            catch (Exception ex) when (!ex.IsCriticalException())
-            {
-            }
+            // 0 for dark mode and |1| for light mode.
+            systemColorMode = Math.Abs((Registry.GetValue(
+                keyName: DarkModeKeyPath,
+                valueName: DarkModeKey,
+                defaultValue: SystemDarkModeDisabled) as int?) ?? systemColorMode);
+        }
+        catch (Exception ex) when (!ex.IsCriticalException())
+        {
         }
 
         return systemColorMode;
@@ -388,7 +403,8 @@ public sealed partial class Application
     [Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
     public static bool IsDarkModeEnabled =>
         !SystemInformation.HighContrast
-        && (ColorMode == SystemColorMode.Dark);
+        && (ColorMode == SystemColorMode.Dark
+            || (ColorMode == SystemColorMode.System && SystemColorMode == SystemColorMode.Dark));
 
     /// <summary>
     ///  Gets the path for the executable file that started the application.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -137,6 +137,10 @@ public partial class Form : ContainerControl
     private static readonly int s_propOpacity = PropertyStore.CreateKey();
     private static readonly int s_propTransparencyKey = PropertyStore.CreateKey();
     private static readonly int s_propFormCornerPreference = PropertyStore.CreateKey();
+    private static readonly int s_propFormBorderColor = PropertyStore.CreateKey();
+
+    private static readonly int s_propFormCaptionTextColor = PropertyStore.CreateKey();
+    private static readonly int s_propFormCaptionBackColor = PropertyStore.CreateKey();
 
     // Form per instance members
     // Note: Do not add anything to this list unless absolutely necessary.
@@ -2344,8 +2348,21 @@ public partial class Form : ContainerControl
     }
 
     /// <summary>
-    ///  Sets or gets the rounding style of the corners using the <see cref="FormCornerPreference"/> enum.
+    ///  Sets or gets the rounding style of the Form's corners using the <see cref="FormCornerPreference"/> enum.
     /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   Note: Reading this property is only for tracking purposes. If the Form's corner preference is
+    ///   changed through other external means (Win32 calls), reading this property will not reflect
+    ///   those changes, as the Win32 API does not provide a mechanism to retrieve the current title
+    ///   bar color.
+    ///  </para>
+    ///  <para>
+    ///   The property only reflects the value that was previously set using this property. The
+    ///   <see cref="FormCornerPreferenceChanged"/> event is raised accordingly when the value is
+    ///   changed, which allows the property to be participating in binding scenarios.
+    ///  </para>
+    /// </remarks>
     [DefaultValue(FormCornerPreference.Default)]
     [SRCategory(nameof(SR.CatWindowStyle))]
     [SRDescription(nameof(SR.FormCornerPreferenceDescr))]
@@ -2395,6 +2412,9 @@ public partial class Form : ContainerControl
     ///  Raises the <see cref="FormCornerPreferenceChanged"/> event when the
     ///  <see cref="FormCornerPreference"/> property changes.
     /// </summary>
+    /// <param name="e">
+    ///  An <see cref="EventArgs"/> that contains the event data, in this case empty.
+    /// </param>
     [Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
     protected virtual void OnFormCornerPreferenceChanged(EventArgs e)
     {
@@ -2427,6 +2447,24 @@ public partial class Form : ContainerControl
     /// <summary>
     ///  Sets or gets the Form's border color.
     /// </summary>
+    /// <returns>
+    ///  The <see cref="Color"/> which has be previously set using this property or <see cref="Color.Empty"/>.
+    ///  Note that the underlying Win32 API does not provide a reliable mechanism to retrieve the current
+    ///  border color.
+    /// </returns>
+    /// <remarks>
+    ///  <para>
+    ///   Note: Reading this property is only for tracking purposes. If the Form's border color is
+    ///   changed through other external means (Win32 calls), reading this property will not reflect
+    ///   those changes, as the Win32 API does not provide a mechanism to retrieve the current title
+    ///   bar color.
+    ///  </para>
+    ///  <para>
+    ///   The property only reflects the value that was previously set using this property. The
+    ///   <see cref="FormBorderColorChanged"/> event is raised accordingly when the value is
+    ///   changed, which allows the property to be participating in binding scenarios.
+    ///  </para>
+    /// </remarks>
     [SRCategory(nameof(SR.CatWindowStyle))]
     [SRDescription(nameof(SR.FormBorderColorDescr))]
     [Browsable(false)]
@@ -2434,13 +2472,18 @@ public partial class Form : ContainerControl
     [Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
     public Color FormBorderColor
     {
-        get => GetFormAttributeColorInternal(DWMWINDOWATTRIBUTE.DWMWA_BORDER_COLOR);
+        get => Properties.ContainsObject(s_propFormBorderColor)
+            ? Properties.GetColor(s_propFormBorderColor)
+            : Color.Empty;
+
         set
         {
             if (value == FormBorderColor)
             {
                 return;
             }
+
+            Properties.SetColor(s_propFormBorderColor, value);
 
             if (IsHandleCreated)
             {
@@ -2454,6 +2497,9 @@ public partial class Form : ContainerControl
     /// <summary>
     ///  Raises the <see cref="FormBorderColorChanged"/> event when the <see cref="FormBorderColor"/> property changes.
     /// </summary>
+    /// <param name="e">
+    ///  An <see cref="EventArgs"/> that contains the event data, in this case empty.
+    /// </param>
     [Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
     protected virtual void OnFormBorderColorChanged(EventArgs e)
     {
@@ -2464,8 +2510,26 @@ public partial class Form : ContainerControl
     }
 
     /// <summary>
-    ///  Sets or gets the Form's title bar back color.
+    ///  Sets or gets the Form's title bar back color (caption back color).
     /// </summary>
+    /// <returns>
+    ///  The <see cref="Color"/>, which has be previously set using this property or <see cref="Color.Empty"/>.
+    ///  Note that the underlying Win32 API does not provide a reliable mechanism to retrieve the current title
+    ///  bar color.
+    /// </returns>
+    /// <remarks>
+    ///  <para>
+    ///   Note: Reading this property is only for tracking purposes. If the window's title bar color is
+    ///   changed through other external means (Win32 calls), reading this property will not reflect
+    ///   those changes, as the Win32 API does not provide a mechanism to retrieve the current title
+    ///   bar color.
+    ///  </para>
+    ///  <para>
+    ///   The property only reflects the value that was previously set using this property. The
+    ///   <see cref="FormCaptionBackColorChanged"/> event is raised accordingly when the value is
+    ///   changed, which allows the property to be participating in binding scenarios.
+    ///  </para>
+    /// </remarks>
     [SRCategory(nameof(SR.CatWindowStyle))]
     [SRDescription(nameof(SR.FormCaptionBackColorDescr))]
     [Browsable(false)]
@@ -2473,13 +2537,18 @@ public partial class Form : ContainerControl
     [Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
     public Color FormCaptionBackColor
     {
-        get => GetFormAttributeColorInternal(DWMWINDOWATTRIBUTE.DWMWA_CAPTION_COLOR);
+        get => Properties.ContainsObject(s_propFormCaptionBackColor)
+            ? Properties.GetColor(s_propFormCaptionBackColor)
+            : Color.Empty;
+
         set
         {
             if (value == FormCaptionBackColor)
             {
                 return;
             }
+
+            Properties.SetColor(s_propFormCaptionBackColor, value);
 
             if (IsHandleCreated)
             {
@@ -2491,8 +2560,12 @@ public partial class Form : ContainerControl
     }
 
     /// <summary>
-    ///  Raises the <see cref="FormCaptionBackColor"/> event when the <see cref="FormCaptionBackColor"/> property changes.
+    ///  Raises the <see cref="FormCaptionBackColorChanged"/> event when the <see cref="FormCaptionBackColor"/>
+    ///  property changes.
     /// </summary>
+    /// <param name="e">
+    ///  An <see cref="EventArgs"/> that contains the event data, in this case empty.
+    /// </param>
     [Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
     protected virtual void OnFormCaptionBackColorChanged(EventArgs e)
     {
@@ -2503,8 +2576,26 @@ public partial class Form : ContainerControl
     }
 
     /// <summary>
-    ///  Sets or gets the Form's title bar back color.
+    ///  Sets or gets the Form's title bar text color (windows caption text color).
     /// </summary>
+    /// <returns>
+    ///  The <see cref="Color"/>, which has be previously set using this property or <see cref="Color.Empty"/>.
+    ///  Note that the underlying Win32 API does not provide a reliable mechanism to retrieve the current title
+    ///  bar text color.
+    /// </returns>
+    /// <remarks>
+    ///  <para>
+    ///   Note: Reading this property is only for tracking purposes. If the Form's title bar's text color
+    ///   (window caption text) is changed through other external means (Win32 calls), reading this property
+    ///   will not reflect those changes, as the Win32 API does not provide a mechanism to retrieve the
+    ///   current title bar color.
+    ///  </para>
+    ///  <para>
+    ///   The property only reflects the value that was previously set using this property. The
+    ///   <see cref="FormCaptionTextColorChanged"/> event is raised accordingly when the value is
+    ///   changed, which allows the property to be participating in binding scenarios.
+    ///  </para>
+    /// </remarks>
     [SRCategory(nameof(SR.CatWindowStyle))]
     [SRDescription(nameof(SR.FormCaptionTextColorDescr))]
     [Browsable(false)]
@@ -2512,13 +2603,17 @@ public partial class Form : ContainerControl
     [Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
     public Color FormCaptionTextColor
     {
-        get => GetFormAttributeColorInternal(DWMWINDOWATTRIBUTE.DWMWA_TEXT_COLOR);
+        get => Properties.ContainsObject(s_propFormCaptionTextColor)
+            ? Properties.GetColor(s_propFormCaptionTextColor)
+            : Color.Empty;
         set
         {
             if (value == FormCaptionTextColor)
             {
                 return;
             }
+
+            Properties.SetColor(s_propFormCaptionTextColor, value);
 
             if (IsHandleCreated)
             {
@@ -2530,12 +2625,16 @@ public partial class Form : ContainerControl
     }
 
     /// <summary>
-    ///  Raises the <see cref="FormCaptionTextColor"/> event when the <see cref="FormCaptionTextColor"/> property changes.
+    ///  Raises the <see cref="FormCaptionTextColorChanged"/> event when the
+    ///  <see cref="FormCaptionTextColor"/> property changes.
     /// </summary>
+    /// <param name="e">
+    ///  An <see cref="EventArgs"/> that contains the event data, in this case empty.
+    /// </param>
     [Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
     protected virtual void OnFormCaptionTextColorChanged(EventArgs e)
     {
-        if (Events[s_formCaptionBackColorChanged] is EventHandler eventHandler)
+        if (Events[s_formCaptionTextColorChanged] is EventHandler eventHandler)
         {
             eventHandler(this, e);
         }
@@ -5854,7 +5953,7 @@ public partial class Form : ContainerControl
     ///   This method immediately returns, even if the form is large and takes a long time to be set up.
     ///  </para>
     ///  <para>
-    ///   If the form is already displayed asynchronously by <see cref="Form.ShowAsync"/>, an <see cref="InvalidOperationException"/> will be thrown.
+    ///   If the form is already displayed asynchronously by <see cref="ShowAsync"/>, an <see cref="InvalidOperationException"/> will be thrown.
     ///  </para>
     ///  <para>
     ///   An <see cref="InvalidOperationException"/> will also occur if no <see cref="WindowsFormsSynchronizationContext"/> could be retrieved or installed.
@@ -5889,7 +5988,7 @@ public partial class Form : ContainerControl
     ///   This method immediately returns, even if the form is large and takes a long time to be set up.
     ///  </para>
     ///  <para>
-    ///   If the form is already displayed asynchronously by <see cref="Form.ShowAsync"/>, an <see cref="InvalidOperationException"/> will be thrown.
+    ///   If the form is already displayed asynchronously by <see cref="ShowAsync"/>, an <see cref="InvalidOperationException"/> will be thrown.
     ///  </para>
     ///  <para>
     ///   An <see cref="InvalidOperationException"/> will also occur if no <see cref="WindowsFormsSynchronizationContext"/> could be retrieved or installed.

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ApplicationTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ApplicationTests.cs
@@ -146,6 +146,37 @@ public class ApplicationTests
         Assert.NotNull(stream);
     }
 
+#pragma warning disable SYSLIB5002 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+    [Fact]
+    public void Application_SetColorMode_PlausibilityTests()
+    {
+        if (SystemInformation.HighContrast)
+        {
+            // We don't run this test in HighContrast mode.
+            return;
+        }
+
+        SystemColorMode systemColorMode = Application.SystemColorMode;
+
+        Application.SetColorMode(SystemColorMode.Classic);
+        Assert.False(Application.IsDarkModeEnabled);
+        Assert.Equal(SystemColorMode.Classic, Application.ColorMode);
+        Assert.False(SystemColors.UseAlternativeColorSet);
+
+        Application.SetColorMode(SystemColorMode.Dark);
+        Assert.True(Application.IsDarkModeEnabled);
+        Assert.Equal(SystemColorMode.Dark, Application.ColorMode);
+        Assert.True(SystemColors.UseAlternativeColorSet);
+
+        Application.SetColorMode(SystemColorMode.System);
+        Assert.False(Application.IsDarkModeEnabled ^ systemColorMode == SystemColorMode.Dark);
+        Assert.Equal(SystemColorMode.System, Application.ColorMode);
+        Assert.False(SystemColors.UseAlternativeColorSet ^ systemColorMode == SystemColorMode.Dark);
+    }
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+#pragma warning restore SYSLIB5002 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
     [WinFormsFact]
     public void Application_DefaultFont_ReturnsNull_IfNoFontSet()
     {


### PR DESCRIPTION
Backport the Dark Mode Fix into .NET 9RC1.
The original bug fix (#11907) addressed a series of issues (#11910, #11898, #11897, #11895).

Since the original bug fix used Properties-APIs, which are not available in .NET 9RC/Rel, a few adjustments had to be made here. To further ensure stability, I added basic unit tests for dark mode. 

## Customer Impact

We introduced a new experimental Feature “Dark Mode”. This accidentally regressed VB Apps, which are no longer able to enable Visual Styles. This PR would also address a couple of minor issues in Dark Mode itself, which have been found in recent testing.

Workaround: For the VB Part, there is no easy workaround, since `Application.EnableVisualStyles` is usually run in Program.cs, and in a VB App Framework App, there is no equivalent. 
The issues of the new features do not have a workaround, but they also did not exist before.

Regression?
- [X] Yes
- [ ] No
 
Risk
- [ ] High
- [ ] Medium
- [X] Low –The changes are isolated and are not affecting anything else.
- 
Verification
- [X] Manual testing – Several manual tests made sure, Visual Basic Apps are no longer broken.
- [X] Automated – We added Dark Mode area specific Unit Tests in addition.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11924)