### PR TITLE
[RC1/9.0] Backport MenuItemFix

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripDropDown.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripDropDown.cs
@@ -1253,7 +1253,6 @@ public partial class ToolStripDropDown : ToolStrip
                    || !(dismissingItem.HasDropDownItems))
                 {    // clicking on a item w/dropdown does not dismiss window
                     Close(ToolStripDropDownCloseReason.ItemClicked);
-                    SelectPreviousToolStrip();
                 }
             }
         }
@@ -1360,7 +1359,7 @@ public partial class ToolStripDropDown : ToolStrip
     {
         // snap the owner item before calling hide as non-auto created dropdowns will
         // exit menu mode if there's no OwnerItem.
-        ToolStripItem? itemOnPreviousMenuToSelect = GetToplevelOwnerItem();
+        ToolStripItem? itemOnPreviousMenuToSelect = OwnerItem;
         Hide();
 
         if (itemOnPreviousMenuToSelect is not null)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripMenuItem.ToolStripMenuItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripMenuItem.ToolStripMenuItemAccessibleObject.cs
@@ -146,22 +146,6 @@ public partial class ToolStripMenuItem
                 _ => ToggleState.ToggleState_Indeterminate
             };
 
-        internal void OnCheckStateChanged(CheckState oldValue, CheckState newValue)
-        {
-            RaiseAutomationPropertyChangedEvent(
-                UIA_PROPERTY_ID.UIA_ToggleToggleStatePropertyId,
-                (VARIANT)(int)CheckStateToToggleState(oldValue),
-                (VARIANT)(int)CheckStateToToggleState(newValue));
-        }
-
-        private static ToggleState CheckStateToToggleState(CheckState checkState)
-            => checkState switch
-            {
-                CheckState.Checked => ToggleState.ToggleState_On,
-                CheckState.Unchecked => ToggleState.ToggleState_Off,
-                _ => ToggleState.ToggleState_Indeterminate
-            };
-
         #endregion
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripMenuItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripMenuItem.cs
@@ -19,7 +19,6 @@ namespace System.Windows.Forms;
     $"System.ComponentModel.Design.Serialization.CodeDomSerializer, {AssemblyRef.SystemDesign}")]
 public partial class ToolStripMenuItem : ToolStripDropDownItem
 {
-    private CheckState _prevCheckState = CheckState.Unchecked;
     private static readonly MenuTimer s_menuTimer = new();
 
     private static readonly int s_propShortcutKeys = PropertyStore.CreateKey();
@@ -312,7 +311,6 @@ public partial class ToolStripMenuItem : ToolStripDropDownItem
 
             if (value != CheckState)
             {
-                _prevCheckState = CheckState;
                 Properties.SetInteger(s_propCheckState, (int)value);
                 OnCheckedChanged(EventArgs.Empty);
                 OnCheckStateChanged(EventArgs.Empty);
@@ -822,13 +820,6 @@ public partial class ToolStripMenuItem : ToolStripDropDownItem
     protected virtual void OnCheckStateChanged(EventArgs e)
     {
         AccessibilityNotifyClients(AccessibleEvents.StateChange);
-
-        if (IsAccessibilityObjectCreated &&
-            AccessibilityObject is ToolStripMenuItemAccessibleObject accessibilityObject)
-        {
-            accessibilityObject.OnCheckStateChanged(_prevCheckState, CheckState);
-        }
-
         ((EventHandler?)Events[s_eventCheckStateChanged])?.Invoke(this, e);
     }
 
@@ -1056,14 +1047,8 @@ public partial class ToolStripMenuItem : ToolStripDropDownItem
 
     protected internal override bool ProcessCmdKey(ref Message m, Keys keyData)
     {
-        if (Enabled && !HasDropDownItems && (ShortcutKeys == keyData || keyData == Keys.Space))
+        if (Enabled && ShortcutKeys == keyData && !HasDropDownItems)
         {
-            if (keyData is Keys.Space)
-            {
-                Checked = CheckOnClick ? !Checked : Checked;
-                return true;
-            }
-
             FireEvent(ToolStripItemEventType.Click);
             return true;
         }


### PR DESCRIPTION
Backport the Menu Item Fix (#11920) into .NET 9RC1 to fix #11909.

Since the original bug fix used Properties-APIs, which are not available in .NET 9RC/Rel, a few adjustments had to be made here. 

## Customer Impact:
The original A11Y PR introduced a breaking change, and it is specifically blocking [Rick Brewster (the maintainer of Paint .NET)](https://blog.getpaint.net/) to migrate Paint.NET to .NET 9, which is another reason why I would like this to get in into RC1 already, to unblock all folks, who have been started to migrate to .NET 9 and are blocked by this.

Workaround: There is none.

## Regression?
- [X] Yes from the previous release
- [ ] No
 
## Risk
- [ ] High
- [ ] Medium
- [X] Low –The changes are isolated and are not affecting anything else. This PR is effectively a revert of the A11Y PR, which needs a different approach. We are not considering the A11Y issue High Prio issue, so it can be addressed again in .NET 10.
## Verification
- [X] Manual testing – Several manual tests made sure that this issue has been mitigated.
- [ ] Automated

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11930)