### PR TITLE
Add unit test for TextBoxBaseDesigner

### DIFF
--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/TextBoxBaseDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/TextBoxBaseDesignerTests.cs
@@ -24,19 +24,6 @@ public class TextBoxBaseDesignerTests : IDisposable
         _textbox.Site = site.Object;
     }
 
-    private void InitializeDesigner(BorderStyle borderStyle)
-    {
-        _textbox.BorderStyle = borderStyle;
-        _designer.Initialize(_textbox);
-    }
-
-    private void InitializeDesigner(bool multiline,bool autoSize)
-    {
-        _textbox.Multiline = multiline;
-        _textbox.AutoSize = autoSize;
-        _designer.Initialize(_textbox);
-    }
-
     public void Dispose()
     {
         _designer.Dispose();
@@ -60,7 +47,8 @@ public class TextBoxBaseDesignerTests : IDisposable
     [InlineData(BorderStyle.Fixed3D, 3)]
     public void SnapLines_ReturnsCorrectSnapLines(BorderStyle borderStyle, int expectedBaselineOffset)
     {
-        InitializeDesigner(borderStyle);
+        _textbox.BorderStyle = borderStyle;
+        _designer.Initialize(_textbox);
 
         List<SnapLine> snapLines = (List<SnapLine>)_designer.SnapLines;
 
@@ -73,14 +61,15 @@ public class TextBoxBaseDesignerTests : IDisposable
         baselineSnapLine.Offset.Should().Be(expectedBaseline);
     }
 
-
     [WinFormsTheory]
     [InlineData(false, true, SelectionRules.LeftSizeable | SelectionRules.RightSizeable)]
     [InlineData(true, true, SelectionRules.AllSizeable)]
     [InlineData(false, false, SelectionRules.AllSizeable)]
     public void SelectionRules_ReturnsCorrectRules(bool multiline, bool autoSize, SelectionRules expectedRules)
     {
-        InitializeDesigner(multiline, autoSize);
+        _textbox.Multiline = multiline;
+        _textbox.AutoSize = autoSize;
+        _designer.Initialize(_textbox);
         SelectionRules rules = _designer.SelectionRules;
 
         rules.Should().HaveFlag(expectedRules);

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/TextBoxBaseDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/TextBoxBaseDesignerTests.cs
@@ -59,7 +59,7 @@ public class TextBoxBaseDesignerTests : IDisposable
         baselineSnapLine.Should().NotBeNull();
         baselineSnapLine!.Priority.Should().Be(SnapLinePriority.Medium);
         int expectedBaseline = DesignerUtils.GetTextBaseline(_textbox, Drawing.ContentAlignment.TopLeft) + expectedBaselineOffset;
-        
+
         baselineSnapLine.Offset.Should().Be(expectedBaseline);
     }
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/TextBoxBaseDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/TextBoxBaseDesignerTests.cs
@@ -1,0 +1,98 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using Moq;
+using System.ComponentModel.Design;
+using System.ComponentModel;
+using System.Windows.Forms.Design.Behavior;
+
+namespace System.Windows.Forms.Design.Tests;
+
+public class TextBoxBaseDesignerTests : IDisposable
+{
+    private readonly TextBoxBaseDesigner _designer;
+    private readonly TextBox _textbox;
+
+    public TextBoxBaseDesignerTests()
+    {
+        _designer = new();
+        _textbox = new();
+        Mock<ISite> site = new();
+        site.Setup(s => s.GetService(typeof(IDesignerHost))).Returns(new Mock<IDesignerHost>().Object);
+        _textbox.Site = site.Object;
+    }
+
+    private void InitializeDesigner(BorderStyle borderStyle)
+    {
+        _textbox.BorderStyle = borderStyle;
+        _designer.Initialize(_textbox);
+    }
+
+    private void InitializeDesigner(bool multiline,bool autoSize)
+    {
+        _textbox.Multiline = multiline;
+        _textbox.AutoSize = autoSize;
+        _designer.Initialize(_textbox);
+    }
+
+    public void Dispose()
+    {
+        _designer.Dispose();
+        _textbox.Dispose();
+    }
+
+    [Fact]
+    public void Constructor_SetsAutoResizeHandlesToTrue_AND_SelectionRules_ReturnsCorrectRules()
+    {       
+        _designer.AutoResizeHandles.Should().BeTrue();
+        _designer.Initialize(_textbox);
+
+        SelectionRules rules = _designer.SelectionRules;
+
+        rules.Should().NotHaveFlag(SelectionRules.TopSizeable | SelectionRules.BottomSizeable);
+    }
+
+    [WinFormsTheory]
+    [InlineData(BorderStyle.None, 0)]
+    [InlineData(BorderStyle.FixedSingle, 2)]
+    [InlineData(BorderStyle.Fixed3D, 3)]
+    public void SnapLines_ReturnsCorrectSnapLines(BorderStyle borderStyle, int expectedBaselineOffset)
+    {
+        InitializeDesigner(borderStyle);
+
+        List<SnapLine> snapLines = (List<SnapLine>)_designer.SnapLines;
+
+        snapLines.Should().NotBeNull();
+        SnapLine? baselineSnapLine = snapLines.Cast<SnapLine>().FirstOrDefault(sl => sl.SnapLineType == SnapLineType.Baseline);
+        baselineSnapLine.Should().NotBeNull();
+        baselineSnapLine!.Priority.Should().Be(SnapLinePriority.Medium);
+        
+        int expectedBaseline = DesignerUtils.GetTextBaseline(_textbox, Drawing.ContentAlignment.TopLeft) + expectedBaselineOffset;
+        baselineSnapLine.Offset.Should().Be(expectedBaseline);
+    }
+
+
+    [WinFormsTheory]
+    [InlineData(false, true, SelectionRules.LeftSizeable | SelectionRules.RightSizeable)]
+    [InlineData(true, true, SelectionRules.AllSizeable)]
+    [InlineData(false, false, SelectionRules.AllSizeable)]
+    public void SelectionRules_ReturnsCorrectRules(bool multiline, bool autoSize, SelectionRules expectedRules)
+    {
+        InitializeDesigner(multiline, autoSize);
+        SelectionRules rules = _designer.SelectionRules;
+
+        rules.Should().HaveFlag(expectedRules);
+    }
+
+    [Fact]
+    public void InitializeNewComponent_ClearsTextProperty_And_NotClearIfReadOnly()
+    {
+        _textbox.Text = "Test Text";
+        _designer.Initialize(_textbox);
+        _textbox.Text.Should().Be("Test Text");
+        _designer.InitializeNewComponent(null);
+        _textbox.Text.Should().BeEmpty();   
+    }
+}

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/TextBoxBaseDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/TextBoxBaseDesignerTests.cs
@@ -32,7 +32,7 @@ public class TextBoxBaseDesignerTests : IDisposable
 
     [Fact]
     public void Constructor_SetsAutoResizeHandlesToTrue_AND_SelectionRules_ReturnsCorrectRules()
-    {       
+    {
         _designer.AutoResizeHandles.Should().BeTrue();
         _designer.Initialize(_textbox);
 
@@ -53,11 +53,14 @@ public class TextBoxBaseDesignerTests : IDisposable
         List<SnapLine> snapLines = (List<SnapLine>)_designer.SnapLines;
 
         snapLines.Should().NotBeNull();
+
         SnapLine? baselineSnapLine = snapLines.Cast<SnapLine>().FirstOrDefault(sl => sl.SnapLineType == SnapLineType.Baseline);
+
         baselineSnapLine.Should().NotBeNull();
         baselineSnapLine!.Priority.Should().Be(SnapLinePriority.Medium);
         
         int expectedBaseline = DesignerUtils.GetTextBaseline(_textbox, Drawing.ContentAlignment.TopLeft) + expectedBaselineOffset;
+
         baselineSnapLine.Offset.Should().Be(expectedBaseline);
     }
 
@@ -78,10 +81,15 @@ public class TextBoxBaseDesignerTests : IDisposable
     [Fact]
     public void InitializeNewComponent_ClearsTextProperty_And_NotClearIfReadOnly()
     {
+        _textbox.Text.Should().BeEmpty();
+
         _textbox.Text = "Test Text";
         _designer.Initialize(_textbox);
+
         _textbox.Text.Should().Be("Test Text");
+
         _designer.InitializeNewComponent(null);
-        _textbox.Text.Should().BeEmpty();   
+
+        _textbox.Text.Should().BeEmpty();
     }
 }

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/TextBoxBaseDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/TextBoxBaseDesignerTests.cs
@@ -58,9 +58,8 @@ public class TextBoxBaseDesignerTests : IDisposable
 
         baselineSnapLine.Should().NotBeNull();
         baselineSnapLine!.Priority.Should().Be(SnapLinePriority.Medium);
-        
         int expectedBaseline = DesignerUtils.GetTextBaseline(_textbox, Drawing.ContentAlignment.TopLeft) + expectedBaselineOffset;
-
+        
         baselineSnapLine.Offset.Should().Be(expectedBaseline);
     }
 
@@ -73,13 +72,12 @@ public class TextBoxBaseDesignerTests : IDisposable
         _textbox.Multiline = multiline;
         _textbox.AutoSize = autoSize;
         _designer.Initialize(_textbox);
-        SelectionRules rules = _designer.SelectionRules;
 
-        rules.Should().HaveFlag(expectedRules);
+        _designer.SelectionRules.Should().HaveFlag(expectedRules);
     }
 
     [Fact]
-    public void InitializeNewComponent_ClearsTextProperty_And_NotClearIfReadOnly()
+    public void InitializeNewComponent_ClearsTextProperty()
     {
         _textbox.Text.Should().BeEmpty();
 


### PR DESCRIPTION
Related https://github.com/dotnet/winforms/issues/10773
## Proposed changes
1. Add unit test TextBoxBaseDesignerTests.cs for public properties and method of the TextBoxBaseDesigner.
2. Enable nullability in TextBoxBaseDesignerTests.cs.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12433)