### PR TITLE
Fixed the autoConvert default values in DataObject.TryGetData

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.Composition.NativeToWinFormsAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.Composition.NativeToWinFormsAdapter.cs
@@ -655,11 +655,11 @@ public unsafe partial class DataObject
             public bool TryGetData<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(
                 string format,
                 [NotNullWhen(true), MaybeNullWhen(false)] out T data) =>
-                    TryGetDataInternal(format, resolver: null!, autoConvert: false, legacyMode: false, out data);
+                    TryGetDataInternal(format, resolver: null!, autoConvert: true, legacyMode: false, out data);
 
             public bool TryGetData<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(
                 [NotNullWhen(true), MaybeNullWhen(false)] out T data) =>
-                    TryGetDataInternal(typeof(T).FullName!, resolver: null!, autoConvert: false, legacyMode: false, out data);
+                    TryGetDataInternal(typeof(T).FullName!, resolver: null!, autoConvert: true, legacyMode: false, out data);
             #endregion
 
             private bool GetDataPresentInner(string format)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.Composition.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.Composition.cs
@@ -131,16 +131,16 @@ public unsafe partial class DataObject
             string format,
             bool autoConvert,
             [NotNullWhen(true), MaybeNullWhen(false)] out T data) =>
-                _winFormsDataObject.TryGetData(format, resolver: null!, autoConvert, out data);
+                _winFormsDataObject.TryGetData(format, autoConvert, out data);
 
         public bool TryGetData<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(
             string format,
             [NotNullWhen(true), MaybeNullWhen(false)] out T data) =>
-                _winFormsDataObject.TryGetData(format, resolver: null!, autoConvert: false, out data);
+                _winFormsDataObject.TryGetData(format, out data);
 
         public bool TryGetData<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(
             [NotNullWhen(true), MaybeNullWhen(false)] out T data) =>
-                _winFormsDataObject.TryGetData(typeof(T).FullName!, resolver: null!, autoConvert: false, out data);
+                _winFormsDataObject.TryGetData(typeof(T).FullName!, out data);
         #endregion
 
         #region Com.IDataObject.Interface

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.cs
@@ -165,11 +165,11 @@ public unsafe partial class DataObject :
     public bool TryGetData<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(
         string format,
         [NotNullWhen(true), MaybeNullWhen(false)] out T data) =>
-            TryGetDataInternal(format, resolver: null, autoConvert: false, out data);
+            TryGetDataInternal(format, resolver: null, autoConvert: true, out data);
 
     public bool TryGetData<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(
         [NotNullWhen(true), MaybeNullWhen(false)] out T data) =>
-            TryGetDataInternal(typeof(T).FullName!, resolver: null, autoConvert: false, out data);
+            TryGetDataInternal(typeof(T).FullName!, resolver: null, autoConvert: true, out data);
     #endregion
 
     /// <summary>

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataObjectTests.cs
@@ -371,6 +371,7 @@ public partial class DataObjectTests
     {
         private readonly string _format;
         private readonly Func<TypeName, Type>? _resolver;
+        // true is the default value for general purpose APIs (GetData).
         private readonly bool _autoConvert;
 
         public DataObjectOverridesTryGetDataCore(string format, Func<TypeName, Type>? resolver, bool autoConvert) : base()
@@ -403,7 +404,7 @@ public partial class DataObjectTests
     [Fact]
     public void DataObject_TryGetData_InvokeString_CallsTryGetDataCore()
     {
-        DataObjectOverridesTryGetDataCore dataObject = new(typeof(string).FullName!, resolver: null, autoConvert: false);
+        DataObjectOverridesTryGetDataCore dataObject = new(typeof(string).FullName!, resolver: null, autoConvert: true);
         dataObject.Count.Should().Be(0);
 
         dataObject.TryGetData(out string? data).Should().BeFalse();
@@ -421,7 +422,7 @@ public partial class DataObjectTests
     [MemberData(nameof(RestrictedAndUnrestrictedFormat))]
     public void TryGetData_InvokeStringString_CallsTryGetDataCore(string format)
     {
-        DataObjectOverridesTryGetDataCore dataObject = new(format, null, autoConvert: false);
+        DataObjectOverridesTryGetDataCore dataObject = new(format, null, autoConvert: true);
         dataObject.Count.Should().Be(0);
 
         dataObject.TryGetData(format, out string? data).Should().BeFalse();
@@ -433,7 +434,7 @@ public partial class DataObjectTests
     public void TryGetData_InvokeStringString_ValidationFails()
     {
         string format = DataFormats.Bitmap;
-        DataObjectOverridesTryGetDataCore dataObject = new(format, null, autoConvert: false);
+        DataObjectOverridesTryGetDataCore dataObject = new(format, null, autoConvert: true);
         dataObject.Count.Should().Be(0);
 
         // Incompatible format and type.


### PR DESCRIPTION
Fixed the autoConvert default values in DataObject.TryGetData  to match default values from DataObject.GetData
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12632)