### PR TITLE
Call Correct HtmlHelp Overload

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/NativeMethods.txt
+++ b/src/System.Windows.Forms.Primitives/src/NativeMethods.txt
@@ -259,6 +259,7 @@ HideCaret
 HitTestThemeBackground
 HT*
 HTML_HELP_COMMAND
+HtmlHelp
 HTREEITEM
 IAccessible
 IAccessibleEx

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.HtmlHelp.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.HtmlHelp.cs
@@ -1,25 +1,19 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Runtime.InteropServices;
 using Windows.Win32.Data.HtmlHelp;
 
 namespace Windows.Win32;
 
 internal static partial class PInvoke
 {
-    internal static unsafe HWND HtmlHelp(HWND hwndCaller, string? pszFile, HTML_HELP_COMMAND uCommand, nuint dwData)
+    /// <inheritdoc cref="HtmlHelp(HWND, string, HTML_HELP_COMMAND, nuint)" />
+    internal static unsafe HWND HtmlHelp<T>(T hwndCaller, string? pszFile, HTML_HELP_COMMAND uCommand, nuint dwData)
+        where T : IHandle<HWND>
     {
-        // Copied from generated code pending resolution of https://github.com/microsoft/win32metadata/issues/1749
-
-        fixed (char* p = pszFile)
-        {
-            HWND __retVal = LocalExternFunction(hwndCaller, p, (uint)uCommand, dwData);
-            return __retVal;
-        }
-
-        [DllImport(Libraries.Hhctrl, ExactSpelling = true, EntryPoint = "HtmlHelpW")]
-        static extern HWND LocalExternFunction(HWND hwndCaller, PCWSTR pszFile, uint uCommand, nuint dwData);
+        HWND result = HtmlHelp(hwndCaller.Handle, pszFile, uCommand, dwData);
+        GC.KeepAlive(hwndCaller.Wrapper);
+        return result;
     }
 
     /// <inheritdoc cref="HtmlHelp(HWND, string, HTML_HELP_COMMAND, nuint)" />

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Help/Help.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Help/Help.cs
@@ -146,7 +146,7 @@ public static class Help
             }
             else if (htmlParam is int intParam)
             {
-                PInvoke.HtmlHelp(handle, pathAndFileName, htmlCommand, in intParam);
+                PInvoke.HtmlHelp(handle, pathAndFileName, htmlCommand, (nuint)intParam);
             }
             else if (htmlParam is HH_FTS_QUERY query)
             {


### PR DESCRIPTION
Fixes https://github.com/dotnet/winforms/issues/12505

In .NET 8 when calling `Help.ShowHelp` with a .chm file and an integer ID for the Topic ID, we would call Help.ShowHelp overload https://github.com/dotnet/winforms/blob/release/8.0/src/System.Windows.Forms.Primitives/src/Interop/Hhctrl/Interop.HtmlHelpW.cs#L13 which takes the integer ID as is. In .NET 9 after updating to use cswin32, we updated to call the wrong overload where instead of taking the integer ID as is, we would take its address, causing the help page to fail to show. https://github.com/dotnet/winforms/blob/release/9.0/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.HtmlHelp.cs#L46

