### PR TITLE
Update DotNetBuild.props header to correct reviewer

### DIFF
--- a/eng/DotNetBuild.props
+++ b/eng/DotNetBuild.props
@@ -1,4 +1,4 @@
-<!-- Whenever altering this or other DotNetBuild files, please include @dotnet/source-build-internal as a reviewer. -->
+<!-- When altering this file, please include @dotnet/product-construction as a reviewer. -->
 
 <Project>
   <PropertyGroup>


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build/issues/4645

This file started off as being source-build specific but with the Unified Build project it has become more general therefore the header needed updating.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12300)