### PR TITLE
Add Dark Mode Visual Style Theme Subclass

### DIFF
--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ContextMenuStripGroupCollectionTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ContextMenuStripGroupCollectionTests.cs
@@ -1,0 +1,55 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+namespace System.Windows.Forms.Design.Tests;
+
+public class ContextMenuStripGroupCollectionTests
+{
+    [Fact]
+    public void Indexer_ShouldCreateNewGroupIfKeyDoesNotExist()
+    {
+        ContextMenuStripGroupCollection collection = new();
+
+        ContextMenuStripGroup group = collection["newKey"];
+
+        group.Should().NotBeNull();
+        group.Should().BeOfType<ContextMenuStripGroup>();
+        collection.ContainsKey("newKey").Should().BeTrue();
+    }
+
+    [Fact]
+    public void ContainsKey_ShouldReturnFalseIfKeyDoesNotExist()
+    {
+        ContextMenuStripGroupCollection collection = new();
+
+        bool containsKey = collection.ContainsKey("nonExistentKey");
+
+        containsKey.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Indexer_ShouldReturnSameGroupForSameKey()
+    {
+        ContextMenuStripGroupCollection collection = new();
+
+        ContextMenuStripGroup group1 = collection["newKey"];
+        ContextMenuStripGroup group2 = collection["newKey"];
+
+        group1.Should().BeSameAs(group2);
+    }
+
+    [Fact]
+    public void Indexer_ShouldReturnDifferentGroupsForDifferentKeys()
+    {
+        ContextMenuStripGroupCollection collection = new();
+
+        ContextMenuStripGroup group1 = collection["key1"];
+        ContextMenuStripGroup group2 = collection["key2"];
+
+        group1.Should().NotBeSameAs(group2);
+        collection.ContainsKey("key1").Should().BeTrue();
+        collection.ContainsKey("key2").Should().BeTrue();
+    }
+}

--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -3320,6 +3320,7 @@ static System.Windows.Forms.VisualStyles.VisualStyleInformation.Url.get -> strin
 static System.Windows.Forms.VisualStyles.VisualStyleInformation.Version.get -> string!
 static System.Windows.Forms.VisualStyles.VisualStyleRenderer.IsElementDefined(System.Windows.Forms.VisualStyles.VisualStyleElement! element) -> bool
 static System.Windows.Forms.VisualStyles.VisualStyleRenderer.IsSupported.get -> bool
+static System.Windows.Forms.VisualStyles.VisualStyleRenderer.IsDarkModeSupported.get -> bool
 static System.Windows.Forms.WindowsFormsSynchronizationContext.AutoInstall.get -> bool
 static System.Windows.Forms.WindowsFormsSynchronizationContext.AutoInstall.set -> void
 static System.Windows.Forms.WindowsFormsSynchronizationContext.Uninstall() -> void

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
@@ -48,8 +48,6 @@ public sealed partial class Application
     private static SystemColorMode? s_colorMode;
 #pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
-    private const string DarkModeKeyPath = "HKEY_CURRENT_USER\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize";
-    private const string DarkModeKey = "AppsUseLightTheme";
     private const int SystemDarkModeDisabled = 1;
 
     /// <summary>
@@ -379,21 +377,9 @@ public sealed partial class Application
             return SystemDarkModeDisabled;
         }
 
-        int systemColorMode = SystemDarkModeDisabled;
-
-        try
-        {
-            // 0 for dark mode and |1| for light mode.
-            systemColorMode = Math.Abs((Registry.GetValue(
-                keyName: DarkModeKeyPath,
-                valueName: DarkModeKey,
-                defaultValue: SystemDarkModeDisabled) as int?) ?? systemColorMode);
-        }
-        catch (Exception ex) when (!ex.IsCriticalException())
-        {
-        }
-
-        return systemColorMode;
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+        return VisualStyleRenderer.IsDarkModeSupported ? 0 : 1;
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     }
 
     private static bool IsSystemDarkModeAvailable =>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -163,7 +163,8 @@ public unsafe partial class Control :
     internal const string ExplorerThemeIdentifier = "Explorer";
     internal const string ItemsViewThemeIdentifier = "ItemsView";
     internal const string ComboBoxButtonThemeIdentifier = "CFD";
