### PR TITLE
fix issue 12680 [HDPI]The dot line disappeared between checkbox and Expand/collapse in HDPI mode

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/TreeView/TreeView.cs
@@ -1915,6 +1915,10 @@ public partial class TreeView : Control
         {
             PInvokeCore.SendMessage(this, PInvoke.TVM_SETINDENT, (WPARAM)_indent);
         }
+        else if (ScaleHelper.IsScalingRequired)
+        {
+            PInvokeCore.SendMessage(this, PInvoke.TVM_SETINDENT, (WPARAM)ScaleHelper.ScaleToInitialSystemDpi(DefaultTreeViewIndent));
+        }
 
         if (_itemHeight != -1)
         {


### PR DESCRIPTION
Fixes #12680 

## Root Cause
The default indent is 19, but we didn't scale it properly in HDPI mode.

## Proposed changes

- 
- scale indent properly in HDPI mode.
- 
<!--
## Customer Impact

- 
- 



## Risk

-

-->


## Screenshots 

### Before

![Image](https://github.com/user-attachments/assets/4bb10f90-cdd9-4db7-b695-96220ea98550)

### After

![image](https://github.com/user-attachments/assets/e1078590-a9dc-44d8-9109-aa1997fc76bd)


## Test methodology 

- 
- manually 
- 
<!--
## Accessibility testing  

## Test environment(s) 
-->
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12706)