### PR TITLE
Adds code coverage to FolderNameEditor

### DIFF
--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/FolderNameEditorTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/FolderNameEditorTests.cs
@@ -1,0 +1,55 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel;
+using System.Windows.Forms.Design;
+using FluentAssertions;
+using Moq;
+using Xunit.Abstractions;
+
+namespace System.Windows.Forms.UITests;
+
+public class FolderNameEditorTests : ControlTestBase
+{
+    public FolderNameEditorTests(ITestOutputHelper testOutputHelper)
+        : base(testOutputHelper)
+    {
+    }
+
+    [WinFormsFact]
+    public void FolderNameEditor_EditValue_ReturnsExpected()
+    {
+        TestFolderNameEditor editor = new();
+        Mock<IServiceProvider> serviceProviderMock = new();
+        var serviceProvider = serviceProviderMock.Object;
+        string value = "value";
+
+        object? result = editor.EditValue(context: null, provider: serviceProvider, value: value);
+
+        result.Should().Be(value);
+    }
+
+    private class TestFolderNameEditor : FolderNameEditor
+    {
+        private FolderBrowser? _folderBrowser;
+
+        public override object? EditValue(ITypeDescriptorContext? context, IServiceProvider provider, object? value)
+        {
+            using DialogHostForm dialogOwnerForm = new();
+
+            if (_folderBrowser is null)
+            {
+                _folderBrowser = new FolderBrowser();
+                InitializeDialog(_folderBrowser);
+            }
+
+            if (_folderBrowser.ShowDialog(dialogOwnerForm) == DialogResult.OK)
+            {
+                return _folderBrowser.DirectoryPath;
+            }
+
+            return value;
+        }
+    }
+}
+


### PR DESCRIPTION
Related #10773

## Proposed changes

- Adds code coverage to `FolderNameEditor`

## Customer Impact

- None

## Regression?

- No

## Risk

- Minimal

## Screenshots

### Before
![before](https://github.com/user-attachments/assets/3e55b079-fa37-457c-bcf8-d82b6bae0ec1)

### After
![after](https://github.com/user-attachments/assets/7180637b-8ed7-4c86-8220-6e07ba06b384)

## Test methodology

- Unit tests

## Test environment(s)

- 9.0.100-preview.7.24407.12
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11973)