### PR TITLE
add unit test for UserControlDocumentDesigner

### DIFF
--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/UserControlDocumentDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/UserControlDocumentDesignerTests.cs
@@ -3,16 +3,78 @@
 
 #nullable enable
 
+using System.ComponentModel.Design;
+using System.ComponentModel.Design.Serialization;
+using System.Drawing.Design;
+using System.Windows.Forms.Design.Behavior;
+using System.Windows.Forms.Design.Tests.Mocks;
+
+using Moq;
+
 namespace System.Windows.Forms.Design.Tests;
 
 public class UserControlDocumentDesignerTests
 {
-    [Fact]
+    [WinFormsFact]
     public void Constructor_ShouldSetAutoResizeHandlesToTrue()
     {
-        UserControlDocumentDesigner userControlDocumentDesigner;
-        userControlDocumentDesigner = new();
+        using UserControlDocumentDesigner designer = new();
+        using UserControl control = new();
 
-        userControlDocumentDesigner.AutoResizeHandles.Should().BeTrue();
+        Mock<IDesignerHost> designerHost = new();
+        Mock<IComponentChangeService> componentChangeService = new(MockBehavior.Strict);
+        designerHost
+            .Setup(s => s.GetService(typeof(IComponentChangeService)))
+            .Returns(componentChangeService.Object);
+        Mock<ISelectionService> selectionService = new(MockBehavior.Strict);
+        designerHost
+            .Setup(s => s.GetService(typeof(ISelectionService)))
+            .Returns(selectionService.Object);
+        designerHost
+            .Setup(s => s.GetService(typeof(IDesignerHost)))
+            .Returns(designerHost.Object);
+
+        var mockSite = MockSite.CreateMockSiteWithDesignerHost(designerHost.Object);
+        mockSite
+            .Setup(s => s.GetService(typeof(IExtenderProviderService)))
+            .Returns(null!);
+        mockSite
+            .Setup(s => s.GetService(typeof(IUIService)))
+            .Returns(null!);
+        mockSite
+            .Setup(s => s.GetService(typeof(IOverlayService)))
+            .Returns(null!);
+        mockSite
+            .Setup(s => s.GetService(typeof(IMenuCommandService)))
+            .Returns(null!);
+        mockSite
+            .Setup(s => s.GetService(typeof(INameCreationService)))
+            .Returns(null!);
+        mockSite
+            .Setup(s => s.GetService(typeof(IPropertyValueUIService)))
+            .Returns(null!);
+        Mock<IEventHandlerService> eventHandlerService = new(MockBehavior.Strict);
+        mockSite
+            .Setup(s => s.GetService(typeof(IEventHandlerService)))
+            .Returns(eventHandlerService.Object);
+        Mock<IDictionaryService> dictionaryService = new(MockBehavior.Strict);
+        dictionaryService
+            .Setup(s => s.GetValue(It.IsAny<object>()))
+            .Returns(null!);
+        dictionaryService
+            .Setup(s => s.SetValue(It.IsAny<object>(), It.IsAny<object>()));
+        mockSite
+            .Setup(s => s.GetService(typeof(IDictionaryService)))
+            .Returns(dictionaryService.Object);
+        mockSite
+            .Setup(s => s.GetService(typeof(ComponentCache)))
+            .Returns(null!);
+        mockSite
+            .Setup(s => s.GetService(typeof(BehaviorService)))
+            .Returns(null!);
+        control.Site = mockSite.Object;
+
+        designer.Initialize(control);
+        designer.AutoResizeHandles.Should().BeTrue();
     }
 }

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/UserControlDocumentDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/UserControlDocumentDesignerTests.cs
@@ -8,7 +8,6 @@ using System.ComponentModel.Design.Serialization;
 using System.Drawing.Design;
 using System.Windows.Forms.Design.Behavior;
 using System.Windows.Forms.Design.Tests.Mocks;
-
 using Moq;
 
 namespace System.Windows.Forms.Design.Tests;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/UserControlDocumentDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/UserControlDocumentDesignerTests.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+namespace System.Windows.Forms.Design.Tests;
+public class UserControlDocumentDesignerTests
+{
+    [Fact]
+    public void Constructor_ShouldSetAutoResizeHandlesToTrue()
+    {
+        UserControlDocumentDesigner userControl = new();
+
+        userControl.AutoResizeHandles.Should().BeTrue();
+    }
+}

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/UserControlDocumentDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/UserControlDocumentDesignerTests.cs
@@ -10,8 +10,9 @@ public class UserControlDocumentDesignerTests
     [Fact]
     public void Constructor_ShouldSetAutoResizeHandlesToTrue()
     {
-        UserControlDocumentDesigner userControl = new();
+        UserControlDocumentDesigner userControlDocumentDesigner;
+        userControlDocumentDesigner = new();
 
-        userControl.AutoResizeHandles.Should().BeTrue();
+        userControlDocumentDesigner.AutoResizeHandles.Should().BeTrue();
     }
 }

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/UserControlDocumentDesignerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/UserControlDocumentDesignerTests.cs
@@ -4,6 +4,7 @@
 #nullable enable
 
 namespace System.Windows.Forms.Design.Tests;
+
 public class UserControlDocumentDesignerTests
 {
     [Fact]


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Related https://github.com/dotnet/winforms/issues/10773


## Proposed changes

- Add unit test UserControlDocumentDesignerTests.cs for public properties and method of the UserControlDocumentDesigner.UserControlDocumentDesigner.
- Enable nullability in UserControlDocumentDesignerTests.cs.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12710)