### PR TITLE
Bump Microsoft.Private.Intellisense version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -52,7 +52,7 @@
   </PropertyGroup>
   <!-- Docs / Intellisense -->
   <PropertyGroup>
-    <MicrosoftPrivateIntellisenseVersion>8.0.0-preview-20230918.1</MicrosoftPrivateIntellisenseVersion>
+    <MicrosoftPrivateIntellisenseVersion>9.0.0-preview-20240830.1</MicrosoftPrivateIntellisenseVersion>
   </PropertyGroup>
   <!-- Arcade -->
   <PropertyGroup>


### PR DESCRIPTION
Bump Microsoft.Private.Intellisense version to consume latest API documentation

This will be backported to release/9.0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12059)