### PR TITLE
Unhook the mouse down hook at the end of PropertyGridView.ProcessEnumUpAndDown

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.cs
@@ -2475,6 +2475,7 @@ internal sealed partial class PropertyGridView :
             }
 
             CommitValue(entry, valueNew, closeDropDown);
+            EditTextBox.HookMouseDown = false;
             EditTextBox?.SelectAll();
             return true;
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.cs
@@ -2476,7 +2476,7 @@ internal sealed partial class PropertyGridView :
 
             CommitValue(entry, valueNew, closeDropDown);
             EditTextBox.HookMouseDown = false;
-            EditTextBox?.SelectAll();
+            EditTextBox.SelectAll();
             return true;
         }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #12434

## Root cause:

After changing the value by pressing up/down keyboard directly in EditTextbox, the `EditTextBox.HookMouseDown` will be set to True

The stack trace:
```
at System.Windows.Forms.PropertyGridInternal.PropertyGridView.GridViewTextBox.set_HookMouseDown(Boolean value)
at System.Windows.Forms.PropertyGridInternal.PropertyGridView.SetCommitError(ErrorState error, Boolean capture)
at System.Windows.Forms.PropertyGridInternal.PropertyGridView.OnEditChange(Object sender, EventArgs e)
at System.Windows.Forms.Control.OnTextChanged(EventArgs e)
at System.Windows.Forms.TextBoxBase.OnTextChanged(EventArgs e)
at System.Windows.Forms.Control.set_Text(String value)
at System.Windows.Forms.TextBoxBase.set_Text(String value)
at System.Windows.Forms.TextBox.set_Text(String value)
at System.Windows.Forms.PropertyGridInternal.PropertyGridView.GridViewTextBox.set_Text(String value)
at System.Windows.Forms.PropertyGridInternal.PropertyGridView.CommitValue(GridEntry entry, Object value, Boolean closeDropDown)
at System.Windows.Forms.PropertyGridInternal.PropertyGridView.ProcessEnumUpAndDown(GridEntry entry, Keys keyCode, Boolean closeDropDown)


```
then pressing `Alt+Down` to open the DropDown list, and select a item, the [CommitValue ](https://github.com/dotnet/winforms/blob/7896a6e7b4d3627c76bd3168d0042f72574d9b14/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.cs#L4663) will be invoked. 
At this time, `EditTextBox.HookMouseDown = true`. In [HookMouseDown](https://github.com/dotnet/winforms/blob/7896a6e7b4d3627c76bd3168d0042f72574d9b14/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.GridViewTextBox.cs#L64-L68), the `Focus()` was invoked, so the DropDown list was collapsed.

## Proposed changes

-  Set  `EditTextBox.HookMouseDown = false` at the end of PropertyGridView.ProcessEnumUpAndDown

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- When pressing the up/down keyboard in the property drop-down list, the drop-down menu will not be collapsed directly

## Regression? 

- No

## Risk

- Mininal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
Pressing Up/Down keyboard in drop-down list of property collapses dropdown directly.
![Image](https://github.com/user-attachments/assets/2d68ad2b-a52a-4348-ac19-ab94a99e1597)

### After
When pressing the up/down keyboard in the property drop-down list, the drop-down menu will not be collapsed directly
![AfterChange](https://github.com/user-attachments/assets/009178c3-58e9-45ce-ad71-e69654848906)

## Test methodology <!-- How did you ensure quality? -->

- Manually

## Test environment(s) <!-- Remove any that don't apply -->

- .net 10.0.0-beta.24562.15

<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12508)