### PR TITLE
Add missing documentation for public methods in System.Drawing

### DIFF
--- a/src/System.Drawing.Common/src/System/Drawing/Drawing2D/Matrix.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Drawing2D/Matrix.cs
@@ -261,6 +261,7 @@ public sealed unsafe class Matrix : MarshalByRefObject, IDisposable
         TransformPoints(pts.AsSpan());
     }
 
+    /// <inheritdoc cref="TransformPoints(Point[])"/>
 #if NET9_0_OR_GREATER
     public
 #else

--- a/src/System.Drawing.Common/src/System/Drawing/Drawing2D/PathGradientBrush.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Drawing2D/PathGradientBrush.cs
@@ -26,7 +26,7 @@ public sealed unsafe class PathGradientBrush : Brush
     /// </summary>
     public PathGradientBrush(PointF[] points, WrapMode wrapMode) : this(wrapMode, points.OrThrowIfNull().AsSpan()) { }
 
-    /// <inheritdoc cref="PathGradientBrush(PointF[])"/>
+    /// <inheritdoc cref="PathGradientBrush(PointF[], WrapMode)"/>
 #if NET9_0_OR_GREATER
     public
 #else

--- a/src/System.Drawing.Common/src/System/Drawing/Graphics.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Graphics.cs
@@ -727,7 +727,8 @@ public sealed unsafe partial class Graphics : MarshalByRefObject, IDisposable, I
     ///  Draws the outline of the specified rounded rectangle.
     /// </summary>
     /// <param name="pen">The <see cref="Pen"/> to draw the outline with.</param>
-    /// <inheritdoc cref="FillRoundedRectangle(Brush, RectangleF, SizeF)"/>
+    /// <param name="rect">The bounds of the rounded rectangle.</param>
+    /// <param name="radius">The radius width and height used to round the corners of the rectangle.</param>
     public void DrawRoundedRectangle(Pen pen, RectangleF rect, SizeF radius)
     {
         using GraphicsPath path = new();

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/ColorMatrix.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/ColorMatrix.cs
@@ -333,6 +333,7 @@ public sealed class ColorMatrix
     /// <summary>
     ///  Initializes a new instance of the <see cref='ColorMatrix'/> class with the elements in the specified matrix.
     /// </summary>
+    /// <param name="newColorMatrix">The values of the elements of the new matrix.</param>
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="newColorMatrix"/> did not have 25 values.</exception>
     public unsafe ColorMatrix(params ReadOnlySpan<float> newColorMatrix)
     {

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/ColorPalette.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/ColorPalette.cs
@@ -42,6 +42,7 @@ public sealed unsafe class ColorPalette
     /// <summary>
     ///  Create a standard color palette.
     /// </summary>
+    /// <param name="fixedPaletteType">The palette type.</param>
     public ColorPalette(PaletteType fixedPaletteType)
     {
         ColorPalette palette = InitializePalette(fixedPaletteType, 0, useTransparentColor: false, bitmap: null);

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/Effects/Effect.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/Effects/Effect.cs
@@ -36,9 +36,12 @@ public abstract unsafe class Effect : IDisposable
         }
     }
 
+    /// <summary>
+    ///  Cleans up Windows resources for this <see cref="Effect"/>
+    /// </summary>
     ~Effect() => Dispose(disposing: false);
 
-    public virtual void Dispose(bool disposing)
+    protected virtual void Dispose(bool disposing)
     {
         if (_nativeEffect is not null)
         {

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/Effects/GrayScaleEffect.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/Effects/GrayScaleEffect.cs
@@ -10,6 +10,9 @@ namespace System.Drawing.Imaging.Effects;
 /// </summary>
 public sealed class GrayScaleEffect : ColorMatrixEffect
 {
+    /// <summary>
+    ///  Creates a <see cref="ColorMatrixEffect"/> that converts an image to grayscale.
+    /// </summary>
     public GrayScaleEffect() : base(
         new(
         [

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/Effects/InvertEffect.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/Effects/InvertEffect.cs
@@ -10,6 +10,9 @@ namespace System.Drawing.Imaging.Effects;
 /// </summary>
 public sealed class InvertEffect : ColorMatrixEffect
 {
+    /// <summary>
+    ///  Creates a <see cref="ColorMatrixEffect"/> that inverts the colors in an image.
+    /// </summary>
     public InvertEffect() : base(
         new(
         [

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/Effects/SepiaEffect.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/Effects/SepiaEffect.cs
@@ -10,6 +10,9 @@ namespace System.Drawing.Imaging.Effects;
 /// </summary>
 public sealed class SepiaEffect : ColorMatrixEffect
 {
+    /// <summary>
+    ///  Creates a new <see cref="ColorMatrixEffect"/> that converts an image to sepia.
+    /// </summary>
     public SepiaEffect() : base(
         new(
         [

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/Effects/VividEffect.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/Effects/VividEffect.cs
@@ -10,6 +10,9 @@ namespace System.Drawing.Imaging.Effects;
 /// </summary>
 public sealed class VividEffect : ColorMatrixEffect
 {
+    /// <summary>
+    ///  Creates a new <see cref="ColorMatrixEffect"/> that makes colors more vivid.
+    /// </summary>
     public VividEffect() : base(
         new(
         [

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/ImageAttributes.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/ImageAttributes.cs
@@ -427,8 +427,10 @@ public sealed unsafe class ImageAttributes : ICloneable, IDisposable
     public void SetBrushRemapTable(params ColorMap[] map) => SetRemapTable(map, ColorAdjustType.Brush);
 
 #if NET9_0_OR_GREATER
+    /// <inheritdoc cref="SetRemapTable(ColorAdjustType, ReadOnlySpan{ColorMap})"/>
     public void SetBrushRemapTable(params ReadOnlySpan<ColorMap> map) => SetRemapTable(ColorAdjustType.Brush, map);
 
+    /// <inheritdoc cref="SetRemapTable(ColorAdjustType, ReadOnlySpan{ColorMap})"/>
     public void SetBrushRemapTable(params ReadOnlySpan<(Color OldColor, Color NewColor)> map) => SetRemapTable(ColorAdjustType.Brush, map);
 #endif
 


### PR DESCRIPTION
Adds/edits some missing documentation for public methods
Also change Effect.Dispose from public -> virtual according to API review https://github.com/dotnet/winforms/issues/8835#issuecomment-1954987873
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12069)