### PR TITLE
Change IPointer interface method to return nint

### DIFF
--- a/src/System.Drawing.Common/src/System/Drawing/Bitmap.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Bitmap.cs
@@ -128,7 +128,7 @@ public sealed unsafe class Bitmap : Image, IPointer<GpBitmap>
     {
     }
 
-    GpBitmap* IPointer<GpBitmap>.Pointer => (GpBitmap*)((Image)this).Pointer();
+    nint IPointer.Pointer => NativeImage;
 
     public static Bitmap FromHicon(IntPtr hicon)
     {

--- a/src/System.Drawing.Common/src/System/Drawing/Bitmap.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Bitmap.cs
@@ -128,7 +128,7 @@ public sealed unsafe class Bitmap : Image, IPointer<GpBitmap>
     {
     }
 
-    nint IPointer.Pointer => NativeImage;
+    nint IPointer<GpBitmap>.Pointer => (nint)((Image)this).Pointer();
 
     public static Bitmap FromHicon(IntPtr hicon)
     {

--- a/src/System.Drawing.Common/src/System/Drawing/FontFamily.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/FontFamily.cs
@@ -16,7 +16,7 @@ public sealed unsafe class FontFamily : MarshalByRefObject, IDisposable, IPointe
     private GpFontFamily* _nativeFamily;
     private bool _fromInstalledFontCollection;
 
-    nint IPointer.Pointer => (nint)_nativeFamily;
+    nint IPointer<GpFontFamily>.Pointer => (nint)_nativeFamily;
 
     private void SetNativeFamily(GpFontFamily* family)
     {

--- a/src/System.Drawing.Common/src/System/Drawing/FontFamily.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/FontFamily.cs
@@ -16,7 +16,7 @@ public sealed unsafe class FontFamily : MarshalByRefObject, IDisposable, IPointe
     private GpFontFamily* _nativeFamily;
     private bool _fromInstalledFontCollection;
 
-    GpFontFamily* IPointer<GpFontFamily>.Pointer => _nativeFamily;
+    nint IPointer.Pointer => (nint)_nativeFamily;
 
     private void SetNativeFamily(GpFontFamily* family)
     {

--- a/src/System.Drawing.Common/src/System/Drawing/Graphics.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Graphics.cs
@@ -195,7 +195,7 @@ public sealed unsafe partial class Graphics : MarshalByRefObject, IDisposable, I
     /// </summary>
     internal GpGraphics* NativeGraphics { get; private set; }
 
-    GpGraphics* IPointer<GpGraphics>.Pointer => NativeGraphics;
+    nint IPointer.Pointer => (nint)NativeGraphics;
 
     public Region Clip
     {

--- a/src/System.Drawing.Common/src/System/Drawing/Graphics.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Graphics.cs
@@ -195,7 +195,7 @@ public sealed unsafe partial class Graphics : MarshalByRefObject, IDisposable, I
     /// </summary>
     internal GpGraphics* NativeGraphics { get; private set; }
 
-    nint IPointer.Pointer => (nint)NativeGraphics;
+    nint IPointer<GpGraphics>.Pointer => (nint)NativeGraphics;
 
     public Region Clip
     {

--- a/src/System.Drawing.Common/src/System/Drawing/Image.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Image.cs
@@ -32,9 +32,7 @@ public abstract unsafe class Image : MarshalByRefObject, IImage, IDisposable, IC
     // to modify it, in order to preserve compatibility.
     public delegate bool GetThumbnailImageAbort();
 
-    nint IPointer.Pointer => NativeImage;
-
-    protected internal nint NativeImage => (nint)_nativeImage;
+    nint IPointer<GpImage>.Pointer => (nint)_nativeImage;
 
     [NonSerialized]
     private GpImage* _nativeImage;

--- a/src/System.Drawing.Common/src/System/Drawing/Image.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Image.cs
@@ -32,7 +32,9 @@ public abstract unsafe class Image : MarshalByRefObject, IImage, IDisposable, IC
     // to modify it, in order to preserve compatibility.
     public delegate bool GetThumbnailImageAbort();
 
-    GpImage* IPointer<GpImage>.Pointer => _nativeImage;
+    nint IPointer.Pointer => NativeImage;
+
+    protected internal nint NativeImage => (nint)_nativeImage;
 
     [NonSerialized]
     private GpImage* _nativeImage;

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/ColorPalette.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/ColorPalette.cs
@@ -108,7 +108,7 @@ public sealed unsafe class ColorPalette
                 (GdiPlus.PaletteType)fixedPaletteType,
                 colorCount,
                 useTransparentColor,
-                bitmap is null ? null : bitmap.Pointer).ThrowIfFailed();
+                bitmap is null ? null : (GpBitmap*)bitmap.Pointer).ThrowIfFailed();
         }
 
         GC.KeepAlive(bitmap);

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/ColorPalette.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/ColorPalette.cs
@@ -108,7 +108,7 @@ public sealed unsafe class ColorPalette
                 (GdiPlus.PaletteType)fixedPaletteType,
                 colorCount,
                 useTransparentColor,
-                bitmap is null ? null : (GpBitmap*)bitmap.Pointer).ThrowIfFailed();
+                bitmap is null ? null : bitmap.GetPointer()).ThrowIfFailed();
         }
 
         GC.KeepAlive(bitmap);

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/Metafile.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/Metafile.cs
@@ -21,7 +21,7 @@ public sealed unsafe class Metafile : Image, IPointer<GpMetafile>
     // GDI+ doesn't handle filenames over MAX_PATH very well
     private const int MaxPath = 260;
 
