### PR TITLE
Add unit tests for DesignerExtenders

### DIFF
--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DesignerExtendersTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DesignerExtendersTests.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using Moq;
+using System.ComponentModel;
+using System.ComponentModel.Design;
+using System.Reflection;
+
+namespace System.Windows.Forms.Design.Tests;
+
+public class DesignerExtendersTests : IDisposable
+{
+    private readonly Mock<IExtenderProviderService> _extenderServiceMock;
+    private readonly DesignerExtenders _designerExtenders;
+
+    public DesignerExtendersTests()
+    {
+        _extenderServiceMock = new();
+        _designerExtenders = new(_extenderServiceMock.Object);
+    }
+
+    public void Dispose()
+    {
+        _designerExtenders.Dispose();
+    }
+
+    [Fact]
+    public void Dispose_RemovesExtenderProviders()
+    {
+        _designerExtenders.Dispose();
+
+        _extenderServiceMock.Verify(s => s.RemoveExtenderProvider(It.IsAny<IExtenderProvider>()), Times.Exactly(2));
+        _designerExtenders.Invoking(d => d.Dispose()).Should().NotThrow();
+
+        var providersField = typeof(DesignerExtenders).GetField("_providers", BindingFlags.NonPublic | BindingFlags.Instance);
+        var extenderServiceField = typeof(DesignerExtenders).GetField("_extenderService", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        providersField.Should().NotBeNull();
+        extenderServiceField.Should().NotBeNull();
+
+        providersField!.GetValue(_designerExtenders).Should().BeNull();
+        extenderServiceField!.GetValue(_designerExtenders).Should().BeNull();
+    }
+}

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DesignerExtendersTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DesignerExtendersTests.cs
@@ -6,7 +6,6 @@
 using Moq;
 using System.ComponentModel;
 using System.ComponentModel.Design;
-using System.Reflection;
 
 namespace System.Windows.Forms.Design.Tests;
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DesignerExtendersTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DesignerExtendersTests.cs
@@ -29,18 +29,20 @@ public class DesignerExtendersTests : IDisposable
     [Fact]
     public void Dispose_RemovesExtenderProviders()
     {
-        _designerExtenders.Dispose();
-
-        _extenderServiceMock.Verify(s => s.RemoveExtenderProvider(It.IsAny<IExtenderProvider>()), Times.Exactly(2));
-        _designerExtenders.Invoking(d => d.Dispose()).Should().NotThrow();
-
-        var providersField = typeof(DesignerExtenders).GetField("_providers", BindingFlags.NonPublic | BindingFlags.Instance);
-        var extenderServiceField = typeof(DesignerExtenders).GetField("_extenderService", BindingFlags.NonPublic | BindingFlags.Instance);
+        IExtenderProvider[] providersField = _designerExtenders.TestAccessor().Dynamic._providers;
+        IExtenderProviderService extenderServiceField = _designerExtenders.TestAccessor().Dynamic._extenderService;
 
         providersField.Should().NotBeNull();
         extenderServiceField.Should().NotBeNull();
 
-        providersField!.GetValue(_designerExtenders).Should().BeNull();
-        extenderServiceField!.GetValue(_designerExtenders).Should().BeNull();
+        _designerExtenders.Dispose();
+        _extenderServiceMock.Verify(s => s.RemoveExtenderProvider(It.IsAny<IExtenderProvider>()), Times.Exactly(2));
+        _designerExtenders.Invoking(d => d.Dispose()).Should().NotThrow();
+
+        providersField = _designerExtenders.TestAccessor().Dynamic._providers;
+        extenderServiceField = _designerExtenders.TestAccessor().Dynamic._extenderService;
+
+        providersField.Should().BeNull();
+        extenderServiceField.Should().BeNull();
     }
 }

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DesignerExtendersTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DesignerExtendersTests.cs
@@ -9,39 +9,28 @@ using System.ComponentModel.Design;
 
 namespace System.Windows.Forms.Design.Tests;
 
-public class DesignerExtendersTests : IDisposable
+public class DesignerExtendersTests
 {
-    private readonly Mock<IExtenderProviderService> _extenderServiceMock;
-    private readonly DesignerExtenders _designerExtenders;
-
-    public DesignerExtendersTests()
-    {
-        _extenderServiceMock = new();
-        _designerExtenders = new(_extenderServiceMock.Object);
-    }
-
-    public void Dispose()
-    {
-        _designerExtenders.Dispose();
-    }
-
     [Fact]
     public void Dispose_RemovesExtenderProviders()
     {
-        IExtenderProvider[] providersField = _designerExtenders.TestAccessor().Dynamic._providers;
-        IExtenderProviderService extenderServiceField = _designerExtenders.TestAccessor().Dynamic._extenderService;
+        Mock<IExtenderProviderService> extenderServiceMock = new();
+        DesignerExtenders designerExtenders = new(extenderServiceMock.Object);
 
-        providersField.Should().NotBeNull();
-        extenderServiceField.Should().NotBeNull();
+        IExtenderProvider[] providers = designerExtenders.TestAccessor().Dynamic._providers;
+        IExtenderProviderService extenderService= designerExtenders.TestAccessor().Dynamic._extenderService;
 
-        _designerExtenders.Dispose();
-        _extenderServiceMock.Verify(s => s.RemoveExtenderProvider(It.IsAny<IExtenderProvider>()), Times.Exactly(2));
-        _designerExtenders.Invoking(d => d.Dispose()).Should().NotThrow();
+        providers.Should().NotBeNull();
+        extenderService.Should().NotBeNull();
 
-        providersField = _designerExtenders.TestAccessor().Dynamic._providers;
-        extenderServiceField = _designerExtenders.TestAccessor().Dynamic._extenderService;
+        designerExtenders.Dispose();
+        extenderServiceMock.Verify(s => s.RemoveExtenderProvider(It.IsAny<IExtenderProvider>()), Times.Exactly(2));
+        designerExtenders.Invoking(d => d.Dispose()).Should().NotThrow();
 
-        providersField.Should().BeNull();
-        extenderServiceField.Should().BeNull();
+        providers = designerExtenders.TestAccessor().Dynamic._providers;
+        extenderService = designerExtenders.TestAccessor().Dynamic._extenderService;
+
+        providers.Should().BeNull();
+        extenderService.Should().BeNull();
     }
 }


### PR DESCRIPTION
Related https://github.com/dotnet/winforms/issues/10773


## Proposed changes

- Add unit test DesignerExtendersTests.cs for public properties and method of the DesignerExtenders.
- Enable nullability in DesignerExtenders.


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12337)