### PR TITLE
Add the DefaultTypeResolver

### DIFF
--- a/src/System.Private.Windows.Core/src/Resources/SR.resx
+++ b/src/System.Private.Windows.Core/src/Resources/SR.resx
@@ -203,4 +203,7 @@
   <data name="Serialization_TypeNotSerializable" xml:space="preserve">
     <value>Type '{0}' is not marked as serializable.</value>
   </data>
+  <data name="Serialization_MissingType" xml:space="preserve">
+    <value>Could not find type '{0}'.</value>
+  </data>
 </root>

--- a/src/System.Private.Windows.Core/src/System/Private/Windows/Core/BinaryFormat/Deserializer/ClassRecordFieldInfoDeserializer.cs
+++ b/src/System.Private.Windows.Core/src/System/Private/Windows/Core/BinaryFormat/Deserializer/ClassRecordFieldInfoDeserializer.cs
@@ -4,7 +4,6 @@
 using System.Reflection;
 using System.Runtime.Serialization;
 using System.Formats.Nrbf;
-using System.Runtime.Serialization.Formatters;
 using System.Private.Windows.Core.Resources;
 
 namespace System.Private.Windows.Core.BinaryFormat;
@@ -52,7 +51,7 @@ internal sealed class ClassRecordFieldInfoDeserializer : ClassRecordDeserializer
             FieldInfo field = (FieldInfo)_fieldInfo[_currentFieldIndex];
             if (!_classRecord.HasMember(field.Name))
             {
-                if (Deserializer.Options.AssemblyMatching == FormatterAssemblyStyle.Simple
+                if (Deserializer.Options.SimpleAssemblyMatching
                     || field.GetCustomAttribute<OptionalFieldAttribute>() is not null)
                 {
                     _currentFieldIndex++;

--- a/src/System.Private.Windows.Core/src/System/Private/Windows/Core/BinaryFormat/Deserializer/DefaultTypeResolver.cs
+++ b/src/System.Private.Windows.Core/src/System/Private/Windows/Core/BinaryFormat/Deserializer/DefaultTypeResolver.cs
@@ -1,0 +1,130 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Private.Windows.Core.Resources;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Runtime.Serialization;
+
+namespace System.Private.Windows.Core.BinaryFormat;
+
+internal sealed class DefaultTypeResolver : ITypeResolver
+{
+    private readonly bool _simpleAssemblyMatching;
+    private readonly ITypeResolver? _binder;
+
+    private readonly Dictionary<string, Assembly> _assemblies = [];
+    private readonly Dictionary<string, Type> _types = [];
+
+    internal DefaultTypeResolver(DeserializationOptions options)
+    {
+        _simpleAssemblyMatching = options.SimpleAssemblyMatching;
+        _binder = options.TypeResolver;
+    }
+
+    /// <summary>
+    ///  Resolves the given type name against the specified library.
+    /// </summary>
+    [RequiresUnreferencedCode("Calls System.Reflection.Assembly.GetType(String)")]
+    [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+    Type ITypeResolver.GetType(TypeName typeName)
+    {
+        Debug.Assert(typeName.AssemblyName is not null);
+
+        if (_types.TryGetValue(typeName.AssemblyQualifiedName, out Type? cachedType))
+        {
+            return cachedType;
+        }
+
+        if (_binder?.GetType(typeName) is Type binderType)
+        {
+            // BinaryFormatter is inconsistent about what caching behavior you get with binders.
+            // It would always cache the last item from the binder, but wouldn't put the result
+            // in the type cache. This could lead to inconsistent results if the binder didn't
+            // always return the same result for a given set of strings. Choosing to always cache
+            // for performance.
+
+            _types[typeName.AssemblyQualifiedName] = binderType;
+            return binderType;
+        }
+
+        if (!_assemblies.TryGetValue(typeName.AssemblyName.FullName, out Assembly? assembly))
+        {
+            AssemblyName assemblyName = typeName.AssemblyName.ToAssemblyName();
+            try
+            {
+                assembly = Assembly.Load(assemblyName);
+            }
+            catch
+            {
+                if (!_simpleAssemblyMatching)
+                {
+                    throw;
+                }
+
+                assembly = Assembly.Load(assemblyName.Name!);
+            }
+
+            _assemblies.Add(typeName.AssemblyName.FullName, assembly);
+        }
+
+        Type? type = _simpleAssemblyMatching
+            ? GetSimplyNamedTypeFromAssembly(assembly, typeName)
+            : assembly.GetType(typeName.FullName);
+
+        _types[typeName.AssemblyQualifiedName] = type
+            ?? throw new SerializationException(string.Format(SR.Serialization_MissingType, typeName.AssemblyQualifiedName));
+
+        return type;
+    }
+
+    [RequiresUnreferencedCode("Calls System.Reflection.Assembly.GetType(String, Boolean, Boolean)")]
+    private static Type? GetSimplyNamedTypeFromAssembly(Assembly assembly, TypeName typeName)
+    {
+        // Catching any exceptions that could be thrown from a failure on assembly load
+        // This is necessary, for example, if there are generic parameters that are qualified
+        // with a version of the assembly that predates the one available.
+
+        try
+        {
+            return assembly.GetType(typeName.FullName, throwOnError: false, ignoreCase: false);
+        }
+        catch (TypeLoadException) { }
+        catch (FileNotFoundException) { }
+        catch (FileLoadException) { }
+        catch (BadImageFormatException) { }
+
+        return Type.GetType(typeName.FullName, ResolveSimpleAssemblyName, new TopLevelAssemblyTypeResolver(assembly).ResolveType, throwOnError: false);
+
+        static Assembly? ResolveSimpleAssemblyName(AssemblyName assemblyName)
+        {
+            try
+            {
+                return Assembly.Load(assemblyName);
+            }
+            catch { }
+
+            try
+            {
+                return Assembly.Load(assemblyName.Name!);
+            }
+            catch { }
+
+            return null;
+        }
+    }
+
+    private sealed class TopLevelAssemblyTypeResolver
+    {
+        private readonly Assembly _topLevelAssembly;
+
+        public TopLevelAssemblyTypeResolver(Assembly topLevelAssembly) => _topLevelAssembly = topLevelAssembly;
+
+        [RequiresUnreferencedCode("Calls System.Reflection.Assembly.GetType(String, Boolean, Boolean)")]
+        public Type? ResolveType(Assembly? assembly, string simpleTypeName, bool ignoreCase)
+        {
+            assembly ??= _topLevelAssembly;
+            return assembly.GetType(simpleTypeName, throwOnError: false, ignoreCase);
+        }
+    }
+}

--- a/src/System.Private.Windows.Core/src/System/Private/Windows/Core/BinaryFormat/Deserializer/DeserializationOptions.cs
+++ b/src/System.Private.Windows.Core/src/System/Private/Windows/Core/BinaryFormat/Deserializer/DeserializationOptions.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.Serialization;
-using System.Runtime.Serialization.Formatters;
 
 namespace System.Private.Windows.Core.BinaryFormat;
 
@@ -11,26 +10,30 @@ internal sealed class DeserializationOptions
     /// <summary>
     ///  How exactly assembly names need to match for deserialization.
     /// </summary>
-#pragma warning disable SYSLIB0050 // Type or member is obsolete
-    public FormatterAssemblyStyle AssemblyMatching { get; set; } = FormatterAssemblyStyle.Simple;
-#pragma warning restore SYSLIB0050 // Type or member is obsolete
+    /// <remarks>
+    ///  <para>
+    ///   Aligned with <see href="https://learn.microsoft.com/dotnet/api/system.runtime.serialization.formatters.formatterassemblystyle">
+    ///   FormatterAssemblyStyle</see> behavior.
+    ///  </para>
+    /// </remarks>
+    public bool SimpleAssemblyMatching { get; set; } = true;
 
     /// <summary>
     ///  Type name binder.
     /// </summary>
-    public SerializationBinder? Binder { get; set; }
+    public ITypeResolver? TypeResolver { get; set; }
 
     /// <summary>
     ///  Optional type <see cref="ISerializationSurrogate"/> provider.
     /// </summary>
 #pragma warning disable SYSLIB0050 // Type or member is obsolete
     public ISurrogateSelector? SurrogateSelector { get; set; }
-#pragma warning restore SYSLIB0050 // Type or member is obsolete
+#pragma warning restore SYSLIB0050
 
     /// <summary>
     ///  Streaming context.
     /// </summary>
 #pragma warning disable SYSLIB0050 // Type or member is obsolete
     public StreamingContext StreamingContext { get; set; } = new(StreamingContextStates.All);
-#pragma warning restore SYSLIB0050 // Type or member is obsolete
+#pragma warning restore SYSLIB0050
 }

--- a/src/System.Private.Windows.Core/src/System/Private/Windows/Core/BinaryFormat/Deserializer/Deserializer.cs
+++ b/src/System.Private.Windows.Core/src/System/Private/Windows/Core/BinaryFormat/Deserializer/Deserializer.cs
@@ -99,12 +99,11 @@ internal sealed partial class Deserializer : IDeserializer
     private Deserializer(
         SerializationRecordId rootId,
         IReadOnlyDictionary<SerializationRecordId, SerializationRecord> recordMap,
-        ITypeResolver typeResolver,
         DeserializationOptions options)
     {
         _rootId = rootId;
         _recordMap = recordMap;
-        _typeResolver = typeResolver;
+        _typeResolver = options.TypeResolver ?? new DefaultTypeResolver(options);
         Options = options;
 
         if (Options.SurrogateSelector is not null)
@@ -120,10 +119,9 @@ internal sealed partial class Deserializer : IDeserializer
     internal static object Deserialize(
         SerializationRecordId rootId,
         IReadOnlyDictionary<SerializationRecordId, SerializationRecord> recordMap,
-        ITypeResolver typeResolver,
         DeserializationOptions options)
     {
-        var deserializer = new Deserializer(rootId, recordMap, typeResolver, options);
+        var deserializer = new Deserializer(rootId, recordMap, options);
         return deserializer.Deserialize();
     }
 


### PR DESCRIPTION
Copy the DefaultTypeResolver back from the Runtime.

This also replaces SerializationBinder in the options with ITypeResolver.

Additionally, use a bool instead of FormatterAssemblyStyle.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12382)