### PR TITLE
Add a null-check for "DataGridView" property before executing OnMouseUp  in function OnMouseUpInternal

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewCell.cs
@@ -3040,6 +3040,8 @@ public abstract partial class DataGridViewCell : DataGridViewElement, ICloneable
             DataGridView.OnCommonCellContentClick(e.ColumnIndex, e.RowIndex, e.Clicks > 1);
         }
 
+        // Verify that the DataGridView is not null again,because a custom
+        // Click event handler may delete the cell and the parent DataGridView.
         if (DataGridView is not null && e.ColumnIndex < DataGridView.Columns.Count && e.RowIndex < DataGridView.Rows.Count)
         {
             OnMouseUp(e);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewCell.cs
@@ -3040,8 +3040,8 @@ public abstract partial class DataGridViewCell : DataGridViewElement, ICloneable
             DataGridView.OnCommonCellContentClick(e.ColumnIndex, e.RowIndex, e.Clicks > 1);
         }
 
-        // Verify that the DataGridView is not null again,because a custom
-        // Click event handler may delete the cell and the parent DataGridView.
+        // Verify that the DataGridView is not null again, because a custom
+        // Click event handler may delete the cell and the reference to parent DataGridView.
         if (DataGridView is not null && e.ColumnIndex < DataGridView.Columns.Count && e.RowIndex < DataGridView.Rows.Count)
         {
             OnMouseUp(e);
@@ -3762,16 +3762,16 @@ public abstract partial class DataGridViewCell : DataGridViewElement, ICloneable
             isFirstDisplayedColumn,
             isFirstDisplayedRow);
 
