### PR TITLE
fix: Border of SplitButton of ToolStrip is not contrasting enough …

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripHighContrastRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripHighContrastRenderer.cs
@@ -146,8 +146,8 @@ internal class ToolStripHighContrastRenderer : ToolStripSystemRenderer
             else if (item.Selected)
             {
                 g.FillRectangle(SystemBrushes.Highlight, bounds);
+                g.DrawRectangle(SystemPens.MenuHighlight, dropDownRect);
                 DrawHightContrastDashedBorder(g, e.Item);
-                g.DrawRectangle(SystemPens.ButtonHighlight, dropDownRect);
             }
 
             Color arrowColor = item.Selected && !item.Pressed ? SystemColors.HighlightText : SystemColors.ControlText;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripHighContrastRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripHighContrastRenderer.cs
@@ -146,7 +146,7 @@ internal class ToolStripHighContrastRenderer : ToolStripSystemRenderer
             else if (item.Selected)
             {
                 g.FillRectangle(SystemBrushes.Highlight, bounds);
-                g.DrawRectangle(SystemPens.MenuHighlight, dropDownRect);
+                g.DrawRectangle(SystemPens.HighlightText, dropDownRect);
                 DrawHightContrastDashedBorder(g, e.Item);
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripHighContrastRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripHighContrastRenderer.cs
@@ -147,6 +147,7 @@ internal class ToolStripHighContrastRenderer : ToolStripSystemRenderer
             {
                 g.FillRectangle(SystemBrushes.Highlight, bounds);
                 g.DrawRectangle(SystemPens.HighlightText, dropDownRect);
+
                 DrawHightContrastDashedBorder(g, e.Item);
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripSystemRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripSystemRenderer.cs
@@ -575,6 +575,17 @@ public class ToolStripSystemRenderer : ToolStripRenderer
             {
                 DrawArrow(new ToolStripArrowRenderEventArgs(g, splitButton, splitButton.DropDownButtonBounds, arrowColor, ArrowDirection.Down));
             }
+
+            ToolBarState state = GetToolBarState(e.Item);
+            if (e.Item is ToolStripSplitButton item && !SystemInformation.HighContrast &&
+                (state == ToolBarState.Hot || state == ToolBarState.Pressed || state == ToolBarState.Checked))
+            {
+                var clientBounds = item.ClientBounds;
+                bounds.Height -= 1;
+                ControlPaint.DrawBorderSimple(g, clientBounds, SystemColors.Highlight);
+                using var brush = SystemColors.Highlight.GetCachedSolidBrushScope();
+                g.FillRectangle(brush, item.SplitterBounds);
+            }
         }
         else
         {
@@ -616,12 +627,6 @@ public class ToolStripSystemRenderer : ToolStripRenderer
             }
 
             DrawArrow(new ToolStripArrowRenderEventArgs(g, splitButton, dropDownRect, arrowColor, ArrowDirection.Down));
-        }
-
-        if (e.Item is ToolStripSplitButton item && (item.ButtonPressed || item.Selected || item.ButtonSelected))
-        {
-            using var brush = SystemColors.WindowFrame.GetCachedSolidBrushScope();
-            g.FillRectangle(brush, item.SplitterBounds);
         }
     }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripSystemRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripSystemRenderer.cs
@@ -617,6 +617,12 @@ public class ToolStripSystemRenderer : ToolStripRenderer
 
             DrawArrow(new ToolStripArrowRenderEventArgs(g, splitButton, dropDownRect, arrowColor, ArrowDirection.Down));
         }
