### PR TITLE
Fix WM_DESTROY message handling

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ActiveX/AxHost.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ActiveX/AxHost.cs
@@ -3204,10 +3204,9 @@ public abstract unsafe partial class AxHost : Control, ISupportInitialize, ICust
 
     private unsafe void DetachAndForward(ref Message m)
     {
-        bool isHandleCreated = IsHandleCreated;
         HWND handle = GetHandleNoCreate();
         DetachWindow();
-        if (isHandleCreated)
+        if (!handle.IsNull)
         {
             void* wndProc = (void*)PInvokeCore.GetWindowLong(handle, WINDOW_LONG_PTR_INDEX.GWL_WNDPROC);
             m.ResultInternal = PInvokeCore.CallWindowProc(

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ActiveX/AxHost.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ActiveX/AxHost.cs
@@ -3205,13 +3205,14 @@ public abstract unsafe partial class AxHost : Control, ISupportInitialize, ICust
     private unsafe void DetachAndForward(ref Message m)
     {
         bool isHandleCreated = IsHandleCreated;
+        HWND handle = GetHandleNoCreate();
         DetachWindow();
         if (isHandleCreated)
         {
-            void* wndProc = (void*)PInvokeCore.GetWindowLong(this, WINDOW_LONG_PTR_INDEX.GWL_WNDPROC);
+            void* wndProc = (void*)PInvokeCore.GetWindowLong(handle, WINDOW_LONG_PTR_INDEX.GWL_WNDPROC);
             m.ResultInternal = PInvokeCore.CallWindowProc(
                 (delegate* unmanaged[Stdcall]<HWND, uint, WPARAM, LPARAM, LRESULT>)wndProc,
-                HWND,
+                handle,
                 (uint)m.Msg,
                 m.WParamInternal,
                 m.LParamInternal);


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #12551


## Proposed changes

- -  The `DetachWindow` method always sets `Handle` and `HWND` value to NULL. This make code inside if block go in recursive infinite loop. To fix this, we now store the value of `Handle` in a variable before calling the `DetachWindow` method. This was the previous behavior but got disrupted due to [this change](https://github.com/dotnet/winforms/commit/834d0a0d364c82bf70803706886ff9a40bd3e090#diff-dc17cf8f6ef4b80a13b2386597a72cd7ae36cab7375583a0a1e76a62f7f9238fL3556).

I had already [completed a PR](https://github.com/dotnet/winforms/pull/12564) which stored `IsHandleCreated` before calling `DetachWindow` method but missed to store and use `Handle` value.

## Testing
Go through [this comment](https://github.com/dotnet/winforms/issues/12551#issuecomment-2545971442) to reproduce this issue. I've validated that this proposed change resolve the issue.
@JeremyKuhne