### PR TITLE
Annotate test utility projects so that they don't get built inside the VMR

### DIFF
--- a/src/Common/tests/TestUtilities/System.Private.Windows.Core.TestUtilities.csproj
+++ b/src/Common/tests/TestUtilities/System.Private.Windows.Core.TestUtilities.csproj
@@ -1,4 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <AssemblyName>System.Private.Windows.Core.TestUtilities</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -6,6 +7,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
     <IsShipping>false</IsShipping>
+    <IsTestUtilityProject>true</IsTestUtilityProject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.VisualBasic/tests/IntegrationTests/VisualBasicRuntimeTest/VisualBasicRuntimeTest.csproj
+++ b/src/Microsoft.VisualBasic/tests/IntegrationTests/VisualBasicRuntimeTest/VisualBasicRuntimeTest.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <IsTestUtilityProject>true</IsTestUtilityProject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/System.Windows.Forms.Primitives.TestUtilities.csproj
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/System.Windows.Forms.Primitives.TestUtilities.csproj
@@ -7,6 +7,7 @@
       SYSLIB5005: System.Formats.Nrbf is experimental
     -->
     <NoWarn>$(NoWarn);SYSLIB5005</NoWarn>
+    <IsTestUtilityProject>true</IsTestUtilityProject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.Windows.Forms/tests/AccessibilityTests/Accessibility_Core_App.csproj
+++ b/src/System.Windows.Forms/tests/AccessibilityTests/Accessibility_Core_App.csproj
@@ -7,6 +7,7 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <EnableXlfLocalization>false</EnableXlfLocalization>
     <UpdateXlfOnBuild>false</UpdateXlfOnBuild>
+    <IsTestUtilityProject>true</IsTestUtilityProject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.Windows.Forms/tests/AxHosts/AxHosts.csproj
+++ b/src/System.Windows.Forms/tests/AxHosts/AxHosts.csproj
@@ -15,6 +15,7 @@
     <UpdateXlfOnBuild>false</UpdateXlfOnBuild>
     <SkipResolvePackageAssets>true</SkipResolvePackageAssets>
     <ResolveComReferenceSilent>true</ResolveComReferenceSilent>
+    <IsTestUtilityProject>true</IsTestUtilityProject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/DemoConsole.csproj
+++ b/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/DemoConsole.csproj
@@ -20,6 +20,7 @@
     <!-- Do not build this project when doing a .NET product build. -->
     <!-- The files for this project have been removed from the .NET product due to licensing issues. -->
     <ExcludeFromDotNetBuild>true</ExcludeFromDotNetBuild>
+    <IsTestUtilityProject>true</IsTestUtilityProject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DesignSurfaceExt/DesignSurfaceExt.csproj
+++ b/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DesignSurfaceExt/DesignSurfaceExt.csproj
@@ -20,6 +20,7 @@
     <!-- Do not build this project when doing a .NET product build. -->
     <!-- The files for this project have been removed from the .NET product due to licensing issues. -->
     <ExcludeFromDotNetBuild>true</ExcludeFromDotNetBuild>
+    <IsTestUtilityProject>true</IsTestUtilityProject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.Windows.Forms/tests/IntegrationTests/NativeHost.ManagedControl/NativeHost.ManagedControl.csproj
+++ b/src/System.Windows.Forms/tests/IntegrationTests/NativeHost.ManagedControl/NativeHost.ManagedControl.csproj
@@ -6,6 +6,7 @@
     <EnableComHosting>true</EnableComHosting>
     <EnableXlfLocalization>false</EnableXlfLocalization>
     <UpdateXlfOnBuild>false</UpdateXlfOnBuild>
+    <IsTestUtilityProject>true</IsTestUtilityProject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.Windows.Forms/tests/IntegrationTests/ScratchProject/ScratchProject.csproj
+++ b/src/System.Windows.Forms/tests/IntegrationTests/ScratchProject/ScratchProject.csproj
@@ -10,6 +10,7 @@
     <!-- These are needed to suppress the localization step picked up from Arcade targets -->
     <EnableXlfLocalization>false</EnableXlfLocalization>
     <UpdateXlfOnBuild>false</UpdateXlfOnBuild>
