### PR TITLE
Add MSAA event to method OnGotFocus of the Control.cs

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.GridViewTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/PropertyGrid/PropertyGridInternal/PropertyGridView.GridViewTextBox.cs
@@ -133,6 +133,9 @@ internal partial class PropertyGridView
             {
                 AccessibilityObject.RaiseAutomationEvent(UIA_EVENT_ID.UIA_AutomationFocusChangedEventId);
             }
+
+            // MSAA Event:
+            AccessibilityNotifyClients(AccessibleEvents.Focus, childID: -1);
         }
 
         protected override void OnKeyDown(KeyEventArgs e)


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #12565


## Proposed changes

- Add MSAA event to method OnGotFocus of the Control.cs

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- NVDA tool can show focus blue rectangle in property edit textbox

## Regression? 

- Yes

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
NVDA does not show focus blue rectangle.

https://github.com/user-attachments/assets/a147db27-d749-4819-840f-d11e26e5aa45

### After
NVDA should show focus blue rectangle.
![AfterChange](https://github.com/user-attachments/assets/4dfed4be-2788-40ad-b4f9-2a90d78ecc81)


## Test methodology <!-- How did you ensure quality? -->

- Manually


## Test environment(s) <!-- Remove any that don't apply -->

- .net 10.0.0-beta.24613.2


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12651)