### PR TITLE
System.Drawing.Primitives types should not require BinaryFormatter in Clipboard operations

### DIFF
--- a/Winforms.sln
+++ b/Winforms.sln
@@ -48,7 +48,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{462AD69A-9395-4E98-882D-569CDE562559}"
 	ProjectSection(SolutionItems) = preProject
 		azure-pipelines.yml = azure-pipelines.yml
-		eng\common\templates\job\build.yml = eng\common\templates\job\build.yml
+		eng\pipelines\build.yml = eng\pipelines\build.yml
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "documentation", "documentation", "{C029199F-7D5C-417C-AA52-913A214E3285}"

--- a/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/FormattedObject/BinaryFormatWriterTests.cs
+++ b/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/FormattedObject/BinaryFormatWriterTests.cs
@@ -31,8 +31,8 @@ public class BinaryFormatWriterTests
     }
 
     [Theory]
-    [MemberData(nameof(TryWriteObject_SupportedObjects_TestData))]
-    public void BinaryFormatWriter_TryWriteObject_SupportedObjects_BinaryFormatterRead(object value)
+    [MemberData(nameof(TryWriteFrameworkObject_SupportedObjects_TestData))]
+    public void BinaryFormatWriter_TryWriteFrameworkObject_SupportedObjects_BinaryFormatterRead(object value)
     {
         using MemoryStream stream = new();
         bool success = BinaryFormatWriter.TryWriteFrameworkObject(stream, value);
@@ -65,15 +65,42 @@ public class BinaryFormatWriterTests
     }
 
     [Theory]
