### PR TITLE
[release/8.0] Update MicroBuild to v4

### DIFF
--- a/eng/pipelines/build-PR.yml
+++ b/eng/pipelines/build-PR.yml
@@ -49,7 +49,7 @@ jobs:
         env:
           Token: $(dn-bot-dnceng-artifact-feeds-rw)
 
-      - task: MicroBuildSigningPlugin@2
+      - task: MicroBuildSigningPlugin@4
         displayName: Install MicroBuild plugin for Signing
         inputs:
           signType: $(_SignType)

--- a/eng/pipelines/build.yml
+++ b/eng/pipelines/build.yml
@@ -56,7 +56,7 @@ jobs:
     env:
       Token: $(dn-bot-dnceng-artifact-feeds-rw)
 
-  - task: MicroBuildSigningPlugin@2
+  - task: MicroBuildSigningPlugin@4
     displayName: Install MicroBuild plugin for Signing
     inputs:
       signType: $(_SignType)


### PR DESCRIPTION
Infrastructure change only. This change updates MicroBuild version to get CI build passing for release/8.0 as it currently fails due to out of date MicroBuild version

Same change was done to main in https://github.com/dotnet/winforms/pull/12666
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12724)