### PR TITLE
Suppress SYSLIB5005 for System.Formats.Nrbf as experimental

### DIFF
--- a/src/System.Private.Windows.Core/src/System.Private.Windows.Core.csproj
+++ b/src/System.Private.Windows.Core/src/System.Private.Windows.Core.csproj
@@ -13,11 +13,12 @@
       users won't be impacted. If some name becomes difficult to adapt to with the @ symbol we can
       cross that bridge when we hit it (if ever).
     -->
-    <NoWarn>$(NoWarn);CS8981;CS3016</NoWarn>
+    <NoWarn>$(NoWarn);CS8981</NoWarn>
     <!--
-      We don't care about CLS compliance since everything here is internal and we want to match native types.
+      CS3016: We don't care about CLS compliance since everything here is internal and we want to match native types.
+      SYSLIB5005: System.Formats.Nrbf is experimental
     -->
-    <NoWarn>$(NoWarn);CS3016</NoWarn>
+    <NoWarn>$(NoWarn);CS3016;SYSLIB5005</NoWarn>
     <Deterministic>true</Deterministic>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <UsePublicApiAnalyzers>false</UsePublicApiAnalyzers>

--- a/src/System.Private.Windows.Core/tests/BinaryFormatTests/BinaryFormatTests.csproj
+++ b/src/System.Private.Windows.Core/tests/BinaryFormatTests/BinaryFormatTests.csproj
@@ -29,8 +29,9 @@
      SYSLIB0011: BinaryFormatter obsolete
      SYSLIB0050: Obsolete attribute
      SYSLIB0051: Formatters obsolete
+     SYSLIB5005: System.Formats.Nrbf is experimental
     -->
-    <NoWarn>$(NoWarn);CS1574;CS1580;CA1036;CA1051;CA1066;SYSLIB0011;SYSLIB0050;SYSLIB0051;xUnit1013</NoWarn>
+    <NoWarn>$(NoWarn);CS1574;CS1580;CA1036;CA1051;CA1066;SYSLIB0011;SYSLIB0050;SYSLIB0051;SYSLIB5005;xUnit1013</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/System.Windows.Forms.Primitives.TestUtilities.csproj
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/System.Windows.Forms.Primitives.TestUtilities.csproj
@@ -3,6 +3,10 @@
     <AssemblyName>System.Windows.Forms.Primitives.TestUtilities</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <RootNamespace>System</RootNamespace>
+    <!--
+      SYSLIB5005: System.Formats.Nrbf is experimental
+    -->
+    <NoWarn>$(NoWarn);SYSLIB5005</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.Windows.Forms/src/System.Windows.Forms.csproj
+++ b/src/System.Windows.Forms/src/System.Windows.Forms.csproj
@@ -11,6 +11,10 @@
       See https://github.com/dotnet/winforms/issues/4649
     -->
     <NoWarn>$(NoWarn);IL2026;IL2050;IL2057;IL2062;IL2067;IL2070;IL2072;IL2075;IL2077;IL2080;IL2092;IL2093;IL2094;IL2096;IL2111;IL2055</NoWarn>
+    <!--
+      SYSLIB5005: System.Formats.Nrbf is experimental
+    -->
+    <NoWarn>$(NoWarn);SYSLIB5005</NoWarn>
     <Win32Manifest>Resources\System\Windows\Forms\XPThemes.manifest</Win32Manifest>
     <Deterministic>true</Deterministic>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>

--- a/src/System.Windows.Forms/tests/UnitTests/System.Windows.Forms.Tests.csproj
+++ b/src/System.Windows.Forms/tests/UnitTests/System.Windows.Forms.Tests.csproj
@@ -10,7 +10,12 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <NoWarn>$(NoWarn),1573,1591,1712,WFDEV001,SYSLIB0050,SYSLIB0051;</NoWarn>
+    <!--
+      SYSLIB0050: Formatter-based serialization is obsolete and should not be used
+      SYSLIB0051: This API supports obsolete formatter-based serialization
+      SYSLIB5005: System.Formats.Nrbf is experimental
+    -->
+    <NoWarn>$(NoWarn),1573,1591,1712,WFDEV001,SYSLIB0050,SYSLIB0051,SYSLIB5005</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
With dotnet/runtime#107905, we are marking `System.Formats.Nrbf` as `[Experimental]`, using diagnostic ID `SYSLIB5005`. This suppresses the diagnostics produced by that annotation.

We plan to backport this change to `release/9.0` and `release/9.0-rc2`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12156)