### PR TITLE
Fixes term due to compliance

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -6723,7 +6723,7 @@ System.Windows.Forms.HtmlElement.InnerHtml.get -> string!
 System.Windows.Forms.HtmlElement.InnerHtml.set -> void
 System.Windows.Forms.HtmlElement.InnerText.get -> string!
 System.Windows.Forms.HtmlElement.InnerText.set -> void
-System.Windows.Forms.HtmlElement.InsertAdjacentElement(System.Windows.Forms.HtmlElementInsertionOrientation orient, System.Windows.Forms.HtmlElement! newElement) -> System.Windows.Forms.HtmlElement?
+System.Windows.Forms.HtmlElement.InsertAdjacentElement(System.Windows.Forms.HtmlElementInsertionOrientation orientation, System.Windows.Forms.HtmlElement! newElement) -> System.Windows.Forms.HtmlElement?
 System.Windows.Forms.HtmlElement.InvokeMember(string! methodName) -> object?
 System.Windows.Forms.HtmlElement.InvokeMember(string! methodName, params object![]? parameter) -> object?
 System.Windows.Forms.HtmlElement.KeyDown -> System.Windows.Forms.HtmlElementEventHandler?

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/WebBrowser/HtmlElement.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/WebBrowser/HtmlElement.cs
@@ -547,10 +547,10 @@ public sealed unsafe partial class HtmlElement
         return iHTMLElementCollection is not null ? new HtmlElementCollection(_shimManager, iHTMLElementCollection) : new HtmlElementCollection(_shimManager);
     }
 
-    public HtmlElement? InsertAdjacentElement(HtmlElementInsertionOrientation orient, HtmlElement newElement)
+    public HtmlElement? InsertAdjacentElement(HtmlElementInsertionOrientation orientation, HtmlElement newElement)
     {
         using var htmlElement2 = GetHtmlElement<IHTMLElement2>();
-        using BSTR where = new(orient.ToString());
+        using BSTR where = new(orientation.ToString());
         using var htmlElement = NativeHtmlElement.GetInterface();
         using var insertedElement = ComHelpers.GetComScope<IHTMLElement>(newElement.DomElement);
         IHTMLElement* adjElement;


### PR DESCRIPTION
Fixes #[2240374](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2240374?src=WorkItemMention&src-action=artifact_link)

## Proposed changes

- Could not fork AzDo dotnet-winforms due to lack of permissions.
- Changes orient to orientation for compliance reasons.

## Customer Impact

- None

## Risk

- Minimal

## Test environment(s)

- 9.0.100-preview.7.24407.12
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12060)