### PR TITLE
Added more  clipboard  roundtrip tests

### DIFF
--- a/src/Common/tests/TestUtilities/BinaryFormatterScope.cs
+++ b/src/Common/tests/TestUtilities/BinaryFormatterScope.cs
@@ -31,29 +31,4 @@ public readonly ref struct BinaryFormatterScope
             Monitor.Exit(typeof(BinaryFormatterScope));
         }
     }
-
-    static BinaryFormatterScope()
-    {
-        // Need to explicitly set the switch to whatever the default is as its default value is in transition.
-
-#pragma warning disable SYSLIB0011 // Type or member is obsolete
-        BinaryFormatter formatter = new();
-#pragma warning restore SYSLIB0011
-        try
-        {
-            formatter.Serialize(null!, null!);
-        }
-        catch (NotSupportedException)
-        {
-            AppContext.SetSwitch(AppContextSwitchNames.EnableUnsafeBinaryFormatterSerialization, false);
-            return;
-        }
-        catch (ArgumentNullException)
-        {
-            AppContext.SetSwitch(AppContextSwitchNames.EnableUnsafeBinaryFormatterSerialization, true);
-            return;
-        }
-
-        throw new InvalidOperationException();
-    }
 }

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/MyServices/ClipboardProxy.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/MyServices/ClipboardProxy.vb
@@ -194,16 +194,16 @@ Namespace Microsoft.VisualBasic.MyServices
         ''' <summary>
         '''  Saves the passed in String to the clipboard.
         ''' </summary>
-        ''' <param name="text">The String to save.</param>
+        ''' <param name="text">The <see cref="String"/> to save.</param>
         Public Sub SetText(text As String)
             Clipboard.SetText(text)
         End Sub
 
         ''' <summary>
