### PR TITLE
Disabling ToolTip visual styles to make it dark enough in Dark mode

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip/ToolTip.cs
@@ -718,6 +718,13 @@ public partial class ToolTip : Component, IExtenderProvider, IHandle<HWND>
             {
                 PInvoke.SetWindowTheme(HWND, string.Empty, string.Empty);
             }
+
+#pragma warning disable WFO5001
+            if (Application.IsDarkModeEnabled)
+            {
+                PInvoke.SetWindowTheme(HWND, string.Empty, string.Empty);
+            }
+#pragma warning restore WFO5001
         }
 
         // If in OwnerDraw mode, we don't want the default border.
@@ -770,15 +777,11 @@ public partial class ToolTip : Component, IExtenderProvider, IHandle<HWND>
         // Set active status.
         PInvokeCore.SendMessage(this, PInvoke.TTM_ACTIVATE, (WPARAM)(BOOL)_active);
 
-        if (BackColor != SystemColors.Info)
-        {
-            PInvokeCore.SendMessage(this, PInvoke.TTM_SETTIPBKCOLOR, (WPARAM)BackColor);
-        }
+        // Set background color.
+        PInvokeCore.SendMessage(this, PInvoke.TTM_SETTIPBKCOLOR, (WPARAM)_backColor);
 
-        if (ForeColor != SystemColors.InfoText)
-        {
-            PInvokeCore.SendMessage(this, PInvoke.TTM_SETTIPTEXTCOLOR, (WPARAM)ForeColor);
-        }
+        // Set text color.
+        PInvokeCore.SendMessage(this, PInvoke.TTM_SETTIPTEXTCOLOR, (WPARAM)_foreColor);
 
         if (_toolTipIcon > 0 || !string.IsNullOrEmpty(_toolTipTitle))
         {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolTipTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolTipTests.cs
@@ -782,6 +782,36 @@ public class ToolTipTests
         Assert.Equal("System.Windows.Forms.ToolTip InitialDelay: 500, ShowAlways: False", toolTip.ToString());
     }
 
+#pragma warning disable WFO5001
+    [WinFormsFact]
+    public void ToolTip_DarkMode_GetColors_ReturnsExpected()
+    {
+        if (SystemInformation.HighContrast)
+        {
+            // We don't run this test in HighContrast mode.
+            return;
+        }
+
+        SystemColorMode colorMode = Application.ColorMode;
+        Application.SetColorMode(SystemColorMode.Dark);
+
+        using SubToolTip toolTip = new();
+
+        Assert.NotEqual(IntPtr.Zero, toolTip.Handle); // A workaround to create the toolTip native window Handle
+
+        var backgroundColor = PInvokeCore.SendMessage(toolTip, PInvoke.TTM_GETTIPBKCOLOR);
+        Color backColor = ColorTranslator.FromWin32((int)backgroundColor);
+
+        var textColor = PInvokeCore.SendMessage(toolTip, PInvoke.TTM_GETTIPTEXTCOLOR);
+        Color foreColor = ColorTranslator.FromWin32((int)textColor);
+
+        Assert.Equal(SystemColors.Info.ToArgb(), backColor.ToArgb());
+        Assert.Equal(SystemColors.InfoText.ToArgb(), foreColor.ToArgb());
+
+        Application.SetColorMode(colorMode);
+    }
+#pragma warning restore WFO5001
+
     [WinFormsFact]
     public void ToolTip_SetToolTipToControl_Invokes_SetToolTip_OfControl()
     {


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #11954 

## Proposed changes

- Disable ToolTip visual styles in dark mode.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Fixes an issue with ToolTip not being dark enough in Dark mode.

## Regression? 

- No

## Risk

- I believe risk is low since this approach is similar to how high contrast mode is handled.

<!-- end TELL-MODE -->

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![ToolTipDarkModeBefore](https://github.com/user-attachments/assets/94231574-f1a4-4bdc-a968-86acde78994c)

### After

![ToolTipDarkModeAfter](https://github.com/user-attachments/assets/8b2604b2-5207-4b02-add5-c87b824b495a)

## Test methodology <!-- How did you ensure quality? -->

- Run unit and integration tests.
- Manually tested.