### PR TITLE
Revert changes in PR11529 and PR11761

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.FlatComboAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.FlatComboAdapter.cs
@@ -23,9 +23,7 @@ public partial class ComboBox
         private const int OFFSET_2PIXELS = 2;
         protected static int s_offsetPixels = OFFSET_2PIXELS;
 
-        private bool ShouldRedrawAsSmallButton { get; }
-
-        public FlatComboAdapter(ComboBox comboBox, bool shouldRedrawAsSmallButton)
+        public FlatComboAdapter(ComboBox comboBox, bool smallButton)
         {
             // adapter is re-created when ComboBox is resized, see IsValid method, thus we don't need to handle DPI changed explicitly
             s_offsetPixels = comboBox.LogicalToDeviceUnits(OFFSET_2PIXELS);
@@ -37,10 +35,8 @@ public partial class ComboBox
             _innerInnerBorder = new Rectangle(_innerBorder.X + 1, _innerBorder.Y + 1, _innerBorder.Width - 2, _innerBorder.Height - 2);
             _dropDownRect = new Rectangle(_innerBorder.Right + 1, _innerBorder.Y, dropDownButtonWidth, _innerBorder.Height + 1);
 
-            ShouldRedrawAsSmallButton = shouldRedrawAsSmallButton;
-
             // fill in several pixels of the dropdown rect with white so that it looks like the combo button is thinner.
-            if (shouldRedrawAsSmallButton)
+            if (smallButton)
             {
                 _whiteFillRect = _dropDownRect;
                 _whiteFillRect.Width = WhiteFillRectWidth;
@@ -69,11 +65,6 @@ public partial class ComboBox
             if (comboBox.DropDownStyle == ComboBoxStyle.Simple)
             {
                 return;
-            }
-
-            if (ShouldRedrawAsSmallButton)
-            {
-                DrawFlatCombo(comboBox, g);
             }
 
             bool rightToLeft = comboBox.RightToLeft == RightToLeft.Yes;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.FlatComboAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.FlatComboAdapter.cs
@@ -60,43 +60,6 @@ public partial class ComboBox
             return (combo.ClientRectangle == _clientRect && combo.RightToLeft == _origRightToLeft);
         }
 
-        public virtual void DrawPopUpCombo(ComboBox comboBox, Graphics g)
-        {
-            if (comboBox.DropDownStyle == ComboBoxStyle.Simple)
-            {
-                return;
-            }
-
-            bool rightToLeft = comboBox.RightToLeft == RightToLeft.Yes;
-
-            // Draw a dark border around everything if we're in popup mode
-            if ((!comboBox.Enabled) || (comboBox.FlatStyle == FlatStyle.Popup))
-            {
-                bool focused = comboBox.ContainsFocus || comboBox.MouseIsOver;
-                Color borderPenColor = GetPopupOuterBorderColor(comboBox, focused);
-
-                using var borderPen = borderPenColor.GetCachedPenScope();
-                Pen innerPen = comboBox.Enabled ? borderPen : SystemPens.Control;
-
-                // Draw a border around the dropdown.
-                if (rightToLeft)
-                {
-                    g.DrawRectangle(
-                        innerPen,
-                        new Rectangle(_outerBorder.X, _outerBorder.Y, _dropDownRect.Width + 1, _outerBorder.Height));
-                }
-                else
-                {
-                    g.DrawRectangle(
-                        innerPen,
-                        new Rectangle(_dropDownRect.X, _outerBorder.Y, _outerBorder.Right - _dropDownRect.X, _outerBorder.Height));
-                }
-
-                // Draw a border around the whole ComboBox.
-                g.DrawRectangle(borderPen, _outerBorder);
-            }
-        }
-
         /// <summary>
         ///  Paints over the edges of the combo box to make it appear flat.
         /// </summary>
@@ -144,6 +107,33 @@ public partial class ComboBox
             using var innerBorderPen = innerBorderColor.GetCachedPenScope();
             g.DrawRectangle(innerBorderPen, _innerBorder);
             g.DrawRectangle(innerBorderPen, _innerInnerBorder);
+
+            // Draw a dark border around everything if we're in popup mode
+            if ((!comboBox.Enabled) || (comboBox.FlatStyle == FlatStyle.Popup))
+            {
+                bool focused = comboBox.ContainsFocus || comboBox.MouseIsOver;
+                Color borderPenColor = GetPopupOuterBorderColor(comboBox, focused);
+
+                using var borderPen = borderPenColor.GetCachedPenScope();
+                Pen innerPen = comboBox.Enabled ? borderPen : SystemPens.Control;
+
+                // Around the dropdown
+                if (rightToLeft)
+                {
+                    g.DrawRectangle(
+                        innerPen,
+                        new Rectangle(_outerBorder.X, _outerBorder.Y, _dropDownRect.Width + 1, _outerBorder.Height));
+                }
+                else
+                {
+                    g.DrawRectangle(
+                        innerPen,
+                        new Rectangle(_dropDownRect.X, _outerBorder.Y, _outerBorder.Right - _dropDownRect.X, _outerBorder.Height));
+                }
+
+                // Around the whole combobox.
+                g.DrawRectangle(borderPen, _outerBorder);
+            }
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.cs
@@ -3856,5 +3856,5 @@ public partial class ComboBox : ListControl
     }
 
     internal virtual FlatComboAdapter CreateFlatComboAdapterInstance()
