### PR TITLE
Add code coverage for RichTextBoxActionList

### DIFF
--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/RichTextBoxActionListTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/RichTextBoxActionListTests.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+namespace System.Windows.Forms.Design.Tests;
+
+public sealed class RichTextBoxActionListTests
+{
+    [Fact]
+    public void Ctor_WithNull_ThrowsException()
+    {
+        Action action = () => new RichTextBoxActionList(null!);
+        action.Should().Throw<NullReferenceException>();
+    }
+
+    [Fact]
+    public void GetSortedActions_WithDesigner_GetsCorrectItemsCount()
+    {
+        using RichTextBoxDesigner designer = new();
+        using RichTextBox richTextBox = new();
+        designer.Initialize(richTextBox);
+        RichTextBoxActionList actionList = new(designer);
+
+        actionList.GetSortedActionItems().Count.Should().Be(1);
+    }
+}


### PR DESCRIPTION
Related #10773

## Proposed changes

- Adds code coverage for `RichTextBoxActionList`
- Coverage for the `EditLines()` method could not be added. The dependent method `EditorServiceContext.EditValue(_designer, Component!, "Lines")` is static and could not be mocked, and the dialog that opens during its execution requires manual intervention to close.

## Customer Impact

- None or succinct description

## Regression?

- No

## Risk

- Minimal

## Test methodology

- Unit tests

## Test environment(s)

- 9.0.100-preview.7.24407.12