### PR TITLE
Fix #12661 Null Reference Exception: System.Windows.Forms.TabControl.<WmSelChange>

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TabControl/TabControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TabControl/TabControl.cs
@@ -1957,7 +1957,14 @@ public partial class TabControl : Control
             if (IsAccessibilityObjectCreated && SelectedTab?.ParentInternal is TabControl)
             {
                 SelectedTab.TabAccessibilityObject.RaiseAutomationEvent(UIA_EVENT_ID.UIA_SelectionItem_ElementSelectedEventId);
-                BeginInvoke((MethodInvoker)(() => SelectedTab?.TabAccessibilityObject.RaiseAutomationEvent(UIA_EVENT_ID.UIA_AutomationFocusChangedEventId)));
+                BeginInvoke((MethodInvoker)(() =>
+                {
+                    if (IsAccessibilityObjectCreated && SelectedTab?.ParentInternal is TabControl &&
+                         !SelectedTab.IsDisposed && SelectedTab.TabAccessibilityObject is not null)
+                    {
+                        SelectedTab.TabAccessibilityObject.RaiseAutomationEvent(UIA_EVENT_ID.UIA_AutomationFocusChangedEventId);
+                    }
+                }));
             }
         }
         else

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TabControl/TabControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TabControl/TabControl.cs
@@ -1957,7 +1957,7 @@ public partial class TabControl : Control
             if (IsAccessibilityObjectCreated && SelectedTab?.ParentInternal is TabControl)
             {
                 SelectedTab.TabAccessibilityObject.RaiseAutomationEvent(UIA_EVENT_ID.UIA_SelectionItem_ElementSelectedEventId);
-                BeginInvoke((MethodInvoker)(() => SelectedTab.TabAccessibilityObject.RaiseAutomationEvent(UIA_EVENT_ID.UIA_AutomationFocusChangedEventId)));
+                BeginInvoke((MethodInvoker)(() => SelectedTab?.TabAccessibilityObject.RaiseAutomationEvent(UIA_EVENT_ID.UIA_AutomationFocusChangedEventId)));
             }
         }
         else

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControlTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControlTests.cs
@@ -5703,6 +5703,30 @@ public class TabControlTests
         Assert.Equal(text, actual);
     }
 
+    [WinFormsFact]
+    public void TabControl_WmSelChange_SelectedTabIsNull_DoesNotThrowException()
+    {
+        using Form form = new();
+        using TabControl control = new();
+        using TabPage page1 = new("text1");
+        using TabPage page2 = new("text2");
+        control.TabPages.Add(page1);
+        control.TabPages.Add(page2);
+        _ = control.AccessibilityObject;
+
+        form.Controls.Add(control);
+        form.Show();
+
+        control.SelectedIndex = 1;
+        control.TabPages.Clear();
+
+        Action act = () => control.TestAccessor().Dynamic.WmSelChange();
+        Application.DoEvents();
+        Thread.Sleep(1000);
+
+        act.Should().NotThrow();
+    }
+
     private class SubTabPage : TabPage
     {
     }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControlTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControlTests.cs
@@ -5730,24 +5730,8 @@ public class TabControlTests
         exception.Should().BeNull();
     }
 
-    public class TabAccessibilityObject
-    {
-        public Action RaiseAutomationEventAction { get; set; }
-        public void RaiseAutomationEvent(UIA_EVENT_ID eventId)
-        {
-            RaiseAutomationEventAction?.Invoke();
-        }
-    }
-
-    public enum UIA_EVENT_ID
-    {
-        UIA_SelectionItem_ElementSelectedEventId,
-        UIA_AutomationFocusChangedEventId
-    }
-
     private class SubTabPage : TabPage
     {
-        public TabAccessibilityObject TabAccessibilityObject { get; set; }
     }
 
     private class NullTextTabPage : TabPage

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControlTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControlTests.cs
@@ -5730,28 +5730,6 @@ public class TabControlTests
         exception.Should().BeNull();
     }
 
-    [WinFormsFact]
-    public void TabControl_WmSelChange_AccessibilityObjectNotCreated_NoAutomationEventRaised()
-    {
-        using TabControl tabControl = new();
-        using SubTabPage tabPage = new();
-        tabControl.SelectedTab = tabPage;
-        tabControl.SelectedIndex = 1;
-
-        var automationEventRaised = false;
-        tabPage.TabAccessibilityObject = new TabAccessibilityObject
-        {
-            RaiseAutomationEventAction = () => automationEventRaised = true
-        };
-
-        tabControl.TestAccessor().Dynamic.WmSelChange();
-
-        Application.DoEvents();
-        Thread.Sleep(100);
-
-        automationEventRaised.Should().BeFalse();
-    }
-
     public class TabAccessibilityObject
     {
         public Action RaiseAutomationEventAction { get; set; }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes https://github.com/dotnet/winforms/issues/12661


## Proposed changes

- Update the WmSelChange method in TabControl.cs to check if the AccessibilityObject is null before calling the method
- Add a unit test to verify the fix

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Throw exception in Application.Run()

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Throw exception in Application.Run()
![Actual](https://github.com/user-attachments/assets/1b8f41ac-2f9e-4a1d-91d6-2504a69a8442)

### After

No exception in runtime


## Test methodology <!-- How did you ensure quality? -->

- Manually
- Unit test

## Test environment(s) <!-- Remove any that don't apply -->

- 10.0.0-alpha.1.24622.1


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12683)