-        => new(this, shouldRedrawAsSmallButton: false);
+        => new(this, smallButton: false);
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ComboBox/ComboBox.cs
@@ -3765,14 +3765,7 @@ public partial class ComboBox : ListControl
                     }
 
                     using Graphics g = Graphics.FromHdcInternal((IntPtr)dc);
-                    if ((!Enabled || FlatStyle == FlatStyle.Popup) && MouseIsOver)
-                    {
-                        FlatComboBoxAdapter.DrawPopUpCombo(this, g);
-                    }
-                    else
-                    {
-                        FlatComboBoxAdapter.DrawFlatCombo(this, g);
-                    }
+                    FlatComboBoxAdapter.DrawFlatCombo(this, g);
 
                     return;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripComboBox.ToolStripComboBoxControl.ToolStripComboBoxFlatComboAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Controls/ToolStrips/ToolStripComboBox.ToolStripComboBoxControl.ToolStripComboBoxFlatComboAdapter.cs
@@ -12,7 +12,7 @@ public partial class ToolStripComboBox
     {
         internal class ToolStripComboBoxFlatComboAdapter : FlatComboAdapter
         {
-            public ToolStripComboBoxFlatComboAdapter(ComboBox comboBox) : base(comboBox, shouldRedrawAsSmallButton: true)
+            public ToolStripComboBoxFlatComboAdapter(ComboBox comboBox) : base(comboBox, smallButton: true)
             {
             }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #12590

## Root Cause

In order to fix the flickering issue#[2053861](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2053861), I modified the drawing logic of ComboBox in https://github.com/dotnet/winforms/pull/11529, this leads to the current issue and issue #11760.

## Proposed changes

- Revert the changes on PR #11529 and PR #11761

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- ComboBox dropdown button can be shown normally when switching RightToLeft property, or recreating the combobox for any other reason.

## Regression? 

- Yes 

## Risk

- Minimal

<!-- end TELL-MODE -->


### Before
When change the **RightToLeft** property **after expanding** the **Popup FlatStyle** comboBox, the dropdown button on the comboBox disappeared
![Image](https://github.com/user-attachments/assets/2e730e12-e569-462b-812a-dcb8cf7ce2b6)

### After
The dropdown button on the comboBox can be show normally
![AfterChanges](https://github.com/user-attachments/assets/41bcbfea-1c44-4ee4-b875-87eada359f38)


## Test methodology <!-- How did you ensure quality? -->

- Manually

## Test environment(s) <!-- Remove any that don't apply -->

- .net 10.0.0-alpha.1.24605.1


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12737)