### PR TITLE
[release/8.0] Ensure proper ref count of underlying ocx

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.cs
@@ -2326,13 +2326,13 @@ public abstract unsafe partial class AxHost : Control, ISupportInitialize, ICust
     private void CreateWithoutLicense(Guid clsid)
     {
         s_axHTraceSwitch.TraceVerbose($"Creating object without license: {clsid}");
-        IUnknown* unknown;
+        using ComScope<IUnknown> unknown = new(null);
         HRESULT hr = PInvoke.CoCreateInstance(
             &clsid,
             (IUnknown*)null,
             CLSCTX.CLSCTX_INPROC_SERVER,
             IID.Get<IUnknown>(),
-            (void**)&unknown);
+            unknown);
         hr.ThrowOnFailure();
 
         _instance = Marshal.GetObjectForIUnknown((nint)unknown);
@@ -2356,8 +2356,8 @@ public abstract unsafe partial class AxHost : Control, ISupportInitialize, ICust
 
             if (hr.Succeeded)
             {
-                IUnknown* unknown;
-                hr = factory.Value->CreateInstanceLic(null, null, IID.Get<IUnknown>(), new BSTR(license), (void**)&unknown);
+                using ComScope<IUnknown> unknown = new(null);
+                hr = factory.Value->CreateInstanceLic(null, null, IID.Get<IUnknown>(), new BSTR(license), unknown);
                 hr.ThrowOnFailure();
 
                 _instance = Marshal.GetObjectForIUnknown((nint)unknown);
@@ -3176,14 +3176,14 @@ public abstract unsafe partial class AxHost : Control, ISupportInitialize, ICust
             transaction = host?.CreateTransaction(SR.AXEditProperties);
 
             HWND handle = ContainingControl is null ? HWND.Null : ContainingControl.HWND;
-            IUnknown* unknown = ComHelpers.GetComPointer<IUnknown>(_instance);
+            using var unknown = ComHelpers.GetComScope<IUnknown>(_instance);
             hr = PInvoke.OleCreatePropertyFrame(
                 handle,
                 0,
                 0,
                 (PCWSTR)null,
                 1,
-                &unknown,
+                unknown,
                 uuids.cElems,
                 uuids.pElems,
                 PInvoke.GetThreadLocale(),

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AxHostTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AxHostTests.cs
@@ -3073,6 +3073,18 @@ public class AxHostTests
         Assert.Equal(0, createdCallCount);
     }
 
+    [WinFormsFact]
+    public unsafe void AxHost_Ocx_Dispose_Success()
+    {
+        SubAxHost control = new(WebBrowserClsidString);
+        control.CreateControl();
+        using var ocx = ComHelpers.GetComScope<IUnknown>(control.GetOcx());
+
+        control.Dispose();
+        ocx.Value->AddRef();
+        Assert.Equal((uint)0, ocx.Value->Release() - 1);
+    }
+
     private class SubComponentEditor : ComponentEditor
     {
         public override bool EditComponent(ITypeDescriptorContext context, object component)


### PR DESCRIPTION
Backport of #12281 to release/8.0

## Customer Impact
Upon doing improvements to our interop code, we had missed releasing a pointer to the underlying ocx of the AxHost control, which was causing the underlying ocx to linger even after customer AxHost control is disposed. This causes the destructor of the underlying ocx to not get called because it still has a ref count of 1, causing issues with resource management in their application.

## Testing
Tested manually with customer repro scenario and added regression test for the scenario.

## Risk
Low. Change involves releasing the pointer we missed, correcting the ref count.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12289)