### PR TITLE
Update InitializeComponent() template 

### DIFF
--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-CSharp/net6.0/Form1.Designer.cs
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-CSharp/net6.0/Form1.Designer.cs
@@ -30,8 +30,8 @@ partial class Form1
     private void InitializeComponent()
     {
         components = new System.ComponentModel.Container();
-        AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-        ClientSize = new System.Drawing.Size(800, 450);
+        AutoScaleMode = AutoScaleMode.Font;
+        ClientSize = new Size(800, 450);
         Text = "Form1";
     }
 
@@ -69,8 +69,8 @@ namespace Company.WinFormsApplication1
         private void InitializeComponent()
         {
             components = new System.ComponentModel.Container();
-            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            ClientSize = new System.Drawing.Size(800, 450);
+            AutoScaleMode = AutoScaleMode.Font;
+            ClientSize = new Size(800, 450);
             Text = "Form1";
         }
 

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-CSharp/net6.0/Form1.Designer.cs
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-CSharp/net6.0/Form1.Designer.cs
@@ -29,10 +29,10 @@ partial class Form1
     /// </summary>
     private void InitializeComponent()
     {
-        this.components = new System.ComponentModel.Container();
-        this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-        this.ClientSize = new System.Drawing.Size(800, 450);
-        this.Text = "Form1";
+        components = new System.ComponentModel.Container();
+        AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+        ClientSize = new System.Drawing.Size(800, 450);
+        Text = "Form1";
     }
 
     #endregion
@@ -68,10 +68,10 @@ namespace Company.WinFormsApplication1
         /// </summary>
         private void InitializeComponent()
         {
-            this.components = new System.ComponentModel.Container();
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(800, 450);
-            this.Text = "Form1";
+            components = new System.ComponentModel.Container();
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            ClientSize = new System.Drawing.Size(800, 450);
+            Text = "Form1";
         }
 
         #endregion

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-VisualBasic/Form1.Designer.vb
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-VisualBasic/Form1.Designer.vb
@@ -23,9 +23,9 @@ Partial Class Form1
     <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
         components = New System.ComponentModel.Container()
-        Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
-        Me.ClientSize = New System.Drawing.Size(800, 450)
-        Me.Text = "Form1"
+        AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        ClientSize = New System.Drawing.Size(800, 450)
+        Text = "Form1"
     End Sub
 
 End Class

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-VisualBasic/Form1.Designer.vb
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-VisualBasic/Form1.Designer.vb
@@ -23,8 +23,8 @@ Partial Class Form1
     <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
         components = New System.ComponentModel.Container()
-        AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
-        ClientSize = New System.Drawing.Size(800, 450)
+        AutoScaleMode = AutoScaleMode.Font
+        ClientSize = New Size(800, 450)
         Text = "Form1"
     End Sub
 

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-CSharp/net6.0/UserControl1.Designer.cs
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-CSharp/net6.0/UserControl1.Designer.cs
@@ -30,8 +30,8 @@ partial class UserControl1
     private void InitializeComponent()
     {
         components = new System.ComponentModel.Container();
-        AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-        ClientSize = new System.Drawing.Size(800, 450);
+        AutoScaleMode = AutoScaleMode.Font;
+        ClientSize = new Size(800, 450);
     }
 
     #endregion
@@ -68,8 +68,8 @@ namespace Company.ControlLibrary1
         private void InitializeComponent()
         {
             components = new System.ComponentModel.Container();
-            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            ClientSize = new System.Drawing.Size(800, 450);
+            AutoScaleMode = AutoScaleMode.Font;
+            ClientSize = new Size(800, 450);
         }
 
         #endregion

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-CSharp/net6.0/UserControl1.Designer.cs
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-CSharp/net6.0/UserControl1.Designer.cs
@@ -30,8 +30,8 @@ partial class UserControl1
     private void InitializeComponent()
     {
         components = new System.ComponentModel.Container();
-        this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-        this.ClientSize = new System.Drawing.Size(800, 450);
+        AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+        ClientSize = new System.Drawing.Size(800, 450);
     }
 
     #endregion
@@ -68,8 +68,8 @@ namespace Company.ControlLibrary1
         private void InitializeComponent()
         {
             components = new System.ComponentModel.Container();
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(800, 450);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            ClientSize = new System.Drawing.Size(800, 450);
         }
 
         #endregion

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-VisualBasic/UserControl1.Designer.vb
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-VisualBasic/UserControl1.Designer.vb
@@ -23,8 +23,8 @@ Partial Class UserControl1
     <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
         components = New System.ComponentModel.Container()
-        AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
-        ClientSize = New System.Drawing.Size(800, 450)
+        AutoScaleMode = AutoScaleMode.Font
+        ClientSize = New Size(800, 450)
     End Sub
 
 End Class

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-VisualBasic/UserControl1.Designer.vb
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-VisualBasic/UserControl1.Designer.vb
@@ -23,8 +23,8 @@ Partial Class UserControl1
     <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
         components = New System.ComponentModel.Container()
-        Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
-        Me.ClientSize = New System.Drawing.Size(800, 450)
+        AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        ClientSize = New System.Drawing.Size(800, 450)
     End Sub
 
 End Class


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #8350


## Proposed changes

-  Removing `this.` and full namespace names from  InitializeComponent() template of the `Form1.Designer.cs` and `Form1.Designer.vb` 

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Modern CodeDom serialization templates can be applied when creating new projects

## Regression? 

-  No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
`this./Me.` still showed in InitializeComponent() when creating a new Winforms C#/VB project
![image](https://user-images.githubusercontent.com/26474449/206338199-235a20df-c947-45df-9441-81c75e1c5694.png)

### After
The `this./Me.` are removed
![image](https://github.com/user-attachments/assets/fc378b43-7a13-4aba-8ecc-3381e445eb53)


## Test methodology <!-- How did you ensure quality? -->

- Manually

## Test environment(s) <!-- Remove any that don't apply -->

- .net 9.0.100


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12398)