### PR TITLE
Notify the drag-image manager prior to invoking the DragDrop and DragLeave events

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/RichTextBox/RichTextBox.OleCallback.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/RichTextBox/RichTextBox.OleCallback.cs
@@ -168,8 +168,6 @@ public partial class RichTextBox
             }
             else
             {
-                _owner.OnDragDrop(e);
-
                 if (e.DropImageType > DropImageType.Invalid)
                 {
                     ClearDropDescription();
@@ -177,6 +175,7 @@ public partial class RichTextBox
                     DragDropHelper.DragLeave();
                 }
 
+                _owner.OnDragDrop(e);
                 _lastDataObject = null;
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripDropTargetManager.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripDropTargetManager.cs
@@ -196,14 +196,14 @@ internal class ToolStripDropTargetManager : IDropTarget
             // tell the last drag target you've left
             if (_lastDropTarget is not null)
             {
-                OnDragLeave(EventArgs.Empty);
-
                 // tell the drag image manager you've left
                 if (e.DropImageType > DropImageType.Invalid)
                 {
                     DragDropHelper.ClearDropDescription(e.Data);
                     DragDropHelper.DragLeave();
                 }
+
+                OnDragLeave(EventArgs.Empty);
             }
 
             _lastDropTarget = newTarget;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DropTarget.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DropTarget.cs
@@ -150,13 +150,13 @@ internal unsafe class DropTarget : Ole.IDropTarget.Interface, IManagedWrapper<Ol
 
     HRESULT Ole.IDropTarget.Interface.DragLeave()
     {
-        _owner.OnDragLeave(EventArgs.Empty);
-
         if (_lastDragEventArgs?.DropImageType > DropImageType.Invalid)
         {
             ClearDropDescription();
             DragDropHelper.DragLeave();
         }
+
+        _owner.OnDragLeave(EventArgs.Empty);
 
         return HRESULT.S_OK;
     }
@@ -170,14 +170,14 @@ internal unsafe class DropTarget : Ole.IDropTarget.Interface, IManagedWrapper<Ol
 
         if (CreateDragEventArgs(pDataObj, grfKeyState, pt, *pdwEffect) is { } dragEvent)
         {
-            _owner.OnDragDrop(dragEvent);
-            *pdwEffect = (Ole.DROPEFFECT)dragEvent.Effect;
-
             if (_lastDragEventArgs?.DropImageType > DropImageType.Invalid)
             {
                 ClearDropDescription();
                 DragDropHelper.Drop(dragEvent);
             }
+
+            _owner.OnDragDrop(dragEvent);
+            *pdwEffect = (Ole.DROPEFFECT)dragEvent.Effect;
         }
         else
         {


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #10504 

## Proposed changes

- Notify the drag-image manager prior to invoking the DragDrop and DragLeave event handlers.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Fixes an issue where a drag-image remnant remains on the screen after a drag and drop completes if an unhandled exception occurs during DragDrop or DragLeave.

## Regression? 

- No

## Risk

-

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->

### After

<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->

- 9.0.100-preview.7.24407.12

<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12070)