### PR TITLE
Backport pr 12356 12431 12508 and 12479

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.cs
@@ -3998,7 +3998,7 @@ internal sealed partial class PropertyGridView :
             startRow = 0;
         }
 
-        if (fullRefresh || OwnerGrid.HavePropertyEntriesChanged())
+        if (OwnerGrid.HavePropertyEntriesChanged())
         {
             if (HasEntries && !InPropertySet && !CommitEditTextBox())
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.cs
@@ -2475,7 +2475,8 @@ internal sealed partial class PropertyGridView :
             }
 
             CommitValue(entry, valueNew, closeDropDown);
-            EditTextBox?.SelectAll();
+            EditTextBox.HookMouseDown = false;
+            EditTextBox.SelectAll();
             return true;
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.cs
@@ -4019,7 +4019,10 @@ internal sealed partial class PropertyGridView :
             if (oldLength > 0 && !_flags.HasFlag(Flags.NoDefault))
             {
                 _positionData = CaptureGridPositionData();
-                CommonEditorHide(true);
+                if (!fullRefresh)
+                {
+                    CommonEditorHide(true);
+                }
             }
 
             UpdateHelpAttributes(_selectedGridEntry, newEntry: null);
@@ -4300,17 +4303,10 @@ internal sealed partial class PropertyGridView :
             return;
         }
 
-        bool newRow = false;
         int oldSelectedRow = _selectedRow;
-        if (_selectedRow != row || !gridEntry.Equals(_selectedGridEntry))
+        if (_selectedRow != row || (_selectedGridEntry is not null && !gridEntry.Equals(_selectedGridEntry)))
         {
             CommonEditorHide();
-            newRow = true;
-        }
-
-        if (!newRow)
-        {
-            CloseDropDown();
         }
 
         Rectangle rect = GetRectangle(row, RowValue);
@@ -4401,7 +4397,7 @@ internal sealed partial class PropertyGridView :
             _selectedGridEntry.HasFocus = FocusInside;
         }
 
