### PR TITLE
ToolTip Appears Partially Off-Screen on Left Border

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip/ToolTip.cs
@@ -1935,6 +1935,11 @@ public partial class ToolTip : Component, IExtenderProvider, IHandle<HWND>
             moveToLocation.X = screen.WorkingArea.Right - tipSize.Width;
         }
 
+        if (moveToLocation.X < screen.WorkingArea.Left)
+        {
+            moveToLocation.X = screen.WorkingArea.Left;
+        }
+
         // re-adjust the Y position of the tool tip if it bleeds off the screen working area.
         if (moveToLocation.Y + tipSize.Height > screen.WorkingArea.Bottom)
         {


### PR DESCRIPTION
 Fixes #12556

## Proposed changes

- Updates the `Reposition()` method in the `ToolTip` class to correctly handle cases where the tooltip extends beyond the left boundary of the screen, ensuring it is fully visible and not truncated.

## Customer Impact

The tooltip will be fully visible regardless of how close it is to the left border of the screen.

## Regression?

- No

## Risk

- Minimal

## Screenshots

### Before

![image](https://github.com/user-attachments/assets/a1fce753-6bd6-499f-a3cc-6956205f13ec)

### After

![after](https://github.com/user-attachments/assets/541e26db-f2f3-4f40-bf2f-da754e153109)

## Test methodology

- Manual

## Test environment(s)

SDK: 9.0.100

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12557)