### PR TITLE
Fixed the issue where edit textBox loses focus when using up/down to switch property values ​​on edit textBox

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.GridViewTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.GridViewTextBox.cs
@@ -306,6 +306,15 @@ internal partial class PropertyGridView
             return false;
         }
 
+        private protected override void SelectInternal(int start, int length, int textLen)
+        {
+            base.SelectInternal(start, length, textLen);
+            if (IsAccessibilityObjectCreated)
+            {
+                AccessibilityObject.RaiseAutomationEvent(UIA_EVENT_ID.UIA_AutomationFocusChangedEventId);
+            }
+        }
+
         protected override void WndProc(ref Message m)
         {
             if (_filter && PropertyGridView.FilterEditWndProc(ref m))

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.GridViewTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.GridViewTextBox.cs
@@ -306,15 +306,6 @@ internal partial class PropertyGridView
             return false;
         }
 
-        private protected override void SelectInternal(int start, int length, int textLen)
-        {
-            base.SelectInternal(start, length, textLen);
-            if (IsAccessibilityObjectCreated)
-            {
-                AccessibilityObject.RaiseAutomationEvent(UIA_EVENT_ID.UIA_AutomationFocusChangedEventId);
-            }
-        }
-
         protected override void WndProc(ref Message m)
         {
             if (_filter && PropertyGridView.FilterEditWndProc(ref m))

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.cs
@@ -3997,7 +3997,7 @@ internal sealed partial class PropertyGridView :
             startRow = 0;
         }
 
-        if (OwnerGrid.HavePropertyEntriesChanged())
+        if (fullRefresh || OwnerGrid.HavePropertyEntriesChanged())
         {
             if (HasEntries && !InPropertySet && !CommitEditTextBox())
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.cs
@@ -3997,7 +3997,7 @@ internal sealed partial class PropertyGridView :
             startRow = 0;
         }
 
-        if (fullRefresh || OwnerGrid.HavePropertyEntriesChanged())
+        if (OwnerGrid.HavePropertyEntriesChanged())
         {
             if (HasEntries && !InPropertySet && !CommitEditTextBox())
             {


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #12440


## Proposed changes

- When setting a property with the [RefreshProperties(RefreshProperties.All)] attribute, suppress recalculation and reset constants for the entire property page

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- The rectangle in the edit text box always stays in the edit textbox when changing the property value using the up/down buttons 

## Regression? 

- No

## Risk

- Mininal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
The rectangle always back to focus on entire row after using the up/down changed the property values directly in the edit textbox
![BeforeChanges](https://github.com/user-attachments/assets/8452b4d2-c08a-4f06-b0b6-4418f5a8a75a)


### After
The rectangle in the edit text box always stays in the edit textbox when changing the property value using the up/down buttons 
![AfterChanges](https://github.com/user-attachments/assets/9e53bbd5-6c55-4eb5-bc31-2392c910417e)

## Test methodology <!-- How did you ensure quality? -->

- Manually


## Test environment(s) <!-- Remove any that don't apply -->

- .net 10.0.0-alpha.1.24554.9


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12431)