### PR TITLE
[release/8.0] Fix ConnectionPointCookie usages

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.OleInterfaces.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.OleInterfaces.cs
@@ -56,7 +56,7 @@ public abstract partial class AxHost
             }
 
             object nativeObject = _host.GetOcx();
-            _connectionPoint = new ConnectionPointCookie(nativeObject, this, typeof(IPropertyNotifySink), throwException: false);
+            _connectionPoint = new ConnectionPointCookie(nativeObject, this, typeof(IPropertyNotifySink.Interface), throwException: false);
         }
 
         internal void StopEvents()

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserSiteBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserSiteBase.cs
@@ -384,11 +384,18 @@ public unsafe class WebBrowserSiteBase :
         {
             try
             {
-                connectionPoint = new AxHost.ConnectionPointCookie(nativeObject, this, typeof(IPropertyNotifySink));
+                connectionPoint = new AxHost.ConnectionPointCookie(nativeObject, this, typeof(IPropertyNotifySink.Interface));
             }
+#if DEBUG
+            catch (Exception)
+            {
+                throw;
+            }
+#else
             catch (Exception ex) when (!ex.IsCriticalException())
             {
             }
+#endif
         }
     }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AxHostTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AxHostTests.cs
@@ -3085,6 +3085,18 @@ public class AxHostTests
         Assert.Equal((uint)0, ocx.Value->Release() - 1);
     }
 
+    [WinFormsFact]
+    public unsafe void AxHost_Ocx_ConnectionPoint_Success()
+    {
+        using SubAxHost control = new(WebBrowserClsidString);
+        control.CreateControl();
+
+        object site = control.TestAccessor().Dynamic._oleSite;
+        AxHost.ConnectionPointCookie cookie = site.TestAccessor().Dynamic._connectionPoint;
+        Assert.NotNull(cookie);
+        Assert.True(cookie.Connected);
+    }
+
     private class SubComponentEditor : ComponentEditor
     {
         public override bool EditComponent(ITypeDescriptorContext context, object component)

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/WebBrowserTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/WebBrowserTests.cs
@@ -4742,4 +4742,32 @@ public class WebBrowserTests
 
         public new void WndProc(ref Message m) => base.WndProc(ref m);
     }
+
+    [WinFormsFact]
+    public void WebBrowser_NavigateToFileFolder()
+    {
+        using Form form = new();
+        using WebBrowser browser = new()
+        {
+            Dock = DockStyle.Fill
+        };
+
+        string navigated = null;
+        browser.Navigated += (sender, e) =>
+        {
+            navigated = browser.Url.ToString();
+            form.Close();
+        };
+
+        form.Controls.Add(browser);
+
+        form.Load += (sender, e) =>
+        {
+            browser.Navigate(@"file://C:/");
+        };
+
+        form.Show();
+
+        Assert.Equal(@"file:///C:/", navigated);
+    }
 }


### PR DESCRIPTION
Backport of #12333 to release/8.0

## Customer Impact
When creating a WebBrowser an InvalidCastException always occurs. Due to this, users will experience usability issues as WebBrowser will be broken and not receive any events. This regressed upon doing improvements to our interop code and was missed because this fails silently due to a try/catch. When constructing a WebBrowser, one of the objects that is created is a ConnectionPointCookie, which checks that an argument of the constructor is an instance of type IPropertyNotifySink. With the move to leveraging cswin32, this should've been updated to IPropertyNotifySink.Interface, but was missed. 

## Testing
Added regression tests to ensure WebBrowser is created successfully and events are received.

## Risk
Low. The change involves updating to check against the correct interface, IPropertyNotifySink.Interface. The change also alters the try/catch to surface the exception instead of silently failing during debug.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12342)