### PR TITLE
replaced end of sentence dot followed by 2 spaces with a dot with a single space

### DIFF
--- a/src/System.Drawing.Common/src/System/Drawing/Printing/PrintController.cs
+++ b/src/System.Drawing.Common/src/System/Drawing/Printing/PrintController.cs
@@ -197,7 +197,7 @@ public abstract partial class PrintController
 
     private PrintPageEventArgs CreatePrintPageEvent(PageSettings pageSettings)
     {
-        Debug.Assert(_modeHandle is not null, "modeHandle is null.  Someone must have forgot to call base.StartPrint");
+        Debug.Assert(_modeHandle is not null, "modeHandle is null. Someone must have forgot to call base.StartPrint");
 
         Rectangle pageBounds = pageSettings.GetBounds(_modeHandle);
         Rectangle marginBounds = new(

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerHost.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerHost.cs
@@ -1113,7 +1113,7 @@ internal sealed partial class DesignerHost : Container, IDesignerLoaderHost2, ID
         }
         catch (Exception ex)
         {
-            Debug.Fail($"Exception thrown on LoadComplete event handler.  You should not throw here : {ex}");
+            Debug.Fail($"Exception thrown on LoadComplete event handler. You should not throw here : {ex}");
 
             // The load complete failed. Put us back in the loading state and unload.
             _state[s_stateLoading] = true;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/InheritanceService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/InheritanceService.cs
@@ -150,7 +150,7 @@ public class InheritanceService : IInheritanceService, IDisposable
 
                     InheritanceAttribute attr;
 
-                    Debug.Assert(value is IComponent, "Value of inherited field is not IComponent.  How did this value get into the datatype?");
+                    Debug.Assert(value is IComponent, "Value of inherited field is not IComponent. How did this value get into the datatype?");
 
                     bool privateInherited = false;
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomDesignerLoader.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomDesignerLoader.cs
@@ -192,7 +192,7 @@ public abstract partial class CodeDomDesignerLoader : BasicDesignerLoader, IName
         // If we do not yet have the compile unit, ask for it.
         if (_documentCompileUnit is null)
         {
-            Debug.Assert(_documentType is null && _documentNamespace is null, "We have no compile unit but we still have a type or namespace.  Our state is inconsistent.");
+            Debug.Assert(_documentType is null && _documentNamespace is null, "We have no compile unit but we still have a type or namespace. Our state is inconsistent.");
             _documentCompileUnit = Parse();
 
             if (_documentCompileUnit is null)

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CollectionCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CollectionCodeDomSerializer.cs
@@ -269,7 +269,7 @@ public class CollectionCodeDomSerializer : CodeDomSerializer
                             else
                             {
                                 // we found another method. Pick the one that uses the most derived type.
-                                Debug.Assert(candidateType!.IsAssignableFrom(type) || type.IsAssignableFrom(candidateType), "These two types are not related.  how were they chosen based on the base type");
+                                Debug.Assert(candidateType!.IsAssignableFrom(type) || type.IsAssignableFrom(candidateType), "These two types are not related, how were they chosen based on the base type");
                                 bool assignable = candidateType.IsAssignableFrom(type);
                                 candidate = assignable ? method : candidate;
                                 candidateType = assignable ? type : candidateType;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ResourceCodeDomSerializer.SerializationResourceManager.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ResourceCodeDomSerializer.SerializationResourceManager.cs
@@ -518,7 +518,7 @@ internal partial class ResourceCodeDomSerializer
 #pragma warning disable SYSLIB0050 // Type or member is obsolete
             if (value is not null && (!value.GetType().IsSerializable))
             {
-                Debug.Fail($"Cannot save a non-serializable value into resources.  Add serializable to {(value is null ? "(null)" : value.GetType().Name)}");
+                Debug.Fail($"Cannot save a non-serializable value into resources. Add serializable to {(value is null ? "(null)" : value.GetType().Name)}");
                 return;
             }
 #pragma warning restore SYSLIB0050
@@ -603,7 +603,7 @@ internal partial class ResourceCodeDomSerializer
 #pragma warning disable SYSLIB0050 // Type or member is obsolete
             if (value is not null && (!value.GetType().IsSerializable))
             {
-                Debug.Fail($"Cannot save a non-serializable value into resources.  Add serializable to {(value is null ? "(null)" : value.GetType().Name)}");
+                Debug.Fail($"Cannot save a non-serializable value into resources. Add serializable to {(value is null ? "(null)" : value.GetType().Name)}");
                 return;
             }
 #pragma warning restore SYSLIB0050

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlCodeDomSerializer.cs
@@ -151,7 +151,7 @@ internal class ControlCodeDomSerializer : CodeDomSerializer
         // Find our base class's serializer.
         if (!manager.TryGetSerializer(typeof(Component), out CodeDomSerializer? serializer))
         {
-            Debug.Fail("Unable to find a CodeDom serializer for 'Component'.  Has someone tampered with the serialization providers?");
+            Debug.Fail("Unable to find a CodeDom serializer for 'Component'. Has someone tampered with the serialization providers?");
 
             return null;
         }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ImageCollectionCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ImageCollectionCodeDomSerializer.cs
@@ -26,7 +26,7 @@ public class ImageListCodeDomSerializer : CodeDomSerializer
         // Find our base class's serializer.
         if (!manager.TryGetSerializer(typeof(Component), out CodeDomSerializer? serializer))
         {
-            Debug.Fail("Unable to find a CodeDom serializer for 'Component'.  Has someone tampered with the serialization providers?");
+            Debug.Fail("Unable to find a CodeDom serializer for 'Component'. Has someone tampered with the serialization providers?");
 
             return null;
         }

--- a/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
@@ -246,7 +246,7 @@ internal static partial class LocalAppContextSwitches
 
     /// <summary>
     ///  If <see langword="true"/>, then Clipboard Get methods will prefer System.Windows.Forms.BinaryFormat.Deserializer
-    ///  to deserialize the payload, if needed.  If <see langword="false"/>, then <see cref="BinaryFormatter"/> is used
+    ///  to deserialize the payload, if needed. If <see langword="false"/>, then <see cref="BinaryFormatter"/> is used
     ///  to get full compatibility with the downlevel versions of .NET.
     /// </summary>
     /// <remarks>

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/RecordTypes/ENHMETAHEADER.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/RecordTypes/ENHMETAHEADER.cs
@@ -12,17 +12,17 @@ namespace System.Windows.Forms.Metafiles;
 internal struct ENHMETAHEADER
 {
     public uint iType;              // Record typeEMR_HEADER
-    public uint nSize;              // Record size in bytes.  This may be greater
+    public uint nSize;              // Record size in bytes. This may be greater
                                     // than the sizeof(ENHMETAHEADER).
     public RECT rclBounds;          // Inclusive-inclusive bounds in device units
     public RECT rclFrame;           // Inclusive-inclusive Picture Frame of metafile in .01 mm units
-    public uint dSignature;         // Signature.  Must be ENHMETA_SIGNATURE.
+    public uint dSignature;         // Signature. Must be ENHMETA_SIGNATURE.
     public uint nVersion;           // Version number
     public uint nBytes;             // Size of the metafile in bytes
     public uint nRecords;           // Number of records in the metafile
     public ushort nHandles;         // Number of handles in the handle table
                                     // Handle index zero is reserved.
-    public ushort sReserved;        // Reserved.  Must be zero.
+    public ushort sReserved;        // Reserved. Must be zero.
     public uint nDescription;       // Number of chars in the unicode description string
                                     // This is 0 if there is no description string
     public uint offDescription;     // Offset to the metafile description record.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
@@ -1138,7 +1138,7 @@ public sealed partial class Application
         ThreadContext? threadContext = ThreadContext.FromId(PInvoke.GetWindowThreadProcessId(handle.Handle, null));
         Debug.Assert(
             threadContext is not null,
-            "No thread context for handle.  This is expected if you saw a previous assert about the handle being invalid.");
+            "No thread context for handle. This is expected if you saw a previous assert about the handle being invalid.");
 
         GC.KeepAlive(handle);
         return threadContext;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ListBoxes/CheckedListBox.CheckedItemCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ListBoxes/CheckedListBox.CheckedItemCollection.cs
@@ -150,7 +150,7 @@ public partial class CheckedListBox
         {
             bool isChecked = InnerArray.GetState(index, s_checkedItemMask);
             bool isIndeterminate = InnerArray.GetState(index, s_indeterminateItemMask);
-            Debug.Assert(!isChecked || !isIndeterminate, "Can't be both checked and indeterminate.  Somebody broke our state.");
+            Debug.Assert(!isChecked || !isIndeterminate, "Can't be both checked and indeterminate. Somebody broke our state.");
             if (isIndeterminate)
             {
                 return CheckState.Indeterminate;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGrid.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGrid.cs
@@ -2040,7 +2040,7 @@ public partial class PropertyGrid : ContainerControl, IComPropertyBrowser, IProp
                 }
                 catch (Exception e)
                 {
-                    Debug.Fail("Bad Tab.  Disable for now.", e.ToString());
+                    Debug.Fail("Bad Tab. Disable for now.", e.ToString());
                     canExtend = false;
                     break;
                 }
@@ -3509,7 +3509,7 @@ public partial class PropertyGrid : ContainerControl, IComPropertyBrowser, IProp
         }
         catch (Exception e)
         {
-            Debug.Fail("Bad Tab.  It's going away.", e.ToString());
+            Debug.Fail("Bad Tab. It's going away.", e.ToString());
             killTab = true;
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TextBox/MaskedTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TextBox/MaskedTextBox.cs
@@ -573,7 +573,7 @@ public partial class MaskedTextBox : TextBoxBase
                     return _flagState[s_insertToggled];
 
                 default:
-                    Debug.Fail("Invalid InsertKeyMode.  This code path should have never been executed.");
+                    Debug.Fail("Invalid InsertKeyMode. This code path should have never been executed.");
                     return false;
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -388,8 +388,8 @@ public partial class Form : ContainerControl
     ///  its controls.
     /// </summary>
     [SRCategory(nameof(SR.CatLayout))]
-    [SRDescription(nameof(SR.FormAutoScaleDescr)),
-    Obsolete("This property has been deprecated. Use the AutoScaleMode property instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
+    [SRDescription(nameof(SR.FormAutoScaleDescr))]
+    [Obsolete("This property has been deprecated. Use the AutoScaleMode property instead.  https://go.microsoft.com/fwlink/?linkid=14202")]
     [Browsable(false)]
     [EditorBrowsable(EditorBrowsableState.Never)]
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MDI/MDIControlStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MDI/MDIControlStrip.cs
@@ -94,7 +94,7 @@ internal partial class MdiControlStrip : MenuStrip
     protected internal override void OnItemAdded(ToolStripItemEventArgs e)
     {
         base.OnItemAdded(e);
-        Debug.Assert(Items.Count <= 4, "Too many items in the MDIControlStrip.  How did we get into this situation?");
+        Debug.Assert(Items.Count <= 4, "Too many items in the MDIControlStrip. How did we get into this situation?");
     }
 
     private void OnTargetWindowDisposed(object? sender, EventArgs e)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NotifyIcon.NotifyIconNativeWindow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NotifyIcon.NotifyIconNativeWindow.cs
@@ -62,7 +62,7 @@ public sealed partial class NotifyIcon
         /// </summary>
         protected override void WndProc(ref Message m)
         {
-            Debug.Assert(_reference is not null, "NotifyIcon was garbage collected while it was still visible.  How did we let that happen?");
+            Debug.Assert(_reference is not null, "NotifyIcon was garbage collected while it was still visible. How did we let that happen?");
             _reference.WndProc(ref m);
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/Clipboard.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/Clipboard.cs
@@ -251,19 +251,19 @@ public static class Clipboard
     ///  Retrieves data from the <see cref="Clipboard"/> in the specified format if that data is of type <typeparamref name="T"/>.
     ///  This is an alternative to <see cref="GetData(string)"/> that uses <see cref="BinaryFormatter"/> only when application
     ///  enabled the <see cref="AppContext"/> switch named "Windows.ClipboardDragDrop.EnableUnsafeBinaryFormatterSerialization".
-    ///  By default the NRBF deserializer attempts to deserialize the stream.  It can be disabled in favor of <see cref="BinaryFormatter"/>
+    ///  By default the NRBF deserializer attempts to deserialize the stream. It can be disabled in favor of <see cref="BinaryFormatter"/>
     ///  with <see cref="AppContext"/> switch named "Windows.ClipboardDragDrop.EnableNrbfSerialization".
     /// </summary>
     /// <param name="format">
     ///  <para>
-    ///   The format of the data to retrieve.  See the <see cref="DataFormats"/> class for a set of predefined data formats.
+    ///   The format of the data to retrieve. See the <see cref="DataFormats"/> class for a set of predefined data formats.
     ///  </para>
     /// </param>
     /// <param name="resolver">
     ///  <para>
-    ///   A <see cref="Func{Type, TypeName}"/> that is used only when deserializing non-OLE formats.  It returns the type if
+    ///   A <see cref="Func{Type, TypeName}"/> that is used only when deserializing non-OLE formats. It returns the type if
     ///   <see cref="TypeName"/> is allowed or throws a <see cref="NotSupportedException"/> if <see cref="TypeName"/> is not
-    ///   expected.  It should not return a <see langword="null"/>.  It should resolve type requested by the user as
+    ///   expected. It should not return a <see langword="null"/>. It should resolve type requested by the user as
     ///   <typeparamref name="T"/>, as well as types of its fields, unless they are primitive or known types.
     ///  </para>
     ///  <para>
@@ -307,31 +307,31 @@ public static class Clipboard
     /// </returns>
     /// <remarks>
     ///  <para>
-    ///   Avoid loading assemblies named in the <see cref="TypeName"/> argument of the resolver function.  Resolve only types
+    ///   Avoid loading assemblies named in the <see cref="TypeName"/> argument of the resolver function. Resolve only types
     ///   available at the compile time, for example do not call the <see cref="Type.GetType(string)"/> method.
     ///  </para>
     ///  <para>
     ///   Some common types, for example <see cref="Bitmap"/>, are type-forwarded from .NET Framework assemblies using the
-    ///   <see cref="Runtime.CompilerServices.TypeForwardedFromAttribute"/>.  <see cref="BinaryFormatter"/> serializes these types
-    ///   using the forwarded from assembly information.  The resolver function should take this into account and either
+    ///   <see cref="Runtime.CompilerServices.TypeForwardedFromAttribute"/>. <see cref="BinaryFormatter"/> serializes these types
+    ///   using the forwarded from assembly information. The resolver function should take this into account and either
     ///   match only namespace qualified type names or read the <see cref="Runtime.CompilerServices.TypeForwardedFromAttribute.AssemblyFullName"/>
     ///   from the allowed type and match it to the <see cref="AssemblyNameInfo.FullName"/> property of <see cref="TypeName.AssemblyName"/>.
     ///  </para>
     ///  <para>
     ///   Make sure to match short assembly names if other information, such as version, is not needed, for example, when your
-    ///   application can read multiple versions of the type.  For exact matching, including assembly version, resolver
+    ///   application can read multiple versions of the type. For exact matching, including assembly version, resolver
     ///   function is required, however primitive and common types are always matched after assembly version is removed.
     ///  </para>
     ///  <para>
     ///   Arrays, generic types, and nullable value types have full element name, including its assembly name, in the
-    ///   <see cref="TypeName.FullName"/> property.  Resolver function should either remove or type-forward these assembly
+    ///   <see cref="TypeName.FullName"/> property. Resolver function should either remove or type-forward these assembly
     ///   names when matching.
     ///  </para>
     /// </remarks>
     /// <exception cref="NotSupportedException">
     ///  If application does not support <see cref="BinaryFormatter"/> and the object can't be deserialized otherwise, or
     ///  application supports <see cref="BinaryFormatter"/> but <typeparamref name="T"/> is an <see cref="object"/>,
-    ///  or not a concrete type, or if <paramref name="resolver"/> does not resolve the actual payload type.  Or
+    ///  or not a concrete type, or if <paramref name="resolver"/> does not resolve the actual payload type. Or
     ///  the <see cref="IDataObject"/> on the <see cref="Clipboard"/> does not implement <see cref="ITypedDataObject"/>
     ///  interface.
     ///  </exception>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.Composition.Binder.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.Composition.Binder.cs
@@ -16,9 +16,9 @@ public unsafe partial class DataObject
         /// <summary>
         ///  A type resolver for use in the <see cref="NativeToWinFormsAdapter"/> when processing binary formatted stream
         ///  contained in our <see cref="DataObject"/> class using the typed consumption side APIs, such as
-        ///  <see cref="TryGetData{T}(out T)"/>.  This class recognizes primitive types, exchange types from
+        ///  <see cref="TryGetData{T}(out T)"/>. This class recognizes primitive types, exchange types from
         ///  System.Drawing.Primitives, <see cref="List{T}"/>s or arrays of primitive types, and common WinForms types.
-        ///  The user can provide a custom resolver for additional types.  If the resolver function is not provided,
+        ///  The user can provide a custom resolver for additional types. If the resolver function is not provided,
         ///  the <see cref="Type"/> parameter specified by the user is resolved automatically.
         /// </summary>
         /// <remarks>
@@ -32,7 +32,7 @@ public unsafe partial class DataObject
             private readonly bool _legacyMode;
 
             // These types are read from and written to serialized stream manually, accessing record field by field.
-            // Thus they are re-hydrated with no formatters and are safe.  The default resolver should recognize them
+            // Thus they are re-hydrated with no formatters and are safe. The default resolver should recognize them
             // to resolve primitive types or fields of the specified type T.
             private static readonly Type[] s_intrinsicTypes =
             [
@@ -122,7 +122,7 @@ public unsafe partial class DataObject
             /// </param>
             /// <param name="legacyMode">
             ///  <see langword="true"/> if the user had not requested any specific type, i.e. the call originates from
-            ///  <see cref="GetData(string)"/> API family, that returns an <see cref="object"/>.  <see langword="false"/>
+            ///  <see cref="GetData(string)"/> API family, that returns an <see cref="object"/>. <see langword="false"/>
             ///  if the user had requested a specific type by calling <see cref="TryGetData{T}(out T)"/> API family.
             /// </param>
             public Binder(Type type, Func<TypeName, Type>? resolver, bool legacyMode)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.Composition.NativeToWinFormsAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.Composition.NativeToWinFormsAdapter.cs
@@ -243,7 +243,7 @@ public unsafe partial class DataObject
             ///  </para>
             ///  <para>
             ///   If <paramref name="dataObject"/> contains <see cref="MemoryStream"/> that contains a serialized object,
-            ///   we return that object cast to <typeparamref name="T"/> or null.  If that <see cref="MemoryStream"/> is
+            ///   we return that object cast to <typeparamref name="T"/> or null. If that <see cref="MemoryStream"/> is
             ///   not a serialized object, and a stream was requested, i.e. can be assigned to <typeparamref name="T"/>
             ///   we return that <see cref="MemoryStream"/>.
             ///  </para>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/IDataObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/IDataObject.cs
@@ -9,8 +9,8 @@ namespace System.Windows.Forms;
 ///  <remarks>
 ///  <para>
 ///   When implementing a <see cref="IDataObject"/>, consider implementing <see cref="ITypedDataObject"/>
-///   interface instead.  This interface will ensure that only data of a specified <see cref="Type"/>
-///   is exchanged.  If <see cref="ITypedDataObject"/> is not implemented by a data object exchanged
+///   interface instead. This interface will ensure that only data of a specified <see cref="Type"/>
+///   is exchanged. If <see cref="ITypedDataObject"/> is not implemented by a data object exchanged
 ///   in the clipboard or drag and drop scenarios, the APIs that specify a <see cref="Type"/>,
 ///   such as <see cref="Clipboard.TryGetData{T}(string, out T)"/>, will throw a <see cref="NotSupportedException"/>.
 ///  </para>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/ITypedDataObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/ITypedDataObject.cs
@@ -12,10 +12,10 @@ namespace System.Windows.Forms;
 /// <remarks>
 ///  <para>
 ///   Implement this interface to use your data object with <see cref="Clipboard.TryGetData{T}(string, out T)"/>
-///   family of methods as well as in the drag and drop operations.  This interface will ensure that only
-///   data of the specified <see cref="Type"/> is exchanged.  Otherwise the APIs that specify a <see cref="Type"/> parameter
-///   will throw a <see cref="NotSupportedException"/>.  This is replacement of <see cref="IDataObject"/>
-///   interface, implement this interface as well.  Otherwise the APIs that specify a <see cref="Type"/> parameter
+///   family of methods as well as in the drag and drop operations. This interface will ensure that only
+///   data of the specified <see cref="Type"/> is exchanged. Otherwise the APIs that specify a <see cref="Type"/> parameter
+///   will throw a <see cref="NotSupportedException"/>. This is replacement of <see cref="IDataObject"/>
+///   interface, implement this interface as well. Otherwise the APIs that specify a <see cref="Type"/> parameter
 ///   will throw a <see cref="NotSupportedException"/>.
 ///  </para>
 /// </remarks>
@@ -55,7 +55,7 @@ public interface ITypedDataObject : IDataObject
     ///  the exchange medium.
     /// </param>
     /// <param name="format">
-    ///  A string that specifies what format to retrieve the data as.  See the <see cref="DataFormats"/> class for
+    ///  A string that specifies what format to retrieve the data as. See the <see cref="DataFormats"/> class for
     ///  a set of predefined data formats.
     /// </param>
     /// <param name="autoConvert">

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WinCategoryAttribute.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WinCategoryAttribute.cs
@@ -32,7 +32,7 @@ internal sealed class WinCategoryAttribute : CategoryAttribute
         localizedValue ??= (string?)GetSRObject("WinFormsCategory" + value);
 
         // This attribute is internal, and we should never have a missing resource string.
-        Debug.Assert(localizedValue is not null, $"All Windows Forms category attributes should have localized strings.  Category '{value}' not found.");
+        Debug.Assert(localizedValue is not null, $"All Windows Forms category attributes should have localized strings. Category '{value}' not found.");
         return localizedValue;
     }
 


### PR DESCRIPTION
I ran this regex on all projects, and hanges only xml doc comments. Remaining double spaces are in .resx files and in build warning that will be eventually visible to the users.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12635)