### PR TITLE
Don't set DWMWA_USE_IMMERSIVE_DARK_MODE unnecessarily

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
@@ -258,8 +258,12 @@ public sealed partial class Application
     ///  </para>
     /// </remarks>
     [Experimental(DiagnosticIDs.ExperimentalDarkMode, UrlFormat = DiagnosticIDs.UrlFormat)]
-    public static SystemColorMode ColorMode =>
-        s_colorMode ?? SystemColorMode.Classic;
+    public static SystemColorMode ColorMode => s_colorMode ?? SystemColorMode.Classic;
+
+    /// <summary>
+    ///  True if the <see cref="ColorMode"/> has been set at least once.
+    /// </summary>
+    internal static bool ColorModeSet => s_colorMode is not null;
 
     /// <summary>
     ///  Sets the default color mode (dark mode) for the application.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -10585,7 +10585,9 @@ public unsafe partial class Control :
                 // bit and call CreateControl()
                 if (IsHandleCreated || value)
                 {
-                    if (value)
+                    // We shouldn't mess with the color mode if users haven't specifically set it.
+                    // https://github.com/dotnet/winforms/issues/12014
+                    if (value && Application.ColorModeSet)
                     {
                         PrepareDarkMode(HWND, Application.IsDarkModeEnabled);
                     }


### PR DESCRIPTION
Don't set DWMWA_USE_IMMERSIVE_DARK_MODE if users haven't explicitly made a choice.

This creates havoc for existing dark mode implementors.

Fixes #12014

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12104)