### PR TITLE
Revert #4808 fix. Due to #12591 and investigations.

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStrip.cs
@@ -4680,16 +4680,9 @@ public partial class ToolStrip : ScrollableControl, IArrangedElement, ISupportTo
         }
     }
 
-    internal void OnItemRemovedInternal(ToolStripItem item, ToolStripItemCollection itemCollection)
+    internal void OnItemRemovedInternal(ToolStripItem item)
     {
         KeyboardToolTipStateMachine.Instance.Unhook(item, ToolTip);
-        if (itemCollection == _toolStripItemCollection)
-        {
-            // To prevent memory leaks when item removed from main collection,
-            // we need to remove it from _displayedItems and _overflowItems too.
-            _displayedItems?.Remove(item);
-            _overflowItems?.Remove(item);
-        }
     }
 
     internal override bool AllowsChildrenToShowToolTips()

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripItemCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripItemCollection.cs
@@ -391,7 +391,7 @@ public class ToolStripItemCollection : ArrangedElementCollection, IList
 
             if (_owner is not null)
             {
-                _owner.OnItemRemovedInternal(item, this);
+                _owner.OnItemRemovedInternal(item);
 
                 if (!_owner.IsDisposingItems)
                 {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripTests.cs
@@ -7337,37 +7337,6 @@ public partial class ToolStripTests
         }
     }
 
-    [WinFormsFact]
-    public void ToolStrip_displayedItems_Clear()
-    {
-        using ToolStripMenuItem toolStripMenuItem = new(nameof(toolStripMenuItem));
-        using ToolStripMenuItem listToolStripMenuItem = new(nameof(listToolStripMenuItem));
-        toolStripMenuItem.DropDownItems.Add(listToolStripMenuItem);
-        toolStripMenuItem.DropDownOpened += (sender, e) =>
-        {
-            for (int i = 0; i < 4; i++)
-                listToolStripMenuItem.DropDownItems.Add("MenuItem" + i);
-
-            listToolStripMenuItem.DropDown.PerformLayout(); // needed to populate DisplayedItems collection
-        };
-
-        toolStripMenuItem.DropDownClosed += (sender, e) =>
-        {
-            while (listToolStripMenuItem.DropDownItems.Count > 0)
-                listToolStripMenuItem.DropDownItems[listToolStripMenuItem.DropDownItems.Count - 1].Dispose();
-
-            GC.Collect();
-            GC.WaitForPendingFinalizers();
-            GC.Collect();
-            GC.WaitForPendingFinalizers();
-        };
-
-        toolStripMenuItem.ShowDropDown();
-        Assert.Equal(4, listToolStripMenuItem.DropDown.DisplayedItems.Count);
-        toolStripMenuItem.HideDropDown();
-        Assert.Empty(listToolStripMenuItem.DropDown.DisplayedItems);
-    }
-
     [WinFormsTheory]
     [InlineData(10, 10)]
     [InlineData(0, 0)]


### PR DESCRIPTION
Fix #12591.
This revert #4808 fix commit from #11358 PR.

The clean up of `DisplayedItems` after removal **has already been implemented** in `DoLayoutIfHandleCreated` but only if handle is created:
https://github.com/dotnet/winforms/blob/034543a7f08086c5ce29d85beaafcae70c3a33a5/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStrip.cs#L3218-L3224
https://github.com/dotnet/winforms/blob/034543a7f08086c5ce29d85beaafcae70c3a33a5/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStrip.cs#L3244-L3247

So we have leak only if handle is destroyed (#4808 case) and we didn't take this into account :(
All are much more complicated than [originally intended](https://github.com/dotnet/winforms/issues/4808#issuecomment-1849319594). And lead to some side affect see this [comment](https://github.com/dotnet/winforms/issues/12591#issuecomment-2573054446).

I think that is safer to revert the fix and reopen #4808 then.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12729)