### PR TITLE
Add unit tests for LinkLabel

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/LinkLabelTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/LinkLabelTests.cs
@@ -7,248 +7,203 @@ using System.Drawing;
 
 namespace System.Windows.Forms.Tests;
 
-public class LinkLabelTests
+public class LinkLabelTests : IDisposable
 {
+    private readonly LinkLabel _linkLabel = new();
+
+    public void Dispose() => _linkLabel.Dispose();
+
     [WinFormsFact]
     public void LinkLabel_Constructor()
     {
-        using LinkLabel label = new();
-
-        Assert.NotNull(label);
-        Assert.True(label.LinkArea.IsEmpty);
-        Assert.Equal(0, label.LinkArea.Start);
-        Assert.Equal(0, label.LinkArea.Length);
+        Assert.NotNull(_linkLabel);
+        Assert.True(_linkLabel.LinkArea.IsEmpty);
+        Assert.Equal(0, _linkLabel.LinkArea.Start);
+        Assert.Equal(0, _linkLabel.LinkArea.Length);
     }
 
     [WinFormsFact]
     public void LinkLabel_FlatStyle_Get_ReturnsExpected()
     {
-        using LinkLabel label = new();
-        label.FlatStyle.Should().Be(FlatStyle.Standard);
+        _linkLabel.FlatStyle.Should().Be(FlatStyle.Standard);
     }
 
     [WinFormsFact]
-    public void LinkLabel_FlatStyle_Set_GetReturnsExpected()
+    public void LinkLabel_FlatStyle_Set_ReturnsExpected()
     {
-        using LinkLabel label = new();
+        _linkLabel.FlatStyle = FlatStyle.Flat;
+        _linkLabel.FlatStyle.Should().Be(FlatStyle.Flat);
 
-        SetAndVerifyFlatStyle(label, FlatStyle.Flat);
-        SetAndVerifyFlatStyle(label, FlatStyle.Popup);
-        SetAndVerifyFlatStyle(label, FlatStyle.System);
-    }
+        _linkLabel.FlatStyle = FlatStyle.Popup;
+        _linkLabel.FlatStyle.Should().Be(FlatStyle.Popup);
 
-    private static void SetAndVerifyFlatStyle(LinkLabel label, FlatStyle style)
-    {
-        label.FlatStyle = style;
-        label.FlatStyle.Should().Be(style);
+        _linkLabel.FlatStyle = FlatStyle.System;
+        _linkLabel.FlatStyle.Should().Be(FlatStyle.System);
     }
 
     [WinFormsFact]
     public void LinkLabel_LinkArea_Get_ReturnsExpected()
     {
-        using LinkLabel label = new();
-        label.LinkArea.Should().Be(new LinkArea(0, 0));
+        _linkLabel.LinkArea.Should().Be(new LinkArea(0, 0));
     }
 
     [WinFormsFact]
-    public void LinkLabel_LinkArea_Set_GetReturnsExpected()
+    public void LinkLabel_LinkArea_Set_ReturnsExpected()
     {
-        using LinkLabel label = new();
+        _linkLabel.LinkArea = new LinkArea(1, 2);
+        _linkLabel.LinkArea.Should().Be(new LinkArea(1, 2));
 
-        SetAndVerifyLinkArea(label, new LinkArea(1, 2));
-        SetAndVerifyLinkArea(label, new LinkArea(3, 4));
-    }
-
-    private static void SetAndVerifyLinkArea(LinkLabel label, LinkArea area)
-    {
-        label.LinkArea = area;
-        label.LinkArea.Should().Be(area);
+        _linkLabel.LinkArea = new LinkArea(3, 4);
+        _linkLabel.LinkArea.Should().Be(new LinkArea(3, 4));
     }
 
     [WinFormsFact]
     public void LinkLabel_LinkArea_SetNegativeStart_ThrowsArgumentOutOfRangeException()
     {
-        using LinkLabel label = new();
-        Action act = () => label.LinkArea = new LinkArea(-1, 2);
+        Action act = () => _linkLabel.LinkArea = new LinkArea(-1, 2);
         act.Should().Throw<ArgumentOutOfRangeException>().WithMessage("*LinkArea*");
     }
 
     [WinFormsFact]
     public void LinkLabel_LinkArea_SetNegativeLength_ThrowsArgumentOutOfRangeException()
     {
-        using LinkLabel label = new();
-        Action act = () => label.LinkArea = new LinkArea(1, -2);
+        Action act = () => _linkLabel.LinkArea = new LinkArea(1, -2);
         act.Should().Throw<ArgumentOutOfRangeException>().WithMessage("*LinkArea*");
     }
 
     [WinFormsFact]
     public void LinkLabel_LinkArea_Set_UpdatesSelectability()
     {
-        using LinkLabel label = new();
-        label.Text = "Text";
+        _linkLabel.Text = "Text";
+        _linkLabel.LinkArea = new LinkArea(1, 2);
+        _linkLabel.TabStop.Should().BeTrue();
 
-        label.LinkArea = new LinkArea(1, 2);
-        label.TabStop.Should().BeTrue();
-
-        label.LinkArea = new LinkArea(0, 0);
-        label.TabStop.Should().BeFalse();
+        _linkLabel.LinkArea = new LinkArea(0, 0);
+        _linkLabel.TabStop.Should().BeFalse();
     }
 
     [WinFormsFact]
     public void LinkLabel_LinkBehavior_Get_ReturnsExpected()
     {
-        using LinkLabel label = new();
-        label.LinkBehavior.Should().Be(LinkBehavior.SystemDefault);
+        _linkLabel.LinkBehavior.Should().Be(LinkBehavior.SystemDefault);
     }
 
     [WinFormsFact]
-    public void LinkLabel_LinkBehavior_Set_GetReturnsExpected()
+    public void LinkLabel_LinkBehavior_Set_ReturnsExpected()
     {
-        using LinkLabel label = new();
+        _linkLabel.LinkBehavior = LinkBehavior.AlwaysUnderline;
+        _linkLabel.LinkBehavior.Should().Be(LinkBehavior.AlwaysUnderline);
 
-        SetAndVerifyLinkBehavior(label, LinkBehavior.AlwaysUnderline);
-        SetAndVerifyLinkBehavior(label, LinkBehavior.HoverUnderline);
-        SetAndVerifyLinkBehavior(label, LinkBehavior.NeverUnderline);
-    }
+        _linkLabel.LinkBehavior = LinkBehavior.HoverUnderline;
+        _linkLabel.LinkBehavior.Should().Be(LinkBehavior.HoverUnderline);
 
-    private static void SetAndVerifyLinkBehavior(LinkLabel label, LinkBehavior behavior)
-    {
-        label.LinkBehavior = behavior;
-        label.LinkBehavior.Should().Be(behavior);
+        _linkLabel.LinkBehavior = LinkBehavior.NeverUnderline;
+        _linkLabel.LinkBehavior.Should().Be(LinkBehavior.NeverUnderline);
     }
 
     [WinFormsFact]
     public void LinkLabel_LinkVisited_Get_ReturnsExpected()
     {
-        using LinkLabel label = new();
-        label.LinkVisited.Should().BeFalse();
+        _linkLabel.LinkVisited.Should().BeFalse();
     }
 
     [WinFormsFact]
     public void LinkLabel_LinkVisited_Set_ReturnsExpected()
     {
-        using LinkLabel label = new();
+        _linkLabel.LinkVisited = true;
+        _linkLabel.LinkVisited.Should().BeTrue();
 
-        SetAndVerifyLinkVisited(label, true);
-        SetAndVerifyLinkVisited(label, false);
-    }
-
-    private static void SetAndVerifyLinkVisited(LinkLabel label, bool visited)
-    {
-        label.LinkVisited = visited;
-        label.LinkVisited.Should().Be(visited);
+        _linkLabel.LinkVisited = false;
+        _linkLabel.LinkVisited.Should().BeFalse();
     }
 
     [WinFormsFact]
     public void LinkLabel_LinkVisited_Set_AddsLinkIfNoneExists()
     {
-        using LinkLabel label = new();
-        label.LinkVisited = true;
-        label.Links.Count.Should().Be(1);
-        label.Links[0].Visited.Should().BeTrue();
+        _linkLabel.LinkVisited = true;
+        _linkLabel.Links.Count.Should().Be(1);
+        _linkLabel.Links[0].Visited.Should().BeTrue();
     }
 
     [WinFormsFact]
     public void LinkLabel_LinkVisited_Set_UpdatesExistingLink()
     {
-        using LinkLabel label = new();
-        label.Links.Add(new LinkLabel.Link(label) { Visited = false });
+        _linkLabel.Links.Add(new LinkLabel.Link(_linkLabel) { Visited = false });
+        _linkLabel.LinkVisited = true;
+        _linkLabel.Links[0].Visited.Should().BeTrue();
 
-        label.LinkVisited = true;
-        label.Links[0].Visited.Should().BeTrue();
-
-        label.LinkVisited = false;
-        label.Links[0].Visited.Should().BeFalse();
+        _linkLabel.LinkVisited = false;
+        _linkLabel.Links[0].Visited.Should().BeFalse();
     }
 
     [WinFormsFact]
     public void LinkLabel_TabStop_Get_ReturnsExpected()
     {
-        using LinkLabel label = new();
-        label.TabStop.Should().BeFalse();
+        _linkLabel.TabStop.Should().BeFalse();
     }
 
     [WinFormsFact]
     public void LinkLabel_TabStop_Set_ReturnsExpected()
     {
-        using LinkLabel label = new();
+        _linkLabel.TabStop = true;
+        _linkLabel.TabStop.Should().BeTrue();
 
-        SetAndVerifyTabStop(label, true);
-        SetAndVerifyTabStop(label, false);
-    }
-
-    private static void SetAndVerifyTabStop(LinkLabel label, bool tabStop)
-    {
-        label.TabStop = tabStop;
-        label.TabStop.Should().Be(tabStop);
+        _linkLabel.TabStop = false;
+        _linkLabel.TabStop.Should().BeFalse();
     }
 
     [WinFormsFact]
     public void LinkLabel_TabStop_Set_RaisesTabStopChangedEvent()
     {
-        using LinkLabel label = new();
         bool eventRaised = false;
-        label.TabStopChanged += (sender, e) => eventRaised = true;
+        _linkLabel.TabStopChanged += (sender, e) => eventRaised = true;
 
-        label.TabStop = true;
+        _linkLabel.TabStop = true;
         eventRaised.Should().BeTrue();
 
         eventRaised = false;
-        label.TabStop = false;
+        _linkLabel.TabStop = false;
         eventRaised.Should().BeTrue();
     }
 
     [WinFormsFact]
     public void LinkLabel_Padding_Get_ReturnsExpected()
     {
-        using LinkLabel label = new();
-        label.Padding.Should().Be(new Padding(0));
+        _linkLabel.Padding.Should().Be(new Padding(0));
     }
 
     [WinFormsFact]
     public void LinkLabel_Padding_Set_ReturnsExpected()
     {
-        using LinkLabel label = new();
+        _linkLabel.Padding = new Padding(1, 2, 3, 4);
+        _linkLabel.Padding.Should().Be(new Padding(1, 2, 3, 4));
 
-        SetAndVerifyPadding(label, new Padding(1, 2, 3, 4));
-        SetAndVerifyPadding(label, new Padding(5));
-    }
-
-    private static void SetAndVerifyPadding(LinkLabel label, Padding padding)
-    {
-        label.Padding = padding;
-        label.Padding.Should().Be(padding);
+        _linkLabel.Padding = new Padding(5);
+        _linkLabel.Padding.Should().Be(new Padding(5));
     }
 
     [WinFormsFact]
     public void LinkLabel_VisitedLinkColor_Get_ReturnsExpected()
     {
-        using LinkLabel label = new();
-        label.VisitedLinkColor.Should().Be(LinkUtilities.GetVisitedLinkColor());
+        _linkLabel.VisitedLinkColor.Should().Be(LinkUtilities.GetVisitedLinkColor());
     }
 
     [WinFormsFact]
     public void LinkLabel_VisitedLinkColor_Set_ReturnsExpected()
     {
-        using LinkLabel label = new();
+        _linkLabel.VisitedLinkColor = Color.Red;
+        _linkLabel.VisitedLinkColor.Should().Be(Color.Red);
 
-        SetAndVerifyVisitedLinkColor(label, Color.Red);
-        SetAndVerifyVisitedLinkColor(label, Color.Blue);
-    }
-
-    private static void SetAndVerifyVisitedLinkColor(LinkLabel label, Color color)
-    {
-        label.VisitedLinkColor = color;
-        label.VisitedLinkColor.Should().Be(color);
+        _linkLabel.VisitedLinkColor = Color.Blue;
+        _linkLabel.VisitedLinkColor.Should().Be(Color.Blue);
     }
 
     [WinFormsFact]
     public void LinkLabel_VisitedLinkColor_Set_UpdatesLink()
     {
-        using LinkLabel label = new();
-        label.Links.Add(new LinkLabel.Link(label) { Visited = true });
-        label.VisitedLinkColor = Color.Red;
-        label.VisitedLinkColor.Should().Be(Color.Red);
+        _linkLabel.Links.Add(new LinkLabel.Link(_linkLabel) { Visited = true });
+        _linkLabel.VisitedLinkColor = Color.Red;
+        _linkLabel.VisitedLinkColor.Should().Be(Color.Red);
     }
 
     [WinFormsFact]
@@ -268,35 +223,32 @@ public class LinkLabelTests
     [WinFormsFact]
     public void LinkLabel_UseCompatibleTextRendering_Get_ReturnsExpected()
     {
-        using LinkLabel label = new();
-        label.UseCompatibleTextRendering.Should().BeTrue();
+        _linkLabel.UseCompatibleTextRendering.Should().BeTrue();
     }
 
     [WinFormsFact]
     public void LinkLabel_UseCompatibleTextRendering_Set_ReturnsExpected()
     {
-        using LinkLabel label = new();
+        _linkLabel.UseCompatibleTextRendering = true;
+        _linkLabel.UseCompatibleTextRendering.Should().BeTrue();
 
-        SetAndVerifyUseCompatibleTextRendering(label, true);
-        SetAndVerifyUseCompatibleTextRendering(label, false);
-    }
-
-    private static void SetAndVerifyUseCompatibleTextRendering(LinkLabel label, bool value)
-    {
-        label.UseCompatibleTextRendering = value;
-        label.UseCompatibleTextRendering.Should().Be(value);
+        _linkLabel.UseCompatibleTextRendering = false;
+        _linkLabel.UseCompatibleTextRendering.Should().BeFalse();
     }
 
     [WinFormsFact]
     public void LinkLabel_UseCompatibleTextRendering_Set_TriggersLayout()
     {
-        using LinkLabel label = new();
         bool layoutCalled = false;
-        label.Layout += (sender, e) => layoutCalled = true;
+        _linkLabel.Layout += (sender, e) => layoutCalled = true;
 
-        label.UseCompatibleTextRendering = true;
-        label.PerformLayout();
+        _linkLabel.UseCompatibleTextRendering = true;
+        _linkLabel.PerformLayout();
+        layoutCalled.Should().BeTrue();
 
+        layoutCalled = false;
+        _linkLabel.UseCompatibleTextRendering = false;
+        _linkLabel.PerformLayout();
         layoutCalled.Should().BeTrue();
     }
 

--- a/src/System.Windows.Forms/tests/UnitTests/LinkLabelTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/LinkLabelTests.cs
@@ -1,6 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
+using System.Drawing;
+
 namespace System.Windows.Forms.Tests;
 
 public class LinkLabelTests
@@ -14,5 +18,290 @@ public class LinkLabelTests
         Assert.True(label.LinkArea.IsEmpty);
         Assert.Equal(0, label.LinkArea.Start);
         Assert.Equal(0, label.LinkArea.Length);
+    }
+
+    [WinFormsFact]
+    public void LinkLabel_FlatStyle_Get_ReturnsExpected()
+    {
+        using LinkLabel label = new();
+        label.FlatStyle.Should().Be(FlatStyle.Standard);
+    }
+
+    [WinFormsFact]
+    public void LinkLabel_FlatStyle_Set_GetReturnsExpected()
+    {
+        using LinkLabel label = new();
+
+        SetAndVerifyFlatStyle(label, FlatStyle.Flat);
+        SetAndVerifyFlatStyle(label, FlatStyle.Popup);
+        SetAndVerifyFlatStyle(label, FlatStyle.System);
+    }
+
+    private static void SetAndVerifyFlatStyle(LinkLabel label, FlatStyle style)
+    {
+        label.FlatStyle = style;
+        label.FlatStyle.Should().Be(style);
+    }
+
+    [WinFormsFact]
+    public void LinkLabel_LinkArea_Get_ReturnsExpected()
+    {
+        using LinkLabel label = new();
+        label.LinkArea.Should().Be(new LinkArea(0, 0));
+    }
+
+    [WinFormsFact]
+    public void LinkLabel_LinkArea_Set_GetReturnsExpected()
+    {
+        using LinkLabel label = new();
+
+        SetAndVerifyLinkArea(label, new LinkArea(1, 2));
+        SetAndVerifyLinkArea(label, new LinkArea(3, 4));
+    }
+
+    private static void SetAndVerifyLinkArea(LinkLabel label, LinkArea area)
+    {
+        label.LinkArea = area;
+        label.LinkArea.Should().Be(area);
+    }
+
+    [WinFormsFact]
+    public void LinkLabel_LinkArea_SetNegativeStart_ThrowsArgumentOutOfRangeException()
+    {
+        using LinkLabel label = new();
+        Action act = () => label.LinkArea = new LinkArea(-1, 2);
+        act.Should().Throw<ArgumentOutOfRangeException>().WithMessage("*LinkArea*");
+    }
+
+    [WinFormsFact]
+    public void LinkLabel_LinkArea_SetNegativeLength_ThrowsArgumentOutOfRangeException()
+    {
+        using LinkLabel label = new();
+        Action act = () => label.LinkArea = new LinkArea(1, -2);
+        act.Should().Throw<ArgumentOutOfRangeException>().WithMessage("*LinkArea*");
+    }
+
+    [WinFormsFact]
+    public void LinkLabel_LinkArea_Set_UpdatesSelectability()
+    {
+        using LinkLabel label = new();
+        label.Text = "Text";
+
+        label.LinkArea = new LinkArea(1, 2);
+        label.TabStop.Should().BeTrue();
+
+        label.LinkArea = new LinkArea(0, 0);
+        label.TabStop.Should().BeFalse();
+    }
+
+    [WinFormsFact]
+    public void LinkLabel_LinkBehavior_Get_ReturnsExpected()
+    {
+        using LinkLabel label = new();
+        label.LinkBehavior.Should().Be(LinkBehavior.SystemDefault);
+    }
+
+    [WinFormsFact]
+    public void LinkLabel_LinkBehavior_Set_GetReturnsExpected()
+    {
+        using LinkLabel label = new();
+
+        SetAndVerifyLinkBehavior(label, LinkBehavior.AlwaysUnderline);
+        SetAndVerifyLinkBehavior(label, LinkBehavior.HoverUnderline);
+        SetAndVerifyLinkBehavior(label, LinkBehavior.NeverUnderline);
+    }
+
+    private static void SetAndVerifyLinkBehavior(LinkLabel label, LinkBehavior behavior)
+    {
+        label.LinkBehavior = behavior;
+        label.LinkBehavior.Should().Be(behavior);
+    }
+
+    [WinFormsFact]
+    public void LinkLabel_LinkVisited_Get_ReturnsExpected()
+    {
+        using LinkLabel label = new();
+        label.LinkVisited.Should().BeFalse();
+    }
+
+    [WinFormsFact]
+    public void LinkLabel_LinkVisited_Set_ReturnsExpected()
+    {
+        using LinkLabel label = new();
+
+        SetAndVerifyLinkVisited(label, true);
+        SetAndVerifyLinkVisited(label, false);
+    }
+
+    private static void SetAndVerifyLinkVisited(LinkLabel label, bool visited)
+    {
+        label.LinkVisited = visited;
+        label.LinkVisited.Should().Be(visited);
+    }
+
+    [WinFormsFact]
+    public void LinkLabel_LinkVisited_Set_AddsLinkIfNoneExists()
+    {
+        using LinkLabel label = new();
+        label.LinkVisited = true;
+        label.Links.Count.Should().Be(1);
+        label.Links[0].Visited.Should().BeTrue();
+    }
+
+    [WinFormsFact]
+    public void LinkLabel_LinkVisited_Set_UpdatesExistingLink()
+    {
+        using LinkLabel label = new();
+        label.Links.Add(new LinkLabel.Link(label) { Visited = false });
+
+        label.LinkVisited = true;
+        label.Links[0].Visited.Should().BeTrue();
+
+        label.LinkVisited = false;
+        label.Links[0].Visited.Should().BeFalse();
+    }
+
+    [WinFormsFact]
+    public void LinkLabel_TabStop_Get_ReturnsExpected()
+    {
+        using LinkLabel label = new();
+        label.TabStop.Should().BeFalse();
+    }
+
+    [WinFormsFact]
+    public void LinkLabel_TabStop_Set_ReturnsExpected()
+    {
+        using LinkLabel label = new();
+
+        SetAndVerifyTabStop(label, true);
+        SetAndVerifyTabStop(label, false);
+    }
+
+    private static void SetAndVerifyTabStop(LinkLabel label, bool tabStop)
+    {
+        label.TabStop = tabStop;
+        label.TabStop.Should().Be(tabStop);
+    }
+
+    [WinFormsFact]
+    public void LinkLabel_TabStop_Set_RaisesTabStopChangedEvent()
+    {
+        using LinkLabel label = new();
+        bool eventRaised = false;
+        label.TabStopChanged += (sender, e) => eventRaised = true;
+
+        label.TabStop = true;
+        eventRaised.Should().BeTrue();
+
+        eventRaised = false;
+        label.TabStop = false;
+        eventRaised.Should().BeTrue();
+    }
+
+    [WinFormsFact]
+    public void LinkLabel_Padding_Get_ReturnsExpected()
+    {
+        using LinkLabel label = new();
+        label.Padding.Should().Be(new Padding(0));
+    }
+
+    [WinFormsFact]
+    public void LinkLabel_Padding_Set_ReturnsExpected()
+    {
+        using LinkLabel label = new();
+
+        SetAndVerifyPadding(label, new Padding(1, 2, 3, 4));
+        SetAndVerifyPadding(label, new Padding(5));
+    }
+
+    private static void SetAndVerifyPadding(LinkLabel label, Padding padding)
+    {
+        label.Padding = padding;
+        label.Padding.Should().Be(padding);
+    }
+
+    [WinFormsFact]
+    public void LinkLabel_VisitedLinkColor_Get_ReturnsExpected()
+    {
+        using LinkLabel label = new();
+        label.VisitedLinkColor.Should().Be(LinkUtilities.GetVisitedLinkColor());
+    }
+
+    [WinFormsFact]
+    public void LinkLabel_VisitedLinkColor_Set_ReturnsExpected()
+    {
+        using LinkLabel label = new();
+
+        SetAndVerifyVisitedLinkColor(label, Color.Red);
+        SetAndVerifyVisitedLinkColor(label, Color.Blue);
+    }
+
+    private static void SetAndVerifyVisitedLinkColor(LinkLabel label, Color color)
+    {
+        label.VisitedLinkColor = color;
+        label.VisitedLinkColor.Should().Be(color);
+    }
+
+    [WinFormsFact]
+    public void LinkLabel_VisitedLinkColor_Set_UpdatesLink()
+    {
+        using LinkLabel label = new();
+        label.Links.Add(new LinkLabel.Link(label) { Visited = true });
+        label.VisitedLinkColor = Color.Red;
+        label.VisitedLinkColor.Should().Be(Color.Red);
+    }
+
+    [WinFormsFact]
+    public void LinkLabel_LinkClicked_RaisesEvent()
+    {
+        using TestLinkLabel label = new();
+        bool eventRaised = false;
+        label.LinkClicked += (sender, e) => eventRaised = true;
+
+        var link = new LinkLabel.Link(label);
+        label.Links.Add(link);
+        label.OnLinkClicked(new LinkLabelLinkClickedEventArgs(link));
+
+        eventRaised.Should().BeTrue();
+    }
+
+    [WinFormsFact]
+    public void LinkLabel_UseCompatibleTextRendering_Get_ReturnsExpected()
+    {
+        using LinkLabel label = new();
+        label.UseCompatibleTextRendering.Should().BeTrue();
+    }
+
+    [WinFormsFact]
+    public void LinkLabel_UseCompatibleTextRendering_Set_ReturnsExpected()
+    {
+        using LinkLabel label = new();
+
+        SetAndVerifyUseCompatibleTextRendering(label, true);
+        SetAndVerifyUseCompatibleTextRendering(label, false);
+    }
+
+    private static void SetAndVerifyUseCompatibleTextRendering(LinkLabel label, bool value)
+    {
+        label.UseCompatibleTextRendering = value;
+        label.UseCompatibleTextRendering.Should().Be(value);
+    }
+
+    [WinFormsFact]
+    public void LinkLabel_UseCompatibleTextRendering_Set_TriggersLayout()
+    {
+        using LinkLabel label = new();
+        bool layoutCalled = false;
+        label.Layout += (sender, e) => layoutCalled = true;
+
+        label.UseCompatibleTextRendering = true;
+        label.PerformLayout();
+
+        layoutCalled.Should().BeTrue();
+    }
+
+    private class TestLinkLabel : LinkLabel
+    {
+        public new void OnLinkClicked(LinkLabelLinkClickedEventArgs e) => base.OnLinkClicked(e);
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/LinkLabelTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/LinkLabelTests.cs
@@ -16,10 +16,10 @@ public class LinkLabelTests : IDisposable
     [WinFormsFact]
     public void LinkLabel_Constructor()
     {
-        Assert.NotNull(_linkLabel);
-        Assert.True(_linkLabel.LinkArea.IsEmpty);
-        Assert.Equal(0, _linkLabel.LinkArea.Start);
-        Assert.Equal(0, _linkLabel.LinkArea.Length);
+        _linkLabel.Should().NotBeNull();
+        _linkLabel.LinkArea.IsEmpty.Should().BeTrue();
+        _linkLabel.LinkArea.Start.Should().Be(0);
+        _linkLabel.LinkArea.Length.Should().Be(0);
     }
 
     [WinFormsFact]
@@ -28,17 +28,15 @@ public class LinkLabelTests : IDisposable
         _linkLabel.FlatStyle.Should().Be(FlatStyle.Standard);
     }
 
