### PR TITLE
Add test for SplitterPanelDesigner.cs

### DIFF
--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/SplitterPanelDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/SplitterPanelDesignerTests.cs
@@ -60,5 +60,4 @@ public sealed class SplitterPanelDesignerTests
         SelectionRules selectionRules = splitterPanelDesigner.SelectionRules;
         selectionRules.Should().Be(SelectionRules.None);
     }
-
 }

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/SplitterPanelDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/SplitterPanelDesignerTests.cs
@@ -14,11 +14,11 @@ public sealed class SplitterPanelDesignerTests
     [Fact]
     public void Initialize_CanBeParentedTo_ReturnsExpectedResults()
     {
-        ToolStripContainerDesigner toolStripContainerDesigner = new();
-        SplitContainerDesigner splitContainerDesigner = new();
-        SplitContainer splitContainer = new();
-        SplitterPanel splitterPanel = new(splitContainer);
-        SplitterPanelDesigner splitterPanelDesigner = new();
+        using ToolStripContainerDesigner toolStripContainerDesigner = new();
+        using SplitContainerDesigner splitContainerDesigner = new();
+        using SplitContainer splitContainer = new();
+        using SplitterPanel splitterPanel = new(splitContainer);
+        using SplitterPanelDesigner splitterPanelDesigner = new();
 
         Mock<IDesignerHost> mockDesignerHost = new();
         mockDesignerHost.Setup(dh => dh.GetDesigner(splitterPanel.Parent!)).Returns(splitContainerDesigner);
@@ -28,6 +28,14 @@ public sealed class SplitterPanelDesignerTests
 
         Mock<IComponentChangeService> mockChangeService = new();
         mockSite.Setup(s => s.GetService(typeof(IComponentChangeService))).Returns(mockChangeService.Object);
+        mockDesignerHost.Setup(dh => dh.GetService(typeof(IComponentChangeService))).Returns(mockChangeService.Object);
+
+        using ToolStripContainer toolStripContainer = new();
+        toolStripContainer.Site = mockSite.Object;
+        toolStripContainerDesigner.Initialize(toolStripContainer);
+
+        splitContainer.Site = mockSite.Object;
+        splitContainerDesigner.Initialize(splitContainer);
 
         splitterPanel.Site = mockSite.Object;
 
@@ -52,4 +60,5 @@ public sealed class SplitterPanelDesignerTests
         SelectionRules selectionRules = splitterPanelDesigner.SelectionRules;
         selectionRules.Should().Be(SelectionRules.None);
     }
+
 }

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/SplitterPanelDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/SplitterPanelDesignerTests.cs
@@ -1,0 +1,52 @@
+﻿#nullable enable
+
+using Moq;
+using System.Collections;
+using System.ComponentModel;
+using System.ComponentModel.Design;
+
+namespace System.Windows.Forms.Design.Tests;
+public sealed class SplitterPanelDesignerTests
+{
+    [Fact]
+    public void Initialize_CanBeParentedTo_ReturnsExpectedResults()
+    {
+        ToolStripContainerDesigner toolStripContainerDesigner = new();
+        SplitContainerDesigner splitContainerDesigner = new();
+        SplitContainer splitContainer = new();
+        SplitterPanel splitterPanel = new(splitContainer);
+        SplitterPanelDesigner splitterPanelDesigner = new();
+
+        Mock<IDesignerHost> mockDesignerHost = new();
+        mockDesignerHost.Setup(dh => dh.GetDesigner(splitterPanel.Parent!)).Returns(splitContainerDesigner);
+
+        Mock<ISite> mockSite = new();
+        mockSite.Setup(s => s.GetService(typeof(IDesignerHost))).Returns(mockDesignerHost.Object);
+
+        Mock<IComponentChangeService> mockChangeService = new();
+        mockSite.Setup(s => s.GetService(typeof(IComponentChangeService))).Returns(mockChangeService.Object);
+
+        splitterPanel.Site = mockSite.Object;
+
+        mockChangeService.VerifyAdd(cs => cs.ComponentChanged += It.IsAny<ComponentChangedEventHandler>(), Times.Never());
+
+        splitterPanelDesigner.Initialize(splitterPanel);
+
+        mockChangeService.VerifyAdd(cs => cs.ComponentChanged += It.IsAny<ComponentChangedEventHandler>(), Times.Once());
+
+        splitterPanelDesigner.CanBeParentedTo(splitContainerDesigner).Should().Be(true);
+        splitterPanelDesigner.CanBeParentedTo(toolStripContainerDesigner).Should().Be(false);
+
+        ((SplitterPanel)splitterPanelDesigner.TestAccessor().Dynamic._splitterPanel).Should().Be(splitterPanel);
+        ((IDesignerHost)splitterPanelDesigner.TestAccessor().Dynamic._designerHost).Should().Be(mockDesignerHost.Object);
+        ((SplitContainerDesigner)splitterPanelDesigner.TestAccessor().Dynamic._splitContainerDesigner).Should().Be(splitContainerDesigner);
+
+        IList snapLines = splitterPanelDesigner.SnapLines;
+        snapLines.Should().NotBeNull();
+        snapLines.Should().BeOfType<ArrayList>();
+        snapLines.Count.Should().BeGreaterThan(0);
+
+        SelectionRules selectionRules = splitterPanelDesigner.SelectionRules;
+        selectionRules.Should().Be(SelectionRules.None);
+    }
+}

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/SplitterPanelDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/SplitterPanelDesignerTests.cs
@@ -1,4 +1,7 @@
-﻿#nullable enable
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
 
 using Moq;
 using System.Collections;


### PR DESCRIPTION
Related https://github.com/dotnet/winforms/issues/10773
## Proposed changes
1. Add unit test SplitterPanelDesignerTests.cs for public properties and method of the SplitterPanelDesigner.
2. Enable nullability in SplitterPanelDesignerTests.cs.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12269)