### PR TITLE
[release/9.0] Get rid of an unexpected white line above the status strip due to a changed renderer

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/StatusStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/StatusStrip.cs
@@ -29,10 +29,7 @@ public partial class StatusStrip : ToolStrip
         SuspendLayout();
         CanOverflow = false;
         LayoutStyle = ToolStripLayoutStyle.Table;
-
-        // Default changed for SystemColorMode from System to ManagerRenderMode.
-        // Also to be consistent to the MenuStrip.
-        RenderMode = ToolStripRenderMode.ManagerRenderMode;
+        RenderMode = ToolStripRenderMode.System;
         GripStyle = ToolStripGripStyle.Hidden;
 
         SetStyle(ControlStyles.ResizeRedraw, true);
@@ -361,6 +358,17 @@ public partial class StatusStrip : ToolStrip
         }
 
         EnsureRightToLeftGrip();
+    }
+
+    internal override void ResetRenderMode()
+    {
+        RenderMode = ToolStripRenderMode.System;
+    }
+
+    internal override bool ShouldSerializeRenderMode()
+    {
+        // We should NEVER serialize custom.
+        return (RenderMode is not ToolStripRenderMode.System and not ToolStripRenderMode.Custom);
     }
 
     internal override bool SupportsUiaProviders => true;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripHighContrastRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripHighContrastRenderer.cs
@@ -146,8 +146,9 @@ internal class ToolStripHighContrastRenderer : ToolStripSystemRenderer
             else if (item.Selected)
             {
                 g.FillRectangle(SystemBrushes.Highlight, bounds);
+                g.DrawRectangle(SystemPens.HighlightText, dropDownRect);
+
                 DrawHightContrastDashedBorder(g, e.Item);
-                g.DrawRectangle(SystemPens.ButtonHighlight, dropDownRect);
             }
 
             Color arrowColor = item.Selected && !item.Pressed ? SystemColors.HighlightText : SystemColors.ControlText;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripSystemRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripSystemRenderer.cs
@@ -575,6 +575,17 @@ public class ToolStripSystemRenderer : ToolStripRenderer
             {
                 DrawArrow(new ToolStripArrowRenderEventArgs(g, splitButton, splitButton.DropDownButtonBounds, arrowColor, ArrowDirection.Down));
             }
+
+            ToolBarState state = GetToolBarState(e.Item);
+            if (e.Item is ToolStripSplitButton item && !SystemInformation.HighContrast &&
+                (state == ToolBarState.Hot || state == ToolBarState.Pressed || state == ToolBarState.Checked))
+            {
+                var clientBounds = item.ClientBounds;
+                bounds.Height -= 1;
+                ControlPaint.DrawBorderSimple(g, clientBounds, SystemColors.Highlight);
+                using var brush = SystemColors.Highlight.GetCachedSolidBrushScope();
+                g.FillRectangle(brush, item.SplitterBounds);
+            }
         }
         else
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolstripProfessionalRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolstripProfessionalRenderer.cs
@@ -296,7 +296,10 @@ public class ToolStripProfessionalRenderer : ToolStripRenderer
 
         if (buttonPressedOrSelected && !item.Pressed)
         {
-            using var brush = ColorTable.ButtonSelectedBorder.GetCachedSolidBrushScope();
+#pragma warning disable WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+            using var brush = Application.IsDarkModeEnabled ?
+                Color.Silver.GetCachedSolidBrushScope() : ColorTable.ButtonSelectedBorder.GetCachedSolidBrushScope();
+#pragma warning restore WFO5001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
             g.FillRectangle(brush, item.SplitterBounds);
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/StatusStripTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/StatusStripTests.cs
@@ -556,7 +556,7 @@ public partial class StatusStripTests
 
         control.RenderMode = ToolStripRenderMode.System;
         Assert.Equal(ToolStripRenderMode.System, control.RenderMode);
-        Assert.True(property.CanResetValue(control));
+        Assert.False(property.CanResetValue(control));
 
         control.Renderer = new SubToolStripRenderer();
         Assert.Equal(ToolStripRenderMode.Custom, control.RenderMode);
@@ -564,10 +564,10 @@ public partial class StatusStripTests
 
         control.RenderMode = ToolStripRenderMode.ManagerRenderMode;
         Assert.Equal(ToolStripRenderMode.ManagerRenderMode, control.RenderMode);
-        Assert.False(property.CanResetValue(control));
+        Assert.True(property.CanResetValue(control));
 
         property.ResetValue(control);
-        Assert.Equal(ToolStripRenderMode.ManagerRenderMode, control.RenderMode);
+        Assert.Equal(ToolStripRenderMode.System, control.RenderMode);
         Assert.False(property.CanResetValue(control));
     }
 
