### PR TITLE
Add unit test for UpDownBaseDesigner

### DIFF
--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/UpDownBaseDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/UpDownBaseDesignerTests.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System.ComponentModel;
+using System.ComponentModel.Design;
+using System.Windows.Forms.Design.Behavior;
+using Moq;
+
+namespace System.Windows.Forms.Design.Tests;
+public class UpDownBaseDesignerTests
+{
+    [Fact]
+    public void Constructor_SetsAutoResizeHandlesToTrue_And_SelectionRules_ShouldNotIncludeTopOrBottomSizeable_SnapLines_ReturnsCorrectSnapLines()
+    {
+        using UpDownBaseDesigner designer = new();
+
+        designer.AutoResizeHandles.Should().BeTrue();
+
+        using NumericUpDown numericUpDown = new();
+        Mock<ISite> site = new();
+        site.Setup(s => s.GetService(typeof(IDesignerHost))).Returns(new Mock<IDesignerHost>().Object);
+        numericUpDown.Site = site.Object;
+
+        designer.Initialize(numericUpDown);
+        SelectionRules rules = designer.SelectionRules;
+
+        rules.Should().NotHaveFlag(SelectionRules.TopSizeable);
+        rules.Should().NotHaveFlag(SelectionRules.BottomSizeable);
+
+        List<SnapLine> snapLines = (List<SnapLine>)designer.SnapLines;
+
+        snapLines.Should().NotBeNull();
+        SnapLine? baselineSnapLine = snapLines.Cast<SnapLine>().FirstOrDefault(sl => sl.SnapLineType == SnapLineType.Baseline);
+        baselineSnapLine.Should().NotBeNull();
+        baselineSnapLine.Should().BeOfType<SnapLine>().Which.Priority.Should().Be(SnapLinePriority.Medium);
+    }
+}


### PR DESCRIPTION
Related https://github.com/dotnet/winforms/issues/10773

## Proposed changes
1. Add unit test UpDownBaseDesignerTests.cs for public properties and method of the UpDownBaseDesigner.
2. Enable nullability in UpDownBaseDesignerTests.cs.