### PR TITLE
fix 12441 [Accessibility] HC themes: The color contrast is less than 4.5:1 for the text "Document does not contain any pages" in printPreviewControl

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewControl.cs
@@ -592,7 +592,13 @@ public partial class PrintPreviewControl : Control
 
     private void DrawMessage(Graphics g, Rectangle rect, bool isExceptionPrinting)
     {
-        using var brush = SystemColors.ControlText.GetCachedSolidBrushScope();
+        Color brushColor = SystemColors.ControlText;
+        if (SystemInformation.HighContrast && Parent is not null)
+        {
+            brushColor = Parent.BackColor;
+        }
+
+        using var brush = brushColor.GetCachedSolidBrushScope();
 
         using StringFormat format = new()
         {
@@ -737,7 +743,7 @@ public partial class PrintPreviewControl : Control
     /// </returns>
     private Color GetBackColor(bool isHighContract)
     {
-        return (isHighContract && !ShouldSerializeBackColor()) ? SystemColors.ControlDark : BackColor;
+        return (isHighContract && !ShouldSerializeBackColor()) ? SystemColors.ControlDarkDark : BackColor;
     }
 
     private static int PixelsToPhysical(int pixels, int dpi) => (int)(pixels * 100.0 / dpi);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewControl.cs
@@ -593,9 +593,9 @@ public partial class PrintPreviewControl : Control
     private void DrawMessage(Graphics g, Rectangle rect, bool isExceptionPrinting)
     {
         Color brushColor = SystemColors.ControlText;
-        if (SystemInformation.HighContrast && Parent is not null)
+        if (SystemInformation.HighContrast && Parent is Control parent)
         {
-            brushColor = Parent.BackColor;
+            brushColor = parent.BackColor;
         }
 
         using var brush = brushColor.GetCachedSolidBrushScope();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Printing/PrintPreviewControlTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Printing/PrintPreviewControlTests.cs
@@ -8,34 +8,37 @@ namespace System.Windows.Forms.Tests;
 // NB: doesn't require thread affinity
 public class PrintPreviewControlTests
 {
-    private const int EmptyColorArgb = 0;
-    private const int BlueColorArgb = -16776961;
-    private const int GreenColorArgb = -16744448;
-    private const int ControlDarkColorArgb = -6250336;
-    private const int AppWorkSpaceNoHcColorArgb = -5526613;
-    private const int AppWorkSpaceHcColorArgb = -1;
-
-    [Theory]
-    [InlineData(EmptyColorArgb, false, AppWorkSpaceNoHcColorArgb)]
-    [InlineData(EmptyColorArgb, true, ControlDarkColorArgb)]
-    [InlineData(BlueColorArgb, false, BlueColorArgb)]
-    [InlineData(GreenColorArgb, true, GreenColorArgb)]
-    public void ShowPrintPreviewControl_BackColorIsCorrect(int customBackColorArgb, bool isHighContrast, int expectedBackColorArgb)
+    [Fact]
+    public void ShowPrintPreviewControl_BackColorIsCorrect()
     {
         PrintPreviewControl control = new();
 
-        if (customBackColorArgb != EmptyColorArgb)
-        {
-            control.BackColor = Color.FromArgb(customBackColorArgb);
-        }
+        int actualBackColorArgb = control.TestAccessor().Dynamic.GetBackColor(false).ToArgb();
+        Assert.Equal(SystemColors.AppWorkspace.ToArgb(), actualBackColorArgb);
 
-        int actualBackColorArgb = control.TestAccessor().Dynamic.GetBackColor(isHighContrast).ToArgb();
-        Assert.Equal(expectedBackColorArgb, actualBackColorArgb);
+        control.BackColor = Color.Green;
 
+        actualBackColorArgb = control.TestAccessor().Dynamic.GetBackColor(false).ToArgb();
+        Assert.Equal(Color.Green.ToArgb(), actualBackColorArgb);
+    }
+
+    [Fact]
+    public void ShowPrintPreviewControlHighContrast_BackColorIsCorrect()
+    {
+        PrintPreviewControl control = new();
+
+        int actualBackColorArgb = control.TestAccessor().Dynamic.GetBackColor(true).ToArgb();
+
+        Assert.Equal(SystemColors.ControlDarkDark.ToArgb(), actualBackColorArgb);
         // Default AppWorkSpace color in HC theme does not allow to follow HC standards.
-        if (isHighContrast)
-        {
-            Assert.True(!AppWorkSpaceHcColorArgb.Equals(actualBackColorArgb));
-        }
+        Assert.False(SystemColors.AppWorkspace.ToArgb().Equals(actualBackColorArgb));
+
+        control.BackColor = Color.Green;
+
+        actualBackColorArgb = control.TestAccessor().Dynamic.GetBackColor(true).ToArgb();
+
+        Assert.Equal(Color.Green.ToArgb(), actualBackColorArgb);
+        // Default AppWorkSpace color in HC theme does not allow to follow HC standards.
+        Assert.False(SystemColors.AppWorkspace.ToArgb().Equals(actualBackColorArgb));
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Printing/PrintPreviewControlTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Printing/PrintPreviewControlTests.cs
@@ -38,7 +38,6 @@ public class PrintPreviewControlTests
         actualBackColorArgb = control.TestAccessor().Dynamic.GetBackColor(true).ToArgb();
 
         Assert.Equal(Color.Green.ToArgb(), actualBackColorArgb);
-        // Default AppWorkSpace color in HC theme does not allow to follow HC standards.
         Assert.False(SystemColors.AppWorkspace.ToArgb().Equals(actualBackColorArgb));
     }
 }


### PR DESCRIPTION


<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #12441


## Proposed changes

- 
- change back color and fore color
- 

<!--  

## Customer Impact

- 
- 

## Regression? 

- Yes / No

## Risk

-
-->
<!--  -->


## Screenshots 
### Before

![Image](https://github.com/user-attachments/assets/e2ddad7f-f191-4de2-82b5-5180efef4777)

### After
![image](https://github.com/user-attachments/assets/fb77d268-02a1-4bef-bd5a-e470e72bae22)
![image](https://github.com/user-attachments/assets/40e0367c-929c-4da4-a72e-56f48474082a)
![image](https://github.com/user-attachments/assets/2a542299-e09e-42d7-ac20-ed1574d85626)
![image](https://github.com/user-attachments/assets/6de43c8c-5830-48fe-b458-b0fb3e26e4ca)
![image](https://github.com/user-attachments/assets/0f46be08-27bf-47e0-b258-7724da5a1844)




## Test methodology 

- 
- manually accessibility insights
- 
<!--
## Accessibility testing  


 

## Test environment(s)   

-->


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12448)