### PR TITLE
Add unit tests for ItemTypeToolStripMenuItem

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ItemTypeToolStripMenuItem.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ItemTypeToolStripMenuItem.cs
@@ -50,13 +50,13 @@ internal class ItemTypeToolStripMenuItem : ToolStripMenuItem
         }
     }
 
-    public ToolboxItem TbxItem { get; set; } = s_invalidToolboxItem;
+    public ToolboxItem ToolboxItem { get; set; } = s_invalidToolboxItem;
 
     protected override void Dispose(bool disposing)
     {
         if (disposing)
         {
-            TbxItem = null!;
+            ToolboxItem = null!;
         }
 
         base.Dispose(disposing);

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ItemTypeToolStripMenuItemTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ItemTypeToolStripMenuItemTests.cs
@@ -6,8 +6,8 @@
 using System.Drawing;
 using System.Drawing.Design;
 
-namespace System.Windows.Forms.Design.Tests
-{
+namespace System.Windows.Forms.Design.Tests;
+
     public class ItemTypeToolStripMenuItemTests
     {
         [Fact]
@@ -49,9 +49,8 @@ namespace System.Windows.Forms.Design.Tests
         [Fact]
         public void Dispose_SetsTbxItemToNull()
         {
-            using ItemTypeToolStripMenuItem item = new(typeof(string));
+            ItemTypeToolStripMenuItem item = new(typeof(string));
             item.Dispose();
             item.TbxItem.Should().BeNull();
         }
     }
-}

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ItemTypeToolStripMenuItemTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ItemTypeToolStripMenuItemTests.cs
@@ -49,7 +49,7 @@ namespace System.Windows.Forms.Design.Tests
         [Fact]
         public void Dispose_SetsTbxItemToNull()
         {
-            ItemTypeToolStripMenuItem item = new(typeof(string));
+            using ItemTypeToolStripMenuItem item = new(typeof(string));
             item.Dispose();
             item.TbxItem.Should().BeNull();
         }

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ItemTypeToolStripMenuItemTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ItemTypeToolStripMenuItemTests.cs
@@ -39,18 +39,18 @@ public class ItemTypeToolStripMenuItemTests
     }
 
     [Fact]
-    public void TbxItem_SetAndGet()
+    public void ToolboxItem_SetAndGet()
     {
         ToolboxItem toolboxItem = new(typeof(string));
-        using ItemTypeToolStripMenuItem item = new(typeof(string)) { TbxItem = toolboxItem };
-        item.TbxItem.Should().Be(toolboxItem);
+        using ItemTypeToolStripMenuItem item = new(typeof(string)) { ToolboxItem = toolboxItem };
+        item.ToolboxItem.Should().Be(toolboxItem);
     }
 
     [Fact]
-    public void Dispose_SetsTbxItemToNull()
+    public void Dispose_SetsToolboxItemToNull()
     {
         ItemTypeToolStripMenuItem item = new(typeof(string));
         item.Dispose();
-        item.TbxItem.Should().BeNull();
+        item.ToolboxItem.Should().BeNull();
     }
 }

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ItemTypeToolStripMenuItemTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ItemTypeToolStripMenuItemTests.cs
@@ -53,8 +53,9 @@ public class ItemTypeToolStripMenuItemTests : IDisposable
     [Fact]
     public void Dispose_SetsToolboxItemToNull()
     {
-        _item.Dispose();
-        _item.ToolboxItem.Should().BeNull();
+        ItemTypeToolStripMenuItem item = new(typeof(string));
+        item.Dispose();
+        item.ToolboxItem.Should().BeNull();
     }
 
     public void Dispose()

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ItemTypeToolStripMenuItemTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ItemTypeToolStripMenuItemTests.cs
@@ -8,49 +8,57 @@ using System.Drawing.Design;
 
 namespace System.Windows.Forms.Design.Tests;
 
