### PR TITLE
[release/8.0] Fix #12661 Null Reference Exception: System.Windows.Forms.TabControl<WmSelChange>

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
@@ -1970,7 +1970,14 @@ public partial class TabControl : Control
             if (IsAccessibilityObjectCreated && SelectedTab?.ParentInternal is TabControl)
             {
                 SelectedTab.TabAccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.SelectionItem_ElementSelectedEventId);
-                BeginInvoke((MethodInvoker)(() => SelectedTab.TabAccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId)));
+                BeginInvoke((MethodInvoker)(() =>
+                {
+                    if (IsAccessibilityObjectCreated && SelectedTab?.ParentInternal is TabControl &&
+                         !SelectedTab.IsDisposed && SelectedTab.TabAccessibilityObject is not null)
+                    {
+                        SelectedTab.TabAccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
+                    }
+                }));
             }
         }
         else

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControlTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControlTests.cs
@@ -5704,6 +5704,40 @@ public class TabControlTests
         Assert.Equal(text, actual);
     }
 
+    [WinFormsFact]
+    public void TabControl_WmSelChange_SelectedTabIsNull_DoesNotThrowException()
+    {
+        using Form form = new();
+        using TabControl control = new();
+        using TabPage page1 = new("text1");
+        control.TabPages.Add(page1);
+        _ = control.AccessibilityObject;
+
+        form.Controls.Add(control);
+        form.Show();
+        control.SelectedIndex = 0;
+
+        Action act = () => control.TestAccessor().Dynamic.WmSelChange();
+        try
+        {
+            act();
+        }
+        catch (Exception ex)
+        {
+            Assert.Fail($"Expected no exception, but got: {ex}");
+        }
+
+        control.TabPages.Clear();
+
+        var exception = Record.Exception(() =>
+        {
+            Application.DoEvents();
+            Thread.Sleep(100);
+        });
+
+        Assert.Null(exception);
+    }
+
     private class SubTabPage : TabPage
     {
     }


### PR DESCRIPTION
Backport of #12683 to release/8.0
Fixes https://github.com/dotnet/winforms/issues/12661

### Customer Impact
A customer reported a crash in their application that uses WinForms TabControl and requested a fix in NET8 release. Application is running under accessibility tools and is removing TabPages from a control dynamically. When the selected page is removed, the selection moves to the next page and the corresponding accessibility event is queued using BeginInvoke to be raised. If by the time the event is raised, the page is removed, a NullReferenceException is thrown. No workaround is available.

### Fix
Test if the selected page is still available before raising the accessibility event inside the BeginInvoke delegate.

### Testing
Manual with the customer repro case and unit tests.

## Risk
Low - this is an additional validation only.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12731)