-        if (DataGridView?.EditingControl is not null)
+        if (DataGridView?.EditingControl is { } editingControl)
         {
             if (setLocation)
             {
-                DataGridView.EditingControl.Location = new Point(editingControlBounds.X, editingControlBounds.Y);
+                editingControl.Location = new Point(editingControlBounds.X, editingControlBounds.Y);
             }
 
             if (setSize)
             {
-                DataGridView.EditingControl.Size = new Size(editingControlBounds.Width, editingControlBounds.Height);
+                editingControl.Size = new Size(editingControlBounds.Width, editingControlBounds.Height);
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/DataGridView/DataGridViewCell.cs
@@ -3040,7 +3040,7 @@ public abstract partial class DataGridViewCell : DataGridViewElement, ICloneable
             DataGridView.OnCommonCellContentClick(e.ColumnIndex, e.RowIndex, e.Clicks > 1);
         }
 
-        if (e.ColumnIndex < DataGridView.Columns.Count && e.RowIndex < DataGridView.Rows.Count)
+        if (DataGridView is not null && e.ColumnIndex < DataGridView.Columns.Count && e.RowIndex < DataGridView.Rows.Count)
         {
             OnMouseUp(e);
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewCellTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewCellTests.cs
@@ -6515,7 +6515,7 @@ public partial class DataGridViewCellTests
 
         using DataGridView dataGridView = new();
         dataGridView.Columns.Add(column);
-        SubDataGridViewCheckBoxCell cell = (SubDataGridViewCheckBoxCell)dataGridView.Rows[0].Cells[0];
+        var cell = (SubDataGridViewCheckBoxCell)dataGridView.Rows[0].Cells[0];
 
         dataGridView.CellContentClick += new DataGridViewCellEventHandler((s, e) =>
         {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewCellTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewCellTests.cs
@@ -6503,6 +6503,35 @@ public partial class DataGridViewCellTests
             Times.Exactly(2));
     }
 
+    // Regression test for https://github.com/dotnet/winforms/issues/12692
+    [WinFormsFact]
+    public void DataGridViewCell_OnContentClick_ClearAndReAddCell_InvokeOnMouseUpInternal()
+    {
+        using SubDataGridViewCheckBoxCell cellTemplate = new();
+        using DataGridViewColumn column = new()
+        {
+            CellTemplate = cellTemplate
+        };
+
+        using DataGridView dataGridView = new();
+        dataGridView.Columns.Add(column);
+        SubDataGridViewCheckBoxCell cell = (SubDataGridViewCheckBoxCell)dataGridView.Rows[0].Cells[0];
+
+        dataGridView.CellContentClick += new DataGridViewCellEventHandler(dataGridView_CellContentClick);
+        string cellName = "TestCellName";
+        cell.Value = false;
+
+        Action act = () => cell.MouseClick(new DataGridViewCellMouseEventArgs(0, 0, 10, 10, new MouseEventArgs(MouseButtons.Left, 1, 10, 10, 0)));
+        act.Should().NotThrow();
+    }
+
+    private void dataGridView_CellContentClick(object sender, DataGridViewCellEventArgs e)
+    {
+        DataGridView dataGridView = (DataGridView)sender;
+        dataGridView.Rows.Clear();
+        dataGridView.Rows.Add();
+    }
+
     private class SubDataGridViewCheckBoxCell : DataGridViewCheckBoxCell
     {
         public SubDataGridViewCheckBoxCell()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewCellTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewCellTests.cs
@@ -6517,19 +6517,17 @@ public partial class DataGridViewCellTests
         dataGridView.Columns.Add(column);
         SubDataGridViewCheckBoxCell cell = (SubDataGridViewCheckBoxCell)dataGridView.Rows[0].Cells[0];
 
-        dataGridView.CellContentClick += new DataGridViewCellEventHandler(dataGridView_CellContentClick);
+        dataGridView.CellContentClick += new DataGridViewCellEventHandler((s, e) =>
+        {
+            DataGridView dataGridView = (DataGridView)s;
+            dataGridView.Rows.Clear();
+            dataGridView.Rows.Add();
+        });
         string cellName = "TestCellName";
         cell.Value = false;
 
         Action act = () => cell.MouseClick(new DataGridViewCellMouseEventArgs(0, 0, 10, 10, new MouseEventArgs(MouseButtons.Left, 1, 10, 10, 0)));
         act.Should().NotThrow();
-    }
-
-    private void dataGridView_CellContentClick(object sender, DataGridViewCellEventArgs e)
-    {
-        DataGridView dataGridView = (DataGridView)sender;
-        dataGridView.Rows.Clear();
-        dataGridView.Rows.Add();
     }
 
     private class SubDataGridViewCheckBoxCell : DataGridViewCheckBoxCell


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #12692

## Root Cause

- This issue is caused by PR #10406，which removes the check whether the control is null before executing `OnMouseUp` in file [DataGridViewCell.cs](https://github.com/dotnet/winforms/pull/10406/files#diff-2f4ea4bfa98a3298b78d36d7385f3100955c9fd85ee1254dfb802929029c5ce0R3098:~:text=%7D-,if%20(DataGridView%20is%20not%20null%20%26%26%20e.ColumnIndex%20%3C,%26%26%20e.RowIndex%20%3C%20DataGridView.Rows.Count),-Comment)
That fix moved the null check for the parent property grid to the top of the method. However, the parent can be set to null when this cell (or a row containing it) is deleted. In the user's case the row is deleted when the DGV cell is clicked.

## Proposed changes

- Add a check if `DataGridView is not null` before executing `OnMouseUp` in function `OnMouseUpInternal`, because the Parent DataGridView might have been disconnected in the user event handler that is executed before this call, for example if the user clears the DataGridView row.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Application crashes when the customer clicks on a DataGridView cell, where previously the content was selected.

## Regression? 

- Yes, from NET8, introduced by nullability changes in PR  #10406

## Risk

- Minimal, we are restoring the previous code, i.e. re-adding a null-check

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
**Object reference not set to an instance of an object** exception pops up after clicked the DataGridViewCell content when the function `DataGridView1_CellContentClick` contains content 
`DataGridView1.Rows.Clear(); `
`DataGridView1.Rows.Add(1, 0, "ABCD");`

![Image](https://github.com/user-attachments/assets/d8da01b1-ac5f-4e45-9ca9-a51399a9df4b)


### After
DataGridView Rows can be cleaned and re-added normally
![AfterChange](https://github.com/user-attachments/assets/05ec751a-73c2-4b61-9f3e-9f188900b661)


## Test methodology <!-- How did you ensure quality? -->

- Manually, added a unit test


## Test environment(s) <!-- Remove any that don't apply -->

- .net 10.0.0-alpha.1.24631.2


<!-- Mention language, UI scaling, or anything else that might be relevant -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12701)