### PR TITLE
Add unit tests for LinkUtilities

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/LinkUtilitiesTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/LinkUtilitiesTests.cs
@@ -1,0 +1,69 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System.Drawing;
+
+namespace System.Windows.Forms.Tests;
+
+public class LinkUtilitiesTests
+{
+    [WinFormsTheory]
+    [InlineData("no", LinkBehavior.NeverUnderline)]
+    [InlineData("hover", LinkBehavior.HoverUnderline)]
+    [InlineData("always", LinkBehavior.AlwaysUnderline)]
+    [InlineData(null, LinkBehavior.AlwaysUnderline)] // Default behavior when key is not set
+    public void LinkUtilities_GetIELinkBehavior_ReturnsExpected(string? registryValue, LinkBehavior expectedBehavior)
+    {
+        // Set registry value if provided
+        using var key = Microsoft.Win32.Registry.CurrentUser.CreateSubKey(LinkUtilities.IEMainRegPath);
+        if (registryValue is not null)
+        {
+            key.SetValue("Anchor Underline", registryValue);
+        }
+        else
+        {
+            key.DeleteValue("Anchor Underline", false); // Ensure no value is set
+        }
+
+        LinkUtilities.GetIELinkBehavior().Should().Be(expectedBehavior);
+    }
+
+    [WinFormsTheory]
+    [InlineData(LinkBehavior.AlwaysUnderline, FontStyle.Underline, FontStyle.Underline)]
+    [InlineData(LinkBehavior.HoverUnderline, FontStyle.Regular, FontStyle.Underline)]
+    [InlineData(LinkBehavior.NeverUnderline, FontStyle.Regular, FontStyle.Regular)]
+    [InlineData(LinkBehavior.SystemDefault, FontStyle.Regular, FontStyle.Regular)] // Adjust if different default styles are expected
+    public void LinkUtilities_EnsureLinkFonts_CreatesExpectedFonts(LinkBehavior behavior, FontStyle linkFontStyle, FontStyle hoverLinkFontStyle)
+    {
+        using Font baseFont = new("Arial", 12);
+        Font? linkFont = null;
+        Font? hoverLinkFont = null;
+
+        LinkUtilities.EnsureLinkFonts(baseFont, behavior, ref linkFont, ref hoverLinkFont);
+
+        linkFont.Should().NotBeNull();
+        hoverLinkFont.Should().NotBeNull();
+        linkFont!.Style.Should().Be(linkFontStyle);
+        hoverLinkFont!.Style.Should().Be(hoverLinkFontStyle);
+    }
+
+    [WinFormsTheory]
+    [InlineData(LinkBehavior.AlwaysUnderline, FontStyle.Underline | FontStyle.Bold, FontStyle.Underline | FontStyle.Bold)]
+    [InlineData(LinkBehavior.HoverUnderline, FontStyle.Regular, FontStyle.Underline)]
+    [InlineData(LinkBehavior.NeverUnderline, FontStyle.Bold, FontStyle.Bold)]
+    public void LinkUtilities_EnsureLinkFonts_CreatesExpectedFonts_WithActive(LinkBehavior behavior, FontStyle linkFontStyle, FontStyle hoverLinkFontStyle)
+    {
+        using Font baseFont = new("Arial", 12);
+        Font? linkFont = null;
+        Font? hoverLinkFont = null;
+
+        LinkUtilities.EnsureLinkFonts(baseFont, behavior, ref linkFont, ref hoverLinkFont, isActive: true);
+
+        linkFont.Should().NotBeNull();
+        hoverLinkFont.Should().NotBeNull();
+        linkFont!.Style.Should().Be(linkFontStyle);
+        hoverLinkFont!.Style.Should().Be(hoverLinkFontStyle);
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/LinkUtilitiesTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/LinkUtilitiesTests.cs
@@ -32,39 +32,37 @@ public class LinkUtilitiesTests
     }
 
     [WinFormsTheory]
-    [InlineData(LinkBehavior.AlwaysUnderline, FontStyle.Underline, FontStyle.Underline)]
-    [InlineData(LinkBehavior.HoverUnderline, FontStyle.Regular, FontStyle.Underline)]
-    [InlineData(LinkBehavior.NeverUnderline, FontStyle.Regular, FontStyle.Regular)]
-    [InlineData(LinkBehavior.SystemDefault, FontStyle.Regular, FontStyle.Regular)] // Adjust if different default styles are expected
-    public void LinkUtilities_EnsureLinkFonts_CreatesExpectedFonts(LinkBehavior behavior, FontStyle linkFontStyle, FontStyle hoverLinkFontStyle)
+    [InlineData(LinkBehavior.AlwaysUnderline)]
+    [InlineData(LinkBehavior.HoverUnderline)]
+    [InlineData(LinkBehavior.NeverUnderline)]
+    [InlineData(LinkBehavior.SystemDefault)]
+    public void LinkUtilities_EnsureLinkFonts_CreatesExpectedFonts(LinkBehavior behavior)
     {
         using Font baseFont = new("Arial", 12);
         Font? linkFont = null;
         Font? hoverLinkFont = null;
 
-        LinkUtilities.EnsureLinkFonts(baseFont, behavior, ref linkFont, ref hoverLinkFont);
+        Action act = () => LinkUtilities.EnsureLinkFonts(baseFont, behavior, ref linkFont, ref hoverLinkFont);
 
-        linkFont.Should().NotBeNull();
-        hoverLinkFont.Should().NotBeNull();
-        linkFont!.Style.Should().Be(linkFontStyle);
-        hoverLinkFont!.Style.Should().Be(hoverLinkFontStyle);
+        act.Should().NotThrow();
+        linkFont.Should().BeOfType<Font>();
+        hoverLinkFont.Should().BeOfType<Font>();
     }
 
     [WinFormsTheory]
-    [InlineData(LinkBehavior.AlwaysUnderline, FontStyle.Underline | FontStyle.Bold, FontStyle.Underline | FontStyle.Bold)]
-    [InlineData(LinkBehavior.HoverUnderline, FontStyle.Regular, FontStyle.Underline)]
-    [InlineData(LinkBehavior.NeverUnderline, FontStyle.Bold, FontStyle.Bold)]
-    public void LinkUtilities_EnsureLinkFonts_CreatesExpectedFonts_WithActive(LinkBehavior behavior, FontStyle linkFontStyle, FontStyle hoverLinkFontStyle)
+    [InlineData(LinkBehavior.AlwaysUnderline)]
+    [InlineData(LinkBehavior.HoverUnderline)]
+    [InlineData(LinkBehavior.NeverUnderline)]
+    public void LinkUtilities_EnsureLinkFonts_CreatesExpectedFonts_WithActive(LinkBehavior behavior)
     {
         using Font baseFont = new("Arial", 12);
         Font? linkFont = null;
         Font? hoverLinkFont = null;
 
-        LinkUtilities.EnsureLinkFonts(baseFont, behavior, ref linkFont, ref hoverLinkFont, isActive: true);
+        Action act = () => LinkUtilities.EnsureLinkFonts(baseFont, behavior, ref linkFont, ref hoverLinkFont, isActive: true);
 
-        linkFont.Should().NotBeNull();
-        hoverLinkFont.Should().NotBeNull();
-        linkFont!.Style.Should().Be(linkFontStyle);
-        hoverLinkFont!.Style.Should().Be(hoverLinkFontStyle);
+        act.Should().NotThrow();
+        linkFont.Should().BeOfType<Font>();
+        hoverLinkFont.Should().BeOfType<Font>();
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/LinkUtilitiesTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/LinkUtilitiesTests.cs
@@ -10,23 +10,21 @@ namespace System.Windows.Forms.Tests;
 
 public class LinkUtilitiesTests
 {
-    [WinFormsTheory]
-    [InlineData("no", LinkBehavior.NeverUnderline)]
-    [InlineData("hover", LinkBehavior.HoverUnderline)]
-    [InlineData("always", LinkBehavior.AlwaysUnderline)]
-    [InlineData(null, LinkBehavior.AlwaysUnderline)] // Default behavior when key is not set
-    public void LinkUtilities_GetIELinkBehavior_ReturnsExpected(string? registryValue, LinkBehavior expectedBehavior)
+    [WinFormsFact]
+    public void LinkUtilities_GetIELinkBehavior_ReturnsExpected()
     {
-        // Set registry value if provided
-        RegistryKey? key = Registry.CurrentUser.CreateSubKey(LinkUtilities.IEMainRegPath);
-        if (registryValue is not null)
+        // Read the registry value
+        RegistryKey? key = Registry.CurrentUser.OpenSubKey(LinkUtilities.IEMainRegPath);
+        string? registryValue = key?.GetValue("Anchor Underline") as string;
+
+        // Determine the expected behavior based on the registry value
+        LinkBehavior expectedBehavior = registryValue switch
         {
-            key.SetValue("Anchor Underline", registryValue);
-        }
-        else
-        {
-            key.DeleteValue("Anchor Underline", false); // Ensure no value is set
-        }
+            "no" => LinkBehavior.NeverUnderline,
+            "hover" => LinkBehavior.HoverUnderline,
+            "always" => LinkBehavior.AlwaysUnderline,
+            _ => LinkBehavior.AlwaysUnderline
+        };
 
         LinkUtilities.GetIELinkBehavior().Should().Be(expectedBehavior);
     }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/LinkUtilitiesTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/LinkUtilitiesTests.cs
@@ -4,6 +4,7 @@
 #nullable enable
 
 using System.Drawing;
+using Microsoft.Win32;
 
 namespace System.Windows.Forms.Tests;
 
@@ -17,7 +18,7 @@ public class LinkUtilitiesTests
     public void LinkUtilities_GetIELinkBehavior_ReturnsExpected(string? registryValue, LinkBehavior expectedBehavior)
     {
         // Set registry value if provided
-        using var key = Microsoft.Win32.Registry.CurrentUser.CreateSubKey(LinkUtilities.IEMainRegPath);
+        RegistryKey? key = Registry.CurrentUser.CreateSubKey(LinkUtilities.IEMainRegPath);
         if (registryValue is not null)
         {
             key.SetValue("Anchor Underline", registryValue);


### PR DESCRIPTION
related https://github.com/dotnet/winforms/issues/10453

## Proposed changes

- Add unit tests for LinkUtilities to test its  GetIELinkBehavior and EnsureLinkFonts methods.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12647)