+    <IsTestUtilityProject>true</IsTestUtilityProject>
   </PropertyGroup>
 
   <!-- Experiment with single file deployments

--- a/src/System.Windows.Forms/tests/IntegrationTests/ScratchProjectWithInternals/ScratchProjectWithInternals.csproj
+++ b/src/System.Windows.Forms/tests/IntegrationTests/ScratchProjectWithInternals/ScratchProjectWithInternals.csproj
@@ -10,6 +10,7 @@
     <!-- These are needed to suppress the localization step picked up from Arcade targets -->
     <EnableXlfLocalization>false</EnableXlfLocalization>
     <UpdateXlfOnBuild>false</UpdateXlfOnBuild>
+    <IsTestUtilityProject>true</IsTestUtilityProject>
   </PropertyGroup>
 
   <!-- These normally come from $(UseWindowsForms) when $(ImplicitUsings) is enabled -->

--- a/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests.Common/System.Windows.Forms.IntegrationTests.Common.csproj
+++ b/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests.Common/System.Windows.Forms.IntegrationTests.Common.csproj
@@ -2,6 +2,7 @@
  
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+    <IsTestUtilityProject>true</IsTestUtilityProject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.Windows.Forms/tests/IntegrationTests/TrimTest/TrimTest.csproj
+++ b/src/System.Windows.Forms/tests/IntegrationTests/TrimTest/TrimTest.csproj
@@ -9,6 +9,7 @@
     <!-- These are needed to suppress the localization step picked up from Arcade targets -->
     <EnableXlfLocalization>false</EnableXlfLocalization>
     <UpdateXlfOnBuild>false</UpdateXlfOnBuild>
+    <IsTestUtilityProject>true</IsTestUtilityProject>
   </PropertyGroup>
 
   <!-- These normally come from $(UseWindowsForms) when $(ImplicitUsings) is enabled -->

--- a/src/System.Windows.Forms/tests/IntegrationTests/TrimTestBinaryDeserialization/TrimTestBinaryDeserialization.csproj
+++ b/src/System.Windows.Forms/tests/IntegrationTests/TrimTestBinaryDeserialization/TrimTestBinaryDeserialization.csproj
@@ -10,6 +10,7 @@
     <EnableXlfLocalization>false</EnableXlfLocalization>
     <UpdateXlfOnBuild>false</UpdateXlfOnBuild>
     <GenerateResourceWarnOnBinaryFormatterUse>false</GenerateResourceWarnOnBinaryFormatterUse>
+    <IsTestUtilityProject>true</IsTestUtilityProject>
   </PropertyGroup>
 
   <!-- <PropertyGroup>

--- a/src/System.Windows.Forms/tests/IntegrationTests/VisualBasicTemplate/VbWinForms.vbproj
+++ b/src/System.Windows.Forms/tests/IntegrationTests/VisualBasicTemplate/VbWinForms.vbproj
@@ -5,6 +5,7 @@
     <RootNamespace>VbWinForms</RootNamespace>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>
+    <IsTestUtilityProject>true</IsTestUtilityProject>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/WinformsControlsTest.csproj
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/WinformsControlsTest.csproj
@@ -12,6 +12,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
     <GenerateResourceWarnOnBinaryFormatterUse>false</GenerateResourceWarnOnBinaryFormatterUse>
+    <IsTestUtilityProject>true</IsTestUtilityProject>
   </PropertyGroup>
 
   <!--ApplicationConfiguration specific settings.-->

--- a/src/System.Windows.Forms/tests/TestUtilities/System.Windows.Forms.TestUtilities.csproj
+++ b/src/System.Windows.Forms/tests/TestUtilities/System.Windows.Forms.TestUtilities.csproj
@@ -1,8 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <AssemblyName>System.Windows.Forms.TestUtilities</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <RootNamespace>System</RootNamespace>
+    <IsTestUtilityProject>true</IsTestUtilityProject>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I noticed that these get built in the normal product build that shouldn't build tests.