### PR TITLE
[release/8.0] Fix issue 12495: Infinite loop in ToolStripItemCollection.AddRange

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItemCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItemCollection.cs
@@ -141,16 +141,23 @@ public class ToolStripItemCollection : ArrangedElementCollection, IList
             throw new NotSupportedException(SR.ToolStripItemCollectionIsReadOnly);
         }
 
+        // Return early if the collection is empty.
+        if (toolStripItems.Count == 0)
+        {
+            return;
+        }
+
         // ToolStripDropDown will look for PropertyNames.Items to determine if it needs
         // to resize itself.
         using (new LayoutTransaction(_owner, _owner!, PropertyNames.Items))
         {
-            for (int i = 0; i < toolStripItems.Count; i++)
+            // Create a temporary array to avoid modifying the original collection during iteration.
+            // Items will be removed from toolStripsItems collection when they are added to this collection
+            // if they had a different owner control.
+            var itemsToAdd = toolStripItems.InnerList.ToArray();
+            foreach (ToolStripItem item in itemsToAdd)
             {
-                // Items are removed from their origin when added to a different owner.
-                // Decrement the index to always add the items from index 0 which will preserve
-                // the original order and avoid a pesky ArgumentOutOfRangeException.
-                Add(toolStripItems[i--]);
+                Add(item);
             }
         }
     }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripItemCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripItemCollectionTests.cs
@@ -113,11 +113,36 @@ public class ToolStripItemCollectionTests
         toolStripDropDownButton.DropDownItems.Add("b");
         toolStripDropDownButton.DropDownItems.Add("c");
         contextMenuStrip.Items.AddRange(toolStripDropDownButton.DropDownItems);
+
+        Assert.Empty(toolStripDropDownButton.DropDownItems);
         Assert.Equal(3, contextMenuStrip.Items.Count);
 
         // Validate order.
         Assert.Equal("a", contextMenuStrip.Items[0].Text);
         Assert.Equal("b", contextMenuStrip.Items[1].Text);
         Assert.Equal("c", contextMenuStrip.Items[2].Text);
+    }
+
+    [WinFormsFact]
+    public void ToolStripItemCollection_AddRange_ToolStripItemCollection_SameOwner_Success()
+    {
+        using ToolStrip toolStrip = new();
+
+        // Create a ToolStripItemCollection with 2 items
+        ToolStripItemCollection itemCollection = new(toolStrip,
+            [
+                new ToolStripButton("Button 1"),
+                new ToolStripButton("Button 2")
+            ]);
+
+        Assert.Equal(0, toolStrip.Items.Count);
+
+        toolStrip.Items.AddRange(itemCollection);
+
+        Assert.Equal(2, itemCollection.Count);
+        Assert.Equal(2, toolStrip.Items.Count);
+
+        Assert.Equal("Button 1", toolStrip.Items[0].Text);
+        Assert.Equal("Button 2", toolStrip.Items[1].Text);
     }
 }


### PR DESCRIPTION
BackPort of https://github.com/dotnet/winforms/pull/12513 to release/8.0
Bugs: https://github.com/dotnet/winforms/issues/12495, https://github.com/dotnet/winforms/issues/4454.
/cc @Tanya-Solyanik @Olina-Zhang

## Regression? 

- Yes, from .NET 6.0


## Customer Impact

- There is an infinite loop to call ToolStripItemCollection.AddRange(ToolStripItemCollection toolStripItems) with items when they have same owner.
- Changes now: converts the ToolStripItemCollection into a temporary array (using ToArray()) to avoid modifying the original collection during iteration. This ensures that items can be safely added to the new collection without causing exceptions or unintended behavior, especially when items are removed from the original collection if they have a different owner control.


## Risk

- Low

## Testing
- Manual scenario testing and unit test
- Regression tests

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12559)