### PR TITLE
Fix spelling of Overridden and IAccessible and doesnt in test names

### DIFF
--- a/src/System.Drawing.Common/tests/System/Drawing/BitmapTests.cs
+++ b/src/System.Drawing.Common/tests/System/Drawing/BitmapTests.cs
@@ -723,7 +723,7 @@ public class BitmapTests : FileCleanupTestBase
     }
 
     [Fact]
-    public void SaveWmfAsPngDoesntChangeImageBoundaries()
+    public void SaveWmfAsPngDoesNotChangeImageBoundaries()
     {
         if (PlatformDetection.IsWindows7)
         {
@@ -855,7 +855,7 @@ public class BitmapTests : FileCleanupTestBase
     }
 
     [Fact]
-    public void MakeTransparent_CustomColorDoesntExist_DoesNothing()
+    public void MakeTransparent_CustomColorDoesNotExist_DoesNothing()
     {
         using Bitmap bitmap = new(10, 10);
         for (int x = 0; x < bitmap.Width; x++)

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/ArrayEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/ArrayEditorTests.cs
@@ -124,7 +124,7 @@ public class ArrayEditorTests
     }
 
     [Fact]
-    public void ArrayEditor_GetDisplayText_ValueDoesntMatchCollectionType_ThrowsTargetException()
+    public void ArrayEditor_GetDisplayText_ValueDoesNotMatchCollectionType_ThrowsTargetException()
     {
         SubArrayEditor editor = new(typeof(ClassWithStringDefaultProperty));
         TargetInvocationException ex = Assert.Throws<TargetInvocationException>(() => editor.GetDisplayText(new ClassWithNonStringDefaultProperty()));

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/CollectionEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/CollectionEditorTests.cs
@@ -806,7 +806,7 @@ public class CollectionEditorTests
     }
 
     [Fact]
-    public void CollectionEditor_GetDisplayText_ValueDoesntMatchCollectionType_ThrowsTargetException()
+    public void CollectionEditor_GetDisplayText_ValueDoesNotMatchCollectionType_ThrowsTargetException()
     {
         SubCollectionEditor editor = new(typeof(ClassWithStringDefaultProperty));
         TargetInvocationException ex = Assert.Throws<TargetInvocationException>(() => editor.GetDisplayText(new ClassWithNonStringDefaultProperty()));

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignerCommandSetTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/DesignerCommandSetTests.cs
@@ -24,7 +24,7 @@ public class DesignerCommandSetTests
     }
 
     [Fact]
-    public void DesignerCommandSet_Verbs_OverridenGetCommands_ReturnsExpected()
+    public void DesignerCommandSet_Verbs_OverriddenGetCommands_ReturnsExpected()
     {
         DesignerVerbCollection collection = [];
         Mock<DesignerCommandSet> mockSet = new(MockBehavior.Strict);
@@ -35,7 +35,7 @@ public class DesignerCommandSetTests
     }
 
     [Fact]
-    public void DesignerCommandSet_Verbs_InvalidOverridenGetCommands_ThrowsInvalidCastException()
+    public void DesignerCommandSet_Verbs_InvalidOverriddenGetCommands_ThrowsInvalidCastException()
     {
         Mock<DesignerCommandSet> mockSet = new(MockBehavior.Strict);
         mockSet
@@ -45,7 +45,7 @@ public class DesignerCommandSetTests
     }
 
     [Fact]
-    public void DesignerCommandSet_ActionLists_OverridenGetCommands_ReturnsExpected()
+    public void DesignerCommandSet_ActionLists_OverriddenGetCommands_ReturnsExpected()
     {
         DesignerActionListCollection collection = [];
         Mock<DesignerCommandSet> mockSet = new(MockBehavior.Strict);
@@ -56,7 +56,7 @@ public class DesignerCommandSetTests
     }
 
     [Fact]
-    public void DesignerCommandSet_ActionLists_InvalidOverridenGetCommands_ThrowsInvalidCastException()
+    public void DesignerCommandSet_ActionLists_InvalidOverriddenGetCommands_ThrowsInvalidCastException()
     {
         Mock<DesignerCommandSet> mockSet = new(MockBehavior.Strict);
         mockSet

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/ComboBoxTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/ComboBoxTests.cs
@@ -13,7 +13,7 @@ public class ComboBoxTests : ControlTestBase
     }
 
     [WinFormsFact]
-    public async Task ComboBoxTest_ChangeAutoCompleteSource_DoesntThrowAsync()
+    public async Task ComboBoxTest_ChangeAutoCompleteSource_DoesNotThrowAsync()
     {
         await RunSingleControlTestAsync<ComboBox>((form, comboBox) =>
         {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/AccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/AccessibleObjectTests.cs
@@ -816,7 +816,7 @@ public partial class AccessibleObjectTests
     [InlineData(-1, 0)]
     [InlineData(0, 0)]
     [InlineData(1, 1)]
-    public void AccessibleObject_IAccessiblaccChildCount_InvokeDefault_ReturnsExpected(int childCount, int expectedChildCount)
+    public void AccessibleObject_IAccessibleAccChildCount_InvokeDefault_ReturnsExpected(int childCount, int expectedChildCount)
     {
         Mock<AccessibleObject> mockAccessibleObject = new(MockBehavior.Strict);
         mockAccessibleObject
@@ -838,7 +838,7 @@ public partial class AccessibleObjectTests
 
     [WinFormsTheory]
     [MemberData(nameof(SelfVarChild_TestData))]
-    public void AccessibleObject_IAccessibleaccDoDefaultAction_InvokeDefaultSelf_Success(object varChild)
+    public void AccessibleObject_IAccessibleAccDoDefaultAction_InvokeDefaultSelf_Success(object varChild)
     {
         Mock<AccessibleObject> mockAccessibleObject = new(MockBehavior.Strict);
         mockAccessibleObject
@@ -852,7 +852,7 @@ public partial class AccessibleObjectTests
     [WinFormsTheory]
     [InlineData(2, 1, 0)]
     [InlineData(3, 0, 1)]
-    public void AccessibleObject_IAccessibleaccDoDefaultAction_InvokeDefaultChild_Success(object varChild, int child1CallCount, int child2CallCount)
+    public void AccessibleObject_IAccessibleAccDoDefaultAction_InvokeDefaultChild_Success(object varChild, int child1CallCount, int child2CallCount)
     {
         Mock<AccessibleObject> mockAccessibleObjectChild1 = new(MockBehavior.Strict);
         mockAccessibleObjectChild1
@@ -886,7 +886,7 @@ public partial class AccessibleObjectTests
     [WinFormsTheory]
     [InlineData(-1)]
     [InlineData(4)]
-    public void AccessibleObject_IAccessibleaccDoDefaultAction_InvokeDefaultNoSuchChild_Success(object varChild)
+    public void AccessibleObject_IAccessibleAccDoDefaultAction_InvokeDefaultNoSuchChild_Success(object varChild)
     {
         Mock<AccessibleObject> mockAccessibleObjectChild1 = new(MockBehavior.Strict);
         Mock<AccessibleObject> mockAccessibleObjectChild2 = new(MockBehavior.Strict);
@@ -917,7 +917,7 @@ public partial class AccessibleObjectTests
 
     [WinFormsTheory]
     [MemberData(nameof(accFocus_TestData))]
-    public void AccessibleObject_IAccessibleget_accFocus_InvokeDefault_ReturnsExpected(AccessibleObject result)
+    public void AccessibleObject_IAccessibleGet_accFocus_InvokeDefault_ReturnsExpected(AccessibleObject result)
     {
         Mock<AccessibleObject> mockAccessibleObject = new(MockBehavior.Strict);
         mockAccessibleObject
@@ -930,7 +930,7 @@ public partial class AccessibleObjectTests
     }
 
     [WinFormsFact]
-    public void AccessibleObject_IAccessiblaccFocus_InvokeDefaultSelf_ReturnsExpected()
+    public void AccessibleObject_IAccessibleAccFocus_InvokeDefaultSelf_ReturnsExpected()
     {
         Mock<AccessibleObject> mockAccessibleObject = new(MockBehavior.Strict);
         mockAccessibleObject
@@ -946,7 +946,7 @@ public partial class AccessibleObjectTests
     [InlineData(-1, -2)]
     [InlineData(0, 0)]
     [InlineData(1, 2)]
-    public void AccessibleObject_IAccessibleaccHitTest_InvokeDefault_ReturnsNull(int x, int y)
+    public void AccessibleObject_IAccessibleAccHitTest_InvokeDefault_ReturnsNull(int x, int y)
     {
         AccessibleObject accessibleObject = new();
         IAccessible iAccessible = accessibleObject;
@@ -957,7 +957,7 @@ public partial class AccessibleObjectTests
     [InlineData(1, 2)]
     [InlineData(2, 3)]
     [InlineData(3, 5)]
-    public void AccessibleObject_IAccessibleaccHitTest_InvokeDefaultWithNoChildrenBoundsValid_ReturnsExpected(int x, int y)
+    public void AccessibleObject_IAccessibleAccHitTest_InvokeDefaultWithNoChildrenBoundsValid_ReturnsExpected(int x, int y)
     {
         Mock<AccessibleObject> mockAccessibleObject = new(MockBehavior.Strict);
         mockAccessibleObject
@@ -979,7 +979,7 @@ public partial class AccessibleObjectTests
     [InlineData(4, 2)]
     [InlineData(1, 6)]
     [InlineData(4, 5)]
-    public void AccessibleObject_IAccessibleaccHitTest_InvokeDefaultWithNoChildrenBoundsInvalid_ReturnsNull(int x, int y)
+    public void AccessibleObject_IAccessibleAccHitTest_InvokeDefaultWithNoChildrenBoundsInvalid_ReturnsNull(int x, int y)
     {
         Mock<AccessibleObject> mockAccessibleObject = new(MockBehavior.Strict);
         mockAccessibleObject
@@ -999,7 +999,7 @@ public partial class AccessibleObjectTests
     [InlineData(-1, -2)]
     [InlineData(0, 0)]
     [InlineData(1, 2)]
-    public void AccessibleObject_IAccessibleaccHitTest_InvokeDefaultWithNoBoundsChildren_ReturnsExpected(int x, int y)
+    public void AccessibleObject_IAccessibleAccHitTest_InvokeDefaultWithNoBoundsChildren_ReturnsExpected(int x, int y)
     {
         using (new NoAssertContext())
         {
@@ -1025,7 +1025,7 @@ public partial class AccessibleObjectTests
     [InlineData(1, 2)]
     [InlineData(2, 3)]
     [InlineData(3, 5)]
-    public void AccessibleObject_IAccessibleaccHitTest_InvokeDefaultWithBoundsChildren_ReturnsExpected(int x, int y)
+    public void AccessibleObject_IAccessibleAccHitTest_InvokeDefaultWithBoundsChildren_ReturnsExpected(int x, int y)
     {
         using (new NoAssertContext())
         {
@@ -1061,7 +1061,7 @@ public partial class AccessibleObjectTests
 
     [WinFormsTheory]
     [MemberData(nameof(SelfVarChild_TestData))]
-    public void AccessibleObject_IAccessibleaccLocation_InvokeDefaultSelf_Success(object varChild)
+    public void AccessibleObject_IAccessibleAccLocation_InvokeDefaultSelf_Success(object varChild)
     {
         Mock<AccessibleObject> mockAccessibleObject = new(MockBehavior.Strict);
         mockAccessibleObject
@@ -1080,7 +1080,7 @@ public partial class AccessibleObjectTests
     [WinFormsTheory]
     [InlineData(2, 1, 0)]
     [InlineData(3, 0, 1)]
-    public void AccessibleObject_IAccessibleaccLocation_InvokeDefaultChild_Success(object varChild, int child1CallCount, int child2CallCount)
+    public void AccessibleObject_IAccessibleAccLocation_InvokeDefaultChild_Success(object varChild, int child1CallCount, int child2CallCount)
     {
         Mock<AccessibleObject> mockAccessibleObjectChild1 = new(MockBehavior.Strict);
         mockAccessibleObjectChild1
@@ -1120,7 +1120,7 @@ public partial class AccessibleObjectTests
     [WinFormsTheory]
     [InlineData(-1)]
     [InlineData(4)]
-    public void AccessibleObject_IAccessibleaccLocation_InvokeDefaultNoSuchChild_Success(object varChild)
+    public void AccessibleObject_IAccessibleAccLocation_InvokeDefaultNoSuchChild_Success(object varChild)
     {
         Mock<AccessibleObject> mockAccessibleObjectChild1 = new(MockBehavior.Strict);
         Mock<AccessibleObject> mockAccessibleObjectChild2 = new(MockBehavior.Strict);
@@ -1152,7 +1152,7 @@ public partial class AccessibleObjectTests
     [InlineData((int)AccessibleNavigation.Right, unchecked((int)0x80020004))]
     [InlineData((int)AccessibleNavigation.Right, "abc")]
     [InlineData((int)AccessibleNavigation.Right, null)]
-    public void AccessibleObject_IAccessibleaccNavigate_InvokeDefaultSelf_Success(int navDir, object varChild)
+    public void AccessibleObject_IAccessibleAccNavigate_InvokeDefaultSelf_Success(int navDir, object varChild)
     {
         Mock<AccessibleObject> mockAccessibleObject = new(MockBehavior.Strict);
         mockAccessibleObject
@@ -1167,7 +1167,7 @@ public partial class AccessibleObjectTests
     [WinFormsTheory]
     [InlineData((int)AccessibleNavigation.Right, 2, 1, 0)]
     [InlineData((int)AccessibleNavigation.Right, 3, 0, 1)]
-    public void AccessibleObject_IAccessibleaccNavigate_InvokeDefaultChild_Success(int navDir, object varChild, int child1CallCount, int child2CallCount)
+    public void AccessibleObject_IAccessibleAccNavigate_InvokeDefaultChild_Success(int navDir, object varChild, int child1CallCount, int child2CallCount)
     {
         Mock<AccessibleObject> mockAccessibleObjectChild1 = new(MockBehavior.Strict);
         mockAccessibleObjectChild1
@@ -1203,7 +1203,7 @@ public partial class AccessibleObjectTests
     [WinFormsTheory]
     [InlineData((int)AccessibleNavigation.Right, 2, 1, 0)]
     [InlineData((int)AccessibleNavigation.Right, 3, 0, 1)]
-    public void AccessibleObject_IAccessibleaccNavigate_InvokeDefaultChildSelf_Success(int navDir, object varChild, int child1CallCount, int child2CallCount)
+    public void AccessibleObject_IAccessibleAccNavigate_InvokeDefaultChildSelf_Success(int navDir, object varChild, int child1CallCount, int child2CallCount)
     {
         Mock<AccessibleObject> mockAccessibleObject = new(MockBehavior.Strict);
         Mock<AccessibleObject> mockAccessibleObjectChild1 = new(MockBehavior.Strict);
@@ -1239,7 +1239,7 @@ public partial class AccessibleObjectTests
     [WinFormsTheory]
     [InlineData((int)AccessibleNavigation.Right, -1)]
     [InlineData((int)AccessibleNavigation.Right, 4)]
-    public void AccessibleObject_IAccessibleaccNavigate_InvokeDefaultNoSuchChild_Success(int navDir, object varChild)
+    public void AccessibleObject_IAccessibleAccNavigate_InvokeDefaultNoSuchChild_Success(int navDir, object varChild)
     {
         Mock<AccessibleObject> mockAccessibleObjectChild1 = new(MockBehavior.Strict);
         Mock<AccessibleObject> mockAccessibleObjectChild2 = new(MockBehavior.Strict);
@@ -1270,7 +1270,7 @@ public partial class AccessibleObjectTests
 
     [WinFormsTheory]
     [MemberData(nameof(accParent_TestData))]
-    public void AccessibleObject_IAccessiblaccParent_InvokeDefault_ReturnsExpected(AccessibleObject result)
+    public void AccessibleObject_IAccessibleAccParent_InvokeDefault_ReturnsExpected(AccessibleObject result)
     {
         Mock<AccessibleObject> mockAccessibleObject = new(MockBehavior.Strict);
         mockAccessibleObject
@@ -1283,7 +1283,7 @@ public partial class AccessibleObjectTests
     }
 
     [WinFormsFact]
-    public void AccessibleObject_IAccessiblaccParent_InvokeDefaultSelf_ReturnsExpected()
+    public void AccessibleObject_IAccessibleAccParent_InvokeDefaultSelf_ReturnsExpected()
     {
         using (new NoAssertContext())
         {
@@ -1303,7 +1303,7 @@ public partial class AccessibleObjectTests
     [InlineData((int)AccessibleSelection.AddSelection, unchecked((int)0x80020004))]
     [InlineData((int)AccessibleSelection.AddSelection, "abc")]
     [InlineData((int)AccessibleSelection.AddSelection, null)]
-    public void AccessibleObject_IAccessibleaccSelect_InvokeDefaultSelf_Success(int flagsSelect, object varChild)
+    public void AccessibleObject_IAccessibleAccSelect_InvokeDefaultSelf_Success(int flagsSelect, object varChild)
     {
         Mock<AccessibleObject> mockAccessibleObject = new(MockBehavior.Strict);
         mockAccessibleObject
@@ -1317,7 +1317,7 @@ public partial class AccessibleObjectTests
     [WinFormsTheory]
     [InlineData((int)AccessibleSelection.AddSelection, 2, 1, 0)]
     [InlineData((int)AccessibleSelection.AddSelection, 3, 0, 1)]
-    public void AccessibleObject_IAccessibleaccSelect_InvokeDefaultChild_Success(int flagsSelect, object varChild, int child1CallCount, int child2CallCount)
+    public void AccessibleObject_IAccessibleAccSelect_InvokeDefaultChild_Success(int flagsSelect, object varChild, int child1CallCount, int child2CallCount)
     {
         Mock<AccessibleObject> mockAccessibleObjectChild1 = new(MockBehavior.Strict);
         mockAccessibleObjectChild1
@@ -1351,7 +1351,7 @@ public partial class AccessibleObjectTests
     [WinFormsTheory]
     [InlineData((int)AccessibleSelection.AddSelection, -1)]
     [InlineData((int)AccessibleSelection.AddSelection, 4)]
-    public void AccessibleObject_IAccessibleaccSelect_InvokeDefaultNoSuchChild_Success(int flagsSelect, object varChild)
+    public void AccessibleObject_IAccessibleAccSelect_InvokeDefaultNoSuchChild_Success(int flagsSelect, object varChild)
     {
         Mock<AccessibleObject> mockAccessibleObjectChild1 = new(MockBehavior.Strict);
         Mock<AccessibleObject> mockAccessibleObjectChild2 = new(MockBehavior.Strict);
@@ -1382,7 +1382,7 @@ public partial class AccessibleObjectTests
 
     [WinFormsTheory]
     [MemberData(nameof(accSelection_TestData))]
-    public void AccessibleObject_IAccessibleget_accSelection_InvokeDefault_ReturnsExpected(AccessibleObject result)
+    public void AccessibleObject_IAccessibleGet_accSelection_InvokeDefault_ReturnsExpected(AccessibleObject result)
     {
         Mock<AccessibleObject> mockAccessibleObject = new(MockBehavior.Strict);
         mockAccessibleObject
@@ -1395,7 +1395,7 @@ public partial class AccessibleObjectTests
     }
 
     [WinFormsFact]
-    public void AccessibleObject_IAccessiblaccSelection_InvokeDefaultSelf_ReturnsExpected()
+    public void AccessibleObject_IAccessibleAccSelection_InvokeDefaultSelf_ReturnsExpected()
     {
         Mock<AccessibleObject> mockAccessibleObject = new(MockBehavior.Strict);
         mockAccessibleObject
@@ -1409,7 +1409,7 @@ public partial class AccessibleObjectTests
 
     [WinFormsTheory]
     [MemberData(nameof(SelfVarChild_TestData))]
-    public void AccessibleObject_IAccessibleget_AccChild_InvokeDefaultSelf_ReturnsExpected(object varChild)
+    public void AccessibleObject_IAccessibleGet_AccChild_InvokeDefaultSelf_ReturnsExpected(object varChild)
     {
         AccessibleObject accessibleObject = new();
         IAccessible iAccessible = accessibleObject;
@@ -1417,7 +1417,7 @@ public partial class AccessibleObjectTests
     }
 
     [WinFormsFact]
-    public void AccessibleObject_IAccessibleget_accChild_InvokeDefaultChild_Success()
+    public void AccessibleObject_IAccessibleGet_accChild_InvokeDefaultChild_Success()
     {
         Mock<AccessibleObject> mockAccessibleObjectChild1 = new(MockBehavior.Strict);
         Mock<AccessibleObject> mockAccessibleObjectChild2 = new(MockBehavior.Strict);
@@ -1445,7 +1445,7 @@ public partial class AccessibleObjectTests
     [WinFormsTheory]
     [InlineData(2)]
     [InlineData(3)]
-    public void AccessibleObject_IAccessibleget_accChild_InvokeDefaultChildSelf_ReturnsExpected(object varChild)
+    public void AccessibleObject_IAccessibleGet_accChild_InvokeDefaultChildSelf_ReturnsExpected(object varChild)
     {
         using (new NoAssertContext())
         {
@@ -1474,7 +1474,7 @@ public partial class AccessibleObjectTests
     [WinFormsTheory]
     [InlineData(-1)]
     [InlineData(4)]
-    public void AccessibleObject_IAccessibleget_accChild_InvokeDefaultNoSuchChild_ReturnsNull(object varChild)
+    public void AccessibleObject_IAccessibleGet_accChild_InvokeDefaultNoSuchChild_ReturnsNull(object varChild)
     {
         Mock<AccessibleObject> mockAccessibleObjectChild1 = new(MockBehavior.Strict);
         Mock<AccessibleObject> mockAccessibleObjectChild2 = new(MockBehavior.Strict);
@@ -1510,7 +1510,7 @@ public partial class AccessibleObjectTests
     [InlineData("value", unchecked((int)0x80020004))]
     [InlineData("value", "abc")]
     [InlineData("value", null)]
-    public void AccessibleObject_IAccessibleget_accDefaultAction_InvokeDefaultSelf_ReturnsExpected(string result, object varChild)
+    public void AccessibleObject_IAccessibleGet_accDefaultAction_InvokeDefaultSelf_ReturnsExpected(string result, object varChild)
     {
         Mock<AccessibleObject> mockAccessibleObject = new(MockBehavior.Strict);
         mockAccessibleObject
@@ -1532,7 +1532,7 @@ public partial class AccessibleObjectTests
     [InlineData(null, 3, 0, 1)]
     [InlineData("", 3, 0, 1)]
     [InlineData("value", 3, 0, 1)]
-    public void AccessibleObject_IAccessibleget_accDefaultAction_InvokeDefaultChild_ReturnsExpected(string result, object varChild, int child1CallCount, int child2CallCount)
+    public void AccessibleObject_IAccessibleGet_accDefaultAction_InvokeDefaultChild_ReturnsExpected(string result, object varChild, int child1CallCount, int child2CallCount)
     {
         Mock<AccessibleObject> mockAccessibleObjectChild1 = new(MockBehavior.Strict);
         mockAccessibleObjectChild1
@@ -1574,7 +1574,7 @@ public partial class AccessibleObjectTests
     [WinFormsTheory]
     [InlineData(-1)]
     [InlineData(4)]
-    public void AccessibleObject_IAccessibleget_accDefaultAction_InvokeDefaultNoSuchChild_ReturnsNull(object varChild)
+    public void AccessibleObject_IAccessibleGet_accDefaultAction_InvokeDefaultNoSuchChild_ReturnsNull(object varChild)
     {
         Mock<AccessibleObject> mockAccessibleObjectChild1 = new(MockBehavior.Strict);
         Mock<AccessibleObject> mockAccessibleObjectChild2 = new(MockBehavior.Strict);
@@ -1610,7 +1610,7 @@ public partial class AccessibleObjectTests
     [InlineData("value", unchecked((int)0x80020004))]
     [InlineData("value", "abc")]
     [InlineData("value", null)]
-    public void AccessibleObject_IAccessibleget_accDescription_InvokeDefaultSelf_ReturnsExpected(string result, object varChild)
+    public void AccessibleObject_IAccessibleGet_accDescription_InvokeDefaultSelf_ReturnsExpected(string result, object varChild)
     {
         Mock<AccessibleObject> mockAccessibleObject = new(MockBehavior.Strict);
         mockAccessibleObject
@@ -1632,7 +1632,7 @@ public partial class AccessibleObjectTests
     [InlineData(null, 3, 0, 1)]
     [InlineData("", 3, 0, 1)]
     [InlineData("value", 3, 0, 1)]
-    public void AccessibleObject_IAccessibleget_accDescription_InvokeDefaultChild_ReturnsExpected(string result, object varChild, int child1CallCount, int child2CallCount)
+    public void AccessibleObject_IAccessibleGet_accDescription_InvokeDefaultChild_ReturnsExpected(string result, object varChild, int child1CallCount, int child2CallCount)
     {
         Mock<AccessibleObject> mockAccessibleObjectChild1 = new(MockBehavior.Strict);
         mockAccessibleObjectChild1
@@ -1677,7 +1677,7 @@ public partial class AccessibleObjectTests
     [WinFormsTheory]
     [InlineData(-1)]
     [InlineData(4)]
-    public void AccessibleObject_IAccessibleget_accDescription_InvokeDefaultNoSuchChild_ReturnsNull(object varChild)
+    public void AccessibleObject_IAccessibleGet_accDescription_InvokeDefaultNoSuchChild_ReturnsNull(object varChild)
     {
         Mock<AccessibleObject> mockAccessibleObjectChild1 = new(MockBehavior.Strict);
         Mock<AccessibleObject> mockAccessibleObjectChild2 = new(MockBehavior.Strict);
@@ -1713,7 +1713,7 @@ public partial class AccessibleObjectTests
     [InlineData("value", unchecked((int)0x80020004))]
     [InlineData("value", "abc")]
     [InlineData("value", null)]
-    public void AccessibleObject_IAccessibleget_accHelp_InvokeDefaultSelf_ReturnsExpected(string result, object varChild)
+    public void AccessibleObject_IAccessibleGet_accHelp_InvokeDefaultSelf_ReturnsExpected(string result, object varChild)
     {
         Mock<AccessibleObject> mockAccessibleObject = new(MockBehavior.Strict);
         mockAccessibleObject
@@ -1735,7 +1735,7 @@ public partial class AccessibleObjectTests
     [InlineData(null, 3, 0, 1)]
     [InlineData("", 3, 0, 1)]
     [InlineData("value", 3, 0, 1)]
-    public void AccessibleObject_IAccessibleget_accHelp_InvokeDefaultChild_ReturnsExpected(string result, object varChild, int child1CallCount, int child2CallCount)
+    public void AccessibleObject_IAccessibleGet_accHelp_InvokeDefaultChild_ReturnsExpected(string result, object varChild, int child1CallCount, int child2CallCount)
     {
         Mock<AccessibleObject> mockAccessibleObjectChild1 = new(MockBehavior.Strict);
         mockAccessibleObjectChild1
@@ -1780,7 +1780,7 @@ public partial class AccessibleObjectTests
     [WinFormsTheory]
     [InlineData(-1)]
     [InlineData(4)]
-    public void AccessibleObject_IAccessibleget_accHelp_InvokeDefaultNoSuchChild_ReturnsNull(object varChild)
+    public void AccessibleObject_IAccessibleGet_accHelp_InvokeDefaultNoSuchChild_ReturnsNull(object varChild)
     {
         Mock<AccessibleObject> mockAccessibleObjectChild1 = new(MockBehavior.Strict);
         Mock<AccessibleObject> mockAccessibleObjectChild2 = new(MockBehavior.Strict);
@@ -1818,7 +1818,7 @@ public partial class AccessibleObjectTests
     [InlineData(0, "value", unchecked((int)0x80020004))]
     [InlineData(1, "value", "abc")]
     [InlineData(2, "value", null)]
-    public void AccessibleObject_IAccessibleget_accHelpTopic_InvokeDefaultSelf_ReturnsExpected(int result, string stringResult, object varChild)
+    public void AccessibleObject_IAccessibleGet_accHelpTopic_InvokeDefaultSelf_ReturnsExpected(int result, string stringResult, object varChild)
     {
         Mock<AccessibleObject> mockAccessibleObject = new(MockBehavior.Strict);
         string dummy;
@@ -1845,7 +1845,7 @@ public partial class AccessibleObjectTests
     [InlineData(-1, null, 3)]
     [InlineData(0, "", 3)]
     [InlineData(1, "value", 3)]
-    public void AccessibleObject_IAccessibleget_accHelpTopic_InvokeDefaultChild_ReturnsExpected(int result, string stringResult, object varChild)
+    public void AccessibleObject_IAccessibleGet_accHelpTopic_InvokeDefaultChild_ReturnsExpected(int result, string stringResult, object varChild)
     {
         string dummy;
         HelpTopicDelegate handler = (out string pszHelpFile) =>
@@ -1894,7 +1894,7 @@ public partial class AccessibleObjectTests
     [WinFormsTheory]
     [InlineData(-1)]
     [InlineData(4)]
-    public void AccessibleObject_IAccessibleget_accHelpTopic_InvokeDefaultNoSuchChild_ReturnsNull(object varChild)
+    public void AccessibleObject_IAccessibleGet_accHelpTopic_InvokeDefaultNoSuchChild_ReturnsNull(object varChild)
     {
         Mock<AccessibleObject> mockAccessibleObjectChild1 = new(MockBehavior.Strict);
         Mock<AccessibleObject> mockAccessibleObjectChild2 = new(MockBehavior.Strict);
@@ -1931,7 +1931,7 @@ public partial class AccessibleObjectTests
     [InlineData("value", unchecked((int)0x80020004))]
     [InlineData("value", "abc")]
     [InlineData("value", null)]
-    public void AccessibleObject_IAccessibleget_accKeyboardShortcut_InvokeDefaultSelf_ReturnsExpected(string result, object varChild)
+    public void AccessibleObject_IAccessibleGet_accKeyboardShortcut_InvokeDefaultSelf_ReturnsExpected(string result, object varChild)
     {
         Mock<AccessibleObject> mockAccessibleObject = new()
         {
@@ -1953,7 +1953,7 @@ public partial class AccessibleObjectTests
     [InlineData(null, 3, 0, 1)]
     [InlineData("", 3, 0, 1)]
     [InlineData("value", 3, 0, 1)]
-    public void AccessibleObject_IAccessibleget_accKeyboardShortcut_InvokeDefaultChild_ReturnsExpected(string result, object varChild, int child1CallCount, int child2CallCount)
+    public void AccessibleObject_IAccessibleGet_accKeyboardShortcut_InvokeDefaultChild_ReturnsExpected(string result, object varChild, int child1CallCount, int child2CallCount)
     {
         Mock<AccessibleObject> mockAccessibleObjectChild1 = new()
         {
@@ -1998,7 +1998,7 @@ public partial class AccessibleObjectTests
     [WinFormsTheory]
     [InlineData(-1)]
     [InlineData(4)]
-    public void AccessibleObject_IAccessibleget_accKeyboardShortcut_InvokeDefaultNoSuchChild_ReturnsNull(object varChild)
+    public void AccessibleObject_IAccessibleGet_accKeyboardShortcut_InvokeDefaultNoSuchChild_ReturnsNull(object varChild)
     {
         Mock<AccessibleObject> mockAccessibleObjectChild1 = new(MockBehavior.Strict);
         Mock<AccessibleObject> mockAccessibleObjectChild2 = new(MockBehavior.Strict);
@@ -2037,7 +2037,7 @@ public partial class AccessibleObjectTests
     [InlineData("value", unchecked((int)0x80020004))]
     [InlineData("value", "abc")]
     [InlineData("value", null)]
-    public void AccessibleObject_IAccessibleget_accName_InvokeDefaultSelf_ReturnsExpected(string result, object varChild)
+    public void AccessibleObject_IAccessibleGet_accName_InvokeDefaultSelf_ReturnsExpected(string result, object varChild)
     {
         Mock<AccessibleObject> mockAccessibleObject = new()
         {
@@ -2059,7 +2059,7 @@ public partial class AccessibleObjectTests
     [InlineData(null, 3, 0, 1)]
     [InlineData("", 3, 0, 1)]
     [InlineData("value", 3, 0, 1)]
-    public void AccessibleObject_IAccessibleget_accName_InvokeDefaultChild_ReturnsExpected(string result, object varChild, int child1CallCount, int child2CallCount)
+    public void AccessibleObject_IAccessibleGet_accName_InvokeDefaultChild_ReturnsExpected(string result, object varChild, int child1CallCount, int child2CallCount)
     {
         Mock<AccessibleObject> mockAccessibleObjectChild1 = new()
         {
@@ -2104,7 +2104,7 @@ public partial class AccessibleObjectTests
     [WinFormsTheory]
     [InlineData(-1)]
     [InlineData(4)]
-    public void AccessibleObject_IAccessibleget_accName_InvokeDefaultNoSuchChild_ReturnsNull(object varChild)
+    public void AccessibleObject_IAccessibleGet_accName_InvokeDefaultNoSuchChild_ReturnsNull(object varChild)
     {
         Mock<AccessibleObject> mockAccessibleObjectChild1 = new(MockBehavior.Strict);
         Mock<AccessibleObject> mockAccessibleObjectChild2 = new(MockBehavior.Strict);
@@ -2143,7 +2143,7 @@ public partial class AccessibleObjectTests
     [InlineData(AccessibleRole.Sound, unchecked((int)0x80020004))]
     [InlineData(AccessibleRole.Sound, "abc")]
     [InlineData(AccessibleRole.Sound, null)]
-    public void AccessibleObject_IAccessibleget_accRole_InvokeDefaultSelf_ReturnsExpected(AccessibleRole result, object varChild)
+    public void AccessibleObject_IAccessibleGet_accRole_InvokeDefaultSelf_ReturnsExpected(AccessibleRole result, object varChild)
     {
         Mock<AccessibleObject> mockAccessibleObject = new(MockBehavior.Strict);
         mockAccessibleObject
@@ -2156,7 +2156,7 @@ public partial class AccessibleObjectTests
     }
 
     [WinFormsFact]
-    public void AccessibleObject_IAccessibleget_accRole_InvokeDefaultSelfNotAClientObject_ReturnsExpected()
+    public void AccessibleObject_IAccessibleGet_accRole_InvokeDefaultSelfNotAClientObject_ReturnsExpected()
     {
         using Control control = new();
         control.CreateControl();
@@ -2175,7 +2175,7 @@ public partial class AccessibleObjectTests
     [InlineData(AccessibleRole.None, 3, 0, 1)]
     [InlineData(AccessibleRole.Default, 3, 0, 1)]
     [InlineData(AccessibleRole.Sound, 3, 0, 1)]
-    public void AccessibleObject_IAccessibleget_accRole_InvokeDefaultChild_ReturnsExpected(AccessibleRole result, object varChild, int child1CallCount, int child2CallCount)
+    public void AccessibleObject_IAccessibleGet_accRole_InvokeDefaultChild_ReturnsExpected(AccessibleRole result, object varChild, int child1CallCount, int child2CallCount)
     {
         Mock<AccessibleObject> mockAccessibleObjectChild1 = new(MockBehavior.Strict);
         mockAccessibleObjectChild1
@@ -2211,7 +2211,7 @@ public partial class AccessibleObjectTests
     [WinFormsTheory]
     [InlineData(-1)]
     [InlineData(4)]
-    public void AccessibleObject_IAccessibleget_accRole_InvokeDefaultNoSuchChild_ReturnsNull(object varChild)
+    public void AccessibleObject_IAccessibleGet_accRole_InvokeDefaultNoSuchChild_ReturnsNull(object varChild)
     {
         Mock<AccessibleObject> mockAccessibleObjectChild1 = new(MockBehavior.Strict);
         Mock<AccessibleObject> mockAccessibleObjectChild2 = new(MockBehavior.Strict);
@@ -2243,7 +2243,7 @@ public partial class AccessibleObjectTests
     [InlineData(AccessibleStates.Mixed, unchecked((int)0x80020004))]
     [InlineData(AccessibleStates.Mixed, "abc")]
     [InlineData(AccessibleStates.Mixed, null)]
-    public void AccessibleObject_IAccessibleget_accState_InvokeDefaultSelf_ReturnsExpected(AccessibleStates result, object varChild)
+    public void AccessibleObject_IAccessibleGet_accState_InvokeDefaultSelf_ReturnsExpected(AccessibleStates result, object varChild)
     {
         Mock<AccessibleObject> mockAccessibleObject = new(MockBehavior.Strict);
         mockAccessibleObject
@@ -2260,7 +2260,7 @@ public partial class AccessibleObjectTests
     [InlineData(AccessibleStates.Mixed, 2, 1, 0)]
     [InlineData(AccessibleStates.None, 3, 0, 1)]
     [InlineData(AccessibleStates.Mixed, 3, 0, 1)]
-    public void AccessibleObject_IAccessibleget_accState_InvokeDefaultChild_ReturnsExpected(AccessibleStates result, object varChild, int child1CallCount, int child2CallCount)
+    public void AccessibleObject_IAccessibleGet_accState_InvokeDefaultChild_ReturnsExpected(AccessibleStates result, object varChild, int child1CallCount, int child2CallCount)
     {
         Mock<AccessibleObject> mockAccessibleObjectChild1 = new(MockBehavior.Strict);
         mockAccessibleObjectChild1
@@ -2296,7 +2296,7 @@ public partial class AccessibleObjectTests
     [WinFormsTheory]
     [InlineData(-1)]
     [InlineData(4)]
-    public void AccessibleObject_IAccessibleget_accState_InvokeDefaultNoSuchChild_ReturnsNull(object varChild)
+    public void AccessibleObject_IAccessibleGet_accState_InvokeDefaultNoSuchChild_ReturnsNull(object varChild)
     {
         Mock<AccessibleObject> mockAccessibleObjectChild1 = new(MockBehavior.Strict);
         Mock<AccessibleObject> mockAccessibleObjectChild2 = new(MockBehavior.Strict);
@@ -2332,7 +2332,7 @@ public partial class AccessibleObjectTests
     [InlineData("value", unchecked((int)0x80020004))]
     [InlineData("value", "abc")]
     [InlineData("value", null)]
-    public void AccessibleObject_IAccessibleget_accValue_InvokeDefaultSelf_ReturnsExpected(string result, object varChild)
+    public void AccessibleObject_IAccessibleGet_accValue_InvokeDefaultSelf_ReturnsExpected(string result, object varChild)
     {
         Mock<AccessibleObject> mockAccessibleObject = new(MockBehavior.Strict);
         mockAccessibleObject
@@ -2354,7 +2354,7 @@ public partial class AccessibleObjectTests
     [InlineData(null, 3, 0, 1)]
     [InlineData("", 3, 0, 1)]
     [InlineData("value", 3, 0, 1)]
-    public void AccessibleObject_IAccessibleget_accValue_InvokeDefaultChild_ReturnsExpected(string result, object varChild, int child1CallCount, int child2CallCount)
+    public void AccessibleObject_IAccessibleGet_accValue_InvokeDefaultChild_ReturnsExpected(string result, object varChild, int child1CallCount, int child2CallCount)
     {
         Mock<AccessibleObject> mockAccessibleObjectChild1 = new(MockBehavior.Strict);
         mockAccessibleObjectChild1
@@ -2399,7 +2399,7 @@ public partial class AccessibleObjectTests
     [WinFormsTheory]
     [InlineData(-1)]
     [InlineData(4)]
-    public void AccessibleObject_IAccessibleget_accValue_InvokeDefaultNoSuchChild_ReturnsNull(object varChild)
+    public void AccessibleObject_IAccessibleGet_accValue_InvokeDefaultNoSuchChild_ReturnsNull(object varChild)
     {
         Mock<AccessibleObject> mockAccessibleObjectChild1 = new(MockBehavior.Strict);
         Mock<AccessibleObject> mockAccessibleObjectChild2 = new(MockBehavior.Strict);
@@ -2435,7 +2435,7 @@ public partial class AccessibleObjectTests
     [InlineData(unchecked((int)0x80020004), "value")]
     [InlineData("abc", "value")]
     [InlineData(null, "value")]
-    public void AccessibleObject_IAccessibleset_accName_InvokeDefaultSelf_ReturnsExpected(object varChild, string value)
+    public void AccessibleObject_IAccessibleSet_accName_InvokeDefaultSelf_ReturnsExpected(object varChild, string value)
     {
         AccessibleObject accessibleObject = new();
         IAccessible iAccessible = accessibleObject;
@@ -2451,7 +2451,7 @@ public partial class AccessibleObjectTests
     [InlineData(3, null)]
     [InlineData(3, "")]
     [InlineData(3, "value")]
-    public void AccessibleObject_IAccessibleset_accName_InvokeDefaultChild_ReturnsExpected(object varChild, string value)
+    public void AccessibleObject_IAccessibleSet_accName_InvokeDefaultChild_ReturnsExpected(object varChild, string value)
     {
         AccessibleObject childAccessibleObject1 = new();
         AccessibleObject childAccessibleObject2 = new();
@@ -2487,7 +2487,7 @@ public partial class AccessibleObjectTests
     [InlineData(4, null)]
     [InlineData(4, "")]
     [InlineData(4, "value")]
-    public void AccessibleObject_IAccessibleset_accName_InvokeDefaultNoSuchChild_ReturnsNull(object varChild, string value)
+    public void AccessibleObject_IAccessibleSet_accName_InvokeDefaultNoSuchChild_ReturnsNull(object varChild, string value)
     {
         AccessibleObject childAccessibleObject1 = new();
         AccessibleObject childAccessibleObject2 = new();
@@ -2529,7 +2529,7 @@ public partial class AccessibleObjectTests
     [InlineData(unchecked((int)0x80020004), "value")]
     [InlineData("abc", "value")]
     [InlineData(null, "value")]
-    public void AccessibleObject_IAccessibleset_accValue_InvokeDefaultSelf_ReturnsExpected(object varChild, string value)
+    public void AccessibleObject_IAccessibleSet_accValue_InvokeDefaultSelf_ReturnsExpected(object varChild, string value)
     {
         AccessibleObject accessibleObject = new();
         IAccessible iAccessible = accessibleObject;
@@ -2545,7 +2545,7 @@ public partial class AccessibleObjectTests
     [InlineData(3, null)]
     [InlineData(3, "")]
     [InlineData(3, "value")]
-    public void AccessibleObject_IAccessibleset_accValue_InvokeDefaultChild_ReturnsExpected(object varChild, string value)
+    public void AccessibleObject_IAccessibleSet_accValue_InvokeDefaultChild_ReturnsExpected(object varChild, string value)
     {
         AccessibleObject childAccessibleObject1 = new();
         AccessibleObject childAccessibleObject2 = new();
@@ -2578,7 +2578,7 @@ public partial class AccessibleObjectTests
     [InlineData(4, null)]
     [InlineData(4, "")]
     [InlineData(4, "value")]
-    public void AccessibleObject_IAccessibleset_accValue_InvokeDefaultNoSuchChild_ReturnsNull(object varChild, string value)
+    public void AccessibleObject_IAccessibleSet_accValue_InvokeDefaultNoSuchChild_ReturnsNull(object varChild, string value)
     {
         AccessibleObject childAccessibleObject1 = new();
         AccessibleObject childAccessibleObject2 = new();
@@ -2688,7 +2688,7 @@ public partial class AccessibleObjectTests
         Assert.Equal(VARIANT.Empty, accessibleObject.GetPropertyValue((UIA_PROPERTY_ID)propertyId));
     }
 
-    public static IEnumerable<object[]> AccessibleObject_RuntimeId_IsOverriden_TestData()
+    public static IEnumerable<object[]> AccessibleObject_RuntimeId_IsOverridden_TestData()
     {
         Assembly assembly = typeof(AccessibleObject).Assembly;
         foreach (Type type in assembly.GetTypes())
@@ -2709,8 +2709,8 @@ public partial class AccessibleObjectTests
     }
 
     [WinFormsTheory]
-    [MemberData(nameof(AccessibleObject_RuntimeId_IsOverriden_TestData))]
-    public void AccessibleObject_RuntimeId_IsOverriden(Type type)
+    [MemberData(nameof(AccessibleObject_RuntimeId_IsOverridden_TestData))]
+    public void AccessibleObject_RuntimeId_IsOverridden(Type type)
     {
         PropertyInfo runtimeIdProperty = type.GetProperty(nameof(AccessibleObject.RuntimeId), BindingFlags.NonPublic | BindingFlags.Instance);
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/Control.ControlAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/Control.ControlAccessibleObjectTests.cs
@@ -1097,7 +1097,7 @@ public class Control_ControlAccessibleObjectTests
     }
 
     [WinFormsFact]
-    public void ControlAccessibleObject_IAccessibleaccFocus_InvokeDefault_ReturnsNull()
+    public void ControlAccessibleObject_IAccessibleAccFocus_InvokeDefault_ReturnsNull()
     {
         using Control ownerControl = new();
         var accessibleObject = new Control.ControlAccessibleObject(ownerControl);
@@ -1112,7 +1112,7 @@ public class Control_ControlAccessibleObjectTests
     [InlineData(false, -1, -2, null)]
     [InlineData(false, 0, 0, null)]
     [InlineData(false, 1, 2, null)]
-    public void AccessibleObject_IAccessibleaccHitTest_InvokeDefault_ReturnsExpectedValue(bool createControl, int x, int y, int? expectedValue)
+    public void AccessibleObject_IAccessibleAccHitTest_InvokeDefault_ReturnsExpectedValue(bool createControl, int x, int y, int? expectedValue)
     {
         using Control ownerControl = new();
         if (createControl)
@@ -1131,7 +1131,7 @@ public class Control_ControlAccessibleObjectTests
     [WinFormsTheory]
     [InlineData(true)]
     [InlineData(false)]
-    public void ControlAccessibleObject_IAccessibleaccParent_InvokeDefault_ReturnsExpectedValue(bool createControl)
+    public void ControlAccessibleObject_IAccessibleAccParent_InvokeDefault_ReturnsExpectedValue(bool createControl)
     {
         using Control ownerControl = new();
         if (createControl)
@@ -1148,7 +1148,7 @@ public class Control_ControlAccessibleObjectTests
     }
 
     [WinFormsFact]
-    public void ControlAccessibleObject_IAccessibleaccSelection_InvokeDefault_ReturnsNull()
+    public void ControlAccessibleObject_IAccessibleAccSelection_InvokeDefault_ReturnsNull()
     {
         using Control ownerControl = new();
         var accessibleObject = new Control.ControlAccessibleObject(ownerControl);
@@ -1159,7 +1159,7 @@ public class Control_ControlAccessibleObjectTests
     [WinFormsTheory]
     [InlineData(-1)]
     [InlineData(1)]
-    public void ControlAccessibleObject_IAccessibleget_accChild_InvokeNoSuchChild_ReturnsNull(int childID)
+    public void ControlAccessibleObject_IAccessibleGet_accChild_InvokeNoSuchChild_ReturnsNull(int childID)
     {
         using Control ownerControl = new();
         var accessibleObject = new Control.ControlAccessibleObject(ownerControl);
@@ -1168,7 +1168,7 @@ public class Control_ControlAccessibleObjectTests
     }
 
     [WinFormsFact]
-    public void ControlAccessibleObject_IAccessibleget_accChildCount_InvokeDefault_ReturnsExpected()
+    public void ControlAccessibleObject_IAccessibleGet_accChildCount_InvokeDefault_ReturnsExpected()
     {
         using Control ownerControl = new();
         var accessibleObject = new Control.ControlAccessibleObject(ownerControl);
@@ -1179,7 +1179,7 @@ public class Control_ControlAccessibleObjectTests
     [WinFormsTheory]
     [InlineData(true, 1)]
     [InlineData(false, 0)]
-    public void ControlAccessibleObject_IAccessibleget_accChildCount_InvokeWithChildren_ReturnsExpected(bool createControl, int expectedCount)
+    public void ControlAccessibleObject_IAccessibleGet_accChildCount_InvokeWithChildren_ReturnsExpected(bool createControl, int expectedCount)
     {
         using Control child = new();
         using Control ownerControl = new();
@@ -1199,7 +1199,7 @@ public class Control_ControlAccessibleObjectTests
     [WinFormsTheory]
     [InlineData(-1)]
     [InlineData(1)]
-    public void ControlAccessibleObject_IAccessibleget_accRole_InvokeNoSuchChild_ReturnsNull(object varChild)
+    public void ControlAccessibleObject_IAccessibleGet_accRole_InvokeNoSuchChild_ReturnsNull(object varChild)
     {
         using Control ownerControl = new();
         var accessibleObject = new Control.ControlAccessibleObject(ownerControl);
@@ -1208,7 +1208,7 @@ public class Control_ControlAccessibleObjectTests
     }
 
     [WinFormsFact]
-    public void ControlAccessibleObject_DoesntSupport_LegacyIAccessiblePattern()
+    public void ControlAccessibleObject_DoesNotSupport_LegacyIAccessiblePattern()
     {
         using Control control = new();
         var accessibleObject = control.AccessibilityObject;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/ErrorProviderAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/ErrorProviderAccessibleObjectTests.cs
@@ -144,7 +144,7 @@ public class ErrorProviderAccessibleObjectTests : IDisposable
     }
 
     [WinFormsFact]
-    public void ErrorProvider_NameDoesntEqualControlTypeOrChildName()
+    public void ErrorProvider_NameDoesNotEqualControlTypeOrChildName()
     {
         // Mas requires us to have no same AccessibleName and LocalizedControlType or child AccessibleName.
         // So we need to check if these properties are not equal.

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ColorDialogTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ColorDialogTests.cs
@@ -33,7 +33,7 @@ public class ColorDialogTests
     }
 
     [WinFormsFact]
-    public void ColorDialog_Ctor_Default_OverridenReset()
+    public void ColorDialog_Ctor_Default_OverriddenReset()
     {
         using EmptyResetColorDialog dialog = new();
         Assert.True(dialog.AllowFullOpen);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBox.ComboBoxUiaTextProviderTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBox.ComboBoxUiaTextProviderTests.cs
@@ -13,7 +13,7 @@ public unsafe class ComboBox_ComboBoxUiaTextProviderTests
     [WinFormsTheory]
     [InlineData(ComboBoxStyle.DropDown)]
     [InlineData(ComboBoxStyle.Simple)]
-    public void ComboBoxUiaTextProvider_Ctor_DoesntCreateControlHandle(ComboBoxStyle dropDownStyle)
+    public void ComboBoxUiaTextProvider_Ctor_DoesNotCreateControlHandle(ComboBoxStyle dropDownStyle)
     {
         using (new NoAssertContext())
         {
@@ -881,7 +881,7 @@ public unsafe class ComboBox_ComboBoxUiaTextProviderTests
     [WinFormsTheory]
     [InlineData(ComboBoxStyle.DropDown)]
     [InlineData(ComboBoxStyle.Simple)]
-    public void ComboBoxUiaTextProvider_RangeFromChild_DoesntThrowAnException(ComboBoxStyle dropDownStyle)
+    public void ComboBoxUiaTextProvider_RangeFromChild_DoesNotThrowAnException(ComboBoxStyle dropDownStyle)
     {
         using (new NoAssertContext())
         {
@@ -907,7 +907,7 @@ public unsafe class ComboBox_ComboBoxUiaTextProviderTests
 
     [WinFormsTheory]
     [MemberData(nameof(ComboBoxUiaTextProvider_RangeFromPoint_TestData))]
-    public void ComboBoxUiaTextProvider_RangeFromPoint_DoesntThrowAnException(ComboBoxStyle dropDownStyle, Point point)
+    public void ComboBoxUiaTextProvider_RangeFromPoint_DoesNotThrowAnException(ComboBoxStyle dropDownStyle, Point point)
     {
         using ComboBox comboBox = new() { DropDownStyle = dropDownStyle };
         comboBox.CreateControl();
@@ -1003,7 +1003,7 @@ public unsafe class ComboBox_ComboBoxUiaTextProviderTests
     [InlineData(ComboBoxStyle.DropDown, 5, 100)]
     [InlineData(ComboBoxStyle.Simple, -5, 10)]
     [InlineData(ComboBoxStyle.Simple, 5, 100)]
-    public void ComboBoxUiaTextProvider_SetSelection_DoesntSelectText_IfIncorrectArguments(ComboBoxStyle dropDownStyle, int start, int end)
+    public void ComboBoxUiaTextProvider_SetSelection_DoesNotSelectText_IfIncorrectArguments(ComboBoxStyle dropDownStyle, int start, int end)
     {
         using (new NoAssertContext())
         {
@@ -1055,7 +1055,7 @@ public unsafe class ComboBox_ComboBoxUiaTextProviderTests
     [InlineData(ComboBoxStyle.DropDown, 2)]
     [InlineData(ComboBoxStyle.Simple, 0)]
     [InlineData(ComboBoxStyle.Simple, 2)]
-    public void ComboBoxUiaTextProvider_LineScroll_DoesntWork_WithoutHandle(ComboBoxStyle dropDownStyle, int newLine)
+    public void ComboBoxUiaTextProvider_LineScroll_DoesNotWork_WithoutHandle(ComboBoxStyle dropDownStyle, int newLine)
     {
         using (new NoAssertContext())
         {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
@@ -2158,7 +2158,7 @@ public class ComboBoxTests
     }
 
     [WinFormsFact]
-    public void ComboBox_CustomAccessibleObject_DoesntCrashControl_WhenAddingItems()
+    public void ComboBox_CustomAccessibleObject_DoesNotCrashControl_WhenAddingItems()
     {
         using AutomationEventCountingComboBox control = new();
         control.Items.Add("item1");

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.ControlCollection.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.ControlCollection.cs
@@ -538,7 +538,7 @@ public class ControlControlCollectionTests
     }
 
     [WinFormsFact]
-    public void ControlCollection_Add_InvokeWithNonOverridenProperties_DoesNotCallPropertyHandlers()
+    public void ControlCollection_Add_InvokeWithNonOverriddenProperties_DoesNotCallPropertyHandlers()
     {
         using Control owner = new();
         using Control control = new();
@@ -581,7 +581,7 @@ public class ControlControlCollectionTests
     }
 
     [WinFormsFact]
-    public void ControlCollection_Add_InvokeWithNonOverridenPropertiesWithHandle_DoesNotCallPropertyHandlers()
+    public void ControlCollection_Add_InvokeWithNonOverriddenPropertiesWithHandle_DoesNotCallPropertyHandlers()
     {
         using Control owner = new();
         using Control control = new();
@@ -624,7 +624,7 @@ public class ControlControlCollectionTests
         Assert.Equal(1, bindingContextChangedCallCount);
     }
 
-    public static IEnumerable<object[]> Add_OverridenProperties_TestData()
+    public static IEnumerable<object[]> Add_OverriddenProperties_TestData()
     {
         BindingContext parentContext = [];
         BindingContext childContext = [];
@@ -635,8 +635,8 @@ public class ControlControlCollectionTests
     }
 
     [WinFormsTheory]
-    [MemberData(nameof(Add_OverridenProperties_TestData))]
-    public void ControlCollection_Add_InvokeWithOverridenProperties_CallsPropertyHandlers(BindingContext parentBindingContext, BindingContext bindingContext, BindingContext expectedBindingContext)
+    [MemberData(nameof(Add_OverriddenProperties_TestData))]
+    public void ControlCollection_Add_InvokeWithOverriddenProperties_CallsPropertyHandlers(BindingContext parentBindingContext, BindingContext bindingContext, BindingContext expectedBindingContext)
     {
         using Control owner = new();
         using Control control = new();
@@ -774,7 +774,7 @@ public class ControlControlCollectionTests
         }
     }
 
-    public static IEnumerable<object[]> Add_OverridenPropertiesWithHandle_TestData()
+    public static IEnumerable<object[]> Add_OverriddenPropertiesWithHandle_TestData()
     {
         BindingContext parentContext = [];
         BindingContext childContext = [];
@@ -785,8 +785,8 @@ public class ControlControlCollectionTests
     }
 
     [WinFormsTheory]
-    [MemberData(nameof(Add_OverridenPropertiesWithHandle_TestData))]
-    public void ControlCollection_Add_InvokeWithOverridenPropertiesWithHandle_CallsPropertyHandlers(BindingContext parentBindingContext, BindingContext bindingContext, BindingContext expectedBindingContext, int expectedBindingContextChangedCallCount)
+    [MemberData(nameof(Add_OverriddenPropertiesWithHandle_TestData))]
+    public void ControlCollection_Add_InvokeWithOverriddenPropertiesWithHandle_CallsPropertyHandlers(BindingContext parentBindingContext, BindingContext bindingContext, BindingContext expectedBindingContext, int expectedBindingContextChangedCallCount)
     {
         using Control owner = new();
         using Control control = new();
@@ -938,8 +938,8 @@ public class ControlControlCollectionTests
     }
 
     [WinFormsTheory]
-    [MemberData(nameof(Add_OverridenProperties_TestData))]
-    public void ControlCollection_Add_InvokeWithOverridenPropertiesAxHost_DoesNotCallPropertyHandlers(BindingContext parentBindingContext, BindingContext bindingContext, BindingContext expectedBindingContext)
+    [MemberData(nameof(Add_OverriddenProperties_TestData))]
+    public void ControlCollection_Add_InvokeWithOverriddenPropertiesAxHost_DoesNotCallPropertyHandlers(BindingContext parentBindingContext, BindingContext bindingContext, BindingContext expectedBindingContext)
     {
         using Control owner = new();
         using SubAxHost control = new("8856f961-340a-11d0-a96b-00c04fd705a2");
@@ -1011,8 +1011,8 @@ public class ControlControlCollectionTests
     }
 
     [WinFormsTheory]
-    [MemberData(nameof(Add_OverridenPropertiesWithHandle_TestData))]
-    public void ControlCollection_Add_InvokeWithOverridenPropertiesAxHostWithHandle_CallSPropertyHandlers(BindingContext parentBindingContext, BindingContext bindingContext, BindingContext expectedBindingContext, int expectedBindingContextChangedCallCount)
+    [MemberData(nameof(Add_OverriddenPropertiesWithHandle_TestData))]
+    public void ControlCollection_Add_InvokeWithOverriddenPropertiesAxHostWithHandle_CallSPropertyHandlers(BindingContext parentBindingContext, BindingContext bindingContext, BindingContext expectedBindingContext, int expectedBindingContextChangedCallCount)
     {
         using Control owner = new();
         using SubAxHost control = new("8856f961-340a-11d0-a96b-00c04fd705a2");
@@ -2232,7 +2232,7 @@ public class ControlControlCollectionTests
     }
 
     [WinFormsFact]
-    public void ControlCollection_Remove_InvokeWithNonOverridenProperties_DoesNotCallPropertyHandlers()
+    public void ControlCollection_Remove_InvokeWithNonOverriddenProperties_DoesNotCallPropertyHandlers()
     {
         using Control owner = new();
         using Control control = new();
@@ -2278,7 +2278,7 @@ public class ControlControlCollectionTests
     }
 
     [WinFormsFact]
-    public void ControlCollection_Remove_InvokeWithNonOverridenPropertiesWithHandle_DoesNotCallPropertyHandlers()
+    public void ControlCollection_Remove_InvokeWithNonOverriddenPropertiesWithHandle_DoesNotCallPropertyHandlers()
     {
         using Control owner = new();
         using Control control = new();
@@ -2324,7 +2324,7 @@ public class ControlControlCollectionTests
         Assert.Equal(1, bindingContextChangedCallCount);
     }
 
-    public static IEnumerable<object[]> Remove_OverridenProperties_TestData()
+    public static IEnumerable<object[]> Remove_OverriddenProperties_TestData()
     {
         BindingContext parentContext = [];
         BindingContext childContext = [];
@@ -2335,8 +2335,8 @@ public class ControlControlCollectionTests
     }
 
     [WinFormsTheory]
-    [MemberData(nameof(Remove_OverridenProperties_TestData))]
-    public void ControlCollection_Remove_InvokeWithOverridenProperties_CallsPropertyHandlers(BindingContext parentBindingContext, BindingContext bindingContext, BindingContext expectedBindingContext)
+    [MemberData(nameof(Remove_OverriddenProperties_TestData))]
+    public void ControlCollection_Remove_InvokeWithOverriddenProperties_CallsPropertyHandlers(BindingContext parentBindingContext, BindingContext bindingContext, BindingContext expectedBindingContext)
     {
         using Control owner = new();
         using Control control = new();
@@ -2468,7 +2468,7 @@ public class ControlControlCollectionTests
         Assert.Equal(0, bindingContextChangedCallCount);
     }
 
-    public static IEnumerable<object[]> Remove_OverridenPropertiesWithHandle_TestData()
+    public static IEnumerable<object[]> Remove_OverriddenPropertiesWithHandle_TestData()
     {
         BindingContext parentContext = [];
         BindingContext childContext = [];
@@ -2479,8 +2479,8 @@ public class ControlControlCollectionTests
     }
 
     [WinFormsTheory]
-    [MemberData(nameof(Remove_OverridenPropertiesWithHandle_TestData))]
-    public void ControlCollection_Remove_InvokeWithOverridenPropertiesWithHandle_CallsPropertyHandlers(BindingContext parentBindingContext, BindingContext bindingContext, BindingContext expectedBindingContext, int expectedBindingContextChangedCallCount)
+    [MemberData(nameof(Remove_OverriddenPropertiesWithHandle_TestData))]
+    public void ControlCollection_Remove_InvokeWithOverriddenPropertiesWithHandle_CallsPropertyHandlers(BindingContext parentBindingContext, BindingContext bindingContext, BindingContext expectedBindingContext, int expectedBindingContextChangedCallCount)
     {
         using Control owner = new();
         using Control control = new();
@@ -2611,8 +2611,8 @@ public class ControlControlCollectionTests
     }
 
     [WinFormsTheory]
-    [MemberData(nameof(Remove_OverridenProperties_TestData))]
-    public void ControlCollection_Remove_InvokeWithOverridenPropertiesAxHost_DoesNotCallPropertyHandlers(BindingContext parentBindingContext, BindingContext bindingContext, BindingContext expectedBindingContext)
+    [MemberData(nameof(Remove_OverriddenProperties_TestData))]
+    public void ControlCollection_Remove_InvokeWithOverriddenPropertiesAxHost_DoesNotCallPropertyHandlers(BindingContext parentBindingContext, BindingContext bindingContext, BindingContext expectedBindingContext)
     {
         using Control owner = new();
         using SubAxHost control = new("8856f961-340a-11d0-a96b-00c04fd705a2");
@@ -2675,8 +2675,8 @@ public class ControlControlCollectionTests
     }
 
     [WinFormsTheory]
-    [MemberData(nameof(Remove_OverridenPropertiesWithHandle_TestData))]
-    public void ControlCollection_Remove_InvokeWithOverridenPropertiesAxHostWithHandle_CallSPropertyHandlers(BindingContext parentBindingContext, BindingContext bindingContext, BindingContext expectedBindingContext, int expectedBindingContextChangedCallCount)
+    [MemberData(nameof(Remove_OverriddenPropertiesWithHandle_TestData))]
+    public void ControlCollection_Remove_InvokeWithOverriddenPropertiesAxHostWithHandle_CallSPropertyHandlers(BindingContext parentBindingContext, BindingContext bindingContext, BindingContext expectedBindingContext, int expectedBindingContextChangedCallCount)
     {
         using Control owner = new();
         using SubAxHost control = new("8856f961-340a-11d0-a96b-00c04fd705a2");

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FileDialogTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FileDialogTests.cs
@@ -47,7 +47,7 @@ public class FileDialogTests
     }
 
     [WinFormsFact]
-    public void FileDialog_Ctor_Default_OverridenReset()
+    public void FileDialog_Ctor_Default_OverriddenReset()
     {
         using EmptyResetFileDialog dialog = new();
         Assert.False(dialog.AddExtension);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FontDialogTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FontDialogTests.cs
@@ -38,7 +38,7 @@ public class FontDialogTests
     }
 
     [WinFormsFact]
-    public void FontDialog_Ctor_Default_OverridenReset()
+    public void FontDialog_Ctor_Default_OverriddenReset()
     {
         using EmptyResetFontDialog dialog = new();
         Assert.True(dialog.AllowScriptChange);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListControlTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListControlTests.cs
@@ -707,7 +707,7 @@ public class ListControlTests
     }
 
     [WinFormsFact]
-    public void ListControl_DataSource_SetOverridenComponent_DisposeValue_DoesNotRemove()
+    public void ListControl_DataSource_SetOverriddenComponent_DisposeValue_DoesNotRemove()
     {
         ComponentList originalValue = new();
         List<int> value = [];
@@ -829,7 +829,7 @@ public class ListControlTests
 
     [WinFormsTheory]
     [BoolData]
-    public void ListControl_DataSource_SetOverridenSupportInitializeNotification_InitializeValue_Success(bool isInitialized)
+    public void ListControl_DataSource_SetOverriddenSupportInitializeNotification_InitializeValue_Success(bool isInitialized)
     {
         SupportInitializeNotificationList originalValue = new();
         List<int> value = [];

--- a/src/System.Windows.Forms/tests/UnitTests/TextBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/TextBoxTests.cs
@@ -279,7 +279,7 @@ public partial class TextBoxTests
         if (value != AutoCompleteSource.ListItems)
         {
             control.AutoCompleteSource.Should().Be(value);
-        }         
+        }
     }
 
     [WinFormsTheory]
@@ -401,7 +401,7 @@ public partial class TextBoxTests
     }
 
     [WinFormsFact]
-    public void TextBox_PlaceholderText_Overriden()
+    public void TextBox_PlaceholderText_Overridden()
     {
         using SubTextBox tb = new();
 


### PR DESCRIPTION
Fixes # #12153

## Proposed changes
- Fix spelling errors is test Names related to Overridden, IAccessible and doesn't

## Customer Impact
-  For developers fewer spelling errors cluttering up the error window 

## Regression?
- No

## Risk
- no code changes only rename if test names

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12195)