-        if (!_flags.HasFlag(Flags.IsNewSelection))
+        if (!_flags.HasFlag(Flags.IsNewSelection) && !_flags.HasFlag(Flags.InPropertySet))
         {
             Focus();
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TextBox/TextBoxBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TextBox/TextBoxBase.cs
@@ -1730,26 +1730,28 @@ public abstract partial class TextBoxBase : Control
     ///  But if you do have it cached, please pass it in. This will avoid
     ///  the expensive call to the TextLength property.
     /// </summary>
-    private protected virtual void SelectInternal(int start, int length, int textLen)
+    private protected virtual void SelectInternal(int selectionStart, int selectionLength, int textLength)
     {
         // if our handle is created - send message...
         if (IsHandleCreated)
         {
-            AdjustSelectionStartAndEnd(start, length, out int s, out int e, textLen);
+            AdjustSelectionStartAndEnd(selectionStart, selectionLength, out int start, out int end, textLength);
 
-            PInvoke.SendMessage(this, PInvoke.EM_SETSEL, (WPARAM)s, (LPARAM)e);
+            PInvoke.SendMessage(this, PInvoke.EM_SETSEL, (WPARAM)start, (LPARAM)end);
 
             if (IsAccessibilityObjectCreated)
             {
-                AccessibilityObject.RaiseAutomationEvent(UIA_EVENT_ID.UIA_Text_TextSelectionChangedEventId);
+                AccessibilityObject.RaiseAutomationEvent(end == 0
+                    ? UIA_EVENT_ID.UIA_AutomationFocusChangedEventId
+                    : UIA_EVENT_ID.UIA_Text_TextSelectionChangedEventId);
             }
         }
         else
         {
             // otherwise, wait until handle is created to send this message.
             // Store the indices until then...
-            _selectionStart = start;
-            _selectionLength = length;
+            _selectionStart = selectionStart;
+            _selectionLength = selectionLength;
             _textBoxFlags[s_setSelectionOnHandleCreated] = true;
         }
     }

--- a/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/MainForm.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/MainForm.cs
@@ -118,22 +118,35 @@ public partial class MainForm : Form
                         // - create some Controls at DesignTime
                         TextBox t1 = surface.CreateControl<TextBox>(new Size(200, 23), new Point(172, 12));
                         Button b1 = surface.CreateControl<Button>(new Size(200, 40), new Point(172, 63));
-                        CustomButton b2 = surface.CreateControl<CustomButton>(new Size(200, 40), new Point(100, 200));
+                        CustomButton b2 = surface.CreateControl<CustomButton>(new Size(200, 40), new Point(172, 200));
                         b1.Text = "I'm the first Button";
                         b2.Text = "I'm the second Button";
                         b1.BackColor = Color.LightGray;
                         b2.BackColor = Color.LightGreen;
 
-                        RadioButton rb1 = surface.CreateControl<RadioButton>(new Size(120, 22), new Point(12, 21));
+                        RadioButton rb1 = surface.CreateControl<RadioButton>(new Size(120, 22), new Point(12, 10));
                         rb1.Text = "Check me!";
-                        RadioButton rb2 = surface.CreateControl<RadioButton>(new Size(120, 22), new Point(12, 50));
+                        RadioButton rb2 = surface.CreateControl<RadioButton>(new Size(120, 22), new Point(12, 35));
                         rb2.Text = "No, check me!";
                         rb2.Checked = true;
 
-                        Panel pnl = surface.CreateControl<Panel>(new Size(130, 100), new Point(12, 21));
+                        CheckBox checkbox1 = surface.CreateControl<CheckBox>(new Size(120, 22), new Point(12, 60));
+                        checkbox1.Text = "I'm Unchecked!";
+                        CheckBox checkbox2 = surface.CreateControl<CheckBox>(new Size(120, 22), new Point(12, 85));
+                        checkbox2.Text = "I'm Indeterminate!";
+                        checkbox2.AutoSize = true;
+                        checkbox2.CheckState = CheckState.Indeterminate;
+                        CheckBox checkbox3 = surface.CreateControl<CheckBox>(new Size(120, 22), new Point(12, 110));
+                        checkbox3.Text = "I'm Checked!";
+                        checkbox3.CheckState = CheckState.Checked;
+
+                        Panel pnl = surface.CreateControl<Panel>(new Size(140, 140), new Point(12, 12));
                         pnl.BackColor = Color.Aquamarine;
                         rb1.Parent = pnl;
                         rb2.Parent = pnl;
+                        checkbox1.Parent = pnl;
+                        checkbox2.Parent = pnl;
+                        checkbox3.Parent = pnl;
 
                         Label l1 = surface.CreateControl<Label>(new Size(100, 25), new Point(12, 12));
                         Label l2 = surface.CreateControl<Label>(new Size(120, 25), new Point(12, 12));
@@ -148,7 +161,7 @@ public partial class MainForm : Form
                         l1.Parent = sct.Panel1;
                         l2.Parent = sct.Panel2;
 
-                        PictureBox pb1 = surface.CreateControl<PictureBox>(new Size(64, 64), new Point(24, 166));
+                        PictureBox pb1 = surface.CreateControl<PictureBox>(new Size(64, 64), new Point(12, 176));
                         pb1.Image = new Icon("painter.ico").ToBitmap();
 
                         ContextMenuStrip cm1 = surface.CreateComponent<ContextMenuStrip>();


### PR DESCRIPTION
Backport of #12508, #12431, #12356 and #12479 to release/9.0
Bug: https://github.com/dotnet/winforms/issues/12434, https://github.com/dotnet/winforms/issues/12421, https://github.com/dotnet/winforms/issues/12440, https://github.com/dotnet/winforms/issues/12031

## Bug Description
There are four issues that occur when using the **up/down keys** to switch property values ​​in the property page. 

1. When navigating to "Auto Size" dropdown using the up/down arrow keys, it is getting auto selected without hitting ENTER

1. After using Tab to switch property values, then using the up/down keys to switch items in the drop-down box expanded by F4 will cause the drop-down box to collapse directly

1. [Accessibility] When using up/down to toggle property value on edit text box, The Accessibility ​​rectangle focuses on the entire property row instead of the original edit text box

1. [Accessibility] Narrator cannot announce items correctly when switching the items by using up/down keyboard arrow that without expand the dropdown list panel


## Customer Impact
Accessibility requirement violation.

## Regression?
no
Yes for issue #12421

## Testing done
* manual, using Accessibility insights, Narrator, NVDA.  
* test team ran migrated automation cases 

## Risk
low.