### PR TITLE
Add unit tests for MaskPropertyEditor

### DIFF
--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/MaskPropertyEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/MaskPropertyEditorTests.cs
@@ -1,0 +1,54 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System.ComponentModel;
+using System.Drawing.Design;
+using Moq;
+
+namespace System.Windows.Forms.Design.Tests;
+public class MaskPropertyEditorTests
+{
+    private readonly MaskedTextBox _maskedTextBox;
+    private readonly MaskPropertyEditor _editor;
+
+    public MaskPropertyEditorTests()
+    {
+        _maskedTextBox = new MaskedTextBox();
+        _editor = new MaskPropertyEditor();
+    }
+
+    [Fact]
+    public void EditValue_WhenContextOrProviderAreNull_ShouldReturnOriginalValue()
+    {
+        var context = new Mock<ITypeDescriptorContext>().Object;
+        var provider = new Mock<IServiceProvider>();
+
+        object? result;
+        if (context.Instance is MaskedTextBox maskedTextBox)
+        {
+            result = _editor.EditValue(context, provider.Object, maskedTextBox.Mask);
+        }
+        else
+        {
+            result = _maskedTextBox.Mask;
+        }
+
+        result.Should().Be(_maskedTextBox.Mask);
+    }
+
+    [Fact]
+    public void GetPaintValueSupported_ShouldReturnFalse()
+    {
+        bool result = _editor.GetPaintValueSupported(null);
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void GetEditStyle_ShouldReturnModal()
+    {
+        var result = _editor.GetEditStyle(null);
+        result.Should().Be(UITypeEditorEditStyle.Modal);
+    }
+}

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/MaskPropertyEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/MaskPropertyEditorTests.cs
@@ -15,15 +15,15 @@ public class MaskPropertyEditorTests
 
     public MaskPropertyEditorTests()
     {
-        _maskedTextBox = new MaskedTextBox();
-        _editor = new MaskPropertyEditor();
+        _maskedTextBox = new();
+        _editor = new();
     }
 
-    [Fact]
+    [WinFormsFact]
     public void EditValue_WhenContextOrProviderAreNull_ShouldReturnOriginalValue()
     {
         var context = new Mock<ITypeDescriptorContext>().Object;
-        var provider = new Mock<IServiceProvider>();
+        Mock<IServiceProvider> provider = new();
 
         object? result;
         if (context.Instance is MaskedTextBox maskedTextBox)


### PR DESCRIPTION
Related https://github.com/dotnet/winforms/issues/10773

## Proposed changes

- Add unit test MaskPropertyEditorTests.cs for public properties and method of the MaskPropertyEditor.
- Enable nullability in MaskPropertyEditor.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11955)