-    internal const string TabThemeIdentifier = "FileExplorerBannerContainer";
+    internal const string BannerContainerThemeIdentifier = "FileExplorerBannerContainer";
+    internal const string NavPaneThemeIdentifier = "ExplorerNavPane";
     private const short PaintLayerBackground = 1;
     private const short PaintLayerForeground = 2;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -163,7 +163,7 @@ public unsafe partial class Control :
     internal const string ExplorerThemeIdentifier = "Explorer";
     internal const string ItemsViewThemeIdentifier = "ItemsView";
     internal const string ComboBoxButtonThemeIdentifier = "CFD";
-    internal const string TabThemeIdentifier = "FileExplorerBannerContainer"; 
+    internal const string TabThemeIdentifier = "FileExplorerBannerContainer";
     private const short PaintLayerBackground = 1;
     private const short PaintLayerForeground = 2;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -163,7 +163,7 @@ public unsafe partial class Control :
     internal const string ExplorerThemeIdentifier = "Explorer";
     internal const string ItemsViewThemeIdentifier = "ItemsView";
     internal const string ComboBoxButtonThemeIdentifier = "CFD";
-
+    internal const string TabThemeIdentifier = "FileExplorerBannerContainer"; 
     private const short PaintLayerBackground = 1;
     private const short PaintLayerForeground = 2;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBoxRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBoxRenderer.cs
@@ -14,7 +14,11 @@ public static class ComboBoxRenderer
     // Make this per-thread, so that different threads can safely use these methods.
     [ThreadStatic]
     private static VisualStyleRenderer? t_visualStyleRenderer;
-    private static readonly VisualStyleElement s_comboBoxElement = VisualStyleElement.ComboBox.DropDownButton.Normal;
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+    private static readonly VisualStyleElement s_comboBoxElement = Application.IsDarkModeEnabled ?
+        VisualStyleElement.CreateElement("DarkMode_CFD::COMBOBOX", 1, 1)
+        : VisualStyleElement.ComboBox.DropDownButton.Normal;
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     private static readonly VisualStyleElement s_textBoxElement = VisualStyleElement.TextBox.TextEdit.Normal;
 
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBoxRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBoxRenderer.cs
@@ -15,8 +15,8 @@ public static class ComboBoxRenderer
     [ThreadStatic]
     private static VisualStyleRenderer? t_visualStyleRenderer;
 #pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-    private static readonly VisualStyleElement s_comboBoxElement = Application.IsDarkModeEnabled ?
-        VisualStyleElement.CreateElement("DarkMode_CFD::COMBOBOX", 1, 1)
+    private static readonly VisualStyleElement s_comboBoxElement = Application.IsDarkModeEnabled
+        ? VisualStyleElement.CreateElement($"{Control.DarkModeIdentifier}_{Control.ComboBoxButtonThemeIdentifier}::COMBOBOX", 1, 1)
         : VisualStyleElement.ComboBox.DropDownButton.Normal;
 #pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     private static readonly VisualStyleElement s_textBoxElement = VisualStyleElement.TextBox.TextEdit.Normal;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewButtonCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewButtonCell.cs
@@ -17,7 +17,12 @@ public partial class DataGridViewButtonCell : DataGridViewCell
     private static readonly int s_propButtonCellFlatStyle = PropertyStore.CreateKey();
     private static readonly int s_propButtonCellState = PropertyStore.CreateKey();
     private static readonly int s_propButtonCellUseColumnTextForButtonValue = PropertyStore.CreateKey();
-    private static readonly VisualStyleElement s_buttonElement = VisualStyleElement.Button.PushButton.Normal;
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+    private static readonly VisualStyleElement s_darkButtonElement = VisualStyleElement.CreateElement("DarkMode_Explorer::BUTTON", 1, 1);
+    private static readonly VisualStyleElement s_lightButtonElement = VisualStyleElement.Button.PushButton.Normal;
+    private static readonly VisualStyleElement s_buttonElement = Application.IsDarkModeEnabled ? s_darkButtonElement : s_lightButtonElement;
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
 
     private const byte DATAGRIDVIEWBUTTONCELL_themeMargin = 100; // Used to calculate the margins required for theming rendering
     private const byte DATAGRIDVIEWBUTTONCELL_horizontalTextMargin = 2;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewButtonCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewButtonCell.cs
