### PR TITLE
fix #12365 [Accessibility] The text "Document does not contain any pages" in printPreviewControl has low color contrast

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewControl.cs
@@ -592,7 +592,7 @@ public partial class PrintPreviewControl : Control
 
     private void DrawMessage(Graphics g, Rectangle rect, bool isExceptionPrinting)
     {
-        using var brush = Color.Black.GetCachedSolidBrushScope();
+        using var brush = SystemColors.ControlText.GetCachedSolidBrushScope();
 
         using StringFormat format = new()
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewControl.cs
@@ -592,7 +592,7 @@ public partial class PrintPreviewControl : Control
 
     private void DrawMessage(Graphics g, Rectangle rect, bool isExceptionPrinting)
     {
-        using var brush = ForeColor.GetCachedSolidBrushScope();
+        using var brush = Color.Black.GetCachedSolidBrushScope();
 
         using StringFormat format = new()
         {


### PR DESCRIPTION


Fixes #12365 

## Proposed changes

- 
- Change the text color to black
- 

<!--

## Customer Impact

- 
- 
  -->
## Regression? 

- No

## Risk

- low


## Screenshots

### Before

 ![Image](https://github.com/user-attachments/assets/4bfcba8b-40ae-416c-89d0-b8a1d283269b)
### After

![image](https://github.com/user-attachments/assets/52f66638-577c-4aec-ae66-420c334384f9)



## Test methodology <!-- How did you ensure quality? -->

- 
- manual 
- 
<!--
## Accessibility testing

  


 

## Test environment(s)

-->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12368)