### PR TITLE
Add Clipboard.Clear(); at the end of the tests

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/TextBoxBaseTests.ClipboardTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/TextBoxBaseTests.ClipboardTests.cs
@@ -156,7 +156,7 @@ public partial class TextBoxBaseTests
             Clipboard.Clear();
             using SubTextBox control = new();
             control.Paste();
-            control.Text.Should().NotBeNull();
+            control.Text.Should().BeEmpty();
             control.IsHandleCreated.Should().BeTrue();
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/TextBoxBaseTests.ClipboardTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/TextBoxBaseTests.ClipboardTests.cs
@@ -11,7 +11,6 @@ public partial class TextBoxBaseTests
         [WinFormsFact]
         public void TextBoxBase_ClearUndo_CanUndo_Success()
         {
-            Clipboard.Clear();
             using SubTextBox control = new()
             {
                 Text = "abc",
@@ -24,18 +23,16 @@ public partial class TextBoxBaseTests
             control.SelectionLength = 2;
             control.Paste();
 
-            Clipboard.GetText().Should().Be("bc");
-            Assert.Equal("bcxt", control.Text);
+            control.Text.Should().Be("bcxt");
 
             control.ClearUndo();
             control.Undo();
-            Assert.Equal("bcxt", control.Text);
+            control.Text.Should().Be("bcxt");
         }
 
         [WinFormsFact]
         public void TextBoxBase_Copy_PasteNotEmpty_Success()
         {
-            Clipboard.Clear();
             using SubTextBox control = new()
             {
                 Text = "abc",
@@ -43,31 +40,29 @@ public partial class TextBoxBaseTests
                 SelectionLength = 2
             };
             control.Copy();
-            Assert.Equal("abc", control.Text);
-            Assert.True(control.IsHandleCreated);
+            control.Text.Should().Be("abc");
+            control.IsHandleCreated.Should().BeTrue();
 
             control.Text = "text";
             control.SelectionLength = 2;
             control.Paste();
 
-            Clipboard.GetText().Should().Be("bc");
-            Assert.Equal("bcxt", control.Text);
-            Assert.True(control.CanUndo);
-            Assert.True(control.Modified);
-            Assert.True(control.IsHandleCreated);
+            control.Text.Should().Be("bcxt");
+            control.CanUndo.Should().BeTrue();
+            control.Modified.Should().BeTrue();
+            control.IsHandleCreated.Should().BeTrue();
         }
 
         [WinFormsFact]
         public void TextBoxBase_Copy_PasteNotEmptyWithHandle_Success()
         {
-            Clipboard.Clear();
             using SubTextBox control = new()
             {
                 Text = "abc",
                 SelectionStart = 1,
                 SelectionLength = 2
             };
-            Assert.NotEqual(IntPtr.Zero, control.Handle);
+            control.Handle.Should().NotBe(IntPtr.Zero);
             int invalidatedCallCount = 0;
             control.Invalidated += (sender, e) => invalidatedCallCount++;
             int styleChangedCallCount = 0;
@@ -76,30 +71,28 @@ public partial class TextBoxBaseTests
             control.HandleCreated += (sender, e) => createdCallCount++;
 
             control.Copy();
-            Assert.Equal("abc", control.Text);
-            Assert.True(control.IsHandleCreated);
-            Assert.Equal(0, invalidatedCallCount);
-            Assert.Equal(0, styleChangedCallCount);
-            Assert.Equal(0, createdCallCount);
+            control.Text.Should().Be("abc");
+            control.IsHandleCreated.Should().BeTrue();
+            invalidatedCallCount.Should().Be(0);
+            styleChangedCallCount.Should().Be(0);
+            createdCallCount.Should().Be(0);
 
             control.Text = "text";
             control.SelectionLength = 2;
             control.Paste();
 
-            Clipboard.GetText().Should().Be("bc");
-            Assert.Equal("bcxt", control.Text);
-            Assert.True(control.CanUndo);
-            Assert.True(control.Modified);
-            Assert.True(control.IsHandleCreated);
-            Assert.Equal(0, invalidatedCallCount);
-            Assert.Equal(0, styleChangedCallCount);
-            Assert.Equal(0, createdCallCount);
+            control.Text.Should().Be("bcxt");
+            control.CanUndo.Should().BeTrue();
+            control.Modified.Should().BeTrue();
+            control.IsHandleCreated.Should().BeTrue();
+            invalidatedCallCount.Should().Be(0);
+            styleChangedCallCount.Should().Be(0);
+            createdCallCount.Should().Be(0);
         }
 
         [WinFormsFact]
         public void TextBoxBase_Cut_PasteNotEmpty_Success()
         {
-            Clipboard.Clear();
             using SubTextBox control = new()
             {
                 Text = "abc",
@@ -107,31 +100,29 @@ public partial class TextBoxBaseTests
                 SelectionLength = 2
             };
             control.Cut();
-            Assert.Equal("a", control.Text);
-            Assert.True(control.IsHandleCreated);
+            control.Text.Should().Be("a");
+            control.IsHandleCreated.Should().BeTrue();
 
             control.Text = "text";
             control.SelectionLength = 2;
             control.Paste();
 
-            Clipboard.GetText().Should().Be("bc");
-            Assert.Equal("bcxt", control.Text);
-            Assert.True(control.CanUndo);
-            Assert.True(control.Modified);
-            Assert.True(control.IsHandleCreated);
+            control.Text.Should().Be("bcxt");
+            control.CanUndo.Should().BeTrue();
+            control.Modified.Should().BeTrue();
+            control.IsHandleCreated.Should().BeTrue();
         }
 
         [WinFormsFact]
         public void TextBoxBase_Cut_PasteNotEmptyWithHandle_Success()
         {
-            Clipboard.Clear();
             using SubTextBox control = new()
             {
                 Text = "abc",
                 SelectionStart = 1,
                 SelectionLength = 2
             };
-            Assert.NotEqual(IntPtr.Zero, control.Handle);
+            control.Handle.Should().NotBe(IntPtr.Zero);
             int invalidatedCallCount = 0;
             control.Invalidated += (sender, e) => invalidatedCallCount++;
             int styleChangedCallCount = 0;
@@ -140,24 +131,23 @@ public partial class TextBoxBaseTests
             control.HandleCreated += (sender, e) => createdCallCount++;
 
             control.Cut();
-            Assert.Equal("a", control.Text);
-            Assert.True(control.IsHandleCreated);
-            Assert.Equal(0, invalidatedCallCount);
-            Assert.Equal(0, styleChangedCallCount);
-            Assert.Equal(0, createdCallCount);
+            control.Text.Should().Be("a");
+            control.IsHandleCreated.Should().BeTrue();
+            invalidatedCallCount.Should().Be(0);
+            styleChangedCallCount.Should().Be(0);
+            createdCallCount.Should().Be(0);
 
             control.Text = "text";
             control.SelectionLength = 2;
             control.Paste();
 
-            Clipboard.GetText().Should().Be("bc");
-            Assert.Equal("bcxt", control.Text);
-            Assert.True(control.CanUndo);
-            Assert.True(control.Modified);
-            Assert.True(control.IsHandleCreated);
-            Assert.Equal(0, invalidatedCallCount);
-            Assert.Equal(0, styleChangedCallCount);
-            Assert.Equal(0, createdCallCount);
+            control.Text.Should().Be("bcxt");
+            control.CanUndo.Should().BeTrue();
+            control.Modified.Should().BeTrue();
+            control.IsHandleCreated.Should().BeTrue();
+            invalidatedCallCount.Should().Be(0);
+            styleChangedCallCount.Should().Be(0);
+            createdCallCount.Should().Be(0);
         }
 
         [WinFormsFact]
@@ -166,8 +156,8 @@ public partial class TextBoxBaseTests
             Clipboard.Clear();
             using SubTextBox control = new();
             control.Paste();
-            Assert.NotNull(control.Text);
-            Assert.True(control.IsHandleCreated);
+            control.Text.Should().NotBeNull();
+            control.IsHandleCreated.Should().BeTrue();
         }
 
         [WinFormsFact]
