### PR TITLE
Add Thread.Sleep before executing control.Paste

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/TextBoxBaseTests.ClipboardTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/TextBoxBaseTests.ClipboardTests.cs
@@ -8,6 +8,8 @@ public partial class TextBoxBaseTests
     [Collection("Sequential")]
     public class ClipboardTests
     {
+        private static void Sleep() => Thread.Sleep(100);
+
         [WinFormsFact]
         public void TextBoxBase_ClearUndo_CanUndo_Success()
         {
@@ -18,12 +20,12 @@ public partial class TextBoxBaseTests
                 SelectionLength = 2
             };
             control.Focus();
-            Thread.Sleep(100);
+            Sleep();
             control.Copy();
 
             control.Text = "text";
             control.SelectionLength = 2;
-            Thread.Sleep(100);
+            Sleep();
             control.Paste();
 
             control.Text.Should().Be("bcxt");
@@ -48,7 +50,7 @@ public partial class TextBoxBaseTests
 
             control.Text = "text";
             control.SelectionLength = 2;
-            Thread.Sleep(100);
+            Sleep();
             control.Paste();
 
             control.Text.Should().Be("bcxt");
@@ -83,7 +85,7 @@ public partial class TextBoxBaseTests
 
             control.Text = "text";
             control.SelectionLength = 2;
-            Thread.Sleep(100);
+            Sleep();
             control.Paste();
 
             control.Text.Should().Be("bcxt");
@@ -110,7 +112,7 @@ public partial class TextBoxBaseTests
 
             control.Text = "text";
             control.SelectionLength = 2;
-            Thread.Sleep(100);
+            Sleep();
             control.Paste();
 
             control.Text.Should().Be("bcxt");
@@ -136,7 +138,7 @@ public partial class TextBoxBaseTests
             int createdCallCount = 0;
             control.HandleCreated += (sender, e) => createdCallCount++;
 
-            Thread.Sleep(100);
+            Sleep();
             control.Cut();
             control.Text.Should().Be("a");
             control.IsHandleCreated.Should().BeTrue();
@@ -146,7 +148,7 @@ public partial class TextBoxBaseTests
 
             control.Text = "text";
             control.SelectionLength = 2;
-            Thread.Sleep(100);
+            Sleep();
             control.Paste();
 
             control.Text.Should().Be("bcxt");
@@ -163,7 +165,7 @@ public partial class TextBoxBaseTests
         {
             Clipboard.Clear();
             using SubTextBox control = new();
-            Thread.Sleep(100);
+            Sleep();
             control.Paste();
             control.Text.Should().BeEmpty();
             control.IsHandleCreated.Should().BeTrue();
@@ -179,7 +181,7 @@ public partial class TextBoxBaseTests
                 SelectionStart = 1,
                 SelectionLength = 2
             };
-            Thread.Sleep(100);
+            Sleep();
             control.Paste();
             control.Text.Should().Be("a");
             control.IsHandleCreated.Should().BeTrue();
@@ -198,7 +200,7 @@ public partial class TextBoxBaseTests
 
             control.Text = "text";
             control.SelectionLength = 2;
-            Thread.Sleep(100);
+            Sleep();
             control.Paste();
 
             control.Text.Should().Be("bcxt");

--- a/src/System.Windows.Forms/tests/UnitTests/TextBoxBaseTests.ClipboardTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/TextBoxBaseTests.ClipboardTests.cs
@@ -17,10 +17,13 @@ public partial class TextBoxBaseTests
                 SelectionStart = 1,
                 SelectionLength = 2
             };
+            control.Focus();
+            Thread.Sleep(100);
             control.Copy();
 
             control.Text = "text";
             control.SelectionLength = 2;
+            Thread.Sleep(100);
             control.Paste();
 
             control.Text.Should().Be("bcxt");
@@ -45,6 +48,7 @@ public partial class TextBoxBaseTests
 
             control.Text = "text";
             control.SelectionLength = 2;
+            Thread.Sleep(100);
             control.Paste();
 
             control.Text.Should().Be("bcxt");
@@ -79,6 +83,7 @@ public partial class TextBoxBaseTests
 
             control.Text = "text";
             control.SelectionLength = 2;
+            Thread.Sleep(100);
             control.Paste();
 
             control.Text.Should().Be("bcxt");
@@ -105,6 +110,7 @@ public partial class TextBoxBaseTests
 
             control.Text = "text";
             control.SelectionLength = 2;
+            Thread.Sleep(100);
             control.Paste();
 
             control.Text.Should().Be("bcxt");
@@ -130,6 +136,7 @@ public partial class TextBoxBaseTests
             int createdCallCount = 0;
             control.HandleCreated += (sender, e) => createdCallCount++;
 
+            Thread.Sleep(100);
             control.Cut();
             control.Text.Should().Be("a");
             control.IsHandleCreated.Should().BeTrue();
@@ -139,6 +146,7 @@ public partial class TextBoxBaseTests
 
             control.Text = "text";
             control.SelectionLength = 2;
+            Thread.Sleep(100);
             control.Paste();
 
             control.Text.Should().Be("bcxt");
@@ -155,6 +163,7 @@ public partial class TextBoxBaseTests
         {
             Clipboard.Clear();
             using SubTextBox control = new();
+            Thread.Sleep(100);
             control.Paste();
             control.Text.Should().BeEmpty();
             control.IsHandleCreated.Should().BeTrue();
@@ -170,6 +179,7 @@ public partial class TextBoxBaseTests
                 SelectionStart = 1,
                 SelectionLength = 2
             };
+            Thread.Sleep(100);
             control.Paste();
             control.Text.Should().Be("a");
             control.IsHandleCreated.Should().BeTrue();
@@ -188,6 +198,7 @@ public partial class TextBoxBaseTests
 
             control.Text = "text";
             control.SelectionLength = 2;
+            Thread.Sleep(100);
             control.Paste();
 
             control.Text.Should().Be("bcxt");


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #12002


## Proposed changes

- Add Thread.Sleep before executing control.Paste
- Add  control.Focus() before control.Copy()

<!-- We are in TELL-MODE the following section must be completed -->

## Regression? 

-  No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Running all tests in TextBoxBaseTests.ClipboardTests, there will always be 3-6 cases failing in 10 iterations

### After
Run all tests in TextBoxBaseTests.ClipboardTests for 100 iterations without failure

<img width="362" alt="image" src="https://github.com/user-attachments/assets/b855eb64-6ad2-492e-a355-bd8eb6808bfc">



## Test methodology <!-- How did you ensure quality? -->

- Manually
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12087)