### PR TITLE
Backport the fix of a Backport of the Async Analyzer

### DIFF
--- a/src/System.Windows.Forms.Analyzers.CSharp/src/System/Windows/Forms/CSharp/Analyzers/AvoidPassingTaskWithoutCancellationToken/AvoidPassingTaskWithoutCancellationTokenAnalyzer.cs
+++ b/src/System.Windows.Forms.Analyzers.CSharp/src/System/Windows/Forms/CSharp/Analyzers/AvoidPassingTaskWithoutCancellationToken/AvoidPassingTaskWithoutCancellationTokenAnalyzer.cs
@@ -11,7 +11,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace System.Windows.Forms.CSharp.Analyzers.AvoidPassingTaskWithoutCancellationToken;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public class AvoidPassingFuncReturningTaskWithoutCancellationTokenAnalyzer : DiagnosticAnalyzer
+public class AvoidPassingTaskWithoutCancellationTokenAnalyzer : DiagnosticAnalyzer
 {
     private const string InvokeAsyncString = "InvokeAsync";
     private const string TaskString = "Task";

--- a/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/Analyzers/AvoidPassingTaskWithoutCancellationToken/AvoidPassingTaskWithoutCancellationTokenTest.cs
+++ b/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/Analyzers/AvoidPassingTaskWithoutCancellationToken/AvoidPassingTaskWithoutCancellationTokenTest.cs
@@ -9,7 +9,7 @@ using Microsoft.CodeAnalysis.Testing;
 
 namespace System.Windows.Forms.Analyzers.Test;
 
-public class AvoidPassingFuncReturningTaskWithoutCancellationTokenTest
+public class AvoidPassingTaskWithoutCancellationTokenTest
 {
     // Currently, we do not have Control.InvokeAsync in the .NET 9.0 Windows reference assemblies.
     // That's why we need to add this Async Control. Once it's there, this test will fail.
@@ -169,14 +169,14 @@ public class AvoidPassingFuncReturningTaskWithoutCancellationTokenTest
 
     [Theory]
     [MemberData(nameof(GetReferenceAssemblies))]
-    public async Task CS_AvoidPassingFuncReturningTaskWithoutCancellationAnalyzer(ReferenceAssemblies referenceAssemblies)
+    public async Task CS_AvoidPassingTaskWithoutCancellationAnalyzer(ReferenceAssemblies referenceAssemblies)
     {
         // If the API does not exist, we need to add it to the test.
         string customControlSource = AsyncControl;
         string diagnosticId = DiagnosticIDs.AvoidPassingFuncReturningTaskWithoutCancellationToken;
 
         var context = new CSharpAnalyzerTest
-            <AvoidPassingFuncReturningTaskWithoutCancellationTokenAnalyzer,
+            <AvoidPassingTaskWithoutCancellationTokenAnalyzer,
              DefaultVerifier>
         {
             TestCode = TestCode,

--- a/src/System.Windows.Forms.Analyzers.VisualBasic/src/Analyzers/AvoidPassingTaskWithoutCancellationToken/AvoidPassingTaskWithoutCancellationTokenAnalyzer.vb
+++ b/src/System.Windows.Forms.Analyzers.VisualBasic/src/Analyzers/AvoidPassingTaskWithoutCancellationToken/AvoidPassingTaskWithoutCancellationTokenAnalyzer.vb
@@ -7,10 +7,10 @@ Imports Microsoft.CodeAnalysis.VisualBasic
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Microsoft.CodeAnalysis.Diagnostics
 
-Namespace System.Windows.Forms.VisualBasic.Analyzers.ConsiderNotPassingATaskWithoutCancellationToken
+Namespace Global.System.Windows.Forms.VisualBasic.Analyzers.AvoidPassingTaskWithoutCancellationToken
 
     <DiagnosticAnalyzer(LanguageNames.VisualBasic)>
-    Public Class AvoidPassingFuncReturningTaskWithoutCancellationTokenAnalyzer
+    Public Class AvoidPassingTaskWithoutCancellationTokenAnalyzer
         Inherits DiagnosticAnalyzer
 
         Private Const InvokeAsyncString As String = "InvokeAsync"
@@ -79,7 +79,7 @@ Namespace System.Windows.Forms.VisualBasic.Analyzers.ConsiderNotPassingATaskWith
                 Dim returnType = TryCast(funcType.DelegateInvokeMethod.ReturnType, INamedTypeSymbol)
 
                 If returnType IsNot Nothing AndAlso (returnType.Name = TaskString OrElse returnType.Name = ValueTaskString) Then
-                    Dim diagnostic As Diagnostic = diagnostic.Create(
+                    Dim diagnostic As Diagnostic = Diagnostic.Create(
                         s_avoidFuncReturningTaskWithoutCancellationToken,
                         invocationExpr.GetLocation())
 

--- a/src/System.Windows.Forms.Analyzers.VisualBasic/src/Analyzers/MissingPropertySerializationConfiguration/MissingPropertySerializationConfigurationDiagnosticAnalyzer.vb
+++ b/src/System.Windows.Forms.Analyzers.VisualBasic/src/Analyzers/MissingPropertySerializationConfiguration/MissingPropertySerializationConfigurationDiagnosticAnalyzer.vb
@@ -6,7 +6,7 @@ Imports System.ComponentModel
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Diagnostics
 
-Namespace System.Windows.Forms.VisualBasic.Analyzers.MissingPropertySerializationConfiguration
+Namespace Global.System.Windows.Forms.VisualBasic.Analyzers.MissingPropertySerializationConfiguration
 
     <DiagnosticAnalyzer(LanguageNames.VisualBasic)>
     Public Class MissingPropertySerializationConfigurationAnalyzer

--- a/src/System.Windows.Forms.Analyzers.VisualBasic/tests/UnitTests/System.Windows.Forms.Analyzers.VisualBasic.Tests/AvoidPassingTaskWithoutCancellationTokenTest.vb
+++ b/src/System.Windows.Forms.Analyzers.VisualBasic/tests/UnitTests/System.Windows.Forms.Analyzers.VisualBasic.Tests/AvoidPassingTaskWithoutCancellationTokenTest.vb
@@ -2,13 +2,13 @@
 ' The .NET Foundation licenses this file to you under the MIT license.
 
 Imports System.Windows.Forms.Analyzers.Diagnostics
-Imports System.Windows.Forms.VisualBasic.Analyzers.ConsiderNotPassingATaskWithoutCancellationToken
+Imports System.Windows.Forms.VisualBasic.Analyzers.AvoidPassingTaskWithoutCancellationToken
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Testing
 Imports Microsoft.CodeAnalysis.VisualBasic.Testing
 Imports Xunit
 
-Public Class AvoidPassingFuncReturningTaskWithoutCancellationTokenTest
+Public Class AvoidPassingTaskWithoutCancellationTokenTest
     ' Currently, we do not have Control.InvokeAsync in the .NET 9.0 Windows reference assemblies.
     ' That's why we need to add this Async Control. Once it's there, this test will fail.
     ' We can then remove the AsyncControl and the test will pass, replace AsyncControl with
@@ -156,7 +156,7 @@ End Namespace
         Dim customControlSource As String = AsyncControl
         Dim diagnosticId As String = DiagnosticIDs.AvoidPassingFuncReturningTaskWithoutCancellationToken
 
-        Dim context As New VisualBasicAnalyzerTest(Of AvoidPassingFuncReturningTaskWithoutCancellationTokenAnalyzer, DefaultVerifier) With
+        Dim context As New VisualBasicAnalyzerTest(Of AvoidPassingTaskWithoutCancellationTokenAnalyzer, DefaultVerifier) With
             {
                 .TestCode = TestCode,
                 .ReferenceAssemblies = referenceAssemblies


### PR DESCRIPTION
There is a file name length check in place for .NET 9, which we either don't have or need for main.
#11976 was hit by that and this needed to be addressed.
So, curiously enough, to be in sync with namespace and filename naming, this is the backport of that backport modification.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11980)