### PR TITLE
Add unit test for MaskDesignerDialog

### DIFF
--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/MaskDesignerDialogTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/MaskDesignerDialogTests.cs
@@ -12,12 +12,11 @@ public sealed class MaskDesignerDialogTests:IDisposable
 {
     private readonly MaskedTextBox _maskedTextBox;
     private readonly MaskDesignerDialog _dialog;
-    private readonly IHelpService? _helpService;
 
     public MaskDesignerDialogTests()
     {
         _maskedTextBox = new MaskedTextBox();
-        _dialog = new MaskDesignerDialog(_maskedTextBox, _helpService);
+        _dialog = new MaskDesignerDialog(_maskedTextBox, null);
     }
 
     public void Dispose()

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/MaskDesignerDialogTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/MaskDesignerDialogTests.cs
@@ -1,0 +1,108 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System.ComponentModel.Design;
+using Moq;
+
+namespace System.Windows.Forms.Design.Tests;
+
+public sealed class MaskDesignerDialogTests:IDisposable
+{
+    private readonly MaskedTextBox _maskedTextBox;
+    private readonly MaskDesignerDialog _dialog;
+    private readonly IHelpService? _helpService;
+
+    public MaskDesignerDialogTests()
+    {
+        _maskedTextBox = new MaskedTextBox();
+        _dialog = new MaskDesignerDialog(_maskedTextBox, _helpService);
+    }
+
+    public void Dispose()
+    {
+        _maskedTextBox.Dispose();
+        _dialog.Dispose();
+    }
+
+    [Fact]
+    public void Constructor_ValidMaskedTextBox_UsesProvidedMaskedTextBox()
+    {
+        var txtBoxMask = (TextBox)_dialog.TestAccessor().Dynamic._txtBoxMask;
+
+        _dialog.Mask.Should().Be(_maskedTextBox.Mask);
+        txtBoxMask.Text.Should().Be(_maskedTextBox.Mask);
+    }
+
+    [Fact]
+    public void ValidatingTypeProperty_ShouldBeSetCorrectly()
+    {
+        _dialog.TestAccessor().Dynamic._maskedTextBox.ValidatingType = typeof(DateTime);
+        _dialog.TestAccessor().Dynamic.btnOK_Click(null, EventArgs.Empty);
+
+        _dialog.ValidatingType.Should().Be(typeof(DateTime));
+    }
+
+    [Fact]
+    public void MaskDescriptorsEnumerator_ShouldReturnCorrectDescriptors()
+    {
+        var enumerator = _dialog.MaskDescriptors;
+
+        List<MaskDescriptor> descriptors = new List<MaskDescriptor>();
+        while (enumerator.MoveNext())
+        {
+            descriptors.Add((MaskDescriptor)enumerator.Current);
+        }
+
+        descriptors.Should().NotBeEmpty();
+    }
+
+    [WinFormsTheory]
+    [InlineData(typeof(ValidMaskDescriptor), true)]
+    [InlineData(typeof(AbstractMaskDescriptor), false)]
+    [InlineData(typeof(NonPublicMaskDescriptor), false)]
+    public void DiscoverMaskDescriptors_ShouldHandleVariousDescriptorTypes(Type descriptorType, bool shouldBeAdded)
+    {
+        Mock<ITypeDiscoveryService> mockDiscoveryService = new Mock<ITypeDiscoveryService>();
+        List<Type> types = new List<Type> { descriptorType };
+
+        mockDiscoveryService.Setup(ds => ds.GetTypes(typeof(MaskDescriptor), false)).Returns(types);
+
+        _dialog.DiscoverMaskDescriptors(mockDiscoveryService.Object);
+        var maskDescriptors = (List<MaskDescriptor>)_dialog.TestAccessor().Dynamic._maskDescriptors;
+
+        if (shouldBeAdded)
+        {
+            maskDescriptors.Should().ContainSingle(descriptor => descriptor.GetType() == descriptorType);
+        }
+        else
+        {
+            maskDescriptors.Should().NotContain(descriptor => descriptor.GetType() == descriptorType);
+        }
+    }
+
+    private abstract class AbstractMaskDescriptor : MaskDescriptor
+    {
+        public override string? Mask => null;
+        public override string? Name => null;
+        public override string? Sample => null;
+        public override Type? ValidatingType => null;
+    }
+
+    private class NonPublicMaskDescriptor : MaskDescriptor
+    {
+        public override string? Mask => null;
+        public override string? Name => null;
+        public override string? Sample => null;
+        public override Type? ValidatingType => null;
+    }
+}
+
+public class ValidMaskDescriptor : MaskDescriptor
+{
+    public override string? Mask => "000-00-0000";
+    public override string? Name => "Valid Mask";
+    public override string? Sample => "123-45-6789";
+    public override Type? ValidatingType => typeof(string);
+}

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/MaskDesignerDialogTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/MaskDesignerDialogTests.cs
@@ -10,12 +10,12 @@ namespace System.Windows.Forms.Design.Tests;
 
 public sealed class MaskDesignerDialogTests : IDisposable
 {
-    private readonly MaskedTextBox _maskedTextBox = new MaskedTextBox();
+    private readonly MaskedTextBox _maskedTextBox = new();
     private readonly MaskDesignerDialog _dialog;
 
     public MaskDesignerDialogTests()
     {
-        _dialog = new MaskDesignerDialog(_maskedTextBox, null);
+        _dialog = new(_maskedTextBox, null);
     }
 
     public void Dispose()
@@ -27,7 +27,7 @@ public sealed class MaskDesignerDialogTests : IDisposable
     [Fact]
     public void Constructor_ValidMaskedTextBox_UsesProvidedMaskedTextBox()
     {
-        TextBox txtBoxMask = _dialog.TestAccessor().Dynamic._txtBoxMask;
+        using TextBox txtBoxMask = _dialog.TestAccessor().Dynamic._txtBoxMask;
 
         _dialog.Mask.Should().Be(_maskedTextBox.Mask);
         txtBoxMask.Text.Should().Be(_maskedTextBox.Mask);
@@ -47,7 +47,7 @@ public sealed class MaskDesignerDialogTests : IDisposable
     {
         Collections.IEnumerator enumerator = _dialog.MaskDescriptors;
 
-        List<MaskDescriptor> descriptors = new List<MaskDescriptor>();
+        List<MaskDescriptor> descriptors = new();
         while (enumerator.MoveNext())
         {
             descriptors.Add((MaskDescriptor)enumerator.Current);
@@ -74,8 +74,8 @@ public sealed class MaskDesignerDialogTests : IDisposable
     [InlineData(typeof(NonPublicMaskDescriptor), false)]
     public void DiscoverMaskDescriptors_ShouldHandleVariousDescriptorTypes(Type descriptorType, bool shouldBeAdded)
     {
-        Mock<ITypeDiscoveryService> mockDiscoveryService = new Mock<ITypeDiscoveryService>();
-        List<Type> types = new List<Type> { descriptorType };
+        Mock<ITypeDiscoveryService> mockDiscoveryService = new();
+        List<Type> types = new(){ descriptorType };
 
         mockDiscoveryService.Setup(ds => ds.GetTypes(typeof(MaskDescriptor), false)).Returns(types);
 

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/MaskDesignerDialogTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/MaskDesignerDialogTests.cs
@@ -8,14 +8,13 @@ using Moq;
 
 namespace System.Windows.Forms.Design.Tests;
 
-public sealed class MaskDesignerDialogTests:IDisposable
+public sealed class MaskDesignerDialogTests : IDisposable
 {
-    private readonly MaskedTextBox _maskedTextBox;
+    private readonly MaskedTextBox _maskedTextBox = new MaskedTextBox();
     private readonly MaskDesignerDialog _dialog;
 
     public MaskDesignerDialogTests()
     {
-        _maskedTextBox = new MaskedTextBox();
         _dialog = new MaskDesignerDialog(_maskedTextBox, null);
     }
 
@@ -28,7 +27,7 @@ public sealed class MaskDesignerDialogTests:IDisposable
     [Fact]
     public void Constructor_ValidMaskedTextBox_UsesProvidedMaskedTextBox()
     {
-        var txtBoxMask = (TextBox)_dialog.TestAccessor().Dynamic._txtBoxMask;
+        TextBox txtBoxMask = _dialog.TestAccessor().Dynamic._txtBoxMask;
 
         _dialog.Mask.Should().Be(_maskedTextBox.Mask);
         txtBoxMask.Text.Should().Be(_maskedTextBox.Mask);
@@ -46,7 +45,7 @@ public sealed class MaskDesignerDialogTests:IDisposable
     [Fact]
     public void MaskDescriptorsEnumerator_ShouldReturnCorrectDescriptors()
     {
-        var enumerator = _dialog.MaskDescriptors;
+        Collections.IEnumerator enumerator = _dialog.MaskDescriptors;
 
         List<MaskDescriptor> descriptors = new List<MaskDescriptor>();
         while (enumerator.MoveNext())
@@ -55,6 +54,18 @@ public sealed class MaskDesignerDialogTests:IDisposable
         }
 
         descriptors.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void DiscoverMaskDescriptors_ShouldHandleNullTypeDiscoveryService()
+    {
+        List<MaskDescriptor> initialDescriptors = _dialog.TestAccessor().Dynamic._maskDescriptors;
+
+        _dialog.DiscoverMaskDescriptors(null);
+
+        List<MaskDescriptor> maskDescriptors = _dialog.TestAccessor().Dynamic._maskDescriptors;
+
+        maskDescriptors.Should().Equal(initialDescriptors);
     }
 
     [WinFormsTheory]
@@ -69,7 +80,7 @@ public sealed class MaskDesignerDialogTests:IDisposable
         mockDiscoveryService.Setup(ds => ds.GetTypes(typeof(MaskDescriptor), false)).Returns(types);
 
         _dialog.DiscoverMaskDescriptors(mockDiscoveryService.Object);
-        var maskDescriptors = (List<MaskDescriptor>)_dialog.TestAccessor().Dynamic._maskDescriptors;
+        List<MaskDescriptor> maskDescriptors = _dialog.TestAccessor().Dynamic._maskDescriptors;
 
         if (shouldBeAdded)
         {


### PR DESCRIPTION
Related https://github.com/dotnet/winforms/issues/10773

## Proposed changes
1. Add unit test MaskDesignerDialogTests.cs for public properties and method of the MaskDesignerDialog.
2. Enable nullability in MaskDesignerDialogTests..cs.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12575)