### PR TITLE
Shorten more lines

### DIFF
--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Logging/FileLogTraceListener.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Logging/FileLogTraceListener.vb
@@ -677,7 +677,9 @@ Namespace Microsoft.VisualBasic.Logging
         ''' <summary>
         '''  Indicates whether or not the current date has changed to new day.
         ''' </summary>
-        ''' <returns><see langword="True"/> if the date has changed, otherwise <see langword="False">.</see></returns>
+        ''' <returns>
+        '''  <see langword="True"/> if the date has changed, otherwise <see langword="False">.</see>
+        ''' </returns>
         Private Function DayChanged() As Boolean
             Return _day.Date <> Now.Date
         End Function

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Logging/FileLogTraceListener.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Logging/FileLogTraceListener.vb
@@ -677,7 +677,7 @@ Namespace Microsoft.VisualBasic.Logging
         ''' <summary>
         '''  Indicates whether or not the current date has changed to new day.
         ''' </summary>
-        ''' <returns><see langword="True"/> if the date has changed, otherwise <see langword="False">.</see>.</returns>
+        ''' <returns><see langword="True"/> if the date has changed, otherwise <see langword="False">.</see></returns>
         Private Function DayChanged() As Boolean
             Return _day.Date <> Now.Date
         End Function

--- a/src/System.Drawing.Common/src/System/Drawing/ImageConverter.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/ImageConverter.cs
@@ -114,7 +114,7 @@ public partial class ImageConverter : TypeConverter
 
         // [MS-OLEDS]: Object Linking and Embedding (OLE)
         // 2.2.5 EmbeddedObject
