### PR TITLE
Add default value to PropertyStore.AddOrRemoveValue

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.Ime.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.Ime.cs
@@ -249,7 +249,7 @@ public partial class Control
     private bool LastCanEnableIme
     {
         get => Properties.GetValueOrDefault(s_lastCanEnableImeProperty, true);
-        set => Properties.AddOrRemoveValue(s_lastCanEnableImeProperty, value, true);
+        set => Properties.AddOrRemoveValue(s_lastCanEnableImeProperty, value, defaultValue: true);
     }
 
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.Ime.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.Ime.cs
@@ -249,7 +249,7 @@ public partial class Control
     private bool LastCanEnableIme
     {
         get => Properties.GetValueOrDefault(s_lastCanEnableImeProperty, true);
-        set => Properties.AddValue(s_lastCanEnableImeProperty, value);
+        set => Properties.AddOrRemoveValue(s_lastCanEnableImeProperty, value, true);
     }
 
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -518,7 +518,7 @@ public unsafe partial class Control :
         {
             // valid values are -1 to 0x40
             SourceGenerated.EnumValidator.Validate(value);
-            Properties.AddOrRemoveValue(s_accessibleRoleProperty, value, AccessibleRole.Default);
+            Properties.AddOrRemoveValue(s_accessibleRoleProperty, value, defaultValue: AccessibleRole.Default);
         }
     }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -518,7 +518,7 @@ public unsafe partial class Control :
         {
             // valid values are -1 to 0x40
             SourceGenerated.EnumValidator.Validate(value);
-            Properties.AddValue(s_accessibleRoleProperty, value);
+            Properties.AddOrRemoveValue(s_accessibleRoleProperty, value, AccessibleRole.Default);
         }
     }
 
@@ -1178,7 +1178,7 @@ public unsafe partial class Control :
                 }
             }
 
-            Properties.AddValue(s_cacheTextCountProperty, cacheTextCounter);
+            Properties.AddOrRemoveValue(s_cacheTextCountProperty, cacheTextCounter);
         }
     }
 
@@ -7135,10 +7135,9 @@ public unsafe partial class Control :
     {
         if (Properties.ContainsKey(s_dataContextProperty))
         {
-            // If this DataContext was the same as the Parent's just became,
             if (Equals(Properties.GetValueOrDefault<object>(s_dataContextProperty), Parent?.DataContext))
             {
-                // we need to make it ambient again by removing it.
+                // Same as the parent context, make it ambient by removing it.
                 Properties.RemoveValue(s_dataContextProperty);
 
                 // Even though internally we don't store it any longer, and the

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.cs
@@ -425,7 +425,7 @@ public partial class ComboBox : ListControl
                 // valid values are 0x0 to 0x2.
                 SourceGenerated.EnumValidator.Validate(value);
                 ResetHeightCache();
-                Properties.AddOrRemoveValue(s_propDrawMode, value, DrawMode.Normal);
+                Properties.AddOrRemoveValue(s_propDrawMode, value, defaultValue: DrawMode.Normal);
                 RecreateHandle();
             }
         }
@@ -1112,7 +1112,7 @@ public partial class ComboBox : ListControl
             // Reset preferred height.
             ResetHeightCache();
 
-            Properties.AddOrRemoveValue(s_propStyle, value, ComboBoxStyle.DropDown);
+            Properties.AddOrRemoveValue(s_propStyle, value, defaultValue: ComboBoxStyle.DropDown);
 
             if (IsHandleCreated)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.cs
@@ -425,7 +425,7 @@ public partial class ComboBox : ListControl
                 // valid values are 0x0 to 0x2.
                 SourceGenerated.EnumValidator.Validate(value);
                 ResetHeightCache();
-                Properties.AddValue(s_propDrawMode, value);
+                Properties.AddOrRemoveValue(s_propDrawMode, value, DrawMode.Normal);
                 RecreateHandle();
             }
         }
@@ -1100,8 +1100,6 @@ public partial class ComboBox : ListControl
                 return;
             }
 
-            // verify that 'value' is a valid enum type...
-            // valid values are 0x0 to 0x2
             SourceGenerated.EnumValidator.Validate(value);
 
             if (value == ComboBoxStyle.DropDownList
@@ -1111,10 +1109,10 @@ public partial class ComboBox : ListControl
                 AutoCompleteMode = AutoCompleteMode.None;
             }
 
-            // reset preferred height.
+            // Reset preferred height.
             ResetHeightCache();
 
-            Properties.AddValue(s_propStyle, value);
+            Properties.AddOrRemoveValue(s_propStyle, value, ComboBoxStyle.DropDown);
 
             if (IsHandleCreated)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewButtonCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewButtonCell.cs
@@ -45,7 +45,7 @@ public partial class DataGridViewButtonCell : DataGridViewCell
             Debug.Assert((value & ~(ButtonState.Normal | ButtonState.Pushed | ButtonState.Checked)) == 0);
             if (ButtonState != value)
             {
-                Properties.AddOrRemoveValue(s_propButtonCellState, value, ButtonState.Normal);
+                Properties.AddOrRemoveValue(s_propButtonCellState, value, defaultValue: ButtonState.Normal);
             }
         }
     }
