### PR TITLE
Add File Classification for runtime pack

### DIFF
--- a/pkg/Microsoft.Private.Winforms/README.md
+++ b/pkg/Microsoft.Private.Winforms/README.md
@@ -5,7 +5,7 @@ This is a transport package consumed by [WPF](https://github.com/dotnet/wpf/) an
 
 ## `sdk\dotnet-windowsdesktop` folder
 
-This folder contains props and targets used to ingest our assemblies into the [Windows Desktop SDK](https://github.com/dotnet/windowsdesktop/) for purpose of bundling of our analyzers into Microsoft.WindowsDesktop.App.Ref pack.
+This folder contains props and targets used to ingest our assemblies into the [Windows Desktop SDK](https://github.com/dotnet/windowsdesktop/), bundling the correct set of assemblies into either the Microsoft.WindowsDesktop.App.Ref pack or Microsoft.WindowsDesktop.App.Runtime pack.
 
 * [`System.Windows.Forms.FileClassification.props`](sdk\dotnet-windowsdesktop\System.Windows.Forms.FileClassification.props) contains a manifest for the "WindowsForms" SDK[&#x00B9;](#ref1), i.e. a list of our assemblies that form it.
 The file is imported by [Microsoft.WindowsDesktop.App.Ref project](https://github.com/dotnet/windowsdesktop/blob/main/src/windowsdesktop/src/sfx/Microsoft.WindowsDesktop.App.Ref.sfxproj).<br/>

--- a/pkg/Microsoft.Private.Winforms/sdk/dotnet-windowsdesktop/System.Windows.Forms.FileClassification.props
+++ b/pkg/Microsoft.Private.Winforms/sdk/dotnet-windowsdesktop/System.Windows.Forms.FileClassification.props
@@ -3,7 +3,8 @@
     pkg\windowsdesktop\sfx\Microsoft.WindowsDesktop.App.Ref.sfxproj.
 -->
 <Project>
-  <ItemGroup Condition="'$(PackageTargetRuntime)' == ''">
+  <!-- File classifications that should be included for both the ref and runtime pack. -->
+  <ItemGroup>
     <FrameworkListFileClass Include="Microsoft.VisualBasic.dll" Profile="WindowsForms" />
     <FrameworkListFileClass Include="Microsoft.VisualBasic.Forms.dll" Profile="WindowsForms" />
     <FrameworkListFileClass Include="System.Design.dll" Profile="WindowsForms" />
@@ -12,14 +13,26 @@
     <FrameworkListFileClass Include="System.Drawing.dll" Profile="WindowsForms" />
     <!-- System.Private.Windows.Core is now used by both WPF and Windows Forms -->
     <FrameworkListFileClass Include="System.Private.Windows.Core.dll" Profile="WindowsForms;WPF" />
+    <FrameworkListFileClass Include="System.Windows.Forms.Design.dll" Profile="WindowsForms" />
+    <FrameworkListFileClass Include="System.Windows.Forms.Design.Editors.dll" Profile="WindowsForms" />
+    <FrameworkListFileClass Include="System.Windows.Forms.dll" Profile="WindowsForms" />
+    <FrameworkListFileClass Include="System.Windows.Forms.Primitives.dll" Profile="WindowsForms" />
+  </ItemGroup>
+
+  <!-- File classifications that should only be included for the ref pack. -->
+  <ItemGroup Condition="'$(PackageTargetRuntime)' == ''">
     <FrameworkListFileClass Include="System.Windows.Forms.Analyzers.CodeFixes.CSharp.dll" Profile="WindowsForms" />
     <FrameworkListFileClass Include="System.Windows.Forms.Analyzers.CodeFixes.VisualBasic.dll" Profile="WindowsForms" />
     <FrameworkListFileClass Include="System.Windows.Forms.Analyzers.CSharp.dll" Profile="WindowsForms" />
     <FrameworkListFileClass Include="System.Windows.Forms.Analyzers.dll" Profile="WindowsForms" />
     <FrameworkListFileClass Include="System.Windows.Forms.Analyzers.VisualBasic.dll" Profile="WindowsForms" />
-    <FrameworkListFileClass Include="System.Windows.Forms.Design.dll" Profile="WindowsForms" />
-    <FrameworkListFileClass Include="System.Windows.Forms.Design.Editors.dll" Profile="WindowsForms" />
-    <FrameworkListFileClass Include="System.Windows.Forms.dll" Profile="WindowsForms" />
-    <FrameworkListFileClass Include="System.Windows.Forms.Primitives.dll" Profile="WindowsForms" />
+  </ItemGroup>
+
+    <!-- File classifications that should only be included for the runtime pack. -->
+  <ItemGroup Condition="'$(PackageTargetRuntime)' != ''">
+    <FrameworkListFileClass Include="Microsoft.VisualBasic.Forms.resources.dll" Profile="WindowsForms" />
+    <FrameworkListFileClass Include="System.Windows.Forms.Design.resources.dll" Profile="WindowsForms" />
+    <FrameworkListFileClass Include="System.Windows.Forms.Primitives.resources.dll" Profile="WindowsForms" />
+    <FrameworkListFileClass Include="System.Windows.Forms.resources.dll" Profile="WindowsForms" />
   </ItemGroup>
 </Project>

--- a/pkg/Microsoft.Private.Winforms/sdk/dotnet-windowsdesktop/System.Windows.Forms.FileClassification.props
+++ b/pkg/Microsoft.Private.Winforms/sdk/dotnet-windowsdesktop/System.Windows.Forms.FileClassification.props
@@ -1,6 +1,6 @@
 ﻿<!--
     This props file comes from dotnet/winforms. It gets ingested by dotnet/windowsdesktop and processed by
-    pkg\windowsdesktop\sfx\Microsoft.WindowsDesktop.App.Ref.sfxproj.
+    src\windowsdesktop\src\sfx\Microsoft.WindowsDesktop.App.Ref.sfxproj and src\windowsdesktop\src\sfx\Microsoft.WindowsDesktop.App.Runtime.sfxproj.
 -->
 <Project>
   <!-- File classifications that should be included for both the ref and runtime pack. -->
@@ -18,7 +18,7 @@
     <FrameworkListFileClass Include="System.Windows.Forms.dll" Profile="WindowsForms" />
     <FrameworkListFileClass Include="System.Windows.Forms.Primitives.dll" Profile="WindowsForms" />
   </ItemGroup>
-
+        
   <!-- File classifications that should only be included for the ref pack. -->
   <ItemGroup Condition="'$(PackageTargetRuntime)' == ''">
     <FrameworkListFileClass Include="System.Windows.Forms.Analyzers.CodeFixes.CSharp.dll" Profile="WindowsForms" />
@@ -28,7 +28,7 @@
     <FrameworkListFileClass Include="System.Windows.Forms.Analyzers.VisualBasic.dll" Profile="WindowsForms" />
   </ItemGroup>
 
-    <!-- File classifications that should only be included for the runtime pack. -->
+  <!-- File classifications that should only be included for the runtime pack. Note analyzers should not be included in the runtime pack. -->
   <ItemGroup Condition="'$(PackageTargetRuntime)' != ''">
     <FrameworkListFileClass Include="Microsoft.VisualBasic.Forms.resources.dll" Profile="WindowsForms" />
     <FrameworkListFileClass Include="System.Windows.Forms.Design.resources.dll" Profile="WindowsForms" />


### PR DESCRIPTION
Related: https://github.com/dotnet/windowsdesktop/issues/4796

This change includes file classification that is needed for the runtime pack in windowsdesktop in our FileClassification.props to avoid maintaining this list in the windowsdesktop repo. These dlls come from winforms so they should be maintained here and simply pulled into windowsdesktop [like how we are already doing for the ref pack](https://github.com/dotnet/windowsdesktop/blob/main/src/windowsdesktop/src/sfx/Microsoft.WindowsDesktop.App.Ref.sfxproj#L25). The list is currently being maintained https://github.com/dotnet/windowsdesktop/blob/main/src/windowsdesktop/src/sfx/Microsoft.WindowsDesktop.App.Runtime.sfxproj#L22-L39
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12578)