### PR TITLE
Fix nullability error CS8620 in tests

### DIFF
--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ToolStripContentPanelDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ToolStripContentPanelDesignerTests.cs
@@ -36,11 +36,11 @@ public sealed class ToolStripContentPanelDesignerTests : IDisposable
     [Fact]
     public void SnapLines_ShouldCallAddPaddingSnapLines()
     {
-        string[] paddingFilters = [SnapLine.PaddingLeft, SnapLine.PaddingRight, SnapLine.PaddingTop, SnapLine.PaddingBottom];
+        string?[] paddingFilters = [SnapLine.PaddingLeft, SnapLine.PaddingRight, SnapLine.PaddingTop, SnapLine.PaddingBottom];
 
         List<SnapLine> snapLines = _toolStripContentPanelDesigner.SnapLines.Cast<SnapLine>().ToList();
 
-        bool containsPaddingSnapLines = snapLines.Any(snapLine => paddingFilters.Contains(snapLine.Filter ?? string.Empty));
+        bool containsPaddingSnapLines = snapLines.Any(snapLine => paddingFilters.Contains(snapLine.Filter));
 
         containsPaddingSnapLines.Should().BeTrue();
     }

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ToolStripContentPanelDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ToolStripContentPanelDesignerTests.cs
@@ -40,7 +40,7 @@ public sealed class ToolStripContentPanelDesignerTests : IDisposable
 
         List<SnapLine> snapLines = _toolStripContentPanelDesigner.SnapLines.Cast<SnapLine>().ToList();
 
-        bool containsPaddingSnapLines = snapLines.Any(snapLine => paddingFilters.Contains(snapLine.Filter));
+        bool containsPaddingSnapLines = snapLines.Any(snapLine => paddingFilters.Contains(snapLine.Filter ?? string.Empty));
 
         containsPaddingSnapLines.Should().BeTrue();
     }


### PR DESCRIPTION
Fix warning (as error):

> src\winforms\src\System.Windows.Forms.Design\tests\UnitTests\System\Windows\Forms\Design\ToolStripContentPanelDesignerTests.cs(43,67): error CS8620: (NETCORE_ENGINEERING_TELEMETRY=Build) Argument of type 'string[]' cannot be used for parameter 'span' of type 'Span<string?>' in 'bool MemoryExtensions.Contains<string?>(Span<string?> span, string? value)' due to differences in the nullability of reference types.

This is to unblock https://github.com/dotnet/sdk/pull/44843. I have tested with `10.0.100-alpha.1.24562.4` in global.json, this is the only instance of the error.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12475)