### PR TITLE
Add unit tests for DataGridViewComponentPropertyGridSite

### DIFF
--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DataGridViewComponentPropertyGridSiteTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DataGridViewComponentPropertyGridSiteTests.cs
@@ -1,0 +1,61 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using Moq;
+using System.ComponentModel;
+
+namespace System.Windows.Forms.Design.Tests;
+
+public class DataGridViewComponentPropertyGridSiteTests
+{
+    [Fact]
+    public void Constructor_ShouldInitializeComponent()
+    {
+        Mock<IComponent> componentMock = new();
+
+        DataGridViewComponentPropertyGridSite site = new(null, componentMock.Object);
+
+        site.Component.Should().Be(componentMock.Object);
+    }
+
+    [Fact]
+    public void GetService_ShouldReturnNull_WhenServiceProviderIsNull()
+    {
+        Mock<IComponent> componentMock = new();
+        DataGridViewComponentPropertyGridSite site = new(null, componentMock.Object);
+
+        var service = site.GetService(typeof(object));
+
+        service.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetService_ShouldReturnNull_WhenInGetServiceIsTrue()
+    {
+        Mock<IComponent> componentMock = new();
+        Mock<IServiceProvider> serviceProviderMock = new();
+        DataGridViewComponentPropertyGridSite site = new(serviceProviderMock.Object, componentMock.Object);
+
+        site.TestAccessor().Dynamic._inGetService = true;
+
+        var service = site.GetService(typeof(object));
+
+        service.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetService_ShouldReturnService_WhenServiceProviderIsNotNullAndInGetServiceIsFalse()
+    {
+        Mock<IComponent> componentMock = new();
+        Mock<IServiceProvider> serviceProviderMock = new();
+        object expectedService = new();
+        serviceProviderMock.Setup(sp => sp.GetService(typeof(object))).Returns(expectedService);
+        DataGridViewComponentPropertyGridSite site = new(serviceProviderMock.Object, componentMock.Object);
+
+        var service = site.GetService(typeof(object));
+
+        service.Should().Be(expectedService);
+    }
+}

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DataGridViewComponentPropertyGridSiteTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DataGridViewComponentPropertyGridSiteTests.cs
@@ -13,18 +13,18 @@ public class DataGridViewComponentPropertyGridSiteTests
     [Fact]
     public void Constructor_ShouldInitializeComponent()
     {
-        Mock<IComponent> componentMock = new();
+        using Component component = new();
 
-        DataGridViewComponentPropertyGridSite site = new(null, componentMock.Object);
+        DataGridViewComponentPropertyGridSite site = new(null, component);
 
-        site.Component.Should().Be(componentMock.Object);
+        site.Component.Should().Be(component);
     }
 
     [Fact]
     public void GetService_ShouldReturnNull_WhenServiceProviderIsNull()
     {
-        Mock<IComponent> componentMock = new();
-        DataGridViewComponentPropertyGridSite site = new(null, componentMock.Object);
+        using Component component = new();
+        DataGridViewComponentPropertyGridSite site = new(null, component);
 
         var service = site.GetService(typeof(object));
 
@@ -34,9 +34,9 @@ public class DataGridViewComponentPropertyGridSiteTests
     [Fact]
     public void GetService_ShouldReturnNull_WhenInGetServiceIsTrue()
     {
-        Mock<IComponent> componentMock = new();
+        using Component component = new();
         Mock<IServiceProvider> serviceProviderMock = new();
-        DataGridViewComponentPropertyGridSite site = new(serviceProviderMock.Object, componentMock.Object);
+        DataGridViewComponentPropertyGridSite site = new(serviceProviderMock.Object, component);
 
         site.TestAccessor().Dynamic._inGetService = true;
 
@@ -48,11 +48,11 @@ public class DataGridViewComponentPropertyGridSiteTests
     [Fact]
     public void GetService_ShouldReturnService_WhenServiceProviderIsNotNullAndInGetServiceIsFalse()
     {
-        Mock<IComponent> componentMock = new();
+        using Component component = new();
         Mock<IServiceProvider> serviceProviderMock = new();
         object expectedService = new();
         serviceProviderMock.Setup(sp => sp.GetService(typeof(object))).Returns(expectedService);
-        DataGridViewComponentPropertyGridSite site = new(serviceProviderMock.Object, componentMock.Object);
+        DataGridViewComponentPropertyGridSite site = new(serviceProviderMock.Object, component);
 
         var service = site.GetService(typeof(object));
 


### PR DESCRIPTION
Related https://github.com/dotnet/winforms/issues/10773

## Proposed changes

- Add unit test DataGridViewComponentPropertyGridSiteTests.cs for public methods of the DataGridViewComponentPropertyGridSite.
- Enable nullability in DataGridViewComponentPropertyGridSiteTests.cs.


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12357)