### PR TITLE
Add unit tests for ContextMenuStripGroup

### DIFF
--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ContextMenuStripGroupTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ContextMenuStripGroupTests.cs
@@ -1,0 +1,72 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+namespace System.Windows.Forms.Design.Tests;
+
+public class ContextMenuStripGroupTests
+{
+    [Fact]
+    public void Items_ShouldInitializeCorrectly()
+    {
+        ContextMenuStripGroup contextMenuStripGroup = new();
+
+        IList<ToolStripItem> items = contextMenuStripGroup.Items;
+
+        items.Should().NotBeNull();
+        items.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Items_ShouldReturnSameInstance()
+    {
+        ContextMenuStripGroup contextMenuStripGroup = new();
+
+        IList<ToolStripItem> items1 = contextMenuStripGroup.Items;
+        IList<ToolStripItem> items2 = contextMenuStripGroup.Items;
+
+        items1.Should().NotBeNull();
+        items2.Should().NotBeNull();
+        items1.Should().BeSameAs(items2);
+    }
+
+    [Fact]
+    public void Items_ShouldAllowAddingItems()
+    {
+        ContextMenuStripGroup contextMenuStripGroup = new();
+        ToolStripMenuItem newItem = new("Test Item");
+
+        contextMenuStripGroup.Items.Add(newItem);
+
+        contextMenuStripGroup.Items.Should().ContainSingle()
+            .Which.Should().Be(newItem);
+    }
+
+    [Fact]
+    public void Items_ShouldAllowAddingMultipleItems()
+    {
+        ContextMenuStripGroup contextMenuStripGroup = new();
+        ToolStripMenuItem newItem1 = new("Test Item1");
+        ToolStripMenuItem newItem2 = new("Test Item2");
+
+        contextMenuStripGroup.Items.Add(newItem1);
+        contextMenuStripGroup.Items.Add(newItem2);
+
+        contextMenuStripGroup.Items.Should().HaveCount(2);
+        contextMenuStripGroup.Items.Should().Contain(newItem1);
+        contextMenuStripGroup.Items.Should().Contain(newItem2);
+    }
+
+    [Fact]
+    public void Items_ShouldAllowClearingItems()
+    {
+        ContextMenuStripGroup contextMenuStripGroup = new();
+        ToolStripMenuItem newItem = new("Test Item");
+
+        contextMenuStripGroup.Items.Add(newItem);
+        contextMenuStripGroup.Items.Clear();
+
+        contextMenuStripGroup.Items.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->
Related https://github.com/dotnet/winforms/issues/10773


## Proposed changes
- Add unit test ContextMenuStripGroupTests.cs for public properties and method of the ContextMenuStripGroup.
- Enable nullability in ContextMenuStripGroup.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/11989)