### PR TITLE
[release/9.0] Informational text in PrintPreviewControl has low contrast in basic and HightContrast themes.

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewControl.cs
@@ -592,7 +592,7 @@ public partial class PrintPreviewControl : Control
 
     private void DrawMessage(Graphics g, Rectangle rect, bool isExceptionPrinting)
     {
-        using var brush = ForeColor.GetCachedSolidBrushScope();
+        using var brush = SystemColors.ControlText.GetCachedSolidBrushScope();
 
         using StringFormat format = new()
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewControl.cs
@@ -592,7 +592,13 @@ public partial class PrintPreviewControl : Control
 
     private void DrawMessage(Graphics g, Rectangle rect, bool isExceptionPrinting)
     {
-        using var brush = SystemColors.ControlText.GetCachedSolidBrushScope();
+        Color brushColor = SystemColors.ControlText;
+        if (SystemInformation.HighContrast && Parent is Control parent)
+        {
+            brushColor = parent.BackColor;
+        }
+
+        using var brush = brushColor.GetCachedSolidBrushScope();
 
         using StringFormat format = new()
         {
@@ -737,7 +743,7 @@ public partial class PrintPreviewControl : Control
     /// </returns>
     private Color GetBackColor(bool isHighContract)
     {
-        return (isHighContract && !ShouldSerializeBackColor()) ? SystemColors.ControlDark : BackColor;
+        return (isHighContract && !ShouldSerializeBackColor()) ? SystemColors.ControlDarkDark : BackColor;
     }
 
     private static int PixelsToPhysical(int pixels, int dpi) => (int)(pixels * 100.0 / dpi);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Printing/PrintPreviewControlTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Printing/PrintPreviewControlTests.cs
@@ -8,34 +8,36 @@ namespace System.Windows.Forms.Tests;
 // NB: doesn't require thread affinity
 public class PrintPreviewControlTests
 {
-    private const int EmptyColorArgb = 0;
-    private const int BlueColorArgb = -16776961;
-    private const int GreenColorArgb = -16744448;
-    private const int ControlDarkColorArgb = -6250336;
-    private const int AppWorkSpaceNoHcColorArgb = -5526613;
-    private const int AppWorkSpaceHcColorArgb = -1;
-
-    [Theory]
-    [InlineData(EmptyColorArgb, false, AppWorkSpaceNoHcColorArgb)]
-    [InlineData(EmptyColorArgb, true, ControlDarkColorArgb)]
-    [InlineData(BlueColorArgb, false, BlueColorArgb)]
-    [InlineData(GreenColorArgb, true, GreenColorArgb)]
-    public void ShowPrintPreviewControl_BackColorIsCorrect(int customBackColorArgb, bool isHighContrast, int expectedBackColorArgb)
+    [Fact]
+    public void ShowPrintPreviewControl_BackColorIsCorrect()
     {
         PrintPreviewControl control = new();
 
-        if (customBackColorArgb != EmptyColorArgb)
-        {
-            control.BackColor = Color.FromArgb(customBackColorArgb);
-        }
+        int actualBackColorArgb = control.TestAccessor().Dynamic.GetBackColor(false).ToArgb();
+        Assert.Equal(SystemColors.AppWorkspace.ToArgb(), actualBackColorArgb);
 
-        int actualBackColorArgb = control.TestAccessor().Dynamic.GetBackColor(isHighContrast).ToArgb();
-        Assert.Equal(expectedBackColorArgb, actualBackColorArgb);
+        control.BackColor = Color.Green;
 
+        actualBackColorArgb = control.TestAccessor().Dynamic.GetBackColor(false).ToArgb();
+        Assert.Equal(Color.Green.ToArgb(), actualBackColorArgb);
+    }
+
+    [Fact]
+    public void ShowPrintPreviewControlHighContrast_BackColorIsCorrect()
+    {
+        PrintPreviewControl control = new();
+
+        int actualBackColorArgb = control.TestAccessor().Dynamic.GetBackColor(true).ToArgb();
+
+        Assert.Equal(SystemColors.ControlDarkDark.ToArgb(), actualBackColorArgb);
         // Default AppWorkSpace color in HC theme does not allow to follow HC standards.
-        if (isHighContrast)
-        {
-            Assert.True(!AppWorkSpaceHcColorArgb.Equals(actualBackColorArgb));
-        }
+        Assert.False(SystemColors.AppWorkspace.ToArgb().Equals(actualBackColorArgb));
+
+        control.BackColor = Color.Green;
+
+        actualBackColorArgb = control.TestAccessor().Dynamic.GetBackColor(true).ToArgb();
+
+        Assert.Equal(Color.Green.ToArgb(), actualBackColorArgb);
+        Assert.False(SystemColors.AppWorkspace.ToArgb().Equals(actualBackColorArgb));
     }
 }


### PR DESCRIPTION
Backport of #12368 and #12448 to release/9.0
BUG: https://github.com/dotnet/winforms/issues/12365, https://github.com/dotnet/winforms/issues/12441


## Bug Description
When `PrintPreviewControl` has no document to show, it shows a text message to that effect.  This message has low color contrast ratio, making it hard to read. Text to background ratio is 2.3:1 or 3.9:1 in high contrast mode instead of the required 4.5:1 (https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html)

## Customer Impact
Accessibility requirement violation.
## Regression?
no
## Testing done
* manual, using Accessibility insights. Testing covered Dark mode and all HC modes on both Windows11 and windows10
* test team ran migrated automation cases 
## Risk
low, these colors are not under user control, they wouldn't interfere with user changes.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12478)