### PR TITLE
Fix ConnectionPointCookie usages

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ActiveX/AxHost.OleInterfaces.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ActiveX/AxHost.OleInterfaces.cs
@@ -56,7 +56,7 @@ public abstract partial class AxHost
             }
 
             object? nativeObject = _host.GetOcx();
-            _connectionPoint = new ConnectionPointCookie(nativeObject, this, typeof(IPropertyNotifySink), throwException: false);
+            _connectionPoint = new ConnectionPointCookie(nativeObject, this, typeof(IPropertyNotifySink.Interface), throwException: false);
         }
 
         internal void StopEvents()

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/WebBrowser/WebBrowserSiteBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/WebBrowser/WebBrowserSiteBase.cs
@@ -381,11 +381,18 @@ public unsafe class WebBrowserSiteBase :
         {
             try
             {
-                _connectionPoint = new AxHost.ConnectionPointCookie(nativeObject, this, typeof(IPropertyNotifySink));
+                _connectionPoint = new AxHost.ConnectionPointCookie(nativeObject, this, typeof(IPropertyNotifySink.Interface));
             }
+#if DEBUG
+            catch (Exception)
+            {
+                throw;
+            }
+#else
             catch (Exception ex) when (!ex.IsCriticalException())
             {
             }
+#endif
         }
     }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AxHostTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AxHostTests.cs
@@ -3085,6 +3085,18 @@ public class AxHostTests
         (ocx.Value->Release() - 1).Should().Be(0);
     }
 
+    [WinFormsFact]
+    public unsafe void AxHost_Ocx_ConnectionPoint_Success()
+    {
+        using SubAxHost control = new(WebBrowserClsidString);
+        control.CreateControl();
+
+        object site = control.TestAccessor().Dynamic._oleSite;
+        AxHost.ConnectionPointCookie cookie = site.TestAccessor().Dynamic._connectionPoint;
+        cookie.Should().NotBeNull();
+        cookie.Connected.Should().BeTrue();
+    }
+
     private class SubComponentEditor : ComponentEditor
     {
         public override bool EditComponent(ITypeDescriptorContext context, object component)

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/WebBrowserTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/WebBrowserTests.cs
@@ -4751,4 +4751,32 @@ public class WebBrowserTests
 
         public new void WndProc(ref Message m) => base.WndProc(ref m);
     }
+
+    [WinFormsFact]
+    public void WebBrowser_NavigateToFileFolder()
+    {
+        Form form = new();
+        WebBrowser browser = new()
+        {
+            Dock = DockStyle.Fill
+        };
+
+        string navigated = null;
+        browser.Navigated += (sender, e) =>
+        {
+            navigated = browser.Url.ToString();
+            form.Close();
+        };
+
+        form.Controls.Add(browser);
+
+        form.Load += (sender, e) =>
+        {
+            browser.Navigate(@"file://C:/");
+        };
+
+        form.Show();
+
+        navigated.Should().Be(@"file:///C:/");
+    }
 }


### PR DESCRIPTION
Broke this when we converted to CsWin32. Missed this as it silently fails, just won't get any events when it is broken.

Adds regression tests to validate the cookie is created and we actually get events returned in WebBrowser.

Fixes #12330