-    nint IPointer.Pointer => NativeImage;
+    nint IPointer<GpMetafile>.Pointer => (nint)this.Pointer();
 
     /// <summary>
     ///  Initializes a new instance of the <see cref='Metafile'/> class from the specified handle and

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/Metafile.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/Metafile.cs
@@ -21,7 +21,7 @@ public sealed unsafe class Metafile : Image, IPointer<GpMetafile>
     // GDI+ doesn't handle filenames over MAX_PATH very well
     private const int MaxPath = 260;
 
-    GpMetafile* IPointer<GpMetafile>.Pointer => this.Pointer();
+    nint IPointer.Pointer => NativeImage;
 
     /// <summary>
     ///  Initializes a new instance of the <see cref='Metafile'/> class from the specified handle and

--- a/src/System.Drawing.Common/src/System/Drawing/PointerExtensions.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/PointerExtensions.cs
@@ -14,19 +14,19 @@ internal static unsafe class PointerExtensions
     public static GpPen* Pointer(this Pen? pen) => pen is null ? null : pen.NativePen;
     public static GpStringFormat* Pointer(this StringFormat? format) => format is null ? null : format._nativeFormat;
 
-    internal static GpFontFamily* Pointer(this IPointer<GpFontFamily>? family) => family is null ? null : family.Pointer;
+    internal static GpFontFamily* Pointer(this IPointer<GpFontFamily>? family) => family is null ? null : (GpFontFamily*)family.Pointer;
 
     internal static GpFontCollection* Pointer(this IPointer<GpFontCollection>? fontCollection) =>
-        fontCollection is null ? null : fontCollection.Pointer;
+        fontCollection is null ? null : (GpFontCollection*)fontCollection.Pointer;
 
     public static GpPath* Pointer(this Drawing2D.GraphicsPath? path) => path is null ? null : path._nativePath;
     public static GpBrush* Pointer(this Brush? brush) => brush is null ? null : brush.NativeBrush;
     public static GpImageAttributes* Pointer(this ImageAttributes? imageAttr) => imageAttr is null ? null : imageAttr._nativeImageAttributes;
     public static GpGraphics* Pointer(this Graphics? graphics) => graphics is null ? null : graphics.NativeGraphics;
     public static GpFont* Pointer(this Font? font) => font is null ? null : font.NativeFont;
-    public static GpBitmap* Pointer(this Bitmap? bitmap) => bitmap is null ? null : ((IPointer<GpBitmap>)bitmap).Pointer;
+    public static GpBitmap* Pointer(this Bitmap? bitmap) => bitmap is null ? null : (GpBitmap*)((IPointer<GpBitmap>)bitmap).Pointer;
     public static GpMetafile* Pointer(this Metafile? metafile) => metafile is null ? null : (GpMetafile*)((Image)metafile).Pointer();