-    [WinFormsFact]
-    public void LinkLabel_FlatStyle_Set_ReturnsExpected()
+    [WinFormsTheory]
+    [InlineData(FlatStyle.Flat)]
+    [InlineData(FlatStyle.Popup)]
+    [InlineData(FlatStyle.System)]
+    public void LinkLabel_FlatStyle_Set_ReturnsExpected(FlatStyle flatStyle)
     {
-        _linkLabel.FlatStyle = FlatStyle.Flat;
-        _linkLabel.FlatStyle.Should().Be(FlatStyle.Flat);
+        _linkLabel.FlatStyle = flatStyle;
 
-        _linkLabel.FlatStyle = FlatStyle.Popup;
-        _linkLabel.FlatStyle.Should().Be(FlatStyle.Popup);
-
-        _linkLabel.FlatStyle = FlatStyle.System;
-        _linkLabel.FlatStyle.Should().Be(FlatStyle.System);
+        _linkLabel.FlatStyle.Should().Be(flatStyle);
     }
 
     [WinFormsFact]
@@ -50,24 +48,22 @@ public class LinkLabelTests : IDisposable
     [WinFormsFact]
     public void LinkLabel_LinkArea_Set_ReturnsExpected()
     {
-        _linkLabel.LinkArea = new LinkArea(1, 2);
-        _linkLabel.LinkArea.Should().Be(new LinkArea(1, 2));
+        LinkArea linkArea1 = new LinkArea(1, 2);
+        LinkArea linkArea2 = new LinkArea(3, 4);
 
-        _linkLabel.LinkArea = new LinkArea(3, 4);
-        _linkLabel.LinkArea.Should().Be(new LinkArea(3, 4));
+        _linkLabel.LinkArea = linkArea1;
+        _linkLabel.LinkArea.Should().Be(linkArea1);
+
+        _linkLabel.LinkArea = linkArea2;
+        _linkLabel.LinkArea.Should().Be(linkArea2);
     }
 
