### PR TITLE
Fix issue 12538: Infinite loop in System.Drawing.Graphics between IsVisible(Point) and IsVisible(int, int)

### DIFF
--- a/src/System.Drawing.Common/src/System/Drawing/Graphics.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Graphics.cs
@@ -580,7 +580,7 @@ public sealed unsafe partial class Graphics : MarshalByRefObject, IDisposable, I
 
     public void TranslateClip(int dx, int dy) => CheckStatus(PInvoke.GdipTranslateClip(NativeGraphics, dx, dy));
 
-    public bool IsVisible(int x, int y) => IsVisible(new Point(x, y));
+    public bool IsVisible(int x, int y) => IsVisible((float)x, y);
 
     public bool IsVisible(Point point) => IsVisible(point.X, point.Y);
 

--- a/src/System.Drawing.Common/tests/System/Drawing/GraphicsTests.cs
+++ b/src/System.Drawing.Common/tests/System/Drawing/GraphicsTests.cs
@@ -2818,6 +2818,45 @@ public partial class GraphicsTests
         Assert.Equal(expectedVisibleClipBounds, graphics.VisibleClipBounds);
     }
 
+    [Fact]
+    public void IsVisible_AllOverloads_ReturnSameResult()
+    {
+        using Bitmap bitmap = new(100, 100);
+        using Graphics graphics = Graphics.FromImage(bitmap);
+
+        // Test points
+        Point point = new(10, 10);
+        PointF pointF = new(10.5f, 10.5f);
+        int x = 10, y = 10;
+        float fx = 10.5f, fy = 10.5f;
+
+        // Test rectangles
+        Rectangle rect = new(10, 10, 50, 50);
+        RectangleF rectF = new(10.5f, 10.5f, 50.5f, 50.5f);
+        int width = 50, height = 50;
+        float fwidth = 50.5f, fheight = 50.5f;
+
+        // Verify that all overloads return the same result for points
+        bool result1 = graphics.IsVisible(x, y);
+        bool result2 = graphics.IsVisible(point);
+        bool result3 = graphics.IsVisible(fx, fy);
+        bool result4 = graphics.IsVisible(pointF);
+
+        result1.Should().Be(result2);
+        result1.Should().Be(result3);
+        result1.Should().Be(result4);
+
+        // Verify that all overloads return the same result for rectangles
+        bool result5 = graphics.IsVisible(x, y, width, height);
+        bool result6 = graphics.IsVisible(rect);
+        bool result7 = graphics.IsVisible(fx, fy, fwidth, fheight);
+        bool result8 = graphics.IsVisible(rectF);
+
+        result5.Should().Be(result6);
+        result5.Should().Be(result7);
+        result5.Should().Be(result8);
+    }
+
 #if NET8_0_OR_GREATER
     [Fact]
     public void DrawCachedBitmap_ThrowsArgumentNullException()


### PR DESCRIPTION
Fixes https://github.com/dotnet/winforms/issues/12538

## Proposed changes

- Remove the recursive call between` IsVisible(int, int)` and `IsVisible(Point)`. Directly convert `int `to `float` in `IsVisible(int x, int y)` and call `IsVisible(float x, float y)` API.

- Add unit test to verify that all overloads of the `IsVisible` method return the same result for both points and rectangles.

## Regression? 

- Yes

## Screenshots
**Before:** cannot run app with exception
![image](https://github.com/user-attachments/assets/45d00bd6-53f8-48a1-b6db-1872d293f939)
**After:** run app successfully
![image](https://github.com/user-attachments/assets/aa45fc0b-6c06-4bdf-b0a9-4f5f47b56202)

## Test methodology
- Test fixing for GH issue: https://github.com/dotnet/winforms/issues/12538 manually
- Unit test


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12540)