@@ -23,7 +23,6 @@ public partial class DataGridViewButtonCell : DataGridViewCell
     private static readonly VisualStyleElement s_buttonElement = Application.IsDarkModeEnabled ? s_darkButtonElement : s_lightButtonElement;
 #pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
-
     private const byte DATAGRIDVIEWBUTTONCELL_themeMargin = 100; // Used to calculate the margins required for theming rendering
     private const byte DATAGRIDVIEWBUTTONCELL_horizontalTextMargin = 2;
     private const byte DATAGRIDVIEWBUTTONCELL_verticalTextMargin = 1;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewCheckBoxCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewCheckBoxCell.cs
@@ -20,7 +20,13 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
     private const DataGridViewContentAlignment AnyBottom = DataGridViewContentAlignment.BottomRight | DataGridViewContentAlignment.BottomCenter | DataGridViewContentAlignment.BottomLeft;
     private const DataGridViewContentAlignment AnyMiddle = DataGridViewContentAlignment.MiddleRight | DataGridViewContentAlignment.MiddleCenter | DataGridViewContentAlignment.MiddleLeft;
 
-    private static readonly VisualStyleElement s_checkBoxElement = VisualStyleElement.Button.CheckBox.UncheckedNormal;
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+    private static readonly VisualStyleElement s_darkCheckBoxElement = VisualStyleElement.CreateElement("DarkMode_Explorer::BUTTON", 3, 1);
+    private static readonly VisualStyleElement s_lightCheckBoxElement = VisualStyleElement.Button.CheckBox.UncheckedNormal;
+    private static readonly VisualStyleElement s_checkBoxElement = Application.IsDarkModeEnabled ? s_darkCheckBoxElement : s_lightCheckBoxElement;
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
+
     private static readonly int s_propButtonCellState = PropertyStore.CreateKey();
     private static readonly int s_propTrueValue = PropertyStore.CreateKey();
     private static readonly int s_propFalseValue = PropertyStore.CreateKey();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewCheckBoxCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewCheckBoxCell.cs
@@ -21,11 +21,12 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
     private const DataGridViewContentAlignment AnyMiddle = DataGridViewContentAlignment.MiddleRight | DataGridViewContentAlignment.MiddleCenter | DataGridViewContentAlignment.MiddleLeft;
 
 #pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-    private static readonly VisualStyleElement s_darkCheckBoxElement = VisualStyleElement.CreateElement("DarkMode_Explorer::BUTTON", 3, 1);
+    private static readonly VisualStyleElement s_darkCheckBoxElement = VisualStyleElement.CreateElement($"{Control.DarkModeIdentifier}_{Control.ExplorerThemeIdentifier}::BUTTON", 3, 1);
     private static readonly VisualStyleElement s_lightCheckBoxElement = VisualStyleElement.Button.CheckBox.UncheckedNormal;
-    private static readonly VisualStyleElement s_checkBoxElement = Application.IsDarkModeEnabled ? s_darkCheckBoxElement : s_lightCheckBoxElement;
+    private static readonly VisualStyleElement s_checkBoxElement = Application.IsDarkModeEnabled
+        ? s_darkCheckBoxElement
+        : s_lightCheckBoxElement;
 #pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-
 
     private static readonly int s_propButtonCellState = PropertyStore.CreateKey();
     private static readonly int s_propTrueValue = PropertyStore.CreateKey();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewColumnHeaderCell.DataGridViewColumnHeaderCellRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewColumnHeaderCell.DataGridViewColumnHeaderCellRenderer.cs
