### PR TITLE
Add unit tests for PictureBoxActionList

### DIFF
--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/PictureBoxActionListTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/PictureBoxActionListTests.cs
@@ -1,0 +1,56 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System.ComponentModel.Design;
+
+namespace System.Windows.Forms.Design.Tests
+{
+    public sealed class PictureBoxActionListTests
+    {
+        [Fact]
+        public void SizeMode_ShouldReturnCorrectValue()
+        {
+            using PictureBox pictureBox = new() { SizeMode = PictureBoxSizeMode.StretchImage };
+            using PictureBoxDesigner designer = new();
+            designer.Initialize(pictureBox);
+            PictureBoxActionList actionList = new(designer);
+
+            PictureBoxSizeMode sizeMode = actionList.SizeMode;
+
+            sizeMode.Should().Be(PictureBoxSizeMode.StretchImage);
+        }
+
+        [Fact]
+        public void SizeMode_ShouldUpdateCorrectly()
+        {
+            using PictureBox pictureBox = new();
+            using PictureBoxDesigner designer = new();
+            designer.Initialize(pictureBox);
+            PictureBoxActionList actionList = new(designer)
+            {
+                SizeMode = PictureBoxSizeMode.Zoom
+            };
+
+            pictureBox.SizeMode.Should().Be(PictureBoxSizeMode.Zoom);
+        }
+
+        [Fact]
+        public void GetSortedActionItems_ShouldReturnCorrectItems()
+        {
+            using PictureBox pictureBox = new();
+            using PictureBoxDesigner designer = new();
+            designer.Initialize(pictureBox);
+            PictureBoxActionList actionList = new(designer);
+
+            DesignerActionItemCollection items = actionList.GetSortedActionItems();
+
+            items.Should().NotBeNull();
+            items.Count.Should().Be(2);
+            items[0].Should().BeOfType<DesignerActionMethodItem>();
+            items[1].Should().BeOfType<DesignerActionPropertyItem>();
+        }
+    }
+}
+


### PR DESCRIPTION
Related https://github.com/dotnet/winforms/issues/10773


## Proposed changes

- Add unit test PictureBoxActionListTests.cs for public properties and method of the PictureBoxActionList.
- Enable nullability in PictureBoxActionList.

