### PR TITLE
Add unit test for TabPageDesigner.cs file

### DIFF
--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/TabPageDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/TabPageDesignerTests.cs
@@ -1,0 +1,71 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System.ComponentModel.Design;
+using Moq;
+
+namespace System.Windows.Forms.Design.Tests;
+
+public class TabPageDesignerTests
+{
+    [Fact]
+    public void CanBeParentedTo_WithNullParentDesigner_ReturnsFalse()
+    {
+        using TabPage tabPage = new();
+        using TabPageDesigner designer = new();
+        designer.Initialize(tabPage);
+
+        bool result = designer.CanBeParentedTo(null);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void CanBeParentedTo_WithNonTabControlParentDesigner_ReturnsFalse()
+    {
+        Mock<IDesigner> mockDesigner = new();
+        using TabPage tabPage = new();
+        using TabPageDesigner designer = new();
+        designer.Initialize(tabPage);
+
+        bool result = designer.CanBeParentedTo(mockDesigner.Object);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void CanBeParentedTo_WithTabControlParentDesigner_ReturnsTrue()
+    {
+        Mock<TabControl> mockTabControl = new();
+        Mock<IDesigner> mockDesigner = new();
+        mockDesigner.Setup(d => d.Component).Returns(mockTabControl.Object);
+        using TabPage tabPage = new();
+        using TabPageDesigner designer = new();
+        designer.Initialize(tabPage);
+
+        bool result = designer.CanBeParentedTo(mockDesigner.Object);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void SelectionRules_WithTabControlParent_ReturnsCorrectSelectionRules()
+    {
+        using TabControl tabControl = new();
+        using TabPage tabPage = new();
+        tabControl.TabPages.Add(tabPage);
+        using TabPageDesigner designer = new();
+        designer.Initialize(tabControl);
+
+        SelectionRules selectionRules;
+        using (new NoAssertContext())
+        {
+            selectionRules = designer.SelectionRules;
+        }
+
+        selectionRules.Should().Be(SelectionRules.AllSizeable | SelectionRules.Moveable | SelectionRules.Visible);
+    }
+}
+

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/TabPageDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/TabPageDesignerTests.cs
@@ -10,23 +10,25 @@ namespace System.Windows.Forms.Design.Tests;
 
 public class TabPageDesignerTests
 {
-    private TabPageDesigner InitializeDesignerWithTabPage()
+    private (TabPageDesigner designer, TabPage tabPage) InitializeDesignerWithTabPage()
     {
-        using TabPage tabPage = new();
+        TabPage tabPage = new();
         TabPageDesigner designer = new();
         designer.Initialize(tabPage);
-        return designer;
+        return (designer, tabPage);
     }
 
     [Fact]
     public void CanBeParentedTo_WithNonTabControlParentDesigner_ReturnsFalse()
     {
         Mock<IDesigner> mockDesigner = new();
-        using var designer = InitializeDesignerWithTabPage();
-
-        bool result = designer.CanBeParentedTo(mockDesigner.Object);
-
-        result.Should().BeFalse();
+        var (designer, tabPage) = InitializeDesignerWithTabPage();
+        using (designer)
+        using (tabPage)
+        {
+            bool result = designer.CanBeParentedTo(mockDesigner.Object);
+            result.Should().BeFalse();
+        }
     }
 
     [Fact]
@@ -35,11 +37,13 @@ public class TabPageDesignerTests
         Mock<TabControl> mockTabControl = new();
         Mock<IDesigner> mockDesigner = new();
         mockDesigner.Setup(d => d.Component).Returns(mockTabControl.Object);
-        using var designer = InitializeDesignerWithTabPage();
-
-        bool result = designer.CanBeParentedTo(mockDesigner.Object);
-
-        result.Should().BeTrue();
+        var (designer, tabPage) = InitializeDesignerWithTabPage();
+        using (designer)
+        using (tabPage)
+        {
+            bool result = designer.CanBeParentedTo(mockDesigner.Object);
+            result.Should().BeTrue();
+        }
     }
 
     [Fact]

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/TabPageDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/TabPageDesignerTests.cs
@@ -10,13 +10,19 @@ namespace System.Windows.Forms.Design.Tests;
 
 public class TabPageDesignerTests
 {
+    private TabPageDesigner InitializeDesignerWithTabPage()
+    {
+        using TabPage tabPage = new();
+        TabPageDesigner designer = new();
+        designer.Initialize(tabPage);
+        return designer;
+    }
+
     [Fact]
     public void CanBeParentedTo_WithNonTabControlParentDesigner_ReturnsFalse()
     {
         Mock<IDesigner> mockDesigner = new();
-        using TabPage tabPage = new();
-        using TabPageDesigner designer = new();
-        designer.Initialize(tabPage);
+        using var designer = InitializeDesignerWithTabPage();
 
         bool result = designer.CanBeParentedTo(mockDesigner.Object);
 
@@ -29,9 +35,7 @@ public class TabPageDesignerTests
         Mock<TabControl> mockTabControl = new();
         Mock<IDesigner> mockDesigner = new();
         mockDesigner.Setup(d => d.Component).Returns(mockTabControl.Object);
-        using TabPage tabPage = new();
-        using TabPageDesigner designer = new();
-        designer.Initialize(tabPage);
+        using var designer = InitializeDesignerWithTabPage();
 
         bool result = designer.CanBeParentedTo(mockDesigner.Object);
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/TabPageDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/TabPageDesignerTests.cs
@@ -11,18 +11,6 @@ namespace System.Windows.Forms.Design.Tests;
 public class TabPageDesignerTests
 {
     [Fact]
-    public void CanBeParentedTo_WithNullParentDesigner_ReturnsFalse()
-    {
-        using TabPage tabPage = new();
-        using TabPageDesigner designer = new();
-        designer.Initialize(tabPage);
-
-        bool result = designer.CanBeParentedTo(null);
-
-        result.Should().BeFalse();
-    }
-
-    [Fact]
     public void CanBeParentedTo_WithNonTabControlParentDesigner_ReturnsFalse()
     {
         Mock<IDesigner> mockDesigner = new();

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/TabPageDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/TabPageDesignerTests.cs
@@ -68,4 +68,3 @@ public class TabPageDesignerTests
         selectionRules.Should().Be(SelectionRules.AllSizeable | SelectionRules.Moveable | SelectionRules.Visible);
     }
 }
-


### PR DESCRIPTION
Related https://github.com/dotnet/winforms/issues/10773


## Proposed changes

- Add unit test file: TabPageDesignerTests.cs for public properties of the TabPageDesigner.cs.
- Enable nullability in TabPageDesignerTests.cs.


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12097)