### PR TITLE
Update CSWin32 to v0.3.106

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -413,8 +413,10 @@ dotnet_diagnostic.IDE0002.severity = error
 # IDE0003: Remove qualification
 dotnet_diagnostic.IDE0003.severity = error
 
+# We cannot do this currently as overload resolution is not fully up to date with params span.
+# Should be able to change back to a warning once VS releases with .NET 9.
 # IDE0004: Remove unnecessary cast
-dotnet_diagnostic.IDE0004.severity = warning
+dotnet_diagnostic.IDE0004.severity = silent
 
 # IDE0017: Simplify object initialization
 dotnet_diagnostic.IDE0017.severity = warning

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,7 +48,7 @@
       Microsoft.NET.Sdk.IL.targets requires definition of MicrosoftNETCoreILAsmVersion
     -->
     <MicrosoftNETCoreILAsmVersion>$(MicrosoftNETCoreILAsmPackageVersion)</MicrosoftNETCoreILAsmVersion>
-    <MicrosoftWindowsCsWin32PackageVersion>0.3.75-beta</MicrosoftWindowsCsWin32PackageVersion>
+    <MicrosoftWindowsCsWin32PackageVersion>0.3.106</MicrosoftWindowsCsWin32PackageVersion>
   </PropertyGroup>
   <!-- Docs / Intellisense -->
   <PropertyGroup>

--- a/src/System.Private.Windows.Core/src/Windows/Win32/Graphics/GdiPlus/EncoderParameters.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/Graphics/GdiPlus/EncoderParameters.cs
@@ -1,12 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Runtime.InteropServices;
-
 namespace Windows.Win32.Graphics.GdiPlus;
 
 internal partial struct EncoderParameters
 {
     [UnscopedRef]
-    internal unsafe Span<EncoderParameter> Parameters => MemoryMarshal.CreateSpan(ref Parameter._0, (int)Count);
+    internal unsafe Span<EncoderParameter> Parameters => Parameter.AsSpan((int)Count);
 }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.ImmGetContext.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.ImmGetContext.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Windows.Win32.Globalization;
+using Windows.Win32.UI.Input.Ime;
 
 namespace Windows.Win32;
 

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.ImmReleaseContext.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.ImmReleaseContext.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Windows.Win32.Globalization;
+using Windows.Win32.UI.Input.Ime;
 
 namespace Windows.Win32;
 

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/EmfRecord.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/EmfRecord.cs
@@ -29,7 +29,7 @@ internal readonly unsafe struct EmfRecord
     }
 
     public ENHANCED_METAFILE_RECORD_TYPE Type => _lpmr->iType;
-    public ReadOnlySpan<uint> Params => _lpmr->dParm.AsReadOnlySpan();
+    public ReadOnlySpan<uint> Params => _lpmr->dParm.AsSpan((int)(_lpmr->nSize / sizeof(uint)) - 2);
     public ReadOnlySpan<HGDIOBJ> Handles => new(_lpht, _nHandles);
 
     public ENHMETAHEADER* HeaderRecord => Type == ENHANCED_METAFILE_RECORD_TYPE.EMR_HEADER ? (ENHMETAHEADER*)_lpmr : null;

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/Interop/Oleaut32/SAFEARRAYTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/Interop/Oleaut32/SAFEARRAYTests.cs
@@ -66,8 +66,8 @@ public unsafe class SAFEARRAYTests
             Assert.Equal(expectedCbElements, psa->cbElements);
             Assert.Equal(0u, psa->cLocks);
             Assert.True(psa->pvData != null);
-            Assert.Equal(10u, psa->rgsabound._0.cElements);
-            Assert.Equal(1, psa->rgsabound._0.lLbound);
+            Assert.Equal(10u, psa->rgsabound.AsSpan(1)[0].cElements);
+            Assert.Equal(1, psa->rgsabound.AsSpan(1)[0].lLbound);
 
             VARENUM arrayVt = VT_EMPTY;
             HRESULT hr = PInvokeCore.SafeArrayGetVartype(psa, &arrayVt);
@@ -102,8 +102,8 @@ public unsafe class SAFEARRAYTests
             Assert.Equal((uint)sizeof(int), psa->cbElements);
             Assert.Equal(0u, psa->cLocks);
             Assert.True(psa->pvData != null);
-            Assert.Equal(10u, psa->rgsabound._0.cElements);
-            Assert.Equal(1, psa->rgsabound._0.lLbound);
+            Assert.Equal(10u, psa->rgsabound.AsSpan(1)[0].cElements);
+            Assert.Equal(1, psa->rgsabound.AsSpan(1)[0].lLbound);
 
             VARENUM arrayVt = VT_EMPTY;
             HRESULT hr = PInvokeCore.SafeArrayGetVartype(psa, &arrayVt);