-    [WinFormsFact]
-    public void LinkLabel_LinkArea_SetNegativeStart_ThrowsArgumentOutOfRangeException()
+    [WinFormsTheory]
+    [InlineData(-1, 2)]  // Test with negative Start
+    [InlineData(1, -2)]  // Test with negative Length
+    public void LinkLabel_LinkArea_Set_InvalidValues_ThrowsArgumentOutOfRangeException(int start, int length)
     {
-        Action act = () => _linkLabel.LinkArea = new LinkArea(-1, 2);
-        act.Should().Throw<ArgumentOutOfRangeException>().WithMessage("*LinkArea*");
-    }
-
-    [WinFormsFact]
-    public void LinkLabel_LinkArea_SetNegativeLength_ThrowsArgumentOutOfRangeException()
-    {
-        Action act = () => _linkLabel.LinkArea = new LinkArea(1, -2);
+        Action act = () => _linkLabel.LinkArea = new LinkArea(start, length);
         act.Should().Throw<ArgumentOutOfRangeException>().WithMessage("*LinkArea*");
     }
 
@@ -88,17 +84,14 @@ public class LinkLabelTests : IDisposable
         _linkLabel.LinkBehavior.Should().Be(LinkBehavior.SystemDefault);
     }
 
-    [WinFormsFact]
-    public void LinkLabel_LinkBehavior_Set_ReturnsExpected()
+    [WinFormsTheory]
+    [InlineData(LinkBehavior.AlwaysUnderline)]
+    [InlineData(LinkBehavior.HoverUnderline)]
+    [InlineData(LinkBehavior.NeverUnderline)]
+    public void LinkLabel_LinkBehavior_Set_ReturnsExpected(LinkBehavior linkBehavior)
     {
-        _linkLabel.LinkBehavior = LinkBehavior.AlwaysUnderline;
-        _linkLabel.LinkBehavior.Should().Be(LinkBehavior.AlwaysUnderline);
-
-        _linkLabel.LinkBehavior = LinkBehavior.HoverUnderline;
-        _linkLabel.LinkBehavior.Should().Be(LinkBehavior.HoverUnderline);
-
-        _linkLabel.LinkBehavior = LinkBehavior.NeverUnderline;
-        _linkLabel.LinkBehavior.Should().Be(LinkBehavior.NeverUnderline);
+        _linkLabel.LinkBehavior = linkBehavior;
+        _linkLabel.LinkBehavior.Should().Be(linkBehavior);
     }
 
     [WinFormsFact]
