### PR TITLE
Fix Setting DataGridViewImageCell.ImageLayout to NotSet

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewImageCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewImageCell.cs
@@ -100,9 +100,9 @@ public partial class DataGridViewImageCell : DataGridViewCell
         {
             // Sequential enum.  Valid values are 0x0 to 0x3
             SourceGenerated.EnumValidator.Validate(value);
-            DataGridViewImageCellLayout previous = Properties.AddOrRemoveValue(s_propImageCellLayout, value);
-            if (previous != value)
+            if (ImageLayout != value)
             {
+                Properties.AddValue(s_propImageCellLayout, value);
                 OnCommonChange();
             }
         }
@@ -113,7 +113,7 @@ public partial class DataGridViewImageCell : DataGridViewCell
         set
         {
             Debug.Assert(value is >= DataGridViewImageCellLayout.NotSet and <= DataGridViewImageCellLayout.Zoom);
-            Properties.AddOrRemoveValue(s_propImageCellLayout, value);
+            Properties.AddValue(s_propImageCellLayout, value);
         }
     }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewCellTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewCellTests.cs
@@ -6534,6 +6534,19 @@ public class DataGridViewCellTests
     }
 
     [WinFormsFact]
+    public void DataGridViewCell_ImageCell_ImageLayout_Set_NotSet_Success()
+    {
+        using DataGridView dataGridView = new();
+        DataGridViewImageColumn imageColumn = new();
+        dataGridView.Columns.Add(imageColumn);
+
+        DataGridViewImageCell cell = dataGridView.Rows[0].Cells[0].Should().BeOfType<DataGridViewImageCell>().Which;
+        cell.ImageLayout.Should().Be(DataGridViewImageCellLayout.Normal);
+        cell.ImageLayout = DataGridViewImageCellLayout.NotSet;
+        cell.ImageLayout.Should().Be(DataGridViewImageCellLayout.NotSet);
+    }
+
+    [WinFormsFact]
     public void DataGridViewCell_OnContentClick_InvokeInternalRaiseAutomationNotification()
     {
         using SubDataGridViewCheckBoxCell cellTemplate = new();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewCellTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewCellTests.cs
@@ -6537,7 +6537,7 @@ public class DataGridViewCellTests
     public void DataGridViewCell_ImageCell_ImageLayout_Set_NotSet_Success()
     {
         using DataGridView dataGridView = new();
-        DataGridViewImageColumn imageColumn = new();
+        using DataGridViewImageColumn imageColumn = new();
         dataGridView.Columns.Add(imageColumn);
 
         DataGridViewImageCell cell = dataGridView.Rows[0].Cells[0].Should().BeOfType<DataGridViewImageCell>().Which;


### PR DESCRIPTION
Fixes #11927

This regressed due to some property store work in .NET 10. `PropertyStore.AddOrRemoveValue` will remove the value from the property store if the value is the default value. 
When setting `DataGridViewImageCell.ImageLayout` we cannot remove the value in the property store even if the value being set is the default because our getter for ImageLayout had always returned `DataGridViewImageCellLayout.Normal` if the property had not been set, not the default value, which is `DataGridViewImageCellLayout.NotSet`. This means with the current code if the user sets the ImageLayout to `DataGridViewImageCellLayout.NotSet`, when retrieving ImageLayout we will receive `DataGridViewImageCellLayout.Normal` instead, which is not expected. 
Updated the code to never remove the property store value for ImageLayout. It will only update the value.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11961)