### PR TITLE
Add unit tests for ControlDesigner.ControlDesignerAccessibleObject

### DIFF
--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ControlDesigner.ControlDesignerAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ControlDesigner.ControlDesignerAccessibleObjectTests.cs
@@ -1,0 +1,189 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using Moq;
+using System.ComponentModel.Design;
+using System.Drawing;
+
+namespace System.Windows.Forms.Design.Tests;
+
+public class ControlDesignerControlDesignerAccessibleObjectTests
+{
+    private class TestControl : Control
+    {
+        private readonly AccessibleObject _accessibilityObject;
+
+        public TestControl(AccessibleObject accessibilityObject)
+        {
+            _accessibilityObject = accessibilityObject;
+        }
+
+        protected override AccessibleObject CreateAccessibilityInstance() => _accessibilityObject;
+    }
+
+    private ControlDesigner.ControlDesignerAccessibleObject CreateAccessibleObject(Mock<AccessibleObject>? mockAccessibleObject = null)
+    {
+        Control control = mockAccessibleObject is not null
+            ? new TestControl(mockAccessibleObject.Object)
+            : new Control();
+
+        ControlDesigner designer = new();
+        return new ControlDesigner.ControlDesignerAccessibleObject(designer, control);
+    }
+
+    [Fact]
+    public void Bounds_ReturnsExpectedBounds()
+    {
+        Rectangle expectedBounds = new(10, 10, 100, 100);
+        Mock<AccessibleObject> mockAccessibleObject = new();
+        mockAccessibleObject.Setup(a => a.Bounds).Returns(expectedBounds);
+        ControlDesigner.ControlDesignerAccessibleObject accessibleObject = CreateAccessibleObject(mockAccessibleObject);
+
+        accessibleObject.Bounds.Should().Be(expectedBounds);
+    }
+
+    [Theory]
+    [InlineData("Test Description", nameof(AccessibleObject.Description))]
+    [InlineData("Test Value", nameof(AccessibleObject.Value))]
+    [InlineData(AccessibleRole.PushButton, nameof(AccessibleObject.Role))]
+    [InlineData("Parent", nameof(AccessibleObject.Parent))]
+    public void Properties_ReturnExpectedValues(object expectedValue, string propertyName)
+    {
+        Mock<AccessibleObject> mockAccessibleObject = new();
+
+        if (propertyName == nameof(AccessibleObject.Description))
+        {
+            mockAccessibleObject.Setup(a => a.Description).Returns((string)expectedValue);
+        }
+        else if (propertyName == nameof(AccessibleObject.Value))
+        {
+            mockAccessibleObject.Setup(a => a.Value).Returns((string)expectedValue);
+        }
+        else if (propertyName == nameof(AccessibleObject.Role))
+        {
+            mockAccessibleObject.Setup(a => a.Role).Returns((AccessibleRole)expectedValue);
+        }
+        else if (propertyName == nameof(AccessibleObject.Parent))
+        {
+            AccessibleObject parentMock = new Mock<AccessibleObject>().Object;
+            mockAccessibleObject.Setup(a => a.Parent).Returns(parentMock);
+            expectedValue = parentMock;
+        }
+
+        ControlDesigner.ControlDesignerAccessibleObject accessibleObject = CreateAccessibleObject(mockAccessibleObject);
+
+        object? result = typeof(ControlDesigner.ControlDesignerAccessibleObject).GetProperty(propertyName)!.GetValue(accessibleObject, null);
+
+        result.Should().Be(expectedValue);
+    }
+
+    [Fact]
+    public void DefaultAction_ReturnsEmptyString()
+    {
+        ControlDesigner.ControlDesignerAccessibleObject accessibleObject = CreateAccessibleObject();
+        accessibleObject.DefaultAction.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Name_ReturnsControlName()
+    {
+        Control control = new() { Name = "TestControl" };
+        ControlDesigner designer = new();
+        ControlDesigner.ControlDesignerAccessibleObject accessibleObject = new(designer, control);
+
+        accessibleObject.Name.Should().Be("TestControl");
+    }
+
+    [Theory]
+    [InlineData(AccessibleStates.Selected, true, true)]
+    [InlineData(AccessibleStates.Focused, true, true)]
+    public void State_ReturnsExpectedStates(AccessibleStates state, bool isSelected, bool isPrimarySelection)
+    {
+        Control control = new();
+        ControlDesigner designer = new();
+        ControlDesigner.ControlDesignerAccessibleObject accessibleObject = new(designer, control);
+
+        Mock<ISelectionService> selectionServiceMock = new();
+        selectionServiceMock.Setup(s => s.GetComponentSelected(control)).Returns(isSelected);
+        selectionServiceMock.Setup(s => s.PrimarySelection).Returns(isPrimarySelection ? control : null);
+
+        dynamic accessor = accessibleObject.TestAccessor().Dynamic;
+        accessor._selectionService = selectionServiceMock.Object;
+
+        accessibleObject.State.Should().HaveFlag(state);
+    }
+
+    [Theory]
+    [InlineData(0, nameof(AccessibleObject.GetChild), typeof(AccessibleObject))]
+    [InlineData(3, nameof(AccessibleObject.GetChildCount), typeof(int))]
+    public void GetChildMethods_ReturnExpectedValues(object expectedValue, string methodName, Type expectedType)
+    {
+        Mock<AccessibleObject> mockAccessibleObject = new();
+        if (methodName == nameof(AccessibleObject.GetChild))
+        {
+            AccessibleObject child = new Mock<AccessibleObject>().Object;
+            mockAccessibleObject.Setup(a => a.GetChild(It.IsAny<int>())).Returns(child);
+            expectedValue = child;
+        }
+        else
+        {
+            mockAccessibleObject.Setup(a => a.GetChildCount()).Returns((int)expectedValue);
+        }
+
+        ControlDesigner.ControlDesignerAccessibleObject accessibleObject = CreateAccessibleObject(mockAccessibleObject);
+
+        object? result = typeof(ControlDesigner.ControlDesignerAccessibleObject)
+            .GetMethod(methodName)!.Invoke(accessibleObject, methodName == nameof(AccessibleObject.GetChild) ? new object[] { 0 } : null);
+
+        result.Should().BeAssignableTo(expectedType);
+        result.Should().Be(expectedValue);
+    }
+
+    public static IEnumerable<object?[]> TestCases =>
+    new List<object?[]>
+    {
+        new object?[] { AccessibleStates.Focused, nameof(ControlDesigner.ControlDesignerAccessibleObject.GetFocused), null },
+        new object?[] { AccessibleStates.Selected, nameof(ControlDesigner.ControlDesignerAccessibleObject.GetSelected), null },
+        new object?[] { AccessibleStates.None, nameof(ControlDesigner.ControlDesignerAccessibleObject.HitTest), 10, 10 }
+    };
+
+    [Theory]
+    [MemberData(nameof(TestCases))]
+    public void Methods_ReturnExpectedResults(AccessibleStates state, string methodName, int x = 0, int y = 0)
+    {
+        Control control = new();
+        ControlDesigner designer = new();
+        Mock<AccessibleObject> mockAccessibleObject = new();
+        mockAccessibleObject.Setup(a => a.State).Returns(state);
+
+        AccessibleObject? expectedAccessibleObject = null;
+        if (methodName == nameof(ControlDesigner.ControlDesignerAccessibleObject.HitTest))
+        {
+            expectedAccessibleObject = new Mock<AccessibleObject>().Object;
+            mockAccessibleObject.Setup(a => a.HitTest(x, y)).Returns(expectedAccessibleObject);
+        }
+
+        TestControl testControl = new(mockAccessibleObject.Object);
+        ControlDesigner.ControlDesignerAccessibleObject accessibleObject = new(designer, testControl);
+
+        object? result = methodName switch
+        {
+            nameof(ControlDesigner.ControlDesignerAccessibleObject.GetFocused) => accessibleObject.GetFocused(),
+            nameof(ControlDesigner.ControlDesignerAccessibleObject.GetSelected) => accessibleObject.GetSelected(),
+            nameof(ControlDesigner.ControlDesignerAccessibleObject.HitTest) => accessibleObject.HitTest(x, y),
+
+            _ => throw new ArgumentException("Invalid method name", nameof(methodName))
+        };
+
+        if (methodName == nameof(ControlDesigner.ControlDesignerAccessibleObject.HitTest))
+        {
+            result.Should().Be(expectedAccessibleObject);
+        }
+        else
+        {
+            result.Should().Be(accessibleObject);
+        }
+    }
+}

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ControlDesignerAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ControlDesignerAccessibleObjectTests.cs
@@ -9,7 +9,7 @@ using System.Drawing;
 
 namespace System.Windows.Forms.Design.Tests;
 
-public class ControlDesignerControlDesignerAccessibleObjectTests : IDisposable
+public class ControlDesignerAccessibleObjectTests : IDisposable
 {
     private class TestControl : Control
     {
@@ -25,15 +25,9 @@ public class ControlDesignerControlDesignerAccessibleObjectTests : IDisposable
 
     private readonly ControlDesigner _designer;
 
-    public ControlDesignerControlDesignerAccessibleObjectTests()
-    {
-        _designer = new();
-    }
+    public ControlDesignerAccessibleObjectTests() => _designer = new();
 
-    public void Dispose()
-    {
-        _designer.Dispose();
-    }
+    public void Dispose() => _designer.Dispose();
 
     private ControlDesigner.ControlDesignerAccessibleObject CreateAccessibleObject(Action<Mock<AccessibleObject>>? configureMock = null)
     {
@@ -46,7 +40,7 @@ public class ControlDesignerControlDesignerAccessibleObjectTests : IDisposable
     }
 
     [Fact]
-    public void Bounds_ReturnsExpectedValue()
+    public void ControlDesignerAccessibleObject_Bounds_ReturnsExpectedValue()
     {
         Rectangle expectedBounds = new(10, 10, 100, 100);
         var accessibleObject = CreateAccessibleObject(mock => mock.Setup(a => a.Bounds).Returns(expectedBounds));
@@ -54,7 +48,7 @@ public class ControlDesignerControlDesignerAccessibleObjectTests : IDisposable
     }
 
     [Fact]
-    public void Description_ReturnsExpectedValue()
+    public void ControlDesignerAccessibleObject_Description_ReturnsExpectedValue()
     {
         string expectedDescription = "Test Description";
         var accessibleObject = CreateAccessibleObject(mock => mock.Setup(a => a.Description).Returns(expectedDescription));
@@ -63,7 +57,7 @@ public class ControlDesignerControlDesignerAccessibleObjectTests : IDisposable
     }
 
     [Fact]
-    public void Value_ReturnsExpectedValue()
+    public void ControlDesignerAccessibleObject_Value_ReturnsExpectedValue()
     {
         string expectedValue = "Test Value";
         var accessibleObject = CreateAccessibleObject(mock => mock.Setup(a => a.Value).Returns(expectedValue));
@@ -71,14 +65,14 @@ public class ControlDesignerControlDesignerAccessibleObjectTests : IDisposable
     }
 
     [Fact]
-    public void Role_ReturnsExpectedValue()
+    public void ControlDesignerAccessibleObject_Role_ReturnsExpectedValue()
     {
         var accessibleObject = CreateAccessibleObject(mock => mock.Setup(a => a.Role).Returns(AccessibleRole.PushButton));
         accessibleObject.Role.Should().Be(AccessibleRole.PushButton);
     }
 
     [Fact]
-    public void Parent_ReturnsExpectedValue()
+    public void ControlDesignerAccessibleObject_Parent_ReturnsExpectedValue()
     {
         Mock<AccessibleObject> mockParent = new();
         var accessibleObject = CreateAccessibleObject(mock => mock.Setup(a => a.Parent).Returns(mockParent.Object));
@@ -87,13 +81,13 @@ public class ControlDesignerControlDesignerAccessibleObjectTests : IDisposable
     }
 
     [Fact]
-    public void DefaultAction_ReturnsEmptyString()
+    public void ControlDesignerAccessibleObject_DefaultAction_ReturnsEmptyString()
     {
         CreateAccessibleObject().DefaultAction.Should().BeEmpty();
     }
 
     [Fact]
-    public void Name_ReturnsExpectedValue()
+    public void ControlDesignerAccessibleObject_Name_ReturnsExpectedValue()
     {
         Control control = new() { Name = "TestControl" };
         var accessibleObject = new ControlDesigner.ControlDesignerAccessibleObject(_designer, control);
@@ -104,7 +98,7 @@ public class ControlDesignerControlDesignerAccessibleObjectTests : IDisposable
     [Theory]
     [InlineData(AccessibleStates.Selected, true, true)]
     [InlineData(AccessibleStates.Focused, true, true)]
-    public void State_ReturnsExpectedValue(AccessibleStates state, bool isSelected, bool isPrimarySelection)
+    public void ControlDesignerAccessibleObject_State_ReturnsExpectedValue(AccessibleStates state, bool isSelected, bool isPrimarySelection)
     {
         Control control = new();
         var accessibleObject = new ControlDesigner.ControlDesignerAccessibleObject(_designer, control);
@@ -118,7 +112,7 @@ public class ControlDesignerControlDesignerAccessibleObjectTests : IDisposable
     }
 
     [Fact]
-    public void GetChild_ReturnsExpectedValue()
+    public void ControlDesignerAccessibleObject_GetChild_ReturnsExpectedValue()
     {
         Mock<AccessibleObject> mockChild = new();
         var accessibleObject = CreateAccessibleObject(mock => mock.Setup(a => a.GetChild(It.IsAny<int>())).Returns(mockChild.Object));
@@ -127,7 +121,7 @@ public class ControlDesignerControlDesignerAccessibleObjectTests : IDisposable
     }
 
     [Fact]
-    public void GetChildCount_ReturnsExpectedValue()
+    public void ControlDesignerAccessibleObject_GetChildCount_ReturnsExpectedValue()
     {
         int expectedChildCount = 3;
         var accessibleObject = CreateAccessibleObject(mock => mock.Setup(a => a.GetChildCount()).Returns(expectedChildCount));
@@ -135,21 +129,21 @@ public class ControlDesignerControlDesignerAccessibleObjectTests : IDisposable
     }
 
     [Fact]
-    public void GetFocused_ReturnsExpectedValue()
+    public void ControlDesignerAccessibleObject_GetFocused_ReturnsExpectedValue()
     {
         var accessibleObject = CreateAccessibleObject(mock => mock.Setup(a => a.State).Returns(AccessibleStates.Focused));
         accessibleObject.GetFocused().Should().Be(accessibleObject);
     }
 
     [Fact]
-    public void GetSelected_ReturnsExpectedValue()
+    public void ControlDesignerAccessibleObject_GetSelected_ReturnsExpectedValue()
     {
         var accessibleObject = CreateAccessibleObject(mock => mock.Setup(a => a.State).Returns(AccessibleStates.Selected));
         accessibleObject.GetSelected().Should().Be(accessibleObject);
     }
 
     [Fact]
-    public void HitTest_ReturnsExpectedValue()
+    public void ControlDesignerAccessibleObject_HitTest_ReturnsExpectedValue()
     {
         Mock<AccessibleObject> mockAccessibleObject = new();
         var accessibleObject = CreateAccessibleObject(mock => mock.Setup(a => a.HitTest(It.IsAny<int>(), It.IsAny<int>())).Returns(mockAccessibleObject.Object));


### PR DESCRIPTION
Related https://github.com/dotnet/winforms/issues/10773


## Proposed changes

- Add unit test ControlDesigner.ControlDesignerAccessibleObjectTests.cs for public properties and method of the ControlDesigner.ControlDesignerAccessibleObject.

- Enable nullability in ControlDesigner.ControlDesignerAccessibleObjectTests.cs.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12664)