### PR TITLE
Reset MouseIsOver when the control loses focus

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.FlatComboAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.FlatComboAdapter.cs
@@ -75,6 +75,11 @@ public partial class ComboBox
             {
                 DrawFlatCombo(comboBox, g);
             }
+            else
+            {
+                // Draw the drop down
+                DrawFlatComboDropDown(comboBox, g, _dropDownRect);
+            }
 
             bool rightToLeft = comboBox.RightToLeft == RightToLeft.Yes;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.cs
@@ -2747,12 +2747,6 @@ public partial class ComboBox : ListControl
 
             base.OnLostFocus(e);
             _canFireLostFocus = false;
-
-            // When the control loses focus, reset the MouseIsOver to False.
-            if (DropDownStyle == ComboBoxStyle.Simple || !DroppedDown)
-            {
-                MouseIsOver = false;
-            }
         }
     }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.cs
@@ -3770,7 +3770,10 @@ public partial class ComboBox : ListControl
                     }
 
                     using Graphics g = Graphics.FromHdcInternal((IntPtr)dc);
-                    if ((!Enabled || FlatStyle == FlatStyle.Popup) && MouseIsOver)
+
+                    // The pop up border needs to be drawn only when the control gets the focus or the mouse hovers over it.
+                    bool isPopupAndActive = FlatStyle == FlatStyle.Popup && (Focused || MouseIsOver);
+                    if (!Enabled || isPopupAndActive)
                     {
                         FlatComboBoxAdapter.DrawPopUpCombo(this, g);
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.cs
@@ -2748,8 +2748,8 @@ public partial class ComboBox : ListControl
             base.OnLostFocus(e);
             _canFireLostFocus = false;
 
-            // If the dropdown is not active, that means the mouse is no longer over the control.
-            if (!DroppedDown)
+            // When the control loses focus, reset the MouseIsOver to False.
+            if (DropDownStyle == ComboBoxStyle.Simple || !DroppedDown)
             {
                 MouseIsOver = false;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.cs
@@ -2747,6 +2747,12 @@ public partial class ComboBox : ListControl
 
             base.OnLostFocus(e);
             _canFireLostFocus = false;
+
+            // If the dropdown is not active, that means the mouse is no longer over the control.
+            if (!DroppedDown)
+            {
+                MouseIsOver = false;
+            }
         }
     }
 
@@ -3826,7 +3832,6 @@ public partial class ComboBox : ListControl
                 base.WndProc(ref m);
                 ReleaseChildWindow();
                 break;
-
             default:
                 if (m.MsgInternal == RegisteredMessage.WM_MOUSEENTER)
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.cs
@@ -3832,6 +3832,7 @@ public partial class ComboBox : ListControl
                 base.WndProc(ref m);
                 ReleaseChildWindow();
                 break;
+
             default:
                 if (m.MsgInternal == RegisteredMessage.WM_MOUSEENTER)
                 {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
@@ -2764,10 +2764,6 @@ public class ComboBoxTests
 
         string matchingText = comboBoxAccessor.MatchingText;
         matchingText.Should().Be("Test");
-
-        // Verifies the fix for issue "https://github.com/dotnet/winforms/issues/12590"
-        // related to ComboBox dropdown button disappear when switching RightToLeft property.
-        comboBox.MouseIsOver.Should().BeFalse();
     }
 
     [WinFormsFact]
@@ -2784,10 +2780,6 @@ public class ComboBoxTests
 
         string matchingText = comboBoxAccessor.MatchingText;
         matchingText.Should().BeEmpty();
-
-        // Verifies the fix for issue "https://github.com/dotnet/winforms/issues/12590"
-        // related to ComboBox dropdown button disappear when switching RightToLeft property.
-        comboBox.MouseIsOver.Should().BeFalse();
     }
 
     private class OwnerDrawComboBox : ComboBox

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
@@ -2750,6 +2750,38 @@ public class ComboBoxTests
         Assert.Equal(numItems, comboBox.Items.Count);
     }
 
