### PR TITLE
Add switch "MoveTreeViewTextLocOnePixel" for update the drawing position of the Treeview control text

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
@@ -28,6 +28,7 @@ internal static partial class LocalAppContextSwitches
     internal const string TreeNodeCollectionAddRangeRespectsSortOrderSwitchName = "System.Windows.Forms.TreeNodeCollectionAddRangeRespectsSortOrder";
     internal const string ClipboardDragDropEnableUnsafeBinaryFormatterSerializationSwitchName = "Windows.ClipboardDragDrop.EnableUnsafeBinaryFormatterSerialization";
     internal const string ClipboardDragDropEnableNrbfSerializationSwitchName = "Windows.ClipboardDragDrop.EnableNrbfSerialization";
+    internal const string MoveTreeViewTextLocOnePixelSwitchName = "System.Windows.Forms.TreeView.MoveTreeViewTextLocOnePixel";
 
     private static int s_scaleTopLevelFormMinMaxSizeForDpi;
     private static int s_anchorLayoutV2;
@@ -41,6 +42,7 @@ internal static partial class LocalAppContextSwitches
     private static int s_treeNodeCollectionAddRangeRespectsSortOrder;
     private static int s_clipboardDragDropEnableUnsafeBinaryFormatterSerialization;
     private static int s_clipboardDragDropEnableNrbfSerialization;
+    private static int s_moveTreeViewTextLocOnePixel;
 
     private static FrameworkName? s_targetFrameworkName;
 
@@ -259,5 +261,15 @@ internal static partial class LocalAppContextSwitches
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         get => GetCachedSwitchValue(ClipboardDragDropEnableNrbfSerializationSwitchName, ref s_clipboardDragDropEnableNrbfSerialization);
+    }
+
+    /// <summary>
+    ///  Indicates whether to move the text position of a TreeView node one pixel
+    ///  to the right relative to the upper-left corner of the TreeView control.
+    /// </summary>
+    public static bool MoveTreeViewTextLocOnePixel
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => GetCachedSwitchValue(MoveTreeViewTextLocOnePixelSwitchName, ref s_moveTreeViewTextLocOnePixel);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
@@ -42,7 +42,7 @@ internal static partial class LocalAppContextSwitches
     private static int s_treeNodeCollectionAddRangeRespectsSortOrder;
     private static int s_clipboardDragDropEnableUnsafeBinaryFormatterSerialization;
     private static int s_clipboardDragDropEnableNrbfSerialization;
-    private static int s_moveTreeViewTextLocOnePixel;
+    private static int s_moveTreeViewTextLocationOnePixel;
 
     private static FrameworkName? s_targetFrameworkName;
 
@@ -270,6 +270,6 @@ internal static partial class LocalAppContextSwitches
     public static bool MoveTreeViewTextLocationOnePixel
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => GetCachedSwitchValue(MoveTreeViewTextLocationOnePixelSwitchName, ref s_moveTreeViewTextLocOnePixel);
+        get => GetCachedSwitchValue(MoveTreeViewTextLocationOnePixelSwitchName, ref s_moveTreeViewTextLocationOnePixel);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
@@ -28,7 +28,7 @@ internal static partial class LocalAppContextSwitches
     internal const string TreeNodeCollectionAddRangeRespectsSortOrderSwitchName = "System.Windows.Forms.TreeNodeCollectionAddRangeRespectsSortOrder";
     internal const string ClipboardDragDropEnableUnsafeBinaryFormatterSerializationSwitchName = "Windows.ClipboardDragDrop.EnableUnsafeBinaryFormatterSerialization";
     internal const string ClipboardDragDropEnableNrbfSerializationSwitchName = "Windows.ClipboardDragDrop.EnableNrbfSerialization";
-    internal const string MoveTreeViewTextLocOnePixelSwitchName = "System.Windows.Forms.TreeView.MoveTreeViewTextLocOnePixel";
+    internal const string MoveTreeViewTextLocationOnePixelSwitchName = "System.Windows.Forms.TreeView.MoveTreeViewTextLocationOnePixel";
 
     private static int s_scaleTopLevelFormMinMaxSizeForDpi;
     private static int s_anchorLayoutV2;