-        '''  Saves the passed in String to the clipboard in the passed in format.
+        '''  Saves the passed in <see cref="String" />  to the clipboard in the passed in <paramref name="format"/>.
         ''' </summary>
-        ''' <param name="text">The String to save.</param>
-        ''' <param name="format">The format in which to save the String.</param>
+        ''' <param name="text">The <see cref="String" />  to save.</param>
+        ''' <param name="format">The format in which to save the <see cref="String" /> .</param>
         Public Sub SetText(text As String, format As TextDataFormat)
             Clipboard.SetText(text, format)
         End Sub

--- a/src/Microsoft.VisualBasic/tests/UnitTests/Microsoft/VisualBasic/MyServices/ClipboardProxyTests.cs
+++ b/src/Microsoft.VisualBasic/tests/UnitTests/Microsoft/VisualBasic/MyServices/ClipboardProxyTests.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System.Drawing;
 using Microsoft.VisualBasic.Devices;
 using DataFormats = System.Windows.Forms.DataFormats;
@@ -11,7 +13,6 @@ namespace Microsoft.VisualBasic.MyServices.Tests;
 // Each registered Clipboard format is an OS singleton,
 // and we should not run this test at the same time as other tests using the same format.
 [Collection("Sequential")]
-[CollectionDefinition("Sequential", DisableParallelization = true)]
 public class ClipboardProxyTests
 {
     private static string GetUniqueText() => Guid.NewGuid().ToString("D");
@@ -55,7 +56,7 @@ public class ClipboardProxyTests
         var clipboard = new Computer().Clipboard;
         object data = GetUniqueText();
         clipboard.SetDataObject(new System.Windows.Forms.DataObject(data));
-        clipboard.GetDataObject().GetData(DataFormats.UnicodeText).Should().Be(System.Windows.Forms.Clipboard.GetDataObject().GetData(DataFormats.UnicodeText));
+        clipboard.GetDataObject().GetData(DataFormats.UnicodeText).Should().Be(System.Windows.Forms.Clipboard.GetDataObject()?.GetData(DataFormats.UnicodeText));
     }
 
     [WinFormsFact]

--- a/src/System.Private.Windows.Core/src/System/Private/Windows/Core/Nrbf/SerializationRecordExtensions.cs
+++ b/src/System.Private.Windows.Core/src/System/Private/Windows/Core/Nrbf/SerializationRecordExtensions.cs
@@ -164,7 +164,7 @@ internal static class SerializationRecordExtensions
         }
     }
 
-        /// <summary>
+    /// <summary>
     ///  Tries to get this object as a <see cref="SizeF"/>.
     /// </summary>
     public static bool TryGetSizeF(this SerializationRecord record, [NotNullWhen(true)] out object? value)

--- a/src/System.Private.Windows.Core/tests/BinaryFormatTests/BinaryFormatTests.csproj
+++ b/src/System.Private.Windows.Core/tests/BinaryFormatTests/BinaryFormatTests.csproj
@@ -31,7 +31,7 @@
      SYSLIB0051: Formatters obsolete
      SYSLIB5005: System.Formats.Nrbf is experimental
     -->
-    <NoWarn>$(NoWarn);CS1574;CS1580;CA1036;CA1051;CA1066;SYSLIB0011;SYSLIB0050;SYSLIB0051;SYSLIB5005;xUnit1013</NoWarn>
+    <NoWarn>$(NoWarn);CS1574;CS1580;CA1036;CA1051;CA1066;SYSLIB0011;SYSLIB0050;SYSLIB0051;SYSLIB5005;xUnit1013;xUnit1045</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/FormattedObject/ListTests.cs
+++ b/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/FormattedObject/ListTests.cs
@@ -3,10 +3,10 @@
 
 using System.Collections;
 using System.Drawing;
-using System.Runtime.Serialization.Formatters.Binary;
-using System.Private.Windows.Core.BinaryFormat;
-using FormatTests.Common;
 using System.Formats.Nrbf;
+using System.Private.Windows.Core.BinaryFormat;
+using System.Runtime.Serialization.Formatters.Binary;
+using FormatTests.Common;
 using System.Windows.Forms.Nrbf;
 
 namespace FormatTests.FormattedObject;
@@ -78,7 +78,7 @@ public class ListTests : SerializationTest
 
     [Theory]
     [MemberData(nameof(PrimitiveLists_TestData))]
-    public void BinaryFormattedObjectExtensions_TryGetPrimitiveList(IList list)
+    public void SerializationRecordExtensions_TryGetPrimitiveList(IList list)
     {
         SerializationRecord rootRecord = NrbfDecoder.Decode(Serialize(list));
         rootRecord.TryGetPrimitiveList(out object? deserialized).Should().BeTrue();

--- a/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/FormattedObject/PrimitiveTypeTests.cs
+++ b/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/FormattedObject/PrimitiveTypeTests.cs
@@ -106,7 +106,7 @@ public class PrimitiveTypeTests : SerializationTest
     [Theory]
     [MemberData(nameof(Primitive_Data))]
     [MemberData(nameof(Primitive_ExtendedData))]
-    public void BinaryFormattedObject_ReadPrimitive(object value)
+    public void SerializationRecord_ReadPrimitive(object value)
     {
         SerializationRecord rootRecord = NrbfDecoder.Decode(Serialize(value));
         rootRecord.TryGetPrimitiveType(out object? deserialized).Should().BeTrue();

--- a/src/System.Windows.Forms/tests/UnitTests/System.Windows.Forms.Tests.csproj
+++ b/src/System.Windows.Forms/tests/UnitTests/System.Windows.Forms.Tests.csproj
@@ -15,7 +15,7 @@
       SYSLIB0051: This API supports obsolete formatter-based serialization
       SYSLIB5005: System.Formats.Nrbf is experimental
     -->
-    <NoWarn>$(NoWarn),1573,1591,1712,WFDEV001,SYSLIB0050,SYSLIB0051,SYSLIB5005</NoWarn>
+    <NoWarn>$(NoWarn),1573,1591,1712,WFDEV001,SYSLIB0050,SYSLIB0051,SYSLIB5005,xUnit1045</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
* Added round trip tests for binary formatted payload under restricted clipboard formats
* Removed verification is BinaryFormatter is on or off from the switch as this behavior is now shipped.
* Removed CollectionDefinition attribute from a test class

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12167)