### PR TITLE
Moved to SDK RC2

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -227,7 +227,7 @@ dotnet_diagnostic.CA2241.severity = error
 # CA2245: Do not assign a property to itself
 dotnet_diagnostic.CA2245.severity = error
 
-# CA2248: Provide correct enumm argument to Enum.HasFlag
+# CA2248: Provide correct enum argument to Enum.HasFlag
 dotnet_diagnostic.CA2248.severity = error
 
 # CA2249: Consider using String.Contains instead of String.IndexOf

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "9.0.100-rc.1.24452.12",
+    "dotnet": "9.0.100-rc.2.24474.12",
     "runtimes": {
       "dotnet/x64": [
         "$(VSRedistCommonNetCoreSharedFrameworkx64100PackageVersion)"
@@ -11,7 +11,7 @@
     }
   },
   "sdk": {
-    "version": "9.0.100-rc.1.24452.12"
+    "version": "9.0.100-rc.2.24474.12"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.24476.2",

--- a/src/System.Drawing.Common/tests/System/Drawing/Drawing2D/GraphicsPathTests.cs
+++ b/src/System.Drawing.Common/tests/System/Drawing/Drawing2D/GraphicsPathTests.cs
@@ -253,7 +253,7 @@ public class GraphicsPathTests
     {
         using GraphicsPath gpi = new();
         using GraphicsPath gpf = new();
-        gpi.AddLines(new Point[] { new(1, 1), new(2, 2) });
+        gpi.AddLines([new(1, 1), new(2, 2)]);
         AssertLine(gpi);
 
         gpf.AddLines(new PointF[] { new(1, 1), new(2, 2) });
@@ -604,7 +604,7 @@ public class GraphicsPathTests
             () => gp.AddCurve(new PointF[2] { new(1f, 1f), new(2f, 2f) }, 0, segment, 0.5f));
 
         AssertExtensions.ThrowsAny<ArgumentException, ArgumentOutOfRangeException>(
-            () => gp.AddCurve(new Point[2] { new(1, 1), new(2, 2) }, 0, segment, 0.5f));
+            () => gp.AddCurve([new(1, 1), new(2, 2)], 0, segment, 0.5f));
     }
 
     [Fact]
@@ -615,7 +615,7 @@ public class GraphicsPathTests
             () => gp.AddCurve(new PointF[3] { new(1f, 1f), new(0f, 20f), new(20f, 0f) }, 1, 2, 0.5f));
 
         AssertExtensions.ThrowsAny<ArgumentException, ArgumentOutOfRangeException>(
-            () => gp.AddCurve(new Point[3] { new(1, 1), new(0, 20), new(20, 0) }, 1, 2, 0.5f));
+            () => gp.AddCurve([new(1, 1), new(0, 20), new(20, 0)], 1, 2, 0.5f));
     }
 
     [Fact]
