### PR TITLE
Fix spelling of AccessibilityExtensions, rename file as well as class

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/AccessibilityExtensions.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/AccessibilityExtensions.cs
@@ -6,7 +6,7 @@ using Accessibility;
 
 namespace System.Windows.Forms;
 
-internal static unsafe class AccessibiltyExtensions
+internal static unsafe class AccessibilityExtensions
 {
     /// <inheritdoc cref="PInvoke.LresultFromObject(Guid*, WPARAM, IUnknown*)"/>
     internal static LRESULT GetLRESULT(this IAccessible accessible, WPARAM wparam)


### PR DESCRIPTION
SMALL fix for part of ##11984

## Proposed changes
- Correct spelling AccessibiltyExtensions for fixe and class

## Customer Impact
- N/A

## Regression? 

- No

## Risk

-Changing name of internal class might have risks but all tests pass

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12188)