### PR TITLE
Get rid of a warning in the latest IntPreview VS build

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/NumericUpDownTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/NumericUpDownTests.cs
@@ -826,8 +826,8 @@ public class NumericUpDownTests
         {
             get
             {
-                var field = typeof(NumericUpDown).GetField("_initializing", BindingFlags.NonPublic | BindingFlags.Instance);
-                return (bool)field.GetValue(this);
+                var initializing = typeof(NumericUpDown).GetField("_initializing", BindingFlags.NonPublic | BindingFlags.Instance);
+                return (bool)initializing.GetValue(this);
             }
         }
 


### PR DESCRIPTION
Warning:

In language version preview, the 'field' keyword binds to a synthesized backing field for the property. To avoid generating a synthesized backing field, and to refer to the existing member, use 'this.field' or '@field' instead.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12251)