### PR TITLE
Adds code coverage to FolderNameEditor

### DIFF
--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/FolderNameEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/FolderNameEditorTests.cs
@@ -4,6 +4,7 @@
 using System.ComponentModel;
 using System.Drawing.Design;
 using System.Windows.Forms.TestUtilities;
+using Moq;
 
 namespace System.Windows.Forms.Design.Tests;
 
@@ -37,6 +38,29 @@ public class FolderNameEditorTests
     {
         SubFolderNameEditor editor = new();
         editor.InitializeDialog();
+    }
+
+    [WinFormsFact]
+    public void FolderNameEditor_EditValue_Invoke_ReturnsExpected()
+    {
+        FolderNameEditor editor = new();
+        Mock<IServiceProvider> serviceProviderMock = new();
+        var serviceProvider = serviceProviderMock.Object;
+        string value = "value";
+
+        Thread thread = new(() =>
+        {
+            Thread.Sleep(500);
+            SendKeys.SendWait("{ESC}");
+        });
+
+        thread.Start();
+
+        object result = editor.EditValue(context: null, provider: serviceProvider, value: value);
+
+        result.Should().Be(value);
+
+        thread.Join();
     }
 
     public class FolderBrowserTests : FolderNameEditor


### PR DESCRIPTION
Related #10773

## Proposed changes

- Adds code coverage to `FolderNameEditor`

## Customer Impact

- None

## Regression?

- No

## Risk

- Minimal

## Test methodology

- Unit tests

## Test environment(s)

- 9.0.100-preview.7.24407.12

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #


## Proposed changes

- 
- 
- 

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- 
- 

## Regression? 

- Yes / No

## Risk

-

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->

### After

<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- 
- 
- 

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

- <!-- use `dotnet --info` -->


<!-- Mention language, UI scaling, or anything else that might be relevant -->