@@ -584,7 +584,7 @@ public partial class StatusStripTests
 
         control.RenderMode = ToolStripRenderMode.System;
         Assert.Equal(ToolStripRenderMode.System, control.RenderMode);
-        Assert.True(property.ShouldSerializeValue(control));
+        Assert.False(property.ShouldSerializeValue(control));
 
         control.Renderer = new SubToolStripRenderer();
         Assert.Equal(ToolStripRenderMode.Custom, control.RenderMode);
@@ -592,10 +592,10 @@ public partial class StatusStripTests
 
         control.RenderMode = ToolStripRenderMode.ManagerRenderMode;
         Assert.Equal(ToolStripRenderMode.ManagerRenderMode, control.RenderMode);
-        Assert.False(property.ShouldSerializeValue(control));
+        Assert.True(property.ShouldSerializeValue(control));
 
         property.ResetValue(control);
-        Assert.Equal(ToolStripRenderMode.ManagerRenderMode, control.RenderMode);
+        Assert.Equal(ToolStripRenderMode.System, control.RenderMode);
         Assert.False(property.ShouldSerializeValue(control));
     }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripButtonTests.Rendering.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripButtonTests.Rendering.cs
@@ -162,8 +162,9 @@ public partial class ToolStripButtonTests
                 bounds: null,
                 points: null,
                 State.Brush(SystemColors.Highlight, BRUSH_STYLE.BS_SOLID)),
+           Validate.SkipType(ENHANCED_METAFILE_RECORD_TYPE.EMR_POLYGON16),
            Validate.Repeat(Validate.SkipType(ENHANCED_METAFILE_RECORD_TYPE.EMR_POLYPOLYGON16), 2),
-           Validate.Repeat(Validate.SkipType(ENHANCED_METAFILE_RECORD_TYPE.EMR_POLYGON16), 2));
+           Validate.SkipType(ENHANCED_METAFILE_RECORD_TYPE.EMR_POLYGON16));
     }
 
     private class ToolStripSystemHighContrastRenderer : ToolStripSystemRenderer


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Back port pr #12646 and #12092 to release9.0
Fixes #12616

## Bug Description

In NET9 to fix accessibility color contrast issue #11450  (the contrast between the focus color and the background color of the `ToolStripSplitButton` in the `StatusStrip` control is less than 3:1), the rendering mode of the `StatusStrip` control was changed in PR #12045. But this fix caused the issue #12616: unexpected white lines appearing in the StatusStrip component when the dialog background is dark.
We had redone the fix for color contrast issue #11450 in NET10 (PR #12092)，by changing Pen to a more contrasting one in `ToolStripSystemRenderer`, `ToolStripHighContrastRenderer` and `ToolstripProfessionalRenderer`, so that the `ToolStripSplitButton` can achieve sufficient contrast regardless of the High Contrast theme or when it gets the focus.
Thus the original fix that replaced the renderer is not needed, and we are reverting that commit and porting the NET10 fix to NET9.

## Customer Impact

- If a dialog has a dark background and uses a `StatusStrip`, an unexpected white line shows in the dialog. This regression was reported by the customer.

## Regression? 

- Yes, it's fine in dotnet 8. This is due to [#11502](https://github.com/dotnet/winforms/pull/11502), in the PR, the default RenderMode of StatusStrip was changed from System to ManagerRenderMode.

## Risk

- Low

## Testing

- Manual testing with the user-provided project and AccessibilityInsights color contrast tool.
- Automation regression test


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12719)