### PR TITLE
Update the logic about the attribute [RefreshProperties(RefreshProperties.All)] on PropertyGridView.cs

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.cs
@@ -4018,7 +4018,10 @@ internal sealed partial class PropertyGridView :
             if (oldLength > 0 && !_flags.HasFlag(Flags.NoDefault))
             {
                 _positionData = CaptureGridPositionData();
-                CommonEditorHide(true);
+                if (!fullRefresh)
+                {
+                    CommonEditorHide(true);
+                }
             }
 
             UpdateHelpAttributes(_selectedGridEntry, newEntry: null);
@@ -4299,17 +4302,10 @@ internal sealed partial class PropertyGridView :
             return;
         }
 
-        bool newRow = false;
         int oldSelectedRow = _selectedRow;
-        if (_selectedRow != row || !gridEntry.Equals(_selectedGridEntry))
+        if (_selectedRow != row || (_selectedGridEntry is not null && !gridEntry.Equals(_selectedGridEntry)))
         {
             CommonEditorHide();
-            newRow = true;
-        }
-
-        if (!newRow)
-        {
-            CloseDropDown();
         }
 
         Rectangle rect = GetRectangle(row, RowValue);
@@ -4400,7 +4396,7 @@ internal sealed partial class PropertyGridView :
             _selectedGridEntry.HasFocus = FocusInside;
         }
 
-        if (!_flags.HasFlag(Flags.IsNewSelection))
+        if (!_flags.HasFlag(Flags.IsNewSelection) && !_flags.HasFlag(Flags.InPropertySet))
         {
             Focus();
         }

--- a/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/MainForm.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/MainForm.cs
@@ -124,22 +124,35 @@ public partial class MainForm : Form
                         // - create some Controls at DesignTime
                         TextBox t1 = surface.CreateControl<TextBox>(new Size(200, 23), new Point(172, 12));
                         Button b1 = surface.CreateControl<Button>(new Size(200, 40), new Point(172, 63));
-                        CustomButton b2 = surface.CreateControl<CustomButton>(new Size(200, 40), new Point(100, 200));
+                        CustomButton b2 = surface.CreateControl<CustomButton>(new Size(200, 40), new Point(172, 200));
                         b1.Text = "I'm the first Button";
                         b2.Text = "I'm the second Button";
                         b1.BackColor = Color.LightGray;
                         b2.BackColor = Color.LightGreen;
 
-                        RadioButton rb1 = surface.CreateControl<RadioButton>(new Size(120, 22), new Point(12, 21));
+                        RadioButton rb1 = surface.CreateControl<RadioButton>(new Size(120, 22), new Point(12, 10));
                         rb1.Text = "Check me!";
-                        RadioButton rb2 = surface.CreateControl<RadioButton>(new Size(120, 22), new Point(12, 50));
+                        RadioButton rb2 = surface.CreateControl<RadioButton>(new Size(120, 22), new Point(12, 35));
                         rb2.Text = "No, check me!";
                         rb2.Checked = true;
 
-                        Panel pnl = surface.CreateControl<Panel>(new Size(130, 100), new Point(12, 21));
+                        CheckBox checkbox1 = surface.CreateControl<CheckBox>(new Size(120, 22), new Point(12, 60));
+                        checkbox1.Text = "I'm Unchecked!";
+                        CheckBox checkbox2 = surface.CreateControl<CheckBox>(new Size(120, 22), new Point(12, 85));
+                        checkbox2.Text = "I'm Indeterminate!";
+                        checkbox2.AutoSize = true;
+                        checkbox2.CheckState = CheckState.Indeterminate;
+                        CheckBox checkbox3 = surface.CreateControl<CheckBox>(new Size(120, 22), new Point(12, 110));
+                        checkbox3.Text = "I'm Checked!";
+                        checkbox3.CheckState = CheckState.Checked;
+
+                        Panel pnl = surface.CreateControl<Panel>(new Size(140, 140), new Point(12, 12));
                         pnl.BackColor = Color.Aquamarine;
                         rb1.Parent = pnl;
                         rb2.Parent = pnl;
+                        checkbox1.Parent = pnl;
+                        checkbox2.Parent = pnl;
+                        checkbox3.Parent = pnl;
 
                         Label l1 = surface.CreateControl<Label>(new Size(100, 25), new Point(12, 12));
                         Label l2 = surface.CreateControl<Label>(new Size(120, 25), new Point(12, 12));
@@ -154,7 +167,7 @@ public partial class MainForm : Form
                         l1.Parent = sct.Panel1;
                         l2.Parent = sct.Panel2;
 
-                        PictureBox pb1 = surface.CreateControl<PictureBox>(new Size(64, 64), new Point(24, 166));
+                        PictureBox pb1 = surface.CreateControl<PictureBox>(new Size(64, 64), new Point(12, 176));
                         pb1.Image = new Icon("painter.ico").ToBitmap();
 
                         ContextMenuStrip cm1 = surface.CreateComponent<ContextMenuStrip>();
@@ -333,7 +346,7 @@ public partial class MainForm : Form
                         splitter.BackColor = Color.Green;
                         splitter.Dock = DockStyle.Bottom;
 
-                        Panel panel = surface.CreateControl<Panel>(new(0, tabPage6.Height/2), new(0, 0));
+                        Panel panel = surface.CreateControl<Panel>(new(0, tabPage6.Height / 2), new(0, 0));
                         panel.Dock = DockStyle.Bottom;
                         NumericUpDown numericUpDown = surface.CreateControl<NumericUpDown>(new(50, 10), new(10, 10));
                         panel.Controls.Add(numericUpDown);


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #12031


## Proposed changes

- Removing `CommonEditorHide` to cancel closing dropdown when performing a refresh on the property page
- In the SelectRow method, when the drop-down box gets the focus, _selectedGridEntry will be null and `CommonEditorHide` should not be executed.
- When property is in set, cancels the action of setting the focus on property page
- Add Checkbox to Demo Console

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

-  The property "Auto size" drop-down menu option now works properly by toggling it using the up/down arrow keys

## Regression? 

-  No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
When we navigate to "Auto Size" dropdown using the up/down arrow keys, it is getting auto selected without hitting ENTER key

![CoreResults](https://github.com/user-attachments/assets/b6cebc6a-d4b1-46d6-9b47-1c86e435d3ad)

### After
When we navigate to the "Auto-Size" drop-down menu using the up/down arrow keys, the selected menu item toggles normally
![AfterChanges](https://github.com/user-attachments/assets/373258d7-95a2-4848-92ff-a4d7f336eb8c)


## Test methodology <!-- How did you ensure quality? -->

-  Manually


## Test environment(s) <!-- Remove any that don't apply -->

- .net 10.0.0-alpha.1.24519.3


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12356)