### PR TITLE
[release/9.0] Change IPointer interface method to return nint (#12103)

### DIFF
--- a/src/System.Drawing.Common/src/System/Drawing/Bitmap.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Bitmap.cs
@@ -128,7 +128,7 @@ public sealed unsafe class Bitmap : Image, IPointer<GpBitmap>
     {
     }
 
-    GpBitmap* IPointer<GpBitmap>.Pointer => (GpBitmap*)((Image)this).Pointer();
+    nint IPointer<GpBitmap>.Pointer => (nint)((Image)this).Pointer();
 
     public static Bitmap FromHicon(IntPtr hicon)
     {

--- a/src/System.Drawing.Common/src/System/Drawing/Graphics.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Graphics.cs
@@ -195,7 +195,7 @@ public sealed unsafe partial class Graphics : MarshalByRefObject, IDisposable, I
     /// </summary>
     internal GpGraphics* NativeGraphics { get; private set; }
 
-    GpGraphics* IPointer<GpGraphics>.Pointer => NativeGraphics;
+    nint IPointer<GpGraphics>.Pointer => (nint)NativeGraphics;
 
     public Region Clip
     {

--- a/src/System.Drawing.Common/src/System/Drawing/Image.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Image.cs
@@ -32,7 +32,7 @@ public abstract unsafe class Image : MarshalByRefObject, IImage, IDisposable, IC
     // to modify it, in order to preserve compatibility.
     public delegate bool GetThumbnailImageAbort();
 
-    GpImage* IPointer<GpImage>.Pointer => _nativeImage;
+    nint IPointer<GpImage>.Pointer => (nint)_nativeImage;
 
     [NonSerialized]
     private GpImage* _nativeImage;

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/ColorPalette.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/ColorPalette.cs
@@ -108,7 +108,7 @@ public sealed unsafe class ColorPalette
                 (GdiPlus.PaletteType)fixedPaletteType,
                 colorCount,
                 useTransparentColor,
-                bitmap is null ? null : bitmap.Pointer).ThrowIfFailed();
+                bitmap is null ? null : bitmap.GetPointer()).ThrowIfFailed();
         }
 
         GC.KeepAlive(bitmap);

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/Metafile.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/Metafile.cs
@@ -21,7 +21,7 @@ public sealed unsafe class Metafile : Image, IPointer<GpMetafile>
     // GDI+ doesn't handle filenames over MAX_PATH very well
     private const int MaxPath = 260;
 
-    GpMetafile* IPointer<GpMetafile>.Pointer => this.Pointer();
+    nint IPointer<GpMetafile>.Pointer => (nint)this.Pointer();
 
     /// <summary>
     ///  Initializes a new instance of the <see cref='Metafile'/> class from the specified handle and

--- a/src/System.Drawing.Common/src/System/Drawing/PointerExtensions.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/PointerExtensions.cs
@@ -19,9 +19,9 @@ internal static unsafe class PointerExtensions
     public static GpImageAttributes* Pointer(this ImageAttributes? imageAttr) => imageAttr is null ? null : imageAttr._nativeImageAttributes;
     public static GpGraphics* Pointer(this Graphics? graphics) => graphics is null ? null : graphics.NativeGraphics;
     public static GpFont* Pointer(this Font? font) => font is null ? null : font.NativeFont;
-    public static GpBitmap* Pointer(this Bitmap? bitmap) => bitmap is null ? null : ((IPointer<GpBitmap>)bitmap).Pointer;
+    public static GpBitmap* Pointer(this Bitmap? bitmap) => bitmap is null ? null : ((IPointer<GpBitmap>)bitmap).GetPointer();
     public static GpMetafile* Pointer(this Metafile? metafile) => metafile is null ? null : (GpMetafile*)((Image)metafile).Pointer();
-    public static GpImage* Pointer(this Image? image) => image is null ? null : ((IPointer<GpImage>)image).Pointer;
+    public static GpImage* Pointer(this Image? image) => image is null ? null : image.GetPointer();
 #if NET9_0_OR_GREATER
     public static CGpEffect* Pointer(this Effect? effect) => effect is null ? null : effect.NativeEffect;
 #endif