-public class ItemTypeToolStripMenuItemTests
+public class ItemTypeToolStripMenuItemTests : IDisposable
 {
+    private readonly ItemTypeToolStripMenuItem _item;
+
+    public ItemTypeToolStripMenuItemTests()
+    {
+        _item = new ItemTypeToolStripMenuItem(typeof(string));
+    }
+
     [Fact]
     public void Constructor_SetsItemType()
     {
-        using ItemTypeToolStripMenuItem item = new(typeof(string));
-        item.ItemType.Should().Be(typeof(string));
+        _item.ItemType.Should().Be(typeof(string));
     }
 
     [Fact]
     public void ConvertTo_SetAndGet()
     {
-        using ItemTypeToolStripMenuItem item = new(typeof(string)) { ConvertTo = true };
-        item.ConvertTo.Should().BeTrue();
+        _item.ConvertTo = true;
+        _item.ConvertTo.Should().BeTrue();
     }
 
     [Fact]
     public void Image_Get_ReturnsCorrectImage()
     {
-        using ItemTypeToolStripMenuItem item = new(typeof(string));
-        item.Image.Should().BeOfType<Bitmap>().Which.Should().Be(ToolStripDesignerUtils.GetToolboxBitmap(typeof(string)));
+        _item.Image.Should().BeOfType<Bitmap>().Which.Should().Be(ToolStripDesignerUtils.GetToolboxBitmap(typeof(string)));
     }
 
     [Fact]
     public void Text_ReturnsCorrectDescription()
     {
-        using ItemTypeToolStripMenuItem item = new(typeof(string));
-        item.Text.Should().BeOfType<string>().Which.Should().Be(ToolStripDesignerUtils.GetToolboxDescription(typeof(string)));
+        _item.Text.Should().BeOfType<string>().Which.Should().Be(ToolStripDesignerUtils.GetToolboxDescription(typeof(string)));
     }
 
     [Fact]
     public void ToolboxItem_SetAndGet()
     {
         ToolboxItem toolboxItem = new(typeof(string));
-        using ItemTypeToolStripMenuItem item = new(typeof(string)) { ToolboxItem = toolboxItem };
-        item.ToolboxItem.Should().Be(toolboxItem);
+        _item.ToolboxItem = toolboxItem;
+        _item.ToolboxItem.Should().Be(toolboxItem);
     }
 
     [Fact]
     public void Dispose_SetsToolboxItemToNull()
     {
-        ItemTypeToolStripMenuItem item = new(typeof(string));
-        item.Dispose();
-        item.ToolboxItem.Should().BeNull();
+        _item.Dispose();
+        _item.ToolboxItem.Should().BeNull();
+    }
+
+    public void Dispose()
+    {
+        _item.Dispose();
     }
 }

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ItemTypeToolStripMenuItemTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ItemTypeToolStripMenuItemTests.cs
@@ -8,49 +8,49 @@ using System.Drawing.Design;
 
 namespace System.Windows.Forms.Design.Tests;
 
