### PR TITLE
Move the Control.DragDrop tests under ControlTests.Methods.cs to Collection "Sequential"

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.Methods.ClipboardTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.Methods.ClipboardTests.cs
@@ -1,0 +1,67 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using Moq;
+using IComDataObject = System.Runtime.InteropServices.ComTypes.IDataObject;
+
+namespace System.Windows.Forms.Tests;
+
+public partial class ControlTests
+{
+    [Collection("Sequential")] // Each registered Clipboard format is an OS singleton,
+                               // and we should not run this test at the same time as other tests using the same format.
+    public class ClipboardTests
+    {
+        public static IEnumerable<object[]> DoDragDrop_TestData()
+        {
+            foreach (DragDropEffects allowedEffects in Enum.GetValues(typeof(DragDropEffects)))
+            {
+                yield return new object[] { "text", allowedEffects };
+                yield return new object[] { new DataObject(), allowedEffects };
+                yield return new object[] { new DataObject("data"), allowedEffects };
+                yield return new object[] { new Mock<IDataObject>(MockBehavior.Strict).Object, allowedEffects };
+                yield return new object[] { new Mock<IComDataObject>(MockBehavior.Strict).Object, allowedEffects };
+            }
+        }
+
+        [WinFormsTheory(Skip = "hangs CI, see https://github.com/dotnet/winforms/issues/3336")]
+        [ActiveIssue("https://github.com/dotnet/winforms/issues/3336")]
+        [MemberData(nameof(DoDragDrop_TestData))]
+        public void Control_DoDragDrop_Invoke_ReturnsNone(object data, DragDropEffects allowedEffects)
+        {
+            using Control control = new();
+            Assert.Equal(DragDropEffects.None, control.DoDragDrop(data, allowedEffects));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory(Skip = "hangs CI, see https://github.com/dotnet/winforms/issues/3336")]
+        [ActiveIssue("https://github.com/dotnet/winforms/issues/3336")]
+        [MemberData(nameof(DoDragDrop_TestData))]
+        public void Control_DoDragDrop_InvokeWithHandle_ReturnsNone(object data, DragDropEffects allowedEffects)
+        {
+            using Control control = new();
+            Assert.NotEqual(IntPtr.Zero, control.Handle);
+            int invalidatedCallCount = 0;
+            control.Invalidated += (sender, e) => invalidatedCallCount++;
+            int styleChangedCallCount = 0;
+            control.StyleChanged += (sender, e) => styleChangedCallCount++;
+            int createdCallCount = 0;
+            control.HandleCreated += (sender, e) => createdCallCount++;
+
+            Assert.Equal(DragDropEffects.None, control.DoDragDrop(data, allowedEffects));
+            Assert.True(control.IsHandleCreated);
+            Assert.Equal(0, invalidatedCallCount);
+            Assert.Equal(0, styleChangedCallCount);
+            Assert.Equal(0, createdCallCount);
+        }
+
+        [WinFormsFact]
+        public void Control_DoDragDrop_NullData_ThrowsArgumentNullException()
+        {
+            using Control control = new();
+            Assert.Throws<ArgumentNullException>("data", () => control.DoDragDrop(null!, DragDropEffects.All));
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.Methods.ClipboardTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.Methods.ClipboardTests.cs
@@ -10,8 +10,9 @@ namespace System.Windows.Forms.Tests;
 
 public partial class ControlTests
 {
-    [Collection("Sequential")] // Each registered Clipboard format is an OS singleton,
-                               // and we should not run this test at the same time as other tests using the same format.
+    // Each registered Clipboard format is an OS singleton,
+    // and we should not run this test at the same time as other tests using the same format.
+    [Collection("Sequential")]
     public class ClipboardTests
     {
         public static IEnumerable<object[]> DoDragDrop_TestData()
@@ -55,13 +56,6 @@ public partial class ControlTests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-        }
-
-        [WinFormsFact]
-        public void Control_DoDragDrop_NullData_ThrowsArgumentNullException()
-        {
-            using Control control = new();
-            Assert.Throws<ArgumentNullException>("data", () => control.DoDragDrop(null!, DragDropEffects.All));
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.Methods.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.Methods.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel;
@@ -1808,6 +1808,8 @@ public partial class ControlTests
         Assert.Equal(1, disposedCallCount);
     }
 
+    // This scenario throws an exception before accessing the native clipboard API,
+    // so it does not touch the clipboard singleton and does not need to be placed in Sequential collection.
     [WinFormsFact]
     public void Control_DoDragDrop_NullData_ThrowsArgumentNullException()
     {
@@ -1870,15 +1872,6 @@ public partial class ControlTests
         Assert.Equal(0, invalidatedCallCount);
         Assert.Equal(0, styleChangedCallCount);
         Assert.Equal(0, createdCallCount);
-    }
-
-    // This scenario throws an exception before accessing the native clipboard API,
-    // so it does not touch the clipboard singleton and does not need to be placed in Sequential collection.
-    [WinFormsFact]
-    public void Control_DoDragDrop_NullData_ThrowsArgumentNullException()
-    {
-        using Control control = new();
-        Assert.Throws<ArgumentNullException>("data", () => control.DoDragDrop(null, DragDropEffects.All));
     }
 
     [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.Methods.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.Methods.cs
@@ -8,7 +8,6 @@ using System.Reflection;
 using System.Windows.Forms.Layout;
 using Moq;
 using System.Windows.Forms.TestUtilities;
-using IComDataObject = System.Runtime.InteropServices.ComTypes.IDataObject;
 
 namespace System.Windows.Forms.Tests;
 
@@ -1807,56 +1806,6 @@ public partial class ControlTests
 
         control.Dispose(true);
         Assert.Equal(1, disposedCallCount);
-    }
-
-    public static IEnumerable<object[]> DoDragDrop_TestData()
-    {
-        foreach (DragDropEffects allowedEffects in Enum.GetValues(typeof(DragDropEffects)))
-        {
-            yield return new object[] { "text", allowedEffects };
-            yield return new object[] { new DataObject(), allowedEffects };
-            yield return new object[] { new DataObject("data"), allowedEffects };
-            yield return new object[] { new Mock<IDataObject>(MockBehavior.Strict).Object, allowedEffects };
-            yield return new object[] { new Mock<IComDataObject>(MockBehavior.Strict).Object, allowedEffects };
-        }
-    }
-
-    [WinFormsTheory(Skip = "hangs CI, see https://github.com/dotnet/winforms/issues/3336")]
-    [ActiveIssue("https://github.com/dotnet/winforms/issues/3336")]
-    [MemberData(nameof(DoDragDrop_TestData))]
-    public void Control_DoDragDrop_Invoke_ReturnsNone(object data, DragDropEffects allowedEffects)
-    {
-        using Control control = new();
-        Assert.Equal(DragDropEffects.None, control.DoDragDrop(data, allowedEffects));
-        Assert.False(control.IsHandleCreated);
-    }
-
-    [WinFormsTheory(Skip = "hangs CI, see https://github.com/dotnet/winforms/issues/3336")]
-    [ActiveIssue("https://github.com/dotnet/winforms/issues/3336")]
-    [MemberData(nameof(DoDragDrop_TestData))]
-    public void Control_DoDragDrop_InvokeWithHandle_ReturnsNone(object data, DragDropEffects allowedEffects)
-    {
-        using Control control = new();
-        Assert.NotEqual(IntPtr.Zero, control.Handle);
-        int invalidatedCallCount = 0;
-        control.Invalidated += (sender, e) => invalidatedCallCount++;
-        int styleChangedCallCount = 0;
-        control.StyleChanged += (sender, e) => styleChangedCallCount++;
-        int createdCallCount = 0;
-        control.HandleCreated += (sender, e) => createdCallCount++;
-
-        Assert.Equal(DragDropEffects.None, control.DoDragDrop(data, allowedEffects));
-        Assert.True(control.IsHandleCreated);
-        Assert.Equal(0, invalidatedCallCount);
-        Assert.Equal(0, styleChangedCallCount);
-        Assert.Equal(0, createdCallCount);
-    }
-
-    [WinFormsFact]
-    public void Control_DoDragDrop_NullData_ThrowsArgumentNullException()
-    {
-        using Control control = new();
-        Assert.Throws<ArgumentNullException>("data", () => control.DoDragDrop(null, DragDropEffects.All));
     }
 
     public static IEnumerable<object[]> DrawToBitmap_TestData()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.Methods.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.Methods.cs
@@ -1856,6 +1856,15 @@ public partial class ControlTests
         Assert.Equal(0, createdCallCount);
     }
 
+    // This scenario throws an exception before accessing the native clipboard API,
+    // so it does not touch the clipboard singleton and does not need to be placed in Sequential collection.
+    [WinFormsFact]
+    public void Control_DoDragDrop_NullData_ThrowsArgumentNullException()
+    {
+        using Control control = new();
+        Assert.Throws<ArgumentNullException>("data", () => control.DoDragDrop(null, DragDropEffects.All));
+    }
+
     [WinFormsFact]
     public void Control_DrawToBitmap_NullBitmap_ThrowsArgumentNullException()
     {


### PR DESCRIPTION

## Proposed changes

- Move the Control.DragDrop tests under ControlTests.Methods.cs to Collection "Sequential"


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12657)