### PR TITLE
Add unit tests for ControlDesigner.TransparentBehavior

### DIFF
--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ControlDesigner.TransparentBehaviorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ControlDesigner.TransparentBehaviorTests.cs
@@ -1,0 +1,103 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System.Drawing;
+
+namespace System.Windows.Forms.Design.Tests;
+
+public class ControlDesignerTransparentBehaviorTests : IDisposable
+{
+    private readonly TestControlDesigner _designer;
+    private readonly TestControl _control;
+
+    public ControlDesignerTransparentBehaviorTests()
+    {
+        _designer = new();
+        _control = new();
+        _designer.Initialize(_control);
+    }
+
+    public void Dispose()
+    {
+        _designer.Dispose();
+        _control.Dispose();
+    }
+
+    private class TestControlDesigner : ControlDesigner
+    {
+        public new void OnDragDrop(DragEventArgs e) => base.OnDragDrop(e);
+        public new void OnDragEnter(DragEventArgs e) => base.OnDragEnter(e);
+        public new void OnDragLeave(EventArgs e) => base.OnDragLeave(e);
+        public new void OnDragOver(DragEventArgs e) => base.OnDragOver(e);
+        public new void OnGiveFeedback(GiveFeedbackEventArgs e) => base.OnGiveFeedback(e);
+    }
+
+    private class TestControl : Control { }
+
+    private Rectangle GetControlRect(ControlDesigner.TransparentBehavior behavior)
+    {
+        dynamic accessor = behavior.TestAccessor().Dynamic;
+        return accessor._controlRect;
+    }
+
+    [Fact]
+    public void TransparentBehavior_OnDragDrop_CallsDesignerOnDragDrop()
+    {
+        ControlDesigner.TransparentBehavior behavior = new(_designer);
+        DragEventArgs dragEventArgs = new(null, 0, 0, 0, DragDropEffects.Copy, DragDropEffects.None);
+
+        behavior.OnDragDrop(null, dragEventArgs);
+
+        Rectangle controlRect = GetControlRect(behavior);
+        controlRect.Should().Be(Rectangle.Empty);
+    }
+
+    [Fact]
+    public void TransparentBehavior_OnDragEnter_SetsControlRect()
+    {
+        ControlDesigner.TransparentBehavior behavior = new(_designer);
+        DragEventArgs dragEventArgs = new(null, 0, 0, 0, DragDropEffects.Copy, DragDropEffects.None);
+
+        behavior.OnDragEnter(null, dragEventArgs);
+
+        Rectangle controlRect = GetControlRect(behavior);
+        controlRect.Should().NotBe(Rectangle.Empty);
+        controlRect.Should().Be(_control.RectangleToScreen(_control.ClientRectangle));
+    }
+
+    [Fact]
+    public void TransparentBehavior_OnDragLeave_ClearsControlRect()
+    {
+        ControlDesigner.TransparentBehavior behavior = new(_designer);
+        behavior.OnDragEnter(null, new DragEventArgs(null, 0, 0, 0, DragDropEffects.Copy, DragDropEffects.None));
+
+        behavior.OnDragLeave(null, EventArgs.Empty);
+
+        Rectangle controlRect = GetControlRect(behavior);
+        controlRect.Should().Be(Rectangle.Empty);
+    }
+
+    [Fact]
+    public void TransparentBehavior_OnDragOver_SetsEffectToNoneIfOutsideControlRect()
+    {
+        ControlDesigner.TransparentBehavior behavior = new(_designer);
+        behavior.OnDragEnter(null, new DragEventArgs(null, 0, 0, 0, DragDropEffects.Copy, DragDropEffects.None));
+        DragEventArgs dragEventArgs = new(null, 0, int.MaxValue, int.MaxValue, DragDropEffects.Copy, DragDropEffects.Copy);
+
+        behavior.OnDragOver(null, dragEventArgs);
+
+        dragEventArgs.Effect.Should().Be(DragDropEffects.None);
+    }
+
+    [Fact]
+    public void TransparentBehavior_OnGiveFeedback_CallsDesignerOnGiveFeedback()
+    {
+        ControlDesigner.TransparentBehavior behavior = new(_designer);
+        GiveFeedbackEventArgs feedbackEventArgs = new(DragDropEffects.Copy, true);
+
+        Exception? exception = Record.Exception(() => behavior.OnGiveFeedback(null, feedbackEventArgs));
+        exception.Should().BeNull();
+    }
+}

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ControlDesigner.TransparentBehaviorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ControlDesigner.TransparentBehaviorTests.cs
@@ -11,12 +11,14 @@ public class ControlDesignerTransparentBehaviorTests : IDisposable
 {
     private readonly TestControlDesigner _designer;
     private readonly TestControl _control;
+    private readonly ControlDesigner.TransparentBehavior _behavior;
 
     public ControlDesignerTransparentBehaviorTests()
     {
         _designer = new();
         _control = new();
         _designer.Initialize(_control);
+        _behavior = new(_designer);
     }
 
     public void Dispose()
@@ -45,24 +47,22 @@ public class ControlDesignerTransparentBehaviorTests : IDisposable
     [Fact]
     public void TransparentBehavior_OnDragDrop_CallsDesignerOnDragDrop()
     {
-        ControlDesigner.TransparentBehavior behavior = new(_designer);
         DragEventArgs dragEventArgs = new(null, 0, 0, 0, DragDropEffects.Copy, DragDropEffects.None);
 
-        behavior.OnDragDrop(null, dragEventArgs);
+        _behavior.OnDragDrop(null, dragEventArgs);
 
-        Rectangle controlRect = GetControlRect(behavior);
+        Rectangle controlRect = GetControlRect(_behavior);
         controlRect.Should().Be(Rectangle.Empty);
     }
 
     [Fact]
     public void TransparentBehavior_OnDragEnter_SetsControlRect()
     {
-        ControlDesigner.TransparentBehavior behavior = new(_designer);
         DragEventArgs dragEventArgs = new(null, 0, 0, 0, DragDropEffects.Copy, DragDropEffects.None);
 
-        behavior.OnDragEnter(null, dragEventArgs);
+        _behavior.OnDragEnter(null, dragEventArgs);
 
-        Rectangle controlRect = GetControlRect(behavior);
+        Rectangle controlRect = GetControlRect(_behavior);
         controlRect.Should().NotBe(Rectangle.Empty);
         controlRect.Should().Be(_control.RectangleToScreen(_control.ClientRectangle));
     }
@@ -70,23 +70,21 @@ public class ControlDesignerTransparentBehaviorTests : IDisposable
     [Fact]
     public void TransparentBehavior_OnDragLeave_ClearsControlRect()
     {
-        ControlDesigner.TransparentBehavior behavior = new(_designer);
-        behavior.OnDragEnter(null, new DragEventArgs(null, 0, 0, 0, DragDropEffects.Copy, DragDropEffects.None));
+        _behavior.OnDragEnter(null, new DragEventArgs(null, 0, 0, 0, DragDropEffects.Copy, DragDropEffects.None));
 
-        behavior.OnDragLeave(null, EventArgs.Empty);
+        _behavior.OnDragLeave(null, EventArgs.Empty);
 
-        Rectangle controlRect = GetControlRect(behavior);
+        Rectangle controlRect = GetControlRect(_behavior);
         controlRect.Should().Be(Rectangle.Empty);
     }
 
     [Fact]
     public void TransparentBehavior_OnDragOver_SetsEffectToNoneIfOutsideControlRect()
     {
-        ControlDesigner.TransparentBehavior behavior = new(_designer);
-        behavior.OnDragEnter(null, new DragEventArgs(null, 0, 0, 0, DragDropEffects.Copy, DragDropEffects.None));
+        _behavior.OnDragEnter(null, new DragEventArgs(null, 0, 0, 0, DragDropEffects.Copy, DragDropEffects.None));
         DragEventArgs dragEventArgs = new(null, 0, int.MaxValue, int.MaxValue, DragDropEffects.Copy, DragDropEffects.Copy);
 
-        behavior.OnDragOver(null, dragEventArgs);
+        _behavior.OnDragOver(null, dragEventArgs);
 
         dragEventArgs.Effect.Should().Be(DragDropEffects.None);
     }
@@ -94,10 +92,9 @@ public class ControlDesignerTransparentBehaviorTests : IDisposable
     [Fact]
     public void TransparentBehavior_OnGiveFeedback_CallsDesignerOnGiveFeedback()
     {
-        ControlDesigner.TransparentBehavior behavior = new(_designer);
         GiveFeedbackEventArgs feedbackEventArgs = new(DragDropEffects.Copy, true);
 
-        Exception? exception = Record.Exception(() => behavior.OnGiveFeedback(null, feedbackEventArgs));
+        Exception? exception = Record.Exception(() => _behavior.OnGiveFeedback(null, feedbackEventArgs));
         exception.Should().BeNull();
     }
 }


### PR DESCRIPTION
Related https://github.com/dotnet/winforms/issues/10773


## Proposed changes

- Add unit test ControlDesigner.TransparentBehaviorTests.cs for public properties and method of the ControlDesigner.TransparentBehavior.
- Enable nullability in ControlDesigner.TransparentBehaviorTests.cs.


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12694)