### PR TITLE
Only Unwrap If Given IDataObject

### DIFF
--- a/src/System.Private.Windows.Core/src/Windows/Win32/System/Com/ComHelpers.cs
+++ b/src/System.Private.Windows.Core/src/Windows/Win32/System/Com/ComHelpers.cs
@@ -132,7 +132,7 @@ internal static unsafe partial class ComHelpers
     /// <summary>
     ///  Attempts to unwrap a ComWrapper CCW as a particular managed object.
     /// </summary>
-    private static bool TryUnwrapComWrapperCCW<TWrapper>(
+    public static bool TryUnwrapComWrapperCCW<TWrapper>(
         IUnknown* unknown,
         [NotNullWhen(true)] out TWrapper? @interface) where TWrapper : class
     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/Clipboard.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/Clipboard.cs
@@ -51,15 +51,13 @@ public static class Clipboard
         ArgumentOutOfRangeException.ThrowIfNegative(retryTimes);
         ArgumentOutOfRangeException.ThrowIfNegative(retryDelay);
 
-        // Always wrap the data in our DataObject since we know how to retrieve our DataObject from the proxy OleGetClipboard returns.
-        DataObject wrappedData = data is DataObject { IsWrappedForClipboard: true } alreadyWrapped
-            ? alreadyWrapped
-            : new DataObject(data) { IsWrappedForClipboard = true };
-        using var dataObject = ComHelpers.GetComScope<Com.IDataObject>(wrappedData);
+        // Always wrap the data if not already a DataObject. Mark whether the data is an IDataObject so we unwrap it properly on retrieval.
+        DataObject dataObject = data as DataObject ?? new DataObject(data) { IsOriginalNotIDataObject = data is not IDataObject };
+        using var iDataObject = ComHelpers.GetComScope<Com.IDataObject>(dataObject);
 
         HRESULT hr;
         int retry = retryTimes;
-        while ((hr = PInvoke.OleSetClipboard(dataObject)).Failed)
+        while ((hr = PInvoke.OleSetClipboard(iDataObject)).Failed)
         {
             if (--retry < 0)
             {
@@ -111,52 +109,24 @@ public static class Clipboard
 
         // OleGetClipboard always returns a proxy. The proxy forwards all IDataObject method calls to the real data object,
         // without giving out the real data object. If the data placed on the clipboard is not one of our CCWs or the clipboard
-        // has been flushed, marshal will create a wrapper around the proxy for us to use. However, if the data placed on
+        // has been flushed, a wrapper around the proxy for us to use will be given. However, if the data placed on
         // the clipboard is one of our own and the clipboard has not been flushed, we need to retrieve the real data object
-        // pointer in order to retrieve the original managed object via ComWrappers. To do this, we must query for an
-        // interface that is not known to the proxy e.g. IComCallableWrapper. If we are able to query for IComCallableWrapper
-        // it means that the real data object is one of our CCWs and we've retrieved it successfully,
+        // pointer in order to retrieve the original managed object via ComWrappers if an IDataObject was set on the clipboard.
+        // To do this, we must query for an interface that is not known to the proxy e.g. IComCallableWrapper.
+        // If we are able to query for IComCallableWrapper it means that the real data object is one of our CCWs and we've retrieved it successfully,
         // otherwise it is not ours and we will use the wrapped proxy.
-        IUnknown* target = default;
         var realDataObject = proxyDataObject.TryQuery<IComCallableWrapper>(out hr);
-        if (hr.Succeeded)
+
+        if (hr.Succeeded
+            && ComHelpers.TryUnwrapComWrapperCCW(realDataObject.AsUnknown, out DataObject? dataObject)
+            && !dataObject.IsOriginalNotIDataObject)
         {
-            target = realDataObject.AsUnknown;
-        }
-        else
-        {
-            target = proxyDataObject.AsUnknown;
+            // An IDataObject was given to us to place on the clipboard. We want to unwrap and return it instead of a proxy.
+            return dataObject.TryUnwrapInnerIDataObject();
         }
 
-        if (!ComHelpers.TryGetObjectForIUnknown(target, out object? managedDataObject))
-        {
-            target->Release();
-            return null;
-        }
-
-        if (managedDataObject is not Com.IDataObject.Interface dataObject)
-        {
-            // We always wrap data set on the Clipboard in a DataObject, so if we do not have
-            // a IDataObject.Interface this means built-in com support is turned off and
-            // we have a proxy where there is no way to retrieve the original data object
-            // pointer from it likely because either the clipboard was flushed or the data on the
-            // clipboard is from another process. We need to mimic built-in com behavior and wrap the proxy ourselves.
-            // DataObject will ref count proxyDataObject properly to take ownership.
-            return new DataObject(proxyDataObject.Value);
-        }
-
-        if (dataObject is DataObject { IsWrappedForClipboard: true } wrappedData)
-        {
-            // There is a DataObject on the clipboard that we placed there. If the real data object
-            // implements IDataObject, we want to unwrap it and return it. Otherwise return
-            // the DataObject as is.
-            return wrappedData.TryUnwrapInnerIDataObject();
-        }
-
-        // We did not place the data on the clipboard. Fall back to old behavior.
-        return dataObject is IDataObject ido && !Marshal.IsComObject(dataObject)
-            ? ido
-            : new DataObject(dataObject);
+        // Original data given wasn't an IDataObject, give the proxy value back.
+        return new DataObject(proxyDataObject.Value);
     }
 
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OLE/DataObject.cs
@@ -84,9 +84,9 @@ public unsafe partial class DataObject :
     internal DataObject(string format, bool autoConvert, object data) : this() => SetData(format, autoConvert, data);
 
     /// <summary>
-    ///  Flags that the original data was wrapped for clipboard purposes.
+    ///  Flags that the original data was not a user passed <see cref="IDataObject"/>.
     /// </summary>
-    internal bool IsWrappedForClipboard { get; init; }
+    internal bool IsOriginalNotIDataObject { get; init; }
 
     /// <summary>
     ///  Returns the inner data that the <see cref="DataObject"/> was created with if the original data implemented
@@ -95,7 +95,7 @@ public unsafe partial class DataObject :
     /// </summary>
     internal IDataObject TryUnwrapInnerIDataObject()
     {
-        Debug.Assert(IsWrappedForClipboard, "This method should only be used for clipboard purposes.");
+        Debug.Assert(!IsOriginalNotIDataObject, "This method should only be used for clipboard purposes.");
         return _innerData.OriginalIDataObject is { } original ? original : this;
     }
 

--- a/src/System.Windows.Forms/tests/ComDisabledTests/ClipboardComTests.cs
+++ b/src/System.Windows.Forms/tests/ComDisabledTests/ClipboardComTests.cs
@@ -3,7 +3,9 @@
 
 #nullable enable
 
+using System.Runtime.InteropServices;
 using static System.Windows.Forms.TestUtilities.DataObjectTestHelpers;
+using ComTypes = System.Runtime.InteropServices.ComTypes;
 
 namespace System.Windows.Forms.Tests;
 
@@ -49,5 +51,69 @@ public class ClipboardComTests
         ITypedDataObject returnedDataObject = Clipboard.GetDataObject().Should().BeAssignableTo<ITypedDataObject>().Subject;
         returnedDataObject.TryGetData("testData", out SimpleTestData deserialized).Should().BeTrue();
         deserialized.Should().BeEquivalentTo(testData);
+    }
+
+    [WinFormsFact]
+    public void Clipboard_GetSet_IDataObject_RoundTrip_ReturnsExpected()
+    {
+        CustomDataObject realDataObject = new();
+        Clipboard.SetDataObject(realDataObject);
+
+        IDataObject clipboardDataObject = Clipboard.GetDataObject().Should().BeAssignableTo<IDataObject>().Subject;
+        clipboardDataObject.Should().BeSameAs(realDataObject);
+        clipboardDataObject.GetDataPresent("Foo").Should().BeTrue();
+        clipboardDataObject.GetData("Foo").Should().Be("Bar");
+    }
+
+    [WinFormsFact]
+    public void Clipboard_SetDataObject_DerivedDataObject_ReturnsExpected()
+    {
+        DerivedDataObject derived = new();
+        Clipboard.SetDataObject(derived);
+        Clipboard.GetDataObject().Should().BeSameAs(derived);
+    }
+
+    private class DerivedDataObject : DataObject { }
+
+    private class CustomDataObject : IDataObject, ComTypes.IDataObject
+    {
+        [DllImport("shell32.dll")]
+        public static extern int SHCreateStdEnumFmtEtc(uint cfmt, ComTypes.FORMATETC[] afmt, out ComTypes.IEnumFORMATETC ppenumFormatEtc);
+
+        int ComTypes.IDataObject.DAdvise(ref ComTypes.FORMATETC pFormatetc, ComTypes.ADVF advf, ComTypes.IAdviseSink adviseSink, out int connection) => throw new NotImplementedException();
+        void ComTypes.IDataObject.DUnadvise(int connection) => throw new NotImplementedException();
+        int ComTypes.IDataObject.EnumDAdvise(out ComTypes.IEnumSTATDATA enumAdvise) => throw new NotImplementedException();
+        ComTypes.IEnumFORMATETC ComTypes.IDataObject.EnumFormatEtc(ComTypes.DATADIR direction)
+        {
+            if (direction == ComTypes.DATADIR.DATADIR_GET)
+            {
+                // Create enumerator and return it
+                ComTypes.IEnumFORMATETC enumerator;
+                if (SHCreateStdEnumFmtEtc(0, [], out enumerator) == 0)
+                {
+                    return enumerator;
+                }
+            }
+
+            throw new NotImplementedException();
+        }
+
+        int ComTypes.IDataObject.GetCanonicalFormatEtc(ref ComTypes.FORMATETC formatIn, out ComTypes.FORMATETC formatOut) => throw new NotImplementedException();
+        object IDataObject.GetData(string format, bool autoConvert) => format == "Foo" ? "Bar" : null!;
+        object IDataObject.GetData(string format) => format == "Foo" ? "Bar" : null!;
+        object IDataObject.GetData(Type format) => null!;
+        void ComTypes.IDataObject.GetData(ref ComTypes.FORMATETC format, out ComTypes.STGMEDIUM medium) => throw new NotImplementedException();
+        void ComTypes.IDataObject.GetDataHere(ref ComTypes.FORMATETC format, ref ComTypes.STGMEDIUM medium) => throw new NotImplementedException();
+        bool IDataObject.GetDataPresent(string format, bool autoConvert) => format == "Foo";
+        bool IDataObject.GetDataPresent(string format) => format == "Foo";
+        bool IDataObject.GetDataPresent(Type format) => false;
+        string[] IDataObject.GetFormats(bool autoConvert) => ["Foo"];
+        string[] IDataObject.GetFormats() => ["Foo"];
+        int ComTypes.IDataObject.QueryGetData(ref ComTypes.FORMATETC format) => throw new NotImplementedException();
+        void IDataObject.SetData(string format, bool autoConvert, object? data) => throw new NotImplementedException();
+        void IDataObject.SetData(string format, object? data) => throw new NotImplementedException();
+        void IDataObject.SetData(Type format, object? data) => throw new NotImplementedException();
+        void IDataObject.SetData(object? data) => throw new NotImplementedException();
+        void ComTypes.IDataObject.SetData(ref ComTypes.FORMATETC formatIn, ref ComTypes.STGMEDIUM medium, bool release) => throw new NotImplementedException();
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataObjectTests.cs
@@ -3032,10 +3032,6 @@ public partial class DataObjectTests
 
         // We don't expose JsonData<T> in public legacy API
         data.GetData(format).Should().BeNull();
-
-        // For the clipboard, we don't expose JsonData<T> either for in proc scenarios.
-        Clipboard.SetDataObject(data, copy: false);
-        Clipboard.GetData(format).Should().BeNull();
     }
 
     [WinFormsFact]


### PR DESCRIPTION
Fixes https://github.com/dotnet/winforms/issues/12665

In .NET 9, we had switched to leveraging cswin32 and ComWrappers for our OLE interop. During this we discovered that switching from built-in COM to ComWrappers took away the ability to automatically cast native pointers back to their original managed object when round tripping through native code. In order to remedy this, we updated to wrap the data on clipboard set and unwrap the object retrieved from the clipboard manually before returning it to get the original data. 

While doing this, we had missed the fact that the native IDataObject interface doesn't have the concept of explicit autoConvert. Meaning that when calling our Clipboard APIs with autoConvert = false, it will effectively be ignored and produce same results as autoConvert = true if we're calling to a native IDataObject interface. In .NET 9, since we always unwrap the object retrieved from the clipboard to get our completely managed DataObject, we lost this behavior for types that don't already derive from managed IDataObject.

To fix this, the change here is that when we wrap types that don't already derive from the managed IDataObject, we won't automatically unwrap to the wrapping DataObject we created.

Changes also includes adding more tests to capture behavior and minor optimization with not wrapping twice
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/winforms/pull/12738)