### PR TITLE
Add unit tests for ToolStripContentPanelDesigner

### DIFF
--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ToolStripContentPanelDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ToolStripContentPanelDesignerTests.cs
@@ -14,15 +14,21 @@ public sealed class ToolStripContentPanelDesignerTests : IDisposable
 
     public ToolStripContentPanelDesignerTests()
     {
-        _toolStripContentPanelDesigner = new ToolStripContentPanelDesigner();
-        _toolStripContentPanel = new ToolStripContentPanel();
+        _toolStripContentPanelDesigner = new();
+        _toolStripContentPanel = new();
         _toolStripContentPanelDesigner.Initialize(_toolStripContentPanel);
+    }
+
+    public void Dispose()
+    {
+        _toolStripContentPanelDesigner.Dispose();
+        _toolStripContentPanel.Dispose();
     }
 
     [Fact]
     public void SnapLines_ShouldReturnNonNullList()
     {
-        var snapLines = _toolStripContentPanelDesigner.SnapLines;
+        IList<SnapLine> snapLines = _toolStripContentPanelDesigner.SnapLines.Cast<SnapLine>().ToList();
 
         snapLines.Should().NotBeNull();
     }
@@ -30,9 +36,9 @@ public sealed class ToolStripContentPanelDesignerTests : IDisposable
     [Fact]
     public void SnapLines_ShouldCallAddPaddingSnapLines()
     {
-        var paddingFilters = new[] { SnapLine.PaddingLeft, SnapLine.PaddingRight, SnapLine.PaddingTop, SnapLine.PaddingBottom };
+        string[] paddingFilters = [SnapLine.PaddingLeft, SnapLine.PaddingRight, SnapLine.PaddingTop, SnapLine.PaddingBottom];
 
-        var snapLines = _toolStripContentPanelDesigner.SnapLines.Cast<SnapLine>().ToList();
+        List<SnapLine> snapLines = _toolStripContentPanelDesigner.SnapLines.Cast<SnapLine>().ToList();
 
         bool containsPaddingSnapLines = snapLines.Any(snapLine => paddingFilters.Contains(snapLine.Filter));
 
@@ -50,16 +56,12 @@ public sealed class ToolStripContentPanelDesignerTests : IDisposable
     [Fact]
     public void CanBeParentedTo_ShouldReturnFalse_WhenParentDesignerIsNotNull()
     {
-        PanelDesigner parentDesigner = new();
+        using PanelDesigner parentDesigner = new();
+        using Panel panel = new();
+        parentDesigner.Initialize(panel);
 
         bool result = _toolStripContentPanelDesigner.CanBeParentedTo(parentDesigner);
 
         result.Should().BeFalse();
-    }
-
-    public void Dispose()
-    {
-        _toolStripContentPanelDesigner.Dispose();
-        _toolStripContentPanel.Dispose();
     }
 }

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ToolStripContentPanelDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ToolStripContentPanelDesignerTests.cs
@@ -1,0 +1,65 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System.Windows.Forms.Design.Behavior;
+
+namespace System.Windows.Forms.Design.Tests;
+
+public sealed class ToolStripContentPanelDesignerTests : IDisposable
+{
+    private readonly ToolStripContentPanelDesigner _toolStripContentPanelDesigner;
+    private readonly ToolStripContentPanel _toolStripContentPanel;
+
+    public ToolStripContentPanelDesignerTests()
+    {
+        _toolStripContentPanelDesigner = new ToolStripContentPanelDesigner();
+        _toolStripContentPanel = new ToolStripContentPanel();
+        _toolStripContentPanelDesigner.Initialize(_toolStripContentPanel);
+    }
+
+    [Fact]
+    public void SnapLines_ShouldReturnNonNullList()
+    {
+        var snapLines = _toolStripContentPanelDesigner.SnapLines;
+
+        snapLines.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void SnapLines_ShouldCallAddPaddingSnapLines()
+    {
+        var paddingFilters = new[] { SnapLine.PaddingLeft, SnapLine.PaddingRight, SnapLine.PaddingTop, SnapLine.PaddingBottom };
+
+        var snapLines = _toolStripContentPanelDesigner.SnapLines.Cast<SnapLine>().ToList();
+
+        bool containsPaddingSnapLines = snapLines.Any(snapLine => paddingFilters.Contains(snapLine.Filter));
+
+        containsPaddingSnapLines.Should().BeTrue();
+    }
+
+    [Fact]
+    public void CanBeParentedTo_ShouldReturnFalse_WhenParentDesignerIsNull()
+    {
+        bool result = _toolStripContentPanelDesigner.CanBeParentedTo(parentDesigner: null!);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void CanBeParentedTo_ShouldReturnFalse_WhenParentDesignerIsNotNull()
+    {
+        PanelDesigner parentDesigner = new();
+
+        bool result = _toolStripContentPanelDesigner.CanBeParentedTo(parentDesigner);
+
+        result.Should().BeFalse();
+    }
+
+    public void Dispose()
+    {
+        _toolStripContentPanelDesigner.Dispose();
+        _toolStripContentPanel.Dispose();
+    }
+}


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Related https://github.com/dotnet/winforms/issues/10773


## Proposed changes

- Add unit test ToolStripContentPanelDesignerTests.cs for public properties and method of the ToolStripContentPanelDesigner.
- Enable nullability in ToolStripContentPanelDesignerTests.cs.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12366)