### PR TITLE
Ensure memory is freed on a serialization failure in the cipboard

### DIFF
--- a/src/System.Private.Windows.Core/src/Windows/Win32/Foundation/HRESULT.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/Foundation/HRESULT.cs
@@ -54,6 +54,7 @@ internal readonly partial struct HRESULT
     public static readonly HRESULT COR_E_SAFEARRAYTYPEMISMATCH  = (HRESULT)unchecked((int)0x80131533);
     public static readonly HRESULT COR_E_TARGETINVOCATION       = (HRESULT)unchecked((int)0x80131604);
     public static readonly HRESULT COR_E_OBJECTDISPOSED         = (HRESULT)unchecked((int)0x80131622);
+    public static readonly HRESULT COR_E_SERIALIZATION          = (HRESULT)unchecked((int)0x8013150c);
 
 #pragma warning restore format
 #pragma warning restore IDE1006

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.Composition.NativeToWinFormsAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.Composition.NativeToWinFormsAdapter.cs
@@ -111,10 +111,10 @@ public unsafe partial class DataObject
 
                 static object ReadObjectFromHGLOBAL(HGLOBAL hglobal, bool restrictDeserialization)
                 {
-                     MemoryStream stream = ReadByteStreamFromHGLOBAL(hglobal, out bool isSerializedObject);
-                     return !isSerializedObject
-                         ? stream
-                         : BinaryFormatUtilities.ReadObjectFromStream(stream, restrictDeserialization);
+                    MemoryStream stream = ReadByteStreamFromHGLOBAL(hglobal, out bool isSerializedObject);
+                    return !isSerializedObject
+                        ? stream
+                        : BinaryFormatUtilities.ReadObjectFromStream(stream, restrictDeserialization);
                 }
             }
 
@@ -266,10 +266,14 @@ public unsafe partial class DataObject
                     // get the data out.
                     Debug.WriteLineIf(hr == HRESULT.CLIPBRD_E_BAD_DATA, "CLIPBRD_E_BAD_DATA returned when trying to get clipboard data.");
                     Debug.WriteLineIf(hr == HRESULT.DV_E_TYMED, "DV_E_TYMED returned when trying to get clipboard data.");
+                    // This happens in copy == false case when the managed type does not have the [Serializable] attribute.
+                    Debug.WriteLineIf(hr == HRESULT.E_UNEXPECTED, "E_UNEXPECTED returned when trying to get clipboard data.");
+                    Debug.WriteLineIf(hr == HRESULT.COR_E_SERIALIZATION,
+                        "COR_E_SERIALIZATION returned when trying to get clipboard data, for example, BinaryFormatter threw SerializationException.");
 
                     try
                     {
-                        if (medium.tymed == Com.TYMED.TYMED_HGLOBAL && !medium.hGlobal.IsNull)
+                        if (medium.tymed == Com.TYMED.TYMED_HGLOBAL && !medium.hGlobal.IsNull && hr != HRESULT.COR_E_SERIALIZATION)
                         {
                             data = GetDataFromHGLOBAL(medium.hGlobal, format);
                         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.Composition.WinFormsToNativeAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.Composition.WinFormsToNativeAdapter.cs
@@ -135,6 +135,13 @@ public unsafe partial class DataObject
                         // of this exception, so it will always work.)
                         return SaveDataToHGLOBAL(ex, format, ref *pmedium);
                     }
+                    catch (Exception) when (!pmedium->hGlobal.IsNull)
+                    {
+                        PInvokeCore.GlobalFree(pmedium->hGlobal);
+                        pmedium->hGlobal = HGLOBAL.Null;
+
+                        throw;
+                    }
                 }
 
                 if (((TYMED)pformatetc->tymed).HasFlag(TYMED.TYMED_GDI))
@@ -335,14 +342,14 @@ public unsafe partial class DataObject
 
             private static HRESULT SaveStreamToHGLOBAL(ref HGLOBAL hglobal, Stream stream)
             {
-                if (hglobal != 0)
+                if (!hglobal.IsNull)
                 {
                     PInvokeCore.GlobalFree(hglobal);
                 }
 
                 int size = checked((int)stream.Length);
                 hglobal = PInvokeCore.GlobalAlloc(GLOBAL_ALLOC_FLAGS.GMEM_MOVEABLE, (uint)size);
-                if (hglobal == 0)
+                if (hglobal.IsNull)
                 {
                     return HRESULT.E_OUTOFMEMORY;
                 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataObjectTests.cs
@@ -2502,4 +2502,25 @@ public partial class DataObjectTests
         data.GetDataPresent("notExist").Should().BeFalse();
         data.GetFormats().Should().BeEquivalentTo([typeof(Bitmap).FullName, nameof(Bitmap), customFormat]);
     }
+
+    [WinFormsFact]
+    public unsafe void DataObject_Native_GetData_SerializationFailure()
+    {
+        using Font value = new("Ariel", 10);
+        using BinaryFormatterScope scope = new(enable: true);
+        DataObject native = new(DataFormats.Locale, value);
+
+        // Simulate receiving DataObject from native.
+        // Clipboard.SetDataObject(native, copy: true);
+        var comDataObject = ComHelpers.GetComPointer<Com.IDataObject>(native);
+        Com.FORMATETC formatetc = new()
+        {
+            tymed = (uint)TYMED.TYMED_HGLOBAL,
+            cfFormat = (ushort)CLIPBOARD_FORMAT.CF_LOCALE
+        };
+        comDataObject->GetData(formatetc, out Com.STGMEDIUM medium);
+
+        // Validate that HGLOBAL had been freed when handling an error.
+        medium.hGlobal.IsNull.Should().BeTrue();
+    }
 }


### PR DESCRIPTION
1. Ensure that HGLOBAL is freed when a serialization exception is thrown when flushing data to the clipboard. Before the change we were always allocating it but freeing only when an HR failure was returned.
2. Ensure that we don't attempt deserialization if we couldn't serialize data from the inproc scenario

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12619)