### PR TITLE
fix issue #11450 scenario  2. Color contrast ratio of focus indicator over 'toolStripSplitButton1' is 1.247:1 which is less than 3:1: A11y_.NET CoreWinforms_StripControls_Toolstripwithmenuitem_NonTextContrast

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewDialog.cs
@@ -797,13 +797,6 @@ public partial class PrintPreviewDialog : Form
 
         _toolStrip1.Name = "toolStrip1";
 
-        // In High Contrast mode the color scheme provided by ToolStripSystemRenderer
-        // is not sufficiently contrast; so disable it in High Contrast mode.
-        if (!SystemInformation.HighContrast)
-        {
-            _toolStrip1.RenderMode = ToolStripRenderMode.System;
-        }
-
         _toolStrip1.GripStyle = ToolStripGripStyle.Hidden;
 
         _printToolStripButton.DisplayStyle = ToolStripItemDisplayStyle.Image;


### PR DESCRIPTION
Fixes #11450
 
 
## Proposed changes
 
- 
- Remove RenderMode
-
 
<!--  
 
## Customer Impact
 
- 
-
 
 
## Regression?
 
- Yes / No
 
## Risk
 
-
-->
 
 
## Screenshots <!-- Remove this section if PR does not change UI -->
 
### Before
 
![image](https://github.com/user-attachments/assets/55b92b9a-f657-4257-9456-962660f01219) 

### After
 
![image](https://github.com/user-attachments/assets/ce684812-e9e3-454f-bcaa-2b6b2274ecd9) 

<!-- 
## Test methodology
 
- 
- manual 


## Test environment(s)
 

-->
 
 