-    [MemberData(nameof(TryWriteObject_SupportedObjects_TestData))]
-    public void BinaryFormatWriter_TryWriteObject_SupportedObjects_RoundTrip(object value)
+    [MemberData(nameof(DrawingPrimitives_TestData))]
+    public void BinaryFormatWriter_TryWriteDrawingPrimitivesObject_SupportedObjects_BinaryFormatterRead(object value)
+    {
+        using MemoryStream stream = new();
+        bool success = BinaryFormatWriter.TryWriteDrawingPrimitivesObject(stream, value);
+        success.Should().BeTrue();
+
+        stream.Position = 0;
+        // cs/binary-formatter-without-binder
+        BinaryFormatter formatter = new(); // CodeQL [SM04191] : This is a test. Safe use because the deserialization process is performed on trusted data and the types are controlled and validated.
+
+        // cs/dangerous-binary-deserialization
+        object deserialized = formatter.Deserialize(stream); // CodeQL [SM03722] : Testing legacy feature. This is a safe use of BinaryFormatter because the data is trusted and the types are controlled and validated.
+
+        if (value is Color color)
+        {
+            deserialized.Should().BeOfType<Color>().Which.Should().BeEquivalentTo(color);
+        }
+        else
+        {
+            deserialized.Should().Be(value);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(TryWriteFrameworkObject_SupportedObjects_TestData))]
+    public void BinaryFormatWriter_TryWriteFrameworkObject_SupportedObjects_RoundTrip(object value)
     {
         using MemoryStream stream = new();
         BinaryFormatWriter.TryWriteFrameworkObject(stream, value).Should().BeTrue();
         stream.Position = 0;
 
         SerializationRecord rootRecord = NrbfDecoder.Decode(stream);
-        rootRecord.TryGetFrameworkObject(out object? deserialized).Should().BeTrue();
+        bool result = rootRecord.TryGetFrameworkObject(out object? deserialized);
+
+        result.Should().BeTrue();
 
         if (value is Hashtable hashtable)
         {
@@ -95,15 +122,47 @@ public class BinaryFormatWriterTests
     }
 
     [Theory]
+    [MemberData(nameof(DrawingPrimitives_TestData))]
+    public void BinaryFormatWriter_TryWriteDrawingPrimitivesObject_SupportedObjects_RoundTrip(object value)
+    {
+        using MemoryStream stream = new();
+        BinaryFormatWriter.TryWriteDrawingPrimitivesObject(stream, value).Should().BeTrue();
+        stream.Position = 0;
+
+        SerializationRecord rootRecord = NrbfDecoder.Decode(stream);
+        bool result = rootRecord.TryGetDrawingPrimitivesObject(out object? deserialized);
+
+        result.Should().BeTrue();
+        deserialized.Should().NotBeNull();
+
+        if (value is Color color)
+        {
+            deserialized.Should().BeOfType<Color>().Which.Should().BeEquivalentTo(color);
+        }
+        else
+        {
+            deserialized.Should().Be(value);
+        }
+    }
+
+    [Theory]
     [MemberData(nameof(TryWriteObject_UnsupportedObjects_TestData))]
-    public void BinaryFormatWriter_TryWriteObject_UnsupportedObjects_RoundTrip(object value)
+    public void BinaryFormatWriter_TryWriteFrameworkObject_UnsupportedObjects_RoundTrip(object value)
     {
         using MemoryStream stream = new();
         BinaryFormatWriter.TryWriteFrameworkObject(stream, value).Should().BeFalse();
         stream.Position.Should().Be(0);
     }
 
-    public static IEnumerable<object[]?> TryWriteObject_SupportedObjects_TestData =>
+    [Fact]
+    public void BinaryFormatWriter_TryWriteDrawingPrimitivesObject_UnsupportedObjects_RoundTrip()
+    {
+        using MemoryStream stream = new();
+        BinaryFormatWriter.TryWriteDrawingPrimitivesObject(stream, Brushes.AliceBlue).Should().BeFalse();
+        stream.Position.Should().Be(0);
+    }
+
+    public static IEnumerable<object[]?> TryWriteFrameworkObject_SupportedObjects_TestData =>
         HashtableTests.Hashtables_TestData.Concat(
             ListTests.PrimitiveLists_TestData).Concat(
             ListTests.ArrayLists_TestData).Concat(
@@ -121,6 +180,30 @@ public class BinaryFormatWriterTests
     {
         new PointF(),
         new RectangleF()
+    };
+
+    public static TheoryData<object> DrawingPrimitives_TestData => new()
+    {
+        new Point(-1, 2),
+        new Point(int.MaxValue, int.MinValue),
+        Point.Empty,
+        Rectangle.Empty,
+        new Rectangle(1, 2, 3, 4),
+        new Rectangle(int.MinValue, int.MaxValue, 0, 0),
+        new Size(6, 7),
+        new Size(int.MaxValue, int.MinValue),
+        new Size(0, 0),
+        new SizeF(7F, 8F),
+        new SizeF(float.MaxValue, float.MinValue),
+        new SizeF(-float.MaxValue, float.PositiveInfinity),
+        new SizeF(0, 0),
+        Color.Empty,
+        Color.AliceBlue,
+        Color.FromKnownColor(KnownColor.ActiveCaption),
+        Color.FromArgb(1, 2, 3),
+        Color.FromArgb(4, Color.Yellow),
+        Color.FromName("Blue"),
+        SystemColors.ButtonFace
     };
 
     public static TheoryData<string?[]> StringArray_Parse_Data => new()

--- a/src/System.Private.Windows.Core/tests/BinaryFormatTests/SerializationRecordExtensionsTests.cs
+++ b/src/System.Private.Windows.Core/tests/BinaryFormatTests/SerializationRecordExtensionsTests.cs
@@ -1,0 +1,97 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections;
+using System.Drawing;
+using System.Formats.Nrbf;
+using System.Runtime.Serialization.Formatters.Binary;
+using FormatTests.FormattedObject;
+
+namespace System.Windows.Forms.Nrbf.Tests;
+
+public class SerializationRecordExtensionsTests
+{
+    public static IEnumerable<object[]?> TryGetFrameworkObject_SupportedObjects_TestData =>
+        BinaryFormatWriterTests.TryWriteFrameworkObject_SupportedObjects_TestData;
+
+    [Theory]
+    [MemberData(nameof(TryGetFrameworkObject_SupportedObjects_TestData))]
+    public void TryGetFrameworkObject_SupportedObjects_Read(object value)
+    {
+        using MemoryStream stream = new();
+        // cs/binary-formatter-without-binder
+        BinaryFormatter formatter = new(); // CodeQL [SM04191] : This is a test. Safe use because the deserialization process is performed on trusted data and the types are controlled and validated.
+
+        formatter.Serialize(stream, value);
+        stream.Position = 0;
+
+        SerializationRecord rootRecord = NrbfDecoder.Decode(stream);
+        bool result = rootRecord.TryGetFrameworkObject(out object? deserialized);
+
+        result.Should().BeTrue();
+
+        if (value is Hashtable hashtable)
+        {
+            Hashtable deserializedHashtable = (Hashtable)deserialized!;
+            deserializedHashtable.Count.Should().Be(hashtable.Count);
+            foreach (object? key in hashtable.Keys)
+            {
+                deserializedHashtable[key].Should().Be(hashtable[key]);
+            }
+        }
+        else if (value is IEnumerable enumerable)
+        {
+            ((IEnumerable)deserialized!).Should().BeEquivalentTo(enumerable);
+        }
+        else
+        {
+            deserialized.Should().Be(value);
+        }
+    }
+
+    public static IEnumerable<object[]?> TryGetDrawingPrimitives_SupportedObjects_TestData =>
+        BinaryFormatWriterTests.DrawingPrimitives_TestData;
+
+    [Theory]
+    [MemberData(nameof(TryGetDrawingPrimitives_SupportedObjects_TestData))]
+    public void TryGetDrawingPrimitivesObject_SupportedObjects_Read(object value)
+    {
+        using MemoryStream stream = new();
+        // cs/binary-formatter-without-binder
+        BinaryFormatter formatter = new(); // CodeQL [SM04191] : This is a test. Safe use because the deserialization process is performed on trusted data and the types are controlled and validated.
+
+        formatter.Serialize(stream, value);
+        stream.Position = 0;
+
+        SerializationRecord rootRecord = NrbfDecoder.Decode(stream);
+        bool result = rootRecord.TryGetDrawingPrimitivesObject(out object? deserialized);
+
+        result.Should().BeTrue();
+
+        if (value is Color color)
+        {
+            deserialized.Should().BeOfType<Color>().Which.Should().BeEquivalentTo(color);
+        }
+        else
+        {
+            deserialized.Should().Be(value);
+        }
+    }
+
+    [Fact]
+    public void BinaryFormatWriter_TryGetDrawingPrimitivesObject_Fail()
+    {
+        using MemoryStream stream = new();
+        // cs/binary-formatter-without-binder
+        BinaryFormatter formatter = new(); // CodeQL [SM04191] : This is a test. Safe use because the deserialization process is performed on trusted data and the types are controlled and validated.
+
+        formatter.Serialize(stream, "abc");
+        stream.Position = 0;
+
+        SerializationRecord rootRecord = NrbfDecoder.Decode(stream);
+
+        bool result = rootRecord.TryGetDrawingPrimitivesObject(out object? deserialized);
+        result.Should().BeFalse();
+        deserialized.Should().BeNull();
+    }
+}

--- a/src/System.Windows.Forms/src/System/Resources/ResXDataNode.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResXDataNode.cs
@@ -430,7 +430,7 @@ public sealed class ResXDataNode : ISerializable
         try
         {
             SerializationRecord rootRecord = stream.Decode();
-            if (rootRecord.TryGetObject(out object? value))
+            if (rootRecord.TryGetResXObject(out object? value))
             {
                 return value;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ActiveX/Control.ActiveXImpl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ActiveX/Control.ActiveXImpl.cs
@@ -980,7 +980,7 @@ public partial class Control
         internal HRESULT IsDirty() => _activeXState[s_isDirty] ? HRESULT.S_OK : HRESULT.S_FALSE;
 
         /// <summary>
-        ///  Looks at the property to see if it should be loaded / saved as a resource or  through a type converter.
+        ///  Looks at the property to see if it should be loaded / saved as a resource or through a type converter.
         /// </summary>
         private bool IsResourceProperty(PropertyDescriptor property)
         {
@@ -1142,7 +1142,7 @@ public partial class Control
                     try
                     {
                         SerializationRecord rootRecord = stream.Decode();
-                        success = rootRecord.TryGetObject(out deserialized);
+                        success = rootRecord.TryGetResXObject(out deserialized);
                     }
                     catch (Exception ex) when (!ex.IsCriticalException())
                     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/BinaryFormat/WinFormsBinaryFormatWriter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/BinaryFormat/WinFormsBinaryFormatWriter.cs
@@ -75,4 +75,13 @@ internal static class WinFormsBinaryFormatWriter
             return false;
         }
     }
+
+    /// <summary>
+    ///  Writes the given Framework, WinForms or System.Drawing.Primitives <paramref name="value"/> if supported.
+    /// </summary>
+    public static bool TryWriteCommonObject(Stream stream, object value)
+    {
+        return TryWriteObject(stream, value)
+            || BinaryFormatWriter.TryWriteDrawingPrimitivesObject(stream, value);
+    }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Nrbf/WinFormsSerializationRecordExtensions.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Nrbf/WinFormsSerializationRecordExtensions.cs
@@ -54,10 +54,14 @@ internal static class WinFormsSerializationRecordExtensions
     }
 
     /// <summary>
-    ///  Try to get a supported object.
+    ///  Try to get a supported object. This supports common types used in WinForms that do not have type converters.
     /// </summary>
-    public static bool TryGetObject(this SerializationRecord record, [NotNullWhen(true)] out object? value) =>
+    public static bool TryGetResXObject(this SerializationRecord record, [NotNullWhen(true)] out object? value) =>
         record.TryGetFrameworkObject(out value)
         || record.TryGetBitmap(out value)
         || record.TryGetImageListStreamer(out value);
+
+    public static bool TryGetCommonObject(this SerializationRecord record, [NotNullWhen(true)] out object? value) =>
+        record.TryGetResXObject(out value)
+        || record.TryGetDrawingPrimitivesObject(out value);
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/Clipboard.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/Clipboard.cs
@@ -15,7 +15,7 @@ namespace System.Windows.Forms;
 public static class Clipboard
 {
     /// <summary>
-    ///  Places nonpersistent data on the system <see cref="Clipboard"/>.
+    ///  Places non-persistent data on the system <see cref="Clipboard"/>.
     /// </summary>
     public static void SetDataObject(object data) => SetDataObject(data, copy: false);
 
@@ -81,7 +81,7 @@ public static class Clipboard
         if (Application.OleRequired() != ApartmentState.STA)
         {
             // Only throw if a message loop was started. This makes the case of trying to query the clipboard from the
-            // finalizer or non-ui MTA thread silently fail, instead of making the app die.
+            // finalizer or non-ui MTA thread silently fail, instead of making the application die.
             return Application.MessageLoop ? throw new ThreadStateException(SR.ThreadMustBeSTA) : null;
         }
 
@@ -166,7 +166,7 @@ public static class Clipboard
         !string.IsNullOrWhiteSpace(format) && ContainsData(format, autoConvert: false);
 
     private static bool ContainsData(string format, bool autoConvert) =>
-        GetDataObject() is { } dataObject && dataObject.GetDataPresent(format, autoConvert: autoConvert);
+        GetDataObject() is IDataObject dataObject && dataObject.GetDataPresent(format, autoConvert: autoConvert);
 
     /// <summary>
     ///  Indicates whether there is data on the Clipboard that is in the <see cref="DataFormats.FileDrop"/> format
@@ -210,7 +210,7 @@ public static class Clipboard
         string.IsNullOrWhiteSpace(format) ? null : GetData(format, autoConvert: false);
 
     private static object? GetData(string format, bool autoConvert) =>
-        GetDataObject() is { } dataObject ? dataObject.GetData(format, autoConvert) : null;
+        GetDataObject() is IDataObject dataObject ? dataObject.GetData(format, autoConvert) : null;
 
     /// <summary>
     ///  Retrieves a collection of file names from the <see cref="Clipboard"/>.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.Composition.BinaryFormatUtilities.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.Composition.BinaryFormatUtilities.cs
@@ -21,7 +21,7 @@ public unsafe partial class DataObject
 
                 try
                 {
-                    success = WinFormsBinaryFormatWriter.TryWriteObject(stream, data);
+                    success = WinFormsBinaryFormatWriter.TryWriteCommonObject(stream, data);
                 }
                 catch (Exception ex) when (!ex.IsCriticalException())
                 {
@@ -55,7 +55,7 @@ public unsafe partial class DataObject
                 long startPosition = stream.Position;
                 try
                 {
-                    if (stream.Decode().TryGetObject(out object? value))
+                    if (stream.Decode().TryGetCommonObject(out object? value))
                     {
                         return value;
                     }

--- a/src/System.Windows.Forms/tests/ComDisabledTests/ClipboardComTests.cs
+++ b/src/System.Windows.Forms/tests/ComDisabledTests/ClipboardComTests.cs
@@ -3,13 +3,11 @@
 
 #nullable enable
 
-using System.Drawing;
-
 namespace System.Windows.Forms.Tests;
 
-[Collection("Sequential")] // Each registered Clipboard format is an OS singleton,
-                           // and we should not run this test at the same time as other tests using the same format.
-public partial class ClipboardTests
+// These tests ensure that Clipboard works when built-in COM is disabled,
+// which is the case in trimming scenarios
+public class ClipboardComTests
 {
     [WinFormsFact]
     public void Clipboard_SetText_InvokeString_GetReturnsExpected()
@@ -18,15 +16,5 @@ public partial class ClipboardTests
 
         Clipboard.GetText().Should().Be("text");
         Clipboard.ContainsText().Should().BeTrue();
-    }
-
-    [WinFormsFact]
-    public void Clipboard_SetData_CustomFormat_Color()
-    {
-        string format = nameof(Clipboard_SetData_CustomFormat_Color);
-        Clipboard.SetData(format, Color.Black);
-
-        Clipboard.ContainsData(format).Should().BeTrue();
-        Clipboard.GetData(format).Should().Be(Color.Black);
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/BinaryFormatUtilitiesTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/BinaryFormatUtilitiesTests.cs
@@ -59,7 +59,12 @@ public partial class BinaryFormatUtilitiesTests : IDisposable
         (nuint)12,
         decimal.MaxValue,
         new PointF(1, 2),
-        new RectangleF(1, 2, 3, 4)
+        new RectangleF(1, 2, 3, 4),
+        new Point(-1, int.MaxValue),
+        new Rectangle(-1, int.MinValue, 10, 13),
+        new Size(int.MaxValue, int.MinValue),
+        new SizeF(float.MaxValue, float.MinValue),
+        Color.Red
     };
 
     public static TheoryData<IList> PrimitiveListObjects_TheoryData => new()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ClipboardTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ClipboardTests.cs
@@ -8,7 +8,6 @@ using System.ComponentModel;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.Runtime.InteropServices;
-using System.Runtime.Serialization.Formatters.Binary;
 using Com = Windows.Win32.System.Com;
 using ComTypes = System.Runtime.InteropServices.ComTypes;
 
@@ -482,29 +481,25 @@ public class ClipboardTests
     }
 
     [WinFormsFact]
-    public void Clipboard_SetData_CustomFormat_Color_BinaryFormatterDisabled_SerializesException()
+    public void Clipboard_SetData_CustomFormat_Color()
+    {
+        string format = nameof(Clipboard_SetData_CustomFormat_Color);
+        Clipboard.SetData(format, Color.Black);
+
+        Clipboard.ContainsData(format).Should().BeTrue();
+        Clipboard.GetData(format).Should().Be(Color.Black);
+    }
+
+    [WinFormsFact]
+    public void Clipboard_SetData_CustomFormat_Exception_BinaryFormatterDisabled_SerializesException()
     {
         using BinaryFormatterScope scope = new(enable: false);
-        string format = nameof(Clipboard_SetData_CustomFormat_Color_BinaryFormatterDisabled_SerializesException);
+        string format = nameof(Clipboard_SetData_CustomFormat_Exception_BinaryFormatterDisabled_SerializesException);
 
         // This will fail and NotSupportedException will be put on the Clipboard instead.
-        Clipboard.SetData(format, Color.Black);
+        Clipboard.SetData(format, new FileNotFoundException());
         Clipboard.ContainsData(format).Should().BeTrue();
-
-        using MemoryStream stream = new();
-#pragma warning disable SYSLIB0011 // Type or member is obsolete
-        BinaryFormatter formatter = new();
-#pragma warning restore SYSLIB0011
-        try
-        {
-            formatter.Serialize(stream, new object());
-        }
-        catch (NotSupportedException)
-        {
-            return;
-        }
-
-        Assert.Fail("Formatting should have failed.");
+        Clipboard.GetData(format).Should().BeOfType<NotSupportedException>();
     }
 
     [WinFormsFact]


### PR DESCRIPTION
Added Nrbf record extension/BinaryFormatWriter read/write functions for System.Drawing.Primitives types that are designer-serialized using TypeConverters, but require BinaryFormatter in Clipboard read/write operations. These types are

Color
Point
Rectangle
Size
SizeF

After this change, Clipboard operations with these types do not require the OOB BinaryFormatter implementation, see changes in ClipboardTests.cs for an example.


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12080)