### PR TITLE
fix issue #5961 Row header border line of the DataGridView control has very low luminosity contrast ratio

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewCell.cs
@@ -3218,7 +3218,8 @@ public abstract partial class DataGridViewCell : DataGridViewElement, ICloneable
                 break;
 
             case DataGridViewAdvancedCellBorderStyle.Outset:
-                graphics.DrawLine(penControlLightLight, bounds.X, bounds.Y, bounds.X, bounds.Bottom - 1);
+                graphics.DrawLine(DataGridView.RightToLeft == RightToLeft.Yes ? penControlDark : penControlLightLight,
+                    bounds.X, bounds.Y, bounds.X, bounds.Bottom - 1);
                 break;
 
             case DataGridViewAdvancedCellBorderStyle.OutsetPartial:


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #5961 

## Proposed changes

-
- use a different color when RightToLeft is set to Yes
- 
- 

<!--    -->
<!--   
## Customer Impact

- 
- 
 -->
## Regression? 

- Yes
<!--  
## Risk

-
  -->



## Screenshots

### Before

![image](https://github.com/user-attachments/assets/012071c6-7232-4719-a0e8-d6cf026b8226)


### After

![image](https://github.com/user-attachments/assets/747a0812-1b0b-42d6-ac5e-fab64b776203)


##### When color applied 

![image](https://github.com/user-attachments/assets/abf3a62b-c10b-4c0c-9af8-b320b37f2cea)

##### When RightToLeft is set to No
![image](https://github.com/user-attachments/assets/05c2aef7-6487-4b18-97a3-86ab9e56ec7a)


## Test methodology 

- 
- manually 
- 
<!--   
## Accessibility testing  
 -->



 

## Test environment(s) 
- 10.0.0-alpha.1.24455.17




 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12210)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12293)