@@ -63,7 +63,7 @@ public partial class DataGridViewButtonCell : DataGridViewCell
             SourceGenerated.EnumValidator.Validate(value);
             if (value != FlatStyle)
             {
-                Properties.AddOrRemoveValue(s_propButtonCellFlatStyle, value, FlatStyle.Standard);
+                Properties.AddOrRemoveValue(s_propButtonCellFlatStyle, value, defaultValue: FlatStyle.Standard);
                 OnCommonChange();
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewButtonCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewButtonCell.cs
@@ -45,20 +45,14 @@ public partial class DataGridViewButtonCell : DataGridViewCell
             Debug.Assert((value & ~(ButtonState.Normal | ButtonState.Pushed | ButtonState.Checked)) == 0);
             if (ButtonState != value)
             {
-                Properties.AddValue(s_propButtonCellState, value);
+                Properties.AddOrRemoveValue(s_propButtonCellState, value, ButtonState.Normal);
             }
         }
     }
 
+    // Buttons can't switch to edit mode
     [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.Interfaces)]
-    public override Type? EditType
-    {
-        get
-        {
-            // Buttons can't switch to edit mode
-            return null;
-        }
-    }
+    public override Type? EditType => null;
 
     [DefaultValue(FlatStyle.Standard)]
     public FlatStyle FlatStyle
@@ -66,11 +60,10 @@ public partial class DataGridViewButtonCell : DataGridViewCell
         get => Properties.GetValueOrDefault(s_propButtonCellFlatStyle, FlatStyle.Standard);
         set
         {
-            // Sequential enum. Valid values are 0x0 to 0x3
             SourceGenerated.EnumValidator.Validate(value);
             if (value != FlatStyle)
             {
-                Properties.AddValue(s_propButtonCellFlatStyle, value);
+                Properties.AddOrRemoveValue(s_propButtonCellFlatStyle, value, FlatStyle.Standard);
                 OnCommonChange();
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewCellStyle.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewCellStyle.cs
@@ -97,7 +97,7 @@ public class DataGridViewCellStyle : ICloneable
             Debug.Assert(Enum.IsDefined(value));
             if (Alignment != value)
             {
-                Properties.AddValue(s_propAlignment, value);
+                Properties.AddOrRemoveValue(s_propAlignment, value, DataGridViewContentAlignment.NotSet);
                 OnPropertyChanged(DataGridViewCellStylePropertyInternal.Other);
             }
         }
@@ -402,7 +402,7 @@ public class DataGridViewCellStyle : ICloneable
             Debug.Assert(value is >= DataGridViewTriState.NotSet and <= DataGridViewTriState.False);
             if (WrapMode != value)
             {
-                Properties.AddValue(s_propWrapMode, value);
+                Properties.AddOrRemoveValue(s_propWrapMode, value, DataGridViewTriState.NotSet);
                 OnPropertyChanged(DataGridViewCellStylePropertyInternal.Other);
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewCellStyle.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewCellStyle.cs
@@ -97,7 +97,7 @@ public class DataGridViewCellStyle : ICloneable
             Debug.Assert(Enum.IsDefined(value));
             if (Alignment != value)
             {
-                Properties.AddOrRemoveValue(s_propAlignment, value, DataGridViewContentAlignment.NotSet);
+                Properties.AddOrRemoveValue(s_propAlignment, value, defaultValue: DataGridViewContentAlignment.NotSet);
                 OnPropertyChanged(DataGridViewCellStylePropertyInternal.Other);
             }
         }
@@ -402,7 +402,7 @@ public class DataGridViewCellStyle : ICloneable
             Debug.Assert(value is >= DataGridViewTriState.NotSet and <= DataGridViewTriState.False);
             if (WrapMode != value)
             {
-                Properties.AddOrRemoveValue(s_propWrapMode, value, DataGridViewTriState.NotSet);
+                Properties.AddOrRemoveValue(s_propWrapMode, value, defaultValue: DataGridViewTriState.NotSet);
                 OnPropertyChanged(DataGridViewCellStylePropertyInternal.Other);
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewCheckBoxCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewCheckBoxCell.cs
@@ -187,7 +187,7 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
             Debug.Assert((value & ~(ButtonState.Normal | ButtonState.Pushed | ButtonState.Checked)) == 0);
             if (ButtonState != value)
             {
-                Properties.AddOrRemoveValue(s_propButtonCellState, value, ButtonState.Normal);
+                Properties.AddOrRemoveValue(s_propButtonCellState, value, defaultValue: ButtonState.Normal);
             }
         }
     }
