### PR TITLE
[release/9.0] Extra Border Color in DataGridView with RightToLeft layout

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridView.cs
@@ -509,7 +509,7 @@ public partial class DataGridView : Control, ISupportInitialize
                         dgvabs = new DataGridViewAdvancedBorderStyle();
                         if (RightToLeftInternal)
                         {
-                            dgvabs.LeftInternal = DataGridViewAdvancedCellBorderStyle.Single;
+                            dgvabs.LeftInternal = DataGridViewAdvancedCellBorderStyle.Outset;
                         }
                         else
                         {
@@ -1254,7 +1254,7 @@ public partial class DataGridView : Control, ISupportInitialize
                             break;
 
                         case DataGridViewCellBorderStyle.Raised:
-                            AdvancedCellBorderStyle.All = DataGridViewAdvancedCellBorderStyle.Single;
+                            AdvancedCellBorderStyle.All = DataGridViewAdvancedCellBorderStyle.Outset;
                             break;
 
                         case DataGridViewCellBorderStyle.Sunken:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewRow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewRow.cs
@@ -418,7 +418,7 @@ public partial class DataGridViewRow : DataGridViewBand
 
                     if (DataGridView.RightToLeftInternal)
                     {
-                        dataGridViewAdvancedBorderStylePlaceholder.LeftInternal = DataGridViewAdvancedCellBorderStyle.Single;
+                        dataGridViewAdvancedBorderStylePlaceholder.LeftInternal = DataGridViewAdvancedCellBorderStyle.Outset;
                     }
                     else
                     {
@@ -522,7 +522,7 @@ public partial class DataGridViewRow : DataGridViewBand
                 case DataGridViewAdvancedCellBorderStyle.OutsetPartial:
                     if (DataGridView is not null && DataGridView.RightToLeftInternal)
                     {
-                        dataGridViewAdvancedBorderStylePlaceholder.LeftInternal = DataGridViewAdvancedCellBorderStyle.Single;
+                        dataGridViewAdvancedBorderStylePlaceholder.LeftInternal = DataGridViewAdvancedCellBorderStyle.Outset;
                         dataGridViewAdvancedBorderStylePlaceholder.RightInternal = DataGridViewAdvancedCellBorderStyle.OutsetDouble;
                     }
                     else

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewRowTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewRowTests.cs
@@ -3581,7 +3581,7 @@ public class DataGridViewRowTests
                 yield return new object[]
                 {
                     true, true, RightToLeft.Yes, DataGridViewAdvancedCellBorderStyle.OutsetPartial, true, true, isFirstDisplayedRow, isLastVisibleRow,
-                    true, DataGridViewAdvancedCellBorderStyle.Single, DataGridViewAdvancedCellBorderStyle.Outset, DataGridViewAdvancedCellBorderStyle.None, DataGridViewAdvancedCellBorderStyle.None
+                    true, DataGridViewAdvancedCellBorderStyle.Outset, DataGridViewAdvancedCellBorderStyle.Outset, DataGridViewAdvancedCellBorderStyle.None, DataGridViewAdvancedCellBorderStyle.None
                 };
             }
         }
@@ -3596,7 +3596,7 @@ public class DataGridViewRowTests
             yield return new object[]
             {
                 true, false, RightToLeft.Yes, DataGridViewAdvancedCellBorderStyle.OutsetPartial, true, true, true, isLastVisibleRow,
-                true, DataGridViewAdvancedCellBorderStyle.Single, DataGridViewAdvancedCellBorderStyle.Outset, DataGridViewAdvancedCellBorderStyle.OutsetDouble, DataGridViewAdvancedCellBorderStyle.None
+                true, DataGridViewAdvancedCellBorderStyle.Outset, DataGridViewAdvancedCellBorderStyle.Outset, DataGridViewAdvancedCellBorderStyle.OutsetDouble, DataGridViewAdvancedCellBorderStyle.None
             };
         }
 
