### PR TITLE
Minor refactoring in DataObject-related code

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Internal/TypeExtensions.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Internal/TypeExtensions.cs
@@ -235,8 +235,10 @@ internal static class TypeExtensions
     }
 
     /// <summary>
-    ///  Convert <paramref name="type"/> to <see cref="TypeName"/>. This method removes nullability wrapper
-    ///  from the top level type only because <see cref="TypeName"/> in the serialization root record is not nullable.
+    ///  Convert <paramref name="type"/> to <see cref="TypeName"/>. Take into account type forwarding in order
+    ///  to create <see cref="TypeName"/> compatible with the type names serialized to the binary format.This
+    ///  method removes nullability wrapper from the top level type only because <see cref="TypeName"/> in the
+    ///  serialization root record is not nullable, but the generic types could be nullable.
     /// </summary>
     public static TypeName ToTypeName(this Type type)
     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.Composition.NativeToWinFormsAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.Composition.NativeToWinFormsAdapter.cs
@@ -133,7 +133,9 @@ public unsafe partial class DataObject
                     MemoryStream stream = ReadByteStreamFromHGLOBAL(hglobal, out bool isSerializedObject);
                     return !isSerializedObject
                         ? stream
-                        : BinaryFormatUtilities.ReadObjectFromStream<T>(stream, restrictDeserialization, resolver, legacyMode);
+                        : restrictDeserialization
+                            ? BinaryFormatUtilities.ReadRestrictedObjectFromStream<T>(stream, resolver, legacyMode)
+                            : BinaryFormatUtilities.ReadObjectFromStream<T>(stream, resolver, legacyMode);
                 }
             }
 


### PR DESCRIPTION
Factored out code that reads formats that allow only restricted deserialization to run, such as OLE formats.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12642)