@@ -16,7 +16,12 @@ public partial class DataGridViewColumnHeaderCell
         {
             get
             {
-                s_visualStyleRenderer ??= new VisualStyleRenderer(s_headerElement);
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+                s_visualStyleRenderer ??= new VisualStyleRenderer(Application.IsDarkModeEnabled ?
+                    VisualStyleElement.CreateElement("DarkMode_ItemsView::Header", 1, 1)
+                    : VisualStyleElement.Header.Item.Normal);
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
 
                 return s_visualStyleRenderer;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewColumnHeaderCell.DataGridViewColumnHeaderCellRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewColumnHeaderCell.DataGridViewColumnHeaderCellRenderer.cs
@@ -22,7 +22,6 @@ public partial class DataGridViewColumnHeaderCell
                     : VisualStyleElement.Header.Item.Normal);
 #pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
-
                 return s_visualStyleRenderer;
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewColumnHeaderCell.DataGridViewColumnHeaderCellRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewColumnHeaderCell.DataGridViewColumnHeaderCellRenderer.cs
@@ -17,8 +17,8 @@ public partial class DataGridViewColumnHeaderCell
             get
             {
 #pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-                s_visualStyleRenderer ??= new VisualStyleRenderer(Application.IsDarkModeEnabled ?
-                    VisualStyleElement.CreateElement("DarkMode_ItemsView::Header", 1, 1)
+                s_visualStyleRenderer ??= new VisualStyleRenderer(Application.IsDarkModeEnabled
+                    ?  VisualStyleElement.CreateElement($"{Control.DarkModeIdentifier}_{Control.ItemsViewThemeIdentifier}::Header", 1, 1)
                     : VisualStyleElement.Header.Item.Normal);
 #pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewColumnHeaderCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewColumnHeaderCell.cs
@@ -11,7 +11,11 @@ namespace System.Windows.Forms;
 
 public partial class DataGridViewColumnHeaderCell : DataGridViewHeaderCell
 {
-    private static readonly VisualStyleElement s_headerElement = VisualStyleElement.Header.Item.Normal;
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+    private static readonly VisualStyleElement s_headerElement = Application.IsDarkModeEnabled ?
+        VisualStyleElement.CreateElement("DarkMode_ItemsView::Header", 1, 1)
+        : VisualStyleElement.Header.Item.Normal;
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
     private const byte SortGlyphSeparatorWidth = 2;     // additional 2 pixels between caption and glyph
     private const byte SortGlyphHorizontalMargin = 4;   // 4 pixels on left & right of glyph

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewColumnHeaderCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewColumnHeaderCell.cs
@@ -12,8 +12,8 @@ namespace System.Windows.Forms;
 public partial class DataGridViewColumnHeaderCell : DataGridViewHeaderCell
 {
 #pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-    private static readonly VisualStyleElement s_headerElement = Application.IsDarkModeEnabled ?
-        VisualStyleElement.CreateElement("DarkMode_ItemsView::Header", 1, 1)
+    private static readonly VisualStyleElement s_headerElement = Application.IsDarkModeEnabled
+        ? VisualStyleElement.CreateElement($"{Control.DarkModeIdentifier}_{Control.ItemsViewThemeIdentifier}::Header", 1, 1)
         : VisualStyleElement.Header.Item.Normal;
 #pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewComboBoxCell.DataGridViewComboBoxCellRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewComboBoxCell.DataGridViewComboBoxCellRenderer.cs
@@ -12,10 +12,29 @@ public partial class DataGridViewComboBoxCell
     {
         [ThreadStatic]
         private static VisualStyleRenderer? t_visualStyleRenderer;
-        private static readonly VisualStyleElement s_comboBoxBorder = VisualStyleElement.ComboBox.Border.Normal;
-        private static readonly VisualStyleElement s_comboBoxDropDownButtonRight = VisualStyleElement.ComboBox.DropDownButtonRight.Normal;
-        private static readonly VisualStyleElement s_comboBoxDropDownButtonLeft = VisualStyleElement.ComboBox.DropDownButtonLeft.Normal;
-        private static readonly VisualStyleElement s_comboBoxReadOnlyButton = VisualStyleElement.ComboBox.ReadOnlyButton.Normal;
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+        private static readonly VisualStyleElement s_comboBoxBorder = Application.IsDarkModeEnabled ?
+            VisualStyleElement.CreateElement("DarkMode_CFD::COMBOBOX", 4, 1)
+            : VisualStyleElement.ComboBox.Border.Normal;
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+        private static readonly VisualStyleElement s_comboBoxDropDownButtonRight = Application.IsDarkModeEnabled ?
+            VisualStyleElement.CreateElement("DarkMode_CFD::COMBOBOX", 6, 1)
+            : VisualStyleElement.ComboBox.DropDownButtonRight.Normal;
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+        private static readonly VisualStyleElement s_comboBoxDropDownButtonLeft = Application.IsDarkModeEnabled ?
+            VisualStyleElement.CreateElement("DarkMode_CFD::COMBOBOX", 7, 1) :
+            VisualStyleElement.ComboBox.DropDownButtonLeft.Normal;
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+        private static readonly VisualStyleElement s_comboBoxReadOnlyButton = Application.IsDarkModeEnabled ?
+            VisualStyleElement.CreateElement("DarkMode_CFD::COMBOBOX", 5, 1)
+            : VisualStyleElement.ComboBox.ReadOnlyButton.Normal;
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
         public static VisualStyleRenderer VisualStyleRenderer
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewComboBoxCell.DataGridViewComboBoxCellRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewComboBoxCell.DataGridViewComboBoxCellRenderer.cs
@@ -13,26 +13,26 @@ public partial class DataGridViewComboBoxCell
         [ThreadStatic]
         private static VisualStyleRenderer? t_visualStyleRenderer;
 #pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-        private static readonly VisualStyleElement s_comboBoxBorder = Application.IsDarkModeEnabled ?
-            VisualStyleElement.CreateElement("DarkMode_CFD::COMBOBOX", 4, 1)
+        private static readonly VisualStyleElement s_comboBoxBorder = Application.IsDarkModeEnabled
+            ? VisualStyleElement.CreateElement($"{Control.DarkModeIdentifier}_{Control.ComboBoxButtonThemeIdentifier}::COMBOBOX", 4, 1)
             : VisualStyleElement.ComboBox.Border.Normal;
 #pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
 #pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-        private static readonly VisualStyleElement s_comboBoxDropDownButtonRight = Application.IsDarkModeEnabled ?
-            VisualStyleElement.CreateElement("DarkMode_CFD::COMBOBOX", 6, 1)
+        private static readonly VisualStyleElement s_comboBoxDropDownButtonRight = Application.IsDarkModeEnabled
+            ? VisualStyleElement.CreateElement($"{Control.DarkModeIdentifier}_{Control.ComboBoxButtonThemeIdentifier}::COMBOBOX", 6, 1)
             : VisualStyleElement.ComboBox.DropDownButtonRight.Normal;
 #pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
 #pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-        private static readonly VisualStyleElement s_comboBoxDropDownButtonLeft = Application.IsDarkModeEnabled ?
-            VisualStyleElement.CreateElement("DarkMode_CFD::COMBOBOX", 7, 1) :
-            VisualStyleElement.ComboBox.DropDownButtonLeft.Normal;
+        private static readonly VisualStyleElement s_comboBoxDropDownButtonLeft = Application.IsDarkModeEnabled
+            ? VisualStyleElement.CreateElement($"{Control.DarkModeIdentifier}_{Control.ComboBoxButtonThemeIdentifier}::COMBOBOX", 7, 1)
+            : VisualStyleElement.ComboBox.DropDownButtonLeft.Normal;
 #pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
 #pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-        private static readonly VisualStyleElement s_comboBoxReadOnlyButton = Application.IsDarkModeEnabled ?
-            VisualStyleElement.CreateElement("DarkMode_CFD::COMBOBOX", 5, 1)
+        private static readonly VisualStyleElement s_comboBoxReadOnlyButton = Application.IsDarkModeEnabled
+            ? VisualStyleElement.CreateElement($"{Control.DarkModeIdentifier}_{Control.ComboBoxButtonThemeIdentifier}::COMBOBOX", 5, 1)
             : VisualStyleElement.ComboBox.ReadOnlyButton.Normal;
 #pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewRowHeaderCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewRowHeaderCell.cs
@@ -11,7 +11,11 @@ namespace System.Windows.Forms;
 
 public partial class DataGridViewRowHeaderCell : DataGridViewHeaderCell
 {
-    private static readonly VisualStyleElement s_headerElement = VisualStyleElement.Header.Item.Normal;
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+    private static readonly VisualStyleElement s_headerElement = Application.IsDarkModeEnabled ?
+        VisualStyleElement.CreateElement("DarkMode_ItemsView::Header", 1, 1)
+        : VisualStyleElement.Header.Item.Normal;
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
     private static Bitmap? s_rightArrowBmp;
     private static Bitmap? s_leftArrowBmp;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewRowHeaderCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewRowHeaderCell.cs
@@ -12,8 +12,8 @@ namespace System.Windows.Forms;
 public partial class DataGridViewRowHeaderCell : DataGridViewHeaderCell
 {
 #pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-    private static readonly VisualStyleElement s_headerElement = Application.IsDarkModeEnabled ?
-        VisualStyleElement.CreateElement("DarkMode_ItemsView::Header", 1, 1)
+    private static readonly VisualStyleElement s_headerElement = Application.IsDarkModeEnabled
+        ? VisualStyleElement.CreateElement($"{Control.DarkModeIdentifier}_{Control.ItemsViewThemeIdentifier}::Header", 1, 1)
         : VisualStyleElement.Header.Item.Normal;
 #pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewTopLeftHeaderCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewTopLeftHeaderCell.cs
@@ -8,7 +8,11 @@ namespace System.Windows.Forms;
 
 public partial class DataGridViewTopLeftHeaderCell : DataGridViewColumnHeaderCell
 {
-    private static readonly VisualStyleElement s_headerElement = VisualStyleElement.Header.Item.Normal;
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+    private static readonly VisualStyleElement s_headerElement = Application.IsDarkModeEnabled ?
+        VisualStyleElement.CreateElement("DarkMode_ItemsView::Header", 1, 1)
+        : VisualStyleElement.Header.Item.Normal;
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
     private const byte DATAGRIDVIEWTOPLEFTHEADERCELL_horizontalTextMarginLeft = 1;
     private const byte DATAGRIDVIEWTOPLEFTHEADERCELL_horizontalTextMarginRight = 2;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewTopLeftHeaderCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewTopLeftHeaderCell.cs
@@ -9,8 +9,8 @@ namespace System.Windows.Forms;
 public partial class DataGridViewTopLeftHeaderCell : DataGridViewColumnHeaderCell
 {
 #pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-    private static readonly VisualStyleElement s_headerElement = Application.IsDarkModeEnabled ?
-        VisualStyleElement.CreateElement("DarkMode_ItemsView::Header", 1, 1)
+    private static readonly VisualStyleElement s_headerElement = Application.IsDarkModeEnabled
+        ? VisualStyleElement.CreateElement($"{Control.DarkModeIdentifier}_{Control.ItemsViewThemeIdentifier}::Header", 1, 1)
         : VisualStyleElement.Header.Item.Normal;
 #pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TabControl/TabControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TabControl/TabControl.cs
@@ -1303,7 +1303,7 @@ public partial class TabControl : Control
             _ = PInvoke.SetWindowTheme(
                 hwnd: HWND,
                 pszSubAppName: null,
-                pszSubIdList: $"{DarkModeIdentifier}::{TabThemeIdentifier}");
+                pszSubIdList: $"{DarkModeIdentifier}::{BannerContainerThemeIdentifier}");
         }
 #pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TabControl/TabControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TabControl/TabControl.cs
@@ -1259,6 +1259,13 @@ public partial class TabControl : Control
                     0, 0, 0, 0,
                     SET_WINDOW_POS_FLAGS.SWP_NOMOVE | SET_WINDOW_POS_FLAGS.SWP_NOSIZE | SET_WINDOW_POS_FLAGS.SWP_NOACTIVATE);
             }
+
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+            if (Application.IsDarkModeEnabled)
+            {
+                PInvoke.SendMessage(tooltipHwnd, PInvoke.TTM_SETWINDOWTHEME, default, "DarkMode_Explorer");
+            }
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         }
 
         // Add the pages
@@ -1288,6 +1295,17 @@ public partial class TabControl : Control
         }
 
         UpdateTabSelection(false);
+        // TabControl didn't have Tab Appearance in  Dark mode  theme to support Dark Mode Tab Appearance we need to draw The buttons in paint event.
+
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+        if (Application.IsDarkModeEnabled && GetStyle(ControlStyles.ApplyThemingImplicitly))
+        {
+            _ = PInvoke.SetWindowTheme(
+                hwnd: HWND,
+                pszSubAppName: null,
+                pszSubIdList: $"{DarkModeIdentifier}::{TabThemeIdentifier}");
+        }
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
     }
 
     protected override void OnHandleDestroyed(EventArgs e)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TabControl/TabRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TabControl/TabRenderer.cs
@@ -144,6 +144,8 @@ public static class TabRenderer
     internal static void DrawTabPage(IDeviceContext deviceContext, Rectangle bounds)
     {
 #pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+        // Using DarkMode Theme Subclass.
+        // see https://learn.microsoft.com/en-us/windows/win32/controls/theme-subclasses.
         VisualStyleElement darkTabPaneElement = VisualStyleElement.CreateElement("DarkMode::ExplorerNavPane", 0, 0);
         VisualStyleElement lightTabPaneElement = VisualStyleElement.Tab.Pane.Normal;
         VisualStyleElement tabPaneElement = Application.IsDarkModeEnabled

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TabControl/TabRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TabControl/TabRenderer.cs
@@ -146,7 +146,7 @@ public static class TabRenderer
 #pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         // Using DarkMode Theme Subclass.
         // see https://learn.microsoft.com/en-us/windows/win32/controls/theme-subclasses.
-        VisualStyleElement darkTabPaneElement = VisualStyleElement.CreateElement("DarkMode::ExplorerNavPane", 0, 0);
+        VisualStyleElement darkTabPaneElement = VisualStyleElement.CreateElement($"{Control.DarkModeIdentifier}::{Control.NavPaneThemeIdentifier}", 0, 0);
         VisualStyleElement lightTabPaneElement = VisualStyleElement.Tab.Pane.Normal;
         VisualStyleElement tabPaneElement = Application.IsDarkModeEnabled
             ? darkTabPaneElement

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TabControl/TabRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TabControl/TabRenderer.cs
@@ -3,7 +3,6 @@
 
 using System.Drawing;
 using System.Windows.Forms.VisualStyles;
-
 namespace System.Windows.Forms;
 
 /// <summary>
@@ -144,7 +143,14 @@ public static class TabRenderer
 
     internal static void DrawTabPage(IDeviceContext deviceContext, Rectangle bounds)
     {
-        InitializeRenderer(VisualStyleElement.Tab.Pane.Normal, 0);
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+        VisualStyleElement darkTabPaneElement = VisualStyleElement.CreateElement("DarkMode::ExplorerNavPane", 0, 0);
+        VisualStyleElement lightTabPaneElement = VisualStyleElement.Tab.Pane.Normal;
+        VisualStyleElement tabPaneElement = Application.IsDarkModeEnabled
+            ? darkTabPaneElement
+            : lightTabPaneElement;
+        InitializeRenderer(tabPaneElement, 0);
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
         t_visualStyleRenderer.DrawBackground(deviceContext, bounds);
     }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleRenderer.cs
@@ -67,10 +67,18 @@ public sealed class VisualStyleRenderer : IHandle<HTHEME>
     }
 
     /// <summary>
-    ///  Returns true if Dark Mode visual styles subclass are 1) supported by the OS 2) enabled in the client area
-    ///  and 3) currently applied to this application. Otherwise, it returns false. Note that
-    ///  if it returns false, attempting to instantiate/use objects of this class
-    ///  will result in exceptions being thrown.
+    /// <para>
+    /// Gets a value specifying whether the operating system has Dark Mode visual styles subclass and the Application can  use this subclass to draw controls with Dark Mode theme.
+    ///</para>
+    ///<para>
+    ///<return>
+    ///<para> Returns true if Visual Style Dark Mode subclass is: </para>
+    /// <para> 1) Supported by the operating system.</para>
+    /// <para> 2) Enabled in the client area.</para>
+    /// <para> 3) operating system not ruining in high contrast mode</para>
+    /// <para> Otherwise, returns false. Note that if false is returned, attempts to create/use objects of this class will throw exceptions.</para>
+    ///</return>
+    ///</para>
     /// </summary>
     [Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
     public static bool IsDarkModeSupported
@@ -81,11 +89,8 @@ public sealed class VisualStyleRenderer : IHandle<HTHEME>
 
             if (supported)
             {
-                // In some cases, this check isn't enough, since the theme handle creation
-                // could fail for some other reason. Try creating a theme handle here - if successful, return true,
-                // else return false.
-                HTHEME hTheme = GetHandle("DarkMode_Explorer::BUTTON", false); // Button is an arbitrary choice.
-                supported = !hTheme.IsNull;
+                IntPtr hTheme = GetHandle($"{Control.DarkModeIdentifier}_{Control.ExplorerThemeIdentifier}::BUTTON", false); // Button is an arbitrary choice.
+                supported = hTheme != IntPtr.Zero && !SystemInformation.HighContrast;
             }
 
             return supported;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleRenderer.cs
@@ -89,8 +89,8 @@ public sealed class VisualStyleRenderer : IHandle<HTHEME>
 
             if (supported)
             {
-                IntPtr hTheme = GetHandle($"{Control.DarkModeIdentifier}_{Control.ExplorerThemeIdentifier}::BUTTON", false); // Button is an arbitrary choice.
-                supported = hTheme != IntPtr.Zero && !SystemInformation.HighContrast;
+                HTHEME hTheme = GetHandle($"{Control.DarkModeIdentifier}_{Control.ExplorerThemeIdentifier}::BUTTON", false); // Button is an arbitrary choice.
+                supported = !hTheme.IsNull && !SystemInformation.HighContrast;
             }
 
             return supported;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleRenderer.cs
@@ -84,8 +84,8 @@ public sealed class VisualStyleRenderer : IHandle<HTHEME>
                 // In some cases, this check isn't enough, since the theme handle creation
                 // could fail for some other reason. Try creating a theme handle here - if successful, return true,
                 // else return false.
-                IntPtr hTheme = GetHandle("DarkMode_Explorer::BUTTON", false); // Button is an arbitrary choice.
-                supported = hTheme != IntPtr.Zero;
+                HTHEME hTheme = GetHandle("DarkMode_Explorer::BUTTON", false); // Button is an arbitrary choice.
+                supported = !hTheme.IsNull;
             }
 
             return supported;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleRenderer.cs
@@ -3,6 +3,7 @@
 
 using System.Drawing;
 using System.Drawing.Interop;
+using System.Windows.Forms.Analyzers.Diagnostics;
 using Microsoft.Win32;
 
 namespace System.Windows.Forms.VisualStyles;
@@ -58,6 +59,32 @@ public sealed class VisualStyleRenderer : IHandle<HTHEME>
                 // could fail for some other reason. Try creating a theme handle here - if successful, return true,
                 // else return false.
                 IntPtr hTheme = GetHandle("BUTTON", false); // Button is an arbitrary choice.
+                supported = hTheme != IntPtr.Zero;
+            }
+
+            return supported;
+        }
+    }
+
+    [Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
+    /// <summary>
+    ///  Returns true if Dark Mode visual styles subclass are 1) supported by the OS 2) enabled in the client area
+    ///  and 3) currently applied to this application. Otherwise, it returns false. Note that
+    ///  if it returns false, attempting to instantiate/use objects of this class
+    ///  will result in exceptions being thrown.
+    /// </summary>
+    public static bool IsDarkModeSupported
+    {
+        get
+        {
+            bool supported = AreClientAreaVisualStylesSupported;
+
+            if (supported)
+            {
+                // In some cases, this check isn't enough, since the theme handle creation
+                // could fail for some other reason. Try creating a theme handle here - if successful, return true,
+                // else return false.
+                IntPtr hTheme = GetHandle("DarkMode_Explorer::BUTTON", false); // Button is an arbitrary choice.
                 supported = hTheme != IntPtr.Zero;
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleRenderer.cs
@@ -66,13 +66,13 @@ public sealed class VisualStyleRenderer : IHandle<HTHEME>
         }
     }
 
-    [Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
     /// <summary>
     ///  Returns true if Dark Mode visual styles subclass are 1) supported by the OS 2) enabled in the client area
     ///  and 3) currently applied to this application. Otherwise, it returns false. Note that
     ///  if it returns false, attempting to instantiate/use objects of this class
     ///  will result in exceptions being thrown.
     /// </summary>
+    [Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
     public static bool IsDarkModeSupported
     {
         get


### PR DESCRIPTION
This is an improvement to  new Dark Mode experimental feature 
 https://github.com/dotnet/winforms/pull/11857
see 
https://learn.microsoft.com/en-us/windows/win32/controls/theme-subclasses#two-ways-to-use-a-theme-subclass

Fixes https://github.com/dotnet/winforms/issues/11893.
Fixes https://github.com/dotnet/winforms/issues/11953.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11985)