### PR TITLE
Adds coverage to ControlDesigner

### DIFF
--- a/src/System.Windows.Forms.Design/src/AssemblyInfo.cs
+++ b/src/System.Windows.Forms.Design/src/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo($"DynamicProxyGenAssembly2, PublicKey={PublicKeys.Moq}")]

--- a/src/System.Windows.Forms.Design/src/AssemblyRef.cs
+++ b/src/System.Windows.Forms.Design/src/AssemblyRef.cs
@@ -1,8 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-using System.Runtime.CompilerServices;
-
-[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")]
 
 internal static class FXAssembly
 {

--- a/src/System.Windows.Forms.Design/src/AssemblyRef.cs
+++ b/src/System.Windows.Forms.Design/src/AssemblyRef.cs
@@ -1,5 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")]
 
 internal static class FXAssembly
 {

--- a/src/System.Windows.Forms.Design/tests/UnitTests/ControlDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/ControlDesignerTests.cs
@@ -364,4 +364,17 @@ public class ControlDesignerTests : IDisposable
 
         action.Should().Throw<NotImplementedException>(SR.NotImplementedByDesign);
     }
+
+    [Fact]
+    public void WndProc_CallsOnMouseDragEnd_WhenLeftMouseButtonReleased()
+    {
+        var msg = Message.Create(_designer._control.Handle, 0x0202, IntPtr.Zero, IntPtr.Zero);
+
+        _designer.WndProc(ref msg);
+
+        _designer.OnMouseDragEndCalled.Should().BeTrue();
+
+        bool _ctrlSelect = (bool)_designer.TestAccessor().Dynamic._ctrlSelect;
+        _ctrlSelect.Should().BeFalse();
+    }
 }

--- a/src/System.Windows.Forms.Design/tests/UnitTests/ControlDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/ControlDesignerTests.cs
@@ -1,15 +1,34 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
+using System.ComponentModel;
 using System.ComponentModel.Design;
+using System.Reflection;
+using System.Windows.Forms.Design.Behavior;
 using System.Windows.Forms.Design.Tests.Mocks;
 using Moq;
 using Windows.Win32;
 
 namespace System.Windows.Forms.Design.Tests;
 
-public class ControlDesignerTests
+public class ControlDesignerTests : IDisposable
 {
+    private readonly ControlDesigner _designer = new();
+    private readonly Control _control = new();
+
+    public ControlDesignerTests()
+    {
+        _designer.Initialize(_control);
+    }
+
+    public void Dispose()
+    {
+        _designer.Dispose();
+        _control.Dispose();
+    }
+
     [WinFormsFact]
     public void ControlDesigner_Ctor_Default()
     {
@@ -226,53 +245,334 @@ public class ControlDesignerTests
         using ControlDesigner designer = new();
         using Button button = new();
         designer.Initialize(button);
-        Message m = new Message
-        {
-            Msg = (int)PInvokeCore.WM_PAINT
-        };
+        Message m = new Message { Msg = (int)PInvokeCore.WM_PAINT };
         designer.TestAccessor().Dynamic.WndProc(ref m);
     }
 
     [Fact]
     public void ControlDesigner_AssociatedComponents_NullSite_Test()
     {
-        using ControlDesigner controlDesigner = new();
-        using Control control = new();
-
         using Control childControl = new();
-        controlDesigner.Initialize(control);
 
-        Assert.Empty(controlDesigner.AssociatedComponents);
+        Assert.Empty(_designer.AssociatedComponents);
 
-        control.Controls.Add(childControl);
+        _control.Controls.Add(childControl);
 
-        Assert.Empty(controlDesigner.AssociatedComponents);
+        Assert.Empty(_designer.AssociatedComponents);
     }
 
     [WinFormsFact]
     public void ControlDesigner_AssociatedComponentsTest()
     {
-        using Control control = new();
-        using ControlDesigner controlDesigner = new();
-
         Mock<IDesignerHost> mockDesignerHost = new(MockBehavior.Strict);
+        mockDesignerHost
+            .Setup(h => h.RootComponent)
+            .Returns(_control);
+        mockDesignerHost
+            .Setup(s => s.GetDesigner(It.IsAny<Control>()))
+            .Returns(() => null);
+        var mockSite = MockSite.CreateMockSiteWithDesignerHost(mockDesignerHost.Object);
+        _control.Site = mockSite.Object;
+
+        Assert.Empty(_designer.AssociatedComponents);
+
+        using Control childControl = new();
+        childControl.Site = mockSite.Object;
+        _control.Controls.Add(childControl);
+
+        Assert.Single(_designer.AssociatedComponents);
+    }
+
+    [Fact]
+    public void GetGlyphs_Locked_ReturnsLockedGlyphs()
+    {
+        Mock<IServiceProvider> mockServiceProvider = new();
+        Mock<ISite> mockSite = new();
+        mockServiceProvider.Setup(s => s.GetService(It.IsAny<Type>())).Returns(null);
+        mockSite.Setup(s => s.GetService(typeof(IServiceProvider))).Returns(mockServiceProvider.Object);
+
+        Mock<DesignerFrame> mockDesignerFrame = new(mockSite.Object) { CallBase = true };
+        BehaviorService behaviorService = new(mockServiceProvider.Object, mockDesignerFrame.Object);
+
+        FieldInfo? behaviorServiceField = typeof(ControlDesigner).GetField("_behaviorService", BindingFlags.NonPublic | BindingFlags.Instance);
+        behaviorServiceField?.SetValue(_designer, behaviorService);
+        _designer.TestAccessor().Dynamic.Locked = true;
+        _designer.TestAccessor().Dynamic._host = new Mock<IDesignerHost>().Object;
+
+        GlyphCollection glyphs = _designer.GetGlyphs(GlyphSelectionType.SelectedPrimary);
+
+        glyphs.Count.Should().BeGreaterThan(0);
+        glyphs.Should().BeOfType<GlyphCollection>();
+        glyphs[0].Should().BeOfType<LockedHandleGlyph>();
+    }
+
+    [Fact]
+    public void GetGlyphs_GlyphSelectionTypeNotSelected_ReturnsEmptyCollection()
+    {
+        GlyphCollection glyphs = _designer.GetGlyphs(GlyphSelectionType.NotSelected);
+
+        glyphs.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public void GetGlyphs_WithNullBehaviorService_ThrowsException()
+    {
+        _designer.TestAccessor().Dynamic._behaviorService = null;
+
+        Action action = () => _designer.GetGlyphs(GlyphSelectionType.SelectedPrimary);
+        action.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void GetGlyphs_NonSizeableControl_ReturnsNoResizeHandleGlyphs()
+    {
+        using Control control = new();
+        control.Dock = DockStyle.Fill;
+        control.AutoSize = false;
+        using ControlDesigner designer = new();
+        Mock<IDesignerHost> mockDesignerHost = new();
         mockDesignerHost
             .Setup(h => h.RootComponent)
             .Returns(control);
         mockDesignerHost
             .Setup(s => s.GetDesigner(It.IsAny<Control>()))
-            .Returns(() => null);
-        var mockSite = MockSite.CreateMockSiteWithDesignerHost(mockDesignerHost.Object);
+            .Returns(designer);
+        Mock<IComponentChangeService> mockComponentChangeService = new();
+        mockDesignerHost
+            .Setup(s => s.GetService(typeof(IComponentChangeService)))
+            .Returns(mockComponentChangeService.Object);
+
+        Mock<ISite> mockSite = CreateMockSiteWithDesignerHost(mockDesignerHost.Object);
         control.Site = mockSite.Object;
 
-        controlDesigner.Initialize(control);
+        using Component component = new()
+        {
+            Site = mockSite.Object
+        };
 
-        Assert.Empty(controlDesigner.AssociatedComponents);
+        designer.Initialize(control);
 
-        using Control childControl = new();
-        childControl.Site = mockSite.Object;
-        control.Controls.Add(childControl);
+        Mock<DesignerFrame> mockDesignerFrame = new(mockSite.Object) { CallBase = true };
+        Mock<IServiceProvider> mockServiceProvider = new();
+        mockServiceProvider.Setup(s => s.GetService(It.IsAny<Type>())).Returns(mockServiceProvider);
+        mockSite.Setup(s => s.GetService(typeof(IServiceProvider))).Returns(mockServiceProvider.Object);
+        BehaviorService behaviorService = new(mockServiceProvider.Object, mockDesignerFrame.Object);
 
-        Assert.Single(controlDesigner.AssociatedComponents);
+        FieldInfo? behaviorServiceField = typeof(ControlDesigner).GetField("_behaviorService", BindingFlags.NonPublic | BindingFlags.Instance);
+        behaviorServiceField?.SetValue(designer, behaviorService);
+        mockSite.Setup(s => s.GetService(typeof(BehaviorService))).Returns(behaviorService);
+
+        GlyphCollection glyphs = designer.GetGlyphs(GlyphSelectionType.SelectedPrimary);
+
+        glyphs[0].Should().BeOfType<NoResizeHandleGlyph>();
+        ((SelectionRules)glyphs[0].TestAccessor().Dynamic.rules).Should().Be(SelectionRules.None);
+        glyphs[1].Should().BeOfType<NoResizeSelectionBorderGlyph>();
+        ((SelectionRules)glyphs[1].TestAccessor().Dynamic.rules).Should().Be(SelectionRules.None);
+        glyphs[2].Should().BeOfType<NoResizeSelectionBorderGlyph>();
+        ((SelectionRules)glyphs[2].TestAccessor().Dynamic.rules).Should().Be(SelectionRules.None);
+        glyphs[3].Should().BeOfType<NoResizeSelectionBorderGlyph>();
+        ((SelectionRules)glyphs[3].TestAccessor().Dynamic.rules).Should().Be(SelectionRules.None);
+        glyphs[4].Should().BeOfType<NoResizeSelectionBorderGlyph>();
+        ((SelectionRules)glyphs[4].TestAccessor().Dynamic.rules).Should().Be(SelectionRules.None);
+    }
+
+    [Fact]
+    public void GetGlyphs_ResizableGlyphs_ReturnsExpected()
+    {
+        _control.Dock = DockStyle.None;
+        _control.AutoSize = false;
+
+        Mock<IServiceProvider> mockServiceProvider = new();
+        Mock<ISite> mockSite = new();
+        mockServiceProvider.Setup(s => s.GetService(It.IsAny<Type>())).Returns(null);
+        mockSite.Setup(s => s.GetService(typeof(IServiceProvider))).Returns(mockServiceProvider.Object);
+
+        Mock<DesignerFrame> mockDesignerFrame = new(mockSite.Object) { CallBase = true };
+        BehaviorService behaviorService = new(mockServiceProvider.Object, mockDesignerFrame.Object);
+
+        FieldInfo? behaviorServiceField = typeof(ControlDesigner).GetField("_behaviorService", BindingFlags.NonPublic | BindingFlags.Instance);
+        behaviorServiceField?.SetValue(_designer, behaviorService);
+        _designer.TestAccessor().Dynamic._host = new Mock<IDesignerHost>().Object;
+
+        GlyphCollection glyphs = _designer.GetGlyphs(GlyphSelectionType.SelectedPrimary);
+
+        glyphs[0].Should().BeOfType<GrabHandleGlyph>();
+        ((SelectionRules)glyphs[0].TestAccessor().Dynamic.rules).Should().Be(SelectionRules.None);
+        glyphs[1].Should().BeOfType<GrabHandleGlyph>();
+        ((SelectionRules)glyphs[1].TestAccessor().Dynamic.rules).Should().Be(SelectionRules.TopSizeable | SelectionRules.LeftSizeable);
+        glyphs[2].Should().BeOfType<GrabHandleGlyph>();
+        ((SelectionRules)glyphs[2].TestAccessor().Dynamic.rules).Should().Be(SelectionRules.TopSizeable | SelectionRules.RightSizeable);
+        glyphs[3].Should().BeOfType<GrabHandleGlyph>();
+        ((SelectionRules)glyphs[3].TestAccessor().Dynamic.rules).Should().Be(SelectionRules.None);
+        glyphs[4].Should().BeOfType<GrabHandleGlyph>();
+        ((SelectionRules)glyphs[4].TestAccessor().Dynamic.rules).Should().Be(SelectionRules.BottomSizeable | SelectionRules.LeftSizeable);
+        glyphs[5].Should().BeOfType<GrabHandleGlyph>();
+        ((SelectionRules)glyphs[5].TestAccessor().Dynamic.rules).Should().Be(SelectionRules.BottomSizeable | SelectionRules.RightSizeable);
+        glyphs[6].Should().BeOfType<GrabHandleGlyph>();
+        ((SelectionRules)glyphs[6].TestAccessor().Dynamic.rules).Should().Be(SelectionRules.None);
+        glyphs[7].Should().BeOfType<GrabHandleGlyph>();
+        ((SelectionRules)glyphs[7].TestAccessor().Dynamic.rules).Should().Be(SelectionRules.None);
+        glyphs[8].Should().BeOfType<SelectionBorderGlyph>();
+        ((SelectionRules)glyphs[8].TestAccessor().Dynamic.rules).Should().Be(SelectionRules.TopSizeable);
+        glyphs[9].Should().BeOfType<SelectionBorderGlyph>();
+        ((SelectionRules)glyphs[9].TestAccessor().Dynamic.rules).Should().Be(SelectionRules.BottomSizeable);
+        glyphs[10].Should().BeOfType<SelectionBorderGlyph>();
+        ((SelectionRules)glyphs[10].TestAccessor().Dynamic.rules).Should().Be(SelectionRules.LeftSizeable);
+        glyphs[11].Should().BeOfType<SelectionBorderGlyph>();
+        ((SelectionRules)glyphs[11].TestAccessor().Dynamic.rules).Should().Be(SelectionRules.RightSizeable);
+    }
+
+    [Theory]
+    [InlineData(DockingBehavior.Never, DockStyle.None)]
+    [InlineData(DockingBehavior.AutoDock, DockStyle.Fill)]
+    public void InitializeNewComponent_DockingBehavior_DefinesDockStyle(DockingBehavior dockingBehavior, DockStyle dockStyle)
+    {
+        using Control control = new();
+        using ControlDesigner designer = new();
+
+        Mock<IDesignerHost> mockDesignerHost = new();
+        mockDesignerHost
+            .Setup(h => h.RootComponent)
+            .Returns(control);
+        mockDesignerHost
+            .Setup(s => s.GetDesigner(It.IsAny<Control>()))
+            .Returns(designer);
+        Mock<IComponentChangeService> mockComponentChangeService = new();
+        mockDesignerHost
+            .Setup(s => s.GetService(typeof(IComponentChangeService)))
+            .Returns(mockComponentChangeService.Object);
+
+        TypeDescriptor.AddAttributes(control, new DockingAttribute(dockingBehavior));
+
+        using Component component = new()
+        {
+            Site = MockSite.CreateMockSiteWithDesignerHost(mockDesignerHost.Object).Object
+        };
+        control.Site = component.Site;
+
+        designer.Initialize(control);
+
+        Mock<ParentControlDesigner> mockParentDesigner = new();
+        mockDesignerHost.Setup(h => h.GetDesigner(It.IsAny<IComponent>())).Returns(mockParentDesigner.Object);
+
+        Dictionary<string, object> defaultValues = new()
+    {
+        { "Parent", new Control() }
+    };
+
+        designer.InitializeNewComponent(defaultValues);
+
+        PropertyDescriptor? dockPropDescriptor = TypeDescriptor.GetProperties(control)["Dock"];
+        dockPropDescriptor.Should().NotBeNull();
+        dockPropDescriptor.Should().BeAssignableTo<PropertyDescriptor>();
+        dockPropDescriptor?.GetValue(control).Should().Be(dockStyle);
+    }
+
+    [Fact]
+    public void InitializeExistingComponent_DockingBehavior_DefinesDockStyle()
+    {
+        using Control control = new();
+        using ControlDesigner designer = new();
+        Mock<IDesignerHost> mockDesignerHost = new();
+        mockDesignerHost
+            .Setup(h => h.RootComponent)
+            .Returns(control);
+        mockDesignerHost
+            .Setup(s => s.GetDesigner(It.IsAny<Control>()))
+            .Returns(designer);
+        Mock<IComponentChangeService> mockComponentChangeService = new();
+        mockDesignerHost
+            .Setup(s => s.GetService(typeof(IComponentChangeService)))
+            .Returns(mockComponentChangeService.Object);
+
+        TypeDescriptor.AddAttributes(control, new DockingAttribute(DockingBehavior.AutoDock));
+
+        using Component component = new()
+        {
+            Site = MockSite.CreateMockSiteWithDesignerHost(mockDesignerHost.Object).Object
+        };
+        control.Site = component.Site;
+        designer.Initialize(control);
+        Mock<ParentControlDesigner> mockParentDesigner = new();
+        mockDesignerHost.Setup(h => h.GetDesigner(It.IsAny<IComponent>())).Returns(mockParentDesigner.Object);
+        Dictionary<string, object> defaultValues = new()
+    {
+        { "Parent", new Control() }
+    };
+        Action action = () => designer.InitializeExistingComponent(defaultValues);
+        action.Should().Throw<NotImplementedException>(SR.NotImplementedByDesign);
+    }
+
+    public static Mock<ISite> CreateMockSiteWithDesignerHost(object designerHost)
+    {
+        Mock<ISite> mockSite = new();
+        mockSite
+            .Setup(s => s.GetService(typeof(IDesignerHost)))
+            .Returns(designerHost);
+        mockSite
+            .Setup(s => s.GetService(typeof(IInheritanceService)))
+            .Returns(null);
+        mockSite
+            .Setup(s => s.GetService(typeof(IDictionaryService)))
+            .Returns(null);
+        mockSite
+            .Setup(s => s.GetService(typeof(IExtenderListService)))
+            .Returns(null);
+        mockSite
+            .Setup(s => s.GetService(typeof(ITypeDescriptorFilterService)))
+            .Returns(null);
+        mockSite
+            .Setup(s => s.GetService(typeof(AmbientProperties)))
+            .Returns(null);
+        mockSite
+            .Setup(s => s.GetService(typeof(DesignerActionService)))
+            .Returns(null);
+        mockSite
+            .Setup(s => s.GetService(typeof(IComponentChangeService)))
+            .Returns(null);
+        mockSite
+            .Setup(s => s.GetService(typeof(ToolStripKeyboardHandlingService)))
+            .Returns(null);
+        mockSite
+            .Setup(s => s.GetService(typeof(ISupportInSituService)))
+            .Returns(null);
+        mockSite
+            .Setup(s => s.GetService(typeof(INestedContainer)))
+            .Returns(null);
+        mockSite
+            .Setup(s => s.GetService(typeof(ToolStripMenuItem)))
+            .Returns(null);
+
+        Mock<IServiceProvider> mockServiceProvider = new();
+
+        mockSite
+            .Setup(s => s.GetService(typeof(IServiceProvider)))
+            .Returns(mockServiceProvider.Object);
+        mockSite
+            .Setup(s => s.GetService(typeof(ToolStripAdornerWindowService)))
+            .Returns(null);
+        mockSite
+            .Setup(s => s.GetService(typeof(DesignerOptionService)))
+            .Returns(mockServiceProvider.Object);
+
+        Mock<ISelectionService> mockSelectionService = new();
+
+        mockSite
+            .Setup(s => s.GetService(typeof(ISelectionService)))
+            .Returns(mockSelectionService.Object);
+        mockSite
+            .Setup(s => s.Container)
+            .Returns((IContainer)null);
+        mockSite
+            .Setup(s => s.Name)
+            .Returns("Site");
+        mockSite
+            .Setup(s => s.DesignMode)
+            .Returns(true);
+        mockSite
+            .Setup(s => s.GetService(typeof(UndoEngine)))
+            .Returns(null);
+
+        return mockSite;
     }
 }

--- a/src/System.Windows.Forms.Design/tests/UnitTests/ControlDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/ControlDesignerTests.cs
@@ -15,12 +15,14 @@ namespace System.Windows.Forms.Design.Tests;
 
 public class ControlDesignerTests : IDisposable
 {
-    private readonly ControlDesigner _designer = new();
+    private readonly TestControlDesigner _designer = new();
     private readonly Control _control = new();
     private readonly Mock<IDesignerHost> _mockDesignerHost = new();
+    private readonly Mock<ISite> _mockSite;
 
     public ControlDesignerTests()
     {
+        Mock<IDesignerHost> _mockDesignerHost = new();
         _mockDesignerHost
             .Setup(h => h.RootComponent)
             .Returns(_control);
@@ -31,8 +33,9 @@ public class ControlDesignerTests : IDisposable
         _mockDesignerHost
             .Setup(s => s.GetService(typeof(IComponentChangeService)))
             .Returns(mockComponentChangeService.Object);
-        Mock<ISite> mockSite = CreateMockSiteWithDesignerHost(_mockDesignerHost.Object);
-        _control.Site = mockSite.Object;
+        _mockSite = CreateMockSiteWithDesignerHost(_mockDesignerHost.Object);
+        _control.Site = _mockSite.Object;
+
         _designer.Initialize(_control);
     }
 
@@ -72,56 +75,38 @@ public class ControlDesignerTests : IDisposable
     [Fact]
     public void AccessibleObjectField()
     {
-        using TestControlDesigner controlDesigner = new();
-        using Button button = new();
-        controlDesigner.Initialize(button);
-        Assert.Null(controlDesigner.GetAccessibleObjectField());
+        Assert.Null(_designer.GetAccessibleObjectField());
     }
 
     [Fact]
     public void BehaviorServiceProperty()
     {
-        using TestControlDesigner controlDesigner = new();
-        using Button button = new();
-        controlDesigner.Initialize(button);
-        Assert.Null(controlDesigner.GetBehaviorServiceProperty());
+        Assert.Null(_designer.GetBehaviorServiceProperty());
     }
 
     [Fact]
     public void AccessibilityObjectField()
     {
-        using TestControlDesigner controlDesigner = new();
-        using Button button = new();
-        controlDesigner.Initialize(button);
-        Assert.NotNull(controlDesigner.AccessibilityObject);
+        Assert.NotNull(_designer.AccessibilityObject);
     }
 
     [Fact]
     public void EnableDragRectProperty()
     {
-        using TestControlDesigner controlDesigner = new();
-        using Button button = new();
-        controlDesigner.Initialize(button);
-        Assert.False(controlDesigner.GetEnableDragRectProperty());
+        Assert.False(_designer.GetEnableDragRectProperty());
     }
 
     [Fact]
     public void ParticipatesWithSnapLinesProperty()
     {
-        using TestControlDesigner controlDesigner = new();
-        using Button button = new();
-        controlDesigner.Initialize(button);
-        Assert.True(controlDesigner.ParticipatesWithSnapLines);
+        Assert.True(_designer.ParticipatesWithSnapLines);
     }
 
     [Fact]
     public void AutoResizeHandlesProperty()
     {
-        using TestControlDesigner controlDesigner = new();
-        using Button button = new();
-        controlDesigner.Initialize(button);
-        Assert.True(controlDesigner.AutoResizeHandles = true);
-        Assert.True(controlDesigner.AutoResizeHandles);
+        Assert.True(_designer.AutoResizeHandles = true);
+        Assert.True(_designer.AutoResizeHandles);
     }
 
     [Theory]
@@ -147,123 +132,82 @@ public class ControlDesignerTests : IDisposable
     [Fact]
     public void InheritanceAttributeProperty()
     {
-        using TestControlDesigner controlDesigner = new();
-        using Button button = new();
-        controlDesigner.Initialize(button);
-        Assert.NotNull(controlDesigner.GetInheritanceAttributeProperty());
+        Assert.NotNull(_designer.GetInheritanceAttributeProperty());
     }
 
     [Fact]
     public void NumberOfInternalControlDesignersTest()
     {
-        using TestControlDesigner controlDesigner = new();
-        using Button button = new();
-        controlDesigner.Initialize(button);
-        Assert.Equal(0, controlDesigner.NumberOfInternalControlDesigners());
+        Assert.Equal(0, _designer.NumberOfInternalControlDesigners());
     }
 
     [Fact]
     public void BaseWndProcTest()
     {
-        using TestControlDesigner controlDesigner = new();
-        using Button button = new();
-        controlDesigner.Initialize(button);
         Message m = default;
-        controlDesigner.BaseWndProcMethod(ref m);
+        _designer.BaseWndProcMethod(ref m);
     }
 
     [Fact]
     public void CanBeParentedToTest()
     {
-        using TestControlDesigner controlDesigner = new();
-        using Button button = new();
-        controlDesigner.Initialize(button);
         using ParentControlDesigner parentDesigner = new();
         using Button parentButton = new();
         parentDesigner.Initialize(parentButton);
-        Assert.True(controlDesigner.CanBeParentedTo(parentDesigner));
+        Assert.True(_designer.CanBeParentedTo(parentDesigner));
     }
 
     [Theory]
     [BoolData]
     public void EnableDragDropTest(bool val)
     {
-        using TestControlDesigner controlDesigner = new();
-        using Button button = new();
-        controlDesigner.Initialize(button);
-        controlDesigner.EnableDragDropMethod(val);
+        _designer.EnableDragDropMethod(val);
     }
 
     [Fact]
     public void GetHitTest()
     {
-        using TestControlDesigner controlDesigner = new();
-        using Button button = new();
-        controlDesigner.Initialize(button);
-        Assert.False(controlDesigner.GetHitTestMethod(default));
+        Assert.False(_designer.GetHitTestMethod(default));
     }
 
     [Fact]
     public void HookChildControlsTest()
     {
-        using TestControlDesigner controlDesigner = new();
-        using Button button = new();
-        controlDesigner.Initialize(button);
-        controlDesigner.HookChildControlsMethod(new Control());
-    }
-
-    [Fact]
-    public void InitializeTest()
-    {
-        using TestControlDesigner controlDesigner = new();
-        using Button button = new();
-        controlDesigner.Initialize(button);
+        _designer.HookChildControlsMethod(new Control());
     }
 
     [Fact]
     public void UninitializedTest()
     {
-        using TestControlDesigner controlDesigner = new();
-        Assert.Throws<InvalidOperationException>(() => controlDesigner.Control);
+        using TestControlDesigner _designer = new();
+        Assert.Throws<InvalidOperationException>(() => _designer.Control);
     }
 
     [Fact]
     public void OnSetComponentDefaultsTest()
     {
-        using TestControlDesigner controlDesigner = new();
-        using Button button = new();
-        controlDesigner.Initialize(button);
 #pragma warning disable CS0618 // Type or member is obsolete
-        controlDesigner.OnSetComponentDefaults();
+        _designer.OnSetComponentDefaults();
 #pragma warning restore CS0618
     }
 
     [Fact]
     public void OnContextMenuTest()
     {
-        using TestControlDesigner controlDesigner = new();
-        using Button button = new();
-        controlDesigner.Initialize(button);
-        controlDesigner.OnContextMenuMethod(0, 0);
+        _designer.OnContextMenuMethod(0, 0);
     }
 
     [Fact]
     public void OnCreateHandleTest()
     {
-        using TestControlDesigner controlDesigner = new();
-        using Button button = new();
-        controlDesigner.Initialize(button);
-        controlDesigner.OnCreateHandleMethod();
+        _designer.OnCreateHandleMethod();
     }
 
     [WinFormsFact]
     public void ControlDesigner_WndProc_InvokePaint_Success()
     {
-        using ControlDesigner designer = new();
-        using Button button = new();
-        designer.Initialize(button);
         Message m = new Message { Msg = (int)PInvokeCore.WM_PAINT };
-        designer.TestAccessor().Dynamic.WndProc(ref m);
+        _designer.TestAccessor().Dynamic.WndProc(ref m);
     }
 
     [Fact]
@@ -281,14 +225,7 @@ public class ControlDesignerTests : IDisposable
     [WinFormsFact]
     public void ControlDesigner_AssociatedComponentsTest()
     {
-        Mock<IDesignerHost> mockDesignerHost = new(MockBehavior.Strict);
-        mockDesignerHost
-            .Setup(h => h.RootComponent)
-            .Returns(_control);
-        mockDesignerHost
-            .Setup(s => s.GetDesigner(It.IsAny<Control>()))
-            .Returns(() => null);
-        var mockSite = MockSite.CreateMockSiteWithDesignerHost(mockDesignerHost.Object);
+        var mockSite = MockSite.CreateMockSiteWithDesignerHost(_mockDesignerHost.Object);
         _control.Site = mockSite.Object;
 
         Assert.Empty(_designer.AssociatedComponents);
@@ -339,43 +276,20 @@ public class ControlDesignerTests : IDisposable
     [Fact]
     public void GetGlyphs_NonSizeableControl_ReturnsNoResizeHandleGlyphs()
     {
-        using Control control = new();
-        control.Dock = DockStyle.Fill;
-        control.AutoSize = false;
-        using ControlDesigner designer = new();
-        Mock<IDesignerHost> mockDesignerHost = new();
-        mockDesignerHost
-            .Setup(h => h.RootComponent)
-            .Returns(control);
-        mockDesignerHost
-            .Setup(s => s.GetDesigner(It.IsAny<Control>()))
-            .Returns(designer);
-        Mock<IComponentChangeService> mockComponentChangeService = new();
-        mockDesignerHost
-            .Setup(s => s.GetService(typeof(IComponentChangeService)))
-            .Returns(mockComponentChangeService.Object);
+        _control.Dock = DockStyle.Fill;
+        _control.AutoSize = false;
 
-        Mock<ISite> mockSite = CreateMockSiteWithDesignerHost(mockDesignerHost.Object);
-        control.Site = mockSite.Object;
-
-        using Component component = new()
-        {
-            Site = mockSite.Object
-        };
-
-        designer.Initialize(control);
-
-        Mock<DesignerFrame> mockDesignerFrame = new(mockSite.Object) { CallBase = true };
+        Mock<DesignerFrame> mockDesignerFrame = new(_mockSite.Object) { CallBase = true };
         Mock<IServiceProvider> mockServiceProvider = new();
         mockServiceProvider.Setup(s => s.GetService(It.IsAny<Type>())).Returns(mockServiceProvider);
-        mockSite.Setup(s => s.GetService(typeof(IServiceProvider))).Returns(mockServiceProvider.Object);
+        _mockSite.Setup(s => s.GetService(typeof(IServiceProvider))).Returns(mockServiceProvider.Object);
         BehaviorService behaviorService = new(mockServiceProvider.Object, mockDesignerFrame.Object);
 
         FieldInfo? behaviorServiceField = typeof(ControlDesigner).GetField("_behaviorService", BindingFlags.NonPublic | BindingFlags.Instance);
-        behaviorServiceField?.SetValue(designer, behaviorService);
-        mockSite.Setup(s => s.GetService(typeof(BehaviorService))).Returns(behaviorService);
+        behaviorServiceField?.SetValue(_designer, behaviorService);
+        _mockSite.Setup(s => s.GetService(typeof(BehaviorService))).Returns(behaviorService);
 
-        GlyphCollection glyphs = designer.GetGlyphs(GlyphSelectionType.SelectedPrimary);
+        GlyphCollection glyphs = _designer.GetGlyphs(GlyphSelectionType.SelectedPrimary);
 
         glyphs[0].Should().BeOfType<NoResizeHandleGlyph>();
         ((SelectionRules)glyphs[0].TestAccessor().Dynamic.rules).Should().Be(SelectionRules.None);
@@ -396,16 +310,14 @@ public class ControlDesignerTests : IDisposable
         _control.AutoSize = false;
 
         Mock<IServiceProvider> mockServiceProvider = new();
-        Mock<ISite> mockSite = new();
         mockServiceProvider.Setup(s => s.GetService(It.IsAny<Type>())).Returns((object?)null);
-        mockSite.Setup(s => s.GetService(typeof(IServiceProvider))).Returns(mockServiceProvider.Object);
+        _mockSite.Setup(s => s.GetService(typeof(IServiceProvider))).Returns(mockServiceProvider.Object);
 
-        Mock<DesignerFrame> mockDesignerFrame = new(mockSite.Object) { CallBase = true };
+        Mock<DesignerFrame> mockDesignerFrame = new(_mockSite.Object) { CallBase = true };
         BehaviorService behaviorService = new(mockServiceProvider.Object, mockDesignerFrame.Object);
 
         FieldInfo? behaviorServiceField = typeof(ControlDesigner).GetField("_behaviorService", BindingFlags.NonPublic | BindingFlags.Instance);
         behaviorServiceField?.SetValue(_designer, behaviorService);
-        _designer.TestAccessor().Dynamic._host = new Mock<IDesignerHost>().Object;
 
         GlyphCollection glyphs = _designer.GetGlyphs(GlyphSelectionType.SelectedPrimary);
 
@@ -442,11 +354,6 @@ public class ControlDesignerTests : IDisposable
     {
         TypeDescriptor.AddAttributes(_control, new DockingAttribute(dockingBehavior));
 
-        using Component component = new()
-        {
-            Site = _control.Site
-        };
-
         Mock<ParentControlDesigner> mockParentDesigner = new();
         _mockDesignerHost.Setup(h => h.GetDesigner(It.IsAny<IComponent>())).Returns(mockParentDesigner.Object);
 
@@ -466,35 +373,15 @@ public class ControlDesignerTests : IDisposable
     [Fact]
     public void InitializeExistingComponent_DockingBehavior_DefinesDockStyle()
     {
-        using Control control = new();
-        using ControlDesigner designer = new();
-        Mock<IDesignerHost> mockDesignerHost = new();
-        mockDesignerHost
-            .Setup(h => h.RootComponent)
-            .Returns(control);
-        mockDesignerHost
-            .Setup(s => s.GetDesigner(It.IsAny<Control>()))
-            .Returns(designer);
-        Mock<IComponentChangeService> mockComponentChangeService = new();
-        mockDesignerHost
-            .Setup(s => s.GetService(typeof(IComponentChangeService)))
-            .Returns(mockComponentChangeService.Object);
+        TypeDescriptor.AddAttributes(_control, new DockingAttribute(DockingBehavior.AutoDock));
 
-        TypeDescriptor.AddAttributes(control, new DockingAttribute(DockingBehavior.AutoDock));
-
-        using Component component = new()
-        {
-            Site = MockSite.CreateMockSiteWithDesignerHost(mockDesignerHost.Object).Object
-        };
-        control.Site = component.Site;
-        designer.Initialize(control);
         Mock<ParentControlDesigner> mockParentDesigner = new();
-        mockDesignerHost.Setup(h => h.GetDesigner(It.IsAny<IComponent>())).Returns(mockParentDesigner.Object);
+        _mockDesignerHost.Setup(h => h.GetDesigner(It.IsAny<IComponent>())).Returns(mockParentDesigner.Object);
         Dictionary<string, object> defaultValues = new()
     {
         { "Parent", new Control() }
     };
-        Action action = () => designer.InitializeExistingComponent(defaultValues);
+        Action action = () => _designer.InitializeExistingComponent(defaultValues);
         action.Should().Throw<NotImplementedException>(SR.NotImplementedByDesign);
     }
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/ControlDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/ControlDesignerTests.cs
@@ -177,6 +177,14 @@ public class ControlDesignerTests : IDisposable
     }
 
     [Fact]
+    public void InitializeTest()
+    {
+        using TestControlDesigner controlDesigner = new();
+        using Button button = new();
+        controlDesigner.Initialize(button);
+    }
+
+    [Fact]
     public void UninitializedTest()
     {
         using TestControlDesigner _designer = new();

--- a/src/System.Windows.Forms.Design/tests/UnitTests/ControlDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/ControlDesignerTests.cs
@@ -4,7 +4,6 @@
 #nullable enable
 
 using System.ComponentModel;
-using System.Reflection;
 using System.Windows.Forms.Design.Behavior;
 using System.Windows.Forms.Design.Tests.Mocks;
 using Moq;
@@ -268,10 +267,9 @@ public class ControlDesignerTests : IDisposable
         Mock<DesignerFrame> mockDesignerFrame = new(_designer._mockSite.Object) { CallBase = true };
         Mock<IServiceProvider> mockServiceProvider = new();
         BehaviorService behaviorService = new(mockServiceProvider.Object, mockDesignerFrame.Object);
-
-        FieldInfo? behaviorServiceField = typeof(ControlDesigner).GetField("_behaviorService", BindingFlags.NonPublic | BindingFlags.Instance);
-        behaviorServiceField?.SetValue(_designer, behaviorService);
         _designer._mockSite.Setup(s => s.GetService(typeof(BehaviorService))).Returns(behaviorService);
+
+        _designer.TestAccessor().Dynamic._behaviorService = behaviorService;
 
         GlyphCollection glyphs = _designer.GetGlyphs(GlyphSelectionType.SelectedPrimary);
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/ControlDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/ControlDesignerTests.cs
@@ -57,12 +57,12 @@ public class ControlDesignerTests : IDisposable
 
         Action action1 = () =>
         {
-            using Control _ = controlDesigner.Control;
+            Control _ = controlDesigner.Control;
         };
 
         Action action2 = () =>
         {
-            using IComponent component = controlDesigner.Component;
+            IComponent component = controlDesigner.Component;
         };
 
         Action action3 = () => controlDesigner.GetParentComponentProperty();
@@ -96,12 +96,18 @@ public class ControlDesignerTests : IDisposable
         _designer.AccessibilityObject.Should().NotBeNull();
         _designer.GetEnableDragRectProperty().Should().BeFalse();
         _designer.ParticipatesWithSnapLines.Should().BeTrue();
-        (_designer.AutoResizeHandles = true).Should().BeTrue();
-        _designer.AutoResizeHandles.Should().BeTrue();
+        _designer.AutoResizeHandles.Should().BeFalse();
         _designer.GetInheritanceAttributeProperty().Should().NotBeNull();
         _designer.NumberOfInternalControlDesigners().Should().Be(0);
         _designer.GetHitTestMethod(default).Should().BeFalse();
-        _designer.HookChildControlsMethod(new Control());
+        _designer.HookChildControlsMethod(_control);
+    }
+
+    [Fact]
+    public void AutoResizeHandles_Set_GetReturnsExpected()
+    {
+        _designer.AutoResizeHandles = true;
+        _designer.AutoResizeHandles.Should().BeTrue();
     }
 
     [Theory]
@@ -356,13 +362,13 @@ public class ControlDesignerTests : IDisposable
         _mockDesignerHost.Setup(h => h.GetDesigner(It.IsAny<IComponent>())).Returns(mockParentDesigner.Object);
 
         Dictionary<string, object> defaultValues = new()
-    {
-        { "Parent", new Control() }
-    };
+        {
+            { "Parent", new Control() }
+        };
 
         _designer.InitializeNewComponent(defaultValues);
 
-        PropertyDescriptor? dockPropDescriptor = TypeDescriptor.GetProperties(_control)["Dock"];
+        PropertyDescriptor? dockPropDescriptor = TypeDescriptor.GetProperties(_control)[nameof(Control.Dock)];
         dockPropDescriptor.Should().NotBeNull();
         dockPropDescriptor.Should().BeAssignableTo<PropertyDescriptor>();
         dockPropDescriptor?.GetValue(_control).Should().Be(dockStyle);
@@ -377,7 +383,7 @@ public class ControlDesignerTests : IDisposable
         _mockDesignerHost.Setup(h => h.GetDesigner(It.IsAny<IComponent>())).Returns(mockParentDesigner.Object);
         Dictionary<string, object> defaultValues = new()
         {
-            { "Parent", new Control() }
+            { nameof(mockParentDesigner.Object.Component), new Control() }
         };
 
         Action action = () => _designer.InitializeExistingComponent(defaultValues);

--- a/src/System.Windows.Forms.Design/tests/UnitTests/TestControlDesigner.Mocks.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/TestControlDesigner.Mocks.cs
@@ -1,0 +1,116 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System.ComponentModel;
+using System.ComponentModel.Design;
+using Moq;
+
+namespace System.Windows.Forms.Design.Tests;
+
+internal partial class TestControlDesigner
+{
+    internal readonly Control _control = new();
+    internal readonly Mock<IDesignerHost> _mockDesignerHost = new();
+    internal readonly Mock<ISite> _mockSite = new();
+
+    public TestControlDesigner(bool isInitialized = true)
+    {
+        _mockDesignerHost
+            .Setup(h => h.RootComponent)
+            .Returns(_control);
+        _mockDesignerHost
+            .Setup(s => s.GetDesigner(It.IsAny<Control>()))
+            .Returns(this);
+        Mock<IComponentChangeService> mockComponentChangeService = new();
+        _mockDesignerHost
+            .Setup(s => s.GetService(typeof(IComponentChangeService)))
+            .Returns(mockComponentChangeService.Object);
+        _mockSite = CreateMockSiteWithDesignerHost(_mockDesignerHost.Object);
+        _control.Site = _mockSite.Object;
+
+        if (isInitialized)
+        {
+            Initialize(_control);
+        }
+    }
+
+    public new void Dispose()
+    {
+        _control.Dispose();
+    }
+
+    public static Mock<ISite> CreateMockSiteWithDesignerHost(object designerHost)
+    {
+        Mock<ISite> mockSite = new();
+        mockSite
+            .Setup(s => s.GetService(typeof(IDesignerHost)))
+            .Returns(designerHost);
+        mockSite
+            .Setup(s => s.GetService(typeof(IInheritanceService)))
+            .Returns((object?)null);
+        mockSite
+            .Setup(s => s.GetService(typeof(IDictionaryService)))
+            .Returns((object?)null);
+        mockSite
+            .Setup(s => s.GetService(typeof(IExtenderListService)))
+            .Returns((object?)null);
+        mockSite
+            .Setup(s => s.GetService(typeof(ITypeDescriptorFilterService)))
+            .Returns((object?)null);
+        mockSite
+            .Setup(s => s.GetService(typeof(AmbientProperties)))
+            .Returns((object?)null);
+        mockSite
+            .Setup(s => s.GetService(typeof(DesignerActionService)))
+            .Returns((object?)null);
+        mockSite
+            .Setup(s => s.GetService(typeof(IComponentChangeService)))
+            .Returns((object?)null);
+        mockSite
+            .Setup(s => s.GetService(typeof(ToolStripKeyboardHandlingService)))
+            .Returns((object?)null);
+        mockSite
+            .Setup(s => s.GetService(typeof(ISupportInSituService)))
+            .Returns((object?)null);
+        mockSite
+            .Setup(s => s.GetService(typeof(INestedContainer)))
+            .Returns((object?)null);
+        mockSite
+            .Setup(s => s.GetService(typeof(ToolStripMenuItem)))
+            .Returns((object?)null);
+
+        Mock<IServiceProvider> mockServiceProvider = new();
+
+        mockSite
+            .Setup(s => s.GetService(typeof(IServiceProvider)))
+            .Returns(mockServiceProvider.Object);
+        mockSite
+            .Setup(s => s.GetService(typeof(ToolStripAdornerWindowService)))
+            .Returns((object?)null);
+        mockSite
+            .Setup(s => s.GetService(typeof(DesignerOptionService)))
+            .Returns(mockServiceProvider.Object);
+
+        Mock<ISelectionService> mockSelectionService = new();
+
+        mockSite
+            .Setup(s => s.GetService(typeof(ISelectionService)))
+            .Returns(mockSelectionService.Object);
+        mockSite
+            .Setup(s => s.Container)
+            .Returns((IContainer?)null);
+        mockSite
+            .Setup(s => s.Name)
+            .Returns("Site");
+        mockSite
+            .Setup(s => s.DesignMode)
+            .Returns(true);
+        mockSite
+            .Setup(s => s.GetService(typeof(UndoEngine)))
+            .Returns((object?)null);
+
+        return mockSite;
+    }
+}

--- a/src/System.Windows.Forms.Design/tests/UnitTests/TestControlDesigner.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/TestControlDesigner.cs
@@ -7,7 +7,7 @@ using System.Windows.Forms.Design.Behavior;
 
 namespace System.Windows.Forms.Design.Tests;
 
-internal class TestControlDesigner : ControlDesigner
+internal partial class TestControlDesigner : ControlDesigner
 {
     internal AccessibleObject GetAccessibleObjectField()
     {

--- a/src/System.Windows.Forms.Design/tests/UnitTests/TestControlDesigner.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/TestControlDesigner.cs
@@ -9,6 +9,8 @@ namespace System.Windows.Forms.Design.Tests;
 
 internal partial class TestControlDesigner : ControlDesigner
 {
+    internal bool OnMouseDragEndCalled { get; private set; }
+
     internal AccessibleObject GetAccessibleObjectField()
     {
         return accessibilityObj;
@@ -87,5 +89,17 @@ internal partial class TestControlDesigner : ControlDesigner
     internal void OnCreateHandleMethod()
     {
         OnCreateHandle();
+    }
+
+    internal new void WndProc(ref Message m)
+    {
+        base.WndProc(ref m);
+    }
+
+    protected override void OnMouseDragEnd(bool cancel)
+    {
+        OnMouseDragEndCalled = true;
+
+        base.OnMouseDragEnd(cancel);
     }
 }


### PR DESCRIPTION
Related #10773

## Proposed changes

- Adds coverage for `ControlDesigner`.
- Introduces the `CreateMockSiteWithDesignerHost()` helper function, as the original (`MockSite.CreateMockSiteWithDesignerHost()`) was configured with `MockBehavior.Strict`, which conflicted with the requirements of `ControlDesigner.GetGlyphs()`.

## Customer Impact

- None

## Regression?

- No

## Risk

- Minimal

## Test methodology

- Unit tests

## Test environment(s)

- 9.0.100-rc.2.24474.12