### PR TITLE
Fix namespace for ImageIndexEditorTests

### DIFF
--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ImageIndexEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ImageIndexEditorTests.cs
@@ -8,7 +8,7 @@ using System.Drawing;
 using System.Drawing.Design;
 using Moq;
 
-namespace System.Windows.Forms.Design;
+namespace System.Windows.Forms.Design.Tests;
 
 public class ImageIndexEditorTests
 {


### PR DESCRIPTION
Fixes #12237 
Related #10773

## Proposed changes

- Fixes namespace for the `ImageIndexEditorTests` class.

## Customer Impact

- None

## Risk

- Minimal

## Test environment(s)

- 9.0.100-rc.2.24474.12 

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12452)