### PR TITLE
Add unit tests for DataGridViewCellStyleBuilder

### DIFF
--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DataGridViewCellStyleBuilderTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DataGridViewCellStyleBuilderTests.cs
@@ -17,9 +17,8 @@ public class DataGridViewCellStyleBuilderTests
         Mock<IServiceProvider> serviceProvider = new();
         Mock<IComponent> component = new();
         using DataGridViewCellStyleBuilder builder = new(serviceProvider.Object, component.Object);
-        var cellStyle = new DataGridViewCellStyle { BackColor = Color.Red };
 
-        builder.CellStyle = cellStyle;
+        builder.CellStyle = new DataGridViewCellStyle { BackColor = Color.Red };
         var result = builder.CellStyle;
 
         result.Should().NotBeNull();
@@ -35,9 +34,8 @@ public class DataGridViewCellStyleBuilderTests
         Mock<ITypeDescriptorContext> context = new();
 
         builder.Context = context.Object;
+        ITypeDescriptorContext result = builder.TestAccessor().Dynamic._context;
 
-        var field = typeof(DataGridViewCellStyleBuilder).GetField("_context", Reflection.BindingFlags.NonPublic | Reflection.BindingFlags.Instance);
-        var result = field?.GetValue(builder);
         result.Should().Be(context.Object);
     }
 }

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DataGridViewCellStyleBuilderTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DataGridViewCellStyleBuilderTests.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using Moq;
+using System.ComponentModel;
+using System.Drawing;
+
+namespace System.Windows.Forms.Design.Tests;
+
+public class DataGridViewCellStyleBuilderTests
+{
+    [Fact]
+    public void CellStyle_SetAndGet_ReturnsCorrectValue()
+    {
+        Mock<IServiceProvider> serviceProvider = new();
+        Mock<IComponent> component = new();
+        using DataGridViewCellStyleBuilder builder = new(serviceProvider.Object, component.Object);
+        var cellStyle = new DataGridViewCellStyle { BackColor = Color.Red };
+
+        builder.CellStyle = cellStyle;
+        var result = builder.CellStyle;
+
+        result.Should().NotBeNull();
+        result.BackColor.Should().Be(Color.Red);
+    }
+
+    [Fact]
+    public void Context_Set_ReturnsCorrectValue()
+    {
+        Mock<IServiceProvider> serviceProvider = new();
+        Mock<IComponent> component = new();
+        using DataGridViewCellStyleBuilder builder = new(serviceProvider.Object, component.Object);
+        Mock<ITypeDescriptorContext> context = new();
+
+        builder.Context = context.Object;
+
+        var field = typeof(DataGridViewCellStyleBuilder).GetField("_context", Reflection.BindingFlags.NonPublic | Reflection.BindingFlags.Instance);
+        var result = field?.GetValue(builder);
+        result.Should().Be(context.Object);
+    }
+}


### PR DESCRIPTION
Related https://github.com/dotnet/winforms/issues/10773

## Proposed changes

- Add unit test DataGridViewCellStyleBuilderTests.cs for public methods of the DataGridViewCellStyleBuilder.
- Enable nullability in DataGridViewCellStyleBuilderTests.cs.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12318)