+
+        if (e.Item is ToolStripSplitButton item && (item.ButtonPressed || item.Selected || item.ButtonSelected))
+        {
+            using var brush = SystemColors.WindowFrame.GetCachedSolidBrushScope();
+            g.FillRectangle(brush, item.SplitterBounds);
+        }
     }
 
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolstripProfessionalRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolstripProfessionalRenderer.cs
@@ -296,7 +296,22 @@ public class ToolStripProfessionalRenderer : ToolStripRenderer
 
         if (buttonPressedOrSelected && !item.Pressed)
         {
-            using var brush = ColorTable.ButtonSelectedBorder.GetCachedSolidBrushScope();
+            //#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+            //            if (Application.IsDarkModeEnabled)
+            //            {
+            //                using var brush = SystemColors.HighlightText.GetCachedSolidBrushScope();
+            //                g.FillRectangle(brush, item.SplitterBounds);
+            //            }
+            //#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+            //            else
+            //            {
+            //                using var brush = ColorTable.ButtonSelectedBorder.GetCachedSolidBrushScope();
+            //                g.FillRectangle(brush, item.SplitterBounds);
+            //            }
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+            using var brush = Application.IsDarkModeEnabled ?
+                Color.Silver.GetCachedSolidBrushScope() : ColorTable.ButtonSelectedBorder.GetCachedSolidBrushScope();
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
             g.FillRectangle(brush, item.SplitterBounds);
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolstripProfessionalRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolstripProfessionalRenderer.cs
@@ -296,18 +296,6 @@ public class ToolStripProfessionalRenderer : ToolStripRenderer
 
         if (buttonPressedOrSelected && !item.Pressed)
         {
-            //#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-            //            if (Application.IsDarkModeEnabled)
-            //            {
-            //                using var brush = SystemColors.HighlightText.GetCachedSolidBrushScope();
-            //                g.FillRectangle(brush, item.SplitterBounds);
-            //            }
-            //#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
-            //            else
-            //            {
-            //                using var brush = ColorTable.ButtonSelectedBorder.GetCachedSolidBrushScope();
-            //                g.FillRectangle(brush, item.SplitterBounds);
-            //            }
 #pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
             using var brush = Application.IsDarkModeEnabled ?
                 Color.Silver.GetCachedSolidBrushScope() : ColorTable.ButtonSelectedBorder.GetCachedSolidBrushScope();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripButtonTests.Rendering.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripButtonTests.Rendering.cs
@@ -162,8 +162,9 @@ public partial class ToolStripButtonTests
                 bounds: null,
                 points: null,
                 State.Brush(SystemColors.Highlight, BRUSH_STYLE.BS_SOLID)),
+           Validate.SkipType(ENHANCED_METAFILE_RECORD_TYPE.EMR_POLYGON16),
            Validate.Repeat(Validate.SkipType(ENHANCED_METAFILE_RECORD_TYPE.EMR_POLYPOLYGON16), 2),
-           Validate.Repeat(Validate.SkipType(ENHANCED_METAFILE_RECORD_TYPE.EMR_POLYGON16), 2));
+           Validate.SkipType(ENHANCED_METAFILE_RECORD_TYPE.EMR_POLYGON16));
     }
 
     private class ToolStripSystemHighContrastRenderer : ToolStripSystemRenderer


### PR DESCRIPTION


<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #12083


## Proposed changes

- 
- Change `Pen` to a more contrasting `Pen`
- 

<!-- 

## Customer Impact

- 
- 

## Regression? 

- Yes / No

## Risk

-


 -->

## Screenshots

### Before


![image](https://github.com/user-attachments/assets/65947dea-4bf2-44c9-b3d7-f5bf024db08d)

![image](https://github.com/user-attachments/assets/2b0da2ef-324c-4242-b39f-95ea55e2035f)


![image](https://github.com/user-attachments/assets/92766ef4-790c-43e4-8d56-60f75828f403)
![image](https://github.com/user-attachments/assets/25c85585-5679-437a-a57a-d3de8b9bdf3e)

### After

![image](https://github.com/user-attachments/assets/a6d6b436-528f-4d30-9ac0-fdf2f0d722d1)
![image](https://github.com/user-attachments/assets/b182af4b-9d2f-4020-8d66-5f49c01ad0e5)

![image](https://github.com/user-attachments/assets/0220e49f-f439-4069-9a2e-e7439d6cf7f0)

![image](https://github.com/user-attachments/assets/549135be-e80c-4b0f-bfdf-863ecd7f53a3)

## Test methodology 

- 
- Manually 
- 
<!-- 
## Accessibility testing  



 

## Test environment(s) 
 -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12092)