-    public class ItemTypeToolStripMenuItemTests
+public class ItemTypeToolStripMenuItemTests
+{
+    [Fact]
+    public void Constructor_SetsItemType()
     {
-        [Fact]
-        public void Constructor_SetsItemType()
-        {
-            using ItemTypeToolStripMenuItem item = new(typeof(string));
-            item.ItemType.Should().Be(typeof(string));
-        }
-
-        [Fact]
-        public void ConvertTo_SetAndGet()
-        {
-            using ItemTypeToolStripMenuItem item = new(typeof(string)) { ConvertTo = true };
-            item.ConvertTo.Should().BeTrue();
-        }
-
-        [Fact]
-        public void Image_Get_ReturnsCorrectImage()
-        {
-            using ItemTypeToolStripMenuItem item = new(typeof(string));
-            item.Image.Should().BeOfType<Bitmap>().Which.Should().Be(ToolStripDesignerUtils.GetToolboxBitmap(typeof(string)));
-        }
-
-        [Fact]
-        public void Text_ReturnsCorrectDescription()
-        {
-            using ItemTypeToolStripMenuItem item = new(typeof(string));
-            item.Text.Should().BeOfType<string>().Which.Should().Be(ToolStripDesignerUtils.GetToolboxDescription(typeof(string)));
-        }
-
-        [Fact]
-        public void TbxItem_SetAndGet()
-        {
-            ToolboxItem toolboxItem = new(typeof(string));
-            using ItemTypeToolStripMenuItem item = new(typeof(string)) { TbxItem = toolboxItem };
-            item.TbxItem.Should().Be(toolboxItem);
-        }
-
-        [Fact]
-        public void Dispose_SetsTbxItemToNull()
-        {
-            ItemTypeToolStripMenuItem item = new(typeof(string));
-            item.Dispose();
-            item.TbxItem.Should().BeNull();
-        }
+        using ItemTypeToolStripMenuItem item = new(typeof(string));
+        item.ItemType.Should().Be(typeof(string));
     }
+
+    [Fact]
+    public void ConvertTo_SetAndGet()
+    {
+        using ItemTypeToolStripMenuItem item = new(typeof(string)) { ConvertTo = true };
+        item.ConvertTo.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Image_Get_ReturnsCorrectImage()
+    {
+        using ItemTypeToolStripMenuItem item = new(typeof(string));
+        item.Image.Should().BeOfType<Bitmap>().Which.Should().Be(ToolStripDesignerUtils.GetToolboxBitmap(typeof(string)));
+    }
+
+    [Fact]
+    public void Text_ReturnsCorrectDescription()
+    {
+        using ItemTypeToolStripMenuItem item = new(typeof(string));
+        item.Text.Should().BeOfType<string>().Which.Should().Be(ToolStripDesignerUtils.GetToolboxDescription(typeof(string)));
+    }
+
+    [Fact]
+    public void TbxItem_SetAndGet()
+    {
+        ToolboxItem toolboxItem = new(typeof(string));
+        using ItemTypeToolStripMenuItem item = new(typeof(string)) { TbxItem = toolboxItem };
+        item.TbxItem.Should().Be(toolboxItem);
+    }
+
+    [Fact]
+    public void Dispose_SetsTbxItemToNull()
+    {
+        ItemTypeToolStripMenuItem item = new(typeof(string));
+        item.Dispose();
+        item.TbxItem.Should().BeNull();
+    }
+}

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ItemTypeToolStripMenuItemTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ItemTypeToolStripMenuItemTests.cs
@@ -1,0 +1,57 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System.Drawing;
+using System.Drawing.Design;
+
+namespace System.Windows.Forms.Design.Tests
+{
+    public class ItemTypeToolStripMenuItemTests
+    {
+        [Fact]
+        public void Constructor_SetsItemType()
+        {
+            using ItemTypeToolStripMenuItem item = new(typeof(string));
+            item.ItemType.Should().Be(typeof(string));
+        }
+
+        [Fact]
+        public void ConvertTo_SetAndGet()
+        {
+            using ItemTypeToolStripMenuItem item = new(typeof(string)) { ConvertTo = true };
+            item.ConvertTo.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Image_Get_ReturnsCorrectImage()
+        {
+            using ItemTypeToolStripMenuItem item = new(typeof(string));
+            item.Image.Should().BeOfType<Bitmap>().Which.Should().Be(ToolStripDesignerUtils.GetToolboxBitmap(typeof(string)));
+        }
+
+        [Fact]
+        public void Text_ReturnsCorrectDescription()
+        {
+            using ItemTypeToolStripMenuItem item = new(typeof(string));
+            item.Text.Should().BeOfType<string>().Which.Should().Be(ToolStripDesignerUtils.GetToolboxDescription(typeof(string)));
+        }
+
+        [Fact]
+        public void TbxItem_SetAndGet()
+        {
+            ToolboxItem toolboxItem = new(typeof(string));
+            using ItemTypeToolStripMenuItem item = new(typeof(string)) { TbxItem = toolboxItem };
+            item.TbxItem.Should().Be(toolboxItem);
+        }
+
+        [Fact]
+        public void Dispose_SetsTbxItemToNull()
+        {
+            ItemTypeToolStripMenuItem item = new(typeof(string));
+            item.Dispose();
+            item.TbxItem.Should().BeNull();
+        }
+    }
+}


### PR DESCRIPTION
Related https://github.com/dotnet/winforms/issues/10773

## Proposed changes

- Add unit test ItemTypeToolStripMenuItemTests.cs for public properties and method of the ItemTypeToolStripMenuItem.
- Enable nullability in ItemTypeToolStripMenuItem.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12199)