### PR TITLE
Override SelectInternal to add UIA_AutomationFocusChangedEventId in PropertyGridView.GridViewTextBox

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.GridViewTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.GridViewTextBox.cs
@@ -306,6 +306,15 @@ internal partial class PropertyGridView
             return false;
         }
 
+        private protected override void SelectInternal(int start, int length, int textLen)
+        {
+            base.SelectInternal(start, length, textLen);
+            if (IsAccessibilityObjectCreated)
+            {
+                AccessibilityObject.RaiseAutomationEvent(UIA_EVENT_ID.UIA_AutomationFocusChangedEventId);
+            }
+        }
+
         protected override void WndProc(ref Message m)
         {
             if (_filter && PropertyGridView.FilterEditWndProc(ref m))


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #12421


## Proposed changes

-  Override `SelectInternal` in PropertyGridView.GridViewTextBox to add `RaiseAutomationEvent(UIA_EVENT_ID.UIA_AutomationFocusChangedEventId)`

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

-  When switching the items by using up/down keyboard arrow that without expand the dropdown list panel, Narrator announced the property item entirety.

## Regression? 

- Yes  

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

When switching the items by using up/down keyboard arrow that without expand the dropdown list panel, Narrator can not announced the property item entirety.
![image](https://github.com/user-attachments/assets/dd08f579-5553-45a4-b02f-07ff81f5c247)

### After
When switching the items by using up/down keyboard arrow that without expand the dropdown list panel, Narrator announced the property item entirety.
![image](https://github.com/user-attachments/assets/e4f8991f-e109-4261-bc35-e480b7d21fa6)



## Test methodology <!-- How did you ensure quality? -->

- Manually
 

## Test environment(s) <!-- Remove any that don't apply -->

- .net 10.0.0-alpha.1.24562.13


<!-- Mention language, UI scaling, or anything else that might be relevant -->