@@ -236,7 +236,7 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
         set
         {
             SourceGenerated.EnumValidator.Validate(value);
-            FlatStyle previous = Properties.AddOrRemoveValue(s_propFlatStyle, value, FlatStyle.Standard);
+            FlatStyle previous = Properties.AddOrRemoveValue(s_propFlatStyle, value, defaultValue: FlatStyle.Standard);
             if (value != previous)
             {
                 OnCommonChange();
@@ -251,7 +251,7 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
             Debug.Assert(value is >= FlatStyle.Flat and <= FlatStyle.System);
             if (value != FlatStyle)
             {
-                Properties.AddOrRemoveValue(s_propFlatStyle, value, FlatStyle.Standard);
+                Properties.AddOrRemoveValue(s_propFlatStyle, value, defaultValue: FlatStyle.Standard);
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewCheckBoxCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewCheckBoxCell.cs
@@ -187,7 +187,7 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
             Debug.Assert((value & ~(ButtonState.Normal | ButtonState.Pushed | ButtonState.Checked)) == 0);
             if (ButtonState != value)
             {
-                Properties.AddValue(s_propButtonCellState, value);
+                Properties.AddOrRemoveValue(s_propButtonCellState, value, ButtonState.Normal);
             }
         }
     }
@@ -235,9 +235,8 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
         get => Properties.GetValueOrDefault(s_propFlatStyle, FlatStyle.Standard);
         set
         {
-            // Sequential enum. Valid values are 0x0 to 0x3
             SourceGenerated.EnumValidator.Validate(value);
-            FlatStyle previous = Properties.AddOrRemoveValue(s_propFlatStyle, value);
+            FlatStyle previous = Properties.AddOrRemoveValue(s_propFlatStyle, value, FlatStyle.Standard);
             if (value != previous)
             {
                 OnCommonChange();
@@ -252,7 +251,7 @@ public partial class DataGridViewCheckBoxCell : DataGridViewCell, IDataGridViewE
             Debug.Assert(value is >= FlatStyle.Flat and <= FlatStyle.System);
             if (value != FlatStyle)
             {
-                Properties.AddValue(s_propFlatStyle, value);
+                Properties.AddOrRemoveValue(s_propFlatStyle, value, FlatStyle.Standard);
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewComboBoxCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewComboBoxCell.cs
@@ -231,11 +231,10 @@ public partial class DataGridViewComboBoxCell : DataGridViewCell
         get => Properties.GetValueOrDefault(s_propComboBoxCellDisplayStyle, DataGridViewComboBoxDisplayStyle.DropDownButton);
         set
         {
-            // Sequential enum. Valid values are 0x0 to 0x2
             SourceGenerated.EnumValidator.Validate(value);
             if (value != DisplayStyle)
             {
-                Properties.AddValue(s_propComboBoxCellDisplayStyle, value);
+                Properties.AddOrRemoveValue(s_propComboBoxCellDisplayStyle, value, DataGridViewComboBoxDisplayStyle.DropDownButton);
                 if (DataGridView is not null)
                 {
                     if (RowIndex != -1)
@@ -359,7 +358,7 @@ public partial class DataGridViewComboBoxCell : DataGridViewCell
             SourceGenerated.EnumValidator.Validate(value);
             if (value != FlatStyle)
             {
-                Properties.AddValue(s_propComboBoxCellFlatStyle, value);
+                Properties.AddOrRemoveValue(s_propComboBoxCellFlatStyle, value, FlatStyle.Standard);
                 OnCommonChange();
             }
         }
@@ -395,7 +394,7 @@ public partial class DataGridViewComboBoxCell : DataGridViewCell
                 throw new ArgumentOutOfRangeException(nameof(MaxDropDownItems), value, string.Format(SR.DataGridViewComboBoxCell_MaxDropDownItemsOutOfRange, 1, 100));
             }
 
-            Properties.AddValue(s_propComboBoxCellMaxDropDownItems, value);
+            Properties.AddOrRemoveValue(s_propComboBoxCellMaxDropDownItems, value, DefaultMaxDropDownItems);
             if (OwnsEditingComboBox(RowIndex))
             {
                 EditingComboBox.MaxDropDownItems = value;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewComboBoxCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewComboBoxCell.cs
@@ -232,19 +232,21 @@ public partial class DataGridViewComboBoxCell : DataGridViewCell
         set
         {
             SourceGenerated.EnumValidator.Validate(value);
-            if (value != DisplayStyle)
+            if (value == DisplayStyle)
             {
-                Properties.AddOrRemoveValue(s_propComboBoxCellDisplayStyle, value, DataGridViewComboBoxDisplayStyle.DropDownButton);
-                if (DataGridView is not null)
+                return;
+            }
+
+            Properties.AddOrRemoveValue(s_propComboBoxCellDisplayStyle, value, defaultValue: DataGridViewComboBoxDisplayStyle.DropDownButton);
+            if (DataGridView is not null)
+            {
+                if (RowIndex != -1)
                 {
-                    if (RowIndex != -1)
-                    {
-                        DataGridView.InvalidateCell(this);
-                    }
-                    else
-                    {
-                        DataGridView.InvalidateColumnInternal(ColumnIndex);
-                    }
+                    DataGridView.InvalidateCell(this);
+                }
+                else
+                {
+                    DataGridView.InvalidateColumnInternal(ColumnIndex);
                 }
             }
         }
@@ -358,7 +360,7 @@ public partial class DataGridViewComboBoxCell : DataGridViewCell
             SourceGenerated.EnumValidator.Validate(value);
             if (value != FlatStyle)
             {
-                Properties.AddOrRemoveValue(s_propComboBoxCellFlatStyle, value, FlatStyle.Standard);
+                Properties.AddOrRemoveValue(s_propComboBoxCellFlatStyle, value, defaultValue: FlatStyle.Standard);
                 OnCommonChange();
             }
         }
@@ -391,10 +393,13 @@ public partial class DataGridViewComboBoxCell : DataGridViewCell
         {
             if (value is < 1 or > 100)
             {
-                throw new ArgumentOutOfRangeException(nameof(MaxDropDownItems), value, string.Format(SR.DataGridViewComboBoxCell_MaxDropDownItemsOutOfRange, 1, 100));
+                throw new ArgumentOutOfRangeException(
+                    nameof(MaxDropDownItems),
+                    value,
+                    string.Format(SR.DataGridViewComboBoxCell_MaxDropDownItemsOutOfRange, 1, 100));
             }
 
-            Properties.AddOrRemoveValue(s_propComboBoxCellMaxDropDownItems, value, DefaultMaxDropDownItems);
+            Properties.AddOrRemoveValue(s_propComboBoxCellMaxDropDownItems, value, defaultValue: DefaultMaxDropDownItems);
             if (OwnsEditingComboBox(RowIndex))
             {
                 EditingComboBox.MaxDropDownItems = value;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewHeaderCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewHeaderCell.cs
@@ -38,7 +38,7 @@ public partial class DataGridViewHeaderCell : DataGridViewCell
             Debug.Assert(Enum.IsDefined(value));
             if (ButtonState != value)
             {
-                Properties.AddValue(s_propButtonState, value);
+                Properties.AddOrRemoveValue(s_propButtonState, value, ButtonState.Normal);
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewHeaderCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewHeaderCell.cs
@@ -38,7 +38,7 @@ public partial class DataGridViewHeaderCell : DataGridViewCell
             Debug.Assert(Enum.IsDefined(value));
             if (ButtonState != value)
             {
-                Properties.AddOrRemoveValue(s_propButtonState, value, ButtonState.Normal);
+                Properties.AddOrRemoveValue(s_propButtonState, value, defaultValue: ButtonState.Normal);
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewImageCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewImageCell.cs
@@ -102,7 +102,7 @@ public partial class DataGridViewImageCell : DataGridViewCell
             SourceGenerated.EnumValidator.Validate(value);
             if (ImageLayout != value)
             {
-                Properties.AddOrRemoveValue(s_propImageCellLayout, value, DataGridViewImageCellLayout.Normal);
+                Properties.AddOrRemoveValue(s_propImageCellLayout, value, defaultValue: DataGridViewImageCellLayout.Normal);
                 OnCommonChange();
             }
         }
@@ -113,7 +113,7 @@ public partial class DataGridViewImageCell : DataGridViewCell
         set
         {
             Debug.Assert(value is >= DataGridViewImageCellLayout.NotSet and <= DataGridViewImageCellLayout.Zoom);
-            Properties.AddOrRemoveValue(s_propImageCellLayout, value, DataGridViewImageCellLayout.Normal);
+            Properties.AddOrRemoveValue(s_propImageCellLayout, value, defaultValue: DataGridViewImageCellLayout.Normal);
         }
     }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewImageCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewImageCell.cs
@@ -102,7 +102,7 @@ public partial class DataGridViewImageCell : DataGridViewCell
             SourceGenerated.EnumValidator.Validate(value);
             if (ImageLayout != value)
             {
-                Properties.AddValue(s_propImageCellLayout, value);
+                Properties.AddOrRemoveValue(s_propImageCellLayout, value, DataGridViewImageCellLayout.Normal);
                 OnCommonChange();
             }
         }
@@ -113,7 +113,7 @@ public partial class DataGridViewImageCell : DataGridViewCell
         set
         {
             Debug.Assert(value is >= DataGridViewImageCellLayout.NotSet and <= DataGridViewImageCellLayout.Zoom);
-            Properties.AddValue(s_propImageCellLayout, value);
+            Properties.AddOrRemoveValue(s_propImageCellLayout, value, DataGridViewImageCellLayout.Normal);
         }
     }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewLinkCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewLinkCell.cs
@@ -120,7 +120,7 @@ public partial class DataGridViewLinkCell : DataGridViewCell
             SourceGenerated.EnumValidator.Validate(value);
             if (value != LinkBehavior)
             {
-                Properties.AddOrRemoveValue(s_propLinkCellLinkBehavior, value, LinkBehavior.SystemDefault);
+                Properties.AddOrRemoveValue(s_propLinkCellLinkBehavior, value, defaultValue: LinkBehavior.SystemDefault);
                 if (DataGridView is not null)
                 {
                     if (RowIndex != -1)
@@ -143,7 +143,7 @@ public partial class DataGridViewLinkCell : DataGridViewCell
             Debug.Assert(value is >= LinkBehavior.SystemDefault and <= LinkBehavior.NeverUnderline);
             if (value != LinkBehavior)
             {
-                Properties.AddOrRemoveValue(s_propLinkCellLinkBehavior, value, LinkBehavior.SystemDefault);
+                Properties.AddOrRemoveValue(s_propLinkCellLinkBehavior, value, defaultValue: LinkBehavior.SystemDefault);
             }
         }
     }
@@ -214,7 +214,7 @@ public partial class DataGridViewLinkCell : DataGridViewCell
         {
             if (LinkState != value)
             {
-                Properties.AddOrRemoveValue(s_propLinkCellLinkState, value, LinkState.Normal);
+                Properties.AddOrRemoveValue(s_propLinkCellLinkState, value, defaultValue: LinkState.Normal);
             }
         }
     }
@@ -253,7 +253,7 @@ public partial class DataGridViewLinkCell : DataGridViewCell
         {
             if (value != TrackVisitedState)
             {
-                Properties.AddOrRemoveValue(s_propLinkCellTrackVisitedState, value, true);
+                Properties.AddOrRemoveValue(s_propLinkCellTrackVisitedState, value, defaultValue: true);
                 if (DataGridView is not null)
                 {
                     if (RowIndex != -1)
@@ -275,7 +275,7 @@ public partial class DataGridViewLinkCell : DataGridViewCell
         {
             if (value != TrackVisitedState)
             {
-                Properties.AddOrRemoveValue(s_propLinkCellTrackVisitedState, value, true);
+                Properties.AddOrRemoveValue(s_propLinkCellTrackVisitedState, value, defaultValue: true);
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewLinkCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewLinkCell.cs
@@ -117,11 +117,10 @@ public partial class DataGridViewLinkCell : DataGridViewCell
         get => Properties.GetValueOrDefault(s_propLinkCellLinkBehavior, LinkBehavior.SystemDefault);
         set
         {
-            // Sequential enum. Valid values are 0x0 to 0x3
             SourceGenerated.EnumValidator.Validate(value);
             if (value != LinkBehavior)
             {
-                Properties.AddValue(s_propLinkCellLinkBehavior, value);
+                Properties.AddOrRemoveValue(s_propLinkCellLinkBehavior, value, LinkBehavior.SystemDefault);
                 if (DataGridView is not null)
                 {
                     if (RowIndex != -1)
@@ -144,7 +143,7 @@ public partial class DataGridViewLinkCell : DataGridViewCell
             Debug.Assert(value is >= LinkBehavior.SystemDefault and <= LinkBehavior.NeverUnderline);
             if (value != LinkBehavior)
             {
-                Properties.AddValue(s_propLinkCellLinkBehavior, value);
+                Properties.AddOrRemoveValue(s_propLinkCellLinkBehavior, value, LinkBehavior.SystemDefault);
             }
         }
     }
@@ -215,23 +214,14 @@ public partial class DataGridViewLinkCell : DataGridViewCell
         {
             if (LinkState != value)
             {
-                Properties.AddValue(s_propLinkCellLinkState, value);
+                Properties.AddOrRemoveValue(s_propLinkCellLinkState, value, LinkState.Normal);
             }
         }
     }
 
     public bool LinkVisited
     {
-        get
-        {
-            if (_linkVisitedSet)
-            {
-                return _linkVisited;
-            }
-
-            // the default is false
-            return false;
-        }
+        get => _linkVisitedSet && _linkVisited;
         set
         {
             _linkVisitedSet = true;
@@ -263,7 +253,7 @@ public partial class DataGridViewLinkCell : DataGridViewCell
         {
             if (value != TrackVisitedState)
             {
-                Properties.AddValue(s_propLinkCellTrackVisitedState, value);
+                Properties.AddOrRemoveValue(s_propLinkCellTrackVisitedState, value, true);
                 if (DataGridView is not null)
                 {
                     if (RowIndex != -1)
@@ -285,7 +275,7 @@ public partial class DataGridViewLinkCell : DataGridViewCell
         {
             if (value != TrackVisitedState)
             {
-                Properties.AddValue(s_propLinkCellTrackVisitedState, value);
+                Properties.AddOrRemoveValue(s_propLinkCellTrackVisitedState, value, true);
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewTextBoxCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewTextBoxCell.cs
@@ -69,7 +69,7 @@ public partial class DataGridViewTextBoxCell : DataGridViewCell
         {
             ArgumentOutOfRangeException.ThrowIfNegative(value);
 
-            Properties.AddValue(s_propTextBoxCellMaxInputLength, value);
+            Properties.AddOrRemoveValue(s_propTextBoxCellMaxInputLength, value, DATAGRIDVIEWTEXTBOXCELL_maxInputLength);
             if (OwnsEditingTextBox(RowIndex))
             {
                 EditingTextBox.MaxLength = value;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewTextBoxCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewTextBoxCell.cs
@@ -25,7 +25,7 @@ public partial class DataGridViewTextBoxCell : DataGridViewCell
     private const byte DATAGRIDVIEWTEXTBOXCELL_verticalTextMarginTopWithoutWrapping = 2;
     private const byte DATAGRIDVIEWTEXTBOXCELL_verticalTextMarginBottom = 1;
 
-    private const int DATAGRIDVIEWTEXTBOXCELL_maxInputLength = 32767;
+    private const int MaxInputLengthDefault = 32767;
 
     private byte _flagsState;  // see DATAGRIDVIEWTEXTBOXCELL_ constants above
 
@@ -61,15 +61,15 @@ public partial class DataGridViewTextBoxCell : DataGridViewCell
         }
     }
 
-    [DefaultValue(DATAGRIDVIEWTEXTBOXCELL_maxInputLength)]
+    [DefaultValue(MaxInputLengthDefault)]
     public virtual int MaxInputLength
     {
-        get => Properties.GetValueOrDefault(s_propTextBoxCellMaxInputLength, DATAGRIDVIEWTEXTBOXCELL_maxInputLength);
+        get => Properties.GetValueOrDefault(s_propTextBoxCellMaxInputLength, MaxInputLengthDefault);
         set
         {
             ArgumentOutOfRangeException.ThrowIfNegative(value);
 
-            Properties.AddOrRemoveValue(s_propTextBoxCellMaxInputLength, value, DATAGRIDVIEWTEXTBOXCELL_maxInputLength);
+            Properties.AddOrRemoveValue(s_propTextBoxCellMaxInputLength, value, defaultValue: MaxInputLengthDefault);
             if (OwnsEditingTextBox(RowIndex))
             {
                 EditingTextBox.MaxLength = value;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/Labels/Label.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/Labels/Label.cs
@@ -561,7 +561,7 @@ public partial class Label : Control, IAutomationLiveRegion
 
             if (value != ImageAlign)
             {
-                Properties.AddValue(s_propImageAlign, value);
+                Properties.AddOrRemoveValue(s_propImageAlign, value, ContentAlignment.MiddleCenter);
                 LayoutTransaction.DoLayoutIf(AutoSize, ParentInternal, this, PropertyNames.ImageAlign);
                 Invalidate();
             }
@@ -705,7 +705,7 @@ public partial class Label : Control, IAutomationLiveRegion
 
             if (TextAlign != value)
             {
-                Properties.AddValue(s_propTextAlign, value);
+                Properties.AddOrRemoveValue(s_propTextAlign, value, ContentAlignment.TopLeft);
                 Invalidate();
 
                 // Change the TextAlignment for SystemDrawn Labels

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/Labels/Label.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/Labels/Label.cs
@@ -561,7 +561,7 @@ public partial class Label : Control, IAutomationLiveRegion
 
             if (value != ImageAlign)
             {
-                Properties.AddOrRemoveValue(s_propImageAlign, value, ContentAlignment.MiddleCenter);
+                Properties.AddOrRemoveValue(s_propImageAlign, value, defaultValue: ContentAlignment.MiddleCenter);
                 LayoutTransaction.DoLayoutIf(AutoSize, ParentInternal, this, PropertyNames.ImageAlign);
                 Invalidate();
             }
@@ -705,7 +705,7 @@ public partial class Label : Control, IAutomationLiveRegion
 
             if (TextAlign != value)
             {
-                Properties.AddOrRemoveValue(s_propTextAlign, value, ContentAlignment.TopLeft);
+                Properties.AddOrRemoveValue(s_propTextAlign, value, defaultValue: ContentAlignment.TopLeft);
                 Invalidate();
 
                 // Change the TextAlignment for SystemDrawn Labels

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripItem.cs
@@ -267,7 +267,7 @@ public abstract partial class ToolStripItem :
         set
         {
             SourceGenerated.EnumValidator.Validate(value);
-            Properties.AddValue(s_accessibleRoleProperty, value);
+            Properties.AddOrRemoveValue(s_accessibleRoleProperty, value, AccessibleRole.Default);
             OnAccessibleRoleChanged(EventArgs.Empty);
         }
     }
@@ -1293,7 +1293,7 @@ public abstract partial class ToolStripItem :
         set
         {
             SourceGenerated.EnumValidator.Validate(value);
-            Properties.AddValue(s_mergeActionProperty, value);
+            Properties.AddOrRemoveValue(s_mergeActionProperty, value, MergeAction.Append);
         }
     }
 
@@ -1306,7 +1306,7 @@ public abstract partial class ToolStripItem :
     public int MergeIndex
     {
         get => Properties.GetValueOrDefault(s_mergeIndexProperty, -1);
-        set => Properties.AddValue(s_mergeIndexProperty, value);
+        set => Properties.AddOrRemoveValue(s_mergeIndexProperty, value, -1);
     }
 
     internal bool MouseDownAndUpMustBeInSameItem

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripItem.cs
@@ -267,7 +267,7 @@ public abstract partial class ToolStripItem :
         set
         {
             SourceGenerated.EnumValidator.Validate(value);
-            Properties.AddOrRemoveValue(s_accessibleRoleProperty, value, AccessibleRole.Default);
+            Properties.AddOrRemoveValue(s_accessibleRoleProperty, value, defaultValue: AccessibleRole.Default);
             OnAccessibleRoleChanged(EventArgs.Empty);
         }
     }
@@ -1293,7 +1293,7 @@ public abstract partial class ToolStripItem :
         set
         {
             SourceGenerated.EnumValidator.Validate(value);
-            Properties.AddOrRemoveValue(s_mergeActionProperty, value, MergeAction.Append);
+            Properties.AddOrRemoveValue(s_mergeActionProperty, value, defaultValue: MergeAction.Append);
         }
     }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripMenuItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripMenuItem.cs
@@ -307,7 +307,7 @@ public partial class ToolStripMenuItem : ToolStripDropDownItem
 
             if (value != CheckState)
             {
-                Properties.AddValue(s_propCheckState, value);
+                Properties.AddOrRemoveValue(s_propCheckState, value, CheckState.Unchecked);
                 OnCheckedChanged(EventArgs.Empty);
                 OnCheckStateChanged(EventArgs.Empty);
             }
@@ -315,9 +315,7 @@ public partial class ToolStripMenuItem : ToolStripDropDownItem
     }
 
     /// <summary>
-    ///  Occurs when the
-    ///  value of the <see cref="CheckBox.Checked"/>
-    ///  property changes.
+    ///  Occurs when the value of the <see cref="CheckBox.Checked"/> property changes.
     /// </summary>
     [SRDescription(nameof(SR.CheckBoxOnCheckedChangedDescr))]
     public event EventHandler? CheckedChanged
@@ -327,9 +325,7 @@ public partial class ToolStripMenuItem : ToolStripDropDownItem
     }
 
     /// <summary>
-    ///  Occurs when the
-    ///  value of the <see cref="CheckBox.CheckState"/>
-    ///  property changes.
+    ///  Occurs when the value of the <see cref="CheckBox.CheckState"/> property changes.
     /// </summary>
     [SRDescription(nameof(SR.CheckBoxOnCheckStateChangedDescr))]
     public event EventHandler? CheckStateChanged
@@ -370,38 +366,40 @@ public partial class ToolStripMenuItem : ToolStripDropDownItem
             }
 
             Keys originalShortcut = ShortcutKeys;
-            if (originalShortcut != value)
+            if (originalShortcut == value)
             {
-                ClearShortcutCache();
-                ToolStrip? owner = Owner;
-                if (owner is not null)
-                {
-                    // add to the shortcut caching system.
-                    if (originalShortcut != Keys.None)
-                    {
-                        owner.Shortcuts.Remove(originalShortcut);
-                    }
+                return;
+            }
 
-                    if (owner.Shortcuts.ContainsKey(value))
-                    {
-                        // last one in wins.
-                        owner.Shortcuts[value] = this;
-                    }
-                    else
-                    {
-                        owner.Shortcuts.Add(value, this);
-                    }
+            ClearShortcutCache();
+            ToolStrip? owner = Owner;
+            if (owner is not null)
+            {
+                // Add to the shortcut caching system.
+                if (originalShortcut != Keys.None)
+                {
+                    owner.Shortcuts.Remove(originalShortcut);
                 }
 
-                Properties.AddValue(s_propShortcutKeys, value);
-
-                if (ShowShortcutKeys && IsOnDropDown)
+                if (owner.Shortcuts.ContainsKey(value))
                 {
-                    if (GetCurrentParentDropDown() is ToolStripDropDownMenu parent)
-                    {
-                        LayoutTransaction.DoLayout(ParentInternal, this, "ShortcutKeys");
-                        parent.AdjustSize();
-                    }
+                    // Last one in wins.
+                    owner.Shortcuts[value] = this;
+                }
+                else
+                {
+                    owner.Shortcuts.Add(value, this);
+                }
+            }
+
+            Properties.AddOrRemoveValue(s_propShortcutKeys, value, Keys.None);
+
+            if (ShowShortcutKeys && IsOnDropDown)
+            {
+                if (GetCurrentParentDropDown() is ToolStripDropDownMenu parent)
+                {
+                    LayoutTransaction.DoLayout(ParentInternal, this, "ShortcutKeys");
+                    parent.AdjustSize();
                 }
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripMenuItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripMenuItem.cs
@@ -307,7 +307,7 @@ public partial class ToolStripMenuItem : ToolStripDropDownItem
 
             if (value != CheckState)
             {
-                Properties.AddOrRemoveValue(s_propCheckState, value, CheckState.Unchecked);
+                Properties.AddOrRemoveValue(s_propCheckState, value, defaultValue: CheckState.Unchecked);
                 OnCheckedChanged(EventArgs.Empty);
                 OnCheckStateChanged(EventArgs.Empty);
             }
@@ -392,7 +392,7 @@ public partial class ToolStripMenuItem : ToolStripDropDownItem
                 }
             }
 
-            Properties.AddOrRemoveValue(s_propShortcutKeys, value, Keys.None);
+            Properties.AddOrRemoveValue(s_propShortcutKeys, value, defaultValue: Keys.None);
 
             if (ShowShortcutKeys && IsOnDropDown)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -2164,7 +2164,7 @@ public partial class Form : ContainerControl
         get => Properties.GetValueOrDefault(s_propTransparencyKey, Color.Empty);
         set
         {
-            Properties.AddOrRemoveValue(s_propTransparencyKey, value);
+            Properties.AddOrRemoveValue(s_propTransparencyKey, value, Color.Empty);
             if (!IsMdiContainer)
             {
                 bool oldLayered = (_formState[s_formStateLayered] == 1);
@@ -2361,14 +2361,7 @@ public partial class Form : ContainerControl
                 _ => throw new ArgumentOutOfRangeException(nameof(value))
             };
 
-            if (value == FormCornerPreference.Default)
-            {
-                Properties.RemoveValue(s_propFormCornerPreference);
-            }
-            else
-            {
-                Properties.AddValue(s_propFormCornerPreference, value);
-            }
+            Properties.AddOrRemoveValue(s_propFormCornerPreference, value, FormCornerPreference.Default);
 
             if (IsHandleCreated)
             {
@@ -2451,7 +2444,7 @@ public partial class Form : ContainerControl
                 return;
             }
 
-            Properties.AddValue(s_propFormBorderColor, value);
+            Properties.AddOrRemoveValue(s_propFormBorderColor, value, Color.Empty);
 
             if (IsHandleCreated)
             {
@@ -2513,7 +2506,7 @@ public partial class Form : ContainerControl
                 return;
             }
 
-            Properties.AddValue(s_propFormCaptionBackColor, value);
+            Properties.AddOrRemoveValue(s_propFormCaptionBackColor, value, Color.Empty);
 
             if (IsHandleCreated)
             {
@@ -2576,7 +2569,7 @@ public partial class Form : ContainerControl
                 return;
             }
 
-            Properties.AddValue(s_propFormCaptionTextColor, value);
+            Properties.AddOrRemoveValue(s_propFormCaptionTextColor, value, Color.Empty);
 
             if (IsHandleCreated)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -2164,7 +2164,7 @@ public partial class Form : ContainerControl
         get => Properties.GetValueOrDefault(s_propTransparencyKey, Color.Empty);
         set
         {
-            Properties.AddOrRemoveValue(s_propTransparencyKey, value, Color.Empty);
+            Properties.AddOrRemoveValue(s_propTransparencyKey, value, defaultValue: Color.Empty);
             if (!IsMdiContainer)
             {
                 bool oldLayered = (_formState[s_formStateLayered] == 1);
@@ -2361,7 +2361,7 @@ public partial class Form : ContainerControl
                 _ => throw new ArgumentOutOfRangeException(nameof(value))
             };
 
-            Properties.AddOrRemoveValue(s_propFormCornerPreference, value, FormCornerPreference.Default);
+            Properties.AddOrRemoveValue(s_propFormCornerPreference, value, defaultValue: FormCornerPreference.Default);
 
             if (IsHandleCreated)
             {
@@ -2444,7 +2444,7 @@ public partial class Form : ContainerControl
                 return;
             }
 
-            Properties.AddOrRemoveValue(s_propFormBorderColor, value, Color.Empty);
+            Properties.AddOrRemoveValue(s_propFormBorderColor, value, defaultValue: Color.Empty);
 
             if (IsHandleCreated)
             {
@@ -2506,7 +2506,7 @@ public partial class Form : ContainerControl
                 return;
             }
 
-            Properties.AddOrRemoveValue(s_propFormCaptionBackColor, value, Color.Empty);
+            Properties.AddOrRemoveValue(s_propFormCaptionBackColor, value, defaultValue: Color.Empty);
 
             if (IsHandleCreated)
             {
@@ -2569,7 +2569,7 @@ public partial class Form : ContainerControl
                 return;
             }
 
-            Properties.AddOrRemoveValue(s_propFormCaptionTextColor, value, Color.Empty);
+            Properties.AddOrRemoveValue(s_propFormCaptionTextColor, value, defaultValue: Color.Empty);
 
             if (IsHandleCreated)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyStore.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyStore.cs
@@ -91,7 +91,7 @@ internal class PropertyStore
     public void SetObject(int key, object? value) => _values[key] = new(value);
 
     /// <summary>
-    ///  Gets the current value for the given key, or the default value for the type if the key is not found.
+    ///  Gets the current value for the given key, or the <paramref name="defaultValue"/> if the key is not found.
     /// </summary>
     public T? GetValueOrDefault<T>(int key, T? defaultValue = default)
     {
@@ -117,9 +117,9 @@ internal class PropertyStore
     }
 
     /// <summary>
-    ///  Tries to get the value for the given key. Returns <see langword="true"/> if the value was found and was
-    ///  not <see langword="null"/>.
+    ///  Tries to get the value for the given key.
     /// </summary>
+    /// <inheritdoc cref="TryGetValueOrNull{T}(int, out T)"/>
     public bool TryGetValue<T>(int key, [NotNullWhen(true)] out T? value)
     {
         if (_values.TryGetValue(key, out Value foundValue))
@@ -136,8 +136,13 @@ internal class PropertyStore
 
     /// <summary>
     ///  Tries to get the value for the given key, allowing explicitly set <see langword="null"/> values.
-    ///  Returns <see langword="true"/> if the value was found.
     /// </summary>
+    /// <param name="value">
+    ///  <para>
+    ///   The value if found, or <see langword="default"/> if not found.
+    ///  </para>
+    /// </param>
+    /// <returns><see langword="true"/> if the value was found.</returns>
     public bool TryGetValueOrNull<T>(int key, out T? value) where T : class
     {
         if (_values.TryGetValue(key, out Value foundValue))
@@ -169,13 +174,15 @@ internal class PropertyStore
     }
 
     /// <summary>
-    ///  Sets the given value or clears it from the store if the value is <see langword="null"/>.
-    ///  Returns the previous value if it was set, or <see langword="null"/>.
+    ///  Sets the given value or clears it from the store if the value equals <paramref name="defaultValue"/>.
     /// </summary>
-    public T? AddOrRemoveValue<T>(int key, T? value)
+    /// <returns>The previous value if it was set, or <see langword="default"/>.</returns>
+    public T? AddOrRemoveValue<T>(int key, T? value, T? defaultValue = default)
     {
         TryGetValue(key, out T? previous);
-        if (value is null || EqualityComparer<T>.Default.Equals(value, default))
+
+        if ((value is null && defaultValue is null)
+            || (value is not null && value.Equals(defaultValue)))
         {
             _values.Remove(key);
         }


### PR DESCRIPTION
It is pretty common to have default values that aren't the same as the type `default`. As such, being explicit about the default value allows pairing with `GetValueOrDefault`.

We don't want to maintain entries in the dictionary for things that aren't actually needed.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12174)