@@ -623,7 +623,7 @@ public class GraphicsPathTests
     {
         using GraphicsPath gpi = new();
         using GraphicsPath gpf = new();
-        gpi.AddClosedCurve(new Point[3] { new(1, 1), new(2, 2), new(3, 3) });
+        gpi.AddClosedCurve([new(1, 1), new(2, 2), new(3, 3)]);
         // AssertClosedCurve() method expects added ClosedCurve with points (1, 1), (2, 2), (3, 3), here and below.
         AssertClosedCurve(gpi);
 
@@ -636,9 +636,9 @@ public class GraphicsPathTests
     {
         using GraphicsPath gpi = new();
         using GraphicsPath gpf = new();
-        gpi.AddClosedCurve(new Point[3] { new(1, 1), new(1, 1), new(1, 1) });
+        gpi.AddClosedCurve([new(1, 1), new(1, 1), new(1, 1)]);
         Assert.Equal(10, gpi.PointCount);
-        gpi.AddClosedCurve(new Point[3] { new(1, 1), new(1, 1), new(1, 1) });
+        gpi.AddClosedCurve([new(1, 1), new(1, 1), new(1, 1)]);
         Assert.Equal(20, gpi.PointCount);
 
         gpf.AddClosedCurve(new PointF[3] { new(1, 1), new(1, 1), new(1, 1) });
@@ -652,7 +652,7 @@ public class GraphicsPathTests
     {
         using GraphicsPath gpi = new();
         using GraphicsPath gpf = new();
-        gpi.AddClosedCurve(new Point[3] { new(1, 1), new(2, 2), new(3, 3) }, 0.5f);
+        gpi.AddClosedCurve([new(1, 1), new(2, 2), new(3, 3)], 0.5f);
         AssertClosedCurve(gpi);
 
         gpf.AddClosedCurve(new PointF[3] { new(1, 1), new(2, 2), new(3, 3) }, 0.5f);
@@ -886,7 +886,7 @@ public class GraphicsPathTests
     {
         using GraphicsPath gpi = new();
         using GraphicsPath gpf = new();
-        gpi.AddPolygon(new Point[3] { new(1, 1), new(2, 2), new(3, 3) });
+        gpi.AddPolygon([new(1, 1), new(2, 2), new(3, 3)]);
         // AssertPolygon() method expects added Polygon with points (1, 1), (2, 2), (3, 3), here and below.
         AssertPolygon(gpi);
 
@@ -899,19 +899,19 @@ public class GraphicsPathTests
     {
         using GraphicsPath gpi = new();
         using GraphicsPath gpf = new();
-        gpi.AddPolygon(new Point[3] { new(1, 1), new(2, 2), new(3, 3) });
+        gpi.AddPolygon([new(1, 1), new(2, 2), new(3, 3)]);
         Assert.Equal(3, gpi.PointCount);
         Assert.Equal(new byte[] { 0, 1, 129 }, gpi.PathTypes);
 
-        gpi.AddPolygon(new Point[3] { new(1, 1), new(2, 2), new(3, 3) });
+        gpi.AddPolygon([new(1, 1), new(2, 2), new(3, 3)]);
         Assert.Equal(6, gpi.PointCount);
         Assert.Equal(new byte[] { 0, 1, 129, 0, 1, 129 }, gpi.PathTypes);
 
-        gpi.AddPolygon(new Point[3] { new(1, 1), new(2, 2), new(3, 3) });
+        gpi.AddPolygon([new(1, 1), new(2, 2), new(3, 3)]);
         Assert.Equal(9, gpi.PointCount);
         Assert.Equal(new byte[] { 0, 1, 129, 0, 1, 129, 0, 1, 129 }, gpi.PathTypes);
 
-        gpi.AddPolygon(new Point[3] { new(1, 1), new(2, 2), new(3, 3) });
+        gpi.AddPolygon([new(1, 1), new(2, 2), new(3, 3)]);
         Assert.Equal(12, gpi.PointCount);
         Assert.Equal(new byte[] { 0, 1, 129, 0, 1, 129, 0, 1, 129, 0, 1, 129 }, gpi.PathTypes);
 
@@ -1194,11 +1194,11 @@ public class GraphicsPathTests
     {
         using GraphicsPath gp = new();
         using GraphicsPath clone = Assert.IsType<GraphicsPath>(gp.Clone());
-        gp.AddClosedCurve(new Point[4]
-        {
-                new(0, 0), new(40, 20),
-                new(20, 40), new(40, 40)
-        });
+        gp.AddClosedCurve(
+        [
+            new(0, 0), new(40, 20),
+            new(20, 40), new(40, 40)
+        ]);
 
         gp.Flatten();
         AssertFlats(gp, clone);
@@ -1209,11 +1209,11 @@ public class GraphicsPathTests
     {
         using GraphicsPath gp = new();
         using GraphicsPath clone = Assert.IsType<GraphicsPath>(gp.Clone());
-        gp.AddCurve(new Point[4]
-        {
-                new(0, 0), new(40, 20),
-                new(20, 40), new(40, 40)
-        });
+        gp.AddCurve(
+        [
+            new(0, 0), new(40, 20),
+            new(20, 40), new(40, 40)
+        ]);
 
         gp.Flatten();
         AssertFlats(gp, clone);
@@ -1254,11 +1254,11 @@ public class GraphicsPathTests
     {
         using GraphicsPath gp = new();
         using GraphicsPath clone = Assert.IsType<GraphicsPath>(gp.Clone());
-        gp.AddPolygon(new Point[4]
-        {
-                new(0, 0), new(10, 10),
-                new(20, 20), new(40, 40)
-        });
+        gp.AddPolygon(
+        [
+            new(0, 0), new(10, 10),
+            new(20, 20), new(40, 40)
+        ]);
 
         gp.Flatten();
         AssertFlats(gp, clone);
@@ -1303,7 +1303,7 @@ public class GraphicsPathTests
     {
         using GraphicsPath gp = new();
         using Matrix matrix = new();
-        gp.AddPolygon(new Point[3] { new(5, 5), new(15, 5), new(10, 15) });
+        gp.AddPolygon([new(5, 5), new(15, 5), new(10, 15)]);
         gp.Warp([new(0, 0)], new RectangleF(10, 20, 30, 40), matrix, (WarpMode)int.MinValue);
         Assert.Equal(0, gp.PointCount);
     }
@@ -1312,7 +1312,7 @@ public class GraphicsPathTests
     public void Warp_RectangleEmpty_Success()
     {
         using GraphicsPath gp = new();
-        gp.AddPolygon(new Point[3] { new(5, 5), new(15, 5), new(10, 15) });
+        gp.AddPolygon([new(5, 5), new(15, 5), new(10, 15)]);
         gp.Warp([new(0, 0)], new Rectangle(), null);
         AssertWrapNaN(gp);
     }
@@ -1431,12 +1431,12 @@ public class GraphicsPathTests
     {
         using GraphicsPath gp = new();
         gp.AddLine(1, 1, 2, 2);
-        gp.AddBeziers(new Point[7]
-        {
-                new(10, 10), new(20, 10), new(20, 20),
-                new(30, 20), new(40, 40), new(50, 40),
-                new(50, 50)
-        });
+        gp.AddBeziers(
+        [
+            new(10, 10), new(20, 10), new(20, 20),
+            new(30, 20), new(40, 40), new(50, 40),
+            new(50, 50)
+        ]);
 
         gp.AddLine(10, 10, 20, 20);
         byte[] types = gp.PathTypes;
@@ -1452,7 +1452,7 @@ public class GraphicsPathTests
     {
         using GraphicsPath gp = new();
         gp.AddLine(1, 1, 2, 2);
-        gp.AddClosedCurve(new Point[3] { new(1, 1), new(2, 2), new(3, 3) });
+        gp.AddClosedCurve([new(1, 1), new(2, 2), new(3, 3)]);
         gp.AddLine(10, 10, 20, 20);
         byte[] types = gp.PathTypes;
 
@@ -1468,7 +1468,7 @@ public class GraphicsPathTests
     {
         using GraphicsPath path = new();
         path.AddLine(1, 1, 2, 2);
-        path.AddCurve(new Point[3] { new(1, 1), new(2, 2), new(3, 3) });
+        path.AddCurve([new(1, 1), new(2, 2), new(3, 3)]);
         path.AddLine(10, 10, 20, 20);
         byte[] types = path.PathTypes;
 
@@ -1514,7 +1514,7 @@ public class GraphicsPathTests
     {
         using GraphicsPath gp = new();
         gp.AddLine(1, 1, 2, 2);
-        gp.AddLines(new Point[4] { new(10, 10), new(20, 10), new(20, 20), new(30, 20) });
+        gp.AddLines([new(10, 10), new(20, 10), new(20, 20), new(30, 20)]);
         gp.AddLine(10, 10, 20, 20);
         byte[] types = gp.PathTypes;
 
@@ -1580,7 +1580,7 @@ public class GraphicsPathTests
     {
         using GraphicsPath gp = new();
         gp.AddLine(1, 1, 2, 2);
-        gp.AddPolygon(new Point[3] { new(1, 1), new(2, 2), new(3, 3) });
+        gp.AddPolygon([new(1, 1), new(2, 2), new(3, 3)]);
         gp.AddLine(10, 10, 20, 20);
         byte[] types = gp.PathTypes;
 
@@ -1691,7 +1691,7 @@ public class GraphicsPathTests
     {
         using GraphicsPath gp = new();
         using Pen pen = new(Color.Blue);
-        gp.AddPolygon(new Point[3] { new(5, 5), new(15, 5), new(10, 15) });
+        gp.AddPolygon([new(5, 5), new(15, 5), new(10, 15)]);
         gp.Widen(pen, null);
         Assert.Equal(9, gp.PointCount);
         AssertWiden3(gp);
@@ -1703,7 +1703,7 @@ public class GraphicsPathTests
         using GraphicsPath gp = new();
         using Pen pen = new(Color.Blue);
         using Matrix matrix = new();
-        gp.AddPolygon(new Point[3] { new(5, 5), new(15, 5), new(10, 15) });
+        gp.AddPolygon([new(5, 5), new(15, 5), new(10, 15)]);
         gp.Widen(pen, new Matrix());
         Assert.Equal(9, gp.PointCount);
         AssertWiden3(gp);

--- a/src/System.Drawing.Common/tests/System/Drawing/GraphicsTests.cs
+++ b/src/System.Drawing.Common/tests/System/Drawing/GraphicsTests.cs
@@ -1850,7 +1850,7 @@ public partial class GraphicsTests
     {
         using Bitmap image = new(10, 10);
         using Graphics graphics = Graphics.FromImage(image);
-        AssertExtensions.Throws<ArgumentException>(null, () => graphics.TransformPoints(destSpace, CoordinateSpace.World, new Point[] { new(1, 1) }));
+        AssertExtensions.Throws<ArgumentException>(null, () => graphics.TransformPoints(destSpace, CoordinateSpace.World, [new(1, 1)]));
         AssertExtensions.Throws<ArgumentException>(null, () => graphics.TransformPoints(destSpace, CoordinateSpace.World, new PointF[] { new(1, 1) }));
     }
 
@@ -1861,7 +1861,7 @@ public partial class GraphicsTests
     {
         using Bitmap image = new(10, 10);
         using Graphics graphics = Graphics.FromImage(image);
-        AssertExtensions.Throws<ArgumentException>(null, () => graphics.TransformPoints(CoordinateSpace.World, srcSpace, new Point[] { new(1, 1) }));
+        AssertExtensions.Throws<ArgumentException>(null, () => graphics.TransformPoints(CoordinateSpace.World, srcSpace, [new(1, 1)]));
         AssertExtensions.Throws<ArgumentException>(null, () => graphics.TransformPoints(CoordinateSpace.World, srcSpace, new PointF[] { new(1, 1) }));
     }
 
@@ -1891,8 +1891,8 @@ public partial class GraphicsTests
         graphics.GetHdc();
         try
         {
-            Assert.Throws<InvalidOperationException>(() => graphics.TransformPoints(CoordinateSpace.Page, CoordinateSpace.Page, new Point[] { Point.Empty }));
-            Assert.Throws<InvalidOperationException>(() => graphics.TransformPoints(CoordinateSpace.Page, CoordinateSpace.Page, new PointF[] { PointF.Empty }));
+            Assert.Throws<InvalidOperationException>(() => graphics.TransformPoints(CoordinateSpace.Page, CoordinateSpace.Page, [Point.Empty]));
+            Assert.Throws<InvalidOperationException>(() => graphics.TransformPoints(CoordinateSpace.Page, CoordinateSpace.Page, [PointF.Empty]));
         }
         finally
         {
@@ -1907,8 +1907,8 @@ public partial class GraphicsTests
         Graphics graphics = Graphics.FromImage(image);
         graphics.Dispose();
 
-        AssertExtensions.Throws<ArgumentException>(null, () => graphics.TransformPoints(CoordinateSpace.Page, CoordinateSpace.Page, new Point[] { Point.Empty }));
-        AssertExtensions.Throws<ArgumentException>(null, () => graphics.TransformPoints(CoordinateSpace.Page, CoordinateSpace.Page, new PointF[] { PointF.Empty }));
+        AssertExtensions.Throws<ArgumentException>(null, () => graphics.TransformPoints(CoordinateSpace.Page, CoordinateSpace.Page, [Point.Empty]));
+        AssertExtensions.Throws<ArgumentException>(null, () => graphics.TransformPoints(CoordinateSpace.Page, CoordinateSpace.Page, [PointF.Empty]));
     }
 
     public static IEnumerable<object[]> GetNearestColor_TestData()

--- a/src/System.Drawing.Common/tests/System/Drawing/Graphics_DrawLineTests.cs
+++ b/src/System.Drawing.Common/tests/System/Drawing/Graphics_DrawLineTests.cs
@@ -12,7 +12,7 @@ public class Graphics_DrawLineTests : DrawingTest
         using Pen pen = new(Color.White);
         using Graphics graphics = Graphics.FromImage(bitmap);
 
-        graphics.DrawLines(pen, new Point[] { new(1, 1), new(1, 10), new(20, 5), new(25, 30) });
+        graphics.DrawLines(pen, [new(1, 1), new(1, 10), new(20, 5), new(25, 30)]);
 
         ValidateBitmapContent(
             bitmap,

--- a/src/System.Drawing.Common/tests/System/Drawing/Imaging/ColorMatrixTests.cs
+++ b/src/System.Drawing.Common/tests/System/Drawing/Imaging/ColorMatrixTests.cs
@@ -112,15 +112,15 @@ public class ColorMatrixTests
     [Fact]
     public void Ctor_TooBigArraySize_MapOnly4and4Elements()
     {
-        ColorMatrix cm = new(new float[][]
-        {
+        ColorMatrix cm = new(
+        [
             [0.0f, 0.1f, 0.2f, 0.3f, 0.4f, 0.5f],
             [1.0f, 1.1f, 1.2f, 1.3f, 1.4f, 1.5f],
             [2.0f, 2.1f, 2.2f, 2.3f, 2.4f, 2.5f],
             [3.0f, 3.1f, 3.2f, 3.3f, 3.4f, 3.5f],
             [4.0f, 4.1f, 4.2f, 4.3f, 4.4f, 4.5f],
             [5.0f, 5.1f, 5.2f, 5.3f, 5.4f, 5.5f]
-        });
+        ]);
 
         Assert.Equal(0.0f, cm.Matrix00);
         Assert.Equal(0.1f, cm.Matrix01);
@@ -152,15 +152,15 @@ public class ColorMatrixTests
     [Fact]
     public void AccessToNotExistingElement_ThrowsIndexOutOfRangeException()
     {
-        ColorMatrix cm = new(new float[][]
-        {
+        ColorMatrix cm = new(
+        [
             [0.0f, 0.1f, 0.2f, 0.3f, 0.4f, 0.5f],
             [1.0f, 1.1f, 1.2f, 1.3f, 1.4f, 1.5f],
             [2.0f, 2.1f, 2.2f, 2.3f, 2.4f, 2.5f],
             [3.0f, 3.1f, 3.2f, 3.3f, 3.4f, 3.5f],
             [4.0f, 4.1f, 4.2f, 4.3f, 4.4f, 4.5f],
             [5.0f, 5.1f, 5.2f, 5.3f, 5.4f, 5.5f]
-        });
+        ]);
         Assert.Throws<IndexOutOfRangeException>(() => _ = cm[5, 5]);
     }
 

--- a/src/System.Drawing.Common/tests/System/Drawing/Imaging/ImageAttributesTests.cs
+++ b/src/System.Drawing.Common/tests/System/Drawing/Imaging/ImageAttributesTests.cs
@@ -34,23 +34,23 @@ public class ImageAttributesTests
     private readonly Color _actualGreen = Color.FromArgb(255, 0, 255, 0);
     private readonly Color _expectedRed = Color.FromArgb(255, 255, 0, 0);
     private readonly Color _expectedBlack = Color.FromArgb(255, 0, 0, 0);
-    private readonly ColorMatrix _greenComponentToZeroColorMatrix = new(new float[][]
-    {
+    private readonly ColorMatrix _greenComponentToZeroColorMatrix = new(
+    [
         [1, 0, 0, 0, 0],
         [0, 0, 0, 0, 0],
         [0, 0, 1, 0, 0],
         [0, 0, 0, 1, 0],
         [0, 0, 0, 0, 0],
-    });
+    ]);
 
-    private readonly ColorMatrix _grayMatrix = new(new float[][]
-    {
+    private readonly ColorMatrix _grayMatrix = new(
+    [
         [1, 0, 0, 0, 0],
         [0, 2, 0, 0, 0],
         [0, 0, 3, 0, 0],
         [0, 0, 0, 1, 0],
         [0, 0, 0, 0, 0],
-    });
+    ]);
 
     private readonly ColorMap[] _yellowToRedColorMap =
     [
@@ -114,14 +114,14 @@ public class ImageAttributesTests
     [MemberData(nameof(ColorMatrix_DropShadowRepaintWhenAreaIsSmallerThanTheFilteredElement_TestData))]
     public void SetColorMatrix_ColorMatrixI_Success(Color color)
     {
-        ColorMatrix colorMatrix = new(new float[][]
-        {
+        ColorMatrix colorMatrix = new(
+        [
             [1, 0, 0, 0, 0],
             [0, 1, 0, 0, 0],
             [0, 0, 1, 0, 0],
             [0, 0, 0, 0.5f, 0],
             [0, 0, 0, 0, 1],
-        });
+        ]);
 
         using SolidBrush brush = new(color);
         using Bitmap bitmapBig = new(200, 100);

--- a/src/System.Drawing.Common/tests/System/Drawing/PenTests.cs
+++ b/src/System.Drawing.Common/tests/System/Drawing/PenTests.cs
@@ -14,7 +14,7 @@ public class PenTests
         yield return new object[] { new HatchBrush(HatchStyle.BackwardDiagonal, Color.Red), PenType.HatchFill };
         yield return new object[] { new LinearGradientBrush(new Point(0, 0), new Point(0, 2), Color.Purple, Color.Plum), PenType.LinearGradient };
         yield return new object[] { new TextureBrush(new Bitmap(1, 1)), PenType.TextureFill };
-        yield return new object[] { new PathGradientBrush(new Point[] { new(1, 2), new(2, 3) }), PenType.PathGradient };
+        yield return new object[] { new PathGradientBrush([new(1, 2), new(2, 3)]), PenType.PathGradient };
     }
 
     [Theory]

--- a/src/System.Drawing.Common/tests/System/Drawing/RegionTests.cs
+++ b/src/System.Drawing.Common/tests/System/Drawing/RegionTests.cs
@@ -205,15 +205,15 @@ public class RegionTests
         yield return new object[] { path3, false };
 
         GraphicsPath path4 = new();
-        path4.AddCurve(new Point[] { new(-4194304, -4194304), new(4194304, 4194304) });
+        path4.AddCurve([new(-4194304, -4194304), new(4194304, 4194304)]);
         yield return new object[] { path4, false };
 
         GraphicsPath path5 = new();
-        path5.AddPolygon(new Point[] { new(-4194304, -4194304), new(-4194304, 4194304), new(4194304, 4194304), new(4194304, -4194304) });
+        path5.AddPolygon([new(-4194304, -4194304), new(-4194304, 4194304), new(4194304, 4194304), new(4194304, -4194304)]);
         yield return new object[] { path5, true };
 
         GraphicsPath path6 = new();
-        path6.AddPolygon(new Point[] { new(-4194304, -4194304), new(-4194304, 4194304), new(4194304, 4194304), new(4194304, -4194304), new(-4194304, -4194304) });
+        path6.AddPolygon([new(-4194304, -4194304), new(-4194304, 4194304), new(4194304, 4194304), new(4194304, -4194304), new(-4194304, -4194304)]);
         yield return new object[] { path6, true };
     }
 
@@ -232,7 +232,7 @@ public class RegionTests
     public void Ctor_GraphicsPathTooLarge_SetsToEmpty()
     {
         using GraphicsPath path = new();
-        path.AddCurve(new Point[] { new(-4194304, -4194304), new(4194304, 4194304) });
+        path.AddCurve([new(-4194304, -4194304), new(4194304, 4194304)]);
 
         using Region region = new(path);
         using Matrix matrix = new();

--- a/src/System.Drawing.Common/tests/mono/System.Drawing/GraphicsTests.cs
+++ b/src/System.Drawing.Common/tests/mono/System.Drawing/GraphicsTests.cs
@@ -728,7 +728,7 @@ public class GraphicsTest : IDisposable
     {
         using Bitmap bitmap = new(20, 20);
         using Graphics g = Graphics.FromImage(bitmap);
-        Assert.Throws<ArgumentException>(() => g.DrawCurve(Pens.Black, new Point[1] { new(10, 10) }, 0.5f));
+        Assert.Throws<ArgumentException>(() => g.DrawCurve(Pens.Black, [new(10, 10)], 0.5f));
 
         // a single point isn't enough
     }
@@ -2535,10 +2535,7 @@ public class GraphicsTest : IDisposable
     {
         using Bitmap bmp = new(40, 40);
         using Graphics g = Graphics.FromImage(bmp);
-        g.DrawImage(bmp, new Point[]
-        {
-                    new(0, 0), new(1, 1), new(2, 2)
-        });
+        g.DrawImage(bmp, [ new(0, 0), new(1, 1), new(2, 2)]);
     }
 
     [Fact]

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/StyleEditorForm.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/StyleEditorForm.cs
@@ -396,13 +396,8 @@ internal partial class StyleCollectionEditor
 
             // absoluteNumericUpDown
             resources.ApplyResources(_absoluteNumericUpDown, "absoluteNumericUpDown");
-            _absoluteNumericUpDown.Maximum = new decimal(
-            [
-                99999,
-                0,
-                0,
-                0
-            ]);
+            _absoluteNumericUpDown.Maximum = new decimal(lo: 99999, mid: 0, hi: 0, isNegative: false, scale: 0);
+
             _absoluteNumericUpDown.Name = "absoluteNumericUpDown";
             _absoluteNumericUpDown.Margin = new Padding(_scaledUpDownLeftMargin, _scaledUpDownTopMargin, 0, 0);
             _absoluteNumericUpDown.AutoScaleMode = AutoScaleMode.Font;
@@ -435,13 +430,7 @@ internal partial class StyleCollectionEditor
             // percentNumericUpDown
             resources.ApplyResources(_percentNumericUpDown, "percentNumericUpDown");
             _percentNumericUpDown.DecimalPlaces = 2;
-            _percentNumericUpDown.Maximum = new decimal(
-            [
-                9999,
-                0,
-                0,
-                0
-            ]);
+            _percentNumericUpDown.Maximum = new decimal(lo: 9999, mid: 0, hi: 0, isNegative: false, scale: 0);
             _percentNumericUpDown.Name = "percentNumericUpDown";
             _percentNumericUpDown.Margin = new Padding(_scaledUpDownLeftMargin, _scaledUpDownTopMargin, 0, 0);
             _percentNumericUpDown.AutoScaleMode = AutoScaleMode.Font;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/StyleEditorForm.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/StyleEditorForm.cs
@@ -396,13 +396,13 @@ internal partial class StyleCollectionEditor
 
             // absoluteNumericUpDown
             resources.ApplyResources(_absoluteNumericUpDown, "absoluteNumericUpDown");
-            _absoluteNumericUpDown.Maximum = new decimal(new int[]
-            {
+            _absoluteNumericUpDown.Maximum = new decimal(
+            [
                 99999,
                 0,
                 0,
                 0
-            });
+            ]);
             _absoluteNumericUpDown.Name = "absoluteNumericUpDown";
             _absoluteNumericUpDown.Margin = new Padding(_scaledUpDownLeftMargin, _scaledUpDownTopMargin, 0, 0);
             _absoluteNumericUpDown.AutoScaleMode = AutoScaleMode.Font;
@@ -435,13 +435,13 @@ internal partial class StyleCollectionEditor
             // percentNumericUpDown
             resources.ApplyResources(_percentNumericUpDown, "percentNumericUpDown");
             _percentNumericUpDown.DecimalPlaces = 2;
-            _percentNumericUpDown.Maximum = new decimal(new int[]
-            {
+            _percentNumericUpDown.Maximum = new decimal(
+            [
                 9999,
                 0,
                 0,
                 0
-            });
+            ]);
             _percentNumericUpDown.Name = "percentNumericUpDown";
             _percentNumericUpDown.Margin = new Padding(_scaledUpDownLeftMargin, _scaledUpDownTopMargin, 0, 0);
             _percentNumericUpDown.AutoScaleMode = AutoScaleMode.Font;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/StyleEditorForm.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/StyleEditorForm.cs
@@ -396,7 +396,7 @@ internal partial class StyleCollectionEditor
 
             // absoluteNumericUpDown
             resources.ApplyResources(_absoluteNumericUpDown, "absoluteNumericUpDown");
-            _absoluteNumericUpDown.Maximum = new decimal(lo: 99999, mid: 0, hi: 0, isNegative: false, scale: 0);
+            _absoluteNumericUpDown.Maximum = new decimal(99999u);
 
             _absoluteNumericUpDown.Name = "absoluteNumericUpDown";
             _absoluteNumericUpDown.Margin = new Padding(_scaledUpDownLeftMargin, _scaledUpDownTopMargin, 0, 0);
@@ -430,7 +430,7 @@ internal partial class StyleCollectionEditor
             // percentNumericUpDown
             resources.ApplyResources(_percentNumericUpDown, "percentNumericUpDown");
             _percentNumericUpDown.DecimalPlaces = 2;
-            _percentNumericUpDown.Maximum = new decimal(lo: 9999, mid: 0, hi: 0, isNegative: false, scale: 0);
+            _percentNumericUpDown.Maximum = new decimal(9999u);
             _percentNumericUpDown.Name = "percentNumericUpDown";
             _percentNumericUpDown.Margin = new Padding(_scaledUpDownLeftMargin, _scaledUpDownTopMargin, 0, 0);
             _percentNumericUpDown.AutoScaleMode = AutoScaleMode.Font;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/Serialization/CodeDomComponentSerializationServiceTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/Serialization/CodeDomComponentSerializationServiceTests.cs
@@ -138,8 +138,8 @@ public class CodeDomComponentSerializationServiceTests
         Dictionary<string, CodeDomComponentSerializationState> state = GetState(info);
         Assert.Equal(2, state.Count);
         CodeDomComponentSerializationState valueState1 = state["name1"];
-        CodeDomHelpers.AssertEqualCodeStatementCollection(new CodeStatementCollection(new CodeStatement[]
-        {
+        CodeDomHelpers.AssertEqualCodeStatementCollection(new CodeStatementCollection(
+        [
             new CodeVariableDeclarationStatement(typeof(DataClass), "name1"),
             new CodeAssignStatement(new CodeVariableReferenceExpression("name1"), new CodeObjectCreateExpression(typeof(DataClass))),
             new CodeCommentStatement(string.Empty),
@@ -148,12 +148,12 @@ public class CodeDomComponentSerializationServiceTests
             new CodeAssignStatement(new CodePropertyReferenceExpression(new CodeVariableReferenceExpression("name1"), "DefaultStringValue"), new CodePrimitiveExpression(null)),
             new CodeAssignStatement(new CodePropertyReferenceExpression(new CodeVariableReferenceExpression("name1"), "IntValue"), new CodePrimitiveExpression(1)),
             new CodeAssignStatement(new CodePropertyReferenceExpression(new CodeVariableReferenceExpression("name1"), "StringValue"), new CodePrimitiveExpression("Value"))
-        }), Assert.IsType<CodeStatementCollection>(valueState1.Code));
+        ]), Assert.IsType<CodeStatementCollection>(valueState1.Code));
         AssertAllNonCodeFieldsArNull(valueState1);
 
         CodeDomComponentSerializationState valueState2 = state["name2"];
-        CodeDomHelpers.AssertEqualCodeStatementCollection(new CodeStatementCollection(new CodeStatement[]
-        {
+        CodeDomHelpers.AssertEqualCodeStatementCollection(new CodeStatementCollection(
+        [
             new CodeVariableDeclarationStatement(typeof(DataClass), "name2"),
             new CodeAssignStatement(new CodeVariableReferenceExpression("name2"), new CodeObjectCreateExpression(typeof(DataClass))),
             new CodeCommentStatement(string.Empty),
@@ -162,7 +162,7 @@ public class CodeDomComponentSerializationServiceTests
             new CodeAssignStatement(new CodePropertyReferenceExpression(new CodeVariableReferenceExpression("name2"), "DefaultStringValue"), new CodePrimitiveExpression(null)),
             new CodeAssignStatement(new CodePropertyReferenceExpression(new CodeVariableReferenceExpression("name2"), "IntValue"), new CodePrimitiveExpression(2)),
             new CodeAssignStatement(new CodePropertyReferenceExpression(new CodeVariableReferenceExpression("name2"), "StringValue"), new CodePrimitiveExpression("OtherValue"))
-        }), Assert.IsType<CodeStatementCollection>(valueState2.Code));
+        ]), Assert.IsType<CodeStatementCollection>(valueState2.Code));
         AssertAllNonCodeFieldsArNull(valueState2);
 
         List<string> names = Assert.IsType<List<string>>(info.GetValue("Names", typeof(List<string>)));
@@ -240,8 +240,8 @@ public class CodeDomComponentSerializationServiceTests
 
         Dictionary<string, CodeDomComponentSerializationState> state = GetState(info);
         CodeDomComponentSerializationState valueState = state["name"];
-        CodeDomHelpers.AssertEqualCodeStatementCollection(new CodeStatementCollection(new CodeStatement[]
-        {
+        CodeDomHelpers.AssertEqualCodeStatementCollection(new CodeStatementCollection(
+        [
             new CodeVariableDeclarationStatement(typeof(DataClass), "name"),
             new CodeAssignStatement(new CodeVariableReferenceExpression("name"), new CodeObjectCreateExpression(typeof(DataClass))),
             new CodeCommentStatement(string.Empty),
@@ -250,7 +250,7 @@ public class CodeDomComponentSerializationServiceTests
             new CodeAssignStatement(new CodePropertyReferenceExpression(new CodeVariableReferenceExpression("name"), "DefaultStringValue"), new CodePrimitiveExpression(null)),
             new CodeAssignStatement(new CodePropertyReferenceExpression(new CodeVariableReferenceExpression("name"), "IntValue"), new CodePrimitiveExpression(1)),
             new CodeAssignStatement(new CodePropertyReferenceExpression(new CodeVariableReferenceExpression("name"), "StringValue"), new CodePrimitiveExpression("Value"))
-        }), Assert.IsType<CodeStatementCollection>(valueState.Code));
+        ]), Assert.IsType<CodeStatementCollection>(valueState.Code));
         AssertAllNonCodeFieldsArNull(valueState);
 
         List<string> names = Assert.IsType<List<string>>(info.GetValue("Names", typeof(List<string>)));
@@ -342,8 +342,8 @@ public class CodeDomComponentSerializationServiceTests
 
         Dictionary<string, CodeDomComponentSerializationState> state = GetState(info);
         CodeDomComponentSerializationState valueState = state["name"];
-        CodeDomHelpers.AssertEqualCodeStatementCollection(new CodeStatementCollection(new CodeStatement[]
-        {
+        CodeDomHelpers.AssertEqualCodeStatementCollection(new CodeStatementCollection(
+        [
             new CodeVariableDeclarationStatement(typeof(DataClass), "name"),
             new CodeAssignStatement(new CodeVariableReferenceExpression("name"), new CodeObjectCreateExpression(typeof(DataClass))),
             new CodeCommentStatement(string.Empty),
@@ -352,7 +352,7 @@ public class CodeDomComponentSerializationServiceTests
             new CodeAssignStatement(new CodePropertyReferenceExpression(new CodeVariableReferenceExpression("name"), "DefaultStringValue"), new CodePrimitiveExpression(null)),
             new CodeAssignStatement(new CodePropertyReferenceExpression(new CodeVariableReferenceExpression("name"), "IntValue"), new CodePrimitiveExpression(1)),
             new CodeAssignStatement(new CodePropertyReferenceExpression(new CodeVariableReferenceExpression("name"), "StringValue"), new CodePrimitiveExpression("Value"))
-        }), Assert.IsType<CodeStatementCollection>(valueState.Code));
+        ]), Assert.IsType<CodeStatementCollection>(valueState.Code));
         AssertAllNonCodeFieldsArNull(valueState);
 
         List<string> names = Assert.IsType<List<string>>(info.GetValue("Names", typeof(List<string>)));
@@ -387,8 +387,8 @@ public class CodeDomComponentSerializationServiceTests
 
         Dictionary<string, CodeDomComponentSerializationState> state = GetState(info);
         CodeDomComponentSerializationState valueState = state["name"];
-        CodeDomHelpers.AssertEqualCodeStatementCollection(new CodeStatementCollection(new CodeStatement[]
-        {
+        CodeDomHelpers.AssertEqualCodeStatementCollection(new CodeStatementCollection(
+        [
             new CodeVariableDeclarationStatement(typeof(DataClass), "name"),
             new CodeAssignStatement(new CodeVariableReferenceExpression("name"), new CodeObjectCreateExpression(typeof(DataClass))),
             new CodeCommentStatement(string.Empty),
@@ -397,7 +397,7 @@ public class CodeDomComponentSerializationServiceTests
             new CodeAssignStatement(new CodePropertyReferenceExpression(new CodeVariableReferenceExpression("name"), "DefaultStringValue"), new CodePrimitiveExpression(null)),
             new CodeAssignStatement(new CodePropertyReferenceExpression(new CodeVariableReferenceExpression("name"), "IntValue"), new CodePrimitiveExpression(1)),
             new CodeAssignStatement(new CodePropertyReferenceExpression(new CodeVariableReferenceExpression("name"), "StringValue"), new CodePrimitiveExpression("Value"))
-        }), Assert.IsType<CodeStatementCollection>(valueState.Code));
+        ]), Assert.IsType<CodeStatementCollection>(valueState.Code));
         AssertAllNonCodeFieldsArNull(valueState);
 
         List<string> names = Assert.IsType<List<string>>(info.GetValue("Names", typeof(List<string>)));
@@ -438,12 +438,12 @@ public class CodeDomComponentSerializationServiceTests
 
         Dictionary<string, CodeDomComponentSerializationState> state = GetState(info);
         CodeDomComponentSerializationState valueState = state["name"];
-        CodeDomHelpers.AssertEqualCodeStatementCollection(new CodeStatementCollection(new CodeStatement[]
-        {
+        CodeDomHelpers.AssertEqualCodeStatementCollection(new CodeStatementCollection(
+        [
             new CodeAssignStatement(new CodePropertyReferenceExpression(new CodeVariableReferenceExpression("name"), "IntValue"), new CodePrimitiveExpression(1)),
             new CodeAssignStatement(new CodePropertyReferenceExpression(new CodeVariableReferenceExpression("name"), "DefaultStringValue"), new CodePrimitiveExpression(null)),
             new CodeAssignStatement(new CodePropertyReferenceExpression(new CodeVariableReferenceExpression("name"), "IntValue"), new CodePrimitiveExpression(1)),
-        }), Assert.IsType<CodeStatementCollection>(valueState.Code));
+        ]), Assert.IsType<CodeStatementCollection>(valueState.Code));
         AssertAllNonCodeFieldsArNull(valueState);
 
         List<string> names = Assert.IsType<List<string>>(info.GetValue("Names", typeof(List<string>)));
@@ -484,12 +484,12 @@ public class CodeDomComponentSerializationServiceTests
 
         Dictionary<string, CodeDomComponentSerializationState> state = GetState(info);
         CodeDomComponentSerializationState valueState = state["name"];
-        CodeDomHelpers.AssertEqualCodeStatementCollection(new CodeStatementCollection(new CodeStatement[]
-        {
+        CodeDomHelpers.AssertEqualCodeStatementCollection(new CodeStatementCollection(
+        [
             new CodeAssignStatement(new CodePropertyReferenceExpression(new CodeVariableReferenceExpression("name"), "IntValue"), new CodePrimitiveExpression(1)),
             new CodeAssignStatement(new CodePropertyReferenceExpression(new CodeVariableReferenceExpression("name"), "DefaultStringValue"), new CodePrimitiveExpression(null)),
             new CodeAssignStatement(new CodePropertyReferenceExpression(new CodeVariableReferenceExpression("name"), "IntValue"), new CodePrimitiveExpression(1))
-        }), Assert.IsType<CodeStatementCollection>(valueState.Code));
+        ]), Assert.IsType<CodeStatementCollection>(valueState.Code));
         AssertAllNonCodeFieldsArNull(valueState);
 
         List<string> names = Assert.IsType<List<string>>(info.GetValue("Names", typeof(List<string>)));
@@ -528,8 +528,8 @@ public class CodeDomComponentSerializationServiceTests
 
         Dictionary<string, CodeDomComponentSerializationState> state = GetState(info);
         CodeDomComponentSerializationState valueState = state["name"];
-        CodeDomHelpers.AssertEqualCodeStatementCollection(new CodeStatementCollection(new CodeStatement[]
-        {
+        CodeDomHelpers.AssertEqualCodeStatementCollection(new CodeStatementCollection(
+        [
             new CodeVariableDeclarationStatement(typeof(DataClass), "name"),
             new CodeAssignStatement(new CodeVariableReferenceExpression("name"), new CodeObjectCreateExpression(typeof(DataClass))),
             new CodeCommentStatement(string.Empty),
@@ -538,7 +538,7 @@ public class CodeDomComponentSerializationServiceTests
             new CodeAssignStatement(new CodePropertyReferenceExpression(new CodeVariableReferenceExpression("name"), "DefaultStringValue"), new CodePrimitiveExpression(null)),
             new CodeAssignStatement(new CodePropertyReferenceExpression(new CodeVariableReferenceExpression("name"), "IntValue"), new CodePrimitiveExpression(1)),
             new CodeAssignStatement(new CodePropertyReferenceExpression(new CodeVariableReferenceExpression("name"), "StringValue"), new CodePrimitiveExpression("Value"))
-        }), Assert.IsType<CodeStatementCollection>(valueState.Code));
+        ]), Assert.IsType<CodeStatementCollection>(valueState.Code));
         AssertAllNonCodeFieldsArNull(valueState);
 
         List<string> names = Assert.IsType<List<string>>(info.GetValue("Names", typeof(List<string>)));
@@ -577,8 +577,8 @@ public class CodeDomComponentSerializationServiceTests
 
         Dictionary<string, CodeDomComponentSerializationState> state = GetState(info);
         CodeDomComponentSerializationState valueState = state["name"];
-        CodeDomHelpers.AssertEqualCodeStatementCollection(new CodeStatementCollection(new CodeStatement[]
-        {
+        CodeDomHelpers.AssertEqualCodeStatementCollection(new CodeStatementCollection(
+        [
             new CodeVariableDeclarationStatement(typeof(DataClass), "name"),
             new CodeAssignStatement(new CodeVariableReferenceExpression("name"), new CodeObjectCreateExpression(typeof(DataClass))),
             new CodeCommentStatement(string.Empty),
@@ -587,7 +587,7 @@ public class CodeDomComponentSerializationServiceTests
             new CodeAssignStatement(new CodePropertyReferenceExpression(new CodeVariableReferenceExpression("name"), "DefaultStringValue"), new CodePrimitiveExpression(null)),
             new CodeAssignStatement(new CodePropertyReferenceExpression(new CodeVariableReferenceExpression("name"), "IntValue"), new CodePrimitiveExpression(1)),
             new CodeAssignStatement(new CodePropertyReferenceExpression(new CodeVariableReferenceExpression("name"), "StringValue"), new CodePrimitiveExpression("Value"))
-        }), Assert.IsType<CodeStatementCollection>(valueState.Code));
+        ]), Assert.IsType<CodeStatementCollection>(valueState.Code));
         AssertAllNonCodeFieldsArNull(valueState);
 
         List<string> names = Assert.IsType<List<string>>(info.GetValue("Names", typeof(List<string>)));

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ControlDesigner.DesignerControlCollectionTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ControlDesigner.DesignerControlCollectionTests.cs
@@ -69,7 +69,7 @@ public class ControlDesignerDesignerControlCollectionTests : IDisposable
     {
         using Control control1 = new();
         using Control control2 = new();
-        Control[] controls = { control1, control2 };
+        Control[] controls = [control1, control2];
         _collection.AddRange(controls);
         _control.Controls.Cast<Control>().Should().Contain(controls);
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.FlatComboAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.FlatComboAdapter.cs
@@ -178,12 +178,11 @@ public partial class ComboBox
 
             g.FillPolygon(
                 brush,
-                new Point[]
-                {
+                [
                     new(middle.X - s_offsetPixels, middle.Y - 1),
                     new(middle.X + s_offsetPixels + 1, middle.Y - 1),
                     new(middle.X, middle.Y + s_offsetPixels)
-                });
+                ]);
         }
 
         protected virtual Color GetOuterBorderColor(ComboBox comboBox)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewComboBoxCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewComboBoxCell.cs
@@ -2162,12 +2162,12 @@ public partial class DataGridViewComboBoxCell : DataGridViewCell
                             // if the height is odd - favor pushing it over one pixel down.
                             middle.Y += (dropRect.Height % 2);
 
-                            g.FillPolygon(SystemBrushes.ControlText, new Point[]
-                            {
+                            g.FillPolygon(SystemBrushes.ControlText,
+                            [
                                 new(middle.X - s_offset2X, middle.Y - 1),
                                 new(middle.X + s_offset2X + 1, middle.Y - 1),
                                 new(middle.X, middle.Y + s_offset2Y)
-                            });
+                            ]);
                         }
                         else if (!paintXPThemes)
                         {
@@ -2185,7 +2185,7 @@ public partial class DataGridViewComboBoxCell : DataGridViewCell
                             middle.Y += (dropRect.Height % 2);
                             Point pt1 = new(middle.X - (s_nonXPTriangleWidth - 1) / 2, middle.Y - s_nonXPTriangleHeight);
                             Point pt2 = new(middle.X + (s_nonXPTriangleWidth - 1) / 2, middle.Y - s_nonXPTriangleHeight);
-                            g.FillPolygon(SystemBrushes.ControlText, new Point[] { pt1, pt2, middle });
+                            g.FillPolygon(SystemBrushes.ControlText, [pt1, pt2, middle]);
                             // quirk in GDI+ : if we don't draw the line below then the top right most pixel of the DropDown triangle will not paint
                             // Would think that g.FillPolygon would have painted that...
                             g.DrawLine(SystemPens.ControlText, pt1.X, pt1.Y, pt2.X, pt2.Y);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.cs
@@ -1515,7 +1515,7 @@ internal sealed partial class PropertyGridView :
             int index = GetCurrentValueIndex(gridEntry);
 
             object[] values = gridEntry.GetPropertyValueList();
-            string letter = new(new char[] { keyChar });
+            string letter = new([keyChar]);
             for (int i = 0; i < values.Length; i++)
             {
                 object currentValue = values[(i + index + 1) % values.Length];

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStrip.cs
@@ -3860,21 +3860,21 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
                 int verticalBeamStart = start + 2;
 
                 // Draw vertical lines.
-                g.DrawLines(SystemPens.ControlText, (ReadOnlySpan<Point>)
+                g.DrawLines(SystemPens.ControlText,
                     [
                         new(verticalBeamStart, _lastInsertionMarkRect.Y), new(verticalBeamStart, _lastInsertionMarkRect.Bottom - 1),
                         new(verticalBeamStart + 1, _lastInsertionMarkRect.Y), new(verticalBeamStart + 1, _lastInsertionMarkRect.Bottom - 1)
                     ]);
 
                 // Draw top horizontal lines.
-                g.DrawLines(SystemPens.ControlText, (ReadOnlySpan<Point>)
+                g.DrawLines(SystemPens.ControlText,
                     [
                         new(start, _lastInsertionMarkRect.Bottom - 1), new(start + widthOfBeam - 1, _lastInsertionMarkRect.Bottom - 1),
                         new(start + 1, _lastInsertionMarkRect.Bottom - 2), new(start + widthOfBeam - 2, _lastInsertionMarkRect.Bottom - 2)
                     ]);
 
                 // Draw bottom horizontal lines.
-                g.DrawLines(SystemPens.ControlText, (ReadOnlySpan<Point>)
+                g.DrawLines(SystemPens.ControlText,
                      [
                          new(start, _lastInsertionMarkRect.Y), new(start + widthOfBeam - 1, _lastInsertionMarkRect.Y),
                          new(start + 1, _lastInsertionMarkRect.Y + 1), new(start + widthOfBeam - 2, _lastInsertionMarkRect.Y + 1)
@@ -3887,21 +3887,21 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
                 int horizontalBeamStart = start + 2;
 
                 // Draw horizontal lines.
-                g.DrawLines(SystemPens.ControlText, (ReadOnlySpan<Point>)
+                g.DrawLines(SystemPens.ControlText,
                     [
                         new(_lastInsertionMarkRect.X, horizontalBeamStart), new(_lastInsertionMarkRect.Right - 1, horizontalBeamStart),
                         new(_lastInsertionMarkRect.X, horizontalBeamStart + 1), new(_lastInsertionMarkRect.Right - 1, horizontalBeamStart + 1)
                     ]);
 
                 // Draw left vertical lines.
-                g.DrawLines(SystemPens.ControlText, (ReadOnlySpan<Point>)
+                g.DrawLines(SystemPens.ControlText,
                     [
                         new(_lastInsertionMarkRect.X, start), new(_lastInsertionMarkRect.X, start + widthOfBeam - 1),
                         new(_lastInsertionMarkRect.X + 1, start + 1), new(_lastInsertionMarkRect.X + 1, start + widthOfBeam - 2)
                     ]);
 
                 // Draw right vertical lines.
-                g.DrawLines(SystemPens.ControlText, (ReadOnlySpan<Point>)
+                g.DrawLines(SystemPens.ControlText,
                      [
                          new(_lastInsertionMarkRect.Right - 1, start), new(_lastInsertionMarkRect.Right - 1, start + widthOfBeam - 1),
                          new(_lastInsertionMarkRect.Right - 2, start + 1), new(_lastInsertionMarkRect.Right - 2, start + widthOfBeam - 2)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripComboBox.ToolStripComboBoxControl.ToolStripComboBoxFlatComboAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripComboBox.ToolStripComboBoxControl.ToolStripComboBoxFlatComboAdapter.cs
@@ -143,12 +143,12 @@ public partial class ToolStripComboBox
 
                 // If the width is odd - favor pushing it over one pixel right.
                 middle.X += (dropDownRect.Width % 2);
-                g.FillPolygon(brush, new Point[]
-                {
+                g.FillPolygon(brush,
+                [
                     new(middle.X - s_offsetPixels, middle.Y - 1),
                     new(middle.X + s_offsetPixels + 1, middle.Y - 1),
                     new(middle.X, middle.Y + s_offsetPixels)
-                });
+                ]);
             }
         }
     }

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/ListViewTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/ListViewTests.cs
@@ -518,9 +518,9 @@ public class ListViewTests : ControlTestBase
         ColumnHeader columnHeader2 = new() { Text = "ColumnHeader2", Width = 140 };
         ColumnHeader columnHeader3 = new() { Text = "ColumnHeader3", Width = 140 };
         listView.Columns.AddRange([columnHeader1, columnHeader2, columnHeader3]);
-        ListViewItem listViewItem1 = new(new[] { "row1", "row1Col2", "row1Col3" }, -1) { StateImageIndex = 0 };
-        ListViewItem listViewItem2 = new(new[] { "row2", "row2Col2", "row2Col3" }, -1) { StateImageIndex = 0 };
-        ListViewItem listViewItem3 = new(new[] { "row3", "row3Col2", "row3Col3" }, -1) { StateImageIndex = 0 };
+        ListViewItem listViewItem1 = new(["row1", "row1Col2", "row1Col3"], -1) { StateImageIndex = 0 };
+        ListViewItem listViewItem2 = new(["row2", "row2Col2", "row2Col3"], -1) { StateImageIndex = 0 };
+        ListViewItem listViewItem3 = new(["row3", "row3Col2", "row3Col3"], -1) { StateImageIndex = 0 };
         listView.RetrieveVirtualItem += (s, e) =>
         {
             e.Item = e.ItemIndex switch

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ListViewTest.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ListViewTest.cs
@@ -36,7 +36,7 @@ public partial class ListViewTest : Form
         AddGroupTasks();
 
         // Manual test for https://github.com/dotnet/winforms/issues/11658
-        string[] TestItems = { "Item 1", "Item 2", "Item 3" };
+        string[] TestItems = ["Item 1", "Item 2", "Item 3"];
         listView3.RetrieveVirtualItem += (s, e) =>
         {
             e.Item = e.ItemIndex switch

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/ListVIew.ListViewAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/ListVIew.ListViewAccessibleObjectTests.cs
@@ -1010,10 +1010,10 @@ public class ListView_ListViewAccessibleObjectTests
             VirtualListSize = 4
         };
 
-        ListViewItem listItem1 = new(new string[] { "Item 1", "Item A" }, -1);
+        ListViewItem listItem1 = new(["Item 1", "Item A"], -1);
         ListViewItem listItem2 = new("Group item 2");
         ListViewItem listItem3 = new("Item 3");
-        ListViewItem listItem4 = new(new string[] { "Item 4", "Item B" }, -1);
+        ListViewItem listItem4 = new(["Item 4", "Item B"], -1);
 
         listView.RetrieveVirtualItem += (s, e) =>
         {
@@ -1389,10 +1389,10 @@ public class ListView_ListViewAccessibleObjectTests
         };
 
         ListViewGroup listViewGroup = new("Test");
-        ListViewItem listItem1 = new(new string[] { "Test Item 1", "Item A" }, -1, listViewGroup);
+        ListViewItem listItem1 = new(["Test Item 1", "Item A"], -1, listViewGroup);
         ListViewItem listItem2 = new("Group item 2", listViewGroup);
         ListViewItem listItem3 = new("Item 3");
-        ListViewItem listItem4 = new(new string[] { "Test Item 4", "Item B", "Item C", "Item D" }, -1);
+        ListViewItem listItem4 = new(["Test Item 4", "Item B", "Item C", "Item D"], -1);
 
         if (!virtualMode)
         {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/ListViewItem.ListViewItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/ListViewItem.ListViewItemAccessibleObjectTests.cs
@@ -562,23 +562,23 @@ public class ListViewItem_ListViewItemAccessibleObjectTests
 
         listView.VirtualListSize = 1;
 
-        ListViewItem listItem1 = new(new string[]
-        {
+        ListViewItem listItem1 = new(
+        [
             "Test A",
             "Alpha"
-        }, -1);
+        ], -1);
 
-        ListViewItem listItem2 = new(new string[]
-        {
+        ListViewItem listItem2 = new(
+        [
             "Test B",
             "Beta"
-        }, -1);
+        ], -1);
 
-        ListViewItem listItem3 = new(new string[]
-        {
+        ListViewItem listItem3 = new(
+        [
             "Test C",
             "Gamma"
-        }, -1);
+        ], -1);
 
         listView.RetrieveVirtualItem += (s, e) =>
         {
@@ -652,7 +652,7 @@ public class ListViewItem_ListViewItemAccessibleObjectTests
             Assert.NotEqual(IntPtr.Zero, listView.Handle);
         }
 
-        ListViewItem listItem1 = new(new string[] { "Test A", "Alpha" }, -1);
+        ListViewItem listItem1 = new(["Test A", "Alpha"], -1);
         listView.Items.Add(listItem1);
         listView.Items[0].Selected = selected;
         AccessibleObject accessibleObject = listView.Items[0].AccessibilityObject;
@@ -696,7 +696,7 @@ public class ListViewItem_ListViewItemAccessibleObjectTests
             VirtualListSize = 1
         };
 
-        ListViewItem listItem1 = new(new string[] { "Test A", "Alpha" }, -1);
+        ListViewItem listItem1 = new(["Test A", "Alpha"], -1);
 
         listView.RetrieveVirtualItem += (s, e) =>
         {
@@ -1194,10 +1194,10 @@ public class ListViewItem_ListViewItemAccessibleObjectTests
             VirtualListSize = 4
         };
 
-        ListViewItem listItem1 = new(new string[] { "Test Item 1", "Item A" }, -1);
+        ListViewItem listItem1 = new(["Test Item 1", "Item A"], -1);
         ListViewItem listItem2 = new("Group item 2");
         ListViewItem listItem3 = new("Item 3");
-        ListViewItem listItem4 = new(new string[] { "Test Item 4", "Item B", "Item C", "Item D" }, -1);
+        ListViewItem listItem4 = new(["Test Item 4", "Item B", "Item C", "Item D"], -1);
 
         if (!virtualMode && groupsEnabled)
         {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/ListViewItem.ListViewItemDetailsAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/ListViewItem.ListViewItemDetailsAccessibleObjectTests.cs
@@ -163,8 +163,8 @@ public class ListViewItem_ListViewItemDetailsAccessibleObjectTests
         ColumnHeader columnHeader2 = new();
         ColumnHeader columnHeader3 = new();
 
-        ListViewItem listViewItem1 = new(new string[] { "Item1", "sub1", "sub2" }, 0);
-        ListViewItem listViewItem2 = new(new string[] { "Item2", "sub1", "sub2" }, 0);
+        ListViewItem listViewItem1 = new(["Item1", "sub1", "sub2"], 0);
+        ListViewItem listViewItem2 = new(["Item2", "sub1", "sub2"], 0);
 
         listView1.Columns.AddRange((ColumnHeader[])[columnHeader1, columnHeader2, columnHeader3]);
         listView1.Items.AddRange((ListViewItem[])[listViewItem1, listViewItem2]);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjects/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObjectTests.cs
@@ -14,12 +14,12 @@ public class ListViewItem_ListViewSubItem_ListViewSubItemAccessibleObjectTests
     public void ListViewSubItemAccessibleObject_GetChild_ReturnCorrectValue()
     {
         using ListView list = new();
-        ListViewItem listViewItem1 = new(new string[]
-        {
-        "Test 1",
-        "Item 1",
-        "Something 1"
-        }, -1);
+        ListViewItem listViewItem1 = new(
+        [
+            "Test 1",
+            "Item 1",
+            "Something 1"
+        ], -1);
 
         ColumnHeader columnHeader1 = new();
         ColumnHeader columnHeader2 = new();
@@ -51,12 +51,12 @@ public class ListViewItem_ListViewSubItem_ListViewSubItemAccessibleObjectTests
     public void ListViewSubItemAccessibleObject_GetPropertyValue_returns_correct_values(bool labelEdit, int childId)
     {
         using ListView list = new();
-        ListViewItem listViewItem1 = new(new string[]
-        {
+        ListViewItem listViewItem1 = new(
+        [
         "Test 1",
         "Test 2",
         "Something 1"
-        }, -1);
+        ], -1);
 
         ColumnHeader columnHeader1 = new();
         ColumnHeader columnHeader2 = new();
@@ -626,12 +626,12 @@ public class ListViewItem_ListViewSubItem_ListViewSubItemAccessibleObjectTests
     public void ListViewSubItemAccessibleObject_Bounds_ReturnCorrectValue()
     {
         using ListView list = new();
-        ListViewItem listViewItem1 = new(new string[]
-        {
+        ListViewItem listViewItem1 = new(
+        [
         "Test 1",
         "Item 1",
         "Something 1"
-        }, -1);
+        ], -1);
 
         ColumnHeader columnHeader1 = new();
         ColumnHeader columnHeader2 = new();
@@ -750,12 +750,12 @@ public class ListViewItem_ListViewSubItem_ListViewSubItemAccessibleObjectTests
     public void ListViewSubItemAccessibleObject_RowProperty_ReturnCorrectValue()
     {
         using ListView list = new();
-        ListViewItem listViewItem1 = new(new string[]
-        {
+        ListViewItem listViewItem1 = new(
+        [
         "Test 1",
         "Item 1",
         "Something 1"
-        }, -1);
+        ], -1);
 
         ColumnHeader columnHeader1 = new();
         ColumnHeader columnHeader2 = new();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
@@ -416,9 +416,9 @@ public class ComboBoxTests
             control.IsHandleCreated.Should().Be(isHandleCreated);
         }
 
-        AssertAutoCompleteCustomSource(new[] { "item1", "item2" }, false);
+        AssertAutoCompleteCustomSource(["item1", "item2"], false);
         AssertAutoCompleteCustomSource(null, false);
-        AssertAutoCompleteCustomSource(new[] { "item3", "item4" }, false);
+        AssertAutoCompleteCustomSource(["item3", "item4"], false);
     }
 
     [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DomainUpDownTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DomainUpDownTests.cs
@@ -679,7 +679,7 @@ public class DomainUpDownTests : IDisposable
         // Set different.
         _sub.Sorted = !value;
         _sub.Sorted.Should().Be(!value);
-        _sub.Items.Cast<string>().Should().Equal(new string[] { "a", "a", "B", "c", "d" });
+        _sub.Items.Cast<string>().Should().Equal(["a", "a", "B", "c", "d"]);
         _sub.SelectedIndex.Should().Be(-1);
         _sub.UserEdit.Should().Be(userEdit);
         _sub.IsHandleCreated.Should().BeFalse();
@@ -722,7 +722,7 @@ public class DomainUpDownTests : IDisposable
         // Set different.
         _sub.Sorted = !value;
         _sub.Sorted.Should().Be(!value);
-        _sub.Items.Cast<string>().Should().Equal(new string[] { "a", "a", "B", "c", "d" });
+        _sub.Items.Cast<string>().Should().Equal(["a", "a", "B", "c", "d"]);
         _sub.SelectedIndex.Should().Be(expectedSelectedIndex);
         _sub.UserEdit.Should().Be(userEdit);
         _sub.IsHandleCreated.Should().BeFalse();
@@ -815,7 +815,7 @@ public class DomainUpDownTests : IDisposable
         // Set different.
         _sub.Sorted = !value;
         _sub.Sorted.Should().Be(!value);
-        _sub.Items.Cast<string>().Should().Equal(new string[] { "a", "a", "B", "c", "d" });
+        _sub.Items.Cast<string>().Should().Equal(["a", "a", "B", "c", "d"]);
         _sub.SelectedIndex.Should().Be(-1);
         _sub.UserEdit.Should().Be(userEdit);
         _sub.IsHandleCreated.Should().BeTrue();
@@ -866,7 +866,7 @@ public class DomainUpDownTests : IDisposable
         // Set different.
         _sub.Sorted = !value;
         _sub.Sorted.Should().Be(!value);
-        _sub.Items.Cast<string>().Should().Equal(new string[] { "a", "a", "B", "c", "d" });
+        _sub.Items.Cast<string>().Should().Equal(["a", "a", "B", "c", "d"]);
         _sub.SelectedIndex.Should().Be(expectedSelectedIndex);
         _sub.UserEdit.Should().Be(userEdit);
         _sub.IsHandleCreated.Should().BeTrue();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItemConverterTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItemConverterTests.cs
@@ -117,109 +117,109 @@ public class ListViewItemConverterTests
         // Item.
         yield return new object[]
         {
-            new ListViewItem(new ListViewItem.ListViewSubItem[] { subItem1 }, "imageKey"),
+            new ListViewItem([subItem1], "imageKey"),
             new Type[] { typeof(string), typeof(string) },
             new object[] { "text1", "imageKey" }
         };
         yield return new object[]
         {
-            new ListViewItem(new ListViewItem.ListViewSubItem[] { subItem1 }, 1),
+            new ListViewItem([subItem1], 1),
             new Type[] { typeof(string), typeof(int) },
             new object[] { "text1", 1 }
         };
         yield return new object[]
         {
-            new ListViewItem(new ListViewItem.ListViewSubItem[] { subItem1 }, "imageKey", group),
+            new ListViewItem([subItem1], "imageKey", group),
             new Type[] { typeof(string), typeof(string) },
             new object[] { "text1", "imageKey" }
         };
         yield return new object[]
         {
-            new ListViewItem(new ListViewItem.ListViewSubItem[] { subItem1 }, 1, group),
+            new ListViewItem([subItem1], 1, group),
             new Type[] { typeof(string), typeof(int) },
             new object[] { "text1", 1 }
         };
         yield return new object[]
         {
-            new ListViewItem(new ListViewItem.ListViewSubItem[] { subItem1, subItem2 }, "imageKey"),
+            new ListViewItem([subItem1, subItem2], "imageKey"),
             new Type[] { typeof(string[]), typeof(string) },
             new object[] { new string[] { "text1", "text2" }, "imageKey" }
         };
         yield return new object[]
         {
-            new ListViewItem(new ListViewItem.ListViewSubItem[] { subItem1, subItem2 }, 1),
+            new ListViewItem([subItem1, subItem2], 1),
             new Type[] { typeof(string[]), typeof(int) },
             new object[] { new string[] { "text1", "text2" }, 1 }
         };
         yield return new object[]
         {
-            new ListViewItem(new ListViewItem.ListViewSubItem[] { subItem1, subItem2 }, "imageKey", group),
+            new ListViewItem([subItem1, subItem2], "imageKey", group),
             new Type[] { typeof(string[]), typeof(string) },
             new object[] { new string[] { "text1", "text2" }, "imageKey" }
         };
         yield return new object[]
         {
-            new ListViewItem(new ListViewItem.ListViewSubItem[] { subItem1, subItem2 }, 1, group),
+            new ListViewItem([subItem1, subItem2], 1, group),
             new Type[] { typeof(string[]), typeof(int) },
             new object[] { new string[] { "text1", "text2" }, 1 }
         };
         yield return new object[]
         {
-            new ListViewItem(new ListViewItem.ListViewSubItem[] { subItem1, subItem2, subItem3, subItem4, subItem5 }, "imageKey"),
+            new ListViewItem([subItem1, subItem2, subItem3, subItem4, subItem5], "imageKey"),
             new Type[] { typeof(ListViewItem.ListViewSubItem[]), typeof(string) },
             new object[] { new ListViewItem.ListViewSubItem[] { subItem1, subItem2, subItem3, subItem4, subItem5 }, "imageKey" }
         };
         yield return new object[]
         {
-            new ListViewItem(new ListViewItem.ListViewSubItem[] { subItem1, subItem2, subItem3, subItem4, subItem5 }, 1),
+            new ListViewItem([subItem1, subItem2, subItem3, subItem4, subItem5], 1),
             new Type[] { typeof(ListViewItem.ListViewSubItem[]), typeof(int) },
             new object[] { new ListViewItem.ListViewSubItem[] { subItem1, subItem2, subItem3, subItem4, subItem5 }, 1 }
         };
         yield return new object[]
         {
-            new ListViewItem(new ListViewItem.ListViewSubItem[] { subItem1, subItem2, subItem3, subItem4, subItem5 }, "imageKey", group),
+            new ListViewItem([subItem1, subItem2, subItem3, subItem4, subItem5], "imageKey", group),
             new Type[] { typeof(ListViewItem.ListViewSubItem[]), typeof(string) },
             new object[] { new ListViewItem.ListViewSubItem[] { subItem1, subItem2, subItem3, subItem4, subItem5 }, "imageKey" }
         };
         yield return new object[]
         {
-            new ListViewItem(new ListViewItem.ListViewSubItem[] { subItem1, subItem2, subItem3, subItem4, subItem5 }, 1, group),
+            new ListViewItem([subItem1, subItem2, subItem3, subItem4, subItem5], 1, group),
             new Type[] { typeof(ListViewItem.ListViewSubItem[]), typeof(int) },
             new object[] { new ListViewItem.ListViewSubItem[] { subItem1, subItem2, subItem3, subItem4, subItem5 }, 1 }
         };
         yield return new object[]
         {
-            new ListViewItem(new ListViewItem.ListViewSubItem[] { subItem3 }, 1),
+            new ListViewItem([subItem3], 1),
             new Type[] { typeof(string[]), typeof(int), typeof(Color), typeof(Color), typeof(Font) },
             new object[] { new string[] { "text3" }, 1, Color.Blue, Color.Empty, null }
         };
         yield return new object[]
         {
-            new ListViewItem(new ListViewItem.ListViewSubItem[] { subItem4 }, 1),
+            new ListViewItem([subItem4], 1),
             new Type[] { typeof(string[]), typeof(int), typeof(Color), typeof(Color), typeof(Font) },
             new object[] { new string[] { "text4" }, 1, Color.Empty, Color.Blue, null }
         };
         yield return new object[]
         {
-            new ListViewItem(new ListViewItem.ListViewSubItem[] { subItem5 }, 1),
+            new ListViewItem([subItem5], 1),
             new Type[] { typeof(string[]), typeof(int), typeof(Color), typeof(Color), typeof(Font) },
             new object[] { new string[] { "text5" }, 1, Color.Empty, Color.Empty, SystemFonts.MenuFont }
         };
         yield return new object[]
         {
-            new ListViewItem(new ListViewItem.ListViewSubItem[] { subItem3 }, "imageKey"),
+            new ListViewItem([subItem3], "imageKey"),
             new Type[] { typeof(string[]), typeof(string), typeof(Color), typeof(Color), typeof(Font) },
             new object[] { new string[] { "text3" }, "imageKey", Color.Blue, Color.Empty, null }
         };
         yield return new object[]
         {
-            new ListViewItem(new ListViewItem.ListViewSubItem[] { subItem4 }, "imageKey"),
+            new ListViewItem([subItem4], "imageKey"),
             new Type[] { typeof(string[]), typeof(string), typeof(Color), typeof(Color), typeof(Font) },
             new object[] { new string[] { "text4" }, "imageKey", Color.Empty, Color.Blue, null }
         };
         yield return new object[]
         {
-            new ListViewItem(new ListViewItem.ListViewSubItem[] { subItem5 }, "imageKey"),
+            new ListViewItem([subItem5], "imageKey"),
             new Type[] { typeof(string[]), typeof(string), typeof(Color), typeof(Color), typeof(Font) },
             new object[] { new string[] { "text5" }, "imageKey", Color.Empty, Color.Empty, SystemFonts.MenuFont }
         };

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewSubItemCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewSubItemCollectionTests.cs
@@ -916,7 +916,7 @@ public class ListViewSubItemCollectionTests
         Assert.Null(subItem1._owner);
         Assert.Null(subItem2._owner);
 
-        listViewItem.SubItems.AddRange(new ListViewItem.ListViewSubItem[] { subItem1, subItem2 });
+        listViewItem.SubItems.AddRange([subItem1, subItem2]);
 
         Assert.Same(listViewItem, subItem1._owner);
         Assert.Same(listViewItem, subItem2._owner);
@@ -927,7 +927,7 @@ public class ListViewSubItemCollectionTests
     {
         ListViewItem listViewItem = new();
 
-        listViewItem.SubItems.AddRange(new string[] { "Test 1", "Test 2" });
+        listViewItem.SubItems.AddRange(["Test 1", "Test 2"]);
 
         Assert.Same(listViewItem, listViewItem.SubItems[1]._owner);
         Assert.Same(listViewItem, listViewItem.SubItems[2]._owner);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripComboBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripComboBoxTests.cs
@@ -182,7 +182,7 @@ public class ToolStripComboBoxTests : IDisposable
     [WinFormsFact]
     public void ToolStripComboBox_Items_AddAndGet()
     {
-        string[] items = { "Item1", "Item2" };
+        string[] items = ["Item1", "Item2"];
         _toolStripComboBox.Items.AddRange(items);
         _toolStripComboBox.Items.Cast<string>().Should().Contain(items);
     }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripMenuItemTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripMenuItemTests.cs
@@ -241,7 +241,7 @@ public class ToolStripMenuItemTests
     {
         using Bitmap image = new(10, 10);
         string text = "Test Item";
-        ToolStripItem[] dropDownItems = { new ToolStripMenuItem("SubItem1"), new ToolStripMenuItem("SubItem2") };
+        ToolStripItem[] dropDownItems = [new ToolStripMenuItem("SubItem1"), new ToolStripMenuItem("SubItem2")];
 
         using ToolStripMenuItem item = new(text, image, dropDownItems);
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripPanel.ToolStripPanelRowCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripPanel.ToolStripPanelRowCollectionTests.cs
@@ -44,7 +44,7 @@ public class ToolStripPanel_ToolStripPanelRowCollectionTests : IDisposable
     public void ToolStripPanelRowCollection_ConstructorWithOwnerAndRows_SetsOwnerAndAddsRows()
     {
         using ToolStripPanelRow toolStripPanelRow1 = new(_toolStripPanel);
-        ToolStripPanelRow[] toolStripPanelRowArray = { toolStripPanelRow1 };
+        ToolStripPanelRow[] toolStripPanelRowArray = [toolStripPanelRow1];
         ToolStripPanelRowCollection toolStripPanelRowCollection = new(_toolStripPanel, toolStripPanelRowArray);
         ToolStripPanel toolStripPanel = toolStripPanelRowCollection.TestAccessor().Dynamic._owner;
 
@@ -73,7 +73,7 @@ public class ToolStripPanel_ToolStripPanelRowCollectionTests : IDisposable
     public void ToolStripPanelRowCollection_Add_AddsRow()
     {
         ToolStripPanelRow row = AddRowToCollection(collection: _toolStripPanelRowCollection, panel: _toolStripPanel);
-        ToolStripPanelRow[] rows = { row };
+        ToolStripPanelRow[] rows = [row];
 
         try
         {
@@ -163,7 +163,7 @@ public class ToolStripPanel_ToolStripPanelRowCollectionTests : IDisposable
     public void ToolStripPanelRowCollection_Remove_RemovesRow()
     {
         var row = AddRowToCollection(collection: _toolStripPanelRowCollection, panel: _toolStripPanel);
-        ToolStripPanelRow[] rows = { row };
+        ToolStripPanelRow[] rows = [row];
 
         try
         {
@@ -182,7 +182,7 @@ public class ToolStripPanel_ToolStripPanelRowCollectionTests : IDisposable
     {
         var row1 = AddRowToCollection(collection: _toolStripPanelRowCollection, panel: _toolStripPanel);
         ToolStripPanelRow row2 = new(_toolStripPanel);
-        ToolStripPanelRow[] rows = { row1, row2 };
+        ToolStripPanelRow[] rows = [row1, row2];
 
         try
         {
@@ -202,7 +202,7 @@ public class ToolStripPanel_ToolStripPanelRowCollectionTests : IDisposable
     {
         var row1 = AddRowToCollection(collection: _toolStripPanelRowCollection, panel: _toolStripPanel);
         var row2 = AddRowToCollection(collection: _toolStripPanelRowCollection, panel: _toolStripPanel);
-        ToolStripPanelRow[] rows = { row1, row2 };
+        ToolStripPanelRow[] rows = [row1, row2];
 
         try
         {
@@ -221,7 +221,7 @@ public class ToolStripPanel_ToolStripPanelRowCollectionTests : IDisposable
     public void ToolStripPanelRowCollection_RemoveAt_IndexOutOfRange_ThrowsArgumentOutOfRangeException()
     {
         var row = AddRowToCollection(collection: _toolStripPanelRowCollection, panel: _toolStripPanel);
-        ToolStripPanelRow[] rows = { row };
+        ToolStripPanelRow[] rows = [row];
 
         try
         {
@@ -277,7 +277,7 @@ public class ToolStripPanel_ToolStripPanelRowCollectionTests : IDisposable
     public void ToolStripPanelRowCollection_CopyTo_IndexOutOfRange_ThrowsArgumentException()
     {
         var row = AddRowToCollection(collection: _toolStripPanelRowCollection, panel: _toolStripPanel);
-        ToolStripPanelRow[] rows = { row };
+        ToolStripPanelRow[] rows = [row];
         var array = new ToolStripPanelRow[1];
 
         try

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
@@ -7534,7 +7534,7 @@ public class TreeViewTests
     [WinFormsFact]
     public void ArraySubsetEnumerator_Behavior_AfterMoveNextAndReset()
     {
-        object[] array = { "a", "b", "c" };
+        object[] array = ["a", "b", "c"];
         ArraySubsetEnumerator enumerator = new(array, 2);
 
         enumerator.MoveNext().Should().BeTrue();


### PR DESCRIPTION
Moved to SDK RC2 to get the same build errors in the VS and CLI build and be able to fix them.

Before this change the IntPreview version of VS was correctly complaining about a redundant cast(IDE0004) in ToolStrip.cs
    g.DrawLines(SystemPens.ControlText, (ReadOnlySpan<Point>)
        [
            new(verticalBeamStart, _lastInsertionMarkRect.Y), new(verticalBeamStart, _lastInsertionMarkRect.Bottom - 1),
            new(verticalBeamStart + 1, _lastInsertionMarkRect.Y), new(verticalBeamStart + 1, _lastInsertionMarkRect.Bottom - 1)
        ]);

But the CLI build required this cast.

After the upgrade to RC2, IDE0300 - Collection initialization can be simplified - became more robust and required code fixes that use collection expressions applied to the solution.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12254)