-    public static GpImage* Pointer(this Image? image) => image is null ? null : ((IPointer<GpImage>)image).Pointer;
+    public static GpImage* Pointer(this Image? image) => image is null ? null : (GpImage*)((IPointer<GpImage>)image).Pointer;
 #if NET9_0_OR_GREATER
     public static CGpEffect* Pointer(this Effect? effect) => effect is null ? null : effect.NativeEffect;
 #endif

--- a/src/System.Drawing.Common/src/System/Drawing/PointerExtensions.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/PointerExtensions.cs
@@ -14,19 +14,19 @@ internal static unsafe class PointerExtensions
     public static GpPen* Pointer(this Pen? pen) => pen is null ? null : pen.NativePen;
     public static GpStringFormat* Pointer(this StringFormat? format) => format is null ? null : format._nativeFormat;
 
-    internal static GpFontFamily* Pointer(this IPointer<GpFontFamily>? family) => family is null ? null : (GpFontFamily*)family.Pointer;
+    internal static GpFontFamily* Pointer(this IPointer<GpFontFamily>? family) => family is null ? null : family.GetPointer();
 
     internal static GpFontCollection* Pointer(this IPointer<GpFontCollection>? fontCollection) =>
-        fontCollection is null ? null : (GpFontCollection*)fontCollection.Pointer;
+        fontCollection is null ? null : fontCollection.GetPointer();
 
     public static GpPath* Pointer(this Drawing2D.GraphicsPath? path) => path is null ? null : path._nativePath;
     public static GpBrush* Pointer(this Brush? brush) => brush is null ? null : brush.NativeBrush;
     public static GpImageAttributes* Pointer(this ImageAttributes? imageAttr) => imageAttr is null ? null : imageAttr._nativeImageAttributes;
     public static GpGraphics* Pointer(this Graphics? graphics) => graphics is null ? null : graphics.NativeGraphics;
     public static GpFont* Pointer(this Font? font) => font is null ? null : font.NativeFont;
-    public static GpBitmap* Pointer(this Bitmap? bitmap) => bitmap is null ? null : (GpBitmap*)((IPointer<GpBitmap>)bitmap).Pointer;
+    public static GpBitmap* Pointer(this Bitmap? bitmap) => bitmap is null ? null : ((IPointer<GpBitmap>)bitmap).GetPointer();
     public static GpMetafile* Pointer(this Metafile? metafile) => metafile is null ? null : (GpMetafile*)((Image)metafile).Pointer();
-    public static GpImage* Pointer(this Image? image) => image is null ? null : (GpImage*)((IPointer<GpImage>)image).Pointer;
+    public static GpImage* Pointer(this Image? image) => image is null ? null : image.GetPointer();
 #if NET9_0_OR_GREATER
     public static CGpEffect* Pointer(this Effect? effect) => effect is null ? null : effect.NativeEffect;
 #endif

