### PR TITLE
fix #12591 Undo operation in DemoConsole causes ContextMenuStrip to become unusable

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStrip.cs
@@ -4683,7 +4683,7 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
     internal void OnItemRemovedInternal(ToolStripItem item, ToolStripItemCollection itemCollection)
     {
         KeyboardToolTipStateMachine.Instance.Unhook(item, ToolTip);
-        if (itemCollection == _toolStripItemCollection)
+        if (itemCollection == _toolStripItemCollection && !DesignMode)
         {
             // To prevent memory leaks when item removed from main collection,
             // we need to remove it from _displayedItems and _overflowItems too.


### PR DESCRIPTION

Fixes #12591

## root cause
In design mode. ContextMenuStript.items contains some default items which have some functionality.

[This PR](https://github.com/dotnet/winforms/pull/11358) addressed [the memory leak issue](https://github.com/dotnet/winforms/issues/4808) which I think is a runtime issue.

## Proposed changes

- 
- Add DesignMode condition to exclude removing logic.
- 

<!-- 

## Customer Impact

- 
- 

## Regression? 

- Yes / No
 -->
## Risk

- low




## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

https://github.com/user-attachments/assets/e108dec4-3987-4687-ab01-3868acfc7e00

### After


https://github.com/user-attachments/assets/747bacbb-4f56-4aec-8b4d-f5f0b383e9e8



https://github.com/user-attachments/assets/a8cc603a-6a79-4519-a2ff-a610fbd24a14



## Test methodology 
- 
- manual 
- 


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12720)