--- a/src/System.Drawing.Common/src/System/Drawing/Region.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Region.cs
@@ -9,7 +9,7 @@ public sealed unsafe class Region : MarshalByRefObject, IDisposable, IPointer<Gp
 {
     internal GpRegion* NativeRegion { get; private set; }
 
-    GpRegion* IPointer<GpRegion>.Pointer => NativeRegion;
+    nint IPointer<GpRegion>.Pointer => (nint)NativeRegion;
 
     public Region()
     {

--- a/src/System.Private.Windows.Core/src/System/Drawing/CoreImageExtensions.cs
+++ b/src/System.Private.Windows.Core/src/System/Drawing/CoreImageExtensions.cs
@@ -25,13 +25,13 @@ internal static unsafe class CoreImageExtensions
         }
 
         using var iStream = stream.ToIStream();
-        PInvokeCore.GdipSaveImageToStream(image.Pointer, iStream, &encoder, encoderParameters).ThrowIfFailed();
+        PInvokeCore.GdipSaveImageToStream(image.GetPointer(), iStream, &encoder, encoderParameters).ThrowIfFailed();
     }
 
     internal static void Save(this IImage image, MemoryStream stream)
     {
         Guid format = default;
-        PInvokeCore.GdipGetImageRawFormat(image.Pointer, &format).ThrowIfFailed();
+        PInvokeCore.GdipGetImageRawFormat(image.GetPointer(), &format).ThrowIfFailed();
 
         Guid encoder = ImageCodecInfoHelper.GetEncoderClsid(format);
 

--- a/src/System.Private.Windows.Core/src/Windows/Win32/Foundation/IPointer.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/Foundation/IPointer.cs
@@ -13,5 +13,10 @@ namespace Windows.Win32.Foundation;
 /// </remarks>
 internal unsafe interface IPointer<TPointer> where TPointer : unmanaged
 {
-    TPointer* Pointer { get; }
+    // This interface method must return a nint instead of a typed pointer directly because
+    // C++/CLI cannot compile when it encounters generic pointers, even in internal interfaces.
+    // System.Private.Windows.Core is included in the ref.
+    // See https://github.com/dotnet/winforms/issues/11983 for more details.
+    [Obsolete("Use extension method GetPointer on IPointer<T> to get the typed pointer instead.")]
+    nint Pointer { get; }
 }

--- a/src/System.Private.Windows.Core/src/Windows/Win32/Foundation/PointerExtensions.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/Foundation/PointerExtensions.cs
@@ -1,0 +1,11 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Windows.Win32.Foundation;
+
+internal static unsafe class PointerExtensions
+{
+#pragma warning disable CS0618 // Type or member is obsolete
+    public static T* GetPointer<T>(this IPointer<T> pointer) where T : unmanaged => (T*)pointer.Pointer;
+#pragma warning restore CS0618
+}

--- a/src/System.Private.Windows.Core/src/Windows/Win32/Graphics/Gdi/RegionScope.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/Graphics/Gdi/RegionScope.cs
@@ -62,7 +62,7 @@ internal unsafe ref struct RegionScope
     /// </summary>
     public RegionScope(IPointer<GpRegion> region, IPointer<GpGraphics> graphics)
     {
-        InitializeFromGdiPlus(region.Pointer, graphics.Pointer);
+        InitializeFromGdiPlus(region.GetPointer(), graphics.GetPointer());
         GC.KeepAlive(region);
         GC.KeepAlive(graphics);
     }
@@ -97,7 +97,7 @@ internal unsafe ref struct RegionScope
     {
         GpGraphics* graphics = null;
         PInvokeCore.GdipCreateFromHWND(hwnd, &graphics).ThrowIfFailed();
-        InitializeFromGdiPlus(region.Pointer, graphics);
+        InitializeFromGdiPlus(region.GetPointer(), graphics);
         GC.KeepAlive(region);
     }
 

--- a/src/System.Private.Windows.Core/src/Windows/Win32/Graphics/GdiPlus/GpBitmapExtensions.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/Graphics/GdiPlus/GpBitmapExtensions.cs
@@ -17,7 +17,7 @@ internal static unsafe class GpBitmapExtensions
     {
         // LockBits always creates a temporary copy of the data.
         PInvokeCore.GdipBitmapLockBits(
-            bitmap.Pointer,
+            bitmap.GetPointer(),
             rect.IsEmpty ? null : (Rect*)&rect,
             (uint)flags,
             (int)format,
@@ -28,7 +28,7 @@ internal static unsafe class GpBitmapExtensions
 
     public static void UnlockBits(this IPointer<GpBitmap> bitmap, ref BitmapData data)
     {
-        PInvokeCore.GdipBitmapUnlockBits(bitmap.Pointer, (BitmapData*)Unsafe.AsPointer(ref data)).ThrowIfFailed();
+        PInvokeCore.GdipBitmapUnlockBits(bitmap.GetPointer(), (BitmapData*)Unsafe.AsPointer(ref data)).ThrowIfFailed();
         GC.KeepAlive(bitmap);
     }
 
@@ -38,7 +38,7 @@ internal static unsafe class GpBitmapExtensions
     {
         HBITMAP hbitmap;
         PInvokeCore.GdipCreateHBITMAPFromBitmap(
-            bitmap.Pointer,
+            bitmap.GetPointer(),
             &hbitmap,
             (uint)ColorTranslator.ToWin32(background)).ThrowIfFailed();
 

--- a/src/System.Private.Windows.Core/src/Windows/Win32/Graphics/GdiPlus/GpImageExtensions.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/Graphics/GdiPlus/GpImageExtensions.cs
@@ -14,7 +14,7 @@ internal static unsafe class GpImageExtensions
         RectangleF bounds;
         Unit unit;
 
-        PInvokeCore.GdipGetImageBounds(image.Pointer, (RectF*)&bounds, &unit).ThrowIfFailed();
+        PInvokeCore.GdipGetImageBounds(image.GetPointer(), (RectF*)&bounds, &unit).ThrowIfFailed();
         GC.KeepAlive(image);
         return bounds;
     }
@@ -24,7 +24,7 @@ internal static unsafe class GpImageExtensions
     {
         int format;
 
-        Status status = PInvokeCore.GdipGetImagePixelFormat(image.Pointer, &format);
+        Status status = PInvokeCore.GdipGetImagePixelFormat(image.GetPointer(), &format);
         GC.KeepAlive(image);
         return status == Status.Ok ? (PixelFormat)format : PixelFormat.Undefined;
     }

--- a/src/System.Private.Windows.Core/src/Windows/Win32/Graphics/GdiPlus/GpMetafileExtensions.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/Graphics/GdiPlus/GpMetafileExtensions.cs
@@ -8,7 +8,7 @@ internal static unsafe class GpMetafileExtensions
     public static HENHMETAFILE GetHENHMETAFILE(this IPointer<GpMetafile> metafile)
     {
         HENHMETAFILE hemf;
-        PInvokeCore.GdipGetHemfFromMetafile(metafile.Pointer, &hemf).ThrowIfFailed();
+        PInvokeCore.GdipGetHemfFromMetafile(metafile.GetPointer(), &hemf).ThrowIfFailed();
         GC.KeepAlive(metafile);
         return hemf;
     }


### PR DESCRIPTION
backport of #12103

**Customer Impact:**
Currently, users are unable to compile some of our controls in CLI/CLR C++ mixed code project because C++/CLI cannot compile when it encounters generic pointers even if it is internal code. The PR is a workaround that makes changes to avoid returning generic pointers in our internal interface. 

**Risk:**
Minimal. This is a change in our internal code to ensure C++/CLI is able to compile successfully by changing the return type of affected interface method. Anywhere we were using the interface method we have updated to use an extension method to achieve the same behavior as before. This has been tested and confirmed C++/CLI is able to compile successfully with change.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12110)