--- a/src/System.Drawing.Common/src/System/Drawing/Region.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Region.cs
@@ -9,7 +9,7 @@ public sealed unsafe class Region : MarshalByRefObject, IDisposable, IPointer<Gp
 {
     internal GpRegion* NativeRegion { get; private set; }
 
-    nint IPointer.Pointer => (nint)NativeRegion;
+    nint IPointer<GpRegion>.Pointer => (nint)NativeRegion;
 
     public Region()
     {

--- a/src/System.Drawing.Common/src/System/Drawing/Region.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Region.cs
@@ -9,7 +9,7 @@ public sealed unsafe class Region : MarshalByRefObject, IDisposable, IPointer<Gp
 {
     internal GpRegion* NativeRegion { get; private set; }
 
-    GpRegion* IPointer<GpRegion>.Pointer => NativeRegion;
+    nint IPointer.Pointer => (nint)NativeRegion;
 
     public Region()
     {

--- a/src/System.Drawing.Common/src/System/Drawing/Text/FontCollection.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Text/FontCollection.cs
@@ -9,7 +9,7 @@ namespace System.Drawing.Text;
 public abstract unsafe class FontCollection : IDisposable, IPointer<GpFontCollection>
 {
     private GpFontCollection* _nativeFontCollection;
-    nint IPointer.Pointer => (nint)_nativeFontCollection;
+    nint IPointer<GpFontCollection>.Pointer => (nint)_nativeFontCollection;
 
     private protected FontCollection(GpFontCollection* nativeFontCollection) => _nativeFontCollection = nativeFontCollection;
 

--- a/src/System.Drawing.Common/src/System/Drawing/Text/FontCollection.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Text/FontCollection.cs
@@ -9,7 +9,7 @@ namespace System.Drawing.Text;
 public abstract unsafe class FontCollection : IDisposable, IPointer<GpFontCollection>
 {
     private GpFontCollection* _nativeFontCollection;
-    GpFontCollection* IPointer<GpFontCollection>.Pointer => _nativeFontCollection;
+    nint IPointer.Pointer => (nint)_nativeFontCollection;
 
     private protected FontCollection(GpFontCollection* nativeFontCollection) => _nativeFontCollection = nativeFontCollection;
 

--- a/src/System.Drawing.Common/tests/System/Drawing/FontFamilyTests.cs
+++ b/src/System.Drawing.Common/tests/System/Drawing/FontFamilyTests.cs
@@ -3,7 +3,6 @@
 
 using System.Drawing.Text;
 using Windows.Win32.Foundation;
-using Windows.Win32.Graphics.GdiPlus;
 
 namespace System.Drawing.Tests;
 
@@ -288,7 +287,7 @@ public class FontFamilyTests
         using FontFamily fontFamily1 = new("Calibri");
         using FontFamily fontFamily2 = new("Calibri");
         Assert.Equal(
-            ((IPointer<GpFontFamily>)fontFamily1).Pointer,
-            ((IPointer<GpFontFamily>)fontFamily2).Pointer);
+            (nint)fontFamily1.GetPointer(),
+            (nint)fontFamily2.GetPointer());
     }
 }

--- a/src/System.Drawing.Common/tests/System/Drawing/FontFamilyTests.cs
+++ b/src/System.Drawing.Common/tests/System/Drawing/FontFamilyTests.cs
@@ -288,7 +288,7 @@ public class FontFamilyTests
         using FontFamily fontFamily1 = new("Calibri");
         using FontFamily fontFamily2 = new("Calibri");
         Assert.Equal(
-            (nint)((IPointer<GpFontFamily>)fontFamily1).Pointer,
-            (nint)((IPointer<GpFontFamily>)fontFamily2).Pointer);
+            ((IPointer<GpFontFamily>)fontFamily1).Pointer,
+            ((IPointer<GpFontFamily>)fontFamily2).Pointer);
     }
 }

--- a/src/System.Private.Windows.Core/src/System/Drawing/CoreImageExtensions.cs
+++ b/src/System.Private.Windows.Core/src/System/Drawing/CoreImageExtensions.cs
@@ -25,13 +25,13 @@ internal static unsafe class CoreImageExtensions
         }
 
         using var iStream = stream.ToIStream();
-        PInvokeCore.GdipSaveImageToStream(image.Pointer, iStream, &encoder, encoderParameters).ThrowIfFailed();
+        PInvokeCore.GdipSaveImageToStream((GpImage*)image.Pointer, iStream, &encoder, encoderParameters).ThrowIfFailed();
     }
 
     internal static void Save(this IImage image, MemoryStream stream)
     {
         Guid format = default;
-        PInvokeCore.GdipGetImageRawFormat(image.Pointer, &format).ThrowIfFailed();
+        PInvokeCore.GdipGetImageRawFormat((GpImage*)image.Pointer, &format).ThrowIfFailed();
 
         Guid encoder = ImageCodecInfoHelper.GetEncoderClsid(format);
 

--- a/src/System.Private.Windows.Core/src/System/Drawing/CoreImageExtensions.cs
+++ b/src/System.Private.Windows.Core/src/System/Drawing/CoreImageExtensions.cs
@@ -25,13 +25,13 @@ internal static unsafe class CoreImageExtensions
         }
 
         using var iStream = stream.ToIStream();
