### PR TITLE
Remove remaining old PropertyStore APIs

### DIFF
--- a/src/System.Private.Windows.Core/src/System/Value.cs
+++ b/src/System.Private.Windows.Core/src/System/Value.cs
@@ -936,7 +936,6 @@ internal readonly partial struct Value
         if (_object is null)
         {
             value = default!;
-            result = typeof(T) == typeof(object);
         }
         else if (typeof(T) == typeof(char[]))
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -431,7 +431,7 @@ public unsafe partial class Control :
             if (!Properties.TryGetValue(s_accessibilityProperty, out AccessibleObject? accessibleObject))
             {
                 accessibleObject = CreateAccessibilityInstance().OrThrowIfNull();
-                Properties.SetObject(s_accessibilityProperty, accessibleObject);
+                Properties.AddValue(s_accessibilityProperty, accessibleObject);
             }
 
             Debug.Assert(accessibleObject is not null, "Failed to create accessibility object");
@@ -450,7 +450,7 @@ public unsafe partial class Control :
             if (!Properties.TryGetValue(s_ncAccessibilityProperty, out AccessibleObject? ncAccessibleObject))
             {
                 ncAccessibleObject = new ControlAccessibleObject(this, (int)OBJECT_IDENTIFIER.OBJID_WINDOW);
-                Properties.SetObject(s_ncAccessibilityProperty, ncAccessibleObject);
+                Properties.AddValue(s_ncAccessibilityProperty, ncAccessibleObject);
             }
 
             Debug.Assert(ncAccessibleObject is not null, "Failed to create NON-CLIENT accessibility object");
@@ -564,11 +564,7 @@ public unsafe partial class Control :
     {
         get
         {
-            AmbientProperties? ambientProperties = (AmbientProperties?)Properties.GetObject(
-                s_ambientPropertiesServiceProperty,
-                out bool found);
-
-            if (found)
+            if (Properties.TryGetValueOrNull(s_ambientPropertiesServiceProperty, out AmbientProperties? ambientProperties))
             {
                 return ambientProperties;
             }
@@ -584,7 +580,7 @@ public unsafe partial class Control :
 
             if (ambientProperties is not null)
             {
-                Properties.SetObject(s_ambientPropertiesServiceProperty, ambientProperties);
+                Properties.AddValue(s_ambientPropertiesServiceProperty, ambientProperties);
             }
 
             return ambientProperties;
@@ -661,16 +657,8 @@ public unsafe partial class Control :
     [DefaultValue(typeof(Point), "0, 0")]
     public virtual Point AutoScrollOffset
     {
-        get => Properties.TryGetObject(s_autoScrollOffsetProperty, out Point point)
-            ? point
-            : Point.Empty;
-        set
-        {
-            if (AutoScrollOffset != value)
-            {
-                Properties.SetObject(s_autoScrollOffsetProperty, value);
-            }
-        }
+        get => Properties.GetValueOrDefault(s_autoScrollOffsetProperty, Point.Empty);
+        set => Properties.AddOrRemoveValue(s_autoScrollOffsetProperty, value, defaultValue: Point.Empty);
     }
 
     protected void SetAutoSizeMode(AutoSizeMode mode) => CommonProperties.SetAutoSizeMode(this, mode);
@@ -750,7 +738,7 @@ public unsafe partial class Control :
     [Bindable(true)]
     public virtual object? DataContext
     {
-        get => Properties.TryGetObject(s_dataContextProperty, out object? value)
+        get => Properties.TryGetValue(s_dataContextProperty, out object? value)
             ? value
             : ParentInternal?.DataContext;
         set
@@ -893,9 +881,7 @@ public unsafe partial class Control :
     [SRDescription(nameof(SR.ControlBackgroundImageLayoutDescr))]
     public virtual ImageLayout BackgroundImageLayout
     {
-        get => Properties.TryGetObject(s_backgroundImageLayoutProperty, out ImageLayout imageLayout)
-            ? imageLayout
-            : ImageLayout.Tile;
+        get => Properties.GetValueOrDefault(s_backgroundImageLayoutProperty, ImageLayout.Tile);
         set
         {
             if (BackgroundImageLayout == value)
@@ -903,7 +889,6 @@ public unsafe partial class Control :
                 return;
             }
 
-            // Valid values are 0x0 to 0x4
             SourceGenerated.EnumValidator.Validate(value);
 
             // Check if the value is either center, stretch or zoom;
@@ -918,7 +903,7 @@ public unsafe partial class Control :
                 }
             }
 
-            Properties.SetObject(s_backgroundImageLayoutProperty, value);
+            Properties.AddOrRemoveValue(s_backgroundImageLayoutProperty, value, defaultValue: ImageLayout.Tile);
             OnBackgroundImageLayoutChanged(EventArgs.Empty);
         }
     }
@@ -939,7 +924,7 @@ public unsafe partial class Control :
         {
             if (value != BecomingActiveControl)
             {
-                Application.ThreadContext.FromCurrent().ActivatingControl = (value) ? this : null;
+                Application.ThreadContext.FromCurrent().ActivatingControl = value ? this : null;
                 SetExtendedState(ExtendedStates.BecomingActiveControl, value);
             }
         }
@@ -1576,8 +1561,7 @@ public unsafe partial class Control :
 
             if (!Properties.TryGetValue(s_bindingsProperty, out ControlBindingsCollection? bindings))
             {
-                bindings = new ControlBindingsCollection(this);
-                Properties.SetObject(s_bindingsProperty, bindings);
+                bindings = Properties.AddValue(s_bindingsProperty, new ControlBindingsCollection(this));
             }
 
             return bindings;
@@ -3043,7 +3027,7 @@ public unsafe partial class Control :
                     oldCursor = Cursor;
                 }
 
-                Properties.SetObject(s_ambientPropertiesServiceProperty, newAmbients);
+                Properties.AddValue(s_ambientPropertiesServiceProperty, newAmbients);
                 base.Site = value;
 
                 if (checkFont && !oldFont!.Equals(Font))

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridView.Methods.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridView.Methods.cs
@@ -5732,10 +5732,9 @@ public partial class DataGridView
             _dataGridViewOper[OperationInDispose] = true;
             try
             {
-                if (Properties.TryGetObject(s_propToolTip, out ToolTip? keyboardToolTip))
+                if (Properties.TryGetValue(s_propToolTip, out ToolTip? keyboardToolTip))
                 {
-                    // null is never set for s_propToolTip
-                    keyboardToolTip!.Dispose();
+                    keyboardToolTip.Dispose();
                 }
 
                 // Remove any Columns contained in this control

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridView.cs
@@ -2947,18 +2947,16 @@ public partial class DataGridView : Control, ISupportInitialize
     {
         get
         {
-            if (Properties.TryGetObject(s_propToolTip, out ToolTip? toolTip))
+            if (!Properties.TryGetValue(s_propToolTip, out ToolTip? toolTip))
             {
-                return toolTip!;
+                toolTip = Properties.AddValue(
+                    s_propToolTip,
+                    new ToolTip
+                    {
+                        ReshowDelay = 500,
+                        InitialDelay = 500
+                    });
             }
-
-            toolTip = new ToolTip
-            {
-                ReshowDelay = 500,
-                InitialDelay = 500
-            };
-
-            Properties.SetObject(s_propToolTip, toolTip);
 
             return toolTip;
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewBand.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewBand.cs
@@ -212,15 +212,9 @@ public class DataGridViewBand : DataGridViewElement, ICloneable, IDisposable
     }
 
     [Browsable(false)]
-    public bool HasDefaultCellStyle
-    {
-        get => Properties.ContainsObjectThatIsNotNull(s_propDefaultCellStyle);
-    }
+    public bool HasDefaultCellStyle => Properties.ContainsKey(s_propDefaultCellStyle);
 
-    internal bool HasDefaultHeaderCellType
-    {
-        get => Properties.ContainsObjectThatIsNotNull(s_propDefaultHeaderCellType);
-    }
+    internal bool HasDefaultHeaderCellType => Properties.ContainsKey(s_propDefaultHeaderCellType);
 
     internal bool HasHeaderCell => Properties.ContainsKey(s_propHeaderCell);
 
@@ -864,19 +858,10 @@ public class DataGridViewBand : DataGridViewElement, ICloneable, IDisposable
         base.OnDataGridViewChanged();
     }
 
-    private bool ShouldSerializeDefaultHeaderCellType()
-    {
-        return Properties.ContainsObjectThatIsNotNull(s_propDefaultHeaderCellType);
-    }
+    private bool ShouldSerializeDefaultHeaderCellType() => Properties.ContainsKey(s_propDefaultHeaderCellType);
 
     // internal because DataGridViewColumn needs to access it
-    internal bool ShouldSerializeResizable()
-    {
-        return (State & DataGridViewElementStates.ResizableSet) != 0;
-    }
+    internal bool ShouldSerializeResizable() => (State & DataGridViewElementStates.ResizableSet) != 0;
 
-    public override string ToString()
-    {
-        return $"DataGridViewBand {{ Index={Index} }}";
-    }
+    public override string ToString() => $"DataGridViewBand {{ Index={Index} }}";
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewCell.cs
@@ -208,12 +208,9 @@ public abstract partial class DataGridViewCell : DataGridViewElement, ICloneable
         get => Properties.GetStringOrEmptyString(s_propCellErrorText);
         set
         {
-            string errorText = ErrorTextInternal;
-            Properties.AddOrRemoveString(s_propCellErrorText, value);
-
-            if (DataGridView is not null && !errorText.Equals(ErrorTextInternal))
+            if (Properties.AddOrRemoveString(s_propCellErrorText, value))
             {
-                DataGridView.OnCellErrorTextChanged(this);
+                DataGridView?.OnCellErrorTextChanged(this);
             }
         }
     }
