### PR TITLE
Comment out test "ListViewItemKeyboardToolTip_InvokeIsHoveredWithMouse_ReturnsExpected(insideListView: True, virtualMode: True, isHovered: True, expected: True)"

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.IKeyboardToolTipTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.IKeyboardToolTipTests.cs
@@ -680,8 +680,10 @@ public class ListViewItem_IKeyboardToolTipTests
         Assert.Equal(expected, ((IKeyboardToolTip)listViewItem).HasRtlModeEnabled());
     }
 
+    [ActiveIssue("https://github.com/dotnet/winforms/issues/12319")]
     [WinFormsTheory]
-    [InlineData(true, true, true, true)]
+    // Comment the data out due to ActiveIssue "https://github.com/dotnet/winforms/issues/12319".
+    // [InlineData(true, true, true, true)]
     [InlineData(true, true, false, false)]
     [InlineData(true, false, true, true)]
     [InlineData(true, false, false, false)]


### PR DESCRIPTION


<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Related #12319


## Proposed changes

- Comment out test scenario `ListViewItemKeyboardToolTip_InvokeIsHoveredWithMouse_ReturnsExpected(insideListView: True, virtualMode: True, isHovered: True, expected: True)` that cause flaky failure

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12321)