@@ -267,9 +267,9 @@ internal static partial class LocalAppContextSwitches
     ///  Indicates whether to move the text position of a TreeView node one pixel
     ///  to the right relative to the upper-left corner of the TreeView control.
     /// </summary>
-    public static bool MoveTreeViewTextLocOnePixel
+    public static bool MoveTreeViewTextLocationOnePixel
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => GetCachedSwitchValue(MoveTreeViewTextLocOnePixelSwitchName, ref s_moveTreeViewTextLocOnePixel);
+        get => GetCachedSwitchValue(MoveTreeViewTextLocationOnePixelSwitchName, ref s_moveTreeViewTextLocOnePixel);
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeView.cs
@@ -2831,7 +2831,7 @@ public partial class TreeView : Control
                     {
                         Rectangle bounds = node.Bounds;
                         Size textSize = TextRenderer.MeasureText(node.Text, node.TreeView!.Font);
-                        Point textLoc = new(LocalAppContextSwitches.MoveTreeViewTextLocOnePixel ? bounds.X : bounds.X - 1, bounds.Y);
+                        Point textLoc = new(LocalAppContextSwitches.MoveTreeViewTextLocationOnePixel ? bounds.X : bounds.X - 1, bounds.Y);
                         bounds = new Rectangle(textLoc, new Size(textSize.Width, bounds.Height));
 
                         DrawTreeNodeEventArgs e = new(g, node, bounds, (TreeNodeStates)(nmtvcd->nmcd.uItemState));

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeView.cs
@@ -7,6 +7,7 @@ using System.Drawing;
 using System.Drawing.Design;
 using System.Runtime.InteropServices;
 using System.Windows.Forms.Layout;
+using System.Windows.Forms.Primitives;
 using System.Windows.Forms.VisualStyles;
 using Windows.Win32.System.Variant;
 using Windows.Win32.UI.Accessibility;
@@ -2830,7 +2831,7 @@ public partial class TreeView : Control
                     {
                         Rectangle bounds = node.Bounds;
                         Size textSize = TextRenderer.MeasureText(node.Text, node.TreeView!.Font);
-                        Point textLoc = new(bounds.X, bounds.Y); // required to center the text
+                        Point textLoc = new(LocalAppContextSwitches.MoveTreeViewTextLocOnePixel ? bounds.X : bounds.X - 1, bounds.Y);
                         bounds = new Rectangle(textLoc, new Size(textSize.Width, bounds.Height));
 
                         DrawTreeNodeEventArgs e = new(g, node, bounds, (TreeNodeStates)(nmtvcd->nmcd.uItemState));

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeView.cs
@@ -2830,7 +2830,7 @@ public partial class TreeView : Control
                     {
                         Rectangle bounds = node.Bounds;
                         Size textSize = TextRenderer.MeasureText(node.Text, node.TreeView!.Font);
-                        Point textLoc = new(bounds.X - 1, bounds.Y); // required to center the text
+                        Point textLoc = new(bounds.X, bounds.Y); // required to center the text
                         bounds = new Rectangle(textLoc, new Size(textSize.Width, bounds.Height));
 
                         DrawTreeNodeEventArgs e = new(g, node, bounds, (TreeNodeStates)(nmtvcd->nmcd.uItemState));


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #12601


## Proposed changes

- Update the drawing position of the Treeview control text

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- The check box of the TreeView control can be fully displayed

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Create a form, add a TreevView with CheckBoxes=true and DrawMode=OwnerDrawText
In OnDrawNode event only set DrawDefault=true
Show the form: checkboxes are shown corrupted on the right border
![Image](https://github.com/user-attachments/assets/7d040abd-344c-4403-b7a3-b7659d247935)

### After
The checkbox of the Treeview control can be fully displayed
![image](https://github.com/user-attachments/assets/2a02ec83-81ab-48be-bd37-62faf8f6e7c4)



## Test methodology <!-- How did you ensure quality? -->

- Manually
 

## Test environment(s) <!-- Remove any that don't apply -->

- .net 10.0.0-alpha.1.24611.1


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12638)