### PR TITLE
Fix VB issues caused by dotnet#12426) in tests

### DIFF
--- a/src/Microsoft.VisualBasic.Forms/tests/UnitTests/System/Windows/Forms/ApplicationServicesExceptionsTests.vb
+++ b/src/Microsoft.VisualBasic.Forms/tests/UnitTests/System/Windows/Forms/ApplicationServicesExceptionsTests.vb
@@ -11,9 +11,9 @@ Imports VbUtils = Microsoft.VisualBasic.CompilerServices.ExceptionUtils
 Namespace Microsoft.VisualBasic.Forms.Tests
 
     Public Class ApplicationServicesExceptionsTests
-        Private Const TestMessage As String = "Test"
         Private Const Test1Message As String = "Test1"
-        Private _innerException As New DirectoryNotFoundException
+        Private Const TestMessage As String = "Test"
+        Private ReadOnly _innerException As New DirectoryNotFoundException
 
         <WinFormsFact>
         Public Sub NewCantStartSingleInstanceException()

--- a/src/Microsoft.VisualBasic.Forms/tests/UnitTests/System/Windows/Forms/CompilerServicesTests.vb
+++ b/src/Microsoft.VisualBasic.Forms/tests/UnitTests/System/Windows/Forms/CompilerServicesTests.vb
@@ -5,7 +5,6 @@ Option Strict Off
 
 Imports System.Windows.Forms
 Imports FluentAssertions
-Imports Microsoft.VisualBasic.CompilerServices
 Imports Xunit
 
 Namespace Microsoft.VisualBasic.Forms.Tests

--- a/src/Microsoft.VisualBasic.Forms/tests/UnitTests/System/Windows/Forms/SingleInstanceHelpersTests.vb
+++ b/src/Microsoft.VisualBasic.Forms/tests/UnitTests/System/Windows/Forms/SingleInstanceHelpersTests.vb
@@ -67,15 +67,16 @@ Namespace Microsoft.VisualBasic.Forms.Tests
                     awaitable.GetAwaiter().GetResult()
                     Dim CancelToken As New CancellationToken
                     Dim buffer As Byte() = New Byte(commandLine.Length) {}
-                    Dim count As Integer = Await pipeServer.ReadAsync(
-                        buffer:=buffer.AsMemory(start:=0, length:=commandLine.Length))
+                    Dim count As Integer =
+                        Await pipeServer.ReadAsync(buffer:=buffer.AsMemory(start:=0, length:=commandLine.Length)) _
+                            .ConfigureAwait(continueOnCapturedContext:=True)
 
                     ' Ensure the result is set
                     Do
-                        Await Task.Delay(5)
+                        Await Task.Delay(5).ConfigureAwait(continueOnCapturedContext:=True)
                     Loop Until _resultArgs IsNot Nothing
                     _resultArgs(0).Should.Be("Hello")
-                    Await tokenSource.CancelAsync()
+                    Await tokenSource.CancelAsync().ConfigureAwait(continueOnCapturedContext:=True)
                 End Using
             End If
         End Function

--- a/src/Microsoft.VisualBasic.Forms/tests/UnitTests/System/Windows/Forms/UserTests.UserPrincipal.vb
+++ b/src/Microsoft.VisualBasic.Forms/tests/UnitTests/System/Windows/Forms/UserTests.UserPrincipal.vb
@@ -10,8 +10,8 @@ Namespace Microsoft.VisualBasic.Forms.Tests
         Private NotInheritable Class UserPrincipal
             Implements IPrincipal
 
-            Private _role As String
-            Private _userIdentity As IIdentity
+            Private ReadOnly _role As String
+            Private ReadOnly _userIdentity As IIdentity
 
             Public Sub New(authenticationType As String, name As String, isAuthenticated As Boolean, role As String)
                 _userIdentity = New UserIdentity(authenticationType, name, isAuthenticated)

--- a/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/Generators/ProjectFileReaderTests.FontConverter.cs
+++ b/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/Generators/ProjectFileReaderTests.FontConverter.cs
@@ -27,7 +27,7 @@ public partial class ProjectFileReaderTests
 
         public static TheoryData<CultureInfo, string, string, float, int, int> TestConvertFormData()
         {
-            TheoryData<CultureInfo, string, string, float, int, int> testData = new();
+            TheoryData<CultureInfo, string, string, float, int, int> testData = [];
 
             foreach (string cultureName in s_locales)
             {

--- a/src/System.Windows.Forms.Analyzers.VisualBasic/tests/UnitTests/System.Windows.Forms.Analyzers.VisualBasic.Tests/AvoidPassingTaskWithoutCancellationTokenTest.vb
+++ b/src/System.Windows.Forms.Analyzers.VisualBasic/tests/UnitTests/System.Windows.Forms.Analyzers.VisualBasic.Tests/AvoidPassingTaskWithoutCancellationTokenTest.vb
@@ -171,7 +171,7 @@ End Namespace
                     DiagnosticResult.CompilerWarning(diagnosticId).WithSpan(46, 25, 46, 102)
                 })
 
-        Await context.RunAsync()
+        Await context.RunAsync().ConfigureAwait(continueOnCapturedContext:=True)
     End Function
 
 End Class

--- a/src/System.Windows.Forms.Analyzers.VisualBasic/tests/UnitTests/System.Windows.Forms.Analyzers.VisualBasic.Tests/MissingPropertySerializationConfigurationAnalyzerTest.vb
+++ b/src/System.Windows.Forms.Analyzers.VisualBasic/tests/UnitTests/System.Windows.Forms.Analyzers.VisualBasic.Tests/MissingPropertySerializationConfigurationAnalyzerTest.vb
@@ -173,7 +173,7 @@ End Namespace
 
         context.TestState.OutputKind = OutputKind.WindowsApplication
 
-        Await context.RunAsync()
+        Await context.RunAsync().ConfigureAwait(continueOnCapturedContext:=True)
     End Function
 
     <Theory>
@@ -189,7 +189,7 @@ End Namespace
 
         context.TestState.OutputKind = OutputKind.WindowsApplication
 
-        Await context.RunAsync()
+        Await context.RunAsync().ConfigureAwait(continueOnCapturedContext:=True)
     End Function
 
     <Theory>
@@ -208,6 +208,6 @@ End Namespace
 
         context.TestState.OutputKind = OutputKind.WindowsApplication
 
-        Await context.RunAsync()
+        Await context.RunAsync().ConfigureAwait(continueOnCapturedContext:=True)
     End Function
 End Class


### PR DESCRIPTION
Fixes VB issues caused by dotnet#12426) in tests

## Proposed changes
- Fix all the VB issues exposed by PR #12426

## Customer Impact
- reduces developer noise in Visual Studio

## Regression? 
- Yes, in source but not with respect to customer using code

## Risk
- None, 100% changes are in tests

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12429)