### PR TITLE
Document additional references required to debug

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -32,6 +32,8 @@ Add references to the binary(-ies) to your project ported to .NET. For example, 
 
 ```xml
 <ItemGroup>
+    <Reference Include="[Drive]:[Path-to-repo]\winforms\artifacts\bin\System.Windows.Forms\Debug\net7.0\System.Drawing.Common.dll" />
+    <Reference Include="[Drive]:[Path-to-repo]\winforms\artifacts\bin\System.Windows.Forms\Debug\net7.0\System.Private.Windows.Core.dll" />
     <Reference Include="[Drive]:[Path-to-repo]\winforms\artifacts\bin\System.Windows.Forms\Debug\net7.0\System.Windows.Forms.dll" />
     <Reference Include="[Drive]:[Path-to-repo]\winforms\artifacts\bin\System.Windows.Forms.Primitives\Debug\net7.0\System.Windows.Forms.Primitives.dll" />
     <!-- Optionally you may need designer -->


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #12114 

## Proposed changes

- Document additional references required to debug Windows Forms binaries using technique <span>#</span>2.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12116)