### PR TITLE
Correct the assignment of the constant TreeNodeCollectionAddRangeRespectsSortOrder in WinFormsAppContextSwitchNames.cs

### DIFF
--- a/src/System.Windows.Forms/tests/TestUtilities/WinFormsAppContextSwitchNames.cs
+++ b/src/System.Windows.Forms/tests/TestUtilities/WinFormsAppContextSwitchNames.cs
@@ -49,5 +49,5 @@ public static class WinFormsAppContextSwitchNames
     ///  The switch that controls whether the TreeNodeCollection will insert nodes in the sorted order.
     /// </summary>
     public const string TreeNodeCollectionAddRangeRespectsSortOrder
-        = "System.Windows.Forms.ApplyParentFontToMenus";
+        = "System.Windows.Forms.TreeNodeCollectionAddRangeRespectsSortOrder";
 }


### PR DESCRIPTION
Correct the assignment of the constant TreeNodeCollectionAddRangeRespectsSortOrder in WinFormsAppContextSwitchNames.cs