### PR TITLE
Ensure GDI+ is initialized for all codepaths

### DIFF
--- a/src/System.Drawing.Common/src/System/Drawing/Imaging/ImageCodecInfo.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Imaging/ImageCodecInfo.cs
@@ -57,6 +57,8 @@ public sealed unsafe class ImageCodecInfo
 
     public static ImageCodecInfo[] GetImageEncoders()
     {
+        GdiPlusInitialization.EnsureInitialized();
+
         ImageCodecInfo[] imageCodecs;
         uint numEncoders;
         uint size;

--- a/src/System.Private.Windows.Core/src/Windows/Win32/Graphics/GdiPlus/GdiPlusInitialization.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/Graphics/GdiPlus/GdiPlusInitialization.cs
@@ -3,6 +3,9 @@
 
 namespace Windows.Win32.Graphics.GdiPlus;
 
+/// <summary>
+///  Helper to ensure GDI+ is initialized before making calls.
+/// </summary>
 internal static partial class GdiPlusInitialization
 {
     private static readonly nuint s_initToken = Init();
@@ -23,5 +26,18 @@ internal static partial class GdiPlusInitialization
     /// <summary>
     ///  Returns true if GDI+ has been started.
     /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   This should be called anywhere you make <see cref="PInvokeCore"/> calls to GDI+ where you don't
+    ///   already have a GDI+ handle. In System.Drawing.Common, this is done in the PInvoke static constructor
+    ///   so it is not necessary for methods defined there.
+    ///  </para>
+    ///  <para>
+    ///   We don't do this implicitly in the Core assembly to avoid unnecessary loading of GDI+.
+    ///  </para>
+    ///  <para>
+    ///   https://github.com/microsoft/CsWin32/issues/1308 tracks a proposal to make this more automatic.
+    ///  </para>
+    /// </remarks>
     internal static bool EnsureInitialized() => s_initToken != 0;
 }


### PR DESCRIPTION
One place slipped through the cracks. If you call GetImageEncoders before any other System.Drawing code you will get a fatal error.

(Port from #12501)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12504)