### PR TITLE
Fix for a regression in how GetData APIs swallow all exceptions.

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.Composition.BinaryFormatUtilities.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.Composition.BinaryFormatUtilities.cs
@@ -139,7 +139,8 @@ public unsafe partial class DataObject
                 // 1. Doesn't allow arrays that have a non-zero base index (can't create these in C# or VB)
                 // 2. Only allows IObjectReference types that contain primitives (to avoid observable cycle
                 //    dependencies to indeterminate state)
-                // But it usually requires a resolver.
+                // But it usually requires a resolver. Resolver is not available in the legacy mode,
+                // so we will fall back to BinaryFormatter in that case.
                 if (LocalAppContextSwitches.ClipboardDragDropEnableNrbfSerialization)
                 {
                     try

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.Composition.NativeToWinFormsAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.Composition.NativeToWinFormsAdapter.cs
@@ -278,7 +278,7 @@ public unsafe partial class DataObject
                         result = TryGetIStreamData(dataObject, format, resolver, legacyMode, out data);
                     }
                 }
-                catch (Exception e) when (e is not NotSupportedException)
+                catch (Exception e) when (legacyMode || e is not NotSupportedException)
                 {
                     Debug.Fail(e.ToString());
                 }
@@ -337,9 +337,8 @@ public unsafe partial class DataObject
                     data = default;
                     doNotContinue = true;
                 }
-                catch (Exception ex) when (ex is not NotSupportedException)
+                catch (Exception ex) when (legacyMode || ex is not NotSupportedException)
                 {
-                    // Should we catch SerializationExceptions that wrap NotSupported when called from the typed API?
                     Debug.WriteLine(ex.ToString());
                 }
                 finally

--- a/src/System.Windows.Forms/tests/ComDisabledTests/ClipboardComTests.cs
+++ b/src/System.Windows.Forms/tests/ComDisabledTests/ClipboardComTests.cs
@@ -27,6 +27,7 @@ public class ClipboardComTests
     {
         SimpleTestData testData = new() { X = 1, Y = 1 };
 
+        using BinaryFormatterScope scope = new(enable: false);
         Clipboard.SetDataAsJson("testData", testData);
         ITypedDataObject dataObject = Clipboard.GetDataObject().Should().BeAssignableTo<ITypedDataObject>().Subject;
         dataObject.GetDataPresent("testData").Should().BeTrue();
@@ -40,6 +41,7 @@ public class ClipboardComTests
     {
         SimpleTestData testData = new() { X = 1, Y = 1 };
 
+        using BinaryFormatterScope scope = new(enable: false);
         DataObject dataObject = new();
         dataObject.SetDataAsJson("testData", testData);
 


### PR DESCRIPTION
restore behavior of
1. app with BinaryFormatter enabled SetData("custom format", new List<Point>(){})
2. app with BInaryFormatter disabled GetData("custom format")

NET8 and NET9 were returning an empty memory stream, I regressed it to throw the NotSupportedException from the spot where we detect that BinaryFormatter is disabled. After this change I retain the NotSupportedException only in the Typed Get APIs
