### PR TITLE
Move child controls collection out of PropertyStore

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ActiveX/Control.ActiveXImpl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ActiveX/Control.ActiveXImpl.cs
@@ -80,8 +80,7 @@ public partial class Control
     {
         get
         {
-            ActiveXImpl? activeXImpl = (ActiveXImpl?)Properties.GetObject(s_activeXImplProperty);
-            if (activeXImpl is null)
+            if (!Properties.TryGetValue(s_activeXImplProperty, out ActiveXImpl? activeXImpl))
             {
                 // Don't allow top level objects to be hosted as activeX controls.
                 if (GetState(States.TopLevel))

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -174,6 +174,8 @@ public unsafe partial class Control :
 
     private static Font? s_defaultFont;
 
+    internal ControlCollection? ChildControls { get; private set; }
+
     // Property store keys for properties. The property store allocates most efficiently
     // in groups of four, so we try to lump properties in groups of four based on how
     // likely they are going to be used in a group.
@@ -182,7 +184,6 @@ public unsafe partial class Control :
     private static readonly int s_fontHeightProperty = PropertyStore.CreateKey();
     private static readonly int s_currentAmbientFontProperty = PropertyStore.CreateKey();
 
-    private static readonly int s_controlsCollectionProperty = PropertyStore.CreateKey();
     private static readonly int s_backColorProperty = PropertyStore.CreateKey();
     private static readonly int s_foreColorProperty = PropertyStore.CreateKey();
     private static readonly int s_fontProperty = PropertyStore.CreateKey();
@@ -427,8 +428,7 @@ public unsafe partial class Control :
     {
         get
         {
-            AccessibleObject? accessibleObject = (AccessibleObject?)Properties.GetObject(s_accessibilityProperty);
-            if (accessibleObject is null)
+            if (!Properties.TryGetValue(s_accessibilityProperty, out AccessibleObject? accessibleObject))
             {
                 accessibleObject = CreateAccessibilityInstance();
                 Properties.SetObject(s_accessibilityProperty, accessibleObject);
@@ -447,8 +447,7 @@ public unsafe partial class Control :
     {
         get
         {
-            AccessibleObject? ncAccessibleObject = (AccessibleObject?)Properties.GetObject(s_ncAccessibilityProperty);
-            if (ncAccessibleObject is null)
+            if (!Properties.TryGetValue(s_ncAccessibilityProperty, out AccessibleObject? ncAccessibleObject))
             {
                 ncAccessibleObject = new ControlAccessibleObject(this, (int)OBJECT_IDENTIFIER.OBJID_WINDOW);
                 Properties.SetObject(s_ncAccessibilityProperty, ncAccessibleObject);
@@ -466,7 +465,7 @@ public unsafe partial class Control :
         this is IAutomationLiveRegion ? AccessibilityObject : null;
 
     /// <summary>
-    ///  The default action description of the control
+    ///  The default action description of the control.
     /// </summary>
     [SRCategory(nameof(SR.CatAccessibility))]
     [Browsable(false)]
@@ -475,12 +474,12 @@ public unsafe partial class Control :
     [SRDescription(nameof(SR.ControlAccessibleDefaultActionDescr))]
     public string? AccessibleDefaultActionDescription
     {
-        get => (string?)Properties.GetObject(s_accessibleDefaultActionProperty);
-        set => Properties.SetObject(s_accessibleDefaultActionProperty, value);
+        get => Properties.GetValueOrDefault<string>(s_accessibleDefaultActionProperty);
+        set => Properties.AddOrRemoveValue(s_accessibleDefaultActionProperty, value);
     }
 
     /// <summary>
-    ///  The accessible description of the control
+    ///  The accessible description of the control.
     /// </summary>
     [SRCategory(nameof(SR.CatAccessibility))]
     [DefaultValue(null)]
@@ -488,12 +487,12 @@ public unsafe partial class Control :
     [SRDescription(nameof(SR.ControlAccessibleDescriptionDescr))]
     public string? AccessibleDescription
     {
-        get => (string?)Properties.GetObject(s_accessibleDescriptionProperty);
-        set => Properties.SetObject(s_accessibleDescriptionProperty, value);
+        get => Properties.GetValueOrDefault<string>(s_accessibleDescriptionProperty);
+        set => Properties.AddOrRemoveValue(s_accessibleDescriptionProperty, value);
     }
 
     /// <summary>
-    ///  The accessible name of the control
+    ///  The accessible name of the control.
     /// </summary>
     [SRCategory(nameof(SR.CatAccessibility))]
     [DefaultValue(null)]
@@ -501,12 +500,12 @@ public unsafe partial class Control :
     [SRDescription(nameof(SR.ControlAccessibleNameDescr))]
     public string? AccessibleName
     {
-        get => (string?)Properties.GetObject(s_accessibleNameProperty);
-        set => Properties.SetObject(s_accessibleNameProperty, value);
+        get => Properties.GetValueOrDefault<string>(s_accessibleNameProperty);
+        set => Properties.AddOrRemoveValue(s_accessibleNameProperty, value);
     }
 
     /// <summary>
-    ///  The accessible role of the control
+    ///  The accessible role of the control.
     /// </summary>
     [SRCategory(nameof(SR.CatAccessibility))]
     [DefaultValue(AccessibleRole.Default)]
@@ -516,14 +515,13 @@ public unsafe partial class Control :
         get => Properties.GetValueOrDefault(s_accessibleRoleProperty, AccessibleRole.Default);
         set
         {
-            // valid values are -1 to 0x40
             SourceGenerated.EnumValidator.Validate(value);
             Properties.AddOrRemoveValue(s_accessibleRoleProperty, value, defaultValue: AccessibleRole.Default);
         }
     }
 
     /// <summary>
-    ///  The AllowDrop property. If AllowDrop is set to true then
+    ///  The AllowDrop property. If AllowDrop is set to <see langword="true"/> then
     ///  this control will allow drag and drop operations and events to be used.
     /// </summary>
     [SRCategory(nameof(SR.CatBehavior))]
@@ -865,7 +863,7 @@ public unsafe partial class Control :
     [SRDescription(nameof(SR.ControlBackgroundImageDescr))]
     public virtual Image? BackgroundImage
     {
-        get => (Image?)Properties.GetObject(s_backgroundImageProperty);
+        get => Properties.GetValueOrDefault<Image>(s_backgroundImageProperty);
         set
         {
             if (BackgroundImage == value)
@@ -873,7 +871,7 @@ public unsafe partial class Control :
                 return;
             }
 
-            Properties.SetObject(s_backgroundImageProperty, value);
+            Properties.AddOrRemoveValue(s_backgroundImageProperty, value);
             OnBackgroundImageChanged(EventArgs.Empty);
         }
     }
@@ -958,22 +956,20 @@ public unsafe partial class Control :
             return;
         }
 
-        ControlBindingsCollection? bindings = (ControlBindingsCollection?)Properties.GetObject(s_bindingsProperty);
-        bindings?.Clear();
+        Properties.GetValueOrDefault<ControlBindingsCollection>(s_bindingsProperty)?.Clear();
     }
 
     /// <summary>
     ///  BindingContextInternal provides a mechanism so that controls like SplitContainer that inherit from the
-    ///  ContainerControl can bypass the "containerControls" bindingContext property and do what the other simple controls
-    ///  do.
+    ///  ContainerControl can bypass the "containerControls" bindingContext property and do what the other simple
+    ///  controls do.
     /// </summary>
     internal BindingContext? BindingContextInternal
     {
         get
         {
             // See if we have locally overridden the binding manager.
-            BindingContext? context = (BindingContext?)Properties.GetObject(s_bindingManagerProperty);
-            if (context is not null)
+            if (Properties.TryGetValue(s_bindingManagerProperty, out BindingContext? context))
             {
                 return context;
             }
@@ -990,14 +986,11 @@ public unsafe partial class Control :
         }
         set
         {
-            BindingContext? oldContext = (BindingContext?)Properties.GetObject(s_bindingManagerProperty);
-            BindingContext? newContext = value;
+            BindingContext? oldContext = Properties.AddOrRemoveValue(s_bindingManagerProperty, value);
 
-            if (oldContext != newContext)
+            if (oldContext != value)
             {
-                Properties.SetObject(s_bindingManagerProperty, newContext);
-
-                // the property change will wire up the bindings.
+                // The property change will wire up the bindings.
                 OnBindingContextChanged(EventArgs.Empty);
             }
         }
@@ -1264,28 +1257,24 @@ public unsafe partial class Control :
     [SRDescription(nameof(SR.ControlContextMenuDescr))]
     public virtual ContextMenuStrip? ContextMenuStrip
     {
-        get => (ContextMenuStrip?)Properties.GetObject(s_contextMenuStripProperty);
+        get => Properties.GetValueOrDefault<ContextMenuStrip>(s_contextMenuStripProperty);
         set
         {
-            ContextMenuStrip? oldValue = Properties.GetObject(s_contextMenuStripProperty) as ContextMenuStrip;
+            ContextMenuStrip? oldValue = Properties.AddOrRemoveValue(s_contextMenuStripProperty, value);
 
             if (oldValue == value)
             {
                 return;
             }
 
-            EventHandler disposedHandler = new(DetachContextMenuStrip);
-
             if (oldValue is not null)
             {
-                oldValue.Disposed -= disposedHandler;
+                oldValue.Disposed -= DetachContextMenuStrip;
             }
-
-            Properties.SetObject(s_contextMenuStripProperty, value);
 
             if (value is not null)
             {
-                value.Disposed += disposedHandler;
+                value.Disposed += DetachContextMenuStrip;
             }
 
             OnContextMenuStripChanged(EventArgs.Empty);
@@ -1306,21 +1295,7 @@ public unsafe partial class Control :
     [Browsable(false)]
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
     [SRDescription(nameof(SR.ControlControlsDescr))]
-    public ControlCollection Controls
-    {
-        get
-        {
-            ControlCollection? controlsCollection = (ControlCollection?)Properties.GetObject(s_controlsCollectionProperty);
-
-            if (controlsCollection is null)
-            {
-                controlsCollection = CreateControlsInstance();
-                Properties.SetObject(s_controlsCollectionProperty, controlsCollection);
-            }
-
-            return controlsCollection;
-        }
-    }
+    public ControlCollection Controls => ChildControls ??= CreateControlsInstance();
 
     /// <summary>
     ///  Indicates whether the control has been created. This property is read-only.
@@ -1519,14 +1494,12 @@ public unsafe partial class Control :
                 return Cursors.WaitCursor;
             }
 
-            Cursor? cursor = (Cursor?)Properties.GetObject(s_cursorProperty);
-            if (cursor is not null)
+            if (Properties.TryGetValue(s_cursorProperty, out Cursor? cursor))
             {
                 return cursor;
             }
 
-            // We only do ambients for things with "Cursors.Default"
-            // as their default.
+            // We only do ambients for things with "Cursors.Default" as their default.
             Cursor localDefault = DefaultCursor;
             if (localDefault != Cursors.Default)
             {
@@ -1549,11 +1522,11 @@ public unsafe partial class Control :
         }
         set
         {
-            Cursor? localCursor = (Cursor?)Properties.GetObject(s_cursorProperty);
+            Cursor? localCursor = Properties.GetValueOrDefault<Cursor>(s_cursorProperty);
             Cursor resolvedCursor = Cursor;
             if (localCursor != value)
             {
-                Properties.SetObject(s_cursorProperty, value);
+                Properties.AddOrRemoveValue(s_cursorProperty, value);
             }
 
             // Other things can change the cursor. We always want to force the correct cursor.
@@ -1601,8 +1574,7 @@ public unsafe partial class Control :
                 throw new NotSupportedException(SR.BindingNotSupported);
             }
 
-            ControlBindingsCollection? bindings = (ControlBindingsCollection?)Properties.GetObject(s_bindingsProperty);
-            if (bindings is null)
+            if (!Properties.TryGetValue(s_bindingsProperty, out ControlBindingsCollection? bindings))
             {
                 bindings = new ControlBindingsCollection(this);
                 Properties.SetObject(s_bindingsProperty, bindings);
@@ -2232,14 +2204,7 @@ public unsafe partial class Control :
     [EditorBrowsable(EditorBrowsableState.Advanced)]
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     [SRDescription(nameof(SR.ControlHasChildrenDescr))]
-    public bool HasChildren
-    {
-        get
-        {
-            ControlCollection? controls = (ControlCollection?)Properties.GetObject(s_controlsCollectionProperty);
-            return controls is not null && controls.Count > 0;
-        }
-    }
+    public bool HasChildren => ChildControls is not null && ChildControls.Count > 0;
 
     /// <summary>
     ///  The height of this control
@@ -2778,8 +2743,7 @@ public unsafe partial class Control :
 
     /// <summary>
     ///  Retrieves our internal property storage object. If you have a property
-    ///  whose value is not always set, you should store it in here to save
-    ///  space.
+    ///  whose value is not always set, you should store it in here to save space.
     /// </summary>
     internal PropertyStore Properties { get; }
 
@@ -3482,16 +3446,12 @@ public unsafe partial class Control :
             if (GetState(States.UseWaitCursor) != value)
             {
                 SetState(States.UseWaitCursor, value);
-                ControlCollection? controlsCollection = (ControlCollection?)Properties.GetObject(s_controlsCollectionProperty);
 
-                if (controlsCollection is not null)
+                if (ChildControls is { } children)
                 {
-                    // PERFNOTE: This is more efficient than using Foreach. Foreach
-                    // forces the creation of an array subset enum each time we
-                    // enumerate
-                    for (int i = 0; i < controlsCollection.Count; i++)
+                    for (int i = 0; i < children.Count; i++)
                     {
-                        controlsCollection[i].UseWaitCursor = value;
+                        children[i].UseWaitCursor = value;
                     }
                 }
             }
@@ -4335,7 +4295,7 @@ public unsafe partial class Control :
                 OnRightToLeftChanged(EventArgs.Empty);
             }
 
-            if (!Properties.ContainsObjectThatIsNotNull(s_bindingManagerProperty) && Created)
+            if (!Properties.ContainsKey(s_bindingManagerProperty) && Created)
             {
                 // We do not want to call our parent's BindingContext property here.
                 // We have no idea if us or any of our children are using data binding,
@@ -4684,7 +4644,7 @@ public unsafe partial class Control :
         bool controlIsAlreadyCreated = Created;
         CreateControl(ignoreVisible: false);
 
-        if (!Properties.ContainsObjectThatIsNotNull(s_bindingManagerProperty) && ParentInternal is not null && !controlIsAlreadyCreated)
+        if (!Properties.ContainsKey(s_bindingManagerProperty) && ParentInternal is not null && !controlIsAlreadyCreated)
         {
             // We do not want to call our parent's BindingContext property here.
             // We have no idea if us or any of our children are using data binding,
@@ -4720,11 +4680,11 @@ public unsafe partial class Control :
                 CreateHandle();
             }
 
-            if (Properties.GetObject(s_controlsCollectionProperty) is ControlCollection controlsCollection)
+            if (ChildControls is { } children)
             {
                 // Snapshot this array because z-order updates from Windows may rearrange it.
-                Control[] controlSnapshot = new Control[controlsCollection.Count];
-                controlsCollection.CopyTo(controlSnapshot, 0);
+                Control[] controlSnapshot = new Control[children.Count];
+                children.CopyTo(controlSnapshot, 0);
 
                 foreach (Control control in controlSnapshot)
                 {
@@ -4873,21 +4833,16 @@ public unsafe partial class Control :
 
                 _parent?.Controls.Remove(this);
 
-                ControlCollection? controlsCollection = (ControlCollection?)Properties.GetObject(s_controlsCollectionProperty);
-
-                if (controlsCollection is not null)
+                if (ChildControls is { } children)
                 {
-                    // PERFNOTE: This is more efficient than using Foreach. Foreach
-                    // forces the creation of an array subset enum each time we
-                    // enumerate
-                    for (int i = 0; i < controlsCollection.Count; i++)
+                    for (int i = 0; i < children.Count; i++)
                     {
-                        Control ctl = controlsCollection[i];
-                        ctl._parent = null;
-                        ctl.Dispose();
+                        Control child = children[i];
+                        child._parent = null;
+                        child.Dispose();
                     }
 
-                    Properties.SetObject(s_controlsCollectionProperty, null);
+                    ChildControls = null;
                 }
 
                 ClearDpiFonts();
@@ -4913,16 +4868,11 @@ public unsafe partial class Control :
     // Package scope to allow AxHost to override.
     internal virtual void DisposeAxControls()
     {
-        ControlCollection? controlsCollection = (ControlCollection?)Properties.GetObject(s_controlsCollectionProperty);
-
-        if (controlsCollection is not null)
+        if (ChildControls is { } children)
         {
-            // PERFNOTE: This is more efficient than using Foreach. Foreach
-            // forces the creation of an array subset enum each time we
-            // enumerate
-            for (int i = 0; i < controlsCollection.Count; i++)
+            for (int i = 0; i < children.Count; i++)
             {
-                controlsCollection[i].DisposeAxControls();
+                children[i].DisposeAxControls();
             }
         }
     }
@@ -5548,9 +5498,7 @@ public unsafe partial class Control :
 
     internal virtual Control? GetFirstChildControlInTabOrder(bool forward)
     {
-        ControlCollection? controls = (ControlCollection?)Properties.GetObject(s_controlsCollectionProperty);
-
-        if (controls is null)
+        if (ChildControls is not { } children)
         {
             return null;
         }
@@ -5558,11 +5506,11 @@ public unsafe partial class Control :
         Control? found = null;
         if (forward)
         {
-            for (int c = 0; c < controls.Count; c++)
+            for (int c = 0; c < children.Count; c++)
             {
-                if (found is null || found._tabIndex > controls[c]._tabIndex)
+                if (found is null || found._tabIndex > children[c]._tabIndex)
                 {
-                    found = controls[c];
+                    found = children[c];
                 }
             }
         }
@@ -5570,11 +5518,11 @@ public unsafe partial class Control :
         {
             // Cycle through the controls in reverse z-order looking for the one with the highest
             // tab index.
-            for (int c = controls.Count - 1; c >= 0; c--)
+            for (int c = children.Count - 1; c >= 0; c--)
             {
-                if (found is null || found._tabIndex < controls[c]._tabIndex)
+                if (found is null || found._tabIndex < children[c]._tabIndex)
                 {
-                    found = controls[c];
+                    found = children[c];
                 }
             }
         }
@@ -5640,9 +5588,7 @@ public unsafe partial class Control :
 
         if (forward)
         {
-            ControlCollection? controls = (ControlCollection?)ctl.Properties.GetObject(s_controlsCollectionProperty);
-
-            if (controls is not null && controls.Count > 0 && (ctl == this || !IsFocusManagingContainerControl(ctl)))
+            if (ChildControls is { } children && children.Count > 0 && (ctl == this || !IsFocusManagingContainerControl(ctl)))
             {
                 Control? found = ctl.GetFirstChildControlInTabOrder(forward: true);
                 if (found is not null)
@@ -5661,37 +5607,37 @@ public unsafe partial class Control :
                 // Cycle through the controls in z-order looking for the one with the next highest
                 // tab index. Because there can be dups, we have to start with the existing tab index and
                 // remember to exclude the current control.
-                int parentControlCount = 0;
+                int parentChildCount = 0;
 
-                ControlCollection? parentControls = (ControlCollection?)p?.Properties.GetObject(s_controlsCollectionProperty);
+                ControlCollection? parentChildren = p?.ChildControls;
 
-                if (parentControls is not null)
+                if (parentChildren is not null)
                 {
-                    parentControlCount = parentControls.Count;
+                    parentChildCount = parentChildren.Count;
                 }
 
-                for (int c = 0; c < parentControlCount; c++)
+                for (int c = 0; c < parentChildCount; c++)
                 {
                     // The logic for this is a bit lengthy, so I have broken it into separate
                     // clauses:
 
                     // We are not interested in ourself.
-                    if (parentControls![c] != ctl)
+                    if (parentChildren![c] != ctl)
                     {
                         // We are interested in controls with >= tab indexes to ctl. We must include those
                         // controls with equal indexes to account for duplicate indexes.
-                        if (parentControls[c]._tabIndex >= targetIndex)
+                        if (parentChildren[c]._tabIndex >= targetIndex)
                         {
                             // Check to see if this control replaces the "best match" we've already
                             // found.
-                            if (found is null || found._tabIndex > parentControls[c]._tabIndex)
+                            if (found is null || found._tabIndex > parentChildren[c]._tabIndex)
                             {
                                 // Finally, check to make sure that if this tab index is the same as ctl,
                                 // that we've already encountered ctl in the z-order. If it isn't the same,
                                 // than we're more than happy with it.
-                                if (parentControls[c]._tabIndex != targetIndex || hitCtl)
+                                if (parentChildren[c]._tabIndex != targetIndex || hitCtl)
                                 {
-                                    found = parentControls[c];
+                                    found = parentChildren[c];
                                 }
                             }
                         }
@@ -5722,7 +5668,7 @@ public unsafe partial class Control :
                 Control? parent = ctl._parent ?? throw new InvalidOperationException(
                     string.Format(SR.ParentPropertyNotSetInGetNextControl, nameof(Parent), ctl));
 
-                ControlCollection? siblings = GetControlCollection(parent) ?? throw new InvalidOperationException(
+                ControlCollection? siblings = parent.ChildControls ?? throw new InvalidOperationException(
                     string.Format(SR.ControlsPropertyNotSetInGetNextControl, nameof(Controls), parent));
 
                 int siblingCount = siblings.Count;
@@ -5800,7 +5746,7 @@ public unsafe partial class Control :
             }
 
             // We found a control. Walk into this control to find the proper child control within it to select.
-            ControlCollection? children = GetControlCollection(ctl);
+            ControlCollection? children = ctl.ChildControls;
 
             while (children is not null && children.Count > 0 && (ctl == this || !IsFocusManagingContainerControl(ctl)))
             {
@@ -5808,7 +5754,7 @@ public unsafe partial class Control :
                 if (found is not null)
                 {
                     ctl = found;
-                    children = GetControlCollection(ctl);
+                    children = ctl.ChildControls;
                 }
                 else
                 {
@@ -5818,9 +5764,6 @@ public unsafe partial class Control :
         }
 
         return ctl == this ? null : ctl;
-
-        static ControlCollection? GetControlCollection(Control control)
-           => (ControlCollection?)control.Properties.GetObject(s_controlsCollectionProperty);
     }
 
     /// <summary>
@@ -6763,15 +6706,11 @@ public unsafe partial class Control :
             eh(this, e);
         }
 
-        ControlCollection? controlsCollection = (ControlCollection?)Properties.GetObject(s_controlsCollectionProperty);
-        if (controlsCollection is not null)
+        if (ChildControls is { } children)
         {
-            // PERFNOTE: This is more efficient than using Foreach. Foreach
-            // forces the creation of an array subset enum each time we
-            // enumerate
-            for (int i = 0; i < controlsCollection.Count; i++)
+            for (int i = 0; i < children.Count; i++)
             {
-                controlsCollection[i].OnParentBackColorChanged(e);
+                children[i].OnParentBackColorChanged(e);
             }
         }
     }
@@ -6791,15 +6730,11 @@ public unsafe partial class Control :
             eh(this, e);
         }
 
-        ControlCollection? controlsCollection = (ControlCollection?)Properties.GetObject(s_controlsCollectionProperty);
-        if (controlsCollection is not null)
+        if (ChildControls is { } children)
         {
-            // PERFNOTE: This is more efficient than using Foreach. Foreach
-            // forces the creation of an array subset enum each time we
-            // enumerate
-            for (int i = 0; i < controlsCollection.Count; i++)
+            for (int i = 0; i < children.Count; i++)
             {
-                controlsCollection[i].OnParentBackgroundImageChanged(e);
+                children[i].OnParentBackgroundImageChanged(e);
             }
         }
     }
@@ -6823,7 +6758,7 @@ public unsafe partial class Control :
     [EditorBrowsable(EditorBrowsableState.Advanced)]
     protected virtual void OnBindingContextChanged(EventArgs e)
     {
-        if (Properties.ContainsObjectThatIsNotNull(s_bindingsProperty))
+        if (Properties.ContainsKey(s_bindingsProperty))
         {
             if (!Binding.IsSupported)
             {
@@ -6838,15 +6773,11 @@ public unsafe partial class Control :
             eh(this, e);
         }
 
-        ControlCollection? controlsCollection = (ControlCollection?)Properties.GetObject(s_controlsCollectionProperty);
-        if (controlsCollection is not null)
+        if (ChildControls is { } children)
         {
-            // PERFNOTE: This is more efficient than using Foreach. Foreach
-            // forces the creation of an array subset enum each time we
-            // enumerate
-            for (int i = 0; i < controlsCollection.Count; i++)
+            for (int i = 0; i < children.Count; i++)
             {
-                controlsCollection[i].OnParentBindingContextChanged(e);
+                children[i].OnParentBindingContextChanged(e);
             }
         }
     }
@@ -6886,15 +6817,11 @@ public unsafe partial class Control :
             eh(this, e);
         }
 
-        ControlCollection? controlsCollection = (ControlCollection?)Properties.GetObject(s_controlsCollectionProperty);
-        if (controlsCollection is not null)
+        if (ChildControls is { } children)
         {
-            // PERFNOTE: This is more efficient than using Foreach. Foreach
-            // forces the creation of an array subset enum each time we
-            // enumerate
-            for (int i = 0; i < controlsCollection.Count; i++)
+            for (int i = 0; i < children.Count; i++)
             {
-                controlsCollection[i].OnParentCursorChanged(e);
+                children[i].OnParentCursorChanged(e);
             }
         }
     }
@@ -6912,12 +6839,11 @@ public unsafe partial class Control :
             eventHandler(this, e);
         }
 
-        ControlCollection? controlsCollection = (ControlCollection?)Properties.GetObject(s_controlsCollectionProperty);
-        if (controlsCollection is not null)
+        if (ChildControls is { } children)
         {
-            for (int i = 0; i < controlsCollection.Count; i++)
+            for (int i = 0; i < children.Count; i++)
             {
-                controlsCollection[i].OnParentDataContextChanged(e);
+                children[i].OnParentDataContextChanged(e);
             }
         }
     }
@@ -6962,15 +6888,11 @@ public unsafe partial class Control :
             eh(this, e);
         }
 
-        ControlCollection? controlsCollection = (ControlCollection?)Properties.GetObject(s_controlsCollectionProperty);
-        if (controlsCollection is not null)
+        if (ChildControls is { } children)
         {
-            // PERFNOTE: This is more efficient than using Foreach. Foreach
-            // forces the creation of an array subset enum each time we
-            // enumerate
-            for (int i = 0; i < controlsCollection.Count; i++)
+            for (int i = 0; i < children.Count; i++)
             {
-                controlsCollection[i].OnParentEnabledChanged(e);
+                children[i].OnParentEnabledChanged(e);
             }
         }
     }
@@ -7007,18 +6929,14 @@ public unsafe partial class Control :
             eh(this, e);
         }
 
-        ControlCollection? controlsCollection = (ControlCollection?)Properties.GetObject(s_controlsCollectionProperty);
-        using (new LayoutTransaction(this, this, PropertyNames.Font, false))
+        if (ChildControls is { } children)
         {
-            if (controlsCollection is not null)
+            using (new LayoutTransaction(this, this, PropertyNames.Font, resumeLayout: false))
             {
                 // This may have changed the sizes of our children.
-                // PERFNOTE: This is more efficient than using Foreach. Foreach
-                // forces the creation of an array subset enum each time we
-                // enumerate
-                for (int i = 0; i < controlsCollection.Count; i++)
+                for (int i = 0; i < children.Count; i++)
                 {
-                    controlsCollection[i].OnParentFontChanged(e);
+                    children[i].OnParentFontChanged(e);
                 }
             }
         }
@@ -7041,15 +6959,11 @@ public unsafe partial class Control :
             eh(this, e);
         }
 
-        ControlCollection? controlsCollection = (ControlCollection?)Properties.GetObject(s_controlsCollectionProperty);
-        if (controlsCollection is not null)
+        if (ChildControls is { } children)
         {
-            // PERFNOTE: This is more efficient than using Foreach. Foreach
-            // forces the creation of an array subset enum each time we
-            // enumerate
-            for (int i = 0; i < controlsCollection.Count; i++)
+            for (int i = 0; i < children.Count; i++)
             {
-                controlsCollection[i].OnParentForeColorChanged(e);
+                children[i].OnParentForeColorChanged(e);
             }
         }
     }
@@ -7073,15 +6987,11 @@ public unsafe partial class Control :
             eh(this, e);
         }
 
-        ControlCollection? controlsCollection = (ControlCollection?)Properties.GetObject(s_controlsCollectionProperty);
-        if (controlsCollection is not null)
+        if (ChildControls is { } children)
         {
-            // PERFNOTE: This is more efficient than using Foreach. Foreach
-            // forces the creation of an array subset enum each time we
-            // enumerate
-            for (int i = 0; i < controlsCollection.Count; i++)
+            for (int i = 0; i < children.Count; i++)
             {
-                controlsCollection[i].OnParentRightToLeftChanged(e);
+                children[i].OnParentRightToLeftChanged(e);
             }
         }
     }
@@ -7115,7 +7025,7 @@ public unsafe partial class Control :
     [EditorBrowsable(EditorBrowsableState.Advanced)]
     protected virtual void OnParentBindingContextChanged(EventArgs e)
     {
-        if (!Properties.ContainsObjectThatIsNotNull(s_bindingManagerProperty))
+        if (!Properties.ContainsKey(s_bindingManagerProperty))
         {
             OnBindingContextChanged(e);
         }
@@ -7124,7 +7034,7 @@ public unsafe partial class Control :
     [EditorBrowsable(EditorBrowsableState.Advanced)]
     protected virtual void OnParentCursorChanged(EventArgs e)
     {
-        if (!Properties.ContainsObjectThatIsNotNull(s_cursorProperty))
+        if (!Properties.ContainsKey(s_cursorProperty))
         {
             OnCursorChanged(e);
         }
@@ -7260,16 +7170,13 @@ public unsafe partial class Control :
     // OnVisibleChanged/OnParentVisibleChanged is not called when a parent becomes invisible
     internal virtual void OnParentBecameInvisible()
     {
-        if (DesiredVisibility)
+        if (DesiredVisibility && ChildControls is { } children)
         {
             // This control became invisible too - notify its children
-            ControlCollection? controlsCollection = (ControlCollection?)Properties.GetObject(s_controlsCollectionProperty);
-            if (controlsCollection is not null)
+
+            for (int i = 0; i < children.Count; i++)
             {
-                for (int i = 0; i < controlsCollection.Count; i++)
-                {
-                    controlsCollection[i].OnParentBecameInvisible();
-                }
+                children[i].OnParentBecameInvisible();
             }
         }
     }
@@ -7365,23 +7272,19 @@ public unsafe partial class Control :
             eh(this, e);
         }
 
-        ControlCollection? controlsCollection = (ControlCollection?)Properties.GetObject(s_controlsCollectionProperty);
-        if (controlsCollection is not null)
+        if (ChildControls is { } children)
         {
-            // PERFNOTE: This is more efficient than using Foreach. Foreach
-            // forces the creation of an array subset enum each time we
-            // enumerate
-            for (int i = 0; i < controlsCollection.Count; i++)
+            for (int i = 0; i < children.Count; i++)
             {
-                Control ctl = controlsCollection[i];
-                if (ctl.Visible)
+                Control child = children[i];
+                if (child.Visible)
                 {
-                    ctl.OnParentVisibleChanged(e);
+                    child.OnParentVisibleChanged(e);
                 }
 
                 if (!visible)
                 {
-                    ctl.OnParentBecameInvisible();
+                    child.OnParentBecameInvisible();
                 }
             }
         }
@@ -7389,15 +7292,11 @@ public unsafe partial class Control :
 
     internal virtual void OnTopMostActiveXParentChanged(EventArgs e)
     {
-        ControlCollection? controlsCollection = (ControlCollection?)Properties.GetObject(s_controlsCollectionProperty);
-        if (controlsCollection is not null)
+        if (ChildControls is { } children)
         {
-            // PERFNOTE: This is more efficient than using Foreach. Foreach
-            // forces the creation of an array subset enum each time we
-            // enumerate
-            for (int i = 0; i < controlsCollection.Count; i++)
+            for (int i = 0; i < children.Count; i++)
             {
-                controlsCollection[i].OnTopMostActiveXParentChanged(e);
+                children[i].OnTopMostActiveXParentChanged(e);
             }
         }
     }
@@ -7826,22 +7725,18 @@ public unsafe partial class Control :
     [EditorBrowsable(EditorBrowsableState.Advanced)]
     protected virtual void OnInvalidated(InvalidateEventArgs e)
     {
-        // Ask the site to change the view...
+        // Ask the site to change the view.
         if (IsActiveX)
         {
             ActiveXViewChanged();
         }
 
-        // Transparent control support
-        ControlCollection? controls = (ControlCollection?)Properties.GetObject(s_controlsCollectionProperty);
-        if (controls is not null)
+        // Transparent control support.
+        if (ChildControls is { } children)
         {
-            // PERFNOTE: This is more efficient than using Foreach. Foreach
-            // forces the creation of an array subset enum each time we
-            // enumerate
-            for (int i = 0; i < controls.Count; i++)
+            for (int i = 0; i < children.Count; i++)
             {
-                controls[i].OnParentInvalidated(e);
+                children[i].OnParentInvalidated(e);
             }
         }
 
@@ -8231,15 +8126,11 @@ public unsafe partial class Control :
     [EditorBrowsable(EditorBrowsableState.Advanced)]
     protected virtual void OnSystemColorsChanged(EventArgs e)
     {
-        ControlCollection? controlsCollection = (ControlCollection?)Properties.GetObject(s_controlsCollectionProperty);
-        if (controlsCollection is not null)
+        if (ChildControls is { } children)
         {
-            // PERFNOTE: This is more efficient than using Foreach. Foreach
-            // forces the creation of an array subset enum each time we
-            // enumerate
-            for (int i = 0; i < controlsCollection.Count; i++)
+            for (int i = 0; i < children.Count; i++)
             {
-                controlsCollection[i].OnSystemColorsChanged(EventArgs.Empty);
+                children[i].OnSystemColorsChanged(EventArgs.Empty);
             }
         }
 
@@ -8249,8 +8140,7 @@ public unsafe partial class Control :
     }
 
     /// <summary>
-    ///  Raises the <see cref="Validating"/>
-    ///  event.
+    ///  Raises the <see cref="Validating"/> event.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Advanced)]
     protected virtual void OnValidating(CancelEventArgs e)
@@ -9413,14 +9303,12 @@ public unsafe partial class Control :
                 // SetParent back after the parent's handle has been recreated.
                 // This behavior can be overridden in OnParentHandleRecreat* and is in ListView.
 
-                // fish out control collection w/o demand creating one.
-                ControlCollection? controlsCollection = (ControlCollection?)Properties.GetObject(s_controlsCollectionProperty);
-                if (controlsCollection is not null && controlsCollection.Count > 0)
+                if (ChildControls is { } children && children.Count > 0)
                 {
-                    controlSnapshot = new Control[controlsCollection.Count];
-                    for (int i = 0; i < controlsCollection.Count; i++)
+                    controlSnapshot = new Control[children.Count];
+                    for (int i = 0; i < children.Count; i++)
                     {
-                        Control childControl = controlsCollection[i];
+                        Control childControl = children[i];
                         if (childControl is not null && childControl.IsHandleCreated)
                         {
                             // SetParent to parking window
@@ -9683,17 +9571,14 @@ public unsafe partial class Control :
         if (!performLayout)
         {
             CommonProperties.xClearPreferredSizeCache(this);
-            ControlCollection? controlsCollection = (ControlCollection?)Properties.GetObject(s_controlsCollectionProperty);
 
-            // PERFNOTE: This is more efficient than using Foreach. Foreach forces the creation of an array subset
-            // enum each time we enumerate.
-            if (controlsCollection is not null)
+            if (ChildControls is { } children)
             {
-                for (int i = 0; i < controlsCollection.Count; i++)
+                for (int i = 0; i < children.Count; i++)
                 {
-                    Control control = controlsCollection[i];
-                    LayoutEngine.InitLayout(control, BoundsSpecified.All);
-                    CommonProperties.xClearPreferredSizeCache(control);
+                    Control child = children[i];
+                    LayoutEngine.InitLayout(child, BoundsSpecified.All);
+                    CommonProperties.xClearPreferredSizeCache(child);
                 }
             }
         }
@@ -9776,19 +9661,11 @@ public unsafe partial class Control :
         using (new LayoutTransaction(this, this, PropertyNames.Bounds, resumeLayout: false))
         {
             ScaleControl(factor, factor);
-            if (ScaleChildren)
+            if (ScaleChildren && ChildControls is { } children)
             {
-                ControlCollection? controlsCollection = (ControlCollection?)Properties.GetObject(s_controlsCollectionProperty);
-                if (controlsCollection is not null)
+                for (int i = 0; i < children.Count; i++)
                 {
-                    // PERFNOTE: This is more efficient than using Foreach. Foreach
-                    // forces the creation of an array subset enum each time we
-                    // enumerate
-                    for (int i = 0; i < controlsCollection.Count; i++)
-                    {
-                        Control c = controlsCollection[i];
-                        c.Scale(factor);
-                    }
+                    children[i].Scale(factor);
                 }
             }
         }
@@ -9854,39 +9731,33 @@ public unsafe partial class Control :
     ///  that need it, i.e. controls using default or inherited font, that are also not user-painted.</param>
     internal void ScaleChildControls(SizeF includedFactor, SizeF excludedFactor, Control requestingControl, bool causedByFontChanged = false)
     {
-        if (ScaleChildren)
+        if (!ScaleChildren || ChildControls is not { } children)
         {
-            var controlsCollection = (ControlCollection?)Properties.GetObject(s_controlsCollectionProperty);
+            return;
+        }
 
-            if (controlsCollection is not null)
+        for (int i = 0; i < children.Count; i++)
+        {
+            Control child = children[i];
+
+            // ContainerControls get their own OnFontChanged Events and scale.
+            // If this scaling is caused by ResumeLayout instead of OnFontChanged,
+            // We would be scaling all container controls.
+            if (child is ContainerControl && causedByFontChanged)
             {
-                // PERFNOTE: This is more efficient than using Foreach. Foreach
-                // forces the creation of an array subset enum each time we
-                // enumerate
-                for (int i = 0; i < controlsCollection.Count; i++)
+                continue;
+            }
+
+            // Update window font before scaling, as controls often use font metrics during scaling.
+            if (causedByFontChanged)
+            {
+                if (ScaleHelper.IsScalingRequirementMet && !GetStyle(ControlStyles.UserPaint) && !IsFontSet())
                 {
-                    Control control = controlsCollection[i];
-
-                    // ContainerControls get their own OnFontChanged Events and scale.
-                    // If this scaling is caused by ResumeLayout instead of OnFontChanged,
-                    // We would be scaling all container controls.
-                    if (control is ContainerControl && causedByFontChanged)
-                    {
-                        continue;
-                    }
-
-                    // Update window font before scaling, as controls often use font metrics during scaling.
-                    if (causedByFontChanged)
-                    {
-                        if (ScaleHelper.IsScalingRequirementMet && !GetStyle(ControlStyles.UserPaint) && !IsFontSet())
-                        {
-                            SetWindowFont();
-                        }
-                    }
-
-                    control.Scale(includedFactor, excludedFactor, requestingControl, causedByFontChanged);
+                    SetWindowFont();
                 }
             }
+
+            child.Scale(includedFactor, excludedFactor, requestingControl, causedByFontChanged);
         }
     }
 
@@ -10082,17 +9953,12 @@ public unsafe partial class Control :
 
         SetBounds(sx, sy, sw, sh, BoundsSpecified.All);
 
-        ControlCollection? controlsCollection = (ControlCollection?)Properties.GetObject(s_controlsCollectionProperty);
-
-        if (controlsCollection is not null)
+        if (ChildControls is { } children)
         {
-            // PERFNOTE: This is more efficient than using Foreach. Foreach
-            // forces the creation of an array subset enum each time we
-            // enumerate
-            for (int i = 0; i < controlsCollection.Count; i++)
+            for (int i = 0; i < children.Count; i++)
             {
 #pragma warning disable CS0618 // Type or member is obsolete - compat
-                controlsCollection[i].Scale(dx, dy);
+                children[i].Scale(dx, dy);
 #pragma warning restore CS0618
             }
         }
@@ -10744,29 +10610,19 @@ public unsafe partial class Control :
     ///  Returns true if the cursor should be persisted in code gen.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    internal virtual bool ShouldSerializeCursor()
-    {
-        return Properties.ContainsObjectThatIsNotNull(s_cursorProperty);
-    }
+    internal virtual bool ShouldSerializeCursor() => Properties.ContainsKey(s_cursorProperty);
 
     /// <summary>
     ///  Returns true if the enabled property should be persisted in code gen.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    private bool ShouldSerializeEnabled()
-    {
-        return (!GetState(States.Enabled));
-    }
+    private bool ShouldSerializeEnabled() => !GetState(States.Enabled);
 
     /// <summary>
     ///  Returns true if the foreColor should be persisted in code gen.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    internal virtual bool ShouldSerializeForeColor()
-    {
-        Color foreColor = Properties.GetValueOrDefault<Color>(s_foreColorProperty);
-        return !foreColor.IsEmpty;
-    }
+    internal virtual bool ShouldSerializeForeColor() => !Properties.GetValueOrDefault<Color>(s_foreColorProperty).IsEmpty;
 
     /// <summary>
     ///  Returns true if the font should be persisted in code gen.
@@ -12890,19 +12746,7 @@ public unsafe partial class Control :
         GC.KeepAlive(this);
     }
 
-    ArrangedElementCollection IArrangedElement.Children
-    {
-        get
-        {
-            ControlCollection? controlsCollection = (ControlCollection?)Properties.GetObject(s_controlsCollectionProperty);
-            if (controlsCollection is null)
-            {
-                return ArrangedElementCollection.Empty;
-            }
-
-            return controlsCollection;
-        }
-    }
+    ArrangedElementCollection IArrangedElement.Children => ChildControls ?? ArrangedElementCollection.Empty;
 
     IArrangedElement? IArrangedElement.Container
     {
@@ -12913,10 +12757,7 @@ public unsafe partial class Control :
         }
     }
 
-    bool IArrangedElement.ParticipatesInLayout
-    {
-        get { return GetState(States.Visible); }
-    }
+    bool IArrangedElement.ParticipatesInLayout => GetState(States.Visible);
 
     void IArrangedElement.PerformLayout(IArrangedElement affectedElement, string? affectedProperty)
     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripMenuItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripMenuItem.cs
@@ -299,7 +299,7 @@ public partial class ToolStripMenuItem : ToolStripDropDownItem
     [SRDescription(nameof(SR.CheckBoxCheckStateDescr))]
     public CheckState CheckState
     {
-        get => Properties.GetValueOrDefault<CheckState>(s_propCheckState, CheckState.Unchecked);
+        get => Properties.GetValueOrDefault(s_propCheckState, CheckState.Unchecked);
         set
         {
             // Valid values are 0x0 to 0x2
@@ -356,12 +356,12 @@ public partial class ToolStripMenuItem : ToolStripDropDownItem
     [SRDescription(nameof(SR.MenuItemShortCutDescr))]
     public Keys ShortcutKeys
     {
-        get => Properties.GetValueOrDefault<Keys>(s_propShortcutKeys, Keys.None);
+        get => Properties.GetValueOrDefault(s_propShortcutKeys, Keys.None);
         set
         {
             if ((value != Keys.None) && !ToolStripManager.IsValidShortcut(value))
             {
-                // prevent use of alt, ctrl, shift modifiers with no key code.
+                // Prevent use of alt, ctrl, shift modifiers with no key code.
                 throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(Keys));
             }
 


### PR DESCRIPTION
It is something we look at constantly when we have it, so I've moved it into an internal auto property. Ths avoids some overhead and complexity.

I've also changed more of the depreciated PropertyStore methods to the new overloads.

Removed the repeated perf note. One should always assume that explicitly using indexing to iterate is intentional.