@@ -190,8 +190,8 @@ public unsafe class SAFEARRAYTests
             Assert.Equal(expectedCbElements, psa->cbElements);
             Assert.Equal(0u, psa->cLocks);
             Assert.True(psa->pvData != null);
-            Assert.Equal(20u, psa->rgsabound._0.cElements);
-            Assert.Equal(0, psa->rgsabound._0.lLbound);
+            Assert.Equal(20u, psa->rgsabound.AsSpan(1)[0].cElements);
+            Assert.Equal(0, psa->rgsabound.AsSpan(1)[0].lLbound);
             Assert.Equal(10u, ((SAFEARRAYBOUND*)&psa->rgsabound)[1].cElements);
             Assert.Equal(1, ((SAFEARRAYBOUND*)&psa->rgsabound)[1].lLbound);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.Ime.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.Ime.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel;
-using Windows.Win32.Globalization;
 using Windows.Win32.UI.Input.Ime;
 
 namespace System.Windows.Forms;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.FlatComboAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.FlatComboAdapter.cs
@@ -178,6 +178,7 @@ public partial class ComboBox
 
             g.FillPolygon(
                 brush,
+                (ReadOnlySpan<Point>)
                 [
                     new(middle.X - s_offsetPixels, middle.Y - 1),
                     new(middle.X + s_offsetPixels + 1, middle.Y - 1),

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewComboBoxCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewComboBoxCell.cs
@@ -2162,12 +2162,14 @@ public partial class DataGridViewComboBoxCell : DataGridViewCell
                             // if the height is odd - favor pushing it over one pixel down.
                             middle.Y += (dropRect.Height % 2);
 
-                            g.FillPolygon(SystemBrushes.ControlText,
-                            [
-                                new(middle.X - s_offset2X, middle.Y - 1),
-                                new(middle.X + s_offset2X + 1, middle.Y - 1),
-                                new(middle.X, middle.Y + s_offset2Y)
-                            ]);
+                            g.FillPolygon(
+                                SystemBrushes.ControlText,
+                                (ReadOnlySpan<Point>)
+                                [
+                                    new(middle.X - s_offset2X, middle.Y - 1),
+                                    new(middle.X + s_offset2X + 1, middle.Y - 1),
+                                    new(middle.X, middle.Y + s_offset2Y)
+                                ]);
                         }
                         else if (!paintXPThemes)
                         {
@@ -2185,7 +2187,7 @@ public partial class DataGridViewComboBoxCell : DataGridViewCell
                             middle.Y += (dropRect.Height % 2);
                             Point pt1 = new(middle.X - (s_nonXPTriangleWidth - 1) / 2, middle.Y - s_nonXPTriangleHeight);
                             Point pt2 = new(middle.X + (s_nonXPTriangleWidth - 1) / 2, middle.Y - s_nonXPTriangleHeight);
-                            g.FillPolygon(SystemBrushes.ControlText, [pt1, pt2, middle]);
+                            g.FillPolygon(SystemBrushes.ControlText, (ReadOnlySpan<Point>)[pt1, pt2, middle]);
                             // quirk in GDI+ : if we don't draw the line below then the top right most pixel of the DropDown triangle will not paint
                             // Would think that g.FillPolygon would have painted that...
                             g.DrawLine(SystemPens.ControlText, pt1.X, pt1.Y, pt2.X, pt2.Y);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TextBox/MaskedTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TextBox/MaskedTextBox.cs
@@ -7,7 +7,6 @@ using System.Drawing;
 using System.Drawing.Design;
 using System.Globalization;
 using System.Windows.Forms.VisualStyles;
-using Windows.Win32.Globalization;
 using Windows.Win32.UI.Accessibility;
 using Windows.Win32.UI.Input.Ime;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStrip.cs
@@ -3860,21 +3860,21 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
                 int verticalBeamStart = start + 2;
 
                 // Draw vertical lines.
-                g.DrawLines(SystemPens.ControlText,
+                g.DrawLines(SystemPens.ControlText, (ReadOnlySpan<Point>)
                     [
                         new(verticalBeamStart, _lastInsertionMarkRect.Y), new(verticalBeamStart, _lastInsertionMarkRect.Bottom - 1),
                         new(verticalBeamStart + 1, _lastInsertionMarkRect.Y), new(verticalBeamStart + 1, _lastInsertionMarkRect.Bottom - 1)
                     ]);
 
                 // Draw top horizontal lines.
-                g.DrawLines(SystemPens.ControlText,
+                g.DrawLines(SystemPens.ControlText, (ReadOnlySpan<Point>)
                     [
                         new(start, _lastInsertionMarkRect.Bottom - 1), new(start + widthOfBeam - 1, _lastInsertionMarkRect.Bottom - 1),
                         new(start + 1, _lastInsertionMarkRect.Bottom - 2), new(start + widthOfBeam - 2, _lastInsertionMarkRect.Bottom - 2)
                     ]);
 
                 // Draw bottom horizontal lines.
-                g.DrawLines(SystemPens.ControlText,
+                g.DrawLines(SystemPens.ControlText, (ReadOnlySpan<Point>)
                      [
                          new(start, _lastInsertionMarkRect.Y), new(start + widthOfBeam - 1, _lastInsertionMarkRect.Y),
                          new(start + 1, _lastInsertionMarkRect.Y + 1), new(start + widthOfBeam - 2, _lastInsertionMarkRect.Y + 1)
@@ -3887,21 +3887,21 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
                 int horizontalBeamStart = start + 2;
 
                 // Draw horizontal lines.
-                g.DrawLines(SystemPens.ControlText,
+                g.DrawLines(SystemPens.ControlText, (ReadOnlySpan<Point>)
                     [
                         new(_lastInsertionMarkRect.X, horizontalBeamStart), new(_lastInsertionMarkRect.Right - 1, horizontalBeamStart),
                         new(_lastInsertionMarkRect.X, horizontalBeamStart + 1), new(_lastInsertionMarkRect.Right - 1, horizontalBeamStart + 1)
                     ]);
 
                 // Draw left vertical lines.
-                g.DrawLines(SystemPens.ControlText,
+                g.DrawLines(SystemPens.ControlText, (ReadOnlySpan<Point>)
                     [
                         new(_lastInsertionMarkRect.X, start), new(_lastInsertionMarkRect.X, start + widthOfBeam - 1),
                         new(_lastInsertionMarkRect.X + 1, start + 1), new(_lastInsertionMarkRect.X + 1, start + widthOfBeam - 2)
                     ]);
 
                 // Draw right vertical lines.
-                g.DrawLines(SystemPens.ControlText,
+                g.DrawLines(SystemPens.ControlText, (ReadOnlySpan<Point>)
                      [
                          new(_lastInsertionMarkRect.Right - 1, start), new(_lastInsertionMarkRect.Right - 1, start + widthOfBeam - 1),
                          new(_lastInsertionMarkRect.Right - 2, start + 1), new(_lastInsertionMarkRect.Right - 2, start + widthOfBeam - 2)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripComboBox.ToolStripComboBoxControl.ToolStripComboBoxFlatComboAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripComboBox.ToolStripComboBoxControl.ToolStripComboBoxFlatComboAdapter.cs
@@ -143,12 +143,14 @@ public partial class ToolStripComboBox
 
                 // If the width is odd - favor pushing it over one pixel right.
                 middle.X += (dropDownRect.Width % 2);
-                g.FillPolygon(brush,
-                [
-                    new(middle.X - s_offsetPixels, middle.Y - 1),
-                    new(middle.X + s_offsetPixels + 1, middle.Y - 1),
-                    new(middle.X, middle.Y + s_offsetPixels)
-                ]);
+                g.FillPolygon(
+                    brush,
+                    (ReadOnlySpan<Point>)
+                    [
+                        new(middle.X - s_offsetPixels, middle.Y - 1),
+                        new(middle.X + s_offsetPixels + 1, middle.Y - 1),
+                        new(middle.X, middle.Y + s_offsetPixels)
+                    ]);
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Input/InputLanguage.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Input/InputLanguage.cs
@@ -3,7 +3,7 @@
 
 using System.Globalization;
 using Microsoft.Win32;
-using Windows.Win32.UI.TextServices;
+using Windows.Win32.UI.Input.KeyboardAndMouse;
 
 namespace System.Windows.Forms;
 
@@ -80,7 +80,11 @@ public sealed class InputLanguage
             int size = PInvoke.GetKeyboardLayoutList(0, null);
 
             var handles = new HKL[size];
-            PInvoke.GetKeyboardLayoutList(handles);
+
+            fixed (HKL* h = handles)
+            {
+                PInvoke.GetKeyboardLayoutList(size, h);
+            }
 
             InputLanguage[] ils = new InputLanguage[size];
             for (int i = 0; i < size; i++)


### PR DESCRIPTION
Updates to the latest release of CSWin32 and updates code where necessary.

Also add back explicit span casts where VS IntelliSense is unable to differentiate. Without this contributors would need to have access to internal preview feeds.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12290)