### PR TITLE
[release/8.0] Avoid Creating Graphics in TabControl.WmReflectDrawItem()

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
@@ -1945,11 +1945,13 @@ public partial class TabControl : Control
         DRAWITEMSTRUCT* dis = (DRAWITEMSTRUCT*)(nint)m.LParamInternal;
 
         using DrawItemEventArgs e = new(
-            dis->hDC.CreateGraphics(),
+            dis->hDC,
             Font,
             dis->rcItem,
-            (int)dis->itemID,
-            (DrawItemState)(int)dis->itemState);
+            dis->itemID,
+            dis->itemState,
+            ForeColor,
+            BackColor);
 
         OnDrawItem(e);
 


### PR DESCRIPTION
Backport of https://github.com/dotnet/winforms/pull/10536, fixes https://github.com/dotnet/winforms/issues/12157

## Customer Impact
We are leaking a Graphics object causing the finalizer to run to dispose it, which is sub optimal. Users can also see a `OutOfMemoryException` surface from this.

## Testing
Manual verification that leak is not present

## Risk
Low. The change involves avoid creating a new Graphics object here, which is unnecessary
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12216)