### PR TITLE
Get rid of an unexpected white line above the status strip due to a changed 

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -1,4 +1,3 @@
-override System.Windows.Forms.StatusStrip.Select(bool directed, bool forward) -> void
 static System.Windows.Forms.Clipboard.TryGetData<T>(string! format, out T data) -> bool
 static System.Windows.Forms.Clipboard.TryGetData<T>(string! format, System.Func<System.Reflection.Metadata.TypeName!, System.Type!>! resolver, out T data) -> bool
 static System.Windows.Forms.DataObjectExtensions.TryGetData<T>(this System.Windows.Forms.IDataObject! dataObject, out T data) -> bool

--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
+override System.Windows.Forms.StatusStrip.Select(bool directed, bool forward) -> void
 static System.Windows.Forms.Clipboard.TryGetData<T>(string! format, out T data) -> bool
 static System.Windows.Forms.Clipboard.TryGetData<T>(string! format, System.Func<System.Reflection.Metadata.TypeName!, System.Type!>! resolver, out T data) -> bool
 static System.Windows.Forms.DataObjectExtensions.TryGetData<T>(this System.Windows.Forms.IDataObject! dataObject, out T data) -> bool

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/StatusStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/StatusStrip.cs
@@ -439,12 +439,6 @@ public partial class StatusStrip : ToolStrip
         base.SetDisplayedItems();
     }
 
-    protected override void Select(bool directed, bool forward)
-    {
-        RenderMode = ToolStripRenderMode.System;
-        base.Select(directed, forward);
-    }
-
     /// <summary>
     ///  Override this function if you want to do custom table layouts for the
     ///  StatusStrip. The default layoutstyle is tablelayout, and we need to play

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/StatusStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/StatusStrip.cs
@@ -29,10 +29,7 @@ public partial class StatusStrip : ToolStrip
         SuspendLayout();
         CanOverflow = false;
         LayoutStyle = ToolStripLayoutStyle.Table;
-
-        // Default changed for SystemColorMode from System to ManagerRenderMode.
-        // Also to be consistent to the MenuStrip.
-        RenderMode = ToolStripRenderMode.ManagerRenderMode;
+        RenderMode = ToolStripRenderMode.System;
         GripStyle = ToolStripGripStyle.Hidden;
 
         SetStyle(ControlStyles.ResizeRedraw, true);
@@ -363,6 +360,17 @@ public partial class StatusStrip : ToolStrip
         EnsureRightToLeftGrip();
     }
 
+    internal override void ResetRenderMode()
+    {
+        RenderMode = ToolStripRenderMode.System;
+    }
+
+    internal override bool ShouldSerializeRenderMode()
+    {
+        // We should NEVER serialize custom.
+        return (RenderMode is not ToolStripRenderMode.System and not ToolStripRenderMode.Custom);
+    }
+
     internal override bool SupportsUiaProviders => true;
 
     protected override void SetDisplayedItems()
@@ -429,6 +437,12 @@ public partial class StatusStrip : ToolStrip
         }
 
         base.SetDisplayedItems();
+    }
+
+    protected override void Select(bool directed, bool forward)
+    {
+        RenderMode = ToolStripRenderMode.System;
+        base.Select(directed, forward);
     }
 
     /// <summary>

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/StatusStripTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/StatusStripTests.cs
@@ -556,7 +556,7 @@ public partial class StatusStripTests
 
         control.RenderMode = ToolStripRenderMode.System;
         Assert.Equal(ToolStripRenderMode.System, control.RenderMode);
-        Assert.True(property.CanResetValue(control));
+        Assert.False(property.CanResetValue(control));
 
         control.Renderer = new SubToolStripRenderer();
         Assert.Equal(ToolStripRenderMode.Custom, control.RenderMode);
@@ -564,10 +564,10 @@ public partial class StatusStripTests
 
         control.RenderMode = ToolStripRenderMode.ManagerRenderMode;
         Assert.Equal(ToolStripRenderMode.ManagerRenderMode, control.RenderMode);
-        Assert.False(property.CanResetValue(control));
+        Assert.True(property.CanResetValue(control));
 
         property.ResetValue(control);
-        Assert.Equal(ToolStripRenderMode.ManagerRenderMode, control.RenderMode);
+        Assert.Equal(ToolStripRenderMode.System, control.RenderMode);
         Assert.False(property.CanResetValue(control));
     }
 
@@ -584,7 +584,7 @@ public partial class StatusStripTests
 
         control.RenderMode = ToolStripRenderMode.System;
         Assert.Equal(ToolStripRenderMode.System, control.RenderMode);
-        Assert.True(property.ShouldSerializeValue(control));
+        Assert.False(property.ShouldSerializeValue(control));
 
         control.Renderer = new SubToolStripRenderer();
         Assert.Equal(ToolStripRenderMode.Custom, control.RenderMode);
@@ -592,10 +592,10 @@ public partial class StatusStripTests
 
         control.RenderMode = ToolStripRenderMode.ManagerRenderMode;
         Assert.Equal(ToolStripRenderMode.ManagerRenderMode, control.RenderMode);
-        Assert.False(property.ShouldSerializeValue(control));
+        Assert.True(property.ShouldSerializeValue(control));
 
         property.ResetValue(control);
-        Assert.Equal(ToolStripRenderMode.ManagerRenderMode, control.RenderMode);
+        Assert.Equal(ToolStripRenderMode.System, control.RenderMode);
         Assert.False(property.ShouldSerializeValue(control));
     }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #12616

## Root Cause
This is due to #11502. We changed the default RenderMode of StatusStrip from System to ManagerRenderMode.

## Proposed changes

- Revert the changes on PR [11502](https://github.com/dotnet/winforms/pull/11502), the corresponding issue [11450 ](https://github.com/dotnet/winforms/issues/11450) was fixed when issue [12083 ](https://github.com/dotnet/winforms/issues/12083) was fixed, so the changes in PR [11502](https://github.com/dotnet/winforms/pull/11502) are no longer needed.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- When upgrading a project with StatusStrip from .net8.0 to .net9.0, there will no longer be extra white lines in the Form

## Regression? 

- Yes 

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
A white line in the dialog when using StatusStrip
<img width="251" alt="image" src="https://github.com/user-attachments/assets/ed22666a-f70f-46eb-87ef-fc7c7e7f10b9">


### After
No extra white line the dialog
<img width="233" alt="image" src="https://github.com/user-attachments/assets/cf28ca25-c665-4154-a0d3-eb3210e52de7">

The color contrast between the focus indicator and toolStripSplitButton1 is still sufficient
![image](https://github.com/user-attachments/assets/64311a8c-f14a-4a51-bb15-bf7194fe0818)

## Test methodology <!-- How did you ensure quality? -->

- Manually

## Test environment(s) <!-- Remove any that don't apply -->

- .net 10.0.0-alpha.1.24606.5


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12646)