@@ -280,9 +277,9 @@ public abstract partial class DataGridViewCell : DataGridViewElement, ICloneable
     private bool HasErrorText => Properties.ContainsKey(s_propCellErrorText);
 
     [Browsable(false)]
-    public bool HasStyle => Properties.ContainsObjectThatIsNotNull(s_propCellStyle);
+    public bool HasStyle => Properties.ContainsKey(s_propCellStyle);
 
-    internal bool HasToolTipText => Properties.ContainsObjectThatIsNotNull(s_propCellToolTipText);
+    internal bool HasToolTipText => Properties.ContainsKey(s_propCellToolTipText);
 
     internal bool HasValue => Properties.ContainsKey(s_propCellValue);
 
@@ -681,10 +678,9 @@ public abstract partial class DataGridViewCell : DataGridViewElement, ICloneable
         get => Properties.GetStringOrEmptyString(s_propCellToolTipText);
         set
         {
-            string toolTipText = Properties.AddOrRemoveString(s_propCellToolTipText, value);
-            if (DataGridView is not null && !toolTipText.Equals(ToolTipTextInternal))
+            if (Properties.AddOrRemoveString(s_propCellToolTipText, value))
             {
-                DataGridView.OnCellToolTipTextChanged(this);
+                DataGridView?.OnCellToolTipTextChanged(this);
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewLinkCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewLinkCell.cs
@@ -44,7 +44,7 @@ public partial class DataGridViewLinkCell : DataGridViewCell
     {
         get
         {
-            if (Properties.TryGetObject(s_propLinkCellActiveLinkColor, out Color color))
+            if (Properties.TryGetValue(s_propLinkCellActiveLinkColor, out Color color))
             {
                 return color;
             }
@@ -54,7 +54,7 @@ public partial class DataGridViewLinkCell : DataGridViewCell
             }
             else
             {
-                // return the default IE Color if cell is not not selected
+                // Return the default IE Color if cell is not not selected.
                 return Selected ? SystemColors.HighlightText : LinkUtilities.IEActiveLinkColor;
             }
         }
@@ -62,7 +62,7 @@ public partial class DataGridViewLinkCell : DataGridViewCell
         {
             if (!value.Equals(ActiveLinkColor))
             {
-                Properties.SetObject(s_propLinkCellActiveLinkColor, value);
+                Properties.AddValue(s_propLinkCellActiveLinkColor, value);
                 if (DataGridView is not null)
                 {
                     if (RowIndex != -1)
@@ -84,7 +84,7 @@ public partial class DataGridViewLinkCell : DataGridViewCell
         {
             if (!value.Equals(ActiveLinkColor))
             {
-                Properties.SetObject(s_propLinkCellActiveLinkColor, value);
+                Properties.AddValue(s_propLinkCellActiveLinkColor, value);
             }
         }
     }
@@ -152,7 +152,7 @@ public partial class DataGridViewLinkCell : DataGridViewCell
     {
         get
         {
-            if (Properties.TryGetObject(s_propLinkCellLinkColor, out Color color))
+            if (Properties.TryGetValue(s_propLinkCellLinkColor, out Color color))
             {
                 return color;
             }
@@ -162,7 +162,7 @@ public partial class DataGridViewLinkCell : DataGridViewCell
             }
             else
             {
-                // return the default IE Color when cell is not selected
+                // Return the default IE Color when cell is not selected
                 return Selected ? SystemColors.HighlightText : LinkUtilities.IELinkColor;
             }
         }
@@ -170,7 +170,7 @@ public partial class DataGridViewLinkCell : DataGridViewCell
         {
             if (!value.Equals(LinkColor))
             {
-                Properties.SetObject(s_propLinkCellLinkColor, value);
+                Properties.AddValue(s_propLinkCellLinkColor, value);
                 if (DataGridView is not null)
                 {
                     if (RowIndex != -1)
@@ -192,31 +192,19 @@ public partial class DataGridViewLinkCell : DataGridViewCell
         {
             if (!value.Equals(LinkColor))
             {
-                Properties.SetObject(s_propLinkCellLinkColor, value);
+                Properties.AddValue(s_propLinkCellLinkColor, value);
             }
         }
     }
 
-    private bool ShouldSerializeLinkColor()
-    {
-        if (SystemInformation.HighContrast)
-        {
-            return !LinkColor.Equals(SystemColors.HotTrack);
-        }
-
-        return !LinkColor.Equals(LinkUtilities.IELinkColor);
-    }
+    private bool ShouldSerializeLinkColor() => SystemInformation.HighContrast
+        ? !LinkColor.Equals(SystemColors.HotTrack)
+        : !LinkColor.Equals(LinkUtilities.IELinkColor);
 
     private LinkState LinkState
     {
         get => Properties.GetValueOrDefault(s_propLinkCellLinkState, LinkState.Normal);
-        set
-        {
-            if (LinkState != value)
-            {
-                Properties.AddOrRemoveValue(s_propLinkCellLinkState, value, defaultValue: LinkState.Normal);
-            }
-        }
+        set => Properties.AddOrRemoveValue(s_propLinkCellLinkState, value, defaultValue: LinkState.Normal);
     }
 
     public bool LinkVisited
@@ -225,19 +213,21 @@ public partial class DataGridViewLinkCell : DataGridViewCell
         set
         {
             _linkVisitedSet = true;
-            if (value != LinkVisited)
+            if (value == LinkVisited)
             {
-                _linkVisited = value;
-                if (DataGridView is not null)
+                return;
+            }
+
+            _linkVisited = value;
+            if (DataGridView is not null)
+            {
+                if (RowIndex != -1)
                 {
-                    if (RowIndex != -1)
-                    {
-                        DataGridView.InvalidateCell(this);
-                    }
-                    else
-                    {
-                        DataGridView.InvalidateColumnInternal(ColumnIndex);
-                    }
+                    DataGridView.InvalidateCell(this);
+                }
+                else
+                {
+                    DataGridView.InvalidateColumnInternal(ColumnIndex);
                 }
             }
         }
@@ -251,19 +241,21 @@ public partial class DataGridViewLinkCell : DataGridViewCell
         get => Properties.GetValueOrDefault(s_propLinkCellTrackVisitedState, true);
         set
         {
-            if (value != TrackVisitedState)
+            if (value == TrackVisitedState)
             {
-                Properties.AddOrRemoveValue(s_propLinkCellTrackVisitedState, value, defaultValue: true);
-                if (DataGridView is not null)
+                return;
+            }
+
+            Properties.AddOrRemoveValue(s_propLinkCellTrackVisitedState, value, defaultValue: true);
+            if (DataGridView is not null)
+            {
+                if (RowIndex != -1)
                 {
-                    if (RowIndex != -1)
-                    {
-                        DataGridView.InvalidateCell(this);
-                    }
-                    else
-                    {
-                        DataGridView.InvalidateColumnInternal(ColumnIndex);
-                    }
+                    DataGridView.InvalidateCell(this);
+                }
+                else
+                {
+                    DataGridView.InvalidateColumnInternal(ColumnIndex);
                 }
             }
         }
@@ -271,13 +263,7 @@ public partial class DataGridViewLinkCell : DataGridViewCell
 
     internal bool TrackVisitedStateInternal
     {
-        set
-        {
-            if (value != TrackVisitedState)
-            {
-                Properties.AddOrRemoveValue(s_propLinkCellTrackVisitedState, value, defaultValue: true);
-            }
-        }
+        set => Properties.AddOrRemoveValue(s_propLinkCellTrackVisitedState, value, defaultValue: true);
     }
 
     [DefaultValue(false)]
@@ -296,21 +282,14 @@ public partial class DataGridViewLinkCell : DataGridViewCell
 
     internal bool UseColumnTextForLinkValueInternal
     {
-        set
-        {
-            // Caller is responsible for invalidation
-            if (value != UseColumnTextForLinkValue)
-            {
-                Properties.AddValue(s_propLinkCellUseColumnTextForLinkValue, value);
-            }
-        }
+        set => Properties.AddOrRemoveValue(s_propLinkCellUseColumnTextForLinkValue, value, defaultValue: false);
     }
 
     public Color VisitedLinkColor
     {
         get
         {
-            if (Properties.TryGetObject(s_propLinkCellVisitedLinkColor, out Color color))
+            if (Properties.TryGetValue(s_propLinkCellVisitedLinkColor, out Color color))
             {
                 return color;
             }
@@ -320,25 +299,27 @@ public partial class DataGridViewLinkCell : DataGridViewCell
             }
             else
             {
-                // return the default IE Color if cell is not not selected
+                // Return the default IE Color if cell is not not selected
                 return Selected ? SystemColors.HighlightText : LinkUtilities.IEVisitedLinkColor;
             }
         }
         set
         {
-            if (!value.Equals(VisitedLinkColor))
+            if (value.Equals(VisitedLinkColor))
             {
-                Properties.SetObject(s_propLinkCellVisitedLinkColor, value);
-                if (DataGridView is not null)
+                return;
+            }
+
+            Properties.AddValue(s_propLinkCellVisitedLinkColor, value);
+            if (DataGridView is not null)
+            {
+                if (RowIndex != -1)
                 {
-                    if (RowIndex != -1)
-                    {
-                        DataGridView.InvalidateCell(this);
-                    }
-                    else
-                    {
-                        DataGridView.InvalidateColumnInternal(ColumnIndex);
-                    }
+                    DataGridView.InvalidateCell(this);
+                }
+                else
+                {
+                    DataGridView.InvalidateColumnInternal(ColumnIndex);
                 }
             }
         }
@@ -350,7 +331,7 @@ public partial class DataGridViewLinkCell : DataGridViewCell
         {
             if (!value.Equals(VisitedLinkColor))
             {
-                Properties.SetObject(s_propLinkCellVisitedLinkColor, value);
+                Properties.AddValue(s_propLinkCellVisitedLinkColor, value);
             }
         }
     }
@@ -376,19 +357,7 @@ public partial class DataGridViewLinkCell : DataGridViewCell
         }
     }
 
-    public override Type ValueType
-    {
-        get
-        {
-            Type? valueType = base.ValueType;
-            if (valueType is not null)
-            {
-                return valueType;
-            }
-
-            return s_defaultValueType;
-        }
-    }
+    public override Type ValueType => base.ValueType ?? s_defaultValueType;
 
     public override object Clone()
     {
@@ -444,17 +413,9 @@ public partial class DataGridViewLinkCell : DataGridViewCell
         return dataGridViewCell;
     }
 
-    private bool LinkBoundsContainPoint(int x, int y, int rowIndex)
-    {
-        Rectangle linkBounds = GetContentBounds(rowIndex);
+    private bool LinkBoundsContainPoint(int x, int y, int rowIndex) => GetContentBounds(rowIndex).Contains(x, y);
 
-        return linkBounds.Contains(x, y);
-    }
-
-    protected override AccessibleObject CreateAccessibilityInstance()
-    {
-        return new DataGridViewLinkCellAccessibleObject(this);
-    }
+    protected override AccessibleObject CreateAccessibilityInstance() => new DataGridViewLinkCellAccessibleObject(this);
 
     protected override Rectangle GetContentBounds(Graphics graphics, DataGridViewCellStyle cellStyle, int rowIndex)
     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewRow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewRow.cs
@@ -166,11 +166,9 @@ public partial class DataGridViewRow : DataGridViewBand
         get => Properties.GetStringOrEmptyString(s_propRowErrorText);
         set
         {
-            string priorValue = Properties.AddOrRemoveString(s_propRowErrorText, value);
-
-            if (DataGridView is not null && !priorValue.Equals(value ?? string.Empty))
+            if (Properties.AddOrRemoveString(s_propRowErrorText, value))
             {
-                DataGridView.OnRowErrorTextChanged(this);
+                DataGridView?.OnRowErrorTextChanged(this);
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ListView/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ListView/ListView.cs
@@ -2248,11 +2248,11 @@ public partial class ListView : Control
     /// </summary>
     private void ApplyUpdateCachedItems()
     {
-        // first check if there is a delayed update array
-        if (Properties.TryGetObject(s_propDelayedUpdateItems, out List<ListViewItem>? newItems) && newItems is not null)
+        // First check if there is a delayed update array.
+        if (Properties.TryGetValue(s_propDelayedUpdateItems, out List<ListViewItem>? newItems))
         {
-            // if there is, clear it and push the items in.
-            Properties.SetObject(s_propDelayedUpdateItems, null);
+            // If there is, clear it and push the items in.
+            Properties.RemoveValue(s_propDelayedUpdateItems);
             if (newItems.Count > 0)
             {
                 InsertItems(_itemCount, [.. newItems], checkHosting: false);
@@ -2381,11 +2381,11 @@ public partial class ListView : Control
     {
         BeginUpdateInternal();
 
-        // if this is the first BeginUpdate call, push an ArrayList into the PropertyStore so
+        // If this is the first BeginUpdate call, push an ArrayList into the PropertyStore so
         // we can cache up any items that have been added while this is active.
-        if (_updateCounter++ == 0 && !Properties.ContainsObjectThatIsNotNull(s_propDelayedUpdateItems))
+        if (_updateCounter++ == 0 && !Properties.ContainsKey(s_propDelayedUpdateItems))
         {
-            Properties.SetObject(s_propDelayedUpdateItems, new List<ListViewItem>());
+            Properties.AddValue(s_propDelayedUpdateItems, new List<ListViewItem>());
         }
     }
 
@@ -3205,7 +3205,7 @@ public partial class ListView : Control
     {
         // On the final EndUpdate, check to see if we've got any cached items.
         // If we do, insert them as normal, then turn off the painting freeze.
-        if (--_updateCounter == 0 && Properties.ContainsObjectThatIsNotNull(s_propDelayedUpdateItems))
+        if (--_updateCounter == 0 && Properties.ContainsKey(s_propDelayedUpdateItems))
         {
             ApplyUpdateCachedItems();
         }
@@ -4087,7 +4087,7 @@ public partial class ListView : Control
 
         // if we're in the middle of a Begin/EndUpdate, just push the items into our array list
         // as they'll get processed on EndUpdate.
-        if (_updateCounter > 0 && Properties.TryGetObject(s_propDelayedUpdateItems, out List<ListViewItem>? itemList) && itemList is not null)
+        if (_updateCounter > 0 && Properties.TryGetValue(s_propDelayedUpdateItems, out List<ListViewItem>? itemList))
         {
             // CheckHosting.
             if (checkHosting)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripItem.cs
@@ -486,16 +486,12 @@ public abstract partial class ToolStripItem :
     [SRDescription(nameof(SR.ControlBackgroundImageLayoutDescr))]
     public virtual ImageLayout BackgroundImageLayout
     {
-        get => Properties.TryGetObject(s_backgroundImageLayoutProperty, out ImageLayout imageLayout)
-            ? imageLayout
-            : ImageLayout.Tile;
+        get => Properties.GetValueOrDefault(s_backgroundImageLayoutProperty, ImageLayout.Tile);
         set
         {
-            if (BackgroundImageLayout != value)
+            SourceGenerated.EnumValidator.Validate(value);
+            if (Properties.AddOrRemoveValue(s_backgroundImageLayoutProperty, value, defaultValue: ImageLayout.Tile) != value)
             {
-                SourceGenerated.EnumValidator.Validate(value);
-
-                Properties.SetObject(s_backgroundImageLayoutProperty, value);
                 Invalidate();
             }
         }
@@ -527,7 +523,7 @@ public abstract partial class ToolStripItem :
         set
         {
             Color previous = BackColor;
-            Properties.AddOrRemoveValue(s_backColorProperty, value);
+            Properties.AddOrRemoveValue(s_backColorProperty, value, defaultValue: Color.Empty);
             if (!previous.Equals(BackColor))
             {
                 OnBackColorChanged(EventArgs.Empty);
@@ -1618,7 +1614,7 @@ public abstract partial class ToolStripItem :
     /// <summary>
     ///  Returns the value of the backColor field -- no asking the parent with its color is, etc.
     /// </summary>
-    internal Color RawBackColor => Properties.GetValueOrDefault<Color>(s_backColorProperty);
+    internal Color RawBackColor => Properties.GetValueOrDefault<Color>(s_backColorProperty, Color.Empty);
 
     /// <summary>
     ///  Returns the parent <see cref="ToolStrip"/>'s renderer
@@ -1854,8 +1850,8 @@ public abstract partial class ToolStripItem :
     [TypeConverter(typeof(StringConverter))]
     public object? Tag
     {
-        get => Properties.TryGetObject(s_tagProperty, out object? tag) ? tag : null;
-        set => Properties.SetObject(s_tagProperty, value);
+        get => Properties.GetValueOrDefault<object>(s_tagProperty);
+        set => Properties.AddOrRemoveValue(s_tagProperty, value);
     }
 
     /// <summary>
@@ -1867,14 +1863,11 @@ public abstract partial class ToolStripItem :
     [SRDescription(nameof(SR.ToolStripItemTextDescr))]
     public virtual string? Text
     {
-        get => Properties.TryGetObject(s_textProperty, out string? text)
-            ? text
-            : string.Empty;
+        get => Properties.TryGetValueOrNull(s_textProperty, out string? value) ? value : string.Empty;
         set
         {
-            if (value != Text)
+            if (Properties.AddOrRemoveValue(s_textProperty, value, defaultValue: string.Empty) != value)
             {
-                Properties.SetObject(s_textProperty, value);
                 OnTextChanged(EventArgs.Empty);
             }
         }
@@ -1916,17 +1909,13 @@ public abstract partial class ToolStripItem :
     {
         get
         {
-            ToolStripTextDirection textDirection = ToolStripTextDirection.Inherit;
-            if (Properties.TryGetObject(s_textDirectionProperty, out ToolStripTextDirection direction))
-            {
-                textDirection = direction;
-            }
+            ToolStripTextDirection textDirection = Properties.GetValueOrDefault(s_textDirectionProperty, ToolStripTextDirection.Inherit);
 
             if (textDirection == ToolStripTextDirection.Inherit)
             {
                 if (ParentInternal is not null)
                 {
-                    // in the case we're on a ToolStripOverflow
+                    // In the case we're on a ToolStripOverflow
                     textDirection = ParentInternal.TextDirection;
                 }
                 else
@@ -1940,8 +1929,7 @@ public abstract partial class ToolStripItem :
         set
         {
             SourceGenerated.EnumValidator.Validate(value);
-
-            Properties.SetObject(s_textDirectionProperty, value);
+            Properties.AddOrRemoveValue(s_textDirectionProperty, value, defaultValue: ToolStripTextDirection.Inherit);
             InvalidateItemLayout("TextDirection");
         }
     }
@@ -2987,11 +2975,7 @@ public abstract partial class ToolStripItem :
     [EditorBrowsable(EditorBrowsableState.Advanced)]
     internal void OnOwnerTextDirectionChanged()
     {
-        ToolStripTextDirection textDirection = ToolStripTextDirection.Inherit;
-        if (Properties.TryGetObject(s_textDirectionProperty, out ToolStripTextDirection direction))
-        {
-            textDirection = direction;
-        }
+        ToolStripTextDirection textDirection = Properties.GetValueOrDefault(s_textDirectionProperty, ToolStripTextDirection.Inherit);
 
         if (textDirection == ToolStripTextDirection.Inherit)
         {
@@ -3383,16 +3367,7 @@ public abstract partial class ToolStripItem :
         return rightToLeft != DefaultRightToLeft;
     }
 
-    private bool ShouldSerializeTextDirection()
-    {
-        ToolStripTextDirection textDirection = ToolStripTextDirection.Inherit;
-        if (Properties.TryGetObject(s_textDirectionProperty, out ToolStripTextDirection direction))
-        {
-            textDirection = direction;
-        }
-
-        return textDirection != ToolStripTextDirection.Inherit;
-    }
+    private bool ShouldSerializeTextDirection() => Properties.ContainsKey(s_textDirectionProperty);
 
     /// <summary>
     ///  Resets the back color to be based on the parent's back color.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripMenuItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripMenuItem.cs
@@ -108,7 +108,7 @@ public partial class ToolStripMenuItem : ToolStripDropDownItem
     internal ToolStripMenuItem(Form mdiForm)
     {
         Initialize();
-        Properties.SetObject(s_propMdiForm, mdiForm);
+        Properties.AddOrRemoveValue(s_propMdiForm, mdiForm);
     }
 
     /// <summary>
@@ -477,7 +477,7 @@ public partial class ToolStripMenuItem : ToolStripDropDownItem
     internal static MenuTimer MenuTimer => s_menuTimer;
 
     /// <summary> Tag property for internal use </summary>
-    internal Form? MdiForm => Properties.TryGetObject(s_propMdiForm, out Form? form) ? form : null;
+    internal Form? MdiForm => Properties.GetValueOrDefault<Form>(s_propMdiForm);
 
     internal ToolStripMenuItem Clone()
     {
@@ -573,10 +573,7 @@ public partial class ToolStripMenuItem : ToolStripDropDownItem
                 }
 
                 _lastOwner = null;
-                if (MdiForm is not null)
-                {
-                    Properties.SetObject(s_propMdiForm, null);
-                }
+                Properties.RemoveValue(s_propMdiForm);
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -251,12 +251,9 @@ public partial class Form : ContainerControl
                 return;
             }
 
-            if (value)
+            if (value && !CanRecreateHandle())
             {
-                if (!CanRecreateHandle())
-                {
-                    return;
-                }
+                return;
             }
 
             _formState[s_formStateIsActive] = value ? 1 : 0;
@@ -3545,7 +3542,7 @@ public partial class Form : ContainerControl
             base.Dispose(disposing);
             _ctlClient = null;
 
-            if (Properties.TryGetObject(s_propDummyMdiMenu, out HMENU dummyMenu) && !dummyMenu.IsNull)
+            if (Properties.TryGetValue(s_propDummyMdiMenu, out HMENU dummyMenu))
             {
                 Properties.RemoveValue(s_propDummyMdiMenu);
                 PInvoke.DestroyMenu(dummyMenu);
@@ -6129,10 +6126,13 @@ public partial class Form : ContainerControl
                 // (set to null) so that duplicate control buttons are not placed on the menu bar when
                 // an ole menu is being removed.
                 // Make MDI forget the mdi item position.
-                if (!Properties.TryGetObject(s_propDummyMdiMenu, out HMENU dummyMenu) || dummyMenu.IsNull || recreateMenu)
+                if (!Properties.TryGetValue(s_propDummyMdiMenu, out HMENU dummyMenu) || recreateMenu)
                 {
                     dummyMenu = PInvoke.CreateMenu();
-                    Properties.SetObject(s_propDummyMdiMenu, dummyMenu);
+                    if (!dummyMenu.IsNull)
+                    {
+                        Properties.AddValue(s_propDummyMdiMenu, dummyMenu);
+                    }
                 }
 
                 PInvoke.SendMessage(_ctlClient, PInvoke.WM_MDISETMENU, (WPARAM)dummyMenu.Value);
@@ -6143,7 +6143,7 @@ public partial class Form : ContainerControl
             {
                 // If MainMenuStrip, we need to remove any Win32 Menu to make room for it.
                 HMENU hMenu = PInvoke.GetMenu(this);
-                if (hMenu != HMENU.Null)
+                if (!hMenu.IsNull)
                 {
                     // Remove the current menu.
                     PInvoke.SetMenu(this, HMENU.Null);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/Containers/ContainerControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/Containers/ContainerControl.cs
@@ -842,7 +842,7 @@ public class ContainerControl : ScrollableControl, IContainerControl
     {
         base.OnCreateControl();
 
-        if (Properties.ContainsObjectThatIsNotNull(s_propAxContainer))
+        if (Properties.ContainsKey(s_propAxContainer))
         {
             AxContainerFormCreated();
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyStore.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyStore.cs
@@ -9,7 +9,12 @@ namespace System.Windows.Forms;
 /// <summary>
 ///  Efficient property store that avoids boxing for common value types.
 /// </summary>
-internal class PropertyStore
+/// <remarks>
+///  <para>
+///   This class discourages storing <see langword="null"/> values.
+///  </para>
+/// </remarks>
+internal sealed class PropertyStore
 {
     private static int s_currentKey;
 
@@ -25,71 +30,34 @@ internal class PropertyStore
     /// </summary>
     public static int CreateKey() => s_currentKey++;
 
-    // REMOVE
-    /// <summary>
-    ///  Retrieves an object value from our property list.
-    ///  This will set value to null and return false if the
-    ///  list does not contain the given key.
-    /// </summary>
-    /// <typeparam name="T">The type of object to retrieve.</typeparam>
-    /// <param name="key">The key corresponding to the object in the property list.</param>
-    /// <param name="value">Output parameter where the object will be set if found.
-    ///  Will be set to null if the key is not present.</param>
-    /// <remarks><para>If a null value is set for a given key
-    ///  it will return true and a null value.</para></remarks>
-    /// <returns>True if an object (including null) is found for the given key; otherwise, false.</returns>
-    public bool TryGetObject<T>(int key, out T? value)
-    {
-        object? entry = GetObject(key, out bool found);
-        Debug.Assert(!found || entry is null || entry is T, $"Entry is not of type {typeof(T)}, but of type {entry?.GetType()}");
-        if (typeof(T).IsValueType || typeof(T).IsEnum || typeof(T).IsPrimitive)
-        {
-            value = found && entry is not null ? (T?)entry : default;
-            return found;
-        }
-
-        value = found ? (T?)entry : default;
-        return found;
-    }
-
-    // REMOVE
-    public bool ContainsObjectThatIsNotNull(int key)
-    {
-        object? entry = GetObject(key, out bool found);
-        return found && entry is not null;
-    }
-
-    // REMOVE
-    /// <summary>
-    ///  Retrieves an object value from our property list.
-    ///  This will set value to null and return false if the
-    ///  list does not contain the given key.
-    /// </summary>
-    public object? GetObject(int key, out bool found)
-    {
-        found = _values.TryGetValue(key, out Value value);
-        return found ? value.GetValue<object?>() : null;
-    }
-
     /// <summary>
     ///  Removes the given key from the store.
     /// </summary>
     public void RemoveValue(int key) => _values.Remove(key);
 
-    // REMOVE
-    /// <summary>
-    ///  Stores the given value in the key.
-    /// </summary>
-    public void SetObject(int key, object? value) => _values[key] = new(value);
-
     /// <summary>
     ///  Gets the current value for the given key, or the <paramref name="defaultValue"/> if the key is not found.
+    ///  Does not allow stored values of <see langword="null"/>.
     /// </summary>
     public T? GetValueOrDefault<T>(int key, T? defaultValue = default)
     {
         if (_values.TryGetValue(key, out Value foundValue))
         {
             return foundValue.GetValue<T>();
+        }
+
+        return defaultValue;
+    }
+
+    /// <summary>
+    ///  Gets the current value for the given key, or the <paramref name="defaultValue"/> if the key is not found.
+    ///  If the stored value is <see langword="null"/>, it will return <see langword="null"/>.
+    /// </summary>
+    public T? GetValueOrDefaultAllowNull<T>(int key, T? defaultValue = default) where T : class?
+    {
+        if (_values.TryGetValue(key, out Value foundValue))
+        {
+            return foundValue.Type is null ? null : foundValue.GetValue<T>();
         }
 
         return defaultValue;
@@ -109,7 +77,8 @@ internal class PropertyStore
     }
 
     /// <summary>
-    ///  Tries to get the value for the given key.
+    ///  Tries to get the value for the given key. Use <see cref="TryGetValueOrNull{T}(int, out T)"/> if
+    ///  <see langword="null"/> values are allowed.
     /// </summary>
     /// <inheritdoc cref="TryGetValueOrNull{T}(int, out T)"/>
     public bool TryGetValue<T>(int key, [NotNullWhen(true)] out T? value)
@@ -124,10 +93,9 @@ internal class PropertyStore
         return false;
     }
 
-    // Ideally we can get rid of this one and just clear values when they are null.
-
     /// <summary>
-    ///  Tries to get the value for the given key, allowing explicitly set <see langword="null"/> values.
+    ///  Tries to get the value for the given key, allowing explicitly set <see langword="null"/> values. Prefer
+    ///  <see cref="TryGetValue{T}(int, out T)"/> if <see langword="null"/> values are not allowed.
     /// </summary>
     /// <param name="value">
     ///  <para>
@@ -139,7 +107,7 @@ internal class PropertyStore
     {
         if (_values.TryGetValue(key, out Value foundValue))
         {
-            value = foundValue.GetValue<T>();
+            value = foundValue.Type is null ? null : foundValue.GetValue<T>();
             return true;
         }
 
@@ -148,21 +116,31 @@ internal class PropertyStore
     }
 
     /// <summary>
-    ///  Previous will be `string.Empty` if not set. Setting `string.Empty` will clear the value.
+    ///  Setting <see langword="null"/> or <see cref="string.Empty"/> will clear the value.
     /// </summary>
-    public string AddOrRemoveString(int key, string? value)
+    /// <returns>
+    ///  <see langword="true"/> if the stored value was changed.
+    /// </returns>
+    public bool AddOrRemoveString(int key, string? value)
     {
-        TryGetValue(key, out string? previous);
+        bool found = TryGetValue(key, out string? previous);
+        bool changed = false;
+
         if (string.IsNullOrEmpty(value))
         {
-            _values.Remove(key);
+            if (found)
+            {
+                _values.Remove(key);
+                changed = true;
+            }
         }
-        else
+        else if (previous != value)
         {
             _values[key] = new(value);
+            changed = true;
         }
 
-        return previous ?? string.Empty;
+        return changed;
     }
 
     /// <summary>
@@ -173,7 +151,7 @@ internal class PropertyStore
     ///   Always explicitly set <paramref name="defaultValue"/> when using enums for clarity.
     ///  </para>
     /// </remarks>
-    /// <returns>The previous value if it was set, or <see langword="default"/>.</returns>
+    /// <returns>The previous value if it was set, or <paramref name="defaultValue"/>.</returns>
     public T? AddOrRemoveValue<T>(int key, T? value, T? defaultValue = default)
     {
         bool found = _values.TryGetValue(key, out Value foundValue);
@@ -181,7 +159,10 @@ internal class PropertyStore
         bool isDefault = (value is null && defaultValue is null)
             || (value is not null && value.Equals(defaultValue));
 
-        T? previous = found ? foundValue.GetValue<T>() : default;
+        // The previous should be whatever we found or what was specified as the default.
+        T? previous = found
+            ? foundValue.Type is null ? default : foundValue.GetValue<T>()
+            : defaultValue;
 
         if (isDefault)
         {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
@@ -5151,7 +5151,7 @@ public class ListViewTests
         SubListViewAccessibleObject accessibleObject = new(listView);
 
         int accessibilityProperty = listView.TestAccessor().Dynamic.s_accessibilityProperty;
-        listView.Properties.SetObject(accessibilityProperty, accessibleObject);
+        listView.Properties.AddValue(accessibilityProperty, accessibleObject);
         listView.AnnounceColumnHeader(new Point(15, 40));
         Assert.Equal(0, accessibleObject.RaiseAutomationNotificationCallCount);
         Assert.False(listView.IsHandleCreated);
@@ -5176,7 +5176,7 @@ public class ListViewTests
         SubListViewAccessibleObject accessibleObject = new(listView);
 
         int accessibilityProperty = listView.TestAccessor().Dynamic.s_accessibilityProperty;
-        listView.Properties.SetObject(accessibilityProperty, accessibleObject);
+        listView.Properties.AddValue(accessibilityProperty, accessibleObject);
         listView.AnnounceColumnHeader(new Point(15, 40));
         Assert.Equal(0, accessibleObject.RaiseAutomationNotificationCallCount);
         Assert.True(listView.IsHandleCreated);
@@ -5201,7 +5201,7 @@ public class ListViewTests
         SubListViewAccessibleObject accessibleObject = new(listView);
 
         int accessibilityProperty = listView.TestAccessor().Dynamic.s_accessibilityProperty;
-        listView.Properties.SetObject(accessibilityProperty, accessibleObject);
+        listView.Properties.AddValue(accessibilityProperty, accessibleObject);
         listView.AnnounceColumnHeader(new Point(10, 20));
         Assert.Equal(0, accessibleObject.RaiseAutomationNotificationCallCount);
         Assert.True(listView.IsHandleCreated);
@@ -5228,7 +5228,7 @@ public class ListViewTests
         SubListViewAccessibleObject accessibleObject = new(listView);
 
         int accessibilityProperty = listView.TestAccessor().Dynamic.s_accessibilityProperty;
-        listView.Properties.SetObject(accessibilityProperty, accessibleObject);
+        listView.Properties.AddValue(accessibilityProperty, accessibleObject);
         listView.AnnounceColumnHeader(new Point(x, y));
 
         Assert.Equal(1, accessibleObject.RaiseAutomationNotificationCallCount);
@@ -5402,7 +5402,7 @@ public class ListViewTests
         using SubListView listView = GetSubListViewWithData(view, virtualMode, showGroups, withinGroup, createControl);
         SubListViewAccessibleObject accessibleObject = new(listView);
         int accessibilityProperty = listView.TestAccessor().Dynamic.s_accessibilityProperty;
-        listView.Properties.SetObject(accessibilityProperty, accessibleObject);
+        listView.Properties.AddValue(accessibilityProperty, accessibleObject);
 
         listView.OnGroupCollapsedStateChanged(new ListViewGroupEventArgs(groupId));
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridInternal/AccessibleObjects/PropertyDescriptorGridEntry.PropertyDescriptorGridEntryAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridInternal/AccessibleObjects/PropertyDescriptorGridEntry.PropertyDescriptorGridEntryAccessibleObjectTests.cs
@@ -16,7 +16,7 @@ public class PropertyDescriptorGridEntryAccessibleObjectTests
         using PropertyGridView propertyGridView = new(serviceProvider: null, propertyGrid);
 
         TestPropertyGridViewAccessibleObject accessibleObject = new(propertyGridView, parentPropertyGrid: null);
-        propertyGridView.Properties.SetObject(propertyGrid.TestAccessor().Dynamic.s_accessibilityProperty, accessibleObject);
+        propertyGridView.Properties.AddValue(propertyGrid.TestAccessor().Dynamic.s_accessibilityProperty, accessibleObject);
 
         TestPropertyDescriptorGridEntry gridEntry = new(propertyGrid, null, false);
         propertyGridView.TestAccessor().Dynamic._selectedGridEntry = gridEntry;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyStoreTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyStoreTests.cs
@@ -9,43 +9,26 @@ namespace System.Windows.Forms.Tests;
 
 public class PropertyStoreTests
 {
-    private static readonly int s_bool = PropertyStore.CreateKey();
-    private static readonly int s_byte = PropertyStore.CreateKey();
-    private static readonly int s_sbyte = PropertyStore.CreateKey();
-    private static readonly int s_char = PropertyStore.CreateKey();
-    private static readonly int s_decimal = PropertyStore.CreateKey();
-    private static readonly int s_double = PropertyStore.CreateKey();
-    private static readonly int s_float = PropertyStore.CreateKey();
-    private static readonly int s_int = PropertyStore.CreateKey();
-    private static readonly int s_uint = PropertyStore.CreateKey();
-    private static readonly int s_long = PropertyStore.CreateKey();
-    private static readonly int s_ulong = PropertyStore.CreateKey();
-    private static readonly int s_short = PropertyStore.CreateKey();
-    private static readonly int s_ushort = PropertyStore.CreateKey();
-    private static readonly int s_object = PropertyStore.CreateKey();
-    private static readonly int s_color = PropertyStore.CreateKey();
-    private static readonly int s_formWindowState = PropertyStore.CreateKey();
-
     public static TheoryData<int, object?> PropertyStore_TryGetValue_Exists_TestData()
     {
         return new TheoryData<int, object?>()
         {
-            { s_bool, true },
-            { s_byte, (byte)1 },
-            { s_sbyte, (sbyte)-1 },
-            { s_char, 'a' },
-            { s_decimal, 1.0m },
-            { s_double, 1.0d },
-            { s_float, 1.0f },
-            { s_int, 1 },
-            { s_uint, (uint)1 },
-            { s_long, 1L },
-            { s_ulong, 1UL },
-            { s_short, (short)1 },
-            { s_ushort, (ushort)1 },
-            { s_object, new() },
-            { s_color, Color.Red },
-            { s_formWindowState, FormWindowState.Maximized }
+            { 1, true },
+            { 2, (byte)1 },
+            { 3, (sbyte)-1 },
+            { 4, 'a' },
+            { 5, 1.0m },
+            { 6, 1.0d },
+            { 7, 1.0f },
+            { 8, 1 },
+            { 9, (uint)1 },
+            { 10, 1L },
+            { 11, 1UL },
+            { 12, (short)1 },
+            { 13, (ushort)1 },
+            { 14, new() },
+            { 15, Color.Red },
+            { 16, FormWindowState.Maximized }
         };
     }
 
@@ -54,10 +37,10 @@ public class PropertyStoreTests
     public void PropertyStore_TryGetValue_Exists(int key, object? value)
     {
         PropertyStore store = new();
-        store.SetObject(key, value);
-        Assert.True(store.ContainsKey(key), "PropertyStore does not contain key.");
-        Assert.True(store.TryGetObject(key, out object? outValue));
-        Assert.Equal(value, outValue);
+        store.AddValue(key, value);
+        store.ContainsKey(key).Should().BeTrue();
+        store.TryGetValue(key, out object? outValue).Should().BeTrue();
+        value.Should().Be(outValue);
     }
 
     [Theory]
@@ -65,10 +48,10 @@ public class PropertyStoreTests
     public void PropertyStore_TryGetValue_Exists_Null(int key, object? value)
     {
         PropertyStore store = new();
-        store.SetObject(key, null);
-        Assert.True(store.ContainsKey(key), "PropertyStore does not contain key.");
-        Assert.True(store.TryGetObject(key, out object? outValue));
-        Assert.NotEqual(value, outValue);
+        store.AddValue<object?>(key, null);
+        store.ContainsKey(key).Should().BeTrue();
+        store.TryGetValueOrNull(key, out object? outValue).Should().BeTrue();
+        value.Should().NotBe(outValue);
     }
 
     [Theory]
@@ -76,131 +59,98 @@ public class PropertyStoreTests
     public void PropertyStore_TryGetValue_NotExists(int key, object? value)
     {
         PropertyStore store = new();
-        store.SetObject(key, null);
+        store.AddValue<object?>(key, null);
         store.RemoveValue(key);
-        Assert.False(store.ContainsKey(key), "PropertyStore contains key.");
-        Assert.False(store.TryGetObject(key, out object? outValue), "PropertyStore contains key.");
-        Assert.NotEqual(value, outValue);
+        store.ContainsKey(key).Should().BeFalse();
+        store.TryGetValue(key, out object? outValue).Should().BeFalse();
+        value.Should().NotBe(outValue);
     }
 
     [Fact]
     public void PropertyStore_TryGetValue_Enum_Unset_IsDefault()
     {
         PropertyStore store = new();
-        Assert.False(store.ContainsKey(s_formWindowState), "PropertyStore contains key.");
-        Assert.False(store.TryGetObject(s_formWindowState, out FormWindowState outValue), "PropertyStore contains key.");
+        store.ContainsKey(1).Should().BeFalse();
+        store.TryGetValue(1, out FormWindowState outValue).Should().BeFalse();
         FormWindowState windowState = default;
-        Assert.Equal(windowState, outValue);
+        windowState.Should().Be(outValue);
     }
 
     [Fact]
     public void PropertyStore_TryGetValue_Struct_Unset_IsDefault()
     {
         PropertyStore store = new();
-        Assert.False(store.ContainsKey(s_color), "PropertyStore contains key.");
-        Assert.False(store.TryGetObject(s_color, out Color outValue), "PropertyStore contains key.");
+        store.ContainsKey(1).Should().BeFalse();
+        store.TryGetValue(1, out Color outValue).Should().BeFalse();
         Color color = default;
-        Assert.Equal(color, outValue);
+        color.Should().Be(outValue);
     }
 
     [Fact]
     public void PropertyStore_TryGetValue_Primitive_Unset_IsDefault()
     {
         PropertyStore store = new();
-        Assert.False(store.ContainsKey(s_int), "PropertyStore does not contain key.");
-        Assert.False(store.TryGetObject(s_int, out int outValue), "PropertyStore contains key.");
+        store.ContainsKey(1).Should().BeFalse();
+        store.TryGetValue(1, out int outValue).Should().BeFalse();
         int intDefault = default;
-        Assert.Equal(intDefault, outValue);
+        intDefault.Should().Be(outValue);
     }
 
     [Fact]
     public void PropertyStore_TryGetValue_Enum_Null()
     {
         PropertyStore store = new();
-        store.SetObject(s_formWindowState, null);
-        Assert.True(store.ContainsKey(s_formWindowState), "PropertyStore contains key.");
-        Assert.True(store.TryGetObject(s_formWindowState, out FormWindowState outValue), "PropertyStore contains key.");
-        FormWindowState windowState = default;
-        Assert.Equal(windowState, outValue);
+        store.AddValue<object?>(1, null);
+        store.ContainsKey(1).Should().BeTrue();
+        Action action = () => store.TryGetValue(1, out FormWindowState outValue);
+        action.Should().Throw<InvalidCastException>();
     }
 
     [Fact]
     public void PropertyStore_TryGetValue_Struct_Null()
     {
         PropertyStore store = new();
-        store.SetObject(s_color, null);
-        Assert.True(store.ContainsKey(s_color), "PropertyStore does not contain key.");
-        Assert.True(store.TryGetObject(s_color, out Color outValue), "PropertyStore does not contain key.");
-        Color color = default;
-        Assert.Equal(color, outValue);
+        store.AddValue<object?>(1, null);
+        store.ContainsKey(1).Should().BeTrue();
+        Action action = () => store.TryGetValue(1, out Color outValue);
+        action.Should().Throw<InvalidCastException>();
     }
 
     [Fact]
     public void PropertyStore_TryGetValue_Primitive_Null()
     {
         PropertyStore store = new();
-        store.SetObject(s_int, null);
-        Assert.True(store.ContainsKey(s_int), "PropertyStore does not contain key.");
-        Assert.True(store.TryGetObject(s_int, out int outValue), "PropertyStore does not contain key.");
-        int intDefault = default;
-        Assert.Equal(intDefault, outValue);
-    }
-
-    [Fact]
-    public void PropertyStore_TryGetValue_Enum_Nullable()
-    {
-        PropertyStore store = new();
-        store.SetObject(s_formWindowState, null);
-        Assert.True(store.ContainsKey(s_formWindowState), "PropertyStore does not contain key.");
-        Assert.True(store.TryGetObject(s_formWindowState, out FormWindowState? outValue), "PropertyStore does not contain key.");
-        Assert.Null(outValue);
-    }
-
-    [Fact]
-    public void PropertyStore_TryGetValue_Struct_Nullable()
-    {
-        PropertyStore store = new();
-        store.SetObject(s_color, null);
-        Assert.True(store.ContainsKey(s_color), "PropertyStore does not contain key.");
-        Assert.True(store.TryGetObject(s_color, out Color? outValue), "PropertyStore does not contain key.");
-        Assert.Null(outValue);
-    }
-
-    [Fact]
-    public void PropertyStore_TryGetValue_Primitive_Nullable()
-    {
-        PropertyStore store = new();
-        store.SetObject(s_int, null);
-        Assert.True(store.ContainsKey(s_int), "PropertyStore contains key.");
-        Assert.True(store.TryGetObject(s_int, out int? outValue), "PropertyStore contains key.");
-        Assert.Null(outValue);
+        store.AddValue<object?>(1, null);
+        store.ContainsKey(1).Should().BeTrue();
+        Action action = () => store.TryGetValue(1, out int outValue);
+        action.Should().Throw<InvalidCastException>();
     }
 
     [Fact]
     public void PropertyStore_TryGetValue_Enum_Unset_Nullable()
     {
         PropertyStore store = new();
-        Assert.False(store.ContainsKey(s_formWindowState), "PropertyStore contains key.");
-        Assert.False(store.TryGetObject(s_formWindowState, out FormWindowState? outValue), "PropertyStore contains key.");
-        Assert.Null(outValue);
+        store.ContainsKey(1).Should().BeFalse();
+        store.TryGetValue(1, out FormWindowState? outValue).Should().BeFalse();
+        outValue.Should().BeNull();
     }
 
     [Fact]
     public void PropertyStore_TryGetValue_Struct_Unset_Nullable()
     {
         PropertyStore store = new();
-        Assert.False(store.ContainsKey(s_color), "PropertyStore contains key.");
-        Assert.False(store.TryGetObject(s_color, out Color? outValue), "PropertyStore contains key.");
-        Assert.Null(outValue);
+        store.ContainsKey(1).Should().BeFalse();
+        store.TryGetValue(1, out Color? outValue).Should().BeFalse();
+        outValue.Should().BeNull();
     }
 
     [Fact]
     public void PropertyStore_TryGetValue_Primitive_Unset_Nullable()
     {
         PropertyStore store = new();
-        Assert.False(store.ContainsKey(s_int), "PropertyStore contains key.");
-        Assert.False(store.TryGetObject(s_int, out int? outValue), "PropertyStore contains key.");
-        Assert.Null(outValue);
+        store.ContainsKey(1).Should().BeFalse();
+        store.TryGetValue(1, out int? outValue).Should().BeFalse();
+        outValue.Should().BeNull();
     }
 
     [Fact]
@@ -264,176 +214,160 @@ public class PropertyStoreTests
     [Fact]
     public void PropertyStore_AddOrRemoveValue_DefaultValuesRemoved_Bool()
     {
-        int key = s_bool;
         bool value = default;
         PropertyStore store = new();
-        store.AddOrRemoveValue(key, value);
-        Assert.False(store.ContainsKey(key), "PropertyStore contains key.");
-        Assert.Equal(value, store.GetValueOrDefault<bool>(key));
+        store.AddOrRemoveValue(1, value);
+        store.ContainsKey(1).Should().BeFalse();
+        value.Should().Be(store.GetValueOrDefault<bool>(1));
     }
 
     [Fact]
     public void PropertyStore_AddOrRemoveValue_DefaultValuesRemoved_Byte()
     {
-        int key = s_byte;
         byte value = default;
         PropertyStore store = new();
-        store.AddOrRemoveValue(key, value);
-        Assert.False(store.ContainsKey(key), "PropertyStore contains key.");
-        Assert.Equal(value, store.GetValueOrDefault<byte>(key));
+        store.AddOrRemoveValue(1, value);
+        store.ContainsKey(1).Should().BeFalse();
+        value.Should().Be(store.GetValueOrDefault<byte>(1));
     }
 
     [Fact]
     public void PropertyStore_AddOrRemoveValue_DefaultValuesRemoved_SByte()
     {
-        int key = s_sbyte;
         sbyte value = default;
         PropertyStore store = new();
-        store.AddOrRemoveValue(key, value);
-        Assert.False(store.ContainsKey(key), "PropertyStore contains key.");
-        Assert.Equal(value, store.GetValueOrDefault<sbyte>(key));
+        store.AddOrRemoveValue(1, value);
+        store.ContainsKey(1).Should().BeFalse();
+        value.Should().Be(store.GetValueOrDefault<sbyte>(1));
     }
 
     [Fact]
     public void PropertyStore_AddOrRemoveValue_DefaultValuesRemoved_Char()
     {
-        int key = s_char;
         char value = default;
         PropertyStore store = new();
-        store.AddOrRemoveValue(key, value);
-        Assert.False(store.ContainsKey(key), "PropertyStore contains key.");
-        Assert.Equal(value, store.GetValueOrDefault<char>(key));
+        store.AddOrRemoveValue(1, value);
+        store.ContainsKey(1).Should().BeFalse();
+        value.Should().Be(store.GetValueOrDefault<char>(1));
     }
 
     [Fact]
     public void PropertyStore_AddOrRemoveValue_DefaultValuesRemoved_Decimal()
     {
-        int key = s_decimal;
         decimal value = default;
         PropertyStore store = new();
-        store.AddOrRemoveValue(key, value);
-        Assert.False(store.ContainsKey(key), "PropertyStore contains key.");
-        Assert.Equal(value, store.GetValueOrDefault<decimal>(key));
+        store.AddOrRemoveValue(1, value);
+        store.ContainsKey(1).Should().BeFalse();
+        value.Should().Be(store.GetValueOrDefault<decimal>(1));
     }
 
     [Fact]
     public void PropertyStore_AddOrRemoveValue_DefaultValuesRemoved_Double()
     {
-        int key = s_double;
         double value = default;
         PropertyStore store = new();
-        store.AddOrRemoveValue(key, value);
-        Assert.False(store.ContainsKey(key), "PropertyStore contains key.");
-        Assert.Equal(value, store.GetValueOrDefault<double>(key));
+        store.AddOrRemoveValue(1, value);
+        store.ContainsKey(1).Should().BeFalse();
+        value.Should().Be(store.GetValueOrDefault<double>(1));
     }
 
     [Fact]
     public void PropertyStore_AddOrRemoveValue_DefaultValuesRemoved_Float()
     {
-        int key = s_float;
         float value = default;
         PropertyStore store = new();
-        store.AddOrRemoveValue(key, value);
-        Assert.False(store.ContainsKey(key), "PropertyStore contains key.");
-        Assert.Equal(value, store.GetValueOrDefault<float>(key));
+        store.AddOrRemoveValue(1, value);
+        store.ContainsKey(1).Should().BeFalse();
+        value.Should().Be(store.GetValueOrDefault<float>(1));
     }
 
     [Fact]
     public void PropertyStore_AddOrRemoveValue_DefaultValuesRemoved_Int()
     {
-        int key = s_int;
         int value = default;
         PropertyStore store = new();
-        store.AddOrRemoveValue(key, value);
-        Assert.False(store.ContainsKey(key), "PropertyStore contains key.");
-        Assert.Equal(value, store.GetValueOrDefault<int>(key));
+        store.AddOrRemoveValue(1, value);
+        store.ContainsKey(1).Should().BeFalse();
+        value.Should().Be(store.GetValueOrDefault<int>(1));
     }
 
     [Fact]
     public void PropertyStore_AddOrRemoveValue_DefaultValuesRemoved_UInt()
     {
-        int key = s_uint;
         uint value = default;
         PropertyStore store = new();
-        store.AddOrRemoveValue(key, value);
-        Assert.False(store.ContainsKey(key), "PropertyStore contains key.");
-        Assert.Equal(value, store.GetValueOrDefault<uint>(key));
+        store.AddOrRemoveValue(1, value);
+        store.ContainsKey(1).Should().BeFalse();
+        value.Should().Be(store.GetValueOrDefault<uint>(1));
     }
 
     [Fact]
     public void PropertyStore_AddOrRemoveValue_DefaultValuesRemoved_Long()
     {
-        int key = s_long;
         long value = default;
         PropertyStore store = new();
-        store.AddOrRemoveValue(key, value);
-        Assert.False(store.ContainsKey(key), "PropertyStore contains key.");
-        Assert.Equal(value, store.GetValueOrDefault<long>(key));
+        store.AddOrRemoveValue(1, value);
+        store.ContainsKey(1).Should().BeFalse();
+        value.Should().Be(store.GetValueOrDefault<long>(1));
     }
 
     [Fact]
     public void PropertyStore_AddOrRemoveValue_DefaultValuesRemoved_ULong()
     {
-        int key = s_ulong;
         ulong value = default;
         PropertyStore store = new();
-        store.AddOrRemoveValue(key, value);
-        Assert.False(store.ContainsKey(key), "PropertyStore contains key.");
-        Assert.Equal(value, store.GetValueOrDefault<ulong>(key));
+        store.AddOrRemoveValue(1, value);
+        store.ContainsKey(1).Should().BeFalse();
+        value.Should().Be(store.GetValueOrDefault<ulong>(1));
     }
 
     [Fact]
     public void PropertyStore_AddOrRemoveValue_DefaultValuesRemoved_Short()
     {
-        int key = s_short;
         short value = default;
         PropertyStore store = new();
-        store.AddOrRemoveValue(key, value);
-        Assert.False(store.ContainsKey(key), "PropertyStore contains key.");
-        Assert.Equal(value, store.GetValueOrDefault<short>(key));
+        store.AddOrRemoveValue(1, value);
+        store.ContainsKey(1).Should().BeFalse();
+        value.Should().Be(store.GetValueOrDefault<short>(1));
     }
 
     [Fact]
     public void PropertyStore_AddOrRemoveValue_DefaultValuesRemoved_UShort()
     {
-        int key = s_ushort;
         ushort value = default;
         PropertyStore store = new();
-        store.AddOrRemoveValue(key, value);
-        Assert.False(store.ContainsKey(key), "PropertyStore contains key.");
-        Assert.Equal(value, store.GetValueOrDefault<ushort>(key));
+        store.AddOrRemoveValue(1, value);
+        store.ContainsKey(1).Should().BeFalse();
+        value.Should().Be(store.GetValueOrDefault<ushort>(1));
     }
 
     [Fact]
     public void PropertyStore_AddOrRemoveValue_DefaultValuesRemoved_Object()
     {
-        int key = s_object;
         object? value = null;
         PropertyStore store = new();
-        store.AddOrRemoveValue(key, value);
-        Assert.False(store.ContainsKey(key), "PropertyStore contains key.");
-        Assert.Equal(value, store.GetValueOrDefault<object>(key));
+        store.AddOrRemoveValue(1, value);
+        store.ContainsKey(1).Should().BeFalse();
+        value.Should().Be(store.GetValueOrDefault<object>(1));
     }
 
     [Fact]
     public void PropertyStore_AddOrRemoveValue_DefaultValuesRemoved_Color()
     {
-        int key = s_color;
         Color value = default;
         PropertyStore store = new();
-        store.AddOrRemoveValue(key, value);
-        Assert.False(store.ContainsKey(key), "PropertyStore contains key.");
-        Assert.Equal(value, store.GetValueOrDefault<Color>(key));
+        store.AddOrRemoveValue(1, value);
+        store.ContainsKey(1).Should().BeFalse();
+        value.Should().Be(store.GetValueOrDefault<Color>(1));
     }
 
     [Fact]
     public void PropertyStore_AddOrRemoveValue_DefaultValuesRemoved_FormWindowState()
     {
-        int key = s_formWindowState;
         FormWindowState value = default;
         PropertyStore store = new();
-        store.AddOrRemoveValue(key, value);
-        Assert.False(store.ContainsKey(key), "PropertyStore contains key.");
-        Assert.Equal(value, store.GetValueOrDefault<FormWindowState>(key));
+        store.AddOrRemoveValue(1, value);
+        store.ContainsKey(1).Should().BeFalse();
+        value.Should().Be(store.GetValueOrDefault<FormWindowState>(1));
     }
 }


### PR DESCRIPTION
- Tweak AddOrRemove methods for better change comparison
- Make it consistently throw if trying to force cast null to T

Follow up:

- Try and lock down harder on insertion of null values. Considering using a sentinel perhaps.
- Try to move away from CreateKey. Considering using enum(s), making PropertyStore generic, etc.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12215)