### PR TITLE
[release/8.0] Fix WM_DESTROY message handling in ActiveX control

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.cs
@@ -3370,14 +3370,14 @@ public abstract unsafe partial class AxHost : Control, ISupportInitialize, ICust
 
     private unsafe void DetachAndForward(ref Message m)
     {
-        bool isHandleCreated = IsHandleCreated;
+        HWND handle = GetHandleNoCreate();
         DetachWindow();
-        if (isHandleCreated)
+        if (!handle.IsNull)
         {
-            void* wndProc = (void*)PInvoke.GetWindowLong(this, WINDOW_LONG_PTR_INDEX.GWL_WNDPROC);
+            void* wndProc = (void*)PInvoke.GetWindowLong(handle, WINDOW_LONG_PTR_INDEX.GWL_WNDPROC);
             m.ResultInternal = PInvoke.CallWindowProc(
                 (delegate* unmanaged[Stdcall]<HWND, uint, WPARAM, LPARAM, LRESULT>)wndProc,
-                HWND,
+                handle,
                 (uint)m.Msg,
                 m.WParamInternal,
                 m.LParamInternal);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.cs
@@ -3370,8 +3370,9 @@ public abstract unsafe partial class AxHost : Control, ISupportInitialize, ICust
 
     private unsafe void DetachAndForward(ref Message m)
     {
+        bool isHandleCreated = IsHandleCreated;
         DetachWindow();
-        if (IsHandleCreated)
+        if (isHandleCreated)
         {
             void* wndProc = (void*)PInvoke.GetWindowLong(this, WINDOW_LONG_PTR_INDEX.GWL_WNDPROC);
             m.ResultInternal = PInvoke.CallWindowProc(


### PR DESCRIPTION
BackPort PR #12564 And #12648 To 8.0
Fixes https://github.com/dotnet/winforms/issues/12551

### Customer Impact
Parent container control is not sending WM_DESTROY message to the child control while disposing the ActiveX child controls. ActixeX child expects a WM_DESTORY message, but the message handler is never called. 

### Regression
Yes. Due to  [Move from IntPtr to nint to avoid runtime casting errors. (#5791) · dotnet/winforms@834d0a0](https://github.com/dotnet/winforms/commit/834d0a0d364c82bf70803706886ff9a40bd3e090#diff-dc17cf8f6ef4b80a13b2386597a72cd7ae36cab7375583a0a1e76a62f7f9238fL3556), We accidentally removed caching of a window handle before destroying it, once the handle was destroyed, we were not able to forward message to its winproc. 

### Testing
Manual testing with the user-provided project
 
### Risk
Low - The change reverts logic to .NET7 state, no workaround is possible