-        // https://learn.Microsoft.com/openspecs/windows_protocols/ms-oleds/3395d95d-97f0-49ff-b792-28d331f254f1
+        // https://learn.microsoft.com/openspecs/windows_protocols/ms-oleds/3395d95d-97f0-49ff-b792-28d331f254f1
 
         // Read and validate the ObjectHeader
         if (!reader.TryRead(out uint version)

--- a/src/System.Drawing.Common/src/System/Drawing/ImageConverter.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/ImageConverter.cs
@@ -114,7 +114,7 @@ public partial class ImageConverter : TypeConverter
 
         // [MS-OLEDS]: Object Linking and Embedding (OLE)
         // 2.2.5 EmbeddedObject
-        // https://learn.microsoft.com/openspecs/windows_protocols/ms-oleds/3395d95d-97f0-49ff-b792-28d331f254f1
+        // https://learn.Microsoft.com/openspecs/windows_protocols/ms-oleds/3395d95d-97f0-49ff-b792-28d331f254f1
 
         // Read and validate the ObjectHeader
         if (!reader.TryRead(out uint version)

--- a/src/System.Drawing.Common/src/Windows/Win32/PInvoke.SHGetStockIconInfo.cs
+++ b/src/System.Drawing.Common/src/Windows/Win32/PInvoke.SHGetStockIconInfo.cs
@@ -13,11 +13,11 @@ internal partial class PInvoke
 
     /// <summary>Retrieves information about system-defined Shell icons.</summary>
     /// <param name="siid">
-    /// <para>Type: <b><a href="https://learn.Microsoft.com/windows/desktop/api/shellapi/ne-shellapi-shstockiconid">
+    /// <para>Type: <b><a href="https://learn.microsoft.com/windows/desktop/api/shellapi/ne-shellapi-shstockiconid">
     /// SHSTOCKICONID</a></b> One of the values from the
-    /// <a href="https://learn.Microsoft.com/windows/desktop/api/shellapi/ne-shellapi-shstockiconid">
+    /// <a href="https://learn.microsoft.com/windows/desktop/api/shellapi/ne-shellapi-shstockiconid">
     /// SHSTOCKICONID</a> enumeration that specifies which icon should be retrieved.</para>
-    /// <para><see href="https://learn.Microsoft.com/windows/win32/api/shellapi/nf-shellapi-shgetstockiconinfo#parameters">
+    /// <para><see href="https://learn.microsoft.com/windows/win32/api/shellapi/nf-shellapi-shgetstockiconinfo#parameters">
     /// Read more on learn.Microsoft.com</see>.</para>
     /// </param>
     /// <param name="uFlags">
@@ -25,16 +25,16 @@ internal partial class PInvoke
     ///  Type: <b>UINT</b> A combination of zero or more of the following flags that specify which information is requested.
     /// </para>
     /// <para>
-    ///  <see href="https://learn.Microsoft.com/windows/win32/api/shellapi/nf-shellapi-shgetstockiconinfo#parameters">
+    ///  <see href="https://learn.microsoft.com/windows/win32/api/shellapi/nf-shellapi-shgetstockiconinfo#parameters">
     ///  Read more on learn.Microsoft.com</see>.</para>
     /// </param>
     /// <param name="psii">
-    /// <para>Type: <b><a href="https://learn.Microsoft.com/windows/desktop/api/shellapi/ns-shellapi-shstockiconinfo">
-    ///  SHSTOCKICONINFO</a>*</b> A pointer to a <a href="https://learn.Microsoft.com/windows/desktop/api/shellapi/ns-shellapi-shstockiconinfo">
+    /// <para>Type: <b><a href="https://learn.microsoft.com/windows/desktop/api/shellapi/ns-shellapi-shstockiconinfo">
+    ///  SHSTOCKICONINFO</a>*</b> A pointer to a <a href="https://learn.microsoft.com/windows/desktop/api/shellapi/ns-shellapi-shstockiconinfo">
     ///  SHSTOCKICONINFO</a> structure. When this function is called, the <b>cbSize</b> member of this structure
     ///  needs to be set to the size of the <b>SHSTOCKICONINFO</b> structure. When this function returns, contains a pointer
     ///  to a <b>SHSTOCKICONINFO</b> structure that contains the requested information.</para>
-    /// <para><see href="https://learn.Microsoft.com/windows/win32/api/shellapi/nf-shellapi-shgetstockiconinfo#parameters">
+    /// <para><see href="https://learn.microsoft.com/windows/win32/api/shellapi/nf-shellapi-shgetstockiconinfo#parameters">
     ///  Read more on learn.Microsoft.com</see>.</para>
     /// </param>
     /// <returns>
@@ -45,9 +45,9 @@ internal partial class PInvoke
     /// <remarks>
     ///  <para>
     ///   If this function returns an icon handle in the <b>hIcon</b> member of the
-    ///   <a href="https://learn.Microsoft.com/windows/desktop/api/shellapi/ns-shellapi-shstockiconinfo">SHSTOCKICONINFO</a>
+    ///   <a href="https://learn.microsoft.com/windows/desktop/api/shellapi/ns-shellapi-shstockiconinfo">SHSTOCKICONINFO</a>
     ///   structure pointed to by <i>psii</i>, you are responsible for freeing the icon with
-    ///   <a href="https://learn.Microsoft.com/windows/desktop/api/winuser/nf-winuser-destroyicon">DestroyIcon</a>
+    ///   <a href="https://learn.microsoft.com/windows/desktop/api/winuser/nf-winuser-destroyicon">DestroyIcon</a>
     ///   when you no longer need it.
     ///  </para>
     /// </remarks>

--- a/src/System.Drawing.Common/src/Windows/Win32/PInvoke.SHGetStockIconInfo.cs
+++ b/src/System.Drawing.Common/src/Windows/Win32/PInvoke.SHGetStockIconInfo.cs
@@ -12,35 +12,46 @@ internal partial class PInvoke
     // (see SHSTOCKICONINFO.cs for more details).
 
     /// <summary>Retrieves information about system-defined Shell icons.</summary>
-    /// <param name="siid">
-    /// <para>Type: <b><a href="https://learn.microsoft.com/windows/desktop/api/shellapi/ne-shellapi-shstockiconid">
-    /// SHSTOCKICONID</a></b> One of the values from the
-    /// <a href="https://learn.microsoft.com/windows/desktop/api/shellapi/ne-shellapi-shstockiconid">
-    /// SHSTOCKICONID</a> enumeration that specifies which icon should be retrieved.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/shellapi/nf-shellapi-shgetstockiconinfo#parameters">
-    /// Read more on learn.Microsoft.com</see>.</para>
-    /// </param>
-    /// <param name="uFlags">
-    /// <para>
-    ///  Type: <b>UINT</b> A combination of zero or more of the following flags that specify which information is requested.
-    /// </para>
-    /// <para>
-    ///  <see href="https://learn.microsoft.com/windows/win32/api/shellapi/nf-shellapi-shgetstockiconinfo#parameters">
-    ///  Read more on learn.Microsoft.com</see>.</para>
-    /// </param>
-    /// <param name="psii">
-    /// <para>Type: <b><a href="https://learn.microsoft.com/windows/desktop/api/shellapi/ns-shellapi-shstockiconinfo">
-    ///  SHSTOCKICONINFO</a>*</b> A pointer to a <a href="https://learn.microsoft.com/windows/desktop/api/shellapi/ns-shellapi-shstockiconinfo">
-    ///  SHSTOCKICONINFO</a> structure. When this function is called, the <b>cbSize</b> member of this structure
-    ///  needs to be set to the size of the <b>SHSTOCKICONINFO</b> structure. When this function returns, contains a pointer
-    ///  to a <b>SHSTOCKICONINFO</b> structure that contains the requested information.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/shellapi/nf-shellapi-shgetstockiconinfo#parameters">
-    ///  Read more on learn.Microsoft.com</see>.</para>
+    ///  <param name="siid">
+    ///   <para>Type: <b><a href="https://learn.microsoft.com/windows/desktop/api/shellapi/ne-shellapi-shstockiconid">
+    ///   SHSTOCKICONID</a></b> One of the values from the
+    ///   <a href="https://learn.microsoft.com/windows/desktop/api/shellapi/ne-shellapi-shstockiconid">
+    ///   SHSTOCKICONID</a> enumeration that specifies which icon should be retrieved.
+    ///   </para>
+    ///   <para>
+    ///    <see href="https://learn.microsoft.com/windows/win32/api/shellapi/nf-shellapi-shgetstockiconinfo#parameters">
+    ///     Read more on learn.Microsoft.com.
+    ///    </see>
+    ///   </para>
+    ///  </param>
+    ///   <param name="uFlags">
+    ///   <para>
+    ///    Type: <b>UINT</b> A combination of zero or more of the following flags that specify which information is requested.
+    ///   </para>
+    ///   <para>
+    ///    <see href="https://learn.microsoft.com/windows/win32/api/shellapi/nf-shellapi-shgetstockiconinfo#parameters">
+    ///     Read more on learn.Microsoft.com.
+    ///    </see>
+    ///   </para>
+    ///  </param>
+    ///  <param name="psii">
+    ///   <para>Type: <b><a href="https://learn.microsoft.com/windows/desktop/api/shellapi/ns-shellapi-shstockiconinfo">
+    ///    SHSTOCKICONINFO</a>*</b> A pointer to a
+    ///    <a href="https://learn.microsoft.com/windows/desktop/api/shellapi/ns-shellapi-shstockiconinfo">
+    ///    SHSTOCKICONINFO</a> structure. When this function is called, the <b>cbSize</b> member of this structure
+    ///    needs to be set to the size of the <b>SHSTOCKICONINFO</b> structure. When this function returns,
+    ///    contains a pointer to a <b>SHSTOCKICONINFO</b> structure that contains the requested information.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/shellapi/nf-shellapi-shgetstockiconinfo#parameters">
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
+    ///  </para>
     /// </param>
     /// <returns>
-    /// <para>
-    ///  Type: <b>HRESULT</b> If this function succeeds, it returns <b>S_OK</b>. Otherwise, it returns an <b>HRESULT</b> error code.
-    /// </para>
+    ///  <para>
+    ///   Type: <b>HRESULT</b> If this function succeeds, it returns <b>S_OK</b>. Otherwise, it returns an <b>HRESULT</b> error code.
+    ///  </para>
     /// </returns>
     /// <remarks>
     ///  <para>

--- a/src/System.Private.Windows.Core/src/System/Private/Windows/Core/BinaryFormat/BinaryType.cs
+++ b/src/System.Private.Windows.Core/src/System/Private/Windows/Core/BinaryFormat/BinaryType.cs
@@ -22,7 +22,7 @@ internal enum BinaryType : byte
 
     /// <summary>
     ///  Type is <see href="https://learn.microsoft.com/openspecs/windows_protocols/ms-nrbf/10b218f5-9b2b-4947-b4b7-07725a2c8127">
-    ///  length prefixed string</see>.
+    ///  length prefixed string.</see>
     /// </summary>
     String,
 

--- a/src/System.Private.Windows.Core/src/System/Private/Windows/Core/BinaryFormat/ClassRecord.cs
+++ b/src/System.Private.Windows.Core/src/System/Private/Windows/Core/BinaryFormat/ClassRecord.cs
@@ -10,8 +10,8 @@ namespace System.Private.Windows.Core.BinaryFormat;
 ///  <para>
 ///   Includes the values for the class (which trail the record)
 ///   <see href="https://learn.microsoft.com/openspecs/windows_protocols/ms-nrbf/c9bc3af3-5a0c-4b29-b517-1b493b51f7bb">
-///    [MS-NRBF] 2.3
-///   </see>.
+///    [MS-NRBF] 2.3.
+///   </see>
 ///  </para>
 /// </remarks>
 internal abstract class ClassRecord : ObjectRecord

--- a/src/System.Private.Windows.Core/src/System/Private/Windows/Core/BinaryFormat/RecordType.cs
+++ b/src/System.Private.Windows.Core/src/System/Private/Windows/Core/BinaryFormat/RecordType.cs
@@ -36,13 +36,15 @@ internal enum RecordType : byte
 
     /*
         /// <summary>
-        ///  Used for remote method invocation. <see href="https://learn.microsoft.com/openspecs/windows_protocols/ms-nrbf/4c727b2f-2c30-468d-b12e-b56406f14862">
+        ///  Used for remote method invocation.
+        ///  <see href="https://learn.microsoft.com/openspecs/windows_protocols/ms-nrbf/4c727b2f-2c30-468d-b12e-b56406f14862">
         ///  [MS-NRBF] 2.2</see>
         /// </summary>
         MethodCall,
 
         /// <summary>
-        ///  Used for remote method invocation. <see href="https://learn.microsoft.com/openspecs/windows_protocols/ms-nrbf/4c727b2f-2c30-468d-b12e-b56406f14862">
+        ///  Used for remote method invocation.
+        ///  <see href="https://learn.microsoft.com/openspecs/windows_protocols/ms-nrbf/4c727b2f-2c30-468d-b12e-b56406f14862">
         ///  [MS-NRBF] 2.2</see>
         /// </summary>
         MethodReturn

--- a/src/System.Private.Windows.Core/src/Windows/Win32/Graphics/Gdi/CreateBitmapScope.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/Graphics/Gdi/CreateBitmapScope.cs
@@ -28,7 +28,8 @@ internal readonly ref struct CreateBitmapScope
         HBITMAP = PInvokeCore.CreateBitmap(nWidth, nHeight, nPlanes, nBitCount, lpvBits);
 
     /// <summary>
-    ///  Creates a bitmap compatible with the given <see cref="HDC"/> via <see cref="PInvokeCore.CreateCompatibleBitmap(HDC, int, int)"/>
+    ///  Creates a bitmap compatible with the given <see cref="HDC"/> via
+    ///  <see cref="PInvokeCore.CreateCompatibleBitmap(HDC, int, int)"/>
     /// </summary>
     public CreateBitmapScope(HDC hdc, int cx, int cy) => HBITMAP = PInvokeCore.CreateCompatibleBitmap(hdc, cx, cy);
 

--- a/src/System.Private.Windows.Core/src/Windows/Win32/System/Com/CY.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/System/Com/CY.cs
@@ -12,7 +12,7 @@ internal partial struct CY : IEquatable<CY>
     public static bool operator ==(CY left, CY right) => left.Equals(right);
     public static bool operator !=(CY left, CY right) => !left.Equals(right);
 
-    // https://learn.Microsoft.com/openspecs/windows_protocols/ms-oaut/5a2b34c4-d109-438e-9ec8-84816d8de40d
+    // https://learn.microsoft.com/openspecs/windows_protocols/ms-oaut/5a2b34c4-d109-438e-9ec8-84816d8de40d
 
     public static explicit operator decimal(CY value) => decimal.FromOACurrency(value.int64);
     public static explicit operator CY(decimal value) => new() { int64 = decimal.ToOACurrency(value) };

--- a/src/System.Private.Windows.Core/src/Windows/Win32/System/Com/CY.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/System/Com/CY.cs
@@ -12,7 +12,7 @@ internal partial struct CY : IEquatable<CY>
     public static bool operator ==(CY left, CY right) => left.Equals(right);
     public static bool operator !=(CY left, CY right) => !left.Equals(right);
 
-    // https://learn.microsoft.com/openspecs/windows_protocols/ms-oaut/5a2b34c4-d109-438e-9ec8-84816d8de40d
+    // https://learn.Microsoft.com/openspecs/windows_protocols/ms-oaut/5a2b34c4-d109-438e-9ec8-84816d8de40d
 
     public static explicit operator decimal(CY value) => decimal.FromOACurrency(value.int64);
     public static explicit operator CY(decimal value) => new() { int64 = decimal.ToOACurrency(value) };

--- a/src/System.Private.Windows.Core/src/Windows/Win32/System/Com/IManagedWrapper.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/System/Com/IManagedWrapper.cs
@@ -33,7 +33,7 @@ internal unsafe interface IManagedWrapper
 
 /// <summary>
 ///  Apply to a class to apply a COM callable wrapper of the given <typeparamref name="TComInterface"/>. The class
-///  must also derive from the given COM wrapper struct's nested Interface.
+///  must also derive from the given COM wrapper <see langword="struct"/>'s nested Interface.
 /// </summary>
 internal unsafe interface IManagedWrapper<TComInterface> : IManagedWrapper
     where TComInterface : unmanaged, IVTable, IComIID
@@ -44,8 +44,9 @@ internal unsafe interface IManagedWrapper<TComInterface> : IManagedWrapper
 }
 
 /// <summary>
-///  Apply to a class to apply a COM callable wrapper of the given <typeparamref name="TComInterface1"/> and <typeparamref name="TComInterface2"/>.
-///  The class must also derive from both of the given COM wrapper struct's nested Interface.
+///  Apply to a class to apply a COM callable wrapper of the given <typeparamref name="TComInterface1"/> and
+///  <typeparamref name="TComInterface2"/>. The class must also derive from both of the given COM wrapper
+///  <see langword="struct"/>'s nested Interface.
 /// </summary>
 internal unsafe interface IManagedWrapper<TComInterface1, TComInterface2> : IManagedWrapper
     where TComInterface1 : unmanaged, IVTable, IComIID

--- a/src/System.Private.Windows.Core/src/Windows/Win32/System/Com/SafeArrayScope.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/System/Com/SafeArrayScope.cs
@@ -7,8 +7,10 @@ using Windows.Win32.System.Variant;
 namespace Windows.Win32.System.Com;
 
 /// <summary>
-///  Helper to scope lifetime of a <see cref="SAFEARRAY"/> created via <see cref="PInvokeCore.SafeArrayCreate(VARENUM, uint, SAFEARRAYBOUND*)"/>
-///  Destroys the <see cref="SAFEARRAY"/> (if any) when disposed. Note that this scope currently only works for a one dimensional <see cref="SAFEARRAY"/>.
+///  Helper to scope lifetime of a <see cref="SAFEARRAY"/> created via
+///  <see cref="PInvokeCore.SafeArrayCreate(VARENUM, uint, SAFEARRAYBOUND*)"/>
+///  Destroys the <see cref="SAFEARRAY"/> (if any) when disposed. Note that this scope currently only works for a
+///  one dimensional <see cref="SAFEARRAY"/>.
 /// </summary>
 /// <remarks>
 ///  <para>

--- a/src/System.Private.Windows.Core/src/Windows/Win32/System/Variant/VARIANT.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/System/Variant/VARIANT.cs
@@ -53,7 +53,7 @@ internal unsafe partial struct VARIANT : IDisposable
         // If the VARTYPE is a VT_VECTOR, the contents are cleared as above and CoTaskMemFree is also called on
         // cabstr.pElems.
         //
-        // https://learn.Microsoft.com/windows/win32/api/oleauto/nf-oleauto-variantclear#remarks
+        // https://learn.microsoft.com/windows/win32/api/oleauto/nf-oleauto-variantclear#remarks
         //
         //     - VT_BSTR (SysFreeString)
         //     - VT_DISPATCH / VT_UNKOWN (->Release(), if not VT_BYREF)

--- a/src/System.Private.Windows.Core/src/Windows/Win32/System/Variant/VARIANT.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/System/Variant/VARIANT.cs
@@ -53,7 +53,7 @@ internal unsafe partial struct VARIANT : IDisposable
         // If the VARTYPE is a VT_VECTOR, the contents are cleared as above and CoTaskMemFree is also called on
         // cabstr.pElems.
         //
-        // https://learn.microsoft.com/windows/win32/api/oleauto/nf-oleauto-variantclear#remarks
+        // https://learn.Microsoft.com/windows/win32/api/oleauto/nf-oleauto-variantclear#remarks
         //
         //     - VT_BSTR (SysFreeString)
         //     - VT_DISPATCH / VT_UNKOWN (->Release(), if not VT_BYREF)

--- a/src/System.Private.Windows.Core/src/Windows/Win32/UI/Controls/Dialogs/DEVNAMES.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/UI/Controls/Dialogs/DEVNAMES.cs
@@ -8,7 +8,9 @@ namespace Windows.Win32.UI.Controls.Dialogs;
 /// </summary>
 /// <remarks>
 ///  <para>
-///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-devnames">Learn more about this API from learn.microsoft.com</see>.
+///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-devnames">
+///    Learn more about this API from learn.Microsoft.com
+///   </see>.
 ///  </para>
 /// </remarks>
 /// <devdoc>
@@ -24,26 +26,57 @@ namespace Windows.Win32.UI.Controls.Dialogs;
 internal partial struct DEVNAMES
 {
     /// <summary>
-    /// <para>Type: <b>WORD</b> The offset, in characters, from the beginning of this structure to a null-terminated string that contains the file name (without the extension) of the device driver. On input, this string is used to determine the printer to display initially in the dialog box.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-devnames#members">Read more on learn.microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>WORD</b> The offset, in characters, from the beginning of this structure to a null-terminated string
+    ///   that contains the file name (without the extension) of the device driver. On input, this string is used to
+    ///   determine the printer to display initially in the dialog box.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-devnames#members">
+    ///    Read more on learn.Microsoft.com
+    ///   </see>.
+    ///  </para>
     /// </summary>
     public ushort wDriverOffset;
 
     /// <summary>
-    /// <para>Type: <b>WORD</b> The offset, in characters, from the beginning of this structure to the null-terminated string that contains the name of the device.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-devnames#members">Read more on learn.microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>WORD</b> The offset, in characters, from the beginning of this structure to the null-terminated
+    ///   string that contains the name of the device.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-devnames#members">
+    ///    Read more on learn.Microsoft.com
+    ///   </see>.
+    ///  </para>
     /// </summary>
     public ushort wDeviceOffset;
 
     /// <summary>
-    /// <para>Type: <b>WORD</b> The offset, in characters, from the beginning of this structure to the null-terminated string that contains the device name for the physical output medium (output port).</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-devnames#members">Read more on learn.microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>WORD</b> The offset, in characters, from the beginning of this structure to the null-terminated
+    ///   string that contains the device name for the physical output medium (output port).
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-devnames#members">
+    ///    Read more on learn.Microsoft.com
+    ///    </see>.
+    ///  </para>
     /// </summary>
     public ushort wOutputOffset;
 
     /// <summary>
-    /// <para>Type: <b>WORD</b> Indicates whether the strings contained in the <b>DEVNAMES</b> structure identify the default printer. This string is used to verify that the default printer has not changed since the last print operation. If any of the strings do not match, a warning message is displayed informing the user that the document may need to be reformatted. On output, the <b>wDefault</b> member is changed only if the <b>Print Setup</b> dialog box was displayed and the user chose the <b>OK</b> button. The <b>DN_DEFAULTPRN</b> flag is used if the default printer was selected. If a specific printer is selected, the flag is not used. All other flags in this member are reserved for internal use by the dialog box procedure for the <b>Print</b> property sheet or <b>Print</b> dialog box.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-devnames#members">Read more on learn.microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>WORD</b> Indicates whether the strings contained in the <b>DEVNAMES</b> structure identify the
+    ///   default printer. This string is used to verify that the default printer has not changed since the last
+    ///   print operation. If any of the strings do not match, a warning message is displayed informing the user
+    ///   that the document may need to be reformatted. On output, the <b>wDefault</b> member is changed only if
+    ///   the <b>Print Setup</b> dialog box was displayed and the user chose the <b>OK</b> button. The <b>DN_DEFAULTPRN</b> flag is used if the default printer was selected. If a specific printer is selected, the flag is not used. All other flags in this member are reserved for internal use by the dialog box procedure for the <b>Print</b> property sheet or <b>Print</b> dialog box.</para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-devnames#members">
+    ///    Read more on learn.Microsoft.com
+    ///   </see>.
+    ///  </para>
     /// </summary>
     public ushort wDefault;
 }

--- a/src/System.Private.Windows.Core/src/Windows/Win32/UI/Controls/Dialogs/DEVNAMES.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/UI/Controls/Dialogs/DEVNAMES.cs
@@ -9,8 +9,8 @@ namespace Windows.Win32.UI.Controls.Dialogs;
 /// <remarks>
 ///  <para>
 ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-devnames">
-///    Learn more about this API from learn.Microsoft.com
-///   </see>.
+///    Learn more about this API from learn.Microsoft.com.
+///   </see>
 ///  </para>
 /// </remarks>
 /// <devdoc>
@@ -33,8 +33,8 @@ internal partial struct DEVNAMES
     ///  </para>
     ///  <para>
     ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-devnames#members">
-    ///    Read more on learn.Microsoft.com
-    ///   </see>.
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
     ///  </para>
     /// </summary>
     public ushort wDriverOffset;
@@ -46,8 +46,8 @@ internal partial struct DEVNAMES
     ///  </para>
     ///  <para>
     ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-devnames#members">
-    ///    Read more on learn.Microsoft.com
-    ///   </see>.
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
     ///  </para>
     /// </summary>
     public ushort wDeviceOffset;
@@ -59,8 +59,8 @@ internal partial struct DEVNAMES
     ///  </para>
     ///  <para>
     ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-devnames#members">
-    ///    Read more on learn.Microsoft.com
-    ///    </see>.
+    ///    Read more on learn.Microsoft.com.
+    ///    </see>
     ///  </para>
     /// </summary>
     public ushort wOutputOffset;
@@ -71,11 +71,15 @@ internal partial struct DEVNAMES
     ///   default printer. This string is used to verify that the default printer has not changed since the last
     ///   print operation. If any of the strings do not match, a warning message is displayed informing the user
     ///   that the document may need to be reformatted. On output, the <b>wDefault</b> member is changed only if
-    ///   the <b>Print Setup</b> dialog box was displayed and the user chose the <b>OK</b> button. The <b>DN_DEFAULTPRN</b> flag is used if the default printer was selected. If a specific printer is selected, the flag is not used. All other flags in this member are reserved for internal use by the dialog box procedure for the <b>Print</b> property sheet or <b>Print</b> dialog box.</para>
+    ///   the <b>Print Setup</b> dialog box was displayed and the user chose the <b>OK</b> button.
+    ///   The <b>DN_DEFAULTPRN</b> flag is used if the default printer was selected. If a specific printer is selected,
+    ///   the flag is not used. All other flags in this member are reserved for internal use by the dialog box
+    ///   procedure for the <b>Print</b> property sheet or <b>Print</b> dialog box.
+    ///  </para>
     ///  <para>
     ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-devnames#members">
     ///    Read more on learn.Microsoft.com
-    ///   </see>.
+    ///   </see>
     ///  </para>
     /// </summary>
     public ushort wDefault;

--- a/src/System.Private.Windows.Core/src/Windows/Win32/UI/Controls/Dialogs/PRINTDLGEXW.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/UI/Controls/Dialogs/PRINTDLGEXW.cs
@@ -11,7 +11,9 @@ namespace Windows.Win32.UI.Controls.Dialogs;
 /// </summary>
 /// <remarks>
 ///  <para>
-///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#">Read more on learn.microsoft.com</see>.
+///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#">
+///    Read more on learn.Microsoft.com
+///   </see>.
 ///  </para>
 /// </remarks>
 /// <devdoc>
@@ -28,31 +30,89 @@ internal partial struct PRINTDLGEXW
 {
     /// <summary>
     ///  <para>Type: <b>DWORD</b> The structure size, in bytes.</para>
-    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#members">Read more on learn.microsoft.com</see>.</para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#members">
+    ///    Read more on learn.Microsoft.com
+    ///   </see>.
+    ///  </para>
     /// </summary>
     public uint lStructSize;
 
     /// <summary>
-    ///  <para>Type: <b>HWND</b> A handle to the window that owns the property sheet. This member must be a valid window handle; it cannot be <b>NULL</b>.</para>
-    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#members">Read more on learn.microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>HWND</b> A handle to the window that owns the property sheet. This member must be a valid
+    ///   window handle; it cannot be <b>NULL</b>.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#members">
+    ///    Read more on learn.Microsoft.com
+    ///   </see>.
+    ///  </para>
     /// </summary>
     public HWND hwndOwner;
 
     /// <summary>
-    ///  <para>Type: <b>HGLOBAL</b> A handle to a movable global memory object that contains a <a href="https://learn.microsoft.com/windows/win32/api/wingdi/ns-wingdi-devmodew">DEVMODE</a> structure. If <b>hDevMode</b> is not <b>NULL</b> on input, you must allocate a movable block of memory for the <b>DEVMODE</b> structure and initialize its members. The <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646942(v=vs.85)">PrintDlgEx</a> function uses the input data to initialize the controls in the property sheet. When <b>PrintDlgEx</b> returns, the <b>DEVMODE</b> members indicate the user's input. If <b>hDevMode</b> is <b>NULL</b> on input, <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646942(v=vs.85)">PrintDlgEx</a> allocates memory for the <a href="https://learn.microsoft.com/windows/win32/api/wingdi/ns-wingdi-devmodea">DEVMODE</a> structure, initializes its members to indicate the user's input, and returns a handle that identifies it. For more information about the <b>hDevMode</b> and <b>hDevNames</b> members, see the Remarks section at the end of this topic.</para>
-    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#members">Read more on learn.microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>HGLOBAL</b> A handle to a movable global memory object that contains a
+    ///   <a href="https://learn.microsoft.com/windows/win32/api/wingdi/ns-wingdi-devmodew">DEVMODE</a> structure.
+    ///   If <b>hDevMode</b> is not <b>NULL</b> on input, you must allocate a movable block of memory for the
+    ///   <b>DEVMODE</b> structure and initialize its members. The
+    ///   <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646942(v=vs.85)">
+    ///   PrintDlgEx</a> function uses the input data to initialize the controls in the property sheet.
+    ///   When <b>PrintDlgEx</b> returns, the <b>DEVMODE</b> members indicate the user's input.
+    ///   If <b>hDevMode</b> is <b>NULL</b> on input,
+    ///   <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646942(v=vs.85)">
+    ///   PrintDlgEx</a> allocates memory for the
+    ///   <a href="https://learn.microsoft.com/windows/win32/api/wingdi/ns-wingdi-devmodea">
+    ///   DEVMODE</a> structure, initializes its members to indicate the user's input, and returns a handle that
+    ///   identifies it. For more information about the <b>hDevMode</b> and <b>hDevNames</b> members,
+    ///   see the Remarks section at the end of this topic.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#members">
+    ///    Read more on learn.Microsoft.com
+    ///   </see>.
+    ///  </para>
     /// </summary>
     public HGLOBAL hDevMode;
 
     /// <summary>
-    ///  <para>Type: <b>HGLOBAL</b> A handle to a movable global memory object that contains a <a href="https://learn.microsoft.com/windows/desktop/api/commdlg/ns-commdlg-devnames">DEVNAMES</a> structure. If <b>hDevNames</b> is not <b>NULL</b> on input, you must allocate a movable block of memory for the <b>DEVNAMES</b> structure and initialize its members. The <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646942(v=vs.85)">PrintDlgEx</a> function uses the input data to initialize the controls in the property sheet. When <b>PrintDlgEx</b> returns, the <b>DEVNAMES</b> members contain information for the printer chosen by the user. You can use this information to create a device context or an information context. The <b>hDevNames</b> member can be <b>NULL</b>, in which case, <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646942(v=vs.85)">PrintDlgEx</a> allocates memory for the <a href="https://learn.microsoft.com/windows/desktop/api/commdlg/ns-commdlg-devnames">DEVNAMES</a> structure, initializes its members to indicate the user's input, and returns a handle that identifies it. For more information about the <b>hDevMode</b> and <b>hDevNames</b> members, see the Remarks section at the end of this topic.</para>
-    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#members">Read more on learn.microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>HGLOBAL</b> A handle to a movable global memory object that contains a
+    ///   <a href="https://learn.microsoft.com/windows/desktop/api/commdlg/ns-commdlg-devnames">DEVNAMES</a> structure.
+    ///   If <b>hDevNames</b> is not <b>NULL</b> on input, you must allocate a movable block of memory
+    ///   for the <b>DEVNAMES</b> structure and initialize its members. The
+    ///   <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646942(v=vs.85)">PrintDlgEx</a>
+    ///   function uses the input data to initialize the controls in the property sheet. When <b>PrintDlgEx</b> returns,
+    ///   the <b>DEVNAMES</b> members contain information for the printer chosen by the user. You can use this
+    ///   information to create a device context or an information context. The <b>hDevNames</b> member can be
+    ///   <b>NULL</b>, in which case,
+    ///   <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646942(v=vs.85)">
+    ///   PrintDlgEx</a> allocates memory for the
+    ///   <a href="https://learn.microsoft.com/windows/desktop/api/commdlg/ns-commdlg-devnames">DEVNAMES</a>
+    ///   structure, initializes its members to indicate the user's input, and returns a handle that identifies it.
+    ///   For more information about the <b>hDevMode</b> and <b>hDevNames</b> members, see the Remarks section at the
+    ///   end of this topic.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#members">
+    ///    Read more on learn.Microsoft.com
+    ///   </see>.
+    ///  </para>
     /// </summary>
     public HGLOBAL hDevNames;
 
     /// <summary>
-    ///  <para>Type: <b>HDC</b> A handle to a device context or an information context, depending on whether the <b>Flags</b> member specifies the <b>PD_RETURNDC</b> or <b>PC_RETURNIC</b> flag. If neither flag is specified, the value of this member is undefined. If both flags are specified, <b>PD_RETURNDC</b> has priority.</para>
-    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#members">Read more on learn.microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>HDC</b> A handle to a device context or an information context, depending on whether the <b>Flags</b>
+    ///   member specifies the <b>PD_RETURNDC</b> or <b>PC_RETURNIC</b> flag. If neither flag is specified, the value
+    ///   of this member is undefined. If both flags are specified, <b>PD_RETURNDC</b> has priority.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#members">
+    ///    Read more on learn.Microsoft.com
+    ///   </see>.
+    ///  </para>
     /// </summary>
     public HDC hDC;
 
@@ -63,80 +123,215 @@ internal partial struct PRINTDLGEXW
     public uint Flags2;
 
     /// <summary>
-    ///  <para>Type: <b>DWORD</b> A set of bit flags that can exclude items from the printer driver property pages in the <b>Print</b> property sheet. This value is used only if the <b>PD_EXCLUSIONFLAGS</b> flag is set in the <b>Flags</b> member. Exclusion flags should be used only if the item to be excluded will be included on either the <b>General</b> page or on an application-defined page in the <b>Print</b> property sheet. This member can specify the following flag.</para>
-    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#members">Read more on learn.microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>DWORD</b> A set of bit flags that can exclude items from the printer driver property pages in the
+    ///   <b>Print</b> property sheet. This value is used only if the <b>PD_EXCLUSIONFLAGS</b> flag is set in the
+    ///   <b>Flags</b> member. Exclusion flags should be used only if the item to be excluded will be included on
+    ///   either the <b>General</b> page or on an application-defined page in the <b>Print</b> property sheet.
+    ///   This member can specify the following flag.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#members">
+    ///    Read more on learn.Microsoft.com
+    ///   </see>.
+    ///  </para>
     /// </summary>
     public uint ExclusionFlags;
 
     /// <summary>
-    ///  <para>Type: <b>DWORD</b> On input, set this member to the initial number of page ranges specified in the <b>lpPageRanges</b> array. When the <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646942(v=vs.85)">PrintDlgEx</a> function returns, <b>nPageRanges</b> indicates the number of user-specified page ranges stored in the <b>lpPageRanges</b> array. If the <b>PD_NOPAGENUMS</b> flag is specified, this value is not valid.</para>
-    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#members">Read more on learn.microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>DWORD</b> On input, set this member to the initial number of page ranges specified in the
+    ///   <b>lpPageRanges</b> array. When the
+    ///   <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646942(v=vs.85)">
+    ///   PrintDlgEx</a> function returns, <b>nPageRanges</b> indicates the number of user-specified page ranges stored
+    ///   in the <b>lpPageRanges</b> array. If the <b>PD_NOPAGENUMS</b> flag is specified, this value is not valid.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#members">
+    ///    Read more on learn.Microsoft.com
+    ///   </see>.
+    ///  </para>
     /// </summary>
     public uint nPageRanges;
 
     /// <summary>
-    ///  <para>Type: <b>DWORD</b> The size, in array elements, of the <b>lpPageRanges</b> buffer. This value indicates the maximum number of page ranges that can be stored in the array. If the <b>PD_NOPAGENUMS</b> flag is specified, this value is not valid. If the <b>PD_NOPAGENUMS</b> flag is not specified, this value must be greater than zero.</para>
-    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#members">Read more on learn.microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>DWORD</b> The size, in array elements, of the <b>lpPageRanges</b> buffer. This value indicates
+    ///   the maximum number of page ranges that can be stored in the array. If the <b>PD_NOPAGENUMS</b> flag
+    ///   is specified, this value is not valid. If the <b>PD_NOPAGENUMS</b> flag is not specified, this
+    ///   value must be greater than zero.
+    ///  </para>
+    ///  <para>
+    ///    <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#members">
+    ///     Read more on learn.Microsoft.com
+    ///    </see>.
+    ///   </para>
     /// </summary>
     public uint nMaxPageRanges;
 
     /// <summary>
-    ///  <para>Type: <b>LPPRINTPAGERANGE</b> Pointer to a buffer containing an array of <a href="https://learn.microsoft.com/windows/desktop/api/commdlg/ns-commdlg-printpagerange">PRINTPAGERANGE</a> structures. On input, the array contains the initial page ranges to display in the <b>Pages</b> edit control. When the <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646942(v=vs.85)">PrintDlgEx</a> function returns, the array contains the page ranges specified by the user. If the <b>PD_NOPAGENUMS</b> flag is specified, this value is not valid. If the <b>PD_NOPAGENUMS</b> flag is not specified, <b>lpPageRanges</b> must be non-<b>NULL</b>.</para>
-    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#members">Read more on learn.microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>LPPRINTPAGERANGE</b> Pointer to a buffer containing an array of
+    ///   <a href="https://learn.microsoft.com/windows/desktop/api/commdlg/ns-commdlg-printpagerange">PRINTPAGERANGE</a>
+    ///   structures. On input, the array contains the initial page ranges to display in the <b>Pages</b> edit control.
+    ///   When the <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646942(v=vs.85)">
+    ///   PrintDlgEx</a> function returns, the array contains the page ranges specified by the user. If the
+    ///   <b>PD_NOPAGENUMS</b> flag is specified, this value is not valid. If the <b>PD_NOPAGENUMS</b> flag is not
+    ///   specified, <b>lpPageRanges</b> must be non-<b>NULL</b>.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#members">
+    ///    Read more on learn.Microsoft.com
+    ///   </see>.
+    ///  </para>
     /// </summary>
     public unsafe PRINTPAGERANGE* lpPageRanges;
 
     /// <summary>
-    /// <para>Type: <b>DWORD</b> The minimum value for the page ranges specified in the <b>Pages</b> edit control. If the <b>PD_NOPAGENUMS</b> flag is specified, this value is not valid.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#members">Read more on learn.microsoft.com</see>.</para>
+    /// <para>
+    ///  Type: <b>DWORD</b> The minimum value for the page ranges specified in the <b>Pages</b> edit control.
+    ///  If the <b>PD_NOPAGENUMS</b> flag is specified, this value is not valid.
+    /// </para>
+    /// <para>
+    ///  <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#members">
+    ///   Read more on learn.Microsoft.com
+    ///  </see>.
+    ///  </para>
     /// </summary>
     public uint nMinPage;
 
     /// <summary>
-    /// <para>Type: <b>DWORD</b> The maximum value for the page ranges specified in the <b>Pages</b> edit control. If the <b>PD_NOPAGENUMS</b> flag is specified, this value is not valid.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#members">Read more on learn.microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>DWORD</b> The maximum value for the page ranges specified in the <b>Pages</b> edit control.
+    ///   If the <b>PD_NOPAGENUMS</b> flag is specified, this value is not valid.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#members">
+    ///    Read more on learn.Microsoft.com
+    ///   </see>.
+    ///  </para>
     /// </summary>
     public uint nMaxPage;
 
     /// <summary>
-    /// <para>Type: <b>DWORD</b> Contains the initial number of copies for the <b>Copies</b> edit control if <b>hDevMode</b> is <b>NULL</b>; otherwise, the <b>dmCopies</b> member of the <a href="https://learn.microsoft.com/windows/win32/api/wingdi/ns-wingdi-devmodea">DEVMODE</a> structure contains the initial value. When <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646942(v=vs.85)">PrintDlgEx</a> returns, <b>nCopies</b> contains the actual number of copies the application must print. This value depends on whether the application or the printer driver is responsible for printing multiple copies. If the <b>PD_USEDEVMODECOPIESANDCOLLATE</b> flag is set in the <b>Flags</b> member, <b>nCopies</b> is always 1 on return, and the printer driver is responsible for printing multiple copies. If the flag is not set, the application is responsible for printing the number of copies specified by <b>nCopies</b>. For more information, see the description of the <b>PD_USEDEVMODECOPIESANDCOLLATE</b> flag.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#members">Read more on learn.microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>DWORD</b> Contains the initial number of copies for the <b>Copies</b> edit control if <b>hDevMode</b>
+    ///   is <b>NULL</b>; otherwise, the <b>dmCopies</b> member of the
+    ///   <a href="https://learn.microsoft.com/windows/win32/api/wingdi/ns-wingdi-devmodea">DEVMODE</a> structure
+    ///   contains the initial value.
+    ///   When <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646942(v=vs.85)">
+    ///   PrintDlgEx</a> returns, <b>nCopies</b> contains the actual number of copies the application must print.
+    ///   This value depends on whether the application or the printer driver is responsible for
+    ///   printing multiple copies. If the <b>PD_USEDEVMODECOPIESANDCOLLATE</b> flag is set in the <b>Flags</b>
+    ///   member, <b>nCopies</b> is always 1 on return, and the printer driver is responsible for printing
+    ///   multiple copies. If the flag is not set, the application is responsible for printing the number of copies
+    ///   specified by <b>nCopies</b>. For more information, see the description of the
+    ///   <b>PD_USEDEVMODECOPIESANDCOLLATE</b> flag.
+    ///   </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#members">
+    ///    Read more on learn.Microsoft.com
+    ///   </see>.
+    ///  </para>
     /// </summary>
     public uint nCopies;
 
     /// <summary>
-    /// <para>Type: <b>HINSTANCE</b> If the <b>PD_ENABLEPRINTTEMPLATE</b> flag is set in the <b>Flags</b> member, <b>hInstance</b> is a handle to the application or module instance that contains the dialog box template named by the <b>lpPrintTemplateName</b> member. If the <b>PD_ENABLEPRINTTEMPLATEHANDLE</b> flag is set in the <b>Flags</b> member, <b>hInstance</b> is a handle to a memory object containing a dialog box template. If neither of the template flags is set in the <b>Flags</b> member, <b>hInstance</b> should be <b>NULL</b>.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#members">Read more on learn.microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>HINSTANCE</b> If the <b>PD_ENABLEPRINTTEMPLATE</b> flag is set in the <b>Flags</b> member,
+    ///   <b>hInstance</b> is a handle to the application or module instance that contains the dialog box
+    ///   template named by the <b>lpPrintTemplateName</b> member. If the <b>PD_ENABLEPRINTTEMPLATEHANDLE</b> flag
+    ///   is set in the <b>Flags</b> member, <b>hInstance</b> is a handle to a memory object containing a
+    ///   dialog box template. If neither of the template flags is set in the <b>Flags</b> member,
+    ///   <b>hInstance</b> should be <b>NULL</b>.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#members">
+    ///    Read more on learn.Microsoft.com
+    ///     </see>.
+    ///    </para>
     /// </summary>
     public HINSTANCE hInstance;
 
     /// <summary>
-    /// <para>Type: <b>LPCTSTR</b> The name of the dialog box template resource in the module identified by the <b>hInstance</b> member. This template replaces the default dialog box template in the lower portion of the <b>General</b> page. The default template contains controls similar to those of the <b>Print</b> dialog box. This member is ignored unless the PD_ENABLEPRINTTEMPLATE flag is set in the <b>Flags</b> member.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#members">Read more on learn.microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>LPCTSTR</b> The name of the dialog box template resource in the module identified by the
+    ///   <b>hInstance</b> member. This template replaces the default dialog box template in the lower portion
+    ///   of the <b>General</b> page. The default template contains controls similar to those of the
+    ///   <b>Print</b> dialog box. This member is ignored unless the PD_ENABLEPRINTTEMPLATE flag is set in the
+    ///   <b>Flags</b> member.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#members">
+    ///    Read more on learn.Microsoft.com
+    ///   </see>.
+    ///   </para>
     /// </summary>
     public PCWSTR lpPrintTemplateName;
 
     /// <summary>
-    /// <para>Type: <b>LPUNKNOWN</b> A pointer to an application-defined callback object. The object should contain the <a href="https://learn.microsoft.com/windows/desktop/api/commdlg/nn-commdlg-iprintdialogcallback">IPrintDialogCallback</a> class to receive messages for the child dialog box in the lower portion of the <b>General</b> page. The callback object should also contain the <a href="https://learn.microsoft.com/windows/desktop/api/ocidl/nn-ocidl-iobjectwithsite">IObjectWithSite</a> class to receive a pointer to the <a href="https://learn.microsoft.com/windows/desktop/api/commdlg/nn-commdlg-iprintdialogservices">IPrintDialogServices</a> interface. The <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646942(v=vs.85)">PrintDlgEx</a> function calls <a href="https://learn.microsoft.com/windows/desktop/api/unknwn/nf-unknwn-iunknown-queryinterface(q)">IUnknown::QueryInterface</a> on the callback object for both <b>IID_IPrintDialogCallback</b> and <b>IID_IObjectWithSite</b> to determine which interfaces are supported. If you do not want to retrieve any of the callback information, set <b>lpCallback</b> to <b>NULL</b>.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#members">Read more on learn.microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>LPUNKNOWN</b> A pointer to an application-defined callback object. The object should contain the
+    ///   <a href="https://learn.microsoft.com/windows/desktop/api/commdlg/nn-commdlg-iprintdialogcallback">
+    ///   IPrintDialogCallback</a> class to receive messages for the child dialog box in the lower portion of the
+    ///   <b>General</b> page. The callback object should also contain the
+    ///   <a href="https://learn.microsoft.com/windows/desktop/api/ocidl/nn-ocidl-iobjectwithsite">
+    ///   IObjectWithSite</a> class to receive a pointer to the
+    ///   <a href="https://learn.microsoft.com/windows/desktop/api/commdlg/nn-commdlg-iprintdialogservices">
+    ///   IPrintDialogServices</a> interface.
+    ///   The <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646942(v=vs.85)">
+    ///   PrintDlgEx</a> function calls
+    ///   <a href="https://learn.microsoft.com/windows/desktop/api/unknwn/nf-unknwn-iunknown-queryinterface(q)">
+    ///   IUnknown::QueryInterface</a> on the callback object for both <b>IID_IPrintDialogCallback</b> and
+    ///   <b>IID_IObjectWithSite</b> to determine which interfaces are supported. If you do not want to retrieve any
+    ///   of the callback information, set <b>lpCallback</b> to <b>NULL</b>.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#members">
+    ///   Read more on learn.Microsoft.com</see>.</para>
     /// </summary>
     public unsafe IUnknown* lpCallback;
 
     /// <summary>
     /// <para>Type: <b>DWORD</b> The number of property page handles in the <b>lphPropertyPages</b> array.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#members">Read more on learn.microsoft.com</see>.</para>
+    ///   <para>
+    ///    <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#members">
+    ///     Read more on learn.Microsoft.com
+    ///    </see>.
+    ///  </para>
     /// </summary>
     public uint nPropertyPages;
 
     /// <summary>
-    /// <para>Type: <b>HPROPSHEETPAGE*</b> Contains an array of property page handles to add to the <b>Print</b> property sheet. The additional property pages follow the <b>General</b> page. Use the <a href="https://learn.microsoft.com/windows/desktop/api/prsht/nf-prsht-createpropertysheetpagea">CreatePropertySheetPage</a> function to create these additional pages. When the <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646942(v=vs.85)">PrintDlgEx</a> function returns, all the <b>HPROPSHEETPAGE</b> handles in the <b>lphPropertyPages</b> array have been destroyed. If <b>nPropertyPages</b> is zero, <b>lphPropertyPages</b> should be <b>NULL</b>.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#members">Read more on learn.microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>HPROPSHEETPAGE*</b> Contains an array of property page handles to add to the <b>Print</b>
+    ///   property sheet. The additional property pages follow the <b>General</b> page. Use the
+    ///   <a href="https://learn.microsoft.com/windows/desktop/api/prsht/nf-prsht-createpropertysheetpagea">
+    ///   CreatePropertySheetPage</a> function to create these additional pages. When the
+    ///   <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646942(v=vs.85)">
+    ///   PrintDlgEx</a> function returns, all the <b>HPROPSHEETPAGE</b> handles in the <b>lphPropertyPages</b>
+    ///   array have been destroyed. If <b>nPropertyPages</b> is zero, <b>lphPropertyPages</b> should be <b>NULL</b>.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#members">
+    ///    Read more on learn.Microsoft.com
+    ///   </see>.
+    ///  </para>
     /// </summary>
     public unsafe HPROPSHEETPAGE* lphPropertyPages;
 
     /// <summary>
-    /// <para>Type: <b>DWORD</b> The property page that is initially displayed. To display the <b>General</b> page, specify <b>START_PAGE_GENERAL</b>. Otherwise, specify the zero-based index of a property page in the array specified in the <b>lphPropertyPages</b> member. For consistency, it is recommended that the property sheet always be started on the <b>General</b> page.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#members">Read more on learn.microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>DWORD</b> The property page that is initially displayed. To display the <b>General</b> page, specify
+    ///   <b>START_PAGE_GENERAL</b>. Otherwise, specify the zero-based index of a property page in the array specified
+    ///   in the <b>lphPropertyPages</b> member. For consistency, it is recommended that the property sheet always be
+    ///   started on the <b>General</b> page.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#members">
+    ///     Read more on learn.Microsoft.com
+    ///    </see>.
+    ///   </para>
     /// </summary>
     public uint nStartPage;
 

--- a/src/System.Private.Windows.Core/src/Windows/Win32/UI/Controls/Dialogs/PRINTDLGEXW.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/UI/Controls/Dialogs/PRINTDLGEXW.cs
@@ -12,8 +12,8 @@ namespace Windows.Win32.UI.Controls.Dialogs;
 /// <remarks>
 ///  <para>
 ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#">
-///    Read more on learn.Microsoft.com
-///   </see>.
+///    Read more on learn.Microsoft.com.
+///   </see>
 ///  </para>
 /// </remarks>
 /// <devdoc>
@@ -32,8 +32,8 @@ internal partial struct PRINTDLGEXW
     ///  <para>Type: <b>DWORD</b> The structure size, in bytes.</para>
     ///  <para>
     ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#members">
-    ///    Read more on learn.Microsoft.com
-    ///   </see>.
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
     ///  </para>
     /// </summary>
     public uint lStructSize;
@@ -45,8 +45,8 @@ internal partial struct PRINTDLGEXW
     ///  </para>
     ///  <para>
     ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#members">
-    ///    Read more on learn.Microsoft.com
-    ///   </see>.
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
     ///  </para>
     /// </summary>
     public HWND hwndOwner;
@@ -70,8 +70,8 @@ internal partial struct PRINTDLGEXW
     ///  </para>
     ///  <para>
     ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#members">
-    ///    Read more on learn.Microsoft.com
-    ///   </see>.
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
     ///  </para>
     /// </summary>
     public HGLOBAL hDevMode;
@@ -96,8 +96,8 @@ internal partial struct PRINTDLGEXW
     ///  </para>
     ///  <para>
     ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#members">
-    ///    Read more on learn.Microsoft.com
-    ///   </see>.
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
     ///  </para>
     /// </summary>
     public HGLOBAL hDevNames;
@@ -110,8 +110,8 @@ internal partial struct PRINTDLGEXW
     ///  </para>
     ///  <para>
     ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#members">
-    ///    Read more on learn.Microsoft.com
-    ///   </see>.
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
     ///  </para>
     /// </summary>
     public HDC hDC;
@@ -132,8 +132,8 @@ internal partial struct PRINTDLGEXW
     ///  </para>
     ///  <para>
     ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#members">
-    ///    Read more on learn.Microsoft.com
-    ///   </see>.
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
     ///  </para>
     /// </summary>
     public uint ExclusionFlags;
@@ -148,8 +148,8 @@ internal partial struct PRINTDLGEXW
     ///  </para>
     ///  <para>
     ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#members">
-    ///    Read more on learn.Microsoft.com
-    ///   </see>.
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
     ///  </para>
     /// </summary>
     public uint nPageRanges;
@@ -163,8 +163,8 @@ internal partial struct PRINTDLGEXW
     ///  </para>
     ///  <para>
     ///    <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#members">
-    ///     Read more on learn.Microsoft.com
-    ///    </see>.
+    ///     Read more on learn.Microsoft.com.
+    ///    </see>
     ///   </para>
     /// </summary>
     public uint nMaxPageRanges;
@@ -181,8 +181,8 @@ internal partial struct PRINTDLGEXW
     ///  </para>
     ///  <para>
     ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#members">
-    ///    Read more on learn.Microsoft.com
-    ///   </see>.
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
     ///  </para>
     /// </summary>
     public unsafe PRINTPAGERANGE* lpPageRanges;
@@ -194,8 +194,8 @@ internal partial struct PRINTDLGEXW
     /// </para>
     /// <para>
     ///  <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#members">
-    ///   Read more on learn.Microsoft.com
-    ///  </see>.
+    ///   Read more on learn.Microsoft.com.
+    ///  </see>
     ///  </para>
     /// </summary>
     public uint nMinPage;
@@ -207,8 +207,8 @@ internal partial struct PRINTDLGEXW
     ///  </para>
     ///  <para>
     ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#members">
-    ///    Read more on learn.Microsoft.com
-    ///   </see>.
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
     ///  </para>
     /// </summary>
     public uint nMaxPage;
@@ -230,8 +230,8 @@ internal partial struct PRINTDLGEXW
     ///   </para>
     ///  <para>
     ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#members">
-    ///    Read more on learn.Microsoft.com
-    ///   </see>.
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
     ///  </para>
     /// </summary>
     public uint nCopies;
@@ -247,9 +247,9 @@ internal partial struct PRINTDLGEXW
     ///  </para>
     ///  <para>
     ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#members">
-    ///    Read more on learn.Microsoft.com
-    ///     </see>.
-    ///    </para>
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
+    ///  </para>
     /// </summary>
     public HINSTANCE hInstance;
 
@@ -263,8 +263,8 @@ internal partial struct PRINTDLGEXW
     ///  </para>
     ///  <para>
     ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#members">
-    ///    Read more on learn.Microsoft.com
-    ///   </see>.
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
     ///   </para>
     /// </summary>
     public PCWSTR lpPrintTemplateName;
@@ -288,7 +288,9 @@ internal partial struct PRINTDLGEXW
     ///  </para>
     ///  <para>
     ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#members">
-    ///   Read more on learn.Microsoft.com</see>.</para>
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
+    ///  </para>
     /// </summary>
     public unsafe IUnknown* lpCallback;
 
@@ -296,8 +298,8 @@ internal partial struct PRINTDLGEXW
     /// <para>Type: <b>DWORD</b> The number of property page handles in the <b>lphPropertyPages</b> array.</para>
     ///   <para>
     ///    <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#members">
-    ///     Read more on learn.Microsoft.com
-    ///    </see>.
+    ///     Read more on learn.Microsoft.com.
+    ///    </see>
     ///  </para>
     /// </summary>
     public uint nPropertyPages;
@@ -314,8 +316,8 @@ internal partial struct PRINTDLGEXW
     ///  </para>
     ///  <para>
     ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#members">
-    ///    Read more on learn.Microsoft.com
-    ///   </see>.
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
     ///  </para>
     /// </summary>
     public unsafe HPROPSHEETPAGE* lphPropertyPages;
@@ -329,8 +331,8 @@ internal partial struct PRINTDLGEXW
     ///  </para>
     ///  <para>
     ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgexw#members">
-    ///     Read more on learn.Microsoft.com
-    ///    </see>.
+    ///     Read more on learn.Microsoft.com.
+    ///    </see>
     ///   </para>
     /// </summary>
     public uint nStartPage;

--- a/src/System.Private.Windows.Core/src/Windows/Win32/UI/Controls/Dialogs/PRINTPAGERANGE.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/UI/Controls/Dialogs/PRINTPAGERANGE.cs
@@ -7,7 +7,7 @@ namespace Windows.Win32.UI.Controls.Dialogs;
 ///  Represents a range of pages in a print job. A print job can have more than one page range. This information is
 ///  supplied in the <see cref="PRINTDLGEXW"/> structure when calling the <see cref="PInvokeCore.PrintDlgEx"/> function.</summary>
 /// <remarks>
-///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printpagerange">Learn more about this API from learn.microsoft.com</see>.</para>
+///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printpagerange">Learn more about this API from learn.Microsoft.com</see>.</para>
 /// </remarks>
 /// <devdoc>
 ///  Manually copied from a 64 bit project CsWin32 generated wrapper. We can't directly use CsWin32 for this as it
@@ -23,13 +23,13 @@ internal partial struct PRINTPAGERANGE
 {
     /// <summary>
     /// <para>Type: <b>DWORD</b> The first page of the range.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printpagerange#members">Read more on learn.microsoft.com</see>.</para>
+    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printpagerange#members">Read more on learn.Microsoft.com</see>.</para>
     /// </summary>
     public uint nFromPage;
 
     /// <summary>
     /// <para>Type: <b>DWORD</b> The last page of the range.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printpagerange#members">Read more on learn.microsoft.com</see>.</para>
+    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printpagerange#members">Read more on learn.Microsoft.com</see>.</para>
     /// </summary>
     public uint nToPage;
 }

--- a/src/System.Private.Windows.Core/src/Windows/Win32/UI/Controls/Dialogs/PRINTPAGERANGE.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/UI/Controls/Dialogs/PRINTPAGERANGE.cs
@@ -5,9 +5,14 @@ namespace Windows.Win32.UI.Controls.Dialogs;
 
 /// <summary>
 ///  Represents a range of pages in a print job. A print job can have more than one page range. This information is
-///  supplied in the <see cref="PRINTDLGEXW"/> structure when calling the <see cref="PInvokeCore.PrintDlgEx"/> function.</summary>
+///  supplied in the <see cref="PRINTDLGEXW"/> structure when calling the <see cref="PInvokeCore.PrintDlgEx"/> function.
+/// </summary>
 /// <remarks>
-///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printpagerange">Learn more about this API from learn.Microsoft.com</see>.</para>
+///  <para>
+///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printpagerange">
+///    Learn more about this API from learn.Microsoft.com.
+///   </see>
+///  </para>
 /// </remarks>
 /// <devdoc>
 ///  Manually copied from a 64 bit project CsWin32 generated wrapper. We can't directly use CsWin32 for this as it
@@ -22,14 +27,22 @@ namespace Windows.Win32.UI.Controls.Dialogs;
 internal partial struct PRINTPAGERANGE
 {
     /// <summary>
-    /// <para>Type: <b>DWORD</b> The first page of the range.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printpagerange#members">Read more on learn.Microsoft.com</see>.</para>
+    ///  <para>Type: <b>DWORD</b> The first page of the range.</para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printpagerange#members">
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
+    ///  </para>
     /// </summary>
     public uint nFromPage;
 
     /// <summary>
-    /// <para>Type: <b>DWORD</b> The last page of the range.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printpagerange#members">Read more on learn.Microsoft.com</see>.</para>
+    ///  <para>Type: <b>DWORD</b> The last page of the range.</para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printpagerange#members">
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
+    ///  </para>
     /// </summary>
     public uint nToPage;
 }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionListsChangedType.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionListsChangedType.cs
@@ -4,7 +4,8 @@
 namespace System.ComponentModel.Design;
 
 /// <summary>
-///  An enum that defines what type of action happened to the related object's <see cref="DesignerActionListCollection">designer action lists collection</see>.
+///  An enum that defines what type of action happened to the related object's
+///  <see cref="DesignerActionListCollection">designer action lists collection.</see>
 /// </summary>
 public enum DesignerActionListsChangedType
 {

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionUIService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionUIService.cs
@@ -54,7 +54,8 @@ public sealed class DesignerActionUIService : IDisposable
             new DesignerActionUIStateChangeEventArgs(component, DesignerActionUIStateChangeType.Show));
 
     /// <summary>
-    ///  Refreshes the <see cref="DesignerActionGlyph">designer action glyph</see> as well as <see cref="DesignerActionPanel">designer action panels</see>.
+    ///  Refreshes the <see cref="DesignerActionGlyph">designer action glyph</see> as well as
+    ///  <see cref="DesignerActionPanel"> designer action panels.</see>
     /// </summary>
     public void Refresh(IComponent? component) =>
         OnDesignerActionUIStateChange(

--- a/src/System.Windows.Forms.Primitives/src/Microsoft/Office/IMsoComponent.cs
+++ b/src/System.Windows.Forms.Primitives/src/Microsoft/Office/IMsoComponent.cs
@@ -240,7 +240,9 @@ internal unsafe struct IMsoComponent : IComIID, IVTable<IMsoComponent, IMsoCompo
     ///   <see cref="IMsoComponentManager.FGetActiveComponent"/>.
     ///  </para>
     ///  <para>
-    ///   <see href="https://learn.microsoft.com/previous-versions/office/developer/office-2007/ff518955(v=office.12)">Microsoft documentation</see>
+    ///   <see href="https://learn.microsoft.com/previous-versions/office/developer/office-2007/ff518955(v=office.12)">
+    ///    Microsoft documentation
+    ///   </see>
     ///  </para>
     /// </remarks>
     [ComImport]

--- a/src/System.Windows.Forms.Primitives/src/Microsoft/Office/IMsoComponentManager.cs
+++ b/src/System.Windows.Forms.Primitives/src/Microsoft/Office/IMsoComponentManager.cs
@@ -206,7 +206,9 @@ internal unsafe partial struct IMsoComponentManager : IComIID
     ///   state of the component manager's state context at its root.
     ///  </para>
     ///  <para>
-    ///   <see href="https://learn.microsoft.com/previous-versions/office/developer/office-2007/ff518963(v=office.12)">Microsoft documentation</see>
+    ///   <see href="https://learn.microsoft.com/previous-versions/office/developer/office-2007/ff518963(v=office.12)">
+    ///    Microsoft documentation
+    ///   </see>
     ///  </para>
     /// </remarks>
     [ComImport]
@@ -455,8 +457,9 @@ internal unsafe partial struct IMsoComponentManager : IComIID
         /// </summary>
         /// <remarks>
         ///  <para>
-        ///   The component manager should push its message loop, calling <see cref="IMsoComponent.FContinueMessageLoop(msoloop, void*, MSG*)"/>
-        ///   during each loop iteration. When <see cref="IMsoComponent.FContinueMessageLoop(msoloop, void*, MSG*)"/> returns <see cref="BOOL.FALSE"/>,
+        ///   The component manager should push its message loop, calling
+        ///   <see cref="IMsoComponent.FContinueMessageLoop(msoloop, void*, MSG*)"/> during each loop iteration.
+        ///   When <see cref="IMsoComponent.FContinueMessageLoop(msoloop, void*, MSG*)"/> returns <see cref="BOOL.FALSE"/>,
         ///   the component manager terminates the loop.
         ///  </para>
         /// </remarks>

--- a/src/System.Windows.Forms.Primitives/src/Microsoft/VisualStudio/Shell/IProvidePropertyBuilder.cs
+++ b/src/System.Windows.Forms.Primitives/src/Microsoft/VisualStudio/Shell/IProvidePropertyBuilder.cs
@@ -105,7 +105,9 @@ internal unsafe struct IProvidePropertyBuilder : IComIID
         /// <param name="dispid">The DISPID of the property in question.</param>
         /// <param name="pdwCtlBldType">The builder to be mapped.</param>
         /// <param name="pbstrGuidBldr">The GUID that identifies the builder for this property.</param>
-        /// <param name="builderAvailable">This parameter is <see cref="VARIANT_BOOL.VARIANT_TRUE"/> if this property currently supports a builder.</param>
+        /// <param name="builderAvailable">
+        ///  This parameter is <see cref="VARIANT_BOOL.VARIANT_TRUE"/> if this property currently supports a builder.
+        /// </param>
         [PreserveSig]
         HRESULT MapPropertyToBuilder(
             int dispid,

--- a/src/System.Windows.Forms.Primitives/src/System/Diagnostics/TraceSwitchExtensions.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Diagnostics/TraceSwitchExtensions.cs
@@ -28,7 +28,8 @@ internal static class TraceSwitchExtensions
     }
 
     /// <summary>
-    ///  Provides an interpolated string handler for <see cref="TraceVerbose(TraceSwitch?, ref TraceVerboseInterpolatedStringHandler)"/>
+    ///  Provides an interpolated string handler for
+    ///  <see cref="TraceVerbose(TraceSwitch?, ref TraceVerboseInterpolatedStringHandler)"/>
     ///  that only performs formatting if the condition applies.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
@@ -9,7 +9,7 @@ namespace System.Windows.Forms.Primitives;
 // Borrowed from https://github.com/dotnet/runtime/blob/main/src/libraries/Common/src/System/LocalAppContextSwitches.Common.cs
 internal static partial class LocalAppContextSwitches
 {
-    // Enabling switches in Core is different from Framework. See https://learn.microsoft.com/dotnet/core/runtime-config/
+    // Enabling switches in Core is different from Framework. See https://learn.Microsoft.com/dotnet/core/runtime-config/
     // for details on how to set switches.
 
     // Switch names declared internal below are used in unit/integration tests. Refer to
@@ -150,7 +150,8 @@ internal static partial class LocalAppContextSwitches
     }
 
     /// <summary>
-    ///  Gets or sets a value indicating whether the parent font (as set by <see cref="M:System.Windows.Forms.Application.SetDefaultFont(System.Drawing.Font)" />
+    ///  Gets or sets a value indicating whether the parent font (as set by
+    ///  <see cref="M:System.Windows.Forms.Application.SetDefaultFont(System.Drawing.Font)" />
     ///  or by the parent control or form's font) is applied to menus.
     /// </summary>
     public static bool ApplyParentFontToMenus

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/AccessibiltyExtensions.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/AccessibiltyExtensions.cs
@@ -11,7 +11,7 @@ internal static unsafe class AccessibiltyExtensions
     /// <inheritdoc cref="PInvoke.LresultFromObject(Guid*, WPARAM, IUnknown*)"/>
     internal static LRESULT GetLRESULT(this IAccessible accessible, WPARAM wparam)
     {
-        // https://learn.microsoft.com/windows/win32/winauto/how-to-handle-wm-getobject
+        // https://learn.Microsoft.com/windows/win32/winauto/how-to-handle-wm-getobject
 
         using var unknown = ComHelpers.TryGetComScope<IUnknown>(accessible, out _);
 

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Automation/UiaTextProvider.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Automation/UiaTextProvider.cs
@@ -99,8 +99,8 @@ internal abstract unsafe class UiaTextProvider : ITextProvider.Interface, ITextP
     /// <summary>
     ///  Bounding rectangles are represented by a VT_ARRAY of doubles in a native VARIANT
     ///  in accessibility interfaces. This method does the conversion. Accessibility will then convert it to an UiaRect.
-    ///  https://learn.microsoft.com/windows/win32/api/uiautomationcore/nf-uiautomationcore-irawelementproviderfragment-get_boundingrectangle
-    ///  https://learn.microsoft.com/windows/win32/api/uiautomationcore/ns-uiautomationcore-uiarect
+    ///  https://learn.Microsoft.com/windows/win32/api/uiautomationcore/nf-uiautomationcore-irawelementproviderfragment-get_boundingrectangle
+    ///  https://learn.Microsoft.com/windows/win32/api/uiautomationcore/ns-uiautomationcore-uiarect
     /// </summary>
     internal static SafeArrayScope<double> BoundingRectangleAsArray(Rectangle bounds)
     {

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Automation/UiaTextRange.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Automation/UiaTextRange.cs
@@ -675,7 +675,7 @@ internal sealed unsafe class UiaTextRange : ITextRangeProvider.Interface, IManag
     private static bool IsApostrophe(char ch) => ch is '\'' or ((char)0x2019); // Unicode Right Single Quote Mark
 
     /// <devdoc>
-    ///  Attribute values and their types are defined here - https://learn.microsoft.com/windows/win32/winauto/uiauto-textattribute-ids
+    ///  Attribute values and their types are defined here - https://learn.Microsoft.com/windows/win32/winauto/uiauto-textattribute-ids
     /// </devdoc>
     private VARIANT GetAttributeValue(UIA_TEXTATTRIBUTE_ID textAttributeIdentifier)
     {

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/HighDpiMode.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/HighDpiMode.cs
@@ -41,7 +41,8 @@ public enum HighDpiMode
     PerMonitor,
 
     /// <summary>
-    ///  Similar to <see cref="PerMonitor"/>, but enables child window DPI change notification, improved scaling of comctl32 controls and dialog scaling.
+    ///  Similar to <see cref="PerMonitor"/>, but enables child window DPI change notification, improved scaling of
+    ///  comctl32 controls and dialog scaling.
     /// </summary>
     PerMonitorV2,
 

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/ScaleHelper.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/ScaleHelper.cs
@@ -19,7 +19,7 @@ internal static partial class ScaleHelper
     /// <remarks>
     ///  <para>
     ///   Some historical discussion of this can be found
-    ///   <see href="https://en.wikipedia.org/wiki/Dots_per_inch#Computer_monitor_DPI_standards">here</see>.
+    ///   <see href="https://en.wikipedia.org/wiki/Dots_per_inch#Computer_monitor_DPI_standards">here.</see>
     ///  </para>
     /// </remarks>
     internal const int OneHundredPercentLogicalDpi = 96;

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/Foundation/COLORREF.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/Foundation/COLORREF.cs
@@ -11,7 +11,7 @@ namespace Windows.Win32.Foundation;
 ///   any conversion in <see cref="Color"/>, <see cref="ColorTranslator"/>, etc. as they can change the value.
 ///   <see cref="COLORREF"/> is a DWORD- passing constants in native code would just pass the value as is.
 ///  </para>
-///  <para><see href="https://learn.microsoft.com/windows/win32/gdi/colorref#">Read more on learn.Microsoft.com</see>.</para>
+///  <para><see href="https://learn.microsoft.com/windows/win32/gdi/colorref#">Read more on learn.Microsoft.com.</see></para>
 /// </remarks>
 internal readonly partial struct COLORREF
 {

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/Foundation/COLORREF.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/Foundation/COLORREF.cs
@@ -11,7 +11,7 @@ namespace Windows.Win32.Foundation;
 ///   any conversion in <see cref="Color"/>, <see cref="ColorTranslator"/>, etc. as they can change the value.
 ///   <see cref="COLORREF"/> is a DWORD- passing constants in native code would just pass the value as is.
 ///  </para>
-///  <para><see href="https://learn.microsoft.com/windows/win32/gdi/colorref#">Read more on learn.microsoft.com</see>.</para>
+///  <para><see href="https://learn.microsoft.com/windows/win32/gdi/colorref#">Read more on learn.Microsoft.com</see>.</para>
 /// </remarks>
 internal readonly partial struct COLORREF
 {

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.MaxClassName.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.MaxClassName.cs
@@ -11,7 +11,9 @@ internal static partial class PInvoke
     ///   the RegisterClassEx function will fail.
     ///  </para>
     ///  <para><see href="https://learn.microsoft.com/windows/win32/api/winuser/ns-winuser-wndclassexw#members">
-    ///  Read more on docs.Microsoft.com.</see></para>
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
+    ///  </para>
     /// </summary>
     public const int MaxClassName = 256;
 }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.MaxClassName.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.MaxClassName.cs
@@ -11,7 +11,7 @@ internal static partial class PInvoke
     ///   the RegisterClassEx function will fail.
     ///  </para>
     ///  <para><see href="https://learn.microsoft.com/windows/win32/api/winuser/ns-winuser-wndclassexw#members">
-    ///  Read more on docs.Microsoft.com</see>.</para>
+    ///  Read more on docs.Microsoft.com.</see></para>
     /// </summary>
     public const int MaxClassName = 256;
 }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.MaxClassName.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.MaxClassName.cs
@@ -6,8 +6,12 @@ namespace Windows.Win32;
 internal static partial class PInvoke
 {
     /// <summary>
-    /// <para>The maximum length for lpszClassName is 256. If lpszClassName is greater than the maximum length, the RegisterClassEx function will fail.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/winuser/ns-winuser-wndclassexw#members">Read more on docs.microsoft.com</see>.</para>
+    ///  <para>
+    ///   The maximum length for lpszClassName is 256. If lpszClassName is greater than the maximum length,
+    ///   the RegisterClassEx function will fail.
+    ///  </para>
+    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/winuser/ns-winuser-wndclassexw#members">
+    ///  Read more on docs.Microsoft.com</see>.</para>
     /// </summary>
     public const int MaxClassName = 256;
 }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/SetTextAlignmentScope.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/SetTextAlignmentScope.cs
@@ -23,7 +23,8 @@ internal readonly ref struct SetTextAlignmentScope
     private readonly HDC _hdc;
 
     /// <summary>
-    ///  Sets <paramref name="ta"/> in the given <paramref name="hdc"/> using <see cref="PInvoke.SetTextAlign(HDC, TEXT_ALIGN_OPTIONS)"/>.
+    ///  Sets <paramref name="ta"/> in the given <paramref name="hdc"/>
+    ///  using <see cref="PInvoke.SetTextAlign(HDC, TEXT_ALIGN_OPTIONS)"/>.
     /// </summary>
     public SetTextAlignmentScope(HDC hdc, TEXT_ALIGN_OPTIONS ta)
     {

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Com/ComSafeArrayScope.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Com/ComSafeArrayScope.cs
@@ -6,10 +6,10 @@ using Windows.Win32.System.Variant;
 namespace Windows.Win32.System.Com;
 
 /// <summary>
-///  Helper to scope lifetime of a <see cref="SAFEARRAY"/> created via <see cref="PInvokeCore.SafeArrayCreate(VARENUM, uint, SAFEARRAYBOUND*)"/>
-///  that holds COM pointers.
-///  Destroys the <see cref="SAFEARRAY"/> (if any) when disposed. Note that this scope currently only works for a one dimensional <see cref="SAFEARRAY"/>
-///  of type <see cref="VARENUM.VT_UNKNOWN"/>
+///  Helper to scope lifetime of a <see cref="SAFEARRAY"/> created via
+///  <see cref="PInvokeCore.SafeArrayCreate(VARENUM, uint, SAFEARRAYBOUND*)"/>
+///  that holds COM pointers. Destroys the <see cref="SAFEARRAY"/> (if any) when disposed. Note that this scope
+///  currently only works for a one dimensional <see cref="SAFEARRAY"/> of type <see cref="VARENUM.VT_UNKNOWN"/>
 /// </summary>
 /// <remarks>
 ///  <para>

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Com/ComSafeArrayScopeExtensions.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Com/ComSafeArrayScopeExtensions.cs
@@ -6,7 +6,8 @@ namespace Windows.Win32.System.Com;
 internal static class ComSafeArrayScopeExtensions
 {
     /// <summary>
-    ///  Creates a <see cref="ComSafeArrayScope{T}"/> where T is <typeparamref name="TComStruct"/> from an array of <typeparamref name="TComInterface"/>.
+    ///  Creates a <see cref="ComSafeArrayScope{T}"/> where T is <typeparamref name="TComStruct"/> from an array of
+    ///  <typeparamref name="TComInterface"/>.
     /// </summary>
     /// <remarks>
     ///  <para>

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Ole/ClassPropertyDispatchAdapter.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Ole/ClassPropertyDispatchAdapter.cs
@@ -134,7 +134,8 @@ internal unsafe class ClassPropertyDispatchAdapter
     /// </summary>
     /// <remarks>
     ///  <para>
-    ///   Matches up to <see cref="IDispatchEx.InvokeEx(IDispatchEx*, int, uint, ushort, DISPPARAMS*, VARIANT*, EXCEPINFO*, Com.IServiceProvider*)"/>
+    ///   Matches up to
+    ///   <see cref="IDispatchEx.InvokeEx(IDispatchEx*, int, uint, ushort, DISPPARAMS*, VARIANT*, EXCEPINFO*, Com.IServiceProvider*)"/>
     ///  </para>
     /// </remarks>
     [UnconditionalSuppressMessage(

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/UI/Accessibility/UIAHelper.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/UI/Accessibility/UIAHelper.cs
@@ -9,7 +9,8 @@ internal static class UIAHelper
 {
     /// <summary>
     ///  Converts a window handle to a <see cref="VARIANT"/> for UIA purposes.
-    ///  Specifically, for <see cref="IRawElementProviderSimple.GetPropertyValue(IRawElementProviderSimple*, UIA_PROPERTY_ID, VARIANT*)"/>
+    ///  Specifically, for
+    ///  <see cref="IRawElementProviderSimple.GetPropertyValue(IRawElementProviderSimple*, UIA_PROPERTY_ID, VARIANT*)"/>
     ///  with <see cref="UIA_PROPERTY_ID.UIA_NativeWindowHandlePropertyId"/> passed.
     /// </summary>
     /// <param name="handle">The handle to the window</param>
@@ -29,7 +30,7 @@ internal static class UIAHelper
         {
             vt = VARENUM.VT_I4,
             // Only the lower 32 bits in window handles contain significant information -
-            // https://learn.microsoft.com/windows/win32/winprog64/interprocess-communication
+            // https://learn.Microsoft.com/windows/win32/winprog64/interprocess-communication
             data = new() { intVal = (int)(handle & 0xFFFF_FFFF) }
         };
 }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/UI/Controls/Dialogs/CHOOSECOLORW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/UI/Controls/Dialogs/CHOOSECOLORW.cs
@@ -20,57 +20,145 @@ namespace Windows.Win32.UI.Controls.Dialogs;
 internal unsafe partial struct CHOOSECOLORW
 {
     /// <summary>
-    /// <para>Type: <b>DWORD</b> The length, in bytes, of the structure.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosecolorw#members">Read more on learn.Microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>DWORD</b> The length, in bytes, of the structure.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosecolorw#members">
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
+    ///  </para>
     /// </summary>
     public uint lStructSize;
 
     /// <summary>
-    /// <para>Type: <b>HWND</b> A handle to the window that owns the dialog box. This member can be any valid window handle, or it can be <b>NULL</b> if the dialog box has no owner.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosecolorw#members">Read more on learn.Microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>HWND</b> A handle to the window that owns the dialog box. This member can be any valid window handle,
+    ///   or it can be <b>NULL</b> if the dialog box has no owner.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosecolorw#members">
+    ///    Read more on learn.Microsoft.com
+    ///   </see>
+    ///  </para>
     /// </summary>
     public HWND hwndOwner;
 
     /// <summary>
-    /// <para>Type: <b>HWND</b> If the <b>CC_ENABLETEMPLATEHANDLE</b> flag is set in the <b>Flags</b> member, <b>hInstance</b> is a handle to a memory object containing a dialog box template. If the <b>CC_ENABLETEMPLATE</b> flag is set, <b>hInstance</b> is a handle to a module that contains a dialog box template named by the <b>lpTemplateName</b> member. If neither <b>CC_ENABLETEMPLATEHANDLE</b> nor <b>CC_ENABLETEMPLATE</b> is set, this member is ignored.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosecolorw#members">Read more on learn.Microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>HWND</b> If the <b>CC_ENABLETEMPLATEHANDLE</b> flag is set in the <b>Flags</b> member,
+    ///   <b>hInstance</b> is a handle to a memory object containing a dialog box template.
+    ///   If the <b>CC_ENABLETEMPLATE</b> flag is set, <b>hInstance</b> is a handle to a module that contains
+    ///   a dialog box template named by the <b>lpTemplateName</b> member. If neither <b>CC_ENABLETEMPLATEHANDLE</b>
+    ///   nor <b>CC_ENABLETEMPLATE</b> is set, this member is ignored.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosecolorw#members">
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
+    ///  </para>
     /// </summary>
     public HWND hInstance;
 
     /// <summary>
-    /// <para>Type: <b><a href="https://learn.microsoft.com/windows/desktop/gdi/colorref">COLORREF</a></b> If the <b>CC_RGBINIT</b> flag is set, <b>rgbResult</b> specifies the color initially selected when the dialog box is created. If the specified color value is not among the available colors, the system selects the nearest solid color available. If <b>rgbResult</b> is zero or <b>CC_RGBINIT</b> is not set, the initially selected color is black. If the user clicks the <b>OK</b> button, <b>rgbResult</b> specifies the user's color selection. To create a <a href="https://learn.microsoft.com/windows/desktop/gdi/colorref">COLORREF</a> color value, use the <a href="https://learn.microsoft.com/windows/desktop/api/wingdi/nf-wingdi-rgb">RGB</a> macro.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosecolorw#members">Read more on learn.Microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b><a href="https://learn.microsoft.com/windows/desktop/gdi/colorref">COLORREF</a></b>
+    ///   If the <b>CC_RGBINIT</b> flag is set, <b>rgbResult</b> specifies the color initially selected when the
+    ///   dialog box is created. If the specified color value is not among the available colors, the system selects
+    ///   the nearest solid color available. If <b>rgbResult</b> is zero or <b>CC_RGBINIT</b> is not set,
+    ///   the initially selected color is black. If the user clicks the <b>OK</b> button, <b>rgbResult</b>
+    ///   specifies the user's color selection. To create a
+    ///   <a href="https://learn.microsoft.com/windows/desktop/gdi/colorref">COLORREF</a> color value,
+    ///   use the <a href="https://learn.microsoft.com/windows/desktop/api/wingdi/nf-wingdi-rgb">RGB</a> macro.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosecolorw#members">
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
+    ///  </para>
     /// </summary>
     public COLORREF rgbResult;
 
     /// <summary>
-    /// <para>Type: <b><a href="https://learn.microsoft.com/windows/desktop/gdi/colorref">COLORREF</a>*</b> A pointer to an array of 16  values that contain red, green, blue (RGB) values for the custom color boxes in the dialog box. If the user modifies these colors, the system updates the array with the new RGB values. To preserve new custom colors between calls to the <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646912(v=vs.85)">ChooseColor</a> function, you should allocate static memory for the array. To create a <a href="https://learn.microsoft.com/windows/desktop/gdi/colorref">COLORREF</a> color value, use the <a href="https://learn.microsoft.com/windows/desktop/api/wingdi/nf-wingdi-rgb">RGB</a> macro.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosecolorw#members">Read more on learn.Microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b><a href="https://learn.microsoft.com/windows/desktop/gdi/colorref">COLORREF</a>*</b> A pointer
+    ///   to an array of 16 values that contain red, green, blue (RGB) values for the custom color boxes in the
+    ///   dialog box. If the user modifies these colors, the system updates the array with the new RGB values.
+    ///   To preserve new custom colors between calls to the
+    ///   <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646912(v=vs.85)">
+    ///   ChooseColor</a> function, you should allocate static memory for the array. To create a
+    ///   <a href="https://learn.microsoft.com/windows/desktop/gdi/colorref">COLORREF</a> color value,
+    ///   use the <a href="https://learn.microsoft.com/windows/desktop/api/wingdi/nf-wingdi-rgb">RGB</a> macro.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosecolorw#members">
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
+    ///  </para>
     /// </summary>
     public unsafe COLORREF* lpCustColors;
 
     /// <summary>
-    /// <para>Type: <b>DWORD</b> A set of bit flags that you can use to initialize the <b>Color</b> dialog box. When the dialog box returns, it sets these flags to indicate the user's input. This member can be a combination of the following flags. </para>
-    /// <para>This doc was truncated.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosecolorw#members">Read more on learn.Microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>DWORD</b> A set of bit flags that you can use to initialize the <b>Color</b> dialog box.
+    ///   When the dialog box returns, it sets these flags to indicate the user's input. This member can be a
+    ///   combination of the following flags.
+    ///  </para>
+    ///  <para>This doc was truncated.</para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosecolorw#members">
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
+    ///  </para>
     /// </summary>
     public CHOOSECOLOR_FLAGS Flags;
 
     /// <summary>
-    /// <para>Type: <b>LPARAM</b> Application-defined data that the system passes to the hook procedure identified by the <b>lpfnHook</b> member. When the system sends the <a href="https://learn.microsoft.com/windows/desktop/dlgbox/wm-initdialog">WM_INITDIALOG</a> message to the hook procedure, the message's <i>lParam</i> parameter is a pointer to the <b>CHOOSECOLOR</b> structure specified when the dialog was created. The hook procedure can use this pointer to get the <b>lCustData</b> value.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosecolorw#members">Read more on learn.Microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>LPARAM</b> Application-defined data that the system passes to the hook procedure identified by
+    ///   the <b>lpfnHook</b> member. When the system sends the
+    ///   <a href="https://learn.microsoft.com/windows/desktop/dlgbox/wm-initdialog">WM_INITDIALOG</a>
+    ///   message to the hook procedure, the message's <i>lParam</i> parameter is a pointer to the <b>CHOOSECOLOR</b>
+    ///   structure specified when the dialog was created. The hook procedure can use this pointer to get the
+    ///   <b>lCustData</b> value.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosecolorw#members">
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
+    ///  </para>
     /// </summary>
     public LPARAM lCustData;
 
     /// <summary>
-    /// <para>Type: <b>LPCCHOOKPROC</b> A pointer to a <a href="https://learn.microsoft.com/windows/desktop/api/commdlg/nc-commdlg-lpcchookproc">CCHookProc</a> hook procedure that can process messages intended for the dialog box. This member is ignored unless the <b>CC_ENABLEHOOK</b> flag is set in the <b>Flags</b> member.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosecolorw#members">Read more on learn.Microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>LPCCHOOKPROC</b> A pointer to a
+    ///   <a href="https://learn.microsoft.com/windows/desktop/api/commdlg/nc-commdlg-lpcchookproc">CCHookProc</a>
+    ///   hook procedure that can process messages intended for the dialog box. This member is ignored unless the
+    ///   <b>CC_ENABLEHOOK</b> flag is set in the <b>Flags</b> member.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosecolorw#members">
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
+    ///  </para>
     /// </summary>
     public unsafe delegate* unmanaged[Stdcall]<HWND, uint, WPARAM, LPARAM, nuint> lpfnHook;
 
     /// <summary>
-    /// <para>Type: <b>LPCTSTR</b> The name of the dialog box template resource in the module identified by the <b>hInstance</b> member. This template is substituted for the standard dialog box template. For numbered dialog box resources, <b>lpTemplateName</b> can be a value returned by the <a href="https://learn.microsoft.com/windows/desktop/api/winuser/nf-winuser-makeintresourcea">MAKEINTRESOURCE</a> macro. This member is ignored unless the <b>CC_ENABLETEMPLATE</b> flag is set in the <b>Flags</b> member.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosecolorw#members">Read more on learn.Microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>LPCTSTR</b> The name of the dialog box template resource in the module identified by the
+    ///   <b>hInstance</b> member. This template is substituted for the standard dialog box template.
+    ///   For numbered dialog box resources, <b>lpTemplateName</b> can be a value returned by the
+    ///   <a href="https://learn.microsoft.com/windows/desktop/api/winuser/nf-winuser-makeintresourcea">
+    ///   MAKEINTRESOURCE</a> macro. This member is ignored unless the <b>CC_ENABLETEMPLATE</b>
+    ///   flag is set in the <b>Flags</b> member.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosecolorw#members">
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
+    ///  </para>
     /// </summary>
     public PCWSTR lpTemplateName;
 }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/UI/Controls/Dialogs/CHOOSECOLORW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/UI/Controls/Dialogs/CHOOSECOLORW.cs
@@ -21,56 +21,56 @@ internal unsafe partial struct CHOOSECOLORW
 {
     /// <summary>
     /// <para>Type: <b>DWORD</b> The length, in bytes, of the structure.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosecolorw#members">Read more on learn.microsoft.com</see>.</para>
+    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosecolorw#members">Read more on learn.Microsoft.com</see>.</para>
     /// </summary>
     public uint lStructSize;
 
     /// <summary>
     /// <para>Type: <b>HWND</b> A handle to the window that owns the dialog box. This member can be any valid window handle, or it can be <b>NULL</b> if the dialog box has no owner.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosecolorw#members">Read more on learn.microsoft.com</see>.</para>
+    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosecolorw#members">Read more on learn.Microsoft.com</see>.</para>
     /// </summary>
     public HWND hwndOwner;
 
     /// <summary>
     /// <para>Type: <b>HWND</b> If the <b>CC_ENABLETEMPLATEHANDLE</b> flag is set in the <b>Flags</b> member, <b>hInstance</b> is a handle to a memory object containing a dialog box template. If the <b>CC_ENABLETEMPLATE</b> flag is set, <b>hInstance</b> is a handle to a module that contains a dialog box template named by the <b>lpTemplateName</b> member. If neither <b>CC_ENABLETEMPLATEHANDLE</b> nor <b>CC_ENABLETEMPLATE</b> is set, this member is ignored.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosecolorw#members">Read more on learn.microsoft.com</see>.</para>
+    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosecolorw#members">Read more on learn.Microsoft.com</see>.</para>
     /// </summary>
     public HWND hInstance;
 
     /// <summary>
     /// <para>Type: <b><a href="https://learn.microsoft.com/windows/desktop/gdi/colorref">COLORREF</a></b> If the <b>CC_RGBINIT</b> flag is set, <b>rgbResult</b> specifies the color initially selected when the dialog box is created. If the specified color value is not among the available colors, the system selects the nearest solid color available. If <b>rgbResult</b> is zero or <b>CC_RGBINIT</b> is not set, the initially selected color is black. If the user clicks the <b>OK</b> button, <b>rgbResult</b> specifies the user's color selection. To create a <a href="https://learn.microsoft.com/windows/desktop/gdi/colorref">COLORREF</a> color value, use the <a href="https://learn.microsoft.com/windows/desktop/api/wingdi/nf-wingdi-rgb">RGB</a> macro.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosecolorw#members">Read more on learn.microsoft.com</see>.</para>
+    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosecolorw#members">Read more on learn.Microsoft.com</see>.</para>
     /// </summary>
     public COLORREF rgbResult;
 
     /// <summary>
     /// <para>Type: <b><a href="https://learn.microsoft.com/windows/desktop/gdi/colorref">COLORREF</a>*</b> A pointer to an array of 16  values that contain red, green, blue (RGB) values for the custom color boxes in the dialog box. If the user modifies these colors, the system updates the array with the new RGB values. To preserve new custom colors between calls to the <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646912(v=vs.85)">ChooseColor</a> function, you should allocate static memory for the array. To create a <a href="https://learn.microsoft.com/windows/desktop/gdi/colorref">COLORREF</a> color value, use the <a href="https://learn.microsoft.com/windows/desktop/api/wingdi/nf-wingdi-rgb">RGB</a> macro.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosecolorw#members">Read more on learn.microsoft.com</see>.</para>
+    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosecolorw#members">Read more on learn.Microsoft.com</see>.</para>
     /// </summary>
     public unsafe COLORREF* lpCustColors;
 
     /// <summary>
     /// <para>Type: <b>DWORD</b> A set of bit flags that you can use to initialize the <b>Color</b> dialog box. When the dialog box returns, it sets these flags to indicate the user's input. This member can be a combination of the following flags. </para>
     /// <para>This doc was truncated.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosecolorw#members">Read more on learn.microsoft.com</see>.</para>
+    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosecolorw#members">Read more on learn.Microsoft.com</see>.</para>
     /// </summary>
     public CHOOSECOLOR_FLAGS Flags;
 
     /// <summary>
     /// <para>Type: <b>LPARAM</b> Application-defined data that the system passes to the hook procedure identified by the <b>lpfnHook</b> member. When the system sends the <a href="https://learn.microsoft.com/windows/desktop/dlgbox/wm-initdialog">WM_INITDIALOG</a> message to the hook procedure, the message's <i>lParam</i> parameter is a pointer to the <b>CHOOSECOLOR</b> structure specified when the dialog was created. The hook procedure can use this pointer to get the <b>lCustData</b> value.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosecolorw#members">Read more on learn.microsoft.com</see>.</para>
+    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosecolorw#members">Read more on learn.Microsoft.com</see>.</para>
     /// </summary>
     public LPARAM lCustData;
 
     /// <summary>
     /// <para>Type: <b>LPCCHOOKPROC</b> A pointer to a <a href="https://learn.microsoft.com/windows/desktop/api/commdlg/nc-commdlg-lpcchookproc">CCHookProc</a> hook procedure that can process messages intended for the dialog box. This member is ignored unless the <b>CC_ENABLEHOOK</b> flag is set in the <b>Flags</b> member.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosecolorw#members">Read more on learn.microsoft.com</see>.</para>
+    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosecolorw#members">Read more on learn.Microsoft.com</see>.</para>
     /// </summary>
     public unsafe delegate* unmanaged[Stdcall]<HWND, uint, WPARAM, LPARAM, nuint> lpfnHook;
 
     /// <summary>
     /// <para>Type: <b>LPCTSTR</b> The name of the dialog box template resource in the module identified by the <b>hInstance</b> member. This template is substituted for the standard dialog box template. For numbered dialog box resources, <b>lpTemplateName</b> can be a value returned by the <a href="https://learn.microsoft.com/windows/desktop/api/winuser/nf-winuser-makeintresourcea">MAKEINTRESOURCE</a> macro. This member is ignored unless the <b>CC_ENABLETEMPLATE</b> flag is set in the <b>Flags</b> member.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosecolorw#members">Read more on learn.microsoft.com</see>.</para>
+    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosecolorw#members">Read more on learn.Microsoft.com</see>.</para>
     /// </summary>
     public PCWSTR lpTemplateName;
 }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/UI/Controls/Dialogs/CHOOSEFONTW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/UI/Controls/Dialogs/CHOOSEFONTW.cs
@@ -17,8 +17,10 @@ internal partial struct CHOOSEFONTW
 {
     /// <summary>
     ///  <para>Type: <b>DWORD</b> The length of the structure, in bytes.</para>
-    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">
-    ///   Read more on learn.Microsoft.com.</see>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
     ///  </para>
     /// </summary>
     public uint lStructSize;
@@ -47,8 +49,8 @@ internal partial struct CHOOSEFONTW
     ///  </para>
     ///  <para>
     ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">
-    ///    Read more on learn.Microsoft.com
-    ///   .</see>
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
     ///  </para>
     /// </summary>
     public HDC hDC;
@@ -179,8 +181,10 @@ internal partial struct CHOOSEFONTW
     ///   uses the data in this buffer to initialize the <b>Font Style</b> combo box. When the user closes the
     ///   dialog box, <b>ChooseFont</b> copies the string in the <b>Font Style</b> combo box into this buffer.
     ///  </para>
-    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">
-    ///   Read more on learn.Microsoft.com.</see>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">
+    ///    Read more on learn.Microsoft.com.
+    ///  </see>
     ///  </para>
     /// </summary>
     public PWSTR lpszStyle;
@@ -191,14 +195,29 @@ internal partial struct CHOOSEFONTW
     public ushort ___MISSING_ALIGNMENT__;
 
     /// <summary>
-    ///  <para>Type: <b>INT</b> The minimum point size a user can select. <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646914(v=vs.85)">ChooseFont</a> recognizes this member only if the <b>CF_LIMITSIZE</b> flag is specified.</para>
-    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">Read more on learn.Microsoft.com.</see></para>
+    ///  <para>
+    ///   Type: <b>INT</b> The minimum point size a user can select.
+    ///   <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646914(v=vs.85)">
+    ///   ChooseFont</a> recognizes this member only if the <b>CF_LIMITSIZE</b> flag is specified.</para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
+    ///  </para>
     /// </summary>
     public int nSizeMin;
 
     /// <summary>
-    ///  <para>Type: <b>INT</b> The maximum point size a user can select. <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646914(v=vs.85)">ChooseFont</a> recognizes this member only if the <b>CF_LIMITSIZE</b> flag is specified.</para>
-    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">Read more on learn.Microsoft.com.</see></para>
+    ///  <para>
+    ///   Type: <b>INT</b> The maximum point size a user can select.
+    ///   <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646914(v=vs.85)">
+    ///   ChooseFont</a> recognizes this member only if the <b>CF_LIMITSIZE</b> flag is specified.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
+    ///  </para>
     /// </summary>
     public int nSizeMax;
 }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/UI/Controls/Dialogs/CHOOSEFONTW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/UI/Controls/Dialogs/CHOOSEFONTW.cs
@@ -18,7 +18,7 @@ internal partial struct CHOOSEFONTW
     /// <summary>
     ///  <para>Type: <b>DWORD</b> The length of the structure, in bytes.</para>
     ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">
-    ///   Read more on learn.Microsoft.com</see>.
+    ///   Read more on learn.Microsoft.com.</see>
     ///  </para>
     /// </summary>
     public uint lStructSize;
@@ -46,20 +46,41 @@ internal partial struct CHOOSEFONTW
     ///  <para>
     ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">
     ///    Read more on learn.Microsoft.com
-    ///   </see>.
+    ///   .</see>
     ///  </para>
     /// </summary>
     public HDC hDC;
 
     /// <summary>
-    /// <para>Type: <b>LPLOGFONT</b> A pointer to a  <a href="https://learn.microsoft.com/windows/desktop/api/wingdi/ns-wingdi-logfonta">LOGFONT</a> structure. If you set the <b>CF_INITTOLOGFONTSTRUCT</b> flag in the <b>Flags</b> member and initialize the other members, the <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646914(v=vs.85)">ChooseFont</a> function initializes the dialog box with a font that matches the <b>LOGFONT</b> members. If the user clicks the <b>OK</b> button, <b>ChooseFont</b> sets the members of the <b>LOGFONT</b> structure based on the user's selections.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">Read more on learn.Microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>LPLOGFONT</b> A pointer to a
+    ///   <a href="https://learn.microsoft.com/windows/desktop/api/wingdi/ns-wingdi-logfonta">
+    ///   LOGFONT</a> structure. If you set the <b>CF_INITTOLOGFONTSTRUCT</b> flag in the <b>Flags</b> member and
+    ///   initialize the other members, the
+    ///   <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646914(v=vs.85)">
+    ///   ChooseFont</a> function initializes the dialog box with a font that matches the <b>LOGFONT</b> members.
+    ///   If the user clicks the <b>OK</b> button, <b>ChooseFont</b> sets the members of the <b>LOGFONT</b>
+    ///   structure based on the user's selections.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
+    ///  </para>
     /// </summary>
     public unsafe LOGFONTW* lpLogFont;
 
     /// <summary>
-    /// <para>Type: <b>INT</b> The size of the selected font, in units of 1/10 of a point. The <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646914(v=vs.85)">ChooseFont</a> function sets this value after the user closes the dialog box.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">Read more on learn.Microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>INT</b> The size of the selected font, in units of 1/10 of a point. The
+    ///   <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646914(v=vs.85)">
+    ///   ChooseFont</a> function sets this value after the user closes the dialog box.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
+    ///  </para>
     /// </summary>
     public int iPointSize;
 
@@ -67,32 +88,85 @@ internal partial struct CHOOSEFONTW
     public CHOOSEFONT_FLAGS Flags;
 
     /// <summary>
-    /// <para>Type: <b><a href="https://learn.microsoft.com/windows/desktop/gdi/colorref">COLORREF</a></b> If the <b>CF_EFFECTS</b> flag is set, <b>rgbColors</b> specifies the initial text color. When <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646914(v=vs.85)">ChooseFont</a> returns successfully, this member contains the RGB value of the text color that the user selected. To create a <a href="https://learn.microsoft.com/windows/desktop/gdi/colorref">COLORREF</a> color value, use the <a href="https://learn.microsoft.com/windows/desktop/api/wingdi/nf-wingdi-rgb">RGB</a> macro.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">Read more on learn.Microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b><a href="https://learn.microsoft.com/windows/desktop/gdi/colorref">
+    ///   COLORREF</a></b> If the <b>CF_EFFECTS</b> flag is set, <b>rgbColors</b> specifies the initial text color.
+    ///   When <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646914(v=vs.85)">
+    ///   ChooseFont</a> returns successfully, this member contains the RGB value of the text color that the user selected.
+    ///   To create a <a href="https://learn.microsoft.com/windows/desktop/gdi/colorref">COLORREF</a> color value,
+    ///   use the <a href="https://learn.microsoft.com/windows/desktop/api/wingdi/nf-wingdi-rgb">RGB</a> macro.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
+    ///  </para>
     /// </summary>
     public COLORREF rgbColors;
 
     /// <summary>
-    /// <para>Type: <b>LPARAM</b> Application-defined data that the system passes to the hook procedure identified by the <b>lpfnHook</b> member. When the system sends the <a href="https://learn.microsoft.com/windows/desktop/dlgbox/wm-initdialog">WM_INITDIALOG</a> message to the hook procedure, the message's <i>lParam</i> parameter is a pointer to the <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646914(v=vs.85)">CHOOSEFONT</a> structure specified when the dialog was created. The hook procedure can use this pointer to get the <b>lCustData</b> value.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">Read more on learn.Microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>LPARAM</b> Application-defined data that the system passes to the hook procedure identified by the
+    ///   <b>lpfnHook</b> member. When the system sends the
+    ///   <a href="https://learn.microsoft.com/windows/desktop/dlgbox/wm-initdialog">WM_INITDIALOG</a> message to
+    ///   the hook procedure, the message's <i>lParam</i> parameter is a pointer to the
+    ///   <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646914(v=vs.85)">
+    ///   CHOOSEFONT</a> structure specified when the dialog was created. The hook procedure can use this pointer
+    ///   to get the <b>lCustData</b> value.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
+    ///  </para>
     /// </summary>
     public LPARAM lCustData;
 
     /// <summary>
-    /// <para>Type: <b>LPCFHOOKPROC</b> A pointer to a <a href="https://learn.microsoft.com/windows/desktop/api/commdlg/nc-commdlg-lpcfhookproc">CFHookProc</a> hook procedure that can process messages intended for the dialog box. This member is ignored unless the <b>CF_ENABLEHOOK</b> flag is set in the <b>Flags</b> member.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">Read more on learn.Microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>LPCFHOOKPROC</b> A pointer to a
+    ///   <a href="https://learn.microsoft.com/windows/desktop/api/commdlg/nc-commdlg-lpcfhookproc">
+    ///   CFHookProc</a> hook procedure that can process messages intended for the dialog box. This member is ignored
+    ///   unless the <b>CF_ENABLEHOOK</b> flag is set in the <b>Flags</b> member.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
+    ///  </para>
     /// </summary>
     public unsafe delegate* unmanaged[Stdcall]<HWND, uint, WPARAM, LPARAM, nuint> lpfnHook;
 
     /// <summary>
-    /// <para>Type: <b>LPCTSTR</b> The name of the dialog box template resource in the module identified by the <b>hInstance</b> member. This template is substituted for the standard dialog box template. For numbered dialog box resources, <b>lpTemplateName</b> can be a value returned by the <a href="https://learn.microsoft.com/windows/desktop/api/winuser/nf-winuser-makeintresourcea">MAKEINTRESOURCE</a> macro. This member is ignored unless the <b>CF_ENABLETEMPLATE</b> flag is set in the <b>Flags</b> member.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">Read more on learn.Microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>LPCTSTR</b> The name of the dialog box template resource in the module identified by the
+    ///   <b>hInstance</b> member. This template is substituted for the standard dialog box template.
+    ///   For numbered dialog box resources, <b>lpTemplateName</b> can be a value returned by the
+    ///   <a href="https://learn.microsoft.com/windows/desktop/api/winuser/nf-winuser-makeintresourcea">
+    ///   MAKEINTRESOURCE</a> macro. This member is ignored unless the <b>CF_ENABLETEMPLATE</b> flag is set in the
+    ///   <b>Flags</b> member.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
+    ///  </para>
     /// </summary>
     public PCWSTR lpTemplateName;
 
     /// <summary>
-    /// <para>Type: <b>HINSTANCE</b> If the <b>CF_ENABLETEMPLATEHANDLE</b> flag is set in the <b>Flags</b> member, <b>hInstance</b> is a handle to a memory object containing a dialog box template. If the <b>CF_ENABLETEMPLATE</b> flag is set, <b>hInstance</b> is a handle to a module that contains a dialog box template named by the <b>lpTemplateName</b> member. If neither <b>CF_ENABLETEMPLATEHANDLE</b> nor <b>CF_ENABLETEMPLATE</b> is set, this member is ignored.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">Read more on learn.Microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>HINSTANCE</b> If the <b>CF_ENABLETEMPLATEHANDLE</b> flag is set in the <b>Flags</b> member,
+    ///   <b>hInstance</b> is a handle to a memory object containing a dialog box template. If the
+    ///   <b>CF_ENABLETEMPLATE</b> flag is set, <b>hInstance</b> is a handle to a module that contains a dialog box
+    ///   template named by the <b>lpTemplateName</b> member. If neither <b>CF_ENABLETEMPLATEHANDLE</b> nor
+    ///   <b>CF_ENABLETEMPLATE</b> is set, this member is ignored.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
+    ///  </para>
     /// </summary>
     public HINSTANCE hInstance;
 
@@ -104,7 +178,7 @@ internal partial struct CHOOSEFONTW
     ///   dialog box, <b>ChooseFont</b> copies the string in the <b>Font Style</b> combo box into this buffer.
     ///  </para>
     ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">
-    ///   Read more on learn.Microsoft.com</see>.
+    ///   Read more on learn.Microsoft.com.</see>
     ///  </para>
     /// </summary>
     public PWSTR lpszStyle;
@@ -115,14 +189,14 @@ internal partial struct CHOOSEFONTW
     public ushort ___MISSING_ALIGNMENT__;
 
     /// <summary>
-    /// <para>Type: <b>INT</b> The minimum point size a user can select. <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646914(v=vs.85)">ChooseFont</a> recognizes this member only if the <b>CF_LIMITSIZE</b> flag is specified.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">Read more on learn.Microsoft.com</see>.</para>
+    ///  <para>Type: <b>INT</b> The minimum point size a user can select. <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646914(v=vs.85)">ChooseFont</a> recognizes this member only if the <b>CF_LIMITSIZE</b> flag is specified.</para>
+    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">Read more on learn.Microsoft.com.</see></para>
     /// </summary>
     public int nSizeMin;
 
     /// <summary>
-    /// <para>Type: <b>INT</b> The maximum point size a user can select. <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646914(v=vs.85)">ChooseFont</a> recognizes this member only if the <b>CF_LIMITSIZE</b> flag is specified.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">Read more on learn.Microsoft.com</see>.</para>
+    ///  <para>Type: <b>INT</b> The maximum point size a user can select. <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646914(v=vs.85)">ChooseFont</a> recognizes this member only if the <b>CF_LIMITSIZE</b> flag is specified.</para>
+    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">Read more on learn.Microsoft.com.</see></para>
     /// </summary>
     public int nSizeMax;
 }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/UI/Controls/Dialogs/CHOOSEFONTW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/UI/Controls/Dialogs/CHOOSEFONTW.cs
@@ -9,39 +9,57 @@ namespace Windows.Win32.UI.Controls.Dialogs;
 /// <remarks>
 ///  <para>
 ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#">
-///    Read more on learn.microsoft.com
+///    Read more on learn.Microsoft.com
 ///   </see>
 ///  </para>
 /// </remarks>
 internal partial struct CHOOSEFONTW
 {
     /// <summary>
-    /// <para>Type: <b>DWORD</b> The length of the structure, in bytes.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">Read more on learn.microsoft.com</see>.</para>
+    ///  <para>Type: <b>DWORD</b> The length of the structure, in bytes.</para>
+    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">
+    ///   Read more on learn.Microsoft.com</see>.
+    ///  </para>
     /// </summary>
     public uint lStructSize;
 
     /// <summary>
-    /// <para>Type: <b>HWND</b> A handle to the window that owns the dialog box. This member can be any valid window handle, or it can be <b>NULL</b> if the dialog box has no owner.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">Read more on learn.microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>HWND</b> A handle to the window that owns the dialog box. This member can be any valid window handle,
+    ///   or it can be <b>NULL</b> if the dialog box has no owner.
+    ///  </para>
+    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">
+    ///   Read more on learn.Microsoft.com</see>.
+    ///  </para>
     /// </summary>
     public HWND hwndOwner;
 
     /// <summary>
-    /// <para>Type: <b>HDC</b> This member is ignored by the <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646914(v=vs.85)">ChooseFont</a> function. <b>Windows Vista and Windows XP/2000:  </b>A handle to the device context or information context of the printer whose fonts will be listed in the dialog box. This member is used only if the <b>Flags</b> member specifies the <b>CF_PRINTERFONTS</b> or <b>CF_BOTH</b> flag; otherwise, this member is ignored.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">Read more on learn.microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>HDC</b> This member is ignored by the
+    ///   <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646914(v=vs.85)">
+    ///   ChooseFont</a> function. <b>Windows Vista and Windows XP/2000:  </b>A handle to the device context or
+    ///   information context of the printer whose fonts will be listed in the dialog box.
+    ///   This member is used only if the <b>Flags</b> member specifies the <b>CF_PRINTERFONTS</b> or <b>CF_BOTH</b>
+    ///   flag; otherwise, this member is ignored.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">
+    ///    Read more on learn.Microsoft.com
+    ///   </see>.
+    ///  </para>
     /// </summary>
     public HDC hDC;
 
     /// <summary>
     /// <para>Type: <b>LPLOGFONT</b> A pointer to a  <a href="https://learn.microsoft.com/windows/desktop/api/wingdi/ns-wingdi-logfonta">LOGFONT</a> structure. If you set the <b>CF_INITTOLOGFONTSTRUCT</b> flag in the <b>Flags</b> member and initialize the other members, the <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646914(v=vs.85)">ChooseFont</a> function initializes the dialog box with a font that matches the <b>LOGFONT</b> members. If the user clicks the <b>OK</b> button, <b>ChooseFont</b> sets the members of the <b>LOGFONT</b> structure based on the user's selections.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">Read more on learn.microsoft.com</see>.</para>
+    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">Read more on learn.Microsoft.com</see>.</para>
     /// </summary>
     public unsafe LOGFONTW* lpLogFont;
 
     /// <summary>
     /// <para>Type: <b>INT</b> The size of the selected font, in units of 1/10 of a point. The <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646914(v=vs.85)">ChooseFont</a> function sets this value after the user closes the dialog box.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">Read more on learn.microsoft.com</see>.</para>
+    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">Read more on learn.Microsoft.com</see>.</para>
     /// </summary>
     public int iPointSize;
 
@@ -50,37 +68,44 @@ internal partial struct CHOOSEFONTW
 
     /// <summary>
     /// <para>Type: <b><a href="https://learn.microsoft.com/windows/desktop/gdi/colorref">COLORREF</a></b> If the <b>CF_EFFECTS</b> flag is set, <b>rgbColors</b> specifies the initial text color. When <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646914(v=vs.85)">ChooseFont</a> returns successfully, this member contains the RGB value of the text color that the user selected. To create a <a href="https://learn.microsoft.com/windows/desktop/gdi/colorref">COLORREF</a> color value, use the <a href="https://learn.microsoft.com/windows/desktop/api/wingdi/nf-wingdi-rgb">RGB</a> macro.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">Read more on learn.microsoft.com</see>.</para>
+    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">Read more on learn.Microsoft.com</see>.</para>
     /// </summary>
     public COLORREF rgbColors;
 
     /// <summary>
     /// <para>Type: <b>LPARAM</b> Application-defined data that the system passes to the hook procedure identified by the <b>lpfnHook</b> member. When the system sends the <a href="https://learn.microsoft.com/windows/desktop/dlgbox/wm-initdialog">WM_INITDIALOG</a> message to the hook procedure, the message's <i>lParam</i> parameter is a pointer to the <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646914(v=vs.85)">CHOOSEFONT</a> structure specified when the dialog was created. The hook procedure can use this pointer to get the <b>lCustData</b> value.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">Read more on learn.microsoft.com</see>.</para>
+    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">Read more on learn.Microsoft.com</see>.</para>
     /// </summary>
     public LPARAM lCustData;
 
     /// <summary>
     /// <para>Type: <b>LPCFHOOKPROC</b> A pointer to a <a href="https://learn.microsoft.com/windows/desktop/api/commdlg/nc-commdlg-lpcfhookproc">CFHookProc</a> hook procedure that can process messages intended for the dialog box. This member is ignored unless the <b>CF_ENABLEHOOK</b> flag is set in the <b>Flags</b> member.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">Read more on learn.microsoft.com</see>.</para>
+    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">Read more on learn.Microsoft.com</see>.</para>
     /// </summary>
     public unsafe delegate* unmanaged[Stdcall]<HWND, uint, WPARAM, LPARAM, nuint> lpfnHook;
 
     /// <summary>
     /// <para>Type: <b>LPCTSTR</b> The name of the dialog box template resource in the module identified by the <b>hInstance</b> member. This template is substituted for the standard dialog box template. For numbered dialog box resources, <b>lpTemplateName</b> can be a value returned by the <a href="https://learn.microsoft.com/windows/desktop/api/winuser/nf-winuser-makeintresourcea">MAKEINTRESOURCE</a> macro. This member is ignored unless the <b>CF_ENABLETEMPLATE</b> flag is set in the <b>Flags</b> member.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">Read more on learn.microsoft.com</see>.</para>
+    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">Read more on learn.Microsoft.com</see>.</para>
     /// </summary>
     public PCWSTR lpTemplateName;
 
     /// <summary>
     /// <para>Type: <b>HINSTANCE</b> If the <b>CF_ENABLETEMPLATEHANDLE</b> flag is set in the <b>Flags</b> member, <b>hInstance</b> is a handle to a memory object containing a dialog box template. If the <b>CF_ENABLETEMPLATE</b> flag is set, <b>hInstance</b> is a handle to a module that contains a dialog box template named by the <b>lpTemplateName</b> member. If neither <b>CF_ENABLETEMPLATEHANDLE</b> nor <b>CF_ENABLETEMPLATE</b> is set, this member is ignored.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">Read more on learn.microsoft.com</see>.</para>
+    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">Read more on learn.Microsoft.com</see>.</para>
     /// </summary>
     public HINSTANCE hInstance;
 
     /// <summary>
-    /// <para>Type: <b>LPTSTR</b> The style data. If the <b>CF_USESTYLE</b> flag is specified, <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646914(v=vs.85)">ChooseFont</a> uses the data in this buffer to initialize the <b>Font Style</b> combo box. When the user closes the dialog box, <b>ChooseFont</b> copies the string in the <b>Font Style</b> combo box into this buffer.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">Read more on learn.microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>LPTSTR</b> The style data. If the <b>CF_USESTYLE</b> flag is specified,
+    ///   <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646914(v=vs.85)">ChooseFont</a>
+    ///   uses the data in this buffer to initialize the <b>Font Style</b> combo box. When the user closes the
+    ///   dialog box, <b>ChooseFont</b> copies the string in the <b>Font Style</b> combo box into this buffer.
+    ///  </para>
+    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">
+    ///   Read more on learn.Microsoft.com</see>.
+    ///  </para>
     /// </summary>
     public PWSTR lpszStyle;
 
@@ -91,13 +116,13 @@ internal partial struct CHOOSEFONTW
 
     /// <summary>
     /// <para>Type: <b>INT</b> The minimum point size a user can select. <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646914(v=vs.85)">ChooseFont</a> recognizes this member only if the <b>CF_LIMITSIZE</b> flag is specified.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">Read more on learn.microsoft.com</see>.</para>
+    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">Read more on learn.Microsoft.com</see>.</para>
     /// </summary>
     public int nSizeMin;
 
     /// <summary>
     /// <para>Type: <b>INT</b> The maximum point size a user can select. <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646914(v=vs.85)">ChooseFont</a> recognizes this member only if the <b>CF_LIMITSIZE</b> flag is specified.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">Read more on learn.microsoft.com</see>.</para>
+    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">Read more on learn.Microsoft.com</see>.</para>
     /// </summary>
     public int nSizeMax;
 }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/UI/Controls/Dialogs/CHOOSEFONTW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/UI/Controls/Dialogs/CHOOSEFONTW.cs
@@ -28,8 +28,10 @@ internal partial struct CHOOSEFONTW
     ///   Type: <b>HWND</b> A handle to the window that owns the dialog box. This member can be any valid window handle,
     ///   or it can be <b>NULL</b> if the dialog box has no owner.
     ///  </para>
-    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">
-    ///   Read more on learn.Microsoft.com</see>.
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-choosefontw#members">
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
     ///  </para>
     /// </summary>
     public HWND hwndOwner;

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/UI/Controls/Dialogs/PAGESETUPDLGW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/UI/Controls/Dialogs/PAGESETUPDLGW.cs
@@ -12,7 +12,7 @@ namespace Windows.Win32.UI.Controls.Dialogs;
 /// <remarks>
 ///  <para>
 ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-pagesetupdlgw#">
-///    Read more on learn.microsoft.com
+///    Read more on learn.Microsoft.com
 ///   </see>.
 ///  </para>
 /// </remarks>
@@ -30,25 +30,25 @@ internal partial struct PAGESETUPDLGW
 {
     /// <summary>
     /// <para>Type: <b>DWORD</b> The size, in bytes, of this structure.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-pagesetupdlgw#members">Read more on learn.microsoft.com</see>.</para>
+    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-pagesetupdlgw#members">Read more on learn.Microsoft.com</see>.</para>
     /// </summary>
     public uint lStructSize;
 
     /// <summary>
     /// <para>Type: <b>HWND</b> A handle to the window that owns the dialog box. This member can be any valid window handle, or it can be <b>NULL</b> if the dialog box has no owner.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-pagesetupdlgw#members">Read more on learn.microsoft.com</see>.</para>
+    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-pagesetupdlgw#members">Read more on learn.Microsoft.com</see>.</para>
     /// </summary>
     public HWND hwndOwner;
 
     /// <summary>
     /// <para>Type: <b>HGLOBAL</b> A handle to a global memory object that contains a <a href="https://learn.microsoft.com/windows/win32/api/wingdi/ns-wingdi-devmodea">DEVMODE</a> structure. On input, if a handle is specified, the values in the corresponding <b>DEVMODE</b> structure are used to initialize the controls in the dialog box. On output, the dialog box sets <b>hDevMode</b> to a global memory handle to a <b>DEVMODE</b> structure that contains values specifying the user's selections. If the user's selections are not available, the dialog box sets <b>hDevMode</b> to <b>NULL</b>.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-pagesetupdlgw#members">Read more on learn.microsoft.com</see>.</para>
+    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-pagesetupdlgw#members">Read more on learn.Microsoft.com</see>.</para>
     /// </summary>
     public HGLOBAL hDevMode;
 
     /// <summary>
     /// <para>Type: <b>HGLOBAL</b> A handle to a global memory object that contains a <a href="https://learn.microsoft.com/windows/desktop/api/commdlg/ns-commdlg-devnames">DEVNAMES</a> structure. This structure contains three strings that specify the driver name, the printer name, and the output port name. On input, if a handle is specified, the strings in the corresponding <b>DEVNAMES</b> structure are used to initialize controls in the dialog box. On output, the dialog box sets <b>hDevNames</b> to a global memory handle to a <b>DEVNAMES</b> structure that contains strings specifying the user's selections. If the user's selections are not available, the dialog box sets <b>hDevNames</b> to <b>NULL</b>.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-pagesetupdlgw#members">Read more on learn.microsoft.com</see>.</para>
+    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-pagesetupdlgw#members">Read more on learn.Microsoft.com</see>.</para>
     /// </summary>
     public HGLOBAL hDevNames;
 
@@ -57,55 +57,88 @@ internal partial struct PAGESETUPDLGW
 
     /// <summary>
     /// <para>Type: <b><a href="https://learn.microsoft.com/windows/win32/api/windef/ns-windef-point">POINT</a></b> The dimensions of the paper selected by the user. The <b>PSD_INTHOUSANDTHSOFINCHES</b> or <b>PSD_INHUNDREDTHSOFMILLIMETERS</b> flag indicates the units of measurement.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-pagesetupdlgw#members">Read more on learn.microsoft.com</see>.</para>
+    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-pagesetupdlgw#members">Read more on learn.Microsoft.com</see>.</para>
     /// </summary>
     public Point ptPaperSize;
 
     /// <summary>
     /// <para>Type: <b><a href="https://learn.microsoft.com/windows/desktop/api/windef/ns-windef-rect">RECT</a></b> The minimum allowable widths for the left, top, right, and bottom margins. The system ignores this member if the <b>PSD_MINMARGINS</b> flag is not set. These values must be less than or equal to the values specified in the <b>rtMargin</b> member. The <b>PSD_INTHOUSANDTHSOFINCHES</b> or <b>PSD_INHUNDREDTHSOFMILLIMETERS</b> flag indicates the units of measurement.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-pagesetupdlgw#members">Read more on learn.microsoft.com</see>.</para>
+    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-pagesetupdlgw#members">Read more on learn.Microsoft.com</see>.</para>
     /// </summary>
     public RECT rtMinMargin;
 
     /// <summary>
     /// <para>Type: <b><a href="https://learn.microsoft.com/windows/desktop/api/windef/ns-windef-rect">RECT</a></b> The widths of the left, top, right, and bottom margins. If you set the <b>PSD_MARGINS</b> flag, <b>rtMargin</b> specifies the initial margin values. When <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646937(v=vs.85)">PageSetupDlg</a> returns, <b>rtMargin</b> contains the margin widths selected by the user. The <b>PSD_INHUNDREDTHSOFMILLIMETERS</b> or <b>PSD_INTHOUSANDTHSOFINCHES</b> flag indicates the units of measurement.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-pagesetupdlgw#members">Read more on learn.microsoft.com</see>.</para>
+    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-pagesetupdlgw#members">Read more on learn.Microsoft.com</see>.</para>
     /// </summary>
     public RECT rtMargin;
 
     /// <summary>
     /// <para>Type: <b>HINSTANCE</b> If the <b>PSD_ENABLEPAGESETUPTEMPLATE</b> flag is set in the <b>Flags</b> member, <b>hInstance</b> is a handle to the application or module instance that contains the dialog box template named by the <b>lpPageSetupTemplateName</b> member.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-pagesetupdlgw#members">Read more on learn.microsoft.com</see>.</para>
+    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-pagesetupdlgw#members">Read more on learn.Microsoft.com</see>.</para>
     /// </summary>
     public HINSTANCE hInstance;
 
     /// <summary>
     /// <para>Type: <b>LPARAM</b> Application-defined data that the system passes to the hook procedure identified by the <b>lpfnPageSetupHook</b> member. When the system sends the <a href="https://learn.microsoft.com/windows/desktop/dlgbox/wm-initdialog">WM_INITDIALOG</a> message to the hook procedure, the message's <i>lParam</i> parameter is a pointer to the <b>PAGESETUPDLG</b> structure specified when the dialog was created. The hook procedure can use this pointer to get the <b>lCustData</b> value.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-pagesetupdlgw#members">Read more on learn.microsoft.com</see>.</para>
+    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-pagesetupdlgw#members">Read more on learn.Microsoft.com</see>.</para>
     /// </summary>
     public LPARAM lCustData;
 
     /// <summary>
-    /// <para>Type: <b>LPPAGESETUPHOOK</b> A pointer to a <a href="https://learn.microsoft.com/windows/desktop/api/commdlg/nc-commdlg-lppagesetuphook">PageSetupHook</a> hook procedure that can process messages intended for the dialog box. This member is ignored unless the <b>PSD_ENABLEPAGESETUPHOOK</b> flag is set in the <b>Flags</b> member.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-pagesetupdlgw#members">Read more on learn.microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>LPPAGESETUPHOOK</b> A pointer to a
+    ///   <a href="https://learn.microsoft.com/windows/desktop/api/commdlg/nc-commdlg-lppagesetuphook">PageSetupHook</a>
+    ///   hook procedure that can process messages intended for the dialog box. This member is ignored unless the
+    ///   <b>PSD_ENABLEPAGESETUPHOOK</b> flag is set in the <b>Flags</b> member.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-pagesetupdlgw#members">
+    ///   Read more on learn.Microsoft.com</see>.
+    ///  </para>
     /// </summary>
     public unsafe delegate* unmanaged[Stdcall]<HWND, uint, WPARAM, LPARAM, nuint> lpfnPageSetupHook;
 
     /// <summary>
-    /// <para>Type: <b>LPPAGEPAINTHOOK</b> A pointer to a <a href="https://learn.microsoft.com/windows/desktop/api/commdlg/nc-commdlg-lppagepainthook">PagePaintHook</a> hook procedure that receives <b>WM_PSD_*</b> messages from the dialog box whenever the sample page is redrawn. By processing the messages, the hook procedure can customize the appearance of the sample page. This member is ignored unless the <b>PSD_ENABLEPAGEPAINTHOOK</b> flag is set in the <b>Flags</b> member.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-pagesetupdlgw#members">Read more on learn.microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>LPPAGEPAINTHOOK</b> A pointer to a
+    ///   <a href="https://learn.microsoft.com/windows/desktop/api/commdlg/nc-commdlg-lppagepainthook">PagePaintHook</a>
+    ///   hook procedure that receives <b>WM_PSD_*</b> messages from the dialog box whenever the sample page is redrawn.
+    ///   By processing the messages, the hook procedure can customize the appearance of the sample page. This member
+    ///   is ignored unless the <b>PSD_ENABLEPAGEPAINTHOOK</b> flag is set in the <b>Flags</b> member.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-pagesetupdlgw#members">
+    ///   Read more on learn.Microsoft.com</see>.
+    ///  </para>
     /// </summary>
     public unsafe delegate* unmanaged[Stdcall]<HWND, uint, WPARAM, LPARAM, nuint> lpfnPagePaintHook;
 
     /// <summary>
-    /// <para>Type: <b>LPCTSTR</b> The name of the dialog box template resource in the module identified by the <b>hInstance</b> member. This template is substituted for the standard dialog box template. For numbered dialog box resources, <b>lpPageSetupTemplateName</b> can be a value returned by the <a href="https://learn.microsoft.com/windows/desktop/api/winuser/nf-winuser-makeintresourcea">MAKEINTRESOURCE</a> macro. This member is ignored unless the <b>PSD_ENABLEPAGESETUPTEMPLATE</b> flag is set in the <b>Flags</b> member.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-pagesetupdlgw#members">Read more on learn.microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>LPCTSTR</b> The name of the dialog box template resource in the module identified by the
+    ///   <b>hInstance</b> member. This template is substituted for the standard dialog box template.
+    ///   For numbered dialog box resources, <b>lpPageSetupTemplateName</b> can be a value returned by the
+    ///   <a href="https://learn.microsoft.com/windows/desktop/api/winuser/nf-winuser-makeintresourcea">
+    ///   MAKEINTRESOURCE</a> macro. This member is ignored unless the <b>PSD_ENABLEPAGESETUPTEMPLATE</b> flag is set
+    ///   in the <b>Flags</b> member.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-pagesetupdlgw#members">
+    ///   Read more on learn.Microsoft.com</see>.
+    ///  </para>
     /// </summary>
     public PCWSTR lpPageSetupTemplateName;
 
     /// <summary>
-    /// <para>Type: <b>HGLOBAL</b> If the <b>PSD_ENABLEPAGESETUPTEMPLATEHANDLE</b> flag is set in the <b>Flags</b> member, <b>hPageSetupTemplate</b> is a handle to a memory object containing a dialog box template.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-pagesetupdlgw#members">Read more on learn.microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>HGLOBAL</b> If the <b>PSD_ENABLEPAGESETUPTEMPLATEHANDLE</b> flag is set in the <b>Flags</b> member,
+    ///   <b>hPageSetupTemplate</b> is a handle to a memory object containing a dialog box template.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-pagesetupdlgw#members">
+    ///   Read more on learn.Microsoft.com</see>.
+    ///  </para>
     /// </summary>
     public HGLOBAL hPageSetupTemplate;
 }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/UI/Controls/Dialogs/PAGESETUPDLGW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/UI/Controls/Dialogs/PAGESETUPDLGW.cs
@@ -12,8 +12,8 @@ namespace Windows.Win32.UI.Controls.Dialogs;
 /// <remarks>
 ///  <para>
 ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-pagesetupdlgw#">
-///    Read more on learn.Microsoft.com
-///   </see>.
+///    Read more on learn.Microsoft.com.
+///   </see>
 ///  </para>
 /// </remarks>
 /// <devdoc>
@@ -29,26 +29,61 @@ namespace Windows.Win32.UI.Controls.Dialogs;
 internal partial struct PAGESETUPDLGW
 {
     /// <summary>
-    /// <para>Type: <b>DWORD</b> The size, in bytes, of this structure.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-pagesetupdlgw#members">Read more on learn.Microsoft.com</see>.</para>
+    ///  <para>Type: <b>DWORD</b> The size, in bytes, of this structure.</para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-pagesetupdlgw#members">
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
+    ///  </para>
     /// </summary>
     public uint lStructSize;
 
     /// <summary>
-    /// <para>Type: <b>HWND</b> A handle to the window that owns the dialog box. This member can be any valid window handle, or it can be <b>NULL</b> if the dialog box has no owner.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-pagesetupdlgw#members">Read more on learn.Microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>HWND</b> A handle to the window that owns the dialog box. This member can be any valid window handle,
+    ///   or it can be <b>NULL</b> if the dialog box has no owner.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-pagesetupdlgw#members">
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
+    ///  </para>
     /// </summary>
     public HWND hwndOwner;
 
     /// <summary>
-    /// <para>Type: <b>HGLOBAL</b> A handle to a global memory object that contains a <a href="https://learn.microsoft.com/windows/win32/api/wingdi/ns-wingdi-devmodea">DEVMODE</a> structure. On input, if a handle is specified, the values in the corresponding <b>DEVMODE</b> structure are used to initialize the controls in the dialog box. On output, the dialog box sets <b>hDevMode</b> to a global memory handle to a <b>DEVMODE</b> structure that contains values specifying the user's selections. If the user's selections are not available, the dialog box sets <b>hDevMode</b> to <b>NULL</b>.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-pagesetupdlgw#members">Read more on learn.Microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>HGLOBAL</b> A handle to a global memory object that contains a
+    ///   <a href="https://learn.microsoft.com/windows/win32/api/wingdi/ns-wingdi-devmodea">
+    ///   DEVMODE</a> structure. On input, if a handle is specified, the values in the corresponding <b>DEVMODE</b>
+    ///   structure are used to initialize the controls in the dialog box. On output, the dialog box sets <b>hDevMode</b>
+    ///   to a global memory handle to a <b>DEVMODE</b> structure that contains values specifying the user's selections.
+    ///   If the user's selections are not available, the dialog box sets <b>hDevMode</b> to <b>NULL</b>.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-pagesetupdlgw#members">
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
+    ///  </para>
     /// </summary>
     public HGLOBAL hDevMode;
 
     /// <summary>
-    /// <para>Type: <b>HGLOBAL</b> A handle to a global memory object that contains a <a href="https://learn.microsoft.com/windows/desktop/api/commdlg/ns-commdlg-devnames">DEVNAMES</a> structure. This structure contains three strings that specify the driver name, the printer name, and the output port name. On input, if a handle is specified, the strings in the corresponding <b>DEVNAMES</b> structure are used to initialize controls in the dialog box. On output, the dialog box sets <b>hDevNames</b> to a global memory handle to a <b>DEVNAMES</b> structure that contains strings specifying the user's selections. If the user's selections are not available, the dialog box sets <b>hDevNames</b> to <b>NULL</b>.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-pagesetupdlgw#members">Read more on learn.Microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>HGLOBAL</b> A handle to a global memory object that contains a
+    ///   <a href="https://learn.microsoft.com/windows/desktop/api/commdlg/ns-commdlg-devnames">
+    ///   DEVNAMES</a> structure. This structure contains three strings that specify the driver name,
+    ///   the printer name, and the output port name. On input, if a handle is specified,
+    ///   the strings in the corresponding <b>DEVNAMES</b> structure are used to initialize controls in the dialog box.
+    ///   On output, the dialog box sets <b>hDevNames</b> to a global memory handle to a <b>DEVNAMES</b>
+    ///   structure that contains strings specifying the user's selections. If the user's selections are not available,
+    ///   the dialog box sets <b>hDevNames</b> to <b>NULL</b>.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-pagesetupdlgw#members">
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
+    ///  </para>
     /// </summary>
     public HGLOBAL hDevNames;
 
@@ -56,32 +91,72 @@ internal partial struct PAGESETUPDLGW
     public PAGESETUPDLG_FLAGS Flags;
 
     /// <summary>
-    /// <para>Type: <b><a href="https://learn.microsoft.com/windows/win32/api/windef/ns-windef-point">POINT</a></b> The dimensions of the paper selected by the user. The <b>PSD_INTHOUSANDTHSOFINCHES</b> or <b>PSD_INHUNDREDTHSOFMILLIMETERS</b> flag indicates the units of measurement.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-pagesetupdlgw#members">Read more on learn.Microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b><a href="https://learn.microsoft.com/windows/win32/api/windef/ns-windef-point">
+    ///   POINT</a></b> The dimensions of the paper selected by the user. The <b>PSD_INTHOUSANDTHSOFINCHES</b> or <b>PSD_INHUNDREDTHSOFMILLIMETERS</b> flag indicates the units of measurement.</para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-pagesetupdlgw#members">
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
+    ///  </para>
     /// </summary>
     public Point ptPaperSize;
 
     /// <summary>
-    /// <para>Type: <b><a href="https://learn.microsoft.com/windows/desktop/api/windef/ns-windef-rect">RECT</a></b> The minimum allowable widths for the left, top, right, and bottom margins. The system ignores this member if the <b>PSD_MINMARGINS</b> flag is not set. These values must be less than or equal to the values specified in the <b>rtMargin</b> member. The <b>PSD_INTHOUSANDTHSOFINCHES</b> or <b>PSD_INHUNDREDTHSOFMILLIMETERS</b> flag indicates the units of measurement.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-pagesetupdlgw#members">Read more on learn.Microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b><a href="https://learn.microsoft.com/windows/desktop/api/windef/ns-windef-rect">
+    ///   RECT</a></b> The minimum allowable widths for the left, top, right, and bottom margins.
+    ///   The system ignores this member if the <b>PSD_MINMARGINS</b> flag is not set.
+    ///   These values must be less than or equal to the values specified in the <b>rtMargin</b> member.
+    ///   The <b>PSD_INTHOUSANDTHSOFINCHES</b> or <b>PSD_INHUNDREDTHSOFMILLIMETERS</b>
+    ///   flag indicates the units of measurement.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-pagesetupdlgw#members">
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
+    ///  </para>
     /// </summary>
     public RECT rtMinMargin;
 
     /// <summary>
-    /// <para>Type: <b><a href="https://learn.microsoft.com/windows/desktop/api/windef/ns-windef-rect">RECT</a></b> The widths of the left, top, right, and bottom margins. If you set the <b>PSD_MARGINS</b> flag, <b>rtMargin</b> specifies the initial margin values. When <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646937(v=vs.85)">PageSetupDlg</a> returns, <b>rtMargin</b> contains the margin widths selected by the user. The <b>PSD_INHUNDREDTHSOFMILLIMETERS</b> or <b>PSD_INTHOUSANDTHSOFINCHES</b> flag indicates the units of measurement.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-pagesetupdlgw#members">Read more on learn.Microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b><a href="https://learn.microsoft.com/windows/desktop/api/windef/ns-windef-rect">
+    ///   RECT</a></b> The widths of the left, top, right, and bottom margins. If you set the <b>PSD_MARGINS</b> flag,
+    ///   <b>rtMargin</b> specifies the initial margin values.
+    ///   When <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646937(v=vs.85)">
+    ///   PageSetupDlg</a> returns, <b>rtMargin</b> contains the margin widths selected by the user.
+    ///   The <b>PSD_INHUNDREDTHSOFMILLIMETERS</b> or <b>PSD_INTHOUSANDTHSOFINCHES</b>
+    ///   flag indicates the units of measurement.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-pagesetupdlgw#members">
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
+    ///  </para>
     /// </summary>
     public RECT rtMargin;
 
     /// <summary>
-    /// <para>Type: <b>HINSTANCE</b> If the <b>PSD_ENABLEPAGESETUPTEMPLATE</b> flag is set in the <b>Flags</b> member, <b>hInstance</b> is a handle to the application or module instance that contains the dialog box template named by the <b>lpPageSetupTemplateName</b> member.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-pagesetupdlgw#members">Read more on learn.Microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>HINSTANCE</b> If the <b>PSD_ENABLEPAGESETUPTEMPLATE</b> flag is set in the <b>Flags</b> member,
+    ///   <b>hInstance</b> is a handle to the application or module instance that contains the dialog box template
+    ///   named by the <b>lpPageSetupTemplateName</b> member.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-pagesetupdlgw#members">
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
+    ///  </para>
     /// </summary>
     public HINSTANCE hInstance;
 
     /// <summary>
-    /// <para>Type: <b>LPARAM</b> Application-defined data that the system passes to the hook procedure identified by the <b>lpfnPageSetupHook</b> member. When the system sends the <a href="https://learn.microsoft.com/windows/desktop/dlgbox/wm-initdialog">WM_INITDIALOG</a> message to the hook procedure, the message's <i>lParam</i> parameter is a pointer to the <b>PAGESETUPDLG</b> structure specified when the dialog was created. The hook procedure can use this pointer to get the <b>lCustData</b> value.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-pagesetupdlgw#members">Read more on learn.Microsoft.com</see>.</para>
+    /// <para>
+    ///  Type: <b>LPARAM</b> Application-defined data that the system passes to the hook procedure identified by the
+    ///  <b>lpfnPageSetupHook</b> member. When the system sends the <a href="https://learn.microsoft.com/windows/desktop/dlgbox/wm-initdialog">WM_INITDIALOG</a> message to the hook procedure, the message's <i>lParam</i> parameter is a pointer to the <b>PAGESETUPDLG</b> structure specified when the dialog was created. The hook procedure can use this pointer to get the <b>lCustData</b> value.</para>
+    /// <para>
+    ///  <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-pagesetupdlgw#members">Read more on learn.Microsoft.com.</see></para>
     /// </summary>
     public LPARAM lCustData;
 
@@ -94,7 +169,7 @@ internal partial struct PAGESETUPDLGW
     ///  </para>
     ///  <para>
     ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-pagesetupdlgw#members">
-    ///   Read more on learn.Microsoft.com</see>.
+    ///   Read more on learn.Microsoft.com.</see>
     ///  </para>
     /// </summary>
     public unsafe delegate* unmanaged[Stdcall]<HWND, uint, WPARAM, LPARAM, nuint> lpfnPageSetupHook;
@@ -109,7 +184,7 @@ internal partial struct PAGESETUPDLGW
     ///  </para>
     ///  <para>
     ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-pagesetupdlgw#members">
-    ///   Read more on learn.Microsoft.com</see>.
+    ///   Read more on learn.Microsoft.com.</see>
     ///  </para>
     /// </summary>
     public unsafe delegate* unmanaged[Stdcall]<HWND, uint, WPARAM, LPARAM, nuint> lpfnPagePaintHook;
@@ -125,7 +200,7 @@ internal partial struct PAGESETUPDLGW
     ///  </para>
     ///  <para>
     ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-pagesetupdlgw#members">
-    ///   Read more on learn.Microsoft.com</see>.
+    ///   Read more on learn.Microsoft.com.</see>
     ///  </para>
     /// </summary>
     public PCWSTR lpPageSetupTemplateName;
@@ -137,7 +212,7 @@ internal partial struct PAGESETUPDLGW
     ///  </para>
     ///  <para>
     ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-pagesetupdlgw#members">
-    ///   Read more on learn.Microsoft.com</see>.
+    ///   Read more on learn.Microsoft.com.</see>
     ///  </para>
     /// </summary>
     public HGLOBAL hPageSetupTemplate;

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/UI/Controls/Dialogs/PRINTDLGW_64.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/UI/Controls/Dialogs/PRINTDLGW_64.cs
@@ -8,7 +8,7 @@ namespace Windows.Win32.UI.Controls.Dialogs;
 ///  dialog box, the system uses this structure to return information about the user's selections.
 /// </summary>
 /// <remarks>
-/// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#">Read more on learn.microsoft.com</see>.</para>
+/// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#">Read more on learn.Microsoft.com</see>.</para>
 /// </remarks>
 /// <devdoc>
 ///  Manually copied from a 64 bit project CsWin32 generated wrapper. We can't directly use CsWin32 for this as it
@@ -19,31 +19,31 @@ internal partial struct PRINTDLGW_64
 {
     /// <summary>
     ///  <para>Type: <b>DWORD</b> The structure size, in bytes.</para>
-    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">Read more on learn.microsoft.com</see>.</para>
+    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">Read more on learn.Microsoft.com</see>.</para>
     /// </summary>
     public uint lStructSize;
 
     /// <summary>
     ///  <para>Type: <b>HWND</b> A handle to the window that owns the dialog box. This member can be any valid window handle, or it can be <b>NULL</b> if the dialog box has no owner.</para>
-    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">Read more on learn.microsoft.com</see>.</para>
+    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">Read more on learn.Microsoft.com</see>.</para>
     /// </summary>
     public HWND hwndOwner;
 
     /// <summary>
-    /// <para>Type: <b>HGLOBAL</b> A handle to a movable global memory object that contains a <a href="https://learn.microsoft.com/windows/win32/api/wingdi/ns-wingdi-devmodea">DEVMODE</a> structure. If <b>hDevMode</b> is not <b>NULL</b> on input, you must allocate a movable block of memory for the <b>DEVMODE</b> structure and initialize its members. The <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646940(v=vs.85)">PrintDlg</a> function uses the input data to initialize the controls in the dialog box. When <b>PrintDlg</b> returns, the <b>DEVMODE</b> members indicate the user's input. If <b>hDevMode</b> is <b>NULL</b> on input, <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646940(v=vs.85)">PrintDlg</a> allocates memory for the <a href="https://learn.microsoft.com/windows/win32/api/wingdi/ns-wingdi-devmodea">DEVMODE</a> structure, initializes its members to indicate the user's input, and returns a handle that identifies it. If the device driver for the specified printer does not support extended device modes, <b>hDevMode</b> is <b>NULL</b> when <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646940(v=vs.85)">PrintDlg</a> returns. If the device name (specified by the <b>dmDeviceName</b> member of the <a href="https://learn.microsoft.com/windows/win32/api/wingdi/ns-wingdi-devmodea">DEVMODE</a> structure) does not appear in the [devices] section of WIN.INI, <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646940(v=vs.85)">PrintDlg</a> returns an error. For more information about the <b>hDevMode</b> and <b>hDevNames</b> members, see the Remarks section at the end of this topic.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">Read more on learn.microsoft.com</see>.</para>
+    ///  <para>Type: <b>HGLOBAL</b> A handle to a movable global memory object that contains a <a href="https://learn.microsoft.com/windows/win32/api/wingdi/ns-wingdi-devmodea">DEVMODE</a> structure. If <b>hDevMode</b> is not <b>NULL</b> on input, you must allocate a movable block of memory for the <b>DEVMODE</b> structure and initialize its members. The <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646940(v=vs.85)">PrintDlg</a> function uses the input data to initialize the controls in the dialog box. When <b>PrintDlg</b> returns, the <b>DEVMODE</b> members indicate the user's input. If <b>hDevMode</b> is <b>NULL</b> on input, <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646940(v=vs.85)">PrintDlg</a> allocates memory for the <a href="https://learn.microsoft.com/windows/win32/api/wingdi/ns-wingdi-devmodea">DEVMODE</a> structure, initializes its members to indicate the user's input, and returns a handle that identifies it. If the device driver for the specified printer does not support extended device modes, <b>hDevMode</b> is <b>NULL</b> when <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646940(v=vs.85)">PrintDlg</a> returns. If the device name (specified by the <b>dmDeviceName</b> member of the <a href="https://learn.microsoft.com/windows/win32/api/wingdi/ns-wingdi-devmodea">DEVMODE</a> structure) does not appear in the [devices] section of WIN.INI, <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646940(v=vs.85)">PrintDlg</a> returns an error. For more information about the <b>hDevMode</b> and <b>hDevNames</b> members, see the Remarks section at the end of this topic.</para>
+    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">Read more on learn.Microsoft.com</see>.</para>
     /// </summary>
     public HGLOBAL hDevMode;
 
     /// <summary>
-    /// <para>Type: <b>HGLOBAL</b> A handle to a movable global memory object that contains a <a href="https://learn.microsoft.com/windows/desktop/api/commdlg/ns-commdlg-devnames">DEVNAMES</a> structure. If <b>hDevNames</b> is not <b>NULL</b> on input, you must allocate a movable block of memory for the <b>DEVNAMES</b> structure and initialize its members. The <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646940(v=vs.85)">PrintDlg</a> function uses the input data to initialize the controls in the dialog box. When <b>PrintDlg</b> returns, the <b>DEVNAMES</b> members contain information for the printer chosen by the user. You can use this information to create a device context or an information context. The <b>hDevNames</b> member can be <b>NULL</b>, in which case, <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646940(v=vs.85)">PrintDlg</a> allocates memory for the <a href="https://learn.microsoft.com/windows/desktop/api/commdlg/ns-commdlg-devnames">DEVNAMES</a> structure, initializes its members to indicate the user's input, and returns a handle that identifies it. For more information about the <b>hDevMode</b> and <b>hDevNames</b> members, see the Remarks section at the end of this topic.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">Read more on learn.microsoft.com</see>.</para>
+    ///  <para>Type: <b>HGLOBAL</b> A handle to a movable global memory object that contains a <a href="https://learn.microsoft.com/windows/desktop/api/commdlg/ns-commdlg-devnames">DEVNAMES</a> structure. If <b>hDevNames</b> is not <b>NULL</b> on input, you must allocate a movable block of memory for the <b>DEVNAMES</b> structure and initialize its members. The <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646940(v=vs.85)">PrintDlg</a> function uses the input data to initialize the controls in the dialog box. When <b>PrintDlg</b> returns, the <b>DEVNAMES</b> members contain information for the printer chosen by the user. You can use this information to create a device context or an information context. The <b>hDevNames</b> member can be <b>NULL</b>, in which case, <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646940(v=vs.85)">PrintDlg</a> allocates memory for the <a href="https://learn.microsoft.com/windows/desktop/api/commdlg/ns-commdlg-devnames">DEVNAMES</a> structure, initializes its members to indicate the user's input, and returns a handle that identifies it. For more information about the <b>hDevMode</b> and <b>hDevNames</b> members, see the Remarks section at the end of this topic.</para>
+    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">Read more on learn.Microsoft.com</see>.</para>
     /// </summary>
     public HGLOBAL hDevNames;
 
     /// <summary>
-    /// <para>Type: <b>HDC</b> A handle to a device context or an information context, depending on whether the <b>Flags</b> member specifies the <b>PD_RETURNDC</b> or <b>PC_RETURNIC</b> flag. If neither flag is specified, the value of this member is undefined. If both flags are specified, <b>PD_RETURNDC</b> has priority.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">Read more on learn.microsoft.com</see>.</para>
+    ///  <para>Type: <b>HDC</b> A handle to a device context or an information context, depending on whether the <b>Flags</b> member specifies the <b>PD_RETURNDC</b> or <b>PC_RETURNIC</b> flag. If neither flag is specified, the value of this member is undefined. If both flags are specified, <b>PD_RETURNDC</b> has priority.</para>
+    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">Read more on learn.Microsoft.com</see>.</para>
     /// </summary>
     public HDC hDC;
 
@@ -51,80 +51,84 @@ internal partial struct PRINTDLGW_64
     public PRINTDLGEX_FLAGS Flags;
 
     /// <summary>
-    /// <para>Type: <b>WORD</b> The initial value for the starting page edit control. When <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646940(v=vs.85)">PrintDlg</a> returns, <b>nFromPage</b> is the starting page specified by the user. If the <b>Pages</b> radio button is selected when the user clicks the <b>Okay</b> button, <b>PrintDlg</b> sets the <b>PD_PAGENUMS</b> flag and does not return until the user enters a starting page value that is within the minimum to maximum page range. If the input value for either <b>nFromPage</b> or <b>nToPage</b> is outside the minimum/maximum range, <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646940(v=vs.85)">PrintDlg</a> returns an error only if the <b>PD_PAGENUMS</b> flag is specified; otherwise, it displays the dialog box but changes the out-of-range value to the minimum or maximum value.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">Read more on learn.microsoft.com</see>.</para>
+    ///  <para>Type: <b>WORD</b> The initial value for the starting page edit control. When <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646940(v=vs.85)">PrintDlg</a> returns, <b>nFromPage</b> is the starting page specified by the user. If the <b>Pages</b> radio button is selected when the user clicks the <b>Okay</b> button, <b>PrintDlg</b> sets the <b>PD_PAGENUMS</b> flag and does not return until the user enters a starting page value that is within the minimum to maximum page range. If the input value for either <b>nFromPage</b> or <b>nToPage</b> is outside the minimum/maximum range, <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646940(v=vs.85)">PrintDlg</a> returns an error only if the <b>PD_PAGENUMS</b> flag is specified; otherwise, it displays the dialog box but changes the out-of-range value to the minimum or maximum value.</para>
+    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">Read more on learn.Microsoft.com</see>.</para>
     /// </summary>
     public ushort nFromPage;
 
     /// <summary>
-    /// <para>Type: <b>WORD</b> The initial value for the ending page edit control. When <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646940(v=vs.85)">PrintDlg</a> returns, <b>nToPage</b> is the ending page specified by the user. If the <b>Pages</b> radio button is selected when the use clicks the <b>Okay</b> button, <b>PrintDlg</b> sets the <b>PD_PAGENUMS</b> flag and does not return until the user enters an ending page value that is within the minimum to maximum page range.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">Read more on learn.microsoft.com</see>.</para>
+    ///  <para>Type: <b>WORD</b> The initial value for the ending page edit control. When <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646940(v=vs.85)">PrintDlg</a> returns, <b>nToPage</b> is the ending page specified by the user. If the <b>Pages</b> radio button is selected when the use clicks the <b>Okay</b> button, <b>PrintDlg</b> sets the <b>PD_PAGENUMS</b> flag and does not return until the user enters an ending page value that is within the minimum to maximum page range.</para>
+    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">Read more on learn.Microsoft.com</see>.</para>
     /// </summary>
     public ushort nToPage;
 
     /// <summary>
-    /// <para>Type: <b>WORD</b> The minimum value for the page range specified in the <b>From</b> and <b>To</b> page edit controls. If <b>nMinPage</b> equals <b>nMaxPage</b>, the <b>Pages</b> radio button and the starting and ending page edit controls are disabled.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">Read more on learn.microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>WORD</b> The minimum value for the page range specified in the <b>From</b> and <b>To</b> page edit
+    ///   controls. If <b>nMinPage</b> equals <b>nMaxPage</b>, the <b>Pages</b> radio button and the starting and
+    ///   ending page edit controls are disabled.
+    ///  </para>
+    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">Read more on learn.Microsoft.com</see>.</para>
     /// </summary>
     public ushort nMinPage;
 
     /// <summary>
-    /// <para>Type: <b>WORD</b> The maximum value for the page range specified in the <b>From</b> and <b>To</b> page edit controls.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">Read more on learn.microsoft.com</see>.</para>
+    ///  <para>Type: <b>WORD</b> The maximum value for the page range specified in the <b>From</b> and <b>To</b> page edit controls.</para>
+    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">Read more on learn.Microsoft.com</see>.</para>
     /// </summary>
     public ushort nMaxPage;
 
     /// <summary>
-    /// <para>Type: <b>WORD</b> The initial number of copies for the <b>Copies</b> edit control if <b>hDevMode</b> is <b>NULL</b>; otherwise, the <b>dmCopies</b> member of the <a href="https://learn.microsoft.com/windows/win32/api/wingdi/ns-wingdi-devmodea">DEVMODE</a> structure contains the initial value. When <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646940(v=vs.85)">PrintDlg</a> returns, <b>nCopies</b> contains the actual number of copies to print. This value depends on whether the application or the printer driver is responsible for printing multiple copies. If the <b>PD_USEDEVMODECOPIESANDCOLLATE</b> flag is set in the <b>Flags</b> member, <b>nCopies</b> is always 1 on return, and the printer driver is responsible for printing multiple copies. If the flag is not set, the application is responsible for printing the number of copies specified by <b>nCopies</b>. For more information, see the description of the <b>PD_USEDEVMODECOPIESANDCOLLATE</b> flag.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">Read more on learn.microsoft.com</see>.</para>
+    ///  <para>Type: <b>WORD</b> The initial number of copies for the <b>Copies</b> edit control if <b>hDevMode</b> is <b>NULL</b>; otherwise, the <b>dmCopies</b> member of the <a href="https://learn.microsoft.com/windows/win32/api/wingdi/ns-wingdi-devmodea">DEVMODE</a> structure contains the initial value. When <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646940(v=vs.85)">PrintDlg</a> returns, <b>nCopies</b> contains the actual number of copies to print. This value depends on whether the application or the printer driver is responsible for printing multiple copies. If the <b>PD_USEDEVMODECOPIESANDCOLLATE</b> flag is set in the <b>Flags</b> member, <b>nCopies</b> is always 1 on return, and the printer driver is responsible for printing multiple copies. If the flag is not set, the application is responsible for printing the number of copies specified by <b>nCopies</b>. For more information, see the description of the <b>PD_USEDEVMODECOPIESANDCOLLATE</b> flag.</para>
+    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">Read more on learn.Microsoft.com</see>.</para>
     /// </summary>
     public ushort nCopies;
 
     /// <summary>
-    /// <para>Type: <b>HINSTANCE</b> If the <b>PD_ENABLEPRINTTEMPLATE</b> or <b>PD_ENABLESETUPTEMPLATE</b> flag is set in the <b>Flags</b> member, <b>hInstance</b> is a handle to the application or module instance that contains the dialog box template named by the <b>lpPrintTemplateName</b> or <b>lpSetupTemplateName</b> member.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">Read more on learn.microsoft.com</see>.</para>
+    ///  <para>Type: <b>HINSTANCE</b> If the <b>PD_ENABLEPRINTTEMPLATE</b> or <b>PD_ENABLESETUPTEMPLATE</b> flag is set in the <b>Flags</b> member, <b>hInstance</b> is a handle to the application or module instance that contains the dialog box template named by the <b>lpPrintTemplateName</b> or <b>lpSetupTemplateName</b> member.</para>
+    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">Read more on learn.Microsoft.com</see>.</para>
     /// </summary>
     public HINSTANCE hInstance;
 
     /// <summary>
-    /// <para>Type: <b>LPARAM</b> Application-defined data that the system passes to the hook procedure identified by the <b>lpfnPrintHook</b> or <b>lpfnSetupHook</b> member. When the system sends the <a href="https://learn.microsoft.com/windows/desktop/dlgbox/wm-initdialog">WM_INITDIALOG</a> message to the hook procedure, the message's <i>lParam</i> parameter is a pointer to the <b>PRINTDLG</b> structure specified when the dialog was created. The hook procedure can use this pointer to get the <b>lCustData</b> value.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">Read more on learn.microsoft.com</see>.</para>
+    ///  <para>Type: <b>LPARAM</b> Application-defined data that the system passes to the hook procedure identified by the <b>lpfnPrintHook</b> or <b>lpfnSetupHook</b> member. When the system sends the <a href="https://learn.microsoft.com/windows/desktop/dlgbox/wm-initdialog">WM_INITDIALOG</a> message to the hook procedure, the message's <i>lParam</i> parameter is a pointer to the <b>PRINTDLG</b> structure specified when the dialog was created. The hook procedure can use this pointer to get the <b>lCustData</b> value.</para>
+    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">Read more on learn.Microsoft.com</see>.</para>
     /// </summary>
     public LPARAM lCustData;
 
     /// <summary>
-    /// <para>Type: <b>LPPRINTHOOKPROC</b> A pointer to a <a href="https://learn.microsoft.com/windows/desktop/api/commdlg/nc-commdlg-lpprinthookproc">PrintHookProc</a> hook procedure that can process messages intended for the <b>Print</b> dialog box. This member is ignored unless the <b>PD_ENABLEPRINTHOOK</b> flag is set in the <b>Flags</b> member.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">Read more on learn.microsoft.com</see>.</para>
+    ///  <para>Type: <b>LPPRINTHOOKPROC</b> A pointer to a <a href="https://learn.microsoft.com/windows/desktop/api/commdlg/nc-commdlg-lpprinthookproc">PrintHookProc</a> hook procedure that can process messages intended for the <b>Print</b> dialog box. This member is ignored unless the <b>PD_ENABLEPRINTHOOK</b> flag is set in the <b>Flags</b> member.</para>
+    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">Read more on learn.Microsoft.com</see>.</para>
     /// </summary>
     public unsafe delegate* unmanaged[Stdcall]<HWND, uint, WPARAM, LPARAM, nuint> lpfnPrintHook;
 
     /// <summary>
-    /// <para>Type: <b>LPSETUPHOOKPROC</b> A pointer to a <a href="https://learn.microsoft.com/windows/desktop/api/commdlg/nc-commdlg-lpsetuphookproc">SetupHookProc</a> hook procedure that can process messages intended for the <b>Print Setup</b> dialog box. This member is ignored unless the <b>PD_ENABLESETUPHOOK</b> flag is set in the <b>Flags</b> member.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">Read more on learn.microsoft.com</see>.</para>
+    ///  <para>Type: <b>LPSETUPHOOKPROC</b> A pointer to a <a href="https://learn.microsoft.com/windows/desktop/api/commdlg/nc-commdlg-lpsetuphookproc">SetupHookProc</a> hook procedure that can process messages intended for the <b>Print Setup</b> dialog box. This member is ignored unless the <b>PD_ENABLESETUPHOOK</b> flag is set in the <b>Flags</b> member.</para>
+    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">Read more on learn.Microsoft.com</see>.</para>
     /// </summary>
     public unsafe delegate* unmanaged[Stdcall]<HWND, uint, WPARAM, LPARAM, nuint> lpfnSetupHook;
 
     /// <summary>
-    /// <para>Type: <b>LPCTSTR</b> The name of the dialog box template resource in the module identified by the <b>hInstance</b> member. This template replaces the default <b>Print</b> dialog box template. This member is ignored unless the <b>PD_ENABLEPRINTTEMPLATE</b> flag is set in the <b>Flags</b> member.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">Read more on learn.microsoft.com</see>.</para>
+    ///  <para>Type: <b>LPCTSTR</b> The name of the dialog box template resource in the module identified by the <b>hInstance</b> member. This template replaces the default <b>Print</b> dialog box template. This member is ignored unless the <b>PD_ENABLEPRINTTEMPLATE</b> flag is set in the <b>Flags</b> member.</para>
+    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">Read more on learn.Microsoft.com</see>.</para>
     /// </summary>
     public PCWSTR lpPrintTemplateName;
 
     /// <summary>
-    /// <para>Type: <b>LPCTSTR</b> The name of the dialog box template resource in the module identified by the <b>hInstance</b> member. This template replaces the default <b>Print Setup</b> dialog box template. This member is ignored unless the <b>PD_ENABLESETUPTEMPLATE</b> flag is set in the <b>Flags</b> member.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">Read more on learn.microsoft.com</see>.</para>
+    ///  <para>Type: <b>LPCTSTR</b> The name of the dialog box template resource in the module identified by the <b>hInstance</b> member. This template replaces the default <b>Print Setup</b> dialog box template. This member is ignored unless the <b>PD_ENABLESETUPTEMPLATE</b> flag is set in the <b>Flags</b> member.</para>
+    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">Read more on learn.Microsoft.com</see>.</para>
     /// </summary>
     public PCWSTR lpSetupTemplateName;
 
     /// <summary>
-    /// <para>Type: <b>HGLOBAL</b> If the <b>PD_ENABLEPRINTTEMPLATEHANDLE</b> flag is set in the <b>Flags</b> member, <b>hPrintTemplate</b> is a handle to a memory object containing a dialog box template. This template replaces the default <b>Print</b> dialog box template.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">Read more on learn.microsoft.com</see>.</para>
+    ///  <para>Type: <b>HGLOBAL</b> If the <b>PD_ENABLEPRINTTEMPLATEHANDLE</b> flag is set in the <b>Flags</b> member, <b>hPrintTemplate</b> is a handle to a memory object containing a dialog box template. This template replaces the default <b>Print</b> dialog box template.</para>
+    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">Read more on learn.Microsoft.com</see>.</para>
     /// </summary>
     public HGLOBAL hPrintTemplate;
 
     /// <summary>
-    /// <para>Type: <b>HGLOBAL</b> If the <b>PD_ENABLESETUPTEMPLATEHANDLE</b> flag is set in the <b>Flags</b> member, <b>hSetupTemplate</b> is a handle to a memory object containing a dialog box template. This template replaces the default <b>Print Setup</b> dialog box template.</para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">Read more on learn.microsoft.com</see>.</para>
+    ///  <para>Type: <b>HGLOBAL</b> If the <b>PD_ENABLESETUPTEMPLATEHANDLE</b> flag is set in the <b>Flags</b> member, <b>hSetupTemplate</b> is a handle to a memory object containing a dialog box template. This template replaces the default <b>Print Setup</b> dialog box template.</para>
+    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">Read more on learn.Microsoft.com</see>.</para>
     /// </summary>
     public HGLOBAL hSetupTemplate;
 }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/UI/Controls/Dialogs/PRINTDLGW_64.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/UI/Controls/Dialogs/PRINTDLGW_64.cs
@@ -8,7 +8,11 @@ namespace Windows.Win32.UI.Controls.Dialogs;
 ///  dialog box, the system uses this structure to return information about the user's selections.
 /// </summary>
 /// <remarks>
-/// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#">Read more on learn.Microsoft.com</see>.</para>
+///  <para>
+///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#">
+///    Read more on learn.Microsoft.com.
+///   </see>
+///  </para>
 /// </remarks>
 /// <devdoc>
 ///  Manually copied from a 64 bit project CsWin32 generated wrapper. We can't directly use CsWin32 for this as it
@@ -18,32 +22,100 @@ namespace Windows.Win32.UI.Controls.Dialogs;
 internal partial struct PRINTDLGW_64
 {
     /// <summary>
-    ///  <para>Type: <b>DWORD</b> The structure size, in bytes.</para>
-    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">Read more on learn.Microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>DWORD</b> The structure size, in bytes.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
+    ///  </para>
     /// </summary>
     public uint lStructSize;
 
     /// <summary>
-    ///  <para>Type: <b>HWND</b> A handle to the window that owns the dialog box. This member can be any valid window handle, or it can be <b>NULL</b> if the dialog box has no owner.</para>
-    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">Read more on learn.Microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>HWND</b> A handle to the window that owns the dialog box. This member can be any valid window handle,
+    ///   or it can be <b>NULL</b> if the dialog box has no owner.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
+    ///  </para>
     /// </summary>
     public HWND hwndOwner;
 
     /// <summary>
-    ///  <para>Type: <b>HGLOBAL</b> A handle to a movable global memory object that contains a <a href="https://learn.microsoft.com/windows/win32/api/wingdi/ns-wingdi-devmodea">DEVMODE</a> structure. If <b>hDevMode</b> is not <b>NULL</b> on input, you must allocate a movable block of memory for the <b>DEVMODE</b> structure and initialize its members. The <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646940(v=vs.85)">PrintDlg</a> function uses the input data to initialize the controls in the dialog box. When <b>PrintDlg</b> returns, the <b>DEVMODE</b> members indicate the user's input. If <b>hDevMode</b> is <b>NULL</b> on input, <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646940(v=vs.85)">PrintDlg</a> allocates memory for the <a href="https://learn.microsoft.com/windows/win32/api/wingdi/ns-wingdi-devmodea">DEVMODE</a> structure, initializes its members to indicate the user's input, and returns a handle that identifies it. If the device driver for the specified printer does not support extended device modes, <b>hDevMode</b> is <b>NULL</b> when <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646940(v=vs.85)">PrintDlg</a> returns. If the device name (specified by the <b>dmDeviceName</b> member of the <a href="https://learn.microsoft.com/windows/win32/api/wingdi/ns-wingdi-devmodea">DEVMODE</a> structure) does not appear in the [devices] section of WIN.INI, <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646940(v=vs.85)">PrintDlg</a> returns an error. For more information about the <b>hDevMode</b> and <b>hDevNames</b> members, see the Remarks section at the end of this topic.</para>
-    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">Read more on learn.Microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>HGLOBAL</b> A handle to a movable global memory object that contains a
+    ///   <a href="https://learn.microsoft.com/windows/win32/api/wingdi/ns-wingdi-devmodea">DEVMODE</a> structure.
+    ///   If <b>hDevMode</b> is not <b>NULL</b> on input, you must allocate a movable block of memory for the
+    ///   <b>DEVMODE</b> structure and initialize its members.
+    ///   The <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646940(v=vs.85)">
+    ///   PrintDlg</a> function uses the input data to initialize the controls in the dialog box.
+    ///   When <b>PrintDlg</b> returns, the <b>DEVMODE</b> members indicate the user's input.
+    ///   If <b>hDevMode</b> is <b>NULL</b> on input,
+    ///   <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646940(v=vs.85)">
+    ///   PrintDlg</a> allocates memory for the
+    ///   <a href="https://learn.microsoft.com/windows/win32/api/wingdi/ns-wingdi-devmodea">
+    ///   DEVMODE</a> structure, initializes its members to indicate the user's input, and returns a handle
+    ///   that identifies it. If the device driver for the specified printer does not support extended device modes,
+    ///   <b>hDevMode</b> is <b>NULL</b> when
+    ///   <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646940(v=vs.85)">
+    ///   PrintDlg</a> returns. If the device name (specified by the <b>dmDeviceName</b> member of the
+    ///   <a href="https://learn.microsoft.com/windows/win32/api/wingdi/ns-wingdi-devmodea">
+    ///   DEVMODE</a> structure) does not appear in the [devices] section of WIN.INI,
+    ///   <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646940(v=vs.85)">
+    ///   PrintDlg</a> returns an error. For more information about the <b>hDevMode</b> and <b>hDevNames</b> members,
+    ///   see the Remarks section at the end of this topic.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
+    ///  </para>
     /// </summary>
     public HGLOBAL hDevMode;
 
     /// <summary>
-    ///  <para>Type: <b>HGLOBAL</b> A handle to a movable global memory object that contains a <a href="https://learn.microsoft.com/windows/desktop/api/commdlg/ns-commdlg-devnames">DEVNAMES</a> structure. If <b>hDevNames</b> is not <b>NULL</b> on input, you must allocate a movable block of memory for the <b>DEVNAMES</b> structure and initialize its members. The <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646940(v=vs.85)">PrintDlg</a> function uses the input data to initialize the controls in the dialog box. When <b>PrintDlg</b> returns, the <b>DEVNAMES</b> members contain information for the printer chosen by the user. You can use this information to create a device context or an information context. The <b>hDevNames</b> member can be <b>NULL</b>, in which case, <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646940(v=vs.85)">PrintDlg</a> allocates memory for the <a href="https://learn.microsoft.com/windows/desktop/api/commdlg/ns-commdlg-devnames">DEVNAMES</a> structure, initializes its members to indicate the user's input, and returns a handle that identifies it. For more information about the <b>hDevMode</b> and <b>hDevNames</b> members, see the Remarks section at the end of this topic.</para>
-    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">Read more on learn.Microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>HGLOBAL</b> A handle to a movable global memory object that contains a
+    ///   <a href="https://learn.microsoft.com/windows/desktop/api/commdlg/ns-commdlg-devnames">
+    ///   DEVNAMES</a> structure. If <b>hDevNames</b> is not <b>NULL</b> on input, you must allocate
+    ///   a movable block of memory for the <b>DEVNAMES</b> structure and initialize its members.
+    ///   The <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646940(v=vs.85)">
+    ///   PrintDlg</a> function uses the input data to initialize the controls in the dialog box. When <b>PrintDlg</b>
+    ///   returns, the <b>DEVNAMES</b> members contain information for the printer chosen by the user.
+    ///   You can use this information to create a device context or an information context. The <b>hDevNames</b>
+    ///   member can be <b>NULL</b>, in which case,
+    ///   <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646940(v=vs.85)">
+    ///   PrintDlg</a> allocates memory for the
+    ///   <a href="https://learn.microsoft.com/windows/desktop/api/commdlg/ns-commdlg-devnames">
+    ///   DEVNAMES</a> structure, initializes its members to indicate the user's input,
+    ///   and returns a handle that identifies it. For more information about the <b>hDevMode</b>
+    ///   and <b>hDevNames</b> members, see the Remarks section at the end of this topic.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
+    ///  </para>
     /// </summary>
     public HGLOBAL hDevNames;
 
     /// <summary>
-    ///  <para>Type: <b>HDC</b> A handle to a device context or an information context, depending on whether the <b>Flags</b> member specifies the <b>PD_RETURNDC</b> or <b>PC_RETURNIC</b> flag. If neither flag is specified, the value of this member is undefined. If both flags are specified, <b>PD_RETURNDC</b> has priority.</para>
-    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">Read more on learn.Microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>HDC</b> A handle to a device context or an information context, depending on whether the <b>Flags</b>
+    ///   member specifies the <b>PD_RETURNDC</b> or <b>PC_RETURNIC</b> flag.
+    ///   If neither flag is specified, the value of this member is undefined. If both flags are specified,
+    ///   <b>PD_RETURNDC</b> has priority.
+    ///  </para>
+    ///  <para>
+    ///  <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
+    ///  </para>
     /// </summary>
     public HDC hDC;
 
@@ -51,14 +123,36 @@ internal partial struct PRINTDLGW_64
     public PRINTDLGEX_FLAGS Flags;
 
     /// <summary>
-    ///  <para>Type: <b>WORD</b> The initial value for the starting page edit control. When <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646940(v=vs.85)">PrintDlg</a> returns, <b>nFromPage</b> is the starting page specified by the user. If the <b>Pages</b> radio button is selected when the user clicks the <b>Okay</b> button, <b>PrintDlg</b> sets the <b>PD_PAGENUMS</b> flag and does not return until the user enters a starting page value that is within the minimum to maximum page range. If the input value for either <b>nFromPage</b> or <b>nToPage</b> is outside the minimum/maximum range, <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646940(v=vs.85)">PrintDlg</a> returns an error only if the <b>PD_PAGENUMS</b> flag is specified; otherwise, it displays the dialog box but changes the out-of-range value to the minimum or maximum value.</para>
-    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">Read more on learn.Microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>WORD</b> The initial value for the starting page edit control.
+    ///   When <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646940(v=vs.85)">
+    ///   PrintDlg</a> returns, <b>nFromPage</b> is the starting page specified by the user. If the <b>Pages</b>
+    ///   radio button is selected when the user clicks the <b>Okay</b> button, <b>PrintDlg</b> sets the
+    ///   <b>PD_PAGENUMS</b> flag and does not return until the user enters a starting page value that is within
+    ///   the minimum to maximum page range. If the input value for either <b>nFromPage</b> or <b>nToPage</b>
+    ///   is outside the minimum/maximum range,
+    ///   <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646940(v=vs.85)">
+    ///   PrintDlg</a> returns an error only if the <b>PD_PAGENUMS</b> flag is specified; otherwise,
+    ///   it displays the dialog box but changes the out-of-range value to the minimum or maximum value.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">
+    ///   Read more on learn.Microsoft.com.</see></para>
     /// </summary>
     public ushort nFromPage;
 
     /// <summary>
-    ///  <para>Type: <b>WORD</b> The initial value for the ending page edit control. When <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646940(v=vs.85)">PrintDlg</a> returns, <b>nToPage</b> is the ending page specified by the user. If the <b>Pages</b> radio button is selected when the use clicks the <b>Okay</b> button, <b>PrintDlg</b> sets the <b>PD_PAGENUMS</b> flag and does not return until the user enters an ending page value that is within the minimum to maximum page range.</para>
-    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">Read more on learn.Microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>WORD</b> The initial value for the ending page edit control.
+    ///   When <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646940(v=vs.85)">
+    ///   PrintDlg</a> returns, <b>nToPage</b> is the ending page specified by the user. If the <b>Pages</b>
+    ///   radio button is selected when the use clicks the <b>Okay</b> button, <b>PrintDlg</b> sets the
+    ///   <b>PD_PAGENUMS</b> flag and does not return until the user enters an ending page value that is within
+    ///   the minimum to maximum page range.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">
+    ///  Read more on learn.Microsoft.com.</see></para>
     /// </summary>
     public ushort nToPage;
 
@@ -68,67 +162,161 @@ internal partial struct PRINTDLGW_64
     ///   controls. If <b>nMinPage</b> equals <b>nMaxPage</b>, the <b>Pages</b> radio button and the starting and
     ///   ending page edit controls are disabled.
     ///  </para>
-    /// <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">Read more on learn.Microsoft.com</see>.</para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
+    ///  </para>
     /// </summary>
     public ushort nMinPage;
 
     /// <summary>
-    ///  <para>Type: <b>WORD</b> The maximum value for the page range specified in the <b>From</b> and <b>To</b> page edit controls.</para>
-    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">Read more on learn.Microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>WORD</b> The maximum value for the page range specified in the <b>From</b> and <b>To</b> page edit controls.
+    ///  </para>
+    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
+    ///  </para>
     /// </summary>
     public ushort nMaxPage;
 
     /// <summary>
-    ///  <para>Type: <b>WORD</b> The initial number of copies for the <b>Copies</b> edit control if <b>hDevMode</b> is <b>NULL</b>; otherwise, the <b>dmCopies</b> member of the <a href="https://learn.microsoft.com/windows/win32/api/wingdi/ns-wingdi-devmodea">DEVMODE</a> structure contains the initial value. When <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646940(v=vs.85)">PrintDlg</a> returns, <b>nCopies</b> contains the actual number of copies to print. This value depends on whether the application or the printer driver is responsible for printing multiple copies. If the <b>PD_USEDEVMODECOPIESANDCOLLATE</b> flag is set in the <b>Flags</b> member, <b>nCopies</b> is always 1 on return, and the printer driver is responsible for printing multiple copies. If the flag is not set, the application is responsible for printing the number of copies specified by <b>nCopies</b>. For more information, see the description of the <b>PD_USEDEVMODECOPIESANDCOLLATE</b> flag.</para>
-    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">Read more on learn.Microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>WORD</b> The initial number of copies for the <b>Copies</b> edit control if <b>hDevMode</b>
+    ///   is <b>NULL</b>; otherwise, the <b>dmCopies</b> member of the
+    ///   <a href="https://learn.microsoft.com/windows/win32/api/wingdi/ns-wingdi-devmodea">
+    ///   DEVMODE</a> structure contains the initial value.
+    ///   When <a href="https://learn.microsoft.com/previous-versions/windows/desktop/legacy/ms646940(v=vs.85)">
+    ///   PrintDlg</a> returns, <b>nCopies</b> contains the actual number of copies to print.
+    ///   This value depends on whether the application or the printer driver is responsible for printing multiple copies.
+    ///   If the <b>PD_USEDEVMODECOPIESANDCOLLATE</b> flag is set in the <b>Flags</b> member, <b>nCopies</b>
+    ///   is always 1 on return, and the printer driver is responsible for printing multiple copies.
+    ///   If the flag is not set, the application is responsible for printing the number of copies specified by
+    ///   <b>nCopies</b>. For more information, see the description of the <b>PD_USEDEVMODECOPIESANDCOLLATE</b> flag.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
+    ///  </para>
     /// </summary>
     public ushort nCopies;
 
     /// <summary>
-    ///  <para>Type: <b>HINSTANCE</b> If the <b>PD_ENABLEPRINTTEMPLATE</b> or <b>PD_ENABLESETUPTEMPLATE</b> flag is set in the <b>Flags</b> member, <b>hInstance</b> is a handle to the application or module instance that contains the dialog box template named by the <b>lpPrintTemplateName</b> or <b>lpSetupTemplateName</b> member.</para>
-    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">Read more on learn.Microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>HINSTANCE</b> If the <b>PD_ENABLEPRINTTEMPLATE</b> or <b>PD_ENABLESETUPTEMPLATE</b> flag is set in the
+    ///   <b>Flags</b> member, <b>hInstance</b> is a handle to the application or module instance that contains
+    ///   the dialog box template named by the <b>lpPrintTemplateName</b> or <b>lpSetupTemplateName</b> member.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
+    ///  </para>
     /// </summary>
     public HINSTANCE hInstance;
 
     /// <summary>
-    ///  <para>Type: <b>LPARAM</b> Application-defined data that the system passes to the hook procedure identified by the <b>lpfnPrintHook</b> or <b>lpfnSetupHook</b> member. When the system sends the <a href="https://learn.microsoft.com/windows/desktop/dlgbox/wm-initdialog">WM_INITDIALOG</a> message to the hook procedure, the message's <i>lParam</i> parameter is a pointer to the <b>PRINTDLG</b> structure specified when the dialog was created. The hook procedure can use this pointer to get the <b>lCustData</b> value.</para>
-    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">Read more on learn.Microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>LPARAM</b> Application-defined data that the system passes to the hook procedure identified by the
+    ///   <b>lpfnPrintHook</b> or <b>lpfnSetupHook</b> member. When the system sends the
+    ///   <a href="https://learn.microsoft.com/windows/desktop/dlgbox/wm-initdialog">WM_INITDIALOG</a> message
+    ///   to the hook procedure, the message's <i>lParam</i> parameter is a pointer to the <b>PRINTDLG</b>
+    ///   structure specified when the dialog was created. The hook procedure can use this pointer to get the
+    ///   <b>lCustData</b> value.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
+    ///  </para>
     /// </summary>
     public LPARAM lCustData;
 
     /// <summary>
-    ///  <para>Type: <b>LPPRINTHOOKPROC</b> A pointer to a <a href="https://learn.microsoft.com/windows/desktop/api/commdlg/nc-commdlg-lpprinthookproc">PrintHookProc</a> hook procedure that can process messages intended for the <b>Print</b> dialog box. This member is ignored unless the <b>PD_ENABLEPRINTHOOK</b> flag is set in the <b>Flags</b> member.</para>
-    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">Read more on learn.Microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>LPPRINTHOOKPROC</b> A pointer to a
+    ///   <a href="https://learn.microsoft.com/windows/desktop/api/commdlg/nc-commdlg-lpprinthookproc">
+    ///   PrintHookProc</a> hook procedure that can process messages intended for the <b>Print</b> dialog box.
+    ///   This member is ignored unless the <b>PD_ENABLEPRINTHOOK</b> flag is set in the <b>Flags</b> member.
+    ///  </para>
+    ///  <para>
+    ///  <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
+    ///  </para>
     /// </summary>
     public unsafe delegate* unmanaged[Stdcall]<HWND, uint, WPARAM, LPARAM, nuint> lpfnPrintHook;
 
     /// <summary>
-    ///  <para>Type: <b>LPSETUPHOOKPROC</b> A pointer to a <a href="https://learn.microsoft.com/windows/desktop/api/commdlg/nc-commdlg-lpsetuphookproc">SetupHookProc</a> hook procedure that can process messages intended for the <b>Print Setup</b> dialog box. This member is ignored unless the <b>PD_ENABLESETUPHOOK</b> flag is set in the <b>Flags</b> member.</para>
-    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">Read more on learn.Microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>LPSETUPHOOKPROC</b> A pointer to a
+    ///   <a href="https://learn.microsoft.com/windows/desktop/api/commdlg/nc-commdlg-lpsetuphookproc">
+    ///   SetupHookProc</a> hook procedure that can process messages intended for the <b>Print Setup</b> dialog box.
+    ///   This member is ignored unless the <b>PD_ENABLESETUPHOOK</b> flag is set in the <b>Flags</b> member.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
+    ///  </para>
     /// </summary>
     public unsafe delegate* unmanaged[Stdcall]<HWND, uint, WPARAM, LPARAM, nuint> lpfnSetupHook;
 
     /// <summary>
-    ///  <para>Type: <b>LPCTSTR</b> The name of the dialog box template resource in the module identified by the <b>hInstance</b> member. This template replaces the default <b>Print</b> dialog box template. This member is ignored unless the <b>PD_ENABLEPRINTTEMPLATE</b> flag is set in the <b>Flags</b> member.</para>
-    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">Read more on learn.Microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>LPCTSTR</b> The name of the dialog box template resource in the module identified by the
+    ///   <b>hInstance</b> member. This template replaces the default <b>Print</b> dialog box template.
+    ///   This member is ignored unless the <b>PD_ENABLEPRINTTEMPLATE</b> flag is set in the <b>Flags</b> member.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
+    ///  </para>
     /// </summary>
     public PCWSTR lpPrintTemplateName;
 
     /// <summary>
-    ///  <para>Type: <b>LPCTSTR</b> The name of the dialog box template resource in the module identified by the <b>hInstance</b> member. This template replaces the default <b>Print Setup</b> dialog box template. This member is ignored unless the <b>PD_ENABLESETUPTEMPLATE</b> flag is set in the <b>Flags</b> member.</para>
-    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">Read more on learn.Microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>LPCTSTR</b> The name of the dialog box template resource in the module identified by the
+    ///   <b>hInstance</b> member. This template replaces the default <b>Print Setup</b> dialog box template.
+    ///   This member is ignored unless the <b>PD_ENABLESETUPTEMPLATE</b> flag is set in the <b>Flags</b> member.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
+    ///  </para>
     /// </summary>
     public PCWSTR lpSetupTemplateName;
 
     /// <summary>
-    ///  <para>Type: <b>HGLOBAL</b> If the <b>PD_ENABLEPRINTTEMPLATEHANDLE</b> flag is set in the <b>Flags</b> member, <b>hPrintTemplate</b> is a handle to a memory object containing a dialog box template. This template replaces the default <b>Print</b> dialog box template.</para>
-    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">Read more on learn.Microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>HGLOBAL</b> If the <b>PD_ENABLEPRINTTEMPLATEHANDLE</b> flag is set in the <b>Flags</b> member,
+    ///   <b>hPrintTemplate</b> is a handle to a memory object containing a dialog box template.
+    ///   This template replaces the default <b>Print</b> dialog box template.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
+    ///  </para>
     /// </summary>
     public HGLOBAL hPrintTemplate;
 
     /// <summary>
-    ///  <para>Type: <b>HGLOBAL</b> If the <b>PD_ENABLESETUPTEMPLATEHANDLE</b> flag is set in the <b>Flags</b> member, <b>hSetupTemplate</b> is a handle to a memory object containing a dialog box template. This template replaces the default <b>Print Setup</b> dialog box template.</para>
-    ///  <para><see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">Read more on learn.Microsoft.com</see>.</para>
+    ///  <para>
+    ///   Type: <b>HGLOBAL</b> If the <b>PD_ENABLESETUPTEMPLATEHANDLE</b> flag is set in the <b>Flags</b> member,
+    ///   <b>hSetupTemplate</b> is a handle to a memory object containing a dialog box template.
+    ///   This template replaces the default <b>Print Setup</b> dialog box template.
+    ///  </para>
+    ///  <para>
+    ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
+    ///  </para>
     /// </summary>
     public HGLOBAL hSetupTemplate;
 }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/UI/Controls/Dialogs/PRINTDLGW_64.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/UI/Controls/Dialogs/PRINTDLGW_64.cs
@@ -137,7 +137,9 @@ internal partial struct PRINTDLGW_64
     ///  </para>
     ///  <para>
     ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">
-    ///   Read more on learn.Microsoft.com.</see></para>
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
+    ///  </para>
     /// </summary>
     public ushort nFromPage;
 
@@ -152,7 +154,9 @@ internal partial struct PRINTDLGW_64
     ///  </para>
     ///  <para>
     ///   <see href="https://learn.microsoft.com/windows/win32/api/commdlg/ns-commdlg-printdlgw#members">
-    ///  Read more on learn.Microsoft.com.</see></para>
+    ///    Read more on learn.Microsoft.com.
+    ///   </see>
+    ///  </para>
     /// </summary>
     public ushort nToPage;
 

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities.Tests/PathLengthTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities.Tests/PathLengthTests.cs
@@ -21,7 +21,7 @@ public class PathLengthTests
 
         const int MaxRootLength = 40;
 
-        // Workaround for MAX_PATH limitation - https://learn.microsoft.com/windows/win32/fileio/maximum-file-path-limitation?tabs=registry
+        // Workaround for MAX_PATH limitation - https://learn.Microsoft.com/windows/win32/fileio/maximum-file-path-limitation?tabs=registry
         // Leave a char for the trailing null (MAX_PATH is 260)
         int maxLength = 260 - 1 - (currentRootLength > MaxRootLength
             ? 0

--- a/src/System.Windows.Forms/src/System/Resources/ResXResourceReader.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResXResourceReader.cs
@@ -585,7 +585,7 @@ public partial class ResXResourceReader : IResourceReader
             WhitespaceHandling oldValue = reader.WhitespaceHandling;
             try
             {
-                // Based on the documentation at https://learn.microsoft.com/dotnet/api/system.xml.xmltextreader.whitespacehandling
+                // Based on the documentation at https://learn.Microsoft.com/dotnet/api/system.xml.xmltextreader.whitespacehandling
                 // this is ok because:
                 //
                 //  "Because the XmlTextReader does not have DTD information available to it,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Accessibility/AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Accessibility/AccessibleObject.cs
@@ -2653,7 +2653,7 @@ public unsafe partial class AccessibleObject :
 
     private VARIANT AsChildIdVariant(AccessibleObject? obj)
     {
-        // https://learn.microsoft.com/windows/win32/winauto/how-child-ids-are-used-in-parameters
+        // https://learn.Microsoft.com/windows/win32/winauto/how-child-ids-are-used-in-parameters
         if (obj == this)
         {
             return (VARIANT)(int)PInvoke.CHILDID_SELF;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Accessibility/AccessibleObjectExtensions.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Accessibility/AccessibleObjectExtensions.cs
@@ -160,7 +160,7 @@ internal static unsafe class AccessibleObjectExtensions
     public static void TrySetName(this AgileComPointer<IAccessible>? agile, VARIANT child, BSTR name)
     {
         // This is not technically supported any more, unclear if this ever actually does anything.
-        // https://learn.microsoft.com/windows/win32/api/oleacc/nf-oleacc-iaccessible-put_accname
+        // https://learn.Microsoft.com/windows/win32/api/oleacc/nf-oleacc-iaccessible-put_accname
 
         if (name.IsNull)
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ActiveX/Control.ActiveXImpl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ActiveX/Control.ActiveXImpl.cs
@@ -1643,7 +1643,7 @@ public partial class Control
                 // Callers don't increment the ref count when they pass IOleClientSite, it is up to us to do so as we're
                 // maintaining a reference to the pointer. Validated this behavior with the ATL/MFC sources.
                 //
-                // https://learn.microsoft.com/windows/win32/api/oleidl/nf-oleidl-ioleobject-setclientsite#notes-to-implementers
+                // https://learn.Microsoft.com/windows/win32/api/oleidl/nf-oleidl-ioleobject-setclientsite#notes-to-implementers
 
                 value->AddRef();
                 _clientSite = new(value, takeOwnership: true);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -2280,7 +2280,7 @@ public unsafe partial class Control :
                         }
 
                         // #32770 is the standard windows dialog class name
-                        // https://learn.microsoft.com/windows/win32/winmsg/about-window-classes#system-classes
+                        // https://learn.Microsoft.com/windows/win32/winmsg/about-window-classes#system-classes
                         ReadOnlySpan<char> className = "#32770";
                         if (className.Equals(buffer[..length], StringComparison.Ordinal))
                         {
@@ -11160,10 +11160,10 @@ public unsafe partial class Control :
         //
         // See:
         //
-        // https://learn.microsoft.com/cpp/mfc/tn061-on-notify-and-wm-notify-messages
-        // https://learn.microsoft.com/cpp/mfc/tn062-message-reflection-for-windows-controls?view=msvc-170
-        // https://learn.microsoft.com/windows/win32/controls/wm-notify
-        // https://learn.microsoft.com/windows/win32/controls/wm-drawitem
+        // https://learn.Microsoft.com/cpp/mfc/tn061-on-notify-and-wm-notify-messages
+        // https://learn.Microsoft.com/cpp/mfc/tn062-message-reflection-for-windows-controls?view=msvc-170
+        // https://learn.Microsoft.com/windows/win32/controls/wm-notify
+        // https://learn.Microsoft.com/windows/win32/controls/wm-drawitem
 
         if (!Disposing && IsHandleCreated)
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -12461,7 +12461,7 @@ public unsafe partial class Control :
     ///  <para>
     ///   The <see cref="WndProc(ref Message)"/> method corresponds exactly to the Windows <c>WindowProc</c>
     ///   function. For more information about processing Windows messages see the
-    ///   <see href="https://go.microsoft.com/fwlink/?LinkId=181565">WindowProc function</see>.
+    ///   <see href="https://go.microsoft.com/fwlink/?LinkId=181565">WindowProc function.</see>
     ///  </para>
     /// </remarks>
     /// <notesToInheritors>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Dialogs/CommonDialogs/FileDialog.Vista.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Dialogs/CommonDialogs/FileDialog.Vista.cs
@@ -52,7 +52,7 @@ public partial class FileDialog
         if (ClientGuid is { } clientGuid)
         {
             // IFileDialog::SetClientGuid should be called immediately after creation of the dialog object.
-            // https://learn.microsoft.com/windows/win32/api/shobjidl_core/nf-shobjidl_core-ifiledialog-setclientguid#remarks
+            // https://learn.Microsoft.com/windows/win32/api/shobjidl_core/nf-shobjidl_core-ifiledialog-setclientguid#remarks
             dialog->SetClientGuid(in clientGuid);
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Dialogs/TaskDialog/TaskDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Dialogs/TaskDialog/TaskDialog.cs
@@ -16,8 +16,8 @@ namespace System.Windows.Forms;
 /// </summary>
 /// <remarks>
 /// <para>
-///   For more information, see
-/// <see href="https://docs.microsoft.com/windows/desktop/Controls/task-dialogs-overview">About Task Dialogs</see>.
+///  For more information, see
+///  <see href="https://docs.microsoft.com/windows/desktop/Controls/task-dialogs-overview">About Task Dialogs.</see>
 /// </para>
 /// <para>
 ///   Note: In order to use the dialog, you need ensure <see cref="Application.EnableVisualStyles"/>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Input/InputLanguage.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Input/InputLanguage.cs
@@ -102,7 +102,7 @@ public sealed class InputLanguage
     {
         get
         {
-            // https://learn.microsoft.com/windows/win32/intl/using-registry-string-redirection#create-resources-for-keyboard-layout-strings
+            // https://learn.Microsoft.com/windows/win32/intl/using-registry-string-redirection#create-resources-for-keyboard-layout-strings
             using RegistryKey? key = Registry.LocalMachine.OpenSubKey($@"{KeyboardLayoutsRegistryPath}\{LayoutId}");
             return key.GetMUIString("Layout Display Name", "Layout Text") ?? SR.UnknownInputLanguageLayout;
         }
@@ -185,8 +185,8 @@ public sealed class InputLanguage
 
             // We need to convert the language identifier to a language tag, because they are deprecated and may have a
             // transient value.
-            // https://learn.microsoft.com/globalization/locale/other-locale-names#lcid
-            // https://learn.microsoft.com/windows/win32/winmsg/wm-inputlangchange#remarks
+            // https://learn.Microsoft.com/globalization/locale/other-locale-names#lcid
+            // https://learn.Microsoft.com/windows/win32/winmsg/wm-inputlangchange#remarks
             //
             // It turns out that the LCIDToLocaleName API, which is used inside CultureInfo, may return incorrect
             // language tags for transient language identifiers. For example, it returns "nqo-GN" and "jv-Java-ID"

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Infra/DataCollectionService.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Infra/DataCollectionService.cs
@@ -46,12 +46,14 @@ internal static class DataCollectionService
     }
 
     /// <summary>
-    /// Register a custom logger to collect data in the event of a test failure.
+    ///  Register a custom logger to collect data in the event of a test failure.
     /// </summary>
     /// <remarks>
-    /// <para>The <paramref name="logId"/> and <paramref name="extension"/> should be chosen to avoid conflicts with
-    /// other loggers. Otherwise, it is possible for logs to be overwritten during data collection. Built-in logs
-    /// include:</para>
+    /// <para>
+    ///  The <paramref name="logId"/> and <paramref name="extension"/> should be chosen to avoid conflicts with
+    ///  other loggers. Otherwise, it is possible for logs to be overwritten during data collection. Built-in logs
+    ///  include:
+    /// </para>
     ///
     /// <list type="table">
     ///   <listheader>
@@ -71,7 +73,9 @@ internal static class DataCollectionService
     ///   </item>
     /// </list>
     /// </remarks>
-    /// <param name="callback">The callback to invoke to collect log information. The argument to the callback is the fully-qualified file path where the log data should be written.</param>
+    /// <param name="callback">The callback to invoke to collect log information. The argument to the callback is
+    ///  the fully-qualified file path where the log data should be written.
+    /// </param>
     /// <param name="logId">An optional log identifier to include in the resulting file name.</param>
     /// <param name="extension">The extension to give the resulting file.</param>
     public static void RegisterCustomLogger(Action<string> callback, string logId, string extension)
@@ -195,7 +199,7 @@ internal static class DataCollectionService
     }
 
     /// <summary>
-    /// Computes a full log file name.
+    ///  Computes a full log file name.
     /// </summary>
     /// <param name="logDirectory">The location where logs are saved.</param>
     /// <param name="timestamp">The timestamp of the failure.</param>

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Infra/ScreenRecordService.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Infra/ScreenRecordService.cs
@@ -109,8 +109,9 @@ internal class ScreenRecordService : IDisposable
         Source = 0,
 
         /// <summary>
-        /// The frame should be composited onto the output buffer based on its alpha, using a simple OVER operation as
-        /// described in <see href="https://www.w3.org/TR/png/#13Alpha-channel-processing">Alpha Channel Processing</see>.
+        ///  The frame should be composited onto the output buffer based on its alpha, using a simple OVER operation as
+        ///  described in <see href="https://www.w3.org/TR/png/#13Alpha-channel-processing">
+        ///  Alpha Channel Processing.</see>
         /// </summary>
         Over = 1,
     }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ApplicationTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ApplicationTests.cs
@@ -327,9 +327,9 @@ public class ApplicationTests
 
             // Retrieve the text scale factor, which is set via Settings > Display > Make Text Bigger.
             using RegistryKey key = Registry.CurrentUser.OpenSubKey("Software\\Microsoft\\Accessibility");
-            int textScale = (int)(key?.GetValue("TextScaleFactor", 100) ?? 100);            
+            int textScale = (int)(key?.GetValue("TextScaleFactor", 100) ?? 100);
             if (textScale == 100) // Application.DefaultFont must be the same
-            {                
+            {
                 font.Should().BeNull("Because TextScaleFactor == 100.");
                 Application.DefaultFont.Should().BeSameAs(customFont, "Because TextScaleFactor == 100.");
             }
@@ -358,7 +358,7 @@ public class ApplicationTests
     }
 
     /// <summary>
-    /// Test <see cref="Application.Exit()"/> fire Closing events in correct order for MDI windows.
+    ///  Test <see cref="Application.Exit()"/> fire Closing events in correct order for MDI windows.
     /// </summary>
     /// <param name="mainMDIFormCountParam">Count of MdiContainers. If == 1 then main form is MdiContainer.</param>
     /// <param name="childFormCountParam">Count of MDI child.</param>
@@ -391,7 +391,7 @@ public class ApplicationTests
             Dictionary<object, int> formClosedProcessed = new(mainMDIFormCount);
             bool exitCalled = false;
 
-            if (mainMDIFormCount == 1) // main form is MdiContainer 
+            if (mainMDIFormCount == 1) // main form is MdiContainer
             {
                 AddMDI(mainForm);
             }
@@ -468,13 +468,15 @@ public class ApplicationTests
     }
 
     /// <summary>
-    /// Test <see cref="Application.Exit()"/> fire Closing events in which we close existing and open new forms.
+    ///  Test <see cref="Application.Exit()"/> fire Closing events in which we close existing and open new forms.
     /// </summary>
     /// <param name="childFormCountParam">Count of child forms.</param>
     /// <param name="removedFormCountParam">
     ///  Count of forms that we will remove during last form <see cref="Form.OnFormClosing(FormClosingEventArgs)"/>.
     /// </param>
-    /// <param name="addFormCountParam">Count of forms that we will add during last form <see cref="Form.OnFormClosing(FormClosingEventArgs)"/>.</param>
+    /// <param name="addFormCountParam">
+    ///  Count of forms that we will add during last form <see cref="Form.OnFormClosing(FormClosingEventArgs)"/>.
+    /// </param>
     /// <param name="cancelParam">If set to <see langword="true" /> we will cancel application exit process.</param>
     [WinFormsTheory]
     [InlineData(0, 0, 0, false)]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/BinaryFormatUtilitiesTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/BinaryFormatUtilitiesTests.cs
@@ -33,7 +33,7 @@ public partial class BinaryFormatUtilitiesTests : IDisposable
     }
 
     // Primitive types as defined by the NRBF spec.
-    // https://learn.microsoft.com/dotnet/api/system.formats.nrbf.primitivetyperecord
+    // https://learn.Microsoft.com/dotnet/api/system.formats.nrbf.primitivetyperecord
     public static TheoryData<object> PrimitiveObjects_TheoryData => new()
     {
         (byte)1,

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/InputLanguageTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/InputLanguageTests.cs
@@ -147,7 +147,7 @@ public class InputLanguageTests
         }
 
         // Also installs default keyboard layout for this language
-        // https://learn.microsoft.com/windows-hardware/manufacture/desktop/default-input-locales-for-windows-language-packs
+        // https://learn.Microsoft.com/windows-hardware/manufacture/desktop/default-input-locales-for-windows-language-packs
         InstallUserLanguage(languageTag);
 
         try


### PR DESCRIPTION
Partially Fixes #12034 for ~100 more files

## Proposed changes
- Shorten comment lines with more that 120 characters.
- NOTE to reviewers: "See" Attributes were many of the long lines, I split them into 3 lines. Please provide feedback if 2 is better and if you want to put the \</see>. at the end of the last line or on a its own line? Also where should the period go.

## Customer Impact
-  None just cleans up code

## Regression? 
- No

## Risk
- None no code changes

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12063)