### PR TITLE
Add unit tests for DesignerVerbToolStripMenuItem

### DIFF
--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DesignerVerbToolStripMenuItemTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/DesignerVerbToolStripMenuItemTests.cs
@@ -1,0 +1,49 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System.ComponentModel.Design;
+
+namespace System.Windows.Forms.Design.Tests;
+
+public class DesignerVerbToolStripMenuItemTests
+{
+    [Fact]
+    public void Constructor_InitializesTextProperty()
+    {
+        DesignerVerb verb = new("TestVerb", (sender, e) => { });
+        DesignerVerbToolStripMenuItem item = new(verb);
+
+        item.Text.Should().Be("TestVerb");
+        item.Enabled.Should().BeTrue();
+        item.Checked.Should().BeFalse();
+    }
+
+    [Fact]
+    public void RefreshItem_UpdatesProperties()
+    {
+        DesignerVerb verb = new("TestVerb", (sender, e) => { })
+        {
+            Enabled = false,
+            Checked = true
+        };
+
+        DesignerVerbToolStripMenuItem item = new(verb);
+        item.RefreshItem();
+
+        item.Enabled.Should().BeFalse();
+        item.Checked.Should().BeTrue();
+    }
+
+    [Fact]
+    public void OnClick_InvokesDesignerVerb()
+    {
+        bool invoked = false;
+        DesignerVerb verb = new("TestVerb", (sender, e) => invoked = true);
+        DesignerVerbToolStripMenuItem item = new(verb);
+        item.PerformClick();
+
+        invoked.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
Related https://github.com/dotnet/winforms/issues/10773


## Proposed changes

- Add unit test DesignerVerbToolStripMenuItemTests.cs for public properties and method of the DesignerVerbToolStripMenuItem.
- Enable nullability in DesignerVerbToolStripMenuItem.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12566)