### PR TITLE
Add unit tests for ListControlStringCollectionEditor

### DIFF
--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ListControlStringCollectionEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ListControlStringCollectionEditorTests.cs
@@ -13,8 +13,8 @@ public class ListControlStringCollectionEditorTests
     [Fact]
     public void EditValue_WithNullContext_ReturnsBaseEditValue()
     {
-        var editor = new ListControlStringCollectionEditor(typeof(string));
-        var provider = new Mock<IServiceProvider>().Object;
+        ListControlStringCollectionEditor editor = new(typeof(string));
+        IServiceProvider provider = new Mock<IServiceProvider>().Object;
         object? value = new();
 
         object? result = editor.EditValue(null, provider, value);
@@ -25,10 +25,10 @@ public class ListControlStringCollectionEditorTests
     [Fact]
     public void EditValue_WithContextInstanceNotListControl_ReturnsBaseEditValue()
     {
-        var editor = new ListControlStringCollectionEditor(typeof(string));
+        ListControlStringCollectionEditor editor = new(typeof(string));
         Mock<ITypeDescriptorContext> context = new();
         context.Setup(c => c.Instance).Returns(new object());
-        var provider = new Mock<IServiceProvider>().Object;
+        IServiceProvider provider = new Mock<IServiceProvider>().Object;
         object? value = new();
 
         object? result = editor.EditValue(context.Object, provider, value);
@@ -39,11 +39,11 @@ public class ListControlStringCollectionEditorTests
     [Fact]
     public void EditValue_WithListControlAndNullDataSource_ReturnsBaseEditValue()
     {
-        var editor = new ListControlStringCollectionEditor(typeof(string));
-        ListBox listControl = new();
+        ListControlStringCollectionEditor editor = new(typeof(string));
+        using ListBox listControl = new();
         Mock<ITypeDescriptorContext> context = new();
         context.Setup(c => c.Instance).Returns(listControl);
-        var provider = new Mock<IServiceProvider>().Object;
+        IServiceProvider provider = new Mock<IServiceProvider>().Object;
         object? value = new();
 
         object? result = editor.EditValue(context.Object, provider, value);
@@ -54,17 +54,17 @@ public class ListControlStringCollectionEditorTests
     [Fact]
     public void EditValue_WithListControlAndNonNullDataSource_ThrowsArgumentException()
     {
-        var editor = new ListControlStringCollectionEditor(typeof(string));
+        ListControlStringCollectionEditor editor = new(typeof(string));
 
-        ListBox listControl = new() { DataSource = new List<string> { "item1", "item2", "item3" } };
+        using ListBox listControl = new() { DataSource = new List<string> { "item1", "item2", "item3" } };
 
         Mock<ITypeDescriptorContext> context = new();
         context.Setup(c => c.Instance).Returns(listControl);
 
-        var provider = new Mock<IServiceProvider>().Object;
+        IServiceProvider provider = new Mock<IServiceProvider>().Object;
         object? value = new();
 
-        ArgumentException exception = Assert.Throws<ArgumentException>(() => editor.EditValue(context.Object, provider, value));
+        ArgumentException exception = ((Action)(() => editor.EditValue(context.Object, provider, value))).Should().Throw<ArgumentException>().Which;
         exception.Message.Should().Be(SR.DataSourceLocksItems);
     }
 }

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ListControlStringCollectionEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ListControlStringCollectionEditorTests.cs
@@ -1,0 +1,70 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using Moq;
+using System.ComponentModel;
+
+namespace System.Windows.Forms.Design.Tests;
+
+public class ListControlStringCollectionEditorTests
+{
+    [Fact]
+    public void EditValue_WithNullContext_ReturnsBaseEditValue()
+    {
+        var editor = new ListControlStringCollectionEditor(typeof(string));
+        var provider = new Mock<IServiceProvider>().Object;
+        object? value = new();
+
+        object? result = editor.EditValue(null, provider, value);
+
+        result.Should().Be(value);
+    }
+
+    [Fact]
+    public void EditValue_WithContextInstanceNotListControl_ReturnsBaseEditValue()
+    {
+        var editor = new ListControlStringCollectionEditor(typeof(string));
+        Mock<ITypeDescriptorContext> context = new();
+        context.Setup(c => c.Instance).Returns(new object());
+        var provider = new Mock<IServiceProvider>().Object;
+        object? value = new();
+
+        object? result = editor.EditValue(context.Object, provider, value);
+
+        result.Should().Be(value);
+    }
+
+    [Fact]
+    public void EditValue_WithListControlAndNullDataSource_ReturnsBaseEditValue()
+    {
+        var editor = new ListControlStringCollectionEditor(typeof(string));
+        ListBox listControl = new();
+        Mock<ITypeDescriptorContext> context = new();
+        context.Setup(c => c.Instance).Returns(listControl);
+        var provider = new Mock<IServiceProvider>().Object;
+        object? value = new();
+
+        object? result = editor.EditValue(context.Object, provider, value);
+
+        result.Should().Be(value);
+    }
+
+    [Fact]
+    public void EditValue_WithListControlAndNonNullDataSource_ThrowsArgumentException()
+    {
+        var editor = new ListControlStringCollectionEditor(typeof(string));
+
+        ListBox listControl = new() { DataSource = new List<string> { "item1", "item2", "item3" } };
+
+        Mock<ITypeDescriptorContext> context = new();
+        context.Setup(c => c.Instance).Returns(listControl);
+
+        var provider = new Mock<IServiceProvider>().Object;
+        object? value = new();
+
+        ArgumentException exception = Assert.Throws<ArgumentException>(() => editor.EditValue(context.Object, provider, value));
+        exception.Message.Should().Be(SR.DataSourceLocksItems);
+    }
+}


### PR DESCRIPTION
Related https://github.com/dotnet/winforms/issues/10773

## Proposed changes

- Add unit test ListControlStringCollectionEditorTests.cs for public properties and method of the ListControlStringCollectionEditor
- Enable nullability in ListControlStringCollectionEditorTests.cs

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12516)