### PR TITLE
Ensure proper ref count of underlying ocx

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ActiveX/AxHost.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ActiveX/AxHost.cs
@@ -2278,13 +2278,13 @@ public abstract unsafe partial class AxHost : Control, ISupportInitialize, ICust
 
     private void CreateWithoutLicense(Guid clsid)
     {
-        IUnknown* unknown;
+        using ComScope<IUnknown> unknown = new(null);
         HRESULT hr = PInvokeCore.CoCreateInstance(
             &clsid,
             (IUnknown*)null,
             CLSCTX.CLSCTX_INPROC_SERVER,
             IID.Get<IUnknown>(),
-            (void**)&unknown);
+            unknown);
         hr.ThrowOnFailure();
 
         _instance = ComHelpers.GetObjectForIUnknown(unknown);
@@ -2305,8 +2305,8 @@ public abstract unsafe partial class AxHost : Control, ISupportInitialize, ICust
 
             if (hr.Succeeded)
             {
-                IUnknown* unknown;
-                hr = factory.Value->CreateInstanceLic(null, null, IID.Get<IUnknown>(), new BSTR(license), (void**)&unknown);
+                using ComScope<IUnknown> unknown = new(null);
+                hr = factory.Value->CreateInstanceLic(null, null, IID.Get<IUnknown>(), new BSTR(license), unknown);
                 hr.ThrowOnFailure();
 
                 _instance = ComHelpers.GetObjectForIUnknown(unknown);
@@ -3056,14 +3056,14 @@ public abstract unsafe partial class AxHost : Control, ISupportInitialize, ICust
             transaction = host?.CreateTransaction(SR.AXEditProperties);
 
             HWND handle = ContainingControl is null ? HWND.Null : ContainingControl.HWND;
-            IUnknown* unknown = ComHelpers.GetComPointer<IUnknown>(_instance);
+            using var unknown = ComHelpers.GetComScope<IUnknown>(_instance);
             PInvoke.OleCreatePropertyFrame(
                 handle,
                 0,
                 0,
                 (PCWSTR)null,
                 1,
-                &unknown,
+                unknown,
                 uuids.cElems,
                 uuids.pElems,
                 PInvokeCore.GetThreadLocale(),

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AxHostTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AxHostTests.cs
@@ -3073,6 +3073,18 @@ public class AxHostTests
         Assert.Equal(0, createdCallCount);
     }
 
+    [WinFormsFact]
+    public unsafe void AxHost_Ocx_Dispose_Success()
+    {
+        SubAxHost control = new(WebBrowserClsidString);
+        control.CreateControl();
+        using var ocx = ComHelpers.GetComScope<IUnknown>(control.GetOcx());
+
+        control.Dispose();
+        ocx.Value->AddRef();
+        (ocx.Value->Release() - 1).Should().Be(0);
+    }
+
     private class SubComponentEditor : ComponentEditor
     {
         public override bool EditComponent(ITypeDescriptorContext context, object component)


### PR DESCRIPTION
Fixes https://github.com/dotnet/winforms/issues/12056

We had missed a release in `CreateWithoutLicense`, causing the underlying ocx to linger after `AxHost` control disposal. Made the same adjustment for `CreateWithLicense`. While investigating also noticed a missing release for `ShowPropertyPages` so fixed this as well. Regression test has been added for this issue scenario.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12281)