### PR TITLE
Avoids a `System.InvalidCastException` error to be thrown when passing `ObjectCollection` to `AddRangeInternal` of the `DataGridViewComboBoxCell.ObjectCollection` class

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewComboBoxCell.ObjectCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewComboBoxCell.ObjectCollection.cs
@@ -93,8 +93,30 @@ public partial class DataGridViewComboBoxCell : DataGridViewCell
         public void AddRange(ObjectCollection value)
         {
             _owner.CheckNoDataSource();
-            AddRangeInternal((ICollection<object>)value);
+
+            InnerAddRange(value);
+
             _owner.OnItemsCollectionChanged();
+
+            void InnerAddRange(ObjectCollection items)
+            {
+                ArgumentNullException.ThrowIfNull(items);
+
+                foreach (object item in items)
+                {
+                    if (item is null)
+                    {
+                        throw new InvalidOperationException(SR.InvalidNullItemInCollection);
+                    }
+
+                    InnerArray.Add(item);
+                }
+
+                if (_owner.Sorted)
+                {
+                    InnerArray.Sort(Comparer);
+                }
+            }
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewComboBoxCell.ObjectCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewComboBoxCell.ObjectCollectionTests.cs
@@ -97,6 +97,18 @@ public class DataGridViewComboBoxCell_ObjectCollectionTests : IDisposable
         _collection[2].Should().Be("C");
     }
 
+    public void ObjectCollection_AddRange_AddsObjectCollectionCorrectly()
+    {
+        DataGridViewComboBoxCell.ObjectCollection items = new(_comboBoxCell) { "Item1", "Item2", "Item3" };
+
+        _collection.AddRange(items);
+
+        _collection.InnerArray.Count.Should().Be(3);
+        _collection[0].Should().Be("Item1");
+        _collection[1].Should().Be("Item2");
+        _collection[2].Should().Be("Item3");
+    }
+
     [WinFormsFact]
     public void ObjectCollection_AddRange_DoesNotAddItems_WhenExceptionIsThrown()
     {


### PR DESCRIPTION
Fixes #12612

## Proposed changes

- Avoids a `System.InvalidCastException` error to be thrown when passing `ObjectCollection` to `AddRangeInternal` of the `DataGridViewComboBoxCell.ObjectCollection` class, by:
  - Modifying the `AddRange(ObjectCollection value)` method
  - Adding the `AddRangeInternal(ObjectCollection items)` methods
- Adds unit test

## Customer Impact

- Avoids a possible `System.InvalidCastException`

## Regression?

- No

## Risk

- Minimal

## Screenshots

### Before

![Captura de tela 2024-12-09 200542](https://github.com/user-attachments/assets/c5b9fa72-cb93-4c67-b17e-9ffb88a3fa0d)

### After

![image](https://github.com/user-attachments/assets/bc52a015-79f0-40e3-b4e5-0b2b3d095893)

## Test methodology

- Unit tests

## Accessibility testing

## Test environment(s)

- `10.0.100-alpha.1.24573.1`

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12613)