### PR TITLE
fix #12663 [Accessibility][High Contrast] ToolStrip grip icon colour contrast is less than 4.5:1 in Normal Mode and HC Desert mode

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripHighContrastRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripHighContrastRenderer.cs
@@ -77,7 +77,7 @@ internal class ToolStripHighContrastRenderer : ToolStripSystemRenderer
                     startY += 4;
                 }
 
-                g.FillRectangles(SystemBrushes.ControlLight, shadowRects);
+                g.FillRectangles(SystemBrushes.ControlText, shadowRects);
             }
         }
         else

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolstripProfessionalRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolstripProfessionalRenderer.cs
@@ -528,8 +528,8 @@ public class ToolStripProfessionalRenderer : ToolStripRenderer
                 shadowRects[i].Offset(xOffset, -1);
             }
 
-            using var gripDarkBrush = ColorTable.GripDark.GetCachedSolidBrushScope();
-            g.FillRectangles(gripDarkBrush, shadowRects);
+            using var controlTextBrush = SystemColors.ControlText.GetCachedSolidBrushScope();
+            g.FillRectangles(controlTextBrush, shadowRects);
         }
     }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #12663 

## root cause
dot color is not contrasting enough compared to the background color.

## Proposed changes

- 
- Change the color to a more contrasting color compared to the background color.
- 

<!-- We are in TELL-MODE the following section must be completed -->



## Regression? 

- No

## Risk

- low

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![Image](https://github.com/user-attachments/assets/ba316b28-5c31-4058-944b-673b804fc02c)

**HC Aquatic**
![Image](https://github.com/user-attachments/assets/eb1e2e15-2908-4fe3-b623-3b488c46ef3d)

**HC Desert** 
![Image](https://github.com/user-attachments/assets/e4c33163-249a-48e0-866a-64d656d532e8)

**HC Dusk**
![Image](https://github.com/user-attachments/assets/f9706f23-12f1-4c7e-b57c-2f08d5fbdc94)

**HC Night Sky**
![Image](https://github.com/user-attachments/assets/0d3fe566-9b73-489e-b1c7-f1942812429d)

### After

#### win11
![image](https://github.com/user-attachments/assets/9e583fad-5ae3-4cf8-bc14-f20fc5b3f6fe)

#### win10

![image](https://github.com/user-attachments/assets/66a1c904-57a1-424e-9f14-5888ff1529b2)


## Test methodology <!-- How did you ensure quality? -->

- 
- manual, 
- 


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12682)