### PR TITLE
Ensure GDI+ is initialized for all codepaths

### DIFF
--- a/src/System.Drawing.Common/src/System/Drawing/Graphics.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Graphics.cs
@@ -3525,6 +3525,7 @@ public sealed unsafe partial class Graphics : MarshalByRefObject, IDisposable, I
             {
                 if (s_halftonePalette.IsNull)
                 {
+                    GdiPlusInitialization.EnsureInitialized();
                     s_halftonePalette = PInvokeCore.GdipCreateHalftonePalette();
                 }
             }

--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/ImageCodecInfo.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/ImageCodecInfo.cs
@@ -38,6 +38,8 @@ public sealed unsafe class ImageCodecInfo
 
     public static ImageCodecInfo[] GetImageDecoders()
     {
+        GdiPlusInitialization.EnsureInitialized();
+
         ImageCodecInfo[] imageCodecs;
         uint numDecoders;
         uint size;
@@ -57,6 +59,8 @@ public sealed unsafe class ImageCodecInfo
 
     public static ImageCodecInfo[] GetImageEncoders()
     {
+        GdiPlusInitialization.EnsureInitialized();
+
         ImageCodecInfo[] imageCodecs;
         uint numEncoders;
         uint size;

--- a/src/System.Private.Windows.Core/src/NativeMethods.txt
+++ b/src/System.Private.Windows.Core/src/NativeMethods.txt
@@ -77,6 +77,9 @@ GetCurrentThreadId
 GetSysColorBrush
 GetWindowText
 GetWindowTextLength
+// All callers of these APIs MUST call GdiPlusInitialization.EnsureInitialized() before use.
+// There is no easy way to do this in Core as we want to make sure it is only done when needed.
+// (If using another GDI+ handle or wrapped object you can assume GDI+ is initialized.)
 GdipBitmapLockBits
 GdipBitmapUnlockBits
 GdipCreateFromHWND

--- a/src/System.Private.Windows.Core/src/Windows/Win32/Graphics/GdiPlus/GdiPlusInitialization.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/Graphics/GdiPlus/GdiPlusInitialization.cs
@@ -3,6 +3,9 @@
 
 namespace Windows.Win32.Graphics.GdiPlus;
 
+/// <summary>
+///  Helper to ensure GDI+ is initialized before making calls.
+/// </summary>
 internal static partial class GdiPlusInitialization
 {
     private static readonly nuint s_initToken = Init();
@@ -23,5 +26,18 @@ internal static partial class GdiPlusInitialization
     /// <summary>
     ///  Returns true if GDI+ has been started.
     /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   This should be called anywhere you make <see cref="PInvokeCore"/> calls to GDI+ where you don't
+    ///   already have a GDI+ handle. In System.Drawing.Common, this is done in the PInvoke static constructor
+    ///   so it is not necessary for methods defined there.
+    ///  </para>
+    ///  <para>
+    ///   We don't do this implicitly in the Core assembly to avoid unnecessary loading of GDI+.
+    ///  </para>
+    ///  <para>
+    ///   https://github.com/microsoft/CsWin32/issues/1308 tracks a proposal to make this more automatic.
+    ///  </para>
+    /// </remarks>
     internal static bool EnsureInitialized() => s_initToken != 0;
 }


### PR DESCRIPTION
A few places slipped through the cracks. If you call GetImageEncoders before any other System.Drawing code, you will get a fatal error.

Fixes #12494

There isn't a great way to add a regression test for this as any other call that initializes GDI+ will cause the test to not find this.

Created https://github.com/microsoft/CsWin32/issues/1308 to try and make this programmatic. If this ends up being problematic, we could add another core assembly `System.Private.Windows.Core.GdiPlus` to handle this scenario. Said assembly would _have_ to depend on `System.Private.Windows.Core`.