### PR TITLE
Update the Update_ToolStripPanelControlCollection_XYCompareTestsFiler…

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripPanel.ToolStripPanelControlCollection.XYComparerTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripPanel.ToolStripPanelControlCollection.XYComparerTests.cs
@@ -7,7 +7,7 @@ using System.Drawing;
 
 namespace System.Windows.Forms.Tests;
 
-public class ToolStripPanel_ToolStripPanelControlCollection_XYComparerTests
+public class ToolStripPanel_ToolStripPanelControlCollection_XYComparerTests : IDisposable
 {
     private readonly ToolStripPanel.ToolStripPanelControlCollection.XYComparer _comparer = new();
     private readonly Control _control1 = new() { Bounds = new Rectangle(10, 20, 100, 100) };


### PR DESCRIPTION
related https://github.com/dotnet/winforms/issues/10453

## Proposed changes
Update the Update_ToolStripPanelControlCollection_XYCompareTestsFile to let the test class inherit from the IDisposable interface.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12736)