### PR TITLE
Replaced string[] with Array as the T in TheoryData 

### DIFF
--- a/src/Common/tests/TestUtilities/TheoryDataExtensions.cs
+++ b/src/Common/tests/TestUtilities/TheoryDataExtensions.cs
@@ -19,9 +19,7 @@ public static class TheoryDataExtensions
         return theoryData;
     }
 
-    /// <summary>
-    ///  Converts an IEnumerable into an Xunit theory compatible enumerable.
-    /// </summary>
+    /// <inheritdoc cref="ToTheoryData{T}"/>
     public static TheoryData<T1, T2> ToTheoryData<T1, T2>(this IEnumerable<(T1, T2)> data)
     {
         TheoryData<T1, T2> theoryData = [];
@@ -33,9 +31,7 @@ public static class TheoryDataExtensions
         return theoryData;
     }
 
-    /// <summary>
-    ///  Converts an IEnumerable into an Xunit theory compatible enumerable.
-    /// </summary>
+    /// <inheritdoc cref="ToTheoryData{T}"/>
     public static TheoryData<T1, T2, T3> ToTheoryData<T1, T2, T3>(this IEnumerable<(T1, T2, T3)> data)
     {
         TheoryData<T1, T2, T3> theoryData = [];

--- a/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/FormattedObject/BinaryFormatWriterTests.cs
+++ b/src/System.Private.Windows.Core/tests/BinaryFormatTests/FormatTests/FormattedObject/BinaryFormatWriterTests.cs
@@ -206,26 +206,26 @@ public class BinaryFormatWriterTests
         SystemColors.ButtonFace
     };
 
-    public static TheoryData<string?[]> StringArray_Parse_Data => new()
-    {
+    public static TheoryData<Array> StringArray_Parse_Data =>
+    [
         new string?[] { "one", "two" },
         new string?[] { "yes", "no", null },
         new string?[] { "same", "same", "same" }
-    };
+    ];
 
-    public static TheoryData<Array> PrimitiveArray_Parse_Data => new()
-    {
+    public static TheoryData<Array> PrimitiveArray_Parse_Data =>
+    [
         new int[] { 1, 2, 3 },
         new int[] { 1, 2, 1 },
         new float[] { 1.0f, float.NaN, float.PositiveInfinity },
         new DateTime[] { DateTime.MaxValue }
-    };
+    ];
 
     public static IEnumerable<object[]> Array_TestData => ((IEnumerable<object[]>)StringArray_Parse_Data).Concat(PrimitiveArray_Parse_Data);
 
-    public static TheoryData<Array> Array_UnsupportedTestData => new()
-    {
+    public static TheoryData<Array> Array_UnsupportedTestData =>
+    [
         new Point[] { default },
         new object[] { new() },
-    };
+    ];
 }


### PR DESCRIPTION
Declared string[] as an Array in order to avoid confusion as to what  the `object` is  - a single string or an array of strings in IEnumerable<object[]>

VS tests fail intermittently with "The test method expected 1 parameter, but received 2"

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12544)