@@ -107,14 +100,13 @@ public class LinkLabelTests : IDisposable
         _linkLabel.LinkVisited.Should().BeFalse();
     }
 
-    [WinFormsFact]
-    public void LinkLabel_LinkVisited_Set_ReturnsExpected()
+    [WinFormsTheory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void LinkLabel_LinkVisited_Set_ReturnsExpected(bool expectedVisited)
     {
-        _linkLabel.LinkVisited = true;
-        _linkLabel.LinkVisited.Should().BeTrue();
-
-        _linkLabel.LinkVisited = false;
-        _linkLabel.LinkVisited.Should().BeFalse();
+        _linkLabel.LinkVisited = expectedVisited;
+        _linkLabel.LinkVisited.Should().Be(expectedVisited);
     }
 
     [WinFormsFact]
@@ -142,14 +134,13 @@ public class LinkLabelTests : IDisposable
         _linkLabel.TabStop.Should().BeFalse();
     }
 
-    [WinFormsFact]
-    public void LinkLabel_TabStop_Set_ReturnsExpected()
+    [WinFormsTheory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void LinkLabel_TabStop_Set_ReturnsExpected(bool expectedTabStop)
     {
-        _linkLabel.TabStop = true;
-        _linkLabel.TabStop.Should().BeTrue();
-
-        _linkLabel.TabStop = false;
-        _linkLabel.TabStop.Should().BeFalse();
+        _linkLabel.TabStop = expectedTabStop;
+        _linkLabel.TabStop.Should().Be(expectedTabStop);
     }
 
     [WinFormsFact]
@@ -175,11 +166,14 @@ public class LinkLabelTests : IDisposable
     [WinFormsFact]
     public void LinkLabel_Padding_Set_ReturnsExpected()
     {
-        _linkLabel.Padding = new Padding(1, 2, 3, 4);
-        _linkLabel.Padding.Should().Be(new Padding(1, 2, 3, 4));
+        Padding padding1 = new(1, 2, 3, 4);
+        Padding padding2 = new(5);
 
-        _linkLabel.Padding = new Padding(5);
-        _linkLabel.Padding.Should().Be(new Padding(5));
+        _linkLabel.Padding = padding1;
+        _linkLabel.Padding.Should().Be(padding1);
+
+        _linkLabel.Padding = padding2;
+        _linkLabel.Padding.Should().Be(padding2);
     }
 
     [WinFormsFact]
@@ -226,14 +220,13 @@ public class LinkLabelTests : IDisposable
         _linkLabel.UseCompatibleTextRendering.Should().BeTrue();
     }
 
-    [WinFormsFact]
-    public void LinkLabel_UseCompatibleTextRendering_Set_ReturnsExpected()
+    [WinFormsTheory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void LinkLabel_UseCompatibleTextRendering_Set_ReturnsExpected(bool expectedValue)
     {
-        _linkLabel.UseCompatibleTextRendering = true;
-        _linkLabel.UseCompatibleTextRendering.Should().BeTrue();
-
-        _linkLabel.UseCompatibleTextRendering = false;
-        _linkLabel.UseCompatibleTextRendering.Should().BeFalse();
+        _linkLabel.UseCompatibleTextRendering = expectedValue;
+        _linkLabel.UseCompatibleTextRendering.Should().Be(expectedValue);
     }
 
     [WinFormsFact]


### PR DESCRIPTION
related https://github.com/dotnet/winforms/issues/10453

## Proposed changes

- Add unit tests for LinkLabel to test its FlatStyle, LinkArea, LinkBehavior, TabStop, Padding, VisitedLinkColor, UseCompatibleTextRendering properties and TabStopChanged, LinkClicked events



 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12572)