-        PInvokeCore.GdipSaveImageToStream((GpImage*)image.Pointer, iStream, &encoder, encoderParameters).ThrowIfFailed();
+        PInvokeCore.GdipSaveImageToStream(image.GetPointer(), iStream, &encoder, encoderParameters).ThrowIfFailed();
     }
 
     internal static void Save(this IImage image, MemoryStream stream)
     {
         Guid format = default;
-        PInvokeCore.GdipGetImageRawFormat((GpImage*)image.Pointer, &format).ThrowIfFailed();
+        PInvokeCore.GdipGetImageRawFormat(image.GetPointer(), &format).ThrowIfFailed();
 
         Guid encoder = ImageCodecInfoHelper.GetEncoderClsid(format);
 

--- a/src/System.Private.Windows.Core/src/Windows/Win32/Foundation/IPointer.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/Foundation/IPointer.cs
@@ -13,5 +13,6 @@ namespace Windows.Win32.Foundation;
 /// </remarks>
 internal unsafe interface IPointer<TPointer> where TPointer : unmanaged
 {
+    [Obsolete("Use extension method GetPointer on IPointer<T> to get the typed pointer instead.")]
     nint Pointer { get; }
 }

--- a/src/System.Private.Windows.Core/src/Windows/Win32/Foundation/IPointer.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/Foundation/IPointer.cs
@@ -4,14 +4,21 @@
 namespace Windows.Win32.Foundation;
 
 /// <summary>
-///  Used to indicate ownership of a native resource pointer.
+///  Used to indicate ownership of a native resource pointer with type information.
 /// </summary>
 /// <remarks>
 ///  <para>
 ///   This should never be put on a struct.
 ///  </para>
 /// </remarks>
-internal unsafe interface IPointer<TPointer> where TPointer : unmanaged
+internal unsafe interface IPointer<TPointer> : IPointer where TPointer : unmanaged
 {
-    TPointer* Pointer { get; }
+}
+
+/// <summary>
+///  Used to indicate ownership of a native resource pointer.
+/// </summary>
+internal interface IPointer
+{
+    nint Pointer { get; }
 }

--- a/src/System.Private.Windows.Core/src/Windows/Win32/Foundation/IPointer.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/Foundation/IPointer.cs
@@ -4,21 +4,14 @@
 namespace Windows.Win32.Foundation;
 
 /// <summary>
-///  Used to indicate ownership of a native resource pointer with type information.
+///  Used to indicate ownership of a native resource pointer.
 /// </summary>
 /// <remarks>
 ///  <para>
 ///   This should never be put on a struct.
 ///  </para>
 /// </remarks>
-internal unsafe interface IPointer<TPointer> : IPointer where TPointer : unmanaged
-{
-}
-
-/// <summary>
-///  Used to indicate ownership of a native resource pointer.
-/// </summary>
-internal interface IPointer
+internal unsafe interface IPointer<TPointer> where TPointer : unmanaged
 {
     nint Pointer { get; }
 }

--- a/src/System.Private.Windows.Core/src/Windows/Win32/Foundation/IPointer.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/Foundation/IPointer.cs
@@ -13,6 +13,10 @@ namespace Windows.Win32.Foundation;
 /// </remarks>
 internal unsafe interface IPointer<TPointer> where TPointer : unmanaged
 {
+    // This interface method must return a nint instead of a typed pointer directly because
+    // CLI/CLR C++ mixed code cannot compile generic pointers and
+    // System.Private.Windows.Core is included in the ref.
+    // See https://github.com/dotnet/winforms/issues/11983 for more details.
     [Obsolete("Use extension method GetPointer on IPointer<T> to get the typed pointer instead.")]
     nint Pointer { get; }
 }

--- a/src/System.Private.Windows.Core/src/Windows/Win32/Foundation/IPointer.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/Foundation/IPointer.cs
@@ -14,7 +14,7 @@ namespace Windows.Win32.Foundation;
 internal unsafe interface IPointer<TPointer> where TPointer : unmanaged
 {
     // This interface method must return a nint instead of a typed pointer directly because
-    // CLI/CLR C++ mixed code cannot compile generic pointers and
+    // C++/CLI cannot compile when it encounters generic pointers, even in internal interfaces.
     // System.Private.Windows.Core is included in the ref.
     // See https://github.com/dotnet/winforms/issues/11983 for more details.
     [Obsolete("Use extension method GetPointer on IPointer<T> to get the typed pointer instead.")]

--- a/src/System.Private.Windows.Core/src/Windows/Win32/Foundation/IPointerExtensions.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/Foundation/IPointerExtensions.cs
@@ -1,0 +1,8 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Windows.Win32.Foundation;
+internal static unsafe class IPointerExtensions
+{
+    public static T* GetPointer<T>(this IPointer pointer) where T : unmanaged => (T*)pointer.Pointer;
+}

--- a/src/System.Private.Windows.Core/src/Windows/Win32/Foundation/PointerExtensions.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/Foundation/PointerExtensions.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Windows.Win32.Foundation;
-internal static unsafe class IPointerExtensions
+internal static unsafe class PointerExtensions
 {
-    public static T* GetPointer<T>(this IPointer pointer) where T : unmanaged => (T*)pointer.Pointer;
+    public static T* GetPointer<T>(this IPointer<T> pointer) where T : unmanaged => (T*)pointer.Pointer;
 }

--- a/src/System.Private.Windows.Core/src/Windows/Win32/Foundation/PointerExtensions.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/Foundation/PointerExtensions.cs
@@ -5,5 +5,7 @@ namespace Windows.Win32.Foundation;
 
 internal static unsafe class PointerExtensions
 {
+#pragma warning disable CS0618 // Type or member is obsolete
     public static T* GetPointer<T>(this IPointer<T> pointer) where T : unmanaged => (T*)pointer.Pointer;
+#pragma warning restore CS0618
 }

--- a/src/System.Private.Windows.Core/src/Windows/Win32/Foundation/PointerExtensions.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/Foundation/PointerExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Windows.Win32.Foundation;
+
 internal static unsafe class PointerExtensions
 {
     public static T* GetPointer<T>(this IPointer<T> pointer) where T : unmanaged => (T*)pointer.Pointer;

--- a/src/System.Private.Windows.Core/src/Windows/Win32/Graphics/Gdi/RegionScope.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/Graphics/Gdi/RegionScope.cs
@@ -62,7 +62,7 @@ internal unsafe ref struct RegionScope
     /// </summary>
     public RegionScope(IPointer<GpRegion> region, IPointer<GpGraphics> graphics)
     {
-        InitializeFromGdiPlus(region.GetPointer(), (GpGraphics*)graphics.Pointer);
+        InitializeFromGdiPlus(region.GetPointer(), graphics.GetPointer());
         GC.KeepAlive(region);
         GC.KeepAlive(graphics);
     }

--- a/src/System.Private.Windows.Core/src/Windows/Win32/Graphics/Gdi/RegionScope.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/Graphics/Gdi/RegionScope.cs
@@ -62,7 +62,7 @@ internal unsafe ref struct RegionScope
     /// </summary>
     public RegionScope(IPointer<GpRegion> region, IPointer<GpGraphics> graphics)
     {
-        InitializeFromGdiPlus(region.Pointer, graphics.Pointer);
+        InitializeFromGdiPlus((GpRegion*)region.Pointer, (GpGraphics*)graphics.Pointer);
         GC.KeepAlive(region);
         GC.KeepAlive(graphics);
     }
@@ -97,7 +97,7 @@ internal unsafe ref struct RegionScope
     {
         GpGraphics* graphics = null;
         PInvokeCore.GdipCreateFromHWND(hwnd, &graphics).ThrowIfFailed();
-        InitializeFromGdiPlus(region.Pointer, graphics);
+        InitializeFromGdiPlus((GpRegion*)region.Pointer, graphics);
         GC.KeepAlive(region);
     }
 

--- a/src/System.Private.Windows.Core/src/Windows/Win32/Graphics/Gdi/RegionScope.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/Graphics/Gdi/RegionScope.cs
@@ -62,7 +62,7 @@ internal unsafe ref struct RegionScope
     /// </summary>
     public RegionScope(IPointer<GpRegion> region, IPointer<GpGraphics> graphics)
     {
-        InitializeFromGdiPlus((GpRegion*)region.Pointer, (GpGraphics*)graphics.Pointer);
+        InitializeFromGdiPlus(region.GetPointer(), (GpGraphics*)graphics.Pointer);
         GC.KeepAlive(region);
         GC.KeepAlive(graphics);
     }
@@ -97,7 +97,7 @@ internal unsafe ref struct RegionScope
     {
         GpGraphics* graphics = null;
         PInvokeCore.GdipCreateFromHWND(hwnd, &graphics).ThrowIfFailed();
-        InitializeFromGdiPlus((GpRegion*)region.Pointer, graphics);
+        InitializeFromGdiPlus(region.GetPointer(), graphics);
         GC.KeepAlive(region);
     }
 

--- a/src/System.Private.Windows.Core/src/Windows/Win32/Graphics/GdiPlus/GpBitmapExtensions.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/Graphics/GdiPlus/GpBitmapExtensions.cs
@@ -17,7 +17,7 @@ internal static unsafe class GpBitmapExtensions
     {
         // LockBits always creates a temporary copy of the data.
         PInvokeCore.GdipBitmapLockBits(
-            bitmap.Pointer,
+            (GpBitmap*)bitmap.Pointer,
             rect.IsEmpty ? null : (Rect*)&rect,
             (uint)flags,
             (int)format,
@@ -28,7 +28,7 @@ internal static unsafe class GpBitmapExtensions
 
     public static void UnlockBits(this IPointer<GpBitmap> bitmap, ref BitmapData data)
     {
-        PInvokeCore.GdipBitmapUnlockBits(bitmap.Pointer, (BitmapData*)Unsafe.AsPointer(ref data)).ThrowIfFailed();
+        PInvokeCore.GdipBitmapUnlockBits((GpBitmap*)bitmap.Pointer, (BitmapData*)Unsafe.AsPointer(ref data)).ThrowIfFailed();
         GC.KeepAlive(bitmap);
     }
 
@@ -38,7 +38,7 @@ internal static unsafe class GpBitmapExtensions
     {
         HBITMAP hbitmap;
         PInvokeCore.GdipCreateHBITMAPFromBitmap(
-            bitmap.Pointer,
+            (GpBitmap*)bitmap.Pointer,
             &hbitmap,
             (uint)ColorTranslator.ToWin32(background)).ThrowIfFailed();
 

--- a/src/System.Private.Windows.Core/src/Windows/Win32/Graphics/GdiPlus/GpBitmapExtensions.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/Graphics/GdiPlus/GpBitmapExtensions.cs
@@ -17,7 +17,7 @@ internal static unsafe class GpBitmapExtensions
     {
         // LockBits always creates a temporary copy of the data.
         PInvokeCore.GdipBitmapLockBits(
-            (GpBitmap*)bitmap.Pointer,
+            bitmap.GetPointer(),
             rect.IsEmpty ? null : (Rect*)&rect,
             (uint)flags,
             (int)format,
@@ -28,7 +28,7 @@ internal static unsafe class GpBitmapExtensions
 
     public static void UnlockBits(this IPointer<GpBitmap> bitmap, ref BitmapData data)
     {
-        PInvokeCore.GdipBitmapUnlockBits((GpBitmap*)bitmap.Pointer, (BitmapData*)Unsafe.AsPointer(ref data)).ThrowIfFailed();
+        PInvokeCore.GdipBitmapUnlockBits(bitmap.GetPointer(), (BitmapData*)Unsafe.AsPointer(ref data)).ThrowIfFailed();
         GC.KeepAlive(bitmap);
     }
 
@@ -38,7 +38,7 @@ internal static unsafe class GpBitmapExtensions
     {
         HBITMAP hbitmap;
         PInvokeCore.GdipCreateHBITMAPFromBitmap(
-            (GpBitmap*)bitmap.Pointer,
+            bitmap.GetPointer(),
             &hbitmap,
             (uint)ColorTranslator.ToWin32(background)).ThrowIfFailed();
 

--- a/src/System.Private.Windows.Core/src/Windows/Win32/Graphics/GdiPlus/GpImageExtensions.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/Graphics/GdiPlus/GpImageExtensions.cs
@@ -14,7 +14,7 @@ internal static unsafe class GpImageExtensions
         RectangleF bounds;
         Unit unit;
 
-        PInvokeCore.GdipGetImageBounds(image.Pointer, (RectF*)&bounds, &unit).ThrowIfFailed();
+        PInvokeCore.GdipGetImageBounds((GpImage*)image.Pointer, (RectF*)&bounds, &unit).ThrowIfFailed();
         GC.KeepAlive(image);
         return bounds;
     }
@@ -24,7 +24,7 @@ internal static unsafe class GpImageExtensions
     {
         int format;
 
-        Status status = PInvokeCore.GdipGetImagePixelFormat(image.Pointer, &format);
+        Status status = PInvokeCore.GdipGetImagePixelFormat((GpImage*)image.Pointer, &format);
         GC.KeepAlive(image);
         return status == Status.Ok ? (PixelFormat)format : PixelFormat.Undefined;
     }

--- a/src/System.Private.Windows.Core/src/Windows/Win32/Graphics/GdiPlus/GpImageExtensions.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/Graphics/GdiPlus/GpImageExtensions.cs
@@ -14,7 +14,7 @@ internal static unsafe class GpImageExtensions
         RectangleF bounds;
         Unit unit;
 
-        PInvokeCore.GdipGetImageBounds((GpImage*)image.Pointer, (RectF*)&bounds, &unit).ThrowIfFailed();
+        PInvokeCore.GdipGetImageBounds(image.GetPointer(), (RectF*)&bounds, &unit).ThrowIfFailed();
         GC.KeepAlive(image);
         return bounds;
     }
@@ -24,7 +24,7 @@ internal static unsafe class GpImageExtensions
     {
         int format;
 
-        Status status = PInvokeCore.GdipGetImagePixelFormat((GpImage*)image.Pointer, &format);
+        Status status = PInvokeCore.GdipGetImagePixelFormat(image.GetPointer(), &format);
         GC.KeepAlive(image);
         return status == Status.Ok ? (PixelFormat)format : PixelFormat.Undefined;
     }

--- a/src/System.Private.Windows.Core/src/Windows/Win32/Graphics/GdiPlus/GpMetafileExtensions.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/Graphics/GdiPlus/GpMetafileExtensions.cs
@@ -8,7 +8,7 @@ internal static unsafe class GpMetafileExtensions
     public static HENHMETAFILE GetHENHMETAFILE(this IPointer<GpMetafile> metafile)
     {
         HENHMETAFILE hemf;
-        PInvokeCore.GdipGetHemfFromMetafile((GpMetafile*)metafile.Pointer, &hemf).ThrowIfFailed();
+        PInvokeCore.GdipGetHemfFromMetafile(metafile.GetPointer(), &hemf).ThrowIfFailed();
         GC.KeepAlive(metafile);
         return hemf;
     }

--- a/src/System.Private.Windows.Core/src/Windows/Win32/Graphics/GdiPlus/GpMetafileExtensions.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/Graphics/GdiPlus/GpMetafileExtensions.cs
@@ -8,7 +8,7 @@ internal static unsafe class GpMetafileExtensions
     public static HENHMETAFILE GetHENHMETAFILE(this IPointer<GpMetafile> metafile)
     {
         HENHMETAFILE hemf;
-        PInvokeCore.GdipGetHemfFromMetafile(metafile.Pointer, &hemf).ThrowIfFailed();
+        PInvokeCore.GdipGetHemfFromMetafile((GpMetafile*)metafile.Pointer, &hemf).ThrowIfFailed();
         GC.KeepAlive(metafile);
         return hemf;
     }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes https://github.com/dotnet/winforms/issues/11983

This issue occurs because System.Private.Windows.Core is included in the ref as C# needs the types to be there when it compiles interface casts (https://github.com/dotnet/winforms/pull/10673), but this also causes issues for us in CLI/CLR C++ mixed mode as shown in issue. 

This is a workaround that updates our `IPointer<T>` interface to avoid returning a generic as it present compile issues in CLI/CLR C++ mixed mode. This looks to be a limitation that is in mix mode as this error occurs with non WindowsForms related classes that have similar implementation. This workaround mitigates this issue while coordination is happening to determine a fix.

Tested by building dlls from change and replacing System.Drawing.Common.dll and System.Private.Windows.Core.dll in C:\Program Files\dotnet\packs\Microsoft.WindowsDesktop.App.Ref\9.0.0-rc.2.24428.1\ref\net9.0
### Before

![image](https://github.com/user-attachments/assets/6f84e825-f16b-4fcb-8e60-6a9b1910b8e6)


### After

![image](https://github.com/user-attachments/assets/27eba8f0-7b53-4311-8bbd-995dfe19c9ad)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12103)