### PR TITLE
Fix MissingPropertySerializationConfiguration CodeFix for XML Comment scenarios.

### DIFF
--- a/src/System.Windows.Forms.Analyzers.CodeFixes.CSharp/System/Windows/Forms/CSharp/CodeFixes/AddDesignerSerializationVisibility/AddDesignerSerializationVisibilityCodeFixProvider.cs
+++ b/src/System.Windows.Forms.Analyzers.CodeFixes.CSharp/System/Windows/Forms/CSharp/CodeFixes/AddDesignerSerializationVisibility/AddDesignerSerializationVisibilityCodeFixProvider.cs
@@ -82,19 +82,17 @@ internal sealed class AddDesignerSerializationVisibilityCodeFixProvider : CodeFi
             SyntaxFactory.ParseName(DesignerSerializationVisibilityAttributeName),
             SyntaxFactory.ParseAttributeArgumentList("(DesignerSerializationVisibility.Hidden)"));
 
-        // Make sure, we keep the white spaces before and after the property
         SyntaxTriviaList leadingTrivia = propertyDeclarationSyntax.GetLeadingTrivia();
-        SyntaxTriviaList trailingTrivia = propertyDeclarationSyntax.GetTrailingTrivia();
+        PropertyDeclarationSyntax newProperty = propertyDeclarationSyntax.WithoutLeadingTrivia();
 
         // Add the attribute to the property:
-        PropertyDeclarationSyntax newProperty = propertyDeclarationSyntax
+        newProperty = newProperty
             .AddAttributeLists(
                 SyntaxFactory.AttributeList(
                     SyntaxFactory.SingletonSeparatedList(designerSerializationVisibilityAttribute)));
 
-        // Let's restore the original trivia:
+        // Add the leading trivia back:
         newProperty = newProperty.WithLeadingTrivia(leadingTrivia);
-        newProperty = newProperty.WithTrailingTrivia(trailingTrivia);
 
         // Produce a new root, which has the updated property with the attribute.
         root = root.ReplaceNode(propertyDeclarationSyntax, newProperty);

--- a/src/System.Windows.Forms.Analyzers.CodeFixes.VisualBasic/AddDesignerSerializationVisibility/AddDesignerSerializationVisibilityCodeFixProvider.vb
+++ b/src/System.Windows.Forms.Analyzers.CodeFixes.VisualBasic/AddDesignerSerializationVisibility/AddDesignerSerializationVisibilityCodeFixProvider.vb
@@ -91,21 +91,16 @@ Namespace Global.System.Windows.Forms.VisualBasic.CodeFixes.AddDesignerSerializa
 
             ' Make sure, we keep the white spaces before and after the property
             Dim leadingTrivia As SyntaxTriviaList = propertyDeclarationSyntax.GetLeadingTrivia()
-            Dim trailingTrivia As SyntaxTriviaList = propertyDeclarationSyntax.GetTrailingTrivia()
+            Dim newProperty = propertyDeclarationSyntax.WithoutLeadingTrivia()
 
             ' Add the attribute to the property:
-            Dim newProperty As PropertyStatementSyntax = propertyDeclarationSyntax.AddAttributeLists(
+            newProperty = newProperty.AddAttributeLists(
                 SyntaxFactory.AttributeList(
                     SyntaxFactory.SingletonSeparatedList(designerSerializationVisibilityAttribute)))
 
-            ' Let's format the property, so the attribute is on top of it:
-            newProperty = newProperty.NormalizeWhitespace()
-
             ' Let's restore the original trivia:
             newProperty = newProperty.
-                WithLeadingTrivia(leadingTrivia).
-                WithTrailingTrivia(trailingTrivia).
-                WithAdditionalAnnotations(Formatter.Annotation)
+                WithLeadingTrivia(leadingTrivia)
 
             ' Let's check, if we already have the imports statement or if we need to add it:
             ' (Remember: We can't throw here, as we are in a code fixer. But this also cannot be null.)

--- a/src/System.Windows.Forms.Analyzers.VisualBasic/tests/UnitTests/System.Windows.Forms.Analyzers.VisualBasic.Tests/MissingPropertySerializationConfigurationAnalyzerTest.vb
+++ b/src/System.Windows.Forms.Analyzers.VisualBasic/tests/UnitTests/System.Windows.Forms.Analyzers.VisualBasic.Tests/MissingPropertySerializationConfigurationAnalyzerTest.vb
@@ -17,22 +17,35 @@ Namespace VBControls
         Public Sub Main()
             Dim control As New ScalableControl()
 
-            ' We deliberately format this weirdly, to make sure we only format code our code fix touches.
             control.ScaleFactor = 1.5F
             control.ScaledSize = New SizeF(100, 100)
             control.ScaledLocation = New PointF(10, 10)
         End Sub
     End Module
 
-    ' We are writing the fully-qualified name here to make sure, the Simplifier doesn't remove it,
-    ' since this is nothing our code fix touches.
     Public Class ScalableControl
         Inherits System.Windows.Forms.Control
 
+        private _scaledSize as SizeF
+
         Public Property [|ScaleFactor|] As Single = 1.0F
 