+    [WinFormsFact]
+    public void ComboBox_OnLostFocus_AutoCompleteModeNone_DoesNotClearMatchingText()
+    {
+        using ComboBox comboBox = new();
+        comboBox.TestAccessor().Dynamic._canFireLostFocus= true;
+        comboBox.AutoCompleteMode = AutoCompleteMode.None;
+        comboBox.AutoCompleteSource = AutoCompleteSource.ListItems;
+        comboBox.TestAccessor().Dynamic.MatchingText = "Test";
+        comboBox.DropDownStyle = ComboBoxStyle.Simple;
+        comboBox.TestAccessor().Dynamic.OnLostFocus(EventArgs.Empty);
+
+        string matchingText = comboBox.TestAccessor().Dynamic.MatchingText;
+        matchingText.Should().Be("Test");
+        comboBox.MouseIsOver.Should().BeFalse();
+    }
+
+    [WinFormsFact]
+    public void ComboBox_OnLostFocus_AutoCompleteModeNotNone_ClearsMatchingText()
+    {
+        using ComboBox comboBox = new();
+        comboBox.TestAccessor().Dynamic._canFireLostFocus = true;
+        comboBox.AutoCompleteMode = AutoCompleteMode.Suggest;
+        comboBox.AutoCompleteSource = AutoCompleteSource.ListItems;
+        comboBox.DropDownStyle = ComboBoxStyle.DropDownList;
+        comboBox.TestAccessor().Dynamic.MatchingText = "Test";
+        comboBox.TestAccessor().Dynamic.OnLostFocus(EventArgs.Empty);
+
+        string matchingText = comboBox.TestAccessor().Dynamic.MatchingText;
+        matchingText.Should().BeEmpty();
+        comboBox.MouseIsOver.Should().BeFalse();
+    }
+
     private class OwnerDrawComboBox : ComboBox
     {
         public OwnerDrawComboBox()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
@@ -2754,15 +2754,19 @@ public class ComboBoxTests
     public void ComboBox_OnLostFocus_AutoCompleteModeNone_DoesNotClearMatchingText()
     {
         using ComboBox comboBox = new();
-        comboBox.TestAccessor().Dynamic._canFireLostFocus= true;
+        var comboBoxAccessor = comboBox.TestAccessor().Dynamic;
+        comboBoxAccessor._canFireLostFocus= true;
         comboBox.AutoCompleteMode = AutoCompleteMode.None;
         comboBox.AutoCompleteSource = AutoCompleteSource.ListItems;
-        comboBox.TestAccessor().Dynamic.MatchingText = "Test";
+        comboBoxAccessor.MatchingText = "Test";
         comboBox.DropDownStyle = ComboBoxStyle.Simple;
-        comboBox.TestAccessor().Dynamic.OnLostFocus(EventArgs.Empty);
+        comboBoxAccessor.OnLostFocus(EventArgs.Empty);
 
-        string matchingText = comboBox.TestAccessor().Dynamic.MatchingText;
+        string matchingText = comboBoxAccessor.MatchingText;
         matchingText.Should().Be("Test");
+
+        // Verifies the fix for issue "https://github.com/dotnet/winforms/issues/12590"
+        // related to ComboBox dropdown button disappear when switching RightToLeft property.
         comboBox.MouseIsOver.Should().BeFalse();
     }
 
@@ -2770,15 +2774,19 @@ public class ComboBoxTests
     public void ComboBox_OnLostFocus_AutoCompleteModeNotNone_ClearsMatchingText()
     {
         using ComboBox comboBox = new();
-        comboBox.TestAccessor().Dynamic._canFireLostFocus = true;
+        var comboBoxAccessor = comboBox.TestAccessor().Dynamic;
+        comboBoxAccessor._canFireLostFocus = true;
         comboBox.AutoCompleteMode = AutoCompleteMode.Suggest;
         comboBox.AutoCompleteSource = AutoCompleteSource.ListItems;
         comboBox.DropDownStyle = ComboBoxStyle.DropDownList;
-        comboBox.TestAccessor().Dynamic.MatchingText = "Test";
-        comboBox.TestAccessor().Dynamic.OnLostFocus(EventArgs.Empty);
+        comboBoxAccessor.MatchingText = "Test";
+        comboBoxAccessor.OnLostFocus(EventArgs.Empty);
 
-        string matchingText = comboBox.TestAccessor().Dynamic.MatchingText;
+        string matchingText = comboBoxAccessor.MatchingText;
         matchingText.Should().BeEmpty();
+
+        // Verifies the fix for issue "https://github.com/dotnet/winforms/issues/12590"
+        // related to ComboBox dropdown button disappear when switching RightToLeft property.
         comboBox.MouseIsOver.Should().BeFalse();
     }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #12590 

## Root Cause

In order to fix the flickering issue#[2053861](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2053861), we modified the drawing logic of ComboBox in https://github.com/dotnet/winforms/pull/11529

When `FlatStyle == FlatStyle.Popup` and the control gets the focus or the mouse entering, draw the black border of the popup instead of re-rendering the entire control

This leads to the current issue. When the drop-down box is expanded by the mouse, and the focus is moved to the property page using Tab, FlatStyle is changed to popup, and then the RightToLeft property is modified

At this time, the conditions for drawing the Popup border are met (i.e. FlatStyle == FlatStyle.Popup and MouseIsOver=true), which causes [DrawFlatCombo](https://github.com/dotnet/winforms/blob/084e6d06f40e8dc889c3ac3f958c75efdcfd3c9b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.cs#L3774) not to be executed

## Proposed changes

- Set MouseIsOver = false in OnLostFocus method of ComboBox.cs

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

-  ComboBox dropdown button can be shown normally when switching RightToLeft property, or recreating the combobox for any other reason.

## Regression? 

- Yes 

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
When change the **RightToLeft** property **after expanding** the **Popup FlatStyle** comboBox, the dropdown button on the comboBox disappeared
![Image](https://github.com/user-attachments/assets/2e730e12-e569-462b-812a-dcb8cf7ce2b6)

### After
The dropdown button on the comboBox can be show normally
![AfterChanges](https://github.com/user-attachments/assets/41bcbfea-1c44-4ee4-b875-87eada359f38)


## Test methodology <!-- How did you ensure quality? -->

- Manually

## Test environment(s) <!-- Remove any that don't apply -->

- .net 10.0.0-alpha.1.24605.1


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12598)