### PR TITLE
Add retry mechanism for clipboard tests

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/ClipboardTestBase.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/ClipboardTestBase.cs
@@ -1,9 +1,0 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-
-namespace System.Windows.Forms.Tests;
-
-public class ClipboardTestBase
-{
-    protected static void Sleep() => Thread.Sleep(100);
-}

--- a/src/System.Windows.Forms/tests/UnitTests/ClipboardTestBase.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/ClipboardTestBase.cs
@@ -1,0 +1,9 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Windows.Forms.Tests;
+
+public class ClipboardTestBase
+{
+    protected static void Sleep() => Thread.Sleep(100);
+}

--- a/src/System.Windows.Forms/tests/UnitTests/TextBoxBaseTests.ClipboardTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/TextBoxBaseTests.ClipboardTests.cs
@@ -6,7 +6,8 @@ namespace System.Windows.Forms.Tests;
 public partial class TextBoxBaseTests
 {
     [Collection("Sequential")]
-    public class ClipboardTests : ClipboardTestBase
+    [UISettings(MaxAttempts = 3)] // Try up to 3 times before failing.
+    public class ClipboardTests
     {
         [WinFormsFact]
         public void TextBoxBase_ClearUndo_CanUndo_Success()
@@ -18,12 +19,10 @@ public partial class TextBoxBaseTests
                 SelectionLength = 2
             };
             control.Focus();
-            Sleep();
             control.Copy();
 
             control.Text = "text";
             control.SelectionLength = 2;
-            Sleep();
             control.Paste();
 
             control.Text.Should().Be("bcxt");
@@ -48,7 +47,6 @@ public partial class TextBoxBaseTests
 
             control.Text = "text";
             control.SelectionLength = 2;
-            Sleep();
             control.Paste();
 
             control.Text.Should().Be("bcxt");
@@ -83,7 +81,6 @@ public partial class TextBoxBaseTests
 
             control.Text = "text";
             control.SelectionLength = 2;
-            Sleep();
             control.Paste();
 
             control.Text.Should().Be("bcxt");
@@ -110,7 +107,6 @@ public partial class TextBoxBaseTests
 
             control.Text = "text";
             control.SelectionLength = 2;
-            Sleep();
             control.Paste();
 
             control.Text.Should().Be("bcxt");
@@ -136,7 +132,6 @@ public partial class TextBoxBaseTests
             int createdCallCount = 0;
             control.HandleCreated += (sender, e) => createdCallCount++;
 
-            Sleep();
             control.Cut();
             control.Text.Should().Be("a");
             control.IsHandleCreated.Should().BeTrue();
@@ -146,7 +141,6 @@ public partial class TextBoxBaseTests
 
             control.Text = "text";
             control.SelectionLength = 2;
-            Sleep();
             control.Paste();
 
             control.Text.Should().Be("bcxt");
@@ -163,7 +157,6 @@ public partial class TextBoxBaseTests
         {
             Clipboard.Clear();
             using SubTextBox control = new();
-            Sleep();
             control.Paste();
             control.Text.Should().BeEmpty();
             control.IsHandleCreated.Should().BeTrue();
@@ -179,7 +172,6 @@ public partial class TextBoxBaseTests
                 SelectionStart = 1,
                 SelectionLength = 2
             };
-            Sleep();
             control.Paste();
             control.Text.Should().Be("a");
             control.IsHandleCreated.Should().BeTrue();
@@ -198,7 +190,6 @@ public partial class TextBoxBaseTests
 
             control.Text = "text";
             control.SelectionLength = 2;
-            Sleep();
             control.Paste();
 
             control.Text.Should().Be("bcxt");

--- a/src/System.Windows.Forms/tests/UnitTests/TextBoxBaseTests.ClipboardTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/TextBoxBaseTests.ClipboardTests.cs
@@ -6,10 +6,8 @@ namespace System.Windows.Forms.Tests;
 public partial class TextBoxBaseTests
 {
     [Collection("Sequential")]
-    public class ClipboardTests
+    public class ClipboardTests : ClipboardTestBase
     {
-        private static void Sleep() => Thread.Sleep(100);
-
         [WinFormsFact]
         public void TextBoxBase_ClearUndo_CanUndo_Success()
         {


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #12229


## Proposed changes

- Add `[UISettings(MaxAttempts = 3)]` instead of `Thread.Sleep(100)` for **TextBoxBaseTests.ClipboardTests.cs**

Results of 1000 iterations：
![image](https://github.com/user-attachments/assets/42bf76f2-e0a1-427d-a27f-6c57047acfff)


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12231)