+        ''' <Summary>
+        '''  Sets or gets the scaled size of some foo bar thing.
+        ''' </Summary>
+        <System.ComponentModel.Description(""Sets or gets the scaled size of some foo bar thing."")>
         Public Property [|ScaledSize|] As SizeF
+            Get
+                Return _scaledSize
+            End Get
+            Set(value As SizeF)
+                _scaledSize = value
+            End Set
+        End Property
 
+        ''' <Summary>
+        '''  Sets or gets the scaled location of some foo bar thing.
+        ''' </Summary>
         Public Property [|ScaledLocation|] As PointF
     End Class
 
@@ -49,28 +62,44 @@ Namespace VBControls
     Public Module Program
         Public Sub Main()
             Dim control As New ScalableControl()
-        
+
             control.ScaleFactor = 1.5F
             control.ScaledSize = New SizeF(100, 100)
             control.ScaledLocation = New PointF(10, 10)
         End Sub
     End Module
-        
-    Public Class ScalableControl
-        Inherits Control
 
-        <DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)>
+    Public Class ScalableControl
+        Inherits System.Windows.Forms.Control
+
+        private _scaledSize as SizeF
+
+        <DefaultValue(1.0F)>
         Public Property ScaleFactor As Single = 1.0F
 
-        <DefaultValue(GetType(SizeF), ""0,0"")>
+        ''' <Summary>
+        '''  Sets or gets the scaled size of some foo bar thing.
+        ''' </Summary>
+        <System.ComponentModel.Description(""Sets or gets the scaled size of some foo bar thing."")>
+        <DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)>
         Public Property ScaledSize As SizeF
+            Get
+                Return _scaledSize
+            End Get
+            Set(value As SizeF)
+                _scaledSize = value
+            End Set
+        End Property
 
+        ''' <Summary>
+        '''  Sets or gets the scaled location of some foo bar thing.
+        ''' </Summary>
         Public Property ScaledLocation As PointF
-        Private Function ShouldSerializeScaledLocation() As Boolean
-            Return Me.ScaledLocation <> PointF.Empty
+
+        Private Function ShouldSerializeScaledLocation as Boolean
+            Return False
         End Function
     End Class
-        
 End Namespace
 "
 
@@ -85,24 +114,37 @@ Namespace VBControls
         Public Sub Main()
             Dim control As New ScalableControl()
 
-            ' We deliberately format this weirdly, to make sure we only format code our code fix touches.
             control.ScaleFactor = 1.5F
             control.ScaledSize = New SizeF(100, 100)
             control.ScaledLocation = New PointF(10, 10)
         End Sub
     End Module
 
-    ' We are writing the fully-qualified name here to make sure, the Simplifier doesn't remove it,
-    ' since this is nothing our code fix touches.
     Public Class ScalableControl
         Inherits System.Windows.Forms.Control
+
+        private _scaledSize as SizeF
 
         <DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)>
         Public Property ScaleFactor As Single = 1.0F
 
+        ''' <Summary>
+        '''  Sets or gets the scaled size of some foo bar thing.
+        ''' </Summary>
+        <System.ComponentModel.Description(""Sets or gets the scaled size of some foo bar thing."")>
         <DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)>
         Public Property ScaledSize As SizeF
+            Get
+                Return _scaledSize
+            End Get
+            Set(value As SizeF)
+                _scaledSize = value
+            End Set
+        End Property
 
+        ''' <Summary>
+        '''  Sets or gets the scaled location of some foo bar thing.
+        ''' </Summary>
         <DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)>
         Public Property ScaledLocation As PointF
     End Class
@@ -120,12 +162,12 @@ End Namespace
 
     <Theory>
     <MemberData(NameOf(GetReferenceAssemblies))>
-    Public Async Function VB_ControlPropertySerializationConfigurationAnalyzer(referenceAssemblies As ReferenceAssemblies) As Task
+    Public Async Function VB_MissingControlPropertySerializationConfigurationAnalyzer(referenceAssemblies As ReferenceAssemblies) As Task
         Dim context = New VisualBasicAnalyzerTest(Of
             MissingPropertySerializationConfigurationAnalyzer,
             DefaultVerifier) With
             {
-                .TestCode = CorrectCode,
+                .TestCode = ProblematicCode,
                 .ReferenceAssemblies = referenceAssemblies
             }
 
@@ -136,12 +178,12 @@ End Namespace
 
     <Theory>
     <MemberData(NameOf(GetReferenceAssemblies))>
-    Public Async Function VB_MissingControlPropertySerializationConfigurationAnalyzer(referenceAssemblies As ReferenceAssemblies) As Task
+    Public Async Function VB_ControlPropertySerializationConfigurationAnalyzer(referenceAssemblies As ReferenceAssemblies) As Task
         Dim context = New VisualBasicAnalyzerTest(Of
             MissingPropertySerializationConfigurationAnalyzer,
             DefaultVerifier) With
             {
-                .TestCode = ProblematicCode,
+                .TestCode = CorrectCode,
                 .ReferenceAssemblies = referenceAssemblies
             }
 


### PR DESCRIPTION
Fixes a scenario where the `DesignerSerializationVisibility` attribute gets added to the respective property at the wrong spot.
@paul1956 FYI.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11981)