### PR TITLE
Add XML Comments to CantStartSingleInstanceException

### DIFF
--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/CantStartSingleInstanceException.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/CantStartSingleInstanceException.vb
@@ -29,10 +29,19 @@ Namespace Microsoft.VisualBasic.ApplicationServices
             MyBase.New(VbUtils.GetResourceString(SR.AppModel_SingleInstanceCantConnect))
         End Sub
 
+        ''' <summary>
+        '''  Creates a new <see cref="Exception"/>.
+        ''' </summary>
+        ''' <param name="message"></param>
         Public Sub New(message As String)
             MyBase.New(message)
         End Sub
 
+        ''' <summary>
+        '''  Creates a new <see cref="Exception"/>.
+        ''' </summary>
+        ''' <param name="message"></param>
+        ''' <param name="inner"> Inner <see cref="Exception"/></param>
         Public Sub New(message As String, inner As Exception)
             MyBase.New(message, inner)
         End Sub

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/CantStartSingleInstanceException.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/CantStartSingleInstanceException.vb
@@ -40,8 +40,7 @@ Namespace Microsoft.VisualBasic.ApplicationServices
         ''' <summary>
         '''  Creates a new <see cref="Exception"/>.
         ''' </summary>
-        ''' <param name="message"></param>
-        ''' <param name="inner"> Inner <see cref="Exception"/></param>
+        ''' <inheritdoc cref="Exception.New(String, Exception)"/>
         Public Sub New(message As String, inner As Exception)
             MyBase.New(message, inner)
         End Sub

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/CantStartSingleInstanceException.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/CantStartSingleInstanceException.vb
@@ -32,7 +32,7 @@ Namespace Microsoft.VisualBasic.ApplicationServices
         ''' <summary>
         '''  Creates a new <see cref="Exception"/>.
         ''' </summary>
-        ''' <param name="message"></param>
+        ''' <inheritdoc cref="Exception.New(String)"/>
         Public Sub New(message As String)
             MyBase.New(message)
         End Sub


### PR DESCRIPTION
Improves XML Comments #11984 


## Proposed changes
- Add missing XML comment to CantStartSingleInstanceException
## Customer Impact
-  Improve development experence
- 
## Regression? 

- No

## Risk
- None only comment additions

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12147)