### PR TITLE
Add the missing "WinFormsFact" annotation to the relevant unit test.

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewComboBoxCell.ObjectCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewComboBoxCell.ObjectCollectionTests.cs
@@ -97,6 +97,7 @@ public class DataGridViewComboBoxCell_ObjectCollectionTests : IDisposable
         _collection[2].Should().Be("C");
     }
 
+    [WinFormsFact]
     public void ObjectCollection_AddRange_AddsObjectCollectionCorrectly()
     {
         DataGridViewComboBoxCell.ObjectCollection items = new(_comboBoxCell) { "Item1", "Item2", "Item3" };


### PR DESCRIPTION
Fixes #12612
Related #12613

## Root Cause

- A `[WinFormsFact]` annotation was missing from a unit test in PR #12613, causing the test not to execute as part of the suite.

## Proposed changes

- Add the missing `[WinFormsFact]` annotation to the relevant unit test.

## Customer Impact

- Ensures the test runs as intended, increasing coverage and preventing regressions in the modified `DataGridViewComboBoxCell.ObjectCollection` class.

## Regression?

- No

## Risk

- Minimal

## Test methodology

- Unit tests

## Test environment(s)

- 10.0.100-alpha.1.24573.1
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12685)