### PR TITLE
Switch default feed to full wildcard

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -40,44 +40,12 @@
     <packageSource key="dotnet10-transport">
       <package pattern="microsoft.*" />
     </packageSource>
-    <packageSource key="dotnet-public">
-      <package pattern="Argon" />
-      <package pattern="Castle.Core" />
-      <package pattern="Codecov" />
-      <package pattern="coverlet.msbuild" />
-      <package pattern="CSharpIsNullAnalyzer" />
-      <package pattern="DiffEngine" />
-      <package pattern="DiffPlex" />
-      <package pattern="DotNetAnalyzers.DocumentationAnalyzers" />
-      <package pattern="DotNetAnalyzers.DocumentationAnalyzers.Unstable" />
-      <package pattern="EmptyFiles" />
-      <package pattern="FluentAssertions" />
-      <package pattern="Humanizer.Core" />
-      <package pattern="microsoft.*" />
-      <package pattern="MicroBuild.Core" />
-      <package pattern="Moq" />
-      <package pattern="NETStandard.Library" />
-      <package pattern="Newtonsoft.Json" />
-      <package pattern="NuGet.Common" />
-      <package pattern="NuGet.Configuration" />
-      <package pattern="NuGet.Frameworks" />
-      <package pattern="NuGet.Packaging" />
-      <package pattern="NuGet.Protocol" />
-      <package pattern="NuGet.Resolver" />
-      <package pattern="NuGet.Versioning" />
-      <package pattern="ReportGenerator" />
-      <package pattern="runtime.*" />
-      <package pattern="SimpleInfoName" />
-      <package pattern="StyleCop.Analyzers" />
-      <package pattern="StyleCop.Analyzers.Unstable" />
-      <package pattern="system.*" />
-      <package pattern="Verify" />
-      <package pattern="Verify.Xunit" />
-      <package pattern="vswhere" />
-      <package pattern="xunit.*" />
-    </packageSource>
     <packageSource key="winsdk">
       <package pattern="microsoft.*" />
+    </packageSource>
+    <!-- This is the default feed -->
+    <packageSource key="dotnet-public">
+      <package pattern="*" />
     </packageSource>
   </packageSourceMapping>
   <disabledPackageSources>


### PR DESCRIPTION
We can apparently use the `*` wildcard for our default feed. I moved that feed to be last for clarity.