### PR TITLE
Changes to main branch to address #12042

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ListView/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ListView/ListView.cs
@@ -56,6 +56,8 @@ public partial class ListView : Control
     private View _viewStyle = View.LargeIcon;
     private string? _toolTipCaption = string.Empty;
 
+    private HBRUSH _hBrush; // To hold created dark mode brush for deletion
+
     private const int LISTVIEWSTATE_ownerDraw = 0x00000001;
     private const int LISTVIEWSTATE_allowColumnReorder = 0x00000002;
     private const int LISTVIEWSTATE_autoArrange = 0x00000004;
@@ -4331,6 +4333,11 @@ public partial class ListView : Control
     protected virtual void OnAfterLabelEdit(LabelEditEventArgs e)
     {
         _onAfterLabelEdit?.Invoke(this, e);
+
+        // Delete created _hBrush if it exists
+        [DllImport("Gdi32.dll", PreserveSig = true)]
+        static extern void DeleteObject(HGDIOBJ ho);
+        DeleteObject(_hBrush);
     }
 
     protected override void OnBackgroundImageChanged(EventArgs e)
@@ -6908,6 +6915,32 @@ public partial class ListView : Control
     {
         switch (m.MsgInternal)
         {
+            case PInvokeCore.WM_CTLCOLOREDIT:
+                // Default handling of edit label colors
+                m.ResultInternal = (LRESULT)0;
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+                if (Application.IsDarkModeEnabled)
+                {
+                    // Make background of dark mode edit labels the correct color
+                    [DllImport("Gdi32.dll", PreserveSig = true)]
+                    static extern HBRUSH CreateSolidBrush(COLORREF color);
+                    [DllImport("Gdi32.dll", PreserveSig = true)]
+                    static extern COLORREF SetBkColor(HDC hdc, COLORREF color);
+                    [DllImport("Gdi32.dll", PreserveSig = true)]
+                    static extern COLORREF SetTextColor(HDC hdc, COLORREF color);
+
+                    Color tvColor = BackColor;
+                    Color tvTextColor = ForeColor;
+                    _hBrush = CreateSolidBrush(tvColor);
+                    HDC editHDC = (HDC)m.WParamInternal;
+                    SetBkColor(editHDC, tvColor);
+                    SetTextColor(editHDC, tvTextColor);
+                    LRESULT lrBrush = (LRESULT)(IntPtr)_hBrush;
+                    m.ResultInternal = lrBrush;
+                }
+#pragma warning restore WFO5001
+                break;
+
             case MessageId.WM_REFLECT_NOTIFY:
                 WmReflectNotify(ref m);
                 break;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeView.cs
@@ -53,6 +53,8 @@ public partial class TreeView : Control
     private bool _hoveredAlready;
     private bool _rightToLeftLayout;
 
+    private HBRUSH _hBrush;     // To hold created dark mode brush for deletion
+
     private nint _mouseDownNode = 0; // ensures we fire nodeClick on the correct node
 
     private const int TREEVIEWSTATE_hideSelection = 0x00000001;
@@ -2102,6 +2104,11 @@ public partial class TreeView : Control
         {
             e.Node.AccessibilityObject?.RaiseAutomationEvent(UIA_EVENT_ID.UIA_AutomationFocusChangedEventId);
         }
+
+        // Delete created _hBrush if it exists
+        [DllImport("Gdi32.dll", PreserveSig = true)]
+        static extern void DeleteObject(HGDIOBJ ho);
+        DeleteObject(_hBrush);
     }
 
     /// <summary>
@@ -3160,6 +3167,32 @@ public partial class TreeView : Control
     {
         switch (m.MsgInternal)
         {
+            case PInvokeCore.WM_CTLCOLOREDIT:
+                // Default handling of edit label colors
+                m.ResultInternal = (LRESULT)0;
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+                if (Application.IsDarkModeEnabled)
+                {
+                    // Make background of dark mode edit labels the correct color
+                    [DllImport("Gdi32.dll", PreserveSig = true)]
+                    static extern HBRUSH CreateSolidBrush(COLORREF color);
+                    [DllImport("Gdi32.dll", PreserveSig = true)]
+                    static extern COLORREF SetBkColor(HDC hdc, COLORREF color);
+                    [DllImport("Gdi32.dll", PreserveSig = true)]
+                    static extern COLORREF SetTextColor(HDC hdc, COLORREF color);
+
+                    Color tvColor = BackColor;
+                    Color tvTextColor = ForeColor;
+                    _hBrush = CreateSolidBrush(tvColor);
+                    HDC editHDC = (HDC)m.WParamInternal;
+                    SetBkColor(editHDC, tvColor);
+                    SetTextColor(editHDC, tvTextColor);
+                    LRESULT lrBrush = (LRESULT)(IntPtr)_hBrush;
+                    m.ResultInternal = lrBrush;
+                }
+#pragma warning restore WFO5001
+                break;
+
             case PInvokeCore.WM_WINDOWPOSCHANGING:
             case PInvokeCore.WM_NCCALCSIZE:
             case PInvokeCore.WM_WINDOWPOSCHANGED:


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #12042 - TreeNode and ListItem not displaying in dark mode during editing, even though application is set to be in dark mode.


## Proposed changes

If the application is in dark mode, capture the parent's windows message to identify the start of editing, and change the colour of the brush to match the parent's window color. 

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

Correction of incorrect color selection.


## Regression? 

- Yes / No

## Risk

I tried to limit the impact of the change to only occurring when the application is in dark mode. I'm not sure of the impact, if any, on custom ListView subitems, or custom-drawn TreeNodes.


<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
![364259285-197881bf-5284-493c-b665-ee5d47c9541c](https://github.com/user-attachments/assets/c4653f28-6b22-47ef-80a3-d0745d1b43c9)

<!-- TODO -->

### After
![image](https://github.com/user-attachments/assets/0063aef6-8787-431e-8713-8a552b835bc5)

<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

I used the test application provided to highlight the bug in the ticket to test the new behaviour.

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

- <!-- use `dotnet --info` -->


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12672)