### PR TITLE
Add code coverage for DataGridViewRowHeightInfoPushedEventArgs

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewRowHeightInfoPushedEventArgsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewRowHeightInfoPushedEventArgsTests.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+namespace System.Windows.Forms.Tests;
+
+public class DataGridViewRowHeightInfoPushedEventArgsTests
+{
+    [WinFormsTheory]
+    [InlineData(1, 20, 10)]
+    [InlineData(0, 20, 10)]
+    [InlineData(1, 0, 10)]
+    [InlineData(1, 20, 0)]
+    [InlineData(-1, 20, 10)]
+    [InlineData(1, 20, 5)]
+    public void Ctor_ValidArguments_SetsProperties(int rowIndex, int height, int minimumHeight)
+    {
+        DataGridViewRowHeightInfoPushedEventArgs e = new(rowIndex, height, minimumHeight);
+
+        e.RowIndex.Should().Be(rowIndex);
+        e.Height.Should().Be(height);
+        e.MinimumHeight.Should().Be(minimumHeight);
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewRowHeightInfoPushedEventArgsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewRowHeightInfoPushedEventArgsTests.cs
@@ -7,7 +7,7 @@ namespace System.Windows.Forms.Tests;
 
 public class DataGridViewRowHeightInfoPushedEventArgsTests
 {
-    [WinFormsTheory]
+    [Theory]
     [InlineData(1, 20, 10)]
     [InlineData(0, 20, 10)]
     [InlineData(1, 0, 10)]


### PR DESCRIPTION
related https://github.com/dotnet/winforms/issues/10453

## Proposed changes
Add unit tests for DataGridViewRowHeightInfoPushedEventArgs.cs to test its properties
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12673)