### PR TITLE
Update the TextFormatFlags of the HelpTextLabel

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignBindingPicker.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignBindingPicker.cs
@@ -1849,11 +1849,11 @@ namespace System.Windows.Forms.Design
         {
             protected override void OnPaint(PaintEventArgs e)
             {
-                TextFormatFlags formatFlags = 
-                    TextFormatFlags.WordBreak 
-                    | TextFormatFlags.EndEllipsis 
+                TextFormatFlags formatFlags =
+                    TextFormatFlags.WordBreak
+                    | TextFormatFlags.EndEllipsis
                     | TextFormatFlags.TextBoxControl
-                    | TextFormatFlags.PreserveGraphicsClipping 
+                    | TextFormatFlags.PreserveGraphicsClipping
                     | TextFormatFlags.PreserveGraphicsTranslateTransform;
                 Rectangle rect = new(ClientRectangle.Location, ClientRectangle.Size);
                 rect.Inflate(-2, -2);

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignBindingPicker.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignBindingPicker.cs
@@ -1849,7 +1849,8 @@ namespace System.Windows.Forms.Design
         {
             protected override void OnPaint(PaintEventArgs e)
             {
-                TextFormatFlags formatFlags = TextFormatFlags.WordBreak | TextFormatFlags.EndEllipsis | TextFormatFlags.TextBoxControl;
+                TextFormatFlags formatFlags = TextFormatFlags.WordBreak | TextFormatFlags.EndEllipsis | TextFormatFlags.TextBoxControl
+                    | TextFormatFlags.PreserveGraphicsClipping | TextFormatFlags.PreserveGraphicsTranslateTransform;
                 Rectangle rect = new(ClientRectangle.Location, ClientRectangle.Size);
                 rect.Inflate(-2, -2);
                 TextRenderer.DrawText(e.Graphics, Text, Font, rect, ForeColor, formatFlags);

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignBindingPicker.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignBindingPicker.cs
@@ -1850,11 +1850,11 @@ namespace System.Windows.Forms.Design
             protected override void OnPaint(PaintEventArgs e)
             {
                 TextFormatFlags formatFlags =
-                    TextFormatFlags.WordBreak
-                    | TextFormatFlags.EndEllipsis
-                    | TextFormatFlags.TextBoxControl
-                    | TextFormatFlags.PreserveGraphicsClipping
-                    | TextFormatFlags.PreserveGraphicsTranslateTransform;
+                    TextFormatFlags.WordBreak |
+                    TextFormatFlags.EndEllipsis |
+                    TextFormatFlags.TextBoxControl |
+                    TextFormatFlags.PreserveGraphicsClipping |
+                    TextFormatFlags.PreserveGraphicsTranslateTransform;
                 Rectangle rect = new(ClientRectangle.Location, ClientRectangle.Size);
                 rect.Inflate(-2, -2);
                 TextRenderer.DrawText(e.Graphics, Text, Font, rect, ForeColor, formatFlags);

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignBindingPicker.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignBindingPicker.cs
@@ -1849,8 +1849,12 @@ namespace System.Windows.Forms.Design
         {
             protected override void OnPaint(PaintEventArgs e)
             {
-                TextFormatFlags formatFlags = TextFormatFlags.WordBreak | TextFormatFlags.EndEllipsis | TextFormatFlags.TextBoxControl
-                    | TextFormatFlags.PreserveGraphicsClipping | TextFormatFlags.PreserveGraphicsTranslateTransform;
+                TextFormatFlags formatFlags = 
+                    TextFormatFlags.WordBreak 
+                    | TextFormatFlags.EndEllipsis 
+                    | TextFormatFlags.TextBoxControl
+                    | TextFormatFlags.PreserveGraphicsClipping 
+                    | TextFormatFlags.PreserveGraphicsTranslateTransform;
                 Rectangle rect = new(ClientRectangle.Location, ClientRectangle.Size);
                 rect.Inflate(-2, -2);
                 TextRenderer.DrawText(e.Graphics, Text, Font, rect, ForeColor, formatFlags);


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #11925


## Proposed changes

- Add  `TextFormatFlags.PreserveGraphicsClipping | TextFormatFlags.PreserveGraphicsTranslateTransform` to TextFormatFlags of the class `HelpTextLabel`

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

-  None

## Regression? 

-  No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
The DemoConsole app under the Winforms repo will stop running when opening the smattag of the DataGridView and click the dropdown button of the "Choose Data Source"

![HelpTextLabel](https://github.com/user-attachments/assets/854d3e50-6301-4c0b-af75-55a239bd1ace)

### After
The DemoConsole app can be debug normally
![AfterChanges](https://github.com/user-attachments/assets/eb92e944-5d6c-42d5-ac58-c37417a6ae84)

## Test methodology <!-- How did you ensure quality? -->

- Manually

## Test environment(s) <!-- Remove any that don't apply -->

- .net 9.0.0-rc.1.24413.14


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11926)