@@ -3608,7 +3608,7 @@ public class DataGridViewRowTests
         yield return new object[]
         {
             false, true, RightToLeft.Yes, DataGridViewAdvancedCellBorderStyle.OutsetPartial, true, true, true, true,
-            true, DataGridViewAdvancedCellBorderStyle.Single, DataGridViewAdvancedCellBorderStyle.OutsetDouble, DataGridViewAdvancedCellBorderStyle.Outset, DataGridViewAdvancedCellBorderStyle.Outset
+            true, DataGridViewAdvancedCellBorderStyle.Outset, DataGridViewAdvancedCellBorderStyle.OutsetDouble, DataGridViewAdvancedCellBorderStyle.Outset, DataGridViewAdvancedCellBorderStyle.Outset
         };
         yield return new object[]
         {
@@ -3618,7 +3618,7 @@ public class DataGridViewRowTests
         yield return new object[]
         {
             false, true, RightToLeft.Yes, DataGridViewAdvancedCellBorderStyle.OutsetPartial, true, true, true, false,
-            true, DataGridViewAdvancedCellBorderStyle.Single, DataGridViewAdvancedCellBorderStyle.OutsetDouble, DataGridViewAdvancedCellBorderStyle.Outset, DataGridViewAdvancedCellBorderStyle.OutsetPartial
+            true, DataGridViewAdvancedCellBorderStyle.Outset, DataGridViewAdvancedCellBorderStyle.OutsetDouble, DataGridViewAdvancedCellBorderStyle.Outset, DataGridViewAdvancedCellBorderStyle.OutsetPartial
         };
         yield return new object[]
         {
@@ -3628,7 +3628,7 @@ public class DataGridViewRowTests
         yield return new object[]
         {
             false, true, RightToLeft.Yes, DataGridViewAdvancedCellBorderStyle.OutsetPartial, true, true, false, true,
-            true, DataGridViewAdvancedCellBorderStyle.Single, DataGridViewAdvancedCellBorderStyle.OutsetDouble, DataGridViewAdvancedCellBorderStyle.OutsetPartial, DataGridViewAdvancedCellBorderStyle.Outset
+            true, DataGridViewAdvancedCellBorderStyle.Outset, DataGridViewAdvancedCellBorderStyle.OutsetDouble, DataGridViewAdvancedCellBorderStyle.OutsetPartial, DataGridViewAdvancedCellBorderStyle.Outset
         };
         yield return new object[]
         {
@@ -3638,7 +3638,7 @@ public class DataGridViewRowTests
         yield return new object[]
         {
             false, true, RightToLeft.Yes, DataGridViewAdvancedCellBorderStyle.OutsetPartial, true, true, false, false,
-            true, DataGridViewAdvancedCellBorderStyle.Single, DataGridViewAdvancedCellBorderStyle.OutsetDouble, DataGridViewAdvancedCellBorderStyle.OutsetPartial, DataGridViewAdvancedCellBorderStyle.OutsetPartial
+            true, DataGridViewAdvancedCellBorderStyle.Outset, DataGridViewAdvancedCellBorderStyle.OutsetDouble, DataGridViewAdvancedCellBorderStyle.OutsetPartial, DataGridViewAdvancedCellBorderStyle.OutsetPartial
         };
         yield return new object[]
         {
@@ -3648,7 +3648,7 @@ public class DataGridViewRowTests
         yield return new object[]
         {
             false, false, RightToLeft.Yes, DataGridViewAdvancedCellBorderStyle.OutsetPartial, true, true, true, true,
-            true, DataGridViewAdvancedCellBorderStyle.Single, DataGridViewAdvancedCellBorderStyle.OutsetDouble, DataGridViewAdvancedCellBorderStyle.OutsetDouble, DataGridViewAdvancedCellBorderStyle.Outset
+            true, DataGridViewAdvancedCellBorderStyle.Outset, DataGridViewAdvancedCellBorderStyle.OutsetDouble, DataGridViewAdvancedCellBorderStyle.OutsetDouble, DataGridViewAdvancedCellBorderStyle.Outset
         };
         yield return new object[]
         {
@@ -3658,7 +3658,7 @@ public class DataGridViewRowTests
         yield return new object[]
         {
             false, false, RightToLeft.Yes, DataGridViewAdvancedCellBorderStyle.OutsetPartial, true, true, false, false,
-            true, DataGridViewAdvancedCellBorderStyle.Single, DataGridViewAdvancedCellBorderStyle.OutsetDouble, DataGridViewAdvancedCellBorderStyle.OutsetPartial, DataGridViewAdvancedCellBorderStyle.OutsetPartial
+            true, DataGridViewAdvancedCellBorderStyle.Outset, DataGridViewAdvancedCellBorderStyle.OutsetDouble, DataGridViewAdvancedCellBorderStyle.OutsetPartial, DataGridViewAdvancedCellBorderStyle.OutsetPartial
         };
 
         // Single.


### PR DESCRIPTION


Fixes https://github.com/dotnet/winforms/issues/12187 in .NET 9.0 release

Revert "Makes DataGridView row header left border have proper luminosity in RightToLeft mode, both with VisualStyles enabled or disabled" commit 9bda02dfd677f1e7d87c223cc5f8717e2add2d8a. This change regresses the color contrast issue that we will re-do in NET10. Besides this regression, the original fix was incomplete, as it applied only to RightToLeft layout.

## Customer Impact
Customer will observe visual difference between NET8 and NET9.
While fixing a color contrast issue https://github.com/dotnet/winforms/issues/5961 in .NET9, we regressed a customization scenario where dev sets a custom DataGridView grid color. The grid color now partially shows in the column header bar. It should be applied only to the regular DGV cells. 

## Regression
- [x] Yes
- [ ] No

## Testing
Manual testing

## Risk
Low. This is a revert to the NET8.0 state.


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12246)