### PR TITLE
Add unit tests for DesignerToolStripControlHost

### DIFF
--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DesignerToolStripControlHostTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DesignerToolStripControlHostTests.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+namespace System.Windows.Forms.Design.Tests;
+
+public class DesignerToolStripControlHostTests
+{
+    [Fact]
+    public void Constructor_SetsMarginToPaddingEmpty()
+    {
+        using Control control = new();
+
+        using DesignerToolStripControlHost host = new(control);
+
+        host.Margin.Should().Be(Padding.Empty);
+        host.Control.Should().NotBeNull();
+        host.Control.Should().Be(control);
+    }
+}


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->
Related https://github.com/dotnet/winforms/issues/10773
## Proposed changes
- Add unit test DesignerToolStripControlHostTests.cs for public properties and method of the DesignerToolStripControlHost.
- Enable nullability in DesignerToolStripControlHost.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12086)