@@ -181,14 +171,13 @@ public partial class TextBoxBaseTests
                 SelectionLength = 2
             };
             control.Paste();
-            Assert.Equal("abc", control.Text);
-            Assert.True(control.IsHandleCreated);
+            control.Text.Should().Be("a");
+            control.IsHandleCreated.Should().BeTrue();
         }
 
         [WinFormsFact]
         public void TextBoxBase_Undo_CanUndo_Success()
         {
-            Clipboard.Clear();
             using SubTextBox control = new()
             {
                 Text = "abc",
@@ -201,34 +190,31 @@ public partial class TextBoxBaseTests
             control.SelectionLength = 2;
             control.Paste();
 
-            Clipboard.GetText().Should().Be("bc");
-            Assert.Equal("bcxt", control.Text);
+            control.Text.Should().Be("bcxt");
 
             control.Undo();
-            Assert.Equal("text", control.Text);
+            control.Text.Should().Be("text");
         }
 
         [WinFormsFact]
         public void TextBoxBase_Copy_PasteEmpty_Success()
         {
-            Clipboard.Clear();
             using SubTextBox control = new();
             control.Copy();
-            Assert.Empty(control.Text);
-            Assert.True(control.IsHandleCreated);
+            control.Text.Should().BeEmpty();
+            control.IsHandleCreated.Should().BeTrue();
 
             control.Text = "text";
             control.SelectionLength = 2;
-            Assert.Equal("text", control.Text);
-            Assert.True(control.IsHandleCreated);
+            control.Text.Should().Be("text");
+            control.IsHandleCreated.Should().BeTrue();
         }
 
         [WinFormsFact]
         public void TextBoxBase_Copy_PasteEmptyWithHandle_Success()
         {
-            Clipboard.Clear();
             using SubTextBox control = new();
-            Assert.NotEqual(IntPtr.Zero, control.Handle);
+            control.Handle.Should().NotBe(IntPtr.Zero);
             int invalidatedCallCount = 0;
             control.Invalidated += (sender, e) => invalidatedCallCount++;
             int styleChangedCallCount = 0;
@@ -237,19 +223,19 @@ public partial class TextBoxBaseTests
             control.HandleCreated += (sender, e) => createdCallCount++;
 
             control.Copy();
-            Assert.Empty(control.Text);
-            Assert.True(control.IsHandleCreated);
-            Assert.Equal(0, invalidatedCallCount);
-            Assert.Equal(0, styleChangedCallCount);
-            Assert.Equal(0, createdCallCount);
+            control.Text.Should().BeEmpty();
+            control.IsHandleCreated.Should().BeTrue();
+            invalidatedCallCount.Should().Be(0);
+            styleChangedCallCount.Should().Be(0);
+            createdCallCount.Should().Be(0);
 
             control.Text = "text";
             control.SelectionLength = 2;
-            Assert.Equal("text", control.Text);
-            Assert.True(control.IsHandleCreated);
-            Assert.Equal(0, invalidatedCallCount);
-            Assert.Equal(0, styleChangedCallCount);
-            Assert.Equal(0, createdCallCount);
+            control.Text.Should().Be("text");
+            control.IsHandleCreated.Should().BeTrue();
+            invalidatedCallCount.Should().Be(0);
+            styleChangedCallCount.Should().Be(0);
+            createdCallCount.Should().Be(0);
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/TextBoxBaseTests.ClipboardTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/TextBoxBaseTests.ClipboardTests.cs
@@ -11,6 +11,7 @@ public partial class TextBoxBaseTests
         [WinFormsFact]
         public void TextBoxBase_ClearUndo_CanUndo_Success()
         {
+            Clipboard.Clear();
             using SubTextBox control = new()
             {
                 Text = "abc",
@@ -22,6 +23,8 @@ public partial class TextBoxBaseTests
             control.Text = "text";
             control.SelectionLength = 2;
             control.Paste();
+
+            Clipboard.GetText().Should().Be("bc");
             Assert.Equal("bcxt", control.Text);
 
             control.ClearUndo();
@@ -32,6 +35,7 @@ public partial class TextBoxBaseTests
         [WinFormsFact]
         public void TextBoxBase_Copy_PasteNotEmpty_Success()
         {
+            Clipboard.Clear();
             using SubTextBox control = new()
             {
                 Text = "abc",
@@ -45,6 +49,8 @@ public partial class TextBoxBaseTests
             control.Text = "text";
             control.SelectionLength = 2;
             control.Paste();
+
+            Clipboard.GetText().Should().Be("bc");
             Assert.Equal("bcxt", control.Text);
             Assert.True(control.CanUndo);
             Assert.True(control.Modified);
@@ -54,6 +60,7 @@ public partial class TextBoxBaseTests
         [WinFormsFact]
         public void TextBoxBase_Copy_PasteNotEmptyWithHandle_Success()
         {
+            Clipboard.Clear();
             using SubTextBox control = new()
             {
                 Text = "abc",
@@ -78,6 +85,8 @@ public partial class TextBoxBaseTests
             control.Text = "text";
             control.SelectionLength = 2;
             control.Paste();
+
+            Clipboard.GetText().Should().Be("bc");
             Assert.Equal("bcxt", control.Text);
             Assert.True(control.CanUndo);
             Assert.True(control.Modified);
@@ -90,6 +99,7 @@ public partial class TextBoxBaseTests
         [WinFormsFact]
         public void TextBoxBase_Cut_PasteNotEmpty_Success()
         {
+            Clipboard.Clear();
             using SubTextBox control = new()
             {
                 Text = "abc",
@@ -103,6 +113,8 @@ public partial class TextBoxBaseTests
             control.Text = "text";
             control.SelectionLength = 2;
             control.Paste();
+
+            Clipboard.GetText().Should().Be("bc");
             Assert.Equal("bcxt", control.Text);
             Assert.True(control.CanUndo);
             Assert.True(control.Modified);
@@ -112,6 +124,7 @@ public partial class TextBoxBaseTests
         [WinFormsFact]
         public void TextBoxBase_Cut_PasteNotEmptyWithHandle_Success()
         {
+            Clipboard.Clear();
             using SubTextBox control = new()
             {
                 Text = "abc",
@@ -136,6 +149,8 @@ public partial class TextBoxBaseTests
             control.Text = "text";
             control.SelectionLength = 2;
             control.Paste();
+
+            Clipboard.GetText().Should().Be("bc");
             Assert.Equal("bcxt", control.Text);
             Assert.True(control.CanUndo);
             Assert.True(control.Modified);
@@ -148,6 +163,7 @@ public partial class TextBoxBaseTests
         [WinFormsFact]
         public void TextBoxBase_Paste_InvokeEmpty_Success()
         {
+            Clipboard.Clear();
             using SubTextBox control = new();
             control.Paste();
             Assert.NotNull(control.Text);
@@ -157,6 +173,7 @@ public partial class TextBoxBaseTests
         [WinFormsFact]
         public void TextBoxBase_Paste_InvokeNotEmpty_Success()
         {
+            Clipboard.Clear();
             using SubTextBox control = new()
             {
                 Text = "abc",
@@ -171,6 +188,7 @@ public partial class TextBoxBaseTests
         [WinFormsFact]
         public void TextBoxBase_Undo_CanUndo_Success()
         {
+            Clipboard.Clear();
             using SubTextBox control = new()
             {
                 Text = "abc",
@@ -182,6 +200,8 @@ public partial class TextBoxBaseTests
             control.Text = "text";
             control.SelectionLength = 2;
             control.Paste();
+
+            Clipboard.GetText().Should().Be("bc");
             Assert.Equal("bcxt", control.Text);
 
             control.Undo();
@@ -191,6 +211,7 @@ public partial class TextBoxBaseTests
         [WinFormsFact]
         public void TextBoxBase_Copy_PasteEmpty_Success()
         {
+            Clipboard.Clear();
             using SubTextBox control = new();
             control.Copy();
             Assert.Empty(control.Text);
@@ -205,6 +226,7 @@ public partial class TextBoxBaseTests
         [WinFormsFact]
         public void TextBoxBase_Copy_PasteEmptyWithHandle_Success()
         {
+            Clipboard.Clear();
             using SubTextBox control = new();
             Assert.NotEqual(IntPtr.Zero, control.Handle);
             int invalidatedCallCount = 0;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Related #12002


## Proposed changes

- Add `Clipboard.Clear();` at the begin of all tests
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12032)