### PR TITLE
Add core coverage for ListAdapter

### DIFF
--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ListAdapterTest.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ListAdapterTest.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System.Collections;
+
+namespace System.Windows.Forms.Design.Tests;
+
+public class ListAdapterTest
+{
+    [Fact]
+    public void ListAdapter_Unwrap_ReturnsOriginalList()
+    {
+        // Arrange
+        var originalList = new ArrayList { 1, 2, 3 };
+        ListAdapter<int> adapter = new(originalList);
+
+        // Act
+        var unwrappedList = adapter.Unwrap();
+
+        // Assert
+        Assert.Same(originalList, unwrappedList);
+    }
+}
+
+


### PR DESCRIPTION
Related https://github.com/dotnet/winforms/issues/10773

## Proposed changes

Add unit test ListAdapterTests.cs for public properties and method of the ListAdapter.
Enable nullability in ListAdapter.
